### PR TITLE
Fix workflow output step entries

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -665,14 +665,11 @@ class WorkflowContentsManager(UsesAnnotations):
         module = module_factory.from_dict( trans, step_dict, secure=secure )
         module.save_to_step( step )
 
-        workflow_outputs_dicts = step_dict.get("workflow_outputs", [])
-        for workflow_output_dict in workflow_outputs_dicts:
-            output_name = workflow_output_dict["output_name"]
-            workflow_output = model.WorkflowOutput(
+        for index in range( len( step.workflow_outputs ) ):
+            step.workflow_outputs[ index ] = model.WorkflowOutput(
                 step,
-                output_name,
+                step.workflow_outputs[ index ][ "output_name" ]
             )
-            step.workflow_outputs.append(workflow_output)
 
         annotation = step_dict[ 'annotation' ]
         if annotation:


### PR DESCRIPTION
Prevents workflow outputs from accumulating/multiplying. Related to: https://github.com/galaxyproject/galaxy/commit/a597e0e8349f33d4d2c642d2e0a74e3da64b156b#diff-ec6f18e1ff51809344ca461c8971b3f6R628 where workflow outputs are parsed/appended the second time after being already parsed in the module factory: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/workflow/modules.py#L541. 
