### PR TITLE
fix for strange package names

### DIFF
--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -999,7 +999,7 @@ class SetEnvironment( RecipeStep ):
         cmds = install_environment.environment_commands( 'set_environment' )
         env_var_dicts = action_dict.get( 'environment_variable', [] )
         root_dir_dict = dict( action='set_to',
-                              name='%s_ROOT_DIR' % tool_dependency.name.upper(),
+                              name='%s_ROOT_DIR' % tool_dependency.name.replace( '-', '_' ).upper(),
                               value=install_environment.install_dir )
         env_var_dicts.append( root_dir_dict )
         for env_var_dict in env_var_dicts:


### PR DESCRIPTION
Some packages do have a dash in their name. This PR replaces it by an underscore.
