### PR TITLE
Added alternative path for setting permissions

### DIFF
--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -84,8 +84,18 @@ class CompressedFile( object ):
                 external_attributes = self.archive.getinfo( filename ).external_attr
                 # The 2 least significant bytes are irrelevant, the next two contain unix permissions.
                 unix_permissions = external_attributes >> 16
-                if unix_permissions != 0 and os.path.exists( absolute_filepath ):
-                    os.chmod( absolute_filepath, unix_permissions )
+                if unix_permissions != 0:
+                    if os.path.exists( absolute_filepath ):
+                        os.chmod( absolute_filepath, unix_permissions )
+                    else:
+                        #absolute_filepath could be wrong because:
+                            #it contains the common prefix twice so use path
+                            #is actually not absolute so use os.path.abspath
+                        absolute_filepath = os.path.abspath(os.path.join(path, filename ))
+                        if os.path.exists( absolute_filepath ):
+                            os.chmod( absolute_filepath, unix_permissions )
+                        else:
+                            log.debug( 'Unable to change permission on extracted file %s as it could not be found.', str( filename )  )
         return os.path.abspath( os.path.join( extraction_path, common_prefix ) )
 
     def getmembers_tar( self ):


### PR DESCRIPTION
The current fix to the permission setting issue after a zip file extraction avoids but does not fix the file not found error.

The file is not found for two reasons.
1. The "absolute_filepath" has the common_prefix in it twice
2. "absolute_filepath" is not actually absolute.

This fix will try an alternative path if the currently tried path does not work.

It may be that the original "absolute_filepath" never works in which case my alternative "absolute_filepath" can be move out of the if os.path.exists( absolute_filepath ) else: 
replacing the current
absolute_filepath = os.path.join( extraction_path, filename )
with
absolute_filepath = os.path.abspath(os.path.join(path, filename ))
