### PR TITLE
Use web.url_for( '/', qualified=True ) instead of '/' to generate

### DIFF
--- a/lib/galaxy/webapps/tool_shed/controllers/repository.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/repository.py
@@ -1226,7 +1226,8 @@ class RepositoryController( BaseUIController, ratings_util.ItemRatings ):
         repository.times_downloaded += 1
         trans.sa_session.add( repository )
         trans.sa_session.flush()
-        download_url = common_util.url_join( '/',
+        tool_shed_url = web.url_for( '/', qualified=True )
+        download_url = common_util.url_join( tool_shed_url,
                                              'repos',
                                              str( repository.user.username ),
                                              str( repository.name ),


### PR DESCRIPTION
URL for toolshed repository downloads. Fixes repository downloads
from toolsheds that are on a subfolder (e.g. http://example.com/toolshed).

I also created a card here:
https://trello.com/c/3ymCjFp0/2695-toolshed-repository-download-broken-when-toolshed-is-in-subdirectory
