### PR TITLE
Request timing middleware via statsd

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -654,13 +654,19 @@ use_interactive = True
 # lot of CPU.
 #use_heartbeat = False
 
-
 # Log to Sentry
 # Sentry is an open source logging and error aggregation platform.  Setting
 # sentry_dsn will enable the Sentry middleware and errors will be sent to the
 # indicated sentry instance.  This connection string is available in your
 # sentry instance under <project_name> -> Settings -> API Keys.
 #sentry_dsn = None
+
+# Log to statsd
+# Statsd is an external statistics aggregator (https://github.com/etsy/statsd)
+# Enabling the following options will cause galaxy to log request timing and
+# other statistics to the configured statsd instance.
+#statsd_host=
+#statsd_port=8125
 
 # -- Data Libraries
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -426,7 +426,7 @@ class Configuration( object ):
         self.sentry_dsn = kwargs.get( 'sentry_dsn', None )
         # Statistics and profiling with statsd
         self.statsd_host = kwargs.get( 'statsd_host', '')
-        self.statsd_port = int( kwargs.get( 'statsd_port', 24224 ) )
+        self.statsd_port = int( kwargs.get( 'statsd_port', 8125 ) )
         # Logging with fluentd
         self.fluent_log = string_as_bool( kwargs.get( 'fluent_log', False ) )
         self.fluent_host = kwargs.get( 'fluent_host', 'localhost' )

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -424,6 +424,9 @@ class Configuration( object ):
         self.new_lib_browse = string_as_bool( kwargs.get( 'new_lib_browse', False ) )
         # Error logging with sentry
         self.sentry_dsn = kwargs.get( 'sentry_dsn', None )
+        # Statistics and profiling with statsd
+        self.statsd_host = kwargs.get( 'statsd_host', '')
+        self.statsd_port = int( kwargs.get( 'statsd_port', 24224 ) )
         # Logging with fluentd
         self.fluent_log = string_as_bool( kwargs.get( 'fluent_log', False ) )
         self.fluent_host = kwargs.get( 'fluent_host', 'localhost' )

--- a/lib/galaxy/web/framework/middleware/statsd.py
+++ b/lib/galaxy/web/framework/middleware/statsd.py
@@ -3,7 +3,13 @@ Middleware for sending request statistics to statsd
 """
 from __future__ import absolute_import
 import time
-import statsd
+
+try:
+    import statsd
+except ImportError:
+    # This middleware will never be used without statsd.  This block allows
+    # unit tests pass on systems without it.
+    statsd = None
 
 
 class StatsdMiddleware(object):

--- a/lib/galaxy/web/framework/middleware/statsd.py
+++ b/lib/galaxy/web/framework/middleware/statsd.py
@@ -1,0 +1,29 @@
+"""
+Middleware for sending request statistics to statsd
+"""
+from __future__ import absolute_import
+import time
+import statsd
+
+
+class StatsdMiddleware(object):
+    """
+    This logging middleware will log request durations to the configured statsd
+    instance.
+    """
+
+    def __init__(self,
+                 application,
+                 statsd_host,
+                 statsd_port):
+        self.application = application
+        self.statsd_client = statsd.StatsClient(statsd_host, statsd_port, prefix='galaxy')
+
+    def __call__(self, environ, start_response):
+        import pprint
+        pprint.pprint(environ)
+        start_time = time.time()
+        req = self.application(environ, start_response)
+        dt = int((time.time() - start_time) * 1000)
+        self.statsd_client.timing(environ.get('PATH_INFO', "NOPATH"), dt)
+        return req

--- a/lib/galaxy/web/framework/middleware/statsd.py
+++ b/lib/galaxy/web/framework/middleware/statsd.py
@@ -22,6 +22,9 @@ class StatsdMiddleware(object):
                  application,
                  statsd_host,
                  statsd_port):
+        if not statsd:
+            raise ImportError( "Statsd middleware configured, but no statsd python module found. "
+                           "Please install the python statsd module to use this functionality." )
         self.application = application
         self.statsd_client = statsd.StatsClient(statsd_host, statsd_port, prefix='galaxy')
 

--- a/lib/galaxy/web/framework/middleware/statsd.py
+++ b/lib/galaxy/web/framework/middleware/statsd.py
@@ -8,7 +8,7 @@ import statsd
 
 class StatsdMiddleware(object):
     """
-    This logging middleware will log request durations to the configured statsd
+    This middleware will log request durations to the configured statsd
     instance.
     """
 

--- a/lib/galaxy/web/framework/middleware/statsd.py
+++ b/lib/galaxy/web/framework/middleware/statsd.py
@@ -20,10 +20,8 @@ class StatsdMiddleware(object):
         self.statsd_client = statsd.StatsClient(statsd_host, statsd_port, prefix='galaxy')
 
     def __call__(self, environ, start_response):
-        import pprint
-        pprint.pprint(environ)
         start_time = time.time()
         req = self.application(environ, start_response)
         dt = int((time.time() - start_time) * 1000)
-        self.statsd_client.timing(environ.get('PATH_INFO', "NOPATH"), dt)
+        self.statsd_client.timing(environ.get('PATH_INFO', "NOPATH").strip('/').replace('/', '.'), dt)
         return req

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -689,6 +689,12 @@ def wrap_in_middleware( app, global_conf, **local_conf ):
         from galaxy.web.framework.middleware.translogger import TransLogger
         app = TransLogger( app )
         log.debug( "Enabling 'trans logger' middleware" )
+    # Statsd request timing and profiling
+    statsd_host = conf.get('statsd_host', None)
+    if statsd_host:
+        from galaxy.web.framework.middleware.statsd import StatsdMiddleware
+        app = StatsdMiddleware( app, statsd_host, int(conf.get('statsd_port', 32768 )))
+        log.debug( "Enabling 'trans logger' middleware" )
     # X-Forwarded-Host handling
     from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
     app = XForwardedHostMiddleware( app )

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -694,7 +694,7 @@ def wrap_in_middleware( app, global_conf, **local_conf ):
     if statsd_host:
         from galaxy.web.framework.middleware.statsd import StatsdMiddleware
         app = StatsdMiddleware( app, statsd_host, int(conf.get('statsd_port', 32768 )))
-        log.debug( "Enabling 'trans logger' middleware" )
+        log.debug( "Enabling 'statsd' middleware" )
     # X-Forwarded-Host handling
     from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
     app = XForwardedHostMiddleware( app )

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -693,7 +693,7 @@ def wrap_in_middleware( app, global_conf, **local_conf ):
     statsd_host = conf.get('statsd_host', None)
     if statsd_host:
         from galaxy.web.framework.middleware.statsd import StatsdMiddleware
-        app = StatsdMiddleware( app, statsd_host, int(conf.get('statsd_port', 32768 )))
+        app = StatsdMiddleware( app, statsd_host, conf.get('statsd_port'))
         log.debug( "Enabling 'statsd' middleware" )
     # X-Forwarded-Host handling
     from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -692,9 +692,15 @@ def wrap_in_middleware( app, global_conf, **local_conf ):
     # Statsd request timing and profiling
     statsd_host = conf.get('statsd_host', None)
     if statsd_host:
-        from galaxy.web.framework.middleware.statsd import StatsdMiddleware
-        app = StatsdMiddleware( app, statsd_host, conf.get('statsd_port'))
-        log.debug( "Enabling 'statsd' middleware" )
+        try:
+            import statsd  # noqa -- we simply ensure availability of the statsd module here before wrapping middleware
+            from galaxy.web.framework.middleware.statsd import StatsdMiddleware
+            app = StatsdMiddleware( app, statsd_host, conf.get('statsd_port'))
+            log.debug( "Enabling 'statsd' middleware" )
+        except ImportError:
+            log.error( "Statsd middleware configured, but no statsd python module found. "
+                       "Please install the python statsd module to use this functionality." )
+
     # X-Forwarded-Host handling
     from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
     app = XForwardedHostMiddleware( app )

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -692,14 +692,9 @@ def wrap_in_middleware( app, global_conf, **local_conf ):
     # Statsd request timing and profiling
     statsd_host = conf.get('statsd_host', None)
     if statsd_host:
-        try:
-            import statsd  # noqa -- we simply ensure availability of the statsd module here before wrapping middleware
-            from galaxy.web.framework.middleware.statsd import StatsdMiddleware
-            app = StatsdMiddleware( app, statsd_host, conf.get('statsd_port'))
-            log.debug( "Enabling 'statsd' middleware" )
-        except ImportError:
-            log.error( "Statsd middleware configured, but no statsd python module found. "
-                       "Please install the python statsd module to use this functionality." )
+        from galaxy.web.framework.middleware.statsd import StatsdMiddleware
+        app = StatsdMiddleware( app, statsd_host, conf.get('statsd_port'))
+        log.debug( "Enabling 'statsd' middleware" )
 
     # X-Forwarded-Host handling
     from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware


### PR DESCRIPTION
This is a very basic implementation of using statsd for request timing.  I've tinkered with additionally using a statsd decorator for timing specific methods or collecting other statistics, but this seems like a good place to start and it'll allow us to isolate slow requests and figure out what needs to be optimized with real data.

There is no new egg for the statsd module, I simply test if it is available and log a debug statement if not.  Once wheels are out, we might want to add one (or not, since this isn't middleware most people will be using).
