### PR TITLE
Remove recovery hack for REALLY old jobs.

### DIFF
--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -212,7 +212,6 @@ class CondorJobRunner( AsynchronousJobRunner ):
         cjs.job_destination = job_wrapper.job_destination
         cjs.user_log = os.path.join( self.app.config.cluster_files_directory, 'galaxy_%s.condor.log' % galaxy_id_tag )
         cjs.register_cleanup_file_attribute( 'user_log' )
-        self.__old_state_paths( cjs )
         if job.state == model.Job.states.RUNNING:
             log.debug( "(%s/%s) is still in running state, adding to the DRM queue" % ( job.id, job.job_runner_external_id ) )
             cjs.running = True
@@ -221,15 +220,3 @@ class CondorJobRunner( AsynchronousJobRunner ):
             log.debug( "(%s/%s) is still in DRM queued state, adding to the DRM queue" % ( job.id, job.job_runner_external_id ) )
             cjs.running = False
             self.monitor_queue.put( cjs )
-
-    def __old_state_paths( self, cjs ):
-        """For recovery of jobs started prior to standardizing the naming of
-        files in the AsychronousJobState object
-        """
-        if cjs.job_wrapper is not None:
-            user_log = "%s/%s.condor.log" % (self.app.config.cluster_files_directory, cjs.job_wrapper.job_id)
-            if not os.path.exists( cjs.user_log ) and os.path.exists( user_log ):
-                cjs.output_file = "%s/%s.o" % (self.app.config.cluster_files_directory, cjs.job_wrapper.job_id)
-                cjs.error_file = "%s/%s.e" % (self.app.config.cluster_files_directory, cjs.job_wrapper.job_id)
-                cjs.job_file = "%s/galaxy_%s.sh" % (self.app.config.cluster_files_directory, cjs.job_wrapper.job_id)
-                cjs.user_log = user_log

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -332,7 +332,6 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         ajs.command_line = job.get_command_line()
         ajs.job_wrapper = job_wrapper
         ajs.job_destination = job_wrapper.job_destination
-        self.__old_state_paths( ajs )
         if job.state == model.Job.states.RUNNING:
             log.debug( "(%s/%s) is still in running state, adding to the DRM queue" % ( job.get_id(), job.get_job_runner_external_id() ) )
             ajs.old_state = drmaa.JobState.RUNNING
@@ -343,18 +342,6 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
             ajs.old_state = drmaa.JobState.QUEUED_ACTIVE
             ajs.running = False
             self.monitor_queue.put( ajs )
-
-    def __old_state_paths( self, ajs ):
-        """For recovery of jobs started prior to standardizing the naming of
-        files in the AsychronousJobState object
-        """
-        if ajs.job_wrapper is not None:
-            job_file = "%s/galaxy_%s.sh" % (self.app.config.cluster_files_directory, ajs.job_wrapper.job_id)
-            if not os.path.exists( ajs.job_file ) and os.path.exists( job_file ):
-                ajs.output_file = "%s.drmout" % os.path.join(os.getcwd(), ajs.job_wrapper.working_directory, ajs.job_wrapper.get_id_tag())
-                ajs.error_file = "%s.drmerr" % os.path.join(os.getcwd(), ajs.job_wrapper.working_directory, ajs.job_wrapper.get_id_tag())
-                ajs.exit_code_file = "%s.drmec" % os.path.join(os.getcwd(), ajs.job_wrapper.working_directory, ajs.job_wrapper.get_id_tag())
-                ajs.job_file = job_file
 
     def store_jobtemplate(self, job_wrapper, jt):
         """ Stores the content of a DRMAA JobTemplate object in a file as a JSON string.


### PR DESCRIPTION
No more upgrading Galaxy straight from 2012 to 2016.

Now is a fine time since the metadata for these entirely fictitious jobs will fail if #1556 is merged.

Ping @natefoo.
