### PR TITLE
[STABLE] Fix job stopping under some conditions

### DIFF
--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -134,9 +134,11 @@ class LocalJobRunner( BaseJobRunner ):
     def stop_job( self, job ):
         #if our local job has JobExternalOutputMetadata associated, then our primary job has to have already finished
         job_ext_output_metadata = job.get_external_output_metadata()
-        if job_ext_output_metadata:
+        try:
             pid = job_ext_output_metadata[0].job_runner_external_pid  # every JobExternalOutputMetadata has a pid set, we just need to take from one of them
-        else:
+            assert pid not in [ None, '' ]
+        except:
+            # metadata internal or job not complete yet
             pid = job.get_job_runner_external_id()
         if pid in [ None, '' ]:
             log.warning( "stop_job(): %s: no PID in database for job, unable to stop" % job.get_id() )

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -137,7 +137,7 @@ class LocalJobRunner( BaseJobRunner ):
         try:
             pid = job_ext_output_metadata[0].job_runner_external_pid  # every JobExternalOutputMetadata has a pid set, we just need to take from one of them
             assert pid not in [ None, '' ]
-        except:
+        except Exception:
             # metadata internal or job not complete yet
             pid = job.get_job_runner_external_id()
         if pid in [ None, '' ]:


### PR DESCRIPTION
1. track_jobs_in_database is False
2. Jobs being stopped were in the local runner
3. Jobs were deleted with the deleted state and not deleted_new

This fixes a common condition under which Pulsar jobs would be stuck in the `queued` state on Main:
1. The monitor submits a job
2. The job is set to `queued` and dispatched to Pulsar
3. Pulsar is down (because of a Stampede maintenance window or whatever reason)
4. The monitor waits for the job to complete
5. The monitor gets tired of waiting and deletes the job (or more correctly, the HDA)
6. The job remains in the `queued` state
7. The monitor quickly hits the job concurrency limit and soon falsely reports that all other job handlers are not working

This remains the case until Pulsar is back up and is able to grab things from the MQ. It may even actually execute them since it most likely never receives a kill message for them?
