### PR TITLE
all commands in new isolated shell

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -832,12 +832,6 @@ use_interactive = True
 # Enable Galaxy to communicate directly with a sequencer
 #enable_sequencer_communication = False
 
-# Separate tool command from rest of job script so tool dependencies
-# don't interfer with metadata generation (this will be the default
-# in a future release).
-#enable_beta_tool_command_isolation = False
-
-
 # Set the following to a number of threads greater than 1 to spawn
 # a Python task queue for dealing with large tool submissions (either
 # through the tool form or as part of an individual workflow step across

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -214,7 +214,6 @@ class Configuration( object ):
         # Tasked job runner.
         self.use_tasked_jobs = string_as_bool( kwargs.get( 'use_tasked_jobs', False ) )
         self.local_task_queue_workers = int(kwargs.get("local_task_queue_workers", 2))
-        self.commands_in_new_shell = string_as_bool( kwargs.get( 'enable_beta_tool_command_isolation', "False" ) )
         self.tool_submission_burst_threads = int( kwargs.get( 'tool_submission_burst_threads', '1' ) )
         self.tool_submission_burst_at = int( kwargs.get( 'tool_submission_burst_at', '10' ) )
         # The transfer manager and deferred job queue

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -786,10 +786,6 @@ class JobWrapper( object ):
         return self.tool.parallelism
 
     @property
-    def commands_in_new_shell(self):
-        return self.app.config.commands_in_new_shell
-
-    @property
     def galaxy_lib_dir(self):
         if self.__galaxy_lib_dir is None:
             self.__galaxy_lib_dir = os.path.abspath( "lib" )  # cwd = galaxy root

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -48,21 +48,20 @@ def build_command(
     if not container:
         __handle_dependency_resolution(commands_builder, job_wrapper, remote_command_params)
 
-    if container or job_wrapper.commands_in_new_shell:
-        externalized_commands = __externalize_commands(job_wrapper, commands_builder, remote_command_params)
-        if container:
-            # Stop now and build command before handling metadata and copying
-            # working directory files back. These should always happen outside
-            # of docker container - no security implications when generating
-            # metadata and means no need for Galaxy to be available to container
-            # and not copying workdir outputs back means on can be more restrictive
-            # of where container can write to in some circumstances.
-            run_in_container_command = container.containerize_command(
-                externalized_commands
-            )
-            commands_builder = CommandsBuilder( run_in_container_command )
-        else:
-            commands_builder = CommandsBuilder( externalized_commands )
+    externalized_commands = __externalize_commands(job_wrapper, commands_builder, remote_command_params)
+    if container:
+        # Stop now and build command before handling metadata and copying
+        # working directory files back. These should always happen outside
+        # of docker container - no security implications when generating
+        # metadata and means no need for Galaxy to be available to container
+        # and not copying workdir outputs back means on can be more restrictive
+        # of where container can write to in some circumstances.
+        run_in_container_command = container.containerize_command(
+            externalized_commands
+        )
+        commands_builder = CommandsBuilder( run_in_container_command )
+    else:
+        commands_builder = CommandsBuilder( externalized_commands )
 
     if include_work_dir_outputs:
         __handle_work_dir_outputs(commands_builder, job_wrapper, runner, remote_command_params)


### PR DESCRIPTION
Remove `enable_beta_tool_command_isolation` from galaxy.ini and activate it by default.

This is more and more essential for tools that are depending on their own python version.
