### PR TITLE
Fix for creating workflow outputs on initial workflow upload.

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -201,6 +201,12 @@ class WorkflowContentsManager(UsesAnnotations):
             steps.append( step )
             steps_by_external_id[ step_dict['id' ] ] = step
 
+            if 'workflow_outputs' in step_dict:
+                for workflow_output in step_dict['workflow_outputs']:
+                    output_name = workflow_output["output_name"]
+                    m = model.WorkflowOutput(workflow_step=step, output_name=output_name)
+                    trans.sa_session.add(m)
+
             if module.type == 'tool' and module.tool is None:
                 # A required tool is not available in the local Galaxy instance.
                 missing_tool_tup = ( step_dict[ 'tool_id' ], step_dict[ 'name' ], step_dict[ 'tool_version' ] )


### PR DESCRIPTION
This fixes the test that began to fail with https://github.com/galaxyproject/galaxy/pull/1306, but I think there are other problems with #1306 - like I don't think it will allow you ever to update workflow outputs after initial creation. I think the right fix is to merge https://github.com/galaxyproject/galaxy/pull/1306 which unifies the handling across update and create of workflows and is more sophisticated.

So I am -0 on merging this if we can merge #1306 today instead.
