### PR TITLE
[15.05] API, HDAs/Datasets: re-add file_name to detailed serializatio…

### DIFF
--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -258,7 +258,6 @@ class HDASerializer( # datasets._UnflattenedMetadataDatasetAssociationSerializer
             # remapped
             'genome_build', 'misc_info', 'misc_blurb',
             'file_ext', 'file_size',
-            'file_path',
 
             'create_time', 'update_time',
             'resubmitted',
@@ -267,6 +266,7 @@ class HDASerializer( # datasets._UnflattenedMetadataDatasetAssociationSerializer
 
             'uuid',
             'permissions',
+            'file_name',
 
             'display_apps',
             'display_types',

--- a/test/unit/managers/test_HDAManager.py
+++ b/test/unit/managers/test_HDAManager.py
@@ -436,6 +436,36 @@ class HDASerializerTestCase( HDATestCase ):
         self.log( 'serialized should jsonify well' )
         self.assertIsJsonifyable( serialized )
 
+    def test_file_name_serializers( self ):
+        hda = self._create_vanilla_hda()
+        owner = hda.history.user
+        keys = [ 'file_name' ]
+
+        self.log( 'file_name should be included if app configured to do so' )
+        # this is on by default in galaxy_mock
+        self.assertTrue( self.app.config.expose_dataset_path )
+        # ... so non-admin user CAN get file_name
+        serialized = self.hda_serializer.serialize( hda, keys, user=None )
+        self.assertTrue( 'file_name' in serialized )
+        serialized = self.hda_serializer.serialize( hda, keys, user=owner )
+        self.assertTrue( 'file_name' in serialized )
+
+        self.log( 'file_name should be skipped for non-admin when not exposed by config' )
+        self.app.config.expose_dataset_path = False
+        serialized = self.hda_serializer.serialize( hda, keys, user=None )
+        self.assertFalse( 'file_name' in serialized )
+        serialized = self.hda_serializer.serialize( hda, keys, user=owner )
+        self.assertFalse( 'file_name' in serialized )
+
+        self.log( 'file_name should be sent for admin in either case' )
+        serialized = self.hda_serializer.serialize( hda, keys, user=self.admin_user )
+        self.assertTrue( 'file_name' in serialized )
+        self.app.config.expose_dataset_path = True
+        serialized = self.hda_serializer.serialize( hda, keys, user=self.admin_user )
+        self.assertTrue( 'file_name' in serialized )
+
+        # TODO: test extra_files_path as well
+
 
 # =============================================================================
 class HDADeserializerTestCase( HDATestCase ):


### PR DESCRIPTION
…n for admin users (resolve #313)

(This also flips 'file_path' back to 'file_name' as the key used to serialize the object store file path used).
