### PR TITLE
[16.01] Add --replace-pip option to common_startup.sh.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -18,7 +18,7 @@ fi
 while :
 do
     case "$1" in
-        --skip-eggs|--skip-wheels|--skip-samples|--dev-wheels|--no-create-venv|--no-replace-pip)
+        --skip-eggs|--skip-wheels|--skip-samples|--dev-wheels|--no-create-venv|--no-replace-pip|--replace-pip)
             common_startup_args="$common_startup_args $1"
             shift
             ;;

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -296,6 +296,10 @@ do
           no_replace_pip='--no-replace-pip'
           shift
           ;;
+      --replace-pip)
+          replace_pip='--replace-pip'
+          shift
+          ;;
       --skip-common-startup)
           # Don't run ./scripts/common_startup.sh (presumably it has already
           # been done, or you know what you're doing).
@@ -322,7 +326,7 @@ if [ -z "$skip_common_startup" ]; then
             GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=$GALAXY_TEST_DBURI
             export GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
     fi
-    ./scripts/common_startup.sh $skip_venv $no_create_venv $no_replace_pip --dev-wheels || exit 1
+    ./scripts/common_startup.sh $skip_venv $no_create_venv $no_replace_pip $replace_pip --dev-wheels || exit 1
 fi
 
 if [ -z "$skip_venv" -a -d .venv ];

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 set -e
 
+SET_VENV=1
+for arg in "$@"; do
+    [ "$arg" = "--skip-venv" ] && SET_VENV=0
+done
+
 DEV_WHEELS=0
 FETCH_WHEELS=1
-SET_VENV=1
 CREATE_VENV=1
-REPLACE_PIP=1
+REPLACE_PIP=$SET_VENV
 COPY_SAMPLE_FILES=1
+
 for arg in "$@"; do
     [ "$arg" = "--skip-eggs" ] && FETCH_WHEELS=0
     [ "$arg" = "--skip-wheels" ] && FETCH_WHEELS=0
@@ -14,6 +19,7 @@ for arg in "$@"; do
     [ "$arg" = "--skip-venv" ] && SET_VENV=0
     [ "$arg" = "--no-create-venv" ] && CREATE_VENV=0
     [ "$arg" = "--no-replace-pip" ] && REPLACE_PIP=0
+    [ "$arg" = "--replace-pip" ] && REPLACE_PIP=1
     [ "$arg" = "--stop-daemon" ] && FETCH_WHEELS=0
     [ "$arg" = "--skip-samples" ] && COPY_SAMPLE_FILES=0
 done
@@ -123,7 +129,7 @@ if [ $SET_VENV -eq 1 ]; then
 fi
 
 : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
-if [ $SET_VENV -eq 1 -a $REPLACE_PIP -eq 1 ]; then
+if [ $REPLACE_PIP -eq 1 ]; then
     pip_version=`pip --version | awk '{print $2}'`
     pre=`python -c "from pkg_resources import parse_version; from sys import stdout; stdout.write('--pre') if parse_version('$pip_version') >= parse_version('1.4') else stdout.write('')"`
     pip install $pre --no-index --find-links ${GALAXY_WHEELS_INDEX_URL}/pip --upgrade pip


### PR DESCRIPTION
Ping @natefoo.

Needed to restore correct functionality to planemo. Planemo manages the virtual environment but by default should probably allow Galaxy to replace `pip` in that environment. So I feel like planemo's behavior should be `--skip-venv --replace-pip` right? This wasn't previously possible.

....

...

Or is this wrong and the correct solution is there more expansive change of allowing `.venv` to be overriddable so planemo can just let Galaxy do its thing and not require skip-venv at all.
