### PR TITLE
Explicitly set eventemitter3 package version (it's a dependency of http-...

### DIFF
--- a/lib/galaxy/web/proxy/js/package.json
+++ b/lib/galaxy/web/proxy/js/package.json
@@ -11,6 +11,7 @@
     "url": "https://bitbucket.org/galaxy/galaxy-central"
   },
   "dependencies": {
+    "eventemitter3": "0.1.6",
     "http-proxy": "1.6.0",
     "commander": "~2.2",
     "sqlite3": "3.0.2"


### PR DESCRIPTION
...proy but the just released v1.0.0+ broke compatibility).

Also see PR #147.
