### PR TITLE
Stronger toolbox filtering.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -550,7 +550,7 @@ class Tool( object, Dictifiable ):
     def get_panel_section( self ):
         return self.app.toolbox.get_integrated_section_for_tool( self )
 
-    def allow_user_access( self, user ):
+    def allow_user_access( self, user, attempting_access=True ):
         """
         :returns: bool -- Whether the user is allowed to access the tool.
         """
@@ -2961,16 +2961,26 @@ class DataManagerTool( OutputParameterJSONTool ):
                     history = None
         return history
 
-    def allow_user_access( self, user ):
+    def allow_user_access( self, user, attempting_access=True ):
         """
+        :param user: model object representing user.
+        :type user: galaxy.model.User
+        :param attempting_access: is the user attempting to do something with the
+                               the tool (set false for incidental checks like toolbox
+                               listing)
+        :type attempting_access:  bool
+
         :returns: bool -- Whether the user is allowed to access the tool.
         Data Manager tools are only accessible to admins.
         """
         if super( DataManagerTool, self ).allow_user_access( user ) and self.app.config.is_admin_user( user ):
             return True
-        if user:
-            user = user.id
-        log.debug( "User (%s) attempted to access a data manager tool (%s), but is not an admin.", user, self.id ) 
+        # If this is just an incidental check - do not log the scary message
+        # about users attempting to do something problematic.
+        if attempting_access:
+            if user:
+                user = user.id
+            log.debug( "User (%s) attempted to access a data manager tool (%s), but is not an admin.", user, self.id )
         return False
 
 # Populate tool_type to ToolClass mappings

--- a/lib/galaxy/tools/toolbox/filters/__init__.py
+++ b/lib/galaxy/tools/toolbox/filters/__init__.py
@@ -19,7 +19,7 @@ class FilterFactory( object ):
         # Prepopulate dict containing filters that are always checked,
         # other filters that get checked depending on context (e.g. coming from
         # trackster or no user found are added in build filters).
-        self.default_filters = dict( tool=[ _not_hidden, _handle_requires_login ], section=[], label=[] )
+        self.default_filters = dict( tool=[ _not_hidden, _handle_authorization ], section=[], label=[] )
         # Add dynamic filters to these default filters.
         config = toolbox.app.config
         self.__base_modules = listify( getattr( config, "toolbox_filter_base_modules", "galaxy.tools.filters" ) )
@@ -95,8 +95,13 @@ def _not_hidden( context, tool ):
     return not tool.hidden
 
 
-def _handle_requires_login( context, tool ):
-    return not tool.require_login or context.trans.user
+def _handle_authorization( context, tool ):
+    user = context.trans.user
+    if tool.require_login and not user:
+        return False
+    if not tool.allow_user_access( user, attempting_access=False ):
+        return False
+    return True
 
 
 def _has_trackster_conf( context, tool ):

--- a/test/unit/tools/test_toolbox_filters.py
+++ b/test/unit/tools/test_toolbox_filters.py
@@ -61,11 +61,16 @@ def is_filtered( filters, trans, tool ):
     return not all( map( lambda filter: filter( context, tool ), filters ) )
 
 
-def mock_tool( require_login=False, hidden=False, trackster_conf=False ):
+def mock_tool( require_login=False, hidden=False, trackster_conf=False, allow_access=True ):
+    def allow_user_access(user, attempting_access):
+        assert not attempting_access
+        return allow_access
+
     tool = Bunch(
         require_login=require_login,
         hidden=hidden,
         trackster_conf=trackster_conf,
+        allow_user_access=allow_user_access,
     )
     return tool
 


### PR DESCRIPTION
- Update toolbox filtering rules to also filter on `tool.allow_user_access`.
- Use toolbox filtering when listing tools not in the context of panel (so filtered tools are not listed in the API in either case).

See also:
- https://trello.com/c/jyl0cvFP
- https://trello.com/c/Sg8D2PBj
- http://dev.list.galaxyproject.org/Bug-Toolbox-filters-not-applied-in-workflows-td4662879.html

Testing:

The following command will run a superset of relevant tests:

```
./run_tests.sh -u test/unit/tools
```

Update: To be clear since there was a Trello card with the same name as the PR - filtering what is visible still does not prevent execution of a tool (though tools that are not `tool.user_can_access` will be both filtered and have their execution prevented).
