### PR TITLE
Allow deserializing dataset permissions

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -383,6 +383,8 @@ class ModelManager( object ):
         """
         Returns an in-order list of models with the matching ids in `ids`.
         """
+        if not ids:
+            return []
         ids_filter = self.model_class.id.in_( ids )
         found = self.list( filters=self._munge_filters( ids_filter, filters ), **kwargs )
         # TODO: this does not order by the original 'ids' array

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -225,8 +225,7 @@ class DatasetDeserializer( base.ModelDeserializer, deletable.PurgableDeserialize
         deletable.PurgableDeserializerMixin.add_deserializers( self )
 
         self.deserializers.update({
-            # TODO: do not enable until fully tested
-            # 'permissions' : self.deserialize_permissions,
+            'permissions' : self.deserialize_permissions,
         })
 
     def deserialize_permissions( self, dataset, key, permissions, user=None, **context ):
@@ -257,7 +256,7 @@ class DatasetDeserializer( base.ModelDeserializer, deletable.PurgableDeserialize
         return permissions
 
     def _list_of_roles_from_ids( self, id_list ):
-        # TODO: this manager may make more sense inside rbac_secured
+        # TODO: this may make more sense inside rbac_secured
         # note: no checking of valid roles is made
         return self.role_manager.by_ids( [ self.app.security.decode_id( id_ ) for id_ in id_list ] )
 
@@ -368,7 +367,7 @@ class _UnflattenedMetadataDatasetAssociationSerializer( base.ModelSerializer,
             # 'dataset_uuid'  : self._proxy_to_dataset( key='uuid' ),
             'file_name'     : self._proxy_to_dataset( serializer=self.dataset_serializer.serialize_file_name ),
             'extra_files_path' : self._proxy_to_dataset( serializer=self.dataset_serializer.serialize_extra_files_path ),
-            'permissions'   : self._proxy_to_dataset( serializer=self.dataset_serializer.serialize_permissions),
+            'permissions'   : self._proxy_to_dataset( serializer=self.dataset_serializer.serialize_permissions ),
             # TODO: do the sizes proxy accurately/in the same way?
             'size'          : lambda i, k, **c: int( i.get_size() ),
             'file_size'     : lambda i, k, **c: self.serializers[ 'size' ]( i, k, **c ),
@@ -565,7 +564,7 @@ class DatasetAssociationFilterParser( base.ModelFilterParser, deletable.Purgable
         """
         comparison_class = self.app.datatypes_registry.get_datatype_class_by_name( class_str )
         return ( comparison_class and
-                 dataset_assoc.datatype.__class__ == comparison_class )
+            dataset_assoc.datatype.__class__ == comparison_class )
 
     def isinstance_datatype( self, dataset_assoc, class_strs ):
         """
@@ -579,4 +578,4 @@ class DatasetAssociationFilterParser( base.ModelFilterParser, deletable.Purgable
             if datatype_class:
                 comparison_classes.append( datatype_class )
         return ( comparison_classes and
-                isinstance( dataset_assoc.datatype, comparison_classes ) )
+            isinstance( dataset_assoc.datatype, comparison_classes ) )

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -8,6 +8,7 @@ import galaxy.datatypes.metadata
 from galaxy.managers import base
 from galaxy.managers import secured
 from galaxy.managers import deletable
+from galaxy.managers import roles
 from galaxy.managers import rbac_secured
 from galaxy.managers import users
 
@@ -109,7 +110,6 @@ class DatasetRBACPermissions( object ):
     def available_roles( self, trans, dataset, controller='root' ):
         return self.app.security_agent.get_legitimate_roles( trans, dataset, controller )
 
-    # TODO: not enough by a long shot
     def get( self, dataset, flush=True ):
         manage = self.manage.by_dataset( dataset )
         access = self.access.by_dataset( dataset )
@@ -199,7 +199,7 @@ class DatasetSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin
     def serialize_permissions( self, dataset, key, user=None, **context ):
         """
         """
-        if not user or not self.dataset_manager.permissions.manage.is_permitted( dataset, user ):
+        if not self.dataset_manager.permissions.manage.is_permitted( dataset, user ):
             self.skip()
 
         management_permissions = self.dataset_manager.permissions.manage.by_dataset( dataset )
@@ -214,23 +214,52 @@ class DatasetSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin
 class DatasetDeserializer( base.ModelDeserializer, deletable.PurgableDeserializerMixin ):
     model_manager_class = DatasetManager
 
+    def __init__( self, app ):
+        super( DatasetDeserializer, self ).__init__( app )
+        # TODO: this manager may make more sense inside rbac_secured
+        self.role_manager = roles.RoleManager( app )
+
     def add_deserializers( self ):
         super( DatasetDeserializer, self ).add_deserializers()
         # not much to set here besides permissions and purged/deleted
         deletable.PurgableDeserializerMixin.add_deserializers( self )
 
         self.deserializers.update({
-            'permissions' : self.deserialize_permissions,
+            # TODO: do not enable until fully tested
+            # 'permissions' : self.deserialize_permissions,
         })
 
-    def deserialize_permissions( self, dataset, key, value, **context ):
+    def deserialize_permissions( self, dataset, key, permissions, user=None, **context ):
         """
+        Create permissions for each list of encoded role ids in the (validated)
+        `permissions` dictionary, where `permissions` is in the form:
+            { 'manage': [ <role id 1>, ... ], 'access': [ <role id 2>, ... ] }
         """
-        permissions = {}
-# TODO: test if different - it's an expensive op
-# TODO: validation will be tricky
-# TODO: use rbac permissions?
+        self.manager.permissions.manage.error_unless_permitted( dataset, user )
+        self._validate_permissions( permissions, **context )
+        manage = self._list_of_roles_from_ids( permissions[ 'manage' ] )
+        access = self._list_of_roles_from_ids( permissions[ 'access' ] )
+        self.manager.permissions.set( dataset, manage, access, flush=False )
         return permissions
+
+    def _validate_permissions( self, permissions, **context ):
+        self.validate.type( 'permissions', permissions, dict )
+        for permission_key in ( 'manage', 'access' ):
+            if( not isinstance( permissions.get( permission_key, None ), list ) ):
+                msg = 'permissions requires "{0}" as a list of role ids'.format( permission_key )
+                raise exceptions.RequestParameterInvalidException( msg )
+
+        # TODO: push down into permissions?
+        manage_permissions = permissions[ 'manage' ]
+        if len( manage_permissions ) < 1:
+            raise exceptions.RequestParameterInvalidException( 'At least one managing role is required' )
+
+        return permissions
+
+    def _list_of_roles_from_ids( self, id_list ):
+        # TODO: this manager may make more sense inside rbac_secured
+        # note: no checking of valid roles is made
+        return self.role_manager.by_ids( [ self.app.security.decode_id( id_ ) for id_ in id_list ] )
 
 
 # ============================================================================= AKA DatasetInstanceManager
@@ -548,6 +577,6 @@ class DatasetAssociationFilterParser( base.ModelFilterParser, deletable.Purgable
         for class_str in class_strs.split( ',' ):
             datatype_class = parse_datatype_fn( class_str )
             if datatype_class:
-                comparison_classes.append(datatype_class)
-        return (comparison_classes and
-                isinstance(dataset_assoc.datatype, comparison_classes))
+                comparison_classes.append( datatype_class )
+        return ( comparison_classes and
+                isinstance( dataset_assoc.datatype, comparison_classes ) )

--- a/lib/galaxy/managers/rbac_secured.py
+++ b/lib/galaxy/managers/rbac_secured.py
@@ -133,9 +133,12 @@ class DatasetRBACPermission( RBACPermission ):
     # TODO: list?
     def _delete( self, permissions, flush=True ):
         for permission in permissions:
-            self.session().delete( permission )
-            if flush:
-                self.session().flush()
+            if permission in self.session().new:
+                self.session().expunge( permission )
+            else:
+                self.session().delete( permission )
+        if flush:
+            self.session().flush()
 
     def _revoke_role( self, dataset, role, flush=True ):
         role_permissions = self.by_roles( dataset, [ role ] )


### PR DESCRIPTION
Permissions for access/management of datasets is now settable through the deserializers by sending in a dictionary keyed with the permission types ('access', 'manage') and values that are lists of role ids that should have those permissions. 

Along with a more fully featured role API, this should lead to the next step of reading/writing permissions through the API.
