### PR TITLE
Fix example api test command.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -34,7 +34,7 @@ Run all TestUserInfo functional tests:
     ./run_tests.sh test/functional/test_user_info.py:TestUserInfo
 
 Run a specific API test requiring the framework test tools:
-    ./run_tests.sh -api -with_framework_test_tools test/api/test_tools.py:ToolsTestCase.test_map_over_with_output_format_actions
+    ./run_tests.sh -with_framework_test_tools -api test/api/test_tools.py:ToolsTestCase.test_map_over_with_output_format_actions
 
 
 Extra options:


### PR DESCRIPTION
The `-api` parameter takes an optional argument so it can be thought of as `-api [testpath]`. So in the example `-with_framework_test_tools` needs to come first.
