### PR TITLE
Two Small Tweaks from CWL Branch

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -69,6 +69,13 @@ fi
 
 python ./scripts/check_python.py || exit 1
 
+if [ ! -z "$GALAXY_RUN_WITH_TEST_TOOLS" ];
+then
+    export GALAXY_CONFIG_OVERRIDE_TOOL_CONFIG_FILE="test/functional/tools/samples_tool_conf.xml"
+    export GALAXY_CONFIG_ENABLE_BETA_WORKFLOW_MODULES="true"
+    export GALAXY_CONFIG_OVERRIDE_ENABLE_BETA_TOOL_FORMATS="true"
+fi
+
 if [ -n "$GALAXY_UNIVERSE_CONFIG_DIR" ]; then
     python ./scripts/build_universe_config.py "$GALAXY_UNIVERSE_CONFIG_DIR"
 fi

--- a/test/api/helpers.py
+++ b/test/api/helpers.py
@@ -83,7 +83,10 @@ class BaseDatasetPopulator( object ):
             raise
 
     def wait_for_job( self, job_id, assert_ok=False, timeout=DEFAULT_TIMEOUT ):
-        return wait_on_state( lambda: self._get( "jobs/%s" % job_id ), assert_ok=assert_ok, timeout=timeout )
+        return wait_on_state( lambda: self.get_job_details( job_id ), assert_ok=assert_ok, timeout=timeout )
+
+    def get_job_details( self, job_id, full=False ):
+        return self._get( "jobs/%s?full=%s" % (job_id, full) )
 
     def _summarize_history_errors( self, history_id ):
         pass


### PR DESCRIPTION
- Set `GALAXY_RUN_WITH_TEST_TOOLS` prior to `run.sh` to enable test tools, making it easier than ever to pop up a Galaxy environment with the test tools loaded. (Previous instructions in https://github.com/galaxyproject/galaxy/tree/dev/test/functional/tools/README.txt involved modifying config files).
- Small refactoring of test utilities for greater generality and reuse.
