### PR TITLE
Core, histories: use sqlalchemy hybrid_property to allow use of Histo…

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -25,7 +25,6 @@ eggs.require('SQLAlchemy')
 from sqlalchemy import and_, func, not_, or_, true
 from sqlalchemy.orm import joinedload, object_session
 from sqlalchemy import join, select
-from sqlalchemy.sql import label
 from sqlalchemy.ext import hybrid
 
 import galaxy.datatypes

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -22,9 +22,8 @@ from galaxy import eggs
 eggs.require("pexpect")
 import pexpect
 eggs.require('SQLAlchemy')
-from sqlalchemy import and_, func, not_, or_, true
+from sqlalchemy import and_, func, not_, or_, true, join, select
 from sqlalchemy.orm import joinedload, object_session, aliased
-from sqlalchemy import join, select
 from sqlalchemy.ext import hybrid
 
 import galaxy.datatypes
@@ -1273,7 +1272,7 @@ class History( object, Dictifiable, UsesAnnotations, HasName ):
         # then, bind as property of history using the cls.id
         size_query = (
             select([
-                func.sum( distinct_datasets_alias.c.dataset_size )
+                func.coalesce( func.sum( distinct_datasets_alias.c.dataset_size ), 0 )
             ])
             .select_from( distinct_datasets_alias )
             .where( distinct_datasets_alias.c.history_id == cls.id )


### PR DESCRIPTION
…ry.disk_size as a column (order, query, filter, etc.) and history.disk_size as an instance property

See: http://docs.sqlalchemy.org/en/rel_1_0/orm/extensions/hybrid.html

Testing:

```
sa_session.query( History.name, History.disk_size ).filter( History.disk_size > 40000 ).all()
sa_session.query( History.name, History.disk_size ).order_by( desc( History.disk_size ) ).limit( 3 ).all()
sa_session.query( History ).get( 24 ).disk_size
```
