### PR TITLE
Significant speedup of tool panel/homepage loading

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -53,6 +53,7 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
         # shed_tool_conf.xml file.
         self._dynamic_tool_confs = []
         self._tools_by_id = {}
+        self._integrated_section_by_tool = {}
         # Tool lineages can contain chains of related tools with different ids
         # so each will be present once in the above dictionary. The following
         # dictionary can instead hold multiple tools with different versions.
@@ -217,19 +218,10 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
 
     def get_integrated_section_for_tool( self, tool ):
         tool_id = tool.id
-        for key, item_type, item in self._integrated_tool_panel.panel_items_iter():
-            if item:
-                if item_type == panel_item_types.TOOL:
-                    if item.id == tool_id:
-                        return '', ''
-                if item_type == panel_item_types.SECTION:
-                    section_id = item.id or ''
-                    section_name = item.name or ''
-                    for section_key, section_item_type, section_item in item.panel_items_iter():
-                        if section_item_type == panel_item_types.TOOL:
-                            if section_item:
-                                if section_item.id == tool_id:
-                                    return section_id, section_name
+
+        if tool_id in self._integrated_section_by_tool:
+            return self._integrated_section_by_tool[tool_id]
+
         return None, None
 
     def __resolve_tool_path(self, tool_path, config_filename):
@@ -310,6 +302,7 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
                 tool_id = key.replace( 'tool_', '', 1 )
                 if tool_id in self._tools_by_id:
                     self.__add_tool_to_tool_panel( val, self._tool_panel, section=False )
+                    self._integrated_section_by_tool[tool_id] = '', ''
             elif item_type == panel_item_types.WORKFLOW:
                 workflow_id = key.replace( 'workflow_', '', 1 )
                 if workflow_id in self._workflows_by_id:
@@ -331,6 +324,7 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
                         tool_id = section_key.replace( 'tool_', '', 1 )
                         if tool_id in self._tools_by_id:
                             self.__add_tool_to_tool_panel( section_val, section, section=True )
+                            self._integrated_section_by_tool[tool_id] = key, val.name
                     elif section_item_type == panel_item_types.WORKFLOW:
                         workflow_id = section_key.replace( 'workflow_', '', 1 )
                         if workflow_id in self._workflows_by_id:
@@ -560,6 +554,9 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
                 itegrated_items = integrated_has_elems.panel_items()
                 if tool_key in itegrated_items:
                     del itegrated_items[ tool_key ]
+
+                if tool_id in self._integrated_section_by_tool:
+                    del self._integrated_section_by_tool[ tool_id ]
 
         if section_key:
             _, tool_section = self.get_section( section_key )
@@ -934,6 +931,10 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
                             break
                 if tool_id in self.data_manager_tools:
                     del self.data_manager_tools[ tool_id ]
+
+                if tool_id in self._integrated_section_by_tool:
+                    del self._integrated_section_by_tool[ tool_id ]
+
             # TODO: do we need to manually remove from the integrated panel here?
             message = "Removed the tool:<br/>"
             message += "<b>name:</b> %s<br/>" % tool.name

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -546,17 +546,21 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
                         has_elems.insert( tool_panel_index,
                                           replacement_tool_key,
                                           replacement_tool_version )
+                        self._integrated_section_by_tool[ tool_id ] = available_tool_section_id, available_tool_section_name
                     else:
                         del has_elems[ tool_key ]
+
+                        if tool_id in self._integrated_section_by_tool:
+                            del self._integrated_section_by_tool[ tool_id ]
                 else:
                     del has_elems[ tool_key ]
+
+                    if tool_id in self._integrated_section_by_tool:
+                        del self._integrated_section_by_tool[ tool_id ]
             if remove_from_config:
                 itegrated_items = integrated_has_elems.panel_items()
                 if tool_key in itegrated_items:
                     del itegrated_items[ tool_key ]
-
-                if tool_id in self._integrated_section_by_tool:
-                    del self._integrated_section_by_tool[ tool_id ]
 
         if section_key:
             _, tool_section = self.get_section( section_key )
@@ -678,6 +682,14 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
                 index=sub_index,
                 internal=True,
             )
+
+        # Ensure each tool's section is stored
+        for section_key, section_item_type, section_item in integrated_elems.panel_items_iter():
+            if section_item_type == panel_item_types.TOOL:
+                if section_item:
+                    tool_id = section_key.replace( 'tool_', '', 1 )
+                    self._integrated_section_by_tool[tool_id] = integrated_section.id, integrated_section.name
+
         if load_panel_dict:
             self._tool_panel[ key ] = section
         # Always load sections into the integrated_tool_panel.
@@ -931,10 +943,6 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
                             break
                 if tool_id in self.data_manager_tools:
                     del self.data_manager_tools[ tool_id ]
-
-                if tool_id in self._integrated_section_by_tool:
-                    del self._integrated_section_by_tool[ tool_id ]
-
             # TODO: do we need to manually remove from the integrated panel here?
             message = "Removed the tool:<br/>"
             message += "<b>name:</b> %s<br/>" % tool.name


### PR DESCRIPTION
Hi,
In short: here is a patch that makes the galaxy tool panel (and as a consequence the whole instance homepage) load much faster.

The whole story:
We had problems with 2 instances: loading the galaxy homepage could take around 10s before anything was displayed in the browser.
Applying all the recommendations in the wiki for performances, did not help very much.

I tried using the profiler available with the use_profile option in galaxy.ini, and found out that galaxy was taking a very long time preparing the list of tools and sections.

I looked at the code and found the problem: when loading the tool list, galaxy needs to associate to each tool the section name and id where it is placed. The way it was done until now, for each tool, it loops through the whole list of section and tools to find where it is placed. So galaxy end up spending a few seconds looping again and again in the tool list. And this is done everytime the tool panel needs to be sent to clients.

I wrote a patch that allows to cache every tools' position in the sections of the tool panel. The dict is created when starting galaxy and is updated whenever needed (tool removal/update).

I made some measures while loading the homepage on our instances (3 measures, the first one without browser cache):

> Without the patch:
> Total size: 2.1Mb/1.8Mb/1.8Mb
> Total time (including assets): 8.48s/7.83s/7.24s
> Base HTML only: 2.48s/2.54s/2.48s
> 
> With the patch:
> Total size: 2.1Mb/1.8Mb/1.8Mb
> Total time (including assets): 6.16s/5.21s/5.46s total
> Base HTML only: 0.352s/0.327s/0.359s

=> for this instance, the homepage begins to appears 2 seconds earlier.
For another instance (with more tools), it's even better: the base HTML is loaded in ~800ms instead of 7.5s.

I can attach the profile output if someone is interested.

I applied the patch to 2 of our production instances and everything seems to work fine.

Tell me if you need any more info or if you see a possible problem with this patch.
Anthony
