### PR TITLE
Fixing string appending error

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2144,7 +2144,7 @@ class Library( object, Dictifiable, HasName ):
         """
         rval = super( Library, self ).to_dict( view=view, value_mapper=value_mapper )
         if 'root_folder_id' in rval:
-            rval[ 'root_folder_id' ] = 'F' + rval[ 'root_folder_id' ]
+            rval[ 'root_folder_id' ] = 'F' + str(rval[ 'root_folder_id' ])
         return rval
     def get_active_folders( self, folder, folders=None ):
         # TODO: should we make sure the library is not deleted?


### PR DESCRIPTION
A fix to observed error:

```
Traceback (most recent call last):
  File "/opt/galaxy/galaxy-app/lib/galaxy/web/framework/decorators.py", line 135, in decorator
    rval = func( self, trans, *args, **kwargs)
  File "/opt/galaxy/galaxy-app/lib/galaxy/webapps/galaxy/api/search.py", line 64, in create
    row = query.item_to_api_value(item)
  File "/opt/galaxy/galaxy-app/lib/galaxy/model/search.py", line 651, in item_to_api_value
    r = item.to_dict( view='element' )
  File "/opt/galaxy/galaxy-app/lib/galaxy/model/__init__.py", line 2147, in to_dict
    rval[ 'root_folder_id' ] = 'F' + rval[ 'root_folder_id' ]
TypeError: cannot concatenate 'str' and 'int' objects
```
