### PR TITLE
[15.05] Fix purging datasets whose total_size is None.

### DIFF
--- a/scripts/cleanup_datasets/cleanup_datasets.py
+++ b/scripts/cleanup_datasets/cleanup_datasets.py
@@ -464,9 +464,10 @@ def _purge_dataset( app, dataset, remove_from_disk, info_only = False ):
                                 hda.purged = True
                                 if hda.history.user is not None and hda.history.user not in usage_users:
                                     usage_users.append( hda.history.user )
-                        for user in usage_users:
-                            user.total_disk_usage -= dataset.total_size
-                            app.sa_session.add( user )
+                        if dataset.total_size:
+                            for user in usage_users:
+                                user.total_disk_usage -= dataset.total_size
+                                app.sa_session.add( user )
                     print "Purging dataset id", dataset.id
                     dataset.purged = True
                     app.sa_session.add( dataset )


### PR DESCRIPTION
Fix the error:

```
Removing disk, file  /opt/galaxy/database/files/000/dataset_192.dat
Error attempting to purge data file:  /opt/galaxy/database/files/000/dataset_192.dat  error:  unsupported operand type(s) for -=: 'Decimal' and 'NoneType'
```

when running:

```
python scripts/cleanup_datasets/cleanup_datasets.py config/galaxy.ini -d 10 -3 -r
```
