### PR TITLE
Use passed in URL for getbuilds method of parse_builds.py

### DIFF
--- a/.ci/pep8_sources.txt
+++ b/.ci/pep8_sources.txt
@@ -1,3 +1,4 @@
+cron/parse_builds.py
 lib/galaxy/auth
 lib/galaxy/config.py
 lib/galaxy/datatypes/data.py

--- a/cron/parse_builds.py
+++ b/cron/parse_builds.py
@@ -23,7 +23,7 @@ def getbuilds(url):
     try:
         tree = ElementTree.fromstring(text)
     except:
-        print "#Invalid xml passed back from " + URL
+        print "#Invalid xml passed back from " + url
         print "?\tunspecified (?)"
         sys.exit(1)
 

--- a/cron/parse_builds.py
+++ b/cron/parse_builds.py
@@ -17,9 +17,9 @@ except IndexError:
 
 def getbuilds(url):
     try:
-        page = urllib.urlopen(URL)
+        page = urllib.urlopen(url)
     except:
-        print "#Unable to open " + URL
+        print "#Unable to open " + url
         print "?\tunspecified (?)"
         sys.exit(1)
 
@@ -31,7 +31,7 @@ def getbuilds(url):
         print "?\tunspecified (?)"
         sys.exit(1)
 
-    print "#Harvested from " + URL
+    print "#Harvested from " + url
     print "?\tunspecified (?)"
     for dsn in tree:
         build = dsn.find("SOURCE").attrib['id']

--- a/cron/parse_builds.py
+++ b/cron/parse_builds.py
@@ -10,11 +10,6 @@ import sys
 import urllib
 import xml.etree.ElementTree as ElementTree
 
-try:
-    URL = sys.argv[1]
-except IndexError:
-    URL = "http://genome.cse.ucsc.edu/cgi-bin/das/dsn"
-
 
 def getbuilds(url):
     try:
@@ -51,5 +46,7 @@ def getbuilds(url):
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         URL = sys.argv[1]
+    else:
+        URL = "http://genome.cse.ucsc.edu/cgi-bin/das/dsn"
     for build in getbuilds(URL):
         print build[0] + "\t" + build[1] + " (" + build[0] + ")"

--- a/cron/parse_builds.py
+++ b/cron/parse_builds.py
@@ -15,6 +15,7 @@ try:
 except IndexError:
     URL = "http://genome.cse.ucsc.edu/cgi-bin/das/dsn"
 
+
 def getbuilds(url):
     try:
         page = urllib.urlopen(url)
@@ -35,21 +36,20 @@ def getbuilds(url):
     print "?\tunspecified (?)"
     for dsn in tree:
         build = dsn.find("SOURCE").attrib['id']
-        description = dsn.find("DESCRIPTION").text.replace(" - Genome at UCSC","").replace(" Genome at UCSC","")
+        description = dsn.find("DESCRIPTION").text.replace(" - Genome at UCSC", "").replace(" Genome at UCSC", "")
 
         fields = description.split(" ")
         temp = fields[0]
-        for i in range(len(fields)-1):
-            if temp == fields[i+1]:
-                fields.pop(i+1)
+        for i in range(len(fields) - 1):
+            if temp == fields[i + 1]:
+                fields.pop(i + 1)
             else:
-                temp = fields[i+1]
+                temp = fields[i + 1]
         description = " ".join(fields)
-        yield [build,description]
+        yield [build, description]
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         URL = sys.argv[1]
     for build in getbuilds(URL):
-        print build[0]+"\t"+build[1]+" ("+build[0]+")"
-
+        print build[0] + "\t" + build[1] + " (" + build[0] + ")"


### PR DESCRIPTION
In `cron/parsebuilds.py` the `getbuilds` method is accepting a `url` parameter, but actually downloading a build list using the var `URL` which is set from `sys.argv[1]` outside of the method.

This breaks the `build_chrom_db.py` script which requires argv[1] to be the directory to store .len files downloaded from UCSC. When called from an invocation of the `build_chrom_db.py` script, `getbuilds` is picking up this dir from the command line args as the download URL, leading to an error.

This change makes `getbuild` use the passed in `url` parameter, thus fixing `build_chrom_db.py` operation.
