### PR TITLE
[15.05] Fix problem with twill's custom subprocess module.

### DIFF
--- a/scripts/functional_tests.py
+++ b/scripts/functional_tests.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# Import system subprocess now before twill so we don't get its
+# variant that breaks things.
+import subprocess
+
 import os
 import sys
 import shutil


### PR DESCRIPTION
There has been for some time a scary warning when testing (http://dev.list.galaxyproject.org/run-test-sh-ImportError-cannot-import-name-args-from-interpreter-flags-td4666277.html) that I now understand is the result of Twill being packaged with its own custom subprocess module that conflicts with modules using multiprocessing (e.g. kombu).

After the #198 this scary warning has become an exception that prevents exception of tests (see https://travis-ci.org/galaxyproject/planemo/jobs/61547827 for instance). Importing subprocess seems to force Python to use the system module instead of twills - which seems to prevent these problems.

There have been other reports of this problem with Twill in other projects and removing the subprocess module didn't seem to break anything for them either.
