### PR TITLE
Quota calculation fixes for managers

### DIFF
--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -143,14 +143,18 @@ class HDAManager( datasets.DatasetAssociationManager,
         return ldda.to_history_dataset_association( history, add_to_history=True )
 
     # .... deletion and purging
-    def purge( self, hda, current_user=None, flush=True ):
+    def purge( self, hda, flush=True):
         """
         Purge this HDA and the dataset underlying it.
         """
+        user = hda.history.user or None
+        quota_amount_reduction = 0
+        if user:
+            quota_amount_reduction = hda.quota_amount( user )
         super( HDAManager, self ).purge( hda, flush=flush )
         # decrease the user's space used
-        if current_user:
-            current_user.total_disk_usage -= hda.quota_amount( current_user )
+        if quota_amount_reduction:
+            user.total_disk_usage -= quota_amount_reduction
         return hda
 
     # .... states

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -82,7 +82,6 @@ class HistoryManager( sharable.SharableModelManager, deletable.PurgableManagerMi
         Purge this history and all HDAs, Collections, and Datasets inside this history.
         """
         self.hda_manager.dataset_manager.error_unless_dataset_purge_allowed()
-
         # First purge all the datasets
         for hda in history.datasets:
             if not hda.purged:


### PR DESCRIPTION
There were a couple bugs here.  Slight refactoring in manager purge -- we don't need to pass the user via context since we can just grab it where applicable from the history (which wasn't being done, but it also wasn't being passed).  Fix another bug in hda manager regarding quota reduction -- quota usage must be calculated prior to actually purging, otherwise the disk usage is 0 and this does nothing.
