### PR TITLE
Allow tools to explicitly produce nested collections.

### DIFF
--- a/lib/galaxy/dataset_collections/builder.py
+++ b/lib/galaxy/dataset_collections/builder.py
@@ -1,4 +1,5 @@
 from galaxy import model
+from galaxy.util.odict import odict
 
 
 def build_collection( type, dataset_instances ):
@@ -24,3 +25,66 @@ def set_collection_elements( dataset_collection, type, dataset_instances ):
 
     dataset_collection.elements = elements
     return dataset_collection
+
+
+class CollectionBuilder(object):
+    """ Purely functional builder pattern for building a dataset collection. """
+
+    def __init__(self, collection_type_description):
+        self._collection_type_description = collection_type_description
+        self._current_elements = odict()
+
+    def get_level(self, identifier):
+        if not self._nested_collection:
+            message_template = "Cannot add nested collection to collection of type [%s]"
+            message = message_template % (self._collection_type_description)
+            raise AssertionError(message)
+        if identifier not in self._current_elements:
+            subcollection_builder = CollectionBuilder(
+                self._subcollection_type_description
+            )
+            self._current_elements[identifier] = subcollection_builder
+
+        return self._current_elements[identifier]
+
+    def add_dataset(self, identifier, dataset_instance):
+        self._current_elements[ identifier ] = dataset_instance
+
+    def build_elements(self):
+        elements = self._current_elements
+        if self._nested_collection:
+            new_elements = odict()
+            for identifier, element in elements.items():
+                new_elements[identifier] = element.build()
+            elements = new_elements
+        return elements
+
+    def build(self):
+        type_plugin = self._collection_type_description.rank_type_plugin()
+        collection = build_collection( type_plugin, self.build_elements() )
+        collection.collection_type = self._collection_type_description.collection_type
+        return collection
+
+    @property
+    def _subcollection_type_description(self):
+        return self._collection_type_description.subcollection_type_description()
+
+    @property
+    def _nested_collection(self):
+        return self._collection_type_description.has_subcollections()
+
+
+class BoundCollectionBuilder( CollectionBuilder ):
+    """ More stateful builder that is bound to a particular model object. """
+
+    def __init__( self, dataset_collection, collection_type_description ):
+        self.dataset_collection = dataset_collection
+        if dataset_collection.populated:
+            raise Exception("Cannot reset elements of an already populated dataset collection.")
+        super( BoundCollectionBuilder, self ).__init__( collection_type_description )
+
+    def populate( self ):
+        elements = self.build_elements()
+        type_plugin = self._collection_type_description.rank_type_plugin()
+        set_collection_elements( self.dataset_collection, type_plugin, elements )
+        self.dataset_collection.mark_as_populated()

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -281,7 +281,9 @@ class DatasetCollectionManager( object ):
             raise MessageException( "Dataset collection element definition (%s) not dictionary-like." % element_identifier )
         encoded_id = element_identifier.get( 'id', None )
         if not src_type or not encoded_id:
-            raise RequestParameterInvalidException( "Problem decoding element identifier %s" % element_identifier )
+            message_template = "Problem decoding element identifier %s - must contain a 'src' and a 'id'."
+            message = message_template % element_identifier
+            raise RequestParameterInvalidException( message )
 
         if src_type == 'hda':
             decoded_id = int( trans.app.security.decode_id( encoded_id ) )

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -159,6 +159,11 @@ class DatasetCollectionManager( object ):
 
         return dataset_collection
 
+    def collection_builder_for( self, dataset_collection ):
+        collection_type = dataset_collection.collection_type
+        collection_type_description = self.collection_type_descriptions.for_collection_type( collection_type )
+        return builder.BoundCollectionBuilder( dataset_collection, collection_type_description )
+
     def delete( self, trans, instance_type, id ):
         dataset_collection_instance = self.get_dataset_collection_instance( trans, instance_type, id, check_ownership=True )
         dataset_collection_instance.deleted = True

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -50,11 +50,13 @@ class DatasetCollectionManager( object ):
         element_identifiers=None,
         elements=None,
         implicit_collection_info=None,
+        trusted_identifiers=None,  # Trust preloaded element objects
     ):
         """
         """
         # Trust embedded, newly created objects created by tool subsystem.
-        trusted_identifiers = implicit_collection_info is not None
+        if trusted_identifiers is None:
+            trusted_identifiers = implicit_collection_info is not None
 
         if element_identifiers and not trusted_identifiers:
             validate_input_element_identifiers( element_identifiers )

--- a/lib/galaxy/managers/collections_util.py
+++ b/lib/galaxy/managers/collections_util.py
@@ -39,7 +39,7 @@ def validate_input_element_identifiers( element_identifiers ):
     identifier_names = set()
     for element_identifier in element_identifiers:
         if "__object__" in element_identifier:
-            message = ERROR_MESSAGE_INVALID_PARAMETER_FOUND % ( "__model_object__", element_identifier )
+            message = ERROR_MESSAGE_INVALID_PARAMETER_FOUND % ( "__object__", element_identifier )
             raise exceptions.RequestParameterInvalidException( message )
         if "name" not in element_identifier:
             message = ERROR_MESSAGE_NO_NAME % element_identifier

--- a/test/functional/test_toolbox.py
+++ b/test/functional/test_toolbox.py
@@ -191,8 +191,12 @@ class ToolTestCase( TwillTestCase ):
                 # the job completed so re-hit the API for more information.
                 data_collection_returned = data_collection_list[ name ]
                 data_collection = galaxy_interactor._get( "dataset_collections/%s" % data_collection_returned[ "id" ], data={"instance_type": "history"} ).json()
-                elements = data_collection[ "elements" ]
-                element_dict = dict( map(lambda e: (e["element_identifier"], e["object"]), elements) )
+
+                def get_element( elements, id ):
+                    for element in elements:
+                        if element["element_identifier"] == id:
+                            return element
+                    return False
 
                 expected_collection_type = output_collection_def.collection_type
                 if expected_collection_type:
@@ -202,20 +206,29 @@ class ToolTestCase( TwillTestCase ):
                         message = template % (name, expected_collection_type, collection_type)
                         raise AssertionError(message)
 
-                for element_identifier, ( element_outfile, element_attrib ) in output_collection_def.element_tests.items():
-                    if element_identifier not in element_dict:
-                        template = "Failed to find identifier [%s] for testing, tool generated collection with identifiers [%s]"
-                        message = template % (element_identifier, ",".join(element_dict.keys()))
-                        raise AssertionError(message)
-                    hda = element_dict[ element_identifier ]
+                def verify_elements( element_objects, element_tests ):
+                    for element_identifier, ( element_outfile, element_attrib ) in element_tests.items():
+                        element = get_element( element_objects, element_identifier )
+                        if not element:
+                            template = "Failed to find identifier [%s] for testing, tool generated collection elements [%s]"
+                            message = template % (element_identifier, element_objects)
+                            raise AssertionError(message)
 
-                    galaxy_interactor.verify_output_dataset(
-                        history,
-                        hda_id=hda["id"],
-                        outfile=element_outfile,
-                        attributes=element_attrib,
-                        shed_tool_id=shed_tool_id
-                    )
+                        element_type = element["element_type"]
+                        if element_type != "dataset_collection":
+                            hda = element[ "object" ]
+                            galaxy_interactor.verify_output_dataset(
+                                history,
+                                hda_id=hda["id"],
+                                outfile=element_outfile,
+                                attributes=element_attrib,
+                                shed_tool_id=shed_tool_id
+                            )
+                        if element_type == "dataset_collection":
+                            elements = element[ "object" ][ "elements" ]
+                            verify_elements( elements, element_attrib.get( "elements", {} ) )
+
+                verify_elements( data_collection[ "elements" ], output_collection_def.element_tests )
             except Exception as e:
                 register_exception(e)
 

--- a/test/functional/tools/collection_creates_dynamic_list_of_pairs.xml
+++ b/test/functional/tools/collection_creates_dynamic_list_of_pairs.xml
@@ -17,6 +17,11 @@
   </inputs>
   <outputs>
     <collection name="list_output" type="list:paired" label="Duplicate List">
+      <!-- Use named regex group to grab pattern
+           <identifier_0>_<identifier_1>.fq. Here identifier_0 is the list
+           identifier in the nested collection and identifier_1 is either
+           forward or reverse (for instance samp1_forward.fq).
+      -->
       <discover_datasets pattern="(?P&lt;identifier_0&gt;[^_]+)_(?P&lt;identifier_1&gt;[^_]+)\.fq" ext="fastqsanger" visible="true" />
     </collection>
   </outputs>

--- a/test/functional/tools/collection_creates_dynamic_list_of_pairs.xml
+++ b/test/functional/tools/collection_creates_dynamic_list_of_pairs.xml
@@ -1,0 +1,66 @@
+<tool id="collection_creates_dynamic_list_of_pairs" name="collection_creates_dynamic_list_of_pairs" version="0.1.0">
+  <command><![CDATA[
+    echo "A" > samp1_1.fq &&
+    echo "B" > samp1_2.fq &&
+    echo "C" > samp2_1.fq &&
+    echo "D" > samp2_2.fq &&
+    echo "E" > samp3_1.fq &&
+    echo "F" > samp3_2.fq &&
+    ## Galaxy wants forward and reverse in pattern not _1 and _2.
+    ##   There is bash magic that would be more concise then this basename
+    ##   pattern but I think this is more portable.
+    for f in *_1.fq; do mv "\$f" "`basename \$f _1.fq`_forward.fq"; done && 
+    for f in *_2.fq; do mv "\$f" "`basename \$f _2.fq`_reverse.fq"; done
+  ]]></command>
+  <inputs>
+    <param name="foo" type="text" label="Dummy Parameter" />
+  </inputs>
+  <outputs>
+    <collection name="list_output" type="list:paired" label="Duplicate List">
+      <discover_datasets pattern="(?P&lt;identifier_0&gt;[^_]+)_(?P&lt;identifier_1&gt;[^_]+)\.fq" ext="fastqsanger" visible="true" />
+    </collection>
+  </outputs>
+  <tests>
+    <test>
+      <param name="foo" value="bar" />
+      <output_collection name="list_output" type="list:paired">
+        <element name="samp1">
+          <element name="forward">
+            <assert_contents>
+              <has_text_matching expression="^A\n$" />
+            </assert_contents>
+          </element>
+          <element name="reverse">
+            <assert_contents>
+              <has_text_matching expression="^B\n$" />
+            </assert_contents>
+          </element>
+        </element>
+        <element name="samp2">
+          <element name="forward">
+            <assert_contents>
+              <has_text_matching expression="^C\n$" />
+            </assert_contents>
+          </element>
+          <element name="reverse">
+            <assert_contents>
+              <has_text_matching expression="^D\n$" />
+            </assert_contents>
+          </element>
+        </element>
+        <element name="samp3">
+          <element name="forward">
+            <assert_contents>
+              <has_text_matching expression="^E\n$" />
+            </assert_contents>
+          </element>
+          <element name="reverse">
+            <assert_contents>
+              <has_text_matching expression="^F\n$" />
+            </assert_contents>
+          </element>
+        </element>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/collection_creates_dynamic_nested.xml
+++ b/test/functional/tools/collection_creates_dynamic_nested.xml
@@ -12,6 +12,11 @@
   </inputs>
   <outputs>
     <collection name="list_output" type="list:list" label="Duplicate List">
+      <!-- Use named regex group to grab pattern
+           <identifier_0>_<identifier_1>.fq. Here identifier_0 is the list
+           identifier of the outer list and identifier_1 is the list identifier
+           of the inner list (for instance oe1_ie2.fq in above example).
+      -->
       <discover_datasets pattern="(?P&lt;identifier_0&gt;[^_]+)_(?P&lt;identifier_1&gt;[^_]+)\.fq" ext="fastqsanger" visible="true" />
     </collection>
   </outputs>

--- a/test/functional/tools/collection_creates_dynamic_nested.xml
+++ b/test/functional/tools/collection_creates_dynamic_nested.xml
@@ -1,0 +1,61 @@
+<tool id="collection_creates_dynamic_nested" name="collection_creates_dynamic_nested" version="0.1.0">
+  <command>
+    echo "A" > oe1_ie1.fq ;
+    echo "B" > oe1_ie2.fq ;
+    echo "C" > oe2_ie1.fq ;
+    echo "D" > oe2_ie2.fq ;
+    echo "E" > oe3_ie1.fq ;
+    echo "F" > oe3_ie2.fq
+  </command>
+  <inputs>
+    <param name="foo" type="text" label="Dummy Parameter" />
+  </inputs>
+  <outputs>
+    <collection name="list_output" type="list:list" label="Duplicate List">
+      <discover_datasets pattern="(?P&lt;identifier_0&gt;[^_]+)_(?P&lt;identifier_1&gt;[^_]+)\.fq" ext="fastqsanger" visible="true" />
+    </collection>
+  </outputs>
+  <tests>
+    <test>
+      <param name="foo" value="bar" />
+      <output_collection name="list_output" type="list:list">
+        <element name="oe1">
+          <element name="ie1">
+            <assert_contents>
+              <has_text_matching expression="^A\n$" />
+            </assert_contents>
+          </element>
+          <element name="ie2">
+            <assert_contents>
+              <has_text_matching expression="^B\n$" />
+            </assert_contents>
+          </element>
+        </element>
+        <element name="oe2">
+          <element name="ie1">
+            <assert_contents>
+              <has_text_matching expression="^C\n$" />
+            </assert_contents>
+          </element>
+          <element name="ie2">
+            <assert_contents>
+              <has_text_matching expression="^D\n$" />
+            </assert_contents>
+          </element>
+        </element>
+        <element name="oe3">
+          <element name="ie1">
+            <assert_contents>
+              <has_text_matching expression="^E\n$" />
+            </assert_contents>
+          </element>
+          <element name="ie2">
+            <assert_contents>
+              <has_text_matching expression="^F\n$" />
+            </assert_contents>
+          </element>
+        </element>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/collection_creates_list_of_pairs.xml
+++ b/test/functional/tools/collection_creates_list_of_pairs.xml
@@ -1,0 +1,50 @@
+<tool id="collection_creates_list_of_pairs" name="collection_creates_list_or_pairs" version="0.1.0">
+  <!-- You usually wouldn't want to do this - just write the operation for
+       a single dataset and allow the user to map that tool over the whole
+       collection. -->
+  <command>
+    #for $list_key in $list_output.keys()#
+    #for $pair_key in $list_output[$list_key].keys()#
+    echo "identifier is $list_key:$pair_key" > "$list_output[$list_key][$pair_key]";
+    #end for#
+    #end for#
+    echo 'ensure not empty';
+  </command>
+  <inputs>
+    <param name="input1" type="data_collection" collection_type="list:paired" label="Input" help="Input collection..." format="txt" />
+  </inputs>
+  <outputs>
+    <collection name="list_output" type="list:paired" label="Duplicate List" structured_like="input1" inherit_format="true">
+      <!-- inherit_format can be used in conjunction with structured_like
+           to perserve format. -->
+    </collection>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input1">
+        <collection type="list:paired">
+          <element name="i1">
+            <collection type="paired">
+              <element name="forward" value="simple_line.txt" />
+              <element name="reverse" value="simple_line_alternative.txt" />
+            </collection>
+          </element>
+        </collection>
+      </param>
+      <output_collection name="list_output" type="list:paired">
+        <element name="i1">
+          <element name="forward">
+            <assert_contents>
+              <has_text_matching expression="^identifier is i1:forward\n$" />
+            </assert_contents>
+          </element>
+          <element name="reverse">
+            <assert_contents>
+              <has_text_matching expression="^identifier is i1:reverse\n$" />
+            </assert_contents>
+          </element>
+        </element>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -55,6 +55,7 @@
   <tool file="collection_creates_pair_from_type.xml" />
   <tool file="collection_creates_list.xml" />
   <tool file="collection_creates_list_2.xml" />
+  <tool file="collection_creates_list_of_pairs.xml" />
   <tool file="collection_optional_param.xml" />
   <tool file="collection_split_on_column.xml" />
 

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -58,7 +58,8 @@
   <tool file="collection_creates_list_of_pairs.xml" />
   <tool file="collection_optional_param.xml" />
   <tool file="collection_split_on_column.xml" />
-
+  <tool file="collection_creates_dynamic_nested.xml" />
+  <tool file="collection_creates_dynamic_list_of_pairs.xml" />
   <tool file="cheetah_casting.xml" />
 
   <tool file="multiple_versions_v01.xml" />


### PR DESCRIPTION
## Background

[PR 634 - BG](https://bitbucket.org/galaxy/galaxy-central/pull-request/634/allow-tools-to-explicitly-produce-dataset) added the ability for tool to create simple collections (lists and pairs). It also outlined three creation scenarios - fixed collections, pre-determinable collection structures (like output lists based on input lists), and fully dynamic output collections. This pull request allows tool to output nested collections for each of these scenarios.
## Implementation

The static versions of nested structure didn't require syntax extensions however for dynamic collections new syntax was needed. Previously, the `<discover_dataset>` tag would just use the `designation` concept as the element identifier when building collections. This was insufficient for nested collections because an identifier must be specified at each level of the collection. Now `<discover_dataset>` tags may define multiple `identifier_N` patterns - e.g. `identifier_0`, `identifier_1`, etc.... If these are specified, a designation no longer must be specified and will just be interpreted as <identifier_value_0>:<identifier_value_1>:.... This scheme is completely backward compatible and when there is only a single identifier - `designation` and `identifier_0` can be used interchangeably.

Additionally, the tool test syntax has been extended to allow testing nested collection elements.
## Examples

Example tools are included that demonstrates this functionality - 
- `test/functional/tools/collection_creates_list_of_pairs.xml` Demonstrates creating nested collections with statically determinable structure - in this case a list of pairs with the same length and identifiers as an input list. This works exactly in a fashion exactly analogous to the flat structure case and does not introduce new tool syntax.
- `test/functional/tools/collection_creates_dynamic_nested.xml` Demonstrates using extensions to the `discover_datasets` tag to define nested structure to build a list of lists.
- `test/functional/tools/collection_creates_dynamic_list_of_pairs.xml` A common use case will probably be building a list of pairs. The <discover_datasets> tag infers dynamic information from the filename - so this tool demonstrates mass renaming of a common file name pattern for pairs (`_1`/`_2` suffixes) into a format more readily consumed by `<discover_datasets>` in a portable shell fashion.
## Testing

The various tool examples above can be tested with the following commands:

```
./run_tests.sh -framework -id collection_creates_list_of_pairs
```

```
./run_tests.sh -framework -id collection_creates_dynamic_nested
```

```
./run_tests.sh -framework -id collection_creates_dynamic_list_of_pairs
```

These each verify the nested datasets are setup properly.

Finally, the following existing test case verifies that `designation` can be used in lieu of `identifier_0` for flat collections (i.e. this generalization is backward compatible):

```
./run_tests.sh -framework -id collection_split_on_column
```
