### PR TITLE
Unify and Abstract Code for Checking if File Looks Like a Tool

### DIFF
--- a/lib/galaxy/tools/parser/factory.py
+++ b/lib/galaxy/tools/parser/factory.py
@@ -9,6 +9,7 @@ from .interface import InputSource
 
 
 from galaxy.tools.loader import load_tool as load_tool_xml
+from galaxy.util.odict import odict
 
 
 import logging
@@ -24,12 +25,27 @@ def get_tool_source(config_file, enable_beta_formats=True):
     if config_file.endswith(".yml"):
         log.info("Loading tool from YAML - this is experimental - tool will not function in future.")
         with open(config_file, "r") as f:
-            as_dict = yaml.load(f)
+            as_dict = ordered_load(f)
             return YamlToolSource(as_dict)
     else:
         tree = load_tool_xml(config_file)
         root = tree.getroot()
         return XmlToolSource(root)
+
+
+def ordered_load(stream):
+    class OrderedLoader(yaml.Loader):
+        pass
+
+    def construct_mapping(loader, node):
+        loader.flatten_mapping(node)
+        return odict(loader.construct_pairs(node))
+
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping)
+
+    return yaml.load(stream, OrderedLoader)
 
 
 def get_input_source(content):

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -96,7 +96,7 @@ class YamlToolSource(ToolSource):
         # TODO: implement tool output action group fixes
         output.actions = ToolOutputActionGroup( output, None )
         discover_datasets_dicts = output_dict.get( "discover_datasets", [] )
-        if isinstance( discover_datasets_dicts, dict ):
+        if _is_dict(discover_datasets_dicts):
             discover_datasets_dicts = [ discover_datasets_dicts ]
         output.dataset_collector_descriptions = dataset_collector_descriptions_from_list( discover_datasets_dicts )
         return output
@@ -115,7 +115,7 @@ class YamlToolSource(ToolSource):
 
 def _parse_test(i, test_dict):
     inputs = test_dict["inputs"]
-    if isinstance(inputs, dict):
+    if _is_dict(inputs):
         new_inputs = []
         for key, value in inputs.iteritems():
             new_inputs.append((key, value, {}))
@@ -124,9 +124,9 @@ def _parse_test(i, test_dict):
     outputs = test_dict["outputs"]
 
     new_outputs = []
-    if isinstance(outputs, dict):
+    if _is_dict(outputs):
         for key, value in outputs.iteritems():
-            if isinstance(value, dict):
+            if _is_dict(value):
                 attributes = value
                 file = attributes.get("file")
             else:
@@ -169,6 +169,10 @@ def _parse_test(i, test_dict):
     return test_dict
 
 
+def _is_dict(item):
+    return isinstance(item, dict) or isinstance(item, odict)
+
+
 def __to_test_assert_list(assertions):
     def expand_dict_form(item):
         key, value = item
@@ -176,7 +180,7 @@ def __to_test_assert_list(assertions):
         new_value["that"] = key
         return new_value
 
-    if isinstance( assertions, dict ):
+    if _is_dict(assertions):
         assertions = map(expand_dict_form, assertions.items() )
 
     assert_list = []

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -25,6 +25,8 @@ from .panel import ToolSection
 from .panel import panel_item_types
 from .integrated_panel import ManagesIntegratedToolPanelMixin
 
+from galaxy.tools.loader_directory import looks_like_a_tool
+
 from .lineages import LineageMap
 from .tags import tool_tag_manager
 
@@ -739,7 +741,7 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
             child_path = os.path.join(directory, name)
             if os.path.isdir(child_path) and recursive:
                 self.__watch_directory(child_path, elems, integrated_elems, load_panel_dict, recursive)
-            elif name.endswith( ".xml" ):
+            elif looks_like_a_tool(child_path):
                 quick_load( child_path, async=False )
                 tool_loaded = True
         if tool_loaded or force_watch:

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -741,7 +741,7 @@ class AbstractToolBox( object, Dictifiable, ManagesIntegratedToolPanelMixin ):
             child_path = os.path.join(directory, name)
             if os.path.isdir(child_path) and recursive:
                 self.__watch_directory(child_path, elems, integrated_elems, load_panel_dict, recursive)
-            elif looks_like_a_tool(child_path):
+            elif looks_like_a_tool(child_path, enable_beta_formats=getattr(self.app.config, "enable_beta_tool_formats", False)):
                 quick_load( child_path, async=False )
                 tool_loaded = True
         if tool_loaded or force_watch:

--- a/lib/galaxy/util/odict.py
+++ b/lib/galaxy/util/odict.py
@@ -3,6 +3,7 @@ Ordered dictionary implementation.
 """
 
 from six.moves import UserDict
+dict_alias = dict
 
 
 class odict(UserDict):
@@ -14,8 +15,15 @@ class odict(UserDict):
     order.
     """
     def __init__( self, dict=None ):
+        item = dict
         self._keys = []
-        UserDict.__init__( self, dict )
+        if isinstance(item, dict_alias):
+            UserDict.__init__( self, item )
+        else:
+            UserDict.__init__( self, None )
+        if isinstance(item, list):
+            for (key, value) in item:
+                self[key] = value
 
     def __delitem__( self, key ):
         UserDict.__delitem__( self, key )

--- a/lib/tool_shed/metadata/metadata_generator.py
+++ b/lib/tool_shed/metadata/metadata_generator.py
@@ -6,8 +6,8 @@ import tempfile
 from sqlalchemy import and_
 
 from galaxy import util
-from galaxy.util import checkers
 from galaxy.tools.data_manager.manager import DataManager
+from galaxy.tools.loader_directory import looks_like_a_tool
 from galaxy.tools.parser.interface import TestCollectionDef
 from galaxy.web import url_for
 from tool_shed.repository_types import util as rt_util
@@ -394,55 +394,47 @@ class MetadataGenerator( object ):
                                                                                              self.shed_config_dict )
                         readme_files.append( relative_path_to_readme )
                     # See if we have a tool config.
-                    elif name not in self.NOT_TOOL_CONFIGS and name.endswith( '.xml' ):
-                        full_path = str( os.path.abspath( os.path.join( root, name ) ) )
-                        if os.path.getsize( full_path ) > 0:
-                            if not ( checkers.check_binary( full_path ) or
-                                     checkers.check_image( full_path ) or
-                                     checkers.check_gzip( full_path )[ 0 ] or
-                                     checkers.check_bz2( full_path )[ 0 ] or
-                                     checkers.check_zip( full_path ) ):
-                                # Make sure we're looking at a tool config and not a display application
-                                # config or something else.
-                                element_tree, error_message = xml_util.parse_xml( full_path )
-                                if element_tree is None:
-                                    is_tool = False
+                    elif looks_like_a_tool(os.path.join( root, name ), invalid_names=self.NOT_TOOL_CONFIGS ):
+                        full_path = str(os.path.abspath(os.path.join( root, name )))  # why the str, seems very odd
+                        element_tree, error_message = xml_util.parse_xml( full_path )
+                        if element_tree is None:
+                            is_tool = False
+                        else:
+                            element_tree_root = element_tree.getroot()
+                            is_tool = element_tree_root.tag == 'tool'
+                        if is_tool:
+                            tool, valid, error_message = \
+                                tv.load_tool_from_config( self.app.security.encode_id( self.repository.id ),
+                                                          full_path )
+                            if tool is None:
+                                if not valid:
+                                    invalid_tool_configs.append( name )
+                                    self.invalid_file_tups.append( ( name, error_message ) )
+                            else:
+                                invalid_files_and_errors_tups = \
+                                    tv.check_tool_input_params( files_dir,
+                                                                name,
+                                                                tool,
+                                                                sample_file_copy_paths )
+                                can_set_metadata = True
+                                for tup in invalid_files_and_errors_tups:
+                                    if name in tup:
+                                        can_set_metadata = False
+                                        invalid_tool_configs.append( name )
+                                        break
+                                if can_set_metadata:
+                                    relative_path_to_tool_config = \
+                                        self.get_relative_path_to_repository_file( root,
+                                                                                   name,
+                                                                                   self.relative_install_dir,
+                                                                                   work_dir,
+                                                                                   self.shed_config_dict )
+                                    metadata_dict = self.generate_tool_metadata( relative_path_to_tool_config,
+                                                                                 tool,
+                                                                                 metadata_dict )
                                 else:
-                                    element_tree_root = element_tree.getroot()
-                                    is_tool = element_tree_root.tag == 'tool'
-                                if is_tool:
-                                    tool, valid, error_message = \
-                                        tv.load_tool_from_config( self.app.security.encode_id( self.repository.id ),
-                                                                  full_path )
-                                    if tool is None:
-                                        if not valid:
-                                            invalid_tool_configs.append( name )
-                                            self.invalid_file_tups.append( ( name, error_message ) )
-                                    else:
-                                        invalid_files_and_errors_tups = \
-                                            tv.check_tool_input_params( files_dir,
-                                                                        name,
-                                                                        tool,
-                                                                        sample_file_copy_paths )
-                                        can_set_metadata = True
-                                        for tup in invalid_files_and_errors_tups:
-                                            if name in tup:
-                                                can_set_metadata = False
-                                                invalid_tool_configs.append( name )
-                                                break
-                                        if can_set_metadata:
-                                            relative_path_to_tool_config = \
-                                                self.get_relative_path_to_repository_file( root,
-                                                                                           name,
-                                                                                           self.relative_install_dir,
-                                                                                           work_dir,
-                                                                                           self.shed_config_dict )
-                                            metadata_dict = self.generate_tool_metadata( relative_path_to_tool_config,
-                                                                                         tool,
-                                                                                         metadata_dict )
-                                        else:
-                                            for tup in invalid_files_and_errors_tups:
-                                                self.invalid_file_tups.append( tup )
+                                    for tup in invalid_files_and_errors_tups:
+                                        self.invalid_file_tups.append( tup )
                     # Find all exported workflows.
                     elif name.endswith( '.ga' ):
                         relative_path = os.path.join( root, name )


### PR DESCRIPTION
The toolshed, toolbox, and planemo all used different methods for quickly checking if a file is supposed to look like a tool previously. This unifies them into a single `looks_like_a_tool` method. Additionally, this makes the method more correct by handling the "enable_beta_tool_formats" config option.

This PR also pulls in some some updates to the dictified representation of tools from my downstream work on dynamically splitting and merging collections using datatype methods. Even if we never expose the YAML format externally - that use of dynamically building a tool per datatype demonstrates the utility of allowing Galaxy to use the format internally. The real utility though is one of code design, helping ensure there is a strict differentiation between the layout of tools in a file and Galaxy's abstract description (the Tool class).
