### PR TITLE
[15.07] Don't update the state of terminal jobs

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1036,6 +1036,10 @@ class JobWrapper( object ):
     def change_state( self, state, info=False ):
         job = self.get_job()
         self.sa_session.refresh( job )
+        if job.state in model.Job.terminal_states:
+            log.warning( "(%s) Ignoring state change from '%s' to '%s' for job "
+                         "that is already terminal", job.id, job.state, state )
+            return
         for dataset_assoc in job.output_datasets + job.output_library_datasets:
             dataset = dataset_assoc.dataset
             self.sa_session.refresh( dataset )

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -317,6 +317,9 @@ class Job( object, HasJobMetrics, Dictifiable ):
                     PAUSED = 'paused',
                     DELETED = 'deleted',
                     DELETED_NEW = 'deleted_new' )
+    terminal_states = [ states.OK,
+                        states.ERROR,
+                        states.DELETED ]
     # Please include an accessor (get/set pair) for any new columns/members.
     def __init__( self ):
         self.session_id = None


### PR DESCRIPTION
This is occurring with the Pulsar "amqp acknowledgement" stuff, which is allowing status updates to be received out of order.

In general, a way to prevent out-of-order messages (or allowing them to be put back in the correct order on the consumer side, whatever that entails) would be good, but this at least prevents things from being stuck in a non-terminal state.
