### PR TITLE
Bug in URL for setAsCurrent

### DIFF
--- a/static/scripts/mvc/history/history-model.js
+++ b/static/scripts/mvc/history/history-model.js
@@ -257,7 +257,7 @@ var History = Backbone.Model.extend( BASE_MVC.LoggableMixin ).extend(
 
     setAsCurrent : function(){
         var history = this,
-            xhr = jQuery.getJSON( '/history/set_as_current?id=' + this.id );
+            xhr = jQuery.getJSON( galaxy_config.root + '/history/set_as_current?id=' + this.id );
 
         xhr.done( function(){
             history.trigger( 'set-as-current', history );

--- a/static/scripts/mvc/history/history-model.js
+++ b/static/scripts/mvc/history/history-model.js
@@ -257,7 +257,7 @@ var History = Backbone.Model.extend( BASE_MVC.LoggableMixin ).extend(
 
     setAsCurrent : function(){
         var history = this,
-            xhr = jQuery.getJSON( galaxy_config.root + '/history/set_as_current?id=' + this.id );
+            xhr = jQuery.getJSON( galaxy_config.root + 'history/set_as_current?id=' + this.id );
 
         xhr.done( function(){
             history.trigger( 'set-as-current', history );


### PR DESCRIPTION
URL for setAsCurrent() function does not use galaxy root in config file. Add galaxy_config.root before 'history/set_as_current?id='
