### PR TITLE
[15.05] Generate base url on client request

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -671,41 +671,19 @@ class ColorToolParameter( ToolParameter ):
     def get_initial_value( self, trans, context, history=None ):
         return self.value.lower();
 
-## This is clearly a HACK, parameters should only be used for things the user
-## can change, there needs to be a different way to specify this. I'm leaving
-## it for now to avoid breaking any tools.
 
-
-class BaseURLToolParameter( ToolParameter ):
+class BaseURLToolParameter( HiddenToolParameter ):
     """
-    Returns a parameter the contains its value prepended by the
+    Returns a parameter that contains its value prepended by the
     current server base url. Used in all redirects.
     """
-
     def __init__( self, tool, input_source ):
         input_source = ensure_input_source( input_source )
-        ToolParameter.__init__( self, tool, input_source )
+        super( BaseURLToolParameter, self ).__init__( tool, input_source )
         self.value = input_source.get( 'value', '' )
 
-    def get_value( self, trans ):
-        # url = trans.request.base + self.value
-        url = url_for( self.value, qualified=True )
-        return url
-
-    def get_html_field( self, trans=None, value=None, other_values={} ):
-        return form_builder.HiddenField( self.name, self.get_value( trans ) )
-
-    def get_initial_value( self, trans, context, history=None ):
-        return self.get_value( trans )
-
-    def get_label( self ):
-        # BaseURLToolParameters are ultimately "hidden" parameters
-        return None
-
-    def to_dict( self, trans, view='collection', value_mapper=None, other_values={} ):
-        d = super( BaseURLToolParameter, self ).to_dict( trans )
-        d['value'] = self.get_value( trans )
-        return d
+    def from_html( self, value=None, trans=None, context={} ):
+        return url_for( self.value, qualified=True )
 
 
 DEFAULT_VALUE_MAP = lambda x: x


### PR DESCRIPTION
See discussion here:
https://trello.com/c/ol4j2Uqo/2645-baseurl-tool-parameter-type-is-broken-on-rerun
