### PR TITLE
Fix framework test failures.

### DIFF
--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -156,6 +156,8 @@ def _parse_test(i, test_dict):
         _ensure_has(attributes, defaults)
 
     test_dict["outputs"] = new_outputs
+    # TODO: implement output collections for YAML tools.
+    test_dict["output_collections"] = []
     test_dict["command"] = __to_test_assert_list( test_dict.get( "command", [] ) )
     test_dict["stdout"] = __to_test_assert_list( test_dict.get( "stdout", [] ) )
     test_dict["stderr"] = __to_test_assert_list( test_dict.get( "stderr", [] ) )


### PR DESCRIPTION
Some other fix caused the yaml example tool to load in the framework and api tests again after a long regression, this in turn caused a more recent regression to pop out in the framework test suite. This fixes that, thanks for the heads up @martenson.
