### PR TITLE
[15.05] Add PyYAML require prior to kombu import, which now depends on it (as…

### DIFF
--- a/lib/galaxy/queues.py
+++ b/lib/galaxy/queues.py
@@ -8,6 +8,7 @@ import sys
 
 from galaxy import eggs
 
+eggs.require('PyYAML')
 eggs.require('anyjson')
 if sys.version_info < (2, 7, 0):
     # Kombu requires importlib and ordereddict to function in Python 2.6.


### PR DESCRIPTION
… of the update a few months ago).  This resolves an issue that can appear in unclean environments regarding yaml already being imported.
