### PR TITLE
Fix for missing included files on history export and import.

### DIFF
--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -197,6 +197,24 @@ class JobImportHistoryArchiveWrapper( object, UsesAnnotations ):
                             raise Exception( "Invalid dataset path: %s" % temp_dataset_file_name )
                         if datasets_usage_counts[ temp_dataset_file_name ] == 1:
                             shutil.move( temp_dataset_file_name, hda.file_name )
+
+                            # Import additional files if present. Histories exported previously might not have this attribute set.
+                            dataset_extra_files_path = ''
+                            try:
+                                dataset_extra_files_path = dataset_attrs[ 'extra_files_path' ]
+                            except KeyError:
+                                pass
+
+                            if dataset_extra_files_path:
+                                try:
+                                    file_list = os.listdir( os.path.join( archive_dir, dataset_extra_files_path ) )
+                                except OSError:
+                                    file_list = []
+
+                                if len( file_list ):
+                                    os.mkdir( hda.extra_files_path )
+                                    for extra_file in file_list:
+                                        shutil.move( os.path.join( archive_dir, dataset_extra_files_path, extra_file ), hda.extra_files_path )
                         else:
                             datasets_usage_counts[ temp_dataset_file_name ] -= 1
                             shutil.copyfile( temp_dataset_file_name, hda.file_name )
@@ -394,6 +412,7 @@ class JobExportHistoryArchiveWrapper( object, UsesAnnotations ):
                         "uuid": ( lambda uuid: str( uuid ) if uuid else None )( obj.dataset.uuid ),
                         "annotation": to_unicode( getattr( obj, 'annotation', '' ) ),
                         "tags": get_item_tag_dict( obj ),
+                        "extra_files_path": obj.extra_files_path
                     }
                     if not obj.visible and not include_hidden:
                         rval['exported'] = False

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -196,25 +196,22 @@ class JobImportHistoryArchiveWrapper( object, UsesAnnotations ):
                         if not file_in_dir( temp_dataset_file_name, os.path.join( archive_dir, "datasets" ) ):
                             raise Exception( "Invalid dataset path: %s" % temp_dataset_file_name )
                         if datasets_usage_counts[ temp_dataset_file_name ] == 1:
-                            shutil.move( temp_dataset_file_name, hda.file_name )
+                            self.app.object_store.update_from_file( hda.dataset, file_name=temp_dataset_file_name, create=True )
 
                             # Import additional files if present. Histories exported previously might not have this attribute set.
-                            dataset_extra_files_path = ''
-                            try:
-                                dataset_extra_files_path = dataset_attrs[ 'extra_files_path' ]
-                            except KeyError:
-                                pass
-
+                            dataset_extra_files_path = dataset_attrs.get( 'extra_files_path', None )
                             if dataset_extra_files_path:
                                 try:
                                     file_list = os.listdir( os.path.join( archive_dir, dataset_extra_files_path ) )
                                 except OSError:
                                     file_list = []
 
-                                if len( file_list ):
-                                    os.mkdir( hda.extra_files_path )
+                                if file_list:
                                     for extra_file in file_list:
-                                        shutil.move( os.path.join( archive_dir, dataset_extra_files_path, extra_file ), hda.extra_files_path )
+                                        self.app.object_store.update_from_file(
+                                            hda.dataset, extra_dir='dataset_%s_files' % hda.dataset.id,
+                                            alt_name=extra_file, file_name=os.path.join( archive_dir, dataset_extra_files_path, extra_file ),
+                                            create=True )
                         else:
                             datasets_usage_counts[ temp_dataset_file_name ] -= 1
                             shutil.copyfile( temp_dataset_file_name, hda.file_name )


### PR DESCRIPTION
Related Trello card: https://trello.com/c/oq1ASbkC

Notes:

If a history was exported previously, galaxy would just serve the cached version.
In that case, it is better to make some changes to the history for example, by re-running
the last job and then exporting it.

Export of histories that haven't been exported previously should work without problems.
