### PR TITLE
[WIP] Add the script integrity check (ABC_TEST_JOB_SCRIPT_INTEGRITY_XYZ=42) to the tool command script ('tool_script.sh').

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -80,7 +80,7 @@ def __externalize_commands(job_wrapper, commands_builder, remote_command_params,
     local_container_script = join( job_wrapper.working_directory, script_name )
     tool_commands = commands_builder.build()
     with open( local_container_script, "w" ) as f:
-        script_contents = u"#!%s\n%s" % (DEFAULT_SHELL, tool_commands)
+        script_contents = u'#!%s\nif [ -n "$ABC_TEST_JOB_SCRIPT_INTEGRITY_XYZ" ]; then\n    exit 42\nfi\n%s' % (DEFAULT_SHELL, tool_commands)
         f.write(script_contents.encode(util.DEFAULT_ENCODING))
     chmod( local_container_script, 0755 )
 

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -4,6 +4,10 @@
 # to ensure this script is runnable before running it directly
 # or submitting it to a cluster manager.
 if [ -n "$ABC_TEST_JOB_SCRIPT_INTEGRITY_XYZ" ]; then
+    $command
+    if [ $? -ne 42 ]; then
+        exit $?
+    fi
     exit 42
 fi
 


### PR DESCRIPTION
Resolves an issue where this additional shell script can now have the same spurious issues of “Text file busy” that can be fixed with a filesystem sync.
