### PR TITLE
Refactor GIE Launching to use -P

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -574,6 +574,12 @@ nglims_config_file = tool-data/nglims.yaml
 # nodejs to wrap connections in SSL).
 #dynamic_proxy_external_proxy=False
 
+# Additionally, when the dynamic proxy is proxied by an upstream server, you'll
+# want to specify a prefixed URL so both Galaxy and the proxy reside under the
+# same path that your cookies are under. This will result in a url like
+# https://FQDN/galaxy-prefix/gie_proxy for proxying
+#dynamic_proxy_prefix=gie_proxy
+
 # -- Logging and Debugging
 
 # If True, Galaxy will attempt to configure a simple root logger if a

--- a/config/plugins/interactive_environments/ipython/templates/ipython.mako
+++ b/config/plugins/interactive_environments/ipython/templates/ipython.mako
@@ -40,8 +40,8 @@ ie_request.launch(env_override={
 
 ## General IE specific
 # Access URLs for the notebook from within galaxy.
-notebook_access_url = ie_request.url_template('${PROXY_URL}/ipython/${PORT}/notebooks/ipython_galaxy_notebook.ipynb')
-notebook_login_url = ie_request.url_template('${PROXY_URL}/ipython/${PORT}/login?next=%2Fipython%2F${PORT}%2Ftree')
+notebook_access_url = ie_request.url_template('${PROXY_URL}/ipython/notebooks/ipython_galaxy_notebook.ipynb')
+notebook_login_url = ie_request.url_template('${PROXY_URL}/ipython/login?next=%2Fipython%2Ftree')
 
 %>
 <html>

--- a/config/plugins/interactive_environments/ipython/templates/ipython.mako
+++ b/config/plugins/interactive_environments/ipython/templates/ipython.mako
@@ -41,7 +41,7 @@ ie_request.launch(env_override={
 ## General IE specific
 # Access URLs for the notebook from within galaxy.
 notebook_access_url = ie_request.url_template('${PROXY_URL}/ipython/notebooks/ipython_galaxy_notebook.ipynb')
-notebook_login_url = ie_request.url_template('${PROXY_URL}/ipython/login?next=%2Fipython%2Ftree')
+notebook_login_url = ie_request.url_template('${PROXY_URL}/ipython/login?next=${PROXY_PREFIX}%2Fipython%2Ftree')
 
 %>
 <html>

--- a/config/plugins/interactive_environments/ipython/templates/ipython.mako
+++ b/config/plugins/interactive_environments/ipython/templates/ipython.mako
@@ -33,17 +33,15 @@ if hda.datatype.__class__.__name__ != "Ipynb":
 else:
     shutil.copy( hda.file_name, empty_nb_path )
 
+# Add all environment variables collected from Galaxy's IE infrastructure
+ie_request.launch(env_override={
+    'notebook_password': PASSWORD,
+})
 
 ## General IE specific
 # Access URLs for the notebook from within galaxy.
 notebook_access_url = ie_request.url_template('${PROXY_URL}/ipython/${PORT}/notebooks/ipython_galaxy_notebook.ipynb')
 notebook_login_url = ie_request.url_template('${PROXY_URL}/ipython/${PORT}/login?next=%2Fipython%2F${PORT}%2Ftree')
-
-
-# Add all environment variables collected from Galaxy's IE infrastructure
-ie_request.launch(env_override={
-    'notebook_password': PASSWORD,
-})
 
 %>
 <html>

--- a/config/plugins/interactive_environments/rstudio/templates/rstudio.mako
+++ b/config/plugins/interactive_environments/rstudio/templates/rstudio.mako
@@ -19,16 +19,15 @@ if hda.datatype.__class__.__name__ == "RData":
 ie_request.launch(env_override={
     'notebook_username': USERNAME,
     'notebook_password': PASSWORD,
-    'cors_origin': ie_request.attr.proxy_url,
 })
 
 ## General IE specific
 # Access URLs for the notebook from within galaxy.
 # TODO: Make this work without pointing directly to IE. Currently does not work
 # through proxy.
-notebook_pubkey_url = ie_request.url_template('${PROXY_URL}/rstudio/${PORT}/auth-public-key')
-notebook_access_url = ie_request.url_template('${PROXY_URL}/rstudio/${PORT}/')
-notebook_login_url =  ie_request.url_template('${PROXY_URL}/rstudio/${PORT}/auth-do-sign-in')
+notebook_pubkey_url = ie_request.url_template('${PROXY_URL}/rstudio/auth-public-key')
+notebook_access_url = ie_request.url_template('${PROXY_URL}/rstudio/')
+notebook_login_url =  ie_request.url_template('${PROXY_URL}/rstudio/auth-do-sign-in')
 
 %>
 <html>

--- a/config/plugins/interactive_environments/rstudio/templates/rstudio.mako
+++ b/config/plugins/interactive_environments/rstudio/templates/rstudio.mako
@@ -12,14 +12,6 @@ temp_dir = ie_request.temp_dir
 PASSWORD = ie_request.notebook_pw
 USERNAME = "galaxy"
 
-## General IE specific
-# Access URLs for the notebook from within galaxy.
-# TODO: Make this work without pointing directly to IE. Currently does not work
-# through proxy.
-notebook_pubkey_url = ie_request.url_template('${PROXY_URL}/rstudio/${PORT}/auth-public-key')
-notebook_access_url = ie_request.url_template('${PROXY_URL}/rstudio/${PORT}/')
-notebook_login_url =  ie_request.url_template('${PROXY_URL}/rstudio/${PORT}/auth-do-sign-in')
-
 # Did the user give us an RData file?
 if hda.datatype.__class__.__name__ == "RData":
     shutil.copy( hda.file_name, os.path.join(temp_dir, '.RData') )
@@ -29,6 +21,15 @@ ie_request.launch(env_override={
     'notebook_password': PASSWORD,
     'cors_origin': ie_request.attr.proxy_url,
 })
+
+## General IE specific
+# Access URLs for the notebook from within galaxy.
+# TODO: Make this work without pointing directly to IE. Currently does not work
+# through proxy.
+notebook_pubkey_url = ie_request.url_template('${PROXY_URL}/rstudio/${PORT}/auth-public-key')
+notebook_access_url = ie_request.url_template('${PROXY_URL}/rstudio/${PORT}/')
+notebook_login_url =  ie_request.url_template('${PROXY_URL}/rstudio/${PORT}/auth-do-sign-in')
+
 %>
 <html>
 <head>

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -443,6 +443,7 @@ class Configuration( object ):
         self.dynamic_proxy_bind_port = int( kwargs.get( "dynamic_proxy_bind_port", "8800" ) )
         self.dynamic_proxy_bind_ip = kwargs.get( "dynamic_proxy_bind_ip", "0.0.0.0" )
         self.dynamic_proxy_external_proxy = string_as_bool( kwargs.get( "dynamic_proxy_external_proxy", "False" ) )
+        self.dynamic_proxy_prefix = kwargs.get( "dynamic_proxy_prefix", "gie_proxy" )
 
         # Default chunk size for chunkable datatypes -- 64k
         self.display_chunk_size = int( kwargs.get( 'display_chunk_size', 65536) )

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -246,11 +246,15 @@ class InteractiveEnviornmentRequest(object):
         containers with multiple ports working.
         """
         command = self.attr.viz_config.get("docker", "command")
-        command.replace(
+        command = command.replace(
             "run {docker_args}",
             "inspect %s" % container_id
         )
-        output = check_output(command)
+        log.info("Inspecting docker container {0} with command [{1}]".format(
+            container_id,
+            command
+        ))
+        output = check_output(command, shell=True)
         inspect_data = json.loads(output)
         # [{
         #     "NetworkSettings" : {
@@ -267,7 +271,7 @@ class InteractiveEnviornmentRequest(object):
             for binding in port_mappings[port_name]:
                 mappings.append((
                     port_name.replace('/tcp', '').replace('/udp', ''),
-                    port_mappings[port_name][binding]['HostIp'],
-                    port_mappings[port_name][binding]['HostPort']
+                    binding['HostIp'],
+                    binding['HostPort']
                 ))
         return mappings

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -102,6 +102,7 @@ class InteractiveEnviornmentRequest(object):
             'remote_host': request.remote_addr,
             # DOCKER_PORT is NO LONGER AVAILABLE. All IEs must update.
             'cors_origin': request.host_url,
+            'user_email': self.trans.user.email,
         }
 
         if self.attr.viz_config.has_option("docker", "galaxy_url"):

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -1,10 +1,11 @@
 import ConfigParser
 
 import os
+import json
 import stat
 import random
 import tempfile
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, check_output
 
 from galaxy.util.bunch import Bunch
 from galaxy import web
@@ -40,11 +41,6 @@ class InteractiveEnviornmentRequest(object):
 
         self.load_deploy_config()
         self.attr.docker_hostname = self.attr.viz_config.get("docker", "docker_hostname")
-        self.attr.proxy_request = trans.app.proxy_manager.setup_proxy(
-            trans, host=self.attr.docker_hostname
-        )
-        self.attr.proxy_url = self.attr.proxy_request[ 'proxy_url' ]
-        self.attr.PORT = self.attr.proxy_request[ 'proxied_port' ]
 
         # Generate per-request passwords the IE plugin can use to configure
         # the destination container.
@@ -102,7 +98,7 @@ class InteractiveEnviornmentRequest(object):
             'history_id': self.attr.history_id,
             'api_key': api_key,
             'remote_host': request.remote_addr,
-            'docker_port': self.attr.PORT,
+            # DOCKER_PORT is NO LONGER AVAILABLE. All IEs must update.
             'cors_origin': request.host_url,
         }
 
@@ -144,7 +140,6 @@ class InteractiveEnviornmentRequest(object):
             There are several variables accessible to the user:
 
                 - ${PROXY_URL} will be replaced with dynamically create proxy
-                - ${PORT} will be replaced with the port the docker image is attached to
         """
         # Figure out our substitutions
 
@@ -156,18 +151,12 @@ class InteractiveEnviornmentRequest(object):
         else:
             protocol = 'http'
 
-        if not self.attr.APACHE_URLS:
-            # If they are not using apache URLs, that implies there's a port attached to the host
-            # string, thus we replace just the first instance of host that we see.
-            url_template = url_template.replace('${HOST}', '${HOST}:${PORT}', 1)
-
         url_template = url_template.replace('${PROTO}', protocol) \
             .replace('${HOST}', self.attr.HOST)
 
         # Only the following replacements are used with Galaxy dynamic proxy
         # URLs
-        url = url_template.replace('${PROXY_URL}', str(self.attr.proxy_url)) \
-            .replace('${PORT}', str(self.attr.PORT))
+        url = url_template.replace('${PROXY_URL}', str(self.attr.proxy_url))
         return url
 
     def volume(self, host_path, container_path, **kwds):
@@ -188,13 +177,11 @@ class InteractiveEnviornmentRequest(object):
         # Then we format in the entire docker command in place of
         # {docker_args}, so as to let the admin not worry about which args are
         # getting passed
-        command = command.format(docker_args='{command_inject} {environment} -d -p {port_ext}:{port_int} -v "{temp_dir}:/import/" {volume_str} {image}')
+        command = command.format(docker_args='{command_inject} {environment} -d -P -v "{temp_dir}:/import/" {volume_str} {image}')
         # Once that's available, we format again with all of our arguments
         command = command.format(
             command_inject=self.attr.viz_config.get("docker", "command_inject"),
             environment=env_str,
-            port_ext=self.attr.PORT,
-            port_int=self.attr.docker_port,
             temp_dir=temp_dir,
             volume_str=volume_str,
             image=self.attr.viz_config.get("docker", "image")
@@ -212,5 +199,73 @@ class InteractiveEnviornmentRequest(object):
         stdout, stderr = p.communicate()
         if p.returncode != 0 or len(stderr):
             log.error( "%s\n%s" % (stdout, stderr) )
+            return None
         else:
             log.debug( "Container id: %s" % stdout)
+            port_mappings = self.get_proxied_ports(stdout)
+            if len(port_mappings) > 1:
+                log.warning("Don't know how to handle proxies to containers with multiple exposed ports. Arbitrarily choosing first")
+            elif len(port_mappings) == 0:
+                log.warning("No exposed ports to map! Images MUST EXPOSE")
+                return None
+            # Fetch the first port_mapping
+            (service, host_ip, host_port) = port_mappings[0]
+
+            # Now we configure our proxy_requst object and we manually specify
+            # the port to map to and ensure the proxy is available.
+            self.attr.proxy_request = self.trans.app.proxy_manager.setup_proxy(
+                self.trans,
+                host=self.attr.docker_hostname,
+                port=host_port,
+            )
+            # These variables then become available for use in templating URLs
+            self.attr.proxy_url = self.attr.proxy_request[ 'proxy_url' ]
+            # Commented out because it needs to be documented and visible that
+            # this variable was moved here. Usually would remove commented
+            # code, but again, needs to be clear where this went. Remove at a
+            # later time.
+            #
+            # PORT is no longer exposed internally. All requests are forced to
+            # go through the proxy we ship.
+            # self.attr.PORT = self.attr.proxy_request[ 'proxied_port' ]
+
+    def get_proxied_ports(self, container_id):
+        """Run docker inspect on a container to figure out which ports were
+        mapped where.
+
+        :type container_id: str
+        :param container_id: a docker container ID
+
+        :returns: a list of triples containing (internal_port, external_ip,
+                  external_port), of which the ports are probably the only
+                  useful information.
+
+        Someday code that calls this should be refactored whenever we get
+        containers with multiple ports working.
+        """
+        command = self.attr.viz_config.get("docker", "command")
+        command.replace(
+            "run {docker_args}",
+            "inspect %s" % container_id
+        )
+        output = check_output(command)
+        inspect_data = json.loads(output)
+        # [{
+        #     "NetworkSettings" : {
+        #         "Ports" : {
+        #             "3306/tcp" : [
+        #                 {
+        #                     "HostIp" : "127.0.0.1",
+        #                     "HostPort" : "3306"
+        #                 }
+        #             ]
+        mappings = []
+        port_mappings = inspect_data[0]['NetworkSettings']['Ports']
+        for port_name in port_mappings:
+            for binding in port_mappings[port_name]:
+                mappings.append((
+                    port_name.replace('/tcp', '').replace('/udp', ''),
+                    port_mappings[port_name][binding]['HostIp'],
+                    port_mappings[port_name][binding]['HostPort']
+                ))
+        return mappings

--- a/lib/galaxy/web/proxy/__init__.py
+++ b/lib/galaxy/web/proxy/__init__.py
@@ -31,7 +31,7 @@ class ProxyManager(object):
     def shutdown( self ):
         self.lazy_process.shutdown()
 
-    def setup_proxy( self, trans, host=DEFAULT_PROXY_TO_HOST, port=None ):
+    def setup_proxy( self, trans, host=DEFAULT_PROXY_TO_HOST, port=None, proxy_prefix="" ):
         if self.manage_dynamic_proxy:
             log.info("Attempting to start dynamic proxy process")
             self.lazy_process.start_process()
@@ -46,9 +46,9 @@ class ProxyManager(object):
             host = host[0:host.index(':')]
         scheme = trans.request.scheme
         if not self.dynamic_proxy_external_proxy:
-            proxy_url = '%s://%s:%d/%s' % (scheme, host, self.dynamic_proxy_bind_port, self.dynamic_proxy_prefix)
+            proxy_url = '%s://%s:%d' % (scheme, host, self.dynamic_proxy_bind_port)
         else:
-            proxy_url = '%s://%s/%s' % (scheme, host, self.dynamic_proxy_prefix)
+            proxy_url = '%s://%s%s' % (scheme, host, proxy_prefix)
         return {
             'proxy_url': proxy_url,
             'proxied_port': proxy_requests.port,

--- a/lib/galaxy/web/proxy/__init__.py
+++ b/lib/galaxy/web/proxy/__init__.py
@@ -17,7 +17,9 @@ SECURE_COOKIE = "galaxysession"
 class ProxyManager(object):
 
     def __init__( self, config ):
-        for option in [ "manage_dynamic_proxy", "dynamic_proxy_bind_port", "dynamic_proxy_bind_ip", "dynamic_proxy_debug", "dynamic_proxy_external_proxy" ]:
+        for option in ["manage_dynamic_proxy", "dynamic_proxy_bind_port",
+                       "dynamic_proxy_bind_ip", "dynamic_proxy_debug",
+                       "dynamic_proxy_external_proxy", "dynamic_proxy_prefix"]:
             setattr( self, option, getattr( config, option ) )
         self.launch_by = "node"  # TODO: Support docker
         if self.manage_dynamic_proxy:
@@ -44,9 +46,9 @@ class ProxyManager(object):
             host = host[0:host.index(':')]
         scheme = trans.request.scheme
         if not self.dynamic_proxy_external_proxy:
-            proxy_url = '%s://%s:%d' % (scheme, host, self.dynamic_proxy_bind_port)
+            proxy_url = '%s://%s:%d/%s' % (scheme, host, self.dynamic_proxy_bind_port, self.dynamic_proxy_prefix)
         else:
-            proxy_url = '%s://%s' % (scheme, host)
+            proxy_url = '%s://%s/%s' % (scheme, host, self.dynamic_proxy_prefix)
         return {
             'proxy_url': proxy_url,
             'proxied_port': proxy_requests.port,


### PR DESCRIPTION
## TL;DR
- **This breaks API compatibility with previous GIE containers.**
- fix IE on remote host
- fix IEs in Galaxy when there's a galaxy url prefix like `/galaxy`
- This is includes code from #782 so that should be considered as a dependency of this PR.
  - [x] #782 
## Why

This is a large refactor to use the `-P` option instead of `-p`. This change lets docker automatically and safely bind the port, rather than our hopeful hack which just found an empty port and bound to it. In this way we fix the remaining issue with launching docker containers on a remote host (inability to check used ports) and clean up our codebase.
## What's new

This PR removes the `DOCKER_PORT` variable which was originally used to allow multiple containers to be shared by a single upstream proxy. Originally we had been using apache/nginx as our upstream proxy, however @jmchilton wrote a simple nodejs proxy which replaced that. That proxy had the lovely feature of being able to distinguish users based on their Galaxy session cookie, and route appropriately from there. This meant that we could have multiple things mapped to the same route, e.g. 100 users could all access `$Proxy_Url/ipython/tree` and see different results as the nodejs proxy handled fanning them out to the right backends. Thus, the `DOCKER_PORT` that was used in our URLs became pointless.

This PR introduces the `PROXY_PREFIX` variable which now allows the nodejs proxy to bind and listen under a prefix such as `/galaxy/gie_proxy`. This is extremely important for enterprise deployments where we have galaxy under a cookie path. Trying to direct users to `/ipython` will consistently fail because the browser refuses to send the galaxy session cookie to that path. Now our URLs are constructed as `$ProxyUrl/$GalaxyCookiePath/$CustomProxyPrefix/ipython/tree`. The nodejs proxy continues to sort out traffic, and we get URLs that can access the correct cookies.

This PR fixes docker-on-another-host which had previously been partially broken. We used a very naïve method to determine whether or not a port was in use, and this method returned factually incorrect results when the containers were launched on a remote host through docker. This PR uses `-P` which randomly selects a port, and then uses `docker inspect` to figure out which port was actually assigned.
## Interested parties

Y'all work on GIEs in some capacity, so you've been mentioned here in case you're wishing/willing to help us test your specific deployment environments. The images have been pinned to `:15.10` following new procedures, however you'll need to change that to `:dev` if you actually wish to test.

@bgruening @jmchilton @scholtalbers @remimarenco @pvanheus 
