### PR TITLE
[15.05] Create empty history if history is unavailable during api call

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1656,8 +1656,6 @@ class BaseDataToolParameter( ToolParameter ):
         class_name = self.__class__.__name__
         assert trans is not None, "%s requires a trans" % class_name
         if history is None:
-            history = trans.get_history()
-        if history is None:
             history = trans.get_history( create=True )
         assert history is not None, "%s requires a history" % class_name
         return history

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1657,6 +1657,8 @@ class BaseDataToolParameter( ToolParameter ):
         assert trans is not None, "%s requires a trans" % class_name
         if history is None:
             history = trans.get_history()
+        if history is None:
+            history = trans.get_history( create=True )
         assert history is not None, "%s requires a history" % class_name
         return history
 

--- a/test/unit/tools/test_data_parameters.py
+++ b/test/unit/tools/test_data_parameters.py
@@ -150,7 +150,7 @@ class DataToolParameterTestCase( BaseParameterTestCase ):
         self.app.model.context.flush()
         self.trans = bunch.Bunch(
             app=self.app,
-            get_history=lambda: self.test_history,
+            get_history=lambda **k: self.test_history,
             get_current_user_roles=lambda: [],
             workflow_building_mode=False,
             webapp=bunch.Bunch( name="galaxy" ),

--- a/test/unit/tools/test_execution.py
+++ b/test/unit/tools/test_execution.py
@@ -478,7 +478,7 @@ class MockTrans( object ):
         self.webapp = Bunch( name="galaxy" )
         self.sa_session = self.app.model.context
 
-    def get_history( self ):
+    def get_history( self, **kwargs ):
         return self.history
 
 

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -91,7 +91,7 @@ class MockTrans( object ):
 
     user = property( get_user, set_user )
 
-    def get_history( self ):
+    def get_history( self, **kwargs ):
         return self.history
 
     def set_history( self, history ):


### PR DESCRIPTION
The tool build api shares the basic.py code with the old tool form. The old tool form is only called from the Galaxy UI i.e. a history is always available. In order to prevent an uncaught exception for a plain api call without a valid history, here we create an empty history on the fly. This is a temporary fix which allows users to retrieve a valid tool model if the history has not been created yet. Once the old tool form is disabled (currently composite uploads prevent us from doing that), the history id will be parsed through the api call and we will remove the concept of 'current' history from basic.py too. Until then this fix is required.
