### PR TITLE
Managers, taggable: make anon set_tags fail silently

### DIFF
--- a/lib/galaxy/managers/taggable.py
+++ b/lib/galaxy/managers/taggable.py
@@ -2,7 +2,7 @@
 Mixins for Taggable model managers and serializers.
 """
 
-from galaxy import exceptions as galaxy_exceptions
+# from galaxy import exceptions as galaxy_exceptions
 
 import logging
 log = logging.getLogger( __name__ )
@@ -27,7 +27,10 @@ def _tags_to_strings( item ):
 def _tags_from_strings( item, tag_handler, new_tags_list, user=None ):
     # TODO: have to assume trans.user here...
     if not user:
-        raise galaxy_exceptions.RequestParameterMissingException( 'User required for tags on ' + str( item ) )
+        # raise galaxy_exceptions.RequestParameterMissingException( 'User required for tags on ' + str( item ) )
+        # TODO: this becomes a 'silent failure' - no tags are set. This is a questionable approach but
+        # I haven't found a better one for anon users copying items with tags
+        return
     # TODO: duped from tags manager - de-dupe when moved to taggable mixin
     tag_handler.delete_item_tags( user, item )
     new_tags_str = ','.join( new_tags_list )


### PR DESCRIPTION
When a manager attempts to set tags on an item with an anonymous user, the taggable manager would previously error. 

If we attempt to copy tags when we copy hdas however, and the user doing the copying is anonymous: the copy should be doable but there is no user to associate with the tags (we can't use the original's user's tags).

An unsatisfying compromise is to fail silently when an anon user copies hdas. The hda will not have the original tags but the copy will be possible.
