### PR TITLE
[STABLE] Bugfixes for runtime parameter handling in the workflow run form.

### DIFF
--- a/templates/webapps/galaxy/workflow/run.mako
+++ b/templates/webapps/galaxy/workflow/run.mako
@@ -154,11 +154,11 @@
 
          $(".workflow-edit-button").on("click",function(){
                 var state = $(this).attr("name");
-                var stepToolBox = $(this).parent().find('input:not([class]):not([type="hidden"]), select:not([class])');
-                var labels = $(this).parent().find('label');
+                var stepToolBox = $(this).parent().parent().find('.editable-param').find('input:not([class]):not([type="hidden"]), select:not([class])');
+                var labels = $(this).parent().parent().find('.editable-param').find('label');
                 var split_name = stepToolBox.attr("name").split("|");
                 var step_id = split_name[0];
-                var step_name = split_name.slice(1, split_name.length).join("|");
+                var step_name = split_name.slice(2, split_name.length).join("|");
                 var hidden_html = "<input type='hidden' name='"+step_id+"|__runtime__"+step_name+"' value='true' />";
                 var html = "";
                 if (state === "edit"){
@@ -179,9 +179,9 @@
                 }
                 else{
                     $(this).parent().find(".editable").hide();
+                    $(this).parent().find(".editable").empty();
                     $(this).parent().parent().find(".uneditable_field").show();
                     $(this).attr("name", "edit");
-                    stepToolBox.hide();
                     readyParameter($(this));
                 }
             }).each(function(i, icon) {
@@ -279,6 +279,9 @@
         margin-bottom: 1em;
     }
     .editable {
+        display: none;
+    }
+    .editable-param {
         display: none;
     }
 
@@ -448,10 +451,16 @@ if wf_parms:
                     </span>
                     <span class="editable_field">
                         <span class="editable">
-                            ${param.get_html_field( t, value, other_values).get_html( str(step.id) + "|"+ prefix )}
                         </span>
 
                         <i class="fa workflow-edit-button"></i>
+                    </span>
+                    <span class="editable-param">
+                        <!-- Pristine variant of param, this will be cloned
+                             and modified when the user opts to make this
+                             editable.
+                        -->
+                        ${param.get_html_field( t, value, other_values).get_html( str(step.id) + "|"+ "editable" + "|" + prefix )}
                     </span>
                 </span>
                 %endif


### PR DESCRIPTION
The behavior of these forms was modified in PR 433 (https://bitbucket.org/galaxy/galaxy-central/pull-request/433/fix-allow-editing-workflows-on-the-fly-for/diff#) - so that the entire workflow would be submitted as runtime parameters on each submission.

In addition to this causing bugs related to unvalidated parameters https://trello.com/c/72WuZ8mu and other problems with select parameters (e.g. http://dev.list.galaxyproject.org/Workflow-bug-when-loc-entries-are-missing-tc4666875.html) - I just discovered it would also cause the modified value to be submitted even if the user opts to undo the selection of a runtime workflow parameter and restore the previous selection (i.e. the form would show the original value but the new value would be submitted).

This PR restores the previous behavior of giving the submitted form elements a unique name so every value in the workflow is not replaced as part of the submission - fixing the former problem. The new technique also fixes the problem of submitting the modified values even when the unmodified values are displayed.
