### PR TITLE
add API endpoint to create TS repository

### DIFF
--- a/lib/galaxy/webapps/tool_shed/buildapp.py
+++ b/lib/galaxy/webapps/tool_shed/buildapp.py
@@ -129,6 +129,11 @@ def app_factory( global_conf, **kwargs ):
                            controller='repositories',
                            action='create_changeset_revision',
                            conditions=dict( method=[ "POST" ] ) )
+    webapp.mapper.connect( 'create_repository',
+                           '/api/repositories',
+                           controller='repositories',
+                           action='create',
+                           conditions=dict( method=[ "POST" ] ) )
 
     webapp.finalize_config()
     # Wrap the webapp in some useful middleware

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -313,8 +313,11 @@ def handle_role_associations( app, role, repository, **kwd ):
     return associations_dict
 
 def validate_repository_name( app, name, user ):
-    # Repository names must be unique for each user, must be at least four characters
-    # in length and must contain only lower-case letters, numbers, and the '_' character.
+    """
+    Validate whether the given name qualifies as a new TS repo name.
+    Repository names must be unique for each user, must be at least two characters
+    in length and must contain only lower-case letters, numbers, and the '_' character.
+    """
     if name in [ 'None', None, '' ]:
         return 'Enter the required repository name.'
     if name in [ 'repos' ]:
@@ -322,13 +325,13 @@ def validate_repository_name( app, name, user ):
     check_existing = suc.get_repository_by_name_and_owner( app, name, user.username )
     if check_existing is not None:
         if check_existing.deleted:
-            return 'You have a deleted repository named <b>%s</b>, so choose a different name.' % name
+            return 'You own a deleted repository named <b>%s</b>, please choose a different name.' % escape( name )
         else:
-            return "You already have a repository named <b>%s</b>, so choose a different name." % name
+            return "You already own a repository named <b>%s</b>, please choose a different name." % escape( name )
     if len( name ) < 2:
         return "Repository names must be at least 2 characters in length."
     if len( name ) > 80:
         return "Repository names cannot be more than 80 characters in length."
     if not( VALID_REPOSITORYNAME_RE.match( name ) ):
-        return "Repository names must contain only lower-case letters, numbers and underscore <b>_</b>."
+        return "Repository names must contain only lower-case letters, numbers and underscore."
     return ''


### PR DESCRIPTION
This PR introduces new endpoint at the Tool Shed
you can **POST {toolshed_url}/api/repository**

``` json
{
"name": "new_repo_17",
"synopsis": "new_synopsis",
"description": "this is some repository",
"type": "unrestricted",
"remote_repository_url": "https://github.com/galaxyproject/tools-devteam",
"homepage_url": "https://github.com/galaxyproject/",
"category_ids[]": [ "adb5f5c93f827949", "529fd61ab1c6cc36" ]
}
```

and you will receive:

``` json
{
"deleted": false,
"deprecated": false,
"description": "new_synopsis",
"homepage_url": "https://github.com/galaxyproject/",
"id": "8cf91205f2f737f4",
"long_description": "this is some repository",
"model_class": "Repository",
"name": "new_repo_17",
"owner": "qqqqqq",
"private": false,
"remote_repository_url": "https://github.com/galaxyproject/tools-devteam",
"times_downloaded": 0,
"type": "unrestricted",
"user_id": "adb5f5c93f827949"
}
```
