### PR TITLE
fix the docker db client_encoding to not be ascii (default)

### DIFF
--- a/test/docker/base/run_test_wrapper.sh
+++ b/test/docker/base/run_test_wrapper.sh
@@ -6,7 +6,7 @@ if [ "$GALAXY_TEST_DATABASE_TYPE" = "postgres" ];
 then
     su -c '/usr/lib/postgresql/9.3/bin/pg_ctl -o "-F" start -D /opt/galaxy/db' postgres
     sleep 3
-    GALAXY_TEST_DBURI="postgres://root@localhost:5930/galaxy"
+    GALAXY_TEST_DBURI="postgres://root@localhost:5930/galaxy?client_encoding=utf8"
 elif [ "$GALAXY_TEST_DATABASE_TYPE" = "mysql" ];
 then
     sh /opt/galaxy/start_mysql.sh


### PR DESCRIPTION
this should help with 
https://jenkins.galaxyproject.org/job/docker-casperjs/111/testReport/casperjs_runner/Test_05_API/test_00_history_api/
according to: http://stackoverflow.com/questions/14783505/encoding-error-with-sqlalchemy-and-postgresql

ping @carlfeberhard 
