### PR TITLE
Expose tool config file path to admins via the API.  This is useful (…

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2303,6 +2303,10 @@ class Tool( object, Dictifiable ):
         # Basic information
         tool_dict = super( Tool, self ).to_dict()
 
+        # If an admin user, expose the path to the actual tool config XML file.
+        if trans.user_is_admin:
+            tool_dict['config_file'] = os.path.abspath(self.config_file)
+
         # Add link details.
         if link_details:
             # Add details for creating a hyperlink to the tool.

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2304,7 +2304,7 @@ class Tool( object, Dictifiable ):
         tool_dict = super( Tool, self ).to_dict()
 
         # If an admin user, expose the path to the actual tool config XML file.
-        if trans.user_is_admin:
+        if trans.user_is_admin():
             tool_dict['config_file'] = os.path.abspath(self.config_file)
 
         # Add link details.

--- a/test/unit/tools/test_toolbox_filters.py
+++ b/test/unit/tools/test_toolbox_filters.py
@@ -75,8 +75,8 @@ def mock_tool( require_login=False, hidden=False, trackster_conf=False, allow_ac
     return tool
 
 
-def mock_trans( has_user=True ):
-    trans = Bunch( )
+def mock_trans( has_user=True, is_admin=False ):
+    trans = Bunch( user_is_admin=lambda: is_admin )
     if has_user:
         trans.user = Bunch(preferences={})
     else:


### PR DESCRIPTION
…not to mention already kinda exposed when using wrappers) for interfacing with planemo for the smc work and I would expect other automation tasks.
