### PR TITLE
[15.10] Fix for no longer being able to access data managers.

### DIFF
--- a/templates/webapps/galaxy/data_manager/index.mako
+++ b/templates/webapps/galaxy/data_manager/index.mako
@@ -21,7 +21,7 @@
             <ul>
             %for data_manager_id, data_manager in sorted( data_managers.data_managers.iteritems(), key=lambda x:x[1].name ):
                 <li>
-                    <a href="${ h.url_for( controller='tool_runner', action='index', tool_id=data_manager.tool.id ) }"><strong>${ data_manager.name | h }</strong></a> - ${ data_manager.description | h }
+                    <a href="${ h.url_for( controller='root', tool_id=data_manager.tool.id ) }" target="_blank"><strong>${ data_manager.name | h }</strong></a> - ${ data_manager.description | h }
                 </li>
                 <p/>
             %endfor

--- a/templates/webapps/galaxy/data_manager/view_job.mako
+++ b/templates/webapps/galaxy/data_manager/view_job.mako
@@ -21,7 +21,7 @@
 <table class="tabletip">
     <thead>
         <tr><th colspan="2" style="font-size: 120%;">
-            Data Manager: <a href="${ h.url_for( controller='tool_runner', action='index', tool_id=data_manager.tool.id ) }">${ data_manager.name | h }</a> - ${ data_manager.description | h } <a class="icon-btn" href="${ h.url_for( controller="tool_runner", action="rerun", job_id=trans.security.encode_id( job.id ) ) }" title="Rerun" data-placement="bottom"><span class="fa fa-refresh"></span></a>
+            Data Manager: <a href="${ h.url_for( controller='root', tool_id=data_manager.tool.id ) }" target="_blank">${ data_manager.name | h }</a> - ${ data_manager.description | h } <a class="icon-btn" href="${ h.url_for( controller="tool_runner", action="rerun", job_id=trans.security.encode_id( job.id ) ) }" title="Rerun" data-placement="bottom"><span class="fa fa-refresh"></span></a>
         </th></tr>
     </thead>
     <tbody>


### PR DESCRIPTION
Have datamanager links point to root with tool_id provided while targeting a new window.

tool_form.mako no longer exists and all tools have an empty string for their default_template value.
