### PR TITLE
Handled the display of non-breaking space in the dynatree's tool shed repository: Replaced by a breaking space

### DIFF
--- a/templates/admin/tool_shed_repository/common.mako
+++ b/templates/admin/tool_shed_repository/common.mako
@@ -57,7 +57,8 @@
                             dataType: "json",
                             data: { file_path: selected_value },
                             success : function( data ) {
-                                cell.html( '<label>'+data+'</label>' )
+                                file_contents_nbsp_cleaned = data.replace(/&nbsp;/g, ' ');
+                                cell.html( '<label>'+file_contents_nbsp_cleaned+'</label>' );
                             }
                         });
                     } else {


### PR DESCRIPTION
Hi!

In the administration of Galaxy / Managed Installed Tools / Browse tool dependency, when I wanted to read *.sh files, the non-breaking space was overriding the parent css and the lines were continuing, expanding to an horizontal scrolling.

Quite annoying :).

It seems the JSON data received from the jquery AJAX request has some `&nbsp;` character (non-breaking space).
So I edited the View to replace the `&nbsp;` character by a breaking space.

Maybe we should also fix this problem (which seems to only appear in *.sh but did not try all extensions) in the action 'get_file_contents' in the 'admin_toolshed' controller to not add/get these non-breaking spaces.
