### PR TITLE
Do not attempt to read the `load` attribute of job runner plugins that do not have a `load` attribute.

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -25,7 +25,7 @@ class ConditionalDependencies( object ):
             "job_config_file",
             join( dirname( self.config_file ), 'job_conf.xml' ) )
         try:
-            for plugin in ElementTree.parse( job_conf_xml ).find( 'plugins' ):
+            for plugin in ElementTree.parse( job_conf_xml ).findall( './plugins/plugin[@load]' ):
                 self.job_runners.append( plugin.attrib['load'] )
         except (OSError, IOError):
             pass


### PR DESCRIPTION
`load` is an optional attrib on the <plugin> tag in job_conf.xml, used by the dynamic runner (which is always/automatically loaded) to pass plugin params. Galaxy servers using a `load`-less plugin will fail to start if using `run.sh` (or the updated `galaxy` Ansible role) without this fix.
