### PR TITLE
Include dependency for grunt-cli in client/package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-bower-install-simple": "^1.1.0",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
This avoids the need for grunt to be installed globally. It can be invoked from the `client` directory as `./node_modules/.bin/grunt`.
