### PR TITLE
[STABLE] Tool Shed: Do not load static middleware when loaded with uWSGI

### DIFF
--- a/lib/galaxy/webapps/tool_shed/buildapp.py
+++ b/lib/galaxy/webapps/tool_shed/buildapp.py
@@ -134,8 +134,23 @@ def app_factory( global_conf, **kwargs ):
     # Wrap the webapp in some useful middleware
     if kwargs.get( 'middleware', True ):
         webapp = wrap_in_middleware( webapp, global_conf, **kwargs )
-    if asbool( kwargs.get( 'static_enabled', True ) ):
-        webapp = wrap_in_static( webapp, global_conf, **kwargs )
+    # TEST FOR UWSGI -- TODO save this somewhere so we only have to do it once.
+    is_uwsgi = False
+    try:
+        # The uwsgi module is automatically injected by the parent uwsgi
+        # process and only exists that way.  If anything works, this is a
+        # uwsgi-managed process.
+        import uwsgi
+        is_uwsgi = uwsgi.numproc
+        is_uwsgi = True
+    except ImportError:
+        # This is not a uwsgi process, or something went horribly wrong.
+        pass
+    if asbool( kwargs.get( 'static_enabled', True) ):
+        if is_uwsgi:
+            log.error("Static middleware is enabled in your configuration but this is a uwsgi process.  Refusing to wrap in static middleware.")
+        else:
+            webapp = wrap_in_static( webapp, global_conf, **kwargs )
     # Close any pooled database connections before forking
     try:
         galaxy.webapps.tool_shed.model.mapping.metadata.engine.connection_provider._pool.dispose()


### PR DESCRIPTION
This is just a copy of the same change that @dannon made to Galaxy back in February.
