### PR TITLE
Better error when tool shed repo dir missing

### DIFF
--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/tag_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/tag_handler.py
@@ -466,6 +466,10 @@ class Repository( RecipeTag, SyncDatabase ):
                     if not os.path.exists( required_repository_package_install_dir ):
                         log.error( 'Missing required tool dependency directory %s' % str( required_repository_package_install_dir ) )
                     repo_files_dir = required_repository.repo_files_directory( self.app )
+                    if not repo_files_dir:
+                        message = "Unable to locate the repository directory for revision %s of installed repository %s owned by %s." % \
+                            ( str( required_repository.changeset_revision ), str( required_repository.name ), str( required_repository.owner ) )
+                        raise Exception( message )
                     tool_dependencies_config = suc.get_absolute_path_to_file_in_repository( repo_files_dir, 'tool_dependencies.xml' )
                     if tool_dependencies_config:
                         config_to_use = tool_dependencies_config


### PR DESCRIPTION
Check for a tool shed repository directory and throw exception if it's
missing. This avoids a cryptic NoneType error when searching for
tool_dependencies.xml file and directory was not found.
