### PR TITLE
Condor fixes

### DIFF
--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -44,7 +44,8 @@ class CondorJobRunner( AsynchronousJobRunner ):
         """Create job script and submit it to the DRM"""
 
         # prepare the job
-        if not self.prepare_job( job_wrapper, include_metadata=True ):
+        include_metadata = asbool( job_wrapper.job_destination.params.get( "embed_metadata_in_job", True ) )
+        if not self.prepare_job( job_wrapper, include_metadata=include_metadata):
             return
 
         # command line has been added to the wrapper by prepare_job()
@@ -178,6 +179,9 @@ class CondorJobRunner( AsynchronousJobRunner ):
                 #cjs.job_wrapper.change_state( model.Job.states.QUEUED )
             if job_complete:
                 if cjs.job_wrapper.get_state() != model.Job.states.DELETED:
+                    external_metadata = not asbool( cjs.job_wrapper.job_destination.params.get( "embed_metadata_in_job", True) )
+                    if external_metadata:
+                        self._handle_metadata_externally( cjs.job_wrapper, resolve_requirements=True )
                     log.debug( "(%s/%s) job has completed" % ( galaxy_id_tag, job_id ) )
                     self.work_queue.put( ( self.finish_job, cjs ) )
                 continue

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -10,6 +10,7 @@ from galaxy.jobs.runners import AsynchronousJobState, AsynchronousJobRunner
 from galaxy.jobs.runners.util.condor import submission_params, build_submit_description
 from galaxy.jobs.runners.util.condor import condor_submit, condor_stop
 from galaxy.jobs.runners.util.condor import summarize_condor_log
+from galaxy.util import asbool
 
 log = logging.getLogger( __name__ )
 


### PR DESCRIPTION
These modifications to the HTCondor job runner put it in line with the DRMAA job runner and fix [this issue](https://trello.com/c/KnvdRRlj) on the trello board. In short, the runner now looks for an appropriate `embed_metadata_in_job` param in `job_conf.xml`. If it finds it and the value is `False`, then metadata will be set locally after a job has successfully finished. If the value is `True` or the parameter doesn't exist, then the default is to have the remote node attempt to set the metadata.

For my own use, it would be more convenient for `embed_metadata_in_job` to default to `False`, but since the other job runners default to `True` it's probably best to keep things the same.
