### PR TITLE
Swap track_jobs_in_database to be True by default.  This removes the …

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -952,12 +952,9 @@ use_interactive = True
 #job_config_file = config/job_conf.xml
 
 # In multiprocess configurations, notification between processes about new jobs
-# is done via the database.  In single process configurations, this is done in
-# memory, which is a bit quicker.  Galaxy tries to automatically determine
-# which method it should used based on your handler configuration in the job
-# config file, but you can explicitly override this behavior by setting the
-# following option to True or False.
-#track_jobs_in_database = None
+# must be done via the database.  In single process configurations, this can be
+# done in memory, which is a bit quicker.
+#track_jobs_in_database = True
 
 # This enables splitting of jobs into tasks, if specified by the particular tool
 # config.

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -206,7 +206,7 @@ class Configuration( object ):
         self.smtp_username = kwargs.get( 'smtp_username', None )
         self.smtp_password = kwargs.get( 'smtp_password', None )
         self.smtp_ssl = kwargs.get( 'smtp_ssl', None )
-        self.track_jobs_in_database = kwargs.get( 'track_jobs_in_database', 'None' )
+        self.track_jobs_in_database = string_as_bool( kwargs.get( 'track_jobs_in_database', 'True') )
         self.start_job_runners = listify(kwargs.get( 'start_job_runners', '' ))
         self.expose_dataset_path = string_as_bool( kwargs.get( 'expose_dataset_path', 'False' ) )
         # External Service types used in sample tracking
@@ -384,13 +384,6 @@ class Configuration( object ):
         self.job_manager = kwargs.get('job_manager', self.server_name).strip()
         self.job_handlers = [ x.strip() for x in kwargs.get('job_handlers', self.server_name).split(',') ]
         self.default_job_handlers = [ x.strip() for x in kwargs.get('default_job_handlers', ','.join( self.job_handlers ) ).split(',') ]
-        # Use database for job running IPC unless this is a standalone server or explicitly set in the config
-        if self.track_jobs_in_database == 'None':
-            self.track_jobs_in_database = False
-            if len(self.server_names) > 1:
-                self.track_jobs_in_database = True
-        else:
-            self.track_jobs_in_database = string_as_bool( self.track_jobs_in_database )
         # Store per-tool runner configs
         self.tool_handlers = self.__read_tool_job_config( global_conf_parser, 'galaxy:tool_handlers', 'name' )
         self.tool_runners = self.__read_tool_job_config( global_conf_parser, 'galaxy:tool_runners', 'url' )


### PR DESCRIPTION
…current multiprocess detection logic in favor of simplifying the configuration, and fixes a bug where uwsgi + 1 handler will not work.

An alternate solution to this would be to make the multiprocess detection smarter, but I don't think it's worth the complexity for what are primarily non-production galaxies.
