### PR TITLE
Allow environment variable definitions in tool XML.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -856,7 +856,7 @@ class JobWrapper( object ):
 
         self.sa_session.flush()
 
-        self.command_line, self.extra_filenames = tool_evaluator.build()
+        self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
         # Ensure galaxy_lib_dir is set in case there are any later chdirs
         self.galaxy_lib_dir
         # Shell fragment to inject dependencies
@@ -1742,7 +1742,7 @@ class TaskWrapper(JobWrapper):
 
         self.sa_session.flush()
 
-        self.command_line, self.extra_filenames = tool_evaluator.build()
+        self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
 
         # Ensure galaxy_lib_dir is set in case there are any later chdirs
         self.galaxy_lib_dir

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -293,6 +293,7 @@ class BaseJobRunner( object ):
         env_setup_commands.extend( self._get_egg_env_opts() or [] )
         destination = job_wrapper.job_destination or {}
         envs = destination.get( "env", [] )
+        envs.extend( job_wrapper.environment_variables )
         for env in envs:
             env_setup_commands.append( env_to_statement( env ) )
         command_line = job_wrapper.runner_command_line

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -634,6 +634,7 @@ class Tool( object, Dictifiable ):
         else:
             self.command = ''
             self.interpreter = None
+        self.environment_variables = tool_source.parse_environment_variables()
 
         # Parameters used to build URL for redirection to external app
         redirect_url_params = tool_source.parse_redirect_url_params_elem()

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -419,8 +419,13 @@ class ToolEvaluator( object ):
             # capture and log parsing errors
             global_tool_errors.add_error(self.tool.config_file, "Building Command Line", e)
             raise e
+        try:
+            self.__build_environment_variables()
+        except Exception, e:
+            global_tool_errors.add_error(self.tool.config_file, "Building Environment Variables", e)
+            raise e
 
-        return self.command_line, self.extra_filenames
+        return self.command_line, self.extra_filenames, self.environment_variables
 
     def __build_command_line( self ):
         """
@@ -469,14 +474,28 @@ class ToolEvaluator( object ):
             else:
                 fd, config_filename = tempfile.mkstemp( dir=directory )
                 os.close( fd )
-            f = open( config_filename, "w" )
-            f.write( fill_template( template_text, context=param_dict ) )
-            f.close()
-            # For running jobs as the actual user, ensure the config file is globally readable
-            os.chmod( config_filename, 0644 )
+            self.__write_workdir_file( config_filename, template_text, param_dict )
             self.__register_extra_file( name, config_filename )
             config_filenames.append( config_filename )
         return config_filenames
+
+    def __build_environment_variables( self ):
+        param_dict = self.param_dict
+        environment_variables = []
+        for environment_variable_def in self.tool.environment_variables:
+            directory = self.local_working_directory
+            environment_variable = environment_variable_def.copy()
+            environment_variable_template = environment_variable_def["template"]
+            fd, config_filename = tempfile.mkstemp( dir=directory )
+            os.close( fd )
+            self.__write_workdir_file( config_filename, environment_variable_template, param_dict )
+            config_file_basename = os.path.basename( config_filename )
+            environment_variable["value"] = "`cat %s`" % config_file_basename
+            environment_variable["raw"] = True
+            environment_variables.append(environment_variable)
+
+        self.environment_variables = environment_variables
+        return environment_variables
 
     def __build_param_file( self ):
         """
@@ -500,6 +519,14 @@ class ToolEvaluator( object ):
             return param_filename
         else:
             return None
+
+    def __write_workdir_file( self, config_filename, template, context ):
+        value = fill_template( template, context=context )
+        f = open( config_filename, "w" )
+        f.write( value )
+        f.close()
+        # For running jobs as the actual user, ensure the config file is globally readable
+        os.chmod( config_filename, 0644 )
 
     def __register_extra_file( self, name, local_config_path ):
         """

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -522,9 +522,8 @@ class ToolEvaluator( object ):
 
     def __write_workdir_file( self, config_filename, template, context ):
         value = fill_template( template, context=context )
-        f = open( config_filename, "w" )
-        f.write( value )
-        f.close()
+        with open( config_filename, "w" ) as f:
+            f.write( value )
         # For running jobs as the actual user, ensure the config file is globally readable
         os.chmod( config_filename, 0644 )
 

--- a/lib/galaxy/tools/parser/interface.py
+++ b/lib/galaxy/tools/parser/interface.py
@@ -82,6 +82,11 @@ class ToolSource(object):
         """
 
     @abstractmethod
+    def parse_environment_variables(self):
+        """ Return environment variable templates to expose.
+        """
+
+    @abstractmethod
     def parse_interpreter(self):
         """ Return string containing the interpreter to prepend to the command
         (for instance this might be 'python' to run a Python wrapper located

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -90,6 +90,22 @@ class XmlToolSource(ToolSource):
         command_el = self._command_el
         return ( ( command_el is not None ) and command_el.text ) or None
 
+    def parse_environment_variables(self):
+        environment_variables_el = self.root.find("environment_variables")
+        if environment_variables_el is None:
+            return []
+
+        environment_variables = []
+        for environment_variable_el in environment_variables_el.findall("environment_variable"):
+            definition = {
+                "name": environment_variable_el.get("name"),
+                "template": environment_variable_el.text,
+            }
+            environment_variables.append(
+                definition
+            )
+        return environment_variables
+
     def parse_interpreter(self):
         command_el = self._command_el
         return (command_el is not None) and command_el.get("interpreter", None)

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -40,6 +40,9 @@ class YamlToolSource(ToolSource):
     def parse_command(self):
         return self.root_dict.get("command")
 
+    def parse_environment_variables(self):
+        return []
+
     def parse_interpreter(self):
         return self.root_dict.get("interpreter")
 

--- a/test/functional/tools/environment_variables.xml
+++ b/test/functional/tools/environment_variables.xml
@@ -1,0 +1,24 @@
+<tool id="environment_variables" name="environment_variables" version="1.0.0">
+    <environment_variables>
+        <environment_variable name="INTVAR">$inttest</environment_variable>
+    </environment_variables>
+    <command>
+        echo "\$INTVAR" > $out_file1
+    </command>
+    <inputs>
+        <param name="inttest" value="1" type="integer" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="inttest" value="2" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="2" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/environment_variables.xml
+++ b/test/functional/tools/environment_variables.xml
@@ -1,9 +1,17 @@
 <tool id="environment_variables" name="environment_variables" version="1.0.0">
     <environment_variables>
         <environment_variable name="INTVAR">$inttest</environment_variable>
+        <environment_variable name="FORTEST">#for i in ['m', 'o', 'o']#$i#end for#</environment_variable>
+        <environment_variable name="IFTEST">#if int($inttest) == 3
+ISTHREE
+#else#
+NOTTHREE
+#end if#</environment_variable>
     </environment_variables>
     <command>
-        echo "\$INTVAR" > $out_file1
+        echo "\$INTVAR"  >  $out_file1;
+        echo "\$FORTEST" >> $out_file1;
+        echo "\$IFTEST"  >> $out_file1;
     </command>
     <inputs>
         <param name="inttest" value="1" type="integer" />
@@ -17,6 +25,8 @@
             <output name="out_file1">
                 <assert_contents>
                     <has_line line="2" />
+                    <has_line line="moo" />
+                    <has_line line="NOTTHREE" />
                 </assert_contents>
             </output>
         </test>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -5,6 +5,7 @@
   <tool file="inheritance_simple.xml" />
   <tool file="boolean_conditional.xml" />
   <tool file="composite.xml" />
+  <tool file="environment_variables.xml" />
   <tool file="compare_bam_as_sam.xml" />
   <tool file="code_file.xml" />
   <tool file="disambiguate_cond.xml" />

--- a/test/unit/jobs/test_job_wrapper.py
+++ b/test/unit/jobs/test_job_wrapper.py
@@ -104,7 +104,7 @@ class MockEvaluator(object):
         pass
 
     def build(self):
-        return TEST_COMMAND, []
+        return TEST_COMMAND, [], []
 
 
 class MockJobQueue(object):

--- a/test/unit/jobs/test_runner_local.py
+++ b/test/unit/jobs/test_runner_local.py
@@ -106,6 +106,7 @@ class MockJobWrapper( object ):
         self.tool = tool
         self.state = model.Job.states.QUEUED
         self.command_line = "echo HelloWorld"
+        self.environment_variables = []
         self.commands_in_new_shell = False
         self.prepare_called = False
         self.write_version_cmd = None

--- a/test/unit/tools/test_evaluation.py
+++ b/test/unit/tools/test_evaluation.py
@@ -48,7 +48,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
     def test_simple_evaluation( self ):
         self._setup_test_bwa_job()
         self._set_compute_environment()
-        command_line, extra_filenames = self.evaluator.build( )
+        command_line, extra_filenames, _ = self.evaluator.build( )
         self.assertEquals( command_line, "bwa --thresh=4 --in=/galaxy/files/dataset_1.dat --out=/galaxy/files/dataset_2.dat" )
 
     def test_repeat_evaluation( self ):
@@ -59,7 +59,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self.job.parameters = [ JobParameter( name="r", value='''[{"thresh": 4, "__index__": 0},{"thresh": 5, "__index__": 1}]''' ) ]
         self.tool._command_line = "prog1 #for $r_i in $r # $r_i.thresh#end for#"
         self._set_compute_environment()
-        command_line, extra_filenames = self.evaluator.build( )
+        command_line, extra_filenames, _ = self.evaluator.build( )
         self.assertEquals( command_line, "prog1  4 5" )
 
     def test_conditional_evaluation( self ):
@@ -77,7 +77,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self.job.parameters = [ JobParameter( name="c", value='''{"thresh": 4, "always_true": "true", "__current_case__": 0}''' ) ]
         self.tool._command_line = "prog1 --thresh=${c.thresh} --test_param=${c.always_true}"
         self._set_compute_environment()
-        command_line, extra_filenames = self.evaluator.build( )
+        command_line, extra_filenames, _ = self.evaluator.build( )
         self.assertEquals( command_line, "prog1 --thresh=4 --test_param=true" )
 
     def test_evaluation_of_optional_datasets( self ):
@@ -89,7 +89,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self.tool.set_params( { "input1": parameter } )
         self.tool._command_line = "prog1 --opt_input='${input1}'"
         self._set_compute_environment()
-        command_line, extra_filenames = self.evaluator.build( )
+        command_line, extra_filenames, _ = self.evaluator.build( )
         self.assertEquals( command_line, "prog1 --opt_input='None'" )
 
     def test_evaluation_with_path_rewrites_wrapped( self ):
@@ -111,14 +111,14 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
             input_paths=[DatasetPath(1, '/galaxy/files/dataset_1.dat', false_path=job_path_1)],
             output_paths=[DatasetPath(2, '/galaxy/files/dataset_2.dat', false_path=job_path_2)],
         )
-        command_line, extra_filenames = self.evaluator.build( )
+        command_line, extra_filenames, _ = self.evaluator.build( )
         self.assertEquals( command_line, "bwa --thresh=4 --in=%s --out=%s" % (job_path_1, job_path_2) )
 
     def test_configfiles_evaluation( self ):
         self.tool.config_files.append( ( "conf1", None, "$thresh" ) )
         self.tool._command_line = "prog1 $conf1"
         self._set_compute_environment()
-        command_line, extra_filenames = self.evaluator.build( )
+        command_line, extra_filenames, _ = self.evaluator.build( )
         self.assertEquals( len( extra_filenames ), 1)
         config_filename = extra_filenames[ 0 ]
         config_basename = os.path.basename( config_filename )
@@ -160,7 +160,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
                 v = v.replace("/old", "/new")
             return v
         self._set_compute_environment(path_rewriter=test_path_rewriter)
-        command_line, extra_filenames = self.evaluator.build( )
+        command_line, extra_filenames, _ = self.evaluator.build( )
         self.assertEquals(command_line, "prog1 /new/path/human")
 
     def test_template_property_app( self ):
@@ -179,7 +179,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self.tool._command_line = "test.exe"
         self.tool.config_files.append( ( "conf1", None, """%s""" % expression) )
         self._set_compute_environment()
-        _, extra_filenames = self.evaluator.build( )
+        _, extra_filenames, _ = self.evaluator.build( )
         config_filename = extra_filenames[ 0 ]
         self.assertEquals(open( config_filename, "r").read(), value)
 
@@ -255,6 +255,7 @@ class MockTool( object ):
     def __init__( self, app ):
         self.app = app
         self.hooks_called = []
+        self.environment_variables = []
         self._config_files = []
         self._command_line = "bwa --thresh=$thresh --in=$input1 --out=$output1"
         self._params = { "thresh": self.test_thresh_param() }


### PR DESCRIPTION
An `<environment_variables>` top-level XML block can be used to define these.

```
<environment_variables>
    <environment_variable name="FOO">$bar</environment_variable>
    <environment_variable name="FOO2">$bar2</environment_variable
</environment_variables>
```

The expressions are contained in the text of the block.

Implementation Detials:

In order to avoid odd shell expression stuff - the evaluated expressions are written to files and environment variables are read from these files at runtime.

Testing:

A demo tool `test/functional/tools/environment_variables.xml` with a test case that can be executed with the following expression.

```
./run_tests.sh -framework -id environment_variables
```
