### PR TITLE
Finish swapping unencoded ids with order_index in workflows API.

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from collections import namedtuple
+import logging
 import json
 import uuid
 
@@ -21,6 +22,8 @@ from galaxy.workflow.modules import module_factory, is_tool_module_type, ToolMod
 from galaxy.tools.parameters.basic import DataToolParameter, DataCollectionToolParameter
 from galaxy.tools.parameters import visit_input_values
 from galaxy.web import url_for
+
+log = logging.getLogger( __name__ )
 
 
 class WorkflowsManager( object ):
@@ -327,8 +330,10 @@ class WorkflowContentsManager(UsesAnnotations):
         """
         if style == "editor":
             return self._workflow_to_dict_editor( trans, stored )
+        elif style == "legacy":
+            return self._workflow_to_dict_instance( stored, legacy=True )
         elif style == "instance":
-            return self._workflow_to_dict_instance( stored )
+            return self._workflow_to_dict_instance( stored, legacy=False )
         else:
             return self._workflow_to_dict_export( trans, stored )
 
@@ -622,7 +627,7 @@ class WorkflowContentsManager(UsesAnnotations):
             data['steps'][step.order_index] = step_dict
         return data
 
-    def _workflow_to_dict_instance(self, stored):
+    def _workflow_to_dict_instance(self, stored, legacy=True):
         encode = self.app.security.encode_id
         sa_session = self.app.model.context
         item = stored.to_dict( view='element', value_mapper={ 'id': encode } )
@@ -639,14 +644,24 @@ class WorkflowContentsManager(UsesAnnotations):
             elif step_type == "data_collection_input":
                 label = "Input Dataset Collection"
             else:
-                raise ValueError("Invalid/unknown input step_type %s" % step_type)
-            inputs[step.id] = {'label': label, 'value': ""}
+                raise ValueError("Invalid step_type %s" % step_type)
+            if legacy:
+                index = step.id
+            else:
+                index = step.order_index
+            step_uuid = str(step.uuid) if step.uuid else None
+            inputs[index] = {'label': label, 'value': "", "uuid": step_uuid}
         item['inputs'] = inputs
         item['annotation'] = self.get_item_annotation_str( sa_session, stored.user, stored )
         steps = {}
+        steps_to_order_index = {}
         for step in workflow.steps:
+            steps_to_order_index[step.id] = step.order_index
+        for step in workflow.steps:
+            step_uuid = str(step.uuid) if step.uuid else None
+            step_id = step.id if legacy else step.order_index
             step_type = step.type
-            step_dict = {'id': step.id,
+            step_dict = {'id': step_id,
                          'type': step_type,
                          'tool_id': step.tool_id,
                          'tool_version': step.tool_version,
@@ -663,9 +678,14 @@ class WorkflowContentsManager(UsesAnnotations):
                 step_dict['workflow_id'] = encode(workflow.id)
 
             for conn in step.input_connections:
-                step_dict['input_steps'][conn.input_name] = {'source_step': conn.output_step_id,
+                step_id = step.id if legacy else step.order_index
+                source_id = conn.output_step_id
+                source_step = source_id if legacy else steps_to_order_index[source_id]
+                step_dict['input_steps'][conn.input_name] = {'source_step': source_step,
                                                              'step_output': conn.output_name}
-            steps[step.id] = step_dict
+
+            steps[step_id] = step_dict
+
         item['steps'] = steps
         return item
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -77,7 +77,11 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             if trans.sa_session.query(trans.app.model.StoredWorkflowUserShareAssociation).filter_by(user=trans.user, stored_workflow=stored_workflow).count() == 0:
                 message = "Workflow is neither importable, nor owned by or shared with current user"
                 raise exceptions.ItemAccessibilityException( message )
-        return self.workflow_contents_manager.workflow_to_dict( trans, stored_workflow, style="instance" )
+        if kwd.get("legacy", False):
+            style = "legacy"
+        else:
+            style = "instance"
+        return self.workflow_contents_manager.workflow_to_dict( trans, stored_workflow, style=style )
 
     @expose_api
     def create(self, trans, payload, **kwd):

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -222,11 +222,21 @@ class WorkflowsApiTestCase( BaseWorkflowsApiTestCase ):
         super( WorkflowsApiTestCase, self ).setUp()
 
     def test_show_valid( self ):
+        workflow_id = self.workflow_populator.simple_workflow( "dummy" )
         workflow_id = self.workflow_populator.simple_workflow( "test_regular" )
-        show_response = self._get( "workflows/%s" % workflow_id )
+        show_response = self._get( "workflows/%s" % workflow_id, {"style": "instance"} )
         workflow = show_response.json()
         self._assert_looks_like_instance_workflow_representation( workflow )
         assert len(workflow["steps"]) == 3
+        self.assertEquals(sorted([step["id"] for step in workflow["steps"].values()]), [0, 1, 2])
+
+        show_response = self._get( "workflows/%s" % workflow_id, {"legacy": True} )
+        workflow = show_response.json()
+        self._assert_looks_like_instance_workflow_representation( workflow )
+        assert len(workflow["steps"]) == 3
+        # Can't reay say what the legacy IDs are but must be greater than 3 because dummy
+        # workflow was created first in this instance.
+        self.assertNotEquals(sorted([step["id"] for step in workflow["steps"].values()]), [0, 1, 2])
 
     def test_show_invalid_key_is_400( self ):
         show_response = self._get( "workflows/%s" % self._random_key() )

--- a/test/unit/workflows/test_run_parameters.py
+++ b/test/unit/workflows/test_run_parameters.py
@@ -79,7 +79,7 @@ def __normalize_parameters_against_fixture( params ):
     __workflow_fixure( trans )
 
     workflow = __workflow_fixure( trans )
-    normalized_params = normalize_step_parameters( workflow.steps, params )
+    normalized_params = normalize_step_parameters( workflow.steps, params, legacy=True )
     return normalized_params
 
 


### PR DESCRIPTION
Running a workflow or showing a workflow can both restore the previous behavior by passing legacy=True as an API parameter. By changing these two endpoints in tandem I believe backward compatibility for most existing code should be maintained unless one of the following two behaviors hold for this external code:
- The external application saved these workflow IDs previously and re-runs workflows without refetching the workflow definition. I could imagine Refinery for instance might do this and will have to update indexed workflows or add legacy=True to workflow requests.
- The external application contacted the database directly after using this API endpoint to fetch more information about the step (seems unlikely).

So for instance, I would expect the bioblend test suite to continue pass without modification, and if it is doesn't there is a bug in here somewhere and I will fix it.

Overall I believe this will add a great deal of consistency to the workflow API (export and show now use the same indices) and will make everything more usable in the long term.

See conversation:
- http://dev.list.galaxyproject.org/workflow-API-step-order-vs-step-id-in-bioblend-td4668367.html

Ping @nsoranzo, @hackdna, @guerler.
