### PR TITLE
Implement type_source on output collections.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -397,13 +397,17 @@ class ToolOutputCollectionStructure( object ):
     def __init__(
         self,
         collection_type,
+        collection_type_source,
         structured_like,
         dataset_collectors,
     ):
         self.collection_type = collection_type
+        self.collection_type_source = collection_type_source
         self.structured_like = structured_like
         self.dataset_collectors = dataset_collectors
-        if collection_type is None and structured_like is None and dataset_collectors is None:
+        if collection_type and collection_type_source:
+            raise ValueError("Cannot set both type and type_source on collection output.")
+        if collection_type is None and structured_like is None and dataset_collectors is None and collection_type_source is None:
             raise ValueError( "Output collection types must be specify type of structured_like" )
         if dataset_collectors and structured_like:
             raise ValueError( "Cannot specify dynamic structure (discovered_datasets) and structured_like attribute." )

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -339,10 +339,22 @@ class DefaultToolAction( object ):
                     else:
                         element_kwds = dict(element_identifiers=element_identifiers)
 
+                    collection_type = output.structure.collection_type
+                    if collection_type is None:
+                        collection_type_source = output.structure.collection_type_source
+                        if collection_type_source is None:
+                            # TODO: Not a new problem, but this should be determined
+                            # sooner.
+                            raise Exception("Could not determine collection type to create.")
+                        if collection_type_source not in input_collections:
+                            raise Exception("Could not find collection type source with name [%s]." % collection_type_source)
+
+                        collection_type = input_collections[collection_type_source].collection.collection_type
+
                     if mapping_over_collection:
                         dc = collections_manager.create_dataset_collection(
                             trans,
-                            collection_type=output.structure.collection_type,
+                            collection_type=collection_type,
                             **element_kwds
                         )
                         out_collections[ name ] = dc
@@ -352,7 +364,7 @@ class DefaultToolAction( object ):
                             trans,
                             history,
                             name=hdca_name,
-                            collection_type=output.structure.collection_type,
+                            collection_type=collection_type,
                             trusted_identifiers=True,
                             **element_kwds
                         )

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -178,6 +178,7 @@ class XmlToolSource(ToolSource):
             label = xml_text( collection_elem, "label" )
             default_format = collection_elem.get( "format", "data" )
             collection_type = collection_elem.get( "type", None )
+            collection_type_source = collection_elem.get( "type_source", None )
             structured_like = collection_elem.get( "structured_like", None )
             inherit_format = False
             inherit_metadata = False
@@ -193,6 +194,7 @@ class XmlToolSource(ToolSource):
                 dataset_collectors = output_collect.dataset_collectors_from_elem( collection_elem )
             structure = galaxy.tools.ToolOutputCollectionStructure(
                 collection_type=collection_type,
+                collection_type_source=collection_type_source,
                 structured_like=structured_like,
                 dataset_collectors=dataset_collectors,
             )

--- a/test/functional/tools/collection_type_source.xml
+++ b/test/functional/tools/collection_type_source.xml
@@ -1,0 +1,62 @@
+<tool id="collection_type_source" name="collection_type_source" version="0.1.0">
+  <command>
+    mkdir output;
+    #for $key in $input_collect.keys()#
+    cat "$header" > output/"$key";
+    cat "$input_collect[$key]" >> output/"$key";
+    #end for#
+  </command>
+  <inputs>
+    <param name="header" type="data" label="Input Data" help="Input data..." />
+    <param name="input_collect" type="data_collection" label="Input Collect" help="Input collection..." />
+  </inputs>
+  <outputs>
+    <collection name="list_output" type_source="input_collect" label="Duplicate List" format_source="header">
+      <discover_datasets pattern="__name__" directory="output" visible="true" />
+    </collection>
+  </outputs>
+  <tests>
+    <test>
+      <param name="header" value="simple_line.txt" />
+      <param name="input_collect">
+        <collection type="list">
+          <element name="samp1" value="simple_line.txt" />
+          <element name="samp2" value="simple_line_alternative.txt" />
+        </collection>
+      </param>
+      <output_collection name="list_output" type="list">
+        <element name="samp1">
+            <assert_contents>
+              <has_text_matching expression="This is a line of text.\nThis is a line of text." />
+            </assert_contents>
+        </element>
+        <element name="samp2">
+          <assert_contents>
+            <has_text_matching expression="This is a line of text.\nThis is a different line of text." />
+          </assert_contents>
+        </element>
+      </output_collection>
+    </test>
+    <test>
+      <param name="header" value="simple_line.txt" />
+      <param name="input_collect">
+        <collection type="paired">
+          <element name="forward" value="simple_line.txt" />
+          <element name="reverse" value="simple_line_alternative.txt" />
+        </collection>
+      </param>
+      <output_collection name="list_output" type="paired">
+        <element name="forward">
+            <assert_contents>
+              <has_text_matching expression="This is a line of text.\nThis is a line of text." />
+            </assert_contents>
+        </element>
+        <element name="reverse">
+          <assert_contents>
+            <has_text_matching expression="This is a line of text.\nThis is a different line of text." />
+          </assert_contents>
+        </element>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -63,6 +63,7 @@
   <tool file="collection_split_on_column.xml" />
   <tool file="collection_creates_dynamic_nested.xml" />
   <tool file="collection_creates_dynamic_list_of_pairs.xml" />
+  <tool file="collection_type_source.xml" />
   <tool file="cheetah_casting.xml" />
 
   <tool file="multiple_versions_v01.xml" />


### PR DESCRIPTION
Inherit collection_type from an input, the way metadata and format can be.

This commit includes a test tool demonstrating this functionality. The tool test for this tool can be executed using the following command:

```
./run_tests.sh -framework -id collection_type_source
```
