### PR TITLE
Fix api TS installation

### DIFF
--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -218,7 +218,8 @@ class RepositoriesController( BaseAPIController ):
                 repository_metadata_dict[ 'url' ] = web.url_for( controller='repository_revisions',
                                                                  action='show',
                                                                  id=encoded_repository_metadata_id )
-                repository_metadata_dict[ 'valid_tools' ] = repository_metadata.metadata[ 'tools' ]
+                if 'tools' in repository_metadata.metadata:
+                    repository_metadata_dict[ 'valid_tools' ] = repository_metadata.metadata[ 'tools' ]
                 # Get the repo_info_dict for installing the repository.
                 repo_info_dict, \
                     includes_tools, \


### PR DESCRIPTION
This should fix an installation issue with tool_dependencies via the API.
Tool dependency repositories to not have any tools specified and with this no metadata associated.

It was broken in https://github.com/galaxyproject/galaxy/commit/bb6a784f13ff3f91762244d4488437ffef9e5acf
So I think this should be part of 15.10, ideally.

Thanks to Greg for fixing this one.
