### PR TITLE
[15.05] Fix problem maintaining input maps when rescheduling workflows.

### DIFF
--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -285,7 +285,10 @@ class WorkflowProgress( object ):
                 raise modules.DelayedWorkflowEvaluation()
         return replacement
 
-    def set_outputs_for_input( self, step, outputs={} ):
+    def set_outputs_for_input( self, step, outputs=None ):
+        if outputs is None:
+            outputs = {}
+
         if self.inputs_by_step_id:
             outputs[ 'output' ] = self.inputs_by_step_id[ step.id ]
 


### PR DESCRIPTION
Fixes #776. I suspect the problem has very little to do with dynamic output collections and in fact exhibits itself when workflow rescheduling occurs, it is just that workflow rescheduling is forced when using dynamic output collections.
