### PR TITLE
Copy pastescript's NiceConfigParser into galaxy.util.properties.

### DIFF
--- a/lib/galaxy/util/properties.py
+++ b/lib/galaxy/util/properties.py
@@ -4,6 +4,10 @@ this should be reusable by tool shed and pulsar as well.
 """
 import os
 import os.path
+import sys
+
+from six.moves.configparser import ConfigParser
+from six import iteritems
 
 
 def load_app_properties(
@@ -18,9 +22,6 @@ def load_app_properties(
             'here': os.path.dirname(os.path.abspath(ini_file)),
             '__file__': os.path.abspath(ini_file)
         }
-        # Mimic the way loadwsgi loads configuration files - needed for
-        # correctness given the very specific ways interpolation is handled.
-        from galaxy.util.pastescript.loadwsgi import NicerConfigParser
         parser = NicerConfigParser(ini_file, defaults=defaults)
         parser.optionxform = str  # Don't lower-case keys
         with open(ini_file) as f:
@@ -39,3 +40,63 @@ def load_app_properties(
                 properties[ config_key ] = os.environ[ key ]
 
     return properties
+
+
+# pastescript's NicerConfigParser, replicated here so this module doesn't
+# need to depend on WSGI.
+class NicerConfigParser(ConfigParser):
+
+    def __init__(self, filename, *args, **kw):
+        ConfigParser.__init__(self, *args, **kw)
+        self.filename = filename
+        if hasattr(self, '_interpolation'):
+            self._interpolation = self.InterpolateWrapper(self._interpolation)
+
+    read_file = getattr(ConfigParser, 'read_file', ConfigParser.readfp)
+
+    def defaults(self):
+        """Return the defaults, with their values interpolated (with the
+        defaults dict itself)
+
+        Mainly to support defaults using values such as %(here)s
+        """
+        defaults = ConfigParser.defaults(self).copy()
+        for key, val in iteritems(defaults):
+            defaults[key] = self.get('DEFAULT', key) or val
+        return defaults
+
+    def _interpolate(self, section, option, rawval, vars):
+        # Python < 3.2
+        try:
+            return ConfigParser._interpolate(
+                self, section, option, rawval, vars)
+        except Exception:
+            e = sys.exc_info()[1]
+            args = list(e.args)
+            args[0] = 'Error in file %s: %s' % (self.filename, e)
+            e.args = tuple(args)
+            e.message = args[0]
+            raise
+
+    class InterpolateWrapper(object):
+        # Python >= 3.2
+        def __init__(self, original):
+            self._original = original
+
+        def __getattr__(self, name):
+            return getattr(self._original, name)
+
+        def before_get(self, parser, section, option, value, defaults):
+            try:
+                return self._original.before_get(parser, section, option,
+                                                 value, defaults)
+            except Exception:
+                e = sys.exc_info()[1]
+                args = list(e.args)
+                args[0] = 'Error in file %s: %s' % (parser.filename, e)
+                e.args = tuple(args)
+                e.message = args[0]
+                raise
+
+
+__all__ = ['load_app_properties']


### PR DESCRIPTION
This is used in galaxy-lib and by utilities such as galaxy/main.py which has no reason to depend on pastescript.
