### PR TITLE
Preserve spaces in Count1 (tools/filters/uniq.xml)

### DIFF
--- a/test-data/species_assignment.tabular
+++ b/test-data/species_assignment.tabular
@@ -1,8 +1,8 @@
 gene1	Prunus mume	Japanese apricot	eudicots	Eukaryota
 gene2	Ancylostoma ceylanicum	Ancylostoma ceylanicum	nematodes	Eukaryota
 gene3	Meloidogyne incognita	southern root-knot nematode	nematodes	Eukaryota
-gene4	No BLAST hit	No BLAST hit	No BLAST hit	No BLAST hit
-gene5	No BLAST hit	No BLAST hit	No BLAST hit	No BLAST hit
+gene4	No BLAST hit	No BLAST hit	No BLAST hit	No BLAST hit      
+gene5	No BLAST hit	No BLAST hit	No BLAST hit    	No BLAST hit
 gene6	Loa loa	eye worm	nematodes	Eukaryota
 gene7	Loa loa	eye worm	nematodes	Eukaryota
 gene8	Loa loa	eye worm	nematodes	Eukaryota
@@ -11,8 +11,8 @@ gene10	Ascaris suum	pig roundworm	nematodes	Eukaryota
 gene11	Ascaris suum	pig roundworm	nematodes	Eukaryota
 gene12	Ascaris suum	pig roundworm	nematodes	Eukaryota
 gene13	Wuchereria bancrofti	Wuchereria bancrofti	nematodes	Eukaryota
-gene14	No BLAST hit	No BLAST hit	No BLAST hit	No BLAST hit
-gene15	No BLAST hit  	No BLAST hit	No BLAST hit	No BLAST hit
+gene14	No BLAST hit	No BLAST hit    	No BLAST hit	No BLAST hit
+gene15	No BLAST hit     	No BLAST hit	No BLAST hit	No BLAST hit
 gene16	Brugia malayi	Brugia malayi	nematodes	Eukaryota
 gene17	Caenorhabditis remanei	Caenorhabditis remanei	nematodes	Eukaryota
 gene18	Ascaris suum	pig roundworm	nematodes	Eukaryota

--- a/test-data/species_assignment.tabular
+++ b/test-data/species_assignment.tabular
@@ -1,0 +1,20 @@
+gene1	Prunus mume	Japanese apricot	eudicots	Eukaryota
+gene2	Ancylostoma ceylanicum	Ancylostoma ceylanicum	nematodes	Eukaryota
+gene3	Meloidogyne incognita	southern root-knot nematode	nematodes	Eukaryota
+gene4	No BLAST hit	No BLAST hit	No BLAST hit	No BLAST hit
+gene5	No BLAST hit	No BLAST hit	No BLAST hit	No BLAST hit
+gene6	Loa loa	eye worm	nematodes	Eukaryota
+gene7	Loa loa	eye worm	nematodes	Eukaryota
+gene8	Loa loa	eye worm	nematodes	Eukaryota
+gene9	Caenorhabditis elegans	Caenorhabditis elegans	nematodes	Eukaryota
+gene10	Ascaris suum	pig roundworm	nematodes	Eukaryota
+gene11	Ascaris suum	pig roundworm	nematodes	Eukaryota
+gene12	Ascaris suum	pig roundworm	nematodes	Eukaryota
+gene13	Wuchereria bancrofti	Wuchereria bancrofti	nematodes	Eukaryota
+gene14	No BLAST hit	No BLAST hit	No BLAST hit	No BLAST hit
+gene15	No BLAST hit  	No BLAST hit	No BLAST hit	No BLAST hit
+gene16	Brugia malayi	Brugia malayi	nematodes	Eukaryota
+gene17	Caenorhabditis remanei	Caenorhabditis remanei	nematodes	Eukaryota
+gene18	Ascaris suum	pig roundworm	nematodes	Eukaryota
+gene19	Strongyloides ratti	Strongyloides ratti	nematodes	Eukaryota
+gene20	Brugia malayi	Brugia malayi	nematodes	Eukaryota

--- a/test-data/species_assignment_c2.tabular
+++ b/test-data/species_assignment_c2.tabular
@@ -1,0 +1,11 @@
+1	Ancylostoma ceylanicum
+4	Ascaris suum
+2	Brugia malayi
+1	Caenorhabditis elegans
+1	Caenorhabditis remanei
+3	Loa loa
+1	Meloidogyne incognita
+4	No BLAST hit
+1	Prunus mume
+1	Strongyloides ratti
+1	Wuchereria bancrofti

--- a/test-data/species_assignment_c2_c3.tabular
+++ b/test-data/species_assignment_c2_c3.tabular
@@ -1,0 +1,12 @@
+1	Ancylostoma ceylanicum	Ancylostoma ceylanicum
+4	Ascaris suum	pig roundworm
+2	Brugia malayi	Brugia malayi
+1	Caenorhabditis elegans	Caenorhabditis elegans
+1	Caenorhabditis remanei	Caenorhabditis remanei
+3	Loa loa	eye worm
+1	Meloidogyne incognita	southern root-knot nematode
+1	No BLAST hit  	No BLAST hit
+3	No BLAST hit	No BLAST hit
+1	Prunus mume	Japanese apricot
+1	Strongyloides ratti	Strongyloides ratti
+1	Wuchereria bancrofti	Wuchereria bancrofti

--- a/test-data/species_assignment_c2_c3.tabular
+++ b/test-data/species_assignment_c2_c3.tabular
@@ -5,8 +5,7 @@
 1	Caenorhabditis remanei	Caenorhabditis remanei
 3	Loa loa	eye worm
 1	Meloidogyne incognita	southern root-knot nematode
-1	No BLAST hit  	No BLAST hit
-3	No BLAST hit	No BLAST hit
+4	No BLAST hit	No BLAST hit
 1	Prunus mume	Japanese apricot
 1	Strongyloides ratti	Strongyloides ratti
 1	Wuchereria bancrofti	Wuchereria bancrofti

--- a/tools/filters/uniq.py
+++ b/tools/filters/uniq.py
@@ -87,9 +87,7 @@ def main():
         return -6
 
     column_list = re.split(",",columns)
-    columns_for_display = ""
-    for col in column_list:
-        columns_for_display += "c"+col+", "
+    columns_for_display = "c" + ", c".join(column_list)
 
     commandline = "cut "
     # Set delimiter

--- a/tools/filters/uniq.py
+++ b/tools/filters/uniq.py
@@ -106,12 +106,18 @@ def main():
 
     # set columns
     commandline += "-f " + columns
+    # we want to remove *trailing* spaces from each field,
+    # so look for spaces then tab (for first and middle selected columns)
+    # and replacw with just tab, and remove any spaces at end of the line
+    # (for the final selected column):
+    commandline += " " + inputfile + " | sed 's/\ *\t/\t/' | sed 's/\ *$//' | sort"
     # uniq -C produces lines with leading spaces, use sed to remove that
     # uniq -C puts a space between the count and the field, want a tab.
     # To replace just first tab, use sed again with 1 as the index
-    commandline += " " + inputfile + " | sed 's/[ \t]*$//' | sort | uniq -c | sed 's/^\ *//' | sed 's/ /\t/1' > " + outputfile
+    commandline += " | uniq -c | sed 's/^\ *//' | sed 's/\ /\t/1' > " + outputfile
+    print commandline
     errorcode, stdout = commands.getstatusoutput(commandline)
-    
+
     print "Count of unique values in " + columns_for_display
     return errorcode
 

--- a/tools/filters/uniq.py
+++ b/tools/filters/uniq.py
@@ -5,7 +5,8 @@
 # This script accepts an input file, an output file, a column
 # delimiter, and a list of columns.  The script then grabs unique
 # lines based on the columns, and returns those records with a count
-# of occurences of each unique column, inserted before the columns.
+# of occurences of each unique column (ignoring trailing spaces),
+# inserted before the columns.
 #
 # This executes the command pipeline:
 #       cut -f $fields | sort  | uniq -C
@@ -107,7 +108,10 @@ def main():
 
     # set columns
     commandline += "-f " + columns
-    commandline += " " + inputfile + " | sed s/\ //g | sort | uniq -c | sed s/^\ *// | tr \" \" \"\t\" > " + outputfile
+    # uniq -C produces lines with leading spaces, use sed to remove that
+    # uniq -C puts a space between the count and the field, want a tab.
+    # To replace just first tab, use sed again with 1 as the index
+    commandline += " " + inputfile + " | sed 's/[ \t]*$//' | sort | uniq -c | sed 's/^\ *//' | sed 's/ /\t/1' > " + outputfile
     errorcode, stdout = commands.getstatusoutput(commandline)
     
     print "Count of unique values in " + columns_for_display

--- a/tools/filters/uniq.xml
+++ b/tools/filters/uniq.xml
@@ -1,4 +1,4 @@
-<tool id="Count1" name="Count">
+<tool id="Count1" name="Count" version="1.0.1">
   <description>occurrences of each record</description>
   <command interpreter="python">uniq.py -i $input -o $out_file1 -c "$column" -d $delim</command>
   <inputs>
@@ -22,6 +22,18 @@
       <param name="input" value="1.bed"/>
       <output name="out_file1" file="uniq_out.dat"/>
       <param name="column" value="1"/>
+      <param name="delim" value="T"/>
+    </test>
+    <test>
+      <param name="input" value="species_assignment.tabular" ftype="tabular"/>
+      <output name="out_file1" file="species_assignment_c2.tabular"/>
+      <param name="column" value="2"/>
+      <param name="delim" value="T"/>
+    </test>
+    <test>
+      <param name="input" value="species_assignment.tabular" ftype="tabular"/>
+      <output name="out_file1" file="species_assignment_c2_c3.tabular"/>
+      <param name="column" value="2,3"/>
       <param name="delim" value="T"/>
     </test>
   </tests>


### PR DESCRIPTION
See https://trello.com/c/Ectva3pr/2510-count1-tool-removes-spaces-tools-filters-uniq-xml

Includes test case showing the change in behaviour from this:

```
$ python tools/filters/uniq.py -i test-data/species_assignment.tabular -o test-data/species_assignment_c2.tabular -c 2 -d T
Count of unique values in c2,
1   Ancylostomaceylanicum
4   Ascarissuum
2   Brugiamalayi
1   Caenorhabditiselegans
1   Caenorhabditisremanei
3   Loaloa
1   Meloidogyneincognita
4   NoBLASThit
1   Prunusmume
1   Strongyloidesratti
1   Wuchereriabancrofti
```

To this space-preserving output:

```
$ python tools/filters/uniq.py -i test-data/species_assignment.tabular -o test-data/species_assignment_c2.tabular -c 2 -d T
Count of unique values in c2
1   Ancylostoma ceylanicum
4   Ascaris suum
2   Brugia malayi
1   Caenorhabditis elegans
1   Caenorhabditis remanei
3   Loa loa
1   Meloidogyne incognita
4   No BLAST hit
1   Prunus mume
1   Strongyloides ratti
1   Wuchereria bancrofti
```

Also includes a multi-column test to confirm that still works nicely.

Also makes the tool version number explicit (would have defaulted to `1.0.0` so now using `1.0.1` as per IUC mailing list discussion).

Also removes the trailing comma in the tool's stdout.
