### PR TITLE
Fix metadata generation bug

### DIFF
--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -48,7 +48,7 @@ class ToolTestBuilder( object ):
         self.name = name
         self.maxseconds = maxseconds
         self.required_files = []
-        self.inputs = []
+        self.inputs = {}
         self.outputs = []
         # By default do not making assertions on number of outputs - but to
         # test filtering allow explicitly state number of outputs.
@@ -134,7 +134,7 @@ class ToolTestBuilder( object ):
             self.expect_failure = test_dict.get("expect_failure", False)
             self.md5 = test_dict.get("md5", None)
         except Exception, e:
-            self.inputs = dict()
+            self.inputs = {}
             self.error = True
             self.exception = e
 

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -134,6 +134,7 @@ class ToolTestBuilder( object ):
             self.expect_failure = test_dict.get("expect_failure", False)
             self.md5 = test_dict.get("md5", None)
         except Exception, e:
+            self.inputs = dict()
             self.error = True
             self.exception = e
 


### PR DESCRIPTION
This will fix a crash in metadata generation, where `self.inputs` is initialised as `list()` but will be changed to a `dict()` in the `try` block. However, if we enter `except` this still is a list and will cause a crash later downstream.

Why is it initialised as `list()` anyway? Maybe a better fix is to initialise it as `dict()`?
