### PR TITLE
[15.05] Collection-y fixes for 15.05

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -73,7 +73,9 @@ class DatasetCollectionManager( object ):
                 for input_name, input_collection in implicit_collection_info[ "implicit_inputs" ]:
                     dataset_collection_instance.add_implicit_input_collection( input_name, input_collection )
                 for output_dataset in implicit_collection_info.get( "outputs" ):
-                    if isinstance( output_dataset, model.HistoryDatasetCollectionAssociation ):
+                    if isinstance( output_dataset, model.HistoryDatasetAssociation ):
+                        output_dataset.hidden_beneath_collection_instance = dataset_collection_instance
+                    elif isinstance( output_dataset, model.HistoryDatasetCollectionAssociation ):
                         dataset_collection_instance.add_implicit_input_collection( input_name, input_collection )
                     else:
                         # dataset collection, don't need to do anything...

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -158,6 +158,7 @@ class XmlToolSource(ToolSource):
 
         for collection_elem in out_elem.findall("collection"):
             name = collection_elem.get( "name" )
+            label = xml_text( collection_elem, "label" )
             default_format = collection_elem.get( "format", "data" )
             collection_type = collection_elem.get( "type", None )
             structured_like = collection_elem.get( "structured_like", None )
@@ -180,6 +181,7 @@ class XmlToolSource(ToolSource):
             output_collection = galaxy.tools.ToolOutputCollection(
                 name,
                 structure,
+                label=label,
                 default_format=default_format,
                 inherit_format=inherit_format,
                 inherit_metadata=inherit_metadata,

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -302,7 +302,7 @@ class ToolsTestCase( api.ApiTestCase ):
         self._assert_has_keys( output_collection, "id", "name", "elements", "populated" )
         assert not output_collection[ "populated" ]
         assert len( output_collection[ "elements" ] ) == 0
-
+        self.assertEquals( output_collection[ "name" ], "Table split on first column" )
         self.dataset_populator.wait_for_job( create["jobs"][0]["id"], assert_ok=True )
 
         get_collection_response = self._get( "dataset_collections/%s" % output_collection[ "id" ], data={"instance_type": "history"} )
@@ -312,6 +312,8 @@ class ToolsTestCase( api.ApiTestCase ):
         self._assert_has_keys( output_collection, "id", "name", "elements", "populated" )
         assert output_collection[ "populated" ]
         assert len( output_collection[ "elements" ] ) == 2
+        self.assertEquals( output_collection[ "name" ], "Table split on first column" )
+
         # TODO: verify element identifiers
 
     @skip_without_tool( "cat1" )


### PR DESCRIPTION
See individual commits for details.
- Restore auto-hiding behavior when mapping over collections (broken with 15.03 - reported by @nekrut ). 1f319b4
- Fix label property on output collections (reported by @kellrott). cdaa505 

Rebased without the broken label fix included in the initial PR - I changed the text in source that I thought should correspond to the GUI - but it doesn't appear to now that I really tried it.
