### PR TITLE
GCC2015 ie updates

### DIFF
--- a/config/plugins/interactive_environments/ipython/templates/ipython.mako
+++ b/config/plugins/interactive_environments/ipython/templates/ipython.mako
@@ -1,4 +1,4 @@
- <%namespace name="ie" file="ie.mako" />
+<%namespace name="ie" file="ie.mako" />
 
 <%
 import os
@@ -16,7 +16,7 @@ if ie_request.attr.PASSWORD_AUTH:
     m.update( ie_request.notebook_pw + ie_request.notebook_pw_salt )
     PASSWORD = 'sha1:%s:%s' % (ie_request.notebook_pw_salt, m.hexdigest())
 else:
-	PASSWORD = "none"
+    PASSWORD = "none"
 
 ## IPython Specific
 # Prepare an empty notebook
@@ -26,6 +26,7 @@ with open( os.path.join( ie_request.attr.our_template_dir, 'notebook.ipynb' ), '
 empty_nb = empty_nb % notebook_id
 # Copy over default notebook, unless the dataset this viz is running on is a notebook
 empty_nb_path = os.path.join(temp_dir, 'ipython_galaxy_notebook.ipynb')
+
 if hda.datatype.__class__.__name__ != "Ipynb":
     with open( empty_nb_path, 'w+' ) as handle:
         handle.write( empty_nb )

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -107,7 +107,7 @@ class Ipynb( Json ):
             ofilename = ofile_handle.name
             ofile_handle.close()
             try:
-                cmd = 'ipython nbconvert --to html --template basic %s --output %s' % (dataset.file_name, ofilename)
+                cmd = 'ipython nbconvert --to html --template full %s --output %s' % (dataset.file_name, ofilename)
                 log.info("Calling command %s" % cmd)
                 subprocess.call(cmd, shell=True)
                 ofilename = '%s.html' % ofilename


### PR DESCRIPTION
Preparing for the IE seminar, a couple of tiny changes.
- whitespace corrected in ipython
- switched to full template for ipython statically rendered HTML, as they look MUCH nicer.

![snapshot8](https://cloud.githubusercontent.com/assets/458683/8443759/15ca4b34-1f4f-11e5-9d3a-8356b2fe7404.png)

vs

![snapshot9](https://cloud.githubusercontent.com/assets/458683/8443760/161f8478-1f4f-11e5-968f-f243c4cffa3a.png)
