### PR TITLE
Have GenomeSpace tools report the GS tool name 

### DIFF
--- a/tools/genomespace/genomespace_exporter.xml
+++ b/tools/genomespace/genomespace_exporter.xml
@@ -31,6 +31,7 @@
         --file_type "${input1.ext}"
         --content_type "${input1.get_mime()}"
         --log "${output_log}"
+        --genomespace_toolname="\${GENOMESPACE_TOOLNAME:-Galaxy}"
     </command>
     <inputs>
         <param format="data" name="input1" type="data" label="Send this dataset to GenomeSpace" />

--- a/tools/genomespace/genomespace_file_browser_dev.xml
+++ b/tools/genomespace/genomespace_file_browser_dev.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tool name="GenomeSpace import" id="genomespace_file_browser_dev" tool_type="data_source" add_galaxy_url="False" force_history_refresh="True" version="0.0.1">
     <description>from file browser (development)</description>
-    <command interpreter="python">genomespace_file_browser.py --json_parameter_file "${output}" --genomespace_site "dev"</command>
+    <command interpreter="python">genomespace_file_browser.py --json_parameter_file "${output}" --genomespace_site "dev" --genomespace_toolname="\${GENOMESPACE_TOOLNAME:-Galaxy}"</command>
     <inputs action="https://dmdev.genomespace.org:8444/datamanager/defaultdirectory" check_values="False" method="post"> 
         <display>go to GenomeSpace Data Manager </display>
         <param name="appCallbackUrl" type="baseurl" value="/tool_runner?tool_id=genomespace_file_browser_dev&amp;runtool_btn=Execute" />

--- a/tools/genomespace/genomespace_file_browser_prod.xml
+++ b/tools/genomespace/genomespace_file_browser_prod.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tool name="GenomeSpace import" id="genomespace_file_browser_prod" tool_type="data_source" add_galaxy_url="False" force_history_refresh="True" version="0.0.1">
     <description>from file browser</description>
-    <command interpreter="python">genomespace_file_browser.py --json_parameter_file "${output}" --genomespace_site "prod"</command>
+    <command interpreter="python">genomespace_file_browser.py --json_parameter_file "${output}" --genomespace_site "prod" --genomespace_toolname="\${GENOMESPACE_TOOLNAME:-Galaxy}"</command>
     <inputs action="https://dm.genomespace.org/datamanager/defaultdirectory" check_values="False" method="post"> 
         <display>go to GenomeSpace Data Manager </display>
         <param name="appCallbackUrl" type="baseurl" value="/tool_runner?tool_id=genomespace_file_browser_prod&amp;runtool_btn=Execute" />

--- a/tools/genomespace/genomespace_file_browser_test.xml
+++ b/tools/genomespace/genomespace_file_browser_test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tool name="GenomeSpace import" id="genomespace_file_browser_test" tool_type="data_source" add_galaxy_url="False" force_history_refresh="True" version="0.0.1">
     <description>from file browser (test)</description>
-    <command interpreter="python">genomespace_file_browser.py --json_parameter_file "${output}" --genomespace_site "test"</command>
+    <command interpreter="python">genomespace_file_browser.py --json_parameter_file "${output}" --genomespace_site "test" --genomespace_toolname="\${GENOMESPACE_TOOLNAME:-Galaxy}"</command>
     <inputs action="https://dmtest.genomespace.org:8444/datamanager/defaultdirectory" check_values="False" method="post"> 
         <display>go to GenomeSpace Data Manager </display>
         <param name="appCallbackUrl" type="baseurl" value="/tool_runner?tool_id=genomespace_file_browser_test&amp;runtool_btn=Execute" />

--- a/tools/genomespace/genomespace_importer.xml
+++ b/tools/genomespace/genomespace_importer.xml
@@ -10,6 +10,7 @@
         --username "${username}"
         --token "${token}"
         --json_parameter_file "${output_file1}"
+        --genomespace_toolname="\${GENOMESPACE_TOOLNAME:-Galaxy}"
     </command>
     <inputs check_values="False">
         <!-- <param name="file_name" type="text" value="" /> -->


### PR DESCRIPTION
(for their internal metrics). Default is "Galaxy", but can be overridden by setting "GENOMESPACE_TOOLNAME" environment variable.
