### PR TITLE
[STABLE] Fix re-run option for data manager tools

### DIFF
--- a/templates/webapps/galaxy/tool_form.mako
+++ b/templates/webapps/galaxy/tool_form.mako
@@ -10,6 +10,7 @@ ${h.css('base', 'jquery-ui/smoothness/jquery-ui')}
         ## This avoids making two separate requests since the classic form requires the mako anyway.
         params = dict(trans.request.params)
         params['__dataset_id__'] = params.get('id', None)
+        params['__job_id__'] = params.get('job_id', None)
         self.form_config = tool.to_json(trans, params)
         self.form_config.update({
             'id'                : tool.id,


### PR DESCRIPTION
Currently the tool form is not filled if users attempt to re-run data manager tools. This fixes the job id parsing such that the job state is properly retrieved.
