### PR TITLE
gitignore doesn't catch data added via data manager to the tool-data …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,7 @@ tool-data/genome/*
 tool-data/*.sample
 tool-data/testtoolshed.g2.bx.psu.edu/
 tool-data/toolshed.g2.bx.psu.edu/
-
+tool-data/**/*.fa 
 
 # Test output
 test-data-cache


### PR DESCRIPTION
…path. This change is only for the reference genome fetching, other data managers download files with different extensions.

I'm pretty sure this can be done in a smarter way to include all files downloaded by data mangers.
