### PR TITLE
[STABLE] Fix logging_connection_proxy for sqlalchemy upgrade.

### DIFF
--- a/lib/galaxy/model/orm/logging_connection_proxy.py
+++ b/lib/galaxy/model/orm/logging_connection_proxy.py
@@ -2,7 +2,7 @@ import time
 import inspect
 import os
 
-from galaxy.model.orm import *
+from galaxy.model.orm import ConnectionProxy
 
 import logging
 


### PR DESCRIPTION
The `import *` was now importing something called inspect from sqlalchemy which was masking the actual desired inspect import above it.
