### PR TITLE
SCRIPT_NAME can be empty or not in the environment at all.  This reso…

### DIFF
--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -353,7 +353,7 @@ class Request( webob.Request ):
 
     @lazy_property
     def path( self ):
-        return self.environ['SCRIPT_NAME'] + self.environ['PATH_INFO']
+        return self.environ.get('SCRIPT_NAME', '') + self.environ['PATH_INFO']
 
     @lazy_property
     def browser_url( self ):


### PR DESCRIPTION
…lves http://dev.list.galaxyproject.org/NGINX-uWSGI-with-require-login-needs-uwsgi-param-SCRIPT-NAME-td4666901.html.   Thanks to @dctrud and @ericenns for the help tracking it down.
