### PR TITLE
[15.10] Update Kombu and AMQP eggs to fix problems with El Capitan's System Integrity Protection

### DIFF
--- a/eggs.ini
+++ b/eggs.ini
@@ -30,7 +30,7 @@ SQLAlchemy = 1.0.8
 ; msgpack_python = 0.2.4
 
 [eggs:noplatform]
-amqp = 1.4.6
+amqp = 1.4.8
 anyjson = 0.3.3
 Beaker = 1.4
 bioblend = 0.5.2
@@ -40,7 +40,7 @@ docutils = 0.7
 drmaa = 0.7.6
 Fabric = 1.7.0
 importlib = 1.0.3
-kombu = 3.0.24
+kombu = 3.0.30
 lrucache = 0.2
 Mako = 0.4.1
 mock = 1.0.1


### PR DESCRIPTION
As reported in [Biostar](https://biostar.usegalaxy.org/p/14492/) and by @gregvonkuster. New eggs are on https://eggs.galaxyproject.org/

This won't be mergeable to dev, I'll create a separate PR there updating the wheels.
