### PR TITLE
[15.05] Fix job resubmission

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1555,6 +1555,13 @@ class JobWrapper( object ):
                 return ExpressionContext( meta, job_context )
         return job_context
 
+    def invalidate_external_metadata( self ):
+        job = self.get_job()
+        self.external_output_metadata.invalidate_external_metadata( [ output_dataset_assoc.dataset for
+                                                                      output_dataset_assoc in
+                                                                      job.output_datasets + job.output_library_datasets ],
+                                                                    self.sa_session )
+
     def setup_external_metadata( self, exec_dir=None, tmp_dir=None,
                                  dataset_files_path=None, config_root=None,
                                  config_file=None, datatypes_config=None,

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -878,9 +878,9 @@ class JobWrapper( object ):
         job = self.get_job()
         try:
             self.app.object_store.create(
-                    job, base_dir='job_work', dir_only=True, obj_dir=True )
+                job, base_dir='job_work', dir_only=True, obj_dir=True )
             self.working_directory = self.app.object_store.get_filename(
-                    job, base_dir='job_work', dir_only=True, obj_dir=True )
+                job, base_dir='job_work', dir_only=True, obj_dir=True )
             log.debug( '(%s) Working directory for job is: %s',
                        self.job_id, self.working_directory )
         except ObjectInvalid:
@@ -897,11 +897,11 @@ class JobWrapper( object ):
             return
 
         self.app.object_store.create(
-                job, base_dir='job_work', dir_only=True, obj_dir=True,
-                extra_dir='_cleared_contents', extra_dir_at_root=True )
+            job, base_dir='job_work', dir_only=True, obj_dir=True,
+            extra_dir='_cleared_contents', extra_dir_at_root=True )
         base = self.app.object_store.get_filename(
-                job, base_dir='job_work', dir_only=True, obj_dir=True,
-                extra_dir='_cleared_contents', extra_dir_at_root=True )
+            job, base_dir='job_work', dir_only=True, obj_dir=True,
+            extra_dir='_cleared_contents', extra_dir_at_root=True )
         date_str = datetime.datetime.now().strftime( '%Y%m%d-%H%M%S' )
         arc_dir = os.path.join( base, date_str )
         shutil.move( self.working_directory, arc_dir )

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -42,6 +42,7 @@ def failure(app, job_runner, job_state):
         new_destination = (job_state.job_wrapper.job_runner_mapper
                            .cache_job_destination(new_destination))
         # Reset job state
+        job_state.job_wrapper.clear_working_directory()
         job = job_state.job_wrapper.get_job()
         if resubmit.get('handler', None):
             log.debug('(%s/%s) Job reassigned to handler %s',

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -43,6 +43,7 @@ def failure(app, job_runner, job_state):
                            .cache_job_destination(new_destination))
         # Reset job state
         job_state.job_wrapper.clear_working_directory()
+        job_state.job_wrapper.invalidate_external_metadata()
         job = job_state.job_wrapper.get_job()
         if resubmit.get('handler', None):
             log.debug('(%s/%s) Job reassigned to handler %s',

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -14,53 +14,55 @@ MESSAGES = dict(
 
 
 def failure(app, job_runner, job_state):
-    if (getattr(job_state, 'runner_state', None)
-        and job_state.runner_state in
-        (job_state.runner_states.WALLTIME_REACHED,
-         job_state.runner_states.MEMORY_LIMIT_REACHED)):
-        # Intercept jobs that hit the walltime and have a walltime or
-        # nonspecific resubmit destination configured
-        for resubmit in job_state.job_destination.get('resubmit'):
-            if (resubmit.get('condition', None) and resubmit['condition'] !=
-                job_state.runner_state):
-                # There is a resubmit defined for the destination but
-                # its condition is not for walltime_reached
-                continue
-            log.info("(%s/%s) Job will be resubmitted to '%s' because %s at "
-                     "the '%s' destination",
-                     job_state.job_wrapper.job_id,
-                     job_state.job_id,
-                     resubmit['destination'],
-                     MESSAGES[job_state.runner_state],
-                     job_state.job_wrapper.job_destination.id )
-            # fetch JobDestination for the id or tag
-            new_destination = app.job_config.get_destination(
-                resubmit['destination'])
-            # Resolve dynamic if necessary
-            new_destination = (job_state.job_wrapper.job_runner_mapper
-                               .cache_job_destination(new_destination))
-            # Reset job state
-            job = job_state.job_wrapper.get_job()
-            if resubmit.get('handler', None):
-                log.debug('(%s/%s) Job reassigned to handler %s',
-                          job_state.job_wrapper.job_id, job_state.job_id,
-                          resubmit['handler'])
-                job.set_handler(resubmit['handler'])
-                job_runner.sa_session.add( job )
-                # Is this safe to do here?
-                job_runner.sa_session.flush()
-            # Cache the destination to prevent rerunning dynamic after
-            # resubmit
-            job_state.job_wrapper.job_runner_mapper \
-                .cached_job_destination = new_destination
-            job_state.job_wrapper.set_job_destination(new_destination)
-            # Clear external ID (state change below flushes the change)
-            job.job_runner_external_id = None
-            # Allow the UI to query for resubmitted state
-            if job.params is None:
-                job.params = {}
-            job_state.runner_state_handled = True
-            info = "This job was resubmitted to the queue because %s on its " \
-                   "compute resource." % MESSAGES[job_state.runner_state]
-            job_runner.mark_as_resubmitted(job_state, info=info)
-            return
+    runner_state = getattr(job_state, 'runner_state', None)
+    if (not runner_state
+        or runner_state not in (job_state.runner_states.WALLTIME_REACHED,
+                                job_state.runner_states.MEMORY_LIMIT_REACHED)):
+        # not set or not a handleable runner state
+        return
+    # Intercept jobs that hit the walltime and have a walltime or
+    # nonspecific resubmit destination configured
+    for resubmit in job_state.job_destination.get('resubmit'):
+        condition = resubmit.get('condition', None)
+        if condition and condition != runner_state:
+            # There is a resubmit defined for the destination but
+            # its condition is not for the encountered state
+            continue
+        log.info("(%s/%s) Job will be resubmitted to '%s' because %s at "
+                 "the '%s' destination",
+                 job_state.job_wrapper.job_id,
+                 job_state.job_id,
+                 resubmit['destination'],
+                 MESSAGES[job_state.runner_state],
+                 job_state.job_wrapper.job_destination.id )
+        # fetch JobDestination for the id or tag
+        new_destination = app.job_config.get_destination(
+            resubmit['destination'])
+        # Resolve dynamic if necessary
+        new_destination = (job_state.job_wrapper.job_runner_mapper
+                           .cache_job_destination(new_destination))
+        # Reset job state
+        job = job_state.job_wrapper.get_job()
+        if resubmit.get('handler', None):
+            log.debug('(%s/%s) Job reassigned to handler %s',
+                      job_state.job_wrapper.job_id, job_state.job_id,
+                      resubmit['handler'])
+            job.set_handler(resubmit['handler'])
+            job_runner.sa_session.add( job )
+            # Is this safe to do here?
+            job_runner.sa_session.flush()
+        # Cache the destination to prevent rerunning dynamic after
+        # resubmit
+        job_state.job_wrapper.job_runner_mapper \
+            .cached_job_destination = new_destination
+        job_state.job_wrapper.set_job_destination(new_destination)
+        # Clear external ID (state change below flushes the change)
+        job.job_runner_external_id = None
+        # Allow the UI to query for resubmitted state
+        if job.params is None:
+            job.params = {}
+        job_state.runner_state_handled = True
+        info = "This job was resubmitted to the queue because %s on its " \
+               "compute resource." % MESSAGES[job_state.runner_state]
+        job_runner.mark_as_resubmitted(job_state, info=info)
+        return

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -485,6 +485,7 @@ model.JobExternalOutputMetadata.table = Table( "job_external_output_metadata", m
     Column( "job_id", Integer, ForeignKey( "job.id" ), index=True ),
     Column( "history_dataset_association_id", Integer, ForeignKey( "history_dataset_association.id" ), index=True, nullable=True ),
     Column( "library_dataset_dataset_association_id", Integer, ForeignKey( "library_dataset_dataset_association.id" ), index=True, nullable=True ),
+    Column( "is_valid", Boolean, default=True ),
     Column( "filename_in", String( 255 ) ),
     Column( "filename_out", String( 255 ) ),
     Column( "filename_results_code", String( 255 ) ),

--- a/lib/galaxy/model/migrate/versions/0129_job_external_output_metadata_validity.py
+++ b/lib/galaxy/model/migrate/versions/0129_job_external_output_metadata_validity.py
@@ -1,0 +1,50 @@
+"""
+Migration script to allow invalidation of job external output metadata temp files
+"""
+from sqlalchemy import *
+from sqlalchemy.orm import *
+from migrate import *
+from migrate.changeset import *
+from galaxy.model.custom_types import *
+
+import datetime
+now = datetime.datetime.utcnow
+
+import logging
+log = logging.getLogger( __name__ )
+
+metadata = MetaData()
+
+
+def upgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    print __doc__
+    metadata.reflect()
+
+    isvalid_column = Column( "is_valid", Boolean, default=True )
+    __add_column( isvalid_column, "job_external_output_metadata", metadata )
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    __drop_column( isvalid_column, "job_external_output_metadata", metadata )
+
+
+def __add_column(column, table_name, metadata, **kwds):
+    try:
+        table = Table( table_name, metadata, autoload=True )
+        column.create( table, **kwds )
+    except Exception as e:
+        print str(e)
+        log.exception( "Adding column %s failed." % column)
+
+
+def __drop_column( column_name, table_name, metadata ):
+    try:
+        table = Table( table_name, metadata, autoload=True )
+        getattr( table.c, column_name ).drop()
+    except Exception as e:
+        print str(e)
+        log.exception( "Dropping column %s failed." % column_name )


### PR DESCRIPTION
When a job is resubmitted with a "dirty" working directory (from the first attempt at running the job), working directory files are staged by Pulsar that cause many tools to fail because the working directory is not clean.

We also need to regenerat the external metadata temp files for resubmission.
