### PR TITLE
Fix reset password mail

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -28,6 +28,7 @@ from galaxy.util import json
 from datetime import datetime
 
 from email.MIMEText import MIMEText
+from email.MIMEMultipart import MIMEMultipart
 
 from os.path import relpath
 from hashlib import md5
@@ -1161,12 +1162,18 @@ def size_to_bytes( size ):
         return int( size )
 
 
-def send_mail( frm, to, subject, body, config ):
+def send_mail( frm, to, subject, body, config, html=None ):
     """
     Sends an email.
     """
     to = listify( to )
-    msg = MIMEText(  body.encode( 'ascii', 'replace' ) )
+    msg = MIMEMultipart('alternative')
+    # Record the MIME types of both parts - text/plain and text/html.
+    part1 = MIMEText(body.encode('ascii', 'replace'), 'plain')
+    msg.attach(part1)
+    if html is not None:
+        part2 = MIMEText(html, 'html')
+    msg.attach(part2)
     msg[ 'To' ] = ', '.join( to )
     msg[ 'From' ] = frm
     msg[ 'Subject' ] = subject

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1173,7 +1173,7 @@ def send_mail( frm, to, subject, body, config, html=None ):
     msg.attach(part1)
     if html is not None:
         part2 = MIMEText(html, 'html')
-    msg.attach(part2)
+        msg.attach(part2)
     msg[ 'To' ] = ', '.join( to )
     msg[ 'From' ] = frm
     msg[ 'Subject' ] = subject

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -48,7 +48,7 @@ PASSWORD_RESET_TEMPLATE = """
 To reset your Galaxy password for the instance at %s use the following link,
 which will expire %s.
 
-<a href="%s">%s</a>
+%s
 
 If you did not make this request, no action is necessary on your part, though
 you may want to notify an administrator.
@@ -56,7 +56,6 @@ you may want to notify an administrator.
 If you're having trouble using the link when clicking it from email client, you
 can also copy and paste it into your browser.
 """
-
 
 class UserOpenIDGrid( grids.Grid ):
     use_panels = False
@@ -1199,11 +1198,14 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
                                          action="change_password",
                                          token=prt.token, qualified=True)
                     body = PASSWORD_RESET_TEMPLATE % ( host, prt.expiration_time.strftime(trans.app.config.pretty_datetime_format),
-                                                       reset_url, reset_url )
+                                                       reset_url )
+                    reset_url_link = '<a href="%s">%s</a>' % ( reset_url, reset_url )
+                    html_body = PASSWORD_RESET_TEMPLATE % ( host, prt.expiration_time.strftime(trans.app.config.pretty_datetime_format),
+                                                            reset_url_link )
                     frm = trans.app.config.email_from or 'galaxy-no-reply@' + host
                     subject = 'Galaxy Password Reset'
                     try:
-                        util.send_mail( frm, email, subject, body, trans.app.config )
+                        util.send_mail( frm, email, subject, body, trans.app.config, html=html_body.replace('\n','<br />') )
                         trans.sa_session.add( reset_user )
                         trans.sa_session.flush()
                         trans.log_event( "User reset password: %s" % email )


### PR DESCRIPTION
This only fixes the mail showing the `<a href>` tag as the mail is not properly set to html. I assume there are more places send_mail should be called with a plain text body and html one.

This does not fix where require_login=True causes the link to be broken e.g. redirecting the user to /root 

Related to http://dev.list.galaxyproject.org/Password-Reset-td4667568.html
