### PR TITLE
Fix base panels to include scripts as the last element of the body,

### DIFF
--- a/templates/base/base_panels.mako
+++ b/templates/base/base_panels.mako
@@ -253,8 +253,8 @@
             %endif
         </div><!--end everything-->
         ## Allow other body level elements
+        ## Scripts can be loaded later since they progressively add features to
+        ## the panels, but do not change layout
+        ${self.late_javascripts()}
     </body>
-    ## Scripts can be loaded later since they progressively add features to
-    ## the panels, but do not change layout
-    ${self.late_javascripts()}
 </html>


### PR DESCRIPTION
instead of after the body closing (which is not valid HTML).  Resolves a
scary IE message.  This could probably be swapped to async/defer as
appropriate.
