### PR TITLE
Add check for HTTP_GX_SECRET

### DIFF
--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -75,6 +75,20 @@ class RemoteUser( object ):
         # Galaxy would not have access to Galaxy itself, and be attempting to
         # attack the system
         if self.config_secret_header is not None:
+            if environ.get('HTTP_GX_SECRET') is None:
+                title = "Access to Galaxy is denied"
+                message = """
+                Galaxy is configured to authenticate users via an external
+                method (such as HTTP authentication in Apache), but
+                no shared secret key was provided by the
+                upstream (proxy) server.</p>
+                <p>Please contact your local Galaxy administrator.  The
+                variable <code>remote_user_secret</code> and
+                <code>GX_SECRET</code> header must be set before you may
+                access Galaxy.
+                """
+                return self.error( start_response, title, message )
+            
             if not safe_str_cmp(environ.get('HTTP_GX_SECRET'), self.config_secret_header):
                 title = "Access to Galaxy is denied"
                 message = """

--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -88,7 +88,7 @@ class RemoteUser( object ):
                 access Galaxy.
                 """
                 return self.error( start_response, title, message )
-                
+
             if not safe_str_cmp(environ.get('HTTP_GX_SECRET'), self.config_secret_header):
                 title = "Access to Galaxy is denied"
                 message = """
@@ -102,7 +102,7 @@ class RemoteUser( object ):
                 access Galaxy.
                 """
                 return self.error( start_response, title, message )
-                
+
         if not environ.get(self.remote_user_header, '(null)').startswith('(null)'):
             if not environ[ self.remote_user_header ].count( '@' ):
                 if self.maildomain is not None:

--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -88,7 +88,7 @@ class RemoteUser( object ):
                 access Galaxy.
                 """
                 return self.error( start_response, title, message )
-            
+                
             if not safe_str_cmp(environ.get('HTTP_GX_SECRET'), self.config_secret_header):
                 title = "Access to Galaxy is denied"
                 message = """

--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -102,7 +102,7 @@ class RemoteUser( object ):
                 access Galaxy.
                 """
                 return self.error( start_response, title, message )
-
+                
         if not environ.get(self.remote_user_header, '(null)').startswith('(null)'):
             if not environ[ self.remote_user_header ].count( '@' ):
                 if self.maildomain is not None:


### PR DESCRIPTION
If not provided, safe_str_cmp crashes and present debug trace log to user.
