### PR TITLE
Docker Testing - Newer versions of phantomjs and casperjs, in container wheels.

### DIFF
--- a/create_db.sh
+++ b/create_db.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
-if [ -d .venv ];
+: ${GALAXY_VIRTUAL_ENV:=.venv}
+
+if [ -d "$GALAXY_VIRTUAL_ENV" ];
 then
-    printf "Activating virtualenv at %s/.venv\n" $(pwd)
-    . .venv/bin/activate
+    printf "Activating virtualenv at $GALAXY_VIRTUAL_ENV\n"
+    . "$GALAXY_VIRTUAL_ENV/bin/activate"
 fi
 
 cd `dirname $0`

--- a/manage_db.sh
+++ b/manage_db.sh
@@ -5,10 +5,12 @@
 # sh manage_db.sh downgrade --version=3 <tool_shed if using that webapp - galaxy is the default>
 #######
 
-if [ -d .venv ];
+: ${GALAXY_VIRTUAL_ENV:=.venv}
+
+if [ -d "$GALAXY_VIRTUAL_ENV" ];
 then
-    printf "Activating virtualenv at %s/.venv\n" $(pwd)
-    . .venv/bin/activate
+    printf "Activating virtualenv at $GALAXY_VIRTUAL_ENV\n"
+    . "$GALAXY_VIRTUAL_ENV/bin/activate"
 fi
 
 cd `dirname $0`

--- a/test/docker/base/Dockerfile
+++ b/test/docker/base/Dockerfile
@@ -32,7 +32,10 @@ RUN apt-get update -y && apt-get install -y software-properties-common curl && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
    
 RUN npm install -g grunt-contrib-qunit grunt grunt-cli && \
-    wget -O/bin/phantomjs https://images.galaxyproject.org/phantomjs/2.0.0-dev-2a1aa983d057aa1f835708bd1f32b13a9a46c14f/phantomjs && \
+    cd /tmp && \
+    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
+    tar xf phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
+    mv phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
     mkdir -p /opt/casperjs /casperjs && wget https://github.com/n1k0/casperjs/tarball/master -O- | tar -xzf- --strip-components=1 -C /opt/casperjs && \
     ln -sf /opt/casperjs/bin/casperjs /usr/local/bin/casperjs
 

--- a/test/docker/base/Dockerfile
+++ b/test/docker/base/Dockerfile
@@ -2,6 +2,8 @@ FROM toolshed/requirements
 MAINTAINER John Chilton <jmchilton@gmail.com>
 
 ENV MYSQL_MAJOR=5.6
+ENV GALAXY_ROOT=/galaxy
+ENV GALAXY_VIRTUAL_ENV /galaxy_venv
 
 # Pre-install a bunch of packages to speed up ansible steps.
 RUN apt-get update -y && apt-get install -y software-properties-common curl && \
@@ -18,7 +20,7 @@ RUN apt-get update -y && apt-get install -y software-properties-common curl && \
 	} | debconf-set-selections && \
     apt-get update -y && \
     apt-get install -y libpq-dev postgresql postgresql-client postgresql-plpython-9.3 \
-            ansible postgresql-server-dev-9.3 wget mysql-server="${MYSQL_MAJOR}"* \
+            ansible postgresql-server-dev-9.3 wget mysql-server="${MYSQL_MAJOR}"* libmysqlclient-dev="${MYSQL_MAJOR}"* \
             slurm-llnl libmunge-dev slurm-drmaa-dev ant atop axel bioperl cmake curl \
             g++ gcc gfortran git-core htop iftop iotop ipython libffi-dev liblapack-dev \
             libncurses5-dev libopenblas-dev libpam0g-dev libpq-dev libsparsehash-dev make \
@@ -27,8 +29,12 @@ RUN apt-get update -y && apt-get install -y software-properties-common curl && \
             python-prettytable python-psycopg2 python-virtualenv python-pip \
             postgresql-server-dev-9.3 rsync slurm-drmaa-dev supervisor swig sysstat unzip \
             wget zlib1g-dev nodejs && \
-    npm install -g grunt-contrib-qunit grunt grunt-cli casperjs phantomjs && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+   
+RUN npm install -g grunt-contrib-qunit grunt grunt-cli && \
+    wget -O/bin/phantomjs https://images.galaxyproject.org/phantomjs/2.0.0-dev-2a1aa983d057aa1f835708bd1f32b13a9a46c14f/phantomjs && \
+    mkdir -p /opt/casperjs /casperjs && wget https://github.com/n1k0/casperjs/tarball/master -O- | tar -xzf- --strip-components=1 -C /opt/casperjs && \
+    ln -sf /opt/casperjs/bin/casperjs /usr/local/bin/casperjs
 
 RUN mkdir -p /tmp/ansible && \
     mkdir -p /opt/galaxy/db && \
@@ -39,7 +45,6 @@ ADD start_mysql.sh /opt/galaxy/start_mysql.sh
 ADD ansible_vars.yml /tmp/ansible/ansible_vars.yml
 ADD provision.yml /tmp/ansible/provision.yml
 
-ENV GALAXY_ROOT=/galaxy
 
 RUN mkdir /etc/galaxy && cd /tmp/ansible && mkdir roles && \
     mkdir roles/galaxyprojectdotorg.galaxy-os && \
@@ -59,23 +64,31 @@ RUN mkdir /etc/galaxy && cd /tmp/ansible && mkdir roles && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN cd $GALAXY_ROOT && \
+    ./scripts/common_startup.sh || { echo "common_startup.sh failed"; exit 1; } && \
+    dev_requirements=./lib/galaxy/dependencies/dev-requirements.txt && \
+    [ -f $dev_requirements ] && $GALAXY_VIRTUAL_ENV/bin/pip install -r $dev_requirements
+
+RUN . $GALAXY_VIRTUAL_ENV/bin/activate && \
+    pip install psycopg2 && \
+    pip install mysql && \
+    cd $GALAXY_ROOT && \
     echo "Prepopulating postgres database" && \
     su -c '/usr/lib/postgresql/9.3/bin/pg_ctl -o "-F" start -D /opt/galaxy/db' postgres && \
     sleep 3 && \
-    GALAXY_CONFIG_DATABASE_CONNECTION="postgresql://root@localhost:5930/galaxy" sh create_db.sh && \
+    GALAXY_CONFIG_DATABASE_CONNECTION="postgresql://root@localhost:5930/galaxy" bash create_db.sh && \
     echo "Prepopulating sqlite database" && \
-    GALAXY_CONFIG_DATABASE_CONNECTION="sqlite:////opt/galaxy/galaxy.sqlite" sh create_db.sh && \
+    GALAXY_CONFIG_DATABASE_CONNECTION="sqlite:////opt/galaxy/galaxy.sqlite" bash create_db.sh && \
     sh /opt/galaxy/start_mysql.sh && \
     echo "Prepopulating mysql database" && \
-    GALAXY_CONFIG_DATABASE_CONNECTION="mysql://galaxy:galaxy@localhost/galaxy?unix_socket=/var/run/mysqld/mysqld.sock" sh create_db.sh && \
+    GALAXY_CONFIG_DATABASE_CONNECTION="mysql://galaxy:galaxy@localhost/galaxy?unix_socket=/var/run/mysqld/mysqld.sock" bash create_db.sh && \
     echo "Prepopulating toolshed postgres database" && \
     su -c '/usr/lib/postgresql/9.3/bin/pg_ctl -o "-F" start -D /opt/galaxy/db' postgres && \
-    GALAXY_CONFIG_DATABASE_CONNECTION="postgresql://root@localhost:5930/toolshed" sh create_db.sh tool_shed && \
+    GALAXY_CONFIG_DATABASE_CONNECTION="postgresql://root@localhost:5930/toolshed" bash create_db.sh tool_shed && \
     echo "Prepopulating toolshed sqlite database" && \
-    GALAXY_CONFIG_DATABASE_CONNECTION="sqlite:////opt/galaxy/toolshed.sqlite" sh create_db.sh tool_shed && \
+    GALAXY_CONFIG_DATABASE_CONNECTION="sqlite:////opt/galaxy/toolshed.sqlite" bash create_db.sh tool_shed && \
     sh /opt/galaxy/start_mysql.sh && \
     echo "Prepopulating toolshed mysql database" && \
-    GALAXY_CONFIG_DATABASE_CONNECTION="mysql://galaxy:galaxy@localhost/toolshed?unix_socket=/var/run/mysqld/mysqld.sock" sh create_db.sh tool_shed
+    GALAXY_CONFIG_DATABASE_CONNECTION="mysql://galaxy:galaxy@localhost/toolshed?unix_socket=/var/run/mysqld/mysqld.sock" bash create_db.sh tool_shed
 
 # bcftools for Galaxy.
 RUN mkdir -p /tmp/install && \
@@ -86,7 +99,7 @@ RUN mkdir -p /tmp/install && \
     make && \
     make install && \
     cd && rm -rf /tmp/install
-    
+
 ADD run_test_wrapper.sh /usr/local/bin/run_test_wrapper.sh
 
 EXPOSE :9009

--- a/test/docker/base/run_test_wrapper.sh
+++ b/test/docker/base/run_test_wrapper.sh
@@ -32,10 +32,12 @@ cd /galaxy
 GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION="$GALAXY_TEST_DBURI";
 export GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
 
+: ${GALAXY_VIRTUAL_ENV:=.venv}
+
 ./scripts/common_startup.sh || { echo "common_startup.sh failed"; exit 1; }
 
 dev_requirements=./lib/galaxy/dependencies/dev-requirements.txt
-[ -f $dev_requirements ] && ./.venv/bin/pip install -r $dev_requirements
+[ -f $dev_requirements ] && $GALAXY_VIRTUAL_ENV/bin/pip install -r $dev_requirements
 
 sh manage_db.sh upgrade
 sh manage_db.sh upgrade tool_shed


### PR DESCRIPTION
We are currently testing against "stable" but very old and unmaintained versions of phantomjs and casperjs. phantomjs folks explicitly state 1.9 is unmaintained and the casperjs README recommends running against master. This updates those dependencies in the docker container for testing.

Additionally, this updates the Docker testing setup to use wheel inside the container. This should speed up fresh install testing and prevent certain classes of problems where the wheels from the galaxy mounted into the container don't match the user, version, etc....
