### PR TITLE
Allow sorting of discover_datasets elements.

### DIFF
--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -347,6 +347,7 @@ class DatasetCollector( object ):
         # built from the tool parsing module - see galaxy.tools.parser.output_colleciton_def
         self.sort_key = dataset_collection_description.sort_key
         self.sort_reverse = dataset_collection_description.sort_reverse
+        self.sort_comp = dataset_collection_description.sort_comp
         self.pattern = dataset_collection_description.pattern
         self.default_dbkey = dataset_collection_description.default_dbkey
         self.default_ext = dataset_collection_description.default_ext
@@ -371,8 +372,18 @@ class DatasetCollector( object ):
     def sort( self, matches ):
         reverse = self.sort_reverse
         sort_key = self.sort_key
+        sort_comp = self.sort_comp
         assert sort_key in ["filename", "dbkey", "name", "designation"]
-        return sorted( matches, key=operator.attrgetter(sort_key), reverse=reverse )
+        assert sort_comp in ["lexical", "numeric"]
+        key = operator.attrgetter(sort_key)
+        if sort_comp == "numeric":
+            key = _compose(int, key)
+
+        return sorted(matches, key=key, reverse=reverse)
+
+
+def _compose(f, g):
+    return lambda x: f(g(x))
 
 
 class CollectedDatasetMatch( object ):

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -310,6 +310,7 @@ def collect_primary_datasets( tool, output, job_working_directory, input_ext ):
 
 def walk_over_extra_files( extra_file_collectors, job_working_directory, matchable ):
     for extra_file_collector in extra_file_collectors:
+        paths = {}
         directory = job_working_directory
         if extra_file_collector.directory:
             directory = os.path.join( directory, extra_file_collector.directory )
@@ -317,12 +318,15 @@ def walk_over_extra_files( extra_file_collectors, job_working_directory, matchab
                 raise Exception( "Problem with tool configuration, attempting to pull in datasets from outside working directory." )
         if not os.path.isdir( directory ):
             continue
-        for filename in sorted( os.listdir( directory ) ):
+        for filename in os.listdir( directory ):
             path = os.path.join( directory, filename )
             if not os.path.isfile( path ):
                 continue
             if extra_file_collector.match( matchable, filename ):
-                yield path, extra_file_collector
+                paths[filename] = path
+
+        for filename in extra_file_collector.sort(paths.keys()):
+            yield paths[filename], extra_file_collector
 
 
 def dataset_collector( dataset_collection_description ):
@@ -359,6 +363,9 @@ class DatasetCollector( object ):
         if re_match:
             match_object = CollectedDatasetMatch( re_match, self )
         return match_object
+
+    def sort( self, filenames ):
+        return sorted( filenames )
 
 
 class CollectedDatasetMatch( object ):

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -322,7 +322,8 @@ def walk_over_extra_files( extra_file_collectors, job_working_directory, matchab
             path = os.path.join( directory, filename )
             if not os.path.isfile( path ):
                 continue
-            if extra_file_collector.match( matchable, filename ):
+            match = extra_file_collector.match( matchable, filename )
+            if match:
                 paths[filename] = path
 
         for filename in extra_file_collector.sort(paths.keys()):
@@ -343,6 +344,8 @@ class DatasetCollector( object ):
     def __init__( self, dataset_collection_description ):
         # dataset_collection_description is an abstract description
         # built from the tool parsing module - see galaxy.tools.parser.output_colleciton_def
+        self.sort_key = dataset_collection_description.sort_key
+        self.sort_reverse = dataset_collection_description.sort_reverse
         self.pattern = dataset_collection_description.pattern
         self.default_dbkey = dataset_collection_description.default_dbkey
         self.default_ext = dataset_collection_description.default_ext
@@ -361,18 +364,22 @@ class DatasetCollector( object ):
         re_match = re.match( pattern, filename )
         match_object = None
         if re_match:
-            match_object = CollectedDatasetMatch( re_match, self )
+            match_object = CollectedDatasetMatch( re_match, self, filename )
         return match_object
 
     def sort( self, filenames ):
-        return sorted( filenames )
+        reverse = self.sort_reverse
+        sort_key = self.sort_key
+        assert sort_key == "filename"
+        return sorted( filenames, reverse=reverse )
 
 
 class CollectedDatasetMatch( object ):
 
-    def __init__( self, re_match, collector ):
+    def __init__( self, re_match, collector, filename ):
         self.re_match = re_match
         self.collector = collector
+        self.filename = filename
 
     @property
     def designation( self ):

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -220,7 +220,7 @@ def collect_primary_datasets( tool, output, job_working_directory, input_ext ):
                 primary_output_assigned = True
                 continue
             if name not in primary_datasets:
-                primary_datasets[ name ] = {}
+                primary_datasets[ name ] = odict.odict()
             visible = fields_match.visible
             ext = fields_match.ext
             if ext == "input":

--- a/lib/galaxy/tools/parser/output_collection_def.py
+++ b/lib/galaxy/tools/parser/output_collection_def.py
@@ -6,6 +6,7 @@ from galaxy.util import asbool
 
 DEFAULT_EXTRA_FILENAME_PATTERN = r"primary_DATASET_ID_(?P<designation>[^_]+)_(?P<visible>[^_]+)_(?P<ext>[^_]+)(_(?P<dbkey>[^_]+))?"
 DEFAULT_SORT_BY = "filename"
+DEFAULT_SORT_COMP = "lexical"
 
 
 # XML can describe custom patterns, but these literals describe named
@@ -51,6 +52,11 @@ class DatasetCollectionDescription(object):
             sort_by = sort_by[len("reverse_"):]
         else:
             self.sort_reverse = False
+        if "_" in sort_by:
+            sort_comp, sort_by = sort_by.split("_", 1)
+            assert sort_comp in ["lexical", "numeric"]
+        else:
+            sort_comp = DEFAULT_SORT_COMP
         assert sort_by in [
             "filename",
             "name",
@@ -58,5 +64,6 @@ class DatasetCollectionDescription(object):
             "dbkey"
         ]
         self.sort_key = sort_by
+        self.sort_comp = sort_comp
 
 DEFAULT_DATASET_COLLECTOR_DESCRIPTION = DatasetCollectionDescription()

--- a/lib/galaxy/tools/parser/output_collection_def.py
+++ b/lib/galaxy/tools/parser/output_collection_def.py
@@ -53,9 +53,9 @@ class DatasetCollectionDescription(object):
             self.sort_reverse = False
         assert sort_by in [
             "filename",
-            # "name",
-            # "designation",
-            # "dbkey"
+            "name",
+            "designation",
+            "dbkey"
         ]
         self.sort_key = sort_by
 

--- a/lib/galaxy/tools/parser/output_collection_def.py
+++ b/lib/galaxy/tools/parser/output_collection_def.py
@@ -5,6 +5,7 @@ dataset collection after jobs are finished.
 from galaxy.util import asbool
 
 DEFAULT_EXTRA_FILENAME_PATTERN = r"primary_DATASET_ID_(?P<designation>[^_]+)_(?P<visible>[^_]+)_(?P<ext>[^_]+)(_(?P<dbkey>[^_]+))?"
+DEFAULT_SORT_BY = "filename"
 
 
 # XML can describe custom patterns, but these literals describe named
@@ -44,5 +45,18 @@ class DatasetCollectionDescription(object):
         self.default_visible = asbool( kwargs.get( "visible", None ) )
         self.directory = kwargs.get( "directory", None )
         self.assign_primary_output = asbool( kwargs.get( 'assign_primary_output', False ) )
+        sort_by = kwargs.get( "sort_by", DEFAULT_SORT_BY )
+        if sort_by.startswith("reverse_"):
+            self.sort_reverse = True
+            sort_by = sort_by[len("reverse_"):]
+        else:
+            self.sort_reverse = False
+        assert sort_by in [
+            "filename",
+            # "name",
+            # "designation",
+            # "dbkey"
+        ]
+        self.sort_key = sort_by
 
 DEFAULT_DATASET_COLLECTOR_DESCRIPTION = DatasetCollectionDescription()

--- a/test/unit/tools/test_collect_primary_datasets.py
+++ b/test/unit/tools/test_collect_primary_datasets.py
@@ -40,6 +40,9 @@ class CollectPrimaryDatasetsTestCase( unittest.TestCase, tools_support.UsesApp, 
         assert DEFAULT_TOOL_OUTPUT in datasets
         self.assertEquals( len( datasets[ DEFAULT_TOOL_OUTPUT ] ), 2 )
 
+        # Test default order of collection.
+        assert list(datasets[ DEFAULT_TOOL_OUTPUT ].keys()) == ["test1", "test2"]
+
         created_hda_1 = datasets[ DEFAULT_TOOL_OUTPUT ][ "test1" ]
         self.app.object_store.assert_created_with_path( created_hda_1.dataset, path1 )
 

--- a/test/unit/tools/test_collect_primary_datasets.py
+++ b/test/unit/tools/test_collect_primary_datasets.py
@@ -81,6 +81,21 @@ class CollectPrimaryDatasetsTestCase( unittest.TestCase, tools_support.UsesApp, 
         # Test default order of collection.
         assert list(datasets[ DEFAULT_TOOL_OUTPUT ].keys()) == ["test1", "test2", "test3"]
 
+    def test_collect_sorted_numeric( self ):
+        self._replace_output_collectors( '''<output>
+            <discover_datasets pattern="[abc](?P&lt;name&gt;.*)" directory="subdir_for_name_discovery" sort_by="numeric_name" ext="txt" />
+        </output>''')
+        # Setup filenames in reverse order and ensure name is used as key.
+        self._setup_extra_file( subdir="subdir_for_name_discovery", filename="c1" )
+        self._setup_extra_file( subdir="subdir_for_name_discovery", filename="b10" )
+        self._setup_extra_file( subdir="subdir_for_name_discovery", filename="a100" )
+
+        datasets = self._collect()
+        assert DEFAULT_TOOL_OUTPUT in datasets
+
+        # Test default order of collection.
+        assert list(datasets[ DEFAULT_TOOL_OUTPUT ].keys()) == ["1", "10", "100"]
+
     def test_collect_hidden( self ):
         self._setup_extra_file( visible="hidden" )
         created_hda = self._collect_default_extra()

--- a/test/unit/tools/test_collect_primary_datasets.py
+++ b/test/unit/tools/test_collect_primary_datasets.py
@@ -62,10 +62,24 @@ class CollectPrimaryDatasetsTestCase( unittest.TestCase, tools_support.UsesApp, 
 
         datasets = self._collect()
         assert DEFAULT_TOOL_OUTPUT in datasets
-        self.assertEquals( len( datasets[ DEFAULT_TOOL_OUTPUT ] ), 2 )
 
         # Test default order of collection.
         assert list(datasets[ DEFAULT_TOOL_OUTPUT ].keys()) == ["test2", "test1"]
+
+    def test_collect_sorted_name( self ):
+        self._replace_output_collectors( '''<output>
+            <discover_datasets pattern="[abc](?P&lt;name&gt;.*)" directory="subdir_for_name_discovery" sort_by="name" ext="txt" />
+        </output>''')
+        # Setup filenames in reverse order and ensure name is used as key.
+        self._setup_extra_file( subdir="subdir_for_name_discovery", filename="ctest1" )
+        self._setup_extra_file( subdir="subdir_for_name_discovery", filename="btest2" )
+        self._setup_extra_file( subdir="subdir_for_name_discovery", filename="atest3" )
+
+        datasets = self._collect()
+        assert DEFAULT_TOOL_OUTPUT in datasets
+
+        # Test default order of collection.
+        assert list(datasets[ DEFAULT_TOOL_OUTPUT ].keys()) == ["test1", "test2", "test3"]
 
     def test_collect_hidden( self ):
         self._setup_extra_file( visible="hidden" )

--- a/test/unit/tools/test_collect_primary_datasets.py
+++ b/test/unit/tools/test_collect_primary_datasets.py
@@ -53,6 +53,20 @@ class CollectPrimaryDatasetsTestCase( unittest.TestCase, tools_support.UsesApp, 
         assert created_hda_1.visible
         assert created_hda_1.dbkey == "?"
 
+    def test_collect_sorted_reverse( self ):
+        self._replace_output_collectors( '''<output>
+            <discover_datasets pattern="__name__" directory="subdir_for_name_discovery" sort_by="reverse_filename" ext="txt" />
+        </output>''')
+        self._setup_extra_file( subdir="subdir_for_name_discovery", filename="test1" )
+        self._setup_extra_file( subdir="subdir_for_name_discovery", filename="test2" )
+
+        datasets = self._collect()
+        assert DEFAULT_TOOL_OUTPUT in datasets
+        self.assertEquals( len( datasets[ DEFAULT_TOOL_OUTPUT ] ), 2 )
+
+        # Test default order of collection.
+        assert list(datasets[ DEFAULT_TOOL_OUTPUT ].keys()) == ["test2", "test1"]
+
     def test_collect_hidden( self ):
         self._setup_extra_file( visible="hidden" )
         created_hda = self._collect_default_extra()


### PR DESCRIPTION
- Force consistent output collection of these datasets with (sorting on filename) d649363
- Allow sort by reverse filename with `sort_by="reverse_filename"`  7be1ca0
- Extend `sort_by` syntax to allow sorting on things other than filename - namely dataset `name`, `designation`, and `dbkey` (e.g. `sort_by="name"` or `sort_by="reverse_dbkey"`). 3d967dc
- Extend `sort_by` syntax to allow other numeric sorting (e.g. `sort_by="reverse_numeric_designation"`). 50a0db4

All with unit tests.

Should work for both collections created this way or to affect the ordering of individual datasets in the history for non-collection use cases.
