### PR TITLE
export ENV vars from all dependend repositories

### DIFF
--- a/lib/tool_shed/galaxy_install/tool_dependencies/env_manager.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/env_manager.py
@@ -143,5 +143,5 @@ class EnvManager( object ):
                 all_env_shell_file_paths.extend( env_shell_file_paths )
         if all_env_shell_file_paths:
             action_dict[ 'env_shell_file_paths' ] = all_env_shell_file_paths
-            action_dict[ 'action_shell_file_paths' ] = env_shell_file_paths
+            action_dict[ 'action_shell_file_paths' ] = all_env_shell_file_paths
         return action_dict

--- a/test/unit/tool_shed_unit_tests/test_td_common_util.py
+++ b/test/unit/tool_shed_unit_tests/test_td_common_util.py
@@ -38,6 +38,9 @@ def test_get_env_shell_file_paths_from_setup_environment_elem():
         <repository name="package_r_3_0_1" owner="bgruening" toolshed="toolshed.g2.bx.psu.edu" changeset_revision="1234567">
             <package name="R" version="3.0.1" />
         </repository>
+        <repository name="package_zlib_1_2_8" owner="iuc" toolshed="toolshed.g2.bx.psu.edu" changeset_revision="7654321">
+            <package name="zlib" version="1.2.8" />
+        </repository>
     </action>
     """
     mock_app = MockApp()
@@ -50,7 +53,7 @@ def test_get_env_shell_file_paths_from_setup_environment_elem():
     r_env_sh = '/path/to/go/env.sh'
 
     def mock_get_env_shell_file_paths( elem ):
-        assert elem.get( 'name' ) == "package_r_3_0_1"
+        assert elem.get( 'name' ) in ["package_r_3_0_1","package_zlib_1_2_8"]
         return [ r_env_sh ]
 
     with __mock_common_util_method( env_manager, "get_env_shell_file_paths", mock_get_env_shell_file_paths ):
@@ -61,10 +64,13 @@ def test_get_env_shell_file_paths_from_setup_environment_elem():
         assert r_env_sh in all_env_paths
         ## env_shell_file_paths includes everything
         assert all( [ env in action_dict[ 'env_shell_file_paths' ] for env in all_env_paths ] )
+        ## for every given repository there should be one env 
+        ## file + the required_for_install_env_sh file
+        assert len( action_dict[ 'env_shell_file_paths' ] ) == 3
 
-        ## action_shell_file_paths includes only env files defined in
+        ## action_shell_file_paths includes only env files defined
         ## inside the setup_ action element.
-        assert required_for_install_env_sh not in action_dict[ 'action_shell_file_paths' ]
+        assert required_for_install_env_sh in action_dict[ 'action_shell_file_paths' ]
         assert r_env_sh in action_dict[ 'action_shell_file_paths' ]
 
 ## Poor man's mocking. Need to get a real mocking library as real Galaxy development


### PR DESCRIPTION
This will export ENV vars from all given repository dependencies and not only the last one.
Taking the last one seems arbitrary to me. and this PR makes the tool_dependencies.xml files a bit easier to write.

@davebx @blankenberg any objections? 
