### PR TITLE
Log command executed during package installation

### DIFF
--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/install_environment.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/install_environment.py
@@ -156,6 +156,8 @@ class InstallEnvironment( object ):
         if len( job_name ) > 0:
             llog_name += ':' + job_name
         llog = logging.getLogger( llog_name )
+        # Print the command we're about to execute, ``set -x`` style.
+        llog.debug('+ ' + str( command ) )
         # Launch the command as subprocess.  A bufsize of 1 means line buffered.
         process_handle = subprocess.Popen( str( command ),
                                            stdout=subprocess.PIPE,


### PR DESCRIPTION
Instead of 

```
install_environment.STDOUT DEBUG 2015-12-08 13:02:00,788 checking build system type... x86_64-unknown-linux-gnu
install_environment.STDOUT DEBUG 2015-12-08 13:02:00,790 checking for gcc... gcc
tool_shed.galaxy_install.tool_dependencies.recipe.install_environment:hmmer DEBUG 2015-12-08 13:02:00,797 configure: Configuring HMMER for your system.
```

You now get 

```
tool_shed.galaxy_install.tool_dependencies.recipe.install_environment:hmmer DEBUG 2015-12-08 13:02:00,685 + ./configure --prefix=/some/long/path/package_hmmer_3_1b1/e49dc46333e2  && make && make install
install_environment.STDOUT DEBUG 2015-12-08 13:02:00,788 checking build system type... x86_64-unknown-linux-gnu
install_environment.STDOUT DEBUG 2015-12-08 13:02:00,790 checking for gcc... gcc
tool_shed.galaxy_install.tool_dependencies.recipe.install_environment:hmmer DEBUG 2015-12-08 13:02:00,797 configure: Configuring HMMER for your system.
```

the salient point being the bit:

```
2015-12-08 13:02:00,685 + ./configure --prefix=/some/long/path/package_hmmer_3_1b1/e49dc46333e2  && make && make install
```

 you actually see what command is being run, rather than just its output.
