### PR TITLE
[WIP]Remove -with_framework_test_tools option, use them by default.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -29,9 +29,6 @@ indicated with the optional parameter (test_path).  A few examples are:
 Run all TestUserInfo functional tests:
     ./run_tests.sh test/functional/test_user_info.py:TestUserInfo
 
-Run a specific API test requiring the framework test tools:
-    ./run_tests.sh -api -with_framework_test_tools test/api/test_tools.py:ToolsTestCase.test_map_over_with_output_format_actions
-
 
 Extra options:
 
@@ -72,7 +69,6 @@ test_script="./scripts/functional_tests.py"
 report_file="run_functional_tests.html"
 xunit_report_file=""
 structured_data_report_file=""
-with_framework_test_tools_arg=""
 
 driver="python"
 
@@ -142,10 +138,6 @@ do
               toolshed_script="./test/tool_shed/functional"
               shift 1
           fi
-          ;;
-      -with_framework_test_tools|--with_framework_test_tools)
-          with_framework_test_tools_arg="-with_framework_test_tools"
-          shift
           ;;
       -w|-workflow|--workflow)
           if [ $# -gt 1 ]; then
@@ -325,7 +317,7 @@ if [ "$driver" = "python" ]; then
     else
         structured_data_args=""
     fi
-    python $test_script $coverage_arg -v --with-nosehtml --html-report-file $report_file $xunit_args $structured_data_args $with_framework_test_tools_arg $extra_args
+    python $test_script $coverage_arg -v --with-nosehtml --html-report-file $report_file $xunit_args $structured_data_args $extra_args
 else
     ensure_grunt
     if [ -n "$watch" ]; then

--- a/scripts/functional_tests.py
+++ b/scripts/functional_tests.py
@@ -216,9 +216,7 @@ def main():
             datatypes_conf_override = os.path.join( framework_tool_dir, 'sample_datatypes_conf.xml' )
         else:
             # Use tool_conf.xml toolbox.
-            tool_conf = None
-            if __check_arg( '-with_framework_test_tools' ):
-                tool_conf = "%s,%s" % ( 'config/tool_conf.xml.sample', os.path.join( framework_tool_dir, 'samples_tool_conf.xml' ) )
+            tool_conf = "%s,%s" % ( 'config/tool_conf.xml.sample', os.path.join( framework_tool_dir, 'samples_tool_conf.xml' ) )
         test_dir = default_galaxy_test_file_dir
         tool_config_file = os.environ.get( 'GALAXY_TEST_TOOL_CONF', tool_conf )
         galaxy_test_file_dir = os.environ.get( 'GALAXY_TEST_FILE_DIR', test_dir )

--- a/test/functional/tools/README.txt
+++ b/test/functional/tools/README.txt
@@ -4,11 +4,6 @@ demonstrating aspects of the tool syntax. Run the test driver script
 these tests. Pass in an '-id' along with one of these tool ids to test
 a single tool.
 
-Some API tests use these tools to test various features of the API,
-tool, and workflow subsystems. Pass the argument
-'-with_framework_test_tools' to 'run_tests.sh' in addition to '-api'
-to ensure these tools get loaded during the testing process.
-
 Finally, to play around with these tools interactively - simply
 replace the 'galaxy.ini' option 'tool_config_file' with:
 


### PR DESCRIPTION
I don't think running tests should require knowledge of whether or not those tests need the framework tools.  My personal annoyance was, prior to this, `./run_tests.sh -api test/api/test_workflows.py` results in 4 SKIP and 7 FAIL.  With this change it's way easier to see there's 1 real failure at a glance.

The alternative is to prevent these tests from running when you don't supply the -with_framework_tests argument, but that seems less productive to me than just using the tools required for the tests by default.
