### PR TITLE
Reorder BAM metadata to set reference names and lengths before attempting to parse header. Add test.

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -303,10 +303,10 @@ class Bam( Binary ):
         # Now use pysam with BAI index to determine additional metadata
         try:
             bam_file = csamtools.Samfile( filename=dataset.file_name, mode='rb', index_filename=index_file.file_name )
-            dataset.metadata.bam_header = bam_file.header
-            dataset.metadata.read_groups = [ read_group['ID'] for read_group in dataset.metadata.bam_header.get( 'RG', [] ) if 'ID' in read_group ]
             dataset.metadata.reference_names = list( bam_file.references )
             dataset.metadata.reference_lengths = list( bam_file.lengths )
+            dataset.metadata.bam_header = bam_file.header
+            dataset.metadata.read_groups = [ read_group['ID'] for read_group in dataset.metadata.bam_header.get( 'RG', [] ) if 'ID' in read_group ]
             dataset.metadata.sort_order = dataset.metadata.bam_header.get( 'HD', {} ).get( 'SO', None )
             dataset.metadata.bam_version = dataset.metadata.bam_header.get( 'HD', {} ).get( 'VN', None )
         except:

--- a/test/functional/tools/metadata_bam.xml
+++ b/test/functional/tools/metadata_bam.xml
@@ -1,0 +1,25 @@
+<tool id="metadata_bam" name="metadata BAM" version="1.0.0">
+  <command>echo "${ref_names}" &gt; "${output_of_input_metadata}"</command>
+  <inputs>
+    <param name="input_bam" type="data" format="bam" label="BAM File"/>
+    <param name="ref_names" type="select" optional="False" label="Select references you would like to restrict bam to" multiple="True">
+        <options>
+            <filter type="data_meta" ref="input_bam" key="reference_names" />
+        </options>
+    </param>
+  </inputs>
+  <outputs>
+    <data format="txt" name="output_of_input_metadata" />
+  </outputs>
+  <tests>
+    <test>
+      <param name="input_bam" value="3unsorted.bam" ftype="bam" />
+      <!-- This output tests setting using bam reference name metadata above -->
+      <param name="ref_names" value="chr10_random,chr11,chrM,chrX,chr16" />
+      <output name="output_of_input_metadata" ftype="txt">
+        <assert_contents>
+          <has_line line="chr10_random,chr11,chrM,chrX,chr16" />
+        </assert_contents>
+      </output>
+    </test>
+  </tests></tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -15,6 +15,7 @@
   <tool file="multi_output_assign_primary.xml" />
   <tool file="composite_output.xml" />
   <tool file="metadata.xml" />
+  <tool file="metadata_bam.xml" />
   <tool file="job_properties.xml" />
   <tool file="gzipped_inputs.xml" />
   <tool file="output_order.xml" />


### PR DESCRIPTION
pysam will die on parsing headers from e.g. 3unsorted.bam (sorted)

3unsorted.bam has broken headers
