### PR TITLE
[WIP] Make more job options configurable at the destination level.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1098,14 +1098,9 @@ class JobWrapper( object ):
         """ Get a destination parameter that can be defaulted back
         in app.config if it needs to be applied globally.
         """
-        job = self.job
-        param_unspecified = object()
-        config_value = job.destination_params.get(key, param_unspecified)
-        if config_value is param_unspecified:
-            config_value = getattr(self.app.config, key, param_unspecified)
-        if config_value is param_unspecified:
-            config_value = default
-        return config_value
+        return self.get_job().get_destination_configuration(
+            self.app.config, key, default
+        )
 
     def finish( self, stdout, stderr, tool_exit_code=None, remote_working_directory=None ):
         """
@@ -1219,7 +1214,7 @@ class JobWrapper( object ):
                     # either use the metadata from originating output dataset, or call set_meta on the copies
                     # it would be quicker to just copy the metadata from the originating output dataset,
                     # but somewhat trickier (need to recurse up the copied_from tree), for now we'll call set_meta()
-                    retry_internally = util.asbool(self.get_destination_configuration("retry_metadata_internally", False))
+                    retry_internally = util.asbool(self.get_destination_configuration("retry_metadata_internally", True))
                     if ( retry_internally and
                             not self.external_output_metadata.external_metadata_set_successfully(dataset, self.sa_session ) ):
                         # If Galaxy was expected to sniff type and didn't - do so.

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -772,7 +772,8 @@ class JobWrapper( object ):
         self.__galaxy_system_pwent = None
 
     def _job_dataset_path_rewriter( self, working_directory ):
-        if self.app.config.outputs_to_working_directory:
+        outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
+        if outputs_to_working_directory:
             dataset_path_rewriter = OutputsToWorkingDirectoryPathRewriter( working_directory )
         else:
             dataset_path_rewriter = NullDatasetPathRewriter( )
@@ -968,7 +969,8 @@ class JobWrapper( object ):
                 m = self.tool.handle_job_failure_exception( evalue )
                 if m:
                     message = m
-            if self.app.config.outputs_to_working_directory:
+            outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
+            if outputs_to_working_directory:
                 for dataset_path in self.get_output_fnames():
                     try:
                         shutil.move( dataset_path.false_path, dataset_path.real_path )
@@ -1092,6 +1094,19 @@ class JobWrapper( object ):
         if flush:
             self.sa_session.flush()
 
+    def get_destination_configuration(self, key, default=None):
+        """ Get a destination parameter that can be defaulted back
+        in app.config if it needs to be applied globally.
+        """
+        job = self.job
+        param_unspecified = object()
+        config_value = job.destination_params.get(key, param_unspecified)
+        if config_value is param_unspecified:
+            config_value = getattr(self.app.config, key, param_unspecified)
+        if config_value is param_unspecified:
+            config_value = default
+        return config_value
+
     def finish( self, stdout, stderr, tool_exit_code=None, remote_working_directory=None ):
         """
         Called to indicate that the associated command has been run. Updates
@@ -1137,7 +1152,8 @@ class JobWrapper( object ):
                 self.version_string = open(version_filename).read()
                 os.unlink(version_filename)
 
-        if self.app.config.outputs_to_working_directory and not self.__link_file_check():
+        outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
+        if outputs_to_working_directory and not self.__link_file_check():
             for dataset_path in self.get_output_fnames():
                 try:
                     shutil.move( dataset_path.false_path, dataset_path.real_path )
@@ -1203,7 +1219,8 @@ class JobWrapper( object ):
                     # either use the metadata from originating output dataset, or call set_meta on the copies
                     # it would be quicker to just copy the metadata from the originating output dataset,
                     # but somewhat trickier (need to recurse up the copied_from tree), for now we'll call set_meta()
-                    if ( self.app.config.retry_metadata_internally and
+                    retry_internally = util.asbool(self.get_destination_configuration("retry_metadata_internally", False))
+                    if ( retry_internally and
                             not self.external_output_metadata.external_metadata_set_successfully(dataset, self.sa_session ) ):
                         # If Galaxy was expected to sniff type and didn't - do so.
                         if dataset.ext == "_sniff_":
@@ -1358,7 +1375,8 @@ class JobWrapper( object ):
             self._collect_metrics( job )
         self.sa_session.flush()
         log.debug( 'job %d ended (finish() executed in %s)' % (self.job_id, finish_timer) )
-        delete_files = self.app.config.cleanup_job == 'always' or ( job.state == job.states.OK and self.app.config.cleanup_job == 'onsuccess' )
+        cleanup_job = self.get_destination_configuration("cleanup_job", "always")
+        delete_files = cleanup_job == 'always' or ( job.state == job.states.OK and cleanup_job == 'onsuccess' )
         self.cleanup( delete_files=delete_files )
 
     def check_tool_output( self, stdout, stderr, tool_exit_code, job ):
@@ -1526,7 +1544,8 @@ class JobWrapper( object ):
         if self.output_paths is None:
             self.get_output_fnames()
         for dp in self.output_paths:
-            if self.app.config.outputs_to_working_directory and os.path.basename( dp.false_path ) == file:
+            outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
+            if outputs_to_working_directory and os.path.basename( dp.false_path ) == file:
                 return dp.dataset_id
             elif os.path.basename( dp.real_path ) == file:
                 return dp.dataset_id
@@ -1648,7 +1667,8 @@ class JobWrapper( object ):
     def _change_ownership( self, username, gid ):
         job = self.get_job()
         # FIXME: hardcoded path
-        cmd = [ '/usr/bin/sudo', '-E', self.app.config.external_chown_script, self.working_directory, username, str( gid ) ]
+        external_chown_script = self.get_destination_configuration("external_chown_script", None)
+        cmd = [ '/usr/bin/sudo', '-E', external_chown_script, self.working_directory, username, str( gid ) ]
         log.debug( '(%s) Changing ownership of working directory with: %s' % ( job.id, ' '.join( cmd ) ) )
         p = subprocess.Popen( cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE )
         # TODO: log stdout/stderr
@@ -1657,7 +1677,8 @@ class JobWrapper( object ):
 
     def change_ownership_for_run( self ):
         job = self.get_job()
-        if self.app.config.external_chown_script and job.user is not None:
+        external_chown_script = self.get_destination_configuration("external_chown_script", None)
+        if external_chown_script and job.user is not None:
             try:
                 self._change_ownership( self.user_system_pwent[0], str( self.user_system_pwent[3] ) )
             except:
@@ -1666,7 +1687,8 @@ class JobWrapper( object ):
 
     def reclaim_ownership( self ):
         job = self.get_job()
-        if self.app.config.external_chown_script and job.user is not None:
+        external_chown_script = self.get_destination_configuration("external_chown_script", None)
+        if external_chown_script and job.user is not None:
             self._change_ownership( self.galaxy_system_pwent[0], str( self.galaxy_system_pwent[3] ) )
 
     @property
@@ -1831,7 +1853,8 @@ class TaskWrapper(JobWrapper):
         # if the job was deleted, don't finish it
         if task.state == task.states.DELETED:
             # Job was deleted by an administrator
-            delete_files = self.app.config.cleanup_job in ( 'always', 'onsuccess' )
+            cleanup_job = self.get_destination_configuration("cleanup_job", "always")
+            delete_files = cleanup_job in ( 'always', 'onsuccess' )
             self.cleanup( delete_files=delete_files )
             return
         elif task.state == task.states.ERROR:

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -84,7 +84,6 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         self.ds = drmaa.Session()
         self.ds.initialize()
 
-        self.external_killJob_script = app.config.drmaa_external_killjob_script
         self.userid = None
 
         self._init_monitor_thread()
@@ -312,9 +311,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         try:
             ext_id = job.get_job_runner_external_id()
             assert ext_id not in ( None, 'None' ), 'External job id is None'
-            kill_script = job.destination_params.get("external_killJob_script", None)
-            if not kill_script:
-                kill_script = getattr(self.app.config, "external_killJob_script", None)
+            kill_script = job.get_destination_configuration(self.app.config, "external_killJob_script", None)
             if kill_script is None:
                 self.ds.control( ext_id, drmaa.JobControlAction.TERMINATE )
             else:

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -84,8 +84,6 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         self.ds = drmaa.Session()
         self.ds.initialize()
 
-        # external_runJob_script can be None, in which case it's not used.
-        self.external_runJob_script = app.config.drmaa_external_runjob_script
         self.external_killJob_script = app.config.drmaa_external_killjob_script
         self.userid = None
 
@@ -115,6 +113,10 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
     def queue_job( self, job_wrapper ):
         """Create job script and submit it to the DRM"""
         # prepare the job
+
+        # external_runJob_script can be None, in which case it's not used.
+        external_runjob_script = job_wrapper.get_destination_configuration("drmaa_external_runjob_script", None)
+
         include_metadata = asbool( job_wrapper.job_destination.params.get( "embed_metadata_in_job", True) )
         if not self.prepare_job( job_wrapper, include_metadata=include_metadata):
             return
@@ -129,7 +131,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         job_name = 'g%s' % galaxy_id_tag
         if job_wrapper.tool.old_id:
             job_name += '_%s' % job_wrapper.tool.old_id
-        if self.external_runJob_script is None:
+        if external_runjob_script is None:
             job_name += '_%s' % job_wrapper.user
         job_name = ''.join( map( lambda x: x if x in ( string.letters + string.digits + '_' ) else '_', job_name ) )
         ajs = AsynchronousJobState( files_dir=job_wrapper.working_directory, job_wrapper=job_wrapper, job_name=job_name )
@@ -168,7 +170,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
             log.debug( "(%s) native specification is: %s", galaxy_id_tag, native_spec )
 
         # runJob will raise if there's a submit problem
-        if self.external_runJob_script is None:
+        if external_runjob_script is None:
             # TODO: create a queue for retrying submission indefinitely
             # TODO: configurable max tries and sleep
             trynum = 0
@@ -208,7 +210,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
             log.debug( '(%s) submitting with credentials: %s [uid: %s]' % ( galaxy_id_tag, pwent[0], pwent[2] ) )
             filename = self.store_jobtemplate(job_wrapper, jt)
             self.userid = pwent[2]
-            external_job_id = self.external_runjob(filename, pwent[2]).strip()
+            external_job_id = self.external_runjob(external_runjob_script, filename, pwent[2]).strip()
         log.info( "(%s) queued as %s" % ( galaxy_id_tag, external_job_id ) )
 
         # store runner information for tracking if Galaxy restarts
@@ -310,11 +312,14 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         try:
             ext_id = job.get_job_runner_external_id()
             assert ext_id not in ( None, 'None' ), 'External job id is None'
-            if self.external_killJob_script is None:
+            kill_script = job.destination_params.get("external_killJob_script", None)
+            if not kill_script:
+                kill_script = getattr(self.app.config, "external_killJob_script", None)
+            if kill_script is None:
                 self.ds.control( ext_id, drmaa.JobControlAction.TERMINATE )
             else:
                 # FIXME: hardcoded path
-                subprocess.Popen( [ '/usr/bin/sudo', '-E', self.external_killJob_script, str( ext_id ), str( self.userid ) ], shell=False )
+                subprocess.Popen( [ '/usr/bin/sudo', '-E', kill_script, str( ext_id ), str( self.userid ) ], shell=False )
             log.debug( "(%s/%s) Removed from DRM queue at user's request" % ( job.get_id(), ext_id ) )
         except drmaa.InvalidJobException:
             log.debug( "(%s/%s) User killed running job, but it was already dead" % ( job.get_id(), ext_id ) )
@@ -361,12 +366,12 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         log.debug( '(%s) Job script for external submission is: %s' % ( job_wrapper.job_id, filename ) )
         return filename
 
-    def external_runjob(self, jobtemplate_filename, username):
+    def external_runjob(self, external_runjob_script, jobtemplate_filename, username):
         """ runs an external script the will QSUB a new job.
         The external script will be run with sudo, and will setuid() to the specified user.
         Effectively, will QSUB as a different user (then the one used by Galaxy).
         """
-        script_parts = self.external_runJob_script.split()
+        script_parts = external_runjob_script.split()
         script = script_parts[0]
         command = [ '/usr/bin/sudo', '-E', script]
         for script_argument in script_parts[1:]:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -694,6 +694,19 @@ class Job( object, JobLike, Dictifiable ):
         if self.workflow_invocation_step:
             self.workflow_invocation_step.update()
 
+    def get_destination_configuration(self, config, key, default=None):
+        """ Get a destination parameter that can be defaulted back
+        in specified config if it needs to be applied globally.
+        """
+        return self.get_job().get_destination_configuration(key, default)
+        param_unspecified = object()
+        config_value = self.destination_params.get(key, param_unspecified)
+        if config_value is param_unspecified:
+            config_value = getattr(config, key, param_unspecified)
+        if config_value is param_unspecified:
+            config_value = default
+        return config_value
+
 
 class Task( object, JobLike ):
     """

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -340,7 +340,6 @@ class Tool( object, Dictifiable ):
         except Exception, e:
             global_tool_errors.add_error(config_file, "Tool Loading", e)
             raise e
-        self.external_runJob_script = app.config.drmaa_external_runjob_script
         self.history_manager = histories.HistoryManager( app )
 
     @property


### PR DESCRIPTION
Makes a host of job-related parameters configurable at the destination level instead of the of only at the app level. This solves major problems like allowing the local job runner and the drmma run as real-user runner to operate within in the same environment and provides little conveniences like allowing configuration of cleanup job at the destination level.

Fixes:
http://dev.list.galaxyproject.org/external-chown-script-py-and-the-local-job-runner-td4668738.html

Addresses (in large part):
https://trello.com/c/6w8bples
