### PR TITLE
S3ObjectStore followup fix 

### DIFF
--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -44,7 +44,7 @@ class S3ObjectStore(ObjectStore):
     def __init__(self, config, config_xml):
         if boto is None:
             raise Exception(NO_BOTO_ERROR_MESSAGE)
-        super(S3ObjectStore, self).__init__(config, config_xml)
+        super(S3ObjectStore, self).__init__(config)
         self.staging_path = self.config.file_path
         self.transfer_progress = 0
         self._parse_config_xml(config_xml)


### PR DESCRIPTION
This removes the historical, now unused config_xml from S3ObjectStore's ObjectStore initialization, and fixes the S3ObjectStore.
