### PR TITLE
Cleaner commit history for #629 and array syntax for pathspec

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
@@ -100,11 +100,10 @@ class ToolShedRepositoriesController( BaseAPIController ):
         # Make sure the current user's API key proves he is an admin user in this Galaxy instance.
         if not trans.user_is_admin():
             raise exceptions.AdminRequiredException( 'You are not authorized to request the latest installable revision for a repository in this Galaxy instance.' )
-        params = '?name=%s&owner=%s' % ( name, owner )
-        url = common_util.url_join( tool_shed_url,
-                                    'api/repositories/get_ordered_installable_revisions%s' % params )
+        params = dict(name=name, owner=owner)
+        pathspec = ['api', 'repositories', 'get_ordered_installable_revisions']
         try:
-            raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, url )
+            raw_text = common_util.tool_shed_get( trans.app, tool_shed_url, pathspec, params )
         except Exception, e:
             message = "Error attempting to retrieve the latest installable revision from tool shed %s for repository %s owned by %s: %s" % \
                 ( str( tool_shed_url ), str( name ), str( owner ), str( e ) )

--- a/lib/tool_shed/util/common_util.py
+++ b/lib/tool_shed/util/common_util.py
@@ -353,7 +353,9 @@ def url_join( base_url, pathspec=None, params=None ):
     """Return a valid URL produced by appending a base URL and a set of request parameters."""
     url = base_url.rstrip( '/' )
     if pathspec is not None:
-        url = '%s/%s' % ( url, '/'.join( pathspec ) )
+        if not isinstance( pathspec, basestring ):
+            pathspec = '/'.join( pathspec )
+        url = '%s/%s' % ( url, pathspec )
     if params is not None:
         url = '%s?%s' % ( url, urllib.urlencode( params ) )
     return url


### PR DESCRIPTION
- Fix get_latest_installable_revision to use pathspec and params to work with recent changes to common_util.url_join
- Fix common_util.url_join to handle a string as pathspec, instead of treating it as an a/r/r/a/y/ /o/f/ /c/h/a/r/a/c/t/e/r/s
