### PR TITLE
Managers: containers and hda permissions

### DIFF
--- a/lib/galaxy/managers/containers.py
+++ b/lib/galaxy/managers/containers.py
@@ -3,10 +3,9 @@ Manager mixins to unify the interface into things that can contain: Datasets
 and other (nested) containers.
 
 (e.g. DatasetCollections, Histories, LibraryFolders)
-
-Histories should be DatasetCollections.
-Libraries should be DatasetCollections.
 """
+# Histories should be DatasetCollections.
+# Libraries should be DatasetCollections.
 
 import operator
 
@@ -28,6 +27,7 @@ class ContainerManagerMixin( object ):
     each of the methods below only work on the first level of
     nesting.
     """
+    # TODO: terminology is getting a bit convoluted and silly at this point: rename three public below?
     # TODO: this should be an open mapping (not just 2)
     #: the classes that can be contained
     contained_class = None
@@ -78,6 +78,7 @@ class HistoryAsContainerManagerMixin( ContainerManagerMixin ):
     order_contents_on = operator.attrgetter( 'hid' )
 
     def _filter_to_contained( self, container, content_class ):
+        # use the backref of the container on the contained
         return content_class.history == container
 
     def _content_manager( self, content ):

--- a/lib/galaxy/managers/containers.py
+++ b/lib/galaxy/managers/containers.py
@@ -71,25 +71,6 @@ class ContainerManagerMixin( object ):
         raise galaxy.exceptions.NotImplemented( 'Abstract class' )
 
 
-class HistoryAsContainerManagerMixin( ContainerManagerMixin ):
-
-    contained_class = model.HistoryDatasetAssociation
-    subcontainer_class = model.HistoryDatasetCollectionAssociation
-    order_contents_on = operator.attrgetter( 'hid' )
-
-    def _filter_to_contained( self, container, content_class ):
-        # use the backref of the container on the contained
-        return content_class.history == container
-
-    def _content_manager( self, content ):
-        # type sniffing is inevitable
-        if isinstance( content, model.HistoryDatasetAssociation ):
-            return self.hda_manager
-        elif isinstance( content, model.HistoryDatasetCollectionAssociation ):
-            return self.hdca_manager
-        raise TypeError( 'Unknown contents class: ' + str( content ) )
-
-
 class LibraryFolderAsContainerManagerMixin( ContainerManagerMixin ):
     # can contain two types of subcontainer: LibraryFolder, LibraryDatasetCollectionAssociation
     # has as the top level container: Library

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -196,11 +196,18 @@ class DatasetSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin
             return dataset.extra_files_path
         self.skip()
 
-    def serialize_permissions( self, dataset, key, **context ):
+    def serialize_permissions( self, dataset, key, user=None, **context ):
         """
         """
-        permissions = {}
-# TODO: use rbac permissions?
+        if not user or not self.dataset_manager.permissions.manage.is_permitted( dataset, user ):
+            self.skip()
+
+        management_permissions = self.dataset_manager.permissions.manage.by_dataset( dataset )
+        access_permissions = self.dataset_manager.permissions.access.by_dataset( dataset )
+        permissions = {
+            'manage' : [ self.app.security.encode_id( perm.role.id ) for perm in management_permissions ],
+            'access' : [ self.app.security.encode_id( perm.role.id ) for perm in access_permissions ],
+        }
         return permissions
 
 

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -27,6 +27,10 @@ class HistoryManager( sharable.SharableModelManager, deletable.PurgableManagerMi
     annotation_assoc = model.HistoryAnnotationAssociation
     rating_assoc = model.HistoryRatingAssociation
 
+    contained_class = model.HistoryDatasetAssociation
+    subcontainer_class = model.HistoryDatasetCollectionAssociation
+    order_contents_on = operator.attrgetter( 'hid' )
+
     # TODO: incorporate imp/exp (or alias to)
 
     def __init__( self, app, *args, **kwargs ):
@@ -166,12 +170,7 @@ class HistoryManager( sharable.SharableModelManager, deletable.PurgableManagerMi
         return { 'history': history_dictionary,
                  'contents': contents_dictionaries }
 
-# class HistoryAsContainerManagerMixin( ContainerManagerMixin ):
-
-    contained_class = model.HistoryDatasetAssociation
-    subcontainer_class = model.HistoryDatasetCollectionAssociation
-    order_contents_on = operator.attrgetter( 'hid' )
-
+    # container interface
     def _filter_to_contained( self, container, content_class ):
         return content_class.history == container
 
@@ -182,7 +181,6 @@ class HistoryManager( sharable.SharableModelManager, deletable.PurgableManagerMi
         elif isinstance( content, model.HistoryDatasetCollectionAssociation ):
             return self.hdca_manager
         raise TypeError( 'Unknown contents class: ' + str( content ) )
-
 
 
 class HistorySerializer( sharable.SharableModelSerializer, deletable.PurgableSerializerMixin ):

--- a/lib/galaxy/managers/rbac_secured.py
+++ b/lib/galaxy/managers/rbac_secured.py
@@ -256,6 +256,6 @@ class AccessDatasetRBACPermission( DatasetRBACPermission ):
 
     def _role_is_permitted( self, dataset, role ):
         current_roles = self._roles( dataset )
-        return ( self._is_public_from_roles( current_roles ) or
-                 # if there's only one role and this is it, let em in
-                 ( ( len( current_roles ) == 1 ) and ( role == current_roles[0] ) ) )
+        return ( self._is_public_from_roles( current_roles )
+            # if there's only one role and this is it, let em in
+            or ( ( len( current_roles ) == 1 ) and ( role == current_roles[0] ) ) )

--- a/test/unit/managers/base.py
+++ b/test/unit/managers/base.py
@@ -120,6 +120,21 @@ class BaseTestCase( test_utils.unittest.TestCase ):
         self.assertIsInstance( json.dumps( item ), basestring )
 
 
+class CreatesCollectionsMixin( object ):
+
+    def build_element_identifiers( self, elements ):
+        identifier_list = []
+        for element in elements:
+            src = 'hda'
+            # if isinstance( element, model.DatasetCollection ):
+            #    src = 'collection'#?
+            # elif isinstance( element, model.LibraryDatasetDatasetAssociation ):
+            #    src = 'ldda'#?
+            encoded_id = self.trans.security.encode_id( element.id )
+            identifier_list.append( dict( src=src, name=element.name, id=encoded_id ) )
+        return identifier_list
+
+
 # =============================================================================
 if __name__ == '__main__':
     # or more generally, nosetests test_resourcemanagers.py -s -v

--- a/test/unit/managers/test_CollectionManager.py
+++ b/test/unit/managers/test_CollectionManager.py
@@ -11,6 +11,7 @@ test_utils = imp.load_source( 'test_utils',
 from galaxy import model
 
 from base import BaseTestCase
+from base import CreatesCollectionsMixin
 from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.histories import HistoryManager
 from galaxy.managers.hdas import HDAManager
@@ -25,7 +26,7 @@ user3_data = dict( email='user3@user3.user3', username='user3', password=default
 
 
 # =============================================================================
-class DatasetCollectionManagerTestCase( BaseTestCase ):
+class DatasetCollectionManagerTestCase( BaseTestCase, CreatesCollectionsMixin ):
 
     def set_up_managers( self ):
         super( DatasetCollectionManagerTestCase, self ).set_up_managers()
@@ -33,18 +34,6 @@ class DatasetCollectionManagerTestCase( BaseTestCase ):
         self.hda_manager = HDAManager( self.app )
         self.history_manager = HistoryManager( self.app )
         self.collection_manager = DatasetCollectionManager( self.app )
-
-    def build_element_identifiers( self, elements ):
-        identifier_list = []
-        for element in elements:
-            src = 'hda'
-            # if isinstance( element, model.DatasetCollection ):
-            #    src = 'collection'#?
-            # elif isinstance( element, model.LibraryDatasetDatasetAssociation ):
-            #    src = 'ldda'#?
-            encoded_id = self.trans.security.encode_id( element.id )
-            identifier_list.append( dict( src=src, name=element.name, id=encoded_id ) )
-        return identifier_list
 
     def test_create_simple_list( self ):
         owner = self.user_manager.create( **user2_data )

--- a/test/unit/managers/test_DatasetManager.py
+++ b/test/unit/managers/test_DatasetManager.py
@@ -112,7 +112,8 @@ class DatasetManagerTestCase( BaseTestCase ):
         self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, user3 ) )
 
     def test_create_public_dataset( self ):
-        self.log( "should be able to create a new Dataset and give it some permissions that actually, you know, might work if there's any justice in this universe" )
+        self.log( "should be able to create a new Dataset and give it some permissions that actually, you know, "
+            "might work if there's any justice in this universe" )
         owner = self.user_manager.create( **user2_data )
         owner_private_role = self.user_manager.private_role( owner )
         dataset = self.dataset_manager.create( manage_roles=[ owner_private_role ] )
@@ -134,7 +135,7 @@ class DatasetManagerTestCase( BaseTestCase ):
         self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, user3 ) )
 
     def test_create_private_dataset( self ):
-        self.log( "should be able to create a new Dataset and give it some permissions that actually, you know, might work if there's any justice in this universe" )
+        self.log( "should be able to create a new Dataset and give it private permissions" )
         owner = self.user_manager.create( **user2_data )
         owner_private_role = self.user_manager.private_role( owner )
         dataset = self.dataset_manager.create(

--- a/test/unit/managers/test_DatasetManager.py
+++ b/test/unit/managers/test_DatasetManager.py
@@ -217,9 +217,10 @@ class DatasetSerializerTestCase( BaseTestCase ):
 
         self.log( 'should be able to use keys with views' )
         serialized = self.dataset_serializer.serialize_to_view( dataset,
-            view='summary', keys=[ 'permissions' ] )
+            # file_name is exposed using app.config.expose_dataset_path = True
+            view='summary', keys=[ 'file_name' ] )
         self.assertKeys( serialized,
-            self.dataset_serializer.views[ 'summary' ] + [ 'permissions' ] )
+            self.dataset_serializer.views[ 'summary' ] + [ 'file_name' ] )
 
         self.log( 'should be able to use keys on their own' )
         serialized = self.dataset_serializer.serialize_to_view( dataset,

--- a/test/unit/managers/test_HDAManager.py
+++ b/test/unit/managers/test_HDAManager.py
@@ -419,7 +419,7 @@ class HDASerializerTestCase( HDATestCase ):
     def test_serializers( self ):
         hda = self._create_vanilla_hda()
         all_keys = list( self.hda_serializer.serializable_keyset )
-        serialized = self.hda_serializer.serialize( hda, all_keys )
+        serialized = self.hda_serializer.serialize( hda, all_keys, user=hda.history.user )
 
         self.log( 'everything serialized should be of the proper type' )
         # base
@@ -433,7 +433,6 @@ class HDASerializerTestCase( HDATestCase ):
         self.assertUUID( serialized[ 'uuid' ] )
         self.assertIsInstance( serialized[ 'file_name' ], basestring )
         self.assertIsInstance( serialized[ 'extra_files_path' ], basestring )
-        self.assertIsInstance( serialized[ 'permissions' ], dict )
         self.assertIsInstance( serialized[ 'size' ], int )
         self.assertIsInstance( serialized[ 'file_size' ], int )
         self.assertIsInstance( serialized[ 'nice_size' ], basestring )


### PR DESCRIPTION
1. Some testing and wiring to have the history manager access the container interface.
2. Wire the RBAC permissions to the dataset association manager and show a list of role ids for each of the hda permissions (grant, access).

``` json
    "permissions": {
        "access": [
            "3f5830403180d620", 
            "df7a1f0c02a5b08e"
        ], 
        "manage": [
            "f2db41e1fa331b3e"
        ]
    }, 
```

Sorry! This should probably have been two separate PRs.
