### PR TITLE
[Stable] Fix for reloading tools. Previously, when a tool was reloaded (of the sa...

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -978,7 +978,9 @@ class AbstractToolBox( object, Dictifiable ):
                     if tool_key in val.elems:
                         self._tool_panel[ key ].elems[ tool_key ] = new_tool
                         break
-            self._tools_by_id[ tool_id ] = new_tool
+            # (Re-)Register the reloaded tool, this will handle
+            #  _tools_by_id and _tool_versions_by_id
+            self.register_tool( new_tool )
             message = "Reloaded the tool:<br/>"
             message += "<b>name:</b> %s<br/>" % old_tool.name
             message += "<b>id:</b> %s<br/>" % old_tool.id


### PR DESCRIPTION
...me version), you would get the new/correct tool when clicking in Tool Panel, but the rerun button would return the old/pre-reload tool; this is due to the reload not replacing the entries in _tool_versions_by_id.
