### PR TITLE
Collection Operations

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -263,6 +263,12 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # Disable the 'Auto-detect' option for file uploads
 #datatypes_disable_auto = False
 
+# Location of nodejs executable. Certain optional features of Galaxy
+# require a nodejs runtime (https://nodejs.org/en/), Galaxy can be configured
+# to target a specific executable with this option. If left commented
+# out Galaxy will just check the PATH for a nodejs executable.
+#nodejs_path = None
+
 # Visualizations config directory: where to look for individual visualization
 # plugins.  The path is relative to the Galaxy root dir.  To use an absolute
 # path begin the path with '/'.  This is a comma separated list.

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -168,6 +168,7 @@ class Configuration( object ):
         self.cluster_files_directory = os.path.abspath( kwargs.get( "cluster_files_directory", "database/pbs" ) )
         self.job_working_directory = resolve_path( kwargs.get( "job_working_directory", "database/job_working_directory" ), self.root )
         self.cleanup_job = kwargs.get( "cleanup_job", "always" )
+        self.nodejs_path = kwargs.get( "nodejs_path", None )
         self.container_image_cache_path = self.resolve_path( kwargs.get( "container_image_cache_path", "database/container_images" ) )
         self.outputs_to_working_directory = string_as_bool( kwargs.get( 'outputs_to_working_directory', False ) )
         self.output_size_limit = int( kwargs.get( 'output_size_limit', 0 ) )

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -13,6 +13,9 @@ from galaxy.managers import tags
 from galaxy.managers.collections_util import validate_input_element_identifiers
 from galaxy.util import odict
 from galaxy.util import validation
+
+from six import iteritems
+
 import logging
 log = logging.getLogger( __name__ )
 
@@ -120,14 +123,18 @@ class DatasetCollectionManager( object ):
         if not collection_type:
             raise RequestParameterInvalidException( ERROR_NO_COLLECTION_TYPE )
         collection_type_description = self.collection_type_descriptions.for_collection_type( collection_type )
+        has_subcollections = collection_type_description.has_subcollections( )
         # If we have elements, this is an internal request, don't need to load
         # objects from identifiers.
         if elements is None:
-            if collection_type_description.has_subcollections( ):
+            if has_subcollections:
                 # Nested collection - recursively create collections and update identifiers.
-                self.__recursively_create_collections( trans, element_identifiers )
+                self.__recursively_create_collections_for_identifiers( trans, element_identifiers )
             elements = self.__load_elements( trans, element_identifiers )
-        # else if elements is set, it better be an ordered dict!
+        else:
+            if has_subcollections:
+                # Nested collection - recursively create collections as needed.
+                self.__recursively_create_collections_for_elements( trans, elements )
 
         if elements is not self.ELEMENTS_UNINITIALIZED:
             type_plugin = collection_type_description.rank_type_plugin()
@@ -231,10 +238,10 @@ class DatasetCollectionManager( object ):
         context.flush()
         return dataset_collection_instance
 
-    def __recursively_create_collections( self, trans, element_identifiers ):
+    def __recursively_create_collections_for_identifiers( self, trans, element_identifiers ):
         for index, element_identifier in enumerate( element_identifiers ):
             try:
-                if not element_identifier[ "src" ] == "new_collection":
+                if element_identifier[ "src" ] != "new_collection":
                     # not a new collection, keep moving...
                     continue
             except KeyError:
@@ -251,6 +258,27 @@ class DatasetCollectionManager( object ):
             element_identifier[ "__object__" ] = collection
 
         return element_identifiers
+
+    def __recursively_create_collections_for_elements( self, trans, elements ):
+        if elements is self.ELEMENTS_UNINITIALIZED:
+            return
+
+        new_elements = odict.odict()
+        for key, element in iteritems(elements):
+            if element[ "src" ] != "new_collection":
+                continue
+
+            # element is a dict with src new_collection and
+            # and odict of named elements
+            collection_type = element.get( "collection_type", None )
+            sub_elements = element[ "elements" ]
+            collection = self.create_dataset_collection(
+                trans=trans,
+                collection_type=collection_type,
+                elements=sub_elements,
+            )
+            new_elements[key] = collection
+        elements.update(new_elements)
 
     def __load_elements( self, trans, element_identifiers ):
         elements = odict.odict()

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2097,6 +2097,10 @@ class DatasetInstance( object ):
         return True
 
     @property
+    def is_ok(self):
+        return self.state == self.states.OK
+
+    @property
     def is_pending( self ):
         """
         Return true if the dataset is neither ready nor in error

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3144,6 +3144,14 @@ class DatasetCollectionInstance( object, HasName ):
     def state( self ):
         return self.collection.state
 
+    @property
+    def populated( self ):
+        return self.collection.populated
+
+    @property
+    def dataset_instances( self ):
+        return self.collection.dataset_instances
+
     def display_name( self ):
         return self.get_display_name()
 
@@ -3152,7 +3160,7 @@ class DatasetCollectionInstance( object, HasName ):
             id=self.id,
             name=self.name,
             collection_type=self.collection.collection_type,
-            populated=self.collection.populated,
+            populated=self.populated,
             populated_state=self.collection.populated_state,
             populated_state_message=self.collection.populated_state_message,
             type="collection",  # contents type (distinguished from file or folder (in case of library))

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2878,6 +2878,32 @@ class DatabaseOperationTool( Tool ):
         return odict()
 
 
+class UsesExpressions:
+    requires_js_runtime = True
+
+    def _expression_environment( self, hda ):
+        raw_as_dict = hda.to_dict()
+        filtered_as_dict = {}
+        # We are more conservative with the API provided to tools
+        # than the API exposed via the web API, so cut down on what
+        # is supplied to the tool. Also, no reason to leak unneeded
+        # data prematurely regardless.
+        for key, value in raw_as_dict.iteritems():
+            include = False
+            if key.startswith("metadata_"):
+                include = True
+            elif key in FilterTool.exposed_hda_keys:
+                include = True
+            if include:
+                filtered_as_dict[key] = value
+        return filtered_as_dict
+
+    def _eval_expression(self, expression, environment_dict):
+        environment = expressions.jshead([], environment_dict)
+        result = expressions.execjs(self.app.config, expression, environment)
+        return result
+
+
 class UnzipCollectionTool( DatabaseOperationTool ):
     tool_type = 'unzip_collection'
 
@@ -2929,8 +2955,7 @@ class FilterFailedDatasetsTool( DatabaseOperationTool ):
         )
 
 
-class FilterTool( DatabaseOperationTool ):
-    requires_js_runtime = True
+class FilterTool( DatabaseOperationTool, UsesExpressions ):
     exposed_hda_keys = ['file_size', 'file_ext', 'genome_build']
     tool_type = 'filter_collection'
 
@@ -2941,9 +2966,8 @@ class FilterTool( DatabaseOperationTool ):
         new_elements = odict()
         for dce in hdca.collection.elements:
             element = dce.element_object
-            environment_dict = self.expression_environment(element)
-            environment = expressions.jshead([], environment_dict)
-            result = expressions.execjs(self.app.config, expression, environment)
+            environment_dict = self._expression_environment(element)
+            result = self._eval_expression(expression, environment_dict)
             if result:
                 element_identifier = dce.element_identifier
                 new_elements[element_identifier] = element.copy()
@@ -2951,23 +2975,6 @@ class FilterTool( DatabaseOperationTool ):
         output_collections.create_collection(
             self.outputs.values()[0], "output", elements=new_elements
         )
-
-    def expression_environment( self, hda ):
-        raw_as_dict = hda.to_dict()
-        filtered_as_dict = {}
-        # We are more conservative with the API provided to tools
-        # than the API exposed via the web API, so cut down on what
-        # is supplied to the tool. Also, no reason to leak unneeded
-        # data prematurely regardless.
-        for key, value in raw_as_dict.iteritems():
-            include = False
-            if key.startswith("metadata_"):
-                include = True
-            elif key in FilterTool.exposed_hda_keys:
-                include = True
-            if include:
-                filtered_as_dict[key] = value
-        return filtered_as_dict
 
 
 class FlattenTool( DatabaseOperationTool ):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -28,6 +28,7 @@ from galaxy.tools.actions import DefaultToolAction
 from galaxy.tools.actions.upload import UploadToolAction
 from galaxy.tools.actions.data_source import DataSourceToolAction
 from galaxy.tools.actions.data_manager import DataManagerToolAction
+from galaxy.tools.actions.model_operations import ModelOperationToolAction
 from galaxy.tools.parameters import params_to_incoming, check_param, params_from_strings, params_to_strings, visit_input_values
 from galaxy.tools.parameters import output_collect
 from galaxy.tools.parameters.basic import (BaseURLToolParameter,
@@ -94,6 +95,10 @@ class ToolErrorLog:
 
 
 global_tool_errors = ToolErrorLog()
+
+
+class ToolInputsNotReadyException( Exception ):
+    pass
 
 
 class ToolNotFoundException( Exception ):
@@ -1200,6 +1205,8 @@ class Tool( object, Dictifiable ):
         except httpexceptions.HTTPFound, e:
             # if it's a paste redirect exception, pass it up the stack
             raise e
+        except ToolInputsNotReadyException as e:
+            return False, e
         except Exception, e:
             log.exception('Exception caught while attempting tool execution:')
             message = 'Error executing tool: %s' % str(e)
@@ -2830,10 +2837,73 @@ class DataManagerTool( OutputParameterJSONTool ):
             log.debug( "User (%s) attempted to access a data manager tool (%s), but is not an admin.", user, self.id )
         return False
 
+
+class DatabaseOperationTool( Tool ):
+    default_tool_action = ModelOperationToolAction
+    require_dataset_ok = True
+
+    def check_inputs_ready( self, input_datasets, input_dataset_collections ):
+        def check_dataset_instance( input_dataset ):
+            if input_dataset.is_pending:
+                raise ToolInputsNotReadyException()
+
+            if self.require_dataset_ok:
+                if input_dataset.state != input_dataset.dataset.states.OK:
+                    raise ValueError("Tool requires inputs to be in valid state.")
+
+        for input_dataset in input_datasets.values():
+            check_dataset_instance( input_dataset )
+
+        for input_dataset_collection in input_dataset_collections.values():
+            if not input_dataset_collection.collection.populated:
+                raise ToolInputsNotReadyException()
+
+            map( check_dataset_instance, input_dataset_collection.dataset_instances )
+
+    def produce_outputs( self, trans, out_data, output_collections, incoming, history ):
+        return self._outputs_dict()
+
+    def _outputs_dict( self ):
+        return odict()
+
+
+class UnzipCollectionTool( DatabaseOperationTool ):
+    tool_type = 'unzip_collection'
+
+    def produce_outputs( self, trans, out_data, output_collections, incoming, history ):
+        hdca = incoming[ "input" ]
+        assert hdca.collection.collection_type == "paired"
+        forward_o, reverse_o = hdca.collection.dataset_instances
+        forward, reverse = forward_o.copy(), reverse_o.copy()
+        # TODO: rename...
+        history.add_dataset( forward, set_hid=True )
+        history.add_dataset( reverse, set_hid=True )
+        out_data["forward"] = forward
+        out_data["reverse"] = reverse
+
+
+class ZipCollectionTool( DatabaseOperationTool ):
+    tool_type = 'zip_collection'
+
+    def produce_outputs( self, trans, out_data, output_collections, incoming, history ):
+        forward_o = incoming[ "input_forward" ]
+        reverse_o = incoming[ "input_reverse" ]
+
+        forward, reverse = forward_o.copy(), reverse_o.copy()
+        new_elements = odict()
+        new_elements["forward"] = forward
+        new_elements["reverse"] = reverse
+
+        output_collections.create_collection(
+            self.outputs.values()[0], "output", elements=new_elements
+        )
+
+
 # Populate tool_type to ToolClass mappings
 tool_types = {}
 for tool_class in [ Tool, SetMetadataTool, OutputParameterJSONTool,
                     DataManagerTool, DataSourceTool, AsyncDataSourceTool,
+                    UnzipCollectionTool, ZipCollectionTool,
                     DataDestinationTool ]:
     tool_types[ tool_class.tool_type ] = tool_class
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3001,6 +3001,34 @@ class FlattenTool( DatabaseOperationTool ):
         )
 
 
+class GroupTool( DatabaseOperationTool, UsesExpressions ):
+    tool_type = 'group_collection'
+
+    def produce_outputs( self, trans, out_data, output_collections, incoming, history ):
+        hdca = incoming[ "input" ]
+        expression = incoming[ "expression" ]
+        new_elements = odict()
+        for dce in hdca.collection.elements:
+            element = dce.element_object
+            environment_dict = self._expression_environment(element)
+            result = str(self._eval_expression(expression, environment_dict))
+            if not result:
+                continue
+
+            if result not in new_elements:
+                result_elements = {}
+                result_elements["src"] = "new_collection"
+                result_elements["collection_type"] = "list"
+                result_elements["elements"] = odict()
+                new_elements[result] = result_elements
+
+            new_elements[result]["elements"][dce.element_identifier] = element.copy()
+
+        output_collections.create_collection(
+            self.outputs.values()[0], "output", elements=new_elements
+        )
+
+
 # Populate tool_type to ToolClass mappings
 tool_types = {}
 for tool_class in [ Tool, SetMetadataTool, OutputParameterJSONTool,

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2899,6 +2899,25 @@ class ZipCollectionTool( DatabaseOperationTool ):
         )
 
 
+class FilterFailedDatasetsTool( DatabaseOperationTool ):
+    tool_type = 'filter_failed_datasets_collection'
+    require_dataset_ok = False
+
+    def produce_outputs( self, trans, out_data, output_collections, incoming, history ):
+        hdca = incoming[ "input" ]
+        assert hdca.collection.collection_type == "list"
+        new_elements = odict()
+        for dce in hdca.collection.elements:
+            element = dce.element_object
+            if element.is_ok:
+                element_identifier = dce.element_identifier
+                new_elements[element_identifier] = element.copy()
+
+        output_collections.create_collection(
+            self.outputs.values()[0], "output", elements=new_elements
+        )
+
+
 # Populate tool_type to ToolClass mappings
 tool_types = {}
 for tool_class in [ Tool, SetMetadataTool, OutputParameterJSONTool,

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2959,6 +2959,30 @@ class FilterTool( DatabaseOperationTool ):
         return filtered_as_dict
 
 
+class FlattenTool( DatabaseOperationTool ):
+    tool_type = 'flatten_collection'
+
+    def produce_outputs( self, trans, out_data, output_collections, incoming, history ):
+        hdca = incoming[ "input" ]
+        join_identifier = incoming["join_identifier"]
+        new_elements = odict()
+
+        def add_elements(collection, prefix=""):
+            for dce in collection.elements:
+                dce_object = dce.element_object
+                dce_identifier = dce.element_identifier
+                identifier = "%s%s%s" % (prefix, join_identifier, dce_identifier) if prefix else dce_identifier
+                if dce.is_collection:
+                    add_elements(dce_object, prefix=identifier)
+                else:
+                    new_elements[identifier] = dce_object.copy()
+
+        add_elements(hdca.collection)
+        output_collections.create_collection(
+            self.outputs.values()[0], "output", elements=new_elements
+        )
+
+
 # Populate tool_type to ToolClass mappings
 tool_types = {}
 for tool_class in [ Tool, SetMetadataTool, OutputParameterJSONTool,

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -216,12 +216,10 @@ class DefaultToolAction( object ):
         current_user_roles = execution_cache.current_user_roles
         history, inp_data, inp_dataset_collections = self._collect_inputs(tool, trans, incoming, history, current_user_roles)
 
-        out_data = odict()
-        out_collections = {}
-        out_collection_instances = {}
+        # Build name for output datasets based on tool name and input names
+        on_text = self._get_on_text( inp_data )
 
-        # Deal with input dataset names, 'dbkey' and types
-        input_names = []
+        # Deal with input 'dbkey' and types
         input_ext = 'data'
         input_dbkey = incoming.get( "dbkey", "?" )
         for name, data in reversed(inp_data.items()):
@@ -234,9 +232,6 @@ class DefaultToolAction( object ):
                 data = data.to_history_dataset_association( None )
                 inp_data[name] = data
 
-            else:  # HDA
-                if data.hid:
-                    input_names.append( 'data %s' % data.hid )
             input_ext = data.ext
 
             if data.dbkey not in [None, '?']:
@@ -260,13 +255,26 @@ class DefaultToolAction( object ):
             # No valid inputs, we will use history defaults
             output_permissions = app.security_agent.history_get_default_permissions( history )
 
-        # Build name for output datasets based on tool name and input names
-        on_text = on_text_for_names( input_names )
-
         # Add the dbkey to the incoming parameters
         incoming[ "dbkey" ] = input_dbkey
         # wrapped params are used by change_format action and by output.label; only perform this wrapping once, as needed
-        wrapped_params = WrappedParameters( trans, tool, incoming )
+        wrapped_params = self._wrapped_params( trans, tool, incoming )
+
+        out_data = odict()
+        input_collections = dict( [ (k, v[0][0]) for k, v in inp_dataset_collections.iteritems() ] )
+        output_collections = OutputCollections(
+            trans,
+            history,
+            tool=tool,
+            tool_action=self,
+            input_collections=input_collections,
+            mapping_over_collection=mapping_over_collection,
+            on_text=on_text,
+            incoming=incoming,
+            params=wrapped_params.params,
+            job_params=job_params,
+        )
+
         # Keep track of parent / child relationships, we'll create all the
         # datasets first, then create the associations
         parent_to_child_pairs = []
@@ -344,7 +352,6 @@ class DefaultToolAction( object ):
                     assert set_output_history, "Cannot create dataset collection for this kind of tool."
 
                     element_identifiers = []
-                    input_collections = dict( [ (k, v[0][0]) for k, v in inp_dataset_collections.iteritems() ] )
                     known_outputs = output.known_outputs( input_collections, collections_manager.type_registry )
                     # Just to echo TODO elsewhere - this should be restructured to allow
                     # nested collections.
@@ -392,38 +399,11 @@ class DefaultToolAction( object ):
                     else:
                         element_kwds = dict(element_identifiers=element_identifiers)
 
-                    collection_type = output.structure.collection_type
-                    if collection_type is None:
-                        collection_type_source = output.structure.collection_type_source
-                        if collection_type_source is None:
-                            # TODO: Not a new problem, but this should be determined
-                            # sooner.
-                            raise Exception("Could not determine collection type to create.")
-                        if collection_type_source not in input_collections:
-                            raise Exception("Could not find collection type source with name [%s]." % collection_type_source)
-
-                        collection_type = input_collections[collection_type_source].collection.collection_type
-
-                    if mapping_over_collection:
-                        dc = collections_manager.create_dataset_collection(
-                            trans,
-                            collection_type=collection_type,
-                            **element_kwds
-                        )
-                        out_collections[ name ] = dc
-                    else:
-                        hdca_name = self.get_output_name( output, None, tool, on_text, trans, incoming, history, wrapped_params.params, job_params )
-                        hdca = collections_manager.create(
-                            trans,
-                            history,
-                            name=hdca_name,
-                            collection_type=collection_type,
-                            trusted_identifiers=True,
-                            **element_kwds
-                        )
-                        # name here is name of the output element - not name
-                        # of the hdca.
-                        out_collection_instances[ name ] = hdca
+                    output_collections.create_collection(
+                        output=output,
+                        name=name,
+                        **element_kwds
+                    )
                 else:
                     handle_output_timer = ExecutionTimer()
                     handle_output( name, output )
@@ -454,8 +434,7 @@ class DefaultToolAction( object ):
         # Create the job object
         job, galaxy_session = self._new_job_for_session( trans, tool, history )
         self._record_inputs( trans, tool, job, incoming, inp_data, inp_dataset_collections, current_user_roles )
-        self._record_outputs( job, out_data, out_collections, out_collection_instances )
-
+        self._record_outputs( job, out_data, output_collections )
         job.object_store_id = object_store_populator.object_store_id
         if job_params:
             job.params = dumps( job_params )
@@ -525,6 +504,18 @@ class DefaultToolAction( object ):
             trans.log_event( "Added job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id )
             return job, out_data
 
+    def _wrapped_params( self, trans, tool, incoming ):
+        wrapped_params = WrappedParameters( trans, tool, incoming )
+        return wrapped_params
+
+    def _get_on_text( self, inp_data ):
+        input_names = []
+        for name, data in reversed( inp_data.items() ):
+            if getattr( data, "hid", None ):
+                input_names.append( 'data %s' % data.hid )
+
+        return on_text_for_names( input_names )
+
     def _new_job_for_session( self, trans, tool, history ):
         job = trans.app.model.Job()
         galaxy_session = None
@@ -566,7 +557,9 @@ class DefaultToolAction( object ):
             job.add_parameter( name, value )
         self._check_input_data_access( trans, job, inp_data, current_user_roles )
 
-    def _record_outputs( self, job, out_data, out_collections, out_collection_instances ):
+    def _record_outputs( self, job, out_data, output_collections ):
+        out_collections = output_collections.out_collections
+        out_collection_instances = output_collections.out_collection_instances
         for name, dataset in out_data.iteritems():
             job.add_output_dataset( name, dataset )
         for name, dataset_collection in out_collections.iteritems():
@@ -622,6 +615,75 @@ class ObjectStorePopulator( object ):
         except ObjectInvalid:
             raise Exception('Unable to create output dataset: object store is full')
         self.object_store_id = data.dataset.object_store_id  # these will be the same thing after the first output
+
+
+class OutputCollections(object):
+    """ Keeps track of collections (DC or HDCA) created by actions.
+
+    Actions do fairly different things depending on whether we are creating
+    just part of an collection or a whole output collection (mapping_over_collection
+    parameter).
+    """
+
+    def __init__(self, trans, history, tool, tool_action, input_collections, mapping_over_collection, on_text, incoming, params, job_params):
+        self.trans = trans
+        self.history = history
+        self.tool = tool
+        self.tool_action = tool_action
+        self.input_collections = input_collections
+        self.mapping_over_collection = mapping_over_collection
+        self.on_text = on_text
+        self.incoming = incoming
+        self.params = params
+        self.job_params = job_params
+        self.out_collections = {}
+        self.out_collection_instances = {}
+
+    def create_collection(self, output, name, **element_kwds):
+        input_collections = self.input_collections
+        collections_manager = self.trans.app.dataset_collections_service
+        collection_type = output.structure.collection_type
+        if collection_type is None:
+            collection_type_source = output.structure.collection_type_source
+            if collection_type_source is None:
+                # TODO: Not a new problem, but this should be determined
+                # sooner.
+                raise Exception("Could not determine collection type to create.")
+            if collection_type_source not in input_collections:
+                raise Exception("Could not find collection type source with name [%s]." % collection_type_source)
+
+            collection_type = input_collections[collection_type_source].collection.collection_type
+
+        if self.mapping_over_collection:
+            dc = collections_manager.create_dataset_collection(
+                self.trans,
+                collection_type=collection_type,
+                **element_kwds
+            )
+            self.out_collections[ name ] = dc
+        else:
+            hdca_name = self.tool_action.get_output_name(
+                output,
+                None,
+                self.tool,
+                self.on_text,
+                self.trans,
+                self.incoming,
+                self.history,
+                self.params,
+                self.job_params,
+            )
+            hdca = collections_manager.create(
+                self.trans,
+                self.history,
+                name=hdca_name,
+                collection_type=collection_type,
+                trusted_identifiers=True,
+                **element_kwds
+            )
+            # name here is name of the output element - not name
+            # of the hdca.
+            self.out_collection_instances[ name ] = hdca
 
 
 def on_text_for_names( input_names ):

--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -1,0 +1,67 @@
+from galaxy.tools.actions import (
+    DefaultToolAction,
+    OutputCollections,
+    ToolExecutionCache,
+)
+from galaxy.util.odict import odict
+
+import logging
+log = logging.getLogger( __name__ )
+
+
+class ModelOperationToolAction( DefaultToolAction ):
+
+    def check_inputs_ready( self, tool, trans, incoming, history ):
+        history, inp_data, inp_dataset_collections = self._collect_inputs(tool, trans, incoming, history)
+
+        tool.check_inputs_ready( inp_data, inp_dataset_collections )
+
+    def execute( self, tool, trans, incoming={}, set_output_hid=False, overwrite=True, history=None, job_params=None, mapping_over_collection=False, execution_cache=None, **kwargs ):
+        if execution_cache is None:
+            execution_cache = ToolExecutionCache(trans)
+
+        current_user_roles = execution_cache.current_user_roles
+        history, inp_data, inp_dataset_collections = self._collect_inputs(tool, trans, incoming, history, current_user_roles)
+
+        # Build name for output datasets based on tool name and input names
+        on_text = self._get_on_text( inp_data )
+
+        # wrapped params are used by change_format action and by output.label; only perform this wrapping once, as needed
+        wrapped_params = self._wrapped_params( trans, tool, incoming )
+
+        out_data = odict()
+        input_collections = dict( [ (k, v[0][0]) for k, v in inp_dataset_collections.iteritems() ] )
+        output_collections = OutputCollections(
+            trans,
+            history,
+            tool=tool,
+            tool_action=self,
+            input_collections=input_collections,
+            mapping_over_collection=mapping_over_collection,
+            on_text=on_text,
+            incoming=incoming,
+            params=wrapped_params.params,
+            job_params=job_params,
+        )
+
+        #
+        # Create job.
+        #
+        job, galaxy_session = self._new_job_for_session( trans, tool, history )
+        self._produce_outputs( trans, tool, out_data, output_collections, incoming=incoming, history=history )
+        self._record_inputs( trans, tool, job, incoming, inp_data, inp_dataset_collections, current_user_roles )
+        self._record_outputs( job, out_data, output_collections )
+        job.state = job.states.OK
+        trans.sa_session.add( job )
+        trans.sa_session.flush()  # ensure job.id are available
+
+        # Queue the job for execution
+        # trans.app.job_queue.put( job.id, tool.id )
+        # trans.log_event( "Added database job action to the job queue, id: %s" % str(job.id), tool_id=job.tool_id )
+        log.info("Calling produce_outputs, tool is %s" % tool)
+        return job, out_data
+
+    def _produce_outputs( self, trans, tool, out_data, output_collections, incoming, history, **kwargs ):
+        tool.produce_outputs( trans, out_data, output_collections, incoming, history=history )
+        trans.sa_session.add_all( out_data.values() )
+        trans.sa_session.flush()

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -56,6 +56,17 @@ def execute( trans, tool, param_combinations, history, rerun_remap_job_id=None, 
     burst_at = getattr( config, 'tool_submission_burst_at', 10 )
     burst_threads = getattr( config, 'tool_submission_burst_threads', 1 )
 
+    tool_action = tool.action
+    if hasattr( tool_action, "check_inputs_ready" ):
+        for params in execution_tracker.param_combinations:
+            # This will throw an exception if the tool is not ready.
+            tool_action.check_inputs_ready(
+                tool,
+                trans,
+                params,
+                history
+            )
+
     if len(execution_tracker.param_combinations) < burst_at or burst_threads < 2:
         for params in execution_tracker.param_combinations:
             execute_single_job(params)

--- a/lib/galaxy/tools/expressions/__init__.py
+++ b/lib/galaxy/tools/expressions/__init__.py
@@ -1,6 +1,6 @@
 from .evaluation import evaluate
 from .sandbox import execjs, interpolate
-from .util import jshead
+from .util import jshead, find_engine
 
 
 __all__ = [
@@ -8,4 +8,5 @@ __all__ = [
     'execjs',
     'jshead',
     'interpolate',
+    'find_engine',
 ]

--- a/lib/galaxy/tools/expressions/__init__.py
+++ b/lib/galaxy/tools/expressions/__init__.py
@@ -1,0 +1,11 @@
+from .evaluation import evaluate
+from .sandbox import execjs, interpolate
+from .util import jshead
+
+
+__all__ = [
+    'evaluate',
+    'execjs',
+    'jshead',
+    'interpolate',
+]

--- a/lib/galaxy/tools/expressions/cwlNodeEngine.js
+++ b/lib/galaxy/tools/expressions/cwlNodeEngine.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env nodejs
+
+"use strict";
+
+process.stdin.setEncoding('utf8');
+
+var incoming = "";
+
+process.stdin.on('readable', function() {
+  var chunk = process.stdin.read();
+    if (chunk !== null) {
+        incoming += chunk;
+    }
+});
+
+process.stdin.on('end', function() {
+    var j = JSON.parse(incoming);
+    var exp = ""
+
+    if (j.script[0] == "{") {
+        exp = "{return function()" + j.script + "();}";
+    }
+    else {
+        exp = "{return " + j.script + ";}";
+    }
+
+    var fn = '"use strict";\n';
+
+    if (j.engineConfig) {
+        for (var index = 0; index < j.engineConfig.length; ++index) {
+            fn += j.engineConfig[index] + "\n";
+        }
+    }
+
+    fn += "var $job = " + JSON.stringify(j.job) + ";\n";
+    fn += "var $self = " + JSON.stringify(j.context) + ";\n"
+
+    fn += "var $runtime = " + JSON.stringify(j.runtime) + ";\n"
+    fn += "var $tmpdir = " + JSON.stringify(j.tmpdir) + ";\n"
+    fn += "var $outdir = " + JSON.stringify(j.outdir) + ";\n"
+
+
+    fn += "(function()" + exp + ")()";
+
+    process.stdout.write(JSON.stringify(require("vm").runInNewContext(fn, {})));
+});

--- a/lib/galaxy/tools/expressions/evaluation.py
+++ b/lib/galaxy/tools/expressions/evaluation.py
@@ -1,0 +1,37 @@
+import json
+import os
+import subprocess
+
+from .util import find_engine
+
+FILE_DIRECTORY = os.path.normpath(os.path.dirname(os.path.join(__file__)))
+NODE_ENGINE = os.path.join(FILE_DIRECTORY, "cwlNodeEngine.js")
+
+
+def evaluate(config, input):
+    application = find_engine(config)
+
+    default_context = {
+        "engineConfig": [],
+        "job": {},
+        "context": None,
+        "outdir": None,
+        "tmpdir": None,
+    }
+
+    new_input = default_context
+    new_input.update(input)
+
+    sp = subprocess.Popen([application, NODE_ENGINE],
+                          shell=False,
+                          close_fds=True,
+                          stdin=subprocess.PIPE,
+                          stdout=subprocess.PIPE)
+
+    (stdoutdata, stderrdata) = sp.communicate(json.dumps(new_input) + "\n\n")
+    if sp.returncode != 0:
+        args = (json.dumps(new_input, indent=4), stdoutdata, stderrdata)
+        message = "Expression engine returned non-zero exit code on evaluation of\n%s%s%s" % args
+        raise Exception(message)
+
+    return json.loads(stdoutdata)

--- a/lib/galaxy/tools/expressions/sandbox.py
+++ b/lib/galaxy/tools/expressions/sandbox.py
@@ -1,0 +1,151 @@
+import subprocess
+import json
+import threading
+
+from .util import find_engine
+
+
+class JavascriptException(Exception):
+    pass
+
+
+def execjs(config, js, jslib):
+    application = find_engine(config)
+    try:
+        nodejs = subprocess.Popen([application], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError as e:
+        if e.errno == 2:
+            nodejs = subprocess.Popen(["docker", "run",
+                                       "--attach=STDIN", "--attach=STDOUT", "--attach=STDERR",
+                                       "--interactive",
+                                       "--rm",
+                                       "commonworkflowlanguage/nodejs-engine", "nodejs"],
+                                      stdin=subprocess.PIPE,
+                                      stdout=subprocess.PIPE,
+                                      stderr=subprocess.PIPE)
+        else:
+            raise
+
+    fn = "\"use strict\";%s\n(function()%s)()" % (jslib, js if isinstance(js, basestring) and len(js) > 1 and js[0] == '{' else ("{return (%s);}" % js))
+    script = "console.log(JSON.stringify(require(\"vm\").runInNewContext(%s, {})));\n" % json.dumps(fn)
+
+    def term():
+        try:
+            nodejs.terminate()
+        except OSError:
+            pass
+
+    # Time out after 5 seconds
+    tm = threading.Timer(5, term)
+    tm.start()
+
+    stdoutdata, stderrdata = nodejs.communicate(script)
+    tm.cancel()
+
+    if nodejs.returncode != 0:
+        raise JavascriptException("Returncode was: %s\nscript was: %s\nstdout was: '%s'\nstderr was: '%s'\n" % (nodejs.returncode, script, stdoutdata, stderrdata))
+    else:
+        return json.loads(stdoutdata)
+
+
+class SubstitutionError(Exception):
+    pass
+
+
+DEFAULT = 0
+DOLLAR = 1
+PAREN = 2
+BRACE = 3
+SINGLE_QUOTE = 4
+DOUBLE_QUOTE = 5
+BACKSLASH = 6
+
+
+def scanner(scan):
+
+    i = 0
+    stack = [DEFAULT]
+    start = 0
+    while i < len(scan):
+        state = stack[-1]
+        c = scan[i]
+
+        if state == DEFAULT:
+            if c == '$':
+                stack.append(DOLLAR)
+            elif c == '\\':
+                stack.append(BACKSLASH)
+        elif state == BACKSLASH:
+            stack.pop()
+            if stack[-1] == DEFAULT:
+                return [i - 1, i + 1]
+        elif state == DOLLAR:
+            if c == '(':
+                start = i - 1
+                stack.append(PAREN)
+            elif c == '{':
+                start = i - 1
+                stack.append(BRACE)
+        elif state == PAREN:
+            if c == '(':
+                stack.append(PAREN)
+            elif c == ')':
+                stack.pop()
+                if stack[-1] == DOLLAR:
+                    return [start, i + 1]
+            elif c == "'":
+                stack.append(SINGLE_QUOTE)
+            elif c == '"':
+                stack.append(DOUBLE_QUOTE)
+        elif state == BRACE:
+            if c == '{':
+                stack.append(BRACE)
+            elif c == '}':
+                stack.pop()
+                if stack[-1] == DOLLAR:
+                    return [start, i + 1]
+            elif c == "'":
+                stack.append(SINGLE_QUOTE)
+            elif c == '"':
+                stack.append(DOUBLE_QUOTE)
+        elif state == SINGLE_QUOTE:
+            if c == "'":
+                stack.pop()
+            elif c == '\\':
+                stack.append(BACKSLASH)
+        elif state == DOUBLE_QUOTE:
+            if c == '"':
+                stack.pop()
+            elif c == '\\':
+                stack.append(BACKSLASH)
+        i += 1
+
+    if len(stack) > 1:
+        raise SubstitutionError("Substitution error, unfinished block starting at position {}: {}".format(start, scan[start:]))
+    else:
+        return None
+
+
+def interpolate(scan, jslib):
+    scan = scan.strip()
+    parts = []
+    w = scanner(scan)
+    while w:
+        parts.append(scan[0:w[0]])
+
+        if scan[w[0]] == '$':
+            e = execjs(scan[w[0] + 1:w[1]], jslib)
+            if w[0] == 0 and w[1] == len(scan):
+                return e
+            leaf = json.dumps(e, sort_keys=True)
+            if leaf[0] == '"':
+                leaf = leaf[1:-1]
+            parts.append(leaf)
+        elif scan[w[0]] == '\\':
+            e = scan[w[1] - 1]
+            parts.append(e)
+
+        scan = scan[w[1]:]
+        w = scanner(scan)
+    parts.append(scan)
+    return ''.join(parts)

--- a/lib/galaxy/tools/expressions/util.py
+++ b/lib/galaxy/tools/expressions/util.py
@@ -1,0 +1,13 @@
+import json
+from galaxy.tools.deps.commands import which
+
+
+def find_engine(config):
+    nodejs_path = getattr(config, "nodejs_path", None)
+    if nodejs_path is None:
+        nodejs_path = which("nodejs") or which("node") or None
+    return nodejs_path
+
+
+def jshead(engine_config, root_vars):
+    return "\n".join(engine_config + ["var %s = %s;" % (k, json.dumps(v)) for k, v in root_vars.items()])

--- a/lib/galaxy/tools/filter_collection.xml
+++ b/lib/galaxy/tools/filter_collection.xml
@@ -1,0 +1,40 @@
+<tool id="__FILTER__"
+      name="Apply Filter"
+      version="1.0.0"
+      tool_type="filter_collection">
+    <description>to a dataset collection</description>
+    <type class="FilterTool" module="galaxy.tools" />
+    <action module="galaxy.tools.actions.model_operations"
+            class="ModelOperationToolAction"/>
+    <inputs>
+        <param type="data_collection" collection_type="list" name="input" label="Input Collection" />
+        <param type="text" name="expression" label="JavaScript expression" help="">
+            <sanitizer sanitize="False"/>
+        </param>
+    </inputs>
+    <outputs>
+        <collection name="output" format_source="input" type_source="input" label="${on_string} (filtered)" >
+        </collection>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input">
+                <collection type="list">
+                    <element name="e1" value="simple_line.txt" />
+                    <element name="e2" value="simple_line_x2.txt" />
+                </collection>
+            </param>
+            <param name="expression" value="metadata_data_lines % 2 == 1" />
+            <!-- TODO: this doesn't actually verify something was 
+                       removed.
+            -->
+            <output_collection name="output" type="list">
+                <element name="e1">
+                  <assert_contents>
+                      <has_text_matching expression="^This is a line of text.\n$" />
+                  </assert_contents>
+                </element>
+            </output_collection>
+        </test>
+    </tests>
+</tool>

--- a/lib/galaxy/tools/filter_failed_collection.xml
+++ b/lib/galaxy/tools/filter_failed_collection.xml
@@ -1,0 +1,37 @@
+<tool id="__FILTER_FAILED_DATASETS__"
+      name="Filter failed"
+      version="1.0.0"
+      tool_type="filter_failed_datasets_collection">
+    <description>datasets from a collection</description>
+    <type class="FilterFailedDatasetsTool" module="galaxy.tools" />
+    <action module="galaxy.tools.actions.model_operations"
+            class="ModelOperationToolAction"/>
+    <inputs>
+        <param type="data_collection" collection_type="list" name="input" label="Input Collection" />
+    </inputs>
+    <outputs>
+        <collection name="output" format_source="input" type_source="input" label="${on_string} (filtered failed datasets)" >
+        </collection>
+    </outputs>
+    <tests>
+        <!-- Test framework has no way of creating a collection with
+             failed elements, so best we can do is verify identity on
+             an okay collection. API tests verify this tool works
+             though.
+        -->
+        <test>
+            <param name="input">
+                <collection type="list">
+                    <element name="e1" value="simple_line.txt" />
+                </collection>
+            </param>
+            <output_collection name="output" type="list">
+                <element name="e1">
+                  <assert_contents>
+                      <has_text_matching expression="^This is a line of text.\n$" />
+                  </assert_contents>
+                </element>
+            </output_collection>
+        </test>
+    </tests>
+</tool>

--- a/lib/galaxy/tools/flatten_collection.xml
+++ b/lib/galaxy/tools/flatten_collection.xml
@@ -1,0 +1,47 @@
+<tool id="__FLATTEN__"
+      name="Flatten Collection"
+      version="1.0.0"
+      tool_type="filter_collection">
+    <description>into a flat list of datasets</description>
+    <type class="FlattenTool" module="galaxy.tools" />
+    <action module="galaxy.tools.actions.model_operations"
+            class="ModelOperationToolAction"/>
+    <inputs>
+        <param type="data_collection" name="input" label="Input Collection" />
+        <param type="select" name="join_identifier" label="Join collection identifiers using" help="">
+            <option value="_">_</option>
+            <option value=":">:</option>
+            <option value="-">-</option>
+        </param>
+    </inputs>
+    <outputs>
+        <collection name="output" format_source="input" type="list" label="${on_string} (flattened)" >
+        </collection>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input">
+                <collection type="list:paired">
+                    <element name="i1">
+                        <collection type="paired">
+                            <element name="forward" value="simple_line.txt" />
+                            <element name="reverse" value="simple_line_alternative.txt" />
+                        </collection>
+                    </element>
+                </collection>
+            </param>
+            <output_collection name="output" type="list">
+              <element name="i1_forward">
+                <assert_contents>
+                  <has_text_matching expression="^This is a line of text.\n$" />
+                </assert_contents>
+              </element>
+              <element name="i1_reverse">
+                <assert_contents>
+                  <has_text_matching expression="^This is a different line of text.\n$" />
+                </assert_contents>
+              </element>
+            </output_collection>
+        </test>
+    </tests>
+</tool>

--- a/lib/galaxy/tools/group_collection.xml
+++ b/lib/galaxy/tools/group_collection.xml
@@ -1,0 +1,46 @@
+<tool id="__GROUP__"
+      name="Group Collection"
+      version="1.0.0"
+      tool_type="group_collection">
+    <description>into a list of lists of datasets</description>
+    <type class="GroupTool" module="galaxy.tools" />
+    <action module="galaxy.tools.actions.model_operations"
+            class="ModelOperationToolAction"/>
+    <inputs>
+        <param type="data_collection" name="input" collection_type="list" label="Input Collection" />
+        <param type="text" name="expression" label="JavaScript expression" help="">
+            <sanitizer sanitize="False"/>
+        </param>
+    </inputs>
+    <outputs>
+        <collection name="output" format_source="input" type="list:list" label="${on_string} (flattened)" >
+        </collection>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input">
+                <collection type="list">
+                    <element name="e1" value="simple_line.txt" />
+                    <element name="e2" value="simple_line_x2.txt" />
+                </collection>
+            </param>
+            <param name="expression" value="((metadata_data_lines % 2) == 0) ? &quot;even&quot; : &quot;odd&quot;" />
+            <output_collection name="output" type="list:list">
+              <element name="odd">
+                  <element name="e1">
+                    <assert_contents>
+                        <has_text_matching expression="^This is a line of text.\n$" />
+                    </assert_contents>
+                  </element>
+              </element>
+              <element name="even">
+                <element name="e2">
+                  <assert_contents>
+                    <has_text_matching expression="This is a line of text.\nThis is a line of text.\n" />
+                  </assert_contents>
+                </element>
+              </element>
+            </output_collection>
+        </test>
+    </tests>
+</tool>

--- a/lib/galaxy/tools/special_tools.py
+++ b/lib/galaxy/tools/special_tools.py
@@ -4,6 +4,8 @@ log = logging.getLogger( __name__ )
 SPECIAL_TOOLS = {
     "history export": "galaxy/tools/imp_exp/exp_history_to_archive.xml",
     "history import": "galaxy/tools/imp_exp/imp_history_from_archive.xml",
+    "collection unzip": "galaxy/tools/unzip_collection.xml",
+    "collection zip": "galaxy/tools/zip_collection.xml",
 }
 
 

--- a/lib/galaxy/tools/special_tools.py
+++ b/lib/galaxy/tools/special_tools.py
@@ -6,6 +6,7 @@ SPECIAL_TOOLS = {
     "history import": "galaxy/tools/imp_exp/imp_history_from_archive.xml",
     "collection unzip": "galaxy/tools/unzip_collection.xml",
     "collection zip": "galaxy/tools/zip_collection.xml",
+    "filter failed datasets": "galaxy/tools/filter_failed_collection.xml",
 }
 
 

--- a/lib/galaxy/tools/special_tools.py
+++ b/lib/galaxy/tools/special_tools.py
@@ -9,6 +9,7 @@ SPECIAL_TOOLS = {
     "filter failed datasets": "galaxy/tools/filter_failed_collection.xml",
     "filter datasets": "galaxy/tools/filter_collection.xml",
     "flatten collection": "galaxy/tools/flatten_collection.xml",
+    "group collection": "galaxy/tools/group_collection.xml",
 }
 
 

--- a/lib/galaxy/tools/special_tools.py
+++ b/lib/galaxy/tools/special_tools.py
@@ -8,6 +8,7 @@ SPECIAL_TOOLS = {
     "collection zip": "galaxy/tools/zip_collection.xml",
     "filter failed datasets": "galaxy/tools/filter_failed_collection.xml",
     "filter datasets": "galaxy/tools/filter_collection.xml",
+    "flatten collection": "galaxy/tools/flatten_collection.xml",
 }
 
 

--- a/lib/galaxy/tools/special_tools.py
+++ b/lib/galaxy/tools/special_tools.py
@@ -7,6 +7,7 @@ SPECIAL_TOOLS = {
     "collection unzip": "galaxy/tools/unzip_collection.xml",
     "collection zip": "galaxy/tools/zip_collection.xml",
     "filter failed datasets": "galaxy/tools/filter_failed_collection.xml",
+    "filter datasets": "galaxy/tools/filter_collection.xml",
 }
 
 

--- a/lib/galaxy/tools/unzip_collection.xml
+++ b/lib/galaxy/tools/unzip_collection.xml
@@ -1,0 +1,15 @@
+<tool id="__UNZIP_COLLECTION__"
+      name="Unzip Collection"
+      version="1.0.0"
+      tool_type="unzip_collection">
+  <type class="UnzipCollectionTool" module="galaxy.tools" />
+  <action module="galaxy.tools.actions.model_operations"
+          class="ModelOperationToolAction"/>
+  <inputs>
+    <param type="data_collection" collection_type="paired" name="input" label="Input Paired Dataset" />
+  </inputs>
+  <outputs>
+    <data name="reverse" />
+    <data name="forward" />
+  </outputs>
+</tool>

--- a/lib/galaxy/tools/zip_collection.xml
+++ b/lib/galaxy/tools/zip_collection.xml
@@ -1,0 +1,18 @@
+<tool id="__ZIP_COLLECTION__"
+      name="Zip Collection"
+      version="1.0.0"
+      tool_type="zip_collection">
+  <type class="ZipCollectionTool" module="galaxy.tools" />
+  <action module="galaxy.tools.actions.model_operations"
+          class="ModelOperationToolAction"/>
+  <inputs>
+    <param type="data" name="input_forward" label="Input Dataset (Forward)" />
+    <param type="data" name="input_reverse" label="Input Dataset (Reverse)" />
+  </inputs>
+  <outputs>
+    <collection name="output" type="paired">
+      <data name="forward" />
+      <data name="reverse" />
+    </collection>
+  </outputs>
+</tool>

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -25,6 +25,7 @@ from galaxy.tools.parameters.basic import (
 )
 from galaxy.tools.parameters.wrapped import make_dict_copy
 from galaxy.tools.execute import execute
+from galaxy.tools import ToolInputsNotReadyException
 from galaxy.util.bunch import Bunch
 from galaxy.util import odict
 from galaxy.util.json import loads
@@ -1163,14 +1164,18 @@ class ToolModule( WorkflowModule ):
                 raise exceptions.MessageException( message )
             param_combinations.append( execution_state.inputs )
 
-        execution_tracker = execute(
-            trans=self.trans,
-            tool=tool,
-            param_combinations=param_combinations,
-            history=invocation.history,
-            collection_info=collection_info,
-            workflow_invocation_uuid=invocation.uuid.hex
-        )
+        try:
+            execution_tracker = execute(
+                trans=self.trans,
+                tool=tool,
+                param_combinations=param_combinations,
+                history=invocation.history,
+                collection_info=collection_info,
+                workflow_invocation_uuid=invocation.uuid.hex
+            )
+        except ToolInputsNotReadyException:
+            raise DelayedWorkflowEvaluation()
+
         if collection_info:
             step_outputs = dict( execution_tracker.implicit_collections )
         else:

--- a/test/api/helpers.py
+++ b/test/api/helpers.py
@@ -145,18 +145,24 @@ class BaseDatasetPopulator( object ):
         return tool_response.json()
 
     def get_history_dataset_content( self, history_id, wait=True, **kwds ):
-        dataset_id = self.__history_dataset_id( history_id, wait=wait, **kwds )
+        dataset_id = self.__history_content_id( history_id, wait=wait, **kwds )
         display_response = self.__get_contents_request( history_id, "/%s/display" % dataset_id )
         assert display_response.status_code == 200, display_response.content
         return display_response.content
 
     def get_history_dataset_details( self, history_id, **kwds ):
-        dataset_id = self.__history_dataset_id( history_id, **kwds )
+        dataset_id = self.__history_content_id( history_id, **kwds )
         details_response = self.__get_contents_request( history_id, "/datasets/%s" % dataset_id )
         assert details_response.status_code == 200
         return details_response.json()
 
-    def __history_dataset_id( self, history_id, wait=True, **kwds ):
+    def get_history_collection_details( self, history_id, **kwds ):
+        hdca_id = self.__history_content_id( history_id, **kwds )
+        details_response = self.__get_contents_request( history_id, "/dataset_collections/%s" % hdca_id )
+        assert details_response.status_code == 200, details_response.content
+        return details_response.json()
+
+    def __history_content_id( self, history_id, wait=True, **kwds ):
         if wait:
             assert_ok = kwds.get( "assert_ok", True )
             self.wait_for_history( history_id, assert_ok=assert_ok )

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -196,6 +196,25 @@ class ToolsTestCase( api.ApiTestCase ):
         filtered_states = map(get_state, filtered_hdca["elements"])
         assert filtered_states == [u"ok", u"ok"], filtered_states
 
+    def test_filter_0( self ):
+        history_id = self.dataset_populator.new_history()
+        hdca_id = self.dataset_collection_populator.create_list_in_history( history_id, contents=["a", "a\nb", "a\nb\nc", "a\nb\nc\nd" ] ).json()["id"]
+        self.dataset_populator.wait_for_history( history_id )
+        inputs = {
+            "input": {"src": "hdca", "id": hdca_id},
+            "expression": "metadata_data_lines % 2 == 0"
+        }
+        response = self._run( "__FILTER__", history_id, inputs, assert_ok=True )
+        output_collections = response["output_collections"]
+        assert len(output_collections) == 1
+
+        filtered_hid = output_collections[0]["hid"]
+        filtered_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=filtered_hid)
+        self.assertEquals(len(filtered_hdca["elements"]), 2)
+        filtered_dataset = filtered_hdca["elements"][0]["object"]
+        filtered_dataset_content = self.dataset_populator.get_history_dataset_content( history_id, dataset=filtered_dataset )
+        self.assertEquals(filtered_dataset_content.strip(), "a\nb")
+
     @skip_without_tool( "multi_select" )
     def test_multi_select_as_list( self ):
         history_id = self.dataset_populator.new_history()

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -721,6 +721,49 @@ test_data:
         content = self.dataset_populator.get_history_dataset_content( history_id )
         self.assertEquals("chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\nchr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n", content)
 
+    @skip_without_tool( "cat1" )
+    @skip_without_tool( "collection_paired_test" )
+    def test_workflow_run_zip_collections( self ):
+        # A more advanced output collection workflow, testing regression of
+        # https://github.com/galaxyproject/galaxy/issues/776
+        history_id = self.dataset_populator.new_history()
+        workflow_id = self._upload_yaml_workflow("""
+class: GalaxyWorkflow
+steps:
+  - label: test_input_1
+    type: input
+  - label: test_input_2
+    type: input
+  - label: first_cat
+    tool_id: cat1
+    state:
+      input1:
+        $link: test_input_1
+  - label: zip_it
+    tool_id: "__ZIP_COLLECTION__"
+    state:
+      input_forward:
+        $link: first_cat#out_file1
+      input_reverse:
+        $link: test_input_2
+  - label: concat_pair
+    tool_id: collection_paired_test
+    state:
+      f1:
+        $link: zip_it#output
+""")
+        hda1 = self.dataset_populator.new_dataset( history_id, content="samp1\t10.0\nsamp2\t20.0\n" )
+        hda2 = self.dataset_populator.new_dataset( history_id, content="samp1\t20.0\nsamp2\t40.0\n" )
+        self.dataset_populator.wait_for_history( history_id, assert_ok=True )
+        inputs = {
+            '0': self._ds_entry(hda1),
+            '1': self._ds_entry(hda2),
+        }
+        invocation_id = self.__invoke_workflow( history_id, workflow_id, inputs )
+        self.wait_for_invocation_and_jobs( history_id, workflow_id, invocation_id )
+        content = self.dataset_populator.get_history_dataset_content( history_id )
+        self.assertEquals(content.strip(), "samp1\t10.0\nsamp2\t20.0\nsamp1\t20.0\nsamp2\t40.0")
+
     def test_workflow_request( self ):
         workflow = self.workflow_populator.load_workflow( name="test_for_queue" )
         workflow_request, history_id = self._setup_workflow_run( workflow )

--- a/test/base/twilltestcase.py
+++ b/test/base/twilltestcase.py
@@ -2498,6 +2498,7 @@ class TwillTestCase( unittest.TestCase ):
         return temp_local, temp_temp
 
     def _format_stream( self, output, stream, format ):
+        output = output or ''
         if format:
             msg = "---------------------- >> begin tool %s << -----------------------\n" % stream
             msg += output + "\n"

--- a/test/functional/tools/exit_code_from_file.xml
+++ b/test/functional/tools/exit_code_from_file.xml
@@ -1,0 +1,13 @@
+<tool id="exit_code_from_file" name="exit_code_from_file">
+    <command detect_errors="exit_code">
+        sh -c "exit `cat $input`"
+    </command>
+    <inputs>
+        <param name="input" type="data" label="Exit code file" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" />
+    </outputs>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -30,6 +30,7 @@
   <tool file="maxseconds.xml" />
   -->
   <tool file="job_properties.xml" />
+  <tool file="exit_code_from_file.xml" />
   <tool file="gzipped_inputs.xml" />
   <tool file="output_order.xml" />
   <tool file="output_format.xml" />

--- a/test/unit/tools/test_expression_basics.py
+++ b/test/unit/tools/test_expression_basics.py
@@ -1,0 +1,8 @@
+from galaxy.tools.expressions import evaluate
+
+
+def test_evaluate():
+    input = {
+        "script": "{return 5;}"
+    }
+    assert evaluate(None, input) == 5


### PR DESCRIPTION
## Overview

This PR introduces a Tool derived framework for dealing collections at the model level instead of at the file level, allowing operations that generate new HDAs and collections without duplicating Dataset objects. Together operations vastly expand the expressiveness of Galaxy workflows.
## The Collection Operations:
- Zip (two datasets -> paired collection). Like all these tools, it can be mapped over - so it can easily be used to take two dataset lists and build a list of pairs for instance.  8945c6e5098c1dcc7c73b534fbae05acce8106f4
- Unzip (paired collection -> two datasets).  8945c6e5098c1dcc7c73b534fbae05acce8106f4
- Filter failed datasets (list -> list). Given a list it produces another list without any failed datasets. (Most commonly requested of these operations.)  c27e5d4f5ee266356bc220d701e4ee58424de9dd
- Flatten collection (\* -> list). Produces a flat list from any collection, joining identifiers on user supplied character. c27e5d4f5ee266356bc220d701e4ee58424de9dd
- Group collection (list -> list:list). Exposes dataset metadata to a user supplied and sandboxed JavaScript expression and uses the result to group the list into a list of lists. (Sort of the inverse of flatten). bbf7ab545b6e3e04d65d514a1d3da92d7304c3fa
- Filter collection (list -> list). Exposes dataset metadata to a user supplied and sandboxed JavaScript expression and uses the result to filter the the collection. (Sort of the inverse of flatten). 4645d671b20871065c0e69d210e97e59c685bdd4
## Issues and Notes

This PR will introduce a new (and mostly optional) Galaxy runtime dependency on nodejs. If node cannot be found the two tools requiring it (filter and group) will simply not be loaded and nice error message will be printed in the logs.

Unlike more traditional tools, these do interactive checking of inputs so they cannot be "queued up" ahead of time during interactive use. They are workflow aware though, so there is no problem using them with workflows.

Currently these "tools' are just loaded into the toolbox and not displayed anyway in the UI. There is to my mind a question of how we want to treat them, we could develop a custom operations widget/section/etc... in the UI or we could just load them in `tool_conf.xml.sample`. If we do put them in `tool_conf.xml.sample`  and decide to treat them more like tools then special operations, I will change the IDs from things like `__FILTER__` to `collection_op_filter`. (TL;DR John developed this feature without caring about the UI at all - shocking huh?)
## Testing

Each operation contains tests (either in the form of API tests or simple tool tests that will be included with `-framwork` tests). There are additional framework and unit tests. These can all be executed using:

```
./run_tests.sh -api test/api/test_tools.py:ToolsTestCase.test_unzip_collection
./run_tests.sh -api test/api/test_tools.py:ToolsTestCase.test_zip_inputs
./run_tests.sh -api test/api/test_tools.py:ToolsTestCase.test_zip_list_inputs
./run_tests.sh -api test/api/test_workflows.py:WorkflowsApiTestCase.test_workflow_run_zip_collections
./run_tests.sh -api test/api/test_tools.py:ToolsTestCase.test_filter_failed
./run_tests.sh -api test/api/test_tools.py:ToolsTestCase.test_filter_0
./run_tests.sh -framework -id __GROUP__
./run_tests.sh -framework -id __FLATTEN__
./run_tests.sh -u
```
