### PR TITLE
Readd jquery.migrate to galaxy.panels template because it is needed f…

### DIFF
--- a/templates/webapps/galaxy/galaxy.panels.mako
+++ b/templates/webapps/galaxy/galaxy.panels.mako
@@ -13,10 +13,10 @@
         'left_panel'    : False,
         'right_panel'   : False,
         'message_box'   : False,
-        
+
         ## root
         'root'          : h.url_for("/"),
-        
+
         ## inject app specific configuration
         'app'           : config['app']
     }
@@ -30,6 +30,7 @@
     ## load jscript libraries
     ${h.js(
         'libs/jquery/jquery',
+        'libs/jquery/jquery.migrate',
         'libs/jquery/jquery-ui',
         "libs/jquery/select2",
         'libs/bootstrap',
@@ -41,7 +42,7 @@
         'galaxy.base',
         'galaxy.panels'
     )}
-    
+
     ## send errors to Sntry server if configured
     %if app.config.sentry_dsn:
         ${h.js( "libs/tracekit", "libs/raven" )}
@@ -52,7 +53,7 @@
             %endif
         </script>
     %endif
-    
+
     ## make sure console exists
     <script type="text/javascript">
         // console protection
@@ -87,7 +88,7 @@
         }
     %endif
     </style>
-    
+
     ## default script wrapper
     <script type="text/javascript">
         ## configure require
@@ -101,7 +102,7 @@
             urlArgs: 'v=${app.server_starttime}'
         });
         var galaxy_config = ${ h.dumps( self.galaxy_config ) };
-        
+
     </script>
 </%def>
 
@@ -130,7 +131,7 @@
     ##precondition: module must call jq onready itself
     ##<% app_config = self.galaxy_config[ 'app' ]; print app_config %>
     ##${ galaxy_client.load( app=( app_config[ 'jscript' ] if 'jscript' in app_config else None )) }
-    
+
     ##TODO: at that point, we can think about optimizing the various apps
 </%def>
 
@@ -139,15 +140,15 @@
     ## Scripts can be loaded later since they progressively add features to
     ## the panels, but do not change layout
     <script type="text/javascript">
-        
+
         ensure_dd_helper();
-        
+
         ## configure left panel
         %if self.galaxy_config['left_panel']:
             var lp = new Panel( { panel: $("#left"), center: $("#center"), drag: $("#left > .unified-panel-footer > .drag" ), toggle: $("#left > .unified-panel-footer > .panel-collapse" ) } );
             force_left_panel = function( x ) { lp.force_panel( x ) };
         %endif
-        
+
         ## configure right panel
         %if self.galaxy_config['right_panel']:
             var rp = new Panel( { panel: $("#right"), center: $("#center"), drag: $("#right > .unified-panel-footer > .drag" ), toggle: $("#right > .unified-panel-footer > .panel-collapse" ), right: true } );
@@ -166,28 +167,28 @@
             %endif
             </title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        
+
         ## for mobile browsers, don't scale up
         <meta name = "viewport" content = "maximum-scale=1.0">
-        
+
         ## force IE to standards mode, and prefer Google Chrome Frame if the user has already installed it
         <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
- 
+
         ## load scripts
         ${self.javascripts()}
         ${self.javascript_app()}
     </head>
-    
+
     <body scroll="no" class="full-content">
         <div id="everything" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
             ## background displays first
             <div id="background"></div>
-            
+
             ## master header
             %if self.galaxy_config['master']:
                 ${masthead.load()}
             %endif
-            
+
             ## message box
             %if self.galaxy_config['message_box']:
                 <div id="messagebox" class="panel-message"></div>
@@ -208,7 +209,7 @@
                     </div>
                 </div>
             %endif
-            
+
             ## center panel
             <div id="center">
                 <div class="unified-panel-header" unselectable="on">
@@ -219,7 +220,7 @@
                 </div>
                 <div class="unified-panel-body"></div>
             </div>
-            
+
             ## right panel
             %if self.galaxy_config['right_panel']:
                 <div id="right">


### PR DESCRIPTION
…or farbtastic, which is used in visualizations. This enables visualization configuration to be done again. I think this should probably be applied to the current release as well.
