### PR TITLE
[16.01] UI, users: allow '/user' and '/user/' to default controller and corre…

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -79,7 +79,7 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
     installed_len_files = None
 
     @web.expose
-    def index( self, trans, cntrller, **kwd ):
+    def index( self, trans, cntrller='user', **kwd ):
         return trans.fill_template( '/user/index.mako', cntrller=cntrller )
 
     @web.expose


### PR DESCRIPTION
…ctly return the user/index.mako template (preventing an internal error)

Fixes #1587 
