### PR TITLE
[15.05] avoid adding data managers to the tool search index

### DIFF
--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -37,6 +37,9 @@ class ToolBoxSearch( object ):
         self.index = self.storage.create_index( schema )
         writer = self.index.writer()
         for id, tool in self.toolbox.tools():
+            #  Do not add data managers to the public index
+            if tool.tool_type == 'manage_data':
+                continue
             add_doc_kwds = {
                 "id": id,
                 "name": to_unicode( tool.name ),


### PR DESCRIPTION
this would occur if you have some DM installed and you install another
tool trigerring the reindexing and then non-admin user uses the
searchbox in the tool panel to search for something that also returns
the data manager tool resulting in API giving you 404 and logging
that user without proper permissions tried to access DM while the user 
will see spinning wheel in the searchbox forever
