### PR TITLE
Fix tool image paths

### DIFF
--- a/lib/galaxy/webapps/tool_shed/buildapp.py
+++ b/lib/galaxy/webapps/tool_shed/buildapp.py
@@ -69,7 +69,7 @@ def app_factory( global_conf, **kwargs ):
     webapp.add_route( '/view/{owner}/{name}', controller='repository', action='sharable_repository' )
     webapp.add_route( '/view/{owner}/{name}/{changeset_revision}', controller='repository', action='sharable_repository_revision' )
     # Handle displaying tool help images and README file images for tools contained in repositories.
-    webapp.add_route( '/repository/static/images/:repository_id/:image_file',
+    webapp.add_route( '/repository/static/images/:repository_id/{image_file:.+?}',
                       controller='repository',
                       action='display_image_in_repository',
                       repository_id=None,

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -1133,12 +1133,6 @@ def set_image_paths( app, encoded_repository_id, text ):
             route_to_images = '/repository/static/images/%s' % encoded_repository_id
         # We used to require $PATH_TO_IMAGES, but we now eliminate it if it's used.
         text = text.replace( '$PATH_TO_IMAGES', '' )
-        # Eliminate the invalid setting of ./static/images since the routes will
-        # properly display images contained in that directory.
-        text = text.replace( './static/images', '' )
-        # Eliminate the default setting of /static/images since the routes will
-        # properly display images contained in that directory.
-        text = text.replace( '/static/images', '' )
         # Use regex to instantiate routes into the defined image paths, but replace
         # paths that start with neither http:// nor https://, which will allow for
         # settings like .. images:: http_files/images/help.png

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -1131,8 +1131,10 @@ def set_image_paths( app, encoded_repository_id, text ):
         else:
             # We're in the tool shed.
             route_to_images = '/repository/static/images/%s' % encoded_repository_id
-        # We used to require $PATH_TO_IMAGES, but we now eliminate it if it's used.
+        # We used to require $PATH_TO_IMAGES and ${static_path}, but
+        # we now eliminate it if it's used.
         text = text.replace( '$PATH_TO_IMAGES', '' )
+        text = text.replace( '${static_path}', '' )
         # Use regex to instantiate routes into the defined image paths, but replace
         # paths that start with neither http:// nor https://, which will allow for
         # settings like .. images:: http_files/images/help.png


### PR DESCRIPTION
This should fix our image-showing issues on TS and Galaxy. The proper way to link images from readme of help is relative path within repo. The distro tools with images should continue working as they won't go through shed_util_common
ping @bgruening 
related: 
https://github.com/galaxyproject/tools-devteam/pull/212
https://github.com/galaxyproject/tools-devteam/issues/126
