### PR TITLE
Bump version of sqlite3 in nodejs proxy

### DIFF
--- a/lib/galaxy/web/proxy/js/package.json
+++ b/lib/galaxy/web/proxy/js/package.json
@@ -14,6 +14,6 @@
     "eventemitter3": "0.1.6",
     "http-proxy": "1.6.0",
     "commander": "~2.2",
-    "sqlite3": "3.0.2"
+    "sqlite3": "3.0.5"
   }
 }


### PR DESCRIPTION
@nitesh1989 and I tested this this morning and it let him install the nodejs proxy on OSX.

cc @jmchilton (who had the issue on cloudman? Anyway)
