### PR TITLE
[15.10] Testing: update casperjs functional tests; change expected size strin…

### DIFF
--- a/test/casperjs/anon-history-tests.js
+++ b/test/casperjs/anon-history-tests.js
@@ -40,7 +40,7 @@ spaceghost.test.begin( 'Testing histories for anonymous users', 0, function suit
         this.test.assertVisible( nameSelector, 'History name is visible' );
         this.test.assertSelectorHasText( nameSelector, unnamedName, 'History name is ' + unnamedName );
 
-        this.test.comment( "history should display size and size should be 0 bytes" );
+        this.test.comment( "history should display size and size should be " + initialSizeStr );
         this.test.assertExists( sizeSelector, 'Found ' + sizeSelector );
         this.test.assertVisible( sizeSelector, 'History size is visible' );
         this.test.assertSelectorHasText( sizeSelector, initialSizeStr,

--- a/test/casperjs/api-hda-tests.js
+++ b/test/casperjs/api-hda-tests.js
@@ -124,7 +124,7 @@ spaceghost.test.begin( 'Test the HDA API', 0, function suite( test ){
         //this.test.comment( 'update should sanitize any new name' );
 
         this.test.comment( 'update should allow unicode in names' );
-        var unicodeName = 'Ржевский сапоги';
+        var unicodeName = 'ржевский сапоги';
         returned = this.api.hdas.update( lastHistory.id, firstHda.id, {
             name : unicodeName
         });

--- a/test/casperjs/api-history-tests.js
+++ b/test/casperjs/api-history-tests.js
@@ -37,7 +37,7 @@ spaceghost.openHomePage().then( function(){
     var historyShow = this.api.histories.show( firstHistory.id );
     //this.debug( this.jsonStr( historyShow ) );
     this.test.assert( this.hasKeys( historyShow, [
-            'id', 'name', 'annotation', 'nice_size', 'contents_url',
+            'id', 'name', 'annotation', 'size', 'contents_url',
             'state', 'state_details', 'state_ids' ]),
         'Has the proper keys' );
 

--- a/test/casperjs/hda-state-tests.js
+++ b/test/casperjs/hda-state-tests.js
@@ -173,8 +173,8 @@ spaceghost.test.begin( 'Test the form of various HDA states', 0, function suite(
         // different states, datatypes will have different action buttons
         testIconButton.call( this, hdaDbId, buttonsSelector, 'info',
             this.historypanel.data.hdaPrimaryActionButtons.info );
-        testIconButton.call( this, hdaDbId, buttonsSelector, 'rerun',
-            this.historypanel.data.hdaPrimaryActionButtons.rerun );
+        // testIconButton.call( this, hdaDbId, buttonsSelector, 'rerun',
+        //     this.historypanel.data.hdaPrimaryActionButtons.rerun );
 
         //TODO: move to testDownloadButton as its own step
         if( !expectedMetadataFiles ){

--- a/test/casperjs/history-panel-tests.js
+++ b/test/casperjs/history-panel-tests.js
@@ -33,12 +33,13 @@ spaceghost.test.begin( 'Testing the form of the main/current history panel', 0, 
         annoIconSelector = spaceghost.historypanel.data.selectors.history.annoIcon,
         emptyMsgSelector = spaceghost.historypanel.data.selectors.history.emptyMsg,
         emptyMsgStr      = spaceghost.historypanel.data.text.history.emptyMsg,
-        tagAreaSelector     = spaceghost.historypanel.data.selectors.history.tagArea,
-        annoAreaSelector    = spaceghost.historypanel.data.selectors.history.annoArea,
+        tagAreaSelector  = spaceghost.historypanel.data.selectors.history.tagArea,
+        annoAreaSelector = spaceghost.historypanel.data.selectors.history.annoArea,
         nameTooltip      = spaceghost.historypanel.data.text.history.tooltips.name,
 
         refreshButtonSelector       = 'a#history-refresh-button',
-        refreshButtonIconSelector   = 'span.fa-refresh';
+        refreshButtonIconSelector   = 'span.fa-refresh',
+        bytesString = 'b';
 
     // local
     var newHistoryName = "Test History",
@@ -145,8 +146,8 @@ spaceghost.test.begin( 'Testing the form of the main/current history panel', 0, 
         this.test.assertSelectorHasText( nameSelector, newHistoryName, 'History name is ' + newHistoryName );
 
         var onetxtFilesize = require( 'fs' ).size( filepathToUpload ),
-            expectedSize = onetxtFilesize + ' bytes';
-        this.test.comment( "history should display size and size should be " + onetxtFilesize + " bytes" );
+            expectedSize = onetxtFilesize + ' ' + bytesString;
+        this.test.comment( "history should display size and size should be " + onetxtFilesize + " " + bytesString );
         this.test.assertExists( sizeSelector, 'Found ' + sizeSelector );
         this.test.assertVisible( sizeSelector, 'History size is visible' );
         this.test.assertSelectorHasText( sizeSelector, expectedSize,

--- a/test/casperjs/modules/historypanel.js
+++ b/test/casperjs/modules/historypanel.js
@@ -414,7 +414,7 @@ HistoryPanel.prototype.data = {
                 annoIcon : 'Edit history annotation'
             },
             newName  : 'Unnamed history',
-            newSize  : '0 bytes',
+            newSize  : '0 b',
             emptyMsg : "This history is empty. You can load your own data or get data from an external source"
         },
         hda : {


### PR DESCRIPTION
…g; remove nice_size from expected history api keys; remove test for rerun button on uploaded dataset; attempt to fix linux+python unicode error in hda api tests

(Back port of #944 to release_15.10).
