### PR TITLE
[15.10] Log a warning for missing tool whitelist file only if explicitly defined.

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -253,7 +253,9 @@ class Configuration( object ):
         self.log_events = string_as_bool( kwargs.get( 'log_events', 'False' ) )
         self.sanitize_all_html = string_as_bool( kwargs.get( 'sanitize_all_html', True ) )
         self.sanitize_whitelist_file = resolve_path( kwargs.get( 'sanitize_whitelist_file', "config/sanitize_whitelist.txt" ), self.root )
-        self.reload_sanitize_whitelist(kwargs.get('sanitize_whitelist_file', None) is not None)
+        self.sanitize_whitelist = []
+        if kwargs.get('sanitize_whitelist_file', None) is not None:
+            self.reload_sanitize_whitelist()
         self.serve_xss_vulnerable_mimetypes = string_as_bool( kwargs.get( 'serve_xss_vulnerable_mimetypes', False ) )
         self.trust_ipython_notebook_conversion = string_as_bool( kwargs.get( 'trust_ipython_notebook_conversion', False ) )
         self.enable_old_display_applications = string_as_bool( kwargs.get( "enable_old_display_applications", "True" ) )
@@ -466,7 +468,7 @@ class Configuration( object ):
         else:
             return None
 
-    def reload_sanitize_whitelist( self, whitelist_file_explicitly_defined ):
+    def reload_sanitize_whitelist( self ):
         self.sanitize_whitelist = []
         try:
             with open(self.sanitize_whitelist_file, 'rt') as f:
@@ -474,8 +476,7 @@ class Configuration( object ):
                     if not line.startswith("#"):
                         self.sanitize_whitelist.append(line.strip())
         except IOError:
-            if whitelist_file_explicitly_defined:
-                log.warning("Sanitize log file %s does not exist, continuing with no tools whitelisted.", self.sanitize_whitelist_file)
+            log.warning("Sanitize log file %s does not exist, continuing with no tools whitelisted.", self.sanitize_whitelist_file)
 
     def __parse_config_file_options( self, kwargs ):
         """

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -253,7 +253,7 @@ class Configuration( object ):
         self.log_events = string_as_bool( kwargs.get( 'log_events', 'False' ) )
         self.sanitize_all_html = string_as_bool( kwargs.get( 'sanitize_all_html', True ) )
         self.sanitize_whitelist_file = resolve_path( kwargs.get( 'sanitize_whitelist_file', "config/sanitize_whitelist.txt" ), self.root )
-        self.reload_sanitize_whitelist()
+        self.reload_sanitize_whitelist(kwargs.get('sanitize_whitelist_file', None) is not None)
         self.serve_xss_vulnerable_mimetypes = string_as_bool( kwargs.get( 'serve_xss_vulnerable_mimetypes', False ) )
         self.trust_ipython_notebook_conversion = string_as_bool( kwargs.get( 'trust_ipython_notebook_conversion', False ) )
         self.enable_old_display_applications = string_as_bool( kwargs.get( "enable_old_display_applications", "True" ) )
@@ -466,7 +466,7 @@ class Configuration( object ):
         else:
             return None
 
-    def reload_sanitize_whitelist( self ):
+    def reload_sanitize_whitelist( self, whitelist_file_explicitly_defined ):
         self.sanitize_whitelist = []
         try:
             with open(self.sanitize_whitelist_file, 'rt') as f:
@@ -474,7 +474,8 @@ class Configuration( object ):
                     if not line.startswith("#"):
                         self.sanitize_whitelist.append(line.strip())
         except IOError:
-            log.warning("Sanitize log file %s does not exist, continuing with no tools whitelisted.")
+            if whitelist_file_explicitly_defined:
+                log.warning("Sanitize log file %s does not exist, continuing with no tools whitelisted.", self.sanitize_whitelist_file)
 
     def __parse_config_file_options( self, kwargs ):
         """


### PR DESCRIPTION
Also fix the log message.

Otherwise the message will pop up even when executing e.g. `python scripts/cleanup_datasets/cleanup_datasets.py` .
