### PR TITLE
Correct newly broken condor runner

### DIFF
--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -90,7 +90,7 @@ class CondorJobRunner( AsynchronousJobRunner ):
             slots_statement=galaxy_slots_statement,
         )
         try:
-            self.write_executable_script( executable.job_file, script )
+            self.write_executable_script( executable, script )
         except:
             job_wrapper.fail( "failure preparing job script", exception=True )
             log.exception( "(%s) failure preparing job script" % galaxy_id_tag )


### PR DESCRIPTION
@jmchilton I think you might've broken condor runner :) https://github.com/erasche/galaxy/commit/b75175f18d15000a2dc5826f49424eba6dc7d489

Judging by the code, `executable` is set [here](https://github.com/erasche/galaxy/blob/daffa942148da1d8aea1eefe795564cc7e753a06/lib/galaxy/jobs/runners/condor.py#L76) with the line:

``` python
executable = cjs.job_file
```

and then L93 accesses `.job_file` on that. That doesn't make a lot of sense.
