### PR TITLE
[15.05] Fix for PR #409.

### DIFF
--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -33,6 +33,12 @@ BASIC_WORKFLOW_STEP_TYPES = [ None, "tool", "data_input", "data_collection_input
 def force_queue( trans, workflow ):
     # Default behavior is still to just schedule workflows completley right
     # away. This can be modified here in various ways.
+
+    # TODO: check for implicit connections - these should also force backgrounding
+    #       this would fix running Dan's data manager workflows via UI.
+    # TODO: ensure state if populated before calling force_queue from old API
+    #       workflow endpoint so the has_module check below is unneeded and these
+    #       interesting workflows will work with the older endpoint.
     config = trans.app.config
     force_for_collection = config.force_beta_workflow_scheduled_for_collections
     force_min_steps = config.force_beta_workflow_scheduled_min_steps
@@ -42,6 +48,10 @@ def force_queue( trans, workflow ):
         log.info("Workflow has many steps %d, backgrounding execution" % step_count)
         return True
     for step in workflow.steps:
+        # State and module haven't been populated if workflow submitted via
+        # the API. API requests for "interesting" workflows should use newer
+        # endpoint that skips this check entirely - POST /api/workflows/<id>/invocations
+        has_module = hasattr(step, "module")
         if step.type not in BASIC_WORKFLOW_STEP_TYPES:
             log.info("Found non-basic workflow step type - backgrounding execution")
             # Force all new beta modules types to be use force queueing of
@@ -50,10 +60,9 @@ def force_queue( trans, workflow ):
         if step.type == "data_collection_input" and force_for_collection:
             log.info("Found collection input step - backgrounding execution")
             return True
-        if step.type == "tool" and step.module.tool.produces_collections_with_unknown_structure:
+        if step.type == "tool" and has_module and step.module.tool.produces_collections_with_unknown_structure:
             log.info("Found dynamically structured output collection - backgrounding execution")
             return True
-
     return False
 
 


### PR DESCRIPTION
Thanks @nsoranzo for the catch - https://github.com/galaxyproject/galaxy/pull/409#issuecomment-117390843. Hadn't remembered that the API also calls this method - and does so before module and state are populate. 

Document two additional fixes that should be done but I don't have time for pre-GCC.

@blankenberg - if someone were to update this method to check connections for implicit connections - your data manager workflows would likely work with the older API endpoint and you could go back to using bioblend :smiley_cat:.
