### PR TITLE
Add configurable Docker hostname

### DIFF
--- a/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
+++ b/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
@@ -21,3 +21,7 @@ command_inject = --sig-proxy=true -e DEBUG=false
 # this falls back to galaxy.ini's galaxy_infrastructure_url and finally to the
 # Docker host of the spawned container if that is also not set.
 #galaxy_url = 
+
+# The Docker hostname. It can be useful to run the Docker daemon on a different
+# host than Galaxy.
+#docker_host = localhost

--- a/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
+++ b/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
@@ -24,4 +24,4 @@ command_inject = --sig-proxy=true -e DEBUG=false
 
 # The Docker hostname. It can be useful to run the Docker daemon on a different
 # host than Galaxy.
-#docker_host = localhost
+#docker_hostname = localhost

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -25,11 +25,8 @@ class InteractiveEnviornmentRequest(object):
         self.attr = Bunch()
         self.attr.viz_id = plugin_config["name"].lower()
         self.attr.history_id = trans.security.encode_id( trans.history.id )
-        self.attr.proxy_request = trans.app.proxy_manager.setup_proxy( trans )
-        self.attr.proxy_url = self.attr.proxy_request[ 'proxy_url' ]
         self.attr.galaxy_config = trans.app.config
         self.attr.galaxy_root_dir = os.path.abspath(self.attr.galaxy_config.root)
-
         self.attr.root = web.url_for("/")
         self.attr.app_root = self.attr.root + "plugins/visualizations/" + self.attr.viz_id + "/static/"
 
@@ -39,6 +36,12 @@ class InteractiveEnviornmentRequest(object):
         self.attr.our_config_dir = os.path.join(plugin_path, "config")
         self.attr.our_template_dir = os.path.join(plugin_path, "templates")
         self.attr.HOST = trans.request.host.rsplit(':', 1)[0]
+
+        self.load_deploy_config()
+        self.attr.proxy_request = trans.app.proxy_manager.setup_proxy(
+            trans, host=self.attr.viz_config.get("docker", "docker_host")
+        )
+        self.attr.proxy_url = self.attr.proxy_request[ 'proxy_url' ]
         self.attr.PORT = self.attr.proxy_request[ 'proxied_port' ]
 
         # Generate per-request passwords the IE plugin can use to configure
@@ -54,6 +57,7 @@ class InteractiveEnviornmentRequest(object):
         # .get() that will ignore missing sections, so we must make use of
         # their defaults dictionary instead.
         default_dict['command_inject'] = '--sig-proxy=true'
+        default_dict['docker_host'] = 'localhost'
         viz_config = ConfigParser.SafeConfigParser(default_dict)
         conf_path = os.path.join( self.attr.our_config_dir, self.attr.viz_id + ".ini" )
         if not os.path.exists( conf_path ):

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -38,8 +38,9 @@ class InteractiveEnviornmentRequest(object):
         self.attr.HOST = trans.request.host.rsplit(':', 1)[0]
 
         self.load_deploy_config()
+        self.attr.docker_hostname = self.attr.viz_config.get("docker", "docker_hostname")
         self.attr.proxy_request = trans.app.proxy_manager.setup_proxy(
-            trans, host=self.attr.viz_config.get("docker", "docker_host")
+            trans, host=self.attr.docker_hostname
         )
         self.attr.proxy_url = self.attr.proxy_request[ 'proxy_url' ]
         self.attr.PORT = self.attr.proxy_request[ 'proxied_port' ]
@@ -57,7 +58,7 @@ class InteractiveEnviornmentRequest(object):
         # .get() that will ignore missing sections, so we must make use of
         # their defaults dictionary instead.
         default_dict['command_inject'] = '--sig-proxy=true'
-        default_dict['docker_host'] = 'localhost'
+        default_dict['docker_hostname'] = 'localhost'
         viz_config = ConfigParser.SafeConfigParser(default_dict)
         conf_path = os.path.join( self.attr.our_config_dir, self.attr.viz_id + ".ini" )
         if not os.path.exists( conf_path ):


### PR DESCRIPTION
This PR will add a new configuration option to Interactive Environments - `docker_host`. With this option you can specify a different docker hostname. This is very useful if you only have a Docker client on your Galaxy host and your Docker daemon is running on somewhere else.

If this is ok, I will add it to RStudio as well.
Questionable point is if it's ok to initialize `load_deploy_config()` in the `__init__`.

ping @jmchilton and @erasche 
