### PR TITLE
Password field for old cloudlaunch's secret key.

### DIFF
--- a/templates/webapps/galaxy/cloud/index.mako
+++ b/templates/webapps/galaxy/cloud/index.mako
@@ -176,7 +176,7 @@
 
                     <div class="form-row">
                         <label for="id_secret">Secret Key</label>
-                        <input type="text" size="50" maxlength="40" name="secret" id="id_secret" value="" tabindex="2"/><br/>
+                        <input type="password" size="50" maxlength="40" name="secret" id="id_secret" value="" tabindex="2"/><br/>
                         <div class="toolParamHelp">
                             This is your AWS Secret Key, also found in the <a href="https://portal.aws.amazon.com/gp/aws/securityCredentials">Security
 Credentials section of the AWS Console</a>.  </div>


### PR DESCRIPTION
We updated the 'new' cloudlaunch, but since this is still in use for now (at least by the coursera course) it'd be nice to fix this too to help prevent folks posting screenshots with keys/etc.
