### PR TITLE
Revise galaxy-lib dependencies.

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -37,8 +37,12 @@ from six.moves import zip
 from os.path import relpath
 from hashlib import md5
 
-import docutils.core
-import docutils.writers.html4css1
+try:
+    import docutils.core as docutils_core
+    import docutils.writers.html4css1 as docutils_html4css1
+except ImportError:
+    docutils_core = None
+    docutils_html4css1 = None
 
 from xml.etree import ElementTree, ElementInclude
 
@@ -707,6 +711,9 @@ def rst_to_html( s ):
     """Convert a blob of reStructuredText to HTML"""
     log = logging.getLogger( "docutils" )
 
+    if docutils_core is None:
+        raise Exception("Attempted to use rst_to_html but docutils unavailable.")
+
     class FakeStream( object ):
         def write( self, str ):
             if len( str ) > 0 and not str.isspace():
@@ -720,8 +727,8 @@ def rst_to_html( s ):
                                   # number of sections in help content.
     }
 
-    return unicodify( docutils.core.publish_string( s,
-                      writer=docutils.writers.html4css1.Writer(),
+    return unicodify( docutils_core.publish_string( s,
+                      writer=docutils_html4css1.Writer(),
                       settings_overrides=settings_overrides ) )
 
 

--- a/lib/galaxy/util/multi_byte.py
+++ b/lib/galaxy/util/multi_byte.py
@@ -1,9 +1,15 @@
-import wchartype
+try:
+    import wchartype
+except ImportError:
+    wchartype = None
 
 from six import text_type
 
 
 def is_multi_byte( chars ):
+    if wchartype is None:
+        message = "Attempted to use galaxy.util.multi_byte but dependency wchartype is unavailable."
+        raise Exception(message)
     for char in chars:
         try:
             char = text_type( char )

--- a/lib/galaxy/util/pastescript/loadwsgi.py
+++ b/lib/galaxy/util/pastescript/loadwsgi.py
@@ -10,6 +10,8 @@ import os
 import sys
 import re
 
+from galaxy.util.properties import NicerConfigParser
+
 import pkg_resources
 
 __all__ = ['loadapp', 'loadserver', 'loadfilter', 'appconfig']
@@ -28,7 +30,6 @@ def print_(template, *args, **kwargs):
     sys.stdout.writelines(template)
 
 if sys.version_info < (3, 0):
-    from ConfigParser import ConfigParser
     from urllib import unquote
     iteritems = lambda d: d.iteritems()
     dictkeys = lambda d: d.keys()
@@ -36,7 +37,6 @@ if sys.version_info < (3, 0):
     def reraise(t, e, tb):
         exec('raise t, e, tb', dict(t=t, e=e, tb=tb))
 else:
-    from configparser import ConfigParser
     from urllib.parse import unquote
     iteritems = lambda d: d.items()
     dictkeys = lambda d: list(d.keys())
@@ -148,61 +148,6 @@ def _flatten(lst):
     for item in lst:
         result.extend(_flatten(item))
     return result
-
-
-class NicerConfigParser(ConfigParser):
-
-    def __init__(self, filename, *args, **kw):
-        ConfigParser.__init__(self, *args, **kw)
-        self.filename = filename
-        if hasattr(self, '_interpolation'):
-            self._interpolation = self.InterpolateWrapper(self._interpolation)
-
-    read_file = getattr(ConfigParser, 'read_file', ConfigParser.readfp)
-
-    def defaults(self):
-        """Return the defaults, with their values interpolated (with the
-        defaults dict itself)
-
-        Mainly to support defaults using values such as %(here)s
-        """
-        defaults = ConfigParser.defaults(self).copy()
-        for key, val in iteritems(defaults):
-            defaults[key] = self.get('DEFAULT', key) or val
-        return defaults
-
-    def _interpolate(self, section, option, rawval, vars):
-        # Python < 3.2
-        try:
-            return ConfigParser._interpolate(
-                self, section, option, rawval, vars)
-        except Exception:
-            e = sys.exc_info()[1]
-            args = list(e.args)
-            args[0] = 'Error in file %s: %s' % (self.filename, e)
-            e.args = tuple(args)
-            e.message = args[0]
-            raise
-
-    class InterpolateWrapper(object):
-        # Python >= 3.2
-        def __init__(self, original):
-            self._original = original
-
-        def __getattr__(self, name):
-            return getattr(self._original, name)
-
-        def before_get(self, parser, section, option, value, defaults):
-            try:
-                return self._original.before_get(parser, section, option,
-                                                 value, defaults)
-            except Exception:
-                e = sys.exc_info()[1]
-                args = list(e.args)
-                args[0] = 'Error in file %s: %s' % (parser.filename, e)
-                e.args = tuple(args)
-                e.message = args[0]
-                raise
 
 
 ############################################################

--- a/lib/galaxy/util/properties.py
+++ b/lib/galaxy/util/properties.py
@@ -42,8 +42,6 @@ def load_app_properties(
     return properties
 
 
-# pastescript's NicerConfigParser, replicated here so this module doesn't
-# need to depend on WSGI.
 class NicerConfigParser(ConfigParser):
 
     def __init__(self, filename, *args, **kw):
@@ -99,4 +97,4 @@ class NicerConfigParser(ConfigParser):
                 raise
 
 
-__all__ = ['load_app_properties']
+__all__ = ['load_app_properties', 'NicerConfigParser']


### PR DESCRIPTION
- Eliminate duplication of NiceConfigParser caused by #1413. I'm a little +0/-0 on this, but it seems like we are fully adopting galaxy.util.pastescript because we have modified it some many times anyway.
- Eliminate 2 remaining required dependencies of galaxy-lib ("wchartype" and "docutils"), these are now optional. The only remaining required dependencies are six and pyyaml. 
