### PR TITLE
[GCC2015] Fixes for ReadTheDocs API documentation.

### DIFF
--- a/.ci/flake8_wrapper.sh
+++ b/.ci/flake8_wrapper.sh
@@ -9,4 +9,4 @@ while read p; do
 done <.ci/pep8_sources.txt
 
 # Look for obviously broken stuff lots more places.
-flake8 --select=E901,E902,F821,F822,F823,F831 --exclude lib/galaxy/util/pastescript/serve.py lib/{galaxy,tool_shed} test/{api,unit}
+flake8 --select=E901,E902,F821,F822,F823,F831 --exclude lib/galaxy/util/pastescript/serve.py,lib/pkg_resources.py lib/ test/{api,unit}

--- a/.ci/pep8_sources.txt
+++ b/.ci/pep8_sources.txt
@@ -7,7 +7,7 @@ lib/galaxy/jobs/{__init__,error_level,manager,stock_rules}.py
 lib/galaxy/main.py
 lib/galaxy/managers/{api_keys,citations,collections,collections_util,datasets,folders,pages,tags,workflows}.py
 lib/galaxy/model/orm/{engine_factory,now}.py
-lib/galaxy/model/util.py
+lib/galaxy/model/{base,custom_types,search,util}.py
 lib/galaxy/model/tool_shed_install/__init__.py
 lib/galaxy/objectstore/{__init__,pulsar,rods,s3}.py
 lib/galaxy/openid/__init__.py

--- a/doc/source/lib/galaxy.webapps.galaxy.api.rst
+++ b/doc/source/lib/galaxy.webapps.galaxy.api.rst
@@ -340,12 +340,6 @@ Galaxy offers the following API controllers:
 .. automodule:: galaxy.webapps.galaxy.api.forms
 
 
-:mod:`ftp_files` Module
-----------------------
-
-.. automodule:: galaxy.webapps.galaxy.api.ftp_files
-
-
 :mod:`genomes` Module
 ---------------------
 
@@ -446,6 +440,12 @@ Galaxy offers the following API controllers:
 --------------------
 
 .. automodule:: galaxy.webapps.galaxy.api.quotas
+
+
+:mod:`remote_files` Module
+----------------------
+
+.. automodule:: galaxy.webapps.galaxy.api.remote_files
 
 
 :mod:`request_types` Module

--- a/lib/galaxy/model/search.py
+++ b/lib/galaxy/model/search.py
@@ -175,7 +175,7 @@ class LibraryDatasetDatasetView(ViewQueryBaseClass):
     FIELDS = {
         'extended_metadata': ViewField('extended_metadata', handler=library_extended_metadata_filter),
         'name': ViewField('name', sqlalchemy_field=(LibraryDatasetDatasetAssociation, "name")),
-        'id': ViewField('id', sqlalchemy_field=LibraryDatasetDatasetAssociation.id, id_decode=True),
+        'id': ViewField('id', sqlalchemy_field=(LibraryDatasetDatasetAssociation, 'id'), id_decode=True),
         'deleted': ViewField('deleted', sqlalchemy_field=(LibraryDatasetDatasetAssociation, "deleted")),
         'parent_library_id': ViewField('parent_library_id', id_decode=True, post_filter=ldda_parent_library_filter),
         'data_type':  ViewField('data_type', sqlalchemy_field=(LibraryDatasetDatasetAssociation, "extension")),
@@ -193,7 +193,7 @@ class LibraryView(ViewQueryBaseClass):
     VIEW_NAME = "library"
     FIELDS = {
         'name': ViewField('name', sqlalchemy_field=(Library, "name")),
-        'id': ViewField('id', sqlalchemy_field=Library.id, id_decode=True),
+        'id': ViewField('id', sqlalchemy_field=(Library, 'id'), id_decode=True),
         'deleted': ViewField('deleted', sqlalchemy_field=(Library, "deleted")),
     }
 

--- a/lib/galaxy/model/search.py
+++ b/lib/galaxy/model/search.py
@@ -108,7 +108,7 @@ class ViewQueryBaseClass(object):
                     clazz, attribute = field.sqlalchemy_field
                     sqlalchemy_field_value = getattr(clazz, attribute)
                     if operator == "=":
-                        #print field.sqlalchemy_field == right, field.sqlalchemy_field, right
+                        # print field.sqlalchemy_field == right, field.sqlalchemy_field, right
                         self.query = self.query.filter( sqlalchemy_field_value == right )
                     elif operator == "!=":
                         self.query = self.query.filter( sqlalchemy_field_value != right )
@@ -141,7 +141,7 @@ class ViewQueryBaseClass(object):
 
 
 ##################
-#Library Dataset Searching
+# Library Dataset Searching
 ##################
 
 
@@ -152,7 +152,7 @@ def library_extended_metadata_filter(view, left, operator, right):
         view.state['extended_metadata_joined'] = True
     alias = aliased( ExtendedMetadataIndex )
     field = "/%s" % ("/".join(left.split(".")[1:]))
-    #print "FIELD", field
+    # print "FIELD", field
     view.query = view.query.filter(
         and_(
             ExtendedMetadata.id == alias.extended_metadata_id,
@@ -178,7 +178,7 @@ class LibraryDatasetDatasetView(ViewQueryBaseClass):
         'id': ViewField('id', sqlalchemy_field=(LibraryDatasetDatasetAssociation, 'id'), id_decode=True),
         'deleted': ViewField('deleted', sqlalchemy_field=(LibraryDatasetDatasetAssociation, "deleted")),
         'parent_library_id': ViewField('parent_library_id', id_decode=True, post_filter=ldda_parent_library_filter),
-        'data_type':  ViewField('data_type', sqlalchemy_field=(LibraryDatasetDatasetAssociation, "extension")),
+        'data_type': ViewField('data_type', sqlalchemy_field=(LibraryDatasetDatasetAssociation, "extension")),
     }
 
     def search(self, trans):
@@ -186,7 +186,7 @@ class LibraryDatasetDatasetView(ViewQueryBaseClass):
 
 
 ##################
-#Library Searching
+# Library Searching
 ##################
 
 class LibraryView(ViewQueryBaseClass):
@@ -202,7 +202,7 @@ class LibraryView(ViewQueryBaseClass):
 
 
 ##################
-#Library Folder Searching
+# Library Folder Searching
 ##################
 def library_folder_parent_library_id_filter(item, left, operator, right):
     if operator == '=':
@@ -236,7 +236,7 @@ class LibraryFolderView(ViewQueryBaseClass):
 
 
 ##################
-#Library Dataset Searching
+# Library Dataset Searching
 ##################
 def library_dataset_name_filter(item, left, operator, right):
     if operator == '=':
@@ -259,7 +259,7 @@ class LibraryDatasetView(ViewQueryBaseClass):
 
 
 ##################
-#Tool Searching
+# Tool Searching
 ##################
 class ToolView(ViewQueryBaseClass):
     VIEW_NAME = "tool"
@@ -273,16 +273,16 @@ class ToolView(ViewQueryBaseClass):
 
 
 ##################
-#History Dataset Searching
+# History Dataset Searching
 ##################
 def history_dataset_handle_tag(view, left, operator, right):
     if operator == "=":
         view.do_query = True
-        #aliasing the tag association table, so multiple links to different tags can be formed during a single query
+        # aliasing the tag association table, so multiple links to different tags can be formed during a single query
         tag_table = aliased(HistoryDatasetAssociationTagAssociation)
 
         view.query = view.query.filter(
-           HistoryDatasetAssociation.id == tag_table.history_dataset_association_id
+            HistoryDatasetAssociation.id == tag_table.history_dataset_association_id
         )
         tmp = right.split(":")
         view.query = view.query.filter( tag_table.user_tname == tmp[0] )
@@ -299,7 +299,7 @@ def history_dataset_extended_metadata_filter(view, left, operator, right):
         view.state['extended_metadata_joined'] = True
     alias = aliased( ExtendedMetadataIndex )
     field = "/%s" % ("/".join(left.split(".")[1:]))
-    #print "FIELD", field
+    # print "FIELD", field
     view.query = view.query.filter(
         and_(
             ExtendedMetadata.id == alias.extended_metadata_id,
@@ -307,7 +307,6 @@ def history_dataset_extended_metadata_filter(view, left, operator, right):
             alias.value == str(right)
         )
     )
-
 
 
 class HistoryDatasetView(ViewQueryBaseClass):
@@ -332,7 +331,7 @@ class HistoryDatasetView(ViewQueryBaseClass):
 
 
 ##################
-#History Searching
+# History Searching
 ##################
 
 
@@ -341,7 +340,7 @@ def history_handle_tag(view, left, operator, right):
         view.do_query = True
         tag_table = aliased(HistoryTagAssociation)
         view.query = view.query.filter(
-           History.id == tag_table.history_id
+            History.id == tag_table.history_id
         )
         tmp = right.split(":")
         view.query = view.query.filter( tag_table.user_tname == tmp[0] )
@@ -357,15 +356,13 @@ def history_handle_annotation(view, left, operator, right):
         view.query = view.query.filter( and_(
             HistoryAnnotationAssociation.history_id == History.id,
             HistoryAnnotationAssociation.annotation == right
-            )
-        )
+        ) )
     elif operator == "like":
         view.do_query = True
         view.query = view.query.filter( and_(
             HistoryAnnotationAssociation.history_id == History.id,
             HistoryAnnotationAssociation.annotation.like( right )
-            )
-        )
+        ) )
     else:
         raise GalaxyParseError("Invalid comparison operator: %s" % (operator))
 
@@ -385,7 +382,7 @@ class HistoryView(ViewQueryBaseClass):
 
 
 ##################
-#Workflow Searching
+# Workflow Searching
 ##################
 
 
@@ -393,7 +390,7 @@ def workflow_tag_handler(view, left, operator, right):
     if operator == "=":
         view.do_query = True
         view.query = view.query.filter(
-           StoredWorkflow.id == StoredWorkflowTagAssociation.stored_workflow_id
+            StoredWorkflow.id == StoredWorkflowTagAssociation.stored_workflow_id
         )
         tmp = right.split(":")
         view.query = view.query.filter( StoredWorkflowTagAssociation.user_tname == tmp[0] )
@@ -417,7 +414,7 @@ class WorkflowView(ViewQueryBaseClass):
 
 
 ##################
-#Job Searching
+# Job Searching
 ##################
 
 
@@ -489,7 +486,7 @@ class JobView(ViewQueryBaseClass):
 
 
 ##################
-#Page Searching
+# Page Searching
 ##################
 
 
@@ -497,7 +494,7 @@ class PageView(ViewQueryBaseClass):
     DOMAIN = "page"
     FIELDS = {
         'id': ViewField('id', sqlalchemy_field=(Page, "id"), id_decode=True),
-        'slug': ViewField('slug', sqlalchemy_field=(Page, "slug")),        
+        'slug': ViewField('slug', sqlalchemy_field=(Page, "slug")),
         'title': ViewField('title', sqlalchemy_field=(Page, "title")),
         'deleted': ViewField('deleted', sqlalchemy_field=(Page, "deleted"))
     }
@@ -507,7 +504,7 @@ class PageView(ViewQueryBaseClass):
 
 
 ##################
-#Page Revision Searching
+# Page Revision Searching
 ##################
 
 
@@ -523,10 +520,9 @@ class PageRevisionView(ViewQueryBaseClass):
         self.query = trans.sa_session.query( PageRevision )
 
 
-"""
-The view mapping takes a user's name for a table and maps it to a View class that will
-handle queries
-"""
+# The view mapping takes a user's name for a table and maps it to a View class
+# that will handle queries.
+
 view_mapping = {
     'library': LibraryView,
     'library_folder': LibraryFolderView,
@@ -544,9 +540,7 @@ view_mapping = {
     'page_revision': PageRevisionView,
 }
 
-"""
-The GQL gramar is defined in Parsley syntax ( http://parsley.readthedocs.org/en/latest/ )
-"""
+# The GQL gramar is defined in Parsley syntax ( http://parsley.readthedocs.org/en/latest/ )
 
 gqlGrammar = """
 expr = 'select' bs field_desc:f bs 'from' bs word:t (
@@ -592,7 +586,7 @@ not_dquote = anything:x ?(x != '"') -> x
 """
 
 
-class GalaxyQuery:
+class GalaxyQuery(object):
     """
     This class represents a data structure of a compiled GQL query
     """
@@ -602,7 +596,7 @@ class GalaxyQuery:
         self.conditional = conditional
 
 
-class GalaxyQueryComparison:
+class GalaxyQueryComparison(object):
     """
     This class represents the data structure of the comparison arguments of a
     compiled GQL query (ie where name='Untitled History')
@@ -613,7 +607,7 @@ class GalaxyQueryComparison:
         self.right = right
 
 
-class GalaxyQueryAnd:
+class GalaxyQueryAnd(object):
     """
     This class represents the data structure of the comparison arguments of a
     compiled GQL query (ie where name='Untitled History')
@@ -628,7 +622,7 @@ class GalaxyParseError(Exception):
     pass
 
 
-class SearchQuery:
+class SearchQuery(object):
     def __init__(self, view, query):
         self.view = view
         self.query = query
@@ -658,7 +652,7 @@ class SearchQuery:
         return o
 
 
-class GalaxySearchEngine:
+class GalaxySearchEngine(object):
     """
     Primary class for searching. Parses GQL (Galaxy Query Language) queries and returns a 'SearchQuery' class
     """

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -1,6 +1,5 @@
 import urllib
 
-from galaxy.exceptions import RequestParameterMissingException
 from galaxy.exceptions import ObjectNotFound
 from galaxy.exceptions import InternalServerError
 from galaxy import web, util
@@ -12,14 +11,7 @@ from galaxy.web.base.controller import BaseAPIController
 from galaxy.web.base.controller import UsesVisualizationMixin
 from galaxy.visualization.genomes import GenomeRegion
 from galaxy.util.json import dumps
-from galaxy.util import string_as_bool
-from galaxy.tools.parameters import check_param
-from galaxy.tools.parameters import visit_input_values
-from galaxy.tools.parameters.meta import expand_meta_parameters
 from galaxy.managers.collections_util import dictify_dataset_collection_instance
-from galaxy.model import HistoryDatasetAssociation
-from galaxy.util.expressions import ExpressionContext
-from collections import Iterable
 
 import galaxy.queue_worker
 
@@ -79,7 +71,7 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
         try:
             return self.app.toolbox.to_dict( trans, in_panel=in_panel, trackster=trackster)
         except Exception:
-            raise InternalServerError ( "Error: Could not convert toolbox to dictionary" )
+            raise InternalServerError( "Error: Could not convert toolbox to dictionary" )
 
     @expose_api_anonymous_and_sessionless
     def show( self, trans, id, **kwd ):
@@ -111,7 +103,6 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
         GET /api/tools/{tool_id}/reload
         Reload specified tool.
         """
-        toolbox = trans.app.toolbox
         galaxy.queue_worker.send_control_task( trans.app, 'reload_tool', noop_self=True, kwargs={ 'tool_id': tool_id } )
         message, status = trans.app.toolbox.reload_tool_by_id( tool_id )
         return { status: message }
@@ -125,7 +116,9 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
         and dependency related problems.
         """
         # TODO: Move this into tool.
-        to_dict = lambda x: x.to_dict()
+        def to_dict(x):
+            return x.to_dict()
+
         tool = self._get_tool( id, user=trans.user )
         if hasattr( tool, 'lineage' ):
             lineage_dict = tool.lineage.to_dict()
@@ -249,10 +242,10 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
             if k.startswith("files_") or k.startswith("__files_"):
                 inputs[k] = v
 
-        #for inputs that are coming from the Library, copy them into the history
+        # for inputs that are coming from the Library, copy them into the history
         input_patch = {}
         for k, v in inputs.iteritems():
-            if  isinstance(v, dict) and v.get('src', '') == 'ldda' and 'id' in v:
+            if isinstance(v, dict) and v.get('src', '') == 'ldda' and 'id' in v:
                 ldda = trans.sa_session.query( trans.app.model.LibraryDatasetDatasetAssociation ).get( self.decode_id(v['id']) )
                 if trans.user_is_admin() or trans.app.security_agent.can_access_dataset( trans.get_current_user_roles(), ldda.dataset ):
                     input_patch[k] = ldda.to_history_dataset_association(target_history, add_to_history=True)
@@ -297,12 +290,12 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
             rval[ "errors" ] = job_errors
 
         outputs = rval[ "outputs" ]
-        #TODO:?? poss. only return ids?
+        # TODO:?? poss. only return ids?
         for output_name, output in output_datasets:
             output_dict = output.to_dict()
-            #add the output name back into the output data structure
-            #so it's possible to figure out which newly created elements
-            #correspond with which tool file outputs
+            # add the output name back into the output data structure
+            # so it's possible to figure out which newly created elements
+            # correspond with which tool file outputs
             output_dict[ 'output_name' ] = output_name
             outputs.append( trans.security.encode_dict_ids( output_dict ) )
 
@@ -417,8 +410,8 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
             for jida in original_job.input_datasets:
                 input_dataset = jida.dataset
                 data_provider = data_provider_registry.get_data_provider( trans, original_dataset=input_dataset, source='data' )
-                if data_provider and ( not data_provider.converted_dataset
-                                       or data_provider.converted_dataset.state != trans.app.model.Dataset.states.OK ):
+                if data_provider and ( not data_provider.converted_dataset or
+                                       data_provider.converted_dataset.state != trans.app.model.Dataset.states.OK ):
                     # Can convert but no converted dataset yet, so return message about why.
                     data_sources = input_dataset.datatype.data_sources
                     msg = input_dataset.convert_dataset( trans, data_sources[ 'data' ] )
@@ -524,12 +517,12 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
                     deps = input_dataset.get_converted_dataset_deps( trans, data_source )
 
                     # Create new HDA for input dataset's subset.
-                    new_dataset = trans.app.model.HistoryDatasetAssociation( extension=input_dataset.ext, \
-                                                                             dbkey=input_dataset.dbkey, \
-                                                                             create_dataset=True, \
+                    new_dataset = trans.app.model.HistoryDatasetAssociation( extension=input_dataset.ext,
+                                                                             dbkey=input_dataset.dbkey,
+                                                                             create_dataset=True,
                                                                              sa_session=trans.sa_session,
-                                                                             name="Subset [%s] of data %i" % \
-                                                                                 ( regions_str, input_dataset.hid ),
+                                                                             name="Subset [%s] of data %i" %
+                                                                                  ( regions_str, input_dataset.hid ),
                                                                              visible=False )
                     target_history.add_dataset( new_dataset )
                     trans.sa_session.add( new_dataset )

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -13,7 +13,6 @@ from galaxy.web.base.controller import UsesVisualizationMixin
 from galaxy.visualization.genomes import GenomeRegion
 from galaxy.util.json import dumps
 from galaxy.util import string_as_bool
-from galaxy.visualization.data_providers.genome import *
 from galaxy.tools.parameters import check_param
 from galaxy.tools.parameters import visit_input_values
 from galaxy.tools.parameters.meta import expand_meta_parameters
@@ -210,7 +209,6 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
         if success:
             trans.response.set_content_type( 'application/x-gzip' )
             download_file = open( tool_tarball )
-            tarball_path, filename = os.path.split( tool_tarball )
             trans.response.headers[ "Content-Disposition" ] = 'attachment; filename="%s.tgz"' % ( id )
             return download_file
 


### PR DESCRIPTION
Plus some PEP-8 fixes.

I'd like to have the ReadTheDocs API documentation fixed before the GCC2015 because people may explore it during the Galaxy API tutorial.

Still to be fixed:
- galaxy.webapps.galaxy.api.datasets:

```
$ make -C doc html
...
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/sphinx/ext/autodoc.py", line 335, in import_object
    __import__(self.modname)
  File "/opt/galaxy/lib/galaxy/webapps/galaxy/api/datasets.py", line 8, in <module>
    from galaxy.visualization.data_providers.genome import FeatureLocationIndexDataProvider
  File "/opt/galaxy/lib/galaxy/visualization/data_providers/genome.py", line 15, in <module>
    from bx.bbi.bigwig_file import BigWigFile
ImportError: cannot import name BigWigFile
...
```

Any idea how to fix this?
