### PR TITLE
Bugfix in test error reporting handling code.

### DIFF
--- a/test/base/interactor.py
+++ b/test/base/interactor.py
@@ -308,7 +308,11 @@ class GalaxyInteractorApi( object ):
         except Exception:
             print "*TEST FRAMEWORK FAILED TO FETCH HISTORY DETAILS*"
 
-        for dataset in history_contents:
+        for history_content in history_contents:
+            if history_content[ 'history_content_type'] != 'dataset':
+                continue
+
+            dataset = history_content
             if dataset[ 'state' ] != 'error':
                 continue
 


### PR DESCRIPTION
The code for showing status of histories in error would fail if there are collections in the history. This fixes that and skips over collections.
