### PR TITLE
[15.05] Fix scary traceback when using task splitting jobs fail.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1801,7 +1801,7 @@ class TaskWrapper(JobWrapper):
         task.command_line = self.command_line
         self.sa_session.flush()
 
-    def cleanup( self ):
+    def cleanup( self, delete_files=True ):
         # There is no task cleanup.  The job cleans up for all tasks.
         pass
 


### PR DESCRIPTION
Regression probably introduced in af846d7b3923a5ef5c1ced7723ac6385e119a1df, must not be too harmful since no one has noticed it though.
