### PR TITLE
Style: fix state-success-bg change that was not reverted during 5fd4daf

### DIFF
--- a/client/galaxy/style/less/galaxy_bootstrap/variables.less
+++ b/client/galaxy/style/less/galaxy_bootstrap/variables.less
@@ -449,7 +449,7 @@
 @state-danger-border:            darken(@state-danger-bg, @border-darken-percent);
 
 @state-success-text:             darken(@brand-success, @state-text-darken-percent);
-@state-success-bg:               saturate(lighten(@brand-success, @state-bg-lighten-percent, relative),@state-bg-saturate-percent);
+@state-success-bg:               saturate(lighten(@brand-success, @state-bg-lighten-percent),@state-bg-saturate-percent);
 @state-success-border:           darken(@state-success-bg, @border-darken-percent);
 
 @state-info-text:                darken(@brand-info, @state-text-darken-percent);


### PR DESCRIPTION
It is _not_ easy being green, apparently.
