### PR TITLE
update and clarify admin menu

### DIFF
--- a/lib/galaxy/web/base/controllers/admin.py
+++ b/lib/galaxy/web/base/controllers/admin.py
@@ -32,10 +32,10 @@ class Admin( object ):
         message = escape( kwd.get( 'message', ''  ) )
         status = kwd.get( 'status', 'done' )
         if trans.webapp.name == 'galaxy':
-            installed_repositories = trans.install_model.context.query( trans.install_model.ToolShedRepository ).first()
+            is_repo_installed = trans.install_model.context.query( trans.install_model.ToolShedRepository ).first() is not None
             installing_repository_ids = suc.get_ids_of_tool_shed_repositories_being_installed( trans.app, as_string=True )
             return trans.fill_template( '/webapps/galaxy/admin/index.mako',
-                                        installed_repositories=installed_repositories,
+                                        is_repo_installed=is_repo_installed,
                                         installing_repository_ids=installing_repository_ids,
                                         message=message,
                                         status=status )
@@ -50,7 +50,11 @@ class Admin( object ):
         message = escape( kwd.get( 'message', ''  ) )
         status = kwd.get( 'status', 'done' )
         if trans.webapp.name == 'galaxy':
+            is_repo_installed = trans.install_model.context.query( trans.install_model.ToolShedRepository ).first() is not None
+            installing_repository_ids = suc.get_ids_of_tool_shed_repositories_being_installed( trans.app, as_string=True )
             return trans.fill_template( '/webapps/galaxy/admin/center.mako',
+                                        is_repo_installed=is_repo_installed,
+                                        installing_repository_ids=installing_repository_ids,
                                         message=message,
                                         status=status )
         else:

--- a/templates/webapps/galaxy/admin/center.mako
+++ b/templates/webapps/galaxy/admin/center.mako
@@ -50,7 +50,7 @@ Please visit <a href="https://wiki.galaxyproject.org/Admin" target="_blank">the 
         <h4>Data</h4>
             <ul>
                 <li>
-                    <strong>Data libraries</strong> - Data libraries enable authorized Galaxy users to share datasets through with other groups or users. Only administrators can create data libraries. See <a href="https://wiki.galaxyproject.org/DataLibraries" target="_blank">wiki</a> for details and <a href="https://wiki.galaxyproject.org/Admin/DataLibraries/LibrarySecurity" target="_blank">this page</a> for security description.
+                    <strong>Data libraries</strong> - Data libraries enable authorized Galaxy users to share datasets with other groups or users. Only administrators can create data libraries. See <a href="https://wiki.galaxyproject.org/DataLibraries" target="_blank">wiki</a> for details and <a href="https://wiki.galaxyproject.org/Admin/DataLibraries/LibrarySecurity" target="_blank">this page</a> for security description.
                 </li>
                 <li>
                     <strong>Local data</strong> - Manage the reference (and other) data that is stored within Tool Data Tables. See <a href="https://wiki.galaxyproject.org/Admin/Tools/DataManagers" target="_blank">wiki</a> for details.

--- a/templates/webapps/galaxy/admin/center.mako
+++ b/templates/webapps/galaxy/admin/center.mako
@@ -11,16 +11,16 @@
         <h4>Repositories</h4>
             <ul>
                 <li>
-                    <strong>Search Tool Shed</strong> - Search and install new tools and other Galaxy utilities from the Tool Shed.
+                    <strong>Search Tool Shed</strong> - Search and install new tools and other Galaxy utilities from the Tool Shed. See <a href="https://wiki.galaxyproject.org/Admin/Tools/AddToolFromToolShedTutorial">the tutorial</a>.
                 </li>
                 <li>
-                    <strong>Monitor installing repositories</strong> - View the status of tools that are being currently installed <i>(Appears only if something from Tool Shed is installed)</i>
+                    <strong>Monitor installing repositories</strong> - View the status of tools that are being currently installed <i>(Appears only if something from Tool Shed is installed.)</i>
                 </li>
                 <li>
-                    <strong>Manage installed</strong> - View and administer installed tools and utilities on this Galaxy. <i>(Appears only if something from Tool Shed is installed)</i>
+                    <strong>Manage installed</strong> - View and administer installed tools and utilities on this Galaxy. <i>(Appears only if something from Tool Shed is installed.)</i>
                 </li>
                 <li>
-                    <strong>Reset metadata</strong> - Select on which repositories you want to reset metadata. <i>(Appears only if something from Tool Shed is installed)</i>
+                    <strong>Reset metadata</strong> - Select on which repositories you want to reset metadata. <i>(Appears only if something from Tool Shed is installed.)</i>
                 </li>
                 <li>
                     <strong>Download local tool</strong> - Download a tarball with a tool from this Galaxy.

--- a/templates/webapps/galaxy/admin/center.mako
+++ b/templates/webapps/galaxy/admin/center.mako
@@ -8,22 +8,53 @@ Please visit <a href="https://wiki.galaxyproject.org/Admin" target="_blank">the 
 %if message:
     ${render_msg( message, status )}
 %else:
-        <h4>Repositories</h4>
+        <h4>Server</h4>
             <ul>
+                <li>
+                    <strong>Data types registry</strong> - See all datatypes available in this Galaxy.
+                </li>
+                <li>
+                    <strong>Data tables registry</strong> - See all data tables available in this Galaxy.
+                </li>
+                <li>
+                    <strong>Display applications</strong> - See all display applications configured in this Galaxy.
+                </li>
+                <li>
+                    <strong>Manage jobs</strong> - Display all jobs that are currently not finished (i.e., their state is new, waiting, queued, or running).  Administrators are able to cleanly stop long-running jobs. 
+                </li>
+            </ul>
+
+        <h4>Tools and Tool Shed</h4>
+            <ul>
+            %if trans.app.tool_shed_registry and trans.app.tool_shed_registry.tool_sheds:
                 <li>
                     <strong>Search Tool Shed</strong> - Search and install new tools and other Galaxy utilities from the Tool Shed. See <a href="https://wiki.galaxyproject.org/Admin/Tools/AddToolFromToolShedTutorial" target="_blank">the tutorial</a>.
                 </li>
+            %endif
+            %if tool_shed_repository_ids:
                 <li>
-                    <strong>Monitor installing repositories</strong> - View the status of tools that are being currently installed <i>(Appears only if something from Tool Shed is installed.)</i>
+                    <strong>Monitor installing repositories</strong> - View the status of tools that are being currently installed.
+                </li>
+            %endif
+            %if is_repo_installed:
+                <li>
+                    <strong>Manage installed tools</strong> - View and administer installed tools and utilities on this Galaxy.
                 </li>
                 <li>
-                    <strong>Manage installed</strong> - View and administer installed tools and utilities on this Galaxy. <i>(Appears only if something from Tool Shed is installed.)</i>
+                    <strong>Reset metadata</strong> - Select on which repositories you want to reset metadata.
                 </li>
-                <li>
-                    <strong>Reset metadata</strong> - Select on which repositories you want to reset metadata. <i>(Appears only if something from Tool Shed is installed.)</i>
-                </li>
+            %endif
                 <li>
                     <strong>Download local tool</strong> - Download a tarball with a tool from this Galaxy.
+                </li>
+                <li>
+                    <strong>Reload a tool's configuration</strong> - Allows a new version of a tool to be loaded while the server is running.
+                </li>
+                <li>
+                    <strong>Tool lineage</strong> - A view of a version lineages for all installed tools. Useful for debugging.
+                </li>
+                <li>
+                    <strong>Review tool migration stages</strong> - See the list of migration stages that moved sets of tools from the distribution to the Tool Shed.
                 </li>
             </ul>
 
@@ -42,13 +73,20 @@ Please visit <a href="https://wiki.galaxyproject.org/Admin" target="_blank">the 
                 <li>
                     <strong>API keys</strong> - A view of all generated API keys with an option to re-generate.
                 </li>
+            %if trans.app.config.allow_user_impersonation:
                 <li>
-                    <strong>Impersonate a user</strong> - Allows to view Galaxy as another user in order to help troubleshoot issues. <i>(Appears only if allowed in the config.)</i>
+                    <strong>Impersonate a user</strong> - Allows to view Galaxy as another user in order to help troubleshoot issues.
                 </li>
+            %endif
             </ul>
 
         <h4>Data</h4>
             <ul>
+            %if trans.app.config.enable_quotas:
+                <li>
+                    <strong>Quotas</strong> - Manage user space quotas. See <a href="https://wiki.galaxyproject.org/Admin/DiskQuotas" target="_blank">wiki</a> for details.
+                </li>
+            %endif
                 <li>
                     <strong>Data libraries</strong> - Data libraries enable authorized Galaxy users to share datasets with other groups or users. Only administrators can create data libraries. See <a href="https://wiki.galaxyproject.org/DataLibraries" target="_blank">wiki</a> for details and <a href="https://wiki.galaxyproject.org/Admin/DataLibraries/LibrarySecurity" target="_blank">this page</a> for security description.
                 </li>
@@ -56,36 +94,17 @@ Please visit <a href="https://wiki.galaxyproject.org/Admin" target="_blank">the 
                     <strong>Local data</strong> - Manage the reference (and other) data that is stored within Tool Data Tables. See <a href="https://wiki.galaxyproject.org/Admin/Tools/DataManagers" target="_blank">wiki</a> for details.
                 </li>
             </ul>
-
-        <h4>Server</h4>
-            <ul>
-                <li>
-                    <strong>Data types registry</strong> - See all datatypes available in this Galaxy.
-                </li>
-                <li>
-                    <strong>Data tables registry</strong> - See all data tables available in this Galaxy.
-                </li>
-                <li>
-                    <strong>Display applications</strong> - See all display applications configured in this Galaxy.
-                </li>
-                <li>
-                    <strong>Manage jobs</strong> - Display all jobs that are currently not finished (i.e., their state is new, waiting, queued, or running).  Administrators are able to cleanly stop long-running jobs. 
-                </li>
-                <li>
-                    <strong>Reload a tool's configuration</strong> - Allows a new version of a tool to be loaded while the server is running.
-                </li>
-                <li>
-                    <strong>Tool lineage</strong> - A view of a version lineages for all installed tools. Useful for debugging.
-                </li>
-                <li>
-                    <strong>Review tool migration stages</strong> - See the list of migration stages that moved sets of tools from the distribution to the Tool Shed.
-                </li>
-            </ul>
-
         <h4>Form definitions</h4>
             <ul>
                 <li>
                     <strong>Form definitions</strong> - Manage local form definitions.
+                </li>
+            </ul>
+
+        <h4>Sample tracking</h4>
+            <ul>
+                <li>
+                    Please see the <a href="https://wiki.galaxyproject.org/Admin/DataLibraries/LibrarySampleTracking" target="_blank">sample tracking tutorial</a>.
                 </li>
             </ul>
 %endif

--- a/templates/webapps/galaxy/admin/center.mako
+++ b/templates/webapps/galaxy/admin/center.mako
@@ -8,185 +8,84 @@
 %if message:
     ${render_msg( message, status )}
 %else:
-    <p>The menu on the left provides the following features</p>
-    <ul>
-        <li><strong>Security</strong> - see the <strong>Data Security and Data Libraries</strong> section below for details
-            <p/>
+        <h4>Repositories</h4>
             <ul>
                 <li>
-                    <strong>Manage users</strong> - provides a view of the registered users and all groups and non-private roles associated 
-                    with each user.  
+                    <strong>Search Tool Shed</strong> - Search and install new tools and other Galaxy utilities from the Tool Shed.
                 </li>
-                <p/>
                 <li>
-                    <strong>Manage groups</strong> - provides a view of all groups along with the members of the group and the roles associated with
-                    each group (both private and non-private roles).  The group names include a link to a page that allows you to manage the users and 
-                    roles that are associated with the group.
+                    <strong>Monitor installing repositories</strong> - View the status of tools that are being currently installed <i>(Appears only if something from Tool Shed is installed)</i>
                 </li>
-                <p/>
                 <li>
-                    <strong>Manage roles</strong> - provides a view of all non-private roles along with the role type, and the users and groups that
-                    are associated with the role.  The role names include a link to a page that allows you to manage the users and groups that are associated 
-                    with the role.  The page also includes a view of the data library datasets that are associated with the role and the permissions applied 
-                    to each dataset.
+                    <strong>Manage installed</strong> - View and administer installed tools and utilities on this Galaxy. <i>(Appears only if something from Tool Shed is installed)</i>
+                </li>
+                <li>
+                    <strong>Reset metadata</strong> - Select on which repositories you want to reset metadata. <i>(Appears only if something from Tool Shed is installed)</i>
+                </li>
+                <li>
+                    <strong>Download local tool</strong> - Download a tarball with a tool from this Galaxy.
                 </li>
             </ul>
-        </li>
-        <p/>
-        <li><strong>Data</strong>
-            <p/>
+
+        <h4>Security</h4>
             <ul>
                 <li>
-                    <strong>Manage data libraries</strong> - Data libraries enable a Galaxy administrator to upload datasets into a data library.  Currently,
-                    only administrators can create data libraries.
-                    <p/>
-                    When a data library is first created, it is considered "public" since it will be displayed in the "Data Libraries" view for any user, even 
-                    those that are not logged in.  The Galaxy administrator can restrict access to a data library by associating roles with the data library's 
-                    "access library" permission.  This permission will conservatively override the [dataset] "access" permission for the data library's contained 
-                    datasets.
-                    <p/>
-                    For example, if a data library's "access library" permission is associated with Role1 and the data library contains "public" datasets, the 
-                    data library will still only be displayed to those users that have Role1.  However, if the data library's "access library" permission is 
-                    associated with both Role1 and Role2 and the data library contains datasets whose [dataset] "access" permission is associated with only Role1, 
-                    then users that have Role2 will be able to access the library, but will not see those contained datasets whose [dataset] "access" permission 
-                    is associated with only Role1.
-                    <p/>
-                    In addition to the "access library" permission, permission to perform the following functions on the data library (and its contents) can 
-                    be granted to users (a library item is one of: a data library, a library folder, a library dataset).
-                    <p/>
-                    <ul>
-                        <li><strong>add library item</strong> - Users that have the role can add library items to this data library or folder</li>
-                        <li><strong>modify library item</strong> - Users that have the role can modify this library item</li>
-                        <li><strong>manage library permissions</strong> - Users that have the role can manage permissions applied to this library item</li>
-                    </ul>
-                    <p/>
-                    The default behavior is for no permissions to be applied to a data library item, but applied permissions are inherited downward (with the exception
-                    of the "access library" permission, which is only available on the data library itself).  Because of this, it is important to set desired permissions 
-                    on a new data library when it is created.  When this is done, new folders and datasets added to the data library will automatically inherit those 
-                    permissions.  In the same way, permissions can be applied to a folder, which will be automatically inherited by all contained datasets and sub-folders.
-                    <p/>
-                    The "Data Libraries" menu item allows users to access the datasets in a data library as long as they are not restricted from accessing them.
-                    Importing a library dataset into a history will not make a copy of the dataset, but will be a "pointer" to the dataset on disk.  This
-                    approach allows for multiple users to use a single (possibly very large) dataset file.
+                    <strong>Users</strong> - A view of all users and all groups and non-private roles associated with each user.  
+                </li>
+                <li>
+                    <strong>Groups</strong> - A view of all groups along with the members of the group and the roles associated with each group.
+                </li>
+                <li>
+                    <strong>Roles</strong> - A view of all non-private roles along with the role type, and the users and groups that are associated with the role.
+                    Also includes a view of the data library datasets that are associated with the role and the permissions applied to each dataset.
+                </li>
+                <li>
+                    <strong>API keys</strong> - A view of all generated API keys with an option to re-generate.
+                </li>
+                <li>
+                    <strong>Impersonate a user</strong> - Allows to view Galaxy as another user in order to help troubleshoot issues. <i>(Appears only if allowed in the config.)</i>
                 </li>
             </ul>
-        </li>
-        <p/>
-        <li><strong>Server</strong>
-            <p/>
+
+        <h4>Data</h4>
             <ul>
                 <li>
-                    <strong>Reload a tool's configuration</strong> - allows a new version of a tool to be loaded while the server is running
+                    <strong>Data libraries</strong> - Data libraries enable authorized Galaxy users to share datasets through with other groups or users. Only administrators can create data libraries. See <a href="https://wiki.galaxyproject.org/DataLibraries">wiki</a> for details and <a href="https://wiki.galaxyproject.org/Admin/DataLibraries/LibrarySecurity">this page</a> for security description.
                 </li>
-                <p/>
                 <li>
-                    <strong>Profile memory usage</strong> - measures system memory used for certain Galaxy functions
-                </li>
-                <p/>
-                <li>
-                    <strong>Manage jobs</strong> - displays all jobs that are currently not finished (i.e., their state is new, waiting, queued, or
-                    running).  Administrators are able to cleanly stop long-running jobs. 
+                    <strong>Local data</strong> - Manage the reference (and other) data that is stored within Tool Data Tables. See <a href="https://wiki.galaxyproject.org/Admin/Tools/DataManagers">wiki</a> for details.
                 </li>
             </ul>
-        </li>
-        <p/>
-        <li><strong>Forms</strong>
-            <p/>To be completed
-        </li>
-        <p/>
-        <li><strong>Sequencing Requests</strong>
-            <p/>To be completed
-        </li>
-        <p/>
-        <li><strong>Cloud</strong>
-            <p/>To be completed
-        </li>
-    </ul>
-    <p/>
-    <p><strong>Data Security and Data Libraries</strong></p>
-    <p/>
-    <strong>Security</strong> - Data security in Galaxy is a new feature, so familiarize yourself with the details which can be found 
-    here or in our <a href="http://wiki.galaxyproject.org/Learn/Security%20Features" target="_blank">data security page</a>.  The data security 
-    process incorporates users, groups and roles, and enables the application of certain permissions on datasets, specifically "access"
-    and "manage permissions".  By default, the "manage permissions" permission is associated with the dataset owner's private role, and
-    the "access" permission is not set, making the dataset public.  With these default permissions, users should not see any difference
-    in the way Galaxy has behaved in the past.
-    <ul>
-        <li>
-            <strong>Users</strong> - registered Galaxy users that have created a Galaxy account.  Users can belong to groups and can
-            be associated with 1 or more roles.  If a user is not authenticated during a Galaxy session, they will not have access to any 
-            of the security features, and datasets they create during that session will have no permissions applied to them (i.e., they
-            will be considered "public", and no one will be allowed to change permissions on them).
-        </li>
-        <p/>
-        <li>
-            <strong>Groups</strong> - a set of 0 or more users which are considered members of the group.  Groups can be associated with 0
-            or more roles, simplifying the process of applying permissions to the data between a select group of users.
-        </li>
-        <p/>
-        <li>
-            <strong>Roles</strong> - associate users and groups with specific permissions on datasets.  For example, users in groups A and B 
-            can be associated with role C which gives them the "access" permission on datasets D, E and F.  Roles have a type which is currently
-            one of the following:
+
+        <h4>Server</h4>
             <ul>
                 <li>
-                    <strong>private</strong> - every user is associated automatically with their own private role.  Administrators cannot 
-                    manage private roles.
+                    <strong>Data types registry</strong> - See all datatypes available in this Galaxy.
                 </li>
                 <li>
-                    <strong>user</strong> - this is currently not used, but eventually any registered user will be able to create a new role
-                    and this will be its type.
+                    <strong>Data tables registry</strong> - See all data tables available in this Galaxy.
                 </li>
                 <li>
-                    <strong>sharing</strong> - a role created automatically during a Galaxy session that enables a user to share data with 
-                    another user.  This can generally be considered a temporary role.
+                    <strong>Display applications</strong> - See all display applications configured in this Galaxy.
                 </li>
-                <li><strong>admin</strong> - a role created by a Galaxy administrator.</li>
+                <li>
+                    <strong>Manage jobs</strong> - Display all jobs that are currently not finished (i.e., their state is new, waiting, queued, or running).  Administrators are able to cleanly stop long-running jobs. 
+                </li>
+                <li>
+                    <strong>Reload a tool's configuration</strong> - Allows a new version of a tool to be loaded while the server is running.
+                </li>
+                <li>
+                    <strong>Tool lineage</strong> - A view of a version lineages for all installed tools. Useful for debugging.
+                </li>
+                <li>
+                    <strong>Review tool migration stages</strong> - See the list of migration stages that moved sets of tools from the distribution to the Tool Shed.
+                </li>
             </ul>
-        </li>
-        <p/>
-        <li>
-            <strong>Dataset Permissions</strong> - applying the following permissions will to a dataset will result in the behavior described.
+
+        <h4>Form definitions</h4>
             <ul>
                 <li>
-                    <strong>access</strong> - users associated with the role can import this dataset into their history for analysis.
-                    <p>
-                        If no roles with the "access" permission are associated with a dataset, the dataset is "public" and may be accessed by anyone 
-                        that can access the data library in which it is contained.  See the <strong>Manage data libraries</strong> section above for 
-                        details.  Public datasets contained in public data libraries will be accessible to all users (as well as anyone not logged in 
-                        during a Galaxy session) from the list of data libraries displayed when the "Data Libraries" menu item is selected.
-                    </p>
-                    <p>
-                        Associating a dataset with a role that includes the "access" permission restricts the set of users that can access it.  
-                        For example, if 'Role A' includes the "access" permission and 'Role A' is associated with the dataset, only those users
-                        and groups who are associated with 'Role A' may access the dataset.
-                    </p>
-                    <p>
-                        If multiple roles that include the "access" permission are associated with a dataset, access to the dataset is derived
-                        from the intersection of the users associated with the roles.  For example, if 'Role A' and 'Role B' are associated with
-                        a dataset, only those users and groups who are associated with both 'Role A' AND 'Role B' may access the dataset.  When
-                        the "access" permission is applied to a dataset, Galaxy checks to make sure that at least 1 user belongs to all groups and
-                        roles associated with the "access" permission (otherwise the dataset would be restricted from everyone).
-                    </p>
-                    <p>
-                        In order for a user to make a dataset private (i.e., only they can access it), they should associate the dataset with
-                        their private role (the role identical to their Galaxy user name / email address).  Associating additional roles that
-                        include the "access" permission is not possible, since it would render the dataset inaccessible to everyone.
-                    <p>
-                        To make a dataset private to themselves and one or more other users, the user can create a new role and associate the dataset 
-                        with that role, not their "private role".  Galaxy makes this easy by telling the user they are about to share a private dataset 
-                        and giving them the option of doing so.  If they respond positively, the sharing role is automatically created for them.
-                    </p>
-                    <p>
-                        Private data (data associated with roles that include the "access" permission) must be made public in order to be used
-                        with external applications like the "view at UCSC" link, or the "Perform genome analysis and prediction with EpiGRAPH" 
-                        tool.  Being made publically accessible means removing the association of all roles that include the "access" permission
-                        from the dataset.
-                    <p>
+                    <strong>Form definitions</strong> - Manage local form definitions.
                 </li>
-                <li><strong>manage permissions</strong> - Role members can manage the permissions applied to this dataset</li>
             </ul>
-        </li>
-    </ul>
-    <br/>
 %endif

--- a/templates/webapps/galaxy/admin/center.mako
+++ b/templates/webapps/galaxy/admin/center.mako
@@ -4,14 +4,14 @@
 <%def name="title()">Galaxy Administration</%def>
 
 <h2>Administration</h2>
-
+Please visit <a href="https://wiki.galaxyproject.org/Admin" target="_blank">the Galaxy administration hub</a> to learn how to keep your Galaxy in best shape.
 %if message:
     ${render_msg( message, status )}
 %else:
         <h4>Repositories</h4>
             <ul>
                 <li>
-                    <strong>Search Tool Shed</strong> - Search and install new tools and other Galaxy utilities from the Tool Shed. See <a href="https://wiki.galaxyproject.org/Admin/Tools/AddToolFromToolShedTutorial">the tutorial</a>.
+                    <strong>Search Tool Shed</strong> - Search and install new tools and other Galaxy utilities from the Tool Shed. See <a href="https://wiki.galaxyproject.org/Admin/Tools/AddToolFromToolShedTutorial" target="_blank">the tutorial</a>.
                 </li>
                 <li>
                     <strong>Monitor installing repositories</strong> - View the status of tools that are being currently installed <i>(Appears only if something from Tool Shed is installed.)</i>
@@ -50,10 +50,10 @@
         <h4>Data</h4>
             <ul>
                 <li>
-                    <strong>Data libraries</strong> - Data libraries enable authorized Galaxy users to share datasets through with other groups or users. Only administrators can create data libraries. See <a href="https://wiki.galaxyproject.org/DataLibraries">wiki</a> for details and <a href="https://wiki.galaxyproject.org/Admin/DataLibraries/LibrarySecurity">this page</a> for security description.
+                    <strong>Data libraries</strong> - Data libraries enable authorized Galaxy users to share datasets through with other groups or users. Only administrators can create data libraries. See <a href="https://wiki.galaxyproject.org/DataLibraries" target="_blank">wiki</a> for details and <a href="https://wiki.galaxyproject.org/Admin/DataLibraries/LibrarySecurity" target="_blank">this page</a> for security description.
                 </li>
                 <li>
-                    <strong>Local data</strong> - Manage the reference (and other) data that is stored within Tool Data Tables. See <a href="https://wiki.galaxyproject.org/Admin/Tools/DataManagers">wiki</a> for details.
+                    <strong>Local data</strong> - Manage the reference (and other) data that is stored within Tool Data Tables. See <a href="https://wiki.galaxyproject.org/Admin/Tools/DataManagers" target="_blank">wiki</a> for details.
                 </li>
             </ul>
 

--- a/templates/webapps/galaxy/admin/index.mako
+++ b/templates/webapps/galaxy/admin/index.mako
@@ -46,13 +46,30 @@
     <div class="unified-panel-body">
         <div class="toolMenu">
             <div class="toolSectionList">
+                    <div class="toolSectionTitle">Repositories</div>
+                    <div class="toolSectionBody">
+                        <div class="toolSectionBg">                        
+                        %if trans.app.tool_shed_registry and trans.app.tool_shed_registry.tool_sheds:
+                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='browse_tool_sheds' )}" target="galaxy_main">Search Tool Shed</a></div>
+                        %endif
+                        %if installing_repository_ids:
+                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='monitor_repository_installation', tool_shed_repository_ids=installing_repository_ids )}" target="galaxy_main">Monitor installing repositories</a></div>
+                        %endif
+                        %if installed_repositories:
+                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='browse_repositories' )}" target="galaxy_main">Manage installed</a></div>
+                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='reset_metadata_on_selected_installed_repositories' )}" target="galaxy_main">Reset metadata</a></div>
+                        %endif
+                            <div class="toolTitle"><a href="${h.url_for( controller='admin', action='package_tool' )}" target="galaxy_main">Download local tools</a></div>
+                        </div>
+                    </div>
+                <div class="toolSectionPad"></div>
                 <div class="toolSectionTitle">Security</div>
                 <div class="toolSectionBody">
                     <div class="toolSectionBg">
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='users' )}" target="galaxy_main">Manage users</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='groups' )}" target="galaxy_main">Manage groups</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='roles' )}" target="galaxy_main">Manage roles</a></div>
-			            <div class="toolTitle"><a href="${h.url_for( controller='userskeys', action='all_users' )}" target="galaxy_main">Manage users API keys</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='users' )}" target="galaxy_main">Users</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='groups' )}" target="galaxy_main">Groups</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='roles' )}" target="galaxy_main">Roles</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='userskeys', action='all_users' )}" target="galaxy_main">API keys</a></div>
                         %if trans.app.config.allow_user_impersonation:
                             <div class="toolTitle"><a href="${h.url_for( controller='admin', action='impersonate' )}" target="galaxy_main">Impersonate a user</a></div>
                         %endif
@@ -63,55 +80,38 @@
                 <div class="toolSectionBody">
                     <div class="toolSectionBg">
                         %if trans.app.config.enable_quotas:
-                            <div class="toolTitle"><a href="${h.url_for( controller='admin', action='quotas' )}" target="galaxy_main">Manage quotas</a></div>
+                            <div class="toolTitle"><a href="${h.url_for( controller='admin', action='quotas' )}" target="galaxy_main">Quotas</a></div>
                         %endif
-                        <div class="toolTitle"><a href="${h.url_for( controller='library_admin', action='browse_libraries' )}" target="galaxy_main">Manage data libraries</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='data_manager' )}" target="galaxy_main">Manage local data (beta)</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='library_admin', action='browse_libraries' )}" target="galaxy_main">Data libraries</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='data_manager' )}" target="galaxy_main">Local data</a></div>
                     </div>
                 </div>
                 <div class="toolSectionPad"></div>
                 <div class="toolSectionTitle">Server</div>
                 <div class="toolSectionBody">
                     <div class="toolSectionBg">
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='view_datatypes_registry' )}" target="galaxy_main">View data types registry</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='view_tool_data_tables' )}" target="galaxy_main">View data tables registry</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='display_applications' )}" target="galaxy_main">View display applications</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='tool_versions' )}" target="galaxy_main">View tool lineage</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='package_tool' )}" target="galaxy_main">Download tool tarball</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='reload_tool' )}" target="galaxy_main">Reload a tool's configuration</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='view_datatypes_registry' )}" target="galaxy_main">Data types registry</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='view_tool_data_tables' )}" target="galaxy_main">Data tables registry</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='display_applications' )}" target="galaxy_main">Display applications</a></div>
                         <div class="toolTitle"><a href="${h.url_for( controller='admin', action='jobs' )}" target="galaxy_main">Manage jobs</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='tool_versions' )}" target="galaxy_main">Tool lineage</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='reload_tool' )}" target="galaxy_main">Reload a tool's configuration</a></div>
                         <div class="toolTitle"><a href="${h.url_for( controller='admin', action='review_tool_migration_stages' )}" target="galaxy_main">Review tool migration stages</a></div>
-                        %if installing_repository_ids:
-                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='monitor_repository_installation', tool_shed_repository_ids=installing_repository_ids )}" target="galaxy_main">Monitor installing tool shed repositories</a></div>
-                        %endif
-                        %if installed_repositories:
-                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='reset_metadata_on_selected_installed_repositories' )}" target="galaxy_main">Reset metadata for tool shed repositories</a></div>
-                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='browse_repositories' )}" target="galaxy_main">Manage installed tool shed repositories</a></div>
-                        %endif
                     </div>
                 </div>
-                %if trans.app.tool_shed_registry and trans.app.tool_shed_registry.tool_sheds:
-                    <div class="toolSectionPad"></div>
-                    <div class="toolSectionTitle">Tool sheds</div>
-                    <div class="toolSectionBody">
-                        <div class="toolSectionBg">                        
-                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='browse_tool_sheds' )}" target="galaxy_main">Search and browse tool sheds</a></div>
-                        </div>
-                    </div>
-                %endif
                 <div class="toolSectionPad"></div>
                 <div class="toolSectionTitle">Form Definitions</div>
                 <div class="toolSectionBody">
                     <div class="toolSectionBg">
-                        <div class="toolTitle"><a href="${h.url_for( controller='forms', action='browse_form_definitions' )}" target="galaxy_main">Manage form definitions</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='forms', action='browse_form_definitions' )}" target="galaxy_main">Form definitions</a></div>
                     </div>
                 </div>
                 <div class="toolSectionPad"></div>
                 <div class="toolSectionTitle">Sample Tracking</div>
                 <div class="toolSectionBody">
                     <div class="toolSectionBg">
-                        <div class="toolTitle"><a href="${h.url_for( controller='external_service', action='browse_external_services' )}" target="galaxy_main">Manage sequencers and external services</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='request_type', action='browse_request_types' )}" target="galaxy_main">Manage request types</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='external_service', action='browse_external_services' )}" target="galaxy_main">Sequencers and external services</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='request_type', action='browse_request_types' )}" target="galaxy_main">Request types</a></div>
                         <div class="toolTitle"><a href="${h.url_for( controller='requests_admin', action='browse_requests' )}" target="galaxy_main">Sequencing requests</a></div>
                         <div class="toolTitle"><a href="${h.url_for( controller='requests_common', action='find_samples', cntrller='requests_admin' )}" target="galaxy_main">Find samples</a></div>
                     </div>

--- a/templates/webapps/galaxy/admin/index.mako
+++ b/templates/webapps/galaxy/admin/index.mako
@@ -46,22 +46,35 @@
     <div class="unified-panel-body">
         <div class="toolMenu">
             <div class="toolSectionList">
-                    <div class="toolSectionTitle">Repositories</div>
-                    <div class="toolSectionBody">
-                        <div class="toolSectionBg">                        
-                        %if trans.app.tool_shed_registry and trans.app.tool_shed_registry.tool_sheds:
-                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='browse_tool_sheds' )}" target="galaxy_main">Search Tool Shed</a></div>
-                        %endif
-                        %if installing_repository_ids:
-                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='monitor_repository_installation', tool_shed_repository_ids=installing_repository_ids )}" target="galaxy_main">Monitor installing repositories</a></div>
-                        %endif
-                        %if installed_repositories:
-                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='browse_repositories' )}" target="galaxy_main">Manage installed</a></div>
-                            <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='reset_metadata_on_selected_installed_repositories' )}" target="galaxy_main">Reset metadata</a></div>
-                        %endif
-                            <div class="toolTitle"><a href="${h.url_for( controller='admin', action='package_tool' )}" target="galaxy_main">Download local tool</a></div>
-                        </div>
+                <div class="toolSectionTitle">Server</div>
+                <div class="toolSectionBody">
+                    <div class="toolSectionBg">
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='view_datatypes_registry' )}" target="galaxy_main">Data types registry</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='view_tool_data_tables' )}" target="galaxy_main">Data tables registry</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='display_applications' )}" target="galaxy_main">Display applications</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='jobs' )}" target="galaxy_main">Manage jobs</a></div>
                     </div>
+                </div>
+                <div class="toolSectionPad"></div>
+                <div class="toolSectionTitle">Tools and Tool Shed</div>
+                <div class="toolSectionBody">
+                    <div class="toolSectionBg">                        
+                    %if trans.app.tool_shed_registry and trans.app.tool_shed_registry.tool_sheds:
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='browse_tool_sheds' )}" target="galaxy_main">Search Tool Shed</a></div>
+                    %endif
+                    %if installing_repository_ids:
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='monitor_repository_installation', tool_shed_repository_ids=installing_repository_ids )}" target="galaxy_main">Monitor installing repositories</a></div>
+                    %endif
+                    %if is_repo_installed:
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='browse_repositories' )}" target="galaxy_main">Manage installed tools</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='reset_metadata_on_selected_installed_repositories' )}" target="galaxy_main">Reset metadata</a></div>
+                    %endif
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='package_tool' )}" target="galaxy_main">Download local tool</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='tool_versions' )}" target="galaxy_main">Tool lineage</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='reload_tool' )}" target="galaxy_main">Reload a tool's configuration</a></div>
+                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='review_tool_migration_stages' )}" target="galaxy_main">Review tool migration stages</a></div>
+                    </div>
+                </div>
                 <div class="toolSectionPad"></div>
                 <div class="toolSectionTitle">Security</div>
                 <div class="toolSectionBody">
@@ -84,19 +97,6 @@
                         %endif
                         <div class="toolTitle"><a href="${h.url_for( controller='library_admin', action='browse_libraries' )}" target="galaxy_main">Data libraries</a></div>
                         <div class="toolTitle"><a href="${h.url_for( controller='data_manager' )}" target="galaxy_main">Local data</a></div>
-                    </div>
-                </div>
-                <div class="toolSectionPad"></div>
-                <div class="toolSectionTitle">Server</div>
-                <div class="toolSectionBody">
-                    <div class="toolSectionBg">
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='view_datatypes_registry' )}" target="galaxy_main">Data types registry</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='view_tool_data_tables' )}" target="galaxy_main">Data tables registry</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='display_applications' )}" target="galaxy_main">Display applications</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='jobs' )}" target="galaxy_main">Manage jobs</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='tool_versions' )}" target="galaxy_main">Tool lineage</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='reload_tool' )}" target="galaxy_main">Reload a tool's configuration</a></div>
-                        <div class="toolTitle"><a href="${h.url_for( controller='admin', action='review_tool_migration_stages' )}" target="galaxy_main">Review tool migration stages</a></div>
                     </div>
                 </div>
                 <div class="toolSectionPad"></div>

--- a/templates/webapps/galaxy/admin/index.mako
+++ b/templates/webapps/galaxy/admin/index.mako
@@ -59,7 +59,7 @@
                             <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='browse_repositories' )}" target="galaxy_main">Manage installed</a></div>
                             <div class="toolTitle"><a href="${h.url_for( controller='admin_toolshed', action='reset_metadata_on_selected_installed_repositories' )}" target="galaxy_main">Reset metadata</a></div>
                         %endif
-                            <div class="toolTitle"><a href="${h.url_for( controller='admin', action='package_tool' )}" target="galaxy_main">Download local tools</a></div>
+                            <div class="toolTitle"><a href="${h.url_for( controller='admin', action='package_tool' )}" target="galaxy_main">Download local tool</a></div>
                         </div>
                     </div>
                 <div class="toolSectionPad"></div>


### PR DESCRIPTION
Reordered admin menu (the most important link is now the first one), updated the admin menu description to reflect the actual structure, included a bullet for features that we added in past years, and shortened the description of data libraries (moved to wiki that is linked).

![screenshot 2015-06-01 10 27 33](https://cloud.githubusercontent.com/assets/1814954/7915110/58489dac-0849-11e5-88b6-542c88d7855c.png)
