### PR TITLE
Extend tool API to allow cross product mapping over collections.

### DIFF
--- a/lib/galaxy/dataset_collections/type_description.py
+++ b/lib/galaxy/dataset_collections/type_description.py
@@ -102,6 +102,10 @@ class CollectionTypeDescription( object ):
     def rank_type_plugin( self ):
         return self.collection_type_description_factory.type_registry.get( self.rank_collection_type() )
 
+    def multiply( self, other_collection_type ):
+        collection_type = map_over_collection_type( self, other_collection_type )
+        return self.collection_type_description_factory.for_collection_type( collection_type )
+
     def __str__( self ):
         return "CollectionTypeDescription[%s]" % self.collection_type
 

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -35,7 +35,7 @@ def expand_meta_parameters( trans, tool, incoming ):
                 classification = permutations.input_classification.SINGLE
             if __collection_multirun_parameter( value ):
                 collection_value = value[ 'values' ][ 0 ]
-                values = __expand_collection_parameter( trans, input_key, collection_value, collections_to_match )
+                values = __expand_collection_parameter( trans, input_key, collection_value, collections_to_match, linked=is_linked )
             else:
                 values = value[ 'values' ]
         else:
@@ -102,7 +102,7 @@ def expand_meta_parameters( trans, tool, incoming ):
     return expanded_incomings, collection_info
 
 
-def __expand_collection_parameter( trans, input_key, incoming_val, collections_to_match ):
+def __expand_collection_parameter( trans, input_key, incoming_val, collections_to_match, linked=False ):
     # If subcollectin multirun of data_collection param - value will
     # be "hdca_id|subcollection_type" else it will just be hdca_id
     if "|" in incoming_val:
@@ -119,7 +119,7 @@ def __expand_collection_parameter( trans, input_key, incoming_val, collections_t
             subcollection_type = None
     hdc_id = trans.app.security.decode_id( encoded_hdc_id )
     hdc = trans.sa_session.query( model.HistoryDatasetCollectionAssociation ).get( hdc_id )
-    collections_to_match.add( input_key, hdc, subcollection_type=subcollection_type )
+    collections_to_match.add( input_key, hdc, subcollection_type=subcollection_type, linked=linked )
     if subcollection_type is not None:
         from galaxy.dataset_collections import subcollections
         subcollection_elements = subcollections.split_dataset_collection_instance( hdc, subcollection_type )


### PR DESCRIPTION
By default if single data parameters are mapped over by collections, the collections are matched up (e.g. for two collections the items are paired off and two collections of dimension (N) will result in running N jobs and producing an (N) dimensional output for each define output). In the parameter meta value wrapper (where batch mode can be set with the `batch` flag), the linked flag is now respected for collection operations. If `linked` is `False`, then the cross product of the inputs will be used to map over the tool. In the above simplest case, this would cause an NxN (`list:list`) collection to be created for each tool output.

This operation was previously available for individual datasets, but when supplied a collection it would not create an implicit collection pulling together all the relevant datasets with the correct structure - it would just run the jobs and leave the datasets uncollected. Now a collection with the correct structure and identifiers is created.
## Limitations:

This does not enable tool form support but the API for collections matches that for doing cross product operations over sets of individual datasets, so once support is added to the tool form for that collection support should be trivial.
## Testing:

The following test case has been extended to now ensure that an implicit collection is created and that it has the right dimensionality/structure and contents.

```
./run_tests.sh -with_framework_test_tools -api test/api/test_tools.py:ToolsTestCase.test_map_over_two_collections_unlinked
```
