### PR TITLE
Fix for GenomeSpace Exporter no longer allowing filenames to contain slashes.

### DIFF
--- a/tools/genomespace/genomespace_exporter.py
+++ b/tools/genomespace/genomespace_exporter.py
@@ -213,6 +213,7 @@ def galaxy_code_get_genomespace_folders( genomespace_site='prod', trans=None, va
     
 
 def send_file_to_genomespace( genomespace_site, username, token, source_filename, target_directory, target_filename, file_type, content_type, log_filename ):
+    target_filename = target_filename.replace( '/', '-' ) # Slashes no longer allowed in filenames
     url_opener = get_cookie_opener( username, token )
     genomespace_site_dict = get_genomespace_site_urls()[ genomespace_site ]
     dm_url = genomespace_site_dict['dmServer']

--- a/tools/genomespace/genomespace_exporter.xml
+++ b/tools/genomespace/genomespace_exporter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="GenomeSpace Exporter" id="genomespace_exporter" require_login="True" version="0.0.3">
+<tool name="GenomeSpace Exporter" id="genomespace_exporter" require_login="True" version="0.0.4">
     <description> - send data to GenomeSpace</description>
     <command interpreter="python">genomespace_exporter.py 
         --genomespace_site "prod"


### PR DESCRIPTION
Used to work... but makes sense to not be allowed if trying to mimic a filesystem.
