### PR TITLE
extract_genomic_dna support for 2bit files from Local data

### DIFF
--- a/tools/extract/extract_genomic_dna.py
+++ b/tools/extract/extract_genomic_dna.py
@@ -37,30 +37,25 @@ def reverse_complement( s ):
 def check_seq_file( dbkey, GALAXY_DATA_INDEX_DIR ):
     # Checks for the presence of *.nib files matching the dbkey within alignseq.loc
     seq_file = "%s/alignseq.loc" % GALAXY_DATA_INDEX_DIR
-    seq_path = ''
-    for line in open( seq_file ):
+    for line in open(seq_file):
         line = line.rstrip( '\r\n' )
         if line and not line.startswith( "#" ) and line.startswith( 'seq' ):
             fields = line.split( '\t' )
             if len( fields) >= 3 and fields[1] == dbkey:
                 print "Using *.nib genomic reference files"
-                seq_path = fields[2].strip()
-                break
-
-    # If no entry in aligseq.loc was found, check for the presence of a *.2bit file in twobit.loc
-    if seq_path == '':
-        seq_file = "%s/twobit.loc" % GALAXY_DATA_INDEX_DIR
-        seq_path = ''
-        for line in open( seq_file ):
-            line = line.rstrip( '\r\n' )
-            if line and not line.startswith( "#" ) and line.endswith( '.2bit' ):
-                fields = line.split( '\t' )
-                if len(fields) >= 2 and fields[0] == dbkey:
-                    print "Using a *.2bit genomic reference file"
-                    seq_path = fields[1].strip()
-                    break
+                return fields[2].strip()
     
-    return seq_path
+    # If no entry in aligseq.loc was found, check for the presence of a *.2bit file in twobit.loc
+    seq_file = "%s/twobit.loc" % GALAXY_DATA_INDEX_DIR
+    for line in open( seq_file ):
+        line = line.rstrip( '\r\n' )
+        if line and not line.startswith( "#" ) and line.endswith( '.2bit' ):
+            fields = line.split( '\t' )
+            if len(fields) >= 2 and fields[0] == dbkey:
+                print "Using a *.2bit genomic reference file"
+                return fields[1].strip()
+    
+    return ''
         
 def __main__():
     #

--- a/tools/extract/extract_genomic_dna.py
+++ b/tools/extract/extract_genomic_dna.py
@@ -4,7 +4,7 @@ usage: %prog $input $out_file1
     -1, --cols=N,N,N,N,N: Columns for start, end, strand in input file
     -d, --dbkey=N: Genome build of input file
     -o, --output_format=N: the data type of the output file
-    -g, --GALAXY_DATA_INDEX_DIR=N: the directory containing alignseq.loc
+    -g, --GALAXY_DATA_INDEX_DIR=N: the directory containing alignseq.loc or twobit.loc
     -I, --interpret_features: if true, complete features are interpreted when input is GFF 
     -F, --fasta=<genomic_sequences>: genomic sequences to use for extraction
     -G, --gff: input and output file, when it is interval, coordinates are treated as GFF format (1-based, half-open) rather than 'traditional' 0-based, closed format.
@@ -35,17 +35,31 @@ def reverse_complement( s ):
     return "".join( reversed_s )
 
 def check_seq_file( dbkey, GALAXY_DATA_INDEX_DIR ):
+    # Checks for the presence of *.nib files matching the dbkey within alignseq.loc
     seq_file = "%s/alignseq.loc" % GALAXY_DATA_INDEX_DIR
     seq_path = ''
     for line in open( seq_file ):
         line = line.rstrip( '\r\n' )
         if line and not line.startswith( "#" ) and line.startswith( 'seq' ):
             fields = line.split( '\t' )
-            if len( fields ) < 3:
-                continue
-            if fields[1] == dbkey:
+            if len( fields) >= 3 and fields[1] == dbkey:
+                print "Using *.nib genomic reference files"
                 seq_path = fields[2].strip()
                 break
+
+    # If no entry in aligseq.loc was found, check for the presence of a *.2bit file in twobit.loc
+    if seq_path == '':
+        seq_file = "%s/twobit.loc" % GALAXY_DATA_INDEX_DIR
+        seq_path = ''
+        for line in open( seq_file ):
+            line = line.rstrip( '\r\n' )
+            if line and not line.startswith( "#" ) and line.endswith( '.2bit' ):
+                fields = line.split( '\t' )
+                if len(fields) >= 2 and fields[0] == dbkey:
+                    print "Using a *.2bit genomic reference file"
+                    seq_path = fields[1].strip()
+                    break
+    
     return seq_path
         
 def __main__():

--- a/tools/extract/extract_genomic_dna.xml
+++ b/tools/extract/extract_genomic_dna.xml
@@ -29,7 +29,7 @@
           <option value="no">No</option>
       </param>
       <conditional name="seq_source">
-          <param name="index_source" type="select" label="Source for Genomic Data">
+          <param name="index_source" type="select" label="Source for Genomic Data" help="If 'Locally cached' is selected, it will use a genomic reference file that matches the input file's dbkey. First it looks whether there are corresponding *.nib files in alignseq.loc. If that is not available, it searches for a corresponding *.2bit in twobit.loc.">
               <option value="cached">Locally cached</option>
               <option value="history">History</option>
           </param>
@@ -39,10 +39,10 @@
               <param name="ref_file" type="data" format="fasta" label="Using reference file" />
           </when>
       </conditional>
-	  <param name="out_format" type="select" label="Output data type">
-    	  <option value="fasta">FASTA</option>
-    	  <option value="interval">Interval</option>
-	  </param>
+      <param name="out_format" type="select" label="Output data type">
+          <option value="fasta">FASTA</option>
+          <option value="interval">Interval</option>
+      </param>
   </inputs>
   <outputs>
       <data format="input" name="out_file1" metadata_source="input">


### PR DESCRIPTION
Extract_genomic_dna has the option to provide a genomic reference from history, with FASTA and 2bit as valid file formats. Because I had those files already configured as Local data, I tried to run it with 'Local data' since I expected it to make use of those configured 2bit (or fasta) files instead. This resulted in an error, indicating that the reference files were not available.

After checking out the code I saw that the tool does not accept 2bit files from Local data, while it does supports 2bit files from history items. I added a few lines that check for the presence of twobit files, if the alignseq files can not be found. The code that does the extraction of the DNA sequence was already capable of dealing with twobit files (from history), so no changes were necessary there.
