### PR TITLE
Have trans.user_ftp_dir return None instead of error if upload dir unset.

### DIFF
--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -139,7 +139,11 @@ class ProvidesUserContext( object ):
     @property
     def user_ftp_dir( self ):
         identifier = self.app.config.ftp_upload_dir_identifier
-        return os.path.join( self.app.config.ftp_upload_dir, getattr( self.user, identifier ) )
+        base_dir = self.app.config.ftp_upload_dir
+        if base_dir is None:
+            return None
+        else:
+            return os.path.join( base_dir, getattr( self.user, identifier ) )
 
 
 class ProvidesHistoryContext( object ):


### PR DESCRIPTION
This is now called on each upload job after eb538e00bdfb6cd87c71a620653c91854642b01a as part of `get_initial_value` and if `ftp_upload_dir` is `None` and this was throwing [this error](https://gist.github.com/jmchilton/fdfb808e13998fbe17bd).

Testing:

Run any tool test (e.g. `./run_tests.sh -framework -id simple_constructs`) before and after patch to verify this fixes the problem.
