### PR TITLE
Remove history+contents serializer _get_history_data

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -562,7 +562,8 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         unencoded_history_id = trans.history.id
         if id:
             unencoded_history_id = self.decode_id( id )
-        history_to_view = self.history_manager.get_accessible( unencoded_history_id, trans.user, current_history=trans.history )
+        history_to_view = self.history_manager.get_accessible( unencoded_history_id, trans.user,
+            current_history=trans.history )
 
         history_dictionary = self.history_serializer.serialize_to_view( history_to_view,
             view='detailed', user=trans.user, trans=trans )
@@ -570,8 +571,8 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
             'contents', trans=trans, user=trans.user )
 
         jobs = ( trans.sa_session.query( trans.app.model.Job )
-                 .filter( trans.app.model.Job.user == history_to_view.user )
-                 .filter( trans.app.model.Job.history_id == unencoded_history_id ) ).all()
+            .filter( trans.app.model.Job.user == history_to_view.user )
+            .filter( trans.app.model.Job.history_id == unencoded_history_id ) ).all()
         jobs = map( lambda j: self.encode_all_ids( trans, j.to_dict( 'element' ), True ), jobs )
 
         tools = {}
@@ -584,7 +585,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
             tools[ tool_id ] = tool.to_dict( trans, io_details=True, link_details=True )
 
         return trans.fill_template( "history/structure.mako", historyId=history_dictionary[ 'id' ],
-                                    history=history_dictionary, hdas=contents, jobs=jobs, tools=tools, **kwargs )
+            history=history_dictionary, contents=contents, jobs=jobs, tools=tools, **kwargs )
 
     @web.expose
     def view( self, trans, id=None, show_deleted=False, show_hidden=False, use_panels=True ):
@@ -624,7 +625,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
             return trans.show_error_message( error_msg, use_panels=use_panels )
 
         return trans.fill_template_mako( "history/view.mako",
-            history=history_dictionary, hdas=contents, user_is_owner=user_is_owner,
+            history=history_dictionary, contents=contents, user_is_owner=user_is_owner,
             show_deleted=show_deleted, show_hidden=show_hidden, use_panels=use_panels )
 
     @web.expose
@@ -697,7 +698,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         #    dataset.annotation = self.get_item_annotation_str( trans.sa_session, history.user, dataset )
 
         return trans.stream_template_mako( "history/display.mako", item=history, item_data=[],
-            user_is_owner=user_is_owner, history_dict=history_dictionary, hda_dicts=contents,
+            user_is_owner=user_is_owner, history_dict=history_dictionary, content_dicts=contents,
             user_item_rating=user_item_rating, ave_item_rating=ave_item_rating, num_ratings=num_ratings )
 
     # ......................................................................... sharing & publishing

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -302,6 +302,7 @@ class PageController( BaseUIController, SharableMixin,
     def __init__( self, app ):
         super( PageController, self ).__init__( app )
         self.history_manager = managers.histories.HistoryManager( app )
+        self.history_serializer = managers.histories.HistorySerializer( self.app )
         self.hda_manager = managers.hdas.HDAManager( app )
 
     @web.expose
@@ -755,15 +756,16 @@ class PageController( BaseUIController, SharableMixin,
         history.annotation = self.get_item_annotation_str( trans.sa_session, history.user, history )
 
         # include all datasets: hidden, deleted, and purged
-        history_data = self.history_manager._get_history_data( trans, history )
-        history_dictionary = history_data[ 'history' ]
-        hda_dictionaries = history_data[ 'contents' ]
+        history_dictionary = self.history_serializer.serialize_to_view( history,
+            view='detailed', user=trans.user, trans=trans )
+        contents = self.history_serializer.serialize_contents( history, 'contents', trans=trans, user=trans.user )
         history_dictionary[ 'annotation' ] = history.annotation
 
-        filled = trans.fill_template( "history/embed.mako", item=history,
-                                      user_is_owner=user_is_owner,
-                                      history_dict=history_dictionary,
-                                      hda_dicts=hda_dictionaries )
+        filled = trans.fill_template( "history/embed.mako",
+            item=history,
+            user_is_owner=user_is_owner,
+            history_dict=history_dictionary,
+            hda_dicts=contents )
         return filled
 
     def _get_embedded_visualization_html( self, trans, id ):

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -765,7 +765,7 @@ class PageController( BaseUIController, SharableMixin,
             item=history,
             user_is_owner=user_is_owner,
             history_dict=history_dictionary,
-            hda_dicts=contents )
+            content_dicts=contents )
         return filled
 
     def _get_embedded_visualization_html( self, trans, id ):

--- a/lib/galaxy/webapps/galaxy/controllers/root.py
+++ b/lib/galaxy/webapps/galaxy/controllers/root.py
@@ -26,6 +26,7 @@ class RootController( BaseUIController, UsesAnnotations ):
     def __init__( self, app ):
         super( RootController, self ).__init__( app )
         self.history_manager = managers.histories.HistoryManager( app )
+        self.history_serializer = managers.histories.HistorySerializer( self.app )
 
     @web.expose
     def default(self, trans, target1=None, target2=None, **kwd):
@@ -124,9 +125,11 @@ class RootController( BaseUIController, UsesAnnotations ):
         history_dictionary = {}
         hda_dictionaries = []
         try:
-            history_data = self.history_manager._get_history_data( trans, trans.get_history( create=True ) )
-            history_dictionary = history_data[ 'history' ]
-            hda_dictionaries = history_data[ 'contents' ]
+            history = trans.get_history( create=True )
+            history_dictionary = self.history_serializer.serialize_to_view( history,
+                view='detailed', user=trans.user, trans=trans )
+            hda_dictionaries = self.history_serializer.serialize_contents( history,
+                'contents', trans=trans, user=trans.user )
 
         except Exception, exc:
             user_id = str( trans.user.id ) if trans.user else '(anonymous)'

--- a/lib/galaxy/webapps/galaxy/controllers/root.py
+++ b/lib/galaxy/webapps/galaxy/controllers/root.py
@@ -123,12 +123,12 @@ class RootController( BaseUIController, UsesAnnotations ):
         show_deleted = string_as_bool_or_none( show_deleted )
 
         history_dictionary = {}
-        hda_dictionaries = []
+        content_dictionaries = []
         try:
             history = trans.get_history( create=True )
             history_dictionary = self.history_serializer.serialize_to_view( history,
                 view='detailed', user=trans.user, trans=trans )
-            hda_dictionaries = self.history_serializer.serialize_contents( history,
+            content_dictionaries = self.history_serializer.serialize_contents( history,
                 'contents', trans=trans, user=trans.user )
 
         except Exception, exc:
@@ -138,8 +138,8 @@ class RootController( BaseUIController, UsesAnnotations ):
                                               'Please contact a Galaxy administrator if the problem persists.' )
 
         return trans.fill_template_mako( "root/history.mako",
-                                         history=history_dictionary, hdas=hda_dictionaries,
-                                         show_deleted=show_deleted, show_hidden=show_hidden )
+            history=history_dictionary, contents=content_dictionaries,
+            show_deleted=show_deleted, show_hidden=show_hidden )
 
     # ---- Dataset display / editing ----------------------------------------
     @web.expose

--- a/templates/webapps/galaxy/history/display.mako
+++ b/templates/webapps/galaxy/history/display.mako
@@ -46,7 +46,7 @@
 </div>
 <script type="text/javascript">
     var historyJSON  = ${h.dumps( history_dict )},
-        hdaJSON      = ${h.dumps( hda_dicts )};
+        contentsJSON = ${h.dumps( content_dicts )};
 
     require.config({
         baseUrl : "${h.url_for( '/static/scripts' )}",
@@ -54,8 +54,7 @@
     })([ 'mvc/history/history-panel-annotated' ], function( panelMod ){
         // history module is already in the dpn chain from the panel. We can re-scope it here.
         var historyModel = require( 'mvc/history/history-model' ),
-            history = new historyModel.History( historyJSON, hdaJSON, {
-            });
+            history = new historyModel.History( historyJSON, contentsJSON, {});
 
         window.historyPanel = new panelMod.AnnotatedHistoryPanel({
             show_deleted    : false,

--- a/templates/webapps/galaxy/history/embed.mako
+++ b/templates/webapps/galaxy/history/embed.mako
@@ -68,7 +68,7 @@
                     el      : $embeddedHistory.find( ".history-panel" ),
                     model   : new historyModel.History(
                         ${h.dumps( history_dict )},
-                        ${h.dumps( hda_dicts )}
+                        ${h.dumps( content_dicts )}
                     )
                 }).render();
 

--- a/templates/webapps/galaxy/history/structure.mako
+++ b/templates/webapps/galaxy/history/structure.mako
@@ -74,7 +74,7 @@ define( 'app', function(){
         'mvc/history/history-structure-view'
     ], function( JOB, HISTORY, StructureView ){
 
-        var historyModel = new HISTORY.History( bootstrapped.history, bootstrapped.hdas );
+        var historyModel = new HISTORY.History( bootstrapped.history, bootstrapped.contents );
 window.historymodel = historyModel;
 window.jobs = bootstrapped.jobs;
 window.tools = bootstrapped.tools;
@@ -89,5 +89,5 @@ window.structure = structure;
     });
 });
 </script>
-${ galaxy_client.load( app='app', historyId=historyId, history=history, hdas=hdas, jobs=jobs, tools=tools ) }
+${ galaxy_client.load( app='app', historyId=historyId, history=history, contents=contents, jobs=jobs, tools=tools ) }
 </%def>

--- a/templates/webapps/galaxy/history/view.mako
+++ b/templates/webapps/galaxy/history/view.mako
@@ -167,7 +167,7 @@ a.btn {
     var hasMasthead  = ${ 'true' if use_panels else 'false' },
         userIsOwner  = ${ 'true' if user_is_owner else 'false' },
         historyJSON  = ${ h.dumps( history ) },
-        hdaJSON      = ${ h.dumps( hdas ) },
+        contentsJSON = ${ h.dumps( contents ) },
         panelToUse   = ( userIsOwner )?
 //TODO: change class names
             ({ location: 'mvc/history/history-panel-edit',  className: 'HistoryPanelEdit' }):
@@ -190,11 +190,11 @@ a.btn {
             if( hasMasthead ){
                 $( '#center' ).css( 'overflow', 'auto' );
             }
-     
+
             var panelClass = panelMod[ panelToUse.className ],
                 // history module is already in the dpn chain from the panel. We can re-scope it here.
                 historyModel = require( 'mvc/history/history-model' ),
-                history = new historyModel.History( historyJSON, hdaJSON );
+                history = new historyModel.History( historyJSON, contentsJSON );
 
             window.historyPanel = new panelClass({
                 show_deleted    : ${show_deleted_json},

--- a/templates/webapps/galaxy/root/history.mako
+++ b/templates/webapps/galaxy/root/history.mako
@@ -20,28 +20,22 @@ $(function(){
 <script type="text/javascript">
 define( 'app', function(){
     require([
-        //'mvc/history/history-panel'
-        //'mvc/history/history-panel-annotated'
         'mvc/history/history-panel-edit'
-        //'mvc/history/history-panel-edit-current'
     ], function( historyPanel ){
         $(function(){
             // history module is already in the dpn chain from the panel. We can re-scope it here.
             var historyModel    = require( 'mvc/history/history-model' );
-            //window.panel = new historyPanel.HistoryPanel({
-            //window.panel = new historyPanel.AnnotatedHistoryPanel({
             window.panel = new historyPanel.HistoryPanelEdit({
-            //window.panel = new historyPanel.CurrentHistoryPanel({
                 show_deleted    : bootstrapped.show_deleted,
                 show_hidden     : bootstrapped.show_hidden,
                 purgeAllowed    : Galaxy.config.allow_user_dataset_purge,
-                model           : new historyModel.History( bootstrapped.history, bootstrapped.hdas )
+                model           : new historyModel.History( bootstrapped.history, bootstrapped.contents )
             });
             panel.render().$el.appendTo( 'body' );
-            //$( 'body' ).css( 'padding', '10px' );
         });
     });
 });
 </script>
-${ galaxy_client.load( app='app', history=history, hdas=hdas, show_deleted=show_deleted, show_hidden=show_hidden ) }
+${ galaxy_client.load( app='app', history=history, contents=contents,
+    show_deleted=show_deleted, show_hidden=show_hidden ) }
 </%def>


### PR DESCRIPTION
Replace with serialize_contents in the five web methods that used it to bootstrap history and history contents data:
- root.history
- history.display_by_username_and_slug (published histories)
- history.view (from 'Saved histories'/url in error report)
- history.structure (the newer version: /history/structure)
- page._get_embedded_history_html
