### PR TITLE
Fixed indentation errors for Reports

### DIFF
--- a/templates/webapps/reports/jobs_errors_per_tool.mako
+++ b/templates/webapps/reports/jobs_errors_per_tool.mako
@@ -25,13 +25,7 @@ ${get_css()}
         <table id="formHeader">
             <tr>
                 <td>
-                    ${
-                        get_pages( sort_id, order, 
-                                   page_specs,
-                                   'jobs',
-                                   'errors_per_tool',
-                                   spark_time=time_period )
-                    }
+                    ${get_pages(sort_id, order, page_specs, 'jobs', 'errors_per_tool', spark_time=time_period)}
                 </td>
                 <td>
                     <h4 align="center">Jobs In Error Per Tool</h4>
@@ -41,30 +35,12 @@ ${get_css()}
                             Click error number to view job details.
                         </p>
 
-                        Graph goes from present to past for 
-                        ${
-                            make_spark_settings( 
-                                "jobs",
-                                "errors_per_tool",
-                                spark_limit,
-                                sort_id,
-                                order,
-                                time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        Graph goes from present to past for
+                        ${make_spark_settings("jobs", "errors_per_tool", spark_limit, sort_id, order, time_period, page=page, offset=offset, entries=entries)}
                     </h5>
                 </td>
                 <td align="right">
-                    ${
-                        get_entry_selector(
-                            "jobs",
-                            "errors_per_tool",
-                            page_specs.entries,
-                            sort_id,
-                            order)
-                    }
+                    ${get_entry_selector("jobs", "errors_per_tool", page_specs.entries, sort_id, order)}
                 </td>
             </tr>
         </table>
@@ -78,59 +54,23 @@ ${get_css()}
             %else:
                 <tr class="header">
                     <td class="half_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'tool_id',
-                                'jobs',
-                                'errors_per_tool',
-                                'Tool ID',
-                                spark_time=time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'tool_id', 'jobs', 'errors_per_tool', 'Tool ID', spark_time=time_period, page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow tool_id'>${arrow}</span>
                     </td>
                     %if is_user_jobs_only:
     					<td class="third_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'errors_per_tool',
-                                    'User Jobs in Error',
-                                    spark_time=time_period,
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'errors_per_tool', 'User Jobs in Error', spark_time=time_period, page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 					%else:
 	                    <td class="third_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'errors_per_tool',
-                                    'User and Monitor Jobs in Error',
-                                    spark_time=time_period,
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'errors_per_tool', 'User and Monitor Jobs in Error', spark_time=time_period, page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 	                %endif
                     <td></td>
                 </tr>
-                <% 
+                <%
                    ctr = 0
                    entries = 1
                 %>
@@ -158,18 +98,12 @@ ${get_css()}
                             </a>
                         </td>
                         %try:
-                            ${
-                                make_sparkline(
-                                    key,
-                                    trends[key],
-                                    "bar",
-                                    "/ " + time_period[:-1])
-                            }
+                            ${make_sparkline(key, trends[key], "bar", "/ " + time_period[:-1])}
                         %except KeyError:
                         %endtry
                         <td id="${key}"></td>
                     </tr>
-                    <% 
+                    <%
                        ctr += 1
                        entries += 1
                     %>

--- a/templates/webapps/reports/jobs_per_month_all.mako
+++ b/templates/webapps/reports/jobs_per_month_all.mako
@@ -22,14 +22,7 @@ ${get_css()}
         <table id="formHeader">
             <tr>
                 <td>
-                    ${
-                        get_pages(
-                            sort_id,
-                            order,
-                            page_specs,
-                            'jobs',
-                            'per_month_all')
-                    }
+                    ${get_pages(sort_id, order, page_specs, 'jobs', 'per_month_all')}
                 </td>
                 <td>
                     <h4 align="center">Jobs Per Month</h4>
@@ -39,68 +32,28 @@ ${get_css()}
                     </h5>
                 </td>
                 <td align="right">
-                    ${
-                        get_entry_selector(
-                            "jobs",
-                            "per_month_all",
-                            page_specs.entries,
-                            sort_id,
-                            order)
-                    }
+                    ${get_entry_selector("jobs", "per_month_all", page_specs.entries, sort_id, order)}
                 </td>
             </tr>
         </table>
-        
+
         <table align="center" width="60%" class="colored">
             %if len( jobs ) == 0:
                 <tr><td colspan="4">There are no jobs.</td></tr>
             %else:
                 <tr class="header">
                     <td class="third_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'date',
-                                'jobs',
-                                'per_month_all',
-                                'Month',
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'date', 'jobs', 'per_month_all', 'Month', page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow date'>${arrow}</span>
                     </td>
                     %if is_user_jobs_only:
     					<td class="third_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'per_month_all',
-                                    'User Jobs',
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'per_month_all', 'User Jobs', page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 					%else:
 	                    <td class="third_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'per_month_all',
-                                    'User and Monitor Jobs',
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'per_month_all', 'User and Monitor Jobs', page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 	                %endif
@@ -129,16 +82,10 @@ ${get_css()}
                             </a>
                         </td>
                         <td>${job[1]}</td>
-                        ${
-                            make_sparkline(
-                                key,
-                                trends[key],
-                                "bar",
-                                "/ day")
-                        }
+                        ${make_sparkline(key, trends[key], "bar", "/ day")}
                         <td id="${key}"></td>
                     </tr>
-                    <% 
+                    <%
                        ctr += 1
                        entries += 1
                     %>

--- a/templates/webapps/reports/jobs_per_month_in_error.mako
+++ b/templates/webapps/reports/jobs_per_month_in_error.mako
@@ -22,28 +22,14 @@ ${get_css()}
         <table id="formHeader">
             <tr>
                 <td>
-                    ${
-                        get_pages(
-                            sort_id,
-                            order,
-                            page_specs,
-                            'jobs',
-                            'per_month_in_error')
-                    }
+                    ${get_pages(sort_id, order, page_specs, 'jobs', 'per_month_in_error')}
                 </td>
                 <td>
                     <h4 align="center">Jobs In Error Per Month</h4>
                     <h5 align="center">Click Month to view details.</h5>
                 </td>
                 <td align="right">
-                    ${
-                        get_entry_selector(
-                            "jobs",
-                            "per_month_in_error",
-                            page_specs.entries,
-                            sort_id,
-                            order)
-                    }
+                    ${get_entry_selector("jobs", "per_month_in_error", page_specs.entries, sort_id, order)}
                 </td>
             </tr>
         </table>
@@ -57,56 +43,23 @@ ${get_css()}
             %else:
                 <tr class="header">
                     <td class="third_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'date',
-                                'jobs',
-                                'per_month_in_error',
-                                'Month',
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'date', 'jobs', 'per_month_in_error', 'Month', page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow date'>${arrow}</span>
                     </td>
                     %if is_user_jobs_only:
     					<td class="third_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'per_month_in_error',
-                                    'User Jobs',
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url( sort_id, order, 'total_jobs', 'jobs', 'per_month_in_error', 'User Jobs', page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 					%else:
 	                    <td class="third_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'per_month_in_error',
-                                    'User and Monitor Jobs',
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'per_month_in_error', 'User and Monitor Jobs', page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 	                %endif
                     <td></td>
                 </tr>
-                <% 
+                <%
                    ctr = 0
                    entries = 1
                 %>
@@ -125,16 +78,10 @@ ${get_css()}
 
                         <td><a href="${h.url_for( controller='jobs', action='specified_month_in_error', specified_date=job[0]+'-01', sort_id='default', order='default' )}">${job[2]}&nbsp;${job[3]}</a></td>
                         <td>${job[1]}</td>
-                        ${
-                            make_sparkline(
-                                key,
-                                trends[key],
-                                "bar",
-                                "/ day")
-                        }
+                        ${make_sparkline(key, trends[key], "bar", "/ day")}
                         <td id="${key}"></td>
                     </tr>
-                    <% 
+                    <%
                        ctr += 1
                        entries += 1
                     %>

--- a/templates/webapps/reports/jobs_per_tool.mako
+++ b/templates/webapps/reports/jobs_per_tool.mako
@@ -25,44 +25,18 @@ ${get_css()}
         <table id="formHeader">
             <tr>
                 <td>
-                    ${
-                        get_pages(
-                            sort_id,
-                            order,
-                            page_specs,
-                            'jobs',
-                            'per_tool',
-                            spark_time=time_period)
-                    }
+                    ${get_pages(sort_id, order, page_specs, 'jobs', 'per_tool', spark_time=time_period)}
                 </td>
                 <td>
                     <h4 align="center">Jobs Per Tool</h4>
                     <h5 align="center">
-                        Click Tool ID to view details. 
-                        Graph goes from present to past 
-                        ${
-                            make_spark_settings(
-                                "jobs",
-                                "per_tool",
-                                spark_limit,
-                                sort_id,
-                                order,
-                                time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        Click Tool ID to view details.
+                        Graph goes from present to past
+                        ${make_spark_settings("jobs", "per_tool", spark_limit, sort_id, order, time_period, page=page, offset=offset, entries=entries)}
                     </h5>
                 </td>
                 <td align="right">
-                    ${
-                        get_entry_selector(
-                            "jobs",
-                            "per_tool",
-                            page_specs.entries,
-                            sort_id,
-                            order)
-                    }
+                    ${get_entry_selector("jobs", "per_tool", page_specs.entries, sort_id, order)}
                 </td>
             </tr>
         </table>
@@ -72,59 +46,23 @@ ${get_css()}
             %else:
                 <tr class="header">
                     <td class="half_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'tool_id',
-                                'jobs',
-                                'per_tool',
-                                'Tool ID',
-                                spark_time=time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'tool_id', 'jobs', 'per_tool', 'Tool ID', spark_time=time_period, page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow tool_id'>${arrow}</span>
                     </td>
                     %if is_user_jobs_only:
                         <td class="third_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'per_tool',
-                                    'User Jobs',
-                                    spark_time=time_period,
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'per_tool', 'User Jobs', spark_time=time_period, page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 					%else:
                         <td class="third_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'per_tool',
-                                    'User and Monitor Jobs',
-                                    spark_time=time_period,
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'per_tool', 'User and Monitor Jobs', spark_time=time_period, page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 	                %endif
                     <td></td>
                 </tr>
-                <% 
+                <%
                    ctr = 0
                    entries = 1
                 %>
@@ -148,18 +86,12 @@ ${get_css()}
                         </td>
                         <td>${job[1]}</td>
                         %try:
-                            ${
-                                make_sparkline(
-                                    key,
-                                    trends[key],
-                                    "bar",
-                                    "/ " + time_period[:-1])
-                            }
+                            ${make_sparkline(key, trends[key], "bar", "/ " + time_period[:-1])}
                         %except KeyError:
                         %endtry
                         <td id="${key}"></td>
                     </tr>
-                    <% 
+                    <%
                        ctr += 1
                        entries += 1
                     %>

--- a/templates/webapps/reports/jobs_per_user.mako
+++ b/templates/webapps/reports/jobs_per_user.mako
@@ -26,44 +26,18 @@ ${q1time}, ${q2time}, ${ttime}
         <table id="formHeader">
             <tr>
                 <td>
-                    ${
-                        get_pages(
-                            sort_id,
-                            order,
-                            page_specs,
-                            'jobs',
-                            'per_user',
-                            spark_time=time_period)
-                    }
+                  ${get_pages(sort_id, order, page_specs, 'jobs', 'per_user', spark_time=time_period)}
                 </td>
                 <td>
                     <h4 align="center">Jobs Per User</h4>
                     <h5 align="center">
                         Click User to view details.
                         Graph goes from present to past
-                        ${
-                            make_spark_settings(
-                                "jobs",
-                                "per_user",
-                                spark_limit,
-                                sort_id,
-                                order,
-                                time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${make_spark_settings("jobs", "per_user", spark_limit, sort_id, order, time_period, page=page, offset=offset, entries=entries)}
                     </h5>
                 </td>
                 <td align="right">
-                    ${
-                        get_entry_selector(
-                            "jobs",
-                            "per_user",
-                            page_specs.entries,
-                            sort_id,
-                            order)
-                    }
+                  ${get_entry_selector("jobs", "per_user", page_specs.entries, sort_id, order)}
                 </td>
             </tr>
         </table>
@@ -73,40 +47,16 @@ ${q1time}, ${q2time}, ${ttime}
             %else:
                 <tr class="header">
                     <td class="half_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'user_email',
-                                'jobs',
-                                'per_user',
-                                'User',
-                                spark_time=time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'user_email', 'jobs', 'per_user', 'User', spark_time=time_period, page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow user_email'>${arrow}</span>
                     </td>
                     <td class="third_width">
-                        ${
-                            get_sort_url(
-                            sort_id,
-                            order,
-                            'total_jobs',
-                            'jobs',
-                            'per_user',
-                            'Total Jobs',
-                            spark_time=time_period,
-                            page=page,
-                            offset=offset,
-                            entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'per_user', 'Total Jobs', spark_time=time_period, page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow total_jobs'>${arrow}</span>
                     </td>
                     <td></td>
                 </tr>
-                <% 
+                <%
                    ctr = 0
                    entries = 1
                 %>
@@ -130,18 +80,12 @@ ${q1time}, ${q2time}, ${ttime}
                         </td>
                         <td>${job[1]}</td>
                         %try:
-                            ${
-                                make_sparkline(
-                                    key,
-                                    trends[key],
-                                    "bar",
-                                    "/ " + time_period[:-1])
-                            }
+                            ${make_sparkline(key, trends[key], "bar", "/ " + time_period[:-1])}
                         %except KeyError:
                         %endtry
                         <td id="${key}"></td>
                     </tr>
-                    <% 
+                    <%
                        ctr += 1
                        entries += 1
                     %>
@@ -151,4 +95,3 @@ ${q1time}, ${q2time}, ${ttime}
     </div>
 </div>
 <!--End jobs_per_user.mako-->
-        

--- a/templates/webapps/reports/jobs_specified_month_all.mako
+++ b/templates/webapps/reports/jobs_specified_month_all.mako
@@ -22,14 +22,7 @@ ${get_css()}
         <table id="formHeader">
             <tr>
                 <td>
-                    ${
-                        get_pages(
-                            sort_id,
-                            order,
-                            page_specs,
-                            'jobs',
-                            'specified_month_all')
-                    }
+                    ${get_pages(sort_id, order, page_specs, 'jobs', 'specified_month_all')}
                 </td>
                 <td>
                     <h4 align="center">
@@ -43,14 +36,7 @@ ${get_css()}
                     </h5>
                 </td>
                 <td align="right">
-                    ${
-                        get_entry_selector(
-                            "jobs",
-                            "specified_month_all",
-                            page_specs.entries,
-                            sort_id,
-                            order)
-                    }
+                    ${get_entry_selector("jobs", "specified_month_all", page_specs.entries, sort_id, order)}
                 </td>
             </tr>
         </table>
@@ -65,56 +51,23 @@ ${get_css()}
                 <tr class="header">
                     <td class="quarter_width">Day</td>
                     <td class="quarter_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'date',
-                                'jobs',
-                                'specified_month_all',
-                                'Date',
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'date', 'jobs', 'specified_month_all', 'Date', page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow date'>${arrow}</span>
                     </td>
                     %if is_user_jobs_only:
     					<td class="quarter_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'specified_month_all',
-                                    'User Jobs',
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'specified_month_all', 'User Jobs', page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 					%else:
 	                    <td class="quarter_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'specified_month_all',
-                                    'User and Monitor Jobs',
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'specified_month_all', 'User and Monitor Jobs', page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 	                %endif
                     <td></td>
                 </tr>
-                <% 
+                <%
                    ctr = 0
                    entries = 1
                 %>
@@ -138,16 +91,10 @@ ${get_css()}
                                 ${job[2]}
                             </a>
                         </td>
-                        ${
-                            make_sparkline(
-                                key,
-                                trends[key],
-                                "bar",
-                                "/ hour")
-                        }
+                        ${make_sparkline(key, trends[key], "bar", "/ hour")}
                         <td id="${key}"></td>
                     </tr>
-                    <% 
+                    <%
                        ctr += 1
                        entries += 1
                     %>

--- a/templates/webapps/reports/jobs_specified_month_in_error.mako
+++ b/templates/webapps/reports/jobs_specified_month_in_error.mako
@@ -21,14 +21,7 @@ ${get_css()}
         <table id="formHeader">
             <tr>
                 <td>
-                    ${
-                        get_pages(
-                            sort_id,
-                            order,
-                            page_specs,
-                            'jobs',
-                            'specified_month_in_error')
-                    }
+                    ${get_pages(sort_id, order, page_specs, 'jobs', 'specified_month_in_error')}
                 </td>
                 <td>
                     <h4 align="center">
@@ -39,14 +32,7 @@ ${get_css()}
                     </h5>
                 </td>
                 <td align="right">
-                    ${
-                        get_entry_selector(
-                            "jobs",
-                            "specified_month_in_error",
-                            page_specs.entries,
-                            sort_id,
-                            order)
-                    }
+                    ${get_entry_selector("jobs", "specified_month_in_error", page_specs.entries, sort_id, order)}
                 </td>
             </tr>
         </table>
@@ -62,56 +48,23 @@ ${get_css()}
                 <tr class="header">
                     <td class="quarter_width">Day</td>
                     <td class="quarter_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'date',
-                                'jobs',
-                                'specified_month_in_error',
-                                'Date',
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'date', 'jobs', 'specified_month_in_error', 'Date', page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow date'>${arrow}</span>
                     </td>
                     %if is_user_jobs_only:
     					<td class="quarter_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'specified_month_in_error',
-                                    'User Jobs in Error',
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'specified_month_in_error', 'User Jobs in Error', page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 					%else:
 	                    <td class="quarter_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'specified_month_in_error',
-                                    'User and Monitor Jobs in Error',
-                                    page=page,
-                                    offset=offset,
-                                    entries=entries)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'specified_month_in_error', 'User and Monitor Jobs in Error', page=page, offset=offset, entries=entries)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 	                %endif
                     <td></td>
                 </tr>
-                <% 
+                <%
                     ctr = 0
                     entries = 1
                 %>
@@ -137,16 +90,10 @@ ${get_css()}
                                 ${job[2]}
                             </a>
                         </td>
-                        ${
-                            make_sparkline(
-                                key,
-                                trends[key],
-                                "bar",
-                                "/ hour")
-                        }
+                        ${make_sparkline(key, trends[key], "bar", "/ hour")}
                         <td id="${key}"></td>
                     </tr>
-                    <% 
+                    <%
                         ctr += 1
                         entries += 1
                     %>

--- a/templates/webapps/reports/jobs_tool_per_month.mako
+++ b/templates/webapps/reports/jobs_tool_per_month.mako
@@ -7,7 +7,7 @@
     ${render_msg( message, 'done' )}
 %endif
 
-${get_css()}   
+${get_css()}
 
 
 <!--jobs_tool_per_month.mako-->
@@ -28,44 +28,17 @@ ${get_css()}
             %else:
                 <tr class="header">
                     <td class="third_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'date',
-                                'jobs',
-                                'tool_per_month',
-                                'Month',
-                                tool_id=tool_id)
-                        }
+                        ${get_sort_url(sort_id, order, 'date', 'jobs', 'tool_per_month', 'Month', tool_id=tool_id)}
                         <span class='dir_arrow date'>${arrow}</span>
                     </td>
                     %if is_user_jobs_only:
     					<td class="third_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'tool_per_month',
-                                    'User Jobs',
-                                    tool_id=tool_id)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'tool_per_month', 'User Jobs', tool_id=tool_id)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 					%else:
 	                    <td class="third_width">
-                            ${
-                                get_sort_url(
-                                    sort_id,
-                                    order,
-                                    'total_jobs',
-                                    'jobs',
-                                    'tool_per_month',
-                                    'User and Monitor Jobs',
-                                    tool_id=tool_id)
-                            }
+                            ${get_sort_url(sort_id, order, 'total_jobs', 'jobs', 'tool_per_month', 'User and Monitor Jobs', tool_id=tool_id)}
                             <span class='dir_arrow total_jobs'>${arrow}</span>
                         </td>
 	                %endif
@@ -81,13 +54,7 @@ ${get_css()}
                     %endif
                         <td>${job[2]}&nbsp;${job[3]}</td>
                         <td><a href="${h.url_for( controller='jobs', action='specified_date_handler', operation='tool_for_month', tool_id=tool_id, specified_date=job[0] )}">${job[1]}</a></td>
-                        ${
-                            make_sparkline(
-                                key,
-                                trends[key],
-                                "bar",
-                                "/ day")
-                        }
+                        ${make_sparkline(key, trends[key], "bar", "/ day")}
                         <td id="${key}"></td>
                     </tr>
                     <% ctr += 1 %>
@@ -97,4 +64,3 @@ ${get_css()}
     </div>
 </div>
 <!--End jobs_tool_per_month.mako-->
-        

--- a/templates/webapps/reports/jobs_user_per_month.mako
+++ b/templates/webapps/reports/jobs_user_per_month.mako
@@ -3,8 +3,8 @@
 <%namespace file="/spark_base.mako" import="make_sparkline" />
 <%namespace file="/sorting_base.mako" import="get_sort_url, get_css" />
 
-<% 
-   from galaxy import util 
+<%
+   from galaxy import util
 %>
 
 %if message:
@@ -16,7 +16,7 @@ ${get_css()}
 <%
    _email = util.restore_text( email )
 %>
-    
+
 <!--jobs_user_per_month.mako-->
 <div class="report">
     <div class="reportBody">
@@ -35,29 +35,11 @@ ${get_css()}
             %else:
                 <tr class="header">
                     <td class="third_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'date',
-                                'jobs',
-                                'user_per_month',
-                                'Month',
-                                email=email)
-                        }
+                        ${get_sort_url(sort_id, order, 'date', 'jobs', 'user_per_month', 'Month', email=email)}
                         <span class='dir_arrow date'>${arrow}</span>
                     </td>
                     <td class="third_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'total_jobs',
-                                'jobs',
-                                'user_per_month',
-                                'Total Jobs',
-                                email=email)
-                        }
+                        ${get_sort_url( sort_id, order, 'total_jobs', 'jobs', 'user_per_month', 'Total Jobs', email=email)}
                         <span class='dir_arrow total_jobs'>${arrow}</span>
                     </td>
                     <td></td>
@@ -76,13 +58,7 @@ ${get_css()}
                                 ${job[1]}
                             </a>
                         </td>
-                        ${
-                            make_sparkline(
-                                key,
-                                trends[key],
-                                "bar",
-                                "/ day")
-                        }
+                        ${make_sparkline(key, trends[key], "bar", "/ day")}
                         <td id="${key}"></td>
                     </tr>
                     <% ctr += 1 %>

--- a/templates/webapps/reports/registered_users_per_month.mako
+++ b/templates/webapps/reports/registered_users_per_month.mako
@@ -21,27 +21,11 @@ ${get_css()}
             %else:
                 <tr class="header">
                     <td class="half_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'date',
-                                'users',
-                                'registered_users_per_month',
-                                'Month')
-                        }
+                        ${get_sort_url(sort_id, order, 'date', 'users', 'registered_users_per_month', 'Month')}
                         <span class='dir_arrow date'>${arrow}</span>
                     </td>
                     <td class="half_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'num_users',
-                                'users',
-                                'registered_users_per_month',
-                                'Number of Registrations')
-                        }
+                        ${get_sort_url(sort_id, order, 'num_users', 'users', 'registered_users_per_month', 'Number of Registrations')}
                         <span class='dir_arrow num_users'>${arrow}</span>
                     </td>
                 </tr>

--- a/templates/webapps/reports/requests_user_per_month.mako
+++ b/templates/webapps/reports/requests_user_per_month.mako
@@ -9,7 +9,7 @@
 %if message:
     ${render_msg( message, 'done' )}
 %endif
-    
+
 ${get_css()}
 
 <div class="report">
@@ -29,27 +29,11 @@ ${get_css()}
             %else:
                 <tr class="header">
                     <td class="half_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'date',
-                                'users',
-                                'requests_users_per_month',
-                                'Month')
-                        }
+                        ${get_sort_url(sort_id, order, 'date', 'users', 'requests_users_per_month', 'Month')}
                         <span class='dir_arrow date'>${arrow}</span>
                     </td>
                     <td class="half_width">Total
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'num_users',
-                                'users',
-                                'requests_users_per_month',
-                                'Month')
-                        }
+                        ${get_sort_url(sort_id, order, 'num_users', 'users', 'requests_users_per_month', 'Month')}
                         <span class='dir_arrow num_users'>${arrow}</span>
                     </td>
                 </tr>

--- a/templates/webapps/reports/users_last_access_date.mako
+++ b/templates/webapps/reports/users_last_access_date.mako
@@ -24,9 +24,9 @@ ${get_css()}
                             ${len( users ) }
                         %else:
                             0
-                        %endif 
-                        &nbsp;users have not logged in to Galaxy for 
-                        <input type="textfield" 
+                        %endif
+                        &nbsp;users have not logged in to Galaxy for
+                        <input type="textfield"
                                value="${days_not_logged_in}"
                                size="3"
                                name="days_not_logged_in">
@@ -46,29 +46,11 @@ ${get_css()}
         %if users:
             <tr class="header">
                 <td class="half_width">
-                    ${
-                        get_sort_url(
-                            sort_id,
-                            order,
-                            'zero',
-                            'users',
-                            'last_access_date',
-                            'Email',
-                            days_not_logged_in=days_not_logged_in)
-                    }
+                    ${get_sort_url(sort_id, order, 'zero', 'users', 'last_access_date', 'Email', days_not_logged_in=days_not_logged_in)}
                     <span class='dir_arrow zero'>${arrow}</span>
                 </td>
                 <td class="half_width">
-                    ${
-                        get_sort_url(
-                            sort_id,
-                            order,
-                            'one',
-                            'users',
-                            'last_access_date',
-                            'Date of last Login',
-                            days_not_logged_in=days_not_logged_in)
-                    }
+                    ${get_sort_url(sort_id, order, 'one', 'users', 'last_access_date', 'Date of last Login', days_not_logged_in=days_not_logged_in)}
                     <span class='dir_arrow one'>${arrow}</span>
                 </td>
             </tr>

--- a/templates/webapps/reports/users_user_disk_usage.mako
+++ b/templates/webapps/reports/users_user_disk_usage.mako
@@ -15,11 +15,11 @@ ${get_css()}
     <table class="colored diskUsageForm">
         <tr>
             <td>
-                <form method="post" 
+                <form method="post"
                       controller="users"
                       action="user_disk_usage">
                     <p>
-                        Top <input type="textfield" 
+                        Top <input type="textfield"
                                    value="${user_cutoff}"
                                    size="3"
                                    name="user_cutoff">
@@ -36,27 +36,11 @@ ${get_css()}
         %if users:
             <tr class="header">
                 <td class="half_width">
-                    ${
-                        get_sort_url(
-                            sort_id,
-                            order,
-                            'email',
-                            'users',
-                            'user_disk_usage',
-                            'Email')
-                    }
+                    ${get_sort_url(sort_id, order, 'email', 'users', 'user_disk_usage', 'Email')}
                     <span class='dir_arrow email'>${arrow}</span>
                 </td>
                 <td class="half_width">
-                    ${
-                        get_sort_url(
-                            sort_id,
-                            order,
-                            'disk_usage',
-                            'users',
-                            'user_disk_usage',
-                            'Disk Usage')
-                    }
+                    ${get_sort_url(sort_id, order, 'disk_usage', 'users', 'user_disk_usage', 'Disk Usage')}
                     <span class='dir_arrow disk_usage'>${arrow}</span>
                 </td>
             </tr>

--- a/templates/webapps/reports/workflows_per_month_all.mako
+++ b/templates/webapps/reports/workflows_per_month_all.mako
@@ -21,27 +21,13 @@ ${get_css()}
         <table id="formHeader">
             <tr>
                 <td>
-                    ${
-                        get_pages(
-                            sort_id,
-                            order,
-                            page_specs,
-                            'workflows',
-                            'per_month_all')
-                    }
+                    ${get_pages(sort_id, order, page_specs, 'workflows', 'per_month_all')}
                 </td>
                 <td>
                     <h3 align="center">Workflows Per Month</h3>
                 </td>
                 <td align="right">
-                    ${
-                        get_entry_selector(
-                            "workflows",
-                            "per_month_all",
-                            page_specs.entries,
-                            sort_id,
-                            order)
-                    }
+                    ${get_entry_selector("workflows", "per_month_all", page_specs.entries, sort_id, order)}
                 </td>
             </tr>
         </table>
@@ -52,33 +38,11 @@ ${get_css()}
             %else:
                 <tr class="header">
                     <td class="half_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'date',
-                                'workflows',
-                                'per_month_all',
-                                'Month',
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'date', 'workflows', 'per_month_all', 'Month', page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow date'>${arrow}</span>
                     </td>
                     <td class="half_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'total_workflows',
-                                'workflows',
-                                'per_month_all',
-                                'Total',
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'total_workflows', 'workflows', 'per_month_all', 'Total', page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow total_workflows'>${arrow}</span>
                     </td>
                     <td></td>
@@ -104,22 +68,16 @@ ${get_css()}
                     %else:
                         <tr class="tr">
                     %endif
-                    
+
                         <td>${month}</td>
                         <td>${total}</td>
                         %try:
-                            ${
-                                make_sparkline(
-                                    key,
-                                    trends[key],
-                                    "bar",
-                                    "/ day")
-                            }
+                            ${make_sparkline(key, trends[key], "bar", "/ day")}
                         %except KeyError:
                         %endtry
                         <td id=${key}></td>
                     </tr>
-                    <% 
+                    <%
                        ctr += 1
                        entries += 1
                     %>

--- a/templates/webapps/reports/workflows_per_user.mako
+++ b/templates/webapps/reports/workflows_per_user.mako
@@ -26,86 +26,37 @@ ${get_css()}
         <table id="formHeader">
             <tr>
                 <td>
-                    ${
-                        get_pages(
-                            sort_id,
-                            order,
-                            page_specs,
-                            'workflows',
-                            'per_user',
-                            spark_time=time_period)
-                    }
+                    ${get_pages(sort_id, order, page_specs, 'workflows', 'per_user', spark_time=time_period)}
                 </td>
                 <td>
                     <h3 align="center">Workflows Per User</h3>
                     <h5 align="center">
-                        Graph goes from present to past 
-                        ${
-                            make_spark_settings(
-                                "jobs",
-                                "per_user",
-                                spark_limit,
-                                sort_id, order,
-                                time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        Graph goes from present to past
+                        ${make_spark_settings("jobs", "per_user", spark_limit, sort_id, order, time_period, page=page, offset=offset, entries=entries)}
                     </h5>
                 </td>
                 <td align="right">
-                    ${
-                        get_entry_selector(
-                            "workflows",
-                            "per_user",
-                            page_specs.entries,
-                            sort_id,
-                            order)
-                    }
+                    ${get_entry_selector("workflows", "per_user", page_specs.entries, sort_id, order)}
                 </td>
             </tr>
         </table>
-        
+
         <table align="center" width="60%" class="colored">
             %if len( workflows ) == 0:
                 <tr><td colspan="2">There are no workflows</td></tr>
             %else:
                 <tr class="header">
                     <td class="half_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'user_email',
-                                'workflows',
-                                'per_user',
-                                'User',
-                                spark_time=time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'user_email', 'workflows', 'per_user', 'User', spark_time=time_period, page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow user_email'>${arrow}</span>
                     </td>
                     <td class="third_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'total_workflows',
-                                'workflows',
-                                'per_user',
-                                'Total Workflows',
-                                spark_time=time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'total_workflows', 'workflows', 'per_user', 'Total Workflows', spark_time=time_period, page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow total_workflows'>${arrow}</span>
                     </td>
                     <td></td>
                 </tr>
-                <% 
+                <%
                    ctr = 0
                    entries = 1
                 %>
@@ -136,18 +87,12 @@ ${get_css()}
                         </td>
                         <td>${total}</td>
                         %try:
-                            ${
-                                make_sparkline(
-                                    key,
-                                    trends[key],
-                                    "bar",
-                                    "/ " + time_period[:-1])
-                            }
+                            ${make_sparkline(key, trends[key], "bar", "/ " + time_period[:-1])}
                         %except KeyError:
                         %endtry
                         <td id="${key}"></td>
                     </tr>
-                    <% 
+                    <%
                        ctr += 1
                        entries += 1
                     %>

--- a/templates/webapps/reports/workflows_per_workflow.mako
+++ b/templates/webapps/reports/workflows_per_workflow.mako
@@ -25,103 +25,41 @@ ${get_css()}
         <table id="formHeader">
             <tr>
                 <td>
-                    ${
-                        get_pages(
-                            sort_id,
-                            order,
-                            page_specs,
-                            'workflows',
-                            'per_workflow',
-                            spark_time=time_period)
-                    }
+                    ${get_pages(sort_id, order, page_specs, 'workflows', 'per_workflow', spark_time=time_period)}
                 </td>
                 <td>
                     <h4 align="center">Runs per Workflow</h4>
                     <h5 align="center">
-                        Graph goes from present to past 
-                        ${
-                            make_spark_settings(
-                                'workflows',
-                                'per_workflow',
-                                spark_limit,
-                                sort_id,
-                                order,
-                                time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        Graph goes from present to past
+                        ${make_spark_settings('workflows', 'per_workflow', spark_limit, sort_id, order, time_period, page=page, offset=offset, entries=entries)}
                     </h5>
                 </td>
                 <td align="right">
-                    ${
-                        get_entry_selector(
-                            "workflows",
-                            "per_workflow",
-                            page_specs.entries,
-                            sort_id,
-                            order)
-                    }
+                    ${get_entry_selector("workflows", "per_workflow", page_specs.entries, sort_id, order)}
                 </td>
             </tr>
         </table>
-        
+
         <table align="center" width="60%" class="colored">
             %if len( runs ) == 0:
                 <tr><td colspan="2">There are no runs.</td></tr>
             %else:
                 <tr class="header">
                     <td class="quarter_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'workflow_id',
-                                'workflows',
-                                'per_workflow',
-                                'Workflow ID',
-                                spark_time=time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'workflow_id', 'workflows', 'per_workflow', 'Workflow ID', spark_time=time_period, page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow workflow_id'>${arrow}</span>
                     </td>
                     <td class="quarter_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'workflow_name',
-                                'workflows',
-                                'per_workflow',
-                                'Workflow Name',
-                                spark_time=time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'workflow_name', 'workflows', 'per_workflow', 'Workflow Name', spark_time=time_period, page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow workflow_name'>${arrow}</span>
                     </td>
                     <td class="quarter_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'total_runs',
-                                'workflows',
-                                'per_workflow',
-                                'Workflow Runs',
-                                spark_time=time_period,
-                                page=page,
-                                offset=offset,
-                                entries=entries)
-                        }
+                        ${get_sort_url(sort_id, order, 'total_runs', 'workflows', 'per_workflow', 'Workflow Runs', spark_time=time_period, page=page, offset=offset, entries=entries)}
                         <span class='dir_arrow total_runs'>${arrow}</span>
                     </td>
                     <td></td>
                 </tr>
-                <% 
+                <%
                    ctr = 0
                    entries = 1
                 %>
@@ -142,18 +80,12 @@ ${get_css()}
                         <td>${run[0]}</td>
                         <td>${run[1]}</td>
                         %try:
-                            ${
-                                make_sparkline(
-                                    key,
-                                    trends[key],
-                                    "bar",
-                                    "/ " + time_period[:-1])
-                            }
+                            ${make_sparkline(key, trends[key], "bar", "/ " + time_period[:-1])}
                         %except KeyError:
                         %endtry
                         <td id="${key}"></td>
                     </tr>
-                    <% 
+                    <%
                        ctr += 1
                        entries += 1
                     %>

--- a/templates/webapps/reports/workflows_user_per_month.mako
+++ b/templates/webapps/reports/workflows_user_per_month.mako
@@ -12,7 +12,7 @@
 %endif
 
 ${get_css()}
-    
+
 <%
    _email = util.restore_text( email )
 %>
@@ -33,29 +33,11 @@ ${get_css()}
             %else:
                 <tr class="header">
                     <td class="third_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'date',
-                                'workflows',
-                                'user_per_month',
-                                'Month',
-                                email=util.sanitize_text( email ))
-                        }
+                        ${get_sort_url(sort_id, order, 'date', 'workflows', 'user_per_month', 'Month', email=util.sanitize_text( email ))}
                         <span class='dir_arrow date'>${arrow}</span>
                     </td>
                     <td class="third_width">
-                        ${
-                            get_sort_url(
-                                sort_id,
-                                order,
-                                'total_workflows',
-                                'workflows',
-                                'user_per_month',
-                                'Total',
-                                email=util.sanitize_text( email ))
-                        }
+                        ${get_sort_url(sort_id, order, 'total_workflows', 'workflows', 'user_per_month', 'Total', email=util.sanitize_text( email ))}
                         <span class='dir_arrow total_workflows'>${arrow}</span>
                     </td>
                     <td></td>
@@ -74,13 +56,7 @@ ${get_css()}
                     %endif
                         <td>${month}</td>
                         <td>${total}</td>
-                        ${
-                            make_sparkline(
-                                key,
-                                trends[key],
-                                "bar",
-                                "/ day")
-                        }
+                        ${make_sparkline(key, trends[key], "bar", "/ day")}
                         <td id="${key}"></td>
                     </tr>
                     <% ctr += 1 %>


### PR DESCRIPTION
Hey guys,

There has been an issue with Reports in that some of the pages don't load due to an indentation error. It appears Python 3.x handles it fine but it's totally broken on Python 2.6:
![before](https://cloud.githubusercontent.com/assets/14098761/11640752/dc4fff74-9cf9-11e5-8b34-a87c0ba970e4.png)

Example of one of the errors:
`SyntaxException: (IndentationError) unexpected indent (<unknown>, line 2) (u"get_sort_url(sort_id, order, 'user_email', 'jobs',") in file 'templates/webapps/reports/jobs_per_user.mako' at line: 50 char: 25`

This PR fixes those errors by removing the indentations so that it works across Python versions. Thanks.
