### PR TITLE
comment out connection to TTS in sample config

### DIFF
--- a/config/tool_sheds_conf.xml.sample
+++ b/config/tool_sheds_conf.xml.sample
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <tool_sheds>
-    <tool_shed name="Galaxy main tool shed" url="https://toolshed.g2.bx.psu.edu/"/>
-    <tool_shed name="Galaxy test tool shed" url="https://testtoolshed.g2.bx.psu.edu/"/>
+    <tool_shed name="Galaxy Main Tool Shed" url="https://toolshed.g2.bx.psu.edu/"/>
+<!-- Test Tool Shed should be used only for testing purposes.
+    <tool_shed name="Galaxy Test Tool Shed" url="https://testtoolshed.g2.bx.psu.edu/"/> 
+-->
 </tool_sheds>


### PR DESCRIPTION
TTS should not be used to install tools on non-test instances. This should prevent people from exploring that option without knowing what they are doing.
