### PR TITLE
Fix the issue where too many datasets are linked to a certain role 

### DIFF
--- a/lib/galaxy/web/base/controllers/admin.py
+++ b/lib/galaxy/web/base/controllers/admin.py
@@ -315,7 +315,7 @@ class Admin( object ):
             else:
                 out_groups.append( ( group.id, group.name ) )
         library_dataset_actions = {}
-        if trans.webapp.name == 'galaxy':
+        if trans.webapp.name == 'galaxy' and len(role.dataset_actions) < 25:
             # Build a list of tuples that are LibraryDatasetDatasetAssociationss followed by a list of actions
             # whose DatasetPermissions is associated with the Role
             # [ ( LibraryDatasetDatasetAssociation [ action, action ] ) ]
@@ -341,6 +341,9 @@ class Admin( object ):
                         library_dataset_actions[ library ][ folder_path ].append( dp.action )
                     except:
                         library_dataset_actions[ library ][ folder_path ] = [ dp.action ]
+        else:
+            message = "Not showing associated datasets, there are too many."
+            status = 'info'
         return trans.fill_template( '/admin/dataset_security/role/role.mako',
                                     role=role,
                                     in_users=in_users,


### PR DESCRIPTION
And as a result the admin/roles page will not load - or takes too long
The `25` is a wild guess, not tested what is acceptable and will probably not relate directly to the actual number of datasets...
