### PR TITLE
Metadata size limiting

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -974,6 +974,11 @@ use_interactive = True
 # option to retry externally, or set metadata manually (when possible).
 #retry_metadata_internally = True
 
+# Very large metadata values can cause Galaxy crashes.  This will allow
+# limiting the maximum metadata size Galaxy will attempt to save with a
+# dataset.  0 to disable this feature.  5000000 is a reasonable size.
+#max_metadata_value_size = 0
+
 # If (for example) you run on a cluster and your datasets (by default,
 # database/files/) are mounted read-only, this option will override tool output
 # paths to write outputs to the working directory instead, and the job manager

--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -975,8 +975,9 @@ use_interactive = True
 #retry_metadata_internally = True
 
 # Very large metadata values can cause Galaxy crashes.  This will allow
-# limiting the maximum metadata size Galaxy will attempt to save with a
-# dataset.  0 to disable this feature.  5000000 is a reasonable size.
+# limiting the maximum metadata key size (in bytes used in memory, not the end
+# result database value size) Galaxy will attempt to save with a dataset.  0 to
+# disable this feature.  5000000 seems to be a reasonable size.
 #max_metadata_value_size = 0
 
 # If (for example) you run on a cluster and your datasets (by default,

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -146,6 +146,7 @@ class Configuration( object ):
         self.tool_secret = kwargs.get( "tool_secret", "" )
         self.id_secret = kwargs.get( "id_secret", "USING THE DEFAULT IS NOT SECURE!" )
         self.retry_metadata_internally = string_as_bool( kwargs.get( "retry_metadata_internally", "True" ) )
+        self.max_metadata_value_size = int( kwargs.get( "max_metadata_value_size", 0 ) )
         self.use_remote_user = string_as_bool( kwargs.get( "use_remote_user", "False" ) )
         self.normalize_remote_user_email = string_as_bool( kwargs.get( "normalize_remote_user_email", "False" ) )
         self.remote_user_maildomain = kwargs.get( "remote_user_maildomain", None )

--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -270,8 +270,10 @@ class MetadataType( JSONType ):
         if value is not None:
             if app.app and app.app.config.max_metadata_value_size:
                 for k, v in value.items():
-                    if total_size(v) > app.app.config.max_metadata_value_size:
+                    sz = total_size(v)
+                    if sz > app.app.config.max_metadata_value_size:
                         del value[k]
+                        log.error('Refusing to bind metadata key %s due to size (%s)' % (k, sz))
             value = json_encoder.encode(value)
         return value
 


### PR DESCRIPTION
Very large metadata can be problematic (and will crash the Galaxy process).  This allows limiting of the metadata maximum size at the database level.  If a particular key's value is larger than the limit, the key is removed from the metadata and is not stored.

Resetting metadata on datasets with very large metadata should resolve the issues we're seeing on main, and I'll follow up with that once merged.
