### PR TITLE
Allow accessing repeat and conditional elements in PJA parameters.

### DIFF
--- a/lib/galaxy/jobs/actions/post.py
+++ b/lib/galaxy/jobs/actions/post.py
@@ -176,6 +176,12 @@ class RenameDatasetAction(DefaultJobAction):
                 operations = []
                 if len(tokens) > 1:
                     input_file_var = tokens[0].strip()
+
+                    # Treat . as special symbol (breaks parameter names anyway)
+                    # to allow access to repeat elements, for instance first
+                    # repeat in cat1 would be something like queries_0.input2.
+                    input_file_var = input_file_var.replace(".", "|")
+
                     for i in range(1, len(tokens)):
                         operations.append(tokens[i].strip())
                 replacement = ""


### PR DESCRIPTION
Use `.` instead of the `|` that would be the actual association name. Cannot use `|` because it is treated as a special character in this code. Parameters with `.` in the names break Galaxy in subtle ways anyway and so treating them as a special character here should not be a problem.
