### PR TITLE
Add RData and RData.gz formats

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -277,7 +277,6 @@
     <datatype extension="stockholm" type="galaxy.datatypes.msa:Stockholm_1_0" display_in_upload="True" />
 
     <datatype extension="RData" type="galaxy.datatypes.binary:RData" display_in_upload="true" description="Stored data from an R session"/>
-    <datatype extension="RDataGZ" type="galaxy.datatypes.binary:RDataGZ" display_in_upload="true" description="Stored data from an R session, gzipped"/>
   </registration>
   <sniffers>
     <!--
@@ -327,7 +326,6 @@
     <sniffer type="galaxy.datatypes.msa:Hmmer3" />
     <sniffer type="galaxy.datatypes.msa:Stockholm_1_0" />
     <sniffer type="galaxy.datatypes.binary:RData" />
-    <sniffer type="galaxy.datatypes.binary:RDataGZ" />
     <sniffer type="galaxy.datatypes.images:Jpg"/>
     <sniffer type="galaxy.datatypes.images:Png"/>
     <sniffer type="galaxy.datatypes.images:Tiff"/>

--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -275,6 +275,9 @@
     <datatype extension="hmm2" type="galaxy.datatypes.msa:Hmmer2" display_in_upload="true" />
     <datatype extension="hmm3" type="galaxy.datatypes.msa:Hmmer3" display_in_upload="true" />
     <datatype extension="stockholm" type="galaxy.datatypes.msa:Stockholm_1_0" display_in_upload="True" />
+
+    <datatype extension="RData" type="galaxy.datatypes.binary:RData" display_in_upload="true" description="Stored data from an R session"/>
+    <datatype extension="RDataGZ" type="galaxy.datatypes.binary:RDataGZ" display_in_upload="true" description="Stored data from an R session, gzipped"/>
   </registration>
   <sniffers>
     <!--
@@ -323,6 +326,8 @@
     <sniffer type="galaxy.datatypes.msa:Hmmer2" />
     <sniffer type="galaxy.datatypes.msa:Hmmer3" />
     <sniffer type="galaxy.datatypes.msa:Stockholm_1_0" />
+    <sniffer type="galaxy.datatypes.binary:RData" />
+    <sniffer type="galaxy.datatypes.binary:RDataGZ" />
     <sniffer type="galaxy.datatypes.images:Jpg"/>
     <sniffer type="galaxy.datatypes.images:Png"/>
     <sniffer type="galaxy.datatypes.images:Tiff"/>

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -862,30 +862,24 @@ class Sra( Binary ):
 Binary.register_sniffable_binary_format('sra', 'sra', Sra)
 
 
-class _RData( Binary ):
+class RData( Binary ):
     """Generic R Data file datatype implementation"""
     file_ext = 'rdata'
 
     def __init__( self, **kwd ):
         Binary.__init__( self, **kwd )
 
-class RData( _RData ):
-
     def sniff( self, filename ):
+        rdata_header = binascii.hexlify('RDX2\nX\n')
         try:
             header = open(filename).read(7)
-            return binascii.b2a_hex(header) == binascii.hexlify('RDX2\nX\n')
-        except:
-            return False
+            if binascii.b2a_hex(header) == rdata_header:
+                return True
 
-class RDataGZ( _RData ):
-
-    def sniff( self, filename ):
-        try:
             header = gzip.open( filename ).read(7)
-            return binascii.b2a_hex(header) == binascii.hexlify('RDX2\nX\n')
+            if binascii.b2a_hex(header) == rdata_header:
+                return True
         except:
             return False
 
 Binary.register_sniffable_binary_format('rdata', 'rdata', RData)
-Binary.register_sniffable_binary_format('rdata', 'rdata', RDataGZ)

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -472,7 +472,7 @@ class Bcf( Binary):
         dataset_symlink = os.path.join( os.path.dirname( index_file.file_name ),
                     '__dataset_%d_%s' % ( dataset.id, os.path.basename( index_file.file_name ) ) )
         os.symlink( dataset.file_name, dataset_symlink )
-           
+
         stderr_name = tempfile.NamedTemporaryFile( prefix = "bcf_index_stderr" ).name
         command = [ 'bcftools', 'index', dataset_symlink ]
         proc = subprocess.Popen( args=command, stderr=open( stderr_name, 'wb' ) )
@@ -753,7 +753,7 @@ class SQlite ( Binary ):
 
 class GeminiSQLite( SQlite ):
     """Class describing a Gemini Sqlite database """
-    MetadataElement( name="gemini_version", default='0.10.0' , param=MetadataParameter, desc="Gemini Version", 
+    MetadataElement( name="gemini_version", default='0.10.0' , param=MetadataParameter, desc="Gemini Version",
                      readonly=True, visible=True, no_value='0.10.0' )
     file_ext = "gemini.sqlite"
 
@@ -772,7 +772,7 @@ class GeminiSQLite( SQlite ):
 
     def sniff( self, filename ):
         if super( GeminiSQLite, self ).sniff( filename ):
-            gemini_table_names = [ "gene_detailed", "gene_summary", "resources", "sample_genotype_counts", "sample_genotypes", "samples", 
+            gemini_table_names = [ "gene_detailed", "gene_summary", "resources", "sample_genotype_counts", "sample_genotypes", "samples",
                                   "variant_impacts", "variants", "version" ]
             try:
                 conn = sqlite.connect( filename )
@@ -861,3 +861,31 @@ class Sra( Binary ):
 
 Binary.register_sniffable_binary_format('sra', 'sra', Sra)
 
+
+class _RData( Binary ):
+    """Generic R Data file datatype implementation"""
+    file_ext = 'rdata'
+
+    def __init__( self, **kwd ):
+        Binary.__init__( self, **kwd )
+
+class RData( _RData ):
+
+    def sniff( self, filename ):
+        try:
+            header = open(filename).read(7)
+            return binascii.b2a_hex(header) == binascii.hexlify('RDX2\nX\n')
+        except:
+            return False
+
+class RDataGZ( _RData ):
+
+    def sniff( self, filename ):
+        try:
+            header = gzip.open( filename ).read(7)
+            return binascii.b2a_hex(header) == binascii.hexlify('RDX2\nX\n')
+        except:
+            return False
+
+Binary.register_sniffable_binary_format('rdata', 'rdata', RData)
+Binary.register_sniffable_binary_format('rdata', 'rdata', RDataGZ)


### PR DESCRIPTION
RData has a wide array of formats, some more useful than others. There's the binary RData format which can optionally be gzipped. Then there's an ascii version of that which only holds a single variable (which we ignore). 

http://biostat.mc.vanderbilt.edu/wiki/Main/RBinaryFormat
http://stackoverflow.com/a/21370351
