### PR TITLE
Mauve XMFA datatype

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -276,6 +276,7 @@
     <datatype extension="hmm2" type="galaxy.datatypes.msa:Hmmer2" display_in_upload="true" />
     <datatype extension="hmm3" type="galaxy.datatypes.msa:Hmmer3" display_in_upload="true" />
     <datatype extension="stockholm" type="galaxy.datatypes.msa:Stockholm_1_0" display_in_upload="True" />
+    <datatype extension="xmfa" type="galaxy.datatypes.msa:MauveXmfa" display_in_upload="True" />
 
     <datatype extension="RData" type="galaxy.datatypes.binary:RData" display_in_upload="true" description="Stored data from an R session"/>
   </registration>
@@ -326,6 +327,7 @@
     <sniffer type="galaxy.datatypes.msa:Hmmer2" />
     <sniffer type="galaxy.datatypes.msa:Hmmer3" />
     <sniffer type="galaxy.datatypes.msa:Stockholm_1_0" />
+    <sniffer type="galaxy.datatypes.msa:MauveXmfa" />
     <sniffer type="galaxy.datatypes.binary:RData" />
     <sniffer type="galaxy.datatypes.images:Jpg"/>
     <sniffer type="galaxy.datatypes.images:Png"/>

--- a/lib/galaxy/datatypes/msa.py
+++ b/lib/galaxy/datatypes/msa.py
@@ -88,7 +88,7 @@ Binary.register_unsniffable_binary_ext("hmmpress")
 class Stockholm_1_0( Text ):
     file_ext = "stockholm"
 
-    MetadataElement( name="number_of_alignments", default=0, desc="Number of multiple alignments", readonly=True, visible=True, optional=True, no_value=0 )
+    MetadataElement( name="number_of_models", default=0, desc="Number of multiple alignments", readonly=True, visible=True, optional=True, no_value=0 )
 
     def set_peek( self, dataset, is_multi_byte=False ):
         if not dataset.dataset.purged:
@@ -166,3 +166,31 @@ class Stockholm_1_0( Text ):
             log.error('Unable to split files: %s' % str(e))
             raise
     split = classmethod(split)
+
+
+class MauveXmfa( Text ):
+    file_ext = "xmfa"
+
+    MetadataElement( name="number_of_models", default=0, desc="Number of alignmened sequences", readonly=True, visible=True, optional=True, no_value=0 )
+
+    def set_peek( self, dataset, is_multi_byte=False ):
+        if not dataset.dataset.purged:
+            dataset.peek = get_file_peek( dataset.file_name, is_multi_byte=is_multi_byte )
+            if (dataset.metadata.number_of_models == 1):
+                dataset.blurb = "1 alignment"
+            else:
+                dataset.blurb = "%s alignments" % dataset.metadata.number_of_models
+            dataset.peek = get_file_peek( dataset.file_name, is_multi_byte=is_multi_byte )
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disc'
+
+    def sniff( self, filename ):
+        with open(filename, 'r') as handle:
+            header = handle.read(21)
+            log.debug("Header is %s" % header)
+            return header == '#FormatVersion Mauve1'
+        return False
+
+    def set_meta( self, dataset, **kwd ):
+        dataset.metadata.number_of_models = generic_util.count_special_lines('^#Sequence([[:digit:]]+)Entry', dataset.file_name)

--- a/lib/galaxy/datatypes/msa.py
+++ b/lib/galaxy/datatypes/msa.py
@@ -187,9 +187,7 @@ class MauveXmfa( Text ):
 
     def sniff( self, filename ):
         with open(filename, 'r') as handle:
-            header = handle.read(21)
-            log.debug("Header is %s" % header)
-            return header == '#FormatVersion Mauve1'
+            return handle.read(21) == '#FormatVersion Mauve1'
         return False
 
     def set_meta( self, dataset, **kwd ):

--- a/lib/galaxy/datatypes/util/generic_util.py
+++ b/lib/galaxy/datatypes/util/generic_util.py
@@ -8,7 +8,7 @@ def count_special_lines( word, filename, invert=False ):
         The number of hits is returned.
     """
     try:
-        cmd = ["grep", "-c"]
+        cmd = ["grep", "-c", "-E"]
         if invert:
             cmd.append('-v')
         cmd.extend([word, filename])


### PR DESCRIPTION
CC @bgruening

The only change I want to discuss is adding the `-E` flag to grep for extended regex. 
- I need `-E` for phrases like `[[:digits:]]+` as sequence counts can go above one digit.
- however, I don't strictly need that function, I could write a custom sniffer which just reads header lines and quits when it sees a `>` line. This would remove the need for `-E`, but results in more code.

Is `-E` a problem for anyone? The grep statement is used in two places:
- stockholm sniffing
- xmfa metadata (I could use it in sniffing too, but .. eh)
