### PR TITLE
Add BIOM v1 in default datatypes.

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -423,6 +423,8 @@
     <datatype extension="plybinary" type="galaxy.datatypes.constructive_solid_geometry:PlyBinary" display_in_upload="true" />
     <datatype extension="vtkascii" type="galaxy.datatypes.constructive_solid_geometry:VtkAscii" display_in_upload="true" />
     <datatype extension="vtkbinary" type="galaxy.datatypes.constructive_solid_geometry:VtkBinary" display_in_upload="true" />
+    <!-- Metagenomic Datatype -->
+    <datatype extension="biom1" type="galaxy.datatypes.text:Biom1" display_in_upload="True" subclass="True" mimetype="application/json" />
   </registration>
   <sniffers>
     <!--
@@ -483,6 +485,7 @@
     <sniffer type="galaxy.datatypes.text:Obo"/>
     <sniffer type="galaxy.datatypes.text:Arff"/>
     <sniffer type="galaxy.datatypes.text:Ipynb"/>
+    <sniffer type="galaxy.datatypes.text:Biom1"/>
     <sniffer type="galaxy.datatypes.text:Json"/>
     <sniffer type="galaxy.datatypes.sequence:RNADotPlotMatrix"/>
     <sniffer type="galaxy.datatypes.sequence:DotBracket"/>


### PR DESCRIPTION
Hi,

In metagenomics the standard format for representing biological samples by observation contingency tables is the format BIOM (http://biom-format.org/).
### Implementation

The BIOM exist in 2 main versions v1 (JSON) and v2 (HDF5). Some softwares accept only the v1, others accept only the v2, others accept every version of BIOM. This pull request implements the v1: Biom1.
Note: to reduce the memory footprint in datatype evaluation the sniffer evaluates only the filles with a size <100MB. Unfortunately for files with size >= 100MB, the solutions with reading by block are too slow.
### Test

To test this change you can use the examples files in http://biom-format.org/documentation/format_versions/biom-1.0.html with tool Upload File.
