### PR TITLE
[15.10] Backport various testing fixes.

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -315,13 +315,36 @@ class BaseJobRunner( object ):
         with open( path, 'w' ) as f:
             f.write( contents )
         os.chmod( path, mode )
-        try:
-            # sync file system to avoid "Text file busy" problems.
-            # These have occurred both in Docker containers and on EC2 clusters
-            # under high load.
-            subprocess.check_call(["sync"])
-        except Exception:
-            pass
+        self._handle_script_integrity( path )
+
+    def _handle_script_integrity( self, path ):
+        if not getattr( self.app.config, "check_job_script_integrity", True ):
+            return
+
+        script_integrity_verified = False
+        for i in range(10):
+            try:
+                proc = subprocess.Popen( [path], shell=True, env={"ABC_TEST_JOB_SCRIPT_INTEGRITY_XYZ": "1"} )
+                proc.wait()
+                if proc.returncode == 42:
+                    script_integrity_verified = True
+                    break
+
+                # Else we will sync and wait to see if the script becomes
+                # executable.
+                try:
+                    # sync file system to avoid "Text file busy" problems.
+                    # These have occurred both in Docker containers and on EC2 clusters
+                    # under high load.
+                    subprocess.check_call(["/bin/sync"])
+                except Exception:
+                    pass
+                time.sleep( .25 )
+            except Exception:
+                pass
+
+        if not script_integrity_verified:
+            raise Exception("Failed to write job script, could not verify job script integrity.")
 
     def _complete_terminal_job( self, ajs, **kwargs ):
         if ajs.job_wrapper.get_state() != model.Job.states.DELETED:

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -306,6 +306,7 @@ def _test_elem_to_dict(test_elem, i):
         stderr=__parse_assert_list_from_elem( test_elem.find("assert_stderr") ),
         expect_exit_code=test_elem.get("expect_exit_code"),
         expect_failure=string_as_bool(test_elem.get("expect_failure", False)),
+        maxseconds=test_elem.get("maxseconds", None),
     )
     _copy_to_dict_if_present(test_elem, rval, ["interactor", "num_outputs"])
     return rval

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -14,7 +14,7 @@ log = logging.getLogger( __name__ )
 DEFAULT_FTYPE = 'auto'
 DEFAULT_DBKEY = 'hg17'
 DEFAULT_INTERACTOR = "api"  # Default mechanism test code uses for interacting with Galaxy instance.
-DEFAULT_MAX_SECS = 120
+DEFAULT_MAX_SECS = None
 
 
 @nottest
@@ -42,7 +42,9 @@ class ToolTestBuilder( object ):
 
     def __init__( self, tool, test_dict, i, default_interactor ):
         name = test_dict.get( 'name', 'Test-%d' % (i + 1) )
-        maxseconds = int( test_dict.get( 'maxseconds', DEFAULT_MAX_SECS ) )
+        maxseconds = test_dict.get( 'maxseconds', DEFAULT_MAX_SECS )
+        if maxseconds is not None:
+            maxseconds = int( maxseconds )
 
         self.tool = tool
         self.name = name

--- a/scripts/functional_tests.py
+++ b/scripts/functional_tests.py
@@ -336,6 +336,7 @@ def main():
                        user_library_import_dir=user_library_import_dir,
                        master_api_key=master_api_key,
                        use_tasked_jobs=True,
+                       check_migrate_tools=False,
                        cleanup_job='onsuccess',
                        enable_beta_tool_formats=True,
                        auto_configure_logging=logging_config_file is None,

--- a/test/api/helpers.py
+++ b/test/api/helpers.py
@@ -70,10 +70,14 @@ class BaseDatasetPopulator( object ):
     Galaxy - implementations must implement _get and _post.
     """
 
-    def new_dataset( self, history_id, content='TestData123', **kwds ):
+    def new_dataset( self, history_id, content='TestData123', wait=False, **kwds ):
         payload = self.upload_payload( history_id, content, **kwds )
-        run_response = self._post( "tools", data=payload )
-        return run_response.json()["outputs"][0]
+        run_response = self._post( "tools", data=payload ).json()
+        if wait:
+            job = run_response["jobs"][0]
+            self.wait_for_job(job["id"])
+            self.wait_for_history(history_id)
+        return run_response["outputs"][0]
 
     def wait_for_history( self, history_id, assert_ok=False, timeout=DEFAULT_TIMEOUT ):
         try:

--- a/test/api/helpers.py
+++ b/test/api/helpers.py
@@ -76,7 +76,7 @@ class BaseDatasetPopulator( object ):
         if wait:
             job = run_response["jobs"][0]
             self.wait_for_job(job["id"])
-            self.wait_for_history(history_id)
+            self.wait_for_history(history_id, assert_ok=True)
         return run_response["outputs"][0]
 
     def wait_for_history( self, history_id, assert_ok=False, timeout=DEFAULT_TIMEOUT ):

--- a/test/api/test_jobs.py
+++ b/test/api/test_jobs.py
@@ -200,8 +200,8 @@ class JobsApiTestCase( api.ApiTestCase, TestsDatasets ):
         return history_id, dataset_id
 
     def __history_with_ok_dataset( self ):
-        history_id, dataset_id = self.__history_with_new_dataset()
-        self._wait_for_history( history_id, assert_ok=True )
+        history_id = self._new_history()
+        dataset_id = self._new_dataset( history_id, wait=True )[ "id" ]
         return history_id, dataset_id
 
     def __jobs_index( self, **kwds ):

--- a/test/api/test_jobs.py
+++ b/test/api/test_jobs.py
@@ -137,17 +137,27 @@ class JobsApiTestCase( api.ApiTestCase, TestsDatasets ):
 
         empty_search_response = self._post( "jobs/search", data=search_payload )
         self._assert_status_code_is( empty_search_response, 200 )
-        assert len( empty_search_response.json() ) == 0
+        self.assertEquals( len( empty_search_response.json() ), 0 )
 
         self.__run_cat_tool( history_id, dataset_id )
         self._wait_for_history( history_id, assert_ok=True )
 
-        self.__assert_one_search_result( search_payload )
+        search_count = -1
+        # in case job and history aren't updated at exactly the same
+        # time give time to wait
+        for i in range(5):
+            search_count = self._search_count(search_payload)
+            if search_count == 1:
+                break
+            time.sleep(.1)
 
-    def __assert_one_search_result( self, search_payload ):
+        self.assertEquals( search_count, 1 )
+
+    def _search_count( self, search_payload ):
         search_response = self._post( "jobs/search", data=search_payload )
         self._assert_status_code_is( search_response, 200 )
-        assert len( search_response.json() ) == 1, search_response.json()
+        search_json = search_response.json()
+        return len(search_json)
 
     def __run_cat_tool( self, history_id, dataset_id ):
         # Code duplication with test_jobs.py, eliminate

--- a/test/base/twilltestcase.py
+++ b/test/base/twilltestcase.py
@@ -40,6 +40,8 @@ tc.config( 'use_tidy', 0 )
 logging.getLogger( "ClientCookie.cookies" ).setLevel( logging.WARNING )
 log = logging.getLogger( __name__ )
 
+DEFAULT_TOOL_TEST_WAIT = os.environ.get("GALAXY_TEST_DEFAULT_WAIT", 86400)
+
 
 class TwillTestCase( unittest.TestCase ):
 
@@ -2443,15 +2445,16 @@ class TwillTestCase( unittest.TestCase ):
     def wait_for( self, func, **kwd ):
         sleep_amount = 0.2
         slept = 0
-        walltime_exceeded = 86400
+        walltime_exceeded = kwd.get("maxseconds", None)
+        if walltime_exceeded is None:
+            walltime_exceeded = DEFAULT_TOOL_TEST_WAIT
+        log.info("walltime_exceeded is %s" % walltime_exceeded)
         while slept <= walltime_exceeded:
             result = func()
             if result:
                 time.sleep( sleep_amount )
                 slept += sleep_amount
                 sleep_amount *= 2
-                if slept + sleep_amount > walltime_exceeded:
-                    sleep_amount = walltime_exceeded - slept  # don't overshoot maxseconds
             else:
                 break
         assert slept < walltime_exceeded, 'Tool run exceeded reasonable walltime of 24 hours, terminating.'

--- a/test/functional/tools/maxseconds.xml
+++ b/test/functional/tools/maxseconds.xml
@@ -1,5 +1,5 @@
 <tool id="maxseconds" name="maxseconds" version="0.1.0">
-    <command>
+    <command detect_errors="exit_code">
         sleep 100
     </command>
     <inputs>

--- a/test/functional/tools/maxseconds.xml
+++ b/test/functional/tools/maxseconds.xml
@@ -1,0 +1,16 @@
+<tool id="maxseconds" name="maxseconds" version="0.1.0">
+    <command>
+        sleep 100
+    </command>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="out_file1" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" maxseconds="5">
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -23,6 +23,7 @@
   <tool file="metadata_bcf.xml" />
   <tool file="detect_errors_aggressive.xml" />
   <tool file="md5sum.xml" />
+  <tool file="maxseconds.xml" />
   <tool file="job_properties.xml" />
   <tool file="gzipped_inputs.xml" />
   <tool file="output_order.xml" />


### PR DESCRIPTION
For the most part these seemed to work to make the API tests fail less.

Other testing improvements in dev have come through improvements to the Docker container which we have regrettably called `galaxy/testing-base:15.10.3` even though it is probably not compatible with Galaxy 15.10 - that should probably `galaxy/testing-base:16.01.2` or something like that. Since this doesn't backport tool shed fixes or address the docker situation, 15.10 still won't run the full suite that dev can.
