### PR TITLE
Do not explicitly require pexpect

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -19,12 +19,15 @@ from string import Template
 from uuid import UUID, uuid4
 
 from galaxy import eggs
-eggs.require("pexpect")
-import pexpect
 eggs.require('SQLAlchemy')
 from sqlalchemy import and_, func, not_, or_, true, join, select
 from sqlalchemy.orm import joinedload, object_session, aliased
 from sqlalchemy.ext import hybrid
+
+try:
+    import pexpect
+except ImportError:
+    pexpect = None
 
 import galaxy.datatypes
 import galaxy.datatypes.registry
@@ -56,6 +59,9 @@ datatypes_registry.load_datatypes()
 # are going to have different limits so it is likely best to not let
 # this be unlimited - filter in Python if over this limit.
 MAX_IN_FILTER_LENGTH = 100
+
+PEXPECT_IMPORT_MESSAGE = ('The Python pexpect package is required to use this '
+                          'feature, please install it')
 
 
 class NoConverterException(Exception):
@@ -4245,6 +4251,8 @@ class Sample( object, Dictifiable ):
     def get_untransferred_dataset_size( self, filepath, scp_configs ):
         def print_ticks( d ):
             pass
+        if pexpect is None:
+            return PEXPECT_IMPORT_MESSAGE
         error_msg = 'Error encountered in determining the file size of %s on the external_service.' % filepath
         if not scp_configs['host'] or not scp_configs['user_name'] or not scp_configs['password']:
             return error_msg

--- a/lib/galaxy/web/framework/__init__.py
+++ b/lib/galaxy/web/framework/__init__.py
@@ -3,7 +3,6 @@ Galaxy web application framework
 """
 
 from galaxy import eggs
-eggs.require( "pexpect" )
 eggs.require( "amqp" )
 
 import base

--- a/lib/galaxy/webapps/galaxy/controllers/requests_admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/requests_admin.py
@@ -10,7 +10,13 @@ from .requests_common import RequestsGrid, invalid_id_redirect
 from galaxy import eggs
 eggs.require("amqp")
 import amqp
-import pexpect
+try:
+    import pexpect
+except ImportError:
+    pexpect = None
+
+PEXPECT_IMPORT_MESSAGE = ('The Python pexpect package is required to use this '
+                          'feature, please install it')
 
 log = logging.getLogger( __name__ )
 
@@ -440,6 +446,8 @@ class RequestsAdmin( BaseUIController, UsesFormDefinitionsMixin ):
         # Avoid caching
         trans.response.headers['Pragma'] = 'no-cache'
         trans.response.headers['Expires'] = '0'
+        if pexpect is None:
+            return PEXPECT_IMPORT_MESSAGE
         external_service = trans.sa_session.query( trans.model.ExternalService ).get( trans.security.decode_id( external_service_id ) )
         external_service.load_data_transfer_settings( trans )
         scp_configs = external_service.data_transfer[ trans.model.ExternalService.data_transfer_protocol.SCP ]
@@ -498,15 +506,20 @@ class RequestsAdmin( BaseUIController, UsesFormDefinitionsMixin ):
         cmd = 'ssh %s@%s "ls -p \'%s\'"' % ( scp_configs[ 'user_name' ], scp_configs[ 'host' ], folder_path )
         # Handle the authentication message if keys are not set - the message is
         # something like: "Are you sure you want to continue connecting (yes/no)."
-        output = pexpect.run( cmd,
-                              events={ '\(yes\/no\)\.*' : 'yes\r\n',
-                                       '.ssword:*' : scp_configs[ 'password' ] + '\r\n',
-                                       pexpect.TIMEOUT : print_ticks },
-                              timeout=10 )
-        if 'No such file or directory' in output:
-            status = 'error'
-            message = "No folder named (%s) exists on the external service." % folder_path
-            ok = False
+        if pexpect is not None:
+            output = pexpect.run( cmd,
+                                  events={ '\(yes\/no\)\.*' : 'yes\r\n',
+                                           '.ssword:*' : scp_configs[ 'password' ] + '\r\n',
+                                           pexpect.TIMEOUT : print_ticks },
+                                  timeout=10 )
+            if 'No such file or directory' in output:
+                status = 'error'
+                message = "No folder named (%s) exists on the external service." % folder_path
+                ok = False
+        else:
+                status = 'error'
+                message = PEXPECT_IMPORT_MESSAGE
+                ok = False
         if ok:
             if 'assword:' in output:
                 # Eliminate the output created using ssh from the tree

--- a/scripts/transfer.py
+++ b/scripts/transfer.py
@@ -11,9 +11,10 @@ sys.path.insert( 0, os.path.abspath( os.path.join( galaxy_root, 'lib' ) ) )
 
 from galaxy import eggs
 
-import pkg_resources
-pkg_resources.require( "pexpect" )
-import pexpect
+try:
+    import pexpect
+except ImportError:
+    pexpect = None
 
 eggs.require( "SQLAlchemy >= 0.4" )
 
@@ -26,6 +27,9 @@ from galaxy.util import json, bunch
 
 eggs.require( 'python_daemon' )
 from daemon import DaemonContext
+
+PEXPECT_IMPORT_MESSAGE = ('The Python pexpect package is required to use this '
+                          'feature, please install it')
 
 log = logging.getLogger( __name__ )
 log.setLevel( logging.DEBUG )
@@ -247,6 +251,8 @@ def scp_transfer( transfer_job ):
     user_name = transfer_job.params[ 'user_name' ]
     password = transfer_job.params[ 'password' ]
     file_path = transfer_job.params[ 'file_path' ]
+    if pexpect is None:
+        return dict( state = transfer_job.states.ERROR, info = PEXPECT_IMPORT_MESSAGE )
     try:
         fh, fn = tempfile.mkstemp()
     except Exception, e:


### PR DESCRIPTION
If anyone wants to use the old and mostly unused features that depend on it (namely remote sequencer transfers via scp) they can pip install pexpect.

There may be a few more of these as I wander down the list of dependencies for wheeling.
