### PR TITLE
Library upload dir script

### DIFF
--- a/doc/source/admin/index.rst
+++ b/doc/source/admin/index.rst
@@ -9,3 +9,5 @@ documentation. These resources should be used together.
    :maxdepth: 3
 
    interactive_environments.rst
+
+   useful_scripts.rst

--- a/doc/source/admin/useful_scripts.rst
+++ b/doc/source/admin/useful_scripts.rst
@@ -15,3 +15,5 @@ This script was developed to be as general as possible, allowing you to pipe the
     $ find /path/to/sequencing-data/ -name '*.fastq' -or -name '*.fa' | python $GALAXY_ROOT/scripts/api/library_upload_dir.py
 
 Find has an extremely expressive command line for selecting specific files that are of interest to you. These will then be recursively uploaded into Galaxy, maintaining the folder hierarchy, a useful feature when moving legacy data into Galaxy. For a complete description of the options of this script, you can run ``python $GALAXY_ROOT/scripts/api/library_upload_dir.py --help``
+
+This tool will not overwrite or re-upload already uploaded datasets. As a result, one can imagine running this on a cron job to keep an "incoming sequencing data" directory synced with a data library.

--- a/doc/source/admin/useful_scripts.rst
+++ b/doc/source/admin/useful_scripts.rst
@@ -12,6 +12,6 @@ This script was developed to be as general as possible, allowing you to pipe the
 
 .. code-block:: console
 
-    $ find /path/to/sequencing-data/ -name '*.fastq' -or -name '*.fa' | python $GALAXY_ROOT/scripts/api/library_upload_files.py
+    $ find /path/to/sequencing-data/ -name '*.fastq' -or -name '*.fa' | python $GALAXY_ROOT/scripts/api/library_upload_dir.py
 
-Find has an extremely expressive command line for selecting specific files that are of interest to you. These will then be recursively uploaded into Galaxy, maintaining the folder hierarchy, a useful feature when moving legacy data into Galaxy.
+Find has an extremely expressive command line for selecting specific files that are of interest to you. These will then be recursively uploaded into Galaxy, maintaining the folder hierarchy, a useful feature when moving legacy data into Galaxy. For a complete description of the options of this script, you can run ``python $GALAXY_ROOT/scripts/api/library_upload_dir.py --help``

--- a/doc/source/admin/useful_scripts.rst
+++ b/doc/source/admin/useful_scripts.rst
@@ -1,0 +1,17 @@
+Useful Scripts and Administration Tricks
+========================================
+
+This page aims to help ease the burden of administration with some easy to use scripts and documentation on what is available for admins to use.
+
+Uploading a directory into a Data Library
+-----------------------------------------
+
+Data libraries can really ease the use of Galaxy for your administrators and end users. They provide a form of shared folders that users can copy datasets from into their history.
+
+This script was developed to be as general as possible, allowing you to pipe the output of a much more complex find command to this script, uploading all of the files into a data library:
+
+.. code-block:: console
+
+    $ find /path/to/sequencing-data/ -name '*.fastq' -or -name '*.fa' | python $GALAXY_ROOT/scripts/api/library_upload_files.py
+
+Find has an extremely expressive command line for selecting specific files that are of interest to you. These will then be recursively uploaded into Galaxy, maintaining the folder hierarchy, a useful feature when moving legacy data into Galaxy.

--- a/doc/source/dev/faq.rst
+++ b/doc/source/dev/faq.rst
@@ -2,7 +2,7 @@ How Do I...
 ===========
 
 This section contains a number of smaller topics with links and examples meant
-to provide relatively concrete answers for specific tool development scenarios.
+to provide relatively concrete answers for specific Galaxy development scenarios.
 
 ... interact with the Galaxy codebase interactively?
 ----------------------------------------------------

--- a/scripts/api/library_upload_dir.py
+++ b/scripts/api/library_upload_dir.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+import argparse
+import os
+from bioblend import galaxy
+
+
+class Uploader:
+
+    def __init__(self, url, api, local_dir, library_id, folder_id):
+        self.gi = galaxy.GalaxyInstance(url=url, key=api)
+        self.local_dir = local_dir
+        self.library_id = library_id
+        self.folder_id = folder_id
+
+        self.memo_path = {}
+
+    def memoized_path(self, path_parts, base_folder=None):
+        """Get the folder ID for a given folder path specified by path_parts.
+
+        If the folder does not exist, it will be created ONCE (during the
+        instantiation of this Uploader object). After that it is stored and
+        recycled. If the Uploader object is re-created, it is not aware of
+        previously existing paths and will not respect those. TODO: handle
+        existing paths.
+        """
+        if base_folder is None:
+            base_folder = self.folder_id
+        dropped_prefix = []
+
+        fk = '/'.join(path_parts)
+        if fk in self.memo_path:
+            # print "Cache hit %s" % fk
+            return self.memo_path[fk]
+        else:
+            # print "Cache miss %s" % fk
+            for i in reversed(range(len(path_parts))):
+                fk = '/'.join(path_parts[0:i + 1])
+                if fk in self.memo_path:
+                    # print "Parent folder hit %s" % fk
+                    dropped_prefix = path_parts[0:i + 1]
+                    path_parts = path_parts[i + 1:]
+                    base_folder = self.memo_path[fk]
+                    break
+
+        nfk = []
+        for i in range(len(path_parts)):
+            nfk.append('/'.join(list(dropped_prefix) + list(path_parts[0:i + 1])))
+
+        # Recursively create the path from our base_folder starting points,
+        # gettting the IDs of each folder per path component
+        ids = self.recursively_build_path(path_parts, base_folder)
+
+        # These are then associated with the paths.
+        for (key, fid) in zip(nfk, ids):
+            self.memo_path[key] = fid
+        return ids[-1]
+
+    def recursively_build_path(self, path_parts, parent_folder_id, ids=None):
+        """Given an iterable of path components and a parent folder id, recursively
+        create directories below parent_folder_id"""
+        if ids is None:
+            ids = []
+        if len(path_parts) == 0:
+            return ids
+        else:
+            pf = self.gi.libraries.create_folder(self.library_id, path_parts[0], base_folder_id=parent_folder_id)
+            ids.append(pf[0]['id'])
+            # print "create_folder(%s, %s, %s) = %s" % (self.library_id, path_parts[0], parent_folder_id, pf[0]['id'])
+            return self.recursively_build_path(path_parts[1:], pf[0]['id'], ids=ids)
+
+    # http://stackoverflow.com/questions/13505819/python-split-path-recursively/13505966#13505966
+    def rec_split(self, s):
+        rest, tail = os.path.split(s)
+        if tail == '.':
+            return ()
+        if rest == '':
+            return tail,
+        return self.rec_split(rest) + (tail,)
+
+    def file_filter(dirName, fname):
+        bad = [
+            '/x' in dirName,
+            '/x' in fname,
+            fname.startswith('xa'),
+            'CONTIG' in fname,
+            'NODE' in fname,
+        ]
+        if any(bad):
+            return False
+
+        good = [
+            fname.endswith('.fa'),
+            fname.endswith('.fna'),
+            fname.endswith('.fastq'),
+            fname.endswith('.sff'),
+        ]
+
+        return any(good)
+
+    def collect_files(self, rootDir):
+        for dirName, subdirList, fileList in os.walk(rootDir):
+            for fname in fileList:
+                if self.file_filter(dirName, fname):
+                    yield (dirName, fname)
+
+    def upload(self):
+        all_files = list(self.collect_files(self.local_dir))
+
+        for idx, (dirName, fname) in enumerate(all_files):
+            if idx < 35:
+                continue
+            if not os.path.exists(os.path.join(dirName, fname)):
+                continue
+            fid = self.memoized_path(self.rec_split(dirName), base_folder=self.folder_id)
+            print('[%s/%s] %s/%s' % (idx, len(all_files), fid, fname))
+            print self.gi.libraries.upload_file_from_local_path(
+                self.library_id,
+                os.path.join(dirName, fname),
+                folder_id=fid,
+            )
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Upload a directory into a data library')
+    parser.add_argument( "-u", "--url", dest="uri", required=True, help="Galaxy URL" )
+    parser.add_argument( "-a", "--api", dest="api", required=True, help="API Key" )
+
+    parser.add_argument( "-d", "--dir", dest="local_dir", required=True, help="Local directory" )
+    parser.add_argument( "-l", "--lib", dest="library_id", required=True, help="Library ID" )
+    parser.add_argument( "-f", "--folder", dest="folder_id", help="Folder ID. If not specified, will go to root of library." )
+    args = parser.parse_args()
+
+    u = Uploader(**vars(args))
+    u.upload()

--- a/scripts/api/library_upload_dir.py
+++ b/scripts/api/library_upload_dir.py
@@ -7,10 +7,11 @@ from bioblend import galaxy
 
 class Uploader:
 
-    def __init__(self, url, api, library_id, folder_id):
+    def __init__(self, url, api, library_id, folder_id, should_link):
         self.gi = galaxy.GalaxyInstance(url=url, key=api)
         self.library_id = library_id
         self.folder_id = folder_id
+        self.should_link
 
         self.memo_path = {}
 
@@ -91,6 +92,7 @@ class Uploader:
                 self.library_id,
                 os.path.join(dirName, fname),
                 folder_id=fid,
+                link_data_only=self.should_link,
             )
 
 
@@ -101,6 +103,8 @@ if __name__ == '__main__':
 
     parser.add_argument( "-l", "--lib", dest="library_id", required=True, help="Library ID" )
     parser.add_argument( "-f", "--folder", dest="folder_id", help="Folder ID. If not specified, will go to root of library." )
+
+    parser.add_argument( "--link", dest="should_link", action="store_true", default=False, help="Link datasets only, do not upload to Galaxy.")
     args = parser.parse_args()
 
     u = Uploader(**vars(args))

--- a/scripts/api/library_upload_dir.py
+++ b/scripts/api/library_upload_dir.py
@@ -78,7 +78,7 @@ class Uploader:
         return self.rec_split(rest) + (tail,)
 
     def upload(self):
-        all_files = list(sys.stdin.readlines())
+        all_files = [x.strip() for x in list(sys.stdin.readlines())]
 
         for idx, (dirName, fname) in enumerate(all_files):
             if idx < 35:

--- a/scripts/api/library_upload_dir.py
+++ b/scripts/api/library_upload_dir.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import sys
 import argparse
 import os
 from bioblend import galaxy
@@ -6,9 +7,8 @@ from bioblend import galaxy
 
 class Uploader:
 
-    def __init__(self, url, api, local_dir, library_id, folder_id):
+    def __init__(self, url, api, library_id, folder_id):
         self.gi = galaxy.GalaxyInstance(url=url, key=api)
-        self.local_dir = local_dir
         self.library_id = library_id
         self.folder_id = folder_id
 
@@ -77,34 +77,8 @@ class Uploader:
             return tail,
         return self.rec_split(rest) + (tail,)
 
-    def file_filter(dirName, fname):
-        bad = [
-            '/x' in dirName,
-            '/x' in fname,
-            fname.startswith('xa'),
-            'CONTIG' in fname,
-            'NODE' in fname,
-        ]
-        if any(bad):
-            return False
-
-        good = [
-            fname.endswith('.fa'),
-            fname.endswith('.fna'),
-            fname.endswith('.fastq'),
-            fname.endswith('.sff'),
-        ]
-
-        return any(good)
-
-    def collect_files(self, rootDir):
-        for dirName, subdirList, fileList in os.walk(rootDir):
-            for fname in fileList:
-                if self.file_filter(dirName, fname):
-                    yield (dirName, fname)
-
     def upload(self):
-        all_files = list(self.collect_files(self.local_dir))
+        all_files = list(sys.stdin.readlines())
 
         for idx, (dirName, fname) in enumerate(all_files):
             if idx < 35:
@@ -122,10 +96,9 @@ class Uploader:
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Upload a directory into a data library')
-    parser.add_argument( "-u", "--url", dest="uri", required=True, help="Galaxy URL" )
+    parser.add_argument( "-u", "--url", dest="url", required=True, help="Galaxy URL" )
     parser.add_argument( "-a", "--api", dest="api", required=True, help="API Key" )
 
-    parser.add_argument( "-d", "--dir", dest="local_dir", required=True, help="Local directory" )
     parser.add_argument( "-l", "--lib", dest="library_id", required=True, help="Library ID" )
     parser.add_argument( "-f", "--folder", dest="folder_id", help="Folder ID. If not specified, will go to root of library." )
     args = parser.parse_args()


### PR DESCRIPTION
This PR adds a little utility script that lets you pipe the output of a find command to a library upload. It should make admins' lives easier. It is also documented in the "Special Topics in Galaxy Administration" section I added in a previous PR this month.

``` console
$ find `pwd` -name '*.fastq' -or -name '*.fasta' | \
  python library_upload_dir.py -u $URL -a $API_KEY  -l $LIBRARY_ID --nonlocal
```

will upload all of files named fasta or fastq. It's admittedly similar to running the find command and pasting into the "add datasets to library" dialog in "Data Libraries (beta)", except that:
- this script actually preserves directory structure (TODO: file a bug on that)
- is scriptable
- handles uploading data, rather than requiring it be in history for non-admin users to add to a data library.
