### PR TITLE
Fix for re-installing an uninstalled TS repository with a dependency

### DIFF
--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -512,6 +512,11 @@ def get_repository_for_dependency_relationship( app, tool_shed, name, owner, cha
                                                owner=owner,
                                                changeset_revision=changeset_revision )
     if not repository:
+        tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( app, tool_shed )
+        repository_clone_url = os.path.join( tool_shed_url, 'repos', owner, name )
+        repo_info_tuple = (None, repository_clone_url, changeset_revision, None, owner, None, None)
+        repository, pcr = repository_was_previously_installed( app, tool_shed_url, name, repo_info_tuple )
+    if not repository:
         # The received changeset_revision is no longer installable, so get the next changeset_revision
         # in the repository's changelog in the tool shed that is associated with repository_metadata.
         tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( app, tool_shed )


### PR DESCRIPTION
where both the repository and the dependency were updated in the TS
after the repository was uninstalled.

This one is for @bgruening ;)  

Here is the scenario:

In Galaxy:
1) Install repo A from TS where A has a dependency on package B (of type tool_dependency_definition), checking the box to install all dependencies.  Both A and B are installed.
2) Uninstall A, leaving B installed

In the Tool Shed:
1) Add an update to A
2) Add an update to B

Back in Galaxy:
1) Re-install A

Old behavior:
The new revision of B would get installed as a "white ghost" in addition to the original B
A would get installed with missing dependency B

Corrected behavior after this PR:
The updated revisions of A and B are installed, with single installed instanced of both.
