### PR TITLE
Visualizations registry: switch to entry_point config definition for …

### DIFF
--- a/config/plugins/interactive_environments/ipython/config/ipython.xml
+++ b/config/plugins/interactive_environments/ipython/config/ipython.xml
@@ -12,5 +12,5 @@
     <params>
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>
-    <template>ipython.mako</template>
+    <entry_point entry_point_type="mako">ipython.mako</entry_point>
 </interactive_environment>

--- a/config/plugins/visualizations/charts/config/charts.xml
+++ b/config/plugins/visualizations/charts/config/charts.xml
@@ -11,5 +11,5 @@
     <params>
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>
-    <template>charts.mako</template>
+    <entry_point entry_point_type="mako">charts.mako</entry_point>
 </visualization>

--- a/config/plugins/visualizations/circster/config/circster.xml
+++ b/config/plugins/visualizations/circster/config/circster.xml
@@ -21,6 +21,6 @@
         <param_modifier type="string" modifies="dataset_id">hda_ldda</param_modifier>
         <param type="dbkey">dbkey</param>
     </params>
-    <template>circster.mako</template>
+    <entry_point entry_point_type="mako">circster.mako</entry_point>
     <render_target>_top</render_target>
 </visualization>

--- a/config/plugins/visualizations/graphview/config/graphview.xml
+++ b/config/plugins/visualizations/graphview/config/graphview.xml
@@ -16,5 +16,5 @@
     <params>
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>
-    <template>graphview.mako</template>
+    <entry_point entry_point_type="mako">graphview.mako</entry_point>
 </visualization>

--- a/config/plugins/visualizations/phyloviz/config/phyloviz.xml
+++ b/config/plugins/visualizations/phyloviz/config/phyloviz.xml
@@ -14,6 +14,6 @@
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
         <param type="integer" default="0">tree_index</param>
     </params>
-    <template>phyloviz.mako</template>
+    <entry_point entry_point_type="mako">phyloviz.mako</entry_point>
     <render_target>_top</render_target>
 </visualization>

--- a/config/plugins/visualizations/scatterplot/config/scatterplot.xml
+++ b/config/plugins/visualizations/scatterplot/config/scatterplot.xml
@@ -11,5 +11,5 @@
     <params>
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>
-    <template>scatterplot.mako</template>
+    <entry_point entry_point_type="mako">scatterplot.mako</entry_point>
 </visualization>

--- a/config/plugins/visualizations/sweepster/config/sweepster.xml
+++ b/config/plugins/visualizations/sweepster/config/sweepster.xml
@@ -20,6 +20,6 @@
         <param type="hda_or_ldda" var_name_in_template="dataset">dataset_id</param>
         <param_modifier type="string" modifies="dataset_id">hda_ldda</param_modifier>
     </params>
-    <template>sweepster.mako</template>
+    <entry_point entry_point_type="mako">sweepster.mako</entry_point>
     <render_target>_top</render_target>
 </visualization>

--- a/config/plugins/visualizations/trackster/config/trackster.xml
+++ b/config/plugins/visualizations/trackster/config/trackster.xml
@@ -23,6 +23,6 @@
         <param type="genome_region">genome_region</param>
         <param type="dbkey">dbkey</param>
     </params>
-    <template>browser.mako</template>
+    <entry_point entry_point_type="mako">browser.mako</entry_point>
     <render_target>_top</render_target>
 </visualization>

--- a/config/plugins/visualizations/visualization.dtd
+++ b/config/plugins/visualizations/visualization.dtd
@@ -1,6 +1,12 @@
 <!-- each visualization must have a template (all other elements are optional) -->
-<!ELEMENT visualization (description*,data_sources*,params*,template_root*,template,render_target*)>
-<!ELEMENT interactive_environment (description*,data_sources*,params*,template_root*,template,render_target*)>
+<!ELEMENT visualization (
+  description*,
+  data_sources*,
+  params*,
+  template_root*,
+  entry_point,
+  render_target*
+)>
 <!-- visualization
         name: the title/display name of the visualization (e.g. 'Trackster', 'Fastq Stats', etc.) REQUIRED
         disabled: if included (value does not matter), this attribute will prevent the visualization being loaded
@@ -13,6 +19,21 @@
     disabled    CDATA #IMPLIED
     embeddable  CDATA #IMPLIED
 >
+
+<!ELEMENT interactive_environment (
+  description*,
+  data_sources*,
+  params*,
+  template_root*,
+  entry_point,
+  render_target*
+)>
+<!ATTLIST interactive_environment
+    name        CDATA #REQUIRED
+    disabled    CDATA #IMPLIED
+    embeddable  CDATA #IMPLIED
+>
+
 
 <!ELEMENT description (#PCDATA)>
 <!-- a text description of what the visualization does -->
@@ -128,8 +149,13 @@
       var_name_in_template  CDATA #IMPLIED
   >
 
-<!-- template: the template used to render the visualization. REQUIRED -->
-<!ELEMENT template (#PCDATA)>
+<!-- template: the template used to render the visualization. DEPRECATED -->
+<!-- <!ELEMENT template (#PCDATA)> -->
+<!-- entry_point: the method the registry will use to begin rendering the visualization - a loading point. REQUIRED -->
+<!ELEMENT entry_point (#PCDATA)>
+<!ATTLIST entry_point
+    entry_point_type  CDATA #REQUIRED
+>
 <!-- render_target: used as the target attribute of the link to the visualization.
       Can be 'galaxy_main', '_top', '_blank'. DEFAULT: 'galaxy_main'
 -->


### PR DESCRIPTION
…built-in visualizations

Take out 'template', put in 'entry_point'. DTD's can't handle open attribute definitions (<!ATTLIST blah ANYTHING_I_WANT>) so we'll have to move to XSD soon.
