### PR TITLE
add error message for bad dependency declaration

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1062,7 +1062,7 @@ class Tool( object, Dictifiable ):
         for name in param.get_dependencies():
             # Let it throw exception, but give some hint what the problem might be
             if name not in context:
-                log.error("Could not find dependency '%s' for tool %s" % (name, self.name) )
+                log.error("Could not find dependency '%s' of parameter '%s' in tool %s" % (name, param.name, self.name) )
             context[ name ].refresh_on_change = True
         return param
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1060,6 +1060,9 @@ class Tool( object, Dictifiable ):
         # If parameter depends on any other paramters, we must refresh the
         # form when it changes
         for name in param.get_dependencies():
+            # Let it throw exception, but give some hint what the problem might be
+            if name not in context:
+                log.error("Could not find dependency '%s' for tool %s" % (name, self.name) )
             context[ name ].refresh_on_change = True
         return param
 


### PR DESCRIPTION
I got crazy identifying this error. The only error was a generic "KeyError"
This will help others to detect the problem in their tool files.

I also raises the question how to use non first-level parameters as dependencies, because in `context` seem to be only first level parameters. Is that known?
