### PR TITLE
[16.01] Tighten up ScIdx sniffer.

### DIFF
--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -1519,9 +1519,12 @@ class ScIdx(Tabular):
                 line = line.strip()
                 # The first line is always a comment like this:
                 # 2015-11-23 20:18:56.51;input.bam;READ1
-                if line.startswith('#'):
-                    count += 1
-                    continue
+                if count == 0:
+                    if line.startswith('#'):
+                        count += 1
+                        continue
+                    else:
+                        return False
                 if not line:
                     # EOF
                     if count > 1:


### PR DESCRIPTION
Otherwise a valid bed file and invalid sciex sniffs as sciex.

Test with `lib/galaxy/datatypes/test/test_tab.bed`.
