### PR TITLE
Enforce metrics related to moving toward modern client infrastructure.

### DIFF
--- a/.ci/check_controller.sh
+++ b/.ci/check_controller.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+MAX_LINE_COUNT=19900
+project_dir=`dirname $0`/..
+cd $project_dir
+bash -c "[ `find lib/galaxy/webapps/galaxy/controllers/ -name '*.py' | xargs wc -l | tail -n 1 | awk '{ printf \$1; }'` -lt $MAX_LINE_COUNT ]"

--- a/.ci/check_mako.sh
+++ b/.ci/check_mako.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+MAX_MAKO_COUNT=330
+project_dir=`dirname $0`/..
+cd $project_dir
+bash -c "[ `find templates -iname '*.mako'  | wc -l | cut -f1 -d' '` -lt $MAX_MAKO_COUNT ]"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
-envlist = py27-lint, py26-lint, py27-unit, py26-unit, qunit
+envlist = py27-lint, py26-lint, py27-unit, py26-unit, qunit, mako-count, web-controller-line-count
 skipsdist = True
+
 
 [testenv:py27-lint]
 commands = bash .ci/flake8_wrapper.sh
@@ -31,4 +32,12 @@ deps =
 
 [testenv:qunit]
 commands = bash run_tests.sh -q
+whitelist_externals = bash
+
+[testenv:mako-count]
+commands = bash .ci/check_mako.sh
+whitelist_externals = bash
+
+[testenv:web-controller-line-count]
+commands = bash .ci/check_controller.sh
 whitelist_externals = bash


### PR DESCRIPTION
Having a CI enforced blacklist and then a whitelist of files failing to meet style guidelines (as well as expanding list of rules enforced) may have helped create incentive to rework Galaxy toward a more compliant and uniform Python styling.

We briefly discussed the possibility of doing this with other team code base objectives on a conference call - in particular to help the transition toward replacing all of the web controllers with API controllers and eliminating the use of Python mako files for rendering web content and replacing it with client side templates.

To do this I have created two rough metrics - the number of lines of web controller code in the Galaxy app and the number of mako files in the templates directory. The hope is that people feel ... compelled to lower these numbers. While these metrics are admittedly rough, they do also encourage de-duplication of mako templates and transition of API code into managers (in addition to elimination of functions) both of these secondary incentives are also good things and should be project objectives.
