### PR TITLE
Ignore sample files from toolshed installed tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ tool-data/shared/ucsc/publicbuilds.txt
 tool-data/shared/ucsc/ucsc_build_sites.txt
 tool-data/*.loc
 tool-data/genome/*
+tool-data/*.sample
 
 # Test output
 test-data-cache


### PR DESCRIPTION
Sample files already being tracked won't be affected.
If an ignored file is to be added, add it with -f.
