### PR TITLE
Add BAM iobio visualisation as Interactive Environment

### DIFF
--- a/config/plugins/interactive_environments/bam_iobio/config/bam_iobio.ini.sample
+++ b/config/plugins/interactive_environments/bam_iobio/config/bam_iobio.ini.sample
@@ -16,7 +16,7 @@
 #command = docker {docker_args}
 
 # The docker image name that should be started.
-image = bgruening/docker-ipython-notebook:15.10
+image = qiaoy/iobio-bundle.bam-iobio:1.0-ondemand
 
 # Additional arguments that are passed to the `docker run` command.
 #command_inject = --sig-proxy=true -e DEBUG=false

--- a/config/plugins/interactive_environments/bam_iobio/config/bam_iobio.xml
+++ b/config/plugins/interactive_environments/bam_iobio/config/bam_iobio.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE interactive_environment SYSTEM "../../interactive_environments.dtd">
+<interactive_environment name="BAM iobio">
+    <data_sources>
+        <data_source>
+            <model_class>HistoryDatasetAssociation</model_class>
+            <test type="isinstance" test_attr="datatype" result_type="datatype">binary.Bam</test>
+            <to_param param_attr="id">dataset_id</to_param>
+        </data_source>
+    </data_sources>
+    <params>
+        <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
+    </params>
+    <entry_point entry_point_type="mako">bam_iobio.mako</entry_point>
+</interactive_environment>

--- a/config/plugins/interactive_environments/bam_iobio/static/js/bam_iobio.js
+++ b/config/plugins/interactive_environments/bam_iobio/static/js/bam_iobio.js
@@ -1,0 +1,39 @@
+function message_failed_auth(password){
+    toastr.info(
+        "Automatic authorization failed.",
+        "Please login manually",
+        {'closeButton': true, 'timeOut': 100000, 'tapToDismiss': false}
+    );
+}
+
+function message_failed_connection(){
+    toastr.error(
+        "Could not connect to BAM iobio. Please contact your administrator.",
+    "Security warning",
+        {'closeButton': true, 'timeOut': 20000, 'tapToDismiss': true}
+    );
+}
+
+/**
+ * Load an interactive environment (IE) from a remote URL
+ * @param {String} password: password used to authenticate to the remote resource
+ * @param {String} notebook_login_url: URL that should be POSTed to for login
+ * @param {String} notebook_access_url: the URL embeded in the page and loaded
+ *
+ */
+function load_notebook(notebook_access_url){
+    $( document ).ready(function() {
+        // Test notebook_login_url for accessibility, executing the login+load function whenever
+        // we've successfully connected to the IE.
+        test_ie_availability(notebook_access_url, function(){
+            _handle_notebook_loading(notebook_access_url);
+        });
+    });
+}
+
+/**
+ * Must be implemented by IEs
+ */
+function _handle_notebook_loading(notebook_access_url){
+    append_notebook(notebook_access_url);
+}

--- a/config/plugins/interactive_environments/bam_iobio/templates/bam_iobio.mako
+++ b/config/plugins/interactive_environments/bam_iobio/templates/bam_iobio.mako
@@ -1,0 +1,62 @@
+ <%namespace name="ie" file="ie.mako" />
+
+<%
+import subprocess
+from galaxy.util import sockets
+
+# Sets ID and sets up a lot of other variables
+ie_request.load_deploy_config()
+ie_request.attr.docker_port = 80
+ie_request.attr.import_volume = False
+
+bam = ie_request.volume(hda.file_name, '/input/bamfile.bam', how='ro')
+bam_index = ie_request.volume(hda.metadata.bam_index.file_name, '/input/bamfile.bam.bai', how='ro')
+
+ie_request.launch(volumes=[bam, bam_index], env_override={
+    'PUB_HTTP_PORT': ie_request.attr.galaxy_config.dynamic_proxy_bind_port,
+    'PUB_HOSTNAME': ie_request.attr.HOST,
+})
+
+notebook_access_url = ie_request.url_template('${PROXY_URL}/?bam=http://localhost/tmp/bamfile.bam')
+
+root = h.url_for( '/' )
+%>
+<html>
+<head>
+    ${ ie.load_default_js() }
+</head>
+<body>
+
+    <script type="text/javascript">
+
+        ${ ie.default_javascript_variables() }
+        var notebook_access_url = '${ notebook_access_url }';
+        ${ ie.plugin_require_config() }
+
+        requirejs(['interactive_environments', 'plugin/bam_iobio'], function(){
+            display_spinner();
+        });
+
+        toastr.info(
+            "BAM io.bio is starting up!",
+            "transferring data ...",
+            {'closeButton': true, 'timeOut': 5000, 'tapToDismiss': false}
+        );
+
+        var startup = function(){
+            // Load notebook
+            requirejs(['interactive_environments', 'plugin/bam_iobio'], function(){
+                load_notebook(notebook_access_url);
+            });
+
+        };
+        // sleep 5 seconds
+        // this is currently needed to get the vis right
+        // plans exists to move this spinner into the container
+        setTimeout(startup, 5000);
+
+    </script>
+<div id="main">
+</div>
+</body>
+</html>

--- a/config/plugins/interactive_environments/common/templates/ie.mako
+++ b/config/plugins/interactive_environments/common/templates/ie.mako
@@ -4,7 +4,6 @@
 // Following three are for older-style IE proxies, newer dynamic Galaxy proxy
 // does not use these.
 ie_password_auth = ${ ie_request.javascript_boolean(ie_request.attr.PASSWORD_AUTH) };
-ie_apache_urls = ${ ie_request.javascript_boolean(ie_request.attr.APACHE_URLS) };
 ie_password = '${ ie_request.notebook_pw }';
 
 

--- a/config/plugins/interactive_environments/ipython/static/js/ipython.js
+++ b/config/plugins/interactive_environments/ipython/static/js/ipython.js
@@ -65,7 +65,7 @@ function _handle_notebook_loading(password, notebook_login_url, notebook_access_
                 append_notebook(notebook_access_url);
             },
             error: function(jqxhr, status, error){
-                if(ie_password_auth && !ie_apache_urls){
+                if(ie_password_auth){
                     // Failure happens due to CORS
                     message_failed_auth(password);
                     append_notebook(notebook_access_url);

--- a/config/plugins/interactive_environments/rstudio/static/js/rstudio.js
+++ b/config/plugins/interactive_environments/rstudio/static/js/rstudio.js
@@ -78,7 +78,7 @@ function _handle_notebook_loading(password, notebook_login_url, notebook_access_
                 append_notebook(notebook_access_url);
             },
             error: function(jqxhr, status, error){
-                if(ie_password_auth && !ie_apache_urls){
+                if(ie_password_auth){
                     // Failure now happens because the redirect that RStudio gives us includes the
                     // port internal to nginx. (E.g. localhost:NNNN/rstudio/NNNN/)
                     // so disabling the message here makes sense as long as it's working correctly

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -25,7 +25,7 @@ class InteractiveEnviornmentRequest(object):
         self.log = log
 
         self.attr = Bunch()
-        self.attr.viz_id = plugin_config["name"].lower()
+        self.attr.viz_id = plugin.name
         self.attr.history_id = trans.security.encode_id( trans.history.id )
         self.attr.galaxy_config = trans.app.config
         self.attr.galaxy_root_dir = os.path.abspath(self.attr.galaxy_config.root)
@@ -95,7 +95,6 @@ class InteractiveEnviornmentRequest(object):
         # we always assume use of Galaxy dynamic proxy? None of these need to be specified
         # if using the Galaxy dynamic proxy.
         self.attr.PASSWORD_AUTH = _boolean_option("password_auth")
-        self.attr.APACHE_URLS = _boolean_option("apache_urls")
         self.attr.SSL_URLS = _boolean_option("ssl")
 
     def get_conf_dict(self):

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -19,8 +19,6 @@ log = logging.getLogger(__name__)
 class InteractiveEnviornmentRequest(object):
 
     def __init__(self, trans, plugin):
-        plugin_config = plugin.config
-
         self.trans = trans
         self.log = log
 


### PR DESCRIPTION
This PR will add the http://bam.iobio.io visualisation for BAM files to Galaxy. To activate this Interactive Environment, you need to adopt your `galaxy.ini`.

`
visualization_plugins_directory = config/plugins/visualizations
` 

Starting the first time an IE can cause troubles if the Docker Image pulling takes too long. To prevent this you can simply pull the needed container in advance:

```
docker pull qiaoy/iobio-bundle.bam-iobio:1.0-ondemand
```

I would like to thank Yi Qiao (@yiq), Chase Miller (chmille4) and Gabor Marth from iobio fame for the fantastic cooperation! This was fun! Also many thanks to @erasche and @jmchilton for improving IE's all over the time!

More to come!

Note: Please open Galaxy with a FQHN - `localhost` or `127.0.0.1` will not work.
