### PR TITLE
[PROCEDURES] Allow changes to Procedures PRs

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -111,7 +111,7 @@ Pull requests changing or clarifying the procedures governing this repository:
 - If the pull request adds or removes *committers*, there must be a separate
   pull request for each person added or removed.
 - Amendments may be made to the pull request by pushing additional changesets
-  but doing so restarts the moratorium and invalidates any votes which have
+  but doing so restarts the moratorium and invalidates any +1 votes which have
   already been cast, *requiring* reaffirmation of those votes prior to merge.
 
 Any other pull request requires at least 1 *+1* binding vote from someone other

--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -106,12 +106,13 @@ Pull requests changing or clarifying the procedures governing this repository:
   *-1* binding votes.
 - Should be titled with the prefix *[PROCEDURES]* and tagged with
   the *procedures* tag in Github.
-- Should not be modified once open. If changes are needed, the pull request
-  should be closed, re-opened with modifications, and votes reset.
 - Should be restricted to just modifying the procedures and generally should not
   contain code modifications.
 - If the pull request adds or removes *committers*, there must be a separate
   pull request for each person added or removed.
+- Amendments may be made to the pull request by pushing additional changesets
+  but doing so restarts the moratorium and invalidates any votes which have
+  already been cast, *requiring* reaffirmation of those votes prior to merge.
 
 Any other pull request requires at least 1 *+1* binding vote from someone other
 than the author of the pull request. A member of the *committers* group merging

--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -110,9 +110,10 @@ Pull requests changing or clarifying the procedures governing this repository:
   contain code modifications.
 - If the pull request adds or removes *committers*, there must be a separate
   pull request for each person added or removed.
-- Amendments may be made to the pull request by pushing additional changesets
-  but doing so restarts the moratorium and invalidates any +1 votes which have
-  already been cast, *requiring* reaffirmation of those votes prior to merge.
+- Amendments may be made to the pull request only by pushing additional
+  changesets (not via rebase), but doing so restarts the moratorium and
+  invalidates any +1 votes which have already been cast, *requiring*
+  reaffirmation of those votes prior to merge.
 
 Any other pull request requires at least 1 *+1* binding vote from someone other
 than the author of the pull request. A member of the *committers* group merging


### PR DESCRIPTION
Re-open for voting (for hopefully the last time ever, closing and re-opening), of #1022 

Allows changes to Procedures PRs (in lieu of close/reopen) with 2 conditions -- this resets the merge moratorium and invalidates any +1 votes already cast.

I included language specifying that changes should be in the form of additional changesets (so, not a rebase) so we retain the history of any dialog that took place.

The intent here is to avoid things like #974, which had minor tweaks, waited for almost two weeks, and then had to be reopened as #1020.
