### PR TITLE
[STABLE] Fixes for using expression contexts in select parameters.

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -15,6 +15,7 @@ from galaxy.util.bunch import Bunch
 from galaxy.util import string_as_bool, sanitize_param, unicodify
 from galaxy.util import listify
 from galaxy.util.odict import odict
+from galaxy.util.expressions import ExpressionContext
 from sanitize import ToolParameterSanitizer
 import validation
 import dynamic_options
@@ -802,8 +803,9 @@ class SelectToolParameter( ToolParameter ):
         self.is_dynamic = ( ( self.dynamic_options is not None ) or ( self.options is not None ) )
 
     def _get_dynamic_options_call_other_values( self, trans, other_values ):
-        call_other_values = { "__trans__": trans }
+        call_other_values = ExpressionContext({ "__trans__": trans })
         if other_values:
+            call_other_values.parent = other_values.parent
             call_other_values.update( other_values.dict )
         return call_other_values
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1507,8 +1507,9 @@ class DrillDownSelectToolParameter( SelectToolParameter ):
 
     def _get_options_from_code( self, trans=None, value=None, other_values=None ):
         assert self.dynamic_options, Exception( "dynamic_options was not specifed" )
-        call_other_values = { '__trans__': trans, '__value__': value }
+        call_other_values = ExpressionContext({ '__trans__': trans, '__value__': value })
         if other_values:
+            call_other_values.parent = other_values.parent
             call_other_values.update( other_values.dict )
         try:
             return eval( self.dynamic_options, self.tool.code_namespace, call_other_values )


### PR DESCRIPTION
The original implementation (which got copied to select parameters) was broken in drilldownselect, but we'd never have noticed it without dynamic_options in a repeat, like this.  Both should be fixed, as well as a similar issue that'd affect get_options_from_code.  TIL these aren't just dicts.
