### PR TITLE
Allow testing tool outputs based on MD5 hashes.

### DIFF
--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -362,11 +362,13 @@ def __parse_test_attributes( output_elem, attrib ):
     metadata = {}
     for metadata_elem in output_elem.findall( 'metadata' ):
         metadata[ metadata_elem.get('name') ] = metadata_elem.get( 'value' )
-    if not (assert_list or file or extra_files or metadata):
-        raise Exception( "Test output defines nothing to check (e.g. must have a 'file' check against, assertions to check, etc...)")
+    md5sum = attrib.get("md5", None)
+    if not (assert_list or file or extra_files or metadata or md5sum):
+        raise Exception( "Test output defines nothing to check (e.g. must have a 'file' check against, assertions to check, metadata or md5 tests, etc...)")
     attributes['assert_list'] = assert_list
     attributes['extra_files'] = extra_files
     attributes['metadata'] = metadata
+    attributes['md5'] = md5sum
     return file, attributes
 
 

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -133,6 +133,7 @@ class ToolTestBuilder( object ):
             self.stderr = test_dict.get("stderr", None)
             self.expect_exit_code = test_dict.get("expect_exit_code", None)
             self.expect_failure = test_dict.get("expect_failure", False)
+            self.md5 = test_dict.get("md5", None)
         except Exception, e:
             self.error = True
             self.exception = e

--- a/test/base/twilltestcase.py
+++ b/test/base/twilltestcase.py
@@ -2271,6 +2271,14 @@ class TwillTestCase( unittest.TestCase ):
                 errmsg = 'History item %s different than expected\n' % (hid)
                 errmsg += str( err )
                 raise AssertionError( errmsg )
+        if attributes is not None and attributes.get("md5", None) is not None:
+            md5 = attributes.get("md5")
+            try:
+                self._verify_md5(data, md5)
+            except AssertionError, err:
+                errmsg = 'History item %s different than expected\n' % (hid)
+                errmsg += str( err )
+                raise AssertionError( errmsg )
         if filename is not None:
             local_name = self.get_filename( filename, shed_tool_id=shed_tool_id )
             temp_name = self.makeTfname(fname=filename)
@@ -2322,6 +2330,18 @@ class TwillTestCase( unittest.TestCase ):
             finally:
                 if 'GALAXY_TEST_NO_CLEANUP' not in os.environ:
                     os.remove( temp_name )
+
+    def _verify_md5( self, data, expected_md5 ):
+        import md5
+        m = md5.new()
+        m.update( data )
+        actual_md5 = m.hexdigest()
+        if expected_md5 != actual_md5:
+            template = "Output md5sum [%s] does not match expected [%s]."
+            message = template % (actual_md5, expected_md5)
+            assert False, message
+
+
 
     def view_external_service( self, external_service_id, strings_displayed=[] ):
         self.visit_url( '%s/external_service/view_external_service?id=%s' % ( self.url, external_service_id ) )

--- a/test/functional/tools/md5sum.xml
+++ b/test/functional/tools/md5sum.xml
@@ -1,0 +1,17 @@
+<tool id="md5sum" name="md5sum" version="1.0.0">
+    <command>
+        cp $input $output
+    </command>
+    <inputs>
+        <param name="input" type="data" format="txt" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="simple_line.txt" />
+            <output name="out_file1" md5="ac94233685713ce99d1e712b0023c381" />
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -17,6 +17,7 @@
   <tool file="metadata.xml" />
   <tool file="metadata_bam.xml" />
   <tool file="detect_errors_aggressive.xml" />
+  <tool file="md5sum.xml" />
   <tool file="job_properties.xml" />
   <tool file="gzipped_inputs.xml" />
   <tool file="output_order.xml" />


### PR DESCRIPTION
This should not be considered the best practice for most text based files, but for binary files Galaxy cannot produce diffs anyway so this is probably better than storing the pointless binary blobs in repositories for instance. In particular Dan and I thought this would be useful for testing index files for data managers.

Includes test tool demonstrating this functionality, run test with

```
./run_tests.sh -framework -id md5sum
```

See also
- https://trello.com/c/Xiv13h2G
