### PR TITLE
Bugfix: Collect extra files before declaring dataset's OK...

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1138,6 +1138,7 @@ class JobWrapper( object ):
                 # Update (non-library) job output datasets through the object store
                 if dataset not in job.output_library_datasets:
                     self.app.object_store.update_from_file(dataset.dataset, create=True)
+                self._collect_extra_files(dataset.dataset, self.working_directory)
                 if job.states.ERROR == final_job_state:
                     dataset.blurb = "error"
                     dataset.mark_unhidden()
@@ -1251,8 +1252,6 @@ class JobWrapper( object ):
         # instead of validated and transformed values during i.e. running workflows
         param_dict = dict( [ ( p.name, p.value ) for p in job.parameters ] )
         param_dict = self.tool.params_from_strings( param_dict, self.app )
-        # Check for and move associated_files
-        self.tool.collect_associated_files(out_data, self.working_directory)
         # Create generated output children and primary datasets and add to param_dict
         collected_datasets = {
             'children': self.tool.collect_child_datasets(out_data, self.working_directory),
@@ -1316,6 +1315,28 @@ class JobWrapper( object ):
                 self.app.object_store.delete(self.get_job(), base_dir='job_work', entire_dir=True, dir_only=True, extra_dir=str(self.job_id))
         except:
             log.exception( "Unable to cleanup job %d" % self.job_id )
+
+    def _collect_extra_files(self, dataset, job_working_directory):
+        temp_file_path = os.path.join( job_working_directory, "dataset_%s_files" % ( dataset.id ) )
+        extra_dir = None
+        try:
+            # This skips creation of directories - object store
+            # automatically creates them.  However, empty directories will
+            # not be created in the object store at all, which might be a
+            # problem.
+            for root, dirs, files in os.walk( temp_file_path ):
+                extra_dir = root.replace(job_working_directory, '', 1).lstrip(os.path.sep)
+                for f in files:
+                    self.app.object_store.update_from_file(
+                        dataset,
+                        extra_dir=extra_dir,
+                        alt_name=f,
+                        file_name=os.path.join(root, f),
+                        create=True,
+                        preserve_symlinks=True
+                    )
+        except Exception, e:
+            log.debug( "Error in collect_associated_files: %s" % ( e ) )
 
     def _collect_metrics( self, has_metrics ):
         job = has_metrics.get_job()

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2109,39 +2109,6 @@ class Tool( object, Dictifiable ):
         """
         pass
 
-    def collect_associated_files( self, output, job_working_directory ):
-        """
-        Find extra files in the job working directory and move them into
-        the appropriate dataset's files directory
-        """
-        for name, hda in output.items():
-            temp_file_path = os.path.join( job_working_directory, "dataset_%s_files" % ( hda.dataset.id ) )
-            extra_dir = None
-            try:
-                # This skips creation of directories - object store
-                # automatically creates them.  However, empty directories will
-                # not be created in the object store at all, which might be a
-                # problem.
-                for root, dirs, files in os.walk( temp_file_path ):
-                    extra_dir = root.replace(job_working_directory, '', 1).lstrip(os.path.sep)
-                    for f in files:
-                        self.app.object_store.update_from_file(hda.dataset,
-                            extra_dir=extra_dir,
-                            alt_name=f,
-                            file_name=os.path.join(root, f),
-                            create=True,
-                            preserve_symlinks=True
-                        )
-                # Clean up after being handled by object store.
-                # FIXME: If the object (e.g., S3) becomes async, this will
-                # cause issues so add it to the object store functionality?
-                if extra_dir is not None:
-                    # there was an extra_files_path dir, attempt to remove it
-                    shutil.rmtree(temp_file_path)
-            except Exception, e:
-                log.debug( "Error in collect_associated_files: %s" % ( e ) )
-                continue
-
     def collect_child_datasets( self, output, job_working_directory ):
         """
         Look for child dataset files, create HDA and attach to parent.


### PR DESCRIPTION
... so the files are available when you try to use them in immediately subsequent parts of an analysis.

@peterjc and I have both verified this fixes bugs in certain makeblastdb workflows - in a cluster and a localhost Docker setting respectively.

Opening to `dev` instead of `release` because the bug is 8 years old anyway and there is a chance fixing this exposes a new bug in some scenarios. For full details [see](https://trello.com/c/J8LPzOyF) - @bgruening and I have a plan to investigate this other potential bug before the next release.
