### PR TITLE
[16.01] Fix to ensure integrity of tool_script.sh also.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -301,6 +301,11 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # Set to false to disable various checks Galaxy will do to ensure it
 # can run job scripts before attempting to execute or submit them.
 #check_job_script_integrity = True
+# Number of checks to execute if check_job_script_integrity is enabled.
+#check_job_script_integrity_count = 35
+# Time to sleep between checks if check_job_script_integrity is enabled (in seconds).
+#check_job_script_integrity_sleep = .25
+
 
 # Citation related caching.  Tool citations information maybe fetched from
 # external sources such as http://dx.doi.org/ by Galaxy - the following

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -1,12 +1,6 @@
 #!/bin/sh
 
-# The following block can be used by the job creation system
-# to ensure this script is runnable before running it directly
-# or submitting it to a cluster manager.
-if [ -n "$ABC_TEST_JOB_SCRIPT_INTEGRITY_XYZ" ]; then
-    exit 42
-fi
-
+$integrity_injection
 $headers
 $slots_statement
 export GALAXY_SLOTS

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -163,6 +163,11 @@ class MockJobWrapper(object):
         self.working_directory = job_dir
         self.prepare_input_files_cmds = None
         self.commands_in_new_shell = False
+        self.app = Bunch(
+            config=Bunch(
+                check_job_script_integrity=False,
+            )
+        )
 
     def get_command_line(self):
         return self.command_line


### PR DESCRIPTION
Previously the job script underwent these checks and I had assumed since that got written later it would never be the case that tool_script.sh wouldn't be synchronized by the job script was - turns out file systems are more creative and less logical than one might expected.

Also increases the count for the number of syncs that will execute because 15 on rare occasion proved not to be enough as well as making both the count and sleep time configurable.

Alternative approach to #1482.
