### PR TITLE
Cleanup of the toolshed's url handling methods.

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -779,9 +779,9 @@ class AdminGalaxy( BaseUIController, Admin, AdminActions, UsesQuotaMixin, QuotaP
                     tool_dependencies_dict = {}
                     repository_name = elem.get( 'name' )
                     changeset_revision = elem.get( 'changeset_revision' )
-                    url = '%s/repository/get_tool_dependencies?name=%s&owner=devteam&changeset_revision=%s' % \
-                        ( tool_shed_url, repository_name, changeset_revision )
-                    text = common_util.tool_shed_get( trans.app, tool_shed_url, url )
+                    params = dict( name=repository_name, owner='devteam', changeset_revision=changeset_revision )
+                    pathspec = [ 'repository', 'get_tool_dependencies' ]
+                    text = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec=pathspec, params=params )
                     if text:
                         tool_dependencies_dict = encoding_util.tool_shed_decode( text )
                         for dependency_key, requirements_dict in tool_dependencies_dict.items():

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -189,8 +189,8 @@ class AdminToolshed( AdminGalaxy ):
     def browse_tool_shed( self, trans, **kwd ):
         tool_shed_url = kwd.get( 'tool_shed_url', '' )
         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( trans.app, tool_shed_url )
-        galaxy_url = web.url_for( '/', qualified=True )
-        url = common_util.url_join( tool_shed_url, 'repository/browse_valid_categories?galaxy_url=%s' % ( galaxy_url ) )
+        params=dict( galaxy_url=web.url_for( '/', qualified=True ) )
+        url = common_util.url_join( tool_shed_url, pathspec=[ 'repository', 'browse_valid_categories' ], params=params )
         return trans.response.send_redirect( url )
 
     @web.expose
@@ -208,12 +208,12 @@ class AdminToolshed( AdminGalaxy ):
         repository_id = kwd.get( 'id', None )
         repository = repository_util.get_installed_tool_shed_repository( trans.app, repository_id )
         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( trans.app, str( repository.tool_shed ) )
-        params = '?galaxy_url=%s&name=%s&owner=%s&changeset_revision=%s' % \
-            ( web.url_for( '/', qualified=True ),
-              str( repository.name ),
-              str( repository.owner ),
-              str( repository.changeset_revision ) )
-        url = common_util.url_join( tool_shed_url, 'repository/check_for_updates%s' % params )
+        params = dict( galaxy_url=web.url_for( '/', qualified=True ),
+                       name=str( repository.name ),
+                       owner=str( repository.owner ),
+                       changeset_revision=str( repository.changeset_revision ) )
+        pathspec = [ 'repository', 'check_for_updates' ]
+        url = common_util.url_join( tool_shed_url, pathspec=pathspec, params=params )
         return trans.response.send_redirect( url )
 
     @web.expose
@@ -369,8 +369,8 @@ class AdminToolshed( AdminGalaxy ):
     def find_tools_in_tool_shed( self, trans, **kwd ):
         tool_shed_url = kwd.get( 'tool_shed_url', '' )
         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( trans.app, tool_shed_url )
-        galaxy_url = web.url_for( '/', qualified=True )
-        url = common_util.url_join( tool_shed_url, 'repository/find_tools?galaxy_url=%s' % galaxy_url )
+        params = dict( galaxy_url=web.url_for( '/', qualified=True ) )
+        url = common_util.url_join( tool_shed_url, pathspec=[ 'repository', 'find_tools' ], params=params )
         return trans.response.send_redirect( url )
 
     @web.expose
@@ -378,8 +378,8 @@ class AdminToolshed( AdminGalaxy ):
     def find_workflows_in_tool_shed( self, trans, **kwd ):
         tool_shed_url = kwd.get( 'tool_shed_url', '' )
         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( trans.app, tool_shed_url )
-        galaxy_url = web.url_for( '/', qualified=True )
-        url = common_util.url_join( tool_shed_url, 'repository/find_workflows?galaxy_url=%s' % galaxy_url )
+        params = dict( galaxy_url=web.url_for( '/', qualified=True ) )
+        url = common_util.url_join( tool_shed_url, pathspec=[ 'repository', 'find_workflows' ], params=params )
         return trans.response.send_redirect( url )
 
     @web.expose
@@ -412,10 +412,9 @@ class AdminToolshed( AdminGalaxy ):
             message += "parameters is None: tool_shed_url: %s, repository_name: %s, repository_owner: %s, changeset_revision: %s " % \
                 ( str( tool_shed_url ), str( repository_name ), str( repository_owner ), str( changeset_revision ) )
             raise Exception( message )
-        params = '?name=%s&owner=%s&changeset_revision=%s' % ( repository_name, repository_owner, changeset_revision )
-        url = common_util.url_join( tool_shed_url,
-                                    'repository/get_tool_dependencies%s' % params )
-        raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, url )
+        params = dict( name=repository_name, owner=repository_owner, changeset_revision=changeset_revision )
+        pathspec = [ 'repository', 'get_tool_dependencies' ]
+        raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec=pathspec, params=params )
         if len( raw_text ) > 2:
             encoded_text = json.loads( raw_text )
             text = encoding_util.tool_shed_decode( encoded_text )
@@ -437,12 +436,11 @@ class AdminToolshed( AdminGalaxy ):
             message += "required parameters is None: tool_shed_url: %s, repository_name: %s, repository_owner: %s, changeset_revision: %s " % \
                 ( str( tool_shed_url ), str( repository_name ), str( repository_owner ), str( changeset_revision ) )
             raise Exception( message )
-        params = '?name=%s&owner=%s&changeset_revision=%s' % ( str( repository_name ),
-                                                               str( repository_owner ),
-                                                               changeset_revision )
-        url = common_util.url_join( tool_shed_url,
-                                    'repository/get_updated_repository_information%s' % params )
-        raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, url )
+        params = dict( name=str( repository_name ),
+                       owner=str( repository_owner ),
+                       changeset_revision=changeset_revision )
+        pathspec = [ 'repository', 'get_updated_repository_information' ]
+        raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec=pathspec, params=params )
         repo_information_dict = json.loads( raw_text )
         return repo_information_dict
 
@@ -528,10 +526,11 @@ class AdminToolshed( AdminGalaxy ):
                 tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( trans.app, str( repository.tool_shed ) )
                 name = str( repository.name )
                 owner = str( repository.owner )
-                params = '?galaxy_url=%s&name=%s&owner=%s' % ( web.url_for( '/', qualified=True ), name, owner )
-                url = common_util.url_join( tool_shed_url,
-                                            'repository/get_latest_downloadable_changeset_revision%s' % params )
-                raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, url )
+                params = dict( galaxy_url=web.url_for( '/', qualified=True ),
+                               name=name,
+                               owner=owner )
+                pathspec = [ 'repository', 'get_latest_downloadable_changeset_revision' ]
+                raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec=pathspec, params=params )
                 latest_downloadable_revision = json.loads( raw_text )
                 if latest_downloadable_revision == hg_util.INITIAL_CHANGELOG_HASH:
                     message = 'Error retrieving the latest downloadable revision for this repository via the url <b>%s</b>.' % url
@@ -542,7 +541,7 @@ class AdminToolshed( AdminGalaxy ):
                     # appropriate repository revision if one exists.  We need to create a temporary repo_info_tuple
                     # with the following entries to handle this.
                     # ( description, clone_url, changeset_revision, ctx_rev, owner, repository_dependencies, tool_dependencies )
-                    tmp_clone_url = common_util.url_join( tool_shed_url, 'repos', owner, name )
+                    tmp_clone_url = common_util.url_join( tool_shed_url, pathspec=[ 'repos', owner, name ] )
                     tmp_repo_info_tuple = ( None, tmp_clone_url, latest_downloadable_revision, None, owner, None, None )
                     installed_repository, installed_changeset_revision = \
                         suc.repository_was_previously_installed( trans.app, tool_shed_url, name, tmp_repo_info_tuple, from_tip=False )
@@ -555,12 +554,11 @@ class AdminToolshed( AdminGalaxy ):
                         status = 'error'
                     else:
                         # Install the latest downloadable revision of the repository.
-                        params = '?name=%s&owner=%s&changeset_revisions=%s&galaxy_url=%s' % ( name,
-                                                                                              owner,
-                                                                                              str( latest_downloadable_revision ),
-                                                                                              web.url_for( '/', qualified=True ) )
-                        url = common_util.url_join( tool_shed_url,
-                                                    'repository/install_repositories_by_revision%s' % params )
+                        params = dict( name=name,
+                                       owner=owner,
+                                       changeset_revisions=str( latest_downloadable_revision ),
+                                       galaxy_url=web.url_for( '/', qualified=True ) )
+                        url = common_util.url_join( tool_shed_url, pathspec=pathspec, params=params )
                         return trans.response.send_redirect( url )
             else:
                 message = 'Cannot locate installed tool shed repository with encoded id <b>%s</b>.' % str( repository_id )
@@ -723,12 +721,12 @@ class AdminToolshed( AdminGalaxy ):
                                                               tool_shed_repository_ids=tool_shed_repository_ids ) )
         if repository.can_install and operation == 'install':
             # Send a request to the tool shed to install the repository.
-            params = '?name=%s&owner=%s&changeset_revisions=%s&galaxy_url=%s' % ( name,
-                                                                                  owner,
-                                                                                  installed_changeset_revision,
-                                                                                  web.url_for( '/', qualified=True ) )
-            url = common_util.url_join( tool_shed_url,
-                                        'repository/install_repositories_by_revision%s' % params )
+            params = dict( name=name,
+                           owner=owner,
+                           changeset_revisions=installed_changeset_revision,
+                           galaxy_url=web.url_for( '/', qualified=True ) )
+            pathspec = [ 'repository', 'install_repositories_by_revision' ]
+            url = common_util.url_join( tool_shed_url, pathspec=pathspec, params=params )
             return trans.response.send_redirect( url )
         description = kwd.get( 'description', repository.description )
         shed_tool_conf, tool_path, relative_install_dir = suc.get_tool_panel_config_tool_path_install_dir( trans.app, repository )
@@ -981,10 +979,10 @@ class AdminToolshed( AdminGalaxy ):
                 repository = suc.get_tool_shed_repository_by_id( trans.app, updating_repository_id )
                 # For backward compatibility to the 12/20/12 Galaxy release.
                 try:
-                    params = '?name=%s&owner=%s' % ( str( repository.name ), str( repository.owner ) )
-                    url = common_util.url_join( tool_shed_url,
-                                                'repository/get_repository_id%s' % params )
-                    repository_ids = common_util.tool_shed_get( trans.app, tool_shed_url, url )
+                    params = dict( name=str( repository.name ), owner=str( repository.owner ) )
+                    # params = '?name=%s&owner=%s' % ( str( repository.name ), str( repository.owner ) )
+                    pathspec = [ 'repository', 'get_repository_id' ]
+                    repository_ids = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec=pathspec, params=params )
                 except Exception, e:
                     # The Tool Shed cannot handle the get_repository_id request, so the code must be older than the
                     # 04/2014 Galaxy release when it was introduced.  It will be safest to error out and let the
@@ -1002,10 +1000,9 @@ class AdminToolshed( AdminGalaxy ):
             else:
                 changeset_revisions = kwd.get( 'changeset_revisions', None )
             # Get the information necessary to install each repository.
-            params = '?repository_ids=%s&changeset_revisions=%s' % ( str( repository_ids ), str( changeset_revisions ) )
-            url = common_util.url_join( tool_shed_url,
-                                        'repository/get_repository_information%s' % params )
-            raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, url )
+            params = dict( repository_ids=str( repository_ids ), changeset_revisions=str( changeset_revisions ) )
+            pathspec = [ 'repository', 'get_repository_information' ]
+            raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec=pathspec, params=params )
             repo_information_dict = json.loads( raw_text )
             for encoded_repo_info_dict in repo_information_dict.get( 'repo_info_dicts', [] ):
                 decoded_repo_info_dict = encoding_util.tool_shed_decode( encoded_repo_info_dict )
@@ -1534,12 +1531,11 @@ class AdminToolshed( AdminGalaxy ):
                 if 'workflows' in metadata:
                     includes_workflows = True
                 # Since we're reinstalling, we need to send a request to the tool shed to get the README files.
-                params = '?name=%s&owner=%s&changeset_revision=%s' % ( str( tool_shed_repository.name ),
-                                                                       str( tool_shed_repository.owner ),
-                                                                       str( tool_shed_repository.installed_changeset_revision ) )
-                url = common_util.url_join( tool_shed_url,
-                                            'repository/get_readme_files%s' % params )
-                raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, url )
+                params = dict( name=tool_shed_repository.name, 
+                               owner=tool_shed_repository.owner,
+                               changeset_revision=tool_shed_repository.installed_changeset_revision )
+                pathspec = [ 'repository', 'get_readme_files' ]
+                raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec=pathspec, params=params )
                 readme_files_dict = json.loads( raw_text )
                 tool_dependencies = metadata.get( 'tool_dependencies', None )
             rdim = repository_dependency_manager.RepositoryDependencyInstallManager( trans.app )
@@ -1738,12 +1734,9 @@ class AdminToolshed( AdminGalaxy ):
         """
         repository = repository_util.get_installed_tool_shed_repository( trans.app, kwd[ 'id' ] )
         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( trans.app, str( repository.tool_shed ) )
-        params = '?name=%s&owner=%s&changeset_revision=%s' % ( str( repository.name ),
-                                                               str( repository.owner ),
-                                                               str( repository.changeset_revision ) )
-        url = common_util.url_join( tool_shed_url,
-                                    'repository/get_tool_versions%s' % params )
-        text = common_util.tool_shed_get( trans.app, tool_shed_url, url )
+        params = dict( name=repository.name, owner=repository.owner, changeset_revision=repository.changeset_revision )
+        pathspec = [ 'repository', 'get_tool_versions' ]
+        text = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec=pathspec, params=params )
         if text:
             tool_version_dicts = json.loads( text )
             tvm = tool_version_manager.ToolVersionManager( trans.app )

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -559,6 +559,7 @@ class AdminToolshed( AdminGalaxy ):
                                        owner=owner,
                                        changeset_revisions=str( latest_downloadable_revision ),
                                        galaxy_url=web.url_for( '/', qualified=True ) )
+                        pathspec = [ 'repository', 'install_repositories_by_revision' ]
                         url = common_util.url_join( tool_shed_url, pathspec=pathspec, params=params )
                         return trans.response.send_redirect( url )
             else:
@@ -981,7 +982,6 @@ class AdminToolshed( AdminGalaxy ):
                 # For backward compatibility to the 12/20/12 Galaxy release.
                 try:
                     params = dict( name=str( repository.name ), owner=str( repository.owner ) )
-                    # params = '?name=%s&owner=%s' % ( str( repository.name ), str( repository.owner ) )
                     pathspec = [ 'repository', 'get_repository_id' ]
                     repository_ids = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec=pathspec, params=params )
                 except Exception, e:

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -189,7 +189,7 @@ class AdminToolshed( AdminGalaxy ):
     def browse_tool_shed( self, trans, **kwd ):
         tool_shed_url = kwd.get( 'tool_shed_url', '' )
         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( trans.app, tool_shed_url )
-        params=dict( galaxy_url=web.url_for( '/', qualified=True ) )
+        params = dict( galaxy_url=web.url_for( '/', qualified=True ) )
         url = common_util.url_join( tool_shed_url, pathspec=[ 'repository', 'browse_valid_categories' ], params=params )
         return trans.response.send_redirect( url )
 
@@ -531,6 +531,7 @@ class AdminToolshed( AdminGalaxy ):
                                owner=owner )
                 pathspec = [ 'repository', 'get_latest_downloadable_changeset_revision' ]
                 raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec=pathspec, params=params )
+                url = common_util.url_join( tool_shed_url, pathspec=pathspec, params=params )
                 latest_downloadable_revision = json.loads( raw_text )
                 if latest_downloadable_revision == hg_util.INITIAL_CHANGELOG_HASH:
                     message = 'Error retrieving the latest downloadable revision for this repository via the url <b>%s</b>.' % url
@@ -1531,7 +1532,7 @@ class AdminToolshed( AdminGalaxy ):
                 if 'workflows' in metadata:
                     includes_workflows = True
                 # Since we're reinstalling, we need to send a request to the tool shed to get the README files.
-                params = dict( name=tool_shed_repository.name, 
+                params = dict( name=tool_shed_repository.name,
                                owner=tool_shed_repository.owner,
                                changeset_revision=tool_shed_repository.installed_changeset_revision )
                 pathspec = [ 'repository', 'get_readme_files' ]

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -867,7 +867,7 @@ class WorkflowController( BaseUIController, SharableMixin, UsesStoredWorkflowMix
             import_button = True
         if tool_shed_url and not import_button:
             # Use urllib (send another request to the tool shed) to retrieve the workflow.
-            params = dict( repository_metadata_id=repository_metadata_id, 
+            params = dict( repository_metadata_id=repository_metadata_id,
                            workflow_name=encoding_util.tool_shed_encode( workflow_name ),
                            open_for_url=True )
             pathspec = [ 'workflow', 'import_workflow' ]

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -867,9 +867,11 @@ class WorkflowController( BaseUIController, SharableMixin, UsesStoredWorkflowMix
             import_button = True
         if tool_shed_url and not import_button:
             # Use urllib (send another request to the tool shed) to retrieve the workflow.
-            workflow_url = '%s/workflow/import_workflow?repository_metadata_id=%s&workflow_name=%s&open_for_url=true' % \
-                ( tool_shed_url, repository_metadata_id, encoding_util.tool_shed_encode( workflow_name ) )
-            workflow_text = common_util.tool_shed_get( trans.app, tool_shed_url, workflow_url )
+            params = dict( repository_metadata_id=repository_metadata_id, 
+                           workflow_name=encoding_util.tool_shed_encode( workflow_name ),
+                           open_for_url=True )
+            pathspec = [ 'workflow', 'import_workflow' ]
+            workflow_text = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec=pathspec, params=params )
             import_button = True
         if import_button:
             workflow_data = None

--- a/lib/galaxy/webapps/tool_shed/controllers/repository.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/repository.py
@@ -902,13 +902,13 @@ class RepositoryController( BaseUIController, ratings_util.ItemRatings ):
             no_update = 'false'
         elif galaxy_url:
             # Start building up the url to redirect back to the calling Galaxy instance.
-            params = '?tool_shed_url=%s&name=%s&owner=%s&changeset_revision=%s&latest_changeset_revision=' % \
-                ( web.url_for( '/', qualified=True ),
-                  str( repository.name ),
-                  str( repository.user.username ),
-                  changeset_revision )
-            url = common_util.url_join( galaxy_url,
-                                        'admin_toolshed/update_to_changeset_revision%s' % params )
+            params = dict( tool_shed_url=web.url_for( '/', qualified=True ),
+                           name=str( repository.name ),
+                           owner=str( repository.user.username ),
+                           changeset_revision=changeset_revision,
+                           latest_changeset_revision=latest_changeset_revision )
+            pathspec = [ 'admin_toolshed', 'update_to_changeset_revision' ]
+            url = common_util.url_join( galaxy_url, pathspec=pathspec, params=params )
         else:
             message = 'Unable to check for updates due to an invalid Galaxy URL: <b>%s</b>.  ' % galaxy_url
             message += 'You may need to enable third-party cookies in your browser.  '
@@ -1219,12 +1219,8 @@ class RepositoryController( BaseUIController, ratings_util.ItemRatings ):
         trans.sa_session.add( repository )
         trans.sa_session.flush()
         tool_shed_url = web.url_for( '/', qualified=True )
-        download_url = common_util.url_join( tool_shed_url,
-                                             'repos',
-                                             str( repository.user.username ),
-                                             str( repository.name ),
-                                             'archive',
-                                             file_type_str )
+        pathspec = [ 'repos', str( repository.user.username ), str( repository.name ), 'archive', file_type_str ]
+        download_url = common_util.url_join( tool_shed_url, pathspec=pathspec )
         return trans.response.send_redirect( download_url )
 
     @web.expose
@@ -1692,11 +1688,8 @@ class RepositoryController( BaseUIController, ratings_util.ItemRatings ):
                     else:
                         time_tested = repository_metadata.time_last_tested.strftime( '%a, %d %b %Y %H:%M:%S UT' )
                     # Generate a citable URL for this repository with owner and changeset revision.
-                    repository_citable_url = common_util.url_join( tool_shed_url,
-                                                                   'view',
-                                                                   str( user.username ),
-                                                                   str( repository.name ),
-                                                                   str( repository_metadata.changeset_revision ) )
+                    pathspec = [ 'view', str( user.username ), str( repository.name ), str( repository_metadata.changeset_revision ) ]
+                    repository_citable_url = common_util.url_join( tool_shed_url, pathspec=pathspec )
                     passed_tests = len( tool_test_results.get( 'passed_tests', [] ) )
                     failed_tests = len( tool_test_results.get( 'failed_tests', [] ) )
                     missing_test_components = len( tool_test_results.get( 'missing_test_components', [] ) )
@@ -2132,12 +2125,11 @@ class RepositoryController( BaseUIController, ratings_util.ItemRatings ):
         galaxy_url = common_util.handle_galaxy_url( trans, **kwd )
         if galaxy_url:
             # Redirect back to local Galaxy to perform install.
-            params = '?tool_shed_url=%s&repository_ids=%s&changeset_revisions=%s' % \
-                ( web.url_for( '/', qualified=True ),
-                  ','.join( util.listify( repository_ids ) ),
-                  ','.join( util.listify( changeset_revisions ) ) )
-            url = common_util.url_join( galaxy_url,
-                                        'admin_toolshed/prepare_for_install%s' % params )
+            params = dict( tool_shed_url=web.url_for( '/', qualified=True ),
+                           repository_ids=','.join( util.listify( repository_ids ) ),
+                           changeset_revisions=','.join( util.listify( changeset_revisions ) ) )
+            pathspec = [ 'admin_toolshed', 'prepare_for_install' ]
+            url = common_util.url_join( galaxy_url, pathspec=pathspec, params=params )
             return trans.response.send_redirect( url )
         else:
             message = 'Repository installation is not possible due to an invalid Galaxy URL: <b>%s</b>.  ' % galaxy_url

--- a/lib/tool_shed/capsule/capsule_manager.py
+++ b/lib/tool_shed/capsule/capsule_manager.py
@@ -117,9 +117,10 @@ class ExportRepositoryManager( object ):
             repositories_archive.close()
         if self.using_api:
             encoded_repositories_archive_name = encoding_util.tool_shed_encode( repositories_archive_filename )
-            params = '?encoded_repositories_archive_name=%s' % encoded_repositories_archive_name
-            download_url = common_util.url_join( web.url_for( '/', qualified=True ),
-                                                'repository/export_via_api%s' % params )
+            params = dict( encoded_repositories_archive_name=encoded_repositories_archive_name )
+            pathspec = [ 'repository', 'export_via_api' ]
+            tool_shed_url = web.url_for( '/', qualified=True )
+            download_url = common_util.url_join( tool_shed_url, pathspec=pathspec, params=params )
             return dict( download_url=download_url, error_messages=error_messages )
         return repositories_archive, error_messages
 

--- a/lib/tool_shed/galaxy_install/dependency_display.py
+++ b/lib/tool_shed/galaxy_install/dependency_display.py
@@ -461,12 +461,11 @@ class DependencyDisplayer( object ):
                       self.app.install_model.ToolShedRepository.installation_status.INSTALLED ]:
                     # Since we're reinstalling, we need to send a request to the tool shed to get the README files.
                     tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( self.app, tool_shed_url )
-                    params = '?name=%s&owner=%s&changeset_revision=%s' % ( str( repository.name ),
-                                                                           str( repository.owner ),
-                                                                           str( repository.installed_changeset_revision ) )
-                    url = common_util.url_join( tool_shed_url,
-                                                'repository/get_readme_files%s' % params )
-                    raw_text = common_util.tool_shed_get( self.app, tool_shed_url, url )
+                    params = dict( name=str( repository.name ),
+                                   owner=str( repository.owner ),
+                                   changeset_revision=str( repository.installed_changeset_revision ) )
+                    pathspec = [ 'repository', 'get_readme_files' ]
+                    raw_text = common_util.tool_shed_get( self.app, tool_shed_url, pathspec=pathspec, params=params )
                     readme_files_dict = json.loads( raw_text )
                 else:
                     readme_files_dict = readme_util.build_readme_files_dict( self.app,

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -469,11 +469,12 @@ class InstallRepositoryManager( object ):
         return None, None
 
     def __get_install_info_from_tool_shed( self, tool_shed_url, name, owner, changeset_revision ):
-        params = '?name=%s&owner=%s&changeset_revision=%s' % ( name, owner, changeset_revision )
-        url = common_util.url_join( tool_shed_url,
-                                    'api/repositories/get_repository_revision_install_info%s' % params )
+        params = dict( name=str( repository.name ),
+                       owner=str( repository.owner ),
+                       changeset_revision=str( repository.changeset_revision ) )
+        pathspec = [ 'api', 'repositories', 'get_repository_revision_install_info' ]
         try:
-            raw_text = common_util.tool_shed_get( self.app, tool_shed_url, url )
+            raw_text = common_util.tool_shed_get( self.app, tool_shed_url, pathspec=pathspec, params=params )
         except Exception, e:
             message = "Error attempting to retrieve installation information from tool shed "
             message += "%s for revision %s of repository %s owned by %s: %s" % \
@@ -1013,12 +1014,11 @@ def fetch_tool_versions( app, tool_shed_repository ):
     failed_to_fetch = False
     try:
         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( app, str( tool_shed_repository.tool_shed ) )
-        params = '?name=%s&owner=%s&changeset_revision=%s' % ( str( tool_shed_repository.name ),
-                                                               str( tool_shed_repository.owner ),
-                                                               str( tool_shed_repository.changeset_revision ) )
-        url = common_util.url_join( tool_shed_url,
-                                    '/repository/get_tool_versions%s' % params )
-        text = common_util.tool_shed_get( app, tool_shed_url, url )
+        params = dict( name=str( tool_shed_repository.name ),
+                       owner=str( tool_shed_repository.owner ),
+                       changeset_revision=str( tool_shed_repository.changeset_revision ) )
+        pathspec = [ 'repository', 'get_tool_versions' ]
+        text = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
         if text:
             return json.loads( text )
         else:

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -1018,7 +1018,7 @@ def fetch_tool_versions( app, tool_shed_repository ):
                        owner=str( tool_shed_repository.owner ),
                        changeset_revision=str( tool_shed_repository.changeset_revision ) )
         pathspec = [ 'repository', 'get_tool_versions' ]
-        url = common_util.url_join( pathspec=pathspec, params=params )
+        url = common_util.url_join( tool_shed_url, pathspec=pathspec, params=params )
         text = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
         if text:
             return json.loads( text )

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -469,9 +469,9 @@ class InstallRepositoryManager( object ):
         return None, None
 
     def __get_install_info_from_tool_shed( self, tool_shed_url, name, owner, changeset_revision ):
-        params = dict( name=str( repository.name ),
-                       owner=str( repository.owner ),
-                       changeset_revision=str( repository.changeset_revision ) )
+        params = dict( name=str( name ),
+                       owner=str( owner ),
+                       changeset_revision=str( changeset_revision ) )
         pathspec = [ 'api', 'repositories', 'get_repository_revision_install_info' ]
         try:
             raw_text = common_util.tool_shed_get( self.app, tool_shed_url, pathspec=pathspec, params=params )
@@ -1018,6 +1018,7 @@ def fetch_tool_versions( app, tool_shed_repository ):
                        owner=str( tool_shed_repository.owner ),
                        changeset_revision=str( tool_shed_repository.changeset_revision ) )
         pathspec = [ 'repository', 'get_tool_versions' ]
+        url = common_util.url_join( pathspec=pathspec, params=params )
         text = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
         if text:
             return json.loads( text )

--- a/lib/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
+++ b/lib/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
@@ -293,7 +293,7 @@ class RepositoryDependencyInstallManager( object ):
         try:
             raw_text = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
         except Exception, e:
-            print "The URL\n%s\nraised the exception:\n%s\n" % ( url, str( e ) )
+            print "The URL\n%s\nraised the exception:\n%s\n" % ( common_util.url_join( tool_shed_url, pathspec=pathspec, params=params ), str( e ) )
             return ''
         if len( raw_text ) > 2:
             encoded_text = json.loads( raw_text )

--- a/lib/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
+++ b/lib/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
@@ -377,7 +377,7 @@ class RepositoryDependencyInstallManager( object ):
                     if suc.is_tool_shed_client( self.app ):
                         # Handle secure / insecure Tool Shed URL protocol changes and port changes.
                         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( self.app, tool_shed_url )
-                        pathspec = [ 'repository', 'get_required_repo_info_dict' ]
+                    pathspec = [ 'repository', 'get_required_repo_info_dict' ]
                     url = common_util.url_join( tool_shed_url, pathspec=pathspec )
                     # Fix for handling 307 redirect not being handled nicely by urllib2.urlopen when the urllib2.Request has data provided
                     url = urllib2.urlopen( urllib2.Request( url ) ).geturl()

--- a/lib/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
+++ b/lib/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
@@ -286,13 +286,12 @@ class RepositoryDependencyInstallManager( object ):
         for the received repository which is installed into Galaxy.  This method is called only from Galaxy.
         """
         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( app, str( repository.tool_shed ) )
-        params = '?name=%s&owner=%s&changeset_revision=%s' % ( str( repository.name ),
-                                                               str( repository.owner ),
-                                                               str( repository.changeset_revision ) )
-        url = common_util.url_join( tool_shed_url,
-                                    'repository/get_repository_dependencies%s' % params )
+        params = dict( name=str( repository.name ),
+                       owner=str( repository.owner ),
+                       changeset_revision=str( repository.changeset_revision ) )
+        pathspec = [ 'repository', 'get_repository_dependencies' ]
         try:
-            raw_text = common_util.tool_shed_get( app, tool_shed_url, url )
+            raw_text = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
         except Exception, e:
             print "The URL\n%s\nraised the exception:\n%s\n" % ( url, str( e ) )
             return ''
@@ -378,7 +377,8 @@ class RepositoryDependencyInstallManager( object ):
                     if suc.is_tool_shed_client( self.app ):
                         # Handle secure / insecure Tool Shed URL protocol changes and port changes.
                         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( self.app, tool_shed_url )
-                    url = common_util.url_join( tool_shed_url, '/repository/get_required_repo_info_dict' )
+                        pathspec = [ 'repository', 'get_required_repo_info_dict' ]
+                    url = common_util.url_join( tool_shed_url, pathspec=pathspec )
                     # Fix for handling 307 redirect not being handled nicely by urllib2.urlopen when the urllib2.Request has data provided
                     url = urllib2.urlopen( urllib2.Request( url ) ).geturl()
                     request = urllib2.Request( url, data=urllib.urlencode( dict( encoded_str=encoded_required_repository_str ) ) )

--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/tag_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/tag_handler.py
@@ -251,9 +251,9 @@ class Repository( RecipeTag, SyncDatabase ):
             message += "following required parameters is None: tool_shed_url: %s, name: %s, owner: %s, changeset_revision: %s " % \
                 ( str( tool_shed_url ), str( name ), str( owner ), str( changeset_revision ) )
             raise Exception( message )
-        params = dict( name=str( repository.name ),
-                       owner=str( repository.owner ),
-                       changeset_revision=str( repository.changeset_revision ) )
+        params = dict( name=name,
+                       owner=owner,
+                       changeset_revision=changeset_revision )
         pathspec = [ 'repository', 'get_tool_dependencies_config_contents' ]
         text = common_util.tool_shed_get( self.app, tool_shed_url, pathspec=pathspec, params=params )
         if text:

--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/tag_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/tag_handler.py
@@ -251,10 +251,11 @@ class Repository( RecipeTag, SyncDatabase ):
             message += "following required parameters is None: tool_shed_url: %s, name: %s, owner: %s, changeset_revision: %s " % \
                 ( str( tool_shed_url ), str( name ), str( owner ), str( changeset_revision ) )
             raise Exception( message )
-        params = '?name=%s&owner=%s&changeset_revision=%s' % ( name, owner, changeset_revision )
-        url = common_util.url_join( tool_shed_url,
-                        'repository/get_tool_dependencies_config_contents%s' % params )
-        text = common_util.tool_shed_get( self.app, tool_shed_url, url )
+        params = dict( name=str( repository.name ),
+                       owner=str( repository.owner ),
+                       changeset_revision=str( repository.changeset_revision ) )
+        pathspec = [ 'repository', 'get_tool_dependencies_config_contents' ]
+        text = common_util.tool_shed_get( self.app, tool_shed_url, pathspec=pathspec, params=params )
         if text:
             # Write the contents to a temporary file on disk so it can be reloaded and parsed.
             fh = tempfile.NamedTemporaryFile( 'wb', prefix="tmp-toolshed-cttdc"  )

--- a/lib/tool_shed/galaxy_install/tool_migration_manager.py
+++ b/lib/tool_shed/galaxy_install/tool_migration_manager.py
@@ -574,9 +574,11 @@ class ToolMigrationManager( object ):
                     irm.update_tool_shed_repository_status( tool_shed_repository,
                                                             self.app.install_model.ToolShedRepository.installation_status.SETTING_TOOL_VERSIONS )
                     # Get the tool_versions from the tool shed for each tool in the installed change set.
-                    url = '%s/repository/get_tool_versions?name=%s&owner=%s&changeset_revision=%s' % \
-                        ( self.tool_shed_url, tool_shed_repository.name, self.repository_owner, tool_shed_repository.installed_changeset_revision )
-                    text = common_util.tool_shed_get( self.app, self.tool_shed_url, url )
+                    params = dict( name=tool_shed_repository.name, 
+                                   owner=self.repository_owner, 
+                                   changeset_revision=tool_shed_repository.installed_changeset_revision )
+                    pathspec = [ 'repository', 'get_tool_versions' ]
+                    text = common_util.tool_shed_get( self.app, self.tool_shed_url, pathspec=pathspec, params=params )
                     if text:
                         tool_version_dicts = json.loads( text )
                         tvm.handle_tool_versions( tool_version_dicts, tool_shed_repository )

--- a/lib/tool_shed/galaxy_install/update_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/update_repository_manager.py
@@ -33,12 +33,12 @@ class UpdateRepositoryManager( object ):
         """Return the changeset revision hash to which the repository can be updated."""
         changeset_revision_dict = {}
         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( self.app, str( repository.tool_shed ) )
-        params = '?name=%s&owner=%s&changeset_revision=%s' % ( str( repository.name ),
-                                                               str( repository.owner ),
-                                                               str( repository.installed_changeset_revision ) )
-        url = common_util.url_join( tool_shed_url, 'repository/get_changeset_revision_and_ctx_rev%s' % params )
+        params = dict( name=str( repository.name ),
+                       owner=str( repository.owner ),
+                       changeset_revision=str( repository.installed_changeset_revision ) )
+        pathspec = [ 'repository', 'get_changeset_revision_and_ctx_rev' ]
         try:
-            encoded_update_dict = common_util.tool_shed_get( self.app, tool_shed_url, url )
+            encoded_update_dict = common_util.tool_shed_get( self.app, tool_shed_url, pathspec=pathspec, params=params )
             if encoded_update_dict:
                 update_dict = encoding_util.tool_shed_decode( encoded_update_dict )
                 includes_data_managers = update_dict.get( 'includes_data_managers', False )

--- a/lib/tool_shed/scripts/api/common.py
+++ b/lib/tool_shed/scripts/api/common.py
@@ -131,14 +131,7 @@ def get_api_url( base, parts=[], params=None ):
         parts.insert( 0, 'api' )
     elif 'api' not in parts:
         parts.insert( 0, 'api' )
-    url = common_util.url_join( base, *parts )
-    if params is not None:
-        try:
-            query_string = urllib.urlencode( params )
-        except Exception, e:
-            # The value of params must be a string.
-            query_string = params
-        url += '?%s' % query_string
+    url = common_util.url_join( base, pathspec=parts, params=params )
     return url
 
 def get_latest_downloadable_changeset_revision_via_api( url, name, owner ):

--- a/lib/tool_shed/scripts/deprecate_repositories_without_metadata.py
+++ b/lib/tool_shed/scripts/deprecate_repositories_without_metadata.py
@@ -30,10 +30,8 @@ log.setLevel( 10 )
 log.addHandler( logging.StreamHandler( sys.stdout ) )
 assert sys.version_info[:2] >= ( 2, 4 )
 
-
 def build_citable_url( host, repository ):
-    return url_join( host, 'view', repository.user.username, repository.name )
-
+    return url_join( host, pathspec=[ 'view', repository.user.username, repository.name ] )
 
 def main():
     '''
@@ -62,7 +60,6 @@ def main():
         print "# Displaying info only ( --info_only )"
 
     deprecate_repositories( app, cutoff_time, days=options.days, info_only=options.info_only, verbose=options.verbose )
-
 
 def send_mail_to_owner( app, name, owner, email, repositories_deprecated, days=14 ):
     '''
@@ -95,7 +92,6 @@ def send_mail_to_owner( app, name, owner, email, repositories_deprecated, days=1
     except Exception, e:
         print "# An error occurred attempting to send email: %s" % str( e )
         return False
-
 
 def deprecate_repositories( app, cutoff_time, days=14, info_only=False, verbose=False ):
     # This method will get a list of repositories that were created on or before cutoff_time, but have never

--- a/lib/tool_shed/util/common_util.py
+++ b/lib/tool_shed/util/common_util.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import urllib
 import urllib2
 from galaxy import util
 from galaxy.util.odict import odict
@@ -108,7 +109,7 @@ def check_tool_tag_set( elem, migrated_tool_configs_dict, missing_tool_configs_d
 def generate_clone_url_for_installed_repository( app, repository ):
     """Generate the URL for cloning a repository that has been installed into a Galaxy instance."""
     tool_shed_url = get_tool_shed_url_from_tool_shed_registry( app, str( repository.tool_shed ) )
-    return url_join( tool_shed_url, 'repos', str( repository.owner ), str( repository.name ) )
+    return url_join( tool_shed_url, pathspec=[ 'repos', str( repository.owner ), str( repository.name ) ] )
 
 def generate_clone_url_for_repository_in_tool_shed( user, repository ):
     """Generate the URL for cloning a repository that is in the tool shed."""
@@ -127,7 +128,7 @@ def generate_clone_url_from_repo_info_tup( app, repo_info_tup ):
         parse_repository_dependency_tuple( repo_info_tup )
     tool_shed_url = get_tool_shed_url_from_tool_shed_registry( app, toolshed )
     # Don't include the changeset_revision in clone urls.
-    return url_join( tool_shed_url, 'repos', owner, name )
+    return url_join( tool_shed_url, pathspec=[ 'repos', owner, name ] )
 
 def get_non_shed_tool_panel_configs( app ):
     """Get the non-shed related tool panel configs - there can be more than one, and the default is tool_conf.xml."""
@@ -147,10 +148,10 @@ def get_non_shed_tool_panel_configs( app ):
 def get_repository_dependencies( app, tool_shed_url, repository_name, repository_owner, changeset_revision ):
     repository_dependencies_dict = {}
     tool_shed_accessible = True
-    url = '%s/repository/get_repository_dependencies?name=%s&owner=%s&changeset_revision=%s' % \
-    ( tool_shed_url, repository_name, repository_owner, changeset_revision )
+    params = dict( name=repository_name, owner=repository_owner, changeset_revision=changeset_revision )
+    pathspec = [ 'repository', 'get_repository_dependencies' ]
     try:
-        raw_text = tool_shed_get( app, tool_shed_url, url )
+        raw_text = tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
         tool_shed_accessible = True
     except Exception, e:
         tool_shed_accessible = False
@@ -177,10 +178,10 @@ def get_protocol_from_tool_shed_url( tool_shed_url ):
 def get_tool_dependencies( app, tool_shed_url, repository_name, repository_owner, changeset_revision ):
     tool_dependencies = []
     tool_shed_accessible = True
-    url = '%s/repository/get_tool_dependencies?name=%s&owner=%s&changeset_revision=%s' % \
-    ( tool_shed_url, repository_name, repository_owner, changeset_revision )
+    params = dict( name=repository_name, owner=repository_owner, changeset_revision=changeset_revision )
+    pathspec = [ 'repository', 'get_tool_dependencies' ]
     try:
-        text = tool_shed_get( app, tool_shed_url, url )
+        text = tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
         tool_shed_accessible = True
     except Exception, e:
         tool_shed_accessible = False
@@ -330,7 +331,7 @@ def remove_protocol_from_tool_shed_url( tool_shed_url ):
             log.exception( "Handled exception removing the protocol from Tool Shed URL %s:\n%s" % ( str( tool_shed_url ), str( e ) ) )
         return tool_shed_url
 
-def tool_shed_get( app, tool_shed_url, uri ):
+def tool_shed_get( app, base_url, pathspec=[], params={} ):
     """Make contact with the tool shed via the uri provided."""
     registry = app.tool_shed_registry
     # urllib2 auto-detects system proxies, when passed a Proxyhandler.
@@ -338,19 +339,22 @@ def tool_shed_get( app, tool_shed_url, uri ):
     proxy = urllib2.ProxyHandler()
     urlopener = urllib2.build_opener( proxy )
     urllib2.install_opener( urlopener )
-    password_mgr = registry.password_manager_for_url( tool_shed_url )
+    password_mgr = registry.password_manager_for_url( base_url )
     if password_mgr is not None:
         auth_handler = urllib2.HTTPBasicAuthHandler( password_mgr )
         urlopener.add_handler( auth_handler )
-    response = urlopener.open( uri )
+    full_url = url_join( base_url, pathspec=pathspec, params=params )
+    response = urlopener.open( full_url )
     content = response.read()
     response.close()
     return content
 
-def url_join( *args ):
+def url_join( base_url, pathspec=None, params=None ):
     """Return a valid URL produced by appending a base URL and a set of request parameters."""
-    parts = []
-    for arg in args:
-        if arg is not None:
-            parts.append( arg.strip( '/' ) )
-    return '/'.join( parts )
+    url = base_url.rstrip( '/' )
+    log.debug( '%s\n%s\n%s', url, pathspec, params )
+    if pathspec is not None:
+        url = '%s/%s' % ( url, '/'.join( pathspec ) )
+    if params is not None:
+        url = '%s?%s' % ( url, urllib.urlencode( params ) )
+    return url

--- a/lib/tool_shed/util/common_util.py
+++ b/lib/tool_shed/util/common_util.py
@@ -155,7 +155,7 @@ def get_repository_dependencies( app, tool_shed_url, repository_name, repository
         tool_shed_accessible = True
     except Exception, e:
         tool_shed_accessible = False
-        print "The URL\n%s\nraised the exception:\n%s\n" % ( url, str( e ) )
+        print "The URL\n%s\nraised the exception:\n%s\n" % ( url_join( tool_shed_url, pathspec=pathspec, params=params ), str( e ) )
     if tool_shed_accessible:
         if len( raw_text ) > 2:
             encoded_text = json.loads( raw_text )
@@ -185,7 +185,7 @@ def get_tool_dependencies( app, tool_shed_url, repository_name, repository_owner
         tool_shed_accessible = True
     except Exception, e:
         tool_shed_accessible = False
-        print "The URL\n%s\nraised the exception:\n%s\n" % ( url, str( e ) )
+        print "The URL\n%s\nraised the exception:\n%s\n" % ( url_join( tool_shed_url, pathspec=pathspec, params=params ), str( e ) )
     if tool_shed_accessible:
         if text:
             tool_dependencies_dict = encoding_util.tool_shed_decode( text )

--- a/lib/tool_shed/util/common_util.py
+++ b/lib/tool_shed/util/common_util.py
@@ -352,7 +352,6 @@ def tool_shed_get( app, base_url, pathspec=[], params={} ):
 def url_join( base_url, pathspec=None, params=None ):
     """Return a valid URL produced by appending a base URL and a set of request parameters."""
     url = base_url.rstrip( '/' )
-    log.debug( '%s\n%s\n%s', url, pathspec, params )
     if pathspec is not None:
         url = '%s/%s' % ( url, '/'.join( pathspec ) )
     if params is not None:

--- a/lib/tool_shed/util/readme_util.py
+++ b/lib/tool_shed/util/readme_util.py
@@ -97,10 +97,9 @@ def get_readme_files_dict_for_display( app, tool_shed_url, repo_info_dict ):
         suc.get_repo_info_tuple_contents( repo_info_tuple )
     # Handle changing HTTP protocols over time.
     tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( app, tool_shed_url )
-    params = '?name=%s&owner=%s&changeset_revision=%s' % ( name, repository_owner, changeset_revision )
-    url = common_util.url_join( tool_shed_url,
-                                'repository/get_readme_files%s' % params )
-    raw_text = common_util.tool_shed_get( app, tool_shed_url, url )
+    params = dict( name=name, owner=repository_owner, changeset_revision=changeset_revision )
+    pathspec = [ 'repository', 'get_readme_files' ]
+    raw_text = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
     readme_files_dict = json.loads( raw_text )
     return readme_files_dict
 

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -201,7 +201,7 @@ def generate_tool_shed_repository_install_dir( repository_clone_url, changeset_r
     tool_shed_url = items[ 0 ]
     repo_path = items[ 1 ]
     tool_shed_url = common_util.remove_port_from_tool_shed_url( tool_shed_url )
-    return common_util.url_join( tool_shed_url, 'repos', repo_path, changeset_revision )
+    return common_util.url_join( tool_shed_url, pathspec=[ 'repos', repo_path, changeset_revision ] )
 
 
 def get_absolute_path_to_file_in_repository( repo_files_dir, file_name ):
@@ -246,10 +246,9 @@ def get_ctx_rev( app, tool_shed_url, name, owner, changeset_revision ):
     combination of a name, owner and changeset revision.
     """
     tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( app, tool_shed_url )
-    params = '?name=%s&owner=%s&changeset_revision=%s' % ( name, owner, changeset_revision )
-    url = common_util.url_join( tool_shed_url,
-                                'repository/get_ctx_rev%s' % params )
-    ctx_rev = common_util.tool_shed_get( app, tool_shed_url, url )
+    params = dict( name=name, owner=owner, changeset_revision=changeset_revision )
+    pathspec = [ 'repository', 'get_ctx_rev' ]
+    ctx_rev = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
     return ctx_rev
 
 
@@ -523,10 +522,9 @@ def get_repository_for_dependency_relationship( app, tool_shed, name, owner, cha
         # The received changeset_revision is no longer installable, so get the next changeset_revision
         # in the repository's changelog in the tool shed that is associated with repository_metadata.
         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( app, tool_shed )
-        params = '?name=%s&owner=%s&changeset_revision=%s' % ( name, owner, changeset_revision )
-        url = common_util.url_join( tool_shed_url,
-                                    'repository/next_installable_changeset_revision%s' % params )
-        text = common_util.tool_shed_get( app, tool_shed_url, url )
+        params = dict( name=name, owner=owner, changeset_revision=changeset_revision )
+        pathspec = [ 'repository', 'next_installable_changeset_revision' ]
+        text = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
         if text:
             repository = get_tool_shed_repository_by_shed_name_owner_changeset_revision( app=app,
                                                                                          tool_shed=tool_shed,
@@ -811,13 +809,10 @@ def get_tool_shed_status_for_installed_repository( app, repository ):
     object from Galaxy.
     """
     tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( app, str( repository.tool_shed ) )
-    params = '?name=%s&owner=%s&changeset_revision=%s' % ( str( repository.name ),
-                                                           str( repository.owner ),
-                                                           str( repository.changeset_revision ) )
-    url = common_util.url_join( tool_shed_url,
-                                'repository/status_for_installed_repository%s' % params )
+    params = dict( name=repository.name, owner=repository.owner, changeset_revision=repository.changeset_revision )
+    pathspec = [ 'repository', 'status_for_installed_repository' ]
     try:
-        encoded_tool_shed_status_dict = common_util.tool_shed_get( app, tool_shed_url, url )
+        encoded_tool_shed_status_dict = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
         tool_shed_status_dict = encoding_util.tool_shed_decode( encoded_tool_shed_status_dict )
         return tool_shed_status_dict
     except HTTPError, e:
@@ -825,14 +820,10 @@ def get_tool_shed_status_for_installed_repository( app, repository ):
         # using a boolean value.
         log.debug( "Error attempting to get tool shed status for installed repository %s: %s\nAttempting older 'check_for_updates' method.\n" %
                    ( str( repository.name ), str( e ) ) )
-        params = '?name=%s&owner=%s&changeset_revision=%s&from_update_manager=True' % ( str( repository.name ),
-                                                                                        str( repository.owner ),
-                                                                                        str( repository.changeset_revision ) )
-        url = common_util.url_join( tool_shed_url,
-                                    'repository/check_for_updates%s' % params )
+        pathspec = [ 'repository', 'check_for_updates' ]
         try:
             # The value of text will be 'true' or 'false', depending upon whether there is an update available for the installed revision.
-            text = common_util.tool_shed_get( app, tool_shed_url, url )
+            text = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
             return dict( revision_update=text )
         except Exception, e:
             # The required tool shed may be unavailable, so default the revision_update value to 'false'.
@@ -925,10 +916,9 @@ def get_updated_changeset_revisions_from_tool_shed( app, tool_shed_url, name, ow
         message += "required parameters is None: tool_shed_url: %s, name: %s, owner: %s, changeset_revision: %s " % \
             ( str( tool_shed_url ), str( name ), str( owner ), str( changeset_revision ) )
         raise Exception( message )
-    params = '?name=%s&owner=%s&changeset_revision=%s' % ( name, owner, changeset_revision )
-    url = common_util.url_join( tool_shed_url,
-                                'repository/updated_changeset_revisions%s' % params )
-    text = common_util.tool_shed_get( app, tool_shed_url, url )
+    params = dict( name=name, owner=owner, changeset_revision=changeset_revision )
+    pathspec = [ 'repository', 'updated_changeset_revisions' ]
+    text = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
     return text
 
 
@@ -1107,14 +1097,13 @@ def repository_was_previously_installed( app, tool_shed_url, repository_name, re
         return tool_shed_repository, changeset_revision
     # Get all previous changeset revisions from the tool shed for the repository back to, but excluding,
     # the previous valid changeset revision to see if it was previously installed using one of them.
-    params = '?galaxy_url=%s&name=%s&owner=%s&changeset_revision=%s&from_tip=%s' % ( url_for( '/', qualified=True ),
-                                                                                     str( repository_name ),
-                                                                                     str( repository_owner ),
-                                                                                     changeset_revision,
-                                                                                     str( from_tip ) )
-    url = common_util.url_join( tool_shed_url,
-                                'repository/previous_changeset_revisions%s' % params )
-    text = common_util.tool_shed_get( app, tool_shed_url, url )
+    params = dict( galaxy_url=url_for( '/', qualified=True ),
+                   name=repository_name,
+                   owner=repository_owner,
+                   changeset_revision=changeset_revision,
+                   from_tip=str( from_tip ) )
+    pathspec = [ 'repository', 'previous_changeset_revisions' ]
+    text = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )
     if text:
         changeset_revisions = util.listify( text )
         for previous_changeset_revision in changeset_revisions:

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -821,6 +821,7 @@ def get_tool_shed_status_for_installed_repository( app, repository ):
         log.debug( "Error attempting to get tool shed status for installed repository %s: %s\nAttempting older 'check_for_updates' method.\n" %
                    ( str( repository.name ), str( e ) ) )
         pathspec = [ 'repository', 'check_for_updates' ]
+        params[ 'from_update_manager' ] = True
         try:
             # The value of text will be 'true' or 'false', depending upon whether there is an update available for the installed revision.
             text = common_util.tool_shed_get( app, tool_shed_url, pathspec=pathspec, params=params )


### PR DESCRIPTION
Use urllib.urlencode to build the url for various operations.

I've tested this as extensively as I could, but more review would likely not hurt.
