### PR TITLE
Added the init file to start/reload/stop Galaxy with uWSGI and job ha…

### DIFF
--- a/contrib/galaxy.fedora.uwsgi.handlers-init
+++ b/contrib/galaxy.fedora.uwsgi.handlers-init
@@ -63,13 +63,16 @@ stop() {
 reload() {
     echo -n "Reloading $SERVICE_NAME... "
     cmd_uwsgi="cd $RUN_IN && (echo r > masterFifo)"
+    cmd_galaxy_daemons="GALAXY_RUN_ALL=1 ./run.sh --wait restart"
 
     case "$(id -un)" in
                 $RUN_AS)
                         eval "$cmd_uwsgi"
+                        eval "$cmd_galaxy_daemons"
                         ;;
                 root)
                         su - $RUN_AS -c "$cmd_uwsgi"
+                        su - $RUN_AS -c "$cmd_galaxy_daemons"
                         ;;
                 *)
                         echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2

--- a/contrib/galaxy.fedora.uwsgi.handlers-init
+++ b/contrib/galaxy.fedora.uwsgi.handlers-init
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# Init file for launching Galaxy with uwsgi and multiple job handlers (http://galaxyproject.org/)
+#   Suitable for use on Fedora and derivatives (RedHat Enterprise Linux, Scientific Linux, CentOS)
+#
+# Contributed by Brad Chapman
+# Improved by Remi Marenco
+#
+# chkconfig: 2345 98 20
+# description: Galaxy http://galaxyproject.org/
+
+#--- config
+
+SERVICE_NAME="galaxy"
+RUN_AS="galaxy"
+RUN_IN="/path/to/galaxy-dist"
+
+#--- main actions
+
+start() {
+	echo "Starting $SERVICE_NAME... "
+	cmd_uwsgi="cd $RUN_IN && PYTHONPATH=eggs/PasteDeploy-1.5.0-py2.7.egg uwsgi --ini-paste config/galaxy.ini --master-fifo masterFifo &"
+        cmd_galaxy_daemons="cd $RUN_IN && GALAXY_RUN_ALL=1 sh run.sh --daemon"
+	case "$(id -un)" in
+		$RUN_AS)
+			eval "$cmd_uwsgi"
+			eval "$cmd_galaxy_daemons"
+			;;
+		root)
+			su - $RUN_AS -c "$cmd_uwsgi"
+                        su - $RUN_AS -c "$cmd_galaxy_daemons"
+			;;
+		*)
+			echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
+			exit 1
+	esac
+	echo "...done."
+}
+
+stop() {
+	echo -n "Stopping $SERVICE_NAME... "
+	
+	cmd_uwsgi="cd $RUN_IN && (echo q > masterFifo)"
+	cmd_galaxy_daemons="cd $RUN_IN && GALAXY_RUN_ALL=1 sh run.sh --stop-daemon"
+
+	case "$(id -un)" in
+		$RUN_AS)
+			eval "$cmd_uwsgi"
+			eval "$cmd_galaxy_daemons"
+			;;
+		root)
+			su - $RUN_AS -c "$cmd_uwsgi"
+			su - $RUN_AS -c "$cmd_galaxy_daemons"
+			;;
+		*)
+			echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
+			exit 1
+	esac
+	
+	echo "done."
+}
+
+reload() {
+	echo -n "Reloading $SERVICE_NAME... "
+	cmd_uwsgi="cd $RUN_IN && (echo r > masterFifo)"
+
+	case "$(id -un)" in
+                $RUN_AS)
+                        eval "$cmd_uwsgi"
+                        ;;
+                root)
+                        su - $RUN_AS -c "$cmd_uwsgi"
+                        ;;
+                *)
+                        echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
+                        exit 1
+        esac
+
+        echo "done."
+}
+
+status() {
+	echo -n "$SERVICE_NAME status: "
+	
+	while read pid; do
+		if [ "$(readlink -m /proc/$pid/cwd)" = "$(readlink -m $RUN_IN)" ]; then
+			echo "started"
+			return 0
+		fi
+	done < <(ps ax -o 'pid cmd' | grep -P '^\s*\d+ python ./scripts/paster.py serve' | awk '{print $1}')
+	echo "stopped"
+	return 3
+}
+
+notsupported() {
+	echo "*** ERROR*** $SERVICE_NAME: operation [$1] not supported"
+}
+
+usage() {
+	echo "Usage: $SERVICE_NAME start|stop|restart|status"
+}
+
+
+#---
+
+case "$1" in
+	start)
+		start "$@"
+		;;
+	stop)
+		stop "$@"
+		;;
+	reload)
+		reload "$@"
+		;;
+	status)
+		set +e
+		status
+		exit $?
+		;;
+	'')
+		usage >&2
+		exit 1
+		;;
+	*)
+		notsupported "$1" >&2
+		usage >&2
+		exit 1
+		;;
+esac

--- a/contrib/galaxy.fedora.uwsgi.handlers-init
+++ b/contrib/galaxy.fedora.uwsgi.handlers-init
@@ -1,6 +1,9 @@
 #!/bin/bash
 #
 # Init file for launching Galaxy with uwsgi and multiple job handlers (http://galaxyproject.org/)
+# 
+# ------- WE STRONGLY ADVISE TO USE SUPERVISORD (http://supervisord.org/) ON PRODUCTION -------
+#
 #   Suitable for use on Fedora and derivatives (RedHat Enterprise Linux, Scientific Linux, CentOS)
 #
 # Contributed by Brad Chapman

--- a/contrib/galaxy.fedora.uwsgi.handlers-init
+++ b/contrib/galaxy.fedora.uwsgi.handlers-init
@@ -18,53 +18,53 @@ RUN_IN="/path/to/galaxy-dist"
 #--- main actions
 
 start() {
-	echo "Starting $SERVICE_NAME... "
-	cmd_uwsgi="cd $RUN_IN && PYTHONPATH=eggs/PasteDeploy-1.5.0-py2.7.egg uwsgi --ini-paste config/galaxy.ini --master-fifo masterFifo &"
-        cmd_galaxy_daemons="cd $RUN_IN && GALAXY_RUN_ALL=1 sh run.sh --daemon"
-	case "$(id -un)" in
-		$RUN_AS)
-			eval "$cmd_uwsgi"
-			eval "$cmd_galaxy_daemons"
-			;;
-		root)
-			su - $RUN_AS -c "$cmd_uwsgi"
+    echo "Starting $SERVICE_NAME... "
+    cmd_uwsgi="cd $RUN_IN && PYTHONPATH=eggs/PasteDeploy-1.5.0-py2.7.egg uwsgi --ini-paste config/galaxy.ini --master-fifo masterFifo &"
+    cmd_galaxy_daemons="cd $RUN_IN && GALAXY_RUN_ALL=1 sh run.sh --daemon"
+    case "$(id -un)" in
+       $RUN_AS)
+            eval "$cmd_uwsgi"
+            eval "$cmd_galaxy_daemons"
+            ;;
+        root)
+            su - $RUN_AS -c "$cmd_uwsgi"
                         su - $RUN_AS -c "$cmd_galaxy_daemons"
-			;;
-		*)
-			echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
-			exit 1
-	esac
-	echo "...done."
+            ;;
+        *)
+            echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
+            exit 1
+    esac
+    echo "...done."
 }
 
 stop() {
-	echo -n "Stopping $SERVICE_NAME... "
-	
-	cmd_uwsgi="cd $RUN_IN && (echo q > masterFifo)"
-	cmd_galaxy_daemons="cd $RUN_IN && GALAXY_RUN_ALL=1 sh run.sh --stop-daemon"
+    echo -n "Stopping $SERVICE_NAME... "
+    
+    cmd_uwsgi="cd $RUN_IN && (echo q > masterFifo)"
+    cmd_galaxy_daemons="cd $RUN_IN && GALAXY_RUN_ALL=1 sh run.sh --stop-daemon"
 
-	case "$(id -un)" in
-		$RUN_AS)
-			eval "$cmd_uwsgi"
-			eval "$cmd_galaxy_daemons"
-			;;
-		root)
-			su - $RUN_AS -c "$cmd_uwsgi"
-			su - $RUN_AS -c "$cmd_galaxy_daemons"
-			;;
-		*)
-			echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
-			exit 1
-	esac
-	
-	echo "done."
+    case "$(id -un)" in
+        $RUN_AS)
+            eval "$cmd_uwsgi"
+            eval "$cmd_galaxy_daemons"
+            ;;
+        root)
+            su - $RUN_AS -c "$cmd_uwsgi"
+            su - $RUN_AS -c "$cmd_galaxy_daemons"
+            ;;
+        *)
+            echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
+            exit 1
+    esac
+    
+    echo "done."
 }
 
 reload() {
-	echo -n "Reloading $SERVICE_NAME... "
-	cmd_uwsgi="cd $RUN_IN && (echo r > masterFifo)"
+    echo -n "Reloading $SERVICE_NAME... "
+    cmd_uwsgi="cd $RUN_IN && (echo r > masterFifo)"
 
-	case "$(id -un)" in
+    case "$(id -un)" in
                 $RUN_AS)
                         eval "$cmd_uwsgi"
                         ;;
@@ -80,51 +80,51 @@ reload() {
 }
 
 status() {
-	echo -n "$SERVICE_NAME status: "
-	
-	while read pid; do
-		if [ "$(readlink -m /proc/$pid/cwd)" = "$(readlink -m $RUN_IN)" ]; then
-			echo "started"
-			return 0
-		fi
-	done < <(ps ax -o 'pid cmd' | grep -P '^\s*\d+ python ./scripts/paster.py serve' | awk '{print $1}')
-	echo "stopped"
-	return 3
+    echo -n "$SERVICE_NAME status: "
+    
+    while read pid; do
+        if [ "$(readlink -m /proc/$pid/cwd)" = "$(readlink -m $RUN_IN)" ]; then
+            echo "started"
+            return 0
+        fi
+    done < <(ps ax -o 'pid cmd' | grep -P '^\s*\d+ python ./scripts/paster.py serve' | awk '{print $1}')
+    echo "stopped"
+    return 3
 }
 
 notsupported() {
-	echo "*** ERROR*** $SERVICE_NAME: operation [$1] not supported"
+    echo "*** ERROR*** $SERVICE_NAME: operation [$1] not supported"
 }
 
 usage() {
-	echo "Usage: $SERVICE_NAME start|stop|restart|status"
+    echo "Usage: $SERVICE_NAME start|stop|restart|status"
 }
 
 
 #---
 
 case "$1" in
-	start)
-		start "$@"
-		;;
-	stop)
-		stop "$@"
-		;;
-	reload)
-		reload "$@"
-		;;
-	status)
-		set +e
-		status
-		exit $?
-		;;
-	'')
-		usage >&2
-		exit 1
-		;;
-	*)
-		notsupported "$1" >&2
-		usage >&2
-		exit 1
-		;;
+    start)
+        start "$@"
+        ;;
+    stop)
+        stop "$@"
+        ;;
+    reload)
+        reload "$@"
+        ;;
+    status)
+        set +e
+        status
+        exit $?
+        ;;
+    '')
+        usage >&2
+        exit 1
+        ;;
+    *)
+        notsupported "$1" >&2
+        usage >&2
+        exit 1
+        ;;
 esac


### PR DESCRIPTION
…ndlers

Hi!

As we are using uWSGI and Job Handlers on our Galaxy instance, we needed to have a script to start/reload/stop.
Here is a first version we wanted to share with you :).

This script is using the following cmds:
- `PYTHONPATH=eggs/PasteDeploy-1.5.0-py2.7.egg uwsgi --ini-paste config/galaxy.ini --master-fifo masterFifo &` as stated [here](https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#line-92)
- `GALAXY_RUN_ALL=1 sh run.sh --daemon`, `GALAXY_RUN_ALL=1 sh run.sh --stop-daemon` and `GALAXY_RUN_ALL=1 ./run.sh --wait restart` from the [Galaxy documentation](https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#Starting_and_Stopping)
- `echo r > masterFifo` and `echo q > masterFifo` from the [uWSGI documentation](http://uwsgi-docs-additions.readthedocs.org/en/latest/MasterFIFO.html) with MasterFIFO file

Configure the `RUN_AS="galaxy"` and the `RUN_IN="/path/to/galaxy-dist"` to match your installation, and put this file to the location you are managing your apps (usually /etc/init.d).
