### PR TITLE
Include grunt-cli in client/package.json.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,128 @@
+# Contributors
+
+The following individuals have contributed code to Galaxy:
+
+* Enis Afgan <afgane@gmail.com>
+* Istvan Albert <istvan.albert@gmail.com>
+* Renato Alves <alves.rjc@gmail.com> <rjalves@igc.gulbenkian.pt>
+* Guruprasad Anada <gua110@bx.psu.edu>
+* Florent Angly <florent.angly@gmail.com>
+* Raj Ayyampalayam <raj76@uga.edu>
+* Finn Bacall <finn.bacall@cs.man.ac.uk>
+* Dannon Baker <dannon.baker@gmail.com>
+* Christopher Bare <christopherbare@gmail.com>
+* Dan Blanchard <dan.blanchard@gmail.com>
+* Daniel Blankenberg <dan.blankenberg@gmail.com> <dan@bx.psu.edu>
+* James Boocock <sfk2001@gmail.com>
+* Carlos Borroto <carlos.borroto@gmail.com>
+* Daniel Bouchard <dbouchard@corefacility.ca> <daniel.bouchard@phac-aspc.gc.ca>
+* Dave Bouvier <dave@bx.psu.edu>
+* Adam Brenner <aebrenne@uci.edu>
+* Anthony Bretaudeau <anthony.bretaudeau@rennes.inra.fr> <abretaud@irisa.fr>
+* Richard Burhans <burhans@bx.psu.edu>
+* Jennifer Cabral <jencabral@gmail.com>
+* Martin Cech <cech.marten@gmail.com> <emulatorer@gmail.com>
+* Ramkrishna Chakrabarty <rc@bx.psu.edu>
+* Brad Chapman <chapmanb@50mail.com>
+* John Chilton <jmchilton@gmail.com>
+* Saket Choudhary <saketkc@gmail.com>
+* Wen-Yu Chung <wychung@bx.psu.edu>
+* Dave Clements <clements@galaxyproject.org>
+* Peter Cock <p.j.a.cock@googlemail.com>
+* Ira Cooke <iracooke@gmail.com>
+* Nate Coraor <nate@bx.psu.edu>
+* Michael Cotterell <mepcotterell@gmail.com>
+* Gianmauro Cuccuru <gmauro@crs4.it>
+* Frederik Delaere <frederik.delaere@gmail.com>
+* Olivia Doppelt <olivia.doppelt@pasteur.fr>
+* John Duddy <jduddy@illumina.com>
+* Carl Eberhard <carlfeberhard@gmail.com>
+* Kyle Ellrott <kellrott@gmail.com> <kellrott@soe.ucsc.edu>
+* Eric Enns <eric.enns@gmail.com>
+* Dorine Francheteau <dorine@bx.psu.edu>
+* Jaime Frey <jfrey@cs.wisc.edu>
+* Carie Genote <cganote@iu.edu>
+* Jeremy Goecks <jeremy.goecks@emory.edu> <jgoecks@gwu.edu>
+* Nuwan Goonasekera <nuwan.goonasekera@gmail.com>
+* Björn Grüning <bjoern.gruening@gmail.com> <bjoern@gruenings.eu>
+* Aysam Guerler <aysam.guerler@gmail.com>
+* Simon Guest <simon.guest@agresearch.co.nz>
+* Jianbin He <jbhe@bx.psu.edu>
+* Morita Hideyuki <h-morita@esm.co.jp>
+* Rob Hooft <rob.hooft@nbic.nl>
+* Y. Hoogstrate <y.hoogstrate@erasmusmc.nl>
+* Jian-Long Huang <jlh@pyhub.org>
+* Gert Hulselmans <gert.hulselmans@med.kuleuven.be>
+* Jennifer Jackson <jen@bx.psu.edu>
+* Joachim Jacob <joachim.jacob@gmail.com>
+* Jim Johnson <jj@umn.edu> <jj@msi.umn.edu>
+* Radhesh Kamath <radhesh@bx.psu.edu>
+* Jan Kanis <jan.code@jankanis.nl>
+* David King <dcking@bx.psu.edu>
+* Rory Kirchner <roryk@mit.edu>
+* Brad Langhorst <langhorst@neb.com>
+* Ross Lazarus <ross.lazarus@gmail.com> <rossl@bx.psu.edu>
+* Simone Leo <simone.leo@gmail.com>
+* Kanwei Li <kanwei@gmail.com>
+* Michael Li <michael.li@uwaterloo.ca>
+* Philip Mabon <philipmabon@gmail.com>
+* Remi Marenco <remi.marenco@gmail.com> <remimarenco@gmail.com>
+* Thomas McGowan <mcgo0092@msi.umn.edu>
+* Scott McManus <scottmcmanus@emory.edu> <scottmcmanus@gatech.edu>
+* Hunter Moseley <hunter.moseley@louisville.edu>
+* Arjun Nath <arjun@bx.psu.edu>
+* Anton Nekrutenko <anton@bx.psu.edu> <anton@nekrut.org>
+* Eric Paniagua <paniagua.cshl@gmail.com>
+* Richard Park <rpark@bu.edu>
+* Lance Parsons <lparsons@princeton.edu>
+* Chinmay Rao <chinmay@bx.psu.edu>
+* Eric Rasche <esr@tamu.edu> <rasche.eric@gmail.com> <rasche.eric@yandex.ru>
+* Andrew Robinson <Andrew.Robinson@latrobe.edu.au>
+* Andrea Sbardellati <andrea.sbardellati@crs4.it>
+* Ian Schenck <ian@bx.psu.edu>
+* Nick Semenkovich <semenko@alum.mit.edu>
+* Matthew Shirley <mdshw5@gmail.com>
+* Clare Sloggett <sloc@unimelb.edu.au>
+* Nicola Soranzo <nicola.soranzo@tgac.ac.uk> <nsoranzo@tiscali.it> <soranzo@crs4.it>
+* Roy Storey <kiwiroy@gmail.com>
+* Hanfei Sun <ad9075@gmail.com>
+* Ilya Sytchev <hackdna@gmail.com>
+* James Taylor <james@jamestaylor.org>
+* Tomithy Too <tomithy.too@gmail.com>
+* David Trudgian <dave@trudgian.net> <david.trudgian@utsouthwestern.edu>
+* Nitesh Turaga <nitesh.turaga@gmail.com>
+* Clayton Turner <clayclay911@gmail.com>
+* Marek Vavruša <marek@vavrusa.com>
+* Martijn Vermaat <m.vermaat.hg@lumc.nl>
+* Kelly Vincent <kpvincent@bx.psu.edu>
+* Greg Von Kuster <greg@bx.psu.edu>
+* Hiral Vora <hvora1@uncc.edu>
+* Andrew Warren <anwarren@vbi.vt.edu>
+* Trevor Wennblom <trevor@well.com>
+* Yi Zhang <yizhang@bx.psu.edu>
+* Freek de Bruijn <freek.de.bruijn@nbic.nl>
+* Peter van Heusden <pvh@sanbi.ac.za>
+* Marius van den Beek <m.vandenbeek@gmail.com>
+
+# Institutional sponsors
+
+Galaxy development began at The Pennsylvania State University in 2006.
+In 2009 all contributions to that point were licensed by Penn State
+under the terms of the Academic Free License 3.0 (see LICENSE.txt). This
+license applies to all subsequent contributions as well.  Significant
+portions of Galaxy development have continued at Penn State, Emory
+University, Johns Hopkins University, and George Washington University
+with support from the following NIH and NSF grants:
+
+* NSF DBI 0543285, “Tailoring genomic data to the needs of experimental
+  biologists and educators”
+* NIH R21 HG005133, “A turnkey solution for next generation sequence
+  data analysis”
+* NIH R01 HG004909, “An efficient lightweight environment for biomedical
+  computation”
+* NSF DBI 0850103, “Cyberinfrastructure for accessible and reproducible
+  research in life sciences”
+* NIH RC2 HG005542, “Dynamically scalable accessible analysis for next
+  generation sequence data”
+* NIH U41 HG006620, “Democratization of data analysis in life sciences
+  through Galaxy”

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2005-2013 Pennsylvania State University
+Copyright (c) 2005-2015 Galaxy Contributors (see CONTRIBUTORS.md)
 
 Licensed under the Academic Free License version 3.0
 
@@ -13,7 +13,7 @@ Licensed under the Academic Free License version 3.0
        Work, thereby creating derivative works ("Derivative Works") based upon 
        the Original Work;
 
-    c) to distribute or communicate copies of the Original Work and Derivative 
+    c) to distribute or communicate copies of the Original Work aGnd Derivative 
        Works to the public, under any license of your choice that does not 
        contradict the terms and conditions, including Licensor's reserved 
        rights and remedies, in this Academic Free License;


### PR DESCRIPTION
This eliminates the need for grunt to be installed globally. It can be run
by invoking `./node_modules/.bin/grunt` in the client directory.
