### PR TITLE
Wait on jobs and history in certain API test cases.

### DIFF
--- a/test/api/helpers.py
+++ b/test/api/helpers.py
@@ -70,10 +70,14 @@ class BaseDatasetPopulator( object ):
     Galaxy - implementations must implement _get and _post.
     """
 
-    def new_dataset( self, history_id, content='TestData123', **kwds ):
+    def new_dataset( self, history_id, content='TestData123', wait=False, **kwds ):
         payload = self.upload_payload( history_id, content, **kwds )
-        run_response = self._post( "tools", data=payload )
-        return run_response.json()["outputs"][0]
+        run_response = self._post( "tools", data=payload ).json()
+        if wait:
+            job = run_response["jobs"][0]
+            self.wait_for_job(job["id"])
+            self.wait_for_history(history_id)
+        return run_response["outputs"][0]
 
     def wait_for_history( self, history_id, assert_ok=False, timeout=DEFAULT_TIMEOUT ):
         try:

--- a/test/api/test_jobs.py
+++ b/test/api/test_jobs.py
@@ -200,8 +200,8 @@ class JobsApiTestCase( api.ApiTestCase, TestsDatasets ):
         return history_id, dataset_id
 
     def __history_with_ok_dataset( self ):
-        history_id, dataset_id = self.__history_with_new_dataset()
-        self._wait_for_history( history_id, assert_ok=True )
+        history_id = self._new_history()
+        dataset_id = self._new_dataset( history_id, wait=True )[ "id" ]
         return history_id, dataset_id
 
     def __jobs_index( self, **kwds ):


### PR DESCRIPTION
This strategy proved to work around certain race conditions in tool testing so hopefully it will solve the transiently failing job searching and filtering test cases.
