### PR TITLE
Outline "Format 2" workflow definitions.

### DIFF
--- a/test/api/test_workflow_extraction.py
+++ b/test/api/test_workflow_extraction.py
@@ -113,6 +113,7 @@ class WorkflowExtractionApiTestCase( BaseWorkflowsApiTestCase ):
     @skip_without_tool( "collection_paired_test" )
     def test_extract_workflows_with_dataset_collections( self ):
         jobs_summary = self._run_jobs("""
+class: GalaxyWorkflow
 steps:
   - label: text_input1
     type: input_collection
@@ -145,6 +146,7 @@ test_data:
     @skip_without_tool( "cat_collection" )
     def test_subcollection_mapping( self ):
         jobs_summary = self._run_jobs("""
+class: GalaxyWorkflow
 steps:
   - label: text_input1
     type: input_collection
@@ -184,6 +186,7 @@ test_data:
     @skip_without_tool( "collection_split_on_column" )
     def test_extract_workflow_with_output_collections( self ):
         jobs_summary = self._run_jobs("""
+class: GalaxyWorkflow
 steps:
   - label: text_input1
     type: input
@@ -228,6 +231,7 @@ test_data:
     @skip_without_tool( "collection_creates_pair" )
     def test_extract_with_mapped_output_collections( self ):
         jobs_summary = self._run_jobs("""
+class: GalaxyWorkflow
 steps:
   - label: text_input1
     type: input_collection

--- a/test/api/test_workflows_from_yaml.py
+++ b/test/api/test_workflows_from_yaml.py
@@ -9,24 +9,26 @@ class WorkflowsFromYamlApiTestCase( BaseWorkflowsApiTestCase ):
 
     def test_simple_upload(self):
         workflow_id = self._upload_yaml_workflow("""
-- type: input
-- tool_id: cat1
-  state:
-    input1:
-      $link: 0
-- tool_id: cat1
-  state:
-    input1:
-      $link: 1#out_file1
-- tool_id: random_lines1
-  state:
-    num_lines: 10
-    input:
-      $link: 2#out_file1
-    seed_source:
-      seed_source_selector: set_seed
-      seed: asdf
-      __current_case__: 1
+class: GalaxyWorkflow
+steps:
+  - type: input
+  - tool_id: cat1
+    state:
+      input1:
+        $link: 0
+  - tool_id: cat1
+    state:
+      input1:
+        $link: 1#out_file1
+  - tool_id: random_lines1
+    state:
+      num_lines: 10
+      input:
+        $link: 2#out_file1
+      seed_source:
+        seed_source_selector: set_seed
+        seed: asdf
+        __current_case__: 1
 """)
         self._get("workflows/%s/download" % workflow_id).content
 
@@ -58,6 +60,7 @@ class WorkflowsFromYamlApiTestCase( BaseWorkflowsApiTestCase ):
     def test_simple_output_actions( self ):
         history_id = self.dataset_populator.new_history()
         self._run_jobs("""
+class: GalaxyWorkflow
 steps:
   - type: input
     label: input1
@@ -86,52 +89,56 @@ test_data:
 
     def test_pause( self ):
         workflow_id = self._upload_yaml_workflow("""
-- label: test_input
-  type: input
-- label: first_cat
-  tool_id: cat1
-  state:
-    input1:
-      $link: test_input
-- label: the_pause
-  type: pause
-  connect:
-    input:
-    - first_cat#out_file1
-- label: second_cat
-  tool_id: cat1
-  state:
-    input1:
-      $link: the_pause
+class: GalaxyWorkflow
+steps:
+  - label: test_input
+    type: input
+  - label: first_cat
+    tool_id: cat1
+    state:
+      input1:
+        $link: test_input
+  - label: the_pause
+    type: pause
+    connect:
+      input:
+      - first_cat#out_file1
+  - label: second_cat
+    tool_id: cat1
+    state:
+      input1:
+        $link: the_pause
 """)
         print self._get("workflows/%s/download" % workflow_id).json()
 
     def test_implicit_connections( self ):
         workflow_id = self._upload_yaml_workflow("""
-- label: test_input
-  type: input
-- label: first_cat
-  tool_id: cat1
-  state:
-    input1:
-      $link: test_input
-- label: the_pause
-  type: pause
-  connect:
-    input:
-    - first_cat#out_file1
-- label: second_cat
-  tool_id: cat1
-  state:
-    input1:
-      $link: the_pause
-- label: third_cat
-  tool_id: cat1
-  connect:
-    $step: second_cat
-  state:
-    input1:
-      $link: test_input
+class: GalaxyWorkflow
+steps:
+  - label: test_input
+    type: input
+  - label: first_cat
+    tool_id: cat1
+    state:
+      input1:
+        $link: test_input
+  - label: the_pause
+    type: pause
+    connect:
+      input:
+      - first_cat#out_file1
+  - label: second_cat
+    tool_id: cat1
+    state:
+      input1:
+        $link: the_pause
+  - label: third_cat
+    tool_id: cat1
+    connect:
+      $step: second_cat
+    state:
+      input1:
+        $link: test_input
 """)
         workflow = self._get("workflows/%s/download" % workflow_id).json()
         print workflow

--- a/test/api/workflows_format_2/README.txt
+++ b/test/api/workflows_format_2/README.txt
@@ -1,0 +1,12 @@
+Format 2 Workflows
+---------------------------------
+
+This module defines a high-level Galaxy workflow description deemed "Format 2". At this point, these workflows are defined entirely client side and
+transcoded into traditional (or Format 1?) Galaxy workflows.
+
+The traditional Galaxy workflow description is not meant to be concise and is neither readily human readable or human writable. Format 2 addresses all three
+of these limitations.
+
+Format 2 workflow is a highly experimental format and will change rapidly in
+potentially backward incompatible ways until the code is merged into the
+Galaxy server and enabled by default.

--- a/test/api/workflows_format_2/__init__.py
+++ b/test/api/workflows_format_2/__init__.py
@@ -1,0 +1,11 @@
+""" This module defines the public interface or entry point for the
+Format 2 workflow code.
+"""
+from .main import convert_and_import_workflow
+from .interface import ImporterGalaxyInterface
+
+
+__all__ = [
+    'convert_and_import_workflow',
+    'ImporterGalaxyInterface',
+]

--- a/test/api/workflows_format_2/converter.py
+++ b/test/api/workflows_format_2/converter.py
@@ -22,9 +22,14 @@ def yaml_to_workflow(has_yaml):
 
 
 def python_to_workflow(as_python):
+    if not isinstance(as_python, dict):
+        raise Exception("This is not a not a valid Galaxy workflow definition.")
 
-    if isinstance(as_python, list):
-        as_python = {"steps": as_python}
+    if "class" not in as_python:
+        raise Exception("This is not a not a valid Galaxy workflow definition, must define a class.")
+
+    if as_python["class"] != "GalaxyWorkflow":
+        raise Exception("This is not a not a valid Galaxy workflow definition, 'class' must be 'GalaxyWorkflow'.")
 
     __ensure_defaults(as_python, {
         "a_galaxy_workflow": "true",

--- a/test/api/workflows_format_2/interface.py
+++ b/test/api/workflows_format_2/interface.py
@@ -1,0 +1,53 @@
+import abc
+import json
+
+import bioblend
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class ImporterGalaxyInterface(object):
+    """ An abstract interface describing the interaction between
+    Galaxy and the workflow import code.
+    """
+
+    @abc.abstractmethod
+    def import_workflow(self, workflow):
+        """ Import a workflow via POST /api/workflows or
+        comparable interface into Galaxy.
+        """
+        pass
+
+
+class BioBlendImporterGalaxyInterface(object):
+
+    def __init__(self, **kwds):
+        """
+        """
+        url = None
+
+        user_key = None
+        user_gi = None
+        if "user_gi" in kwds:
+            user_gi = kwds["user_gi"]
+        elif "gi" in kwds:
+            user_gi = kwds["gi"]
+        elif "url" in kwds and "user_key" in kwds:
+            url = kwds["url"]
+            user_key = kwds["user_key"]
+
+        if user_gi is None:
+            assert url is not None
+            assert user_key is not None
+            user_gi = bioblend.GalaxyInstance(url=url, key=user_key)
+
+        self._user_gi = user_gi
+
+    def import_workflow(self, workflow):
+        workflow_str = json.dumps(workflow, indent=4)
+        return self._user_gi.workflows.import_workflow_json(
+            workflow_str
+        )
+
+    def import_tool(self, tool_representation):
+        pass

--- a/test/api/workflows_format_2/main.py
+++ b/test/api/workflows_format_2/main.py
@@ -1,0 +1,21 @@
+from .interface import BioBlendImporterGalaxyInterface
+from .converter import yaml_to_workflow, python_to_workflow
+
+
+def convert_and_import_workflow(has_workflow, **kwds):
+    """
+    """
+    galaxy_interface = kwds.get("galaxy_interface", None)
+    if galaxy_interface is None:
+        galaxy_interface = BioBlendImporterGalaxyInterface(**kwds)
+
+    if isinstance(has_workflow, dict):
+        workflow = python_to_workflow(has_workflow)
+    else:
+        workflow = yaml_to_workflow(has_workflow)
+
+    return galaxy_interface.import_workflow(workflow)
+
+__all__ = [
+    'convert_and_import_workflow',
+]

--- a/test/functional/tools/simple_constructs.yml
+++ b/test/functional/tools/simple_constructs.yml
@@ -1,5 +1,6 @@
 id: simple_constructs_y
 name: simple_constructs_y
+class: GalaxyTool
 version: 1.0
 command:
   >

--- a/test/unit/tools/test_parsing.py
+++ b/test/unit/tools/test_parsing.py
@@ -45,6 +45,7 @@ TOOL_XML_1 = """
 
 TOOL_YAML_1 = """
 name: "Bowtie Mapper"
+class: GalaxyTool
 id: bowtie
 version: 1.0.2
 description: "The Bowtie Mapper"


### PR DESCRIPTION
This is a slight tightening up of the ad-hoc, experimental workflow YAML definition used by the test framework (and by Kyle, but lets just admit Kyle is part of Galaxy's test framework).

This format is still defined entirely client side by transcoding the YAML or python object description into real (or format 1) Galaxy workflows - so these cannot realisticaly be declared part of Galaxy's public interface and can remain experimental and subject to change.

In addition to refactoring the code implementing these workflows for upstream modifications to explore new features, the format itself has been made slightly more stringent in two ways:
- 'steps' must now be explicit (previously converted auto-convert list to dict).
- Ensure the workflow declared a 'class' is defined and the class is 'GalaxyWorkflow'.

This will help with discovery of workflow objects with downstream tooling (planemo for workflows?) and brings the Galaxy definition slightly more inline with the CWL definition for workflows (very slightly).

Work cherry-picked out of the [fork](https://github.com/common-workflow-language/galaxy) of Galaxy attempting to implement CWL support.
