### PR TITLE
Implement ``detect_errors`` attribute on command of tool XML.

### DIFF
--- a/lib/galaxy/tools/parser/util.py
+++ b/lib/galaxy/tools/parser/util.py
@@ -1,0 +1,38 @@
+from .interface import ToolStdioExitCode
+from .interface import ToolStdioRegex
+
+
+def error_on_exit_code():
+    exit_code_lower = ToolStdioExitCode()
+    exit_code_lower.range_start = float("-inf")
+    exit_code_lower.range_end = -1
+    _set_fatal(exit_code_lower)
+    exit_code_high = ToolStdioExitCode()
+    exit_code_high.range_start = 1
+    exit_code_high.range_end = float("inf")
+    _set_fatal(exit_code_high)
+    return [exit_code_lower, exit_code_high], []
+
+
+def aggressive_error_checks():
+    exit_codes, _ = error_on_exit_code()
+    # these regexes are processed as case insensitive by default
+    regexes = [
+        _error_regex("exception:"),
+        _error_regex("error:")
+    ]
+    return exit_codes, regexes
+
+
+def _error_regex(match):
+    regex = ToolStdioRegex()
+    _set_fatal(regex)
+    regex.match = match
+    regex.stdout_match = True
+    regex.stderr_match = True
+    return regex
+
+
+def _set_fatal(obj):
+    from galaxy.jobs.error_level import StdioErrorLevel
+    obj.error_level = StdioErrorLevel.FATAL

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -2,7 +2,7 @@ from .interface import ToolSource
 from .interface import PagesSource
 from .interface import PageSource
 from .interface import InputSource
-from .interface import ToolStdioExitCode
+from .util import error_on_exit_code
 
 from galaxy.tools.deps import requirements
 from galaxy.tools.parameters import output_collect
@@ -57,18 +57,7 @@ class YamlToolSource(ToolSource):
         return PagesSource([page_source])
 
     def parse_stdio(self):
-        from galaxy.jobs.error_level import StdioErrorLevel
-
-        # New format - starting out just using exit code.
-        exit_code_lower = ToolStdioExitCode()
-        exit_code_lower.range_start = float("-inf")
-        exit_code_lower.range_end = -1
-        exit_code_lower.error_level = StdioErrorLevel.FATAL
-        exit_code_high = ToolStdioExitCode()
-        exit_code_high.range_start = 1
-        exit_code_high.range_end = float("inf")
-        exit_code_lower.error_level = StdioErrorLevel.FATAL
-        return [exit_code_lower, exit_code_high], []
+        return error_on_exit_code()
 
     def parse_help(self):
         return self.root_dict.get("help", None)

--- a/test/functional/tools/detect_errors_aggressive.xml
+++ b/test/functional/tools/detect_errors_aggressive.xml
@@ -1,0 +1,51 @@
+<tool id="detect_errors_aggressive" name="detect_errors_aggressive" version="1.0.0">
+    <command detect_errors="aggressive">
+        #if $error_bool
+            echo "ERROR: Problem...."
+        #elif $exception_bool
+            echo "Exception: Problem..."
+        #else
+            echo "Everything is OK."
+        #end if
+        ; sh -c "exit $exit_code"
+
+    </command>
+    <inputs>
+        <param name="error_bool" type="boolean" label="error bool" />
+        <param name="exception_bool" type="boolean" label="exception bool" checked="false" />
+        <param name="exit_code" type="integer" value="0" label="exit code"/>
+    </inputs>
+    <outputs>
+        <data name="out_file1" />
+    </outputs>
+    <tests>
+        <test expect_exit_code="0" expect_failure="false">
+            <param name="error_bool" value="false" />
+            <param name="exception_bool" value="false" />
+            <param name="exit_code" value="0" />
+            <assert_stdout>
+                <has_line line="Everything is OK." />
+            </assert_stdout>
+        </test>
+        <test expect_exit_code="1" expect_failure="true">
+            <param name="error_bool" value="false" />
+            <param name="exception_bool" value="false" />
+            <param name="exit_code" value="1" />
+            <assert_stdout>
+                <has_line line="Everything is OK." />
+            </assert_stdout>
+        </test>
+        <test expect_exit_code="0" expect_failure="true">
+            <param name="error_bool" value="true" />
+            <param name="exception_bool" value="false" />
+            <param name="exit_code" value="0" />
+        </test>
+        <test expect_exit_code="0" expect_failure="true">
+            <param name="error_bool" value="false" />
+            <param name="exception_bool" value="true" />
+            <param name="exit_code" value="0" />
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -16,6 +16,7 @@
   <tool file="composite_output.xml" />
   <tool file="metadata.xml" />
   <tool file="metadata_bam.xml" />
+  <tool file="detect_errors_aggressive.xml" />
   <tool file="job_properties.xml" />
   <tool file="gzipped_inputs.xml" />
   <tool file="output_order.xml" />

--- a/test/unit/tools/test_parsing.py
+++ b/test/unit/tools/test_parsing.py
@@ -104,8 +104,15 @@ class BaseLoaderTestCase(unittest.TestCase):
 
     @property
     def _tool_source(self):
-        path = os.path.join(self.temp_directory, self.source_file_name)
-        open(path, "w").write(self.source_contents)
+        return self._get_tool_source()
+
+    def _get_tool_source(self, source_file_name=None, source_contents=None):
+        if source_file_name is None:
+            source_file_name = self.source_file_name
+        if source_contents is None:
+            source_contents = self.source_contents
+        path = os.path.join(self.temp_directory, source_file_name)
+        open(path, "w").write(source_contents)
         tool_source = get_tool_source(path)
         return tool_source
 
@@ -211,6 +218,27 @@ class XmlLoaderTestCase(BaseLoaderTestCase):
         attributes1 = output2[2]
         assert attributes1["compare"] == "sim_size"
         assert attributes1["lines_diff"] == 4
+
+    def test_exit_code(self):
+        tool_source = self._get_tool_source(source_contents="""<tool id="bwa" name="bwa">
+            <command detect_errors="exit_code">
+                ls
+            </command>
+        </tool>
+        """)
+        exit, regexes = tool_source.parse_stdio()
+        assert len(exit) == 2, exit
+        assert len(regexes) == 0, regexes
+
+        tool_source = self._get_tool_source(source_contents="""<tool id="bwa" name="bwa">
+            <command detect_errors="aggressive">
+                ls
+            </command>
+        </tool>
+        """)
+        exit, regexes = tool_source.parse_stdio()
+        assert len(exit) == 2, exit
+        assert len(regexes) == 2, regexes
 
 
 class YamlLoaderTestCase(BaseLoaderTestCase):


### PR DESCRIPTION
If present, it can be one of
- `default`, no-op fallback to stdio tags and erroring on standard error output.
- `exit_code`, error if tool exit code is not 0. (The @jmchilton recommendation).
- `aggressive`, error if tool exit code is not 0 or either Exception: or Error: appears in standard error/output. (The @bgruening recommendation).

The `stdio` tag is a very heavy solution when many (most?) tools use either this `exit_code` or `aggressive` strategy leading to a lot of duplicated XML - and if there is one thing I like less than XML it is duplicated XML.

Refactoring and unit/functional tests to support and demonstrate this.

Run relevant functional tests with:

```
./run_tests.sh -framework -id detect_errors_aggressive
```

Run relevant unit tests:

```
nosetests test/unit/tools/test_parsing.py
```
