### PR TITLE
Exclude curly braces from API-key to fix toolshed bootstrapping.

### DIFF
--- a/lib/tool_shed/scripts/bootstrap_tool_shed/bootstrap_tool_shed.sh
+++ b/lib/tool_shed/scripts/bootstrap_tool_shed/bootstrap_tool_shed.sh
@@ -76,7 +76,7 @@ while : ; do
 done
 
 echo -n "Retrieving admin user's API key from $local_shed_url..."
-api_key=`curl -s --user $admin_user_email:$admin_user_password $local_shed_url/api/authenticate/baseauth/ | sed 's/..*api_key[^0-9a-f][^0-9a-f]*\([0-9a-f]*\)..*/\1/'`
+api_key=`curl -s --user $admin_user_email:$admin_user_password $local_shed_url/api/authenticate/baseauth/ | sed 's/..*api_key[^0-9a-f][^0-9a-f]*\([0-9a-f]*\)..*/\1/'| sed 's/[{}]//g'`
 
 if [[ -z $api_key && ${api_key+x} ]] ; then
 		stop_err "Error getting API key for user $admin_user_email."


### PR DESCRIPTION
As mentioned on the mailing list:
https://lists.galaxyproject.org/pipermail/galaxy-dev/2015-June/022125.html
