### PR TITLE
Tool lineage fixes.

### DIFF
--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -606,8 +606,8 @@ class ToolVersion( object, Dictifiable ):
 
     def get_versions( self, app ):
         tool_versions = []
-        # Prepend ancestors.
 
+        # Prepend ancestors.
         def __ancestors( app, tool_version ):
             # Should we handle multiple parents at each level?
             previous_version = tool_version.get_previous_version( app )
@@ -624,6 +624,7 @@ class ToolVersion( object, Dictifiable ):
                 if next_version not in tool_versions:
                     tool_versions.append( next_version )
                     __descendants( app, next_version )
+
         __ancestors( app, self )
         if self not in tool_versions:
             tool_versions.append( self )
@@ -631,12 +632,10 @@ class ToolVersion( object, Dictifiable ):
         return tool_versions
 
     def get_version_ids( self, app, reverse=False ):
+        version_ids = [ tool_version.tool_id for tool_version in self.get_versions( app ) ]
         if reverse:
-            version_ids = []
-            for tool_version in self.get_versions( app ):
-                version_ids.insert( 0, tool_version.tool_id )
-            return version_ids
-        return [ tool_version.tool_id for tool_version in self.get_versions( app ) ]
+            version_ids.reverse()
+        return version_ids
 
     def to_dict( self, view='element' ):
         rval = super( ToolVersion, self ).to_dict( view=view )

--- a/lib/galaxy/tools/toolbox/lineages/stock.py
+++ b/lib/galaxy/tools/toolbox/lineages/stock.py
@@ -36,7 +36,7 @@ class StockLineage(ToolLineage):
         versions = [ ToolLineageVersion( self.tool_id, v ) for v in self.tool_versions ]
         # Sort using LooseVersion which defines an appropriate __cmp__
         # method for comparing tool versions.
-        return sorted( versions, key=_to_loose_version )
+        return sorted( versions, key=_to_loose_version, reverse=reverse )
 
     def to_dict(self):
         return dict(

--- a/lib/tool_shed/tools/tool_version_manager.py
+++ b/lib/tool_shed/tools/tool_version_manager.py
@@ -2,7 +2,7 @@ import logging
 
 from galaxy import eggs
 eggs.require('SQLAlchemy')
-from sqlalchemy import and_
+from sqlalchemy import and_, or_
 
 from tool_shed.util import hg_util
 from tool_shed.util import shed_util_common as suc
@@ -23,8 +23,8 @@ class ToolVersionManager( object ):
 
     def get_tool_version_association( self, parent_tool_version, tool_version ):
         """
-        Return a ToolVersionAssociation if one exists that associates the two received
-        tool_versions  This function is called only from Galaxy.
+        Return a ToolVersionAssociation if one exists that associates the two
+        received tool_versions. This function is called only from Galaxy.
         """
         context = self.app.install_model.context
         return context.query( self.app.install_model.ToolVersionAssociation ) \
@@ -92,6 +92,16 @@ class ToolVersionManager( object ):
                                                             tool_shed_repository=tool_shed_repository )
                     context.add( tool_version_using_parent_id )
                     context.flush()
+                # Remove existing wrong tool version associations having
+                # tool_version_using_parent_id as parent or
+                # tool_version_using_tool_guid as child.
+                context.query( self.app.install_model.ToolVersionAssociation ) \
+                       .filter( or_( and_( self.app.install_model.ToolVersionAssociation.table.c.parent_id == tool_version_using_parent_id.id,
+                                           self.app.install_model.ToolVersionAssociation.table.c.tool_id != tool_version_using_tool_guid.id ),
+                                     and_( self.app.install_model.ToolVersionAssociation.table.c.parent_id != tool_version_using_parent_id.id,
+                                           self.app.install_model.ToolVersionAssociation.table.c.tool_id == tool_version_using_tool_guid.id ) ) ) \
+                       .delete()
+                context.flush()
                 tool_version_association = \
                     self.get_tool_version_association( tool_version_using_parent_id,
                                                        tool_version_using_tool_guid )


### PR DESCRIPTION
In particular, this fixes #552 by removing existing wrong tool version associations when the admin clicks "Set tool versions" on the "Repository Actions" menu or when the Tool Shed repository is uninstalled and reinstalled.
