### PR TITLE
Fix interface and usage of WorkflowModule.get_runtime_inputs.

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -132,7 +132,7 @@ class WorkflowModule( object ):
 
     # ---- Run time ---------------------------------------------------------
 
-    def get_runtime_inputs( self ):
+    def get_runtime_inputs( self, **kwds ):
         """ Used internally by modules and when displaying inputs in workflow
         editor and run workflow templates.
 

--- a/templates/webapps/galaxy/workflow/run.mako
+++ b/templates/webapps/galaxy/workflow/run.mako
@@ -612,7 +612,7 @@ if wf_parms:
               if not type_filter:
                   type_filter = ['data']
               %>
-              ${do_inputs( module.get_runtime_inputs(type_filter), step.state.inputs, errors.get( step.id, dict() ), "", step, None, used_accumulator )}
+              ${do_inputs( module.get_runtime_inputs(filter_set=type_filter), step.state.inputs, errors.get( step.id, dict() ), "", step, None, used_accumulator )}
           </div>
       </div>
     %endif


### PR DESCRIPTION
Run workflow workflow form was broken for workflows with pause steps.

Fixes #1015 (thanks @afgane).
