### PR TITLE
[Stable] Bind the IPython IE to a fixed Docker Image

### DIFF
--- a/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
+++ b/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
@@ -8,7 +8,7 @@
 
 [docker]
 command = docker
-image = bgruening/docker-ipython-notebook
+image = bgruening/docker-ipython-notebook:0.2
 
 # URL to access the Galaxy API with from the spawn Docker containter, if empty
 # this falls back to galaxy.ini's galaxy_infrastructure_url and finally to the


### PR DESCRIPTION
We need to bind the IPython IE to a specific Image version, because this is under heavy development.
