### PR TITLE
[15.10] Add enhancements to the Galaxy repository install process

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -1296,6 +1296,21 @@ class AdminToolshed( AdminGalaxy ):
                 # Just in case the tool_section.id differs from tool_panel_section_id, which it shouldn't...
                 tool_panel_section_id = str( tool_section.id )
         if tool_shed_repository.status == trans.install_model.ToolShedRepository.installation_status.UNINSTALLED:
+            repository_type = suc.get_repository_type_from_tool_shed(trans.app,
+                                                                     tool_shed_url,
+                                                                     tool_shed_repository.name,
+                                                                     tool_shed_repository.owner)
+            if repository_type == rt_util.TOOL_DEPENDENCY_DEFINITION:
+                # Repositories of type tool_dependency_definition must get the latest
+                # metadata from the Tool Shed since they have only a single installable
+                # revision.
+                raw_text = suc.get_tool_dependency_definition_metadata_from_tool_shed(trans.app,
+                                                                                      tool_shed_url,
+                                                                                      tool_shed_repository.name,
+                                                                                      tool_shed_repository.owner)
+                new_meta = json.loads(raw_text)
+                # Clean up old repository dependency and tool dependency relationships.
+                suc.clean_dependency_relationships(trans, new_meta, tool_shed_repository, tool_shed_url)
             # The repository's status must be updated from 'Uninstalled' to 'New' when initiating reinstall
             # so the repository_installation_updater will function.
             tool_shed_repository = suc.create_or_update_tool_shed_repository( trans.app,

--- a/lib/galaxy/webapps/tool_shed/controllers/repository.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/repository.py
@@ -1684,6 +1684,14 @@ class RepositoryController( BaseUIController, ratings_util.ItemRatings ):
                      includes_tool_dependencies=includes_tool_dependencies,
                      repo_info_dicts=repo_info_dicts )
 
+    @web.expose
+    def get_repository_type( self, trans, **kwd ):
+        """Given a repository name and owner, return the type."""
+        repository_name = kwd[ 'name' ]
+        repository_owner = kwd[ 'owner' ]
+        repository = suc.get_repository_by_name_and_owner( trans.app, repository_name, repository_owner )
+        return str( repository.type )
+
     @web.json
     def get_required_repo_info_dict( self, trans, encoded_str=None ):
         """
@@ -1750,6 +1758,22 @@ class RepositoryController( BaseUIController, ratings_util.ItemRatings ):
             tool_dependencies_config_file.close()
             return contents
         return ''
+
+    @web.json
+    def get_tool_dependency_definition_metadata( self, trans, **kwd ):
+        """
+        Given a repository name and ownerof a repository whose type is
+        tool_dependency_definition, return the current metadata.
+        """
+        repository_name = kwd[ 'name' ]
+        repository_owner = kwd[ 'owner' ]
+        repository = suc.get_repository_by_name_and_owner( trans.app, repository_name, repository_owner )
+        encoded_id = trans.app.security.encode_id( repository.id )
+        repository_tip = repository.tip( trans.app )
+        repository_metadata = suc.get_repository_metadata_by_changeset_revision( trans.app,
+                                                                                 encoded_id,
+                                                                                 repository_tip )
+        return repository_metadata.metadata
 
     @web.expose
     def get_tool_versions( self, trans, **kwd ):


### PR DESCRIPTION
## this is a cherrypick of #1193 

to cleanly handle the case described here:
https://github.com/galaxyproject/galaxy/issues/667.  Specifically, the
following scenario is now cleanly handled:

Example use case: In a toolshed I have a repository of a tool, say

package_new_gene_db_1_2_3, and in revision 1 it depends on
package_sqlite_1_0_0:

package_new_gene_db_1_2_3
package_sqlite_1_0_0

At some point in time I discover that postgres is a better solution for
my gene database, and I upload revision 2:

package_new_gene_db_1_2_3
package_postgres__2_0_0

And I remove the dependecy of sqlite.  If I go to my galaxy instance and
I remove revision 1 and install revision 2, the installation is cleanly
handled with theis PR.

It should be noted that this enhancement could adversely impact
reproducibility if best practices are not followed with regard to
defining package dependencies.  Since it is now cleanly possible to
eliminate dependencies over time, best practices must be followed to
ensure that elimination of a dependency does not affect the output of a
tool that uses the underlying hierarchy of packages.
