### PR TITLE
binary_compatibility.py shouldn't fail

### DIFF
--- a/scripts/binary_compatibility.py
+++ b/scripts/binary_compatibility.py
@@ -29,7 +29,7 @@ except ImportError:
 import sys
 import json
 
-from pip.pep425tags import get_platform, get_supported
+from pip.pep425tags import get_supported
 from pip.platform import get_specific_platform
 
 
@@ -39,7 +39,10 @@ compatible_platforms = {
 
 
 def install_compat():
-    this_plat = get_specific_platform()[0]
+    spec_plat = get_specific_platform()
+    if spec_plat is None:
+        return None
+    this_plat = spec_plat[0]
     compat_plat = compatible_platforms.get(this_plat, None)
     rval = {}
     if compat_plat:


### PR DESCRIPTION
...on platforms that don't return anything for get_specific_platform() (e.g. things other than Linux).

As a consequence of this bug, Galaxy will probably not start (if using `run.sh`) on anything other than Linux in the dev branch.
