### PR TITLE
[15.05] Fix AuthManager.active_authenticators(). Partially re...

### DIFF
--- a/config/auth_conf.xml.sample
+++ b/config/auth_conf.xml.sample
@@ -2,7 +2,11 @@
 <auth>
 <!--<authenticator>
         <type>ldap</type>
-        <filter>'{email}'.endswith('@example.com')</filter>
+-->
+        <!-- Filter users for which this authenticator applies. This is a Python
+             expression which is evaluated after replacing instances of {email}
+             and {username} with the corresponding user's values. -->
+<!--    <filter>'{email}'.endswith('@example.com')</filter>
         <options>
             <auto-register>True</auto-register>
             <server>ldap://dc1.example.com</server>
@@ -20,7 +24,7 @@
             <auto-register-username>{sAMAccountName}</auto-register-username>
             <auto-register-email>{mail}</auto-register-email>
 -->
-            <!-- To allow login with username instead of email -->
+            <!-- To allow login with username instead of email, default is False -->
 <!--        <login-use-username>True</login-use-username>
         </options>
      </authenticator>

--- a/config/auth_conf.xml.sample
+++ b/config/auth_conf.xml.sample
@@ -1,5 +1,31 @@
 <?xml version="1.0"?>
 <auth>
+<!--<authenticator>
+        <type>ldap</type>
+        <filter>'{email}'.endswith('@example.com')</filter>
+        <options>
+            <auto-register>True</auto-register>
+            <server>ldap://dc1.example.com</server>
+-->
+            <!-- If search-fields is not present, all other search-* elements are ignored -->
+<!--        <search-fields>sAMAccountName,mail</search-fields>
+            <search-filter>(&amp;(objectClass=user)(mail={email}))</search-filter>
+            <search-base>dc=dc1,dc=example,dc=com</search-base>
+-->
+            <!-- If search-user not specified will bind anonymously to LDAP for search -->
+<!--        <search-user>jsmith</search-user>
+            <search-password>mysecret</search-password>
+            <bind-user>{sAMAccountName}@example.com</bind-user>
+            <bind-password>{password}</bind-password>
+            <auto-register-username>{sAMAccountName}</auto-register-username>
+            <auto-register-email>{mail}</auto-register-email>
+-->
+            <!-- To allow login with username instead of email -->
+<!--        <login-use-username>True</login-use-username>
+        </options>
+     </authenticator>
+-->
+
     <authenticator>
         <type>localdb</type>
         <options>

--- a/lib/galaxy/auth/__init__.py
+++ b/lib/galaxy/auth/__init__.py
@@ -18,31 +18,6 @@ from galaxy.util import plugin_config
 import logging
 log = logging.getLogger(__name__)
 
-# <auth>
-#     <authenticator>
-#         <type>ldap</type>
-#         <filter>'[login]'.endswith('@students.latrobe.edu.au')</filter>
-#         <options>
-#             <auto-register>True</auto-register>
-#             <server>ldap://STUDENTS.ltu.edu.au</server>
-#             [<search-filter>(&amp;(objectClass=user)(mail={login}))</search-filter>
-#             <search-base>dc=STUDENTS,dc=ltu,dc=edu,dc=au</search-base>
-#             <!-- If search-user not specified will bind anonymously to LDAP for search -->
-#             <search-user>jsmith</search-user>
-#             <search-password>mysecret</search-password>
-#             <search-fields>sAMAccountName,mail</search-fields>]
-#             <bind-user>{sAMAccountName}@STUDENTS.ltu.edu.au</bind-user>
-#             <bind-password>{password}</bind-password>
-#             <auto-register-username>{sAMAccountName}</auto-register-username>
-#             <auto-register-email>{mail}</auto-register-email>
-#      <!-- To allow login with username instead of email
-#            <login-use-username>True</login-use-username>
-#      -->
-#         </options>
-#     </authenticator>
-#     ...
-# </auth>
-
 
 class AuthManager(object):
 
@@ -85,14 +60,14 @@ class AuthManager(object):
             authenticators.append(authenticator)
         self.authenticators = authenticators
 
-    def check_registration_allowed(self, login, password):
+    def check_registration_allowed(self, email, username, password):
         """Checks if the provided email/username is allowed to register."""
         message = ''
         status = 'done'
-        for provider, options in self.active_authenticators(login, password):
+        for provider, options in self.active_authenticators(email, password):
             allow_reg = _get_tri_state(options, 'allow-register', True)
             if allow_reg is None:  # i.e. challenge
-                auth_result, msg = provider.authenticate(login, password, options)
+                auth_result, msg = provider.authenticate(email, username, password, options)
                 if auth_result is True:
                     break
                 if auth_result is None:
@@ -116,7 +91,10 @@ class AuthManager(object):
             if provider is None:
                 log.debug( "Unable to find module: %s" % options )
             else:
-                auth_result, auto_email, auto_username = provider.authenticate(login, password, options)
+                if '@' in login:
+                    auth_result, auto_email, auto_username = provider.authenticate(login, None, password, options)
+                else:
+                    auth_result, auto_email, auto_username = provider.authenticate(None, login, password, options)
                 auto_email = str(auto_email).lower()
                 auto_username = str(auto_username).lower()
                 if auth_result is True:
@@ -139,7 +117,7 @@ class AuthManager(object):
 
     def check_password(self, user, password):
         """Checks the username/email and password using auth providers."""
-        for provider, options in self.active_authenticators(user, password):
+        for provider, options in self.active_authenticators(user.email, password):
             if provider is None:
                 log.debug( "Unable to find module: %s" % options )
             else:
@@ -154,7 +132,7 @@ class AuthManager(object):
         """Checks that auth provider allows password changes and current_password
         matches.
         """
-        for provider, options in self.active_authenticators(user, current_password):
+        for provider, options in self.active_authenticators(user.email, current_password):
             if provider is None:
                 log.debug( "Unable to find module: %s" % options )
             else:
@@ -168,7 +146,7 @@ class AuthManager(object):
                     return (False, 'Password change not supported')
         return (False, 'Invalid current password')
 
-    def active_authenticators(self, login, password):
+    def active_authenticators(self, email, password):
         """Yields AuthProvider instances for the provided configfile that match the
         filters.
         """
@@ -176,7 +154,7 @@ class AuthManager(object):
             for authenticator in self.authenticators:
                 filter_template = authenticator.filter_template
                 if filter_template:
-                    filter_str = filter_template.format(login=login, password=password)
+                    filter_str = filter_template.format(email=email, password=password)
                     passed_filter = eval(filter_str, {"__builtins__": None}, {'str': str})
                     if not passed_filter:
                         continue  # skip to next

--- a/lib/galaxy/auth/providers/__init__.py
+++ b/lib/galaxy/auth/providers/__init__.py
@@ -16,15 +16,17 @@ class AuthProvider(object):
         """ Short string providing labelling this plugin """
 
     @abc.abstractmethod
-    def authenticate(self, login, password, options):
+    def authenticate(self, email, username, password, options):
         """
-        Check that the username and password are correct.
+        Check that the user credentials are correct.
 
         NOTE: Used within auto-registration to check it is ok to register this
         user.
 
-        :param  login: the user's email address or username
-        :type   login: str
+        :param  email: the user's email address
+        :type   email: str
+        :param  username: the user's username
+        :type   username: str
         :param  password: the plain text password they typed
         :type   password: str
         :param  options: options provided in auth_config_file
@@ -44,8 +46,8 @@ class AuthProvider(object):
         NOTE: used on normal login to check authentication and update user
         details if required.
 
-        :param  username: the user's email address or username
-        :type   username: str
+        :param  user: the user to authenticate
+        :type   user: galaxy.model.User
         :param  password: the plain text password they typed
         :type   password: str
         :param  options: options provided in auth_config_file

--- a/lib/galaxy/auth/providers/alwaysreject.py
+++ b/lib/galaxy/auth/providers/alwaysreject.py
@@ -16,7 +16,7 @@ class AlwaysReject(AuthProvider):
     """
     plugin_type = 'alwaysreject'
 
-    def authenticate(self, login, password, options):
+    def authenticate(self, email, username, password, options):
         """
         See abstract method documentation.
         """

--- a/lib/galaxy/auth/providers/localdb.py
+++ b/lib/galaxy/auth/providers/localdb.py
@@ -13,7 +13,7 @@ class LocalDB(AuthProvider):
     """Authenticate users against the local Galaxy database (as per usual)."""
     plugin_type = 'localdb'
 
-    def authenticate(self, login, password, options):
+    def authenticate(self, email, username, password, options):
         """
         See abstract method documentation.
         """

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -678,7 +678,7 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
             status = 'error'
         else:
             # check user is allowed to register
-            message, status = trans.app.auth_manager.check_registration_allowed(email, password)
+            message, status = trans.app.auth_manager.check_registration_allowed(email, username, password)
             if message == '':
                 if not refresh_frames:
                     if trans.webapp.name == 'galaxy':


### PR DESCRIPTION
...vert changes in `auth_conf.xml` syntax.

After PR https://github.com/galaxyproject/galaxy/pull/75 , the `<filter>` tag of
`config/auth_conf.xml` is broken, see https://github.com/galaxyproject/galaxy/pull/75#issuecomment-98194386 .
I don't think that there is a meaningful way to filter on usernames, so I
changed it to filter on email instead of login.
Also:
- fix `AuthManager.check_registration_allowed()` to use both email and username
  since which is used for login depends on the `AuthProvider` used;
- move ldap `<authenticator>` example to `config/auth_conf.xml.sample` .

Pinging @dctrud and @andrewjrobinson for feedback.
