### PR TITLE
Add argument to tool parameters.

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -37,14 +37,15 @@ class ToolParameter( object, Dictifiable ):
     moment but in the future should encapsulate more complex parameters (lists
     of valid choices, validation logic, ...)
     """
-    dict_collection_visible_keys = ( 'name', 'type', 'label', 'help' )
+    dict_collection_visible_keys = ( 'name', 'argument', 'type', 'label', 'help' )
 
     def __init__( self, tool, input_source, context=None ):
         input_source = ensure_input_source(input_source)
         self.tool = tool
         self.refresh_on_change = False
         self.refresh_on_change_values = []
-        self.name = input_source.get("name")
+        self.argument = input_source.get("argument")
+        self.name = ToolParameter.parse_name( input_source )
         self.type = input_source.get("type")
         self.hidden = input_source.get("hidden", False)
         self.is_dynamic = False
@@ -224,9 +225,7 @@ class ToolParameter( object, Dictifiable ):
     @classmethod
     def build( cls, tool, param ):
         """Factory method to create parameter of correct type"""
-        param_name = param.get( "name" )
-        if not param_name:
-            raise ValueError( "Tool parameter '%s' requires a 'name'" % (param_name ) )
+        param_name = cls.parse_name( param )
         param_type = param.get("type")
         if not param_type:
             raise ValueError( "Tool parameter '%s' requires a 'type'" % ( param_name ) )
@@ -234,6 +233,17 @@ class ToolParameter( object, Dictifiable ):
             raise ValueError( "Tool parameter '%s' uses an unknown type '%s'" % ( param_name, param_type ) )
         else:
             return parameter_types[param_type]( tool, param )
+
+    @classmethod
+    def parse_name(cls, input_source):
+        name = input_source.get("name", None)
+        if name is None:
+            argument = input_source.get("argument")
+            if argument:
+                name = argument.lstrip("-")
+            else:
+                raise ValueError("Tool parameter must specify a name.")
+        return name
 
 
 class TextToolParameter( ToolParameter ):

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -58,7 +58,7 @@ class ToolsTestCase( api.ApiTestCase ):
         self._assert_has_keys( case2, "value", "inputs" )
         case2_inputs = case2[ "inputs" ]
         assert len( case2_inputs ) == 1
-        self._assert_has_keys( case2_inputs[ 0 ], 'name', 'type', 'label', 'help' )
+        self._assert_has_keys( case2_inputs[ 0 ], 'name', 'type', 'label', 'help', 'argument' )
         assert case2_inputs[ 0 ][ "name" ] == "seed"
 
     def _show_valid_tool( self, tool_id ):


### PR DESCRIPTION
- Expose via the API to help command-line construction.
- Default the name of a parameter to be this (minus dashes) if name is not otherwise found.
