### PR TITLE
Improved Cheetah type casting for int/float values.

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -98,6 +98,12 @@ class InputValueWrapper( ToolParameterValueWrapper ):
     def __getattr__( self, key ):
         return getattr( self.value, key )
 
+    def __int__(self):
+        return int(str(self))
+
+    def __float__(self):
+        return float(str(self))
+
 
 class SelectToolParameterWrapper( ToolParameterValueWrapper ):
     """

--- a/test/functional/tools/cheetah_casting.xml
+++ b/test/functional/tools/cheetah_casting.xml
@@ -1,0 +1,27 @@
+<tool id="cheetah_casting" name="cheetah_casting" version="1.0.0">
+    <command>
+        #set $int_val_inc = int($inttest) + 1
+        #set $float_val_inc = float($floattest) + 1
+        echo $int_val_inc   >> $out_file1;
+        echo $float_val_inc >> $out_file1;
+    </command>
+    <inputs>
+        <param name="inttest" value="1" type="integer" />
+        <param name="floattest" value="1.0" type="float" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="inttest" value="1" />
+            <param name="floattest" value="2.5" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="2" />
+                    <has_line line="3.5" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -51,6 +51,8 @@
   <tool file="collection_optional_param.xml" />
   <tool file="collection_split_on_column.xml" />
 
+  <tool file="cheetah_casting.xml" />
+
   <tool file="multiple_versions_v01.xml" />
   <tool file="multiple_versions_v02.xml" />
 


### PR DESCRIPTION
Based on idea by @peterjc in a discussion here - http://dev.list.galaxyproject.org/Geting-integer-value-from-InputValueWrapper-in-plugin-xml-file-td4666971.html. With simple test demonstrating new functionality. Run test with

```
./run_tests.sh -framework -id cheetah_casting
```
