### PR TITLE
Modify function "pretty_print_time_interval"

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -352,7 +352,7 @@ def pretty_print_time_interval( time=False, precise=False ):
     elif isinstance( time, datetime ):
         diff = now - time
     elif isinstance( time, basestring ):
-        time = datetime.strptime( time, "%Y-%m-%dT%H:%M:%S.%f" )
+        time = datetime.strptime( time, "%Y-%m-%dT%H:%M:%S" )
         diff = now - time
     else:
         diff = now - now


### PR DESCRIPTION
I've been having an issues with the API when creating data libraries through the new interface. I have a Galaxy server running on Ubuntu 14.04.3 with a MariaDB server in the back. Apparently, the time returned from the database doesn't include the milliseconds, hence dropping the requirement for milliseconds fixes my issues.
I've been in talks with @martenson and @natefoo about this over at Biostar
https://biostar.usegalaxy.org/p/15330/#15373
