### PR TITLE
Revise baseurl parameter such that the full url is not stored permanently

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -676,36 +676,19 @@ class ColorToolParameter( ToolParameter ):
 ## it for now to avoid breaking any tools.
 
 
-class BaseURLToolParameter( ToolParameter ):
+class BaseURLToolParameter( HiddenToolParameter ):
     """
     Returns a parameter the contains its value prepended by the
     current server base url. Used in all redirects.
     """
-
-    def __init__( self, tool, input_source ):
-        input_source = ensure_input_source( input_source )
-        ToolParameter.__init__( self, tool, input_source )
-        self.value = input_source.get( 'value', '' )
-
-    def get_value( self, trans ):
-        # url = trans.request.base + self.value
-        url = url_for( self.value, qualified=True )
-        return url
-
-    def get_html_field( self, trans=None, value=None, other_values={} ):
-        return form_builder.HiddenField( self.name, self.get_value( trans ) )
-
     def get_initial_value( self, trans, context, history=None ):
+        self.url_for = url_for( '', qualified=True )
         return self.value
 
-    def get_label( self ):
-        # BaseURLToolParameters are ultimately "hidden" parameters
-        return None
-
-    def to_dict( self, trans, view='collection', value_mapper=None, other_values={} ):
-        d = super( BaseURLToolParameter, self ).to_dict( trans )
-        d['value'] = self.get_value( trans )
-        return d
+    def to_param_dict_string( self, value, other_values={} ):
+        if value is None:
+            value = ''
+        return '%s/%s' % (self.url_for, value)
 
 
 DEFAULT_VALUE_MAP = lambda x: x

--- a/test/unit/tools/test_parameter_parsing.py
+++ b/test/unit/tools/test_parameter_parsing.py
@@ -159,16 +159,16 @@ class ParameterParsingTestCase( BaseParameterTestCase ):
 
     def test_base_url(self):
         param = self._parameter_for(xml="""
-            <param name="urlp" type="baseurl" value="http://twitter.com/" />
+            <param name="urlp" type="baseurl" value="history/list" />
         """)
         assert param.name == "urlp"
         assert param.type == "baseurl"
-        assert param.value == "http://twitter.com/"
+        assert param.value == "history/list"
 
         param = self._parameter_for(xml="""
             <param name="urlp" type="baseurl" />
         """)
-        assert param.value == ""
+        assert param.value is None
 
     def test_select_static(self):
         param = self._parameter_for(xml="""


### PR DESCRIPTION
This revises the base url parameter handling such that the root url is added to the parameter value only before being parsed to the xml template i.e. the root url is not stored in the database anymore. This fixes problems with re-running tools which use the base url parameter. However this fix needs to be reviewed carefully in order to ensure that the full url is created properly when executing the job thread.
