### PR TITLE
Fix to get custom datatypes working after TabularData class was added

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -744,7 +744,7 @@ class Text( Data ):
                 data_lines += 1
         return data_lines
 
-    def set_peek( self, dataset, line_count=None, is_multi_byte=False, WIDTH=256, skipchars=[] ):
+    def set_peek( self, dataset, line_count=None, is_multi_byte=False, WIDTH=256, skipchars=None ):
         """
         Set the peek.  This method is used by various subclasses of Text.
         """
@@ -952,7 +952,7 @@ def get_test_fname( fname ):
     return full_path
 
 
-def get_file_peek( file_name, is_multi_byte=False, WIDTH=256, LINE_COUNT=5, skipchars=[] ):
+def get_file_peek( file_name, is_multi_byte=False, WIDTH=256, LINE_COUNT=5, skipchars=None ):
     """
     Returns the first LINE_COUNT lines wrapped to WIDTH
 
@@ -966,6 +966,8 @@ def get_file_peek( file_name, is_multi_byte=False, WIDTH=256, LINE_COUNT=5, skip
     # long lines.
     if WIDTH == 'unlimited':
         WIDTH = -1
+    if skipchars is None:
+        skipchars = []
     lines = []
     count = 0
     file_type = None

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -37,8 +37,8 @@ class TabularData( data.Text ):
     MetadataElement( name="column_names", default=[], desc="Column names", readonly=True, visible=False, optional=True, no_value=[] )
     MetadataElement( name="delimiter", default='\t', desc="Data delimiter", readonly=True, visible=False, optional=True, no_value=[] )
 
-    def set_peek( self, dataset, line_count=None, is_multi_byte=False):
-        super(TabularData, self).set_peek( dataset, line_count=line_count, is_multi_byte=is_multi_byte)
+    def set_peek( self, dataset, line_count=None, is_multi_byte=False, WIDTH=256, skipchars=None ):
+        super(TabularData, self).set_peek( dataset, line_count=line_count, is_multi_byte=is_multi_byte, WIDTH=WIDTH, skipchars=skipchars)
         if dataset.metadata.comment_lines:
             dataset.blurb = "%s, %s comments" % ( dataset.blurb, util.commaify( str( dataset.metadata.comment_lines ) ) )
 


### PR DESCRIPTION
The TabularData class was inserted between the Text and Tabular classes.  Unfortunately, TabularData.set_peek() was missing parameters present in Text.set_peek().  As such, when our custom datatype called it's superclass's set_peek() method, it would fail and print a traceback in the log.

I also changed default parameter value of skipchars in Text.set_peek() from [] to None so it's no longer mutable.
