### PR TITLE
[15.01] Tool reloading fix

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -77,14 +77,14 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin, UsesHistoryMix
     
     @_future_expose_api
     @web.require_admin
-    def reload( self, trans, tool_id, **kwd ):
+    def reload( self, trans, id, **kwd ):
         """
         GET /api/tools/{tool_id}/reload
         Reload specified tool.
         """
         toolbox = trans.app.toolbox
-        galaxy.queue_worker.send_control_task( trans, 'reload_tool', noop_self=True, kwargs={ 'tool_id': tool_id } )
-        message, status = trans.app.toolbox.reload_tool_by_id( tool_id )
+        galaxy.queue_worker.send_control_task( trans, 'reload_tool', noop_self=True, kwargs={ 'tool_id': id } )
+        message, status = trans.app.toolbox.reload_tool_by_id( id )
         return { status: message }
 
     @_future_expose_api_anonymous


### PR DESCRIPTION
Based on discussion from https://github.com/galaxyproject/galaxy/pull/619#issuecomment-132745977 onwards, this bug has existed since 15.01, and could/should be patched from there forwards (15.03, 15.05, 15.07, #619 merged it into dev)
