### PR TITLE
[15.10] "Fix" collection outputs to hide the HDAs in the history.

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -224,7 +224,7 @@ class DefaultToolAction( object ):
         child_dataset_names = set()
         object_store_populator = ObjectStorePopulator( trans.app )
 
-        def handle_output( name, output ):
+        def handle_output( name, output, hidden=None ):
             if output.parent:
                 parent_to_child_pairs.append( ( output.parent, name ) )
                 child_dataset_names.add( name )
@@ -240,7 +240,9 @@ class DefaultToolAction( object ):
             else:
                 ext = determine_output_format( output, wrapped_params.params, inp_data, input_ext )
                 data = trans.app.model.HistoryDatasetAssociation( extension=ext, create_dataset=True, sa_session=trans.sa_session )
-                if output.hidden:
+                if hidden is None:
+                    hidden = output.hidden
+                if hidden:
                     data.visible = False
                 # Commit the dataset immediately so it gets database assigned unique id
                 trans.sa_session.add( data )
@@ -318,7 +320,10 @@ class DefaultToolAction( object ):
                             current_element_identifiers = current_element_identifiers[ index ][ "element_identifiers" ]
 
                         effective_output_name = output_part_def.effective_output_name
-                        element = handle_output( effective_output_name, output_part_def.output_def )
+                        element = handle_output( effective_output_name, output_part_def.output_def, hidden=True )
+                        # TODO: this shouldn't exist in the top-level of the history at all
+                        # but for now we are still working around that by hiding the contents
+                        # there.
                         # Following hack causes dataset to no be added to history...
                         child_dataset_names.add( effective_output_name )
 

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -296,8 +296,8 @@ class ToolsTestCase( api.ApiTestCase ):
         output_collection = self._assert_one_job_one_collection_run( create )
         element0, element1 = self._assert_elements_are( output_collection, "forward", "reverse" )
         self.dataset_populator.wait_for_history( history_id, assert_ok=True )
-        self._verify_element( history_id, element0, contents="123\n789\n", file_ext="txt" )
-        self._verify_element( history_id, element1, contents="456\n0ab\n", file_ext="txt" )
+        self._verify_element( history_id, element0, contents="123\n789\n", file_ext="txt", visible=False )
+        self._verify_element( history_id, element1, contents="456\n0ab\n", file_ext="txt", visible=False )
 
     @skip_without_tool( "collection_creates_list" )
     def test_list_collection_output( self ):


### PR DESCRIPTION
Long term this is just not a solution, but it is the strategy we use for mapped over output HDAs also.

xref https://github.com/galaxyproject/tools-iuc/pull/412/files

Sorry for delay @nsoranzo, I had read that thread a few times in a hurry but didn't quite understand.
