### PR TITLE
Adding uuid support to directory_hash_id

### DIFF
--- a/lib/galaxy/util/directory_hash.py
+++ b/lib/galaxy/util/directory_hash.py
@@ -11,7 +11,7 @@ def directory_hash_id( id ):
     >>> directory_hash_id("777777777")
     ['000', '777', '777']
     >>> directory_hash_id("135ee48a-4f51-470c-ae2f-ce8bd78799e6")
-    ['1','3','5']
+    ['1', '3', '5']
     """
     s = str( id )
     l = len( s )
@@ -26,5 +26,5 @@ def directory_hash_id( id ):
         # Break into chunks of three
         return [ padded[ i * 3 : (i + 1 ) * 3 ] for i in range( len( padded ) // 3 ) ]
     else:
-        #assume it is a UUID
+        # assume it is a UUID
         return list(iter(s[0:3]))

--- a/lib/galaxy/util/directory_hash.py
+++ b/lib/galaxy/util/directory_hash.py
@@ -1,6 +1,7 @@
 
 from galaxy.util import is_uuid
 
+
 def directory_hash_id( id ):
     """
 

--- a/lib/galaxy/util/directory_hash.py
+++ b/lib/galaxy/util/directory_hash.py
@@ -1,4 +1,5 @@
 
+from galaxy.util import is_uuid
 
 def directory_hash_id( id ):
     """
@@ -9,15 +10,21 @@ def directory_hash_id( id ):
     ['090']
     >>> directory_hash_id("777777777")
     ['000', '777', '777']
+    >>> directory_hash_id("135ee48a-4f51-470c-ae2f-ce8bd78799e6")
+    ['1','3','5']
     """
     s = str( id )
     l = len( s )
     # Shortcut -- ids 0-999 go under ../000/
     if l < 4:
         return [ "000" ]
-    # Pad with zeros until a multiple of three
-    padded = ( ( 3 - len( s ) % 3 ) * "0" ) + s
-    # Drop the last three digits -- 1000 files per directory
-    padded = padded[:-3]
-    # Break into chunks of three
-    return [ padded[ i * 3 : (i + 1 ) * 3 ] for i in range( len( padded ) // 3 ) ]
+    if not is_uuid(s):
+        # Pad with zeros until a multiple of three
+        padded = ( ( 3 - len( s ) % 3 ) * "0" ) + s
+        # Drop the last three digits -- 1000 files per directory
+        padded = padded[:-3]
+        # Break into chunks of three
+        return [ padded[ i * 3 : (i + 1 ) * 3 ] for i in range( len( padded ) // 3 ) ]
+    else:
+        #assume it is a UUID
+        return list(iter(s[0:3]))


### PR DESCRIPTION
If a UUID is passed directory_hash_id, currently it would produce something like
/9a1/c39/ded/10-/607/3-1/1e4/-98/03-/080/020/0c9

With this patch it will produce 

/9/a/1
