### PR TITLE
Yet More Tool Execution Optimizations

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -832,6 +832,20 @@ use_interactive = True
 #enable_beta_tool_command_isolation = False
 
 
+# Set the following to a number of threads greater than 1 to spawn
+# a Python task queue for dealing with large tool submissions (either
+# through the tool form or as part of an individual workflow step across
+# large collection). This number of Python threads will spawned per 
+# large request - so you may wish to set it to a number smaller than
+# the core count of your server. This affects workflow scheduling and 
+# web processes, not job handlers.
+#tool_submission_burst_threads = 1
+
+# If the above setting is to set to greater than 1, that number of 
+# threads will be used to process requests resulting in greater than
+# the number of jobs specified by the following setting.
+#tool_submission_burst_at = 10
+
 # Enable beta workflow modules that should not yet be considered part of Galaxy's
 # stable API.
 #enable_beta_workflow_modules = False

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -215,6 +215,8 @@ class Configuration( object ):
         self.use_tasked_jobs = string_as_bool( kwargs.get( 'use_tasked_jobs', False ) )
         self.local_task_queue_workers = int(kwargs.get("local_task_queue_workers", 2))
         self.commands_in_new_shell = string_as_bool( kwargs.get( 'enable_beta_tool_command_isolation', "False" ) )
+        self.tool_submission_burst_threads = int( kwargs.get( 'tool_submission_burst_threads', '0' ) )
+        self.tool_submission_burst_at = int( kwargs.get( 'tool_submission_burst_at', '10' ) )
         # The transfer manager and deferred job queue
         self.enable_beta_job_managers = string_as_bool( kwargs.get( 'enable_beta_job_managers', 'False' ) )
         # These workflow modules should not be considered part of Galaxy's

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -106,10 +106,12 @@ class BaseJobRunner( object ):
         """Add a job to the queue (by job identifier), indicate that the job is ready to run.
         """
         put_timer = ExecutionTimer()
+        job = job_wrapper.get_job()
         # Change to queued state before handing to worker thread so the runner won't pick it up again
-        job_wrapper.change_state( model.Job.states.QUEUED )
+        job_wrapper.change_state( model.Job.states.QUEUED, flush=False, job=job )
         # Persist the destination so that the job will be included in counts if using concurrency limits
-        job_wrapper.set_job_destination( job_wrapper.job_destination, None )
+        job_wrapper.set_job_destination( job_wrapper.job_destination, None, flush=False, job=job )
+        self.sa_session.flush()
         self.mark_as_queued(job_wrapper)
         log.debug("Job [%s] queued %s" % (job_wrapper.job_id, put_timer))
 

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -77,6 +77,8 @@ class DatasetCollectionManager( object ):
                 for input_name, input_collection in implicit_collection_info[ "implicit_inputs" ]:
                     dataset_collection_instance.add_implicit_input_collection( input_name, input_collection )
                 for output_dataset in implicit_collection_info.get( "outputs" ):
+                    if output_dataset not in trans.sa_session:
+                        output_dataset = trans.sa_session.query( type( output_dataset ) ).get( output_dataset.id )
                     if isinstance( output_dataset, model.HistoryDatasetAssociation ):
                         output_dataset.hidden_beneath_collection_instance = dataset_collection_instance
                     elif isinstance( output_dataset, model.HistoryDatasetCollectionAssociation ):
@@ -265,7 +267,11 @@ class DatasetCollectionManager( object ):
         # Previously created collection already found in request, just pass
         # through as is.
         if "__object__" in element_identifier:
-            return element_identifier[ "__object__" ]
+            the_object = element_identifier[ "__object__" ]
+            context = self.model.context
+            if the_object not in context:
+                the_object = context.query( type(the_object) ).get(the_object.id)
+            return the_object
 
         # dateset_identifier is dict {src=hda|ldda|hdca|new_collection, id=<encoded_id>}
         try:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1103,16 +1103,16 @@ class History( object, Dictifiable, UsesAnnotations, HasName ):
     def empty( self ):
         return self.hid_counter == 1
 
-    def _next_hid( self ):
+    def _next_hid( self, n=1 ):
         # this is overriden in mapping.py db_next_hid() method
         if len( self.datasets ) == 0:
-            return 1
+            return n
         else:
             last_hid = 0
             for dataset in self.datasets:
                 if dataset.hid > last_hid:
                     last_hid = dataset.hid
-            return last_hid + 1
+            return last_hid + n
 
     def add_galaxy_session( self, galaxy_session, association=None ):
         if association is None:
@@ -1146,6 +1146,41 @@ class History( object, Dictifiable, UsesAnnotations, HasName ):
             self.genome_build = genome_build
         self.datasets.append( dataset )
         return dataset
+
+    def add_datasets( self, sa_session, datasets, parent_id=None, genome_build=None, set_hid=True, quota=True, flush=False ):
+        """ Optimized version of add_dataset above that minimizes database
+        interactions when adding many datasets to history at once.
+        """
+        all_hdas = all( map( lambda d: isinstance( d, HistoryDatasetAssociation ), datasets ) )
+        optimize = len( datasets) > 1 and parent_id is None and all_hdas and set_hid and not quota
+        if optimize:
+            self.__add_datasets_optimized( datasets, genome_build=genome_build )
+            sa_session.add_all( datasets )
+            if flush:
+                sa_session.flush()
+        else:
+            for dataset in datasets:
+                self.add_dataset( dataset, parent_id=parent_id, genome_build=genome_build, set_hid=set_hid, quota=quota )
+                sa_session.add( dataset )
+                if flush:
+                    sa_session.flush()
+
+    def __add_datasets_optimized( self, datasets, genome_build=None ):
+        """ Optimized version of add_dataset above that minimizes database
+        interactions when adding many datasets to history at once under
+        certain cirucumstances.
+        """
+        n = len( datasets )
+
+        base_hid = self._next_hid( n=n )
+
+        for i, dataset in enumerate( datasets ):
+            dataset.hid = base_hid + i
+            dataset.history = self
+            if genome_build not in [None, '?']:
+                self.genome_build = genome_build
+        self.datasets.extend( datasets )
+        return datasets
 
     def add_dataset_collection( self, history_dataset_collection, set_hid=True ):
         if set_hid:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -556,8 +556,11 @@ class Job( object, JobLike, Dictifiable ):
     def add_parameter( self, name, value ):
         self.parameters.append( JobParameter( name, value ) )
 
-    def add_input_dataset( self, name, dataset ):
-        self.input_datasets.append( JobToInputDatasetAssociation( name, dataset ) )
+    def add_input_dataset( self, name, dataset=None, dataset_id=None ):
+        assoc = JobToInputDatasetAssociation( name, dataset )
+        if dataset is None and dataset_id is not None:
+            assoc.dataset_id = dataset_id
+        self.input_datasets.append( assoc )
 
     def add_output_dataset( self, name, dataset ):
         self.output_datasets.append( JobToOutputDatasetAssociation( name, dataset ) )
@@ -1484,10 +1487,13 @@ class DefaultQuotaAssociation( Quota, Dictifiable ):
 
 
 class DatasetPermissions( object ):
-    def __init__( self, action, dataset, role ):
+    def __init__( self, action, dataset, role=None, role_id=None ):
         self.action = action
         self.dataset = dataset
-        self.role = role
+        if role is not None:
+            self.role = role
+        else:
+            self.role_id = role_id
 
 
 class LibraryPermissions( object ):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1789,10 +1789,17 @@ class DatasetInstance( object ):
             return self._state
         return self.dataset.state
 
+    def raw_set_dataset_state( self, state ):
+        if state != self.dataset.state:
+            self.dataset.state = state
+            return True
+        else:
+            return False
+
     def set_dataset_state( self, state ):
-        self.dataset.state = state
-        object_session( self ).add( self.dataset )
-        object_session( self ).flush()  # flush here, because hda.flush() won't flush the Dataset object
+        if self.raw_set_dataset_state( state ):
+            object_session( self ).add( self.dataset )
+            object_session( self ).flush()  # flush here, because hda.flush() won't flush the Dataset object
     state = property( get_dataset_state, set_dataset_state )
 
     def get_file_name( self ):

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2449,7 +2449,7 @@ class_mapper( model.HistoryDatasetCollectionAssociation ).add_property(
 
 
 # Helper methods.
-def db_next_hid( self ):
+def db_next_hid( self, n=1 ):
     """
     db_next_hid( self )
 
@@ -2465,7 +2465,7 @@ def db_next_hid( self ):
     trans = conn.begin()
     try:
         next_hid = select( [table.c.hid_counter], table.c.id == self.id, for_update=True ).scalar()
-        table.update( table.c.id == self.id ).execute( hid_counter=( next_hid + 1 ) )
+        table.update( table.c.id == self.id ).execute( hid_counter=( next_hid + n ) )
         trans.commit()
         return next_hid
     except:

--- a/lib/galaxy/security/__init__.py
+++ b/lib/galaxy/security/__init__.py
@@ -898,7 +898,8 @@ class GalaxyRBACAgent( RBACAgent ):
         for action, roles in permissions.items():
             if isinstance( action, Action ):
                 action = action.action
-            for dp in [ self.model.DatasetPermissions( action, dataset, role ) for role in roles ]:
+            for role in roles:
+                dp = self.model.DatasetPermissions( action, dataset, role_id=role.id )
                 self.sa_session.add( dp )
                 flush_needed = True
         if flush_needed:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1290,6 +1290,7 @@ class Tool( object, Dictifiable ):
 
         all_errors = []
         all_params = []
+        validate_input = self.get_hook( 'validate_input' )
         for expanded_incoming in expanded_incomings:
             expanded_state = self.new_state( trans, history=history )
             # Process incoming data
@@ -1304,7 +1305,6 @@ class Tool( object, Dictifiable ):
                 # values from `incoming`.
                 errors = self.populate_state( trans, self.inputs, expanded_state.inputs, expanded_incoming, history, source=source )
                 # If the tool provides a `validate_input` hook, call it.
-                validate_input = self.get_hook( 'validate_input' )
                 if validate_input:
                     validate_input( trans, errors, expanded_state.inputs, self.inputs )
                 params = expanded_state.inputs

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -39,6 +39,7 @@ from galaxy.tools.parser import get_tool_source
 from galaxy.tools.parser.xml import XmlPageSource
 from galaxy.tools.toolbox import AbstractToolBox
 from galaxy.util import rst_to_html, string_as_bool
+from galaxy.util import ExecutionTimer
 from galaxy.tools.parameters.meta import expand_meta_parameters
 from galaxy.util.bunch import Bunch
 from galaxy.util.expressions import ExpressionContext
@@ -1288,6 +1289,7 @@ class Tool( object, Dictifiable ):
         if rerun_remap_job_id and len( expanded_incomings ) > 1:
             raise exceptions.MessageException( 'Failure executing tool (cannot create multiple jobs when remapping existing job).' )
 
+        validation_timer = ExecutionTimer()
         all_errors = []
         all_params = []
         validate_input = self.get_hook( 'validate_input' )
@@ -1310,7 +1312,7 @@ class Tool( object, Dictifiable ):
                 params = expanded_state.inputs
             all_errors.append( errors )
             all_params.append( params )
-
+        log.info("Validated and populated state for tool request %s" % validation_timer)
         # If there were errors, we stay on the same page and display
         # error messages
         if any( all_errors ):

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -162,6 +162,8 @@ class DefaultToolAction( object ):
         # Set history.
         if not history:
             history = tool.get_default_history_by_trans( trans, create=True )
+        if history not in trans.sa_session:
+            history = trans.sa_session.query( trans.app.model.History ).get( history.id )
 
         out_data = odict()
         out_collections = {}
@@ -425,7 +427,7 @@ class DefaultToolAction( object ):
             if dataset:
                 if not trans.app.security_agent.can_access_dataset( current_user_roles, dataset.dataset ):
                     raise Exception("User does not have permission to use a dataset (%s) provided for input." % data.id)
-                job.add_input_dataset( name, dataset )
+                job.add_input_dataset( name, dataset_id=dataset.id )
             else:
                 job.add_input_dataset( name, None )
         log.info("Verified access to datasets %s" % access_timer)

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -20,6 +20,7 @@ def execute( trans, tool, param_combinations, history, rerun_remap_job_id=None, 
     failures, etc...).
     """
     execution_tracker = ToolExecutionTracker( tool, param_combinations, collection_info )
+    all_jobs_timer = ExecutionTimer()
     for params in execution_tracker.param_combinations:
         job_timer = ExecutionTimer()
         if workflow_invocation_uuid:
@@ -35,7 +36,7 @@ def execute( trans, tool, param_combinations, history, rerun_remap_job_id=None, 
             execution_tracker.record_success( job, result )
         else:
             execution_tracker.record_error( result )
-
+    log.info("Executed all jobs for tool request: %s" % all_jobs_timer)
     if collection_info:
         history = history or tool.get_default_history_by_trans( trans )
         execution_tracker.create_output_collections( trans, history, params )

--- a/test/functional/tools/create_10.xml
+++ b/test/functional/tools/create_10.xml
@@ -1,0 +1,35 @@
+<tool id="create_10" name="Create 10">
+    <description>create 10</description>
+    <command>
+        echo "1" > 1;
+        echo "2" > 2;
+        echo "3" > 3;
+        echo "4" > 4;
+        echo "5" > 5;
+        echo "6" > 6;
+        echo "7" > 7;
+        echo "8" > 8;
+        echo "9" > 9;
+        echo "10" > 10;
+    </command>
+    <inputs>
+        <param name="input1" type="data" label="Concatenate Dataset"/>
+        <param name="input2" type="data" label="Concatenate Dataset"/>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" from_work_dir="1" />
+        <data name="out_file2" format="txt" from_work_dir="2" />
+        <data name="out_file3" format="txt" from_work_dir="3" />
+        <data name="out_file4" format="txt" from_work_dir="4" />
+        <data name="out_file5" format="txt" from_work_dir="5" />
+        <data name="out_file6" format="txt" from_work_dir="6" />
+        <data name="out_file7" format="txt" from_work_dir="7" />
+        <data name="out_file8" format="txt" from_work_dir="8" />
+        <data name="out_file9" format="txt" from_work_dir="9" />
+        <data name="out_file10" format="txt" from_work_dir="10" />
+    </outputs>
+    <tests>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -33,6 +33,7 @@
   <tool file="output_filter.xml" />
   <tool file="output_collection_filter.xml" />
   <tool file="output_auto_format.xml" />
+  <tool file="create_10.xml" />
   <tool file="disambiguate_repeats.xml" />
   <tool file="min_repeat.xml" />
   <tool file="parallelism.xml" />


### PR DESCRIPTION
See individual commits for details:
- 627498a Is a large win for tools that produce many outputs - greatly reducing the number of flushes and fetches HIDs for all outputs at once.
- f85a72a Is a pretty clear optimization, but I'm not sure it actually happens in the request thread, should result in less database contention at the time of submission at least and result in an improved user experience for small jobs like batch uploads for instance.
- 7f6514a Introduces a couple new config options that allow admins to parallelize batch submissions of jobs, set `tool_submission_burst_threads` to `4` for instance to have large requests batched out and have Galaxy work on the creation of 4 jobs at a time.
