### PR TITLE
Fix lack of a return in hda manager

### DIFF
--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -435,7 +435,7 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
 
     def serialize_creating_job( self, hda, key, **context ):
         if hda.creating_job:
-            self.app.security.encode_id(hda.creating_job.id),
+            return self.app.security.encode_id(hda.creating_job.id),
         else:
             return None
 


### PR DESCRIPTION
I'd shifted this from a lambda to a proper method to be more clear and to fix the tests for #739 with a7ca9586bb8bffaf61d751e6b21da46a187bbad1 but broke it at the last second.  Thanks for the catch @guerler
