### PR TITLE
[15.05] Fix workflow run for certain kinds of explicit output collections.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -500,6 +500,16 @@ class Tool( object, Dictifiable ):
     def produces_collections( self ):
         return any( o.collection for o in self.outputs.values() )
 
+    @property
+    def produces_collections_with_unknown_structure( self ):
+
+        def output_is_dynamic(output):
+            if not output.collection:
+                return False
+            return output.dynamic_structure
+
+        return any( map( output_is_dynamic, self.outputs.values() ) )
+
     def __get_job_tool_configuration(self, job_params=None):
         """Generalized method for getting this tool's job configuration.
 

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -50,6 +50,8 @@ def force_queue( trans, workflow ):
         if step.type == "data_collection_input" and force_for_collection:
             log.info("Found collection input step - backgrounding execution")
             return True
+        if step.type == "tool" and step.module.tool.produces_collections_with_unknown_structure:
+            return True
 
     return False
 

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -51,6 +51,7 @@ def force_queue( trans, workflow ):
             log.info("Found collection input step - backgrounding execution")
             return True
         if step.type == "tool" and step.module.tool.produces_collections_with_unknown_structure:
+            log.info("Found dynamically structured output collection - backgrounding execution")
             return True
 
     return False


### PR DESCRIPTION
Workflows with steps that produce an unknown number of datasets must explicitly be sent to the new workflow engine - since the workflow needs be re-evaluated after such steps have completed. This change updates the `force_queue` method to check workflow steps for such collections and return `True` if any are found - this is what causes certain GUI driven workflows to use the new workflow engine.

Thanks to Alexander Vowinkel for reporting the problem.
