### PR TITLE
[release_15.07] fix regenerating repo metadata when coming from batch interface

### DIFF
--- a/lib/tool_shed/metadata/repository_metadata_manager.py
+++ b/lib/tool_shed/metadata/repository_metadata_manager.py
@@ -947,6 +947,7 @@ class RepositoryMetadataManager( metadata_generator.MetadataGenerator ):
                 try:
                     repository = suc.get_repository_in_tool_shed( self.app, repository_id )
                     self.set_repository( repository )
+                    self.resetting_all_metadata_on_repository = True
                     self.reset_all_metadata_on_repository_in_tool_shed()
                     if self.invalid_file_tups:
                         message = tool_util.generate_message_for_invalid_tools( self.app,


### PR DESCRIPTION
it used to create only single instalable revision (the latest); this broken state is currently on all devteam-managed repos on MTS
