### PR TITLE
[15.05] Fixes for boolean & select handling in test data elements.

### DIFF
--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -71,9 +71,8 @@ class ToolTestBuilder( object ):
                 # No explicit value for param in test case, determine from default
                 query_value = test_param.checked
             else:
-                # Test case supplied value, check cases against this.
-                query_value = string_as_bool( declared_value )
-            matches_declared_value = lambda case_value: string_as_bool(case_value) == query_value
+                query_value = _process_bool_param_value( test_param, declared_value )
+            matches_declared_value = lambda case_value: _process_bool_param_value( test_param, case_value ) == query_value
         elif isinstance(test_param, galaxy.tools.parameters.basic.SelectToolParameter):
             if declared_value is not None:
                 # Test case supplied explicit value to check against.
@@ -166,7 +165,8 @@ class ToolTestBuilder( object ):
                         # as a new instance with value defined and hence enter
                         # an infinite loop - hence the "case_value is not None"
                         # check.
-                        expanded_inputs[ case_context.for_state() ] = expanded_case_value
+                        processed_value = _process_simple_value( value.test_param, expanded_case_value )
+                        expanded_inputs[ case_context.for_state() ] = processed_value
             elif isinstance( value, galaxy.tools.parameters.grouping.Section ):
                 context = ParamContext( name=value.name, parent_context=parent_context )
                 for r_name, r_value in value.inputs.iteritems():
@@ -203,33 +203,8 @@ class ToolTestBuilder( object ):
                         for ( name, value, extra ) in collection_def.collect_inputs():
                             require_file( name, value, extra, self.required_files )
                         processed_value = collection_def
-                    elif isinstance( value, galaxy.tools.parameters.basic.SelectToolParameter ) and hasattr( value, 'static_options' ):
-                        # Tests may specify values as either raw value or the value
-                        # as they appear in the list - the API doesn't and shouldn't
-                        # accept the text value - so we need to convert the text
-                        # into the form value.
-                        def process_param_value( param_value ):
-                            found_value = False
-                            value_for_text = None
-                            if value.static_options:
-                                for (text, opt_value, selected) in value.static_options:
-                                    if param_value == opt_value:
-                                        found_value = True
-                                    if value_for_text is None and param_value == text:
-                                        value_for_text = opt_value
-                            if not found_value and value_for_text is not None:
-                                processed_value = value_for_text
-                            else:
-                                processed_value = param_value
-                            return processed_value
-                        # Do replacement described above for lists or singleton
-                        # values.
-                        if isinstance( param_value, list ):
-                            processed_value = map( process_param_value, param_value )
-                        else:
-                            processed_value = process_param_value( param_value )
                     else:
-                        processed_value = param_value
+                        processed_value = _process_simple_value( value, param_value )
                     expanded_inputs[ context.for_state() ] = processed_value
         return expanded_inputs
 
@@ -238,6 +213,54 @@ class ToolTestBuilder( object ):
             assert input_parameter.optional, '%s is not optional. You must provide a valid filename.' % name
             return value
         return require_file( name, value, extra, self.required_files )
+
+
+def _process_simple_value( param, param_value ):
+    if isinstance( param, galaxy.tools.parameters.basic.SelectToolParameter ) and hasattr( param, 'static_options' ):
+        # Tests may specify values as either raw value or the value
+        # as they appear in the list - the API doesn't and shouldn't
+        # accept the text value - so we need to convert the text
+        # into the form value.
+        def process_param_value( param_value ):
+            found_value = False
+            value_for_text = None
+            if param.static_options:
+                for (text, opt_value, selected) in param.static_options:
+                    if param_value == opt_value:
+                        found_value = True
+                    if value_for_text is None and param_value == text:
+                        value_for_text = opt_value
+            if not found_value and value_for_text is not None:
+                processed_value = value_for_text
+            else:
+                processed_value = param_value
+            return processed_value
+        # Do replacement described above for lists or singleton
+        # values.
+        if isinstance( param_value, list ):
+            processed_value = map( process_param_value, param_value )
+        else:
+            processed_value = process_param_value( param_value )
+    elif isinstance( param, galaxy.tools.parameters.basic.BooleanToolParameter ):
+        # Like above, tests may use the tool define values of simply
+        # true/false.
+        processed_value = _process_bool_param_value( param, param_value )
+    else:
+        processed_value = param_value
+    return processed_value
+
+
+def _process_bool_param_value( param, param_value ):
+    assert isinstance( param, galaxy.tools.parameters.basic.BooleanToolParameter )
+    if isinstance( param_value, list ):
+        param_value = param_value[0]
+    if param.truevalue == param_value:
+        processed_value = True
+    elif param.falsevalue == param_value:
+        processed_value = False
+    else:
+        processed_value = string_as_bool( param_value )
+    return processed_value
 
 
 @nottest

--- a/test/functional/tools/boolean_conditional.xml
+++ b/test/functional/tools/boolean_conditional.xml
@@ -1,0 +1,53 @@
+<tool id="boolean_conditional" name="boolean_conditional" version="1.0.0">
+    <command>
+        echo "$p1.p1val" >> $out_file1;
+    </command>
+    <inputs>
+        <conditional name="p1">
+            <param type="boolean" name="p1use" truevalue="booltrue" falsevalue="boolfalse" />
+            <when value="booltrue">
+                <param name="p1val" value="p1used" type="text" />
+            </when>
+            <when value="boolfalse">
+                <param name="p1val" value="p1notused" type="text" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="p1use" value="true" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="p1used" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="p1use" value="booltrue" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="p1used" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="p1use" value="false" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="p1notused" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="p1use" value="boolfalse" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="p1notused" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -3,6 +3,7 @@
   <tool file="upload.xml"/>
   <tool file="simple_constructs.xml" />
   <tool file="inheritance_simple.xml" />
+  <tool file="boolean_conditional.xml" />
   <tool file="composite.xml" />
   <tool file="compare_bam_as_sam.xml" />
   <tool file="code_file.xml" />

--- a/test/functional/tools/simple_constructs.xml
+++ b/test/functional/tools/simple_constructs.xml
@@ -61,5 +61,17 @@
                 </assert_contents>
             </output>
         </test>
+        <test>
+            <!-- Again but using boolean's truevalue -->
+            <param name="p1use" value="true" />
+            <param name="booltest" value="booltrue" />
+            <param name="file" value="simple_line.txt" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="p1used" />
+                    <has_line line="booltrue" />
+                </assert_contents>
+            </output>
+        </test>
     </tests>
 </tool>


### PR DESCRIPTION
- Allow boolean "truevalue"/"falsevalue" to be used in plain (non-conditional test element) parameters (see https://trello.com/c/iGk3f1pE).
- Fix conditionals to use processed values - so this fix and 5b6c092aa0a85455b4daacd318541e92bd08b876 are applid to these elements as well. (http://osdir.com/ml/general/2015-05/msg24402.html).

This also adds tests to verify these behaviors.

Run most relevant tests with commands:

```
./run_tests.sh -framework -id simple_constructs
./run_tests.sh -framework -id multi_select
./run_tests.sh -framework -id boolean_conditional
```
