### PR TITLE
Workflow run_complete new-history link fix.

### DIFF
--- a/templates/webapps/galaxy/workflow/run_complete.mako
+++ b/templates/webapps/galaxy/workflow/run_complete.mako
@@ -31,7 +31,7 @@
 </div>
 
 <script type="text/javascript">
-    if( top.Galaxy && top.Galaxy.currHistoryPanel ){
-        top.Galaxy.currHistoryPanel.refreshContents();
+    if( parent.Galaxy && parent.Galaxy.currHistoryPanel ){
+        parent.Galaxy.currHistoryPanel.refreshContents();
     }
 </script>

--- a/templates/webapps/galaxy/workflow/run_complete.mako
+++ b/templates/webapps/galaxy/workflow/run_complete.mako
@@ -7,8 +7,11 @@
     %for invocation in invocations:
         <div class="workflow-invocation-complete">
             %if invocation['new_history']:
+                <%
+                    encoded_new_history = trans.security.encode_id(invocation['new_history'].id)
+                %>
                 <p>These datasets will appear in a new history:
-                <a class='new_history_link' id="nhl:${trans.security.encode_id(invocation['new_history'].id)}" target='_top' href="${h.url_for( controller='history', action='switch_to_history', hist_id=trans.security.encode_id(invocation['new_history'].id) ) | n}">
+                <a class='new-history-link' data-history-id="${encoded_new_history}" target='_top' href="${h.url_for( controller='history', action='switch_to_history', hist_id=encoded_new_history ) | n}">
                     '${h.to_unicode(invocation['new_history'].name)}'.
                 </a></p>
             %endif
@@ -31,14 +34,13 @@
 </div>
 
 <script type="text/javascript">
-    if( parent.Galaxy && parent.Galaxy.currHistoryPanel ){
+    if(parent.Galaxy && parent.Galaxy.currHistoryPanel){
         parent.Galaxy.currHistoryPanel.refreshContents();
     }
-    $('a.new_history_link').click(function(event){
-        if( parent.Galaxy && parent.Galaxy.currHistoryPanel ){
+    $('a.new-history-link').click(function(event){
+        if(parent.Galaxy && parent.Galaxy.currHistoryPanel){
             event.preventDefault();
-            // new_history_links have the id 'nhl:<id>'
-            parent.Galaxy.currHistoryPanel.switchToHistory(this.id.slice(4));
+            parent.Galaxy.currHistoryPanel.switchToHistory($(this).data('history-id'));
         }
     });
 </script>

--- a/templates/webapps/galaxy/workflow/run_complete.mako
+++ b/templates/webapps/galaxy/workflow/run_complete.mako
@@ -8,7 +8,7 @@
         <div class="workflow-invocation-complete">
             %if invocation['new_history']:
                 <p>These datasets will appear in a new history:
-                <a target='_top' href="${h.url_for( controller='history', action='switch_to_history', hist_id=trans.security.encode_id(invocation['new_history'].id) ) | n}">
+                <a class='new_history_link' id="nhl:${trans.security.encode_id(invocation['new_history'].id)}" target='_top' href="${h.url_for( controller='history', action='switch_to_history', hist_id=trans.security.encode_id(invocation['new_history'].id) ) | n}">
                     '${h.to_unicode(invocation['new_history'].name)}'.
                 </a></p>
             %endif
@@ -34,4 +34,11 @@
     if( parent.Galaxy && parent.Galaxy.currHistoryPanel ){
         parent.Galaxy.currHistoryPanel.refreshContents();
     }
+    $('a.new_history_link').click(function(event){
+        if( parent.Galaxy && parent.Galaxy.currHistoryPanel ){
+            event.preventDefault();
+            // new_history_links have the id 'nhl:<id>'
+            parent.Galaxy.currHistoryPanel.switchToHistory(this.id.slice(4));
+        }
+    });
 </script>

--- a/templates/webapps/galaxy/workflow/run_complete.mako
+++ b/templates/webapps/galaxy/workflow/run_complete.mako
@@ -8,7 +8,7 @@
         <div class="workflow-invocation-complete">
             %if invocation['new_history']:
                 <p>These datasets will appear in a new history:
-                <a target='galaxy_history' href="${h.url_for( controller='history', action='list', operation="Switch", id=trans.security.encode_id(invocation['new_history'].id), use_panels=False, show_deleted=False ) | n}">
+                <a target='_top' href="${h.url_for( controller='history', action='switch_to_history', hist_id=trans.security.encode_id(invocation['new_history'].id) ) | n}">
                     '${h.to_unicode(invocation['new_history'].name)}'.
                 </a></p>
             %endif


### PR DESCRIPTION
In addition to fixing it, swapped it to (by default, though you can still open in a new window, and it will still fail through to the full-page-refresh) just manipulate the existing history panel using switchToHistory when possible.
