### PR TITLE
[15.10] Fix typo causing the option "Link files instead of copying" to be ignored.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/lda_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/lda_datasets.py
@@ -413,7 +413,7 @@ class LibraryDatasetsController( BaseAPIController, UsesVisualizationMixin ):
 
         :param  encoded_folder_id:      the encoded id of the folder to import dataset(s) to
         :type   encoded_folder_id:      an encoded id string
-        :param  source:                 source the datasets should be loaded form
+        :param  source:                 source the datasets should be loaded from
         :type   source:                 str
         :param  link_data:              flag whether to link the dataset to data or copy it to Galaxy, defaults to copy
                                         while linking is set to True all symlinks will be resolved _once_
@@ -434,7 +434,7 @@ class LibraryDatasetsController( BaseAPIController, UsesVisualizationMixin ):
         kwd[ 'to_posix_lines' ] = 'True'
         kwd[ 'dbkey' ] = kwd.get( 'dbkey', '?' )
         kwd[ 'file_type' ] = kwd.get( 'file_type', 'auto' )
-        kwd[' link_data_only' ] = 'link_to_files' if util.string_as_bool( kwd.get( 'link_data', False ) ) else 'copy_files'
+        kwd['link_data_only'] = 'link_to_files' if util.string_as_bool( kwd.get( 'link_data', False ) ) else 'copy_files'
         encoded_folder_id = kwd.get( 'encoded_folder_id', None )
         if encoded_folder_id is not None:
             folder_id = self.folder_manager.cut_and_decode( trans, encoded_folder_id )


### PR DESCRIPTION
When uploading folders with the new data library interface.

That is what we get for not respecting E201 and E202 PEP-8 rules...
