### PR TITLE
Tools don't start with <tool_dependencies

### DIFF
--- a/lib/galaxy/tools/loader_directory.py
+++ b/lib/galaxy/tools/loader_directory.py
@@ -40,7 +40,7 @@ def __looks_like_a_tool(path):
                 line = f.next()
             except StopIteration:
                 break
-            if "<tool" in line:
+            if "<tool " in line:
                 return True
     return False
 


### PR DESCRIPTION
Tools start with `'<tool '` not `'<tool'`.

Please review **thoroughly** as I feel like this is an extremely important bit of code and if this change is incorrect, it could be pretty unpleasant for people. This one character change ensures that the only things picked up by `__looks_like_a_tool` are actually tools and not `tool_dependencies.xml` files which also have `<tool` in them.

This will fix https://github.com/galaxyproject/planemo/issues/313 as soon as planemo inherits this.
