### PR TITLE
Fix bug whereby repo type was always unrestricted

### DIFF
--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -619,7 +619,7 @@ class RepositoriesController( BaseAPIController ):
         category_ids = util.listify( params.get( 'category_ids[]', '' ) )
         selected_categories = [ trans.security.decode_id( id ) for id in category_ids ]
 
-        repo_type = kwd.get( 'type', rt_util.UNRESTRICTED )
+        repo_type = params.get( 'type', rt_util.UNRESTRICTED )
         if repo_type not in rt_util.types:
             raise exceptions.RequestParameterInvalidException( 'This repository type is not valid' )
 


### PR DESCRIPTION
Checked the wrong dict for parameters, and thus all repos were always unrestricted. Necessary for https://github.com/galaxyproject/tools-iuc/issues/73 to function correctly.
