### PR TITLE
Reorder workflow inputs to top

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -983,26 +983,36 @@ def load_module_sections( trans ):
     """ Get abstract description of the workflow modules this Galaxy instance
     is configured with.
     """
-    inputs_section = {
+    module_sections = {}
+    module_sections['inputs'] = {
         "name": "inputs",
         "title": "Inputs",
         "modules": [
-            {"name": "data_input", "title": "Input Dataset", "description": "Input dataset"},
-            {"name": "data_collection_input", "title": "Input Dataset Collection", "description": "Input dataset collection"},
+            {
+                "name": "data_input",
+                "title": "Input Dataset",
+                "description": "Input dataset"
+            },
+            {
+                "name": "data_collection_input",
+                "title": "Input Dataset Collection",
+                "description": "Input dataset collection"
+            },
         ],
     }
-    module_sections = [
-        inputs_section
-    ]
+
     if trans.app.config.enable_beta_workflow_modules:
-        experimental_modules = {
+        module_sections['experimental'] = {
             "name": "experimental",
             "title": "Experimental",
             "modules": [
-                {"name": "pause", "title": "Pause Workflow for Dataset Review", "description": "Pause for Review"},
+                {
+                    "name": "pause",
+                    "title": "Pause Workflow for Dataset Review",
+                    "description": "Pause for Review"
+                },
             ],
         }
-        module_sections.append(experimental_modules)
 
     return module_sections
 

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -259,6 +259,24 @@
                       "<div class='progress progress-striped progress-info active'><div class='progress-bar' style='width: 100%;'></div></div>", self.overlay_visible )}
 </%def>
 
+
+<%def name="render_module_section(module_section)">
+    <div class="toolSectionTitle" id="title___workflow__${module_section['name']}__">
+        <span>${module_section["title"]}</span>
+    </div>
+    <div id="__workflow__${module_section['name']}__" class="toolSectionBody">
+        <div class="toolSectionBg">
+            %for module in module_section["modules"]:
+                <div class="toolTitle">
+                    <a href="#" onclick="workflow_view.add_node_for_module( '${module['name']}', '${module['title']}' )">
+                        ${module['description']}
+                    </a>
+                </div>
+            %endfor
+        </div>
+    </div>
+</%def>
+
 <%def name="left_panel()">
     <%
        from galaxy.tools import Tool
@@ -272,11 +290,20 @@
     </div>
 
     <div class="unified-panel-body" style="overflow: auto;">
-            <div class="toolMenu">
+        <div class="toolMenu">
+            <%
+                from galaxy.workflow.modules import load_module_sections
+                module_sections = load_module_sections( trans )
+            %>
             <div id="tool-search" style="padding-bottom: 5px; position: relative; display: block; width: 100%">
                 <input type="text" name="query" placeholder="search tools" id="tool-search-query" class="search-query parent-width" />
                 <img src="${h.url_for('/static/images/loading_small_white_bg.gif')}" id="search-spinner" class="search-spinner" />
             </div>
+
+            <div class="toolSectionWrapper">
+                ${render_module_section(module_sections['inputs'])}
+            </div>
+
             <div class="toolSectionList">
                 %for val in app.toolbox.tool_panel_contents( trans ):
                     <div class="toolSectionWrapper">
@@ -321,35 +348,20 @@
                 %endif
                 ## End Data Manager Tools
             </div>
+            <div>&nbsp;</div>
+            %for section_name, module_section in module_sections.items():
+                %if section_name != "inputs":
+                    ${render_module_section(module_section)}
+                %endif
+            %endfor
+
             ## Feedback when search returns no results.
             <div id="search-no-results" style="display: none; padding-top: 5px">
                 <em><strong>Search did not match any tools.</strong></em>
             </div>
-            <div>&nbsp;</div>
 
-            <div class="toolMenuGroupHeader">Workflow control</div>
-            <%
-                from galaxy.workflow.modules import load_module_sections
-            %>
-            %for module_section in load_module_sections( trans ):
-                <% section_title = module_section["title"] %>
-                <% section_name = module_section["name"] %>
-                <div class="toolSectionTitle" id="title___workflow__${section_name}__">
-                <span>${section_title}</span>
-                </div>
-                <div id="__workflow__${section_name}__" class="toolSectionBody">
-                <div class="toolSectionBg">
-                %for module in module_section["modules"]:
-                    <div class="toolTitle">
-                        <a href="#" onclick="workflow_view.add_node_for_module( '${module['name']}', '${module['title']}' )">${module['description']}</a>
-                    </div><!-- end toolTitle -->
-                %endfor
-                </div>
-                </div>
-            %endfor
         </div>
     </div>
-
 </%def>
 
 <%def name="center_panel()">


### PR DESCRIPTION
This renders the workflow inputs at the top of the tool list. This feels more natural to me as a user. 
However, the workflow modules sections are now in a dictionary and explicit ordering might be needed if more are actually added.

http://pasteboard.co/1mLyQ4sT.png
