### PR TITLE
[15.05] Fix purging datasets whose total_size is None.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1434,13 +1434,11 @@ class Dataset( object ):
     def get_total_size( self ):
         if self.total_size is not None:
             return self.total_size
-        if self.file_size:
-            # for backwards compatibility, set if unset
-            self.set_total_size()
-            db_session = object_session( self )
-            db_session.flush()
-            return self.total_size
-        return 0
+        # for backwards compatibility, set if unset
+        self.set_total_size()
+        db_session = object_session( self )
+        db_session.flush()
+        return self.total_size
     def set_total_size( self ):
         if self.file_size is None:
             self.set_size()

--- a/scripts/cleanup_datasets/cleanup_datasets.py
+++ b/scripts/cleanup_datasets/cleanup_datasets.py
@@ -465,7 +465,7 @@ def _purge_dataset( app, dataset, remove_from_disk, info_only = False ):
                                 if hda.history.user is not None and hda.history.user not in usage_users:
                                     usage_users.append( hda.history.user )
                         for user in usage_users:
-                            user.total_disk_usage -= dataset.total_size
+                            user.total_disk_usage -= dataset.get_total_size()
                             app.sa_session.add( user )
                     print "Purging dataset id", dataset.id
                     dataset.purged = True

--- a/test/unit/test_galaxy_mapping.py
+++ b/test/unit/test_galaxy_mapping.py
@@ -413,7 +413,7 @@ class MappingTests( unittest.TestCase ):
     @classmethod
     def setUpClass(cls):
         # Start the database and connect the mapping
-        cls.model = mapping.init( "/tmp", "sqlite:///:memory:", create_tables=True )
+        cls.model = mapping.init( "/tmp", "sqlite:///:memory:", create_tables=True, object_store=MockObjectStore() )
         assert cls.model.engine is not None
 
     @classmethod
@@ -440,6 +440,21 @@ class MappingTests( unittest.TestCase ):
     def expunge(cls):
         cls.model.session.flush()
         cls.model.session.expunge_all()
+
+
+class MockObjectStore(object):
+
+    def __init__(self):
+        pass
+
+    def size(self, dataset):
+        return 42
+
+    def exists(self, *args, **kwds):
+        return True
+
+    def get_filename(self, *args, **kwds):
+        return "dataest_14.dat"
 
 
 def get_suite():


### PR DESCRIPTION
Fix the error:

```
Removing disk, file  /opt/galaxy/database/files/000/dataset_192.dat
Error attempting to purge data file:  /opt/galaxy/database/files/000/dataset_192.dat  error:  unsupported operand type(s) for -=: 'Decimal' and 'NoneType'
```

when running:

```
python scripts/cleanup_datasets/cleanup_datasets.py config/galaxy.ini -d 10 -3 -r
```
