### PR TITLE
Allow tools to explicitly create nested collections with static structure.

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -277,7 +277,9 @@ class DatasetCollectionManager( object ):
             raise MessageException( "Dataset collection element definition (%s) not dictionary-like." % element_identifier )
         encoded_id = element_identifier.get( 'id', None )
         if not src_type or not encoded_id:
-            raise RequestParameterInvalidException( "Problem decoding element identifier %s" % element_identifier )
+            message_template = "Problem decoding element identifier %s - must contain a 'src' and a 'id'."
+            message = message_template % element_identifier
+            raise RequestParameterInvalidException( message )
 
         if src_type == 'hda':
             decoded_id = int( trans.app.security.decode_id( encoded_id ) )

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -48,11 +48,13 @@ class DatasetCollectionManager( object ):
         element_identifiers=None,
         elements=None,
         implicit_collection_info=None,
+        trusted_identifiers=None,  # Trust preloaded element objects
     ):
         """
         """
         # Trust embedded, newly created objects created by tool subsystem.
-        trusted_identifiers = implicit_collection_info is not None
+        if trusted_identifiers is None:
+            trusted_identifiers = implicit_collection_info is not None
 
         if element_identifiers and not trusted_identifiers:
             validate_input_element_identifiers( element_identifiers )

--- a/lib/galaxy/managers/collections_util.py
+++ b/lib/galaxy/managers/collections_util.py
@@ -39,7 +39,7 @@ def validate_input_element_identifiers( element_identifiers ):
     identifier_names = set()
     for element_identifier in element_identifiers:
         if "__object__" in element_identifier:
-            message = ERROR_MESSAGE_INVALID_PARAMETER_FOUND % ( "__model_object__", element_identifier )
+            message = ERROR_MESSAGE_INVALID_PARAMETER_FOUND % ( "__object__", element_identifier )
             raise exceptions.RequestParameterInvalidException( message )
         if "name" not in element_identifier:
             message = ERROR_MESSAGE_NO_NAME % element_identifier

--- a/test/functional/test_toolbox.py
+++ b/test/functional/test_toolbox.py
@@ -209,8 +209,8 @@ class ToolTestCase( TwillTestCase ):
                     for element_identifier, ( element_outfile, element_attrib ) in element_tests.items():
                         element = get_element( element_objects, element_identifier )
                         if not element:
-                            template = "Failed to find identifier [%s] for testing, tool generated collection with identifiers [%s]"
-                            message = template % (element_identifier, ",".join(element_dict.keys()))
+                            template = "Failed to find identifier [%s] for testing, tool generated collection elements [%s]"
+                            message = template % (element_identifier, element_objects)
                             raise AssertionError(message)
 
                         element_type = element["element_type"]

--- a/test/functional/test_toolbox.py
+++ b/test/functional/test_toolbox.py
@@ -190,8 +190,12 @@ class ToolTestCase( TwillTestCase ):
                 # the job completed so re-hit the API for more information.
                 data_collection_returned = data_collection_list[ name ]
                 data_collection = galaxy_interactor._get( "dataset_collections/%s" % data_collection_returned[ "id" ], data={"instance_type": "history"} ).json()
-                elements = data_collection[ "elements" ]
-                element_dict = dict( map(lambda e: (e["element_identifier"], e["object"]), elements) )
+
+                def get_element( elements, id ):
+                    for element in elements:
+                        if element["element_identifier"] == id:
+                            return element
+                    return False
 
                 expected_collection_type = output_collection_def.collection_type
                 if expected_collection_type:
@@ -201,20 +205,29 @@ class ToolTestCase( TwillTestCase ):
                         message = template % (name, expected_collection_type, collection_type)
                         raise AssertionError(message)
 
-                for element_identifier, ( element_outfile, element_attrib ) in output_collection_def.element_tests.items():
-                    if element_identifier not in element_dict:
-                        template = "Failed to find identifier [%s] for testing, tool generated collection with identifiers [%s]"
-                        message = template % (element_identifier, ",".join(element_dict.keys()))
-                        raise AssertionError(message)
-                    hda = element_dict[ element_identifier ]
+                def verify_elements( element_objects, element_tests ):
+                    for element_identifier, ( element_outfile, element_attrib ) in element_tests.items():
+                        element = get_element( element_objects, element_identifier )
+                        if not element:
+                            template = "Failed to find identifier [%s] for testing, tool generated collection with identifiers [%s]"
+                            message = template % (element_identifier, ",".join(element_dict.keys()))
+                            raise AssertionError(message)
 
-                    galaxy_interactor.verify_output_dataset(
-                        history,
-                        hda_id=hda["id"],
-                        outfile=element_outfile,
-                        attributes=element_attrib,
-                        shed_tool_id=shed_tool_id
-                    )
+                        element_type = element["element_type"]
+                        if element_type != "dataset_collection":
+                            hda = element[ "object" ]
+                            galaxy_interactor.verify_output_dataset(
+                                history,
+                                hda_id=hda["id"],
+                                outfile=element_outfile,
+                                attributes=element_attrib,
+                                shed_tool_id=shed_tool_id
+                            )
+                        if element_type == "dataset_collection":
+                            elements = element[ "object" ][ "elements" ]
+                            verify_elements( elements, element_attrib.get( "elements", {} ) )
+
+                verify_elements( data_collection[ "elements" ], output_collection_def.element_tests )
             except Exception as e:
                 register_exception(e)
 

--- a/test/functional/tools/collection_creates_list_of_pairs.xml
+++ b/test/functional/tools/collection_creates_list_of_pairs.xml
@@ -1,0 +1,50 @@
+<tool id="collection_creates_list_of_pairs" name="collection_creates_list_or_pairs" version="0.1.0">
+  <!-- You usually wouldn't want to do this - just write the operation for
+       a single dataset and allow the user to map that tool over the whole
+       collection. -->
+  <command>
+    #for $list_key in $list_output.keys()#
+    #for $pair_key in $list_output[$list_key].keys()#
+    echo "identifier is $list_key:$pair_key" > "$list_output[$list_key][$pair_key]";
+    #end for#
+    #end for#
+    echo 'ensure not empty';
+  </command>
+  <inputs>
+    <param name="input1" type="data_collection" collection_type="list:paired" label="Input" help="Input collection..." format="txt" />
+  </inputs>
+  <outputs>
+    <collection name="list_output" type="list:paired" label="Duplicate List" structured_like="input1" inherit_format="true">
+      <!-- inherit_format can be used in conjunction with structured_like
+           to perserve format. -->
+    </collection>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input1">
+        <collection type="list:paired">
+          <element name="i1">
+            <collection type="paired">
+              <element name="forward" value="simple_line.txt" />
+              <element name="reverse" value="simple_line_alternative.txt" />
+            </collection>
+          </element>
+        </collection>
+      </param>
+      <output_collection name="list_output" type="list:paired">
+        <element name="i1">
+          <element name="forward">
+            <assert_contents>
+              <has_text_matching expression="^identifier is i1:forward\n$" />
+            </assert_contents>
+          </element>
+          <element name="reverse">
+            <assert_contents>
+              <has_text_matching expression="^identifier is i1:reverse\n$" />
+            </assert_contents>
+          </element>
+        </element>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -55,6 +55,7 @@
   <tool file="collection_creates_pair_from_type.xml" />
   <tool file="collection_creates_list.xml" />
   <tool file="collection_creates_list_2.xml" />
+  <tool file="collection_creates_list_of_pairs.xml" />
   <tool file="collection_optional_param.xml" />
   <tool file="collection_split_on_column.xml" />
 


### PR DESCRIPTION
https://bitbucket.org/galaxy/galaxy-central/pull-request/634/allow-tools-to-explicitly-produce-dataset added the ability for tool to create simple collections (lists and pairs). It also outlined three creation scenarios - fixed collections, pre-determinable collection structures (like output lists based on input lists), and fully dynamic output collections. This pull request allows tool to output nested collections for these first two.

Fully dynamic nested collections (using `<discover_datasets>` tags) is not implemented in this pull request.

Additionally, the tool test syntax has been extended to allow testing nested collection elements and an example tool is included that demonstrates this functionality - test/functional/tools/collection_creates_list_of_pairs.xml.

The new functionality in this pull request can be functionally tested with the following command:

```
./run_tests.sh -framework -id collection_creates_list_of_pairs
```

Another smaller commit improving the exception logging/messages for the collections API has been included as well.

Progress toward #460.
