### PR TITLE
Add a --dev-wheels arg to common_startup.sh

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -1,3 +1,4 @@
 nose
 NoseHTML
 twill==0.9.1
+mock

--- a/run.sh
+++ b/run.sh
@@ -18,7 +18,7 @@ fi
 while :
 do
     case "$1" in
-        --skip-eggs|--skip-wheels|--skip-samples)
+        --skip-eggs|--skip-wheels|--skip-samples|--dev-wheels)
             common_startup_args="$common_startup_args $1"
             shift
             ;;

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -313,7 +313,7 @@ do
 done
 
 if [ -z "$skip_common_startup" ]; then
-    ./scripts/common_startup.sh $skip_venv
+    ./scripts/common_startup.sh $skip_venv --dev-wheels || exit 1
 fi
 
 if [ -z "$skip_venv" -a -d .venv ];


### PR DESCRIPTION
As pointed out by @nsoranzo, tests will fail to run by default if the things in dev-requirements.txt were not installed by hand (or by tox/docker testing-base).
