### PR TITLE
Add a workaround to return a proper error code 

### DIFF
--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -1368,7 +1368,7 @@ class SetupREnvironment( Download, RecipeStep ):
                     # Use raw strings so that python won't automatically unescape the quotes before passing the command
                     # to subprocess.Popen.
                     cmd = r'''PATH=$PATH:$R_HOME/bin; export PATH; R_LIBS=$INSTALL_DIR:$R_LIBS; export R_LIBS;
-                        Rscript -e "install.packages(c('%s'),lib='$INSTALL_DIR', repos=NULL, dependencies=FALSE)"''' % \
+                        Rscript -e "tryCatch( install.packages(c('%s'),lib='$INSTALL_DIR', repos=NULL, dependencies=FALSE), error = exit(1))"''' % \
                         ( str( tarball_name ) )
                     cmd = install_environment.build_command( basic_util.evaluate_template( cmd, install_environment ) )
                     return_code = install_environment.handle_command( tool_dependency=tool_dependency,


### PR DESCRIPTION
If an R package fails to install it usually do not return an error code. 
With this PR we return the error code 1, which Galaxy will catch up and fail as expected.
