### PR TITLE
Revise and fix waiting for tool tests.

### DIFF
--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -306,6 +306,7 @@ def _test_elem_to_dict(test_elem, i):
         stderr=__parse_assert_list_from_elem( test_elem.find("assert_stderr") ),
         expect_exit_code=test_elem.get("expect_exit_code"),
         expect_failure=string_as_bool(test_elem.get("expect_failure", False)),
+        maxseconds=test_elem.get("maxseconds", None),
     )
     _copy_to_dict_if_present(test_elem, rval, ["interactor", "num_outputs"])
     return rval

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -14,7 +14,7 @@ log = logging.getLogger( __name__ )
 DEFAULT_FTYPE = 'auto'
 DEFAULT_DBKEY = 'hg17'
 DEFAULT_INTERACTOR = "api"  # Default mechanism test code uses for interacting with Galaxy instance.
-DEFAULT_MAX_SECS = 120
+DEFAULT_MAX_SECS = None
 
 
 @nottest
@@ -42,7 +42,9 @@ class ToolTestBuilder( object ):
 
     def __init__( self, tool, test_dict, i, default_interactor ):
         name = test_dict.get( 'name', 'Test-%d' % (i + 1) )
-        maxseconds = int( test_dict.get( 'maxseconds', DEFAULT_MAX_SECS ) )
+        maxseconds = test_dict.get( 'maxseconds', DEFAULT_MAX_SECS )
+        if maxseconds is not None:
+            maxseconds = int( maxseconds )
 
         self.tool = tool
         self.name = name

--- a/test/base/twilltestcase.py
+++ b/test/base/twilltestcase.py
@@ -37,6 +37,8 @@ tc.config( 'use_tidy', 0 )
 logging.getLogger( "ClientCookie.cookies" ).setLevel( logging.WARNING )
 log = logging.getLogger( __name__ )
 
+DEFAULT_TOOL_TEST_WAIT = os.environ.get("GALAXY_TEST_DEFAULT_WAIT", 86400)
+
 
 class TwillTestCase( unittest.TestCase ):
 
@@ -2440,15 +2442,16 @@ class TwillTestCase( unittest.TestCase ):
     def wait_for( self, func, **kwd ):
         sleep_amount = 0.2
         slept = 0
-        walltime_exceeded = 86400
+        walltime_exceeded = kwd.get("maxseconds", None)
+        if walltime_exceeded is None:
+            walltime_exceeded = DEFAULT_TOOL_TEST_WAIT
+        log.info("walltime_exceeded is %s" % walltime_exceeded)
         while slept <= walltime_exceeded:
             result = func()
             if result:
                 time.sleep( sleep_amount )
                 slept += sleep_amount
                 sleep_amount *= 2
-                if slept + sleep_amount > walltime_exceeded:
-                    sleep_amount = walltime_exceeded - slept  # don't overshoot maxseconds
             else:
                 break
         assert slept < walltime_exceeded, 'Tool run exceeded reasonable walltime of 24 hours, terminating.'

--- a/test/functional/tools/maxseconds.xml
+++ b/test/functional/tools/maxseconds.xml
@@ -1,0 +1,16 @@
+<tool id="maxseconds" name="maxseconds" version="0.1.0">
+    <command>
+        sleep 100
+    </command>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="out_file1" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" maxseconds="5">
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -24,6 +24,7 @@
   <tool file="metadata_bcf.xml" />
   <tool file="detect_errors_aggressive.xml" />
   <tool file="md5sum.xml" />
+  <tool file="maxseconds.xml" />
   <tool file="job_properties.xml" />
   <tool file="gzipped_inputs.xml" />
   <tool file="output_order.xml" />


### PR DESCRIPTION
- maxseconds on test tag stopped being respected at some point, fix that.
- maxseconds on test tag stopped being parsed at some later point, fix that.
- Revise default behavior so it can be overridden with yet another testing environment variable GALAXY_TEST_DEFAULT_WAIT.
- Add test case to ensure there is no future regression of these behaviors.

Fixes https://github.com/galaxyproject/galaxy/issues/964 sort of, the default wait is still 24 hours (ekkk) but I will have planemo use `GALAXY_TEST_DEFAULT_WAIT` to set that to 5 minutes for `test` and 25 minutes for `shed_test`.
