### PR TITLE
Implement <filter> tag for output collections.

### DIFF
--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -329,7 +329,8 @@ class ToolEvaluator( object ):
                 # Assume the reason we lack this output is because a filter
                 # failed to pass; for tool writing convienence, provide a
                 # NoneDataset
-                param_dict[ out_name ] = NoneDataset( datatypes_registry=self.app.datatypes_registry, ext=output.format )
+                ext = getattr( output, "format", None )  # populate only for output datasets (not collections)
+                param_dict[ out_name ] = NoneDataset( datatypes_registry=self.app.datatypes_registry, ext=ext )
 
     def __populate_non_job_params(self, param_dict):
         # -- Add useful attributes/functions for use in creating command line.

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -186,6 +186,7 @@ class XmlToolSource(ToolSource):
                 inherit_metadata = string_as_bool( collection_elem.get( "inherit_metadata", None ) )
             default_format_source = collection_elem.get( "format_source", None )
             default_metadata_source = collection_elem.get( "metadata_source", "" )
+            filters = collection_elem.findall( 'filter' )
 
             dataset_collectors = None
             if collection_elem.find( "discover_datasets" ) is not None:
@@ -199,6 +200,7 @@ class XmlToolSource(ToolSource):
                 name,
                 structure,
                 label=label,
+                filters=filters,
                 default_format=default_format,
                 inherit_format=inherit_format,
                 inherit_metadata=inherit_metadata,

--- a/test/functional/tools/output_collection_filter.xml
+++ b/test/functional/tools/output_collection_filter.xml
@@ -1,0 +1,52 @@
+<tool id="output_collection_filter" name="output_collection_filter" version="1.0.0">
+  <command>
+    echo "AF" > af.txt;
+    echo "AR" > ar.txt;
+    echo "BF" > bf.txt;
+    echo "BR" > br.txt;
+  </command>
+  <inputs>
+    <param name="output_type" type="select" label="Output Type">
+      <option value="a">A</option>
+      <option value="b">B</option>
+    </param>
+  </inputs>
+  <outputs>
+    <collection name="a_paired_output" type="paired" label="A Pair">
+      <data name="forward" format="txt" from_work_dir="af.txt"  />
+      <data name="reverse" format="txt" from_work_dir="ar.txt"  />
+      <filter>output_type == "a"</filter>
+    </collection>
+    <collection name="b_paired_output" type="paired" label="B Pair">
+      <data name="forward" format="txt" from_work_dir="bf.txt"  />
+      <data name="reverse" format="txt" from_work_dir="br.txt"  />
+      <filter>output_type == "b"</filter>
+    </collection>
+  </outputs>
+  <tests>
+    <!-- TODO: Enhance test cases to actually verify other collection not 
+         created. -->
+    <test>
+      <param name="output_type" value="a" />
+      <output_collection name="a_paired_output" type="paired">
+        <element name="forward" ftype="txt">
+          <assert_contents><has_line line="AF" /></assert_contents>
+        </element>
+        <element name="reverse" ftype="txt">
+          <assert_contents><has_line line="AR" /></assert_contents>
+        </element>
+      </output_collection>
+    </test>
+    <test>
+      <param name="output_type" value="b" />
+      <output_collection name="b_paired_output" type="paired">
+        <element name="forward" ftype="txt">
+          <assert_contents><has_line line="BF" /></assert_contents>
+        </element>
+        <element name="reverse" ftype="txt">
+          <assert_contents><has_line line="BR" /></assert_contents>
+        </element>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -27,6 +27,7 @@
   <tool file="output_order.xml" />
   <tool file="output_format.xml" />
   <tool file="output_filter.xml" />
+  <tool file="output_collection_filter.xml" />
   <tool file="output_auto_format.xml" />
   <tool file="disambiguate_repeats.xml" />
   <tool file="min_repeat.xml" />


### PR DESCRIPTION
This tag matches functionality and syntax of the plain dataset version. This pull request includes test tool demonstrating this functionality. Run the test with the command:

```
./run_tests.sh -framework -id output_collection_filter 
```

Closes #445.
