### PR TITLE
Fix fasta_to_tabular_converter.py (for implicit conversion)

### DIFF
--- a/lib/galaxy/datatypes/converters/fasta_to_tabular_converter.py
+++ b/lib/galaxy/datatypes/converters/fasta_to_tabular_converter.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python
-# This code exists in 2 places: ~/datatypes/converters and ~/tools/fasta_tools
+# Variants of this code exists in 2 places, this file which has no
+# user facing options which is called for implicit data conversion,
+# lib/galaxy/datatypes/converters/fasta_to_tabular_converter.py
+# and the user-facing Galaxy tool of the same name which has many
+# options. That version is now on GitHub and the Galaxy Tool Shed:
+# https://github.com/galaxyproject/tools-devteam/tree/master/tools/fasta_to_tabular
+# https://toolshed.g2.bx.psu.edu/view/devteam/fasta_to_tabular
 """
-Input: fasta, minimal length, maximal length
-Output: fasta
-Return sequences whose lengths are within the range.
+Input: fasta
+Output: tabular
 """
 
 import sys, os
@@ -22,7 +27,7 @@ def __main__():
             if sequence:
                 sequence_count += 1
                 seq_hash[( sequence_count, title )] = sequence
-            title = line
+            title = line[1:]  # strip off the '>'
             sequence = ''
         else:
             if line:
@@ -31,7 +36,6 @@ def __main__():
                     sequence += ' '
     if sequence:
         seq_hash[( sequence_count, title )] = sequence
-    # return only those lengths are in the range
     out = open( outfile, 'w' )
     title_keys = seq_hash.keys()
     title_keys.sort()

--- a/lib/galaxy/datatypes/converters/fasta_to_tabular_converter.py
+++ b/lib/galaxy/datatypes/converters/fasta_to_tabular_converter.py
@@ -27,7 +27,9 @@ def __main__():
             if sequence:
                 sequence_count += 1
                 seq_hash[( sequence_count, title )] = sequence
-            title = line[1:]  # strip off the '>'
+            # Strip off the leading '>' and remove any pre-existing
+            # tabs which would trigger extra columns:
+            title = line[1:].replace('\t', ' ')
             sequence = ''
         else:
             if line:

--- a/lib/galaxy/datatypes/converters/fasta_to_tabular_converter.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_tabular_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_fasta_to_tabular" name="Convert FASTA to Tabular" version="1.0.0">
+<tool id="CONVERTER_fasta_to_tabular" name="Convert FASTA to Tabular" version="1.0.1">
   <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
   <!-- Used on the metadata edit page. -->
   <command interpreter="python">fasta_to_tabular_converter.py $input $output</command>

--- a/lib/galaxy/datatypes/converters/fasta_to_tabular_converter.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_tabular_converter.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_fasta_to_tabular" name="Convert FASTA to Tabular" version="1.0.1">
   <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
   <!-- Used on the metadata edit page. -->
-  <command interpreter="python">fasta_to_tabular_converter.py $input $output</command>
+  <command interpreter="python">fasta_to_tabular_converter.py "$input" "$output"</command>
   <inputs>
     <param name="input" type="data" format="fasta" label="Fasta file"/>
   </inputs>


### PR DESCRIPTION
I was just surprised to find what I consider to be a major bug in the `fasta_to_tabular_converter.py` used to convert FASTA into tabular (not the user facing Galaxy tool with a similar name). Consider this toy example:

```
>alpha
ACGTAC
>beta
AGTGTA
>gamma with some description
AGGTACCA
```

What the converter gives is two columns (title line and sequence), but the `>` is left in:

```
>alpha (tab) ACGTAC
>beta (tab) AGTGTA
>gamma with some description (tab) AGGTACCA
```

Given it would be just two columns, what I was expecting was:

```
alpha (tab) ACGTAC
beta (tab) AGTGTA
gamma with some description (tab) AGGTACCA
```

I think this is a bug. In support of this view, I note the user-facing (now in the Tool Shed) removes the `>` symbol:

https://toolshed.g2.bx.psu.edu/view/devteam/fasta_to_tabular
https://github.com/galaxyproject/tools-devteam/tree/master/tools/fasta_to_tabular

This pull request fixes this (removes the `>` symbol) and later commits address other less critical issues.

The final commit is larger - it rewrites the Python script to avoid holding all the file in memory as a Python dictionary. Feel free to skip that if being conservative.

I have not (yet) written or run any tests. How are the converters automatically tested?
