### PR TITLE
[15.05] Set a default limit for metadata key size

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -975,9 +975,10 @@ use_interactive = True
 
 # Very large metadata values can cause Galaxy crashes.  This will allow
 # limiting the maximum metadata key size (in bytes used in memory, not the end
-# result database value size) Galaxy will attempt to save with a dataset.  0 to
-# disable this feature.  5000000 seems to be a reasonable size.
-#max_metadata_value_size = 0
+# result database value size) Galaxy will attempt to save with a dataset.  Use
+# 0 to disable this feature.  The default is 5MB, but as low as 1MB seems to be
+# a reasonable size.
+#max_metadata_value_size = 5242880
 
 # If (for example) you run on a cluster and your datasets (by default,
 # database/files/) are mounted read-only, this option will override tool output

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -148,7 +148,7 @@ class Configuration( object ):
         self.tool_secret = kwargs.get( "tool_secret", "" )
         self.id_secret = kwargs.get( "id_secret", "USING THE DEFAULT IS NOT SECURE!" )
         self.retry_metadata_internally = string_as_bool( kwargs.get( "retry_metadata_internally", "True" ) )
-        self.max_metadata_value_size = int( kwargs.get( "max_metadata_value_size", 0 ) )
+        self.max_metadata_value_size = int( kwargs.get( "max_metadata_value_size", 5242880 ) )
         self.use_remote_user = string_as_bool( kwargs.get( "use_remote_user", "False" ) )
         self.normalize_remote_user_email = string_as_bool( kwargs.get( "normalize_remote_user_email", "False" ) )
         self.remote_user_maildomain = kwargs.get( "remote_user_maildomain", None )


### PR DESCRIPTION
This feature was introduced by @dannon during the last development cycle to fix performance/memory problems we were having on usegalaxy.org with new bam metadata keys introduced in 15.05. It should be enabled by default to prevent Galaxy from rendering itself unusable.

xref #345 #416 
