### PR TITLE
Add testing environment variable GALAXY_TEST_LOGGING_CONFIG.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -614,6 +614,10 @@ nglims_config_file = tool-data/nglims.yaml
 
 # -- Logging and Debugging
 
+# If True, Galaxy will attempt to configure a simple root logger if a
+# "loggers" section does not appear in this configuration file.
+#auto_configure_logging = True
+
 # Verbosity of console log messages.  Acceptable values can be found here:
 # https://docs.python.org/2/library/logging.html#logging-levels
 #log_level = DEBUG

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -697,7 +697,9 @@ def configure_logging( config ):
     # PasteScript will have already configured the logger if the
     # 'loggers' section was found in the config file, otherwise we do
     # some simple setup using the 'log_*' values from the config.
-    if not config.global_conf_parser.has_section( "loggers" ):
+    paste_configures_logging = config.global_conf_parser.has_section( "loggers" )
+    auto_configure_logging = not paste_configures_logging and string_as_bool( config.get( "auto_configure_logging", "True" ) )
+    if auto_configure_logging:
         format = config.get( "log_format", "%(name)s %(levelname)s %(asctime)s %(message)s" )
         level = logging._levelNames[ config.get( "log_level", "DEBUG" ) ]
         destination = config.get( "log_destination", "stdout" )

--- a/scripts/functional_tests.py
+++ b/scripts/functional_tests.py
@@ -13,6 +13,7 @@ new_path = [ os.path.join( cwd, "lib" ), os.path.join( cwd, "test" ) ]
 new_path.extend( sys.path[1:] )
 sys.path = new_path
 
+from base.test_logging import logging_config_file
 from base.tool_shed_util import parse_tool_panel_config
 
 from galaxy import eggs
@@ -337,6 +338,7 @@ def main():
                        use_tasked_jobs=True,
                        cleanup_job='onsuccess',
                        enable_beta_tool_formats=True,
+                       auto_configure_logging=logging_config_file is None,
                        data_manager_config_file=data_manager_config_file )
         if install_database_connection is not None:
             kwargs[ 'install_database_connection' ] = install_database_connection

--- a/test/base/test_logging.py
+++ b/test/base/test_logging.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import
+
+import os
+
+import logging
+import logging.config
+
+# This is done in paster or galaxy.main for server app, provide
+# an entry point testing as well.
+logging_config = os.environ.get("GALAXY_TEST_LOGGING_CONFIG", None)
+logging_config_file = None
+if logging_config:
+    logging_config_file = os.path.abspath(logging_config)
+    logging.config.fileConfig(
+        logging_config_file,
+        dict(__file__=logging_config_file, here=os.path.dirname(logging_config_file)),
+    )


### PR DESCRIPTION
Unifies logging through the testing process. Requires adding a Galaxy option to disable its own attempts to configure a different root logger.

Should more readily enable https://github.com/galaxyproject/planemo/issues/275.
