### PR TITLE
Add a script for creating binary-compatibility.cfg and run it from common_startup.sh

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -62,7 +62,7 @@ class ConditionalDependencies( object ):
         return asbool( self.config["fluent_log"] )
 
     def check_raven( self ):
-        return asbool( self.config["sentry_dsn"] )
+        return self.config.get("sentry_dsn", None) is not None
 
     def check_weberror( self ):
         return ( asbool( self.config["debug"] ) and

--- a/scripts/binary_compatibility.py
+++ b/scripts/binary_compatibility.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""
+Creates a Python binary-compatibility.cfg as described here:
+
+    https://mail.python.org/pipermail/distutils-sig/2015-July/026617.html
+"""
+from __future__ import print_function
+
+# Vaguely Python 2.6 compatibile ArgumentParser import
+try:
+    from argparse import ArgumentParser
+except ImportError:
+    from optparse import OptionParser
+
+    class ArgumentParser(OptionParser):
+
+        def __init__(self, **kwargs):
+            self.delegate = OptionParser(**kwargs)
+
+        def add_argument(self, *args, **kwargs):
+            if "required" in kwargs:
+                del kwargs["required"]
+            return self.delegate.add_option(*args, **kwargs)
+
+        def parse_args(self, args=None):
+            (options, args) = self.delegate.parse_args(args)
+            return options
+
+import sys
+import json
+
+from pip.pep425tags import get_platform, get_supported
+from pip.platform import get_specific_platform
+
+
+compatible_platforms = {
+    'centos': 'rhel'
+}
+
+
+def install_compat():
+    this_plat = get_specific_platform()[0]
+    compat_plat = compatible_platforms.get(this_plat, None)
+    rval = {}
+    if compat_plat:
+        print('{} is binary compatible with {} (and can install {} wheels)'
+              .format(this_plat, compat_plat, compat_plat),
+              file=sys.stderr)
+        for py, abi, plat in get_supported():
+            if this_plat in plat:
+                rval[plat] = {'install': [plat.replace(this_plat, compat_plat)]}
+    return rval
+
+
+def main():
+    arg_parser = ArgumentParser()
+    arg_parser.add_argument('-o', '--output', default=None, help='Output to file')
+    args = arg_parser.parse_args()
+
+    compat = install_compat()
+
+    if compat:
+        if args.output is not None:
+            with open(args.output, 'w') as out:
+                json.dump(compat, out)
+        else:
+            print(json.dumps(install_compat()))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -106,6 +106,8 @@ if [ $FETCH_WHEELS -eq 1 ]; then
     # venv (e.g. virtualenv-burrito's pip and six)
     unset PYTHONPATH
     pip install --pre --no-index --find-links ${GALAXY_WHEELS_INDEX_URL}/pip --upgrade pip
+    # binary-compatibility.cfg may need to be created (e.g. on CentOS)
+    [ ! -f ${VIRTUAL_ENV}/binary-compatibility.cfg ] && python ./scripts/binary_compatibility.py -o ${VIRTUAL_ENV}/binary-compatibility.cfg
     pip install -r requirements.txt --index-url ${GALAXY_WHEELS_INDEX_URL}
     GALAXY_CONDITIONAL_DEPENDENCIES=`PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))"`
     [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url ${GALAXY_WHEELS_INDEX_URL}


### PR DESCRIPTION
[Context is here](https://mail.python.org/pipermail/distutils-sig/2015-July/026617.html).

This allows CentOS to install RHEL wheels from wheels.galaxyproject.org since they are binary compatible. Annoyingly, this will take some maintenance by hand, but hopefully there are not many platforms like this out there.
