### PR TITLE
Refactor AbstractToolbox toward reuse outside Galaxy

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -41,6 +41,7 @@ from galaxy.tools.parser import ToolOutputCollectionPart
 from galaxy.tools.toolbox import AbstractToolBox
 from galaxy.util import rst_to_html, string_as_bool
 from galaxy.util import ExecutionTimer
+from galaxy.util import listify
 from galaxy.tools.parameters.meta import expand_meta_parameters
 from galaxy.util.bunch import Bunch
 from galaxy.util.expressions import ExpressionContext
@@ -48,6 +49,7 @@ from galaxy.util.hash_util import hmac_new
 from galaxy.util.odict import odict
 from galaxy.util.template import fill_template
 from galaxy.web import url_for
+from galaxy.web.form_builder import SelectField
 from galaxy.util.dictifiable import Dictifiable
 from tool_shed.util import common_util
 from tool_shed.util import shed_util_common as suc
@@ -164,6 +166,46 @@ class ToolBox( AbstractToolBox ):
             tool = self._tools_by_id[ tool_id ]
             if isinstance( tool.tool_action, UploadToolAction ):
                 self.reload_tool_by_id( tool_id )
+
+    def get_tool_components( self, tool_id, tool_version=None, get_loaded_tools_by_lineage=False, set_selected=False ):
+        """
+        Retrieve all loaded versions of a tool from the toolbox and return a select list enabling
+        selection of a different version, the list of the tool's loaded versions, and the specified tool.
+        """
+        toolbox = self
+        tool_version_select_field = None
+        tools = []
+        tool = None
+        # Backwards compatibility for datasource tools that have default tool_id configured, but which
+        # are now using only GALAXY_URL.
+        tool_ids = listify( tool_id )
+        for tool_id in tool_ids:
+            if get_loaded_tools_by_lineage:
+                tools = toolbox.get_loaded_tools_by_lineage( tool_id )
+            else:
+                tools = toolbox.get_tool( tool_id, tool_version=tool_version, get_all_versions=True )
+            if tools:
+                tool = toolbox.get_tool( tool_id, tool_version=tool_version, get_all_versions=False )
+                if len( tools ) > 1:
+                    tool_version_select_field = self.__build_tool_version_select_field( tools, tool.id, set_selected )
+                break
+        return tool_version_select_field, tools, tool
+
+    def __build_tool_version_select_field( self, tools, tool_id, set_selected ):
+        """Build a SelectField whose options are the ids for the received list of tools."""
+        options = []
+        refresh_on_change_values = []
+        for tool in tools:
+            options.insert( 0, ( tool.version, tool.id ) )
+            refresh_on_change_values.append( tool.id )
+        select_field = SelectField( name='tool_id', refresh_on_change=True, refresh_on_change_values=refresh_on_change_values )
+        for option_tup in options:
+            selected = set_selected and option_tup[ 1 ] == tool_id
+            if selected:
+                select_field.add_option( 'version %s' % option_tup[ 0 ], option_tup[ 1 ], selected=True )
+            else:
+                select_field.add_option( 'version %s' % option_tup[ 0 ], option_tup[ 1 ] )
+        return select_field
 
 
 class DefaultToolState( object ):

--- a/lib/galaxy/tools/toolbox/lineages/tool_shed.py
+++ b/lib/galaxy/tools/toolbox/lineages/tool_shed.py
@@ -1,7 +1,10 @@
 from .interface import ToolLineage
 from .interface import ToolLineageVersion
 
-from galaxy.model.tool_shed_install import ToolVersion
+try:
+    from galaxy.model.tool_shed_install import ToolVersion
+except ImportError:
+    ToolVersion = None
 
 
 class ToolShedLineage(ToolLineage):
@@ -9,6 +12,8 @@ class ToolShedLineage(ToolLineage):
     installations. """
 
     def __init__(self, app, tool_version, tool_shed_repository=None):
+        if ToolVersion is None:
+            raise Exception("Tool shed models not present, can't create tool shed lineages.")
         self.app = app
         self.tool_version_id = tool_version.id
         # Only used for logging

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -58,6 +58,21 @@ NULL_CHAR = '\000'
 BINARY_CHARS = [ NULL_CHAR ]
 
 
+def remove_protocol_from_url( url ):
+    """ Supplied URL may be null, if not ensure http:// or https://
+    etc... is stripped off.
+    """
+    if url is None:
+        return url
+
+    # We have a URL
+    if url.find( '://' ) > 0:
+        new_url = url.split( '://' )[1]
+    else:
+        new_url = url
+    return new_url.rstrip( '/' )
+
+
 def is_binary( value, binary_chars=None ):
     """
     File is binary if it contains a null-byte by default (e.g. behavior of grep, etc.).

--- a/lib/tool_shed/util/common_util.py
+++ b/lib/tool_shed/util/common_util.py
@@ -337,18 +337,7 @@ def remove_protocol_and_user_from_clone_url( repository_clone_url ):
 
 def remove_protocol_from_tool_shed_url( tool_shed_url ):
     """Return a partial Tool Shed URL, eliminating the protocol if it exists."""
-    try:
-        if tool_shed_url.find( '://' ) > 0:
-            new_tool_shed_url = tool_shed_url.split( '://' )[1]
-        else:
-            new_tool_shed_url = tool_shed_url
-        return new_tool_shed_url.rstrip( '/' )
-    except Exception, e:
-        # We receive a lot of calls here where the tool_shed_url is None.  The container_util uses
-        # that value when creating a header row.  If the tool_shed_url is not None, we have a problem.
-        if tool_shed_url is not None:
-            log.exception( "Handled exception removing the protocol from Tool Shed URL %s:\n%s", str( tool_shed_url ), e )
-        return tool_shed_url
+    return util.remove_protocol_from_url( tool_shed_url )
 
 
 def tool_shed_get( app, base_url, pathspec=[], params={} ):


### PR DESCRIPTION
- Make ToolShed lineage optionally load (requires database, models, etc...)
- Move other tool shed and UI code up out of AbstractToolBox and into ToolBox which has many more dependencies and couldn't easily be extracted from the rest of Galaxy.
