### PR TITLE
[15.10] Fix endless redirect cycle when login is required

### DIFF
--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -492,7 +492,7 @@ class GalaxyWebTransaction( base.DefaultWebTransaction,
                 except IndexError:
                     pass
             if self.request.path not in allowed_paths:
-                self.response.send_redirect( url_for( controller='root', action='index' ) )
+                self.response.send_redirect( url_for( controller='user', action='login' ) )
 
     def __create_new_session( self, prev_galaxy_session=None, user_for_new_session=None ):
         """


### PR DESCRIPTION
For require_login=True, redirect directly to login without showing empty (and broken) looking panels, and potentially hitting an endless reload cycle.

ping @guerler @erasche @bgruening 
