### PR TITLE
[15.05] Fix bug with runtime post job actions.

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -863,10 +863,13 @@ class ToolModule( WorkflowModule ):
         # Create new PJA associations with the created job, to be run on completion.
         # PJA Parameter Replacement (only applies to immediate actions-- rename specifically, for now)
         # Pass along replacement dict with the execution of the PJA so we don't have to modify the object.
-        post_job_actions = step.post_job_actions
+
+        # Combine workflow and runtime post job actions into the effective post
+        # job actions for this execution.
+        effective_post_job_actions = step.post_job_actions[:]
         for key, value in self.runtime_post_job_actions.iteritems():
-            post_job_actions.append( self.__to_pja( key, value, step ) )
-        for pja in post_job_actions:
+            effective_post_job_actions.append( self.__to_pja( key, value, None ) )
+        for pja in effective_post_job_actions:
             if pja.action_type in ActionBox.immediate_actions:
                 ActionBox.execute( self.trans.app, self.trans.sa_session, pja, job, replacement_dict )
             else:

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -867,6 +867,13 @@ test_data:
         content = self.dataset_populator.get_history_dataset_details( history_id, wait=True, assert_ok=True )
         assert content[ "name" ] == "foo was replaced", content[ "name" ]
 
+        # Test for regression of previous behavior where runtime post job actions
+        # would be added to the original workflow post job actions.
+        workflow_id = workflow_request["workflow_id"]
+        downloaded_workflow = self._download_workflow( workflow_id )
+        pjas = downloaded_workflow[ "steps" ][ "2" ][ "post_job_actions" ].values()
+        assert len( pjas ) == 0, len( pjas )
+
     @skip_without_tool( "cat1" )
     def test_run_with_delayed_runtime_pja( self ):
         workflow_id = self._upload_yaml_workflow("""


### PR DESCRIPTION
Runtime post job actions are post job actions inserted when the workflow is invoked instead of being part of the workflow object in the database. The bug noticed by @kellrott was that these actions were being appended to the original workflow post job actions instead of being transient things just attached to the jobs themselves.

This fixes that problem and adds a test to try to prevent regressions.
