### PR TITLE
Add 2 missing dependencies of dependencies

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -26,8 +26,9 @@ class ConditionalDependencies( object ):
             "job_config_file",
             join( dirname( self.config_file ), 'job_conf.xml' ) )
         try:
-            for plugin in ElementTree.parse( job_conf_xml ).findall( './plugins/plugin[@load]' ):
-                self.job_runners.append( plugin.attrib['load'] )
+            for plugin in ElementTree.parse( job_conf_xml ).find( 'plugins' ).findall( 'plugin' ):
+                if 'load' in plugin.attrib:
+                    self.job_runners.append( plugin.attrib['load'] )
         except (OSError, IOError):
             pass
 

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -3,6 +3,7 @@ Determine what optional dependencies are needed.
 """
 import pkg_resources
 
+from sys import version_info
 from os.path import dirname, join
 from xml.etree import ElementTree
 
@@ -67,6 +68,12 @@ class ConditionalDependencies( object ):
     def check_weberror( self ):
         return ( asbool( self.config["debug"] ) and
                  asbool( self.config["use_interactive"] ) )
+
+    def check_importlib( self ):
+        return version_info < (2, 7)
+
+    def check_ordereddict( self ):
+        return version_info < (2, 7)
 
 
 def optional( config_file ):

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -1,6 +1,8 @@
 # These dependencies are only required when certain config options are set
 psycopg2==2.6.1
 WebError==0.11
+importlib==1.0.3
+ordereddict==1.1
 python-openid
 MySQL-python
 fluent-logger

--- a/lib/galaxy/dependencies/requirements.txt
+++ b/lib/galaxy/dependencies/requirements.txt
@@ -1,5 +1,4 @@
 # packages with C extensions
-Cheetah==2.4.4
 bx-python==0.7.3
 MarkupSafe==0.23
 PyYAML==3.11
@@ -26,10 +25,15 @@ pytz==2015.4
 Babel==2.0
 Beaker==1.7.0
 
+# Cheetah and dependencies
+Cheetah==2.4.4
+Markdown==2.6.3
+
 # BioBlend and dependencies
 bioblend==0.6.1
 boto==2.38.0
 requests==2.8.1
+requests-toolbelt==0.4.0
 
 # WebError and dependences
 WebError==0.11


### PR DESCRIPTION
As a nice benefit of using nearly standard tooling, Galaxy still started fine without these being explicitly defined and placed out on the wheels server. Previously the `requests-toolbelt` wheel would be downloaded from PyPI, and the `Markdown` sdist (which is also pure Python but only has an sdist in PyPI) would be pulled from PyPI and built/installed by pip.
