### PR TITLE
[15.07] Fix dbkey filtering of multiple input targets.

### DIFF
--- a/test/functional/test_toolbox.py
+++ b/test/functional/test_toolbox.py
@@ -44,6 +44,7 @@ class ToolTestCase( TwillTestCase ):
         job_stdio = None
         job_output_exceptions = None
         tool_execution_exception = None
+        expected_failure_occurred = False
         try:
             try:
                 tool_response = galaxy_interactor.run_tool( testdef, test_history )
@@ -52,22 +53,26 @@ class ToolTestCase( TwillTestCase ):
             except RunToolException as e:
                 tool_inputs = e.inputs
                 tool_execution_exception = e
-                raise e
+                if not testdef.expect_failure:
+                    raise e
+                else:
+                    expected_failure_occurred = True
             except Exception as e:
                 tool_execution_exception = e
                 raise e
 
-            self.assertTrue( data_list or data_collection_list )
+            if not expected_failure_occurred:
+                self.assertTrue( data_list or data_collection_list )
 
-            try:
-                job_stdio = self._verify_outputs( testdef, test_history, jobs, shed_tool_id, data_list, data_collection_list, galaxy_interactor )
-            except JobOutputsError as e:
-                job_stdio = e.job_stdio
-                job_output_exceptions = e.output_exceptions
-                raise e
-            except Exception as e:
-                job_output_exceptions = [e]
-                raise e
+                try:
+                    job_stdio = self._verify_outputs( testdef, test_history, jobs, shed_tool_id, data_list, data_collection_list, galaxy_interactor )
+                except JobOutputsError as e:
+                    job_stdio = e.job_stdio
+                    job_output_exceptions = e.output_exceptions
+                    raise e
+                except Exception as e:
+                    job_output_exceptions = [e]
+                    raise e
         finally:
             job_data = {}
             if tool_inputs is not None:

--- a/test/functional/tool-data/fasta_indexes.loc
+++ b/test/functional/tool-data/fasta_indexes.loc
@@ -1,0 +1,2 @@
+hg19	hg19	hg19	hg19
+hg18	hg18	hg18	hg18

--- a/test/functional/tool-data/sample_tool_data_tables.xml
+++ b/test/functional/tool-data/sample_tool_data_tables.xml
@@ -7,4 +7,8 @@
     <columns>value, path</columns>
     <file path="${__HERE__}/testbeta.loc" />
   </table>
+  <table name="test_fasta_indexes" comment_char="#">
+    <columns>value, dbkey, name, path</columns>
+    <file path="${__HERE__}/fasta_indexes.loc" />
+  </table>
 </tables>

--- a/test/functional/tools/dbkey_filter_input.xml
+++ b/test/functional/tools/dbkey_filter_input.xml
@@ -1,0 +1,39 @@
+<tool id="dbkey_filter_input" name="dbkey_filter_input" version="0.1.0">
+    <description>Filter (single) input on a dbkey</description>
+    <command>
+        cat $inputs > $output
+    </command>
+    <inputs>
+        <param format="txt" name="inputs" type="data" label="Inputs" help="" />
+        <param name="index" type="select" label="Using reference genome">
+          <options from_data_table="test_fasta_indexes">
+            <filter type="data_meta" ref="inputs" key="dbkey" column="1" />
+            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+          </options>
+        </param>
+    </inputs>
+
+    <outputs>
+        <data format="txt" name="output" />
+    </outputs>
+
+    <tests>
+        <!-- can choose a dbkey if it matches input -->
+        <test>
+            <param name="inputs" value="simple_line.txt" dbkey="hg19" />
+            <param name="index" value="hg19" />
+            <output name="output" file="simple_line.txt"/>
+        </test>
+        <!-- cannot pick index otherwise -->
+        <!-- Does this make sense - if no dbkey is defined there is no option
+             available? -->
+        <test expect_failure="true">
+            <param name="inputs" value="simple_line.txt" />
+            <param name="index" value="hg18" />
+            <output name="output" file="simple_line.txt"/>
+        </test>
+    </tests>
+
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/dbkey_filter_multi_input.xml
+++ b/test/functional/tools/dbkey_filter_multi_input.xml
@@ -1,0 +1,34 @@
+<tool id="dbkey_filter_multi_input" name="dbkey_filter_multi_input" version="0.1.0">
+    <description>Filter select on dbkey of multiple inputs</description>
+    <command><![CDATA[
+        #for $input in $inputs#
+        cat $input >> $output;
+        #end for#
+    ]]>
+    </command>
+    <inputs>
+        <param format="txt" name="inputs" type="data" label="Inputs" multiple="true" help="" />
+        <param name="index" type="select" label="Using reference genome">
+          <options from_data_table="test_fasta_indexes">
+            <filter type="data_meta" ref="inputs" key="dbkey" column="1" />
+            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+          </options>
+        </param>
+    </inputs>
+
+    <outputs>
+        <data format="txt" name="output" />
+    </outputs>
+
+    <tests>
+        <!-- can choose a dbkey if it matches input -->
+        <test>
+            <param name="inputs" value="simple_line.txt,simple_line.txt" dbkey="hg19" />
+            <param name="index" value="hg19" />
+            <output name="output" file="simple_line_x2.txt"/>
+        </test>
+    </tests>
+
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -17,6 +17,7 @@
   <tool file="multi_output_configured.xml" />
   <tool file="multi_output_assign_primary.xml" />
   <tool file="dbkey_filter_input.xml" />
+  <tool file="dbkey_filter_multi_input.xml" />
   <tool file="composite_output.xml" />
   <tool file="metadata.xml" />
   <tool file="metadata_bam.xml" />

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -16,6 +16,7 @@
   <tool file="multi_output.xml" />
   <tool file="multi_output_configured.xml" />
   <tool file="multi_output_assign_primary.xml" />
+  <tool file="dbkey_filter_input.xml" />
   <tool file="composite_output.xml" />
   <tool file="metadata.xml" />
   <tool file="metadata_bam.xml" />


### PR DESCRIPTION
Fixes #388 - which causes the latest variant of the cuffmerge wrappers to be unusable in some circumstances. This includes test cases and fixes to the test framework to allow these test cases to function properly.
