### PR TITLE
PEP-8 fixes for galaxy.tools.toolbox.

### DIFF
--- a/.ci/pep8_sources.txt
+++ b/.ci/pep8_sources.txt
@@ -15,6 +15,7 @@ lib/galaxy/tags
 lib/galaxy/tools/deps/{commands,containers,dependencies,dockerfiles,docker_util,__init__,requirements}.py
 lib/galaxy/tools/filters
 lib/galaxy/tools/parser
+lib/galaxy/tools/toolbox
 lib/galaxy/tools/{errors,loader_directory,test}.py
 lib/galaxy/util/{__init__,json,permutations,plugin_config,properties,simplegraph,sockets,sleeper,streamball,submodules}.py
 lib/galaxy/web/{proxy,security}

--- a/lib/galaxy/tools/toolbox/filters/__init__.py
+++ b/lib/galaxy/tools/toolbox/filters/__init__.py
@@ -90,7 +90,7 @@ class FilterFactory( object ):
         raise Exception("Failed to find filter %s.%s" % (module_name, function_name))
 
 
-## Stock Filter Functions
+# Stock Filter Functions
 def _not_hidden( context, tool ):
     return not tool.hidden
 


### PR DESCRIPTION
Bring 1578 more lines of Python under PEP-8 watch.

(Opening as a PR to test Travis CI on actual repository.)
