### PR TITLE
Fixed: Return integer values when 'round to nearest integer' is selected in Group tool

### DIFF
--- a/tools/stats/grouping.py
+++ b/tools/stats/grouping.py
@@ -151,7 +151,7 @@ def main():
                     rval = round(rval)
                 else:
                     rval = '%g' % rval
-                        
+                rval = int(rval)
             out_str += "\t%s" % rval
         
         fout.write(out_str + "\n")

--- a/tools/stats/grouping.py
+++ b/tools/stats/grouping.py
@@ -148,10 +148,10 @@ def main():
                     sys.exit( 1 )
                 rval = getattr(numpy, op)( data )
                 if round_val[i] == 'yes':
-                    rval = round(rval)
+                    rval = int(round(rval))
                 else:
                     rval = '%g' % rval
-                rval = int(rval)
+                rval = rval
             out_str += "\t%s" % rval
         
         fout.write(out_str + "\n")


### PR DESCRIPTION
From #425.

I wanted to get this fix in to 15.07 and since the freeze is today I went ahead and merged in @moskalenko's change locally and applied the correction from @nsoranzo.

Close #425 if merged.
