### PR TITLE
Support for CSV and other dialects in tabular

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -51,7 +51,7 @@
       <converter file="bed_gff_or_vcf_to_bigwig_converter.xml" target_datatype="bigwig"/>
     </datatype>
     <!-- MSI added Datatypes -->
-    <datatype extension="csv" type="galaxy.datatypes.tabular:Tabular" subclass="True" display_in_upload="true" /> <!-- FIXME: csv is 'tabular'ized data, but not 'tab-delimited'; the class used here is intended for 'tab-delimited' -->
+    <datatype extension="csv" type="galaxy.datatypes.tabular:CSV" subclass="True" display_in_upload="true" />
     <!-- End MSI added Datatypes -->
     <datatype extension="customtrack" type="galaxy.datatypes.interval:CustomTrack"/>
     <datatype extension="bowtie_color_index" type="galaxy.datatypes.ngsindex:BowtieColorIndex" mimetype="text/html" display_in_upload="False"/>
@@ -307,6 +307,7 @@
     <sniffer type="galaxy.datatypes.interval:Gff"/>
     <sniffer type="galaxy.datatypes.interval:Gff3"/>
     <sniffer type="galaxy.datatypes.tabular:Pileup"/>
+    <sniffer type="galaxy.datatypes.tabular:CSV"/>
     <sniffer type="galaxy.datatypes.interval:Interval"/>
     <sniffer type="galaxy.datatypes.tabular:Sam"/>
     <sniffer type="galaxy.datatypes.data:Newick"/>

--- a/lib/galaxy/datatypes/dataproviders/column.py
+++ b/lib/galaxy/datatypes/dataproviders/column.py
@@ -37,13 +37,13 @@ class ColumnarDataProvider( line.RegexLineDataProvider ):
         'column_count'  : 'int',
         'column_types'  : 'list:str',
         'parse_columns' : 'bool',
-        'deliminator'   : 'str',
+        'delimiter'     : 'str',
         'filters'       : 'list:str'
     }
 
     def __init__( self, source, indeces=None,
             column_count=None, column_types=None, parsers=None, parse_columns=True,
-            deliminator='\t', filters=None, **kwargs ):
+            delimiter='\t', filters=None, **kwargs ):
         """
         :param indeces: a list of indeces of columns to gather from each row
             Optional: will default to `None`.
@@ -74,14 +74,13 @@ class ColumnarDataProvider( line.RegexLineDataProvider ):
             Optional: defaults to `True`.
         :type parse_columns: bool
 
-        :param deliminator: character(s) used to split each row/line of the source.
+        :param delimiter: character(s) used to split each row/line of the source.
             Optional: defaults to the tab character.
-        :type deliminator: str
+        :type delimiter: str
 
         .. note: that the subclass constructors are passed kwargs - so they're
         params (limit, offset, etc.) are also applicable here.
         """
-        #TODO: other columnar formats: csv, etc.
         super( ColumnarDataProvider, self ).__init__( source, **kwargs )
 
         #IMPLICIT: if no indeces, column_count, or column_types passed: return all columns
@@ -98,7 +97,7 @@ class ColumnarDataProvider( line.RegexLineDataProvider ):
         if not self.selected_column_indeces and self.column_count:
             self.selected_column_indeces = list( xrange( self.column_count ) )
 
-        self.deliminator = deliminator
+        self.delimiter = delimiter
 
         # how/whether to parse each column value
         self.parsers = {}
@@ -256,7 +255,7 @@ class ColumnarDataProvider( line.RegexLineDataProvider ):
         :type line: str
         """
         #TODO: too much going on in this loop - the above should all be precomputed AMAP...
-        all_columns = line.split( self.deliminator )
+        all_columns = line.split( self.delimiter )
         # if no indeces were passed to init, return all columns
         selected_indeces = self.selected_column_indeces or list( xrange( len( all_columns ) ) )
         parsed_columns = []

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -249,7 +249,11 @@ class Tabular( data.Text ):
             columns = dataset.metadata.columns
             if columns is None:
                 columns = dataset.metadata.spec.columns.no_value
+            i = 0
             for line in dataset.peek.splitlines():
+                if i < dataset.metadata.comment_lines:
+                   i += 1
+                   continue
                 if line.startswith( tuple( skipchars ) ):
                     out.append( '<tr><td colspan="100%%">%s</td></tr>' % escape( line ) )
                 elif line:
@@ -281,6 +285,15 @@ class Tabular( data.Text ):
         while cursor and ck_data[-1] != '\n':
             ck_data += cursor
             cursor = f.read(1)
+        # If this is first chunk, skip comment lines
+        if ck_index == 0:
+            to_skip = 0
+            for i in range(0, dataset.metadata.comment_lines):
+                to_skip = ck_data.find('\n', to_skip) + 1
+            ck_data = ck_data[to_skip:]
+        # Replace non-standard delimiter
+        if self.delimiter != '\t':
+            ck_data = ck_data.replace(self.delimiter, '\t')
         return dumps( { 'ck_data': util.unicodify( ck_data ), 'ck_index': ck_index + 1 } )
 
     def display_data(self, trans, dataset, preview=False, filename=None, to_ext=None, chunk=None, **kwd):

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -851,3 +851,19 @@ class FeatureLocationIndex( Tabular ):
     MetadataElement( name="columns", default=2, desc="Number of columns", readonly=True, visible=False )
     MetadataElement( name="column_types", default=['str', 'str'], param=metadata.ColumnTypesParameter, desc="Column types", readonly=True, visible=False, no_value=[] )
 
+class CSV( Tabular ):
+    """
+    CSV-style table containing a header.
+    """
+    file_ext = 'csv'
+    delimiter = ','
+
+    def sniff( self, filename ):
+        """ Is valid if it has a CSV header. """
+        return csv.Sniffer().has_header(open(filename, 'r').read(1024))
+
+    def set_meta( self, dataset, **kwd ):
+        """ Read the column names from header and skip it. """
+        with open(dataset.file_name, 'r') as csvfile:
+            dataset.metadata.column_names = csv.reader(csvfile).next()
+        Tabular.set_meta( self, dataset, skip = 1, **kwd )

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -66,7 +66,7 @@ class Tabular( data.Text ):
         try:
             dialect = sniffer.sniff(open(dataset.file_name, 'r').read(self.peek_size))
             self.delimiter = dialect.delimiter
-        except:
+        except Exception:
             # We're interested only if sniffing is successful or not
             pass
 
@@ -139,7 +139,7 @@ class Tabular( data.Text ):
                     try:
                         if line.startswith( '#' ) and sniffer.has_header( line[1:] ):
                             column_names = line[1:]
-                    except:
+                    except Exception:
                         pass # Failed to identify CSV file
                 else:
                     data_lines += 1

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -118,6 +118,7 @@ class Tabular( data.Text ):
         data_lines = 0
         comment_lines = 0
         column_types = []
+        column_names = ''
         first_line_column_types = [default_column_type] # default value is one column of type str
         if dataset.has_data():
             #NOTE: if skip > num_check_lines, we won't detect any metadata, and will use default
@@ -130,6 +131,9 @@ class Tabular( data.Text ):
                 if i < skip or not line or line.startswith( '#' ):
                     # We'll call blank lines comments
                     comment_lines += 1
+                    # Check if it resembles a header
+                    if line.startswith( '#' ) and csv.Sniffer().has_header( line[1:] ):
+                        column_names = line[1:]
                 else:
                     data_lines += 1
                     if max_guess_type_data_lines is None or data_lines <= max_guess_type_data_lines:
@@ -181,6 +185,10 @@ class Tabular( data.Text ):
         dataset.metadata.comment_lines = comment_lines
         dataset.metadata.column_types = column_types
         dataset.metadata.columns = len( column_types )
+        # Try to unpack column names
+        column_names = [c.strip() for c in column_names.split(self.delimiter)]
+        if len(column_names) == dataset.metadata.columns:
+            dataset.metadata.column_names = column_names
     def make_html_table( self, dataset, **kwargs ):
         """Create HTML table, used for displaying peek"""
         out = ['<table cellspacing="0" cellpadding="3">']

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -322,12 +322,12 @@ class Tabular( data.Text ):
             #Fancy tabular display is only suitable for datasets without an incredibly large number of columns.
             #We should add a new datatype 'matrix', with its own draw method, suitable for this kind of data.
             #For now, default to the old behavior, ugly as it is.  Remove this after adding 'matrix'.
-            if os.stat( dataset.file_name ).st_size < max_peek_size:
+            if os.stat( dataset.file_name ).st_size < self.max_peek_size:
                 return open( dataset.file_name )
             else:
                 trans.response.set_content_type( "text/html" )
                 return trans.stream_template_mako( "/dataset/large_file.mako",
-                                            truncated_data = open( dataset.file_name ).read(max_peek_size),
+                                            truncated_data = open( dataset.file_name ).read(self.max_peek_size),
                                             data = dataset)
         else:
             column_names = 'null'

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -60,8 +60,9 @@ class Tabular( data.Text ):
            of the set_peek() processing here, and we now check the entire contents of the file.
         """
         # Sniff delimiter from the dataset
+        sniffer = csv.Sniffer()
         try:
-            dialect = csv.Sniffer().sniff(open(dataset.file_name, 'r').read(1024))
+            dialect = sniffer.sniff(open(dataset.file_name, 'r').read(1024))
             self.delimiter = dialect.delimiter
         except:
             pass
@@ -132,8 +133,11 @@ class Tabular( data.Text ):
                     # We'll call blank lines comments
                     comment_lines += 1
                     # Check if it resembles a header
-                    if line.startswith( '#' ) and csv.Sniffer().has_header( line[1:] ):
-                        column_names = line[1:]
+                    try:
+                        if line.startswith( '#' ) and sniffer.has_header( line[1:] ):
+                            column_names = line[1:]
+                    except:
+                        pass # Failed to identify CSV file
                 else:
                     data_lines += 1
                     if max_guess_type_data_lines is None or data_lines <= max_guess_type_data_lines:

--- a/tools/stats/gsummary.py
+++ b/tools/stats/gsummary.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
 import sys, re, tempfile
-from rpy import *
+try:
+    from rpy2.rpy_classic import *
+except:
+    # RPy isn't maintained, and doesn't work with R>3.0, use it as a fallback
+    from rpy import *
+
 # Older py compatibility
 try:
     set()
@@ -87,11 +92,11 @@ def main():
         stop_err( "Invalid column or column data values invalid for computation.  See tool tips and syntax for data requirements." )
     else:
         # summary function and return labels
+        set_default_mode( NO_CONVERSION )
         summary_func = r( "function( x ) { c( sum=sum( as.numeric( x ), na.rm=T ), mean=mean( as.numeric( x ), na.rm=T ), stdev=sd( as.numeric( x ), na.rm=T ), quantile( as.numeric( x ), na.rm=TRUE ) ) }" )
         headings = [ 'sum', 'mean', 'stdev', '0%', '25%', '50%', '75%', '100%' ]
         headings_str = "\t".join( headings )
         
-        set_default_mode( NO_CONVERSION )
         r_data_frame = r.read_table( tmp_file.name, header=True, sep="\t" )
         
         outfile = open( outfile_name, 'w' )
@@ -105,7 +110,7 @@ def main():
             stop_err( "Computation resulted in the following error: %s" % str( s ) )
         summary = summary.as_py( BASIC_CONVERSION )
         outfile.write( "#%s\n" % headings_str )
-        outfile.write( "%s\n" % "\t".join( [ "%g" % ( summary[ k ] ) for k in headings ] ) )
+        outfile.write( "%s\n" % "\t".join( [ "%g" % k for k in summary ] ) )
         outfile.close()
 
         if skipped_lines:


### PR DESCRIPTION
## Fixes
- separator can be changed a/o sniffed from the dataset (preview and table view)
- fixed hardcoded separator in the dataproviders (visualization)
- skipped rows are not displayed in the preview
- sniffing of dataset column names from the header
- sniffer for CSV datasets containing a header
## Enhances
- `stats/gsummary` works with [RPy2](http://rpy.sourceforge.net/rpy2/doc-dev/html/overview.html) classic mode, as the original RPy is [pretty much dead](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=705847)
- it also supports arbitrary CSV dialects

TL;DR works well with all CSV dialects now and is able to sniff some of them
## How to test

I have attached some example files at https://gist.github.com/vavrusa/f8bb8d059c6c96dc7585
to test it, the one with the first line as a header should be sniffed correctly when uploading, the rest should be correctly displayed when saved as `tabular`. Visualization for all should be correct.
