### PR TITLE
Regression test case and fix for #776

### DIFF
--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -285,7 +285,10 @@ class WorkflowProgress( object ):
                 raise modules.DelayedWorkflowEvaluation()
         return replacement
 
-    def set_outputs_for_input( self, step, outputs={} ):
+    def set_outputs_for_input( self, step, outputs=None ):
+        if outputs is None:
+            outputs = {}
+
         if self.inputs_by_step_id:
             outputs[ 'output' ] = self.inputs_by_step_id[ step.id ]
 

--- a/test/functional/tools/min_repeat.xml
+++ b/test/functional/tools/min_repeat.xml
@@ -1,4 +1,4 @@
-<tool id="min_repeat" name="min_repeat">
+<tool id="min_repeat" name="min_repeat" version="0.1.0">
     <command>
         cat #for $q in $queries# ${q.input} #end for# > $out_file1 ;
         cat #for $q in $queries2# ${q.input2} #end for# > $out_file2
@@ -12,8 +12,8 @@
         </repeat>
     </inputs>
     <outputs>
-        <data name="out_file1" format="txt" />
-        <data name="out_file2" format="txt" />
+        <data name="out_file1" format="txt" label="Repeat 1 Datasets on ${on_string}" />
+        <data name="out_file2" format="txt" label="Repeat 2 Datasets on ${on_string}" />
     </outputs>
     <tests>
         <test>


### PR DESCRIPTION
PR'ed for backporting to 15.05 with https://github.com/galaxyproject/galaxy/pull/794, but this PR targets dev and is more complete, including the test case and improvements to the test tool `min_repeat`.

Run the test case with:

```
./run_tests.sh -with_framework_test_tools -api test/api/test_workflows.py:WorkflowsApiTestCase.test_workflow_run_dynamic_output_collections_2
```
