### PR TITLE
Add NCBI SRA datatype mdshw5/sra-tools-galaxy#1

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -186,6 +186,7 @@
         <converter file="tabular_to_dbnsfp.xml" target_datatype="snpsiftdbnsfp"/>
     </datatype>
     <datatype extension="sff" type="galaxy.datatypes.binary:Sff" mimetype="application/octet-stream" display_in_upload="true" description="A binary file in 'Standard Flowgram Format' with a '.sff' file extension." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Sff"/>
+    <datatype extension="sra" type="galaxy.datatypes.binary:Sra" mimetype="application/octet-stream" display_in_upload="true" description="A binary file archive format from the NCBI Sequence Read Archive with a '.sra' file extension." description_url="http://www.ncbi.nlm.nih.gov/books/n/helpsra/SRA_Overview_BK/#SRA_Overview_BK.4_SRA_Data_Structure"/>
     <datatype extension="svg" type="galaxy.datatypes.images:Image" mimetype="image/svg+xml"/>
     <datatype extension="taxonomy" type="galaxy.datatypes.tabular:Taxonomy" display_in_upload="true"/>
     <datatype extension="tabular" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" description="Any data in tab delimited format (tabular)." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Tabular_.28tab_delimited.29"/>
@@ -285,6 +286,7 @@
     <sniffer type="galaxy.datatypes.binary:SQlite"/>
     <sniffer type="galaxy.datatypes.binary:Bam"/>
     <sniffer type="galaxy.datatypes.binary:Sff"/>
+    <sniffer type="galaxy.datatypes.binary:Sra"/>
     <sniffer type="galaxy.datatypes.xml:Phyloxml"/>
     <sniffer type="galaxy.datatypes.xml:Owl"/>
     <sniffer type="galaxy.datatypes.xml:GenericXml"/>

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -753,3 +753,40 @@ class Xlsx(Binary):
 
 Binary.register_sniffable_binary_format("xlsx", "xlsx", Xlsx)
 
+
+class Sra( Binary ):
+    """ Sequence Read Archive (SRA) datatype originally from mdshw5/sra-tools-galaxy"""
+    file_ext = 'sra'
+
+    def __init__( self, **kwd ):
+        Binary.__init__( self, **kwd )
+
+    def sniff( self, filename ):
+        """ The first 8 bytes of any NCBI sra file is 'NCBI.sra', and the file is binary.
+        For details about the format, see http://www.ncbi.nlm.nih.gov/books/n/helpsra/SRA_Overview_BK/#SRA_Overview_BK.4_SRA_Data_Structure
+        """
+        try:
+            header = open(filename).read(8)
+            if binascii.b2a_hex(header) == binascii.hexlify('NCBI.sra'):
+                return True
+            else:
+                return False
+        except:
+            return False
+
+    def set_peek(self, dataset, is_multi_byte=False):
+        if not dataset.dataset.purged:
+            dataset.peek  = 'Binary sra file'
+            dataset.blurb = data.nice_size(dataset.get_size())
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def display_peek(self, dataset):
+        try:
+            return dataset.peek
+        except:
+            return 'Binary sra file (%s)' % (data.nice_size(dataset.get_size()))
+
+Binary.register_sniffable_binary_format('sra', 'sra', Sra)
+


### PR DESCRIPTION
Note that the ncbi/sra-tools [wiki](https://github.com/ncbi/sra-tools/wiki/HowTo:-Access-SRA-Data) discourages users downloading SRA data  using anything other than `prefetch`, `ascp`, or the "on-demand" fetching built in to all newer toolkit versions. However, it is still a common occurrence for Galaxy users to email me asking how to upload a ".sra" file into their history.

Support for SRA datatypes also partially mitigates the problem of shared caching for the `prefetch` and "on-demand" download methods of the toolkit.

CC: @jmchilton
