### PR TITLE
Fixes for DRMAA when Galaxy instance isn't on a shared volume with compute nodes

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -236,6 +236,10 @@
         </destination>
         <destination id="remote_cluster" runner="drmaa" tags="longjobs"/>
         <destination id="java_cluster" runner="drmaa">
+          <!-- Allow users that are not mapped to any real users to run jobs
+               as a Galaxy (fallback). Default is False.
+          -->
+          <param id="allow_guests">True</param>
           <!-- Set to False if cluster nodes don't shared Galaxy library,
                it will perform metadata calculation locally after the job finishes.
           -->

--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -236,6 +236,10 @@
         </destination>
         <destination id="remote_cluster" runner="drmaa" tags="longjobs"/>
         <destination id="java_cluster" runner="drmaa">
+          <!-- Set to False if cluster nodes don't shared Galaxy library,
+               it will perform metadata calculation locally after the job finishes.
+          -->
+          <param id="embed_metadata_in_job">True</param>
           <!-- set arbitrary environment variables at runtime. General
                dependencies for tools should be configured via
                tool_dependency_dir and package options and these

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -25,7 +25,7 @@ __all__ = [ 'DRMAAJobRunner' ]
 drmaa = None
 
 DRMAA_jobTemplate_attributes = [ 'args', 'remoteCommand', 'outputPath', 'errorPath', 'nativeSpecification',
-                                 'jobName', 'email', 'project' ]
+                                 'workingDirectory', 'jobName', 'email', 'project' ]
 
 
 class DRMAAJobRunner( AsynchronousJobRunner ):
@@ -134,6 +134,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         jt = self.ds.createJobTemplate()
         jt.remoteCommand = ajs.job_file
         jt.jobName = ajs.job_name
+        jt.workingDirectory = job_wrapper.working_directory
         jt.outputPath = ":%s" % ajs.output_file
         jt.errorPath = ":%s" % ajs.error_file
 

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -358,7 +358,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
             except:
                 pass
         s = json.dumps(data)
-        f = open(filename,'w')
+        f = open(filename,'w+')
         f.write(s)
         f.close()
         log.debug( '(%s) Job script for external submission is: %s' % ( job_wrapper.job_id, filename ) )

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -194,10 +194,14 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
                 return
         else:
             job_wrapper.change_ownership_for_run()
-            log.debug( '(%s) submitting with credentials: %s [uid: %s]' % ( galaxy_id_tag, job_wrapper.user_system_pwent[0], job_wrapper.user_system_pwent[2] ) )
+            # if user credentials are not available, use galaxy credentials
+            pwent = job_wrapper.user_system_pwent
+            if pwent is None:
+                pwent = job_wrapper.galaxy_system_pwent
+            log.debug( '(%s) submitting with credentials: %s [uid: %s]' % ( galaxy_id_tag, pwent[0], pwent[2] ) )
             filename = self.store_jobtemplate(job_wrapper, jt)
-            self.userid =  job_wrapper.user_system_pwent[2]
-            external_job_id = self.external_runjob(filename, job_wrapper.user_system_pwent[2]).strip()
+            self.userid =  pwent[2]
+            external_job_id = self.external_runjob(filename, pwent[2]).strip()
         log.info( "(%s) queued as %s" % ( galaxy_id_tag, external_job_id ) )
 
         # store runner information for tracking if Galaxy restarts

--- a/scripts/drmaa_external_runner.py
+++ b/scripts/drmaa_external_runner.py
@@ -23,7 +23,7 @@ pkg_resources.require("drmaa")
 import drmaa
 
 DRMAA_jobTemplate_attributes = [ 'args', 'remoteCommand', 'outputPath', 'errorPath', 'nativeSpecification',
-                                 'jobName', 'email', 'project' ]
+                                 'workingDirectory', 'jobName', 'email', 'project' ]
 
 
 def load_job_template_from_file(jt, filename):


### PR DESCRIPTION
## Issues fixed
- DRMAA `workingDirectory` wasn't set correctly
- JobRunner crashed with anonymous sessions (no credentials)
- JSON job description file failed to create when strict `fopen()` semantics was followed
- Metadata calculation was always embedded in job, but it doesn't work when the Galaxy instance is detached from compute nodes
## Issues not fixed
- [Documentation page](https://wiki.galaxyproject.org/Admin/Config/Performance/Cluster) doesn't provide much help at all for DRMAA and the final email excerpt is confusing
  - `embed_metadata_in_job` added in the sample XML, but it should be referenced in the Wiki as well
