### PR TITLE
Allow updating toolshed repository from API

### DIFF
--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -601,7 +601,7 @@ class RepositoriesController( BaseAPIController ):
         :returns:   detailed repository information
         :rtype:     dict
 
-        :raises: RequestParameterMissingException
+        :raises: RequestParameterInvalidException, InsufficientPermissionsException, ActionInputError
         """
         params = util.Params( payload )
         # Mostly copied from create() except defaulting to Nones

--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -47,7 +47,7 @@ class RepositoriesController( BaseAPIController ):
         Adds appropriate entries to the repository registry for the repository defined by the received name and owner.
 
         :param key: the user's API key
-        
+
         The following parameters are included in the payload.
         :param tool_shed_url (required): the base URL of the Tool Shed containing the Repository
         :param name (required): the name of the Repository
@@ -164,7 +164,7 @@ class RepositoriesController( BaseAPIController ):
             ]
         }
         """
-        # Example URL: 
+        # Example URL:
         # http://<xyz>/api/repositories/get_repository_revision_install_info?name=<n>&owner=<o>&changeset_revision=<cr>
         if name and owner and changeset_revision:
             # Get the repository information.
@@ -327,7 +327,7 @@ class RepositoriesController( BaseAPIController ):
         clause_list = [ and_( trans.app.model.Repository.table.c.deprecated == False,
                               trans.app.model.Repository.table.c.deleted == deleted ) ]
         if owner is not None:
-            clause_list.append( and_( trans.app.model.User.table.c.username == owner, 
+            clause_list.append( and_( trans.app.model.User.table.c.username == owner,
                                       trans.app.model.Repository.table.c.user_id == trans.app.model.User.table.c.id ) )
         if name is not None:
             clause_list.append( trans.app.model.Repository.table.c.name == name )
@@ -349,7 +349,7 @@ class RepositoriesController( BaseAPIController ):
         Removes appropriate entries from the repository registry for the repository defined by the received name and owner.
 
         :param key: the user's API key
-        
+
         The following parameters are included in the payload.
         :param tool_shed_url (required): the base URL of the Tool Shed containing the Repository
         :param name (required): the name of the Repository
@@ -425,7 +425,7 @@ class RepositoriesController( BaseAPIController ):
         type tool_dependecy_definition first followed by repositories of type unrestricted, and only one pass is necessary.  If
         a new repository type is introduced, the process will undoubtedly need to be revisited.  To facilitate this order, an
         in-memory list of repository ids that have been processed is maintained.
-        
+
         :param key: the API key of the Tool Shed user.
 
         The following parameters can optionally be included in the payload.
@@ -515,9 +515,9 @@ class RepositoriesController( BaseAPIController ):
         PUT /api/repositories/reset_metadata_on_repository
 
         Resets all metadata on a specified repository in the Tool Shed.
-        
+
         :param key: the API key of the Tool Shed user.
-        
+
         The following parameters must be included in the payload.
         :param repository_id: the encoded id of the repository on which metadata is to be reset.
         """
@@ -583,7 +583,7 @@ class RepositoriesController( BaseAPIController ):
     @expose_api
     def update(self, trans, id, payload, **kwd ):
         """
-        POST /api/repositories/{encoded_repository_id}
+        PUT /api/repositories/{encoded_repository_id}
         Updates information about a repository in the Tool Shed.
 
         :param id: the encoded id of the Repository object
@@ -603,7 +603,6 @@ class RepositoriesController( BaseAPIController ):
 
         :raises: RequestParameterMissingException
         """
-        log.debug("HI")
         params = util.Params( payload )
         # Mostly copied from create() except defaulting to Nones
         name = util.restore_text( params.get( 'name', None ) )

--- a/lib/galaxy/webapps/tool_shed/buildapp.py
+++ b/lib/galaxy/webapps/tool_shed/buildapp.py
@@ -124,6 +124,11 @@ def app_factory( global_conf, **kwargs ):
                             name_prefix='user_',
                             path_prefix='/api',
                             parent_resources=dict( member_name='user', collection_name='users' ) )
+    webapp.mapper.connect( 'update_repository',
+                          '/api/repositories/:id',
+                           controller='repositories',
+                           action='update',
+                           conditions=dict( method=[ "PUT" ] ) )
     webapp.mapper.connect( 'repository_create_changeset_revision',
                            '/api/repositories/:id/changeset_revision',
                            controller='repositories',

--- a/lib/galaxy/webapps/tool_shed/controllers/repository.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/repository.py
@@ -1143,7 +1143,7 @@ class RepositoryController( BaseUIController, ratings_util.ItemRatings ):
         Open an image file that is contained in repository or that is referenced by a URL for display.  The image can be defined in
         either a README.rst file contained in the repository or the help section of a Galaxy tool config that is contained in the repository.
         The following image definitions are all supported.  The former $PATH_TO_IMAGES is no longer required, and is now ignored.
-        .. image:: https://raw.github.com/galaxy/some_image.png 
+        .. image:: https://raw.github.com/galaxy/some_image.png
         .. image:: $PATH_TO_IMAGES/some_image.png
         .. image:: /static/images/some_image.gif
         .. image:: some_image.jpg
@@ -2272,55 +2272,23 @@ class RepositoryController( BaseUIController, ratings_util.ItemRatings ):
         error = False
         user = trans.user
         if kwd.get( 'edit_repository_button', False ):
-            flush_needed = False
-            if not ( trans.user_is_admin() or trans.app.security_agent.user_can_administer_repository( user, repository ) ):
-                message = "You are not the owner of this repository, so you cannot administer it."
+            update_kwds = dict(
+                name=repo_name,
+                description=description,
+                long_description=long_description,
+                remote_repository_url=remote_repository_url,
+                homepage_url=homepage_url,
+                type=repository_type,
+            )
+
+            repository, message = repository_util.update_repository( app=trans.app, trans=trans, id=id, **update_kwds )
+            if repository is None:
                 return trans.response.send_redirect( web.url_for( controller='repository',
                                                                   action='view_repository',
                                                                   id=id,
                                                                   message=message,
                                                                   status='error' ) )
-            if repository_type != repository.type:
-                repository.type = repository_type
-                flush_needed = True
-            if remote_repository_url != repository.remote_repository_url:
-                repository.remote_repository_url = remote_repository_url
-                flush_needed = True
-            if homepage_url != repository.homepage_url:
-                repository.homepage_url = homepage_url
-                flush_needed = True
-            if description != repository.description:
-                repository.description = description
-                flush_needed = True
-            if long_description != repository.long_description:
-                repository.long_description = long_description
-                flush_needed = True
-            if repository.times_downloaded == 0 and repo_name != repository.name:
-                message = repository_util.validate_repository_name( trans.app, repo_name, user )
-                if message:
-                    error = True
-                else:
-                    # Change the entry in the hgweb.config file for the repository.
-                    old_lhs = "repos/%s/%s" % ( repository.user.username, repository.name )
-                    new_lhs = "repos/%s/%s" % ( repository.user.username, repo_name )
-                    trans.app.hgweb_config_manager.change_entry( old_lhs, new_lhs, repo_dir )
-                    # Change the entry in the repository's hgrc file.
-                    hgrc_file = os.path.join( repo_dir, '.hg', 'hgrc' )
-                    repository_util.change_repository_name_in_hgrc_file( hgrc_file, repo_name )
-                    # Rename the repository's admin role to match the new repository name.
-                    repository_admin_role = repository.admin_role
-                    repository_admin_role.name = \
-                        repository_util.get_repository_admin_role_name( str( repo_name ),
-                                                                        str( repository.user.username ) )
-                    trans.sa_session.add( repository_admin_role )
-                    repository.name = repo_name
-                    flush_needed = True
-            elif repository.times_downloaded != 0 and repo_name != repository.name:
-                message = "Repository names cannot be changed if the repository has been cloned.  "
-            if flush_needed:
-                trans.sa_session.add( repository )
-                trans.sa_session.flush()
-                message += "The repository information has been updated."
+
         elif kwd.get( 'skip_tool_tests_button', False ):
             repository_metadata = suc.get_repository_metadata_by_changeset_revision( trans.app, id, changeset_revision )
             skip_tool_test = repository_metadata.skip_tool_tests
@@ -3256,8 +3224,8 @@ class RepositoryController( BaseUIController, ratings_util.ItemRatings ):
         options_dict[ 'maxfile' ] = basic_util.MAXDIFFSIZE
         options_dict[ 'maxtotal' ] = basic_util.MAXDIFFSIZE
         diffopts = mdiff.diffopts( **options_dict )
-        for diff in patch.diff( repo, node1=ctx_parent.node(), node2=ctx.node(), opts=diffopts ):  
-            if len( diff ) > basic_util.MAXDIFFSIZE:    
+        for diff in patch.diff( repo, node1=ctx_parent.node(), node2=ctx.node(), opts=diffopts ):
+            if len( diff ) > basic_util.MAXDIFFSIZE:
                 diff = util.shrink_string_by_size( diff, basic_util.MAXDIFFSIZE )
             diffs.append( basic_util.to_html_string( diff ) )
         modified, added, removed, deleted, unknown, ignored, clean = repo.status( node1=ctx_parent.node(), node2=ctx.node() )

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -175,6 +175,10 @@ def update_repository( app, trans, id, **kwds):
     sa_session = app.model.context.current
     # Add the repository record to the database.
     repository = sa_session.query( app.model.Repository ).get( app.security.decode_id( id ) )
+
+    if repository is None:
+        return None, "Unknown repository ID"
+
     message = None
 
     if not ( trans.user_is_admin() or


### PR DESCRIPTION
In support of https://github.com/galaxyproject/tools-iuc/issues/73 we would like to be able to push changes made to .shed.yml with planemo to the toolshed.

This extracts the logic (mostly copy+paste) from the original repository controller into the repository util, then wraps that in an API PUT method.

This opens the door for the view to allow updating category IDs in the same step as updating the rest of the repo metadata, but that isn't implemented in this PR.
