### PR TITLE
Managers

### DIFF
--- a/.ci/pep8_sources.txt
+++ b/.ci/pep8_sources.txt
@@ -3,7 +3,7 @@ lib/galaxy/config.py
 lib/galaxy/exceptions/error_codes.py
 lib/galaxy/jobs/{__init__,error_level,manager,stock_rules}.py
 lib/galaxy/main.py
-lib/galaxy/managers/{api_keys,citations,collections,collections_util,folders,tags,workflows}.py
+lib/galaxy/managers/{api_keys,citations,collections,collections_util,datasets,folders,pages,tags,workflows}.py
 lib/galaxy/model/orm/{engine_factory,now}.py
 lib/galaxy/model/util.py
 lib/galaxy/model/tool_shed_install/__init__.py

--- a/.ci/pep8_sources.txt
+++ b/.ci/pep8_sources.txt
@@ -3,7 +3,7 @@ lib/galaxy/config.py
 lib/galaxy/exceptions/error_codes.py
 lib/galaxy/jobs/{__init__,error_level,manager,stock_rules}.py
 lib/galaxy/main.py
-lib/galaxy/managers/{api_keys,citations,collections,collections_util,datasets,folders,pages,tags,workflows}.py
+lib/galaxy/managers/{api_keys,citations,collections,collections_util,folders,tags,workflows}.py
 lib/galaxy/model/orm/{engine_factory,now}.py
 lib/galaxy/model/util.py
 lib/galaxy/model/tool_shed_install/__init__.py

--- a/lib/galaxy/managers/annotatable.py
+++ b/lib/galaxy/managers/annotatable.py
@@ -12,18 +12,18 @@ class AnnotatableManagerMixin( object ):
 
     # TODO: most of this seems to be covered by item_attrs.UsesAnnotations
     # TODO: use these below (serializer/deserializer)
-    def user_annotation( self, trans, item, user ):
+    def user_annotation( self, item, user ):
         return item.get_item_annotation_str( self.session(), user, item )
 
-    def owner_annotation( self, trans, item ):
-        return self.user_annotation( trans, item, item.user )
+    def owner_annotation( self, item ):
+        return self.user_annotation( item, item.user )
 
-    def delete_annotation( self, trans, item, user ):
+    def delete_annotation( self, item, user ):
         return item.delete_item_annotation( self.session(), user, item )
 
-    def annotate( self, trans, item, user, annotation ):
+    def annotate( self, item, user, annotation ):
         if annotation is None:
-            self.delete_annotation( self, trans, item, user )
+            self.delete_annotation( item, user )
             return None
 
         annotation_obj = item.add_item_annotation( self.session(), user, item, annotation )

--- a/lib/galaxy/managers/annotatable.py
+++ b/lib/galaxy/managers/annotatable.py
@@ -29,7 +29,7 @@ class AnnotatableManagerMixin( object ):
         annotation_obj = item.add_item_annotation( self.session(), user, item, annotation )
         return annotation_obj.annotation
 
-    #def by_user( self, trans, user, **kwargs ):
+    #def by_user( self, user, **kwargs ):
     #    pass
 
 
@@ -38,13 +38,11 @@ class AnnotatableSerializerMixin( object ):
     def add_serializers( self ):
         self.serializers[ 'annotation' ] = self.serialize_annotation
 
-    def serialize_annotation( self, trans, item, key ):
+    def serialize_annotation( self, item, key, user=None, **context ):
         """
         Get and serialize an `item`'s annotation.
         """
         # user = item.user
-        #TODO: trans
-        user = trans.user
         sa_session = self.app.model.context
         returned = item.get_item_annotation_str( sa_session, user, item )
         return returned
@@ -55,22 +53,25 @@ class AnnotatableDeserializerMixin( object ):
     def add_deserializers( self ):
         self.deserializers[ 'annotation' ] = self.deserialize_annotation
 
-    def deserialize_annotation( self, trans, item, key, val ):
+    def deserialize_annotation( self, item, key, val, user=None, **context ):
         """
         Make sure `val` is a valid annotation and assign it, deleting any existing
         if `val` is None.
         """
+        print '-' * 20
+        print item
+        print key
+        print val
+        print user
         val = self.validate.nullable_basestring( key, val )
+        # sa_session = self.app.model.context
+        # if val is None:
+        #     item.delete_item_annotation( sa_session, user, item )
+        #     return None
 
-        sa_session = self.app.model.context
-        #TODO: trans
-        user = trans.user
-        if val is None:
-            item.delete_item_annotation( sa_session, user, item )
-            return None
-
-        annotated_item = item.add_item_annotation( sa_session, user, item, val )
-        return annotated_item.annotation
+        # annotated_item = item.add_item_annotation( sa_session, user, item, val )
+        # return annotated_item.annotation
+        return self.manager.annotate( item, user, val )
 
 
 # TODO: I'm not entirely convinced this (or tags) are a good idea for filters since they involve a/the user

--- a/lib/galaxy/managers/annotatable.py
+++ b/lib/galaxy/managers/annotatable.py
@@ -58,19 +58,7 @@ class AnnotatableDeserializerMixin( object ):
         Make sure `val` is a valid annotation and assign it, deleting any existing
         if `val` is None.
         """
-        print '-' * 20
-        print item
-        print key
-        print val
-        print user
         val = self.validate.nullable_basestring( key, val )
-        # sa_session = self.app.model.context
-        # if val is None:
-        #     item.delete_item_annotation( sa_session, user, item )
-        #     return None
-
-        # annotated_item = item.add_item_annotation( sa_session, user, item, val )
-        # return annotated_item.annotation
         return self.manager.annotate( item, user, val )
 
 

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -542,8 +542,9 @@ class ModelSerializer( object ):
         Register a map of attribute keys -> serializing functions that will serialize
         the attribute.
         """
-        # to be overridden in subclasses
-        pass
+        self.serializers.update({
+            'id' : self.serialize_id,
+        })
 
     def add_view( self, view_name, key_list, include_keys_from=None ):
         """

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -730,7 +730,7 @@ class ModelDeserializer( object ):
             setattr( item, key, val )
         return val
 
-    def deserialize_basestring( self, item, key, val, convert_none_to_empty=True, **context ):
+    def deserialize_basestring( self, item, key, val, convert_none_to_empty=False, **context ):
         val = '' if ( convert_none_to_empty and val is None ) else self.validate.basestring( key, val )
         return self.default_deserializer( item, key, val, **context )
 

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -277,7 +277,7 @@ class DatasetCollectionManager( object ):
 
         if src_type == 'hda':
             decoded_id = int( trans.app.security.decode_id( encoded_id ) )
-            element = self.hda_manager.get_accessible( trans, decoded_id, trans.user )
+            element = self.hda_manager.get_accessible( decoded_id, trans.user )
         elif src_type == 'ldda':
             element = self.ldda_manager.get( trans, encoded_id )
         elif src_type == 'hdca':
@@ -312,9 +312,9 @@ class DatasetCollectionManager( object ):
         instance_id = int( trans.app.security.decode_id( id ) )
         collection_instance = trans.sa_session.query( trans.app.model.HistoryDatasetCollectionAssociation ).get( instance_id )
         if check_ownership:
-            self.history_manager.error_unless_owner( trans, collection_instance.history, trans.user )
+            self.history_manager.error_unless_owner( collection_instance.history, trans.user, current_history=trans.history )
         if check_accessible:
-            self.history_manager.error_unless_accessible( trans, collection_instance.history, trans.user )
+            self.history_manager.error_unless_accessible( collection_instance.history, trans.user, current_history=trans.history )
         return collection_instance
 
     def __get_library_collection_instance( self, trans, id, check_ownership=False, check_accessible=True ):

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -15,6 +15,7 @@ import logging
 log = logging.getLogger( __name__ )
 
 
+#TODO: for lack of a manager file for the config. May well be better in config.py? Circ imports?
 class ConfigSerializer( base.ModelSerializer ):
 
     def __init__( self, app ):
@@ -23,61 +24,64 @@ class ConfigSerializer( base.ModelSerializer ):
         self.default_view = 'all'
         self.add_view( 'all', self.serializers.keys() )
 
-    def default_serializer( self, trans, config, key ):
-        return config.get( key, None )
-
-    def _defaults_to( self, default ):
-        return lambda t, i, k: i.get( k, default )
+    def default_serializer( self, config, key ):
+        return getattr( config, key, None )
 
     def add_serializers( self ):
+        def _defaults_to( default ):
+            return lambda i, k, **c: getattr( i, k, default )
+
         self.serializers = {
             #TODO: this is available from user data, remove
-            'is_admin_user'             : lambda *a: False,
+            'is_admin_user'             : lambda *a, **c: False,
 
-            'brand'                     : lambda t, i, k: i.get( k, "" ),
+            'brand'                     : _defaults_to( '' ),
             #TODO: this doesn't seem right
-            'logo_url'                  : lambda t, i, k: web.url_for( i.get( k, '/') ),
-            'terms_url'                 : lambda t, i, k: i.get( k, "" ),
+            'logo_url'                  : lambda i, k, **c: self.url_for( i.get( k, '/' ) ),
+            'terms_url'                 : _defaults_to( '' ),
 
             #TODO: don't hardcode here - hardcode defaults once in config.py
-            'wiki_url'                  : self._defaults_to( "http://galaxyproject.org/" ),
-            'search_url'                : self._defaults_to( "http://galaxyproject.org/search/usegalaxy/" ),
-            'mailing_lists'             : self._defaults_to( "http://wiki.galaxyproject.org/MailingLists" ),
-            'screencasts_url'           : self._defaults_to( "http://vimeo.com/galaxyproject" ),
-            'citation_url'              : self._defaults_to( "http://wiki.galaxyproject.org/CitingGalaxy" ),
-            'support_url'               : self._defaults_to( "http://wiki.galaxyproject.org/Support" ),
-            'lims_doc_url'              : self._defaults_to( "http://main.g2.bx.psu.edu/u/rkchak/p/sts" ),
-            'biostar_url'               : lambda t, i, k: i.biostar_url,
-            'biostar_url_redirect'      : lambda *a: web.url_for( controller='biostar', action='biostar_redirect',
-                                                                qualified=True ),
+            'wiki_url'                  : _defaults_to( "http://galaxyproject.org/" ),
+            'search_url'                : _defaults_to( "http://galaxyproject.org/search/usegalaxy/" ),
+            'mailing_lists'             : _defaults_to( "http://wiki.galaxyproject.org/MailingLists" ),
+            'screencasts_url'           : _defaults_to( "http://vimeo.com/galaxyproject" ),
+            'citation_url'              : _defaults_to( "http://wiki.galaxyproject.org/CitingGalaxy" ),
+            'support_url'               : _defaults_to( "http://wiki.galaxyproject.org/Support" ),
+            'lims_doc_url'              : _defaults_to( "http://main.g2.bx.psu.edu/u/rkchak/p/sts" ),
+            'biostar_url'               : _defaults_to( '' ),
+            'biostar_url_redirect'      : lambda *a, **c: self.url_for( controller='biostar', action='biostar_redirect',
+                                                                   qualified=True ),
 
-            'allow_user_creation'       : lambda t, i, k: i.allow_user_creation,
-            'use_remote_user'           : lambda t, i, k: i.use_remote_user,
-            'remote_user_logout_href'   : lambda t, i, k: i.remote_user_logout_href,
-            'enable_cloud_launch'       : self._defaults_to( False ),
-            'datatypes_disable_auto'    : self._defaults_to( False ),
-            'allow_user_dataset_purge'  : self._defaults_to( False ),
-            'enable_unique_workflow_defaults' : self._defaults_to( False ),
+            'allow_user_creation'       : lambda i, k, **c: i.allow_user_creation,
+            'use_remote_user'           : _defaults_to( None ),
+            'remote_user_logout_href'   : _defaults_to( '' ),
+            'enable_cloud_launch'       : _defaults_to( False ),
+            'datatypes_disable_auto'    : _defaults_to( False ),
+            'allow_user_dataset_purge'  : _defaults_to( False ),
+            'enable_unique_workflow_defaults' : _defaults_to( False ),
 
-            'nginx_upload_path'         : self._defaults_to( web.url_for( controller='api', action='tools' ) ),
-            'ftp_upload_dir'            : self._defaults_to( None ),
-            'ftp_upload_site'           : self._defaults_to( None ),
+            'nginx_upload_path'         : _defaults_to( self.url_for( controller='api', action='tools' ) ),
+            'ftp_upload_dir'            : _defaults_to( None ),
+            'ftp_upload_site'           : _defaults_to( None ),
+            'version_major'             : _defaults_to( None ),
         }
 
 
 class AdminConfigSerializer( ConfigSerializer ):
-    """Config attributes viewable by admin users"""
+    # config attributes viewable by admin users
 
     def add_serializers( self ):
         super( AdminConfigSerializer, self ).add_serializers()
+        def _defaults_to( default ):
+            return lambda i, k, **c: getattr( i, k, default )
 
         self.serializers.update({
             #TODO: this is available from user data, remove
             'is_admin_user'             : lambda *a: True,
 
-            'library_import_dir'        : self._defaults_to( None ),
-            'user_library_import_dir'   : self._defaults_to( None ),
-            'allow_library_path_paste'  : self._defaults_to( None ),
-            'allow_user_creation'       : self._defaults_to( False ),
-            'allow_user_deletion'       : self._defaults_to( False ),
+            'library_import_dir'        : _defaults_to( None ),
+            'user_library_import_dir'   : _defaults_to( None ),
+            'allow_library_path_paste'  : _defaults_to( False ),
+            'allow_user_creation'       : _defaults_to( False ),
+            'allow_user_deletion'       : _defaults_to( False ),
         })

--- a/lib/galaxy/managers/containers.py
+++ b/lib/galaxy/managers/containers.py
@@ -10,6 +10,7 @@ Libraries should be DatasetCollections.
 
 import operator
 
+from galaxy import model
 import galaxy.exceptions
 import galaxy.util
 
@@ -95,7 +96,7 @@ class LibraryFolderAsContainerManagerMixin( ContainerManagerMixin ):
     # can contain two types of subcontainer: LibraryFolder, LibraryDatasetCollectionAssociation
     # has as the top level container: Library
 
-    contained_class = model.LibraryDatasetAssociation
+    contained_class = model.LibraryDataset
     subcontainer_class = model.LibraryFolder
     # subcontainer_class = model.LibraryDatasetCollectionAssociation
     order_contents_on = operator.attrgetter( 'create_time' )
@@ -107,7 +108,7 @@ class LibraryFolderAsContainerManagerMixin( ContainerManagerMixin ):
 
     def _content_manager( self, content ):
         # type snifffing is inevitable
-        if   isinstance( content, model.LibraryDatasetAssociation ):
+        if   isinstance( content, model.LibraryDataset ):
             return self.lda_manager
         elif isinstance( content, model.LibraryFolder ):
             return self.folder_manager

--- a/lib/galaxy/managers/containers.py
+++ b/lib/galaxy/managers/containers.py
@@ -69,7 +69,7 @@ class ContainerManagerMixin( object ):
     def _filter_to_contained( self, container, content_class ):
         raise galaxy.exceptions.NotImplemented( 'Abstract class' )
 
-    def _get_content_manager( self, content_class ):
+    def _content_manager( self, content_class ):
         raise galaxy.exceptions.NotImplemented( 'Abstract class' )
 
 
@@ -82,11 +82,11 @@ class HistoryAsContainerManagerMixin( ContainerManagerMixin ):
     def _filter_to_contained( self, container, content_class ):
         return content_class.history == container
 
-    def _get_content_manager( self, content_class ):
+    def _content_manager( self, content ):
         # type snifffing is inevitable
-        if   content_class == model.HistoryDatasetAssociation:
+        if   isinstance( content, model.HistoryDatasetAssociation ):
             return self.hda_manager
-        elif content_class == model.HistoryDatasetCollectionAssociation:
+        elif isinstance( content, model.HistoryDatasetCollectionAssociation ):
             return self.hdca_manager
         raise TypeError( 'Unknown contents class: ' + str( content_class ) )
 
@@ -105,11 +105,11 @@ class LibraryFolderAsContainerManagerMixin( ContainerManagerMixin ):
             return subcontainer_class.parent == container
         return contained_class.folder == container
 
-    def _get_content_manager( self, content_class ):
+    def _content_manager( self, content ):
         # type snifffing is inevitable
-        if   content_class == model.LibraryDatasetAssociation:
+        if   isinstance( content, model.LibraryDatasetAssociation ):
             return self.lda_manager
-        elif content_class == model.LibraryFolder:
+        elif isinstance( content, model.LibraryFolder ):
             return self.folder_manager
         raise TypeError( 'Unknown contents class: ' + str( content_class ) )
 
@@ -124,11 +124,11 @@ class DatasetCollectionAsContainerManagerMixin( ContainerManagerMixin ):
     def _filter_to_contained( self, container, content_class ):
         return content_class.collection == container
 
-    def _get_content_manager( self, content_class ):
+    def _content_manager( self, content ):
         # type snifffing is inevitable
-        if   content_class == model.DatasetCollectionElement:
+        if   isinstance( content, model.DatasetCollectionElement ):
             return self.collection_manager
-        elif content_class == model.DatasetCollection:
+        elif isinstance( content, model.DatasetCollection ):
             return self.collection_manager
         raise TypeError( 'Unknown contents class: ' + str( content_class ) )
 

--- a/lib/galaxy/managers/containers.py
+++ b/lib/galaxy/managers/containers.py
@@ -48,20 +48,20 @@ class ContainerManagerMixin( object ):
         iters.append( self.subcontainers( container ) )
         return galaxy.util.merge_sorted_iterables( self.order_contents_on, *iters )
 
-    def contained( self, container ):
+    def contained( self, container, **kwargs ):
         """
         Returns non-container objects.
         """
-        return self._filter_contents( container, self.contained_class, **kwds )
+        return self._filter_contents( container, self.contained_class, **kwargs )
 
-    def subcontainers( self, container ):
+    def subcontainers( self, container, **kwargs ):
         """
         Returns only the containers within this one.
         """
-        return self._filter_contents( container, self.subcontainer_class, **kwds )
+        return self._filter_contents( container, self.subcontainer_class, **kwargs )
 
     # ---- private
-    def _filter_contents( self, container, content_class, **kwds ):
+    def _filter_contents( self, container, content_class, **kwargs ):
         # TODO: use list (or by_history etc.)
         container_filter = self._filter_to_contained( container, content_class )
         query = self.session().query( content_class ).filter( container_filter )
@@ -70,7 +70,7 @@ class ContainerManagerMixin( object ):
     def _filter_to_contained( self, container, content_class ):
         raise galaxy.exceptions.NotImplemented( 'Abstract class' )
 
-    def _content_manager( self, content_class ):
+    def _content_manager( self, content ):
         raise galaxy.exceptions.NotImplemented( 'Abstract class' )
 
 
@@ -84,12 +84,12 @@ class HistoryAsContainerManagerMixin( ContainerManagerMixin ):
         return content_class.history == container
 
     def _content_manager( self, content ):
-        # type snifffing is inevitable
+        # type sniffing is inevitable
         if   isinstance( content, model.HistoryDatasetAssociation ):
             return self.hda_manager
         elif isinstance( content, model.HistoryDatasetCollectionAssociation ):
             return self.hdca_manager
-        raise TypeError( 'Unknown contents class: ' + str( content_class ) )
+        raise TypeError( 'Unknown contents class: ' + str( content ) )
 
 
 class LibraryFolderAsContainerManagerMixin( ContainerManagerMixin ):
@@ -102,9 +102,9 @@ class LibraryFolderAsContainerManagerMixin( ContainerManagerMixin ):
     order_contents_on = operator.attrgetter( 'create_time' )
 
     def _filter_to_contained( self, container, content_class ):
-        if content_class == subcontainer_class:
-            return subcontainer_class.parent == container
-        return contained_class.folder == container
+        if content_class == self.subcontainer_class:
+            return self.subcontainer_class.parent == container
+        return self.contained_class.folder == container
 
     def _content_manager( self, content ):
         # type snifffing is inevitable
@@ -112,7 +112,7 @@ class LibraryFolderAsContainerManagerMixin( ContainerManagerMixin ):
             return self.lda_manager
         elif isinstance( content, model.LibraryFolder ):
             return self.folder_manager
-        raise TypeError( 'Unknown contents class: ' + str( content_class ) )
+        raise TypeError( 'Unknown contents class: ' + str( content ) )
 
 
 class DatasetCollectionAsContainerManagerMixin( ContainerManagerMixin ):
@@ -131,7 +131,7 @@ class DatasetCollectionAsContainerManagerMixin( ContainerManagerMixin ):
             return self.collection_manager
         elif isinstance( content, model.DatasetCollection ):
             return self.collection_manager
-        raise TypeError( 'Unknown contents class: ' + str( content_class ) )
+        raise TypeError( 'Unknown contents class: ' + str( content ) )
 
 
 # ====

--- a/lib/galaxy/managers/containers.py
+++ b/lib/galaxy/managers/containers.py
@@ -1,0 +1,150 @@
+"""
+Manager mixins to unify the interface into things that can contain: Datasets
+and other (nested) containers.
+
+(e.g. DatasetCollections, Histories, LibraryFolders)
+
+Histories should be DatasetCollections.
+Libraries should be DatasetCollections.
+"""
+
+import operator
+
+import galaxy.exceptions
+import galaxy.util
+
+from galaxy.managers import base
+
+import logging
+log = logging.getLogger( __name__ )
+
+
+# ====
+class ContainerManagerMixin( object ):
+    """
+    A class that tracks/contains two types of items:
+        1) some non-container object (such as datasets)
+        2) other sub-containers nested within this one
+
+    Levels of nesting are not considered here; In other words,
+    each of the methods below only work on the first level of
+    nesting.
+    """
+    # TODO: this should be an open mapping (not just 2)
+    #: the classes that can be contained
+    contained_class = None
+    subcontainer_class = None
+    #: how any contents lists produced are ordered
+    order_contents_on = None
+
+    # ---- interface
+    def contents( self, container ):
+        """
+        Returns both types of contents: filtered and in some order.
+        """
+        iters = []
+        iters.append( self.contained( container ) )
+        iters.append( self.subcontainers( container ) )
+        return galaxy.util.merge_sorted_iterables( self.order_contents_on, *iters )
+
+    def contained( self, container ):
+        """
+        Returns non-container objects.
+        """
+        return self._filter_contents( container, self.contained_class, **kwds )
+
+    def subcontainers( self, container ):
+        """
+        Returns only the containers within this one.
+        """
+        return self._filter_contents( container, self.subcontainer_class, **kwds )
+
+    # ---- private
+    def _filter_contents( self, container, content_class, **kwds ):
+        # TODO: use list (or by_history etc.)
+        container_filter = self._filter_to_contained( container, content_class )
+        query = self.session().query( content_class ).filter( container_filter )
+        return query
+
+    def _filter_to_contained( self, container, content_class ):
+        raise galaxy.exceptions.NotImplemented( 'Abstract class' )
+
+    def _get_content_manager( self, content_class ):
+        raise galaxy.exceptions.NotImplemented( 'Abstract class' )
+
+
+class HistoryAsContainerManagerMixin( ContainerManagerMixin ):
+
+    contained_class = model.HistoryDatasetAssociation
+    subcontainer_class = model.HistoryDatasetCollectionAssociation
+    order_contents_on = operator.attrgetter( 'hid' )
+
+    def _filter_to_contained( self, container, content_class ):
+        return content_class.history == container
+
+    def _get_content_manager( self, content_class ):
+        # type snifffing is inevitable
+        if   content_class == model.HistoryDatasetAssociation:
+            return self.hda_manager
+        elif content_class == model.HistoryDatasetCollectionAssociation:
+            return self.hdca_manager
+        raise TypeError( 'Unknown contents class: ' + str( content_class ) )
+
+
+class LibraryFolderAsContainerManagerMixin( ContainerManagerMixin ):
+    # can contain two types of subcontainer: LibraryFolder, LibraryDatasetCollectionAssociation
+    # has as the top level container: Library
+
+    contained_class = model.LibraryDatasetAssociation
+    subcontainer_class = model.LibraryFolder
+    # subcontainer_class = model.LibraryDatasetCollectionAssociation
+    order_contents_on = operator.attrgetter( 'create_time' )
+
+    def _filter_to_contained( self, container, content_class ):
+        if content_class == subcontainer_class:
+            return subcontainer_class.parent == container
+        return contained_class.folder == container
+
+    def _get_content_manager( self, content_class ):
+        # type snifffing is inevitable
+        if   content_class == model.LibraryDatasetAssociation:
+            return self.lda_manager
+        elif content_class == model.LibraryFolder:
+            return self.folder_manager
+        raise TypeError( 'Unknown contents class: ' + str( content_class ) )
+
+
+class DatasetCollectionAsContainerManagerMixin( ContainerManagerMixin ):
+
+    # (note: unlike the other collections, dc's wrap both contained and subcontainers in this class)
+    contained_class = model.DatasetCollectionElement
+    subcontainer_class = model.DatasetCollection
+    order_contents_on = operator.attrgetter( 'element_index' )
+
+    def _filter_to_contained( self, container, content_class ):
+        return content_class.collection == container
+
+    def _get_content_manager( self, content_class ):
+        # type snifffing is inevitable
+        if   content_class == model.DatasetCollectionElement:
+            return self.collection_manager
+        elif content_class == model.DatasetCollection:
+            return self.collection_manager
+        raise TypeError( 'Unknown contents class: ' + str( content_class ) )
+
+
+# ====
+class ContainableModelMixin:
+    """
+    Mixin for that which goes in a container.
+    """
+
+    # ---- interface
+    def parent_container( self, containable ):
+        """
+        Return this item's parent container or None if unrecorded.
+        """
+        raise galaxy.exceptions.NotImplemented( 'Abstract class' )
+
+    def set_parent_container( self, containable, new_parent_container ):
+        raise galaxy.exceptions.NotImplemented( 'Abstract class' )

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -1,8 +1,6 @@
 """
 Manager and Serializer for Datasets.
 """
-import json
-
 from galaxy import model
 from galaxy import exceptions
 import galaxy.datatypes.metadata
@@ -125,7 +123,7 @@ class DatasetRBACPermissions( object ):
     # ---- conv. settings
     def set_public_with_single_manager( self, dataset, user, flush=True ):
         manage = self.manage.grant( dataset, user, flush=flush )
-        access = self.access.clear( dataset, flush=False )
+        self.access.clear( dataset, flush=False )
         return ( [ manage ], [] )
 
     def set_private_to_one_user( self, dataset, user, flush=True ):
@@ -327,7 +325,7 @@ class _UnflattenedMetadataDatasetAssociationSerializer( base.ModelSerializer,
             # underlying dataset
             'dataset'       : lambda i, k, **c: self.dataset_serializer.serialize_to_view( i.dataset, view='summary', **c ),
             'dataset_id'    : self._proxy_to_dataset( key='id' ),
-            #TODO: why is this named uuid!? The da doesn't have a uuid - it's the underlying dataset's uuid!
+            # TODO: why is this named uuid!? The da doesn't have a uuid - it's the underlying dataset's uuid!
             'uuid'          : self._proxy_to_dataset( key='uuid' ),
             # 'dataset_uuid'  : self._proxy_to_dataset( key='uuid' ),
             'file_name'     : self._proxy_to_dataset( serializer=self.dataset_serializer.serialize_file_name ),

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -277,6 +277,7 @@ class DatasetAssociationManager( base.ModelManager,
         """
         raise galaxy.exceptions.NotImplemented( 'Abstract Method' )
 
+    # .... associated job
     def creating_job( self, dataset_assoc ):
         # TODO: is this needed? Can't you use the dataset_assoc.creating_job attribute? When is this None?
         # TODO: this would be even better if outputs and inputs were the underlying datasets

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -1,12 +1,16 @@
 """
 Manager and Serializer for Datasets.
 """
+import json
+
 from galaxy import model
 from galaxy import exceptions
+import galaxy.datatypes.metadata
 
 from galaxy.managers import base
 from galaxy.managers import secured
 from galaxy.managers import deletable
+from galaxy.managers import rbac_secured
 from galaxy.managers import users
 
 import logging
@@ -24,47 +28,27 @@ class DatasetManager( base.ModelManager, secured.AccessibleManagerMixin, deletab
 
     def __init__( self, app ):
         super( DatasetManager, self ).__init__( app )
+        self.permissions = DatasetRBACPermissions( app )
         # need for admin test
         self.user_manager = users.UserManager( app )
 
-    def create( self, trans, flush=True, **kwargs ):
+    def create( self, trans, manage_roles=None, access_roles=None, flush=True, **kwargs ):
         """
         Create and return a new Dataset object.
         """
         # default to NEW state on new datasets
         kwargs.update( dict( state=( kwargs.get( 'state', model.Dataset.states.NEW ) ) ) )
         dataset = model.Dataset( **kwargs )
+        self.session().add( dataset )
 
-        self.app.model.context.add( dataset )
+        self.permissions.set( dataset, manage_roles, access_roles, flush=False )
+
         if flush:
-            self.app.model.context.flush()
+            self.session().flush()
         return dataset
 
-    # def copy( self, dataset, **kwargs ):
-    #    """
-    #    Clone, update, and return the given dataset.
-    #    """
-    #    pass
-
-    # def to_hda( self, trans, dataset, history, **kwargs ):
-    #    """
-    #    Create an hda from this dataset.
-    #    """
-    #    pass
-
-    # def to_ldda( self, trans, dataset, library_folder, **kwargs ):
-    #    """
-    #    Create an ldda from this dataset.
-    #    """
-    #    pass
-
-    # TODO: this may be more conv. somewhere else
-    # TODO: how to allow admin bypass?
-    def error_unless_dataset_purge_allowed( self, trans, item, msg=None ):
-        if not self.app.config.allow_user_dataset_purge:
-            msg = msg or 'This instance does not allow user dataset purging'
-            raise exceptions.ConfigDoesNotAllowException( msg )
-        return item
+    def copy( self, dataset, **kwargs ):
+        raise galaxy.exceptions.NotImplemented( 'Datasets cannot be copied' )
 
     def purge( self, trans, dataset, flush=True ):
         """
@@ -77,10 +61,18 @@ class DatasetManager( base.ModelManager, secured.AccessibleManagerMixin, deletab
 
         # the following also marks dataset as purged and deleted
         dataset.full_delete()
-        self.app.model.context.add( dataset )
+        self.session().add( dataset )
         if flush:
-            self.app.model.context.flush()
+            self.session().flush()
         return dataset
+
+    # TODO: this may be more conv. somewhere else
+    # TODO: how to allow admin bypass?
+    def error_unless_dataset_purge_allowed( self, trans, item, msg=None ):
+        if not self.app.config.allow_user_dataset_purge:
+            msg = msg or 'This instance does not allow user dataset purging'
+            raise exceptions.ConfigDoesNotAllowException( msg )
+        return item
 
     # .... accessibility
     # datasets can implement the accessible interface, but accessibility is checked in an entirely different way
@@ -91,117 +83,74 @@ class DatasetManager( base.ModelManager, secured.AccessibleManagerMixin, deletab
         """
         if self.user_manager.is_admin( trans, user ):
             return True
-        if self.has_access_permission( trans, dataset, user ):
+        if self.has_access_permission( dataset, user ):
             return True
         return False
 
-    def has_access_permission( self, trans, dataset, user ):
+    def has_access_permission( self, dataset, user ):
         """
         Return T/F if the user has role-based access to the dataset.
         """
         roles = user.all_roles() if user else []
         return self.app.security_agent.can_access_dataset( roles, dataset )
 
-    # TODO: these need work
-    def _access_permission( self, trans, dataset, user=None, role=None ):
-        """
-        Return most recent DatasetPermissions for the dataset and user.
-        """
-        security_agent = self.app.security_agent
-        access_action = security_agent.permitted_actions.DATASET_ACCESS.action
-
-        # get a list of role ids to check access for (defaulting to all_roles)
-        user_roles = [ role ] if role else user.all_roles()
-        user_role_ids = [ r.id for r in user_roles ]
-        query = ( self.app.model.context.query( model.DatasetPermissions )
-                  .filter( model.DatasetPermissions.action == access_action )
-                  .filter( model.DatasetPermissions.dataset == dataset )
-                  .filter( model.DatasetPermissions.role_id.in_( user_role_ids ) ) )
-        # TODO:?? most recent?
-        return query.first()
-
-    def _create_access_permission( self, trans, dataset, role, flush=True ):
-        """
-        Create a new DatasetPermissions for the given dataset and role.
-        """
-        access_action = self.app.security_agent.permitted_actions.DATASET_ACCESS.action
-        permission = model.DatasetPermissions( access_action, dataset, role )
-        self.app.model.context.add( permission )
-        if flush:
-            self.app.model.context.flush()
-        return permission
-
-    # def give_access_permission( self, trans, dataset, user, flush=True ):
-    #    """
-    #    """
-    #    # for now, use the user's private role
-    #    security_agent = self.app.security_agent
-    #    user_role = security_agent.get_private_user_role( user )
-    #
-    #    existing_permission = self._access_permission( trans, dataset, role=user_role )
-    #    print 'existing access_perm:', existing_permission
-    #    if existing_permission:
-    #        return dataset
-    #
-    #    permission = self._create_access_permission( trans, dataset, user_role )
-    #    print 'access_roles:', [ role.name for role in dataset.get_access_roles( trans ) ]
-    #
-    #    #access_action = security_agent.permitted_actions.DATASET_ACCESS.action
-    #    #access_action = security_agent.get_action( access_action )
-    #    #permissions = { access_action : [ user_role ] }
-    #    #security_agent.set_dataset_permission( dataset, permissions )
-    #
-    #    #self.app.model.context.add( dataset )
-    #    #if flush:
-    #    #    self.app.model.context.flush()
-    #
-    #    dbl_chk = self._access_permission( trans, dataset, role=user_role )
-    #    print 'access_perm:', dbl_chk
-    #
-    #    return dataset
-
-    # def remove_access_permission( self, trans, dataset, user ):
-    #    """
-    #    """
-    #    pass
-
-    # .... manage/modify
-    # def has_manage_permission( self, trans, dataset, user ):
-    #    """
-    #    """
-    #    pass
-    #
-    # def give_manage_permission( self, trans, dataset, user ):
-    #    """
-    #    """
-    #    pass
-    #
-    # def remove_manage_permission( self, trans, dataset, user ):
-    #    """
-    #    """
-    #    pass
-
     # TODO: implement above for groups
     # TODO: datatypes?
-
     # .... data, object_store
+
+
+class DatasetRBACPermissions( object ):
+
+    def __init__( self, app ):
+        self.app = app
+        self.access = rbac_secured.AccessDatasetRBACPermission( app )
+        self.manage = rbac_secured.ManageDatasetRBACPermission( app )
+
+    # TODO: temporary facade over security_agent
+    def available_roles( self, trans, dataset, controller='root' ):
+        return self.app.security_agent.get_legitimate_roles( trans, dataset, controller )
+
+    def get( self, dataset, flush=True ):
+        manage = self.manage.by_dataset( dataset )
+        access = self.access.by_dataset( dataset )
+        return ( manage, access )
+
+    def set( self, dataset, manage_roles, access_roles, flush=True ):
+        manage = self.manage.set( dataset, manage_roles or [], flush=False )
+        access = self.access.set( dataset, access_roles or [], flush=flush )
+        return ( manage, access )
+
+    def set_public_with_single_manager( self, dataset, user, flush=True ):
+        manage = self.manage.grant( dataset, user, flush=flush )
+        access = self.access.clear( dataset, flush=False )
+        return ( [ manage ], [] )
+
+    def set_private_to_one_user( self, dataset, user, flush=True ):
+        manage = self.manage.grant( user, flush=False )
+        access = self.access.set_private( dataset, user, flush=flush )
+        return ( [ manage ], access )
 
 
 class DatasetSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin ):
 
     def __init__( self, app ):
         super( DatasetSerializer, self ).__init__( app )
+        self.dataset_manager = DatasetManager( app )
 
         self.default_view = 'summary'
         self.add_view( 'summary', [
             'id',
-            'create_time', 'update_time',
+            'create_time',
+            'update_time',
             'state',
-            'deleted', 'purged', 'purgable',
+            'deleted',
+            'purged',
+            'purgable',
             # 'object_store_id',
             # 'external_filename',
             # 'extra_files_path',
-            'file_size', 'total_size',
+            'file_size',
+            'total_size',
             'uuid',
         ])
         # could do visualizations and/or display_apps
@@ -211,11 +160,46 @@ class DatasetSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin
         deletable.PurgableSerializerMixin.add_serializers( self )
 
         self.serializers.update({
-            'id': self.serialize_id,
-            'create_time': self.serialize_date,
-            'update_time': self.serialize_date,
-            'uuid': lambda t, i, k: str( i.uuid ) if i.uuid else None,
+            'id'            : self.serialize_id,
+            'create_time'   : self.serialize_date,
+            'update_time'   : self.serialize_date,
+
+            'uuid'          : lambda t, i, k: str( i.uuid ) if i.uuid else None,
+            'file_name'     : self.serialize_file_name,
+            'extra_files_path' : self.serialize_extra_files_path,
+            'permissions'   : self.serialize_permissions,
+
+            'total_size'    : lambda t, i, k: int( i.get_total_size() ),
+            'file_size'     : lambda t, i, k: int( i.get_size() )
         })
+
+    def serialize_file_name( self, trans, dataset, key ):
+        """
+        If the config allows or the user is admin, return the file name
+        of the file that contains this dataset's data.
+        """
+        # TODO: allow admin
+        # conifg due to cost of operation
+        if not self.app.config.expose_dataset_path:
+            self.skip()
+        return dataset.file_name
+
+    def serialize_extra_files_path( self, trans, dataset, key ):
+        """
+        If the config allows or the user is admin, return the file path.
+        """
+        # TODO: allow admin
+        # conifg due to cost of operation
+        if not self.app.config.expose_dataset_path:
+            self.skip()
+        return dataset.extra_files_path
+
+    def serialize_permissions( self, trans, dataset, key ):
+        """
+        """
+        permissions = {}
+# TODO: use rbac permissions?
+        return permissions
 
 
 class DatasetDeserializer( base.ModelDeserializer, deletable.PurgableDeserializerMixin ):
@@ -223,11 +207,27 @@ class DatasetDeserializer( base.ModelDeserializer, deletable.PurgableDeserialize
 
     def add_deserializers( self ):
         super( DatasetDeserializer, self ).add_deserializers()
+        # not much to set here besides permissions and purged/deleted
         deletable.PurgableDeserializerMixin.add_deserializers( self )
+
+        self.deserializers.update({
+            'permissions' : self.deserialize_permissions,
+        })
+
+    def deserialize_permissions( self, trans, dataset, key, value ):
+        """
+        """
+        permissions = {}
+# TODO: test if different - it's an expensive op
+# TODO: validation will be tricky
+# TODO: use rbac permissions?
+        return permissions
 
 
 # ============================================================================= AKA DatasetInstanceManager
-class DatasetAssociationManager( base.ModelManager, secured.AccessibleManagerMixin, deletable.PurgableManagerMixin ):
+class DatasetAssociationManager( base.ModelManager,
+                                 secured.AccessibleManagerMixin,
+                                 deletable.PurgableManagerMixin ):
     """
     DatasetAssociation/DatasetInstances are intended to be working
     proxies to a Dataset, associated with either a library or a
@@ -248,25 +248,219 @@ class DatasetAssociationManager( base.ModelManager, secured.AccessibleManagerMix
         # defer to the dataset
         return self.dataset_manager.is_accessible( trans, dataset_assoc.dataset, user )
 
-    # def metadata( self, trans, dataset_assoc ):
-    #    """
-    #    Return the metadata collection.
-    #    """
-    #    # get metadata
-    #    pass
+    def purge( self, trans, dataset_assoc, flush=True ):
+        """
+        Purge this DatasetInstance and the dataset underlying it.
+        """
+        # error here if disallowed - before jobs are stopped
+        # TODO: this check may belong in the controller
+        self.dataset_manager.error_unless_dataset_purge_allowed( trans, dataset_assoc )
+        super( DatasetAssociationManager, self ).purge( trans, dataset_assoc, flush=flush )
 
-    # def is_being_used( self, trans, dataset_assoc ):
-    #    """
-    #    """
-    #    #TODO: check history_associations, library_associations
-    #    pass
+        # stop any jobs outputing the dataset_assoc
+        if dataset_assoc.creating_job_associations:
+            job = dataset_assoc.creating_job_associations[0].job
+            if not job.finished:
+                # signal to stop the creating job
+                job.mark_deleted( self.app.config.track_jobs_in_database )
+                self.app.job_manager.job_stop_queue.put( job.id )
+
+        # more importantly, purge underlying dataset as well
+        if dataset_assoc.dataset.user_can_purge:
+            self.dataset_manager.purge( trans, dataset_assoc.dataset )
+        return dataset_assoc
+
+    def by_user( self, trans, user ):
+        """
+        """
+        raise galaxy.exceptions.NotImplemented( 'Abstract Method' )
+
+    # def creating_job( self, trans, dataset_assoc ):
+    #     # TODO: this would be even better if outputs and inputs were the underlying datasets
+    #     # TODO: is this needed? Can't you use the dataset_assoc.creating_job attribute? When is this None?
+    #     job = None
+    #     for job_output_assoc in dataset_assoc.creating_job_associations:
+    #         job = job_output_assoc.job
+    #         break
+    #     return job
+
+    # def stop_creating_job( self, dataset_assoc ):
+    #     """
+    #     Stops an dataset_assoc's creating job if all the job's other outputs are deleted.
+    #     """
+    #     RUNNING_STATES = (
+    #         self.app.model.Job.states.QUEUED,
+    #         self.app.model.Job.states.RUNNING,
+    #         self.app.model.Job.states.NEW
+    #     )
+    #     if dataset_assoc.parent_id is None and len( dataset_assoc.creating_job_associations ) > 0:
+    #         # Mark associated job for deletion
+    #         job = dataset_assoc.creating_job_associations[0].job
+    #         if job.state in RUNNING_STATES:
+    #             # Are *all* of the job's other output datasets deleted?
+    #             if job.check_if_output_datasets_deleted():
+    #                 job.mark_deleted( self.app.config.track_jobs_in_database )
+    #                 self.app.job_manager.job_stop_queue.put( job.id )
+    #                 return True
+    #     return False
 
 
-class DatasetAssociationSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin ):
+class _UnflattenedMetadataDatasetAssociationSerializer( base.ModelSerializer,
+                                                        deletable.PurgableSerializerMixin ):
+
+    def __init__( self, app ):
+        self.dataset_serializer = DatasetSerializer( app )
+        super( _UnflattenedMetadataDatasetAssociationSerializer, self ).__init__( app )
+
+    def add_serializers( self ):
+        super( _UnflattenedMetadataDatasetAssociationSerializer, self ).add_serializers()
+        deletable.PurgableSerializerMixin.add_serializers( self )
+
+        self.serializers.update({
+            'id'            : self.serialize_id,
+            'create_time'   : self.serialize_date,
+            'update_time'   : self.serialize_date,
+
+            # underlying dataset
+            'dataset'       : lambda t, i, k: self.dataset_serializer.serialize_to_view( t, i.dataset, view='summary' ),
+            'dataset_id'    : self._proxy_to_dataset( key='id' ),
+            #TODO: why is this named uuid!? The da doesn't have a uuid - it's the underlying dataset's uuid!
+            'uuid'          : self._proxy_to_dataset( key='uuid' ),
+            # 'dataset_uuid'  : self._proxy_to_dataset( key='uuid' ),
+            'file_name'     : self._proxy_to_dataset( serializer=self.dataset_serializer.serialize_file_name ),
+            'extra_files_path' : self._proxy_to_dataset( serializer=self.dataset_serializer.serialize_extra_files_path ),
+            'permissions'   : self._proxy_to_dataset( serializer=self.dataset_serializer.serialize_permissions),
+            # TODO: do the sizes proxy accurately/in the same way?
+            'size'          : lambda t, i, k: int( i.get_size() ),
+            'file_size'     : lambda t, i, k: self.serializers[ 'size' ]( t, i, k ),
+            'nice_size'     : lambda t, i, k: i.get_size( nice_size=True ),
+
+            # common to lddas and hdas - from mapping.py
+            'copied_from_history_dataset_association_id'        : self.serialize_id,
+            'copied_from_library_dataset_dataset_association_id': self.serialize_id,
+            'info'          : lambda t, i, k: i.info.strip() if isinstance( i.info, basestring ) else i.info,
+            'blurb'         : lambda t, i, k: i.blurb,
+            'peek'          : lambda t, i, k: i.display_peek() if i.peek and i.peek != 'no peek' else None,
+
+            'meta_files'    : self.serialize_meta_files,
+            'metadata'      : self.serialize_metadata,
+
+            'parent_id'     : self.serialize_id,
+            'designation'   : lambda t, i, k: i.designation,
+
+            # 'extended_metadata'     : self.serialize_extended_metadata,
+            # 'extended_metadata_id'  : self.serialize_id,
+
+            # remapped
+            'genome_build'  : lambda t, i, k: i.dbkey,
+
+            # derived (not mapped) attributes
+            'data_type'     : lambda t, i, k: i.datatype.__class__.__module__ + '.' + i.datatype.__class__.__name__,
+
+            # TODO: conversions
+            # TODO: metadata/extra files
+        })
+        # this an abstract superclass, so no views created
+        # because of that: we need to add a few keys that will use the default serializer
+        self.serializable_keyset.update([ 'name', 'state', 'tool_version', 'extension', 'visible', 'dbkey' ])
+
+    def _proxy_to_dataset( self, serializer=None, key=None ):
+        if key:
+            serializer = self.dataset_serializer.serializers.get( key )
+        if serializer:
+            return lambda t, i, k: serializer( t, i.dataset, key or k )
+        raise TypeError( 'kwarg serializer or key needed')
+
+    def serialize_meta_files( self, trans, dataset_assoc, key ):
+        """
+        Cycle through meta files and return them as a list of dictionaries.
+        """
+        meta_files = []
+        for meta_type in dataset_assoc.metadata.spec.keys():
+            if isinstance( dataset_assoc.metadata.spec[ meta_type ].param, galaxy.datatypes.metadata.FileParameter ):
+                meta_files.append( dict( file_type=meta_type ) )
+        return meta_files
+
+    def serialize_metadata( self, trans, dataset_assoc, key, excluded=None ):
+        """
+        Cycle through metadata and return as dictionary.
+        """
+        # dbkey is a repeat actually (metadata_dbkey == genome_build)
+        # excluded = [ 'dbkey' ] if excluded is None else excluded
+        excluded = [] if excluded is None else excluded
+
+        metadata = {}
+        for name, spec in dataset_assoc.metadata.spec.items():
+            if name in excluded:
+                continue
+            val = dataset_assoc.metadata.get( name )
+            # NOTE: no files
+            if isinstance( val, model.MetadataFile ):
+                # only when explicitly set: fetching filepaths can be expensive
+                if not self.app.config.expose_dataset_path:
+                    continue
+                val = val.file_name
+            # TODO:? possibly split this off?
+            # If no value for metadata, look in datatype for metadata.
+            elif val is None and hasattr( dataset_assoc.datatype, name ):
+                val = getattr( dataset_assoc.datatype, name )
+            metadata[ name ] = val
+
+        return metadata
+
+
+class DatasetAssociationSerializer( _UnflattenedMetadataDatasetAssociationSerializer ):
+    # TODO: remove this class - metadata should be a sub-object instead as in the superclass
 
     def add_serializers( self ):
         super( DatasetAssociationSerializer, self ).add_serializers()
-        deletable.PurgableSerializerMixin.add_serializers( self )
+        # remove the single nesting key here
+        del self.serializers[ 'metadata' ]
+
+    def serialize( self, trans, dataset_assoc, keys ):
+        """
+        Override to add metadata as flattened keys on the serialized DatasetInstance.
+        """
+        # if 'metadata' isn't removed from keys here serialize will retrieve the un-serializable MetadataCollection
+        # TODO: remove these when metadata is sub-object
+        KEYS_HANDLED_SEPARATELY = ( 'metadata', )
+        left_to_handle = self.pluck_from_list( keys, KEYS_HANDLED_SEPARATELY )
+        serialized = super( DatasetAssociationSerializer, self ).serialize( trans, dataset_assoc, keys )
+
+        # add metadata directly to the dict instead of as a sub-object
+        if 'metadata' in left_to_handle:
+            metadata = self.prefixed_metadata( trans, dataset_assoc )
+            serialized.update( metadata )
+        return serialized
+
+    # TODO: this is more util/gen. use
+    def pluck_from_list( self, l, elems ):
+        """
+        Removes found elems from list l and returns list of found elems if found.
+        """
+        found = []
+        for elem in elems:
+            try:
+                index = l.index( elem )
+                found.append( l.pop( index ) )
+            except ValueError:
+                pass
+        return found
+
+    def prefixed_metadata( self, trans, dataset_assoc ):
+        """
+        Adds (a prefixed version of) the DatasetInstance metadata to the dict,
+        prefixing each key with 'metadata_'.
+        """
+        # build the original, nested dictionary
+        metadata = self.serialize_metadata( trans, dataset_assoc, 'metadata' )
+
+        # prefix each key within and return
+        prefixed = {}
+        for key, val in metadata.items():
+            prefixed_key = 'metadata_' + key
+            prefixed[ prefixed_key ] = val
+        return prefixed
 
 
 class DatasetAssociationDeserializer( base.ModelDeserializer, deletable.PurgableDeserializerMixin ):
@@ -275,15 +469,75 @@ class DatasetAssociationDeserializer( base.ModelDeserializer, deletable.Purgable
         super( DatasetAssociationDeserializer, self ).add_deserializers()
         deletable.PurgableDeserializerMixin.add_deserializers( self )
 
+        self.deserializers.update({
+            'name'          : self.deserialize_basestring,
+            'info'          : self.deserialize_basestring,
+        })
+        self.deserializable_keyset.update( self.deserializers.keys() )
+
+    def deserialize_metadata( self, trans, dataset_assoc, metadata_key, metadata_dict ):
+        """
+        """
+        self.validate.type( metadata_key, metadata_dict, dict )
+        returned = {}
+        for key, val in metadata_dict.items():
+            returned[ key ] = self.deserialize_metadatum( trans, dataset_assoc, key, val )
+        return returned
+
+    def deserialize_metadatum( self, trans, dataset_assoc, key, val ):
+        """
+        """
+        if key not in dataset_assoc.datatype.metadata_spec:
+            return
+        metadata_specification = dataset_assoc.datatype.metadata_spec[ key ]
+        if metadata_specification.get( 'readonly' ):
+            return
+        unwrapped_val = metadata_specification.unwrap( val )
+        setattr( dataset_assoc.metadata, key, unwrapped_val )
+        # ...?
+        return unwrapped_val
+
 
 class DatasetAssociationFilters( base.ModelFilterParser, deletable.PurgableFiltersMixin ):
+
+    def _datatype_from_string( class_str ):
+        """
+        """
+        return self.app.datatypes_registry.get_datatype_class_by_name( class_str )
 
     def _add_parsers( self ):
         super( DatasetAssociationFilters, self )._add_parsers()
         deletable.PurgableFiltersMixin._add_parsers( self )
 
         self.orm_filter_parsers.update({
-            'name': { 'op': ( 'eq', 'contains', 'like' ) },
-            'state': { 'op': ( 'eq', 'in' ) },
+            'name'      : { 'op': ( 'eq', 'contains', 'like' ) },
+            'state'     : { 'op': ( 'eq', 'in' ) },
+            'visible'   : { 'op': ( 'eq' ), 'val': self.parse_bool },
+            'genome_build' : { 'op': ( 'eq', 'contains', 'like' ) },
         })
-        # self.fn_filter_parsers.update({})
+        self.fn_filter_parsers.update({
+            'data_type' : {
+                'op': {
+                    'eq' : self.eq_datatype,
+                    'is' : self.is_datatype
+                }
+            }
+        })
+
+    def eq_datatype( self, dataset_assoc, class_str ):
+        """
+        """
+        comparison_class = self._datatype_from_string( class_str )
+        return ( comparison_class
+             and dataset_assoc.datatype.__class__ == comparison_class )
+
+    def is_datatype( self, dataset_assoc, class_strs ):
+        """
+        """
+        comparison_classes = []
+        for class_str in class_strs.split( ',' ):
+            datatype_class = self._datatype_from_string( class_str )
+            if datatype_class:
+                comparison_classes.append( datatype_class )
+        return ( comparison_classes
+             and isinstance( dataset_assoc.datatype, comparison_classes ) )

--- a/lib/galaxy/managers/deletable.py
+++ b/lib/galaxy/managers/deletable.py
@@ -103,6 +103,7 @@ class PurgableDeserializerMixin( DeletableDeserializerMixin ):
         new_purged = self.validate.bool( key, val )
         if new_purged == item.purged:
             return item.purged
+        # do we want to error if something attempts to 'unpurge'?
         if new_purged:
             self.manager.purge( trans, item, flush=False )
         return item.purged

--- a/lib/galaxy/managers/deletable.py
+++ b/lib/galaxy/managers/deletable.py
@@ -19,13 +19,13 @@ class DeletableManagerMixin( object ):
     removed by an admin/script.
     """
 
-    def delete( self, trans, item, flush=True, **kwargs ):
+    def delete( self, item, flush=True, **kwargs ):
         """
         Mark as deleted and return.
         """
         return self._session_setattr( item, 'deleted', True, flush=flush )
 
-    def undelete( self, trans, item, flush=True, **kwargs ):
+    def undelete( self, item, flush=True, **kwargs ):
         """
         Mark as not deleted and return.
         """
@@ -53,9 +53,9 @@ class DeletableDeserializerMixin( object ):
             return item.deleted
         # TODO:?? flush=False?
         if new_deleted:
-            self.manager.delete( trans, item, flush=False )
+            self.manager.delete( item, flush=False )
         else:
-            self.manager.undelete( trans, item, flush=False )
+            self.manager.undelete( item, flush=False )
         return item.deleted
 
 
@@ -74,7 +74,7 @@ class PurgableManagerMixin( DeletableManagerMixin ):
     file).
     """
 
-    def purge( self, trans, item, flush=True, **kwargs ):
+    def purge( self, item, flush=True, **kwargs ):
         """
         Mark as purged and return.
 
@@ -105,7 +105,7 @@ class PurgableDeserializerMixin( DeletableDeserializerMixin ):
             return item.purged
         # do we want to error if something attempts to 'unpurge'?
         if new_purged:
-            self.manager.purge( trans, item, flush=False )
+            self.manager.purge( item, flush=False )
         return item.purged
 
 

--- a/lib/galaxy/managers/deletable.py
+++ b/lib/galaxy/managers/deletable.py
@@ -18,7 +18,6 @@ class DeletableManagerMixin( object ):
     that they are no longer needed, should not be displayed, or may be actually
     removed by an admin/script.
     """
-
     def delete( self, item, flush=True, **kwargs ):
         """
         Mark as deleted and return.
@@ -44,7 +43,7 @@ class DeletableDeserializerMixin( object ):
     def add_deserializers( self ):
         self.deserializers[ 'deleted' ] = self.deserialize_deleted
 
-    def deserialize_deleted( self, trans, item, key, val ):
+    def deserialize_deleted( self, item, key, val, **context ):
         """
         Delete or undelete `item` based on `val` then return `item.deleted`.
         """
@@ -73,7 +72,6 @@ class PurgableManagerMixin( DeletableManagerMixin ):
     purging is often removal of some additional, non-db resource (e.g. a dataset's
     file).
     """
-
     def purge( self, item, flush=True, **kwargs ):
         """
         Mark as purged and return.
@@ -96,7 +94,7 @@ class PurgableDeserializerMixin( DeletableDeserializerMixin ):
         DeletableDeserializerMixin.add_deserializers( self )
         self.deserializers[ 'purged' ] = self.deserialize_purged
 
-    def deserialize_purged( self, trans, item, key, val ):
+    def deserialize_purged( self, item, key, val, **context ):
         """
         If `val` is True, purge `item` and return `item.purged`.
         """

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -11,7 +11,6 @@ import gettext
 from galaxy import model
 from galaxy import exceptions
 from galaxy import datatypes
-import galaxy.datatypes.metadata
 from galaxy import objectstore
 
 from galaxy.managers import datasets
@@ -91,9 +90,9 @@ class HDAManager( datasets.DatasetAssociationManager,
             history.add_dataset( hda )
         #TODO:?? some internal sanity check here (or maybe in add_dataset) to make sure hids are not duped?
 
-        self.app.model.context.add( hda )
+        self.session().add( hda )
         if flush:
-            self.app.model.context.flush()
+            self.session().flush()
         return hda
 
     def copy( self, trans, hda, history=None, **kwargs ):
@@ -125,15 +124,15 @@ class HDAManager( datasets.DatasetAssociationManager,
         # TODO: update from kwargs?
 
         # Need to set after flushed, as MetadataFiles require dataset.id
-        self.app.model.context.add( copy )
-        self.app.model.context.flush()
+        self.session().add( copy )
+        self.session().flush()
         copy.metadata = hda.metadata
 
         # In some instances peek relies on dataset_id, i.e. gmaj.zip for viewing MAFs
         if not hda.datatype.copy_safe_peek:
             copy.set_peek()
 
-        self.app.model.context.flush()
+        self.session().flush()
         return copy
 
     def copy_ldda( self, trans, history, ldda, **kwargs ):
@@ -142,40 +141,18 @@ class HDAManager( datasets.DatasetAssociationManager,
         """
         return ldda.to_history_dataset_association( history, add_to_history=True )
 
-    # TODO: stub
-    # def is_a_copy( self, trans, hda ):
-    #     pass
-
-    # TODO: stub
-    # def copied_from( self, trans, hda ):
-    #     pass
-
-    # TODO: stub
-    # def by_user( self, trans, user ):
-    #     pass
-
+    # .... deletion and purging
     def purge( self, trans, hda, flush=True ):
         """
         Purge this HDA and the dataset underlying it.
         """
-        # error here if disallowed - before jobs are stopped
-        # TODO: poss. move to DatasetAssociationManager
-        self.dataset_manager.error_unless_dataset_purge_allowed( trans, hda )
+        super( HDAManager, self ).purge( trans, hda, flush=flush )
+        # decreate the user's space used
         if trans.user:
             trans.user.total_disk_usage -= hda.quota_amount( trans.user )
-        super( HDAManager, self ).purge( trans, hda, flush=flush )
-        if hda.creating_job_associations:
-            job = hda.creating_job_associations[0].job
-            if not job.finished:
-                # signal to stop the creating job
-                job.mark_deleted( self.app.config.track_jobs_in_database )
-                self.app.job_manager.job_stop_queue.put( job.id )
-
-        # more importantly, purge dataset as well
-        if hda.dataset.user_can_purge:
-            self.dataset_manager.purge( trans, hda.dataset )
         return hda
 
+    # .... states
     def error_if_uploading( self, trans, hda ):
         """
         Raise error if HDA is still uploading.
@@ -185,83 +162,22 @@ class HDAManager( datasets.DatasetAssociationManager,
             raise exceptions.Conflict( "Please wait until this dataset finishes uploading" )
         return hda
 
-    # .... via history
-    # def by_history_id( self, trans, history_id, filters=None, **kwargs ):
-    #    history_id_filter = self.model_class.history_id == history_id
-    #    filters = self._munge_filters( history_id_filter, filters )
-    #    return self.list( trans, filters=filters, **kwargs )
-
-    # def by_history( self, trans, history, filters=None, **kwargs ):
-    #    return history.datasets
-
-    # .... associated
-    def creating_job( self, trans, hda ):
-        # TODO: is this needed? Can't you use the hda.creating_job attribute? When is this None?
-        job = None
-        for job_output_assoc in hda.creating_job_associations:
-            job = job_output_assoc.job
-            break
-        return job
-
-    # .... serialization
-    def get_display_apps( self, trans, hda ):
+    def data_conversion_status( self, trans, hda ):
         """
-        Return dictionary containing new-style display app urls.
+        Returns a message if dataset is not ready to be used in visualization.
         """
-        display_apps = []
-        for display_app in hda.get_display_applications( trans ).itervalues():
+        # this is a weird syntax and return val
+        if not hda:
+            return hda.conversion_messages.NO_DATA
+        if hda.state == model.Job.states.ERROR:
+            return hda.conversion_messages.ERROR
+        if hda.state != model.Job.states.OK:
+            return hda.conversion_messages.PENDING
+        return None
 
-            app_links = []
-            for link_app in display_app.links.itervalues():
-                app_links.append({
-                    'target': link_app.url.get( 'target_frame', '_blank' ),
-                    'href': link_app.get_display_url( hda, trans ),
-                    'text': gettext.gettext( link_app.name )
-                })
-            if app_links:
-                display_apps.append( dict( label=display_app.name, links=app_links ) )
+    # .... associated job
 
-        return display_apps
-
-    def get_old_display_applications( self, trans, hda ):
-        """
-        Return dictionary containing old-style display app urls.
-        """
-        display_apps = []
-        if not self.app.config.enable_old_display_applications:
-            return display_apps
-
-        for display_app in hda.datatype.get_display_types():
-            target_frame, display_links = hda.datatype.get_display_links( hda,
-                                                                          display_app,
-                                                                          self.app,
-                                                                          trans.request.base )
-
-            if len( display_links ) > 0:
-                display_label = hda.datatype.get_display_label( display_app )
-
-                app_links = []
-                for display_name, display_link in display_links:
-                    app_links.append({
-                        'target': target_frame,
-                        'href': display_link,
-                        'text': gettext.gettext( display_name )
-                    })
-                if app_links:
-                    display_apps.append( dict( label=display_label, links=app_links ) )
-
-        return display_apps
-
-    def get_visualizations( self, trans, hda ):
-        """
-        Return a list of dictionaries with links to visualization pages
-        for those visualizations that apply to this hda.
-        """
-        # use older system if registry is off in the config
-        if not self.app.visualizations_registry:
-            return hda.get_visualizations()
-        return self.app.visualizations_registry.get_visualizations( trans, hda )
-
+    # .... data
     # TODO: to data provider or Text datatype directly
     def text_data( self, dataset, preview=True ):
         """
@@ -283,41 +199,9 @@ class HDAManager( datasets.DatasetAssociationManager,
                 dataset_data = None
         return truncated, dataset_data
 
-    # this is a weird syntax and return val
-    def data_conversion_status( self, trans, hda ):
-        """
-        Returns a message if dataset is not ready to be used in visualization.
-        """
-        if not hda:
-            return hda.conversion_messages.NO_DATA
-        if hda.state == model.Job.states.ERROR:
-            return hda.conversion_messages.ERROR
-        if hda.state != model.Job.states.OK:
-            return hda.conversion_messages.PENDING
-        return None
 
-    def stop_creating_job( self, hda ):
-        """
-        Stops an HDA's creating job if all the job's other outputs are deleted.
-        """
-        RUNNING_STATES = (
-            self.app.model.Job.states.QUEUED,
-            self.app.model.Job.states.RUNNING,
-            self.app.model.Job.states.NEW
-        )
-        if hda.parent_id is None and len( hda.creating_job_associations ) > 0:
-            # Mark associated job for deletion
-            job = hda.creating_job_associations[0].job
-            if job.state in RUNNING_STATES:
-                # Are *all* of the job's other output datasets deleted?
-                if job.check_if_output_datasets_deleted():
-                    job.mark_deleted( self.app.config.track_jobs_in_database )
-                    self.app.job_manager.job_stop_queue.put( job.id )
-                    return True
-        return False
-
-
-class HDASerializer( datasets.DatasetAssociationSerializer,
+class HDASerializer( # datasets._UnflattenedMetadataDatasetAssociationSerializer,
+                     datasets.DatasetAssociationSerializer,
                      taggable.TaggableSerializerMixin,
                      annotatable.AnnotatableSerializerMixin ):
     # TODO: inherit from datasets.DatasetAssociationSerializer
@@ -330,6 +214,7 @@ class HDASerializer( datasets.DatasetAssociationSerializer,
         self.default_view = 'summary'
         self.add_view( 'summary', [
             'id', 'name',
+            'type_id',
             'history_id', 'hid',
             # why include if model_class is there?
             'history_content_type',
@@ -349,17 +234,15 @@ class HDASerializer( datasets.DatasetAssociationSerializer,
             # remapped
             'genome_build', 'misc_info', 'misc_blurb',
             'file_ext', 'file_size',
+            'file_path',
 
             'create_time', 'update_time',
             'metadata', 'meta_files', 'data_type',
             'peek',
 
-            #TODO: why is this named uuid!? The hda doesn't have a uuid - it's the underlying dataset's uuid!
             'uuid',
-            # should be:
-            #'dataset_uuid',
+            'permissions',
 
-            'file_path',
             'display_apps',
             'display_types',
             'visualizations',
@@ -389,53 +272,23 @@ class HDASerializer( datasets.DatasetAssociationSerializer,
 
         self.serializers.update({
             'model_class'   : lambda *a: 'HistoryDatasetAssociation',
-            # TODO: accessible needs to go away
-            'accessible'    : lambda *a: True,
-
-            'id'            : self.serialize_id,
-            'history_id'    : self.serialize_id,
             'history_content_type': lambda *a: 'dataset',
-            'dataset_id'    : self.serialize_id,
             'hda_ldda'      : lambda *a: 'hda',
+            'type_id'       : self.serialize_type_id,
+
+            'history_id'    : self.serialize_id,
 
             # remapped
-            'info'          : lambda t, i, k: i.info.strip() if isinstance( i.info, basestring ) else i.info,
-            'misc_info'     : lambda t, i, k: self.serializers[ 'info' ]( t, i, k ),
-            'misc_blurb'    : lambda t, i, k: i.blurb,
-            'genome_build'  : lambda t, i, k: i.dbkey,
-            'file_ext'      : lambda t, i, k: i.extension,
-            'file_size'     : lambda t, i, k: self.serializers[ 'size' ]( t, i, k ),
-
-            'create_time'   : self.serialize_date,
-            'update_time'   : self.serialize_date,
-            'copied_from_history_dataset_association_id'        : self.serialize_id,
-            'copied_from_library_dataset_dataset_association_id': self.serialize_id,
+            'misc_info'     : self._remap_from( 'info' ),
+            'misc_blurb'    : self._remap_from( 'blurb' ),
+            'file_ext'      : self._remap_from( 'extension' ),
+            'file_path'     : self._remap_from( 'file_name' ),
 
             'resubmitted'   : lambda t, i, k: i._state == t.app.model.Dataset.states.RESUBMITTED,
 
-            'meta_files'    : self.serialize_meta_files,
-            'file_path'     : self.serialize_file_path,
-
-            'size'          : lambda t, i, k: int( i.get_size() ),
-            'nice_size'     : lambda t, i, k: i.get_size( nice_size=True ),
-            'data_type'     : lambda t, i, k: i.datatype.__class__.__module__ + '.' + i.datatype.__class__.__name__,
-            'peek'          : lambda t, i, k: i.display_peek() if i.peek and i.peek != 'no peek' else None,
-
-            # currently we send this sub-obj flattened (see serialize and add_flattened_metadata below)
-            # 'metadata'      : self.serialize_metadata,
-            #   make it available here under a different key
-            'metadata_dict' : self.serialize_metadata,
-
-            'parent_id'     : self.serialize_id,
-            'annotation'    : self.serialize_annotation,
-            'tags'          : self.serialize_tags,
-
-            'display_apps'  : lambda t, i, k: self.hda_manager.get_display_apps( t, i ),
-            'display_types' : lambda t, i, k: self.hda_manager.get_old_display_applications( t, i ),
-            'visualizations': lambda t, i, k: self.hda_manager.get_visualizations( t, i ),
-
-            'dataset_uuid'  : lambda t, i, k: str( i.dataset.uuid ) if i.dataset.uuid else None,
-            'uuid'          : lambda t, i, k: self.serializers[ 'dataset_uuid' ]( t, i, k ),
+            'display_apps'  : self.serialize_display_apps,
+            'display_types' : self.serialize_old_display_applications,
+            'visualizations': self.serialize_visualization_links,
 
             # 'url'   : url_for( 'history_content_typed', history_id=encoded_history_id, id=encoded_id, type="dataset" ),
             # TODO: this intermittently causes a routes.GenerationException - temp use the legacy route to prevent this
@@ -443,111 +296,76 @@ class HDASerializer( datasets.DatasetAssociationSerializer,
             #   see also: https://sentry.galaxyproject.org/galaxy/galaxy-main/group/20769/events/9352883/
             'url'           : lambda t, i, k: self.url_for( 'history_content',
                 history_id=t.security.encode_id( i.history_id ), id=t.security.encode_id( i.id ) ),
-
             'urls'          : self.serialize_urls,
+
+            # TODO: backwards compat: need to go away
             'download_url'  : lambda t, i, k: self.url_for( 'history_contents_display',
                 history_id=t.security.encode_id( i.history.id ),
                 history_content_id=t.security.encode_id( i.id ) ),
-
+            'parent_id'     : self.serialize_id,
+            'accessible'    : lambda *a: True,
             'api_type'      : lambda *a: 'file',
             'type'          : lambda *a: 'file'
         })
 
-    def serialize( self, trans, hda, keys ):
-        """
-        Override to add metadata as flattened keys on the serialized HDA.
-        """
-        # if 'metadata' isn't removed from keys here serialize will retrieve the un-serializable MetadataCollection
-        # TODO: remove these when metadata is sub-object
-        KEYS_HANDLED_SEPARATELY = ( 'metadata', )
-        left_to_handle = self.pluck_from_list( keys, KEYS_HANDLED_SEPARATELY )
-        serialized = super( HDASerializer, self ).serialize( trans, hda, keys )
+    def serialize_type_id( self, trans, hda, key ):
+        return 'dataset-' + self.serializers[ 'id' ]( trans, hda, 'id' )
 
-        if 'metadata' in left_to_handle:
-            # we currently add metadata directly to the dict instead of as a sub-object
-            metadata = self.prefixed_metadata( trans, hda )
-            serialized.update( metadata )
-        return serialized
+    def serialize_display_apps( self, trans, hda, key ):
+        """
+        Return dictionary containing new-style display app urls.
+        """
+        display_apps = []
+        for display_app in hda.get_display_applications( trans ).itervalues():
 
-    # TODO: this is more util/gen. use
-    def pluck_from_list( self, l, elems ):
-        """
-        Removes found elems from list l and returns list of found elems if found.
-        """
-        found = []
-        for elem in elems:
-            try:
-                index = l.index( elem )
-                found.append( l.pop( index ) )
-            except ValueError:
-                pass
-        return found
+            app_links = []
+            for link_app in display_app.links.itervalues():
+                app_links.append({
+                    'target': link_app.url.get( 'target_frame', '_blank' ),
+                    'href': link_app.get_display_url( hda, trans ),
+                    'text': gettext.gettext( link_app.name )
+                })
+            if app_links:
+                display_apps.append( dict( label=display_app.name, links=app_links ) )
 
-    def prefixed_metadata( self, trans, hda ):
-        """
-        Adds (a prefixed version of) the hda metadata to the dict, prefixing each key
-        with 'metadata_'.
-        """
-        metadata = self.serialize_metadata( trans, hda, 'metadata' )
-        # TODO: this is factored out for removal - metadata should be a sub-object instead:
-        #   i.e.  'metadata' : self.serialize_metadata,
-        prefixed = {}
-        for key, val in metadata.items():
-            prefixed_key = 'metadata_' + key
-            prefixed[ prefixed_key ] = val
-        return prefixed
+        return display_apps
 
-    def serialize_metadata( self, trans, hda, key, excluded=None ):
+    def serialize_old_display_applications( self, trans, hda, key ):
         """
-        Cycle through metadata and return as dictionary.
+        Return dictionary containing old-style display app urls.
         """
-        # dbkey is a repeat actually (metadata_dbkey == genome_build)
-        # excluded = [ 'dbkey' ] if excluded is None else excluded
-        excluded = [] if excluded is None else excluded
+        display_apps = []
+        if not self.app.config.enable_old_display_applications:
+            return display_apps
 
-        metadata = {}
-        for name, spec in hda.metadata.spec.items():
-            if name in excluded:
-                continue
-            val = hda.metadata.get( name )
-            # NOTE: no files
-            if isinstance( val, model.MetadataFile ):
-                # only when explicitly set: fetching filepaths can be expensive
-                if not self.app.config.expose_dataset_path:
-                    continue
-                val = val.file_name
-            # TODO:? possibly split this off?
-            # If no value for metadata, look in datatype for metadata.
-            elif val is None and hasattr( hda.datatype, name ):
-                val = getattr( hda.datatype, name )
-            metadata[ name ] = val
+        display_link_fn = hda.datatype.get_display_links
+        for display_app in hda.datatype.get_display_types():
+            target_frame, display_links = display_link_fn( hda, display_app, self.app, trans.request.base )
 
-        return metadata
+            if len( display_links ) > 0:
+                display_label = hda.datatype.get_display_label( display_app )
 
-    # add to serialize_metadata above
-    def serialize_meta_files( self, trans, hda, key ):
-        """
-        Cycle through meta files and return them as a list of dictionaries.
-        """
-        meta_files = []
-        for meta_type in hda.metadata.spec.keys():
-            if isinstance( hda.metadata.spec[ meta_type ].param, galaxy.datatypes.metadata.FileParameter ):
-                meta_files.append( dict( file_type=meta_type ) )
-        return meta_files
+                app_links = []
+                for display_name, display_link in display_links:
+                    app_links.append({
+                        'target': target_frame,
+                        'href': display_link,
+                        'text': gettext.gettext( display_name )
+                    })
+                if app_links:
+                    display_apps.append( dict( label=display_label, links=app_links ) )
 
-    # def file_info #TODO
-    # TODO: and to dataset instead (passing through object store)
-    def serialize_file_path( self, trans, hda, key ):
+        return display_apps
+
+    def serialize_visualization_links( self, trans, hda, key ):
         """
-        Return the `file_name` of the HDA if the config exposes it, None otherwise.
+        Return a list of dictionaries with links to visualization pages
+        for those visualizations that apply to this hda.
         """
-        # TODO: allow admin
-        if self.app.config.expose_dataset_path:
-            try:
-                return hda.file_name
-            except objectstore.ObjectNotFound:
-                log.exception( 'objectstore.ObjectNotFound, HDA %s.', hda.id )
-        return None
+        # use older system if registry is off in the config
+        if not self.app.visualizations_registry:
+            return hda.get_visualizations()
+        return self.app.visualizations_registry.get_visualizations( trans, hda )
 
     def serialize_urls( self, trans, hda, key ):
         """
@@ -590,40 +408,20 @@ class HDADeserializer( datasets.DatasetAssociationDeserializer,
         annotatable.AnnotatableDeserializerMixin.add_deserializers( self )
 
         self.deserializers.update({
-            'name'          : self.deserialize_basestring,
             'visible'       : self.deserialize_bool,
-
             # remapped
             'genome_build'  : lambda t, i, k, v: self.deserialize_genome_build( t, i, 'dbkey', v ),
             'misc_info'     : lambda t, i, k, v: self.deserialize_basestring( t, i, 'info', v ),
-
-            # TODO: mixin: deletable
-            'deleted'       : self.deserialize_bool,
-            # sharable
-            'published'     : self.deserialize_bool,
-            'importable'    : self.deserialize_bool,
-
         })
         self.deserializable_keyset.update( self.deserializers.keys() )
 
 
-class HDAFilters( datasets.DatasetAssociationFilters ):
+class HDAFilters( datasets.DatasetAssociationFilters,
+                  taggable.TaggableFilterMixin,
+                  annotatable.AnnotatableFilterMixin ):
     model_class = model.HistoryDatasetAssociation
 
     def _add_parsers( self ):
         super( HDAFilters, self )._add_parsers()
-
-        self.fn_filter_parsers.update({
-            # TODO: filter_string_attr_contains, filter_string_attr_eq
-            # 'dbkey' : { 'op': { 'has' : self.filter_annotation_contains, } },
-
-            # TODO: add this in annotatable mixin
-            'annotation': { 'op': { 'has': self.filter_annotation_contains, } },
-            # TODO: add this in taggable mixin
-            'tag': {
-                'op': {
-                    'eq': self.filter_has_tag,
-                    'has': self.filter_has_partial_tag,
-                }
-            }
-        })
+        taggable.TaggableFilterMixin._add_parsers( self )
+        annotatable.AnnotatableFilterMixin._add_parsers( self )

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -220,7 +220,7 @@ class HDAManager( datasets.DatasetAssociationManager,
             return truncated, hda_data
 
         truncated = preview and os.stat( hda.file_name ).st_size > MAX_PEEK_SIZE
-        hda_data = open( hda.file_name ).read( max_peek_size )
+        hda_data = open( hda.file_name ).read( MAX_PEEK_SIZE )
         return truncated, hda_data
 
 

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -88,11 +88,8 @@ class HDAManager( datasets.DatasetAssociationManager,
             sa_session=self.app.model.context, **kwargs )
 
         if history:
-# TODO Probably Bug:  set_hid is never used, and should be passed
-# to history.add_dataset here.
-            set_hid = not ( 'hid' in kwargs )
-            history.add_dataset( hda )
-#TODO:?? some internal sanity check here (or maybe in add_dataset) to make sure hids are not duped?
+            history.add_dataset( hda, set_hid=( 'hid' not in kwargs ) )
+        #TODO:?? some internal sanity check here (or maybe in add_dataset) to make sure hids are not duped?
 
         self.session().add( hda )
         if flush:
@@ -178,8 +175,6 @@ class HDAManager( datasets.DatasetAssociationManager,
         if hda.state != model.Job.states.OK:
             return self.model_class.conversion_messages.PENDING
         return None
-
-    # .... associated job
 
     # .... data
     # TODO: to data provider or Text datatype directly

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -140,15 +140,16 @@ class HistoryManager( sharable.SharableModelManager, deletable.PurgableManagerMi
                 elif isinstance( content, model.HistoryDatasetCollectionAssociation ):
                     try:
                         service = self.app.dataset_collections_service
-                        dataset_collection_instance = service.get_dataset_collection_instance(
+                        collection = service.get_dataset_collection_instance(
                             trans=trans,
                             instance_type='history',
                             id=self.app.security.encode_id( content.id ),
                         )
-                        contents_dict = dictify_dataset_collection_instance( dataset_collection_instance,
-                                                                             security=self.app.security,
-                                                                             parent=dataset_collection_instance.history,
-                                                                             view="element" )
+                        serializer = collections_util.dictify_dataset_collection_instance
+                        contents_dict = serializer( collection,
+                                                    security=self.app.security,
+                                                    parent=collection.history,
+                                                    view="element" )
                     except Exception, exc:
                         log.exception( "Error in history API at listing dataset collection: %s", exc )
                         # TODO: return some dict with the error

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -342,33 +342,20 @@ class HistoryDeserializer( sharable.SharableModelDeserializer, deletable.Purgabl
         deletable.PurgableDeserializerMixin.add_deserializers( self )
 
         self.deserializers.update({
-            'name': self.deserialize_basestring,
-            'genome_build': self.deserialize_genome_build,
+            'name'          : self.deserialize_basestring,
+            'genome_build'  : self.deserialize_genome_build,
         })
 
 
-class HistoryFilters( sharable.SharableModelFilters, deletable.PurgableFiltersMixin ):
+class HistoryFilters( sharable.SharableModelFilters,
+                      deletable.PurgableFiltersMixin ):
     model_class = model.History
 
     def _add_parsers( self ):
         super( HistoryFilters, self )._add_parsers()
         deletable.PurgableFiltersMixin._add_parsers( self )
-
         self.orm_filter_parsers.update({
             # history specific
-            'name': { 'op': ( 'eq', 'contains', 'like' ) },
-            'genome_build': { 'op': ( 'eq', 'contains', 'like' ) },
-        })
-
-        # TODO: I'm not entirely convinced this (or tags) are a good idea for filters since they involve a/the user
-        self.fn_filter_parsers.update({
-            # TODO: add this in annotatable mixin
-            'annotation': { 'op': { 'has': self.filter_annotation_contains, } },
-            # TODO: add this in taggable mixin
-            'tag': {
-                'op': {
-                    'eq': self.filter_has_tag,
-                    'has': self.filter_has_partial_tag,
-                }
-            }
+            'name'          : { 'op': ( 'eq', 'contains', 'like' ) },
+            'genome_build'  : { 'op': ( 'eq', 'contains', 'like' ) },
         })

--- a/lib/galaxy/managers/ratable.py
+++ b/lib/galaxy/managers/ratable.py
@@ -26,12 +26,12 @@ class RatableSerializerMixin( object ):
         self.serializers[ 'user_rating' ] = self.serialize_user_rating
         self.serializers[ 'community_rating' ] = self.serialize_community_rating
 
-    def serialize_user_rating( self, trans, item, key ):
+    def serialize_user_rating( self, item, key, user=None, **context ):
         """
         """
         pass
 
-    def serialize_community_rating( self, trans, item, key ):
+    def serialize_community_rating( self, item, key, **context ):
         """
         """
         pass

--- a/lib/galaxy/managers/rbac_secured.py
+++ b/lib/galaxy/managers/rbac_secured.py
@@ -1,0 +1,255 @@
+from galaxy import security
+import galaxy.exceptions
+from galaxy import model
+from galaxy.managers import users
+
+import logging
+log = logging.getLogger( __name__ )
+
+class RBACPermissionFailedException( galaxy.exceptions.InsufficientPermissionsException ): pass
+
+class RBACPermission( object ):
+    """
+    Base class for wrangling/controlling the permissions ORM models (*Permissions, Roles)
+    that control which users can perform certain actions on their associated models
+    (Libraries, Datasets).
+    """
+
+    permissions_class = None
+    permission_failed_error_class = RBACPermissionFailedException
+
+    def __init__( self, app ):
+        self.app = app
+        self.user_manager = users.UserManager( app )
+
+    def session( self ):
+        return self.app.model.context
+
+    # TODO: implement group
+    # TODO: how does admin play into this?
+    def is_permitted( self, item, user ):
+        raise NotImplementedError( "abstract parent class" )
+
+    def error_unless_permitted( self, item, user ):
+        if not self.is_permitted( item, user ):
+            error_info = dict( model_class=item.__class__, id=getattr( item, 'id', None ) )
+            raise self.permission_failed_error_class( **error_info )
+
+    def grant( self, item, user, flush=True ):
+        raise NotImplementedError( "abstract parent class" )
+
+    def revoke( self, item, user, flush=True ):
+        raise NotImplementedError( "abstract parent class" )
+
+    def _role_is_permitted( self, item, role ):
+        raise NotImplementedError( "abstract parent class" )
+
+    def _error_unless_role_permitted( self, item, role ):
+        if not self._role_is_permitted( item, role ):
+            error_info = dict( model_class=item.__class__, id=getattr( item, 'id', None ) )
+            raise self.permission_failed_error_class( **error_info )
+
+    def _grant_role( self, item, role, flush=True ):
+        raise NotImplementedError( "abstract parent class" )
+
+    def _revoke_role( self, item, role, flush=True ):
+        raise NotImplementedError( "abstract parent class" )
+
+class DatasetRBACPermission( RBACPermission ):
+    """
+    Base class for the manage and access RBAC permissions used by dataset security.
+
+    The DatasetPermissions used by the RBAC agent are associations between a Dataset
+    and a single Role.
+
+    DatasetPermissions are typed (but not polymorphic themselves) by a string 'action'.
+    There are two types:
+        - manage permissions : can a role manage the permissions on a dataset
+        - access : can a role read/look at/copy a dataset
+    """
+    permissions_class = model.DatasetPermissions
+    action_name = None
+
+    # ---- double secrect probation
+    def __assert_action( self ):
+        if not self.action_name:
+            raise NotImplementedError( "abstract parent class" + " needs action_name" )
+
+    # ---- interface
+    def by_dataset( self, dataset ):
+        self.__assert_action()
+        all_permissions = self._all_types_by_dataset( dataset )
+        return filter( lambda p: p.action == self.action_name, all_permissions )
+
+#TODO: list?
+    def by_roles( self, dataset, roles ):
+        permissions = self.by_dataset( dataset )
+        return filter( lambda p: p.role in roles, permissions )
+
+    def by_role( self, dataset, role ):
+        permissions = self.by_dataset( dataset )
+        found = filter( lambda p: p.role == role, permissions )
+        if not found:
+            return None
+        if len( found ) > 1:
+            raise galaxy.exceptions.InconsistentDatabase( dataset=dataset.id, role=role.id )
+        return found[0]
+
+    def set( self, dataset, roles, flush=True ):
+        # NOTE: this removes all previous permissions of this type
+        self.clear( dataset, flush=False )
+        permissions = []
+        for role in roles:
+            permissions.append( self._create( dataset, role, flush=False ) )
+        if flush:
+            self.session().flush()
+        return permissions
+
+    def clear( self, dataset, flush=True ):
+        permissions = self.by_dataset( dataset )
+        return self._delete( permissions, flush=flush )
+
+    # ---- private
+    def _create( self, dataset, role, flush=True ):
+        permission = self.permissions_class( self.action_name, dataset, role )
+        self.session().add( permission )
+        if flush:
+            self.session().flush()
+        return permission
+
+    def _roles( self, dataset ):
+        return [ permission.role for permission in self.by_dataset( dataset ) ]
+
+    def _all_types_by_dataset( self, dataset ):
+        return dataset.actions
+
+    # as a general rule, DatasetPermissions are considered disposable
+    #   and there is no reason to update the models
+
+#TODO: list?
+    def _delete( self, permissions, flush=True ):
+        for permission in permissions:
+            self.session().delete( permission )
+            if flush:
+                self.session().flush()
+
+    def _revoke_role( self, dataset, role, flush=True ):
+        role_permissions = self.by_roles( dataset, [ role ] )
+        return self._delete( role_permissions, flush=flush )
+
+
+def iterable_has_all( iterable, has_these ):
+    for item in has_these:
+        if item not in iterable:
+            return False
+    return True
+
+
+class DatasetManagePermissionFailedException( RBACPermissionFailedException ): pass
+
+
+class ManageDatasetRBACPermission( DatasetRBACPermission ):
+    """
+    A class that controls the dataset permissions that control
+    who can manage that dataset's permissions.
+
+    When checking permissions for a user, if any of the user's roles
+    have permission on the dataset
+    """
+    # TODO: We may also be able to infer/record the dataset 'owner' as well.
+    action_name = security.RBACAgent.permitted_actions.DATASET_MANAGE_PERMISSIONS.action
+    permission_failed_error_class = DatasetManagePermissionFailedException
+
+    # ---- interface
+    def is_permitted( self, dataset, user ):
+        # anonymous users cannot manage permissions on datasets
+        if self.user_manager.is_anonymous( user ):
+            return False
+        for role in user.all_roles():
+            if self._role_is_permitted( dataset, role ):
+                return True
+        return False
+
+    def grant( self, dataset, user, flush=True ):
+        private_role = self._user_private_role( user )
+        return self._grant_role( dataset, private_role, flush=flush )
+
+    def revoke( self, dataset, user, flush=True ):
+        private_role = self._user_private_role( user )
+        return self._revoke_role( dataset, private_role, flush=flush )
+
+    # ---- private
+    def _role_is_permitted( self, dataset, role ):
+        return role in self._roles( dataset )
+
+    def _user_private_role( self, user ):
+        # error with 401 if no user
+        self.user_manager.error_if_anonymous( user )
+        return self.user_manager.private_role( user )
+
+    def _grant_role( self, dataset, role, flush=True ):
+        existing = self.by_role( dataset, role )
+        if existing:
+            return existing
+        return self._create( dataset, role, flush=flush )
+
+    def _revoke_role( self, dataset, role, flush=True ):
+        permission = self.by_roles( dataset, [ role ] )
+        return self._delete( [ permission ], flush=flush )
+
+
+class DatasetAccessPermissionFailedException( RBACPermissionFailedException ): pass
+
+
+class AccessDatasetRBACPermission( DatasetRBACPermission ):
+    """
+    A class to manage access permissions on a dataset.
+
+    An user must have all the Roles of all the access permissions associated
+    with a dataset in order to access it.
+    """
+    action_name = security.RBACAgent.permitted_actions.DATASET_ACCESS.action
+    permission_failed_error_class = DatasetAccessPermissionFailedException
+
+    # ---- interface
+    def is_permitted( self, dataset, user ):
+        current_roles = self._roles( dataset )
+        # NOTE: that because of short circuiting this allows
+        #   anonymous access to public datasets
+        return ( self._is_public_from_roles( current_roles )
+              or self._user_has_all_roles( user, current_roles ) )
+
+    def grant( self, item, user ):
+        pass
+        # not so easy
+        # need to check for a sharing role
+        # then add the new user to it
+
+    def revoke( self, item, user ):
+        pass
+        # not so easy
+
+    # TODO: these are a lil off message
+    def is_public( self, dataset ):
+        current_roles = self._roles( dataset )
+        return self._is_public_from_roles( current_roles )
+
+    def set_private( self, dataset, user, flush=True ):
+        private_role = self.user_manager.private_role( user )
+        return self.set( dataset, [ private_role ], flush=flush )
+
+    # ---- private
+    def _is_public_from_roles( self, roles ):
+        return len( roles ) == 0
+
+    def _user_has_all_roles( self, user, roles ):
+        user_roles = []
+        if not self.user_manager.is_anonymous( user ):
+            user_roles = user.all_roles()
+        return iterable_has_all( user_roles, roles )
+
+    def _role_is_permitted( self, dataset, role ):
+        current_roles = self._roles( dataset )
+        return ( self._is_public_from_roles( current_roles )
+            # if there's only one role and this is it, let em in
+            or ( ( len( current_roles ) == 1 ) and ( role == current_roles[0] ) ) )

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -2,40 +2,49 @@
 Manager and Serializer for Roles.
 """
 
-import galaxy.web
-from galaxy import exceptions
-from galaxy.model import orm
-from sqlalchemy.orm.exc import MultipleResultsFound
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.orm import exc as sqlalchemy_exceptions
+
+import galaxy.exceptions
+from galaxy import model
+from galaxy.managers import base
 
 import logging
 log = logging.getLogger( __name__ )
 
 
 # =============================================================================
-class RoleManager( object ):
+class RoleManager( base.ModelManager ):
     """
-    Interface/service object for interacting with folders.
+    Business logic for roles.
     """
+    model_class = model.Role
+    foreign_key_name = 'role'
 
-    def get( self, trans, decoded_role_id):
-      """
-      Method loads the role from the DB based on the given role id.
+    user_assoc = model.UserRoleAssociation
+    group_assoc = model.GroupRoleAssociation
 
-      :param  decoded_role_id:      id of the role to load from the DB
-      :type   decoded_role_id:      int
+    def __init__( self, app ):
+        super( RoleManager, self ).__init__( app )
 
-      :returns:   the loaded Role object
-      :rtype:     Role
+    def get( self, trans, decoded_role_id ):
+        """
+        Method loads the role from the DB based on the given role id.
 
-      :raises: InconsistentDatabase, RequestParameterInvalidException, InternalServerError
-      """
-      try:
-          role = trans.sa_session.query( trans.app.model.Role ).filter( trans.model.Role.table.c.id == decoded_role_id ).one()
-      except MultipleResultsFound:
-          raise exceptions.InconsistentDatabase( 'Multiple roles found with the same id.' )
-      except NoResultFound:
-          raise exceptions.RequestParameterInvalidException( 'No role found with the id provided.' )
-      except Exception, e:
-          raise exceptions.InternalServerError( 'Error loading from the database.' + str(e) )
-      return role
+        :param  decoded_role_id:      id of the role to load from the DB
+        :type   decoded_role_id:      int
+
+        :returns:   the loaded Role object
+        :rtype:     Role
+
+        :raises: InconsistentDatabase, RequestParameterInvalidException, InternalServerError
+        """
+        try:
+            role = ( self.session().query( self.model_class )
+                        .filter( self.model_class.id == decoded_role_id ).one() )
+        except sqlalchemy_exceptions.MultipleResultsFound:
+            raise galaxy.exceptions.InconsistentDatabase( 'Multiple roles found with the same id.' )
+        except sqlalchemy_exceptions.NoResultFound:
+            raise galaxy.exceptions.RequestParameterInvalidException( 'No role found with the id provided.' )
+        except Exception, e:
+            raise galaxy.exceptions.InternalServerError( 'Error loading from the database.' + str(e) )
+        return role

--- a/lib/galaxy/managers/secured.py
+++ b/lib/galaxy/managers/secured.py
@@ -16,35 +16,35 @@ class AccessibleManagerMixin( object ):
     """
 
     # don't want to override by_id since consumers will also want to fetch w/o any security checks
-    def is_accessible( self, trans, item, user ):
+    def is_accessible( self, item, user, **kwargs ):
         """
         Return True if the item accessible to user.
         """
         # override in subclasses
         raise exceptions.NotImplemented( "Abstract interface Method" )
 
-    def get_accessible( self, trans, id, user, **kwargs ):
+    def get_accessible( self, id, user, **kwargs ):
         """
         Return the item with the given id if it's accessible to user,
         otherwise raise an error.
 
         :raises exceptions.ItemAccessibilityException:
         """
-        item = self.by_id( trans, id )
-        return self.error_unless_accessible( trans, item, user )
+        item = self.by_id( id )
+        return self.error_unless_accessible( item, user, **kwargs )
 
-    def error_unless_accessible( self, trans, item, user ):
+    def error_unless_accessible( self, item, user, **kwargs ):
         """
         Raise an error if the item is NOT accessible to user, otherwise return the item.
 
         :raises exceptions.ItemAccessibilityException:
         """
-        if self.is_accessible( trans, item, user ):
+        if self.is_accessible( item, user, **kwargs ):
             return item
         raise exceptions.ItemAccessibilityException( "%s is not accessible by user" % ( self.model_class.__name__ ) )
 
     # TODO:?? are these even useful?
-    def list_accessible( self, trans, user, **kwargs ):
+    def list_accessible( self, user, **kwargs ):
         """
         Return a list of items accessible to the user, raising an error if ANY
         are inaccessible.
@@ -56,7 +56,7 @@ class AccessibleManagerMixin( object ):
         # items = ModelManager.list( self, trans, **kwargs )
         # return [ self.error_unless_accessible( trans, item, user ) for item in items ]
 
-    def filter_accessible( self, trans, user, **kwargs ):
+    def filter_accessible( self, user, **kwargs ):
         """
         Return a list of items accessible to the user.
         """
@@ -76,34 +76,34 @@ class OwnableManagerMixin( object ):
     This can also be thought of as write/edit privileges.
     """
 
-    def is_owner( self, trans, item, user ):
+    def is_owner( self, item, user, **kwargs ):
         """
         Return True if user owns the item.
         """
         # override in subclasses
         raise exceptions.NotImplemented( "Abstract interface Method" )
 
-    def get_owned( self, trans, id, user, **kwargs ):
+    def get_owned( self, id, user, **kwargs ):
         """
         Return the item with the given id if owned by the user,
         otherwise raise an error.
 
         :raises exceptions.ItemOwnershipException:
         """
-        item = self.by_id( trans, id )
-        return self.error_unless_owner( trans, item, user )
+        item = self.by_id( id )
+        return self.error_unless_owner( item, user, **kwargs )
 
-    def error_unless_owner( self, trans, item, user ):
+    def error_unless_owner( self, item, user, **kwargs ):
         """
         Raise an error if the item is NOT owned by user, otherwise return the item.
 
         :raises exceptions.ItemAccessibilityException:
         """
-        if self.is_owner( trans, item, user ):
+        if self.is_owner( item, user, **kwargs ):
             return item
         raise exceptions.ItemOwnershipException( "%s is not owned by user" % ( self.model_class.__name__ ) )
 
-    def list_owned( self, trans, user, **kwargs ):
+    def list_owned( self, user, **kwargs ):
         """
         Return a list of items owned by the user, raising an error if ANY
         are not.
@@ -114,9 +114,9 @@ class OwnableManagerMixin( object ):
         # just alias to by_user (easier/same thing)
         #return self.by_user( trans, user, **kwargs )
 
-    def filter_owned( self, trans, user, **kwargs ):
+    def filter_owned( self, user, **kwargs ):
         """
         Return a list of items owned by the user.
         """
         # just alias to list_owned
-        return self.list_owned( trans, user, **kwargs )
+        return self.list_owned( user, **kwargs )

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -321,13 +321,13 @@ class SharableModelSerializer( base.ModelSerializer,
             'importable', 'published', 'slug'
         ])
 
-    def serialize_username_and_slug( self, trans, item, key ):
+    def serialize_username_and_slug( self, item, key, **context ):
         if not ( item.user and item.slug and self.SINGLE_CHAR_ABBR ):
             return None
 #TODO: self.url_for
         return ( '/' ).join(( 'u', item.user.username, self.SINGLE_CHAR_ABBR, item.slug ) )
 
-    #def published_url( self, trans, item, key ):
+    #def published_url( self, item, key, **context ):
     #    """
     #    """
     #    url = url_for(controller='history', action="display_by_username_and_slug",
@@ -354,7 +354,7 @@ class SharableModelDeserializer( base.ModelDeserializer,
             'importable'    : self.deserialize_importable,
         })
 
-    def deserialize_published( self, trans, item, key, val ):
+    def deserialize_published( self, item, key, val, **context ):
         """
         """
         val = self.validate.bool( key, val )
@@ -367,7 +367,7 @@ class SharableModelDeserializer( base.ModelDeserializer,
             self.manager.unpublish( item, flush=False )
         return item.published
 
-    def deserialize_importable( self, trans, item, key, val ):
+    def deserialize_importable( self, item, key, val, **context ):
         """
         """
         val = self.validate.bool( key, val )
@@ -380,7 +380,7 @@ class SharableModelDeserializer( base.ModelDeserializer,
             self.manager.make_non_importable( item, flush=False )
         return item.published
 
-    #def deserialize_slug( self, trans, item, val ):
+    #def deserialize_slug( self, item, val, **context ):
     #    """
     #    """
     #    #TODO: call manager.set_slug

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -42,30 +42,26 @@ class SharableModelManager( base.ModelManager, secured.OwnableManagerMixin, secu
         self.user_manager = users.UserManager( app )
 
     # .... has a user
-    def by_user( self, trans, user, filters=None, **kwargs ):
+    def by_user( self, user, filters=None, **kwargs ):
         """
         Return list for all items (of model_class type) associated with the given
         `user`.
         """
         user_filter = self.model_class.user_id == user.id
         filters=self._munge_filters( user_filter, filters )
-        return self.list( trans, filters=filters, **kwargs )
+        return self.list( filters=filters, **kwargs )
 
-    # .... owned model interface
-    def is_owner( self, trans, item, user ):
+    # .... owned/accessible interfaces
+    def is_owner( self, item, user, **kwargs ):
         """
         Return true if this sharable belongs to `user` (or `user` is an admin).
         """
-        if self.user_manager.is_anonymous( user ):
-            # note: this needs to be overridden in the case of anon users and session.current_history
-            return False
         # ... effectively a good fit to have this here, but not semantically
-        if self.user_manager.is_admin( trans, user ):
+        if self.user_manager.is_admin( user ):
             return True
         return item.user == user
 
-    # .... accessible interface
-    def is_accessible( self, trans, item, user ):
+    def is_accessible( self, item, user, **kwargs ):
         """
         If the item is importable, is owned by `user`, or (the valid) `user`
         is in 'users shared with' list for the item: return True.
@@ -73,7 +69,7 @@ class SharableModelManager( base.ModelManager, secured.OwnableManagerMixin, secu
         if item.importable:
             return True
         # note: owners always have access - checking for accessible implicitly checks for ownership
-        if self.is_owner( trans, item, user ):
+        if self.is_owner( item, user, **kwargs ):
             return True
         if self.user_manager.is_anonymous( user ):
             return False
@@ -82,16 +78,16 @@ class SharableModelManager( base.ModelManager, secured.OwnableManagerMixin, secu
         return False
 
     # .... importable
-    def make_importable( self, trans, item, flush=True ):
+    def make_importable( self, item, flush=True ):
         """
         Makes item accessible--viewable and importable--and sets item's slug.
         Does not flush/commit changes, however. Item must have name, user,
         importable, and slug attributes.
         """
-        self.create_unique_slug( trans, item, flush=False )
+        self.create_unique_slug( item, flush=False )
         return self._session_setattr( item, 'importable', True, flush=flush )
 
-    def make_non_importable( self, trans, item, flush=True ):
+    def make_non_importable( self, item, flush=True ):
         """
         Makes item accessible--viewable and importable--and sets item's slug.
         Does not flush/commit changes, however. Item must have name, user,
@@ -99,110 +95,112 @@ class SharableModelManager( base.ModelManager, secured.OwnableManagerMixin, secu
         """
         # item must be unpublished if non-importable
         if item.published:
-            self.unpublish( trans, item, flush=False )
+            self.unpublish( item, flush=False )
         return self._session_setattr( item, 'importable', False, flush=flush )
 
     # .... published
-    def publish( self, trans, item, flush=True ):
+    def publish( self, item, flush=True ):
         """
         Set both the importable and published flags on `item` to True.
         """
         # item must be importable to be published
         if not item.importable:
-            self.make_importable( trans, item, flush=False )
+            self.make_importable( item, flush=False )
         return self._session_setattr( item, 'published', True, flush=flush )
 
-    def unpublish( self, trans, item, flush=True ):
+    def unpublish( self, item, flush=True ):
         """
         Set the published flag on `item` to False.
         """
         return self._session_setattr( item, 'published', False, flush=flush )
 
-    #def _query_published( self, trans, filters=None, **kwargs ):
-    #    """
-    #    """
-    #    published_filter = self.model_class.published == True
-    #    filters = self._munge_filters( published_filter, filters )
-    #    return self.list( trans, filters=filters, **kwargs )
-    #
-    #def list_published( self, trans, **kwargs ):
-    #    """
-    #    """
-    #    query = self._query_published( trans, user, **kwargs )
-    #    return self.list( trans, query=query, **kwargs )
+    def _query_published( self, filters=None, **kwargs ):
+       """
+       Query all published items.
+       """
+       published_filter = self.model_class.published == True
+       filters = self._munge_filters( published_filter, filters )
+       return self.list( filters=filters, **kwargs )
+
+    def list_published( self, **kwargs ):
+       """
+       Return a list of all published items.
+       """
+       query = self._query_published( user, **kwargs )
+       return self.list( query=query, **kwargs )
 
     # .... user sharing
     # sharing is often done via a 3rd table btwn a User and an item -> a <Item>UserShareAssociation
-    def get_share_assocs( self, trans, item, user=None ):
+    def get_share_assocs( self, item, user=None ):
         """
         Get the UserShareAssociations for the `item`.
 
         Optionally send in `user` to test for a single match.
         """
-        query = self.query_associated( trans, self.user_share_model, item )
+        query = self.query_associated( self.user_share_model, item )
         if user is not None:
             query = query.filter_by( user=user )
         return query.all()
 
-    def share_with( self, trans, item, user, flush=True ):
+    def share_with( self, item, user, flush=True ):
         """
         Get or create a share for the given user (or users if `user` is a list).
         """
         # allow user to be a list and call recursivly
         if isinstance( user, list ):
-            return map( lambda user: self.share_with( trans, item, user, flush=False ), user )
+            return map( lambda user: self.share_with( item, user, flush=False ), user )
         # get or create
-        existing = self.get_share_assocs( trans, item, user=user )
+        existing = self.get_share_assocs( item, user=user )
         if existing:
             return existing.pop( 0 )
-        return self._create_user_share_assoc( trans, item, user, flush=flush )
+        return self._create_user_share_assoc( item, user, flush=flush )
 
-    def _create_user_share_assoc( self, trans, item, user, flush=True ):
+    def _create_user_share_assoc( self, item, user, flush=True ):
         """
         Create a share for the given user.
         """
         user_share_assoc = self.user_share_model()
         self.session().add( user_share_assoc )
-        self.associate( trans, user_share_assoc, item )
+        self.associate( user_share_assoc, item )
         user_share_assoc.user = user
 
         # ensure an item slug so shared users can access
         if not item.slug:
-            self.create_unique_slug( trans, item )
+            self.create_unique_slug( item )
 
         if flush:
             self.session().flush()
         return user_share_assoc
 
-    def unshare_with( self, trans, item, user, flush=True ):
+    def unshare_with( self, item, user, flush=True ):
         """
         Delete a user share (or list of shares) from the database.
         """
         if isinstance( user, list ):
-            return map( lambda user: self.unshare_with( trans, item, user, flush=False ), user )
+            return map( lambda user: self.unshare_with( item, user, flush=False ), user )
         # Look for and delete sharing relation for user.
-        user_share_assoc = self.get_share_assocs( trans, item, user=user )[0]
+        user_share_assoc = self.get_share_assocs( item, user=user )[0]
         self.session().delete( user_share_assoc )
         if flush:
             self.session().flush()
         return user_share_assoc
 
-    #def _query_shared_with( self, trans, user, filters=None, **kwargs ):
+    #def _query_shared_with( self, user, filters=None, **kwargs ):
     ##TODO:
     #    """
     #    """
     #    pass
 
-    #def list_shared_with( self, trans, user, **kwargs ):
+    #def list_shared_with( self, user, **kwargs ):
     #    """
     #    """
-    #    query = self._query_shared_with( trans, user, **kwargs )
-    #    return self.list( trans, query=query, **kwargs )
+    #    query = self._query_shared_with( user, **kwargs )
+    #    return self.list( query=query, **kwargs )
 
     # .... slugs
     # slugs are human readable strings often used to link to sharable resources (replacing ids)
     #TODO: as validator, deserializer, etc. (maybe another object entirely?)
-    def set_slug( self, trans, item, new_slug, flush=True ):
+    def set_slug( self, item, new_slug, user, flush=True ):
         """
         Validate and set the new slug for `item`.
         """
@@ -211,7 +209,7 @@ class SharableModelManager( base.ModelManager, secured.OwnableManagerMixin, secu
             raise exceptions.RequestParameterInvalidException( "Invalid slug", slug=new_slug )
 
         # error if slug is already in use
-        if self._slug_exists( trans, trans.user, new_slug ):
+        if self._slug_exists( user, new_slug ):
             raise exceptions.Conflict( "Slug already exists", slug=new_slug )
 
         item.slug = new_slug
@@ -226,12 +224,12 @@ class SharableModelManager( base.ModelManager, secured.OwnableManagerMixin, secu
         VALID_SLUG_RE = re.compile( "^[a-z0-9\-]+$" )
         return VALID_SLUG_RE.match( slug )
 
-    def _existing_set_of_slugs( self, trans, user ):
+    def _existing_set_of_slugs( self, user ):
         query = ( self.session().query( self.model_class.slug )
                     .filter_by( user=user ) )
-        return set( query.all() )
+        return list( set( query.all() ) )
 
-    def _slug_exists( self, trans, user, slug ):
+    def _slug_exists( self, user, slug ):
         query = ( self.session().query( self.model_class.slug )
                     .filter_by( user=user, slug=slug ) )
         return query.count() != 0
@@ -246,13 +244,13 @@ class SharableModelManager( base.ModelManager, secured.OwnableManagerMixin, secu
             slug_base = slug_base[:-1]
         return slug_base
 
-    def _default_slug_base( self, trans, item ):
+    def _default_slug_base( self, item ):
         # override in subclasses
         if hasattr( item, 'title' ):
             return item.title.lower()
         return item.name.lower()
 
-    def get_unique_slug( self, trans, item ):
+    def get_unique_slug( self, item ):
         """
         Returns a slug that is unique among user's importable items
         for item's class.
@@ -261,7 +259,7 @@ class SharableModelManager( base.ModelManager, secured.OwnableManagerMixin, secu
 
         # Setup slug base.
         if cur_slug is None or cur_slug == "":
-            slug_base = self._slugify( self._default_slug_base( trans, item ) )
+            slug_base = self._slugify( self._default_slug_base( item ) )
         else:
             slug_base = cur_slug
 
@@ -279,28 +277,28 @@ class SharableModelManager( base.ModelManager, secured.OwnableManagerMixin, secu
 
         return new_slug
 
-    def create_unique_slug( self, trans, item, flush=True ):
+    def create_unique_slug( self, item, flush=True ):
         """
         Set a new, unique slug on the item.
         """
-        item.slug = self.get_unique_slug( trans, item )
+        item.slug = self.get_unique_slug( item )
         self.session().add( item )
         if flush:
             self.session().flush()
         return item
 
-    #def by_slug( self, trans, user, **kwargs ):
+    #def by_slug( self, user, **kwargs ):
     #    """
     #    """
     #    pass
 
     # .... display
-    #def display_by_username_and_slug( self, trans, username, slug ):
+    #def display_by_username_and_slug( self, username, slug ):
     #    """ Display item by username and slug. """
 
-    #def set_public_username( self, trans, id, username, **kwargs ):
+    #def set_public_username( self, id, username, **kwargs ):
     #    """ Set user's public username and delegate to sharing() """
-    #def sharing( self, trans, id, **kwargs ):
+    #def sharing( self, id, **kwargs ):
     #    """ Handle item sharing. """
 
 
@@ -364,9 +362,9 @@ class SharableModelDeserializer( base.ModelDeserializer,
             return val
 
         if val:
-            self.manager.publish( trans, item, flush=False )
+            self.manager.publish( item, flush=False )
         else:
-            self.manager.unpublish( trans, item, flush=False )
+            self.manager.unpublish( item, flush=False )
         return item.published
 
     def deserialize_importable( self, trans, item, key, val ):
@@ -377,9 +375,9 @@ class SharableModelDeserializer( base.ModelDeserializer,
             return val
 
         if val:
-            self.manager.make_importable( trans, item, flush=False )
+            self.manager.make_importable( item, flush=False )
         else:
-            self.manager.make_non_importable( trans, item, flush=False )
+            self.manager.make_non_importable( item, flush=False )
         return item.published
 
     #def deserialize_slug( self, trans, item, val ):

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -317,6 +317,7 @@ class SharableModelSerializer( base.ModelSerializer,
             'user_id'           : self.serialize_id,
             'username_and_slug' : self.serialize_username_and_slug
         })
+        # these use the default serializer but must still be white-listed
         self.serializable_keyset.update([
             'importable', 'published', 'slug'
         ])
@@ -324,13 +325,13 @@ class SharableModelSerializer( base.ModelSerializer,
     def serialize_username_and_slug( self, item, key, **context ):
         if not ( item.user and item.slug and self.SINGLE_CHAR_ABBR ):
             return None
-#TODO: self.url_for
         return ( '/' ).join(( 'u', item.user.username, self.SINGLE_CHAR_ABBR, item.slug ) )
 
-    #def published_url( self, item, key, **context ):
+    # def serialize_username_and_slug( self, item, key, **context ):
     #    """
     #    """
-    #    url = url_for(controller='history', action="display_by_username_and_slug",
+    #     #TODO: replace the above with this
+    #    url = self.url_for(controller='history', action="display_by_username_and_slug",
     #        username=item.user.username, slug=item.slug )
     #    return url
 

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -126,7 +126,7 @@ class SharableModelManager( base.ModelManager, secured.OwnableManagerMixin, secu
        """
        Return a list of all published items.
        """
-       query = self._query_published( user, **kwargs )
+       query = self._query_published( **kwargs )
        return self.list( query=query, **kwargs )
 
     # .... user sharing

--- a/lib/galaxy/managers/taggable.py
+++ b/lib/galaxy/managers/taggable.py
@@ -15,7 +15,7 @@ class TaggableManagerMixin( object ):
 
     #TODO: most of this can be done by delegating to the TagManager?
 
-    #def by_user( self, trans, user, **kwargs ):
+    #def by_user( self, user, **kwargs ):
     #    pass
 
 
@@ -24,7 +24,7 @@ class TaggableSerializerMixin( object ):
     def add_serializers( self ):
         self.serializers[ 'tags' ] = self.serialize_tags
 
-    def serialize_tags( self, trans, item, key ):
+    def serialize_tags( self, item, key, **context ):
         """
         Return tags as a list of strings.
         """
@@ -45,7 +45,7 @@ class TaggableDeserializerMixin( object ):
     def add_deserializers( self ):
         self.deserializers[ 'tags' ] = self.deserialize_tags
 
-    def deserialize_tags( self, trans, item, key, val ):
+    def deserialize_tags( self, item, key, val, user=None, **context ):
         """
         Make sure `val` is a valid list of tag strings and assign them.
 
@@ -53,8 +53,6 @@ class TaggableDeserializerMixin( object ):
         """
         new_tags_list = self.validate.basestring_list( key, val )
         #TODO: have to assume trans.user here...
-        #TODO: trans
-        user = trans.user
         #TODO: duped from tags manager - de-dupe when moved to taggable mixin
         tag_handler = self.app.tag_handler
         tag_handler.delete_item_tags( user, item )

--- a/lib/galaxy/managers/taggable.py
+++ b/lib/galaxy/managers/taggable.py
@@ -64,3 +64,43 @@ class TaggableDeserializerMixin( object ):
         #TODO:!! does the creation of new_tags_list mean there are now more and more unused tag rows in the db?
         return item.tags
 
+class TaggableFilterMixin( object ):
+
+    def _tag_str_gen( self, item ):
+        """
+        Return a list of strings built from the item's tags.
+        """
+        #TODO: which user is this? all?
+        for tag in item.tags:
+            tag_str = tag.user_tname
+            if tag.value is not None:
+                tag_str += ":" + tag.user_value
+            yield tag_str
+
+    def filter_has_partial_tag( self, item, val ):
+        """
+        Return True if any tag partially contains `val`.
+        """
+        for tag_str in self._tag_str_gen( item ):
+            if val in tag_str:
+                return True
+        return False
+
+    def filter_has_tag( self, item, val ):
+        """
+        Return True if any tag exactly equals `val`.
+        """
+        for tag_str in self._tag_str_gen( item ):
+            if val == tag_str:
+                return True
+        return False
+
+    def _add_parsers( self ):
+        self.fn_filter_parsers.update({
+            'tag': {
+                'op': {
+                    'eq'    : self.filter_has_tag,
+                    'has'   : self.filter_has_partial_tag,
+                }
+            }
+        })

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -168,9 +168,6 @@ class UserManager( base.ModelManager, deletable.PurgableManagerMixin ):
                     .filter_by( user=user )
                     .order_by( sqlalchemy.desc( model.APIKeys.create_time ) ) )
         all = query.all()
-        for a in all:
-            print a.user.username, a.key, a.create_time
-        print all
         if len( all ):
             return all[0]
         return None

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -103,7 +103,6 @@ model.HistoryDatasetAssociation.table = Table( "history_dataset_association", me
     Column( "state", TrimmedString( 64 ), index=True, key="_state" ),
     Column( "copied_from_history_dataset_association_id", Integer, ForeignKey( "history_dataset_association.id" ), nullable=True ),
     Column( "copied_from_library_dataset_dataset_association_id", Integer, ForeignKey( "library_dataset_dataset_association.id" ), nullable=True ),
-    Column( "hid", Integer ),
     Column( "name", TrimmedString( 255 ) ),
     Column( "info", TrimmedString( 255 ) ),
     Column( "blurb", TrimmedString( 255 ) ),
@@ -114,12 +113,14 @@ model.HistoryDatasetAssociation.table = Table( "history_dataset_association", me
     Column( "parent_id", Integer, ForeignKey( "history_dataset_association.id" ), nullable=True ),
     Column( "designation", TrimmedString( 255 ) ),
     Column( "deleted", Boolean, index=True, default=False ),
-    Column( "purged", Boolean, index=True, default=False ),
     Column( "visible", Boolean ),
+    Column( "extended_metadata_id", Integer, ForeignKey( "extended_metadata.id" ), index=True ),
+    # differs from ldda
+    Column( "hid", Integer ),
+    Column( "purged", Boolean, index=True, default=False ),
     Column( "hidden_beneath_collection_instance_id", ForeignKey( "history_dataset_collection_association.id" ), nullable=True ),
-    Column( "extended_metadata_id", Integer,
-        ForeignKey( "extended_metadata.id" ), index=True )
-    )
+)
+
 
 model.Dataset.table = Table( "dataset", metadata,
     Column( "id", Integer, primary_key=True ),
@@ -322,11 +323,11 @@ model.LibraryDatasetDatasetAssociation.table = Table( "library_dataset_dataset_a
     Column( "designation", TrimmedString( 255 ) ),
     Column( "deleted", Boolean, index=True, default=False ),
     Column( "visible", Boolean ),
+    Column( "extended_metadata_id", Integer, ForeignKey( "extended_metadata.id" ), index=True ),
+    # differs from hda
     Column( "user_id", Integer, ForeignKey( "galaxy_user.id" ), index=True ),
     Column( "message", TrimmedString( 255 ) ),
-    Column( "extended_metadata_id", Integer,
-        ForeignKey( "extended_metadata.id" ), index=True )
-    )
+)
 
 
 model.ExtendedMetadata.table = Table("extended_metadata", metadata,

--- a/lib/galaxy/visualization/registry.py
+++ b/lib/galaxy/visualization/registry.py
@@ -961,7 +961,7 @@ class ResourceParser( object ):
 
         elif param_type == 'dataset':
             decoded_dataset_id = trans.security.decode_id( query_param )
-            parsed_param = controller.hda_manager.get_accessible( trans, decoded_dataset_id, trans.user )
+            parsed_param = controller.hda_manager.get_accessible( decoded_dataset_id, trans.user )
 
         elif param_type == 'hda_or_ldda':
             encoded_dataset_id = query_param

--- a/lib/galaxy/webapps/galaxy/api/annotations.py
+++ b/lib/galaxy/webapps/galaxy/api/annotations.py
@@ -63,7 +63,7 @@ class HistoryAnnotationsController(BaseAnnotationsController):
 
     def _get_item_from_id(self, trans, idstr):
         decoded_idstr = self.decode_id( idstr )
-        history = self.history_manager.get_accessible( trans, decoded_idstr, trans.user )
+        history = self.history_manager.get_accessible( decoded_idstr, trans.user, current_history=trans.history )
         return history
 
 
@@ -77,8 +77,8 @@ class HistoryContentAnnotationsController( BaseAnnotationsController ):
 
     def _get_item_from_id(self, trans, idstr):
         decoded_idstr = self.decode_id( idstr )
-        hda = self.hda_manager.get_accessible( trans, decoded_idstr, trans.user )
-        hda = self.hda_manager.error_if_uploading( trans, hda )
+        hda = self.hda_manager.get_accessible( decoded_idstr, trans.user )
+        hda = self.hda_manager.error_if_uploading( hda )
         return hda
 
 

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -9,6 +9,7 @@ from galaxy.web import require_admin
 from galaxy.web.base.controller import BaseAPIController
 
 from galaxy.managers import base
+from galaxy.managers import configuration
 
 import logging
 log = logging.getLogger( __name__ )
@@ -18,8 +19,8 @@ class ConfigurationController( BaseAPIController ):
 
     def __init__( self, app ):
         super( ConfigurationController, self ).__init__( app )
-        self.config_serializer = ConfigSerializer( app )
-        self.admin_config_serializer = AdminConfigSerializer( app )
+        self.config_serializer = configuration.ConfigSerializer( app )
+        self.admin_config_serializer = configuration.AdminConfigSerializer( app )
 
     @expose_api_anonymous_and_sessionless
     def index( self, trans, **kwd ):
@@ -57,8 +58,7 @@ class ConfigurationController( BaseAPIController ):
             #TODO: this should probably just be under a different route: 'admin/configuration'
             serializer = self.admin_config_serializer
 
-        serialized = serializer.serialize_to_view( trans, self.app.config,
-                                                   view=view, keys=keys, default_view=default_view )
+        serialized = serializer.serialize_to_view( self.app.config, view=view, keys=keys, default_view=default_view )
         return serialized
 
     @expose_api
@@ -83,77 +83,6 @@ class ConfigurationController( BaseAPIController ):
             )
             rval.append(entry)
         return rval
-
-
-#TODO: for lack of a manager file for the config. May well be better in config.py? Circ imports?
-class ConfigSerializer( base.ModelSerializer ):
-
-    def __init__( self, app ):
-        super( ConfigSerializer, self ).__init__( app )
-
-        self.default_view = 'all'
-        self.add_view( 'all', self.serializers.keys() )
-
-    def default_serializer( self, trans, config, key ):
-        return getattr( config, key, None )
-
-    def add_serializers( self ):
-        def _defaults_to( default ):
-            return lambda t, i, k: getattr( i, k, default )
-
-        self.serializers = {
-            #TODO: this is available from user data, remove
-            'is_admin_user'             : lambda *a: False,
-
-            'brand'                     : _defaults_to( '' ),
-            #TODO: this doesn't seem right
-            'logo_url'                  : lambda t, i, k: self.url_for( i.get( k, '/' ) ),
-            'terms_url'                 : _defaults_to( '' ),
-
-            #TODO: don't hardcode here - hardcode defaults once in config.py
-            'wiki_url'                  : _defaults_to( "http://galaxyproject.org/" ),
-            'search_url'                : _defaults_to( "http://galaxyproject.org/search/usegalaxy/" ),
-            'mailing_lists'             : _defaults_to( "http://wiki.galaxyproject.org/MailingLists" ),
-            'screencasts_url'           : _defaults_to( "http://vimeo.com/galaxyproject" ),
-            'citation_url'              : _defaults_to( "http://wiki.galaxyproject.org/CitingGalaxy" ),
-            'support_url'               : _defaults_to( "http://wiki.galaxyproject.org/Support" ),
-            'lims_doc_url'              : _defaults_to( "http://main.g2.bx.psu.edu/u/rkchak/p/sts" ),
-            'biostar_url'               : _defaults_to( '' ),
-            'biostar_url_redirect'      : lambda *a: self.url_for( controller='biostar', action='biostar_redirect',
-                                                                   qualified=True ),
-
-            'use_remote_user'           : _defaults_to( None ),
-            'remote_user_logout_href'   : _defaults_to( '' ),
-            'enable_cloud_launch'       : _defaults_to( False ),
-            'datatypes_disable_auto'    : _defaults_to( False ),
-            'allow_user_dataset_purge'  : _defaults_to( False ),
-            'enable_unique_workflow_defaults' : _defaults_to( False ),
-
-            'nginx_upload_path'         : _defaults_to( self.url_for( controller='api', action='tools' ) ),
-            'ftp_upload_dir'            : _defaults_to( None ),
-            'ftp_upload_site'           : _defaults_to( None ),
-            'version_major'             : _defaults_to( None ),
-        }
-
-
-class AdminConfigSerializer( ConfigSerializer ):
-    # config attributes viewable by admin users
-
-    def add_serializers( self ):
-        super( AdminConfigSerializer, self ).add_serializers()
-        def _defaults_to( default ):
-            return lambda t, i, k: getattr( i, k, default )
-
-        self.serializers.update({
-            #TODO: this is available from user data, remove
-            'is_admin_user'             : lambda *a: True,
-
-            'library_import_dir'        : _defaults_to( None ),
-            'user_library_import_dir'   : _defaults_to( None ),
-            'allow_library_path_paste'  : _defaults_to( False ),
-            'allow_user_creation'       : _defaults_to( False ),
-            'allow_user_deletion'       : _defaults_to( False ),
-        })
 
 
 def _tool_conf_to_dict(conf):

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -29,7 +29,7 @@ class ConfigurationController( BaseAPIController ):
 
         Note: a more complete list is returned if the user is an admin.
         """
-        is_admin = self.user_manager.is_admin( trans, trans.user )
+        is_admin = self.user_manager.is_admin( trans.user )
         serialization_params = self._parse_serialization_params( kwd, 'all' )
         return self.get_config_dict( trans, is_admin, **serialization_params )
 

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -45,7 +45,7 @@ class DatasetCollectionsController(
         if instance_type == "history":
             history_id = payload.get( 'history_id' )
             history_id = self.decode_id( history_id )
-            history = self.history_manager.get_owned( trans, history_id, trans.user )
+            history = self.history_manager.get_owned( history_id, trans.user, current_history=trans.history )
             create_params[ "parent" ] = history
         elif instance_type == "library":
             folder_id = payload.get( 'folder_id' )

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -66,7 +66,8 @@ class DatasetsController( BaseAPIController, UsesVisualizationMixin ):
             else:
                 # Default: return dataset as dict.
                 if hda_ldda == 'hda':
-                    return self.hda_serializer.serialize_to_view( trans, dataset, view=kwd.get( 'view', 'detailed' ) )
+                    return self.hda_serializer.serialize_to_view( dataset,
+                        view=kwd.get( 'view', 'detailed' ), user=trans.user, trans=trans )
                 else:
                     rval = dataset.to_dict()
 

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -80,7 +80,7 @@ class DatasetsController( BaseAPIController, UsesVisualizationMixin ):
         """
         Returns state of dataset.
         """
-        msg = self.hda_manager.data_conversion_status( trans, dataset )
+        msg = self.hda_manager.data_conversion_status( dataset )
         if not msg:
             msg = dataset.conversion_messages.DATA
 
@@ -91,7 +91,7 @@ class DatasetsController( BaseAPIController, UsesVisualizationMixin ):
         Init-like method that returns state of dataset's converted datasets.
         Returns valid chroms for that dataset as well.
         """
-        msg = self.hda_manager.data_conversion_status( trans, dataset )
+        msg = self.hda_manager.data_conversion_status( dataset )
         if msg:
             return msg
 
@@ -140,7 +140,7 @@ class DatasetsController( BaseAPIController, UsesVisualizationMixin ):
             return dataset.conversion_messages.NO_DATA
 
         # Dataset check.
-        msg = self.hda_manager.data_conversion_status( trans, dataset )
+        msg = self.hda_manager.data_conversion_status( dataset )
         if msg:
             return msg
 
@@ -233,7 +233,7 @@ class DatasetsController( BaseAPIController, UsesVisualizationMixin ):
         be slow because indexes need to be created.
         """
         # Dataset check.
-        msg = self.hda_manager.data_conversion_status( trans, dataset )
+        msg = self.hda_manager.data_conversion_status( dataset )
         if msg:
             return msg
 
@@ -280,7 +280,7 @@ class DatasetsController( BaseAPIController, UsesVisualizationMixin ):
 
         rval = ''
         try:
-            hda = self.hda_manager.get_accessible( trans, decoded_content_id, trans.user )
+            hda = self.hda_manager.get_accessible( decoded_content_id, trans.user )
 
             if raw:
                 if filename and filename != 'index':

--- a/lib/galaxy/webapps/galaxy/api/extended_metadata.py
+++ b/lib/galaxy/webapps/galaxy/api/extended_metadata.py
@@ -71,7 +71,7 @@ class HistoryDatasetExtendMetadataController(BaseExtendedMetadataController):
     def _get_item_from_id(self, trans, idstr, check_writable=True):
         decoded_idstr = self.decode_id( idstr )
         if check_writable:
-            return self.hda_manager.get_owned( trans, decoded_idstr, trans.user )
+            return self.hda_manager.get_owned( decoded_idstr, trans.user, current_history=trans.history )
         else:
-            hda = self.hda_manager.get_accessible( trans, decoded_idstr, trans.user )
-            return self.hda_manager.error_if_uploading( trans, hda )
+            hda = self.hda_manager.get_accessible( decoded_idstr, trans.user )
+            return self.hda_manager.error_if_uploading( hda )

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -130,7 +130,7 @@ class FolderContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrary
 
         # Check whether user can modify the current folder
         can_modify_folder = is_admin or trans.app.security_agent.can_modify_library_item( current_user_roles, folder )
-        
+
         parent_library_id = None
         if folder.parent_library is not None:
             parent_library_id = trans.security.encode_id( folder.parent_library.id )
@@ -268,8 +268,8 @@ class FolderContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrary
         rval = {}
         try:
             decoded_hda_id = self.decode_id( from_hda_id )
-            hda = self.hda_manager.get_owned( trans, decoded_hda_id, trans.user )
-            hda = self.hda_manager.error_if_uploading( trans, hda )
+            hda = self.hda_manager.get_owned( decoded_hda_id, trans.user, current_history=trans.history )
+            hda = self.hda_manager.error_if_uploading( hda )
             folder = self.get_library_folder( trans, encoded_folder_id_16, check_accessible=True )
 
             library = folder.parent_library

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -102,7 +102,7 @@ class HistoryContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrar
 
             if isinstance( content, trans.app.model.HistoryDatasetAssociation ):
                 view = 'detailed' if detailed else 'summary'
-                hda_dict = self.hda_serializer.serialize_to_view( trans, content, view=view )
+                hda_dict = self.hda_serializer.serialize_to_view( content, view=view, user=trans.user, trans=trans )
                 rval.append( hda_dict )
 
             elif isinstance( content, trans.app.model.HistoryDatasetCollectionAssociation ):
@@ -144,8 +144,8 @@ class HistoryContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrar
 
     def __show_dataset( self, trans, id, **kwd ):
         hda = self.hda_manager.get_accessible( self.decode_id( id ), trans.user )
-        return self.hda_serializer.serialize_to_view( trans, hda,
-            **self._parse_serialization_params( kwd, 'detailed' ) )
+        return self.hda_serializer.serialize_to_view( hda,
+            user=trans.user, trans=trans, **self._parse_serialization_params( kwd, 'detailed' ) )
 
     def __show_dataset_collection( self, trans, id, history_id, **kwd ):
         try:
@@ -257,8 +257,8 @@ class HistoryContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrar
         trans.sa_session.flush()
         if not hda:
             return None
-        return self.hda_serializer.serialize_to_view( trans, hda,
-            **self._parse_serialization_params( kwd, 'detailed' ) )
+        return self.hda_serializer.serialize_to_view( hda,
+            user=trans.user, trans=trans, **self._parse_serialization_params( kwd, 'detailed' ) )
 
     def __create_dataset_collection( self, trans, history, payload, **kwd ):
         source = kwd.get("source", "new_collection")
@@ -344,12 +344,12 @@ class HistoryContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrar
         # make the actual changes
         #TODO: is this if still needed?
         if hda and isinstance( hda, trans.model.HistoryDatasetAssociation ):
-            self.hda_deserializer.deserialize( trans, hda, payload )
+            self.hda_deserializer.deserialize( hda, payload, user=trans.user, trans=trans )
             #TODO: this should be an effect of deleting the hda
             if payload.get( 'deleted', False ):
                 self.hda_manager.stop_creating_job( hda )
-            return self.hda_serializer.serialize_to_view( trans, hda,
-                **self._parse_serialization_params( kwd, 'detailed' ) )
+            return self.hda_serializer.serialize_to_view( hda,
+                user=trans.user, trans=trans, **self._parse_serialization_params( kwd, 'detailed' ) )
 
         return {}
 
@@ -407,8 +407,8 @@ class HistoryContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrar
             self.hda_manager.purge( hda )
         else:
             self.hda_manager.delete( hda )
-        return self.hda_serializer.serialize_to_view( trans, hda,
-            **self._parse_serialization_params( kwd, 'detailed' ) )
+        return self.hda_serializer.serialize_to_view( hda,
+            user=trans.user, trans=trans, **self._parse_serialization_params( kwd, 'detailed' ) )
 
     def __handle_unknown_contents_type( self, trans, contents_type ):
         raise exceptions.UnknownContentsType('Unknown contents type: %s' % type)

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -262,7 +262,7 @@ class JobController( BaseAPIController, UsesLibraryMixinItems ):
                 if 'id' in v:
                     if 'src' not in v or v[ 'src' ] == 'hda':
                         hda_id = self.decode_id( v['id'] )
-                        dataset = self.hda_manager.get_accessible( trans, hda_id, trans.user )
+                        dataset = self.hda_manager.get_accessible( hda_id, trans.user )
                     else:
                         dataset = self.get_library_dataset_dataset_association( trans, v['id'] )
                     if dataset is None:

--- a/lib/galaxy/webapps/galaxy/api/lda_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/lda_datasets.py
@@ -33,7 +33,7 @@ class LibraryDatasetsController( BaseAPIController, UsesVisualizationMixin ):
     def __init__( self, app ):
         super( LibraryDatasetsController, self ).__init__( app )
         self.folder_manager = folders.FolderManager()
-        self.role_manager = roles.RoleManager()
+        self.role_manager = roles.RoleManager( app )
 
     @expose_api_anonymous
     def show( self, trans, id, **kwd ):
@@ -402,7 +402,7 @@ class LibraryDatasetsController( BaseAPIController, UsesVisualizationMixin ):
         """
         load( self, trans, **kwd ):
         * POST /api/libraries/datasets
-        Load dataset from the given source into the library. 
+        Load dataset from the given source into the library.
         Source can be:
             user directory - root folder specified in galaxy.ini as "$user_library_import_dir"
                 example path: path/to/galaxy/$user_library_import_dir/user@example.com/{user can browse everything here}
@@ -410,7 +410,7 @@ class LibraryDatasetsController( BaseAPIController, UsesVisualizationMixin ):
             (admin)import directory - root folder specified in galaxy ini as "$library_import_dir"
                 example path: path/to/galaxy/$library_import_dir/{admin can browse everything here}
             (admin)any absolute or relative path - option allowed with "allow_library_path_paste" in galaxy.ini
-         
+
         :param  encoded_folder_id:      the encoded id of the folder to import dataset(s) to
         :type   encoded_folder_id:      an encoded id string
         :param  source:                 source the datasets should be loaded form
@@ -427,7 +427,7 @@ class LibraryDatasetsController( BaseAPIController, UsesVisualizationMixin ):
         :type   dbkey:                  str
 
         :returns:   dict containing information about the created upload job
-        :rtype:     dictionary        
+        :rtype:     dictionary
         """
 
         kwd[ 'space_to_tab' ] = 'False'

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -18,7 +18,7 @@ class LibrariesController( BaseAPIController ):
         super( LibrariesController, self ).__init__( app )
         self.folder_manager = folders.FolderManager()
         self.library_manager = libraries.LibraryManager()
-        self.role_manager = roles.RoleManager()
+        self.role_manager = roles.RoleManager( app )
 
     @expose_api_anonymous
     def index( self, trans, **kwd ):

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -304,8 +304,8 @@ class LibraryContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrar
             # check permissions on (all three?) resources: hda, library, folder
             # TODO: do we really need the library??
             from_hda_id = self.decode_id( from_hda_id )
-            hda = self.hda_manager.get_owned( trans, from_hda_id, trans.user )
-            hda = self.hda_manager.error_if_uploading( trans, hda )
+            hda = self.hda_manager.get_owned( from_hda_id, trans.user, current_history=trans.history )
+            hda = self.hda_manager.error_if_uploading( hda )
             # library = self.get_library( trans, library_id, check_accessible=True )
             folder = self.get_library_folder( trans, folder_id, check_accessible=True )
 

--- a/lib/galaxy/webapps/galaxy/api/provenance.py
+++ b/lib/galaxy/webapps/galaxy/api/provenance.py
@@ -41,7 +41,7 @@ class BaseProvenanceController( BaseAPIController ):
     def _get_provenance( self, trans, item_class_name, item_id, follow=True ):
         provenance_item = self.get_object( trans, item_id, item_class_name, check_ownership=False, check_accessible=False)
         if item_class_name == "HistoryDatasetAssociation":
-            self.hda_manager.error_unless_accessible( trans, provenance_item, trans.user )
+            self.hda_manager.error_unless_accessible( provenance_item, trans.user )
         else:
             self.security_check( trans, provenance_item, check_accessible=True )
         out = self._get_record( trans, provenance_item, follow )

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -241,7 +241,7 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
         history_id = payload.get("history_id", None)
         if history_id:
             decoded_id = self.decode_id( history_id )
-            target_history = self.history_manager.get_owned( trans, decoded_id, trans.user )
+            target_history = self.history_manager.get_owned( decoded_id, trans.user, current_history=trans.history )
         else:
             target_history = None
 
@@ -387,9 +387,9 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
 
         # Dataset check.
         decoded_dataset_id = self.decode_id( payload.get( 'target_dataset_id' ) )
-        original_dataset = self.hda_manager.get_accessible( trans, decoded_dataset_id, user=trans.user )
-        original_dataset = self.hda_manager.error_if_uploading( trans, original_dataset )
-        msg = self.hda_manager.data_conversion_status( trans, original_dataset )
+        original_dataset = self.hda_manager.get_accessible( decoded_dataset_id, user=trans.user )
+        original_dataset = self.hda_manager.error_if_uploading( original_dataset )
+        msg = self.hda_manager.data_conversion_status( original_dataset )
         if msg:
             return msg
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -152,7 +152,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         if 'from_history_id' in payload:
             from_history_id = payload.get( 'from_history_id' )
             from_history_id = self.decode_id( from_history_id )
-            history = self.history_manager.get_accessible( trans, from_history_id, trans.user )
+            history = self.history_manager.get_accessible( from_history_id, trans.user, current_history=trans.history )
 
             job_ids = map( self.decode_id, payload.get( 'job_ids', [] ) )
             dataset_ids = payload.get( 'dataset_ids', [] )
@@ -318,10 +318,10 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         tool_version    = payload.get( 'tool_version', None )
         tool_inputs     = payload.get( 'inputs', None )
         annotation      = payload.get( 'annotation', '' )
-        
+
         # load tool
         tool = self._get_tool( tool_id, tool_version=tool_version, user=trans.user )
-        
+
         # initialize module
         trans.workflow_building_mode = True
         module = module_factory.from_dict( trans, {
@@ -329,7 +329,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             'tool_id'       : tool.id,
             'tool_state'    : None
         } )
-        
+
         # create tool model and default tool state (if missing)
         tool_model = module.tool.to_json(trans, tool_inputs, is_dynamic=False)
         module.state.inputs = copy.deepcopy(tool_model['state_inputs'])

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -529,8 +529,8 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
     def get_name_and_link_async( self, trans, id=None ):
         """ Returns dataset's name and link. """
         decoded_id = self.decode_id( id )
-        dataset = self.hda_manager.get_accessible( trans, decoded_id, trans.user )
-        dataset = self.hda_manager.error_if_uploading( trans, dataset )
+        dataset = self.hda_manager.get_accessible( decoded_id, trans.user )
+        dataset = self.hda_manager.error_if_uploading( dataset )
         return_dict = { "name" : dataset.name, "link" : url_for( controller='dataset', action="display_by_username_and_slug", username=dataset.history.user.username, slug=trans.security.encode_id( dataset.id ) ) }
         return return_dict
 
@@ -538,8 +538,8 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
     def get_embed_html_async( self, trans, id ):
         """ Returns HTML for embedding a dataset in a page. """
         decoded_id = self.decode_id( id )
-        dataset = self.hda_manager.get_accessible( trans, decoded_id, trans.user )
-        dataset = self.hda_manager.error_if_uploading( trans, dataset )
+        dataset = self.hda_manager.get_accessible( decoded_id, trans.user )
+        dataset = self.hda_manager.error_if_uploading( dataset )
         if dataset:
             return "Embedded Dataset '%s'" % dataset.name
 
@@ -556,8 +556,8 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
         """ Rate a dataset asynchronously and return updated community data. """
 
         decoded_id = self.decode_id( id )
-        dataset = self.hda_manager.get_accessible( trans, decoded_id, trans.user )
-        dataset = self.hda_manager.error_if_uploading( trans, dataset )
+        dataset = self.hda_manager.get_accessible( decoded_id, trans.user )
+        dataset = self.hda_manager.error_if_uploading( dataset )
         if not dataset:
             return trans.show_error_message( "The specified dataset does not exist." )
 
@@ -571,8 +571,8 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
         """ Display dataset by username and slug; because datasets do not yet have slugs, the slug is the dataset's id. """
         id = slug
         decoded_id = self.decode_id( id )
-        dataset = self.hda_manager.get_accessible( trans, decoded_id, trans.user )
-        dataset = self.hda_manager.error_if_uploading( trans, dataset )
+        dataset = self.hda_manager.get_accessible( decoded_id, trans.user )
+        dataset = self.hda_manager.error_if_uploading( dataset )
         if dataset:
             # Filename used for composite types.
             if filename:
@@ -614,8 +614,8 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
         """ Returns item content in HTML format. """
 
         decoded_id = self.decode_id( id )
-        dataset = self.hda_manager.get_accessible( trans, decoded_id, trans.user )
-        dataset = self.hda_manager.error_if_uploading( trans, dataset )
+        dataset = self.hda_manager.get_accessible( decoded_id, trans.user )
+        dataset = self.hda_manager.error_if_uploading( dataset )
         if dataset is None:
             raise web.httpexceptions.HTTPNotFound()
         truncated, dataset_data = self.hda_manager.text_data( dataset, preview=True )
@@ -627,8 +627,8 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
     def annotate_async( self, trans, id, new_annotation=None, **kwargs ):
         #TODO:?? why is this an access check only?
         decoded_id = self.decode_id( id )
-        dataset = self.hda_manager.get_accessible( trans, decoded_id, trans.user )
-        dataset = self.hda_manager.error_if_uploading( trans, dataset )
+        dataset = self.hda_manager.get_accessible( decoded_id, trans.user )
+        dataset = self.hda_manager.error_if_uploading( dataset )
         if not dataset:
             web.httpexceptions.HTTPNotFound()
         if dataset and new_annotation:
@@ -641,8 +641,8 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
     @web.expose
     def get_annotation_async( self, trans, id ):
         decoded_id = self.decode_id( id )
-        dataset = self.hda_manager.get_accessible( trans, decoded_id, trans.user )
-        dataset = self.hda_manager.error_if_uploading( trans, dataset )
+        dataset = self.hda_manager.get_accessible( decoded_id, trans.user )
+        dataset = self.hda_manager.error_if_uploading( dataset )
         if not dataset:
             web.httpexceptions.HTTPNotFound()
         annotation = self.get_item_annotation_str( trans.sa_session, trans.user, dataset )
@@ -1023,7 +1023,7 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
         user = trans.get_user()
         if source_history is not None:
             decoded_source_history_id = self.decode_id( source_history )
-            history = self.history_manager.get_owned( trans, decoded_source_history_id, trans.user )
+            history = self.history_manager.get_owned( decoded_source_history_id, trans.user, current_history=trans.history )
             current_history = trans.get_history()
         else:
             history = current_history = trans.get_history()
@@ -1129,8 +1129,8 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
                     error_msg = error_msg + "You do not have permission to add datasets to %i requested histories.  " % ( len( target_histories ) )
             for dataset_id in dataset_ids:
                 decoded_id = self.decode_id( dataset_id )
-                data = self.hda_manager.get_accessible( trans, decoded_id, trans.user )
-                data = self.hda_manager.error_if_uploading( trans, data )
+                data = self.hda_manager.get_accessible( decoded_id, trans.user )
+                data = self.hda_manager.error_if_uploading( data )
 
                 if data is None:
                     error_msg = error_msg + "You tried to copy a dataset that does not exist or that you do not have access to.  "

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -642,7 +642,8 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
 
         history_dictionaries = []
         for history in self.history_manager.by_user( trans.user, filters=deleted_filter ):
-            history_dictionary = self.history_serializer.serialize_to_view( trans, history, view='detailed' )
+            history_dictionary = self.history_serializer.serialize_to_view( history,
+                view='detailed', user=trans.user, trans=trans )
             history_dictionaries.append( history_dictionary )
 
         return trans.fill_template_mako( "history/view_multiple.mako",
@@ -1501,7 +1502,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
     def history_data( self, trans, history ):
         """
         """
-        return self.history_serializer.serialize_to_view( trans, history, view='detailed' )
+        return self.history_serializer.serialize_to_view( history, view='detailed', user=trans.user, trans=trans )
 
     #TODO: combine these next two - poss. with a redirect flag
     #@web.require_login( "switch to a history" )
@@ -1512,7 +1513,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         try:
             history = self.history_manager.get_owned( self.decode_id( id ), trans.user, current_history=trans.history )
             trans.set_history( history )
-            return self.history_serializer.serialize_to_view( trans, history, view='detailed' )
+            return self.history_serializer.serialize_to_view( history, view='detailed', user=trans.user, trans=trans )
         except exceptions.MessageException, msg_exc:
             trans.response.status = msg_exc.err_code.code
             return { 'err_msg': msg_exc.err_msg, 'err_code': msg_exc.err_code.code }
@@ -1522,13 +1523,13 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         """
         """
         history = trans.get_history( create=True )
-        return self.history_serializer.serialize_to_view( trans, history, view='detailed' )
+        return self.history_serializer.serialize_to_view( history, view='detailed', user=trans.user, trans=trans )
 
     @web.json
     def create_new_current( self, trans, name=None ):
         """
         """
         new_history = trans.new_history( name )
-        return self.history_serializer.serialize_to_view( trans, new_history, view='detailed' )
+        return self.history_serializer.serialize_to_view( new_history, view='detailed', user=trans.user, trans=trans )
 
     #TODO: /history/current to do all of the above: if ajax, return json; if post, read id and set to current

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -254,7 +254,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
                 return self.rename( trans, **kwargs )
             if operation == "view":
                 decoded_id = self.decode_id( kwargs.get( 'id', None ) )
-                history = self.history_manager.get_owned( trans, decoded_id, trans.user )
+                history = self.history_manager.get_owned( decoded_id, trans.user, current_history=trans.history )
                 return trans.response.send_redirect( url_for( controller='history',
                                                               action='view',
                                                               id=kwargs['id'],
@@ -268,7 +268,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
             # Load the histories and ensure they all belong to the current user
             histories = []
             for history_id in history_ids:
-                history = self.history_manager.get_owned( trans, self.decode_id( history_id ), trans.user )
+                history = self.history_manager.get_owned( self.decode_id( history_id ), trans.user, current_history=trans.history )
                 if history:
                     # Ensure history is owned by current user
                     if history.user_id != None and trans.user:
@@ -313,7 +313,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
                     if history_ids:
                         histories = []
                         for history_id in history_ids:
-                            history = self.history_manager.get_owned( trans, self.decode_id( history_id ), trans.user )
+                            history = self.history_manager.get_owned( self.decode_id( history_id ), trans.user, current_history=trans.history )
                             if history.importable:
                                 history.importable = False
                             histories.append( history )
@@ -439,7 +439,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
             operation = kwargs['operation'].lower()
             if operation == "view":
                 # Display history.
-                history = self.history_manager.get_accessible( trans, self.decode_id( ids[0] ), trans.user )
+                history = self.history_manager.get_accessible( self.decode_id( ids[0] ), trans.user, current_history=trans.history )
                 return self.display_by_username_and_slug( trans, history.user.username, history.slug )
             elif operation == "copy":
                 if not ids:
@@ -455,7 +455,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
                 for id in ids:
                     # No need to check security, association below won't yield a
                     # hit if this user isn't having the history shared with her.
-                    history = self.history_manager.by_id( trans, self.decode_id( id ) )
+                    history = self.history_manager.by_id( self.decode_id( id ) )
                     # Current user is the user with which the histories were shared
                     association = ( trans.sa_session.query( trans.app.model.HistoryUserShareAssociation )
                                         .filter_by( user=trans.user, history=history ).one() )
@@ -555,7 +555,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         unencoded_history_id = trans.history.id
         if id:
             unencoded_history_id = self.decode_id( id )
-        history_to_view = self.history_manager.get_accessible( trans, unencoded_history_id, trans.user )
+        history_to_view = self.history_manager.get_accessible( unencoded_history_id, trans.user, current_history=trans.history )
 
         history_data = self.history_manager._get_history_data( trans, history_to_view )
         history_dictionary = history_data[ 'history' ]
@@ -595,7 +595,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         hda_dictionaries   = []
         user_is_owner = False
         try:
-            history_to_view = self.history_manager.get_accessible( trans, self.decode_id( id ), trans.user )
+            history_to_view = self.history_manager.get_accessible( self.decode_id( id ), trans.user, current_history=trans.history )
             user_is_owner = history_to_view.user == trans.user
 
             # include all datasets: hidden, deleted, and purged
@@ -641,7 +641,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         current_history_id = trans.security.encode_id( current_history.id ) if current_history else None
 
         history_dictionaries = []
-        for history in self.history_manager.by_user( trans, trans.user, filters=deleted_filter ):
+        for history in self.history_manager.by_user( trans.user, filters=deleted_filter ):
             history_dictionary = self.history_serializer.serialize_to_view( trans, history, view='detailed' )
             history_dictionaries.append( history_dictionary )
 
@@ -661,7 +661,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         if history is None:
            raise web.httpexceptions.HTTPNotFound()
         # Security check raises error if user cannot access history.
-        self.history_manager.error_unless_accessible( trans, history, trans.user )
+        self.history_manager.error_unless_accessible( history, trans.user, current_history=trans.history )
 
         # Get rating data.
         user_item_rating = 0
@@ -701,7 +701,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         if id:
             ids = galaxy.util.listify( id )
             if ids:
-                histories = [ self.history_manager.get_accessible( trans, self.decode_id( history_id ), trans.user )
+                histories = [ self.history_manager.get_accessible( self.decode_id( history_id ), trans.user, current_history=trans.history )
                               for history_id in ids ]
         elif not histories:
             histories = [ trans.history ]
@@ -771,7 +771,9 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
             send_to_err = err_msg
             histories = []
             for history_id in id:
-                histories.append( self.history_manager.get_owned( trans, self.decode_id( history_id ), trans.user ) )
+                history_id = self.decode_id( history_id )
+                history = self.history_manager.get_owned( history_id, trans.user, current_history=trans.history )
+                histories.append( history )
             return trans.fill_template( "/history/share.mako",
                                         histories=histories,
                                         email=email,
@@ -894,7 +896,9 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         ids = galaxy.util.listify( ids )
         histories = []
         for history_id in ids:
-            histories.append( self.history_manager.get_owned( trans, self.decode_id( history_id ), trans.user ) )
+            history_id = self.decode_id( history_id )
+            history = self.history_manager.get_owned( history_id, trans.user, current_history=trans.history )
+            histories.append(  )
         return histories
 
     def _get_users( self, trans, user, emails_or_ids ):
@@ -908,14 +912,14 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
             send_to_user = None
             if '@' in string:
                 email_address = string
-                send_to_user = self.user_manager.by_email( trans, email_address,
+                send_to_user = self.user_manager.by_email( email_address,
                     filters=[ trans.app.model.User.table.c.deleted == False ] )
 
             else:
                 user_id = string
                 try:
                     decoded_user_id = self.decode_id( string )
-                    send_to_user = self.user_manager.by_id( trans, decoded_user_id )
+                    send_to_user = self.user_manager.by_id( decoded_user_id )
                     if send_to_user.deleted:
                         send_to_user = None
                 #TODO: in an ideal world, we would let this bubble up to web.expose which would handle it
@@ -1144,7 +1148,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
                     trans.app.job_manager.job_stop_queue.put( job.id )
 
         # Regardless of whether it was previously deleted, get the most recent history or create a new one.
-        most_recent_history = self.history_manager.most_recent( trans, user=trans.user )
+        most_recent_history = self.history_manager.most_recent( user=trans.user )
         if most_recent_history:
             trans.set_history( most_recent_history )
             return trans.show_ok_message( "History deleted, your most recent history is now active",
@@ -1188,7 +1192,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
     @web.json
     def rate_async( self, trans, id, rating ):
         """ Rate a history asynchronously and return updated community data. """
-        history = self.history_manager.get_accessible( trans, self.decode_id( id ), trans.user )
+        history = self.history_manager.get_accessible( self.decode_id( id ), trans.user, current_history=trans.history )
         if not history:
             return trans.show_error_message( "The specified history does not exist." )
         # Rate history.
@@ -1232,7 +1236,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         # Get history to export.
         #
         if id:
-            history = self.history_manager.get_accessible( trans, self.decode_id( id ), trans.user )
+            history = self.history_manager.get_accessible( self.decode_id( id ), trans.user, current_history=trans.history )
         else:
             # Use current history.
             history = trans.history
@@ -1265,7 +1269,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
     @web.require_login( "get history name and link" )
     def get_name_and_link_async( self, trans, id=None ):
         """ Returns history's name and link. """
-        history = self.history_manager.get_accessible( trans, self.decode_id( id ), trans.user )
+        history = self.history_manager.get_accessible( self.decode_id( id ), trans.user, current_history=trans.history )
         if self.create_item_slug( trans.sa_session, history ):
             trans.sa_session.flush()
         return_dict = {
@@ -1279,7 +1283,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
     @web.require_login( "set history's accessible flag" )
     def set_accessible_async( self, trans, id=None, accessible=False ):
         """ Set history's importable attribute and slug. """
-        history = self.history_manager.get_owned( trans, self.decode_id( id ), trans.user )
+        history = self.history_manager.get_owned( self.decode_id( id ), trans.user, current_history=trans.history )
         # Only set if importable value would change; this prevents a change in the update_time unless attribute really changed.
         importable = accessible in ['True', 'true', 't', 'T'];
         if history and history.importable != importable:
@@ -1327,11 +1331,11 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         # Do import.
         if not id:
             return trans.show_error_message( "You must specify a history you want to import.<br>You can %s." % referer_message, use_panels=True )
-        import_history = self.history_manager.by_id( trans, self.decode_id( id ) )
+        import_history = self.history_manager.by_id( self.decode_id( id ) )
         if not import_history:
             return trans.show_error_message( "The specified history does not exist.<br>You can %s." % referer_message, use_panels=True )
         # History is importable if user is admin or it's accessible. TODO: probably want to have app setting to enable admin access to histories.
-        if not self.history_manager.is_accessible( trans, import_history, trans.user ):
+        if not self.history_manager.is_accessible( import_history, trans.user, current_history=trans.history ):
             return trans.show_error_message( "You cannot access this history.<br>You can %s." % referer_message, use_panels=True )
         if user:
             #dan: I can import my own history.
@@ -1397,7 +1401,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         histories = []
 
         for history_id in id:
-            history = self.history_manager.get_owned( trans, self.decode_id( history_id ), trans.user )
+            history = self.history_manager.get_owned( self.decode_id( history_id ), trans.user, current_history=trans.history )
             if history and history.user_id == user.id:
                 histories.append( history )
         if not name or len( histories ) != len( name ):
@@ -1454,7 +1458,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
             ids = galaxy.util.listify( id )
             histories = []
             for history_id in ids:
-                history = self.history_manager.get_accessible( trans, self.decode_id( history_id ), trans.user )
+                history = self.history_manager.get_accessible( self.decode_id( history_id ), trans.user, current_history=trans.history )
                 histories.append( history )
         user = trans.get_user()
         for history in histories:
@@ -1491,7 +1495,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         return trans.response.send_redirect( url_for( "/" ) )
 
     def get_item( self, trans, id ):
-        return self.history_manager.get_owned( trans, self.decode_id( id ), trans.user )
+        return self.history_manager.get_owned( self.decode_id( id ), trans.user, current_history=trans.history )
         #TODO: override of base ui controller?
 
     def history_data( self, trans, history ):
@@ -1506,7 +1510,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         """
         """
         try:
-            history = self.history_manager.get_owned( trans, self.decode_id( id ), trans.user )
+            history = self.history_manager.get_owned( self.decode_id( id ), trans.user, current_history=trans.history )
             trans.set_history( history )
             return self.history_serializer.serialize_to_view( trans, history, view='detailed' )
         except exceptions.MessageException, msg_exc:

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -748,7 +748,7 @@ class PageController( BaseUIController, SharableMixin,
         # TODO: should be moved to history controller and/or called via ajax from the template
         decoded_id = self.decode_id( id )
         # histories embedded in pages are set to importable when embedded, check for access here
-        history = self.history_manager.get_accessible( trans, decoded_id, trans.user )
+        history = self.history_manager.get_accessible( decoded_id, trans.user, current_history=trans.history )
 
         # create ownership flag for template, dictify models
         # note: adding original annotation since this is published - get_dict returns user-based annos
@@ -798,8 +798,8 @@ class PageController( BaseUIController, SharableMixin,
 
         elif item_class == model.HistoryDatasetAssociation:
             decoded_id = self.decode_id( item_id )
-            dataset = self.hda_manager.get_accessible( trans, decoded_id, trans.user )
-            dataset = self.hda_manager.error_if_uploading( trans, dataset )
+            dataset = self.hda_manager.get_accessible( decoded_id, trans.user )
+            dataset = self.hda_manager.error_if_uploading( dataset )
 
             dataset.annotation = self.get_item_annotation_str( trans.sa_session, dataset.history.user, dataset )
             if dataset:

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -871,7 +871,7 @@ class VisualizationController( BaseUIController, SharableMixin, UsesVisualizatio
             dbkey = None
             if new_dataset_id:
                 decoded_id = self.decode_id( new_dataset_id )
-                hda = self.hda_manager.get_owned( trans, decoded_id, trans.user )
+                hda = self.hda_manager.get_owned( decoded_id, trans.user, current_history=trans.user )
                 dbkey = hda.dbkey
                 if dbkey == '?':
                     dbkey = kwargs.get( "dbkey", None )
@@ -981,7 +981,7 @@ class VisualizationController( BaseUIController, SharableMixin, UsesVisualizatio
             viz = self.get_visualization( trans, id )
             viz_config = self.get_visualization_config( trans, viz )
             decoded_id = self.decode_id( viz_config[ 'dataset_id' ] )
-            dataset = self.hda_manager.get_owned( trans, decoded_id, trans.user )
+            dataset = self.hda_manager.get_owned( decoded_id, trans.user, current_history=trans.history )
         else:
             # Loading new visualization.
             dataset = self.get_hda_or_ldda( trans, hda_ldda, dataset_id )
@@ -1016,7 +1016,7 @@ class VisualizationController( BaseUIController, SharableMixin, UsesVisualizatio
         # get the hda if we can, then its data using the phyloviz parsers
         if dataset_id:
             decoded_id = self.decode_id( dataset_id )
-            hda = self.hda_manager.get_accessible( trans, decoded_id, trans.user )
+            hda = self.hda_manager.get_accessible( decoded_id, trans.user )
             hda = self.hda_manager.error_if_uploading( hda )
         else:
             return trans.show_message( "Phyloviz couldn't find a dataset_id" )

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -196,7 +196,7 @@ def build_workflow_run_config( trans, workflow, payload ):
         # Passing an existing history to use.
         encoded_history_id = history_param[ 8: ]
         history_id = __decode_id( trans, encoded_history_id, model_type="history" )
-        history = history_manager.get_owned( trans, history_id, trans.user )
+        history = history_manager.get_owned( history_id, trans.user, current_history=trans.history )
     else:
         # Send workflow outputs to new history.
         history = app.model.History(name=history_param, user=trans.user)

--- a/test/casperjs/spaceghost.js
+++ b/test/casperjs/spaceghost.js
@@ -532,7 +532,7 @@ SpaceGhost.prototype.openHomePage = function openHomePage( then, delay ){
             },
             then,
             function openHomePageTimeout(){
-                throw new GalaxyError( 'Homepage timed out' );
+                throw new GalaxyError( 'Homepage timed out - are you sure your instance is running?' );
             },
             delay
         );

--- a/test/unit/managers/mock.py
+++ b/test/unit/managers/mock.py
@@ -16,6 +16,8 @@ from galaxy import objectstore
 from galaxy.model import mapping
 from galaxy.util.bunch import Bunch
 
+from galaxy.managers import tags
+from galaxy import quota
 
 # =============================================================================
 class OpenObject( object ):
@@ -29,6 +31,8 @@ class MockApp( object ):
         self.model = mapping.init( "/tmp", "sqlite:///:memory:", create_tables=True, object_store=self.object_store )
         self.security_agent = self.model.security_agent
         self.visualizations_registry = MockVisualizationsRegistry()
+        self.tag_handler = tags.GalaxyTagManager( self )
+        self.quota_agent = quota.QuotaAgent( self.model )
 
 class MockAppConfig( Bunch ):
     def __init__( self, **kwargs ):
@@ -53,10 +57,15 @@ class MockWebapp( object ):
     def __init__( self, **kwargs ):
         self.name = kwargs.get( 'name', 'galaxy' )
 
+class MockVisualizationsRegistry( object ):
+    def get_visualizations( self, trans, target ):
+        return []
+
 class MockTrans( object ):
     def __init__( self, user=None, history=None, **kwargs ):
 
         self.app = MockApp( **kwargs )
+        self.model = self.app.model
         self.webapp = MockWebapp( **kwargs )
         self.sa_session = self.app.model.session
 
@@ -91,7 +100,3 @@ class MockTrans( object ):
         template = template_lookup.get_template( filename )
         template.output_encoding = 'utf-8'
         return template.render( **kwargs )
-
-class MockVisualizationsRegistry( object ):
-    def get_visualizations( self, trans, target ):
-        return []

--- a/test/unit/managers/test_CollectionManager.py
+++ b/test/unit/managers/test_CollectionManager.py
@@ -36,10 +36,10 @@ class DatasetCollectionManagerTestCase( BaseTestCase ):
 
     def set_up_managers( self ):
         super( DatasetCollectionManagerTestCase, self ).set_up_managers()
-        self.dataset_mgr = DatasetManager( self.app )
-        self.hda_mgr = HDAManager( self.app )
-        self.history_mgr = HistoryManager( self.app )
-        self.collection_mgr = DatasetCollectionManager( self.app )
+        self.dataset_manager = DatasetManager( self.app )
+        self.hda_manager = HDAManager( self.app )
+        self.history_manager = HistoryManager( self.app )
+        self.collection_manager = DatasetCollectionManager( self.app )
 
     def build_element_identifiers( self, elements ):
         identifier_list = []
@@ -54,20 +54,20 @@ class DatasetCollectionManagerTestCase( BaseTestCase ):
         return identifier_list
 
     def test_create_simple_list( self ):
-        owner = self.user_mgr.create( self.trans, **user2_data )
+        owner = self.user_manager.create( **user2_data )
 
-        history = self.history_mgr.create( self.trans, name='history1', user=owner )
+        history = self.history_manager.create( name='history1', user=owner )
 
-        hda1 = self.hda_mgr.create( self.trans, name='one',
-            history=history, dataset=self.dataset_mgr.create( self.trans ) )
-        hda2 = self.hda_mgr.create( self.trans, name='two',
-            history=history, dataset=self.dataset_mgr.create( self.trans ) )
-        hda3 = self.hda_mgr.create( self.trans, name='three',
-            history=history, dataset=self.dataset_mgr.create( self.trans ) )
+        hda1 = self.hda_manager.create( name='one',
+            history=history, dataset=self.dataset_manager.create() )
+        hda2 = self.hda_manager.create( name='two',
+            history=history, dataset=self.dataset_manager.create() )
+        hda3 = self.hda_manager.create( name='three',
+            history=history, dataset=self.dataset_manager.create() )
 
         self.log( "should be able to create a new Collection via ids" )
         element_identifiers = self.build_element_identifiers( [ hda1, hda2, hda3 ] )
-        hdca = self.collection_mgr.create( self.trans, history, 'test collection', 'list',
+        hdca = self.collection_manager.create( self.trans, history, 'test collection', 'list',
                                            element_identifiers=element_identifiers )
         self.assertIsInstance( hdca, model.HistoryDatasetCollectionAssociation )
         self.assertEqual( hdca.name, 'test collection' )
@@ -117,26 +117,26 @@ class DatasetCollectionManagerTestCase( BaseTestCase ):
 
         self.log( "should be able to create a new Collection via objects" )
         elements = dict( one=hda1, two=hda2, three=hda3 )
-        hdca2 = self.collection_mgr.create( self.trans, history, 'test collection 2', 'list', elements=elements )
+        hdca2 = self.collection_manager.create( self.trans, history, 'test collection 2', 'list', elements=elements )
         self.assertIsInstance( hdca2, model.HistoryDatasetCollectionAssociation )
 
     def test_update_from_dict( self ):
-        owner = self.user_mgr.create( self.trans, **user2_data )
+        owner = self.user_manager.create( **user2_data )
 
-        history = self.history_mgr.create( self.trans, name='history1', user=owner )
+        history = self.history_manager.create( name='history1', user=owner )
 
-        hda1 = self.hda_mgr.create( self.trans, name='one',
-            history=history, dataset=self.dataset_mgr.create( self.trans ) )
-        hda2 = self.hda_mgr.create( self.trans, name='two',
-            history=history, dataset=self.dataset_mgr.create( self.trans ) )
-        hda3 = self.hda_mgr.create( self.trans, name='three',
-            history=history, dataset=self.dataset_mgr.create( self.trans ) )
+        hda1 = self.hda_manager.create( name='one',
+            history=history, dataset=self.dataset_manager.create() )
+        hda2 = self.hda_manager.create( name='two',
+            history=history, dataset=self.dataset_manager.create() )
+        hda3 = self.hda_manager.create( name='three',
+            history=history, dataset=self.dataset_manager.create() )
 
         elements = dict( one=hda1, two=hda2, three=hda3 )
-        hdca = self.collection_mgr.create( self.trans, history, 'test collection', 'list', elements=elements )
+        hdca = self.collection_manager.create( self.trans, history, 'test collection', 'list', elements=elements )
 
         self.log( "should be set from a dictionary" )
-        self.collection_mgr._set_from_dict( self.trans, hdca, {
+        self.collection_manager._set_from_dict( self.trans, hdca, {
             'deleted'   : True,
             'visible'   : False,
             'name'      : 'New Name',

--- a/test/unit/managers/test_DatasetManager.py
+++ b/test/unit/managers/test_DatasetManager.py
@@ -234,7 +234,7 @@ class DatasetSerializerTestCase( BaseTestCase ):
     def test_serializers( self ):
         user2 = self.user_mgr.create( self.trans, **user2_data )
         dataset = self.dataset_mgr.create( self.trans )
-        all_keys = list( self.hda_serializer.serializable_keyset )
+        all_keys = list( self.dataset_serializer.serializable_keyset )
         serialized = self.dataset_serializer.serialize( self.trans, dataset, all_keys )
 
         self.log( 'everything serialized should be of the proper type' )

--- a/test/unit/managers/test_DatasetManager.py
+++ b/test/unit/managers/test_DatasetManager.py
@@ -197,11 +197,11 @@ class DatasetSerializerTestCase( BaseTestCase ):
         dataset = self.dataset_manager.create()
 
         self.log( 'should have a summary view' )
-        summary_view = self.dataset_serializer.serialize_to_view( self.trans, dataset, view='summary' )
+        summary_view = self.dataset_serializer.serialize_to_view( dataset, view='summary' )
         self.assertKeys( summary_view, self.dataset_serializer.views[ 'summary' ] )
 
         self.log( 'should have the summary view as default view' )
-        default_view = self.dataset_serializer.serialize_to_view( self.trans, dataset, default_view='summary' )
+        default_view = self.dataset_serializer.serialize_to_view( dataset, default_view='summary' )
         self.assertKeys( summary_view, self.dataset_serializer.views[ 'summary' ] )
 
         self.log( 'should have a serializer for all serializable keys' )
@@ -217,13 +217,13 @@ class DatasetSerializerTestCase( BaseTestCase ):
         dataset = self.dataset_manager.create()
 
         self.log( 'should be able to use keys with views' )
-        serialized = self.dataset_serializer.serialize_to_view( self.trans, dataset,
+        serialized = self.dataset_serializer.serialize_to_view( dataset,
             view='summary', keys=[ 'permissions' ] )
         self.assertKeys( serialized,
             self.dataset_serializer.views[ 'summary' ] + [ 'permissions' ] )
 
         self.log( 'should be able to use keys on their own' )
-        serialized = self.dataset_serializer.serialize_to_view( self.trans, dataset,
+        serialized = self.dataset_serializer.serialize_to_view( dataset,
             keys=[ 'purgable', 'file_size' ] )
         self.assertKeys( serialized, [ 'purgable', 'file_size' ] )
 
@@ -235,7 +235,7 @@ class DatasetSerializerTestCase( BaseTestCase ):
         user2 = self.user_manager.create( **user2_data )
         dataset = self.dataset_manager.create()
         all_keys = list( self.dataset_serializer.serializable_keyset )
-        serialized = self.dataset_serializer.serialize( self.trans, dataset, all_keys )
+        serialized = self.dataset_serializer.serialize( dataset, all_keys )
 
         self.log( 'everything serialized should be of the proper type' )
         self.assertEncodedId( serialized[ 'id' ] )
@@ -270,13 +270,13 @@ class DatasetDeserializerTestCase( BaseTestCase ):
         self.log( 'should raise when deserializing deleted from non-bool' )
         self.assertFalse( dataset.deleted )
         self.assertRaises( exceptions.RequestParameterInvalidException,
-            self.dataset_deserializer.deserialize, self.trans, dataset, data={ 'deleted': None } )
+            self.dataset_deserializer.deserialize, dataset, data={ 'deleted': None } )
         self.assertFalse( dataset.deleted )
         self.log( 'should be able to deserialize deleted from True' )
-        self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'deleted': True } )
+        self.dataset_deserializer.deserialize( dataset, data={ 'deleted': True } )
         self.assertTrue( dataset.deleted )
         self.log( 'should be able to reverse by deserializing deleted from False' )
-        self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'deleted': False } )
+        self.dataset_deserializer.deserialize( dataset, data={ 'deleted': False } )
         self.assertFalse( dataset.deleted )
 
     def test_deserialize_purge( self ):
@@ -284,14 +284,14 @@ class DatasetDeserializerTestCase( BaseTestCase ):
 
         self.log( 'should raise when deserializing purged from non-bool' )
         self.assertRaises( exceptions.RequestParameterInvalidException,
-            self.dataset_deserializer.deserialize, self.trans, dataset, data={ 'purged': None } )
+            self.dataset_deserializer.deserialize, dataset, data={ 'purged': None } )
         self.assertFalse( dataset.purged )
         self.log( 'should be able to deserialize purged from True' )
-        self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'purged': True } )
+        self.dataset_deserializer.deserialize( dataset, data={ 'purged': True } )
         self.assertTrue( dataset.purged )
         # TODO: should this raise an error?
         self.log( 'should NOT be able to deserialize purged from False (will remain True)' )
-        self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'purged': False } )
+        self.dataset_deserializer.deserialize( dataset, data={ 'purged': False } )
         self.assertTrue( dataset.purged )
 
     # def test_deserialize_permissions( self ):

--- a/test/unit/managers/test_DatasetManager.py
+++ b/test/unit/managers/test_DatasetManager.py
@@ -5,6 +5,7 @@ import sys
 import os
 import pprint
 import unittest
+import json
 
 __GALAXY_ROOT__ = os.getcwd() + '/../../../'
 sys.path.insert( 1, __GALAXY_ROOT__ + 'lib' )
@@ -19,7 +20,8 @@ from galaxy.util.bunch import Bunch
 
 import mock
 from test_ModelManager import BaseTestCase
-from galaxy.managers.datasets import DatasetManager
+from galaxy.managers.datasets import (
+    DatasetManager, DatasetRBACPermissions, DatasetSerializer, DatasetDeserializer )
 from galaxy.managers.datasets import DatasetAssociationManager
 from galaxy.managers.histories import HistoryManager
 from galaxy.managers.hdas import HDAManager
@@ -70,7 +72,7 @@ class DatasetManagerTestCase( BaseTestCase ):
     def test_delete( self ):
         item1 = self.dataset_mgr.create( self.trans )
 
-        self.log( "should be able to delete and undelete an hda" )
+        self.log( "should be able to delete and undelete a dataset" )
         self.assertFalse( item1.deleted )
         self.assertEqual( self.dataset_mgr.delete( self.trans, item1 ), item1 )
         self.assertTrue( item1.deleted )
@@ -81,53 +83,221 @@ class DatasetManagerTestCase( BaseTestCase ):
         self.trans.app.config.allow_user_dataset_purge = True
         item1 = self.dataset_mgr.create( self.trans )
 
-        self.log( "should purge an hda if config does allow" )
+        self.log( "should purge a dataset if config does allow" )
         self.assertFalse( item1.purged )
         self.assertEqual( self.dataset_mgr.purge( self.trans, item1 ), item1 )
         self.assertTrue( item1.purged )
+
+        self.log( "should delete a dataset when purging" )
+        self.assertTrue( item1.deleted )
 
     def test_purge_not_allowed( self ):
         self.trans.app.config.allow_user_dataset_purge = False
         item1 = self.dataset_mgr.create( self.trans )
 
-        self.log( "should raise an error when purging an hda if config does not allow" )
+        self.log( "should raise an error when purging a dataset if config does not allow" )
         self.assertFalse( item1.purged )
         self.assertRaises( exceptions.ConfigDoesNotAllowException, self.dataset_mgr.purge, self.trans, item1 )
         self.assertFalse( item1.purged )
 
-    ##TODO: I'm unclear as to how these work, so I'm kicking this down the road a bit....
-    #def test_access_permission( self ):
-    #    owner = self.user_mgr.create( self.trans, **user2_data )
-    #    dataset = self.dataset_mgr.create( self.trans )
-    #    # giving one user access permission makes it non-public, removing access for anyone else
-    #    self.dataset_mgr.give_access_permission( self.trans, dataset, owner )
-    #
-    #    user3 = self.user_mgr.create( self.trans, **user3_data )
-    #    user4 = self.user_mgr.create( self.trans,
-    #        email='user4@user4.user4', username='user4', password=default_password )
-    #
-    #    self.assertTrue( self.dataset_mgr.has_access_permission( self.trans, dataset, owner ) )
-    #    self.assertFalse( self.dataset_mgr.has_access_permission( self.trans, dataset, user3 ) )
-    #    self.assertFalse( self.dataset_mgr.has_access_permission( self.trans, dataset, user4 ) )
-    #
-    #    # should be able to progressively add more roles without removing the previous
-    #    self.dataset_mgr.give_access_permission( self.trans, dataset, user3 )
-    #    self.assertTrue( self.dataset_mgr.has_access_permission( self.trans, dataset, user3 ) )
-    #    self.assertTrue( self.dataset_mgr.has_access_permission( self.trans, dataset, owner ) )
-    #    self.assertFalse( self.dataset_mgr.has_access_permission( self.trans, dataset, user4 ) )
-    #
-    #    #self.assertTrue( self.dataset_mgr.is_accessible( self.trans, dataset, owner ) )
-    #    #self.assertFalse( self.dataset_mgr.is_accessible( self.trans, dataset, non_owner ) )
-
-    def test_accessible( self ):
-        owner = self.user_mgr.create( self.trans, **user2_data )
-        non_owner = self.user_mgr.create( self.trans, **user3_data )
-
+    def test_create_with_no_permissions( self ):
+        self.log( "should be able to create a new Dataset without any permissions" )
         dataset = self.dataset_mgr.create( self.trans )
 
-        self.log( "(by default, dataset permissions are lax) should be accessible to all" )
-        for user in self.user_mgr.list( self.trans ):
-            self.assertTrue( self.dataset_mgr.is_accessible( self.trans, dataset, user ) )
+        permissions = self.dataset_mgr.permissions.get( dataset )
+        self.assertIsInstance( permissions, tuple )
+        self.assertEqual( len( permissions ), 2 )
+        manage_permissions, access_permissions = permissions
+        self.assertEqual( manage_permissions, [] )
+        self.assertEqual( access_permissions, [] )
+
+        user3 = self.user_mgr.create( self.trans, **user3_data )
+        self.log( "a dataset without permissions shouldn't be manageable to just anyone" )
+        self.assertFalse( self.dataset_mgr.permissions.manage.is_permitted( dataset, user3 ) )
+        self.log( "a dataset without permissions should be accessible" )
+        self.assertTrue( self.dataset_mgr.permissions.access.is_permitted( dataset, user3 ) )
+
+    def test_create_public_dataset( self ):
+        self.log( "should be able to create a new Dataset and give it some permissions that actually, you know, might work if there's any justice in this universe" )
+        owner = self.user_mgr.create( self.trans, **user2_data )
+        owner_private_role = self.user_mgr.private_role( owner )
+        dataset = self.dataset_mgr.create( self.trans, manage_roles=[ owner_private_role ] )
+
+        permissions = self.dataset_mgr.permissions.get( dataset )
+        self.assertIsInstance( permissions, tuple )
+        self.assertEqual( len( permissions ), 2 )
+        manage_permissions, access_permissions = permissions
+        self.assertIsInstance( manage_permissions, list )
+        self.assertIsInstance( manage_permissions[0], model.DatasetPermissions )
+        self.assertEqual( access_permissions, [] )
+
+        user3 = self.user_mgr.create( self.trans, **user3_data )
+        self.log( "a public dataset should be manageable to it's owner" )
+        self.assertTrue( self.dataset_mgr.permissions.manage.is_permitted( dataset, owner ) )
+        self.log( "a public dataset shouldn't be manageable to just anyone" )
+        self.assertFalse( self.dataset_mgr.permissions.manage.is_permitted( dataset, user3 ) )
+        self.log( "a public dataset should be accessible" )
+        self.assertTrue( self.dataset_mgr.permissions.access.is_permitted( dataset, user3 ) )
+
+    def test_create_private_dataset( self ):
+        self.log( "should be able to create a new Dataset and give it some permissions that actually, you know, might work if there's any justice in this universe" )
+        owner = self.user_mgr.create( self.trans, **user2_data )
+        owner_private_role = self.user_mgr.private_role( owner )
+        dataset = self.dataset_mgr.create( self.trans,
+            manage_roles=[ owner_private_role ], access_roles=[ owner_private_role ] )
+
+        permissions = self.dataset_mgr.permissions.get( dataset )
+        self.assertIsInstance( permissions, tuple )
+        self.assertEqual( len( permissions ), 2 )
+        manage_permissions, access_permissions = permissions
+        self.assertIsInstance( manage_permissions, list )
+        self.assertIsInstance( manage_permissions[0], model.DatasetPermissions )
+        self.assertIsInstance( access_permissions, list )
+        self.assertIsInstance( access_permissions[0], model.DatasetPermissions )
+
+        self.log( "a private dataset should be manageable by it's owner" )
+        self.assertTrue( self.dataset_mgr.permissions.manage.is_permitted( dataset, owner ) )
+        self.log( "a private dataset should be accessible to it's owner" )
+        self.assertTrue( self.dataset_mgr.permissions.access.is_permitted( dataset, owner ) )
+
+        user3 = self.user_mgr.create( self.trans, **user3_data )
+        self.log( "a private dataset shouldn't be manageable to just anyone" )
+        self.assertFalse( self.dataset_mgr.permissions.manage.is_permitted( dataset, user3 ) )
+        self.log( "a private dataset shouldn't be accessible to just anyone" )
+        self.assertFalse( self.dataset_mgr.permissions.access.is_permitted( dataset, user3 ) )
+
+
+# =============================================================================
+class DatasetRBACPermissionsTestCase( BaseTestCase ):
+
+    def set_up_managers( self ):
+        super( DatasetRBACPermissionsTestCase, self ).set_up_managers()
+        self.dataset_mgr = DatasetManager( self.app )
+
+    # def test_manage( self ):
+    #     self.log( "should be able to create a new Dataset" )
+    #     dataset1 = self.dataset_mgr.create( self.trans )
+    #     self.assertIsInstance( dataset1, model.Dataset )
+    #     self.assertEqual( dataset1, self.trans.sa_session.query( model.Dataset ).get( dataset1.id ) )
+    #
+
+
+# =============================================================================
+# web.url_for doesn't work well in the framework
+testable_url_for = lambda *a, **k: '(fake url): %s, %s' % ( a, k )
+DatasetSerializer.url_for = staticmethod( testable_url_for )
+
+class DatasetSerializerTestCase( BaseTestCase ):
+
+    def set_up_managers( self ):
+        super( DatasetSerializerTestCase, self ).set_up_managers()
+        self.dataset_mgr = DatasetManager( self.app )
+        self.dataset_serializer = DatasetSerializer( self.app )
+
+    def test_views( self ):
+        dataset = self.dataset_mgr.create( self.trans )
+
+        self.log( 'should have a summary view' )
+        summary_view = self.dataset_serializer.serialize_to_view( self.trans, dataset, view='summary' )
+        self.assertKeys( summary_view, self.dataset_serializer.views[ 'summary' ] )
+
+        self.log( 'should have the summary view as default view' )
+        default_view = self.dataset_serializer.serialize_to_view( self.trans, dataset, default_view='summary' )
+        self.assertKeys( summary_view, self.dataset_serializer.views[ 'summary' ] )
+
+        self.log( 'should have a serializer for all serializable keys' )
+        need_no_serializers = ( basestring, bool, type( None ) )
+        for key in self.dataset_serializer.serializable_keyset:
+            instantiated_attribute = getattr( dataset, key, None )
+            if not ( ( key in self.dataset_serializer.serializers )
+                  or ( isinstance( instantiated_attribute, need_no_serializers ) ) ):
+                self.fail( 'no serializer for: %s (%s)' % ( key, instantiated_attribute ) )
+        else:
+            self.assertTrue( True, 'all serializable keys have a serializer' )
+
+    def test_views_and_keys( self ):
+        dataset = self.dataset_mgr.create( self.trans )
+
+        self.log( 'should be able to use keys with views' )
+        serialized = self.dataset_serializer.serialize_to_view( self.trans, dataset,
+            view='summary', keys=[ 'permissions' ] )
+        self.assertKeys( serialized,
+            self.dataset_serializer.views[ 'summary' ] + [ 'permissions' ] )
+
+        self.log( 'should be able to use keys on their own' )
+        serialized = self.dataset_serializer.serialize_to_view( self.trans, dataset,
+            keys=[ 'purgable', 'file_size' ] )
+        self.assertKeys( serialized, [ 'purgable', 'file_size' ] )
+
+    def test_serialize_permissions( self ):
+        dataset = self.dataset_mgr.create( self.trans )
+        self.log( 'serialized permissions should be well formed' )
+
+    def test_serializers( self ):
+        user2 = self.user_mgr.create( self.trans, **user2_data )
+        dataset = self.dataset_mgr.create( self.trans )
+        all_keys = self.dataset_serializer.serializable_keyset
+        serialized = self.dataset_serializer.serialize( self.trans, dataset, all_keys )
+
+        self.log( 'everything serialized should be of the proper type' )
+        self.assertEncodedId( serialized[ 'id' ] )
+        self.assertDate( serialized[ 'create_time' ] )
+        self.assertDate( serialized[ 'update_time' ] )
+
+        self.assertUUID( serialized[ 'uuid' ] )
+        self.assertIsInstance( serialized[ 'state' ], basestring )
+        self.assertIsInstance( serialized[ 'deleted' ], bool )
+        self.assertIsInstance( serialized[ 'purged' ], bool )
+        self.assertIsInstance( serialized[ 'purgable' ], bool )
+
+        # # TODO: no great way to do these with mocked dataset
+        # self.assertIsInstance( serialized[ 'file_size' ], int )
+        # self.assertIsInstance( serialized[ 'total_size' ], int )
+
+        self.log( 'serialized should jsonify well' )
+        self.assertIsInstance( json.dumps( serialized ), basestring )
+
+
+# =============================================================================
+class DatasetDeserializerTestCase( BaseTestCase ):
+
+    def set_up_managers( self ):
+        super( DatasetDeserializerTestCase, self ).set_up_managers()
+        self.dataset_mgr = DatasetManager( self.app )
+        self.dataset_deserializer = DatasetDeserializer( self.app )
+
+    def test_deserialize_delete( self ):
+        dataset = self.dataset_mgr.create( self.trans )
+
+        self.log( 'should raise when deserializing deleted from non-bool' )
+        self.assertFalse( dataset.deleted )
+        self.assertRaises( exceptions.RequestParameterInvalidException,
+            self.dataset_deserializer.deserialize, self.trans, dataset, data={ 'deleted': None }, flush=True )
+        self.assertFalse( dataset.deleted )
+        self.log( 'should be able to deserialize deleted from True' )
+        self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'deleted': True }, flush=True )
+        self.assertTrue( dataset.deleted )
+        self.log( 'should be able to reverse by deserializing deleted from False' )
+        self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'deleted': False }, flush=True )
+        self.assertFalse( dataset.deleted )
+
+    def test_deserialize_purge( self ):
+        dataset = self.dataset_mgr.create( self.trans )
+
+        self.log( 'should raise when deserializing purged from non-bool' )
+        self.assertRaises( exceptions.RequestParameterInvalidException,
+            self.dataset_deserializer.deserialize, self.trans, dataset, data={ 'purged': None }, flush=True )
+        self.assertFalse( dataset.purged )
+        self.log( 'should be able to deserialize purged from True' )
+        self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'purged': True }, flush=True )
+        self.assertTrue( dataset.purged )
+        # TODO: should this raise an error?
+        self.log( 'should NOT be able to deserialize purged from False (will remain True)' )
+        self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'purged': False }, flush=True )
+        self.assertTrue( dataset.purged )
+
+    # def test_deserialize_permissions( self ):
+    #     pass
 
 
 # =============================================================================
@@ -135,9 +305,31 @@ class DatasetAssociationManagerTestCase( BaseTestCase ):
 
     def set_up_managers( self ):
         super( DatasetAssociationManagerTestCase, self ).set_up_managers()
-        self.dataset_mgr = DatasetAssociationManager( self.app )
+        self.dataset_assoc_mgr = HDAManager( self.app )
         self.hda_mgr = HDAManager( self.app )
         self.history_mgr = HistoryManager( self.app )
+
+    def test_purge_allowed( self ):
+        self.trans.app.config.allow_user_dataset_purge = True
+        item1 = self.dataset_assoc_mgr.create( self.trans )
+
+        self.log( "should purge a dataset assoc if config does allow" )
+        self.assertFalse( item1.purged )
+        self.assertEqual( self.dataset_assoc_mgr.purge( self.trans, item1 ), item1 )
+        self.assertTrue( item1.purged )
+
+        # not necc. true for dataset assocs
+        # self.log( "should delete a dataset assoc when purging" )
+        # self.assertTrue( item1.deleted )
+
+    def test_purge_not_allowed( self ):
+        self.trans.app.config.allow_user_dataset_purge = False
+        item1 = self.dataset_assoc_mgr.create( self.trans )
+
+        self.log( "should raise an error when purging a dataset assoc if config does not allow" )
+        self.assertFalse( item1.purged )
+        self.assertRaises( exceptions.ConfigDoesNotAllowException, self.dataset_assoc_mgr.purge, self.trans, item1 )
+        self.assertFalse( item1.purged )
 
     #def test_metadata( self ):
     #    owner = self.user_mgr.create( self.trans, **user2_data )

--- a/test/unit/managers/test_HDAManager.py
+++ b/test/unit/managers/test_HDAManager.py
@@ -324,23 +324,23 @@ class HDASerializerTestCase( HDATestCase ):
         hda = self._create_vanilla_hda()
 
         self.log( 'should have a summary view' )
-        summary_view = self.hda_serializer.serialize_to_view( self.trans, hda, view='summary' )
+        summary_view = self.hda_serializer.serialize_to_view( hda, view='summary' )
         self.assertKeys( summary_view, self.hda_serializer.views[ 'summary' ] )
 
         self.log( 'should have the summary view as default view' )
-        default_view = self.hda_serializer.serialize_to_view( self.trans, hda, default_view='summary' )
+        default_view = self.hda_serializer.serialize_to_view( hda, default_view='summary' )
         self.assertKeys( summary_view, self.hda_serializer.views[ 'summary' ] )
 
         # self.log( 'should have a detailed view' )
-        # detailed_view = self.hda_serializer.serialize_to_view( self.trans, hda, view='detailed' )
+        # detailed_view = self.hda_serializer.serialize_to_view( hda, view='detailed' )
         # self.assertKeys( detailed_view, self.hda_serializer.views[ 'detailed' ] )
 
         # self.log( 'should have a extended view' )
-        # extended_view = self.hda_serializer.serialize_to_view( self.trans, hda, view='extended' )
+        # extended_view = self.hda_serializer.serialize_to_view( hda, view='extended' )
         # self.assertKeys( extended_view, self.hda_serializer.views[ 'extended' ] )
 
         self.log( 'should have a inaccessible view' )
-        inaccessible_view = self.hda_serializer.serialize_to_view( self.trans, hda, view='inaccessible' )
+        inaccessible_view = self.hda_serializer.serialize_to_view( hda, view='inaccessible' )
         self.assertKeys( inaccessible_view, self.hda_serializer.views[ 'inaccessible' ] )
 
         # skip metadata for this test
@@ -362,20 +362,20 @@ class HDASerializerTestCase( HDATestCase ):
         hda = self._create_vanilla_hda()
 
         self.log( 'should be able to use keys with views' )
-        serialized = self.hda_serializer.serialize_to_view( self.trans, hda,
+        serialized = self.hda_serializer.serialize_to_view( hda,
             view='summary', keys=[ 'uuid' ] )
         self.assertKeys( serialized,
             self.hda_serializer.views[ 'summary' ] + [ 'uuid' ] )
 
         self.log( 'should be able to use keys on their own' )
-        serialized = self.hda_serializer.serialize_to_view( self.trans, hda,
+        serialized = self.hda_serializer.serialize_to_view( hda,
             keys=[ 'file_path', 'visualizations' ] )
         self.assertKeys( serialized, [ 'file_path', 'visualizations' ] )
 
     def test_serializers( self ):
         hda = self._create_vanilla_hda()
         all_keys = list( self.hda_serializer.serializable_keyset )
-        serialized = self.hda_serializer.serialize( self.trans, hda, all_keys )
+        serialized = self.hda_serializer.serialize( hda, all_keys )
 
         self.log( 'everything serialized should be of the proper type' )
         # base
@@ -449,13 +449,13 @@ class HDADeserializerTestCase( HDATestCase ):
         self.log( 'should raise when deserializing deleted from non-bool' )
         self.assertFalse( hda.deleted )
         self.assertRaises( exceptions.RequestParameterInvalidException,
-            self.hda_deserializer.deserialize, self.trans, hda, data={ 'deleted': None } )
+            self.hda_deserializer.deserialize, hda, { 'deleted': None } )
         self.assertFalse( hda.deleted )
         self.log( 'should be able to deserialize deleted from True' )
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'deleted': True } )
+        self.hda_deserializer.deserialize( hda, { 'deleted': True } )
         self.assertTrue( hda.deleted )
         self.log( 'should be able to reverse by deserializing deleted from False' )
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'deleted': False } )
+        self.hda_deserializer.deserialize( hda, { 'deleted': False } )
         self.assertFalse( hda.deleted )
 
     def test_deserialize_purge( self ):
@@ -463,14 +463,14 @@ class HDADeserializerTestCase( HDATestCase ):
 
         self.log( 'should raise when deserializing purged from non-bool' )
         self.assertRaises( exceptions.RequestParameterInvalidException,
-            self.hda_deserializer.deserialize, self.trans, hda, data={ 'purged': None } )
+            self.hda_deserializer.deserialize, hda, { 'purged': None } )
         self.assertFalse( hda.purged )
         self.log( 'should be able to deserialize purged from True' )
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'purged': True } )
+        self.hda_deserializer.deserialize( hda, { 'purged': True } )
         self.assertTrue( hda.purged )
         # TODO: should this raise an error?
         self.log( 'should NOT be able to deserialize purged from False (will remain True)' )
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'purged': False } )
+        self.hda_deserializer.deserialize( hda, { 'purged': False } )
         self.assertTrue( hda.purged )
 
     def test_deserialize_visible( self ):
@@ -479,13 +479,13 @@ class HDADeserializerTestCase( HDATestCase ):
         self.log( 'should raise when deserializing from non-bool' )
         self.assertTrue( hda.visible )
         self.assertRaises( exceptions.RequestParameterInvalidException,
-            self.hda_deserializer.deserialize, self.trans, hda, data={ 'visible': 'None' } )
+            self.hda_deserializer.deserialize, hda, { 'visible': 'None' } )
         self.assertTrue( hda.visible )
         self.log( 'should be able to deserialize from False' )
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'visible': False } )
+        self.hda_deserializer.deserialize( hda, { 'visible': False } )
         self.assertFalse( hda.visible )
         self.log( 'should be able to reverse by deserializing from True' )
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'visible': True } )
+        self.hda_deserializer.deserialize( hda, { 'visible': True } )
         self.assertTrue( hda.visible )
 
     def test_deserialize_genome_build( self ):
@@ -493,17 +493,17 @@ class HDADeserializerTestCase( HDATestCase ):
 
         self.assertIsInstance( hda.dbkey, basestring )
         self.log( 'should deserialize to "?" from None' )
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'genome_build': None } )
+        self.hda_deserializer.deserialize( hda, { 'genome_build': None } )
         self.assertEqual( hda.dbkey, '?' )
         self.log( 'should raise when deserializing from non-string' )
         self.assertRaises( exceptions.RequestParameterInvalidException,
-            self.hda_deserializer.deserialize, self.trans, hda, data={ 'genome_build': 12 } )
+            self.hda_deserializer.deserialize, hda, { 'genome_build': 12 } )
         self.log( 'should be able to deserialize from unicode' )
         date_palm = u'نخيل التمر'
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'genome_build': date_palm } )
+        self.hda_deserializer.deserialize( hda, { 'genome_build': date_palm } )
         self.assertEqual( hda.dbkey, date_palm )
         self.log( 'should be deserializable from empty string' )
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'genome_build': '' } )
+        self.hda_deserializer.deserialize( hda, { 'genome_build': '' } )
         self.assertEqual( hda.dbkey, '' )
 
     def test_deserialize_name( self ):
@@ -511,19 +511,19 @@ class HDADeserializerTestCase( HDATestCase ):
 
         self.log( 'should raise when deserializing from non-string' )
         self.assertRaises( exceptions.RequestParameterInvalidException,
-            self.hda_deserializer.deserialize, self.trans, hda, data={ 'name': True } )
+            self.hda_deserializer.deserialize, hda, { 'name': True } )
         self.log( 'should raise when deserializing from None' )
         self.assertRaises( exceptions.RequestParameterInvalidException,
-            self.hda_deserializer.deserialize, self.trans, hda, data={ 'name': None } )
+            self.hda_deserializer.deserialize, hda, { 'name': None } )
         # self.log( 'should deserialize to empty string from None' )
-        # self.hda_deserializer.deserialize( self.trans, hda, data={ 'name': None } )
+        # self.hda_deserializer.deserialize( hda, { 'name': None } )
         # self.assertEqual( hda.name, '' )
         self.log( 'should be able to deserialize from unicode' )
         olive = u'ελιά'
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'name': olive } )
+        self.hda_deserializer.deserialize( hda, { 'name': olive } )
         self.assertEqual( hda.name, olive )
         self.log( 'should be deserializable from empty string' )
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'name': '' } )
+        self.hda_deserializer.deserialize( hda, { 'name': '' } )
         self.assertEqual( hda.name, '' )
 
     def test_deserialize_info( self ):
@@ -531,16 +531,16 @@ class HDADeserializerTestCase( HDATestCase ):
 
         self.log( 'should raise when deserializing from non-string' )
         self.assertRaises( exceptions.RequestParameterInvalidException,
-            self.hda_deserializer.deserialize, self.trans, hda, data={ 'info': True } )
+            self.hda_deserializer.deserialize, hda, { 'info': True } )
         self.log( 'should raise when deserializing from None' )
         self.assertRaises( exceptions.RequestParameterInvalidException,
-            self.hda_deserializer.deserialize, self.trans, hda, data={ 'info': None } )
+            self.hda_deserializer.deserialize, hda, { 'info': None } )
         self.log( 'should be able to deserialize from unicode' )
         rice = u'飯'
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'info': rice } )
+        self.hda_deserializer.deserialize( hda, { 'info': rice } )
         self.assertEqual( hda.info, rice )
         self.log( 'should be deserializable from empty string' )
-        self.hda_deserializer.deserialize( self.trans, hda, data={ 'info': '' } )
+        self.hda_deserializer.deserialize( hda, { 'info': '' } )
         self.assertEqual( hda.info, '' )
 
 

--- a/test/unit/managers/test_HDAManager.py
+++ b/test/unit/managers/test_HDAManager.py
@@ -454,122 +454,87 @@ class HDADeserializerTestCase( HDATestCase ):
         self.hda_deserializer.deserialize( self.trans, hda, data={ 'genome_build': '' } )
         self.assertEqual( hda.dbkey, '' )
 
+    def test_deserialize_name( self ):
+        hda = self._create_vanilla_hda()
 
-# # =============================================================================
-# # web.url_for doesn't work well in the framework
-# testable_url_for = lambda *a, **k: '(fake url): %s, %s' % ( a, k )
-# DatasetSerializer.url_for = staticmethod( testable_url_for )
+        self.log( 'should raise when deserializing from non-string' )
+        self.assertRaises( exceptions.RequestParameterInvalidException,
+            self.hda_deserializer.deserialize, self.trans, hda, data={ 'name': True } )
+        self.log( 'should raise when deserializing from None' )
+        self.assertRaises( exceptions.RequestParameterInvalidException,
+            self.hda_deserializer.deserialize, self.trans, hda, data={ 'name': None } )
+        # self.log( 'should deserialize to empty string from None' )
+        # self.hda_deserializer.deserialize( self.trans, hda, data={ 'name': None } )
+        # self.assertEqual( hda.name, '' )
+        self.log( 'should be able to deserialize from unicode' )
+        olive = u'ελιά'
+        self.hda_deserializer.deserialize( self.trans, hda, data={ 'name': olive } )
+        self.assertEqual( hda.name, olive )
+        self.log( 'should be deserializable from empty string' )
+        self.hda_deserializer.deserialize( self.trans, hda, data={ 'name': '' } )
+        self.assertEqual( hda.name, '' )
 
-# class DatasetAssociationSerializerTestCase( BaseTestCase ):
+    def test_deserialize_info( self ):
+        hda = self._create_vanilla_hda()
 
-#     def set_up_managers( self ):
-#         super( DatasetAssociationSerializerTestCase, self ).set_up_managers()
-#         self.dataset_assoc_mgr = DatasetAssociationManager( self.app )
-#         self.dataset_assoc_serializer = DatasetAssocationSerializer( self.app )
-
-#     def test_views( self ):
-#         dataset_assoc = self.dataset_mgr.create( self.trans )
-
-#         self.log( 'should have a summary view' )
-#         summary_view = self.dataset_serializer.serialize_to_view( self.trans, dataset, view='summary' )
-#         self.assertKeys( summary_view, self.dataset_serializer.views[ 'summary' ] )
-
-#         self.log( 'should have the summary view as default view' )
-#         default_view = self.dataset_serializer.serialize_to_view( self.trans, dataset, default_view='summary' )
-#         self.assertKeys( summary_view, self.dataset_serializer.views[ 'summary' ] )
-
-#         self.log( 'should have a serializer for all serializable keys' )
-#         for key in self.dataset_serializer.serializable_keyset:
-#             instantiated_attribute = getattr( dataset, key, None )
-#             if not ( ( key in self.dataset_serializer.serializers )
-#                   or ( isinstance( instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS ) ) ):
-#                 self.fail( 'no serializer for: %s (%s)' % ( key, instantiated_attribute ) )
-#         else:
-#             self.assertTrue( True, 'all serializable keys have a serializer' )
-
-#     def test_views_and_keys( self ):
-#         dataset = self.dataset_mgr.create( self.trans )
-
-#         self.log( 'should be able to use keys with views' )
-#         serialized = self.dataset_serializer.serialize_to_view( self.trans, dataset,
-#             view='summary', keys=[ 'permissions' ] )
-#         self.assertKeys( serialized,
-#             self.dataset_serializer.views[ 'summary' ] + [ 'permissions' ] )
-
-#         self.log( 'should be able to use keys on their own' )
-#         serialized = self.dataset_serializer.serialize_to_view( self.trans, dataset,
-#             keys=[ 'purgable', 'file_size' ] )
-#         self.assertKeys( serialized, [ 'purgable', 'file_size' ] )
-
-#     def test_serialize_permissions( self ):
-#         dataset = self.dataset_mgr.create( self.trans )
-#         self.log( 'serialized permissions should be well formed' )
-
-#     def test_serializers( self ):
-#         user2 = self.user_mgr.create( self.trans, **user2_data )
-#         dataset = self.dataset_mgr.create( self.trans )
-#         all_keys = list( self.hda_serializer.serializable_keyset )
-#         serialized = self.dataset_serializer.serialize( self.trans, dataset, all_keys )
-
-#         self.log( 'everything serialized should be of the proper type' )
-#         self.assertEncodedId( serialized[ 'id' ] )
-#         self.assertDate( serialized[ 'create_time' ] )
-#         self.assertDate( serialized[ 'update_time' ] )
-
-#         self.assertUUID( serialized[ 'uuid' ] )
-#         self.assertIsInstance( serialized[ 'state' ], basestring )
-#         self.assertIsInstance( serialized[ 'deleted' ], bool )
-#         self.assertIsInstance( serialized[ 'purged' ], bool )
-#         self.assertIsInstance( serialized[ 'purgable' ], bool )
-
-#         # # TODO: no great way to do these with mocked dataset
-#         # self.assertIsInstance( serialized[ 'file_size' ], int )
-#         # self.assertIsInstance( serialized[ 'total_size' ], int )
-
-#         self.log( 'serialized should jsonify well' )
-#         self.assertIsJsonifyable( serialized )
+        self.log( 'should raise when deserializing from non-string' )
+        self.assertRaises( exceptions.RequestParameterInvalidException,
+            self.hda_deserializer.deserialize, self.trans, hda, data={ 'info': True } )
+        self.log( 'should raise when deserializing from None' )
+        self.assertRaises( exceptions.RequestParameterInvalidException,
+            self.hda_deserializer.deserialize, self.trans, hda, data={ 'info': None } )
+        self.log( 'should be able to deserialize from unicode' )
+        rice = u'飯'
+        self.hda_deserializer.deserialize( self.trans, hda, data={ 'info': rice } )
+        self.assertEqual( hda.info, rice )
+        self.log( 'should be deserializable from empty string' )
+        self.hda_deserializer.deserialize( self.trans, hda, data={ 'info': '' } )
+        self.assertEqual( hda.info, '' )
 
 
-# # =============================================================================
-# class DatasetAssocationDeserializerTestCase( BaseTestCase ):
+# =============================================================================
+class HDAFilterParserTestCase( HDATestCase ):
 
-#     def set_up_managers( self ):
-#         super( DatasetAssocationDeserializerTestCase, self ).set_up_managers()
-#         self.dataset_mgr = DatasetAssocationManager( self.app )
-#         self.dataset_deserializer = DatasetAssocationDeserializer( self.app )
+    def set_up_managers( self ):
+        super( HDAFilterParserTestCase, self ).set_up_managers()
+        self.filter_parser = hdas.HDAFilterParser( self.app )
 
-#     def test_deserialize_delete( self ):
-#         dataset = self.dataset_mgr.create( self.trans )
+    def test_parsable( self ):
+        self.log( 'the following filters should be parsable' )
+        # base
+        self.assertORMFilter( self.filter_parser.parse_filter( 'id', 'in', [ 1, 2 ] ) )
+        encoded_id_string = ','.join([ self.app.security.encode_id( id_ ) for id_ in [ 1, 2 ] ] )
+        self.assertORMFilter( self.filter_parser.parse_filter( 'encoded_id', 'in', encoded_id_string ) )
+        self.assertORMFilter( self.filter_parser.parse_filter( 'create_time', 'le', '2015-03-15' ) )
+        self.assertORMFilter( self.filter_parser.parse_filter( 'create_time', 'ge', '2015-03-15' ) )
+        self.assertORMFilter( self.filter_parser.parse_filter( 'update_time', 'le', '2015-03-15' ) )
+        self.assertORMFilter( self.filter_parser.parse_filter( 'update_time', 'ge', '2015-03-15' ) )
+        # purgable
+        self.assertORMFilter( self.filter_parser.parse_filter( 'deleted', 'eq', True ) )
+        self.assertORMFilter( self.filter_parser.parse_filter( 'purged', 'eq', True ) )
+        # dataset asociation
+        self.assertORMFilter( self.filter_parser.parse_filter( 'name', 'eq', 'wot' ) )
+        self.assertORMFilter( self.filter_parser.parse_filter( 'name', 'contains', 'wot' ) )
+        self.assertORMFilter( self.filter_parser.parse_filter( 'name', 'like', 'wot' ) )
+        self.assertORMFilter( self.filter_parser.parse_filter( 'state', 'eq', 'ok' ) )
+        self.assertORMFilter( self.filter_parser.parse_filter( 'state', 'in', [ 'queued', 'running' ] ) )
+        self.assertORMFilter( self.filter_parser.parse_filter( 'visible', 'eq', True ) )
+        self.assertFnFilter( self.filter_parser.parse_filter( 'genome_build', 'eq', 'wot' ) )
+        self.assertFnFilter( self.filter_parser.parse_filter( 'genome_build', 'contains', 'wot' ) )
+        self.assertFnFilter( self.filter_parser.parse_filter( 'data_type', 'eq', 'wot' ) )
+        self.assertFnFilter( self.filter_parser.parse_filter( 'data_type', 'isinstance', 'wot' ) )
+        # taggable
+        self.assertFnFilter( self.filter_parser.parse_filter( 'tag', 'eq', 'wot' ) )
+        self.assertFnFilter( self.filter_parser.parse_filter( 'tag', 'has', 'wot' ) )
+        # annotatable
+        self.assertFnFilter( self.filter_parser.parse_filter( 'annotation', 'has', 'wot' ) )
 
-#         self.log( 'should raise when deserializing deleted from non-bool' )
-#         self.assertFalse( dataset.deleted )
-#         self.assertRaises( exceptions.RequestParameterInvalidException,
-#             self.dataset_deserializer.deserialize, self.trans, dataset, data={ 'deleted': None } )
-#         self.assertFalse( dataset.deleted )
-#         self.log( 'should be able to deserialize deleted from True' )
-#         self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'deleted': True } )
-#         self.assertTrue( dataset.deleted )
-#         self.log( 'should be able to reverse by deserializing deleted from False' )
-#         self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'deleted': False } )
-#         self.assertFalse( dataset.deleted )
 
-#     def test_deserialize_purge( self ):
-#         dataset = self.dataset_mgr.create( self.trans )
+    def test_genome_build_filters( self ):
+        pass
 
-#         self.log( 'should raise when deserializing purged from non-bool' )
-#         self.assertRaises( exceptions.RequestParameterInvalidException,
-#             self.dataset_deserializer.deserialize, self.trans, dataset, data={ 'purged': None } )
-#         self.assertFalse( dataset.purged )
-#         self.log( 'should be able to deserialize purged from True' )
-#         self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'purged': True } )
-#         self.assertTrue( dataset.purged )
-#         # TODO: should this raise an error?
-#         self.log( 'should NOT be able to deserialize purged from False (will remain True)' )
-#         self.dataset_deserializer.deserialize( self.trans, dataset, data={ 'purged': False } )
-#         self.assertTrue( dataset.purged )
-
-#     # def test_deserialize_permissions( self ):
-#     #     pass
+    def test_data_type_filters( self ):
+        pass
 
 
 # =============================================================================

--- a/test/unit/managers/test_HistoryManager.py
+++ b/test/unit/managers/test_HistoryManager.py
@@ -316,7 +316,6 @@ testable_url_for = lambda *a, **k: '(fake url): %s, %s' % ( a, k )
 HistorySerializer.url_for = staticmethod( testable_url_for )
 hdas.HDASerializer.url_for = staticmethod( testable_url_for )
 
-
 class HistorySerializerTestCase( BaseTestCase ):
 
     def set_up_managers( self ):

--- a/test/unit/managers/test_HistoryManager.py
+++ b/test/unit/managers/test_HistoryManager.py
@@ -5,6 +5,7 @@ import sys
 import os
 import pprint
 import unittest
+import json
 
 __GALAXY_ROOT__ = os.getcwd() + '/../../../'
 sys.path.insert( 1, __GALAXY_ROOT__ + 'lib' )
@@ -398,10 +399,15 @@ class HistorySerializerTestCase( BaseTestCase ):
     def test_history_serializers( self ):
         user2 = self.user_mgr.create( self.trans, **user2_data )
         history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
-        
-        serialized = self.history_serializer.serialize( self.trans, history1, [ 'size', 'nice_size' ])
+        all_keys = self.history_serializer.serializable_keyset
+        serialized = self.history_serializer.serialize( self.trans, history1, all_keys )
+
+        self.log( 'everything serialized should be of the proper type' )
         self.assertIsInstance( serialized[ 'size' ], int )
         self.assertIsInstance( serialized[ 'nice_size' ], basestring )
+
+        self.log( 'serialized should jsonify well' )
+        self.assertIsInstance( json.dumps( serialized ), basestring )
 
     def test_contents( self ):
         user2 = self.user_mgr.create( self.trans, **user2_data )
@@ -464,7 +470,7 @@ class HistoryFiltersTestCase( BaseTestCase ):
         self.assertEqual( len( filters ), 3 )
 
         self.log( 'values should be parsed' )
-        self.assertEqual( filters[1].right.value, True )
+        self.assertIsInstance( filters[1].right, sqlalchemy.sql.elements.True_ )
 
     def test_parse_filters_invalid_filters( self ):
         self.log( 'should error on non-column attr')

--- a/test/unit/managers/test_HistoryManager.py
+++ b/test/unit/managers/test_HistoryManager.py
@@ -396,7 +396,7 @@ class HistorySerializerTestCase( BaseTestCase ):
     def test_history_serializers( self ):
         user2 = self.user_mgr.create( self.trans, **user2_data )
         history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
-        all_keys = list( self.hda_serializer.serializable_keyset )
+        all_keys = list( self.history_serializer.serializable_keyset )
         serialized = self.history_serializer.serialize( self.trans, history1, all_keys )
 
         self.log( 'everything serialized should be of the proper type' )
@@ -404,7 +404,7 @@ class HistorySerializerTestCase( BaseTestCase ):
         self.assertIsInstance( serialized[ 'nice_size' ], basestring )
 
         self.log( 'serialized should jsonify well' )
-        self.assertIsInstance( json.dumps( serialized ), basestring )
+        self.assertIsJsonifyable( serialized )
 
     def test_contents( self ):
         user2 = self.user_mgr.create( self.trans, **user2_data )

--- a/test/unit/managers/test_HistoryManager.py
+++ b/test/unit/managers/test_HistoryManager.py
@@ -39,14 +39,14 @@ class HistoryManagerTestCase( BaseTestCase ):
 
     def set_up_managers( self ):
         super( HistoryManagerTestCase, self ).set_up_managers()
-        self.history_mgr = HistoryManager( self.app )
+        self.history_manager = HistoryManager( self.app )
 
     def test_base( self ):
-        user2 = self.user_mgr.create( self.trans, **user2_data )
-        user3 = self.user_mgr.create( self.trans, **user3_data )
+        user2 = self.user_manager.create( **user2_data )
+        user3 = self.user_manager.create( **user3_data )
 
         self.log( "should be able to create a new history" )
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
+        history1 = self.history_manager.create( name='history1', user=user2 )
         self.assertIsInstance( history1, model.History )
         self.assertEqual( history1.name, 'history1' )
         self.assertEqual( history1.user, user2 )
@@ -57,7 +57,7 @@ class HistoryManagerTestCase( BaseTestCase ):
             self.trans.sa_session.query( model.History ).filter( model.History.user == user2 ).one() )
 
         self.log( "should be able to copy a history" )
-        history2 = self.history_mgr.copy( self.trans, history1, user=user3 )
+        history2 = self.history_manager.copy( history1, user=user3 )
         self.assertIsInstance( history2, model.History )
         self.assertEqual( history2.user, user3 )
         self.assertEqual( history2, self.trans.sa_session.query( model.History ).get( history2.id ) )
@@ -66,184 +66,184 @@ class HistoryManagerTestCase( BaseTestCase ):
 
         self.log( "should be able to query" )
         histories = self.trans.sa_session.query( model.History ).all()
-        self.assertEqual( self.history_mgr.one( self.trans, filters=( model.History.id == history1.id ) ), history1 )
-        self.assertEqual( self.history_mgr.list( self.trans ), histories )
-        self.assertEqual( self.history_mgr.by_id( self.trans, history1.id ), history1 )
-        self.assertEqual( self.history_mgr.by_ids( self.trans, [ history2.id, history1.id ] ), [ history2, history1 ] )
+        self.assertEqual( self.history_manager.one( filters=( model.History.id == history1.id ) ), history1 )
+        self.assertEqual( self.history_manager.list(), histories )
+        self.assertEqual( self.history_manager.by_id( history1.id ), history1 )
+        self.assertEqual( self.history_manager.by_ids( [ history2.id, history1.id ] ), [ history2, history1 ] )
 
         self.log( "should be able to limit and offset" )
-        self.assertEqual( self.history_mgr.list( self.trans, limit=1 ), histories[0:1] )
-        self.assertEqual( self.history_mgr.list( self.trans, offset=1 ), histories[1:] )
-        self.assertEqual( self.history_mgr.list( self.trans, limit=1, offset=1 ), histories[1:2] )
+        self.assertEqual( self.history_manager.list( limit=1 ), histories[0:1] )
+        self.assertEqual( self.history_manager.list( offset=1 ), histories[1:] )
+        self.assertEqual( self.history_manager.list( limit=1, offset=1 ), histories[1:2] )
 
-        self.assertEqual( self.history_mgr.list( self.trans, limit=0 ), [] )
-        self.assertEqual( self.history_mgr.list( self.trans, offset=3 ), [] )
+        self.assertEqual( self.history_manager.list( limit=0 ), [] )
+        self.assertEqual( self.history_manager.list( offset=3 ), [] )
 
         self.log( "should be able to order" )
-        history3 = self.history_mgr.create( self.trans, name="history3", user=user2 )
+        history3 = self.history_manager.create( name="history3", user=user2 )
         name_first_then_time = ( model.History.name, sqlalchemy.desc( model.History.create_time ) )
-        self.assertEqual( self.history_mgr.list( self.trans, order_by=name_first_then_time ),
+        self.assertEqual( self.history_manager.list( order_by=name_first_then_time ),
             [ history2, history1, history3 ] )
 
     def test_has_user( self ):
-        owner = self.user_mgr.create( self.trans, **user2_data )
-        non_owner = self.user_mgr.create( self.trans, **user3_data )
+        owner = self.user_manager.create( **user2_data )
+        non_owner = self.user_manager.create( **user3_data )
 
-        item1 = self.history_mgr.create( self.trans, user=owner )
-        item2 = self.history_mgr.create( self.trans, user=owner )
-        item3 = self.history_mgr.create( self.trans, user=non_owner )
+        item1 = self.history_manager.create( user=owner )
+        item2 = self.history_manager.create( user=owner )
+        item3 = self.history_manager.create( user=non_owner )
 
         self.log( "should be able to list items by user" )
-        user_histories = self.history_mgr.by_user( self.trans, owner )
+        user_histories = self.history_manager.by_user( owner )
         self.assertEqual( user_histories, [ item1, item2 ] )
 
     def test_ownable( self ):
-        owner = self.user_mgr.create( self.trans, **user2_data )
-        non_owner = self.user_mgr.create( self.trans, **user3_data )
+        owner = self.user_manager.create( **user2_data )
+        non_owner = self.user_manager.create( **user3_data )
 
-        item1 = self.history_mgr.create( self.trans, user=owner )
+        item1 = self.history_manager.create( user=owner )
 
         self.log( "should be able to poll whether a given user owns an item" )
-        self.assertTrue(  self.history_mgr.is_owner( self.trans, item1, owner ) )
-        self.assertFalse( self.history_mgr.is_owner( self.trans, item1, non_owner ) )
+        self.assertTrue(  self.history_manager.is_owner( item1, owner ) )
+        self.assertFalse( self.history_manager.is_owner( item1, non_owner ) )
 
         self.log( "should raise an error when checking ownership with non-owner" )
         self.assertRaises( exceptions.ItemOwnershipException,
-            self.history_mgr.error_unless_owner, self.trans, item1, non_owner )
+            self.history_manager.error_unless_owner, item1, non_owner )
         self.assertRaises( exceptions.ItemOwnershipException,
-            self.history_mgr.get_owned, self.trans, item1.id, non_owner )
+            self.history_manager.get_owned, item1.id, non_owner )
 
         self.log( "should not raise an error when checking ownership with owner" )
-        self.assertEqual( self.history_mgr.error_unless_owner( self.trans, item1, owner ), item1 )
-        self.assertEqual( self.history_mgr.get_owned( self.trans, item1.id, owner ), item1 )
+        self.assertEqual( self.history_manager.error_unless_owner( item1, owner ), item1 )
+        self.assertEqual( self.history_manager.get_owned( item1.id, owner ), item1 )
 
         self.log( "should not raise an error when checking ownership with admin" )
-        self.assertTrue( self.history_mgr.is_owner( self.trans, item1, self.admin_user ) )
-        self.assertEqual( self.history_mgr.error_unless_owner( self.trans, item1, self.admin_user ), item1 )
-        self.assertEqual( self.history_mgr.get_owned( self.trans, item1.id, self.admin_user ), item1 )
+        self.assertTrue( self.history_manager.is_owner( item1, self.admin_user ) )
+        self.assertEqual( self.history_manager.error_unless_owner( item1, self.admin_user ), item1 )
+        self.assertEqual( self.history_manager.get_owned( item1.id, self.admin_user ), item1 )
 
     def test_accessible( self ):
-        owner = self.user_mgr.create( self.trans, **user2_data )
-        item1 = self.history_mgr.create( self.trans, user=owner )
+        owner = self.user_manager.create( **user2_data )
+        item1 = self.history_manager.create( user=owner )
 
-        non_owner = self.user_mgr.create( self.trans, **user3_data )
+        non_owner = self.user_manager.create( **user3_data )
 
         self.log( "should be inaccessible by default except to owner" )
-        self.assertTrue( self.history_mgr.is_accessible( self.trans, item1, owner ) )
-        self.assertTrue( self.history_mgr.is_accessible( self.trans, item1, self.admin_user ) )
-        self.assertFalse( self.history_mgr.is_accessible( self.trans, item1, non_owner ) )
+        self.assertTrue( self.history_manager.is_accessible( item1, owner ) )
+        self.assertTrue( self.history_manager.is_accessible( item1, self.admin_user ) )
+        self.assertFalse( self.history_manager.is_accessible( item1, non_owner ) )
 
         self.log( "should raise an error when checking accessibility with non-owner" )
         self.assertRaises( exceptions.ItemAccessibilityException,
-            self.history_mgr.error_unless_accessible, self.trans, item1, non_owner )
+            self.history_manager.error_unless_accessible, item1, non_owner )
         self.assertRaises( exceptions.ItemAccessibilityException,
-            self.history_mgr.get_accessible, self.trans, item1.id, non_owner )
+            self.history_manager.get_accessible, item1.id, non_owner )
 
         self.log( "should not raise an error when checking ownership with owner" )
-        self.assertEqual( self.history_mgr.error_unless_accessible( self.trans, item1, owner ), item1 )
-        self.assertEqual( self.history_mgr.get_accessible( self.trans, item1.id, owner ), item1 )
+        self.assertEqual( self.history_manager.error_unless_accessible( item1, owner ), item1 )
+        self.assertEqual( self.history_manager.get_accessible( item1.id, owner ), item1 )
 
         self.log( "should not raise an error when checking ownership with admin" )
-        self.assertTrue( self.history_mgr.is_accessible( self.trans, item1, self.admin_user ) )
-        self.assertEqual( self.history_mgr.error_unless_accessible( self.trans, item1, self.admin_user ), item1 )
-        self.assertEqual( self.history_mgr.get_accessible( self.trans, item1.id, self.admin_user ), item1 )
+        self.assertTrue( self.history_manager.is_accessible( item1, self.admin_user ) )
+        self.assertEqual( self.history_manager.error_unless_accessible( item1, self.admin_user ), item1 )
+        self.assertEqual( self.history_manager.get_accessible( item1.id, self.admin_user ), item1 )
 
     def test_importable( self ):
-        owner = self.user_mgr.create( self.trans, **user2_data )
+        owner = self.user_manager.create( **user2_data )
         self.trans.set_user( owner )
-        non_owner = self.user_mgr.create( self.trans, **user3_data )
+        non_owner = self.user_manager.create( **user3_data )
 
-        item1 = self.history_mgr.create( self.trans, user=owner )
+        item1 = self.history_manager.create( user=owner )
 
         self.log( "should not be importable by default" )
         self.assertFalse( item1.importable )
         self.assertIsNone( item1.slug )
 
         self.log( "should be able to make importable (accessible by link) to all users" )
-        accessible = self.history_mgr.make_importable( self.trans, item1 )
+        accessible = self.history_manager.make_importable( item1 )
         self.assertEqual( accessible, item1 )
         self.assertIsNotNone( accessible.slug )
         self.assertTrue( accessible.importable )
 
-        for user in self.user_mgr.list( self.trans ):
-            self.assertTrue( self.history_mgr.is_accessible( self.trans, accessible, user ) )
+        for user in self.user_manager.list():
+            self.assertTrue( self.history_manager.is_accessible( accessible, user ) )
 
         self.log( "should be able to make non-importable/inaccessible again" )
-        inaccessible = self.history_mgr.make_non_importable( self.trans, accessible )
+        inaccessible = self.history_manager.make_non_importable( accessible )
         self.assertEqual( inaccessible, accessible )
         self.assertIsNotNone( inaccessible.slug )
         self.assertFalse( inaccessible.importable )
 
-        self.assertTrue( self.history_mgr.is_accessible( self.trans, inaccessible, owner ) )
-        self.assertFalse( self.history_mgr.is_accessible( self.trans, inaccessible, non_owner ) )
-        self.assertTrue( self.history_mgr.is_accessible( self.trans, inaccessible, self.admin_user ) )
+        self.assertTrue( self.history_manager.is_accessible( inaccessible, owner ) )
+        self.assertFalse( self.history_manager.is_accessible( inaccessible, non_owner ) )
+        self.assertTrue( self.history_manager.is_accessible( inaccessible, self.admin_user ) )
 
     def test_published( self ):
-        owner = self.user_mgr.create( self.trans, **user2_data )
+        owner = self.user_manager.create( **user2_data )
         self.trans.set_user( owner )
-        non_owner = self.user_mgr.create( self.trans, **user3_data )
+        non_owner = self.user_manager.create( **user3_data )
 
-        item1 = self.history_mgr.create( self.trans, user=owner )
+        item1 = self.history_manager.create( user=owner )
 
         self.log( "should not be published by default" )
         self.assertFalse( item1.published )
         self.assertIsNone( item1.slug )
 
         self.log( "should be able to publish (listed publicly) to all users" )
-        published = self.history_mgr.publish( self.trans, item1 )
+        published = self.history_manager.publish( item1 )
         self.assertEqual( published, item1 )
         self.assertTrue( published.published )
         # note: publishing sets importable to true as well
         self.assertTrue( published.importable )
         self.assertIsNotNone( published.slug )
 
-        for user in self.user_mgr.list( self.trans ):
-            self.assertTrue( self.history_mgr.is_accessible( self.trans, published, user ) )
+        for user in self.user_manager.list():
+            self.assertTrue( self.history_manager.is_accessible( published, user ) )
 
         self.log( "should be able to make non-importable/inaccessible again" )
-        unpublished = self.history_mgr.unpublish( self.trans, published )
+        unpublished = self.history_manager.unpublish( published )
         self.assertEqual( unpublished, published )
         self.assertFalse( unpublished.published )
         # note: unpublishing does not make non-importable, you must explicitly do that separately
         self.assertTrue( published.importable )
-        self.history_mgr.make_non_importable( self.trans, unpublished )
+        self.history_manager.make_non_importable( unpublished )
         self.assertFalse( published.importable )
         # note: slug still remains after unpublishing
         self.assertIsNotNone( unpublished.slug )
 
-        self.assertTrue( self.history_mgr.is_accessible( self.trans, unpublished, owner ) )
-        self.assertFalse( self.history_mgr.is_accessible( self.trans, unpublished, non_owner ) )
-        self.assertTrue( self.history_mgr.is_accessible( self.trans, unpublished, self.admin_user ) )
+        self.assertTrue( self.history_manager.is_accessible( unpublished, owner ) )
+        self.assertFalse( self.history_manager.is_accessible( unpublished, non_owner ) )
+        self.assertTrue( self.history_manager.is_accessible( unpublished, self.admin_user ) )
 
     def test_sharable( self ):
-        owner = self.user_mgr.create( self.trans, **user2_data )
+        owner = self.user_manager.create( **user2_data )
         self.trans.set_user( owner )
-        item1 = self.history_mgr.create( self.trans, user=owner )
+        item1 = self.history_manager.create( user=owner )
 
-        non_owner = self.user_mgr.create( self.trans, **user3_data )
-        #third_party = self.user_mgr.create( self.trans, **user4_data )
+        non_owner = self.user_manager.create( **user3_data )
+        #third_party = self.user_manager.create( **user4_data )
 
         self.log( "should be unshared by default" )
-        self.assertEqual( self.history_mgr.get_share_assocs( self.trans, item1 ), [] )
+        self.assertEqual( self.history_manager.get_share_assocs( item1 ), [] )
         self.assertEqual( item1.slug, None )
 
         self.log( "should be able to share with specific users" )
-        share_assoc = self.history_mgr.share_with( self.trans, item1, non_owner )
+        share_assoc = self.history_manager.share_with( item1, non_owner )
         self.assertIsInstance( share_assoc, model.HistoryUserShareAssociation )
-        self.assertTrue( self.history_mgr.is_accessible( self.trans, item1, non_owner ) )
+        self.assertTrue( self.history_manager.is_accessible( item1, non_owner ) )
         self.assertEqual(
-            len( self.history_mgr.get_share_assocs( self.trans, item1 ) ), 1 )
+            len( self.history_manager.get_share_assocs( item1 ) ), 1 )
         self.assertEqual(
-            len( self.history_mgr.get_share_assocs( self.trans, item1, user=non_owner ) ), 1 )
+            len( self.history_manager.get_share_assocs( item1, user=non_owner ) ), 1 )
         self.assertIsInstance( item1.slug, basestring )
 
         self.log( "should be able to unshare with specific users" )
-        share_assoc = self.history_mgr.unshare_with( self.trans, item1, non_owner )
+        share_assoc = self.history_manager.unshare_with( item1, non_owner )
         self.assertIsInstance( share_assoc, model.HistoryUserShareAssociation )
-        self.assertFalse( self.history_mgr.is_accessible( self.trans, item1, non_owner ) )
-        self.assertEqual( self.history_mgr.get_share_assocs( self.trans, item1 ), [] )
+        self.assertFalse( self.history_manager.is_accessible( item1, non_owner ) )
+        self.assertEqual( self.history_manager.get_share_assocs( item1 ), [] )
         self.assertEqual(
-            self.history_mgr.get_share_assocs( self.trans, item1, user=non_owner ), [] )
+            self.history_manager.get_share_assocs( item1, user=non_owner ), [] )
 
     #TODO: test slug formation
 
@@ -252,61 +252,64 @@ class HistoryManagerTestCase( BaseTestCase ):
         self.trans.set_user( anon_user )
 
         self.log( "should not allow access and owner for anon user on a history by another anon user (None)" )
-        anon_history1 = self.history_mgr.create( self.trans, user=None )
-        self.assertFalse( self.history_mgr.is_owner( self.trans, anon_history1, anon_user ) )
-        self.assertFalse( self.history_mgr.is_accessible( self.trans, anon_history1, anon_user ) )
+        anon_history1 = self.history_manager.create( user=None )
+        # do not set the trans.history!
+        self.assertFalse( self.history_manager.is_owner( anon_history1, anon_user, current_history=self.trans.history ) )
+        self.assertFalse( self.history_manager.is_accessible( anon_history1, anon_user, current_history=self.trans.history ) )
 
         self.log( "should allow access and owner for anon user on a history if it's the session's current history" )
-        anon_history2 = self.history_mgr.create( self.trans, user=anon_user )
+        anon_history2 = self.history_manager.create( user=anon_user )
         self.trans.set_history( anon_history2 )
-        self.assertTrue( self.history_mgr.is_owner( self.trans, anon_history2, anon_user ) )
-        self.assertTrue( self.history_mgr.is_accessible( self.trans, anon_history2, anon_user ) )
+        self.assertTrue( self.history_manager.is_owner( anon_history2, anon_user, current_history=self.trans.history ) )
+        self.assertTrue( self.history_manager.is_accessible( anon_history2, anon_user, current_history=self.trans.history ) )
 
         self.log( "should not allow owner or access for anon user on someone elses history" )
-        owner = self.user_mgr.create( self.trans, **user2_data )
-        someone_elses = self.history_mgr.create( self.trans, user=owner )
-        self.assertFalse( self.history_mgr.is_owner( self.trans, someone_elses, anon_user ) )
-        self.assertFalse( self.history_mgr.is_accessible( self.trans, someone_elses, anon_user ) )
+        owner = self.user_manager.create( **user2_data )
+        someone_elses = self.history_manager.create( user=owner )
+        self.assertFalse( self.history_manager.is_owner( someone_elses, anon_user, current_history=self.trans.history ) )
+        self.assertFalse( self.history_manager.is_accessible( someone_elses, anon_user, current_history=self.trans.history ) )
 
         self.log( "should allow access for anon user if the history is published or importable" )
-        self.history_mgr.make_importable( self.trans, someone_elses )
-        self.assertTrue( self.history_mgr.is_accessible( self.trans, someone_elses, anon_user ) )
-        self.history_mgr.publish( self.trans, someone_elses )
-        self.assertTrue( self.history_mgr.is_accessible( self.trans, someone_elses, anon_user ) )
+        self.history_manager.make_importable( someone_elses )
+        self.assertTrue( self.history_manager.is_accessible( someone_elses, anon_user, current_history=self.trans.history ) )
+        self.history_manager.publish( someone_elses )
+        self.assertTrue( self.history_manager.is_accessible( someone_elses, anon_user, current_history=self.trans.history ) )
 
     def test_delete_and_purge( self ):
-        user2 = self.user_mgr.create( self.trans, **user2_data )
+        user2 = self.user_manager.create( **user2_data )
         self.trans.set_user( user2 )
 
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
+        history1 = self.history_manager.create( name='history1', user=user2 )
         self.trans.set_history( history1 )
 
+        self.log( "should allow deletion and undeletion" )
         self.assertFalse( history1.deleted )
 
-        self.history_mgr.delete( self.trans, history1 )
+        self.history_manager.delete(  history1 )
         self.assertTrue( history1.deleted )
 
-        self.history_mgr.undelete( self.trans, history1 )
+        self.history_manager.undelete( history1 )
         self.assertFalse( history1.deleted )
 
-        history2 = self.history_mgr.create( self.trans, name='history2', user=user2 )
-        self.history_mgr.purge( self.trans, history1 )
-        self.assertTrue( history1.purged )
+        self.log( "should allow purging" )
+        history2 = self.history_manager.create( name='history2', user=user2 )
+        self.history_manager.purge( history2 )
+        self.assertTrue( history2.purged )
 
-    def test_histories( self ):
-        user2 = self.user_mgr.create( self.trans, **user2_data )
+    def test_current( self ):
+        user2 = self.user_manager.create( **user2_data )
         self.trans.set_user( user2 )
 
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
+        history1 = self.history_manager.create( name='history1', user=user2 )
         self.trans.set_history( history1 )
-        history2 = self.history_mgr.create( self.trans, name='history2', user=user2 )
+        history2 = self.history_manager.create( name='history2', user=user2 )
 
         self.log( "should be able to set or get the current history for a user" )
-        self.assertEqual( self.history_mgr.get_current( self.trans ), history1 )
-        self.assertEqual( self.history_mgr.set_current( self.trans, history2 ), history2 )
-        self.assertEqual( self.history_mgr.get_current( self.trans ), history2 )
-        self.assertEqual( self.history_mgr.set_current_by_id( self.trans, history1.id ), history1 )
-        self.assertEqual( self.history_mgr.get_current( self.trans ), history1 )
+        self.assertEqual( self.history_manager.get_current( self.trans ), history1 )
+        self.assertEqual( self.history_manager.set_current( self.trans, history2 ), history2 )
+        self.assertEqual( self.history_manager.get_current( self.trans ), history2 )
+        self.assertEqual( self.history_manager.set_current_by_id( self.trans, history1.id ), history1 )
+        self.assertEqual( self.history_manager.get_current( self.trans ), history1 )
 
 
 # =============================================================================
@@ -319,13 +322,13 @@ class HistorySerializerTestCase( BaseTestCase ):
 
     def set_up_managers( self ):
         super( HistorySerializerTestCase, self ).set_up_managers()
-        self.history_mgr = HistoryManager( self.app )
-        self.hda_mgr = hdas.HDAManager( self.app )
+        self.history_manager = HistoryManager( self.app )
+        self.hda_manager = hdas.HDAManager( self.app )
         self.history_serializer = HistorySerializer( self.app )
 
     def test_views( self ):
-        user2 = self.user_mgr.create( self.trans, **user2_data )
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
+        user2 = self.user_manager.create( **user2_data )
+        history1 = self.history_manager.create( name='history1', user=user2 )
 
         self.log( 'should have a summary view' )
         summary_view = self.history_serializer.serialize_to_view( self.trans, history1, view='summary' )
@@ -349,8 +352,8 @@ class HistorySerializerTestCase( BaseTestCase ):
             self.assertTrue( True, 'all serializable keys have a serializer' )
 
     def test_views_and_keys( self ):
-        user2 = self.user_mgr.create( self.trans, **user2_data )
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
+        user2 = self.user_manager.create( **user2_data )
+        history1 = self.history_manager.create( name='history1', user=user2 )
 
         self.log( 'should be able to use keys with views' )
         serialized = self.history_serializer.serialize_to_view( self.trans, history1,
@@ -364,8 +367,8 @@ class HistorySerializerTestCase( BaseTestCase ):
         self.assertKeys( serialized, [ 'state_ids', 'user_id' ] )
 
     def test_sharable( self ):
-        user2 = self.user_mgr.create( self.trans, **user2_data )
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
+        user2 = self.user_manager.create( **user2_data )
+        history1 = self.history_manager.create( name='history1', user=user2 )
 
         self.log( 'should have a serializer for all SharableModel keys' )
         sharable_attrs = [ 'user_id', 'username_and_slug', 'importable', 'published', 'slug' ]
@@ -373,8 +376,8 @@ class HistorySerializerTestCase( BaseTestCase ):
         self.assertKeys( serialized, sharable_attrs )
 
     def test_purgable( self ):
-        user2 = self.user_mgr.create( self.trans, **user2_data )
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
+        user2 = self.user_manager.create( **user2_data )
+        history1 = self.history_manager.create( name='history1', user=user2 )
 
         self.log( 'deleted and purged should be returned in their default states' )
         keys = [ 'deleted', 'purged' ]
@@ -383,19 +386,19 @@ class HistorySerializerTestCase( BaseTestCase ):
         self.assertEqual( serialized[ 'purged' ], False )
 
         self.log( 'deleted and purged should return their current state' )
-        self.history_mgr.delete( self.trans, history1 )
+        self.history_manager.delete( history1 )
         serialized = self.history_serializer.serialize( self.trans, history1, keys )
         self.assertEqual( serialized[ 'deleted' ], True )
         self.assertEqual( serialized[ 'purged' ], False )
 
-        self.history_mgr.purge( self.trans, history1 )
+        self.history_manager.purge( history1 )
         serialized = self.history_serializer.serialize( self.trans, history1, keys )
         self.assertEqual( serialized[ 'deleted' ], True )
         self.assertEqual( serialized[ 'purged' ], True )
 
     def test_history_serializers( self ):
-        user2 = self.user_mgr.create( self.trans, **user2_data )
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
+        user2 = self.user_manager.create( **user2_data )
+        history1 = self.history_manager.create( name='history1', user=user2 )
         all_keys = list( self.history_serializer.serializable_keyset )
         serialized = self.history_serializer.serialize( self.trans, history1, all_keys )
 
@@ -407,8 +410,8 @@ class HistorySerializerTestCase( BaseTestCase ):
         self.assertIsJsonifyable( serialized )
 
     def test_contents( self ):
-        user2 = self.user_mgr.create( self.trans, **user2_data )
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
+        user2 = self.user_manager.create( **user2_data )
+        history1 = self.history_manager.create( name='history1', user=user2 )
 
         self.log( 'a history with no contents should be properly reflected in empty, etc.' )
         keys = [ 'empty', 'count', 'state_ids', 'state_details', 'state', 'hdas' ]
@@ -421,8 +424,8 @@ class HistorySerializerTestCase( BaseTestCase ):
         self.assertIsInstance( serialized[ 'hdas' ], list )
 
         self.log( 'a history with contents should be properly reflected in empty, etc.' )
-        hda1 = self.hda_mgr.create( self.trans, history=history1, hid=1 )
-        self.hda_mgr.update( self.trans, hda1, dict( state='ok' ) )
+        hda1 = self.hda_manager.create( history=history1, hid=1 )
+        self.hda_manager.update( hda1, dict( state='ok' ) )
 
         serialized = self.history_serializer.serialize( self.trans, history1, keys )
         self.assertEqual( serialized[ 'state' ], 'ok' )
@@ -440,16 +443,16 @@ class HistorySerializerTestCase( BaseTestCase ):
         self.assertIsJsonifyable( serialized )
 
 
-# =============================================================================
-class HistoryDeserializerTestCase( BaseTestCase ):
+# # =============================================================================
+# class HistoryDeserializerTestCase( BaseTestCase ):
 
-    def set_up_managers( self ):
-        super( HistoryDeserializerTestCase, self ).set_up_managers()
-        self.history_mgr = HistoryManager( self.app )
-        self.history_deserializer = HistoryDeserializer( self.app )
+#     def set_up_managers( self ):
+#         super( HistoryDeserializerTestCase, self ).set_up_managers()
+#         self.history_manager = HistoryManager( self.app )
+#         self.history_deserializer = HistoryDeserializer( self.app )
 
-    def test_base( self ):
-        pass
+#     def test_base( self ):
+#         pass
 
 
 # =============================================================================
@@ -457,7 +460,7 @@ class HistoryFiltersTestCase( BaseTestCase ):
 
     def set_up_managers( self ):
         super( HistoryFiltersTestCase, self ).set_up_managers()
-        self.history_mgr = HistoryManager( self.app )
+        self.history_manager = HistoryManager( self.app )
         self.filter_parser = HistoryFilters( self.app )
 
     # ---- functional and orm filter splitting and resolution
@@ -496,47 +499,47 @@ class HistoryFiltersTestCase( BaseTestCase ):
         ])
 
     def test_orm_filter_parsing( self ):
-        user2 = self.user_mgr.create( self.trans, **user2_data )
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
-        history2 = self.history_mgr.create( self.trans, name='history2', user=user2 )
-        history3 = self.history_mgr.create( self.trans, name='history3', user=user2 )
+        user2 = self.user_manager.create( **user2_data )
+        history1 = self.history_manager.create( name='history1', user=user2 )
+        history2 = self.history_manager.create( name='history2', user=user2 )
+        history3 = self.history_manager.create( name='history3', user=user2 )
 
         filters = self.filter_parser.parse_filters([
             ( 'name', 'like', 'history%' ),
         ])
-        histories = self.history_mgr.list( self.trans, filters=filters )
+        histories = self.history_manager.list( filters=filters )
         #for h in histories:
         #    print h.name
         self.assertEqual( histories, [ history1, history2, history3 ])
 
         filters = self.filter_parser.parse_filters([ ( 'name', 'like', '%2' ), ])
-        self.assertEqual( self.history_mgr.list( self.trans, filters=filters ), [ history2 ])
+        self.assertEqual( self.history_manager.list( filters=filters ), [ history2 ])
 
         filters = self.filter_parser.parse_filters([ ( 'name', 'eq', 'history2' ), ])
-        self.assertEqual( self.history_mgr.list( self.trans, filters=filters ), [ history2 ])
+        self.assertEqual( self.history_manager.list( filters=filters ), [ history2 ])
 
-        self.history_mgr.update( self.trans, history1, dict( deleted=True ) )
+        self.history_manager.update( history1, dict( deleted=True ) )
         filters = self.filter_parser.parse_filters([ ( 'deleted', 'eq', 'True' ), ])
-        self.assertEqual( self.history_mgr.list( self.trans, filters=filters ), [ history1 ])
+        self.assertEqual( self.history_manager.list( filters=filters ), [ history1 ])
         filters = self.filter_parser.parse_filters([ ( 'deleted', 'eq', 'False' ), ])
-        self.assertEqual( self.history_mgr.list( self.trans, filters=filters ), [ history2, history3 ])
-        self.assertEqual( self.history_mgr.list( self.trans ), [ history1, history2, history3 ])
+        self.assertEqual( self.history_manager.list( filters=filters ), [ history2, history3 ])
+        self.assertEqual( self.history_manager.list(), [ history1, history2, history3 ])
 
-        self.history_mgr.update( self.trans, history3, dict( deleted=True ) )
-        self.history_mgr.update( self.trans, history1, dict( importable=True ) )
-        self.history_mgr.update( self.trans, history2, dict( importable=True ) )
+        self.history_manager.update( history3, dict( deleted=True ) )
+        self.history_manager.update( history1, dict( importable=True ) )
+        self.history_manager.update( history2, dict( importable=True ) )
         filters = self.filter_parser.parse_filters([
             ( 'deleted', 'eq', 'True' ),
             ( 'importable', 'eq', 'True' ),
         ])
-        self.assertEqual( self.history_mgr.list( self.trans, filters=filters ), [ history1 ])
-        self.assertEqual( self.history_mgr.list( self.trans ), [ history1, history2, history3 ])
+        self.assertEqual( self.history_manager.list( filters=filters ), [ history1 ])
+        self.assertEqual( self.history_manager.list(), [ history1, history2, history3 ])
 
     def test_fn_filter_parsing( self ):
-        user2 = self.user_mgr.create( self.trans, **user2_data )
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
-        history2 = self.history_mgr.create( self.trans, name='history2', user=user2 )
-        history3 = self.history_mgr.create( self.trans, name='history3', user=user2 )
+        user2 = self.user_manager.create( **user2_data )
+        history1 = self.history_manager.create( name='history1', user=user2 )
+        history2 = self.history_manager.create( name='history2', user=user2 )
+        history3 = self.history_manager.create( name='history3', user=user2 )
 
         filters = self.filter_parser.parse_filters([ ( 'annotation', 'has', 'no play' ), ])
         anno_filter = filters[0]
@@ -547,15 +550,15 @@ class HistoryFiltersTestCase( BaseTestCase ):
         self.assertTrue( anno_filter( history3 ) )
         self.assertFalse( anno_filter( history2 ) )
 
-        self.assertEqual( self.history_mgr.list( self.trans, filters=filters ), [ history3 ])
+        self.assertEqual( self.history_manager.list( filters=filters ), [ history3 ])
 
         self.log( 'should allow combinations of orm and fn filters' )
-        self.history_mgr.update( self.trans, history3, dict( importable=True ) )
-        self.history_mgr.update( self.trans, history2, dict( importable=True ) )
+        self.history_manager.update( history3, dict( importable=True ) )
+        self.history_manager.update( history2, dict( importable=True ) )
         history1.add_item_annotation( self.trans.sa_session, user2, history1, "All work and no play" )
         self.trans.sa_session.flush()
 
-        shining_examples = self.history_mgr.list( self.trans, filters=self.filter_parser.parse_filters([
+        shining_examples = self.history_manager.list( filters=self.filter_parser.parse_filters([
             ( 'importable', 'eq', 'True' ),
             ( 'annotation', 'has', 'no play' ),
         ]))
@@ -586,15 +589,15 @@ class HistoryFiltersTestCase( BaseTestCase ):
         """
         Test limit and offset in conjunction with both orm and fn filtering.
         """
-        user2 = self.user_mgr.create( self.trans, **user2_data )
-        history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
-        history2 = self.history_mgr.create( self.trans, name='history2', user=user2 )
-        history3 = self.history_mgr.create( self.trans, name='history3', user=user2 )
-        history4 = self.history_mgr.create( self.trans, name='history4', user=user2 )
+        user2 = self.user_manager.create( **user2_data )
+        history1 = self.history_manager.create( name='history1', user=user2 )
+        history2 = self.history_manager.create( name='history2', user=user2 )
+        history3 = self.history_manager.create( name='history3', user=user2 )
+        history4 = self.history_manager.create( name='history4', user=user2 )
 
-        self.history_mgr.delete( self.trans, history1 )
-        self.history_mgr.delete( self.trans, history2 )
-        self.history_mgr.delete( self.trans, history3 )
+        self.history_manager.delete( history1 )
+        self.history_manager.delete( history2 )
+        self.history_manager.delete( history3 )
 
         test_annotation = "testing"
         history2.add_item_annotation( self.trans.sa_session, user2, history2, test_annotation )
@@ -608,50 +611,50 @@ class HistoryFiltersTestCase( BaseTestCase ):
         deleted_and_annotated = [ history2, history3 ]
 
         self.log( "no offset, no limit should work" )
-        self.assertEqual( self.history_mgr.list( self.trans, offset=None, limit=None ), all_histories )
-        self.assertEqual( self.history_mgr.list( self.trans ), all_histories )
+        self.assertEqual( self.history_manager.list( offset=None, limit=None ), all_histories )
+        self.assertEqual( self.history_manager.list(), all_histories )
         self.log( "no offset, limit should work" )
-        self.assertEqual( self.history_mgr.list( self.trans, limit=2 ), [ history1, history2 ] )
+        self.assertEqual( self.history_manager.list( limit=2 ), [ history1, history2 ] )
         self.log( "offset, no limit should work" )
-        self.assertEqual( self.history_mgr.list( self.trans, offset=1 ), [ history2, history3, history4 ] )
+        self.assertEqual( self.history_manager.list( offset=1 ), [ history2, history3, history4 ] )
         self.log( "offset, limit should work" )
-        self.assertEqual( self.history_mgr.list( self.trans, offset=1, limit=1 ), [ history2 ] )
+        self.assertEqual( self.history_manager.list( offset=1, limit=1 ), [ history2 ] )
 
         self.log( "zero limit should return empty list" )
-        self.assertEqual( self.history_mgr.list( self.trans, limit=0 ), [] )
+        self.assertEqual( self.history_manager.list( limit=0 ), [] )
         self.log( "past len offset should return empty list" )
-        self.assertEqual( self.history_mgr.list( self.trans, offset=len( all_histories ) ), [] )
+        self.assertEqual( self.history_manager.list( offset=len( all_histories ) ), [] )
         self.log( "negative limit should return full list" )
-        self.assertEqual( self.history_mgr.list( self.trans, limit=-1 ), all_histories )
+        self.assertEqual( self.history_manager.list( limit=-1 ), all_histories )
         self.log( "negative offset should return full list" )
-        self.assertEqual( self.history_mgr.list( self.trans, offset=-1 ), all_histories )
+        self.assertEqual( self.history_manager.list( offset=-1 ), all_histories )
 
         filters = [ model.History.deleted == True ]
         self.log( "orm filtered, no offset, no limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters )
+        found = self.history_manager.list( filters=filters )
         self.assertEqual( found, [ history1, history2, history3 ] )
         self.log( "orm filtered, no offset, limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters, limit=2 )
+        found = self.history_manager.list( filters=filters, limit=2 )
         self.assertEqual( found, [ history1, history2 ] )
         self.log( "orm filtered, offset, no limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters, offset=1 )
+        found = self.history_manager.list( filters=filters, offset=1 )
         self.assertEqual( found, [ history2, history3 ] )
         self.log( "orm filtered, offset, limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters, offset=1, limit=1 )
+        found = self.history_manager.list( filters=filters, offset=1, limit=1 )
         self.assertEqual( found, [ history2 ] )
 
         filters = self.filter_parser.parse_filters([ ( 'annotation', 'has', test_annotation ) ])
         self.log( "fn filtered, no offset, no limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters )
+        found = self.history_manager.list( filters=filters )
         self.assertEqual( found, [ history2, history3, history4 ] )
         self.log( "fn filtered, no offset, limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters, limit=2 )
+        found = self.history_manager.list( filters=filters, limit=2 )
         self.assertEqual( found, [ history2, history3 ] )
         self.log( "fn filtered, offset, no limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters, offset=1 )
+        found = self.history_manager.list( filters=filters, offset=1 )
         self.assertEqual( found, [ history3, history4 ] )
         self.log( "fn filtered, offset, limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters, offset=1, limit=1 )
+        found = self.history_manager.list( filters=filters, offset=1, limit=1 )
         self.assertEqual( found, [ history3 ] )
 
         filters = self.filter_parser.parse_filters([
@@ -659,29 +662,29 @@ class HistoryFiltersTestCase( BaseTestCase ):
             ( 'annotation', 'has', test_annotation )
         ])
         self.log( "orm and fn filtered, no offset, no limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters )
+        found = self.history_manager.list( filters=filters )
         self.assertEqual( found, [ history2, history3 ] )
         self.log( "orm and fn filtered, no offset, limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters, limit=1 )
+        found = self.history_manager.list( filters=filters, limit=1 )
         self.assertEqual( found, [ history2 ] )
         self.log( "orm and fn filtered, offset, no limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters, offset=1 )
+        found = self.history_manager.list( filters=filters, offset=1 )
         self.assertEqual( found, [ history3 ] )
         self.log( "orm and fn filtered, offset, limit should work" )
-        found = self.history_mgr.list( self.trans, filters=filters, offset=1, limit=1 )
+        found = self.history_manager.list( filters=filters, offset=1, limit=1 )
         self.assertEqual( found, [ history3 ] )
 
         self.log( "orm and fn filtered, zero limit should return empty list" )
-        found = self.history_mgr.list( self.trans, filters=filters, limit=0 )
+        found = self.history_manager.list( filters=filters, limit=0 )
         self.assertEqual( found, [] )
         self.log( "orm and fn filtered, past len offset should return empty list" )
-        found = self.history_mgr.list( self.trans, filters=filters, offset=len( deleted_and_annotated ) )
+        found = self.history_manager.list( filters=filters, offset=len( deleted_and_annotated ) )
         self.assertEqual( found, [] )
         self.log( "orm and fn filtered, negative limit should return full list" )
-        found = self.history_mgr.list( self.trans, filters=filters, limit=-1 )
+        found = self.history_manager.list( filters=filters, limit=-1 )
         self.assertEqual( found, deleted_and_annotated )
         self.log( "orm and fn filtered, negative offset should return full list" )
-        found = self.history_mgr.list( self.trans, filters=filters, offset=-1 )
+        found = self.history_manager.list( filters=filters, offset=-1 )
         self.assertEqual( found, deleted_and_annotated )
 
 

--- a/test/unit/managers/test_HistoryManager.py
+++ b/test/unit/managers/test_HistoryManager.py
@@ -331,15 +331,15 @@ class HistorySerializerTestCase( BaseTestCase ):
         history1 = self.history_manager.create( name='history1', user=user2 )
 
         self.log( 'should have a summary view' )
-        summary_view = self.history_serializer.serialize_to_view( self.trans, history1, view='summary' )
+        summary_view = self.history_serializer.serialize_to_view( history1, view='summary' )
         self.assertKeys( summary_view, self.history_serializer.views[ 'summary' ] )
 
         self.log( 'should have a detailed view' )
-        detailed_view = self.history_serializer.serialize_to_view( self.trans, history1, view='detailed' )
+        detailed_view = self.history_serializer.serialize_to_view( history1, view='detailed' )
         self.assertKeys( detailed_view, self.history_serializer.views[ 'detailed' ] )
 
         self.log( 'should have the summary view as default view' )
-        default_view = self.history_serializer.serialize_to_view( self.trans, history1, default_view='summary' )
+        default_view = self.history_serializer.serialize_to_view( history1, default_view='summary' )
         self.assertKeys( summary_view, self.history_serializer.views[ 'summary' ] )
 
         self.log( 'should have a serializer for all serializable keys' )
@@ -356,13 +356,13 @@ class HistorySerializerTestCase( BaseTestCase ):
         history1 = self.history_manager.create( name='history1', user=user2 )
 
         self.log( 'should be able to use keys with views' )
-        serialized = self.history_serializer.serialize_to_view( self.trans, history1,
+        serialized = self.history_serializer.serialize_to_view( history1,
             view='summary', keys=[ 'state_ids', 'user_id' ] )
         self.assertKeys( serialized,
             self.history_serializer.views[ 'summary' ] + [ 'state_ids', 'user_id' ] )
 
         self.log( 'should be able to use keys on their own' )
-        serialized = self.history_serializer.serialize_to_view( self.trans, history1,
+        serialized = self.history_serializer.serialize_to_view( history1,
             keys=[ 'state_ids', 'user_id' ] )
         self.assertKeys( serialized, [ 'state_ids', 'user_id' ] )
 
@@ -372,7 +372,7 @@ class HistorySerializerTestCase( BaseTestCase ):
 
         self.log( 'should have a serializer for all SharableModel keys' )
         sharable_attrs = [ 'user_id', 'username_and_slug', 'importable', 'published', 'slug' ]
-        serialized = self.history_serializer.serialize( self.trans, history1, sharable_attrs )
+        serialized = self.history_serializer.serialize( history1, sharable_attrs )
         self.assertKeys( serialized, sharable_attrs )
 
     def test_purgable( self ):
@@ -381,18 +381,18 @@ class HistorySerializerTestCase( BaseTestCase ):
 
         self.log( 'deleted and purged should be returned in their default states' )
         keys = [ 'deleted', 'purged' ]
-        serialized = self.history_serializer.serialize( self.trans, history1, keys )
+        serialized = self.history_serializer.serialize( history1, keys )
         self.assertEqual( serialized[ 'deleted' ], False )
         self.assertEqual( serialized[ 'purged' ], False )
 
         self.log( 'deleted and purged should return their current state' )
         self.history_manager.delete( history1 )
-        serialized = self.history_serializer.serialize( self.trans, history1, keys )
+        serialized = self.history_serializer.serialize( history1, keys )
         self.assertEqual( serialized[ 'deleted' ], True )
         self.assertEqual( serialized[ 'purged' ], False )
 
         self.history_manager.purge( history1 )
-        serialized = self.history_serializer.serialize( self.trans, history1, keys )
+        serialized = self.history_serializer.serialize( history1, keys )
         self.assertEqual( serialized[ 'deleted' ], True )
         self.assertEqual( serialized[ 'purged' ], True )
 
@@ -400,7 +400,7 @@ class HistorySerializerTestCase( BaseTestCase ):
         user2 = self.user_manager.create( **user2_data )
         history1 = self.history_manager.create( name='history1', user=user2 )
         all_keys = list( self.history_serializer.serializable_keyset )
-        serialized = self.history_serializer.serialize( self.trans, history1, all_keys )
+        serialized = self.history_serializer.serialize( history1, all_keys )
 
         self.log( 'everything serialized should be of the proper type' )
         self.assertIsInstance( serialized[ 'size' ], int )
@@ -415,7 +415,7 @@ class HistorySerializerTestCase( BaseTestCase ):
 
         self.log( 'a history with no contents should be properly reflected in empty, etc.' )
         keys = [ 'empty', 'count', 'state_ids', 'state_details', 'state', 'hdas' ]
-        serialized = self.history_serializer.serialize( self.trans, history1, keys )
+        serialized = self.history_serializer.serialize( history1, keys )
         self.assertEqual( serialized[ 'state' ], 'new' )
         self.assertEqual( serialized[ 'empty' ], True )
         self.assertEqual( serialized[ 'count' ], 0 )
@@ -427,7 +427,7 @@ class HistorySerializerTestCase( BaseTestCase ):
         hda1 = self.hda_manager.create( history=history1, hid=1 )
         self.hda_manager.update( hda1, dict( state='ok' ) )
 
-        serialized = self.history_serializer.serialize( self.trans, history1, keys )
+        serialized = self.history_serializer.serialize( history1, keys )
         self.assertEqual( serialized[ 'state' ], 'ok' )
         self.assertEqual( serialized[ 'empty' ], False )
         self.assertEqual( serialized[ 'count' ], 1 )
@@ -436,7 +436,7 @@ class HistorySerializerTestCase( BaseTestCase ):
         self.assertIsInstance( serialized[ 'hdas' ], list )
         self.assertIsInstance( serialized[ 'hdas' ][0], basestring )
 
-        serialized = self.history_serializer.serialize( self.trans, history1, [ 'contents' ] )
+        serialized = self.history_serializer.serialize( history1, [ 'contents' ] )
         self.assertHasKeys( serialized[ 'contents' ][0], [ 'id', 'name', 'peek', 'create_time' ])
 
         self.log( 'serialized should jsonify well' )

--- a/test/unit/managers/test_HistoryManager.py
+++ b/test/unit/managers/test_HistoryManager.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 """
 import sys
 import os
 import pprint
 import unittest
-import json
 
 __GALAXY_ROOT__ = os.getcwd() + '/../../../'
 sys.path.insert( 1, __GALAXY_ROOT__ + 'lib' )
@@ -341,11 +340,10 @@ class HistorySerializerTestCase( BaseTestCase ):
         self.assertKeys( summary_view, self.history_serializer.views[ 'summary' ] )
 
         self.log( 'should have a serializer for all serializable keys' )
-        need_no_serializers = ( basestring, bool, type( None ) )
         for key in self.history_serializer.serializable_keyset:
             instantiated_attribute = getattr( history1, key, None )
             if not ( ( key in self.history_serializer.serializers )
-                  or ( isinstance( instantiated_attribute, need_no_serializers ) ) ):
+                  or ( isinstance( instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS ) ) ):
                 self.fail( 'no serializer for: %s (%s)' % ( key, instantiated_attribute ) )
         else:
             self.assertTrue( True, 'all serializable keys have a serializer' )
@@ -398,7 +396,7 @@ class HistorySerializerTestCase( BaseTestCase ):
     def test_history_serializers( self ):
         user2 = self.user_mgr.create( self.trans, **user2_data )
         history1 = self.history_mgr.create( self.trans, name='history1', user=user2 )
-        all_keys = self.history_serializer.serializable_keyset
+        all_keys = list( self.hda_serializer.serializable_keyset )
         serialized = self.history_serializer.serialize( self.trans, history1, all_keys )
 
         self.log( 'everything serialized should be of the proper type' )
@@ -437,6 +435,10 @@ class HistorySerializerTestCase( BaseTestCase ):
 
         serialized = self.history_serializer.serialize( self.trans, history1, [ 'contents' ] )
         self.assertHasKeys( serialized[ 'contents' ][0], [ 'id', 'name', 'peek', 'create_time' ])
+
+        self.log( 'serialized should jsonify well' )
+        self.assertIsJsonifyable( serialized )
+
 
 # =============================================================================
 class HistoryDeserializerTestCase( BaseTestCase ):

--- a/test/unit/managers/test_ModelManager.py
+++ b/test/unit/managers/test_ModelManager.py
@@ -61,11 +61,10 @@ class BaseTestCase( unittest.TestCase ):
         self.app = self.trans.app
 
     def set_up_managers( self ):
-        self.user_mgr = UserManager( self.app )
+        self.user_manager = UserManager( self.app )
 
     def set_up_trans( self ):
-        self.admin_user = self.user_mgr.create( self.trans,
-            email=admin_email, username='admin', password=default_password )
+        self.admin_user = self.user_manager.create( email=admin_email, username='admin', password=default_password )
         self.trans.set_user( self.admin_user )
         self.trans.set_history( None )
 

--- a/test/unit/managers/test_ModelManager.py
+++ b/test/unit/managers/test_ModelManager.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 """
 from __future__ import print_function
@@ -7,6 +6,7 @@ import sys
 import os
 import pprint
 import unittest
+import json
 
 __GALAXY_ROOT__ = os.getcwd() + '/../../../'
 sys.path.insert( 1, __GALAXY_ROOT__ + 'lib' )
@@ -76,6 +76,8 @@ class BaseTestCase( unittest.TestCase ):
         print( *args, **kwargs )
 
     # ---- additional test types
+    TYPES_NEEDING_NO_SERIALIZERS = ( basestring, bool, type( None ), int, float )
+
     def assertKeys( self, obj, key_list ):
         self.assertEqual( sorted( obj.keys() ), sorted( key_list ) )
 
@@ -86,11 +88,23 @@ class BaseTestCase( unittest.TestCase ):
         else:
             self.assertTrue( True, 'keys found in object' )
 
+    def assertNullableBasestring( self, item ):
+        if not isinstance( item, ( basestring, type( None ) ) ):
+            self.fail( 'Non-nullable basestring: ' + str( type( item ) ) )
+        # TODO: len mod 8 and hex re
+        self.assertTrue( True, 'is nullable basestring: ' + str( item ) )
+
     def assertEncodedId( self, item ):
         if not isinstance( item, basestring ):
             self.fail( 'Non-string: ' + str( type( item ) ) )
         # TODO: len mod 8 and hex re
         self.assertTrue( True, 'is id: ' + item )
+
+    def assertNullableEncodedId( self, item ):
+        if item is None:
+            self.assertTrue( True, 'nullable id is None' )
+        else:
+            self.assertEncodedId( item )
 
     def assertDate( self, item ):
         if not isinstance( item, basestring ):
@@ -111,6 +125,9 @@ class BaseTestCase( unittest.TestCase ):
         # TODO: re for d4d76d69-80d4-4ed7-80c7-211ebcc1a358
         self.assertTrue( True, msg or ( 'is an orm filter: ' + item ) )
 
+    def assertIsJsonifyable( self, item ):
+        # TODO: use galaxy's override
+        self.assertIsInstance( json.dumps( item ), basestring )
 
 
 # =============================================================================

--- a/test/unit/managers/test_ModelManager.py
+++ b/test/unit/managers/test_ModelManager.py
@@ -88,22 +88,28 @@ class BaseTestCase( unittest.TestCase ):
 
     def assertEncodedId( self, item ):
         if not isinstance( item, basestring ):
-            self.fail( 'Non-string: ' + type( item ) )
+            self.fail( 'Non-string: ' + str( type( item ) ) )
         # TODO: len mod 8 and hex re
         self.assertTrue( True, 'is id: ' + item )
 
     def assertDate( self, item ):
         if not isinstance( item, basestring ):
-            self.fail( 'Non-string: ' + type( item ) )
+            self.fail( 'Non-string: ' + str( type( item ) ) )
         # TODO: no great way to parse this fully (w/o python-dateutil)
         # TODO: re?
         self.assertTrue( True, 'is date: ' + item )
 
     def assertUUID( self, item ):
         if not isinstance( item, basestring ):
-            self.fail( 'Non-string: ' + type( item ) )
+            self.fail( 'Non-string: ' + str( type( item ) ) )
         # TODO: re for d4d76d69-80d4-4ed7-80c7-211ebcc1a358
         self.assertTrue( True, 'is uuid: ' + item )
+
+    def assertORMFilter( self, item, msg=None ):
+        if not isinstance( item, sqlalchemy.sql.elements.BinaryExpression ):
+            self.fail( 'Not an orm filter: ' + str( type( item ) ) )
+        # TODO: re for d4d76d69-80d4-4ed7-80c7-211ebcc1a358
+        self.assertTrue( True, msg or ( 'is an orm filter: ' + item ) )
 
 
 

--- a/test/unit/managers/test_ModelManager.py
+++ b/test/unit/managers/test_ModelManager.py
@@ -86,6 +86,26 @@ class BaseTestCase( unittest.TestCase ):
         else:
             self.assertTrue( True, 'keys found in object' )
 
+    def assertEncodedId( self, item ):
+        if not isinstance( item, basestring ):
+            self.fail( 'Non-string: ' + type( item ) )
+        # TODO: len mod 8 and hex re
+        self.assertTrue( True, 'is id: ' + item )
+
+    def assertDate( self, item ):
+        if not isinstance( item, basestring ):
+            self.fail( 'Non-string: ' + type( item ) )
+        # TODO: no great way to parse this fully (w/o python-dateutil)
+        # TODO: re?
+        self.assertTrue( True, 'is date: ' + item )
+
+    def assertUUID( self, item ):
+        if not isinstance( item, basestring ):
+            self.fail( 'Non-string: ' + type( item ) )
+        # TODO: re for d4d76d69-80d4-4ed7-80c7-211ebcc1a358
+        self.assertTrue( True, 'is uuid: ' + item )
+
+
 
 # =============================================================================
 if __name__ == '__main__':

--- a/test/unit/managers/test_ModelManager.py
+++ b/test/unit/managers/test_ModelManager.py
@@ -122,8 +122,12 @@ class BaseTestCase( unittest.TestCase ):
     def assertORMFilter( self, item, msg=None ):
         if not isinstance( item, sqlalchemy.sql.elements.BinaryExpression ):
             self.fail( 'Not an orm filter: ' + str( type( item ) ) )
-        # TODO: re for d4d76d69-80d4-4ed7-80c7-211ebcc1a358
-        self.assertTrue( True, msg or ( 'is an orm filter: ' + item ) )
+        self.assertTrue( True, msg or ( 'is an orm filter: ' + str( item ) ) )
+
+    def assertFnFilter( self, item, msg=None ):
+        if not item or not callable( item ):
+            self.fail( 'Not a fn filter: ' + str( type( item ) ) )
+        self.assertTrue( True, msg or ( 'is a fn filter: ' + str( item ) ) )
 
     def assertIsJsonifyable( self, item ):
         # TODO: use galaxy's override

--- a/test/unit/managers/test_UserManager.py
+++ b/test/unit/managers/test_UserManager.py
@@ -142,11 +142,11 @@ class UserSerializerTestCase( BaseTestCase ):
         user = self.user_manager.create( **user2_data )
 
         self.log( 'should have a summary view' )
-        summary_view = self.user_serializer.serialize_to_view( self.trans, user, view='summary' )
+        summary_view = self.user_serializer.serialize_to_view( user, view='summary' )
         self.assertKeys( summary_view, self.user_serializer.views[ 'summary' ] )
 
         self.log( 'should have the summary view as default view' )
-        default_view = self.user_serializer.serialize_to_view( self.trans, user, default_view='summary' )
+        default_view = self.user_serializer.serialize_to_view( user, default_view='summary' )
         self.assertKeys( summary_view, self.user_serializer.views[ 'summary' ] )
 
         self.log( 'should have a serializer for all serializable keys' )
@@ -162,20 +162,20 @@ class UserSerializerTestCase( BaseTestCase ):
         user = self.user_manager.create( **user2_data )
 
         self.log( 'should be able to use keys with views' )
-        serialized = self.user_serializer.serialize_to_view( self.trans, user,
+        serialized = self.user_serializer.serialize_to_view( user,
             view='summary', keys=[ 'create_time' ] )
         self.assertKeys( serialized,
             self.user_serializer.views[ 'summary' ] + [ 'create_time' ] )
 
         self.log( 'should be able to use keys on their own' )
-        serialized = self.user_serializer.serialize_to_view( self.trans, user,
+        serialized = self.user_serializer.serialize_to_view( user,
             keys=[ 'tags_used', 'is_admin' ] )
         self.assertKeys( serialized, [ 'tags_used', 'is_admin' ] )
 
     def test_serializers( self ):
         user = self.user_manager.create( **user2_data )
         all_keys = list( self.user_serializer.serializable_keyset )
-        serialized = self.user_serializer.serialize( self.trans, user, all_keys )
+        serialized = self.user_serializer.serialize( user, all_keys, trans=self.trans )
         # pprint.pprint( serialized )
 
         self.log( 'everything serialized should be of the proper type' )
@@ -207,10 +207,10 @@ class CurrentUserSerializerTestCase( BaseTestCase ):
     def test_anonymous( self ):
         anonym = None
         # need a history here for total_disk_usage
-        self.trans.set_history( self.history_manager.create( self.trans ) )
+        self.trans.set_history( self.history_manager.create() )
 
         self.log( 'should be able to serialize anonymous user' )
-        serialized = self.user_serializer.serialize_to_view( self.trans, anonym, view='detailed' )
+        serialized = self.user_serializer.serialize_to_view( anonym, view='detailed', trans=self.trans )
         self.assertKeys( serialized,
             [ 'id', 'total_disk_usage', 'nice_total_disk_usage', 'quota_percent' ] )
 

--- a/test/unit/managers/test_UserManager.py
+++ b/test/unit/managers/test_UserManager.py
@@ -174,7 +174,7 @@ class UserSerializerTestCase( BaseTestCase ):
 
     def test_serializers( self ):
         user = self.user_mgr.create( self.trans, **user2_data )
-        all_keys = list( self.hda_serializer.serializable_keyset )
+        all_keys = list( self.user_serializer.serializable_keyset )
         serialized = self.user_serializer.serialize( self.trans, user, all_keys )
         # pprint.pprint( serialized )
 
@@ -222,7 +222,7 @@ class CurrentUserSerializerTestCase( BaseTestCase ):
         self.assertIsInstance( serialized[ 'quota_percent' ], ( type( None ), float ) )
 
         self.log( 'serialized should jsonify well' )
-        self.assertIsInstance( json.dumps( serialized ), basestring )
+        self.assertIsJsonifyable( serialized )
 
 
 # =============================================================================

--- a/test/unit/managers/test_UserManager.py
+++ b/test/unit/managers/test_UserManager.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 """
 import sys
 import os
 import pprint
 import unittest
-import json
 
 __GALAXY_ROOT__ = os.getcwd() + '/../../../'
 sys.path.insert( 1, __GALAXY_ROOT__ + 'lib' )
@@ -151,11 +150,10 @@ class UserSerializerTestCase( BaseTestCase ):
         self.assertKeys( summary_view, self.user_serializer.views[ 'summary' ] )
 
         self.log( 'should have a serializer for all serializable keys' )
-        need_no_serializers = ( basestring, bool, type( None ) )
         for key in self.user_serializer.serializable_keyset:
             instantiated_attribute = getattr( user, key, None )
             if not ( ( key in self.user_serializer.serializers )
-                  or ( isinstance( instantiated_attribute, need_no_serializers ) ) ):
+                  or ( isinstance( instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS ) ) ):
                 self.fail( 'no serializer for: %s (%s)' % ( key, instantiated_attribute ) )
         else:
             self.assertTrue( True, 'all serializable keys have a serializer' )
@@ -176,7 +174,7 @@ class UserSerializerTestCase( BaseTestCase ):
 
     def test_serializers( self ):
         user = self.user_mgr.create( self.trans, **user2_data )
-        all_keys = self.user_serializer.serializable_keyset
+        all_keys = list( self.hda_serializer.serializable_keyset )
         serialized = self.user_serializer.serialize( self.trans, user, all_keys )
         # pprint.pprint( serialized )
 
@@ -196,7 +194,7 @@ class UserSerializerTestCase( BaseTestCase ):
         self.assertIsInstance( serialized[ 'requests' ], list )
 
         self.log( 'serialized should jsonify well' )
-        self.assertIsInstance( json.dumps( serialized ), basestring )
+        self.assertIsJsonifyable( serialized )
 
 
 class CurrentUserSerializerTestCase( BaseTestCase ):


### PR DESCRIPTION
- More tests for existing managers
- Removing trans from function signatures (this unfortunately makes those functions that still need trans or a portion of it - like current history - a bit clunkier) in managers and de/serializers
- laying some foundation for an interface over the rbac dataset permissions
- and some foundation for a unified 'contents' interface for dataset collections, histories, and libraries (things that can contain datasets and subcontainers)
- Refactoring of existing managers
