### PR TITLE
[STABLE] Metadata Fixes

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -34,6 +34,8 @@ JOB_RUNNER_PARAMETER_UNKNOWN_MESSAGE = "Invalid job runner parameter for this pl
 JOB_RUNNER_PARAMETER_MAP_PROBLEM_MESSAGE = "Job runner parameter '%s' value '%s' could not be converted to the correct type"
 JOB_RUNNER_PARAMETER_VALIDATION_FAILED_MESSAGE = "Job runner parameter %s failed validation"
 
+GALAXY_LIB_ADJUST_TEMPLATE = """GALAXY_LIB="%s"; if [ "$GALAXY_LIB" != "None" ]; then if [ -n "$PYTHONPATH" ]; then PYTHONPATH="$GALAXY_LIB:$PYTHONPATH"; else PYTHONPATH="$GALAXY_LIB"; fi; export PYTHONPATH; fi;"""
+
 
 class RunnerParams( ParamsWithSpecs ):
 
@@ -250,11 +252,13 @@ class BaseJobRunner( object ):
         #this is terminate-able when output dataset/job is deleted
         #so that long running set_meta()s can be canceled without having to reboot the server
         if job_wrapper.get_state() not in [ model.Job.states.ERROR, model.Job.states.DELETED ] and job_wrapper.output_paths:
+            lib_adjust = GALAXY_LIB_ADJUST_TEMPLATE % job_wrapper.galaxy_lib_dir
             external_metadata_script = job_wrapper.setup_external_metadata( output_fnames=job_wrapper.get_output_fnames(),
                                                                             set_extension=True,
                                                                             tmp_dir=job_wrapper.working_directory,
                                                                             #we don't want to overwrite metadata that was copied over in init_meta(), as per established behavior
                                                                             kwds={ 'overwrite' : False } )
+            external_metadata_script = "%s %s" % (lib_adjust, external_metadata_script)
             if resolve_requirements:
                 dependency_shell_commands = self.app.datatypes_registry.set_external_metadata_tool.build_dependency_shell_commands()
                 if dependency_shell_commands:

--- a/lib/galaxy/jobs/runners/tasks.py
+++ b/lib/galaxy/jobs/runners/tasks.py
@@ -124,19 +124,7 @@ class TaskedJobRunner( BaseJobRunner ):
         #run the metadata setting script here
         #this is terminate-able when output dataset/job is deleted
         #so that long running set_meta()s can be canceled without having to reboot the server
-        if job_wrapper.get_state() not in [ model.Job.states.ERROR, model.Job.states.DELETED ] and job_wrapper.output_paths:
-            external_metadata_script = job_wrapper.setup_external_metadata( output_fnames=job_wrapper.get_output_fnames(),
-                                                                            set_extension=True,
-                                                                            kwds={ 'overwrite' : False } )  # we don't want to overwrite metadata that was copied over in init_meta(), as per established behavior
-            log.debug( 'executing external set_meta script for job %d: %s' % ( job_wrapper.job_id, external_metadata_script ) )
-            external_metadata_proc = subprocess.Popen( args=external_metadata_script,
-                                         shell=True,
-                                         env=os.environ,
-                                         preexec_fn=os.setpgrp )
-            job_wrapper.external_output_metadata.set_job_runner_external_pid( external_metadata_proc.pid, self.sa_session )
-            external_metadata_proc.wait()
-            log.debug( 'execution of external set_meta finished for job %d' % job_wrapper.job_id )
-
+        self._handle_metadata_externally(job_wrapper, resolve_requirements=True )
         # Finish the job
         try:
             job_wrapper.finish( stdout, stderr, job_exit_code )


### PR DESCRIPTION
Two bug fixes - the more important is 6676535 which fixes metadata handling when used with the task runner or Pulsar. The other fix reduces some code duplication to make 6676535 cleaner but does indeed also fix a bug related to not resolving dependencies properly when using the Task runner.

This bug was reported on [galaxy-dev](http://dev.list.galaxyproject.org/metadata-in-parallelization-td4666989.html).

Testing: The following test will not strictly fail but the logs show a traceback without these fixes that goes away when fixes are applied:

```
./run_tests.sh -framework -id parallelism
```
