### PR TITLE
Use both SLURM_NTASKS and SLURM_CPUS_PER_TASK to set GALAXY_SLOTS

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
@@ -1,9 +1,9 @@
 export GALAXY_SLOTS_CONFIGURED="1"
-if [ -n "$SLURM_NTASKS" ]; then
-    # May want to multiply this by ${SLURM_CPUS_PER_TASK:-1}.
-    # SLURM_NTASKS is total tasks over all nodes so this is 
-    # shouldn't be used for multi-node requests.
-    GALAXY_SLOTS="$SLURM_NTASKS"
+if [ -n "$SLURM_NTASKS" ] || [ -n "$SLURM_CPUS_PER_TASK" ]; then
+    # Multiply these values since SLURM_NTASKS is total tasks over all nodes.
+    # GALAXY_SLOTS maps to CPUS on a single node and shouldn't be used for
+    # multi-node requests.
+    GALAXY_SLOTS=`expr "${SLURM_NTASKS:-1}" \* "${SLURM_CPUS_PER_TASK:-1}"`
 elif [ -n "$NSLOTS" ]; then
     GALAXY_SLOTS="$NSLOTS"
 elif [ -n "$PBS_NCPUS" ]; then

--- a/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
@@ -1,5 +1,14 @@
 export GALAXY_SLOTS_CONFIGURED="1"
-if [ -n "$SLURM_NTASKS" ] || [ -n "$SLURM_CPUS_PER_TASK" ]; then
+if [ -n "$SLURM_CPUS_ON_NODE" ]; then
+    # This should be valid on SLURM except in the case that srun is used to
+    # submit additional job steps under an existing allocation, which we do not
+    # currently do.
+    GALAXY_SLOTS="$SLURM_CPUS_ON_NODE"
+elif [ -n "$SLURM_NTASKS" ] || [ -n "$SLURM_CPUS_PER_TASK" ]; then
+    # $SLURM_CPUS_ON_NODE should be set correctly on SLURM (even on old
+    # installations), but keep the $SLURM_NTASKS logic as a backup since this
+    # was the previous method under SLURM.
+    #
     # Multiply these values since SLURM_NTASKS is total tasks over all nodes.
     # GALAXY_SLOTS maps to CPUS on a single node and shouldn't be used for
     # multi-node requests.


### PR DESCRIPTION
SLURM_NTASKS is the total number of tasks over all nodes. SLURM_CPUS_PER_TASK more closely maps to GALAXY_SLOTS. We use both here to maintain backward compatibility.
