### PR TITLE
fix double import for travis

### DIFF
--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -10,7 +10,6 @@ import time
 import urllib2
 import zipfile
 import hashlib
-import re
 
 from galaxy.util import asbool
 from galaxy.util.template import fill_template


### PR DESCRIPTION
I think this was broken in #457 and was causing this: https://travis-ci.org/galaxyproject/galaxy/builds/79709791
