### PR TITLE
activedirectory auth - anonymous search binding and dn param support

### DIFF
--- a/lib/galaxy/auth/providers/activedirectory.py
+++ b/lib/galaxy/auth/providers/activedirectory.py
@@ -52,13 +52,13 @@ class ActiveDirectory(AuthProvider):
                 ldap.set_option(ldap.OPT_REFERRALS, 0)
                 l = ldap.initialize(_get_subs(options, 'server', params))
                 l.protocol_version = 3
-                
-		if 'search-user' in options:
-		    l.simple_bind_s(_get_subs(options, 'search-user', params), _get_subs(options, 'search-password', params))
+
+                if 'search-user' in options:
+                    l.simple_bind_s(_get_subs(options, 'search-user', params), _get_subs(options, 'search-password', params))
                 else:
                     l.simple_bind_s()
 
-		scope = ldap.SCOPE_SUBTREE
+                scope = ldap.SCOPE_SUBTREE
 
                 # setup search
                 attributes = [_.strip().format(**params) for _ in options['search-fields'].split(',')]
@@ -75,7 +75,7 @@ class ActiveDirectory(AuthProvider):
                             params[attr] = str(attrs[attr][0])
                         else:
                             params[attr] = ""
-		params['dn'] = dn
+                params['dn'] = dn
             except Exception:
                 log.exception('ACTIVEDIRECTORY Search Exception for User: %s' % username)
                 return (failure_mode, '')


### PR DESCRIPTION
Support for a common authentication pattern against an OpenLDAP directory.

1) Allow anonymous binding when searching for a user entry in the directory. If 'search-filter' is set but 'search-user' is not set then bind anonymously to LDAP for the search.

2) OpenLDAP users must commonly bind for authentication using their full dn. Providing 'dn' in the 'search-fields' and 'bind-user' options doesn't work. The dn is returned as a key in the results structure from python-ldap, and will not be returned as an attribute. To allow use of dn for auth binding, always extract it into the params dict. Then `<bind-user>{dn}</bind-user>` in auth_conf.xml works as expected.
