### PR TITLE
Allow reuse of parent /tmp directory in dockerized testing.

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -73,9 +73,9 @@ def build_command(
 
 def __externalize_commands(job_wrapper, commands_builder, remote_command_params, script_name="tool_script.sh"):
     local_container_script = join( job_wrapper.working_directory, script_name )
-    fh = file( local_container_script, "w" )
-    fh.write( "#!%s\n%s" % (DEFAULT_SHELL, commands_builder.build()))
-    fh.close()
+    with open( local_container_script, "w" ) as f:
+        script_contents = "#!%s\n%s" % (DEFAULT_SHELL, commands_builder.build())
+        f.write( script_contents )
     chmod( local_container_script, 0755 )
 
     commands = local_container_script


### PR DESCRIPTION
Also improved file handling and fixes a small bug in environment variable handling related to Docker in run_tests.sh.
