### PR TITLE
ts search - rename config value

### DIFF
--- a/lib/galaxy/webapps/tool_shed/api/search.py
+++ b/lib/galaxy/webapps/tool_shed/api/search.py
@@ -20,7 +20,7 @@ class SearchController ( BaseAPIController ):
         Perform a search over the Whoosh index. 
         The index has to be pre-created with build_ts_whoosh_index.sh.
         TS config option toolshed_search_on has to be turned on and
-        toolshed_whoosh_index_dir has to be specified and existing.
+        whoosh_index_dir has to be specified.
 
         :param search_term:   (required)the term to search
         :type  search_term:   str
@@ -39,7 +39,7 @@ class SearchController ( BaseAPIController ):
         """
         if not self.app.config.toolshed_search_on:
             raise exceptions.ConfigDoesNotAllowException( 'Searching the TS through the API is turned off for this instance.' )
-        if not self.app.config.toolshed_whoosh_index_dir:
+        if not self.app.config.whoosh_index_dir:
             raise exceptions.ConfigDoesNotAllowException( 'There is no directory for the search index specified. Please ontact the administrator.' )
         search_term = search_term.strip()
         if len( search_term ) < 3:

--- a/lib/galaxy/webapps/tool_shed/search/repo_search.py
+++ b/lib/galaxy/webapps/tool_shed/search/repo_search.py
@@ -83,10 +83,10 @@ class RepoSearch( object ):
         :returns results: dictionary containing number of hits, hits themselves and matched terms for each
         """
         if search_ready:
-            toolshed_whoosh_index_dir = trans.app.config.toolshed_whoosh_index_dir
-            index_exists = whoosh.index.exists_in( toolshed_whoosh_index_dir )
+            whoosh_index_dir = trans.app.config.whoosh_index_dir
+            index_exists = whoosh.index.exists_in( whoosh_index_dir )
             if index_exists:
-                index = whoosh.index.open_dir( toolshed_whoosh_index_dir )
+                index = whoosh.index.open_dir( whoosh_index_dir )
                 try:
                     # Some literature about BM25F:
                     # http://trec.nist.gov/pubs/trec13/papers/microsoft-cambridge.web.hard.pdf


### PR DESCRIPTION
I forgot to rename some variables when changing config.
