### PR TITLE
Only allow f_email if admin/emails exposed by admin

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -38,8 +38,8 @@ class UserAPIController( BaseAPIController, UsesTagsMixin, CreatesUsersMixin, Cr
         rval = []
         query = trans.sa_session.query( trans.app.model.User )
         deleted = util.string_as_bool( deleted )
-        if f_email:
-            query = query.filter(trans.app.model.User.email.like("%%%s%%" % f_email))
+        if f_email and ( trans.app.config.expose_user_email or trans.user_is_admin() ):
+            query = query.filter( trans.app.model.User.email.like("%%%s%%" % f_email) )
         if deleted:
             query = query.filter( trans.app.model.User.table.c.deleted == true() )
             # only admins can see deleted users


### PR DESCRIPTION
This is a minor security patch, however it only applies in the (relatively rare, and completely useless) case of:

``` ini
expose_user_name = True
# expose_user_email = False
```

I say "useless" because if you've exposed the user name, there's really nothing that can be done. All of the nifty "share-by-select2" widgets I've added require the email address and won't work on anonymous user names. (Hopefully someday we can add share-by-galaxy ID and can get share-by-username without emails involved.)
## How it works

``` console
$ curl http://localhost:8000/galaxy/api/users?f_email=
[
    {
        "email": "a@b.com", 
        "id": "f2db41e1fa331b3e", 
        "model_class": "User", 
        "username": "xyz"
    }, 
    {
        "id": "f597429621d6eb2b", 
        "model_class": "User", 
        "username": "alice"
    }
]
```

Note the intentionally redacted email on the second model reference. However, if you start supplying email characters, you can slowly (and easily detectably) bruteforce their email. 

``` console
$ curl http://localhost:8000/galaxy/api/users?f_email=c@d.com
[
    {
        "id": "f597429621d6eb2b", 
        "model_class": "User", 
        "username": "alice"
    }
]
```
