### PR TITLE
[next-stable] Revert "Reduce default step count for beta workflow scheduling to 40."

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -860,7 +860,7 @@ use_interactive = True
 # scheduling).
 # Workflows containing more than the specified number of steps will always use
 # the Galaxy's beta workflow scheduling.
-#force_beta_workflow_scheduled_min_steps=40
+#force_beta_workflow_scheduled_min_steps=250
 # Switch to using Galaxy's beta workflow scheduling for all workflows involving
 # ccollections.
 #force_beta_workflow_scheduled_for_collections=False

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -231,7 +231,7 @@ class Configuration( object ):
         # be someday - the following two properties can also be used to force this
         # behavior in under conditions - namely for workflows that have a minimum
         # number of steps or that consume collections.
-        self.force_beta_workflow_scheduled_min_steps = int( kwargs.get( 'force_beta_workflow_scheduled_min_steps', '40' ) )
+        self.force_beta_workflow_scheduled_min_steps = int( kwargs.get( 'force_beta_workflow_scheduled_min_steps', '250' ) )
         self.force_beta_workflow_scheduled_for_collections = string_as_bool( kwargs.get( 'force_beta_workflow_scheduled_for_collections', 'False' ) )
 
         # Per-user Job concurrency limitations


### PR DESCRIPTION
This reverts commit ce90b2da277113516480fe74d075ac975f93c828.

From IRC:

```
19:01 < g2roboto> [jgoecks] so, about the asynch workflow submission...
19:02 < g2roboto> [jgoecks] ...what happens when there's an error?
19:02 < jmchilton> jgoecks: yes indeed - one of the reasons it is not on by default
19:03 < g2roboto> [jgoecks] hmm, I just updated my dev branch, made no other changes, and it was "on"
19:03 < jmchilton> Big workflow?
19:03 < g2roboto> [jgoecks] yes
19:03 < jmchilton> how many steps?
19:03 < g2roboto> [jgoecks] 43
19:03 < jmchilton> Ah - just over the 40 cutoff
19:03 < jmchilton> I can turn the default back up if you would like
19:04 < g2roboto> [jgoecks] where the threshold? I need to figure out why the workflow is failing, which is my
                  biggest issue right now
19:04 < jmchilton> we just dropped it from 250 to 40
19:05 < jmchilton> if you want to just change it - I can give you the option , one second
19:05 < jmchilton> force_beta_workflow_scheduled_min_steps=40
19:06 < g2roboto> [jgoecks] If there's no way to show or recover from error, 40 may be too low.
19:06 < jmchilton> yeah - I think you are right
19:06 < jmchilton> clearly - the fact that someone has already hit the problem
19:07 < jmchilton> the long term solution was I think to a invocations into the history panel - but maybe a medium
                   term solution is just to montior the workflow invocations like tool shed installs... hmm... at
                   any rate I'll put the default back up
```
