### PR TITLE
Tool optimization - don't set state to queued twice.

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -294,7 +294,8 @@ class HistorySerializer( sharable.SharableModelSerializer, deletable.PurgableSer
                     hda_state_counts[states.UPLOAD] > 0):
                 state = states.RUNNING
             # TODO: this method may be more useful if we *also* polled the histories jobs here too
-            elif hda_state_counts[ states.QUEUED ] > 0:
+            elif (hda_state_counts[ states.QUEUED ] > 0 or
+                    hda_state_counts[states.NEW] > 0):
                 state = states.QUEUED
             elif (hda_state_counts[states.ERROR] > 0 or
                     hda_state_counts[states.FAILED_METADATA] > 0):

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -285,8 +285,6 @@ class DefaultToolAction( object ):
             # Take dbkey from LAST input
             data.dbkey = str(input_dbkey)
             # Set state
-            # FIXME: shouldn't this be NEW until the job runner changes it?
-            data.state = data.states.QUEUED
             data.blurb = "queued"
             # Set output label
             data.name = self.get_output_name( output, data, tool, on_text, trans, incoming, history, wrapped_params.params, job_params )


### PR DESCRIPTION
Just keep the dataset in the correct NEW state until it has actually been queued. Addresses FIXME comment added by James 7 years ago in https://github.com/galaxyproject/galaxy/commit/4c3db1af95fb0520960046ae549462aebd78b326.

This behavior feels correct to me, but it does have ramifications in the GUI. I had previously never actually seen a dataset in the "NEW" state - but the GUI seems to handle it fine.

Saves an extra flush per dataset, on sqlite this translates to 50ms per dataset for me.

This is the a commit in #1199.
