### PR TITLE
Remove bad HTML tags from login template

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -36,7 +36,6 @@ REQUIRE_LOGIN_TEMPLATE = """
 <p>
     This %s has been configured such that only users who are logged in may use it.%s
 </p>
-<p/>
 """
 
 PASSWORD_RESET_TEMPLATE = """

--- a/lib/galaxy/webapps/galaxy/controllers/userskeys.py
+++ b/lib/galaxy/webapps/galaxy/controllers/userskeys.py
@@ -17,7 +17,6 @@ require_login_template = """
 <p>
     This %s has been configured such that only users who are logged in may use it.%s
 </p>
-<p/>
 """
 
 # FIXME: This controller is using unencoded IDs, but I am not going to address


### PR DESCRIPTION
Self-closing `<p/>` are not valid in HTML5 and have no visual effect.
