### PR TITLE
More small adjustments to test script.

### DIFF
--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -1,1 +1,0 @@
-run_tests.sh

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -126,6 +126,7 @@ do
           fi 
           ;;
     -a|-api|--api)
+          with_framework_test_tools_arg="-with_framework_test_tools"
           test_script="./scripts/functional_tests.py"
           report_file="./run_api_tests.html"
           if [ $# -gt 1 ]; then
@@ -173,6 +174,7 @@ do
       -j|-casperjs|--casperjs)
           # TODO: Support running casper tests against existing
           # Galaxy instances.
+          with_framework_test_tools_arg="-with_framework_test_tools"
           if [ $# -gt 1 ]; then
               casperjs_test_name=$2
               shift 2


### PR DESCRIPTION
Make `--with_framework_test_tools` implicit with `--casperjs` and `--api`. These tests are explicitly designed to test the framework and use a tool panel. `sh run_tests.sh`, `sh run_tests.sh -id`, `sh run_tests.sh -installed`, `sh run_tests.sh -migrated` are meant to test Galaxy's configuration to some degree, and other tests qunit, unit, and toolshed do not depend on the toolbox at all.

Also, remove the long deprecated `run_functional_tests.sh`.

See discussion on #185, this implements some of the behavior we agreed would be good in that pull request. There may still be open tasks with respect to what was discussed in #185, but these particular changes in this PR are steps in the right direction and positive changes in their own right.
