### PR TITLE
Fix BBI data provider underflow bug when computing standard deviation

### DIFF
--- a/lib/galaxy/visualization/data_providers/genome.py
+++ b/lib/galaxy/visualization/data_providers/genome.py
@@ -1180,7 +1180,7 @@ class BBIDataProvider( GenomeDataProvider ):
                     # Compute $\mu \pm 2\sigma$ to provide an estimate for upper and lower
                     # bounds that contain ~95% of the data.
                     mean = summary.sum_data[0] / valid_count
-                    var = max( summary.sum_squares[0] - mean, 0 ) # Prevent variance underflow.
+                    var = max( summary.sum_squares[0] - mean, 0 )  # Prevent variance underflow.
                     if valid_count > 1:
                         var /= valid_count - 1
                     sd = math.sqrt( var )

--- a/lib/galaxy/visualization/data_providers/genome.py
+++ b/lib/galaxy/visualization/data_providers/genome.py
@@ -1180,7 +1180,7 @@ class BBIDataProvider( GenomeDataProvider ):
                     # Compute $\mu \pm 2\sigma$ to provide an estimate for upper and lower
                     # bounds that contain ~95% of the data.
                     mean = summary.sum_data[0] / valid_count
-                    var = summary.sum_squares[0] - mean
+                    var = max( summary.sum_squares[0] - mean, 0 ) # Prevent variance underflow.
                     if valid_count > 1:
                         var /= valid_count - 1
                     sd = math.sqrt( var )


### PR DESCRIPTION
Bug occurs when data in a region is minimal causing SD calculation to fail and no data to be returned or displayed.
