### PR TITLE
Only cleanup successful jobs when testing.

### DIFF
--- a/scripts/functional_tests.py
+++ b/scripts/functional_tests.py
@@ -345,6 +345,7 @@ def main():
                        user_library_import_dir=user_library_import_dir,
                        master_api_key=master_api_key,
                        use_tasked_jobs=True,
+                       cleanup_job='onsuccess',
                        enable_beta_tool_formats=True,
                        data_manager_config_file=data_manager_config_file,
         )


### PR DESCRIPTION
As per the recommendation of Ryan G. at http://dev.list.galaxyproject.org/keep-job-output-and-scripts-on-failed-tests-td4667327.html.

I considered making this 'never' - since those files will get cleaned up at the end anyway. This would actually reduce our test coverage related to job cleanup logic - so I have decided this is a fine a middle ground.
