### PR TITLE
Fix _JAVA_OPTIONS example in job_conf.xml.sample_advanced

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -263,7 +263,7 @@
                options should be reserved for defining cluster
                specific options.
           -->
-          <env id="_JAVA_OPTIONS">-Xmx=6GB</env>
+          <env id="_JAVA_OPTIONS">-Xmx6G</env>
           <env id="ANOTHER_OPTION" raw="true">'5'</env> <!-- raw disables auto quoting -->
           <env file="/mnt/java_cluster/environment_setup.sh" /> <!-- will be sourced -->
           <env exec="module load javastuff/2.10" /> <!-- will be sourced -->


### PR DESCRIPTION
Thanks detailed bug report by Damion Dooley (http://dev.list.galaxyproject.org/JAVA-OPTIONS-config-parameter-in-job-conf-xml-sample-advanced-td4667993.html).
