### PR TITLE
open selected data source tools that do not have SSL in _blank

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2763,6 +2763,10 @@ class DataSourceTool( OutputParameterJSONTool ):
 
     def parse_inputs( self, tool_source ):
         super( DataSourceTool, self ).parse_inputs( tool_source )
+        # The following servers don't provide SSL connection thus preventing users to access them within Galaxy's frame.
+        # Open them in _blank instead.
+        if self.id in [ 'flymine', 'ucsc_table_direct_archaea1', 'modmine', 'mousemine', 'ratmine', 'yeastmine', 'zebrafishmine', 'eupathdb' ]:
+            self.target = '_blank'
         if 'GALAXY_URL' not in self.inputs:
             self.inputs[ 'GALAXY_URL' ] = self._build_GALAXY_URL_parameter()
             self.inputs_by_page[0][ 'GALAXY_URL' ] = self.inputs[ 'GALAXY_URL' ]

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2763,10 +2763,8 @@ class DataSourceTool( OutputParameterJSONTool ):
 
     def parse_inputs( self, tool_source ):
         super( DataSourceTool, self ).parse_inputs( tool_source )
-        # The following servers don't provide SSL connection thus preventing users to access them within Galaxy's frame.
-        # Open them in _blank instead.
-        if self.id in [ 'flymine', 'ucsc_table_direct_archaea1', 'modmine', 'mousemine', 'ratmine', 'yeastmine', 'zebrafishmine', 'eupathdb' ]:
-            self.target = '_blank'
+        # Open all data_source tools in _top.
+        self.target = '_top'
         if 'GALAXY_URL' not in self.inputs:
             self.inputs[ 'GALAXY_URL' ] = self._build_GALAXY_URL_parameter()
             self.inputs_by_page[0][ 'GALAXY_URL' ] = self.inputs[ 'GALAXY_URL' ]


### PR DESCRIPTION
Could not think of a better way how to handle this big usability issue. Main purpose of this PR is to start discussion.
Weaknesses:
- ~~user ends up with two windows/tabs with Galaxy opened~~
- ~~we have to maintain this 'blacklist'~~
- ~~Galaxies without SSL have no need for this and as it seems undetectable at this point - I guess this should be configurable~~

Constructive feedback welcomed.

edit: @jxtx suggested to just open all data_source tools in _top instead, which helps us in future to get rid of frames. This PR was updated with this suggestion which nicely solves all weaknesses..
