### PR TITLE
[15.10] Use fixed path to sync like in dev.

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -319,7 +319,7 @@ class BaseJobRunner( object ):
             # sync file system to avoid "Text file busy" problems.
             # These have occurred both in Docker containers and on EC2 clusters
             # under high load.
-            subprocess.check_call(["sync"])
+            subprocess.check_call(["/bin/sync"])
         except Exception:
             pass
 


### PR DESCRIPTION
It keeps picking up something else on my PATH and breaking my tests when I switch to release_15.10.
