### PR TITLE
[15.05] Fix implicit output collection names when mapping over collections.

### DIFF
--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -113,12 +113,13 @@ class ToolExecutionTracker( object ):
                 outputs=outputs
             )
             try:
-                output_collection_name = self.tool_action.get_output_name(
+                output_collection_name = self.tool.tool_action.get_output_name(
                     output,
                     dataset=None,
                     tool=self.tool,
                     on_text=on_text,
                     trans=trans,
+                    history=history,
                     params=params,
                     incoming=None,
                     job_params=None,


### PR DESCRIPTION
Having the 5 different output collections from Tophat have different and useful names would have improved this live demo from @nekrut.
