### PR TITLE
Lazy load HDA/LDDA metadata to speed up history loading

### DIFF
--- a/lib/galaxy/datatypes/metadata.py
+++ b/lib/galaxy/datatypes/metadata.py
@@ -798,6 +798,9 @@ class JobExternalOutputMetadataWrapper( object ):
                 dataset.dataset  # force dataset_association.dataset to be loaded before pickling
                 # A better fix could be setting 'expire_on_commit=False' on the session, or modifying where commits occur, or ?
 
+                # Touch also deferred column
+                dataset._metadata
+
                 cPickle.dump( dataset, open( metadata_files.filename_in, 'wb+' ) )
                 # file to store metadata results of set_meta()
                 metadata_files.filename_out = abspath( tempfile.NamedTemporaryFile( dir=tmp_dir, prefix="metadata_out_%s_" % key ).name )

--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -102,7 +102,7 @@ class MutationObj(Mutable):
 
         def load(state, *args):
             val = state.dict.get(key, None)
-            if coerce:
+            if coerce and key not in state.unloaded:
                 val = cls.coerce(key, val)
                 state.dict[key] = val
             if isinstance(val, cls):

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1578,7 +1578,7 @@ simple_mapping( model.HistoryDatasetAssociation,
                         model.HistoryDatasetCollectionAssociation.table.c.id ) ),
         uselist=False,
         backref="hidden_dataset_instances"),
-        _metadata=deferred(model.HistoryDatasetAssociation.table.c._metadata)
+    _metadata=deferred(model.HistoryDatasetAssociation.table.c._metadata)
 )
 
 simple_mapping( model.Dataset,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -10,7 +10,7 @@ from sqlalchemy import ( and_, asc, Boolean, Column, DateTime, desc, false, Fore
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy.types import BigInteger
-from sqlalchemy.orm import backref, object_session, relation, mapper, class_mapper
+from sqlalchemy.orm import backref, object_session, relation, mapper, class_mapper, deferred
 from sqlalchemy.orm.collections import attribute_mapped_collection
 
 from galaxy import model
@@ -1577,7 +1577,8 @@ simple_mapping( model.HistoryDatasetAssociation,
         primaryjoin=( ( model.HistoryDatasetAssociation.table.c.hidden_beneath_collection_instance_id ==
                         model.HistoryDatasetCollectionAssociation.table.c.id ) ),
         uselist=False,
-        backref="hidden_dataset_instances" )
+        backref="hidden_dataset_instances"),
+        _metadata=deferred(model.HistoryDatasetAssociation.table.c._metadata)
 )
 
 simple_mapping( model.Dataset,
@@ -1945,7 +1946,8 @@ mapper( model.LibraryDatasetDatasetAssociation, model.LibraryDatasetDatasetAssoc
         remote_side=[model.LibraryDatasetDatasetAssociation.table.c.id] ),
     extended_metadata=relation( model.ExtendedMetadata,
         primaryjoin=( ( model.LibraryDatasetDatasetAssociation.table.c.extended_metadata_id == model.ExtendedMetadata.table.c.id ) )
-    )
+    ),
+    _metadata=deferred(model.LibraryDatasetDatasetAssociation.table.c._metadata)
 ) )
 
 mapper( model.LibraryDatasetDatasetInfoAssociation, model.LibraryDatasetDatasetInfoAssociation.table, properties=dict(


### PR DESCRIPTION
Hi,
I have some performance problems to view a history containing ~900 datasets (not created by me :smile: ) : loading the history takes several seconds, and sometimes fails.
I did some hacking, and I found out that:
-it is taking a long time to load because it tries to convert from json to MutationDict huge amounts of json stored in the metadata column of HDA or LDDA in the postgres db
-this huge amount of json is generated when the dataset is a bam file created by some tool. In our case we analyse genomes with >20,000 scaffolds, and they are all listed with their length in this metadata.

As I think most of the time this metadata is not read by the code listing an history content, I have written this little patch which defers the loading of this json until it is really needed (if it is).
In my test config, the history loads in <100ms instead of >2,5s before the patch.

I have some profiling information if you're interested

I hope there is no side effect I haven't seen. Tell me if it needs some improvements!
Thanks
Anthony
