### PR TITLE
Add search on username/any for API calls to user, use Select2 for sharing workflows/pages/histories

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -34,6 +34,25 @@ class UserAPIController( BaseAPIController, UsesTagsMixin, CreatesUsersMixin, Cr
         GET /api/users
         GET /api/users/deleted
         Displays a collection (list) of users.
+
+        :param deleted: (optional) If true, show deleted users
+        :type  deleted: bool
+
+        :param f_email: (optional) An email address to filter on. (Non-admin
+                        users can only use this if ``expose_user_email`` is ``True`` in
+                        galaxy.ini)
+        :type  f_email: str
+
+        :param f_name: (optional) A username to filter on. (Non-admin users
+                       can only use this if ``expose_user_name`` is ``True`` in
+                       galaxy.ini)
+        :type  f_name: str
+
+        :param f_any: (optional) Filter on username OR email. (Non-admin users
+                       can use this, the email filter and username filter will
+                       only be active if their corresponding ``expose_user_*`` is
+                       ``True`` in galaxy.ini)
+        :type  f_any: str
         """
         rval = []
         query = trans.sa_session.query( trans.app.model.User )

--- a/templates/ind_share_base.mako
+++ b/templates/ind_share_base.mako
@@ -93,7 +93,8 @@
                             Email address of user to share with
                         </label>
                         <div style="float: left; width: 250px; margin-right: 10px;">
-                            <input type="text" name="email" value="${email | h}" size="40">
+                            <input type="hidden" id="email_select" name="email" >
+                            </input>
                         </div>
                         <div style="clear: both"></div>
                     </div>
@@ -103,9 +104,92 @@
                     <div class="form-row">
                         <a href="${h.url_for(controller=item_controller, action="sharing", id=trans.security.encode_id( item.id ) )}">Back to ${item_class_name}'s Sharing Home</a>
                     </div>
-                    
                 </form>
             </div>
         </div>
     </div>
+
+    <script type="text/javascript">
+    /*  This should be ripped out and made generic at some point for the
+     *  various API bindings available, and once the API can filter list
+     *  queries (term, below) */
+
+    var user_id = "${trans.security.encode_id(trans.user.id)}";
+
+    function item_to_label(item){
+        var text = "";
+        if(typeof(item.username) === "string" && typeof(item.email) === "string"){
+            text = item.username + " <" + item.email + ">";
+        }else if(typeof(item.username) === "string"){
+            text = item.username;
+        }else{
+            text = item.email;
+        }
+        return text;
+        //return "id:" + item.id + "|e:" + item.email + "|u:" + item.username;
+    }
+
+    $("#email_select").select2({
+        placeholder: "Select a user",
+        multiple: false,
+        initSelection: function(element, callback) {
+            var data = [];
+            callback(data);
+        },
+        // Required for initSelection
+        id: function(object) {
+            return object.id;
+        },
+        ajax: {
+            url: "${h.url_for(controller="/api/users", action="index")}",
+            data: function (term) {
+                return {
+                    f_email: term,
+                    f_name: term,
+                };
+            },
+            dataType: 'json',
+            quietMillis: 250,
+            results: function (data) {
+                var results = [];
+                // For every user returned by the API call,
+                $.each(data, function(index, item){
+                    // If they aren't the requesting user, add to the
+                    // list that will populate the select
+                    if(item.id != "${trans.security.encode_id(trans.user.id)}"){
+                        // Because we "share-by-email", we can ONLY add a
+                        // result if we can see the email. Hopefully someday
+                        // someone will allow sharing by Galaxy user ID (or
+                        // something else "opaque" and people will be able to
+                        // share-by-username.)
+                        if(item.email !== undefined){
+                            results.push({
+                              id: item.email,
+                              name: item.username,
+                              text: item_to_label(item),
+                            });
+                        }
+                    }
+                });
+                return {
+                    results: results
+                };
+            }
+        },
+        createSearchChoice: function(term, data) {
+            // Check for a user with a matching email.
+            var matches = _.filter(data, function(user){
+                return user.text.indexOf(term) > -1;
+            });
+            // If there aren't any users with matching object labels, then
+            // display a "default" entry with whatever text they're entering.
+            // id is set to term as that will be used in 
+            if(matches.length == 0){
+                return {id: term, text:term};
+            }else{
+                // No extra needed
+            }
+        }
+    });
+    </script>
 </%def>

--- a/templates/ind_share_base.mako
+++ b/templates/ind_share_base.mako
@@ -144,8 +144,7 @@
             url: "${h.url_for(controller="/api/users", action="index")}",
             data: function (term) {
                 return {
-                    f_email: term,
-                    f_name: term,
+                    f_any: term,
                 };
             },
             dataType: 'json',

--- a/templates/webapps/galaxy/history/share.mako
+++ b/templates/webapps/galaxy/history/share.mako
@@ -103,7 +103,7 @@
                     url: "${h.url_for(controller="/api/users", action="index")}",
                     data: function (term) {
                         return {
-                            f_email: term
+                            f_any: term,
                         };
                     },
                     dataType: 'json',

--- a/templates/webapps/galaxy/history/share.mako
+++ b/templates/webapps/galaxy/history/share.mako
@@ -115,11 +115,13 @@
                             // If they aren't the requesting user, add to the
                             // list that will populate the select
                             if(item.id != "${trans.security.encode_id(trans.user.id)}"){
-                                results.push({
-                                  id: item.id,
-                                  name: item.username,
-                                  text: item_to_label(item),
-                                });
+                                if(item.email !== undefined){
+                                    results.push({
+                                      id: item.id,
+                                      name: item.username,
+                                      text: item_to_label(item),
+                                    });
+                                }
                             }
                         });
                         return {


### PR DESCRIPTION
- Includes an alternative patch to #1109, except with more features. 
- All of the security considerations from that patch apply to this one, but I'm closing that one with the advances made in this one.
- This adjusts the default 'share' template to use the select2/exposed user list implemented in 60ad9e9. As previously, if the email list is not exposed then you may still enter an email address manually.
- If usernames are exposed but not emails (e.g. public galaxies) we currently just hide those results even if searches match.
- The code for select2 box is mostly copied from 60ad9e9 with minor alterations as this was `multiple: false.`

Fixes:
- Fixes #977
- Fixes #816 

Sorry for the extra noise/extra PRs, I should've cleaned those up more first but I wanted to get the minor security patch out quickly, and then I wanted to add features and then ... "if you give a programmer a feature request...", well, you know the rest of that story.
