### PR TITLE
Fix qunit shim to match base_panels.mako shim.

### DIFF
--- a/test/qunit/test-common.js
+++ b/test/qunit/test-common.js
@@ -35,7 +35,7 @@ require.config({
             deps: [ 'sinon', "QUnit" ],
             exports: "sinon"  // Odd but seems to work
         },
-        "underscore": {
+        "libs/underscore": {
             exports: "_"
         },
         "backbone": {


### PR DESCRIPTION
QUnit tests of things with underscore require statements would not work without this change.

Ping @carlfeberhard 
