### PR TITLE
Implement special config file to dump parameters as json.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -646,11 +646,7 @@ class Tool( object, Dictifiable ):
                 name = inputs_elem.get( "name" )
                 filename = inputs_elem.get( "filename", None )
                 format = inputs_elem.get("format", "json")
-                version_str = inputs_elem.get("version", "1")
-                if not version_str:
-                    raise ValueError("inputs configfile tag must define a version attribute")
-                version = int(version_str)
-                content = dict(format=format, version=version)
+                content = dict(format=format)
                 self.config_files.append( ( name, filename, content ) )
             for conf_elem in conf_parent_elem.findall( "configfile" ):
                 name = conf_elem.get( "name" )

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -641,11 +641,22 @@ class Tool( object, Dictifiable ):
         root = tool_source.root
         conf_parent_elem = root.find("configfiles")
         if conf_parent_elem is not None:
+            inputs_elem = conf_parent_elem.find( "inputs" )
+            if inputs_elem is not None:
+                name = inputs_elem.get( "name" )
+                filename = inputs_elem.get( "filename", None )
+                format = inputs_elem.get("format", "json")
+                version_str = inputs_elem.get("version", "1")
+                if not version_str:
+                    raise ValueError("inputs configfile tag must define a version attribute")
+                version = int(version_str)
+                content = dict(format=format, version=version)
+                self.config_files.append( ( name, filename, content ) )
             for conf_elem in conf_parent_elem.findall( "configfile" ):
                 name = conf_elem.get( "name" )
                 filename = conf_elem.get( "filename", None )
-                text = conf_elem.text
-                self.config_files.append( ( name, filename, text ) )
+                content = conf_elem.text
+                self.config_files.append( ( name, filename, content ) )
 
     def __parse_trackster_conf(self, tool_source):
         self.trackster_conf = None

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -533,8 +533,11 @@ class ToolEvaluator( object ):
         if isinstance( content, basestring ):
             return content, True
 
-        assert content["format"] == "json"
-        assert content["version"] == 1
+        content_format = content["format"]
+        if content_format != "json":
+            template = "Galaxy can only currently convert inputs to json, format [%s] is unhandled"
+            message = template % content_format
+            raise Exception(message)
 
         return json.dumps(wrapped_json.json_wrap(self.tool.inputs, self.param_dict)), False
 

--- a/lib/galaxy/tools/parameters/wrapped_json.py
+++ b/lib/galaxy/tools/parameters/wrapped_json.py
@@ -55,7 +55,7 @@ def _json_wrap_input(input, value, handle_files="SKIP"):
         if handle_files == "SKIP":
             return SKIP_INPUT
         raise NotImplementedError()
-    elif input_type == "select" or input_type == "text" or input_type == "color":
+    elif input_type in ["select", "text", "color", "hidden"]:
         json_value = _cast_if_not_none(value, str)
     elif input_type == "float":
         json_value = _cast_if_not_none(value, float, empty_to_none=True)

--- a/lib/galaxy/tools/parameters/wrapped_json.py
+++ b/lib/galaxy/tools/parameters/wrapped_json.py
@@ -1,0 +1,72 @@
+import logging
+log = logging.getLogger(__name__)
+
+
+def json_wrap(inputs, input_values, as_dict=None, handle_files="SKIP"):
+    if as_dict is None:
+        as_dict = {}
+
+    for input in inputs.itervalues():
+        input_name = input.name
+        input_type = input.type
+        value = input_values[input_name]
+        if input_type == "repeat":
+            repeat_job_value = []
+            for d in input_values[input.name]:
+                repeat_instance_job_value = {}
+                json_wrap(input.inputs, d, repeat_instance_job_value)
+                repeat_job_value.append(repeat_instance_job_value)
+            as_dict[input_name] = repeat_job_value
+        if input_type == "conditional":
+            values = input_values[input_name]
+            current = values["__current_case__"]
+            conditional_job_value = {}
+            json_wrap(input.cases[current].inputs, values, conditional_job_value)
+            as_dict[input_name] = conditional_job_value
+        if input_type == "section":
+            values = input_values[input_name]
+            section_job_value = {}
+            json_wrap(input.inputs, values, section_job_value)
+            as_dict[input_name] = section_job_value
+        elif input_type == "data" and input.multiple:
+            if handle_files == "SKIP":
+                continue
+            raise NotImplementedError()
+        elif input_type == "data":
+            if handle_files == "SKIP":
+                continue
+            raise NotImplementedError()
+        elif input_type == "data_collection":
+            if handle_files == "SKIP":
+                continue
+            raise NotImplementedError()
+        elif input_type == "select" or input_type == "text":
+            value = input_values[input_name]
+            json_value = _cast_if_not_none(value, str)
+            as_dict[input_name] = json_value
+        elif input_type == "float":
+            value = input_values[input_name]
+            json_value = _cast_if_not_none(value, float, empty_to_none=True)
+            as_dict[input_name] = json_value
+        elif input_type == "integer":
+            value = input_values[input_name]
+            json_value = _cast_if_not_none(value, int, empty_to_none=True)
+            as_dict[input_name] = json_value
+        elif input_type == "boolean":
+            value = input_values[input_name]
+            json_value = _cast_if_not_none(value, bool)
+            as_dict[input_name] = json_value
+        else:
+            raise NotImplementedError("input_type [%s] not implemented" % input_type)
+    return as_dict
+
+
+def _cast_if_not_none(value, cast_to, empty_to_none=False):
+    # log.debug("value [%s], type[%s]" % (value, type(value)))
+    if value is None or (empty_to_none and str(value) == ''):
+        return None
+    else:
+        return cast_to(value)
+
+
+__all__ = ['json_wrap']

--- a/lib/galaxy/tools/parameters/wrapped_json.py
+++ b/lib/galaxy/tools/parameters/wrapped_json.py
@@ -2,63 +2,71 @@ import logging
 log = logging.getLogger(__name__)
 
 
+SKIP_INPUT = object()
+
+
 def json_wrap(inputs, input_values, as_dict=None, handle_files="SKIP"):
     if as_dict is None:
         as_dict = {}
 
     for input in inputs.itervalues():
         input_name = input.name
-        input_type = input.type
         value = input_values[input_name]
-        if input_type == "repeat":
-            repeat_job_value = []
-            for d in input_values[input.name]:
-                repeat_instance_job_value = {}
-                json_wrap(input.inputs, d, repeat_instance_job_value)
-                repeat_job_value.append(repeat_instance_job_value)
-            as_dict[input_name] = repeat_job_value
-        if input_type == "conditional":
-            values = input_values[input_name]
-            current = values["__current_case__"]
-            conditional_job_value = {}
-            json_wrap(input.cases[current].inputs, values, conditional_job_value)
-            as_dict[input_name] = conditional_job_value
-        if input_type == "section":
-            values = input_values[input_name]
-            section_job_value = {}
-            json_wrap(input.inputs, values, section_job_value)
-            as_dict[input_name] = section_job_value
-        elif input_type == "data" and input.multiple:
-            if handle_files == "SKIP":
-                continue
-            raise NotImplementedError()
-        elif input_type == "data":
-            if handle_files == "SKIP":
-                continue
-            raise NotImplementedError()
-        elif input_type == "data_collection":
-            if handle_files == "SKIP":
-                continue
-            raise NotImplementedError()
-        elif input_type == "select" or input_type == "text":
-            value = input_values[input_name]
-            json_value = _cast_if_not_none(value, str)
-            as_dict[input_name] = json_value
-        elif input_type == "float":
-            value = input_values[input_name]
-            json_value = _cast_if_not_none(value, float, empty_to_none=True)
-            as_dict[input_name] = json_value
-        elif input_type == "integer":
-            value = input_values[input_name]
-            json_value = _cast_if_not_none(value, int, empty_to_none=True)
-            as_dict[input_name] = json_value
-        elif input_type == "boolean":
-            value = input_values[input_name]
-            json_value = _cast_if_not_none(value, bool)
-            as_dict[input_name] = json_value
-        else:
-            raise NotImplementedError("input_type [%s] not implemented" % input_type)
+        json_value = _json_wrap_input(input, value, handle_files=handle_files)
+        if json_value is SKIP_INPUT:
+            continue
+        as_dict[input_name] = json_value
     return as_dict
+
+
+def _json_wrap_input(input, value, handle_files="SKIP"):
+    input_type = input.type
+    if input_type == "repeat":
+        repeat_job_value = []
+        for d in value:
+            repeat_instance_job_value = {}
+            json_wrap(input.inputs, d, repeat_instance_job_value)
+            repeat_job_value.append(repeat_instance_job_value)
+        json_value = repeat_job_value
+    elif input_type == "conditional":
+        values = value
+        current = values["__current_case__"]
+        conditional_job_value = {}
+        json_wrap(input.cases[current].inputs, values, conditional_job_value)
+        test_param = input.test_param
+        test_param_name = test_param.name
+        test_value = _json_wrap_input(test_param, values[test_param_name])
+        conditional_job_value[test_param_name] = test_value
+        json_value = conditional_job_value
+    elif input_type == "section":
+        values = value
+        section_job_value = {}
+        json_wrap(input.inputs, values, section_job_value)
+        json_value = section_job_value
+    elif input_type == "data" and input.multiple:
+        if handle_files == "SKIP":
+            return SKIP_INPUT
+        raise NotImplementedError()
+    elif input_type == "data":
+        if handle_files == "SKIP":
+            return SKIP_INPUT
+        raise NotImplementedError()
+    elif input_type == "data_collection":
+        if handle_files == "SKIP":
+            return SKIP_INPUT
+        raise NotImplementedError()
+    elif input_type == "select" or input_type == "text" or input_type == "color":
+        json_value = _cast_if_not_none(value, str)
+    elif input_type == "float":
+        json_value = _cast_if_not_none(value, float, empty_to_none=True)
+    elif input_type == "integer":
+        json_value = _cast_if_not_none(value, int, empty_to_none=True)
+    elif input_type == "boolean":
+        json_value = _cast_if_not_none(value, bool)
+    else:
+        raise NotImplementedError("input_type [%s] not implemented" % input_type)
+
+    return json_value
 
 
 def _cast_if_not_none(value, cast_to, empty_to_none=False):

--- a/test/functional/tools/inputs_as_json.xml
+++ b/test/functional/tools/inputs_as_json.xml
@@ -1,4 +1,7 @@
 <tool id="inputs_as_json" name="inputs_as_json" version="1.0.0">
+    <command detect_errors="exit_code">
+        python $check_inputs $inputs $test_case
+    </command>
     <configfiles>
         <inputs name="inputs" format="json" version="1" />
         <configfile name="check_inputs"><![CDATA[
@@ -17,28 +20,36 @@ if test_case == "1":
     assert_equals(as_dict["test_case"], 1)
     assert_equals(as_dict["text_test"], "foo")
     assert_equals(as_dict["booltest"], True)
+    assert_equals(as_dict["booltest2"], True)
     assert_equals(as_dict["inttest"], 12456)
     assert_equals(as_dict["floattest"], 6.789)
     assert_equals(as_dict["radio_select"], "a_radio")
+    assert_equals(as_dict["repeat"][0]["r"], "000000")
+    assert_equals(as_dict["repeat"][1]["r"], "FFFFFF")
+    assert_equals(as_dict["cond"]["more_text"], "fdefault")
+    assert_equals(as_dict["section_example"]["section_text"], "section_default")
 elif test_case == "2":
     assert_equals(as_dict["test_case"], 2)
     assert_equals(as_dict["text_test"], "bar")
     assert_equals(as_dict["booltest"], False)
+    assert_equals(as_dict["booltest2"], False)
     assert_equals(as_dict["inttest"], None)
     assert_equals(as_dict["floattest"], 1.0)
     assert_equals(as_dict["radio_select"], "a_radio")
+    assert_equals(as_dict["repeat"][0]["r"], "000000")
+    assert_equals(as_dict["cond"]["cond_test"], "second")
+    assert_equals(as_dict["cond"]["more_text"], "sdefault")
+    assert_equals(as_dict["section_example"]["section_text"], "section_default")
 
 with open("output", "w") as f:
     f.write("okay\n")
 ]]></configfile>
     </configfiles>
-    <command>
-        python $check_inputs $inputs $test_case
-    </command>
     <inputs>
         <param name="test_case" type="integer" value="0" />
         <param name="text_test" type="text" />
         <param name="booltest" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
+        <param name="booltest2" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
         <param name="inttest" type="integer" optional="true" />
         <param name="floattest" value="1.0" type="float" />
         <param name="radio_select" type="select" display="radio">
@@ -46,6 +57,24 @@ with open("output", "w") as f:
             <option value="b_radio">B Radio</option>
             <option value="c_radio">C Radio</option>
         </param>
+        <repeat name="repeat" title="Repeat" min="1">
+            <param name="r" type="color" />
+        </repeat>
+        <conditional name="cond">
+            <param name="cond_test" type="select">
+                <option value="first" selected="true">First</option>
+                <option value="second">Second</option>
+            </param>
+            <when value="first">
+                <param name="more_text" type="text" value="fdefault" />
+            </when>
+            <when value="second">
+                <param name="more_text" type="text" value="sdefault" />
+            </when> 
+        </conditional>
+        <section name="section_example">
+            <param name="section_text" type="text" value="section_default" />
+        </section>
     </inputs>
     <outputs>
         <data name="out_file1" from_work_dir="output" format="txt" />
@@ -55,8 +84,18 @@ with open("output", "w") as f:
             <param name="test_case" value="1" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
+            <param name="booltest2" value="booltrue" />
             <param name="inttest" value="12456" />
             <param name="floattest" value="6.789" />
+            <repeat name="repeat">
+                <param name="r" value="000000"/>
+            </repeat>
+            <repeat name="repeat">
+                <param name="r" value="FFFFFF"/>
+            </repeat>
+            <conditional name="cond">
+                <param name="cond_test" value="first" />
+            </conditional>
             <output name="out_file1">
                 <assert_contents>
                     <has_line line="okay" />
@@ -67,8 +106,13 @@ with open("output", "w") as f:
             <param name="test_case" value="2" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
+            <param name="booltest2" value="boolfalse" />
             <!-- Testing null integers -->
             <!-- <param name="inttest" value="12456" /> -->
+            <param name="r" value="000000" />
+            <conditional name="cond">
+                <param name="cond_test" value="second" />
+            </conditional>
             <output name="out_file1">
                 <assert_contents>
                     <has_line line="okay" />
@@ -76,4 +120,7 @@ with open("output", "w") as f:
             </output>
         </test>
     </tests>
+    <help>
+        Test tool demonstrating the special inputs config file.
+    </help>
 </tool>

--- a/test/functional/tools/inputs_as_json.xml
+++ b/test/functional/tools/inputs_as_json.xml
@@ -1,0 +1,79 @@
+<tool id="inputs_as_json" name="inputs_as_json" version="1.0.0">
+    <configfiles>
+        <inputs name="inputs" format="json" version="1" />
+        <configfile name="check_inputs"><![CDATA[
+import json
+import sys
+
+input_json_path = sys.argv[1]
+test_case = sys.argv[2]
+as_dict = json.load(open(input_json_path, "r"))
+
+
+def assert_equals(x, y):
+    assert x == y, "%s != %s" % (x, y)
+
+if test_case == "1":
+    assert_equals(as_dict["test_case"], 1)
+    assert_equals(as_dict["text_test"], "foo")
+    assert_equals(as_dict["booltest"], True)
+    assert_equals(as_dict["inttest"], 12456)
+    assert_equals(as_dict["floattest"], 6.789)
+    assert_equals(as_dict["radio_select"], "a_radio")
+elif test_case == "2":
+    assert_equals(as_dict["test_case"], 2)
+    assert_equals(as_dict["text_test"], "bar")
+    assert_equals(as_dict["booltest"], False)
+    assert_equals(as_dict["inttest"], None)
+    assert_equals(as_dict["floattest"], 1.0)
+    assert_equals(as_dict["radio_select"], "a_radio")
+
+with open("output", "w") as f:
+    f.write("okay\n")
+]]></configfile>
+    </configfiles>
+    <command>
+        python $check_inputs $inputs $test_case
+    </command>
+    <inputs>
+        <param name="test_case" type="integer" value="0" />
+        <param name="text_test" type="text" />
+        <param name="booltest" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
+        <param name="inttest" type="integer" optional="true" />
+        <param name="floattest" value="1.0" type="float" />
+        <param name="radio_select" type="select" display="radio">
+            <option value="a_radio" selected="true">A Radio</option>
+            <option value="b_radio">B Radio</option>
+            <option value="c_radio">C Radio</option>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="out_file1" from_work_dir="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="test_case" value="1" />
+            <param name="text_test" value="foo" />
+            <param name="booltest" value="true" />
+            <param name="inttest" value="12456" />
+            <param name="floattest" value="6.789" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="okay" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="test_case" value="2" />
+            <param name="text_test" value="bar" />
+            <param name="booltest" value="false" />
+            <!-- Testing null integers -->
+            <!-- <param name="inttest" value="12456" /> -->
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="okay" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/inputs_as_json.xml
+++ b/test/functional/tools/inputs_as_json.xml
@@ -3,7 +3,10 @@
         python $check_inputs $inputs $test_case
     </command>
     <configfiles>
-        <inputs name="inputs" format="json" version="1" />
+        <inputs name="inputs" />
+        <!-- Can specify with fixed path in working directory instead:
+        <inputs name="inputs" filename="input.json" />
+        -->
         <configfile name="check_inputs"><![CDATA[
 import json
 import sys

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -15,6 +15,7 @@
   <tool file="multi_output.xml" />
   <tool file="multi_output_configured.xml" />
   <tool file="multi_output_assign_primary.xml" />
+  <tool file="inputs_as_json.xml" />
   <tool file="dbkey_filter_input.xml" />
   <tool file="dbkey_filter_multi_input.xml" />
   <tool file="composite_output.xml" />


### PR DESCRIPTION
```
    <configfiles>
        <inputs name="inputs" />
    </configfiles>
```

Version is specified as 1, because the Galaxy tool plumbing doesn't really distinguish between parameter is '', parameter was explicitly supplied as None, parameter was absent, etc... - everything is a just a string in some ways. This distinction may be more important with JSON and for instance the CWL will require more precision, so we may want to revise Galaxy's tool handling in a backward compatible way someday.

Both @erasche  and @bgruening are working on tools that seem they would benefit from this.
