### PR TITLE
Fix for fix for handling of unix permissions in .zip files.

### DIFF
--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -80,7 +80,7 @@ class CompressedFile( object ):
         if self.file_type == 'zip':
             for zipped_file in self.getmembers():
                 filename = self.getname( zipped_file )
-                absolute_filepath = os.path.join( path, filename )
+                absolute_filepath = os.path.join( extraction_path, filename )
                 external_attributes = self.archive.getinfo( filename ).external_attr
                 # The 2 least significant bytes are irrelevant, the next two contain unix permissions.
                 unix_permissions = external_attributes >> 16


### PR DESCRIPTION
Code was joining the .zip member to the wrong path, causing an error when installing devteam's package_picard_1_56_0 from the main toolshed. This pull request corrects that error.
