### PR TITLE
Upgrade sqlalchemy to 1.0.8.  

### DIFF
--- a/eggs.ini
+++ b/eggs.ini
@@ -26,7 +26,7 @@ pysam = 0.4.2
 pysqlite = 2.5.6
 python_lzo = 1.08_2.03_static
 PyYAML = 3.10
-SQLAlchemy = 1.0.1
+SQLAlchemy = 1.0.8
 ; msgpack_python = 0.2.4
 
 [eggs:noplatform]


### PR DESCRIPTION
This was primarily done in an attempt to fix a mysql-specific unicode bug (which it didn't fix).  I've created the various platform eggs already.
