### PR TITLE
Remove test_workflow_from_yaml due to inconsistent yaml loading

### DIFF
--- a/test/api/test_workflows_from_yaml.py
+++ b/test/api/test_workflows_from_yaml.py
@@ -30,25 +30,30 @@ class WorkflowsFromYamlApiTestCase( BaseWorkflowsApiTestCase ):
 """)
         self._get("workflows/%s/download" % workflow_id).content
 
-    def test_multiple_input( self ):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
-steps:
-  - type: input
-    label: input1
-  - type: input
-    label: input2
-  - tool_id: cat_list
-    state:
-      input1:
-      - $link: input1
-      - $link: input2
-test_data:
-  input1: "hello world"
-  input2: "123"
-""", history_id=history_id)
-        contents1 = self.dataset_populator.get_history_dataset_content(history_id)
-        assert contents1 == "hello world\n123\n"
+# FIXME:  This test fails on some machines due to (we're guessing) yaml loading
+# order being not guaranteed and inconsistent across platforms.  The workflow
+# yaml loader probably needs to enforce order using something like the
+# approach described here:
+# https://stackoverflow.com/questions/13297744/pyyaml-control-ordering-of-items-called-by-yaml-load
+#     def test_multiple_input( self ):
+#         history_id = self.dataset_populator.new_history()
+#         self._run_jobs("""
+# steps:
+#   - type: input
+#     label: input1
+#   - type: input
+#     label: input2
+#   - tool_id: cat_list
+#     state:
+#       input1:
+#       - $link: input1
+#       - $link: input2
+# test_data:
+#   input1: "hello world"
+#   input2: "123"
+# """, history_id=history_id)
+#         contents1 = self.dataset_populator.get_history_dataset_content(history_id)
+#         assert contents1 == "hello world\n123\n"
 
     def test_simple_output_actions( self ):
         history_id = self.dataset_populator.new_history()


### PR DESCRIPTION
This is a part of the effort to ship a fully passing test suite with 15.05.  This test fails on some machines due to (we're guessing) yaml loading order being not guaranteed and inconsistent across platforms.  It's also not part of our public API, so I'm just removing the test for now per @jmchilton's suggestion.

The workflow yaml loader needs to enforce order using something like the approach described here: https://stackoverflow.com/questions/13297744/pyyaml-control-ordering-of-items-called-by-yaml-load
