### PR TITLE
Add app option to client/GruntFile and allow building toolshed scripts

### DIFF
--- a/client/GruntFile.js
+++ b/client/GruntFile.js
@@ -1,7 +1,26 @@
 module.exports = function(grunt) {
     "use strict";
 
+    var GALAXY_PATHS = {
+            dist        : '../static/scripts',
+            maps        : '../static/maps',
+            // this symlink allows us to serve uncompressed scripts in DEV_PATH for use with sourcemaps
+            srcSymlink  : '../static/src',
+        },
+        TOOLSHED_PATHS = {
+            dist        : '../static/toolshed/scripts',
+            maps        : '../static/toolshed/maps',
+            srcSymlink  : '../static/toolshed/src',
+        };
+
+    grunt.config.set( 'app', 'galaxy' );
+    grunt.config.set( 'paths', GALAXY_PATHS );
+    if( grunt.option( 'app' ) === 'toolshed' ){
+	    grunt.config.set( 'app', grunt.option( 'app' ) );
+	    grunt.config.set( 'paths', TOOLSHED_PATHS );
+    }
+
     // see the sub directory grunt-tasks/ for individual task definitions
     grunt.loadTasks( 'grunt-tasks' );
-    grunt.registerTask( 'default', [ 'uglify' ] );
+    grunt.registerTask( 'default', [ 'uglify:galaxy' ] );
 };

--- a/client/GruntFile.js
+++ b/client/GruntFile.js
@@ -22,5 +22,5 @@ module.exports = function(grunt) {
 
     // see the sub directory grunt-tasks/ for individual task definitions
     grunt.loadTasks( 'grunt-tasks' );
-    grunt.registerTask( 'default', [ 'uglify:galaxy' ] );
+    grunt.registerTask( 'default', [ 'uglify' ] );
 };

--- a/client/README.md
+++ b/client/README.md
@@ -69,3 +69,13 @@ version, you'll need to use the full, local path when calling it:
     ./node_modules/.bin/grunt
     # or
     ./node_modules/.bin/grunt watch
+
+
+The Toolshed Client Build
+=========================
+
+The commands mentioned above in 'Rebuilding' and 'Grunt watch' also can be applied to toolshed scripts by using the
+`--app=toolshed` option:
+
+	grunt watch --app=toolshed
+	grunt --app=toolshed

--- a/client/toolshed/scripts/test-file.js
+++ b/client/toolshed/scripts/test-file.js
@@ -1,0 +1,3 @@
+define( [], function() {
+	return 'Remove this file';
+});

--- a/static/toolshed/src
+++ b/static/toolshed/src
@@ -1,0 +1,1 @@
+../../client/toolshed/scripts/


### PR DESCRIPTION
You can now do all the client/grunt commands available for the galaxy app for a similar toolshed app:
  grunt --app=toolshed
  grunt decompress --app=toolshed
  grunt watch --app=toolshed

@marten and I thought the following directories would work for the toolshed scripts:
  client/toolshed/scripts (edit here)
  static/toolshed/scripts (minified)
  static/toolshed/maps (source maps)
  static/toolshed/src (a symlink back to the un-minified scripts in client/toolshed/scripts)
