### PR TITLE
Pass the other_values dictionary consisting of tool inputs to the

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2541,7 +2541,7 @@ class Tool( object, Dictifiable ):
             other_values = ExpressionContext( state_inputs, other_values )
             for input_index, input in enumerate( inputs.itervalues() ):
                 # create model dictionary
-                tool_dict = input.to_dict(trans)
+                tool_dict = input.to_dict(trans, other_values=other_values)
                 if tool_dict is None:
                     continue
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -207,7 +207,7 @@ class ToolParameter( object, Dictifiable ):
         tool_dict = super( ToolParameter, self ).to_dict()
         # TODO: wrapping html as it causes a lot of errors on subclasses - needs histories, etc.
         try:
-            tool_dict[ 'html' ] = urllib.quote( util.smart_str( self.get_html( trans ) ) )
+            tool_dict[ 'html' ] = urllib.quote( util.smart_str( self.get_html( trans, other_values=other_values ) ) )
         except AssertionError:
             pass  # HACK for assert trans.history, 'requires a history'
 
@@ -1027,7 +1027,7 @@ class SelectToolParameter( ToolParameter ):
             return []
 
     def to_dict( self, trans, view='collection', value_mapper=None, other_values={} ):
-        d = super( SelectToolParameter, self ).to_dict( trans )
+        d = super( SelectToolParameter, self ).to_dict( trans, other_values=other_values )
 
         # Get options, value.
         options = []


### PR DESCRIPTION
to_dict function of the ToolParameter and SelectToolParameter classes so
that the ToolParameter's get_html function has access to the tool input
parameters, allowing for multiple associated dynamically generated
select lists on the tool form, one of whose options are generated based
on the selected option of the other.  This provides the ability to
handle the request in this email:
http://dev.list.galaxyproject.org/Question-about-using-dynamic-options-and-refresh-on-change-for-rendering-2-associated-select-lists-td4667943.html
