### PR TITLE
[15.05] Disable automated history creation in data tool parameters

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1653,7 +1653,7 @@ class BaseDataToolParameter( ToolParameter ):
         class_name = self.__class__.__name__
         assert trans is not None, "%s requires a trans" % class_name
         if history is None:
-            history = trans.get_history( create=True )
+            history = trans.get_history()
         assert history is not None, "%s requires a history" % class_name
         return history
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/pull/217/files. The automated creation of empty histories in data tool parameters had undesired effects. Instead the initial issue can probably be solved by allowing users to specify the selected history within the api call. A PR for this is in the pipeline: https://github.com/galaxyproject/galaxy/pull/268.
