### PR TITLE
Don't bother querying on unencoded IDs for error form

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -119,12 +119,8 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
 
     @web.expose
     def errors( self, trans, id ):
-        try:
-            hda = trans.sa_session.query( model.HistoryDatasetAssociation ).get( id )
-        except:
-            hda = None
-        if not hda:
-            hda = trans.sa_session.query( model.HistoryDatasetAssociation ).get( self.decode_id( id ) )
+        hda = trans.sa_session.query( model.HistoryDatasetAssociation ).get( self.decode_id( id ) )
+
         if not hda or not self._can_access_dataset( trans, hda ):
             return trans.show_error_message( "Either this dataset does not exist or you do not have permission to access it." )
         return trans.fill_template( "dataset/errors.mako", hda=hda )


### PR DESCRIPTION
This generates really, really ugly database logs:

```
galaxydb_1 | ERROR:  invalid input syntax for integer: "ad358f505df89510" at character 2775
galaxydb_1 | STATEMENT:  DECLARE "c_7f369b315110_2e6f" CURSOR WITHOUT HOLD FOR SELECT 
      history_dataset_association.id AS history_dataset_association_id, 
      history_dataset_association.history_id AS history_dataset_association_history_id,
      history_dataset_association.dataset_id AS history_dataset_association_dataset_id, 
      history_dataset_association.create_time AS history_dataset_association_create_time, 
      history_dataset_association.update_time AS history_dataset_association_update_time, 
      history_dataset_association.state AS history_dataset_association_state, 
      history_dataset_association.copied_from_history_dataset_association_id AS 
      history_dataset_association_copied_from_history_dataset_a_1, 
      history_dataset_association.copied_from_library_dataset_dataset_association_id AS 
      history_dataset_association_copied_from_library_dataset_d_2,
      history_dataset_association.name AS history_dataset_association_name, 
      history_dataset_association.info AS history_dataset_association_info, 
      history_dataset_association.blurb AS history_dataset_association_blurb, 
      history_dataset_association.peek AS history_dataset_association_peek, 
      history_dataset_association.tool_version AS history_dataset_association_tool_version, 
      history_dataset_association.extension AS history_dataset_association_extension, 
      history_dataset_association.metadata AS history_dataset_association_metadata, 
      history_dataset_association.parent_id AS history_dataset_association_parent_id, 
      history_dataset_association.designation AS history_dataset_association_designation, 
      history_dataset_association.deleted AS history_dataset_association_deleted, 
      history_dataset_association.visible AS history_dataset_association_visible, 
      history_dataset_association.extended_metadata_id AS 
      history_dataset_association_extended_metadata_id, history_dataset_association.hid AS 
      history_dataset_association_hid, history_dataset_association.purged AS 
      history_dataset_association_purged, 
      history_dataset_association.hidden_beneath_collection_instance_id AS 
      history_dataset_association_hidden_beneath_collection_ins_3,
      dataset_1.id AS dataset_1_id, dataset_1.create_time AS dataset_1_create_time, 
      dataset_1.update_time AS dataset_1_update_time, dataset_1.state AS dataset_1_state, 
      dataset_1.deleted AS dataset_1_deleted, dataset_1.purged AS dataset_1_purged, 
      dataset_1.purgable AS dataset_1_purgable, dataset_1.object_store_id AS 
      dataset_1_object_store_id, dataset_1.external_filename AS dataset_1_external_filename, 
      dataset_1._extra_files_path AS dataset_1__extra_files_path, dataset_1.file_size AS 
      dataset_1_file_size, dataset_1.total_size AS dataset_1_total_size, dataset_1.uuid 
      AS dataset_1_uuid 
galaxydb_1 |    FROM history_dataset_association LEFT OUTER JOIN dataset AS dataset_1 ON dataset_1.id = history_dataset_association.dataset_id 
galaxydb_1 |    WHERE history_dataset_association.id = 'ad358f505df89510'
```
