### PR TITLE
Fix error when displaying job params for tools containing a section

### DIFF
--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -22,8 +22,8 @@
                 %for i in range( len(param_values[input.name]) ):
                     ${ inputs_recursive(input.inputs, param_values[input.name][i], depth=depth+1) }
                 %endfor
-           %elif input.type == "section":
-               <tr>
+            %elif input.type == "section":
+                <tr>
                     ##<!-- Get the value of the current Section parameter -->
                     ${inputs_recursive_indent( text=input.name, depth=depth )}
                     <td></td>

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -22,6 +22,13 @@
                 %for i in range( len(param_values[input.name]) ):
                     ${ inputs_recursive(input.inputs, param_values[input.name][i], depth=depth+1) }
                 %endfor
+           %elif input.type == "section":
+               <tr>
+                    ##<!-- Get the value of the current Section parameter -->
+                    ${inputs_recursive_indent( text=input.name, depth=depth )}
+                    <td></td>
+                </tr>
+                ${ inputs_recursive( input.inputs, param_values[input.name], depth=depth+1, upgrade_messages=upgrade_messages.get( input.name ) ) }
             %elif input.type == "conditional":
                 <%
                 try:


### PR DESCRIPTION
Hi,
When trying to view the parameters that were used to launch a job ('i' icon), there is an error that prevent the whole page to be displayed if the tool contains a section. This patch fixes the error.
Thanks to @cmonjeau for the patch!
Anthony
