### PR TITLE
Small test tool updates

### DIFF
--- a/test/functional/tools/inheritance_simple.xml
+++ b/test/functional/tools/inheritance_simple.xml
@@ -1,0 +1,24 @@
+<tool id="inheritance_simple" name="inheritance_simple" version="1.0.0">
+    <description>(demonstrates subtypes are usable for parent format)</description>
+    <command>
+        cat $input1 > $out_file1
+    </command>
+    <inputs>
+        <param name="input1" type="data" label="Copy FASTQ" format="fastq" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format_source="input1" metadata_source="input1"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" value="1.fastqsanger" ftype="fastqsanger" />
+            <output name="out_file1" file="1.fastqsanger" ftype="fastqsanger" />
+        </test>
+        <test>
+            <param name="input1" value="1.fastqsolexa" ftype="fastqsolexa" />
+            <output name="out_file1" file="1.fastqsolexa" ftype="fastqsolexa" />
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -2,6 +2,7 @@
 <toolbox tool_path="${tool_conf_dir}">
   <tool file="upload.xml"/>
   <tool file="simple_constructs.xml" />
+  <tool file="inheritance_simple.xml" />
   <tool file="composite.xml" />
   <tool file="compare_bam_as_sam.xml" />
   <tool file="code_file.xml" />

--- a/test/functional/tools/simple_constructs.xml
+++ b/test/functional/tools/simple_constructs.xml
@@ -1,10 +1,13 @@
-<tool id="simple_constructs" name="simple_constructs">
+<tool id="simple_constructs" name="simple_constructs" version="1.0.0">
     <command>
         echo "$p1.p1val"  >> $out_file1;
         echo "$booltest"  >> $out_file1;
         echo "$inttest"   >> $out_file1; 
-        echo "$floattest" >> $out_file1; 
-        cat "$files[0].file"   >> $out_file1;
+        echo "$floattest" >> $out_file1;
+        echo "$radio_select" >> $out_file1;
+        echo "$check_select" >> $out_file1;
+        echo "$drop_select"  >> $out_file1;
+        cat "$files[0].file" >> $out_file1;
     </command>
     <inputs>
         <conditional name="p1">
@@ -19,6 +22,21 @@
         <param name="booltest" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
         <param name="inttest" value="1" type="integer" />
         <param name="floattest" value="1.0" type="float" />
+        <param name="radio_select" type="select" display="radio">
+            <option value="a_radio" selected="true">A Radio</option>
+            <option value="b_radio">B Radio</option>
+            <option value="c_radio">C Radio</option>
+        </param>
+        <param name="check_select" type="select" display="checkboxes" multiple="true">
+            <option value="a_check" selected="true">A Check</option>
+            <option value="b_check">B Check</option>
+            <option value="c_check">C Check</option>
+        </param>
+        <param name="drop_select" type="select">
+            <option value="a_drop" selected="true">A Drop</option>
+            <option value="b_drop">B Drop</option>
+            <option value="c_drop">C Drop</option>
+        </param>
         <repeat name="files" title="Files">
             <param name="file" type="data" format="txt" />
         </repeat>


### PR DESCRIPTION
- Add tool demonstrating/validating datatype inheritance.
- Update simple constructs tool to demonstrate a variety of select display types (this was useful in debugging the workflow runtime parameter problem).

New test is runnable via: 

```
 ./run_tests.sh -framework -id inheritance_simple   
```
