### PR TITLE
Do not decompresse zip if it contains several files

### DIFF
--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -131,6 +131,24 @@ def check_zip( file_path ):
         return True
     return False
 
+def check_zip_multi_files( file_path ):
+    if not check_zip(file_path):
+        return False
+    z = zipfile.ZipFile( file_path )
+    zipped_files = z.namelist()    
+    # skip directory in the count
+    r_directory = re.compile('.*/$')
+    zipped_files = [ i for i in zipped_files if not i in filter(r_directory.match, zipped_files )]
+    # skip __MACOSX directories and subfiles in the count
+    r_mac = re.compile('.*__MACOSX.*')
+    zipped_files = [ i for i in zipped_files if not i in filter(r_mac.match, zipped_files )]
+    # skip desktop.ini from Microsoft Windows in the count
+    r_windows = re.compile('.*/?desktop.ini')
+    zipped_files = [ i for i in zipped_files if not i in filter(r_windows.match, zipped_files ) ]
+
+    if len(zipped_files) > 1:
+        return True
+    return False
 
 def is_bz2( file_path ):
     is_bz2, is_valid = check_bz2( file_path )

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -131,24 +131,26 @@ def check_zip( file_path ):
         return True
     return False
 
+
 def check_zip_multi_files( file_path ):
     if not check_zip(file_path):
         return False
     z = zipfile.ZipFile( file_path )
-    zipped_files = z.namelist()    
+    zipped_files = z.namelist()
     # skip directory in the count
     r_directory = re.compile('.*/$')
-    zipped_files = [ i for i in zipped_files if not i in filter(r_directory.match, zipped_files )]
-    # skip __MACOSX directories and subfiles in the count
+    zipped_files = [ i for i in zipped_files if i not in filter(r_directory.match, zipped_files ) ]
+    # skip __MACOSX directories and subfiles from Mac OSX in the count
     r_mac = re.compile('.*__MACOSX.*')
-    zipped_files = [ i for i in zipped_files if not i in filter(r_mac.match, zipped_files )]
+    zipped_files = [ i for i in zipped_files if i not in filter(r_mac.match, zipped_files ) ]
     # skip desktop.ini from Microsoft Windows in the count
     r_windows = re.compile('.*/?desktop.ini')
-    zipped_files = [ i for i in zipped_files if not i in filter(r_windows.match, zipped_files ) ]
+    zipped_files = [ i for i in zipped_files if i not in filter(r_windows.match, zipped_files ) ]
 
     if len(zipped_files) > 1:
         return True
     return False
+
 
 def is_bz2( file_path ):
     is_bz2, is_valid = check_bz2( file_path )


### PR DESCRIPTION
Hi,

I'm Gildas Le Corguillé from Roscoff/France.

Since a couple of years, I always ask you the same question. Why unzip files ? Expecially when they contain several files.

I already propose a dedicated datatype: https://toolshed.g2.bx.psu.edu/view/lecorguille/no_unzip_datatype/7800ba9a4c1e
But because, it isn't in the core of Galaxy, the planemo tests fail.

It's time for me to move :)

This patch will allow users to keep intact their zip file if they contain more than one files.
It's useful for us, because one of our R libraries that we use, need a hierarchie of directories to segregate conditions.

However, I tried to preserve the behaviour of Galaxy if there is only one file (in a directory or not) in the zip. I also manage to avoid "the system files" like __MACOSX/ and desktop.ini during the checking.

Thanks a lot

Gildas
