### PR TITLE
Raise exception if some Active Directory options are not defined

### DIFF
--- a/lib/galaxy/auth/providers/activedirectory.py
+++ b/lib/galaxy/auth/providers/activedirectory.py
@@ -4,16 +4,17 @@ Created on 15/07/2014
 @author: Andrew Robinson
 """
 
+from galaxy.exceptions import ConfigurationError
 from ..providers import AuthProvider
 
 import logging
 log = logging.getLogger(__name__)
 
 
-def _get_subs(d, k, params, default=''):
-    if k in d:
-        return str(d[k]).format(**params)
-    return str(default).format(**params)
+def _get_subs(d, k, params):
+    if k not in d:
+        raise ConfigurationError("Missing '%s' parameter in Active Directory options" % k)
+    return str(d[k]).format(**params)
 
 
 class ActiveDirectory(AuthProvider):

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 from datetime import timedelta
 from galaxy import eggs
+from galaxy.exceptions import ConfigurationError
 from galaxy.util import listify
 from galaxy.util import string_as_bool
 from galaxy.util.dbkeys import GenomeBuilds
@@ -29,10 +30,6 @@ def resolve_path( path, root ):
     if not os.path.isabs( path ):
         path = os.path.join( root, path )
     return path
-
-
-class ConfigurationError( Exception ):
-    pass
 
 
 class Configuration( object ):
@@ -421,7 +418,7 @@ class Configuration( object ):
         self.pretty_datetime_format = expand_pretty_datetime_format( kwargs.get( 'pretty_datetime_format', '$locale (UTC)' ) )
         self.master_api_key = kwargs.get( 'master_api_key', None )
         if self.master_api_key == "changethis":  # default in sample config file
-            raise Exception("Insecure configuration, please change master_api_key to something other than default (changethis)")
+            raise ConfigurationError("Insecure configuration, please change master_api_key to something other than default (changethis)")
 
         # Experimental: This will not be enabled by default and will hide
         # nonproduction code.

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -26,7 +26,7 @@ log = logging.getLogger( __name__ )
 
 def resolve_path( path, root ):
     """If 'path' is relative make absolute by prepending 'root'"""
-    if not( os.path.isabs( path ) ):
+    if not os.path.isabs( path ):
         path = os.path.join( root, path )
     return path
 
@@ -204,7 +204,7 @@ class Configuration( object ):
                 with open( self.blacklist_file ) as blacklist:
                     self.blacklist_content = [ line.rstrip() for line in blacklist.readlines() ]
             except IOError:
-                    print ( "CONFIGURATION ERROR: Can't open supplied blacklist file from path: " + str( self.blacklist_file ) )
+                print ( "CONFIGURATION ERROR: Can't open supplied blacklist file from path: " + str( self.blacklist_file ) )
         self.smtp_server = kwargs.get( 'smtp_server', None )
         self.smtp_username = kwargs.get( 'smtp_username', None )
         self.smtp_password = kwargs.get( 'smtp_password', None )
@@ -636,7 +636,7 @@ class Configuration( object ):
               database in the future.
         """
         admin_users = [ x.strip() for x in self.get( "admin_users", "" ).split( "," ) ]
-        return ( user is not None and user.email in admin_users )
+        return user is not None and user.email in admin_users
 
     def resolve_path( self, path ):
         """ Resolve a path relative to Galaxy's root.

--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -146,6 +146,10 @@ class Conflict( MessageException ):
     err_code = error_codes.CONFLICT
 
 
+class ConfigurationError( Exception ):
+    status_code = 500
+    err_code = error_codes.CONFIG_ERROR
+
 class InconsistentDatabase ( MessageException ):
     status_code = 500
     err_code = error_codes.INCONSISTENT_DATABASE

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -125,6 +125,11 @@
     "message": "Inconsistent database prevented fulfilling the request."
    },
    {
+    "name": "CONFIG_ERROR",
+    "code": 500003,
+    "message": "Error in a configuration file."
+   },
+   {
     "name": "NOT_IMPLEMENTED",
     "code": 501001,
     "message": "Method is not implemented."


### PR DESCRIPTION
Bug fixed: when using authenticating against an AD provider which allows anonymous LDAP binds, if bind-user and bind-password are not configured in the <options> section of auth_conf.xml, the password is not checked and the user is always logged in.

Also:
- pylint fixes
- generalize use of ConfigurationError exception.

Ping @andrewjrobinson for review.
