### PR TITLE
Refactor the remote user middleware for complexity

### DIFF
--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -129,7 +129,7 @@ class RemoteUser( object ):
                 pass
             elif environ[self.remote_user_header] in self.admin_users and \
                     any([path_info.startswith(prefix) for prefix in admin_accessible_paths]):
-                # If the user is an admin user, and any of the admin accessible paths match..., allow them too execute that action.
+                # If the user is an admin user, and any of the admin accessible paths match..., allow them to execute that action.
                 pass
             elif any([path_info.startswith(prefix) for prefix in user_accessible_paths]):
                 # If the user is allowed to access the path, pass

--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -106,30 +106,34 @@ class RemoteUser( object ):
                         before you may access Galaxy.
                     """
                     return self.error( start_response, title, message )
+
+            user_accessible_paths = (
+                '/user/api_keys',
+                '/user/edit_username',
+                '/user/dbkeys',
+                '/user/toolbox_filters',
+                '/user/set_default_permissions',
+            )
+
+            admin_accessible_paths = (
+                '/user/create',
+                '/user/logout',
+                '/user/manage_user_info',
+                '/user/edit_info',
+                '/userskeys/all_users',
+            )
+
             if not path_info.startswith('/user'):
                 # shortcut the following whitelist for non-user-controller
                 # requests.
                 pass
-            elif path_info.startswith( '/user/create' ) and environ[ self.remote_user_header ] in self.admin_users:
-                pass  # admins can create users
-            elif path_info.startswith( '/user/logout' ) and environ[ self.remote_user_header ] in self.admin_users:
-                pass  # Admin users may be impersonating, allow logout.
-            elif path_info.startswith( '/user/manage_user_info' ) and environ[ self.remote_user_header ] in self.admin_users:
-                pass  # Admin users need to be able to change user information
-            elif path_info.startswith( '/user/edit_info' ) and environ[ self.remote_user_header ] in self.admin_users:
-                pass  # Admin users need to be able to change user information
-            elif path_info.startswith( '/userskeys/all_users' ) and environ[ self.remote_user_header ] in self.admin_users:
-                pass  # Admin users need to be able to manage API keys for all users.
-            elif path_info.startswith( '/user/api_keys' ):
-                pass  # api keys can be managed when remote_user is in use
-            elif path_info.startswith( '/user/edit_username' ):
-                pass  # username can be managed when remote_user is in use
-            elif path_info.startswith( '/user/dbkeys' ):
-                pass  # dbkeys can be managed when remote_user is in use
-            elif path_info.startswith( '/user/toolbox_filters' ):
-                pass  # toolbox filters can be managed when remote_user is in use
-            elif path_info.startswith( '/user/set_default_permissions' ):
-                pass  # default permissions can be managed when remote_user is in use
+            elif environ[self.remote_user_header] in self.admin_users and \
+                    any([path_info.startswith(prefix) for prefix in admin_accessible_paths]):
+                # If the user is an admin user, and any of the admin accessible paths match..., allow them too execute that action.
+                pass
+            elif any([path_info.startswith(prefix) for prefix in user_accessible_paths]):
+                # If the user is allowed to access the path, pass
+                pass
             elif path_info == '/user' or path_info == '/user/':
                 pass  # We do allow access to the root user preferences page.
             elif path_info.startswith( '/user' ):


### PR DESCRIPTION
Instead of a whole mess of if/else checks, refactor into a list of accessible paths and just calculate `any()`.

Question: is the admin_path stuff really necessary? Are there any routes which should absolutely be prohibited to admins under remote_user? If not we can simplify this greatly and avoid issues like #872 going forward.
