### PR TITLE
Update Kombu and AMQP wheels to fix problems with El Capitan's System Integrity Protection

### DIFF
--- a/lib/galaxy/dependencies/requirements.txt
+++ b/lib/galaxy/dependencies/requirements.txt
@@ -37,8 +37,8 @@ requests==2.8.1
 requests-toolbelt==0.4.0
 
 # kombu and dependencies
-kombu==3.0.26
-amqp==1.4.6
+kombu==3.0.30
+amqp==1.4.8
 anyjson==0.3.3
 
 # sqlalchemy-migrate and dependencies


### PR DESCRIPTION
The dev/wheels version of #1282 (see also galaxyproject/starforge#47).

I'll merge `release_15.10` -> `dev` after this is merged to clear up the resulting merge conflict.
