### PR TITLE
[15.05] Mark also HDAs as purged when purging datasets via cleanup script.

### DIFF
--- a/scripts/cleanup_datasets/cleanup_datasets.py
+++ b/scripts/cleanup_datasets/cleanup_datasets.py
@@ -460,8 +460,10 @@ def _purge_dataset( app, dataset, remove_from_disk, info_only = False ):
                             shutil.rmtree( dataset.extra_files_path ) #we need to delete the directory and its contents; os.unlink would always fail on a directory
                         usage_users = []
                         for hda in dataset.history_associations:
-                            if not hda.purged and hda.history.user is not None and hda.history.user not in usage_users:
-                                usage_users.append( hda.history.user )
+                            if not hda.purged:
+                                hda.purged = True
+                                if hda.history.user is not None and hda.history.user not in usage_users:
+                                    usage_users.append( hda.history.user )
                         for user in usage_users:
                             user.total_disk_usage -= dataset.total_size
                             app.sa_session.add( user )


### PR DESCRIPTION
This will make purged datasets be shown as purged in histories, preventing them to be undeleted through the UI.
This will not fix datasets previously purged through this script, `scripts/cleanup_datasets/pgcleanup.py` may be used for that.

Reviewed by @Unode and @natefoo on IRC.
