### PR TITLE
Set default value for sig proxy

### DIFF
--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -43,6 +43,11 @@ class InteractiveEnviornmentRequest(object):
         self.attr.PORT = self.attr.proxy_request[ 'proxied_port' ]
 
     def load_deploy_config(self, default_dict={}):
+        # For backwards compat, any new variables added to the base .ini file
+        # will need to be recorded here. The ConfigParser doesn't provide a
+        # .get() that will ignore missing sections, so we must make use of
+        # their defaults dictionary instead.
+        default_dict['command_inject'] = '--sig-proxy=true'
         viz_config = ConfigParser.SafeConfigParser(default_dict)
         conf_path = os.path.join( self.attr.our_config_dir, self.attr.viz_id + ".ini" )
         if not os.path.exists( conf_path ):


### PR DESCRIPTION
@afgane [reported](https://github.com/galaxyproject/galaxy/commit/cef67fb4f1fda56dcec93f9865883adfd4694d12#commitcomment-11004271) a backwards compatibility issue whereby an out of date `.ini` file would trigger an error when Galaxy tried to access a new variable.

cc @bgruening
