### PR TITLE
Fix importing pre-16.01 workflows with missing tools.

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -216,7 +216,12 @@ class WorkflowContentsManager(UsesAnnotations):
             module, step = self.__track_module_from_dict( trans, steps, steps_by_external_id, step_dict, secure=False )
             if module.type == 'tool' and module.tool is None:
                 # A required tool is not available in the local Galaxy instance.
-                missing_tool_tup = ( step_dict[ 'content_id' ], step_dict[ 'name' ], step_dict[ 'tool_version' ] )
+                if 'content_id' in step_dict:
+                    tool_id = step_dict[ 'content_id' ]
+                else:
+                    # Support legacy workflows... (created pre 16.01)
+                    tool_id = step_dict[ 'tool_id' ]
+                missing_tool_tup = ( tool_id, step_dict[ 'name' ], step_dict[ 'tool_version' ])
                 if missing_tool_tup not in missing_tool_tups:
                     missing_tool_tups.append( missing_tool_tup )
                 # Save the entire step_dict in the unused config field, be parsed later

--- a/test/api/test_workflow_missing_tool.ga
+++ b/test/api/test_workflow_missing_tool.ga
@@ -1,0 +1,87 @@
+{
+    "a_galaxy_workflow": "true", 
+    "annotation": "simple workflow",
+    "format-version": "0.1", 
+    "name": "TestWorkflow1", 
+    "steps": {
+        "0": {
+            "annotation": "input1 description", 
+            "id": 0, 
+            "input_connections": {}, 
+            "inputs": [
+                {
+                    "description": "input1 description", 
+                    "name": "WorkflowInput1"
+                }
+            ], 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 199.55555772781372, 
+                "top": 200.66666460037231
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"WorkflowInput1\"}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "user_outputs": []
+        }, 
+        "1": {
+            "annotation": "", 
+            "id": 1, 
+            "input_connections": {}, 
+            "inputs": [
+                {
+                    "description": "", 
+                    "name": "WorkflowInput2"
+                }
+            ], 
+            "name": "Input dataset", 
+            "outputs": [], 
+            "position": {
+                "left": 206.22221422195435, 
+                "top": 327.33335161209106
+            }, 
+            "tool_errors": null, 
+            "tool_id": null, 
+            "tool_state": "{\"name\": \"WorkflowInput2\"}", 
+            "tool_version": null, 
+            "type": "data_input", 
+            "user_outputs": []
+        }, 
+        "2": {
+            "annotation": "", 
+            "id": 2, 
+            "input_connections": {
+                "input1": {
+                    "id": 0, 
+                    "output_name": "output"
+                }, 
+                "queries_0|input2": {
+                    "id": 1, 
+                    "output_name": "output"
+                }
+            }, 
+            "inputs": [], 
+            "name": "Concatenate datasets", 
+            "outputs": [
+                {
+                    "name": "out_file1", 
+                    "type": "input"
+                }
+            ], 
+            "position": {
+                "left": 419.33335876464844, 
+                "top": 200.44446563720703
+            }, 
+            "post_job_actions": {}, 
+            "tool_errors": null, 
+            "tool_id": "cat_missing_tool", 
+            "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input1\": \"null\", \"chromInfo\": \"\\\"/home/john/workspace/galaxy-central/tool-data/shared/ucsc/chrom/?.len\\\"\", \"queries\": \"[{\\\"input2\\\": null, \\\"__index__\\\": 0}]\"}", 
+            "tool_version": "1.0.0", 
+            "type": "tool", 
+            "user_outputs": []
+        }
+    }
+}

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -455,6 +455,14 @@ class WorkflowsApiTestCase( BaseWorkflowsApiTestCase ):
                 'label',
             )
 
+    def test_import_missing_tool( self ):
+        workflow = self.workflow_populator.load_workflow_from_resource( name="test_workflow_missing_tool" )
+        workflow_id = self.workflow_populator.create_workflow( workflow )
+        workflow_description = self._show_workflow( workflow_id )
+        steps = workflow_description["steps"]
+        missing_tool_steps = filter(lambda v: v['tool_id'] == 'cat_missing_tool', steps.values())
+        assert len(missing_tool_steps) == 1
+
     def test_import_export_with_runtime_inputs( self ):
         workflow = self.workflow_populator.load_workflow_from_resource( name="test_workflow_with_runtime_input" )
         workflow_id = self.workflow_populator.create_workflow( workflow )


### PR DESCRIPTION
bed79b5 fixes #1386 (thanks to @trevor for the bug report). 61f4c82 adds a test case to verify this behavior, this test case works against 15.10 and clearly demonstrates this behavior was indeed broken with the subworkflow PR. 

Test with:

```
./run_tests.sh -api test/api/test_workflows.py:WorkflowsApiTestCase.test_import_missing_tool
```
