### PR TITLE
Fixed a typo error in visualization/plugins/resource_parser.py

### DIFF
--- a/lib/galaxy/visualization/plugins/resource_parser.py
+++ b/lib/galaxy/visualization/plugins/resource_parser.py
@@ -23,7 +23,7 @@ class ResourceParser( object ):
     in a new dictionary.
 
     The keys used to store the new values can optionally be re-mapped to
-    new keys (e.g. dataset_id="NNN" -> hda=<HistoryDatasetAsscoation>).
+    new keys (e.g. dataset_id="NNN" -> hda=<HistoryDatasetAssociation>).
     """
     primitive_parsers = {
         'str'   : lambda param: galaxy.util.sanitize_html.sanitize_html( param, 'utf-8' ),


### PR DESCRIPTION
#### Description of why the change should be made.

For readibility purpose.
#### Description of implementation of the change.

Juste changed a word in the ResourceParser class comment, in Visualization/Plugins :smile: 
#### Description of how to test the change.

No need, it's a comment.
