### PR TITLE
fix shared mako templates that would not work properly with TS

### DIFF
--- a/templates/export_base.mako
+++ b/templates/export_base.mako
@@ -6,10 +6,12 @@
     def inherit(context):
         if context.get('use_panels', False) == True:
             if context.get('webapp'):
-                webapp = context.get('webapp')
+                app_name = context.get('webapp')
+            elif context.get('app'):
+                app_name = context.get('app').name
             else:
-                webapp = 'galaxy'
-            return '/webapps/%s/base_panels.mako' % webapp
+                app_name = 'galaxy'
+            return '/webapps/%s/base_panels.mako' % app_name
         else:
             return '/base.mako'
 %>

--- a/templates/form.mako
+++ b/templates/form.mako
@@ -2,10 +2,12 @@
     def inherit(context):
         if context.get('use_panels'):
             if context.get('webapp'):
-                webapp = context.get('webapp')
+                app_name = context.get('webapp')
+            elif context.get('app'):
+                app_name = context.get('app').name
             else:
-                webapp = 'galaxy'
-            return '/webapps/%s/base_panels.mako' % webapp
+                app_name = 'galaxy'
+            return '/webapps/%s/base_panels.mako' % app_name
         else:
             return '/base.mako'
 %>

--- a/templates/grid_base.mako
+++ b/templates/grid_base.mako
@@ -9,10 +9,12 @@
 
         if context.get('use_panels'):
             if context.get('webapp'):
-                webapp = context.get('webapp')
+                app_name = context.get('webapp')
+            elif context.get('app'):
+                app_name = context.get('app').name
             else:
-                webapp = 'galaxy'
-            return '/webapps/%s/base_panels.mako' % webapp
+                app_name = 'galaxy'
+            return '/webapps/%s/base_panels.mako' % app_name
         else:
             return '/base.mako'
 %>

--- a/templates/ind_share_base.mako
+++ b/templates/ind_share_base.mako
@@ -6,10 +6,12 @@
     def inherit(context):
         if context.get('use_panels'):
             if context.get('webapp'):
-                webapp = context.get('webapp')
+                app_name = context.get('webapp')
+            elif context.get('app'):
+                app_name = context.get('app').name
             else:
-                webapp = 'galaxy'
-            return '/webapps/%s/base_panels.mako' % webapp
+                app_name = 'galaxy'
+            return '/webapps/%s/base_panels.mako' % app_name
         else:
             return '/base.mako'
 %>

--- a/templates/message.mako
+++ b/templates/message.mako
@@ -2,10 +2,12 @@
     def inherit(context):
         if context.get('use_panels'):
             if context.get('webapp'):
-                webapp = context.get('webapp')
+                app_name = context.get('webapp')
+            elif context.get('app'):
+                app_name = context.get('app').name
             else:
-                webapp = 'galaxy'
-            return '/webapps/%s/base_panels.mako' % webapp
+                app_name = 'galaxy'
+            return '/webapps/%s/base_panels.mako' % app_name
         else:
             return '/base.mako'
 %>

--- a/templates/sharing_base.mako
+++ b/templates/sharing_base.mako
@@ -6,10 +6,12 @@
     def inherit(context):
         if context.get('use_panels', False) == True:
             if context.get('webapp'):
-                webapp = context.get('webapp')
+                app_name = context.get('webapp')
+            elif context.get('app'):
+                app_name = context.get('app').name
             else:
-                webapp = 'galaxy'
-            return '/webapps/%s/base_panels.mako' % webapp
+                app_name = 'galaxy'
+            return '/webapps/%s/base_panels.mako' % app_name
         else:
             return '/base.mako'
 %>


### PR DESCRIPTION
by also looking for 'app' within context when 'webapp' is not present
and defaulting to 'galaxy' afterwards

This bug would e.g. load Galaxy masthead if you link TS page with `use_panels=true`
