### PR TITLE
Added gitignore rules to ignore custom tool-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ tool-data/shared/ucsc/ucsc_build_sites.txt
 tool-data/*.loc
 tool-data/genome/*
 tool-data/*.sample
+tool-data/testtoolshed.g2.bx.psu.edu/
+tool-data/toolshed.g2.bx.psu.edu/
+
 
 # Test output
 test-data-cache
@@ -120,4 +123,3 @@ doc/build
 .DS_Store
 *.rej
 *~
-


### PR DESCRIPTION
After installing tools with custom tool-data from the tool sheds (e.g. gatk2, rgrnastar), the corresponding tool data will be stored in a tool shed specific directory: `<galaxy_root>/tool-data/<tool_shed>/`. Git and hg consider these directories as changes with respect to the galaxy repo. This PR adds 2 rules to .gitignore to solve this.
