### PR TITLE
Normalize datatypes_by_ext upon entry

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -126,6 +126,8 @@ class Registry( object ):
                 # Keep a status of the process steps to enable stopping the process of handling the datatype if necessary.
                 ok = True
                 extension = elem.get( 'extension', None )
+                if extension:
+                    extension = extension.lower()
                 dtype = elem.get( 'type', None )
                 type_extension = elem.get( 'type_extension', None )
                 mimetype = elem.get( 'mimetype', None )


### PR DESCRIPTION
… Elsewhere in the codebase (tools/parameters/basic.py, for example) we expect all extensions to be normalized to lower for matching.  This resolves a bug where RData and Roadmap datatypes would never get detected and would be silently default to matching datatypes.Text.
