### PR TITLE
Fix issue #525. Repo info dicts and tsr_ids were filtered for pre-ins…

### DIFF
--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -795,7 +795,7 @@ class InstallRepositoryManager( object ):
                 shed_tool_conf=shed_tool_conf,
                 tool_path=tool_path,
                 tool_panel_section_keys=tool_panel_section_keys,
-                repo_info_dicts=repo_info_dicts,
+                repo_info_dicts=filtered_repo_info_dicts,
                 install_tool_dependencies=install_tool_dependencies,
             )
             return self.install_repositories(tsr_ids, decoded_kwd, reinstalling=False)


### PR DESCRIPTION
...stalled tools, but the unfiltered info_dict was passed on, causing misalignment of repository and tsr_id.
