### PR TITLE
Reduce default step count for beta workflow scheduling to 40.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -860,7 +860,7 @@ use_interactive = True
 # scheduling).
 # Workflows containing more than the specified number of steps will always use
 # the Galaxy's beta workflow scheduling.
-#force_beta_workflow_scheduled_min_steps=250
+#force_beta_workflow_scheduled_min_steps=40
 # Switch to using Galaxy's beta workflow scheduling for all workflows involving
 # ccollections.
 #force_beta_workflow_scheduled_for_collections=False

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -231,7 +231,7 @@ class Configuration( object ):
         # be someday - the following two properties can also be used to force this
         # behavior in under conditions - namely for workflows that have a minimum
         # number of steps or that consume collections.
-        self.force_beta_workflow_scheduled_min_steps = int( kwargs.get( 'force_beta_workflow_scheduled_min_steps', '250' ) )
+        self.force_beta_workflow_scheduled_min_steps = int( kwargs.get( 'force_beta_workflow_scheduled_min_steps', '40' ) )
         self.force_beta_workflow_scheduled_for_collections = string_as_bool( kwargs.get( 'force_beta_workflow_scheduled_for_collections', 'False' ) )
 
         # Per-user Job concurrency limitations


### PR DESCRIPTION
Was going to do this once per release and forgot to. This scheduler has been used in production and seems to work properly.
