### PR TITLE
common_startup.sh fixes for run_tests.sh --dockerize and wheels

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,8 +3,6 @@
 pwd_dir=$(pwd)
 cd `dirname $0`
 
-./scripts/common_startup.sh
-
 # A good place to look for nose info: http://somethingaboutorange.com/mrl/projects/nose/
 rm -f run_functional_tests.log
 
@@ -286,6 +284,12 @@ do
           watch=1
           shift
           ;;
+      --skip-common-startup)
+          # Don't run ./scripts/common_startup.sh (presumably it has already
+          # been done, or you know what you're doing).
+          skip_common_startup=1
+          shift
+          ;;
       --) 
           shift
           break
@@ -300,6 +304,10 @@ do
           ;;
     esac
 done
+
+if [ -z "$skip_common_startup" ]; then
+    ./scripts/common_startup.sh
+fi
 
 if [ -n "$migrated_test" ] ; then
     [ -n "$test_id" ] && class=":TestForTool_$test_id" || class=""

--- a/test/docker/base/run_test_wrapper.sh
+++ b/test/docker/base/run_test_wrapper.sh
@@ -24,11 +24,13 @@ cd /galaxy
 GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION="$GALAXY_TEST_DBURI";
 export GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
 
+[ ! -d .venv ] && ./scripts/common_startup.sh
+
 sh manage_db.sh upgrade
 
 if [ -z "$GALAXY_NO_TESTS" ];
 then
-    sh run_tests.sh $@
+    sh run_tests.sh --skip-common-startup $@
 else
     GALAXY_CONFIG_MASTER_API_KEY=${GALAXY_CONFIG_MASTER_API_KEY:-"testmasterapikey"}
     GALAXY_CONFIG_FILE=${GALAXY_CONFIG_FILE:-config/galaxy.ini.sample}


### PR DESCRIPTION
Run ./scripts/common_startup.sh inside docker when using `run_tests.sh --dockerize`. Requires a rebuild of galaxy/base-testing.

Note this would be relevant even without wheels, since running common_startup.sh outside docker could install the wrong versions of eggs if the docker base image != the OS on which you are running. But since with wheels, common_startup.sh will create a virtualenv, this is even more necessary.

Necessary for tests to run on #428 (and anything else once #428 is
merged).
