### PR TITLE
Allow accessing collection elements in format_source.

### DIFF
--- a/test/functional/tools/output_format_collection.xml
+++ b/test/functional/tools/output_format_collection.xml
@@ -1,0 +1,35 @@
+<tool id="output_format_collection" name="output_format_collection" version="1.0.0">
+  <command>
+    echo "test" > 1;
+    echo "test" > 2;
+  </command>
+  <inputs>
+    <param name="input_collection" type="data_collection" format="data" />
+  </inputs>
+  <outputs>
+    <!-- Access by element name (for paired data) -->
+    <data format="txt" from_work_dir="1" name="format_source_1_output" format_source="input_collection['forward']" />
+    <!-- Access by element index (for any collection) -->
+    <data format="txt" from_work_dir="2" name="format_source_2_output" format_source="input_collection[0]" />
+  </outputs>
+  <tests>
+    <test>
+      <param name="input_collection">
+        <collection type="paired">
+          <element name="forward" value="simple_line.txt" />
+          <element name="reverse" value="simple_line_alternative.txt" />
+        </collection>
+      </param>
+      <output name="format_source_1_output" ftype="txt">
+          <assert_contents>
+            <has_line line="test" />
+          </assert_contents>
+      </output>
+      <output name="format_source_2_output" ftype="txt">
+          <assert_contents>
+            <has_line line="test" />
+          </assert_contents>
+      </output>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -28,6 +28,7 @@
   <tool file="gzipped_inputs.xml" />
   <tool file="output_order.xml" />
   <tool file="output_format.xml" />
+  <tool file="output_format_collection.xml" />
   <tool file="output_filter.xml" />
   <tool file="output_collection_filter.xml" />
   <tool file="output_auto_format.xml" />


### PR DESCRIPTION
Can do it by numeric index or element name, e.g. input[0] or input["forward"]. Only works for 1-D collections.

Implements #699.

Run new and most relevant existing tests with the following commands:

```
nosetests test/unit/tools/test_actions.py
./run_tests.sh -framework -id output_format_collection
./run_tests.sh -framework -id output_format
```
