### PR TITLE
Ensure removal of temporary files.

### DIFF
--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -915,7 +915,8 @@ class RepositoriesController( BaseAPIController ):
                     message = error_message
         else:
             trans.response.status = 500
-
+        if os.path.exists( uploaded_file_name ):
+            os.remove( uploaded_file_name )
         if not ok:
             return {
                 "err_msg": message,

--- a/lib/tool_shed/capsule/capsule_manager.py
+++ b/lib/tool_shed/capsule/capsule_manager.py
@@ -112,6 +112,10 @@ class ExportRepositoryManager( object ):
         except Exception, e:
             log.exception( str( e ) )
         finally:
+            if os.path.exists( tmp_export_info ):
+                os.remove( tmp_export_info )
+            if os.path.exists( tmp_manifest ):
+                os.remove( tmp_manifest )
             lock.release()
         if repositories_archive is not None:
             repositories_archive.close()


### PR DESCRIPTION
Specifically, export_info.xml and manifest.xml were not being deleted after the capsule was created.
