### PR TITLE
Fix copied outputs being discarded when deleting/purging histories in the view all histories interface

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -680,6 +680,9 @@ class JobHandlerStopQueue( object ):
         except Empty:
             pass
         for job, error_msg in jobs_to_check:
+            if job.finished:
+                log.debug('Job %s already finished, not deleting or stopping', job.id)
+                continue
             final_state = job.states.DELETED
             if error_msg is not None:
                 final_state = job.states.ERROR

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -160,6 +160,7 @@ class HDAManager( datasets.DatasetAssociationManager, secured.OwnableManagerMixi
             job = hda.creating_job_associations[0].job
             if not job.finished:
                 # signal to stop the creating job
+                job.mark_deleted( self.app.config.track_jobs_in_database )
                 self.app.job_manager.job_stop_queue.put( job.id )
 
         # more importantly, purge dataset as well

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -517,6 +517,9 @@ class Job( object, HasJobMetrics, Dictifiable ):
         """
         Mark this job as deleted, and mark any output datasets as discarded.
         """
+        if self.finished:
+            # Do not modify the state/outputs of jobs that are already terminal
+            return
         if track_jobs_in_database:
             self.state = Job.states.DELETED_NEW
         else:


### PR DESCRIPTION
`Job.mark_deleted()` did not previously expect to be called on a job that was already terminal. Likewise, the job stopper did not actually check whether a job should be stopped. This causes the bug reported here:

https://biostar.usegalaxy.org/p/11108/
