### PR TITLE
Managers, users: properly return a boolean from has_requests

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -283,8 +283,7 @@ class UserSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin ):
             'quota_percent' : lambda i, k, **c: self.user_manager.quota( i ),
 
             'tags_used'     : lambda i, k, **c: self.user_manager.tags_used( i ),
-            # TODO: 'has_requests' is more apt
-            'requests'      : lambda i, k, trans=None, **c: self.user_manager.has_requests( i, trans )
+            'has_requests'  : lambda i, k, trans=None, **c: self.user_manager.has_requests( i, trans )
         })
 
 

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -235,7 +235,7 @@ class UserManager( base.ModelManager, deletable.PurgableManagerMixin ):
         if self.is_anonymous( user ):
             return False
         request_types = self.app.security_agent.get_accessible_request_types( trans, user )
-        return ( user.requests or request_types )
+        return bool( user.requests or request_types )
 
 
 class UserSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin ):

--- a/test/unit/managers/test_UserManager.py
+++ b/test/unit/managers/test_UserManager.py
@@ -182,7 +182,7 @@ class UserSerializerTestCase( BaseTestCase ):
         self.assertIsInstance( serialized[ 'nice_total_disk_usage' ], basestring )
         self.assertIsInstance( serialized[ 'quota_percent' ], ( type( None ), float ) )
         self.assertIsInstance( serialized[ 'tags_used' ], list )
-        self.assertIsInstance( serialized[ 'requests' ], list )
+        self.assertIsInstance( serialized[ 'has_requests' ], bool )
 
         self.log( 'serialized should jsonify well' )
         self.assertIsJsonifyable( serialized )


### PR DESCRIPTION
Previously returned zero or more Request objects which were not serializable to json.
