### PR TITLE
Attempt to fix transiently failing tool test on Jenkins

### DIFF
--- a/test/functional/tools/maxseconds.xml
+++ b/test/functional/tools/maxseconds.xml
@@ -1,5 +1,5 @@
 <tool id="maxseconds" name="maxseconds" version="0.1.0">
-    <command>
+    <command detect_errors="exit_code">
         sleep 100
     </command>
     <inputs>


### PR DESCRIPTION
Fail maxseconds test tool if sleep is interrupted.

The fact it works locally proves to me the maxseconds behavior, I don't know what in the Jenkins/Docker setup causes this to finish before 100 seconds and without an error - but it might be an interruption. In that case failing the tool will cause the test to pass at least - even if it isn't proving that maxseconds works in that specific case.
