### PR TITLE
Fix command line generation with setting metadata and history export

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -653,12 +653,15 @@ class Registry( object ):
                   <requirement type="package">samtools</requirement>
               </requirements>
               <action module="galaxy.tools.actions.metadata" class="SetMetadataToolAction"/>
-              <command>$__SET_EXTERNAL_METADATA_COMMAND_LINE__</command>
+              <command>python $set_metadata $__SET_EXTERNAL_METADATA_COMMAND_LINE__</command>
               <inputs>
                 <param format="data" name="input1" type="data" label="File to set metadata on."/>
                 <param name="__ORIGINAL_DATASET_STATE__" type="hidden" value=""/>
                 <param name="__SET_EXTERNAL_METADATA_COMMAND_LINE__" type="hidden" value=""/>
               </inputs>
+              <configfiles>
+                <configfile name="set_metadata">from galaxy.metadata.set_metadata import set_metadata; set_metadata()</configfile>
+              </configfiles>
             </tool>
             """
         tmp_name = tempfile.NamedTemporaryFile()

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -831,8 +831,7 @@ class JobWrapper( object ):
 
         self.command_line, self.extra_filenames = tool_evaluator.build()
         # FIXME: for now, tools get Galaxy's lib dir in their path
-        if self.command_line and self.command_line.startswith( 'python' ):
-            self.galaxy_lib_dir = os.path.abspath( "lib" )  # cwd = galaxy root
+        self.galaxy_lib_dir = os.path.abspath( "lib" )  # cwd = galaxy root
         # Shell fragment to inject dependencies
         self.dependency_shell_commands = self.tool.build_dependency_shell_commands()
         # We need command_line persisted to the db in order for Galaxy to re-queue the job

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -145,7 +145,7 @@ def __handle_metadata(commands_builder, job_wrapper, runner, remote_command_para
     metadata_command = metadata_command.strip()
     if metadata_command:
         commands_builder.capture_return_code()
-        commands_builder.append_command("cd %s; %s" % (exec_dir, metadata_command))
+        commands_builder.append_command(metadata_command)
 
 
 def __copy_if_exists_command(work_dir_output):

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -1,0 +1,2 @@
+""" Work with Galaxy metadata
+"""

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -1,0 +1,122 @@
+"""
+Execute an external process to set_meta() on a provided list of pickled datasets.
+
+This was formerly scripts/set_metadata.py and expects the same arguments as
+that script.
+"""
+
+import logging
+logging.basicConfig()
+log = logging.getLogger( __name__ )
+
+import cPickle
+import json
+import os
+import sys
+
+# ensure supported version
+assert sys.version_info[:2] >= ( 2, 6 ) and sys.version_info[:2] <= ( 2, 7 ), 'Python version must be 2.6 or 2.7, this is: %s' % sys.version
+
+new_path = [ os.path.join( os.getcwd(), "lib" ) ]
+new_path.extend( sys.path[ 1: ] )  # remove scripts/ from the path
+sys.path = new_path
+
+from galaxy import eggs
+import pkg_resources
+import galaxy.model.mapping  # need to load this before we unpickle, in order to setup properties assigned by the mappers
+galaxy.model.Job()  # this looks REAL stupid, but it is REQUIRED in order for SA to insert parameters into the classes defined by the mappers --> it appears that instantiating ANY mapper'ed class would suffice here
+from galaxy.util import stringify_dictionary_keys
+from sqlalchemy.orm import clear_mappers
+
+
+def set_meta_with_tool_provided( dataset_instance, file_dict, set_meta_kwds ):
+    # This method is somewhat odd, in that we set the metadata attributes from tool,
+    # then call set_meta, then set metadata attributes from tool again.
+    # This is intentional due to interplay of overwrite kwd, the fact that some metadata
+    # parameters may rely on the values of others, and that we are accepting the
+    # values provided by the tool as Truth. 
+    for metadata_name, metadata_value in file_dict.get( 'metadata', {} ).iteritems():
+        setattr( dataset_instance.metadata, metadata_name, metadata_value )
+    dataset_instance.datatype.set_meta( dataset_instance, **set_meta_kwds )
+    for metadata_name, metadata_value in file_dict.get( 'metadata', {} ).iteritems():
+        setattr( dataset_instance.metadata, metadata_name, metadata_value )
+
+def set_metadata():
+    # locate galaxy_root for loading datatypes
+    galaxy_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir))
+    galaxy.datatypes.metadata.MetadataTempFile.tmp_dir = tool_job_working_directory = os.path.abspath(os.getcwd())
+
+    # Set up datatypes registry
+    datatypes_config = sys.argv.pop( 1 )
+    datatypes_registry = galaxy.datatypes.registry.Registry()
+    datatypes_registry.load_datatypes( root_dir=config_root, config=datatypes_config )
+    galaxy.model.set_datatypes_registry( datatypes_registry )
+
+    job_metadata = sys.argv.pop( 1 )
+    existing_job_metadata_dict = {}
+    new_job_metadata_dict = {}
+    if job_metadata != "None" and os.path.exists( job_metadata ):
+        for line in open( job_metadata, 'r' ):
+            try:
+                line = stringify_dictionary_keys( json.loads( line ) )
+                if line['type'] == 'dataset':
+                    existing_job_metadata_dict[ line['dataset_id'] ] = line
+                elif line['type'] == 'new_primary_dataset':
+                    new_job_metadata_dict[ line[ 'filename' ] ] = line
+            except:
+                continue
+
+    for filenames in sys.argv[1:]:
+        fields = filenames.split( ',' )
+        filename_in = fields.pop( 0 )
+        filename_kwds = fields.pop( 0 )
+        filename_out = fields.pop( 0 )
+        filename_results_code = fields.pop( 0 )
+        dataset_filename_override = fields.pop( 0 )
+        # Need to be careful with the way that these parameters are populated from the filename splitting,
+        # because if a job is running when the server is updated, any existing external metadata command-lines
+        #will not have info about the newly added override_metadata file
+        if fields:
+            override_metadata = fields.pop( 0 )
+        else:
+            override_metadata = None
+        set_meta_kwds = stringify_dictionary_keys( json.load( open( filename_kwds ) ) )  # load kwds; need to ensure our keywords are not unicode
+        try:
+            dataset = cPickle.load( open( filename_in ) )  # load DatasetInstance
+            if dataset_filename_override:
+                dataset.dataset.external_filename = dataset_filename_override
+            files_path = os.path.abspath(os.path.join( tool_job_working_directory, "dataset_%s_files" % (dataset.dataset.id) ))
+            dataset.dataset.external_extra_files_path = files_path
+            if dataset.dataset.id in existing_job_metadata_dict:
+                dataset.extension = existing_job_metadata_dict[ dataset.dataset.id ].get( 'ext', dataset.extension )
+            # Metadata FileParameter types may not be writable on a cluster node, and are therefore temporarily substituted with MetadataTempFiles
+            if override_metadata:
+                override_metadata = json.load( open( override_metadata ) )
+                for metadata_name, metadata_file_override in override_metadata:
+                    if galaxy.datatypes.metadata.MetadataTempFile.is_JSONified_value( metadata_file_override ):
+                        metadata_file_override = galaxy.datatypes.metadata.MetadataTempFile.from_JSON( metadata_file_override )
+                    setattr( dataset.metadata, metadata_name, metadata_file_override )
+            file_dict = existing_job_metadata_dict.get( dataset.dataset.id, {} )
+            set_meta_with_tool_provided( dataset, file_dict, set_meta_kwds )
+            dataset.metadata.to_JSON_dict( filename_out )  # write out results of set_meta
+            json.dump( ( True, 'Metadata has been set successfully' ), open( filename_results_code, 'wb+' ) )  # setting metadata has succeeded
+        except Exception, e:
+            json.dump( ( False, str( e ) ), open( filename_results_code, 'wb+' ) )  # setting metadata has failed somehow
+
+    for i, ( filename, file_dict ) in enumerate( new_job_metadata_dict.iteritems(), start=1 ):
+        new_dataset = galaxy.model.Dataset( id=-i, external_filename=os.path.join( tool_job_working_directory, file_dict[ 'filename' ] ) )
+        extra_files = file_dict.get( 'extra_files', None )
+        if extra_files is not None:
+            new_dataset._extra_files_path = os.path.join( tool_job_working_directory, extra_files )
+        new_dataset.state = new_dataset.states.OK
+        new_dataset_instance = galaxy.model.HistoryDatasetAssociation( id=-i, dataset=new_dataset, extension=file_dict.get( 'ext', 'data' ) )
+        set_meta_with_tool_provided( new_dataset_instance, file_dict, set_meta_kwds )
+        file_dict[ 'metadata' ] = json.loads( new_dataset_instance.metadata.to_JSON_dict() ) #storing metadata in external form, need to turn back into dict, then later jsonify
+    if existing_job_metadata_dict or new_job_metadata_dict:
+        with open( job_metadata, 'wb' ) as job_metadata_fh:
+            for value in existing_job_metadata_dict.values() + new_job_metadata_dict.values():
+                job_metadata_fh.write( "%s\n" % ( json.dumps( value ) ) )
+
+    clear_mappers()
+    # Shut down any additional threads that might have been created via the ObjectStore
+    object_store.shutdown()

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -76,6 +76,7 @@ class SetMetadataToolAction( ToolAction ):
                                                                       config_file = app.config.config_file,
                                                                       datatypes_config = app.datatypes_registry.integrated_datatypes_configs,
                                                                       job_metadata = None,
+                                                                      include_command = False,
                                                                       kwds = { 'overwrite' : overwrite } )
         incoming[ '__SET_EXTERNAL_METADATA_COMMAND_LINE__' ] = cmd_line
         for name, value in tool.params_to_strings( incoming, app ).iteritems():

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -17,12 +17,15 @@ EXPORT_HISTORY_TEXT = """
         <tool id="__EXPORT_HISTORY__" name="Export History" version="0.1" tool_type="export_history">
           <type class="ExportHistoryTool" module="galaxy.tools"/>
           <action module="galaxy.tools.actions.history_imp_exp" class="ExportHistoryToolAction"/>
-          <command>$__EXPORT_HISTORY_COMMAND_INPUTS_OPTIONS__ $output_file</command>
+          <command>python $export_history $__EXPORT_HISTORY_COMMAND_INPUTS_OPTIONS__ $output_file</command>
           <inputs>
             <param name="__HISTORY_TO_EXPORT__" type="hidden"/>
             <param name="compress" type="boolean"/>
             <param name="__EXPORT_HISTORY_COMMAND_INPUTS_OPTIONS__" type="hidden"/>
           </inputs>
+          <configfiles>
+            <configfile name="export_history">from galaxy.tools.imp_exp.export_history import main; main()</configfile>
+          </configfiles>
           <outputs>
             <data format="gzip" name="output_file"/>
           </outputs>
@@ -530,11 +533,9 @@ class JobExportHistoryArchiveWrapper( object, UsesAnnotations ):
         options = ""
         if jeha.compressed:
             options = "-G"
-        return "python %s %s %s %s %s" % ( os.path.join( os.path.abspath( os.getcwd() ),
-                                           "lib/galaxy/tools/imp_exp/export_history.py" ),
-                                           options, history_attrs_filename,
-                                           datasets_attrs_filename,
-                                           jobs_attrs_filename )
+        return "%s %s %s %s" % ( options, history_attrs_filename,
+                                 datasets_attrs_filename,
+                                 jobs_attrs_filename )
 
     def cleanup_after_job( self, db_session ):
         """ Remove temporary directory and attribute files generated during setup for this job. """

--- a/lib/galaxy/tools/imp_exp/export_history.py
+++ b/lib/galaxy/tools/imp_exp/export_history.py
@@ -70,7 +70,7 @@ def create_archive( history_attrs_file, datasets_attrs_file, jobs_attrs_file, ou
     except Exception, e:
         return 'Error creating history archive: %s' % str( e ), sys.stderr
 
-if __name__ == "__main__":
+def main():
     # Parse command line.
     parser = optparse.OptionParser()
     parser.add_option( '-G', '--gzip', dest='gzip', action="store_true", help='Compress archive using gzip.' )
@@ -81,3 +81,6 @@ if __name__ == "__main__":
     # Create archive.
     status = create_archive( history_attrs, dataset_attrs, job_attrs, out_file, gzip )
     print status
+
+if __name__ == "__main__":
+    main()

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -72,7 +72,7 @@ class TestCommandFactory(TestCase):
         self.include_metadata = True
         self.include_work_dir_outputs = False
         self.job_wrapper.metadata_line = TEST_METADATA_LINE
-        expected_command = '%s; return_code=$?; cd %s; %s; sh -c "exit $return_code"' % (MOCK_COMMAND_LINE, getcwd(), TEST_METADATA_LINE)
+        expected_command = '%s; return_code=$?; %s; sh -c "exit $return_code"' % (MOCK_COMMAND_LINE, TEST_METADATA_LINE)
         self.__assert_command_is( expected_command )
 
     def test_empty_metadata(self):


### PR DESCRIPTION
Previously this was done prior to job creation, which made the paths absolute. This breaks splitting web and handler directories (and presumably Pulsar as well).

Cherry picked and rebased/squashed from dev as noted in the commit messages.
