### PR TITLE
More Interactive Environment Configureability

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -476,6 +476,15 @@ nglims_config_file = tool-data/nglims.yaml
 # IPython Docker container for communicating back with Galaxy via the API.
 #galaxy_infrastructure_url = http://localhost:8080
 
+# If the above URL cannot be determined ahead of time in dynamic environments
+# but the port which should be used to access Galaxy can be - this should be
+# set to prevent Galaxy from having to guess. For example if Galaxy is sitting
+# behind a proxy with REMOTE_USER enabled - infrastructure shouldn't talk to
+# Python processes directly and this should be set to 80 or 443, etc.... If
+# unset this file will be read for a server block defining a port
+# corresponding to the webapp.
+#galaxy_infrastructure_web_port = 8080
+
 # The URL of the page to display in Galaxy's middle pane when loaded.  This can
 # be an absolute or relative URL.
 #welcome_url = /static/welcome.html

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -356,6 +356,8 @@ class Configuration( object ):
 
         # Default URL (with schema http/https) of the Galaxy instance within the
         # local network - used to remotely communicate with the Galaxy API.
+        web_port = kwargs.get("galaxy_infrastructure_web_port", None)
+        self.galaxy_infrastructure_web_port = web_port
         galaxy_infrastructure_url = kwargs.get( 'galaxy_infrastructure_url', None )
         galaxy_infrastructure_url_set = True
         if galaxy_infrastructure_url is None:
@@ -363,9 +365,9 @@ class Configuration( object ):
             # so dependending on the context a better default can be used (
             # request url in a web thread, Docker parent in IE stuff, etc...)
             galaxy_infrastructure_url = "http://localhost"
-            port = self.guess_galaxy_port()
-            if port:
-                galaxy_infrastructure_url += ":%s" % (port)
+            web_port = self.galaxy_infrastructure_web_port or self.guess_galaxy_port()
+            if web_port:
+                galaxy_infrastructure_url += ":%s" % (web_port)
             galaxy_infrastructure_url_set = False
         if "HOST_IP" in galaxy_infrastructure_url:
             galaxy_infrastructure_url = string.Template(galaxy_infrastructure_url).safe_substitute({

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -86,7 +86,8 @@ class InteractiveEnviornmentRequest(object):
             conf_file['galaxy_url'] = self.attr.galaxy_config.galaxy_infrastructure_url.rstrip('/') + '/'
         else:
             conf_file['galaxy_url'] = request.application_url.rstrip('/') + '/'
-            conf_file['galaxy_paster_port'] = self.attr.galaxy_config.guess_galaxy_port()
+            web_port = self.attr.galaxy_config.galaxy_infrastructure_web_port
+            conf_file['galaxy_paster_port'] = web_port or self.attr.galaxy_config.guess_galaxy_port()
 
         if self.attr.PASSWORD_AUTH:
             # Generate a random password + salt


### PR DESCRIPTION
Allow configuration of port infrastructure services should access Galaxy using.

For dynamic scenarios when a galaxy_infrastructure_url cannot be known ahead of time - but the port is. See comments in config.ini.sample for more information.
