### PR TITLE
run tests from outer directories

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -51,7 +51,7 @@ EOF
 }
 
 show_list() {
-    python $parental_dir"tool_list.py"
+    python tool_list.py
     echo "==========================================================================================================================================="
     echo "'${0##*/} -id bbb'               for testing one tool with id 'bbb' ('bbb' is the tool id)"
     echo "'${0##*/} -sid ccc'              for testing one section with sid 'ccc' ('ccc' is the string after 'section::')"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -307,6 +307,12 @@ if [ "$driver" = "python" ]; then
     else
         structured_data_args=""
     fi
+    # The following lines allow to run ./run_tests from directories outside the galaxy home directory
+    parental_dir=$(dirname $0)
+    if [ "$parental_dir" != "" ]; then
+        export PYTHONPATH=$PYTHONPATH:$parental_dir"/test"
+        test_script=$parental_dir"/"$test_script
+    fi
     python $test_script $coverage_arg -v --with-nosehtml --html-report-file $report_file $xunit_args $structured_data_args $with_framework_test_tools_arg $extra_args
 else
     ensure_grunt

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,30 +1,44 @@
 #!/bin/sh
 
+pwd_dir=$(pwd)
+cd `dirname $0`
+
 ./scripts/common_startup.sh
 
 # A good place to look for nose info: http://somethingaboutorange.com/mrl/projects/nose/
-rm -f run_functional_tests.log 
+rm -f run_functional_tests.log
 
 show_help() {
 cat <<EOF
-'${0##*/}'                          for testing all the tools in functional directory
-'${0##*/} aaa'                      for testing one test case of 'aaa' ('aaa' is the file name with path)
+'${0##*/} (test_path)'              for testing all the tools in functional directory
 '${0##*/} -id bbb'                  for testing one tool with id 'bbb' ('bbb' is the tool id)
 '${0##*/} -sid ccc'                 for testing one section with sid 'ccc' ('ccc' is the string after 'section::')
 '${0##*/} -list'                    for listing all the tool ids
-'${0##*/} -api'                     for running all the test scripts in the ./test/api directory
-'${0##*/} -toolshed'                for running all the test scripts in the ./test/tool_shed/functional directory
-'${0##*/} -toolshed testscriptname' for running one test script named testscriptname in the .test/tool_shed/functional directory
+'${0##*/} -api (test_path)'         for running all the test scripts in the ./test/api directory
+'${0##*/} -toolshed (test_path)'    for running all the test scripts in the ./test/tool_shed/functional directory
 '${0##*/} -workflow test.xml'       for running a workflow test case as defined by supplied workflow xml test file (experimental)
-'${0##*/} -framework'               for running through example tool tests testing framework features in test/functional/tools"   
+'${0##*/} -framework'               for running through example tool tests testing framework features in test/functional/tools"
 '${0##*/} -framework -id toolid'    for testing one framework tool (in test/functional/tools/) with id 'toolid'
 '${0##*/} -data_managers -id data_manager_id'    for testing one Data Manager with id 'data_manager_id'
-'${0##*/} -unit'                    for running all unit tests (doctests in lib and tests in test/unit)
-'${0##*/} -unit testscriptath'      running particular tests scripts
+'${0##*/} -unit (test_path)'        for running all unit tests (doctests in lib and tests in test/unit)
 '${0##*/} -qunit'                   for running qunit JavaScript tests
 '${0##*/} -qunit testname'          for running single JavaScript test with given name
 
+
+Nose tests will allow specific tests to be selected per the documentation at
+https://nose.readthedocs.org/en/latest/usage.html#selecting-tests.  These are
+indicated with the optional parameter (test_path).  A few examples are:
+
+Run all TestUserInfo functional tests:
+    ./run_tests.sh test/functional/test_user_info.py:TestUserInfo
+
+Run a specific API test requiring the framework test tools:
+    ./run_tests.sh -api -with_framework_test_tools test/api/test_tools.py:ToolsTestCase.test_map_over_with_output_format_actions
+
+
 Extra options:
+
+
 
  --verbose_errors      Force some tests produce more verbose error reporting.
  --no_cleanup          Do not delete temp files for Python functional tests (-toolshed, -framework, etc...)
@@ -37,7 +51,7 @@ EOF
 }
 
 show_list() {
-    python tool_list.py
+    python $parental_dir"tool_list.py"
     echo "==========================================================================================================================================="
     echo "'${0##*/} -id bbb'               for testing one tool with id 'bbb' ('bbb' is the tool id)"
     echo "'${0##*/} -sid ccc'              for testing one section with sid 'ccc' ('ccc' is the string after 'section::')"
@@ -307,12 +321,6 @@ if [ "$driver" = "python" ]; then
     else
         structured_data_args=""
     fi
-    # The following lines allow to run ./run_tests from directories outside the galaxy home directory
-    parental_dir=$(dirname $0)
-    if [ "$parental_dir" != "" ]; then
-        export PYTHONPATH=$PYTHONPATH:$parental_dir"/test"
-        test_script=$parental_dir"/"$test_script
-    fi
     python $test_script $coverage_arg -v --with-nosehtml --html-report-file $report_file $xunit_args $structured_data_args $with_framework_test_tools_arg $extra_args
 else
     ensure_grunt
@@ -331,3 +339,5 @@ else
     # functional tests.
     grunt --gruntfile=$gruntfile $grunt_task $grunt_args
 fi
+
+cd $pwd_dir


### PR DESCRIPTION
Allows run_tests.sh to be executed from directories outside the galaxy home directory without returning the error "python: can't open file './scripts/functional_tests.py': [Errno 2] No such file or directory"
