### PR TITLE
[15.10] Fix macro bug with empty CDATA being None instead of ''.

### DIFF
--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -16,7 +16,7 @@ def load(path):
     _import_macros(root, path)
 
     # Collect tokens
-    tokens = _macros_of_type(root, 'token', lambda el: el.text)
+    tokens = _macros_of_type(root, 'token', lambda el: el.text or '')
 
     # Expand xml macros
     macro_dict = _macros_of_type(root, 'xml', lambda el: XmlMacroDef(el))

--- a/test/unit/tools/test_tool_loader.py
+++ b/test/unit/tools/test_tool_loader.py
@@ -216,6 +216,22 @@ def test_loader():
         value = tag_el.get('value')
         assert value == "The value.", value
 
+    with TestToolDirectory() as tool_dir:
+        tool_dir.write('''
+<tool>
+    <macros>
+        <token name="@TAG_VAL@"><![CDATA[]]></token>
+    </macros>
+    <another>
+        <tag value="@TAG_VAL@" />
+    </another>
+</tool>
+''')
+        xml = tool_dir.load()
+        tag_el = xml.find("another").find("tag")
+        value = tag_el.get('value')
+        assert value == "", value
+
     # Test macros XML macros with $$ expansions in attributes
     with TestToolDirectory() as tool_dir:
         tool_dir.write('''


### PR DESCRIPTION
Fixes galaxyproject/planemo#362 thanks for the report @erasche.

Test using the following command:

```
nosetests test/unit/tools/test_tool_loader.py
```
