### PR TITLE
[15.10] IE11 history-stuck fix

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1512,6 +1512,8 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
     @web.json
     def set_as_current( self, trans, id ):
         """Change the current user's current history to one with `id`."""
+        # Prevent IE11 from caching this, since we actually use it via GET.
+        trans.response.headers[ 'Cache-Control' ] = ["max-age=0", "no-cache", "no-store"]
         try:
             history = self.history_manager.get_owned( self.decode_id( id ), trans.user, current_history=trans.history )
             trans.set_history( history )
@@ -1523,6 +1525,8 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
     @web.json
     def current_history_json( self, trans ):
         """Return the current user's current history in a serialized, dictionary form."""
+        # Prevent IE11 from caching this
+        trans.response.headers[ 'Cache-Control' ] = ["max-age=0", "no-cache", "no-store"]
         history = trans.get_history( create=True )
         return self.history_serializer.serialize_to_view( history, view='detailed', user=trans.user, trans=trans )
 


### PR DESCRIPTION
Fixes for switching history (standard as well as multiview) when using IE11.  This is an intentionally minimal fix for 15.10, with more comprehensive refactoring+solution forthcoming for dev.
