### PR TITLE
Add a debug message for when dynamic_options (code files) encounter exce...

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -816,7 +816,8 @@ class SelectToolParameter( ToolParameter ):
             call_other_values = self._get_dynamic_options_call_other_values( trans, other_values )
             try:
                 return eval( self.dynamic_options, self.tool.code_namespace, call_other_values )
-            except Exception:
+            except Exception, e:
+                log.debug( "Error determining dynamic options for parameter '%s' in tool '%s':", self.name, self.tool.id, exc_info=e )
                 return []
         else:
             return self.static_options


### PR DESCRIPTION
...ptions when generating lists of options.

Using debug level as these exceptions can be chatty and code files have been previously written to expect any exceptions/errors to simply result in an empty options list.
