### PR TITLE
[15.10] Fix for getting shed_config_dict when an old/invalid shed_config_filename has been stored. 

### DIFF
--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -96,7 +96,14 @@ class ToolShedRepository( object ):
         Return the in-memory version of the shed_tool_conf file, which is stored in the config_elems entry
         in the shed_tool_conf_dict.
         """
-        if not self.shed_config_filename:
+
+        def _is_valid_shed_config_filename( filename ):
+            for shed_tool_conf_dict in app.toolbox.dynamic_confs( include_migrated_tool_conf=True ):
+                if filename == shed_tool_conf_dict[ 'config_filename' ]:
+                    return True
+            return False
+
+        if not self.shed_config_filename or not _is_valid_shed_config_filename( self.shed_config_filename ):
             self.guess_shed_config( app, default=default )
         if self.shed_config_filename:
             for shed_tool_conf_dict in app.toolbox.dynamic_confs( include_migrated_tool_conf=True ):


### PR DESCRIPTION
Fixes issue updating repositories that have had shed_tool_conf.xml changed since installation.
