### PR TITLE
Unify the docker command, command_inject, and command_wrapper

### DIFF
--- a/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
+++ b/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
@@ -35,3 +35,10 @@ image = bgruening/docker-ipython-notebook:dev
 # where 'sudo docker' is not able to mount the folder otherwise.
 # "finalize namespace chdir to /import permission denied"
 #wx_tempdir = False
+
+# Overwride the IE tempdirectory. This can be useful if you regular tempdir is
+# located on an NFS share, which does not work well as Docker volume. In this case
+# you can have a shared sshfs share which you can use as temporary directory to
+# share data between the IE and Galaxy.
+#docker_galaxy_temp_dir = None
+

--- a/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
+++ b/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
@@ -9,10 +9,18 @@
 # Command to launch docker container. For example `sudo docker` or `docker-lxc`.
 # If you need to use a command like `sg` you can do that here, just be sure to
 # wrap all of the docker portion in single quotes. E.g. `sg 'docker' 'docker {docker_args}'`
-command = docker run --sig-proxy=true -e DEBUG=false {docker_args}
+#
+# It is recommended that you use command_inject if you need to inject
+# additional parameters. This command string is re-used for a `docker inspect`
+# command and will likely cause errors if it is extensively modified, past the
+# usual group/sudo changes.
+command = docker run {docker_args}
 
 # The docker image name that should be started.
 image = bgruening/docker-ipython-notebook:dev
+
+# Additional arguments that are passed to the `docker run` command.
+command_inject = --sig-proxy=true -e DEBUG=false
 
 # URL to access the Galaxy API with from the spawn Docker containter, if empty
 # this falls back to galaxy.ini's galaxy_infrastructure_url and finally to the

--- a/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
+++ b/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
@@ -1,5 +1,4 @@
 [main]
-
 # Following options are ignored if using the Galaxy dynamic proxy but
 # are useful if mapping a range of ports for environment consumption.
 #apache_urls = False
@@ -7,26 +6,18 @@
 #ssl = False
 
 [docker]
-
-# Command to execute docker. For example `sudo docker` or `docker-lxc`.
-command = docker
+# Command to launch docker container. For example `sudo docker` or `docker-lxc`.
+# If you need to use a command like `sg` you can do that here, just be sure to
+# wrap all of the docker portion in single quotes. E.g. `sg 'docker' 'docker {docker_args}'`
+command = docker run --sig-proxy=true -e DEBUG=false {docker_args}
 
 # The docker image name that should be started.
 image = bgruening/docker-ipython-notebook:dev
 
-# Additional arguments that are passed to the `docker run` command.
-command_inject = --sig-proxy=true -e DEBUG=false
-
-# Command to wrap around the full docker command.
-# For example, `sg 'docker' '{cmd}'` where {cmd} will be replaced by the full
-# docker command. Make sure to surround the {cmd} with single quotes(').
-# Default: empty
-#command_wrapper = 
-
 # URL to access the Galaxy API with from the spawn Docker containter, if empty
 # this falls back to galaxy.ini's galaxy_infrastructure_url and finally to the
 # Docker host of the spawned container if that is also not set.
-#galaxy_url = 
+#galaxy_url =
 
 # The Docker hostname. It can be useful to run the Docker daemon on a different
 # host than Galaxy.

--- a/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
+++ b/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
@@ -14,7 +14,7 @@
 # additional parameters. This command string is re-used for a `docker inspect`
 # command and will likely cause errors if it is extensively modified, past the
 # usual group/sudo changes.
-#command = docker run {docker_args}
+#command = docker {docker_args}
 
 # The docker image name that should be started.
 image = bgruening/docker-ipython-notebook:dev

--- a/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
+++ b/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
@@ -14,13 +14,13 @@
 # additional parameters. This command string is re-used for a `docker inspect`
 # command and will likely cause errors if it is extensively modified, past the
 # usual group/sudo changes.
-command = docker run {docker_args}
+#command = docker run {docker_args}
 
 # The docker image name that should be started.
 image = bgruening/docker-ipython-notebook:dev
 
 # Additional arguments that are passed to the `docker run` command.
-command_inject = --sig-proxy=true -e DEBUG=false
+#command_inject = --sig-proxy=true -e DEBUG=false
 
 # URL to access the Galaxy API with from the spawn Docker containter, if empty
 # this falls back to galaxy.ini's galaxy_infrastructure_url and finally to the
@@ -34,4 +34,4 @@ command_inject = --sig-proxy=true -e DEBUG=false
 # Try to set the tempdirectory to world execute - this can fix the issue 
 # where	  'sudo docker' is not able to mount the folder otherwise.
 # "finalize namespace chdir to /import permission denied"
-wx_tempdir = False
+#wx_tempdir = False

--- a/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
+++ b/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
@@ -32,6 +32,6 @@ image = bgruening/docker-ipython-notebook:dev
 #docker_hostname = localhost
 
 # Try to set the tempdirectory to world execute - this can fix the issue 
-# where	  'sudo docker' is not able to mount the folder otherwise.
+# where 'sudo docker' is not able to mount the folder otherwise.
 # "finalize namespace chdir to /import permission denied"
 #wx_tempdir = False

--- a/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
+++ b/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
@@ -10,10 +10,18 @@ password_auth = True
 # Command to launch docker container. For example `sudo docker` or `docker-lxc`.
 # If you need to use a command like `sg` you can do that here, just be sure to
 # wrap all of the docker portion in single quotes. E.g. `sg 'docker' 'docker {docker_args}'`
-command = docker run --sig-proxy=true -e DEBUG=false {docker_args} 
+#
+# It is recommended that you use command_inject if you need to inject
+# additional parameters. This command string is re-used for a `docker inspect`
+# command and will likely cause errors if it is extensively modified, past the
+# usual group/sudo changes.
+command = docker run {docker_args}
 
 # The docker image name that should be started.
 image = erasche/docker-rstudio-notebook:dev
+
+# Additional arguments that are passed to the `docker run` command.
+command_inject = --sig-proxy=true -e DEBUG=false
 
 # URL to access the Galaxy API with from the spawn Docker containter, if empty
 # this falls back to galaxy.ini's galaxy_infrastructure_url and finally to the

--- a/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
+++ b/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
@@ -33,6 +33,6 @@ image = erasche/docker-rstudio-notebook:dev
 #docker_hostname = localhost
 
 # Try to set the tempdirectory to world execute - this can fix the issue 
-# where	  'sudo docker' is not able to mount the folder otherwise.
+# where 'sudo docker' is not able to mount the folder otherwise.
 # "finalize namespace chdir to /import permission denied"
 #wx_tempdir = False

--- a/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
+++ b/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
@@ -15,7 +15,7 @@ password_auth = True
 # additional parameters. This command string is re-used for a `docker inspect`
 # command and will likely cause errors if it is extensively modified, past the
 # usual group/sudo changes.
-#command = docker run {docker_args}
+#command = docker {docker_args}
 
 # The docker image name that should be started.
 image = erasche/docker-rstudio-notebook:dev

--- a/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
+++ b/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
@@ -1,19 +1,30 @@
 [main]
 # This cannot be changed
 password_auth = True
-# Other
-apache_urls = False
-ssl = False
+# Following options are ignored if using the Galaxy dynamic proxy but
+# are useful if mapping a range of ports for environment consumption.
+#apache_urls = False
+#ssl = False
 
 [docker]
-command = docker
+# Command to launch docker container. For example `sudo docker` or `docker-lxc`.
+# If you need to use a command like `sg` you can do that here, just be sure to
+# wrap all of the docker portion in single quotes. E.g. `sg 'docker' 'docker {docker_args}'`
+command = docker run --sig-proxy=true -e DEBUG=false {docker_args} 
+
+# The docker image name that should be started.
 image = erasche/docker-rstudio-notebook:dev
 
-# Additional arguments that are passed to the `docker run` command. `-u`
-# settings are completely ignored.
-command_inject = --sig-proxy=true -e DEBUG=false
-
-# URL to access the Galaxy API with from the spawned Docker container, if empty
+# URL to access the Galaxy API with from the spawn Docker containter, if empty
 # this falls back to galaxy.ini's galaxy_infrastructure_url and finally to the
-# Docker host of the spawned container, if that is also not set.
-#galaxy_url=
+# Docker host of the spawned container if that is also not set.
+#galaxy_url =
+
+# The Docker hostname. It can be useful to run the Docker daemon on a different
+# host than Galaxy.
+#docker_hostname = localhost
+
+# Try to set the tempdirectory to world execute - this can fix the issue 
+# where	  'sudo docker' is not able to mount the folder otherwise.
+# "finalize namespace chdir to /import permission denied"
+wx_tempdir = False

--- a/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
+++ b/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
@@ -1,5 +1,5 @@
 [main]
-# This cannot be changed
+# This CANNOT be changed. Eventually will be deprecated
 password_auth = True
 # Following options are ignored if using the Galaxy dynamic proxy but
 # are useful if mapping a range of ports for environment consumption.
@@ -15,13 +15,13 @@ password_auth = True
 # additional parameters. This command string is re-used for a `docker inspect`
 # command and will likely cause errors if it is extensively modified, past the
 # usual group/sudo changes.
-command = docker run {docker_args}
+#command = docker run {docker_args}
 
 # The docker image name that should be started.
 image = erasche/docker-rstudio-notebook:dev
 
 # Additional arguments that are passed to the `docker run` command.
-command_inject = --sig-proxy=true -e DEBUG=false
+#command_inject = --sig-proxy=true -e DEBUG=false
 
 # URL to access the Galaxy API with from the spawn Docker containter, if empty
 # this falls back to galaxy.ini's galaxy_infrastructure_url and finally to the
@@ -35,4 +35,4 @@ command_inject = --sig-proxy=true -e DEBUG=false
 # Try to set the tempdirectory to world execute - this can fix the issue 
 # where	  'sudo docker' is not able to mount the folder otherwise.
 # "finalize namespace chdir to /import permission denied"
-wx_tempdir = False
+#wx_tempdir = False

--- a/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
+++ b/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
@@ -36,3 +36,9 @@ image = erasche/docker-rstudio-notebook:dev
 # where 'sudo docker' is not able to mount the folder otherwise.
 # "finalize namespace chdir to /import permission denied"
 #wx_tempdir = False
+
+# Overwride the IE tempdirectory. This can be useful if you regular tempdir is
+# located on an NFS share, which does not work well as Docker volume. In this case
+# you can have a shared sshfs share which you can use as temporary directory to
+# share data between the IE and Galaxy.
+#docker_galaxy_temp_dir = None

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -65,6 +65,7 @@ class InteractiveEnviornmentRequest(object):
         # will need to be recorded here. The ConfigParser doesn't provide a
         # .get() that will ignore missing sections, so we must make use of
         # their defaults dictionary instead.
+        default_dict['command_inject'] = '--sig-proxy=true'
         default_dict['docker_hostname'] = 'localhost'
         default_dict['wx_tempdir'] = 'False'
         default_dict['command_wrapper'] = ''
@@ -187,9 +188,10 @@ class InteractiveEnviornmentRequest(object):
         # Then we format in the entire docker command in place of
         # {docker_args}, so as to let the admin not worry about which args are
         # getting passed
-        command = command.format(docker_args='{environment} -d -p {port_ext}:{port_int} -v "{temp_dir}:/import/" {volume_str} {image}')
+        command = command.format(docker_args='{command_inject} {environment} -d -p {port_ext}:{port_int} -v "{temp_dir}:/import/" {volume_str} {image}')
         # Once that's available, we format again with all of our arguments
         command = command.format(
+            command_inject=self.attr.viz_config.get("docker", "command_inject"),
             environment=env_str,
             port_ext=self.attr.PORT,
             port_int=self.attr.docker_port,

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -65,10 +65,12 @@ class InteractiveEnviornmentRequest(object):
         # will need to be recorded here. The ConfigParser doesn't provide a
         # .get() that will ignore missing sections, so we must make use of
         # their defaults dictionary instead.
-        default_dict['command_inject'] = '--sig-proxy=true'
-        default_dict['docker_hostname'] = 'localhost'
-        default_dict['wx_tempdir'] = 'False'
-        default_dict['command_wrapper'] = ''
+        default_dict = {
+            'command': 'docker run {docker_args}',
+            'command_inject': '--sig-proxy=true -e DEBUG=false',
+            'docker_hostname': 'localhost',
+            'wx_tempdir': 'False',
+        }
         viz_config = ConfigParser.SafeConfigParser(default_dict)
         conf_path = os.path.join( self.attr.our_config_dir, self.attr.viz_id + ".ini" )
         if not os.path.exists( conf_path ):

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -190,7 +190,7 @@ class InteractiveEnviornmentRequest(object):
         # Then we format in the entire docker command in place of
         # {docker_args}, so as to let the admin not worry about which args are
         # getting passed
-        command = command.format(docker_args='{command_inject} {environment} -d -p {port_ext}:{port_int} -v "{temp_dir}:/import/" {volume_str} {image}')
+        command = command.format(docker_args='run {command_inject} {environment} -d -p {port_ext}:{port_int} -v "{temp_dir}:/import/" {volume_str} {image}')
         # Once that's available, we format again with all of our arguments
         command = command.format(
             command_inject=self.attr.viz_config.get("docker", "command_inject"),

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -51,7 +51,9 @@ class InteractiveEnviornmentRequest(object):
         self.notebook_pw_salt = self.generate_password(length=12)
         self.notebook_pw = self.generate_password(length=24)
 
-        self.temp_dir = os.path.abspath( tempfile.mkdtemp() )
+        ie_parent_temp_dir = self.attr.viz_config.get("docker", "docker_galaxy_temp_dir") or None
+        self.temp_dir = os.path.abspath( tempfile.mkdtemp( dir=ie_parent_temp_dir ) )
+
         if self.attr.viz_config.getboolean("docker", "wx_tempdir"):
             # Ensure permissions are set
             try:
@@ -70,6 +72,7 @@ class InteractiveEnviornmentRequest(object):
             'command_inject': '--sig-proxy=true -e DEBUG=false',
             'docker_hostname': 'localhost',
             'wx_tempdir': 'False',
+            'docker_galaxy_temp_dir': None
         }
         viz_config = ConfigParser.SafeConfigParser(default_dict)
         conf_path = os.path.join( self.attr.our_config_dir, self.attr.viz_id + ".ini" )

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -66,7 +66,7 @@ class InteractiveEnviornmentRequest(object):
         # .get() that will ignore missing sections, so we must make use of
         # their defaults dictionary instead.
         default_dict = {
-            'command': 'docker run {docker_args}',
+            'command': 'docker {docker_args}',
             'command_inject': '--sig-proxy=true -e DEBUG=false',
             'docker_hostname': 'localhost',
             'wx_tempdir': 'False',


### PR DESCRIPTION
Assigned to Björn to ensure he's happy with the change as well. CC @scholtalbers can you test this with your `sg` setup please?

Instead of three separate options: `command`, `command_inject`, and `command_wrapper`, they've been unified into the `command` option. This makes life easier and it _looks_ more like the docker command you run on the command line, so a little less magic for the admins.
