### PR TITLE
Expose API keys to admins under REMOTE_USER

### DIFF
--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -118,6 +118,8 @@ class RemoteUser( object ):
                 pass  # Admin users need to be able to change user information
             elif path_info.startswith( '/user/edit_info' ) and environ[ self.remote_user_header ] in self.admin_users:
                 pass  # Admin users need to be able to change user information
+            elif path_info.startswith( '/userskeys/all_users' ) and environ[ self.remote_user_header ] in self.admin_users:
+                pass  # Admin users need to be able to manage API keys for all users.
             elif path_info.startswith( '/user/api_keys' ):
                 pass  # api keys can be managed when remote_user is in use
             elif path_info.startswith( '/user/edit_username' ):


### PR DESCRIPTION
This is the default setting for non-remote-user setups, this commit adjusts the middleware to behave as expected.

Issue raised in http://dev.list.galaxyproject.org/User-API-keys-with-External-LDAP-authentication-disabled-td4668052.html

(Tagging bug due to confirmed by two people and this behaviour is the standard, the REMOTE_USER middleware just failed to catch it.)
