### PR TITLE
Improvements and fixes for abstract tool interface

### DIFF
--- a/lib/galaxy/tools/parser/interface.py
+++ b/lib/galaxy/tools/parser/interface.py
@@ -207,7 +207,7 @@ class InputSource(object):
         return self.get("label")
 
     def parse_help(self):
-        return self.get("label")
+        return self.get("help")
 
     def parse_sanitizer_elem(self):
         """ Return an XML description of sanitizers. This is a stop gap

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -251,6 +251,16 @@ class YamlInputSource(InputSource):
             sources.append((value, case_page_source))
         return sources
 
+    def parse_static_options(self):
+        static_options = list()
+        input_dict = self.input_dict
+        for index, option in enumerate(input_dict.get("options", {})):
+            value = option.get( "value" )
+            label = option.get( "label", value )
+            selected = option.get( "selected", False )
+            static_options.append( ( label, value, selected ) )
+        return static_options
+
 
 def _ensure_has(dict, defaults):
     for key, value in defaults.iteritems():

--- a/test/functional/tools/simple_constructs.yml
+++ b/test/functional/tools/simple_constructs.yml
@@ -7,6 +7,9 @@ command:
     echo "$inttest"   >> $out_file1;
     echo "$floattest" >> $out_file1;
     cat "$simp_file"   >> $out_file1;
+    echo "$drop_select"  >> $out_file1;
+    echo "$radio_select" >> $out_file1;
+    echo "$check_select" >> $out_file1;
     cat "$more_files[0].nestinput"   >> $out_file1;
     echo "$p1.p1val"  >> $out_file1;
 inputs:
@@ -23,6 +26,39 @@ inputs:
   value: 1.0
 - name: simp_file
   type: data
+- name: drop_select
+  type: select
+  options:
+    - value: a_drop
+      selected: true
+      label: A Drop
+    - value: b_drop
+      label: B Drop
+    - value: c_drop
+      label: C Drop
+- name: radio_select
+  type: select
+  display: radio
+  options:
+    - value: a_radio
+      label: A Radio
+      selected: true
+    - value: b_radio
+      label: B Radio
+    - value: c_radio
+      label: C Radio
+- name: check_select
+  display: checkboxes
+  type: select
+  multiple: true
+  options:
+    - value: a_check
+      selected: true
+      label: A Check
+    - value: b_check
+      label: B Check
+    - value: c_check
+      label: C Check
 - name: more_files
   label: "More Files"
   type: repeat
@@ -70,6 +106,21 @@ tests:
           line: "This is a different line of text."
         has_line:
           line: p1used
+        has_line:
+          line: a_drop
+        has_line:
+          line: a_check
+        has_line:
+          line: a_radio
+- inputs:
+    simp_file: simple_line.txt
+    nestinput: simple_line_alternative.txt
+    check_select: "a_check,b_check"
+  outputs:
+    out_file1:
+      asserts:
+        has_line:
+          line: "a_check,b_check"
 - inputs:
     simp_file: simple_line.txt
     nestinput: simple_line_alternative.txt


### PR DESCRIPTION
- 24dba3b - Fixes a small bug in the abstract interface for tool parsing.
- 652bd0f - Enhances the abstract dictionary implementation (exposed via YAML tools for testing) to allow `select` parameters.

From 652bd0f:

"This doesn't represent official support of (vastly superior) YAML tools, this representation continues to serve as an easy way to exercise the abstract tool parsing interface."

Test:

```
./run_tests.sh -framework -id simple_constructs_y
```
