### PR TITLE
Fix run_tests.sh exit code.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -347,4 +347,3 @@ else
     grunt --gruntfile=$gruntfile $grunt_task $grunt_args
 fi
 
-cd $pwd_dir


### PR DESCRIPTION
Recently broken with merge of PR #137.

There was a `cd` at at the top of the file and this was probably added to restore the state - but this doesn't seem necessary.
