### PR TITLE
[16.01] Force --skip-venv if we can detect that Python is Conda Python.

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -6,6 +6,11 @@ for arg in "$@"; do
     [ "$arg" = "--skip-venv" ] && SET_VENV=0
 done
 
+# Conda Python is in use, do not use virtualenv
+if python -V 2>&1 | grep -q 'Continuum Analytics'; then
+    SET_VENV=0
+fi
+
 DEV_WHEELS=0
 FETCH_WHEELS=1
 CREATE_VENV=1


### PR DESCRIPTION
This should help fix a lot of unintentional errors (i.e. replacing Conda's pip). Since Conda and virtualenv are not compatible this is far safer than not doing it.
