### PR TITLE
[STABLE] Fix documentation for run-as-real-user parameters.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -960,6 +960,17 @@ use_interactive = True
 # always, onsuccess, never
 #cleanup_job = always
 
+# For sites where all users in Galaxy match users on the system on which Galaxy
+# runs, the DRMAA job runner can be configured to submit jobs to the DRM as the
+# actual user instead of as the user running the Galaxy server process.  For
+# details on these options, see the documentation at:
+#
+# http://galaxyproject.org/wiki/Admin/Config/Performance/Cluster
+#
+#drmaa_external_runjob_script = scripts/drmaa_external_runner.py
+#drmaa_external_killjob_script = scripts/drmaa_external_killer.py
+#external_chown_script = scripts/external_chown_script.py
+
 # File to source to set up the environment when running jobs.  By default, the
 # environment in which the Galaxy server starts is used when running jobs
 # locally, and the environment set up per the DRM's submission method and

--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -252,10 +252,7 @@
           -->
         </destination>
         <destination id="real_user_cluster" runner="drmaa">
-            <!-- TODO: The real user options should maybe not be considered runner params. -->
-            <param id="galaxy_external_runjob_script">scripts/drmaa_external_runner.py</param>
-            <param id="galaxy_external_killjob_script">scripts/drmaa_external_killer.py</param>
-            <param id="galaxy_external_chown_script">scripts/external_chown_script.py</param>
+            <!-- Make sure to setup 3 real user parameters in galaxy.ini. -->
         </destination>
         <destination id="dynamic" runner="dynamic">
             <!-- A destination that represents a method in the dynamic runner. -->


### PR DESCRIPTION
I think what was documented was the ideal case - which would be great if these could be set per destination - but they cannot be so they shouldn't be documented that way. I believe these options must still be set in galaxy.ini.

Documentation broken in https://github.com/galaxyproject/galaxy/commit/9b7775be03728f724c025a83bc7ffa9e28c2c932.
