### PR TITLE
Allow setting ``auto_format="True"`` on tool ``output``s.

### DIFF
--- a/lib/galaxy/datatypes/metadata.py
+++ b/lib/galaxy/datatypes/metadata.py
@@ -166,6 +166,9 @@ class MetadataCollection( object ):
                 # if the metadata value is not found in our externally set metadata but it has a value in the 'old'
                 # metadata associated with our dataset, we'll delete it from our dataset's metadata dict
                 del dataset._metadata[ name ]
+        if '__extension__' in JSONified_dict:
+            dataset.extension = JSONified_dict['__extension__']
+
 
     def to_JSON_dict( self, filename=None ):
         # galaxy.model.customtypes.json_encoder.encode()
@@ -174,6 +177,8 @@ class MetadataCollection( object ):
         for name, spec in self.spec.items():
             if name in dataset_meta_dict:
                 meta_dict[ name ] = spec.param.to_external_value( dataset_meta_dict[ name ] )
+        if '__extension__' in dataset_meta_dict:
+            meta_dict[ '__extension__' ] = dataset_meta_dict['__extension__']
         if filename is None:
             return json.dumps( meta_dict )
         json.dump( meta_dict, open( filename, 'wb+' ) )

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -26,6 +26,7 @@ from galaxy.util.bunch import Bunch
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.json import loads
 from galaxy.util import unicodify
+from galaxy.datatypes import sniff
 
 from .output_checker import check_output
 from .datasets import TaskPathRewriter
@@ -1153,6 +1154,11 @@ class JobWrapper( object ):
                     # but somewhat trickier (need to recurse up the copied_from tree), for now we'll call set_meta()
                     if ( not self.external_output_metadata.external_metadata_set_successfully( dataset, self.sa_session )
                          and self.app.config.retry_metadata_internally ):
+                        # If Galaxy was expected to sniff type and didn't - do so.
+                        if dataset.ext == "_sniff_":
+                            extension = sniff.handle_uploaded_dataset_file( dataset.dataset.file_name, self.app.datatypes_registry )
+                            dataset.extension = extension
+
                         # call datatype.set_meta directly for the initial set_meta call during dataset creation
                         dataset.datatype.set_meta( dataset, overwrite=False )
                     elif ( not self.external_output_metadata.external_metadata_set_successfully( dataset, self.sa_session )

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -217,7 +217,13 @@ class XmlToolSource(ToolSource):
         default_metadata_source="",
     ):
         output = galaxy.tools.ToolOutput( data_elem.get("name") )
-        output.format = data_elem.get("format", default_format)
+        output_format = data_elem.get("format", default_format)
+        auto_format = string_as_bool( data_elem.get( "auto_format", "false" ) )
+        if auto_format and output_format != "data":
+            raise ValueError("Setting format and auto_format is not supported at this time.")
+        elif auto_format:
+            output_format = "_sniff_"
+        output.format = output_format
         output.change_format = data_elem.findall("change_format")
         output.format_source = data_elem.get("format_source", default_format_source)
         output.metadata_source = data_elem.get("metadata_source", default_metadata_source)

--- a/test/functional/tools/output_auto_format.xml
+++ b/test/functional/tools/output_auto_format.xml
@@ -1,0 +1,16 @@
+<tool id="output_auto_format" name="output_auto_format" version="1.0.0">
+  <command>cp $input 'out'</command>
+  <inputs>
+    <param name="input" type="data" format="data" label="An input dataset" help=""/>
+  </inputs>
+  <outputs>
+    <data auto_format="true" name="output" label="Auto Output" from_work_dir="out">
+    </data>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input" value="simple_line.txt" ftype="txt" />
+      <output name="output" file="simple_line.txt" ftype="txt" />
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -23,6 +23,7 @@
   <tool file="output_order.xml" />
   <tool file="output_format.xml" />
   <tool file="output_filter.xml" />
+  <tool file="output_auto_format.xml" />
   <tool file="disambiguate_repeats.xml" />
   <tool file="min_repeat.xml" />
   <tool file="parallelism.xml" />


### PR DESCRIPTION
The metadata system will then "sniff" the outputs and set the type appropriately. This will be good for tools like upload or genomespace importer where the output type is not known ahead of time - similar tools should no longer need to use wrappers that import galaxy internals in the future.

Tool used to demonstrate and test this functionality is included, run the test with:

```
./run_tests.sh -framework -id output_auto_format
```

See also:
- https://trello.com/c/FZ67pAAE
- http://dev.list.galaxyproject.org/Multiple-outputs-of-unknown-types-td4666891.html
- https://github.com/jmchilton/galaxy/pull/1

Ping @blankenberg 
