### PR TITLE
TS hide test results

### DIFF
--- a/config/tool_shed.ini.sample
+++ b/config/tool_shed.ini.sample
@@ -103,6 +103,9 @@ require_login = False
 # path to sendmail
 sendmail_path = /usr/sbin/sendmail
 
+# Enables displaying of test run results on repo pages.
+#display_legacy_test_results = True
+
 # Number of saved tool test results produced by the install and test
 # framework for each repository.
 #num_tool_test_results_saved = 5

--- a/config/tool_shed.ini.sample
+++ b/config/tool_shed.ini.sample
@@ -5,17 +5,19 @@
 use = egg:Paste#http
 port = 9009
 
-# The address on which to listen.  By default, only listen to localhost (the tool shed will not
-# be accessible over the network).  Use '0.0.0.0' to listen on all available network interfaces.
+# The address on which to listen. By default, only listen to localhost
+# (the Tool Shed will not be accessible over the network).
+# Use '0.0.0.0' to listen on all available network interfaces.
 #host = 0.0.0.0
 host = 127.0.0.1
 
 use_threadpool = true
 threadpool_workers = 10
-# Set the number of seconds a thread can work before you should kill it (assuming it will never finish) to 3 hours.
+# Set the number of seconds a thread can work before you should kill it
+# (assuming it will never finish) to 3 hours.
 threadpool_kill_thread_limit = 10800
 
-# ---- Galaxy Webapps Community Interface -------------------------------------------------
+# ---- Galaxy Tool Shed -----------------------------------------------------
 
 [app:main]
 
@@ -25,15 +27,18 @@ log_level = DEBUG
 
 # Database connection
 database_file = database/community.sqlite
-# You may use a SQLAlchemy connection string to specify an external database instead
+# You may use a SQLAlchemy connection string to specify
+# an external database instead
 #database_connection = postgres:///community_test?host=/var/run/postgresql
 
-# Where the hgweb.config file is stored.  The default is the Galaxy installation directory.
+# Where the hgweb.config file is stored.
+# The default is the Galaxy installation directory.
 #hgweb_config_dir = None
 
 # Where tool shed repositories are stored.
 file_path = database/community_files
-# Temporary storage for additional datasets, this should be shared through the cluster
+# Temporary storage for additional datasets,
+# this should be shared through the cluster
 new_file_path = database/tmp
 
 # File containing old-style genome builds
@@ -78,8 +83,8 @@ id_secret = changethisinproductiontoo
 # If use_remote_user is enabled, anyone who can log in to the Galaxy host may
 # impersonate any other user by simply sending the appropriate header. Thus a
 # secret shared between the upstream proxy server, and Galaxy is required.
-# If anyone other than the Galaxy user is using the server, then apache/nginx should
-# pass a value in the header 'GX_SECRET' that is identical the one below
+# If anyone other than the Galaxy user is using the server, then apache/nginx
+# should pass a value in the header 'GX_SECRET' that is identical the one below
 #remote_user_secret = changethisinproductiontoo
 
 # Configuration for debugging middleware
@@ -98,7 +103,8 @@ require_login = False
 # path to sendmail
 sendmail_path = /usr/sbin/sendmail
 
-# Number of saved tool test results produced by the install and test framework for each repository.
+# Number of saved tool test results produced by the install and test
+# framework for each repository.
 #num_tool_test_results_saved = 5
 
 # For use by email messages sent from the tool shed
@@ -108,11 +114,12 @@ sendmail_path = /usr/sbin/sendmail
 # The URL linked by the "Support" link in the "Help" menu.
 #support_url = https://wiki.galaxyproject.org/Support
 
-# Write thread status periodically to 'heartbeat.log' (careful, uses disk space rapidly!)
-## use_heartbeat = True
+# Write thread status periodically to 'heartbeat.log' (careful, uses disk
+#  space rapidly!)
+#use_heartbeat = True
 
 # Profiling middleware (cProfile based)
-## use_profile = True
+#use_profile = True
 
 # Enable creation of Galaxy flavor Docker Image
 #enable_galaxy_flavor_docker_image = False

--- a/lib/galaxy/webapps/tool_shed/config.py
+++ b/lib/galaxy/webapps/tool_shed/config.py
@@ -64,6 +64,7 @@ class Configuration( object ):
         self.len_file_path = resolve_path( kwargs.get( "len_file_path", os.path.join( self.tool_data_path, 'shared','ucsc','chrom') ), self.root )
         self.ftp_upload_dir = kwargs.get( 'ftp_upload_dir', None )
         # Install and test framework for testing tools contained in repositories.
+        self.display_legacy_test_results = string_as_bool( kwargs.get( 'display_legacy_test_results', True ) )
         self.num_tool_test_results_saved = kwargs.get( 'num_tool_test_results_saved', 5 )
         self.update_integrated_tool_panel = False
         # Galaxy flavor Docker Image

--- a/templates/webapps/tool_shed/repository/common.mako
+++ b/templates/webapps/tool_shed/repository/common.mako
@@ -1231,7 +1231,7 @@
             </div>
         </div>
     %endif
-    %if tool_test_results_root_folder:
+    %if tool_test_results_root_folder and trans.app.config.tool_data_path:
         ${render_table_wrap_style( "test_environment" )}
         <p/>
         <div class="toolForm">

--- a/templates/webapps/tool_shed/repository/common.mako
+++ b/templates/webapps/tool_shed/repository/common.mako
@@ -1231,7 +1231,7 @@
             </div>
         </div>
     %endif
-    %if tool_test_results_root_folder and trans.app.config.tool_data_path:
+    %if tool_test_results_root_folder and trans.app.config.display_legacy_test_results:
         ${render_table_wrap_style( "test_environment" )}
         <p/>
         <div class="toolForm">


### PR DESCRIPTION
introduce a config option to hide results of install & test framework

on MTS these are not providing any meaningfull results for months and are only confusing users

Also discussed here: http://dev.list.galaxyproject.org/Functional-test-for-BAM-output-tp4667310p4667329.html
