### PR TITLE
Accept history id in tool model building api

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2268,7 +2268,7 @@ class Tool( object, Dictifiable ):
             else:
                 history = trans.get_history()
             if history is None:
-                raise Exception('No current history available. Please specify a valid history id')
+                raise Exception('History unavailable. Please specify a valid history id')
         except Exception, e:
             trans.response.status = 500
             error = '[history_id=%s] Failed to retrieve history. %s.' % (history_id, str(e))

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -27,6 +27,7 @@ from mako.template import Template
 from paste import httpexceptions
 
 from galaxy import model
+from galaxy.managers import histories
 from galaxy.datatypes.metadata import JobExternalOutputMetadataWrapper
 from galaxy import exceptions
 from galaxy.tools.actions import DefaultToolAction
@@ -61,7 +62,6 @@ from tool_shed.util import shed_util_common as suc
 from .loader import template_macro_params, raw_tool_xml_tree, imported_macro_paths
 from .execute import execute as execute_job
 import galaxy.jobs
-
 
 log = logging.getLogger( __name__ )
 
@@ -454,6 +454,7 @@ class Tool( object, Dictifiable ):
         # Parse XML element containing configuration
         self.parse( tool_source, guid=guid )
         self.external_runJob_script = app.config.drmaa_external_runjob_script
+        self.history_manager = histories.HistoryManager( app )
 
     @property
     def sa_session( self ):
@@ -2257,6 +2258,7 @@ class Tool( object, Dictifiable ):
         """
         job_id = kwd.get('__job_id__', None)
         dataset_id = kwd.get('__dataset_id__', None)
+        history_id = kwd.get('history_id', None)
 
         # load job details if provided
         job = None
@@ -2302,6 +2304,11 @@ class Tool( object, Dictifiable ):
 
         # create parameter object
         params = galaxy.util.Params( kwd, sanitize = False )
+
+        # history id
+        history = None
+        if not history_id is None:
+            history = self.history_manager.get_owned( trans.security.decode_id( history_id ), trans.user, current_history=trans.history )
 
         # convert value to jsonifiable value
         def jsonify(v):
@@ -2388,7 +2395,7 @@ class Tool( object, Dictifiable ):
         def populate_state(trans, inputs, state, errors, incoming, prefix="", context=None ):
             context = ExpressionContext(state, context)
             for input in inputs.itervalues():
-                state[input.name] = input.get_initial_value(trans, context)
+                state[input.name] = input.get_initial_value(trans, context, history=history)
                 key = prefix + input.name
                 if input.type == 'repeat':
                     group_state = state[input.name]
@@ -2454,7 +2461,7 @@ class Tool( object, Dictifiable ):
                 elif input.type == 'conditional':
                     if 'test_param' in tool_dict:
                         test_param = tool_dict['test_param']
-                        test_param['default_value'] = jsonify(input.test_param.get_initial_value(trans, other_values))
+                        test_param['default_value'] = jsonify(input.test_param.get_initial_value(trans, other_values, history=history))
                         test_param['value'] = jsonify(group_state.get(test_param['name'], test_param['default_value']))
                         for i in range (len ( tool_dict['cases'] ) ):
                             current_state = {}
@@ -2476,7 +2483,7 @@ class Tool( object, Dictifiable ):
 
                     # backup default value
                     try:
-                        tool_dict['default_value'] = input.get_initial_value(trans, other_values)
+                        tool_dict['default_value'] = input.get_initial_value(trans, other_values, history=history)
                     except Exception:
                         log.exception('tools::to_json() - Getting initial value failed %s.' % input_name)
                         # get initial value failed due to improper late validation

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2294,7 +2294,7 @@ class Tool( object, Dictifiable ):
             try:
                 job_params = job.get_param_values( trans.app, ignore_errors = True )
                 job_messages = self.check_and_update_param_values( job_params, trans, update_values=False )
-                self._map_source_to_history( trans, self.inputs, job_params )
+                self._map_source_to_history( trans, self.inputs, job_params, history=history )
                 tool_message = self._compare_tool_version(trans, job)
                 params_to_incoming( kwd, self.inputs, job_params, trans.app, to_html=False )
             except Exception, exception:
@@ -2385,7 +2385,7 @@ class Tool( object, Dictifiable ):
                 if input.type == 'boolean' and isinstance(default_value, basestring):
                     value, error = [string_as_bool(default_value), None]
                 else:
-                    value, error = check_param(trans, input, default_value, context)
+                    value, error = check_param(trans, input, default_value, context, history=history)
             except Exception, err:
                 log.error('Checking parameter %s failed. %s', input.name, str(err))
                 pass
@@ -2604,11 +2604,10 @@ class Tool( object, Dictifiable ):
                     pass
         return False
 
-    def _map_source_to_history(self, trans, tool_inputs, params):
+    def _map_source_to_history(self, trans, tool_inputs, params, history):
         # Need to remap dataset parameters. Job parameters point to original
         # dataset used; parameter should be the analygous dataset in the
         # current history.
-        history = trans.get_history()
 
         # Create index for hdas.
         hda_source_dict = {}

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -47,7 +47,7 @@ def visit_input_values( inputs, input_values, callback, name_prefix="", label_pr
                 input_values[input.name] = new_value
 
 
-def check_param( trans, param, incoming_value, param_values, source='html' ):
+def check_param( trans, param, incoming_value, param_values, source='html', history=None ):
     """
     Check the value of a single parameter `param`. The value in
     `incoming_value` is converted from its HTML encoding and validated.
@@ -58,6 +58,8 @@ def check_param( trans, param, incoming_value, param_values, source='html' ):
     value = incoming_value
     error = None
     try:
+        if history is None:
+            history = trans.history
         if value is not None or isinstance( param, DataToolParameter ) or isinstance( param, DataCollectionToolParameter ):
             # Convert value from HTML representation
             if source == 'html':
@@ -67,10 +69,10 @@ def check_param( trans, param, incoming_value, param_values, source='html' ):
             # Allow the value to be converted if necessary
             filtered_value = param.filter_value( value, trans, param_values )
             # Then do any further validation on the value
-            param.validate( filtered_value, trans.history )
+            param.validate( filtered_value, history )
         elif value is None and isinstance( param, SelectToolParameter ):
             # An empty select list or column list
-            param.validate( value, trans.history )
+            param.validate( value, history )
     except ValueError, e:
         error = str( e )
     return value, error

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1678,7 +1678,7 @@ class BaseDataToolParameter( ToolParameter ):
         class_name = self.__class__.__name__
         assert trans is not None, "%s requires a trans" % class_name
         if history is None:
-            history = trans.get_history( create=True )
+            history = trans.get_history()
         assert history is not None, "%s requires a history" % class_name
         return history
 


### PR DESCRIPTION
This PR integrates the history id parsing for the tool model build api (api/tools/build) using the history data manager. It can be tested by providing a history id:
http://127.0.0.1:8080/api/tools/cat1/build?io_details=true&history_id=HISTORY_ID
Additionally, it fixes the regular tools api by not enforcing the existence of a 'current' history.
