### PR TITLE
Clarify area github tags.

### DIFF
--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -127,7 +127,7 @@ particular domain, as well as more organized release notes.
 -  ``area/toolshed``- Changes to the tool shed client or server.
 -  ``area/UI-UX``
 -  ``area/util``
--  ``area/visualization``
+-  ``area/visualizations``
 -  ``area/workflows``
 
 New labels should be proposed by opening a pull request against this document

--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -130,6 +130,9 @@ particular domain, as well as more organized release notes.
 -  ``area/visualization``
 -  ``area/workflows``
 
+New labels should be proposed by opening a pull request against this document
+in the dev branch of Galaxy.
+
 Other Useful Labels
 -------------------
 

--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -105,19 +105,22 @@ Area Labels
 
 The 'area' label is used for tagging issues and pull requests to a
 particular focus area. This allows for easy searching within that
-particular domain, as well as more organized release notes. Some
-examples, not-exhaustive, are here:
+particular domain, as well as more organized release notes.
 
 -  ``area/API``
 -  ``area/cleanup``
--  ``area/jobs``
+-  ``area/dataset-collections``
 -  ``area/documentation``
+-  ``area/framework``
+-  ``area/jobs``
 -  ``area/GIEs``
+-  ``area/performance``
+-  ``area/reports``
+-  ``area/tools``
 -  ``area/toolshed``
 -  ``area/UI-UX``
+-  ``area/visaulization``
 -  ``area/workflows``
-
-This list will definitely grow over time.
 
 Other Useful Labels
 -------------------

--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -123,7 +123,7 @@ particular domain, as well as more organized release notes.
 -  ``area/reports``
 -  ``area/system`` - Changes to scripts used to run or manage Galaxy.
 -  ``area/tools`` - Changes to specific tools in Galaxy.
--  ``area/tooling`` - Changes to Galaxy's tool framework.
+-  ``area/tool-framework``
 -  ``area/toolshed``- Changes to the tool shed client or server.
 -  ``area/UI-UX``
 -  ``area/util``

--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -107,19 +107,27 @@ The 'area' label is used for tagging issues and pull requests to a
 particular focus area. This allows for easy searching within that
 particular domain, as well as more organized release notes.
 
+-  ``area/admin`` - Changes to admin functionality of the Galaxy webapp.
 -  ``area/API``
--  ``area/cleanup``
+-  ``area/cleanup`` - General code cleanup.
+-  ``area/database`` - Change requires a modification to Galaxy's database.
 -  ``area/dataset-collections``
+-  ``area/datatypes`` - Changes to Galaxy's datatypes
+-  ``area/datatype-framework`` - Changes to Galaxy's datatype and metadata framework
 -  ``area/documentation``
 -  ``area/framework``
--  ``area/jobs``
 -  ``area/GIEs``
+-  ``area/histories``
+-  ``area/jobs``
 -  ``area/performance``
 -  ``area/reports``
--  ``area/tools``
--  ``area/toolshed``
+-  ``area/system`` - Changes to scripts used to run or manage Galaxy.
+-  ``area/tools`` - Changes to specific tools in Galaxy.
+-  ``area/tooling`` - Changes to Galaxy's tool framework.
+-  ``area/toolshed``- Changes to the tool shed client or server.
 -  ``area/UI-UX``
--  ``area/visaulization``
+-  ``area/util``
+-  ``area/visualization``
 -  ``area/workflows``
 
 Other Useful Labels


### PR DESCRIPTION
I'm still trying to work through our tag metadata for PRs 16.01 - it is taking a long time. I want to take a break to refine the areas based on my experiences so far. Other people have just been adding tags as they feel like I think, this has an appeal to efficiency - but I don't feel comfortable making such unilateral changes though. So against my better judgement I going to try to propose a policy regarding area tags so we can discuss these.

This PR moves the definitive list into the project so it requires a PR for modification, updates the existing list mentioned in-document to reflect the current state of Galaxy, and puts forward several new tags and one rename to an existing tag.

\* Basically all the `area/tools` PRs in my opinion should be `area/tooling` and `area/tools` should be reserved for changes to actual tools. This would mirror the new `datatypes` tag which would let someone filter on changes to actual implemented datatypes (the idea being that changes to specific tools are datatypes are more interesting to deployers and changes to the datatype framework and tooling framework are more interesting to developers).
