### PR TITLE
[STABLE] Fix proxied API tool downloads.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -145,7 +145,6 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
         if success:
             trans.response.set_content_type( 'application/x-gzip' )
             download_file = open( tool_tarball )
-            os.unlink( tool_tarball )
             tarball_path, filename = os.path.split( tool_tarball )
             trans.response.headers[ "Content-Disposition" ] = 'attachment; filename="%s.tgz"' % ( id )
             return download_file


### PR DESCRIPTION
From IRC:

```
17:22 < kellrott> Any ideas about how to deal with https://github.com/bgruening/docker-galaxy-stable/issues/50 ?
17:22 < mrscribe> Title: Tool downloads are not working · Issue #50 · bgruening/docker-galaxy-stable · GitHub (at
                  github.com)
17:24 < kellrott> I think its from how the tool download function unlinks a file while holding the open file handle
                  ( https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/webapps/galaxy/api/tools.py#L208 )
17:24 < mrscribe> Title: galaxy/tools.py at dev · galaxyproject/galaxy · GitHub (at github.com)
17:27 < jmchilton> Have you tried not unlinking that file?
17:28 < jmchilton> If that fixes it I have no problem just leaving the file in temp - Galaxy leaves a lot of stuff
                   in temp anyway
17:46 < kellrott> yep, that does the trick
```

Closes bgruening/docker-galaxy-stable#50.
