### PR TITLE
HistoryQuery object not having the 'collection_type_description' attribute

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2449,7 +2449,7 @@ class DataCollectionToolParameter( BaseDataToolParameter ):
 
         # append matching subcollections
         for hdca in self.match_multirun_collections( trans, history, dataset_matcher ):
-            subcollection_type = self._history_query( trans ).collection_type_description.collection_type
+            subcollection_type = self._history_query( trans ).collection_type_descriptions[0].collection_type
             d['options']['hdca'].append({
                 'id': trans.security.encode_id( hdca.id ),
                 'hid': hdca.hid,


### PR DESCRIPTION
This is to fix the following exception being thrown when having a DataCollectionTool:

Traceback (most recent call last):
  File "/home/workspace/sanbi/src/galaxy/lib/galaxy/tools/**init**.py", line 2325, in iterate
    tool_dict = input.to_dict(trans, other_values=other_values)
  File "/home/workspace/sanbi/src/galaxy/lib/galaxy/tools/parameters/basic.py", line 2452, in to_dict
    subcollection_type = self._history_query( trans ).collection_type_description.collection_type
AttributeError: 'HistoryQuery' object has no attribute 'collection_type_description'

I noticed that the static method in HistoryQuery "from_parameter" is now returning a sorted list of objects. This then affects, the collection_type being assigned in to_dict() method of DataCollectionToolParameter class as it was expecting a single object with collection_type attribute.
