### PR TITLE
[16.01] Add a requirements file suitable for use with `conda {create,install} --file`

### DIFF
--- a/lib/galaxy/dependencies/conda-environment.txt
+++ b/lib/galaxy/dependencies/conda-environment.txt
@@ -1,3 +1,21 @@
+# This file can be used with conda's `--file` option to install as many of
+# Galaxy's dependencies as possible using Conda. The file
+# conda-requirements.txt in this directory can be used to install the remaining
+# missing dependencies using pip:
+#
+# $ conda create --name galaxy --file lib/galaxy/dependencies/conda-environment.txt
+# $ source activate galaxy
+# $ pip install --index-url=https://wheels.galaxyproject.org/simple/ -r lib/galaxy/dependencies/requirements.txt
+#
+# or if you already have an environment:
+#
+# $ source activate galaxy
+# $ conda install --file lib/galaxy/dependencies/conda-environment.txt
+# $ pip install --index-url=https://wheels.galaxyproject.org/simple/ -r lib/galaxy/dependencies/requirements.txt
+#
+# More details are available in the administration section of the Galaxy
+# documentation at https://galaxy.readthedocs.org/
+
 # packages with C extensions
 # numpy should be installed before bx to enable extra features in bx
 numpy

--- a/lib/galaxy/dependencies/conda-requirements.txt
+++ b/lib/galaxy/dependencies/conda-requirements.txt
@@ -1,0 +1,63 @@
+# packages with C extensions
+# numpy should be installed before bx to enable extra features in bx
+numpy
+bx-python
+MarkupSafe
+PyYAML
+SQLAlchemy
+# Mercurial >= 3.5 changed the bundle format, which breaks hg push of TS repositories
+mercurial<3.5
+pycrypto
+
+# Install python_lzo if you want to support indexed access to lzo-compressed
+# locally cached maf files via bx-python
+#python_lzo
+
+# pure Python packages
+Paste
+PasteDeploy
+docutils
+#wchartype
+repoze.lru
+Routes
+WebOb
+#WebHelpers
+Mako
+pytz
+Babel
+#Beaker
+
+# Cheetah and dependencies
+Cheetah
+
+# BioBlend and dependencies
+bioblend
+boto
+requests
+
+# kombu and dependencies
+#kombu
+
+# sqlalchemy-migrate and dependencies
+#sqlalchemy-migrate
+decorator
+#Tempita
+sqlparse
+six
+#Parsley
+nose
+#SVGFig
+
+# Fabric and dependencies
+Fabric
+
+# We still pin these dependencies because of modifications to the upstream packages
+
+# Can't use Whoosh latest due to a bug but need to backport a bugfix from a
+# newer release.
+#
+# https://bitbucket.org/mchaput/whoosh/pull-requests/50/fix-lru-thread-safety/diff
+#Whoosh==2.4.1+gx1
+
+# Flexible BAM index naming
+#pysam==0.8.3+gx1


### PR DESCRIPTION
Should ease the dependency transition for Conda users.
