### PR TITLE
[STABLE] Fix workflow step uuid handling to handle UUID being the string None in ...

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -569,7 +569,7 @@ class WorkflowContentsManager(UsesAnnotations):
         for step_index in step_indices:
             step_dict = supplied_steps[ step_index ]
             uuid = step_dict.get("uuid", None)
-            if uuid:
+            if uuid and uuid != "None":
                 if uuid in discovered_uuids:
                     raise exceptions.DuplicatedIdentifierException("Duplicate step UUID in request.")
                 discovered_uuids.add(uuid)
@@ -586,10 +586,9 @@ class WorkflowContentsManager(UsesAnnotations):
         type-specific functionality from the incoming dicitionary.
         """
         step = model.WorkflowStep()
-
         # TODO: Consider handling position inside module.
         step.position = step_dict['position']
-        if "uuid" in step_dict:
+        if "uuid" in step_dict and step_dict['uuid'] != "None":
             step.uuid = step_dict["uuid"]
         if "label" in step_dict:
             step.label = step_dict["label"]


### PR DESCRIPTION
...input JSON.  This fixes export/import that was broken with release_15.03 -- both the pre-pass that checks for duplication (Duplicate step UUID in request), and the followup parsing.  I intentionally fixed both of these at the point of use instead of manipulating the step dict early to minimize changes and potential side-effects in stable.
