### PR TITLE
[release_15.07] pin GIE image versions

### DIFF
--- a/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
+++ b/config/plugins/interactive_environments/ipython/config/ipython.ini.sample
@@ -12,7 +12,7 @@
 command = docker
 
 # The docker image name that should be started.
-image = bgruening/docker-ipython-notebook:dev
+image = bgruening/docker-ipython-notebook:15.07
 
 # Additional arguments that are passed to the `docker run` command.
 command_inject = --sig-proxy=true -e DEBUG=false

--- a/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
+++ b/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
@@ -7,7 +7,7 @@ ssl = False
 
 [docker]
 command = docker
-image = erasche/docker-rstudio-notebook:dev
+image = erasche/docker-rstudio-notebook:15.07
 
 # Additional arguments that are passed to the `docker run` command. `-u`
 # settings are completely ignored.


### PR DESCRIPTION
After this, we'll stop writing `:dev` in our image configuration in `:dev` of galaxy, so we don't have to do this patching process again.
