### PR TITLE
[15.05] Fix function names for dynamic tool test functions.

### DIFF
--- a/test/functional/test_toolbox.py
+++ b/test/functional/test_toolbox.py
@@ -263,13 +263,18 @@ def build_tests( app=None, testing_shed_tools=False, master_api_key=None, user_a
             baseclasses = ( ToolTestCase, )
             namespace = dict()
             for j, testdef in enumerate( tool.tests ):
+                test_function_name = 'test_tool_%06d' % j
+
                 def make_test_method( td ):
                     def test_tool( self ):
                         self.do_it( td )
+                    test_tool.__name__ = test_function_name
+
                     return test_tool
+
                 test_method = make_test_method( testdef )
                 test_method.__doc__ = "%s ( %s ) > %s" % ( tool.name, tool.id, testdef.name )
-                namespace[ 'test_tool_%06d' % j ] = test_method
+                namespace[ test_function_name ] = test_method
                 namespace[ 'shed_tool_id' ] = shed_tool_id
                 namespace[ 'master_api_key' ] = master_api_key
                 namespace[ 'user_api_key' ] = user_api_key


### PR DESCRIPTION
Backport of fix applied to dev in https://github.com/galaxyproject/galaxy/pull/266.

Important fix for `planemo test --failed`.
