### PR TITLE
Fix bug with referer attribute type change in WebOb

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -519,7 +519,7 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
         """ Import another user's dataset via a shared URL; dataset is added to user's current history. """
         # Set referer message.
         referer = trans.request.referer
-        if referer is not "":
+        if referer is not None:
             referer_message = "<a href='%s'>return to the previous page</a>" % escape(referer)
         else:
             referer_message = "<a href='%s'>go to Galaxy's start page</a>" % url_for( '/' )

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -519,7 +519,7 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
         """ Import another user's dataset via a shared URL; dataset is added to user's current history. """
         # Set referer message.
         referer = trans.request.referer
-        if referer is not None:
+        if referer:
             referer_message = "<a href='%s'>return to the previous page</a>" % escape(referer)
         else:
             referer_message = "<a href='%s'>go to Galaxy's start page</a>" % url_for( '/' )

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1322,7 +1322,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
             referer = kwd['referer']
         else:
             referer = trans.request.referer
-        if referer is not None:
+        if referer:
             referer_message = "<a href='%s'>return to the previous page</a>" % escape(referer)
         else:
             referer_message = "<a href='%s'>go to Galaxy's start page</a>" % url_for( '/' )

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1322,7 +1322,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
             referer = kwd['referer']
         else:
             referer = trans.request.referer
-        if referer is not "":
+        if referer is not None:
             referer_message = "<a href='%s'>return to the previous page</a>" % escape(referer)
         else:
             referer_message = "<a href='%s'>go to Galaxy's start page</a>" % url_for( '/' )

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -463,7 +463,8 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
     @web.expose
     def login( self, trans, refresh_frames=[], **kwd ):
         '''Handle Galaxy Log in'''
-        redirect = self.__get_redirect_url( kwd.get( 'redirect', trans.request.referer ).strip() )
+        referer = trans.request.referer or ''
+        redirect = self.__get_redirect_url( kwd.get( 'redirect', referer ).strip() )
         redirect_url = ''  # always start with redirect_url being empty
         use_panels = util.string_as_bool( kwd.get( 'use_panels', False ) )
         message = kwd.get( 'message', '' )
@@ -516,7 +517,8 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
         status = kwd.get( 'status', 'error' )
         login = kwd.get( 'login', '' )
         password = kwd.get( 'password', '' )
-        redirect = kwd.get( 'redirect', trans.request.referer ).strip()
+        referer = trans.request.referer or ''
+        redirect = kwd.get( 'redirect', referer ).strip()
         success = False
         user = trans.sa_session.query( trans.app.model.User ).filter(or_(
             trans.app.model.User.table.c.email == login,
@@ -671,7 +673,8 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
         username = util.restore_text( params.get( 'username', '' ) )
         subscribe = params.get( 'subscribe', '' )
         subscribe_checked = CheckboxField.is_checked( subscribe )
-        redirect = kwd.get( 'redirect', trans.request.referer ).strip()
+        referer = trans.request.referer or ''
+        redirect = kwd.get( 'redirect', referer ).strip()
         is_admin = cntrller == 'admin' and trans.user_is_admin
         if not trans.app.config.allow_user_creation and not trans.user_is_admin():
             message = 'User registration is disabled.  Please contact your local Galaxy administrator for an account.'

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -457,7 +457,7 @@ class VisualizationController( BaseUIController, SharableMixin, UsesVisualizatio
         """ Import a visualization into user's workspace. """
         # Set referer message.
         referer = trans.request.referer
-        if referer is not None:
+        if referer:
             referer_message = "<a href='%s'>return to the previous page</a>" % escape(referer)
         else:
             referer_message = "<a href='%s'>go to Galaxy's start page</a>" % web.url_for( '/' )

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -457,7 +457,7 @@ class VisualizationController( BaseUIController, SharableMixin, UsesVisualizatio
         """ Import a visualization into user's workspace. """
         # Set referer message.
         referer = trans.request.referer
-        if referer is not "":
+        if referer is not None:
             referer_message = "<a href='%s'>return to the previous page</a>" % escape(referer)
         else:
             referer_message = "<a href='%s'>go to Galaxy's start page</a>" % web.url_for( '/' )

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -396,7 +396,7 @@ class WorkflowController( BaseUIController, SharableMixin, UsesStoredWorkflowMix
         """Imports a workflow shared by other users."""
         # Set referer message.
         referer = trans.request.referer
-        if referer is not "":
+        if referer is not None:
             referer_message = "<a href='%s'>return to the previous page</a>" % escape(referer)
         else:
             referer_message = "<a href='%s'>go to Galaxy's start page</a>" % url_for( '/' )

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -396,7 +396,7 @@ class WorkflowController( BaseUIController, SharableMixin, UsesStoredWorkflowMix
         """Imports a workflow shared by other users."""
         # Set referer message.
         referer = trans.request.referer
-        if referer is not None:
+        if referer:
             referer_message = "<a href='%s'>return to the previous page</a>" % escape(referer)
         else:
             referer_message = "<a href='%s'>go to Galaxy's start page</a>" % url_for( '/' )


### PR DESCRIPTION
Newer versions of WebOb set `None` in `referer`, older versions set an empty
string. Handle cases where it is assumed to be a string.

I checked all other `trans.request` attributes to find other cases where
this might crop up and didn't find any.

This is breaking the monitor on Test, which hits `/user/login` without a referer set.
