### PR TITLE
Small tweaks to tool loading.

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -634,32 +634,9 @@ class Registry( object ):
     def load_external_metadata_tool( self, toolbox ):
         """Adds a tool which is used to set external metadata"""
         # We need to be able to add a job to the queue to set metadata. The queue will currently only accept jobs with an associated
-        # tool.  We'll create a special tool to be used for Auto-Detecting metadata; this is less than ideal, but effective
-        # Properly building a tool without relying on parsing an XML file is near impossible...so we'll create a temporary file
-        tool_xml_text = """
-            <tool id="__SET_METADATA__" name="Set External Metadata" version="1.0.1" tool_type="set_metadata">
-              <type class="SetMetadataTool" module="galaxy.tools"/>
-              <requirements>
-                  <requirement type="package">samtools</requirement>
-              </requirements>
-              <action module="galaxy.tools.actions.metadata" class="SetMetadataToolAction"/>
-              <command>python "${set_metadata}" ${__SET_EXTERNAL_METADATA_COMMAND_LINE__}</command>
-              <inputs>
-                <param format="data" name="input1" type="data" label="File to set metadata on."/>
-                <param name="__ORIGINAL_DATASET_STATE__" type="hidden" value=""/>
-                <param name="__SET_EXTERNAL_METADATA_COMMAND_LINE__" type="hidden" value="">
-                  <sanitizer sanitize="False"/>
-                </param>
-              </inputs>
-              <configfiles>
-                <configfile name="set_metadata">from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()</configfile>
-              </configfiles>
-            </tool>
-            """
-        tmp_name = tempfile.NamedTemporaryFile()
-        tmp_name.write( tool_xml_text )
-        tmp_name.flush()
-        set_meta_tool = toolbox.load_hidden_tool( tmp_name.name )
+        # tool.  We'll load a special tool to be used for Auto-Detecting metadata; this is less than ideal, but effective
+        # Properly building a tool without relying on parsing an XML file is near difficult...so we bundle with Galaxy.
+        set_meta_tool = toolbox.load_hidden_lib_tool( "galaxy/datatypes/set_metadata_tool.xml" )
         self.set_external_metadata_tool = set_meta_tool
         self.log.debug( "Loaded external metadata tool: %s", self.set_external_metadata_tool.id )
 

--- a/lib/galaxy/datatypes/set_metadata_tool.xml
+++ b/lib/galaxy/datatypes/set_metadata_tool.xml
@@ -1,0 +1,18 @@
+<tool id="__SET_METADATA__" name="Set External Metadata" version="1.0.1" tool_type="set_metadata">
+  <type class="SetMetadataTool" module="galaxy.tools"/>
+  <requirements>
+      <requirement type="package">samtools</requirement>
+  </requirements>
+  <action module="galaxy.tools.actions.metadata" class="SetMetadataToolAction"/>
+  <command>python "${set_metadata}" ${__SET_EXTERNAL_METADATA_COMMAND_LINE__}</command>
+  <inputs>
+    <param format="data" name="input1" type="data" label="File to set metadata on."/>
+    <param name="__ORIGINAL_DATASET_STATE__" type="hidden" value=""/>
+    <param name="__SET_EXTERNAL_METADATA_COMMAND_LINE__" type="hidden" value="">
+      <sanitizer sanitize="False"/>
+    </param>
+  </inputs>
+  <configfiles>
+    <configfile name="set_metadata">from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()</configfile>
+  </configfiles>
+</tool>

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3008,10 +3008,6 @@ class ImportHistoryTool( Tool ):
     tool_type = 'import_history'
 
 
-class GenomeIndexTool( Tool ):
-    tool_type = 'index_genome'
-
-
 class DataManagerTool( OutputParameterJSONTool ):
     tool_type = 'manage_data'
     default_tool_action = DataManagerToolAction

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -19,42 +19,16 @@ from sqlalchemy.sql import expression
 
 log = logging.getLogger(__name__)
 
-EXPORT_HISTORY_TEXT = """
-        <tool id="__EXPORT_HISTORY__" name="Export History" version="0.1" tool_type="export_history">
-          <type class="ExportHistoryTool" module="galaxy.tools"/>
-          <action module="galaxy.tools.actions.history_imp_exp" class="ExportHistoryToolAction"/>
-          <command>python $export_history $__EXPORT_HISTORY_COMMAND_INPUTS_OPTIONS__ $output_file</command>
-          <inputs>
-            <param name="__HISTORY_TO_EXPORT__" type="hidden"/>
-            <param name="compress" type="boolean"/>
-            <param name="__EXPORT_HISTORY_COMMAND_INPUTS_OPTIONS__" type="hidden"/>
-          </inputs>
-          <configfiles>
-            <configfile name="export_history">from galaxy.tools.imp_exp.export_history import main; main()</configfile>
-          </configfiles>
-          <outputs>
-            <data format="gzip" name="output_file"/>
-          </outputs>
-        </tool>
-"""
-
 
 def load_history_imp_exp_tools( toolbox ):
     """ Adds tools for importing/exporting histories to archives. """
-    # Use same process as that used in load_external_metadata_tool; see that
-    # method for why create tool description files on the fly.
-    tool_xml_text = EXPORT_HISTORY_TEXT
 
     # Load export tool.
-    tmp_name = tempfile.NamedTemporaryFile()
-    tmp_name.write( tool_xml_text )
-    tmp_name.flush()
-    history_exp_tool = toolbox.load_hidden_tool( tmp_name.name )
+    history_exp_tool = toolbox.load_hidden_lib_tool( "galaxy/tools/imp_exp/exp_history_to_archive.xml" )
     log.debug( "Loaded history export tool: %s", history_exp_tool.id )
 
     # Load import tool.
-    tool_xml = os.path.join( os.getcwd(), "lib/galaxy/tools/imp_exp/imp_history_from_archive.xml" )
-    history_imp_tool = toolbox.load_hidden_tool( tool_xml )
+    history_imp_tool = toolbox.load_hidden_lib_tool( "galaxy/tools/imp_exp/imp_history_from_archive.xml" )
     log.debug( "Loaded history import tool: %s", history_imp_tool.id )
 
 

--- a/lib/galaxy/tools/imp_exp/exp_history_to_archive.xml
+++ b/lib/galaxy/tools/imp_exp/exp_history_to_archive.xml
@@ -1,0 +1,16 @@
+<tool id="__EXPORT_HISTORY__" name="Export History" version="0.1" tool_type="export_history">
+  <type class="ExportHistoryTool" module="galaxy.tools"/>
+  <action module="galaxy.tools.actions.history_imp_exp" class="ExportHistoryToolAction"/>
+  <command>python $export_history $__EXPORT_HISTORY_COMMAND_INPUTS_OPTIONS__ $output_file</command>
+  <inputs>
+    <param name="__HISTORY_TO_EXPORT__" type="hidden"/>
+    <param name="compress" type="boolean"/>
+    <param name="__EXPORT_HISTORY_COMMAND_INPUTS_OPTIONS__" type="hidden"/>
+  </inputs>
+  <configfiles>
+    <configfile name="export_history">from galaxy.tools.imp_exp.export_history import main; main()</configfile>
+  </configfiles>
+  <outputs>
+    <data format="gzip" name="output_file"/>
+  </outputs>
+</tool>

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -741,6 +741,10 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
             self._tool_watcher.watch_file( config_file, tool.id )
         return tool
 
+    def load_hidden_lib_tool( self, path ):
+        tool_xml = os.path.join( os.getcwd(), "lib", path )
+        return self.load_hidden_tool( tool_xml )
+
     def load_hidden_tool( self, config_file, **kwds ):
         """ Load a hidden tool (in this context meaning one that does not
         appear in the tool panel) and register it in _tools_by_id.

--- a/test/unit/tools/test_parsing.py
+++ b/test/unit/tools/test_parsing.py
@@ -1,11 +1,11 @@
 from math import isinf
 
+import os
 import os.path
 import tempfile
 import shutil
 
 from galaxy.tools.parser.factory import get_tool_source
-from galaxy.tools.imp_exp import EXPORT_HISTORY_TEXT
 
 import unittest
 
@@ -111,8 +111,11 @@ class BaseLoaderTestCase(unittest.TestCase):
             source_file_name = self.source_file_name
         if source_contents is None:
             source_contents = self.source_contents
-        path = os.path.join(self.temp_directory, source_file_name)
-        open(path, "w").write(source_contents)
+        if not os.path.isabs(source_file_name):
+            path = os.path.join(self.temp_directory, source_file_name)
+            open(path, "w").write(source_contents)
+        else:
+            path = source_file_name
         tool_source = get_tool_source(path)
         return tool_source
 
@@ -404,8 +407,8 @@ class DataSourceLoaderTestCase(BaseLoaderTestCase):
 
 
 class SpecialToolLoaderTestCase(BaseLoaderTestCase):
-    source_file_name = "export.xml"
-    source_contents = EXPORT_HISTORY_TEXT
+    source_file_name = os.path.join(os.getcwd(), "lib/galaxy/tools/imp_exp/exp_history_to_archive.xml")
+    source_contents = None
 
     def test_tool_type(self):
         tool_module = self._tool_source.parse_tool_module()


### PR DESCRIPTION
Remove some unused code and improve performance and abstractions for loading "special" lib tools into Galaxy (metadata, import, export).

Need the new abstractions for downstream work on collection operations - which will behave sort of like these tools.

Testing:

The following two API tests should cover the modified behavior, they verify that metadata is still detectable and that history import and export still works.

```
./run_tests.sh -api test/api/test_histories.py:HistoriesApiTestCase.test_import_export
./run_tests.sh -with_framework_test_tools -api test/api/test_tools.py:ToolsTestCase.test_rdata_not_decompressed
```
