### PR TITLE
[15.10] Fix Remote User failures due to apache null headers.

### DIFF
--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -397,9 +397,10 @@ class GalaxyWebTransaction( base.DefaultWebTransaction,
                     # No user, associate
                     galaxy_session.user = self.get_or_create_remote_user( remote_user_email )
                     galaxy_session_requires_flush = True
-                elif ((galaxy_session.user.email != remote_user_email) and
+                elif (not remote_user_email.startswith('(null)') and  # Apache does this, see remoteuser.py
+                      (galaxy_session.user.email != remote_user_email) and
                       ((not self.app.config.allow_user_impersonation) or
-                      (remote_user_email not in self.app.config.admin_users_list))):
+                       (remote_user_email not in self.app.config.admin_users_list))):
                     # Session exists but is not associated with the correct
                     # remote user, and the currently set remote_user is not a
                     # potentially impersonating admin.


### PR DESCRIPTION
Ping @hrhotz, this should fix it up for you.

@erasche Were you having a problem with this as well?
