### PR TITLE
Allowed for capitalised package names such as R

### DIFF
--- a/lib/galaxy/tools/deps/resolvers/unlinked_tool_shed_packages.py
+++ b/lib/galaxy/tools/deps/resolvers/unlinked_tool_shed_packages.py
@@ -75,7 +75,7 @@ class UnlinkedToolShedPackageDependencyResolver(GalaxyPackageDependencyResolver)
                 for owner in listdir(path):
                     owner_path = join(path, owner)
                     for package_name in listdir(owner_path):
-                        if package_name.startswith("package_" + name):
+                        if package_name.lower().startswith("package_" + name.lower()):
                             package_path = join(owner_path, package_name)
                             for revision in listdir(package_path):
                                 revision_path = join(package_path, revision)


### PR DESCRIPTION
Tiny improvement to https://github.com/galaxyproject/galaxy/pull/441

Package names are always lower case but for style so dependency names such as "R" are in upper case.

By casting both to lower these can now be found too!
