### PR TITLE
Add API route to show galaxy version

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/version.py
+++ b/lib/galaxy/webapps/galaxy/api/version.py
@@ -1,0 +1,28 @@
+"""
+API to show galaxy version information
+"""
+from galaxy.web import _future_expose_api as expose_api
+from galaxy.web.base.controller import BaseAPIController
+
+from galaxy.version import VERSION
+
+import logging
+log = logging.getLogger(__name__)
+
+
+class RemoteFilesAPIController(BaseAPIController):
+
+    @expose_api
+    def index(self, trans):
+        """
+        GET /api/version/
+
+        Displays version/system information
+
+        :returns:   dictionary of information
+        :rtype:     dict
+        """
+        response = {
+            'version': VERSION
+        }
+        return response

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -235,6 +235,8 @@ def populate_api_routes( webapp, app ):
     webapp.mapper.resource( 'group', 'groups', path_prefix='/api' )
     webapp.mapper.resource_with_deleted( 'quota', 'quotas', path_prefix='/api' )
 
+    webapp.mapper.connect( '/api/version', controller='version' )
+
     # =======================
     # ====== TOOLS API ======
     # =======================


### PR DESCRIPTION
Tired of asking "what version of galaxy are you running" only to receive blank stares because there's no easy way for users/admins to find out without being familiar with deployment details
