### PR TITLE
[16.01] Always install a specific version of Galaxy pip in common_startup.sh.

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -142,7 +142,7 @@ if [ $REPLACE_PIP -eq 1 ]; then
     method=`python - << EOF
 from pkg_resources import parse_version
 from sys import stdout
-if parse_version('$pip_version') >= parse_version('1.6'):
+if parse_version('$pip_version') >= parse_version('6.0'):
     stdout.write('req')
 elif parse_version('$pip_version') >= parse_version('1.5'):
     stdout.write('wheel')

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+GXPIP_VERSION='8.0.2+gx1'
+
 SET_VENV=1
 for arg in "$@"; do
     [ "$arg" = "--skip-venv" ] && SET_VENV=0
@@ -138,7 +140,7 @@ fi
 if [ $REPLACE_PIP -eq 1 ]; then
     pip_version=`pip --version | awk '{print $2}'`
     pre=`python -c "from pkg_resources import parse_version; from sys import stdout; stdout.write('--pre') if parse_version('$pip_version') >= parse_version('1.4') else stdout.write('')"`
-    pip install $pre --no-index --find-links ${GALAXY_WHEELS_INDEX_URL}/pip --upgrade pip
+    pip install $pre --no-index --find-links ${GALAXY_WHEELS_INDEX_URL}/pip --upgrade "pip==${GXPIP_VERSION}"
     # binary-compatibility.cfg may need to be created (e.g. on CentOS)
     [ -n "$VIRTUAL_ENV" -a ! -f ${VIRTUAL_ENV}/binary-compatibility.cfg ] && python ./scripts/binary_compatibility.py -o ${VIRTUAL_ENV}/binary-compatibility.cfg
 fi

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -139,8 +139,28 @@ fi
 : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
 if [ $REPLACE_PIP -eq 1 ]; then
     pip_version=`pip --version | awk '{print $2}'`
-    pre=`python -c "from pkg_resources import parse_version; from sys import stdout; stdout.write('--pre') if parse_version('$pip_version') >= parse_version('1.4') else stdout.write('')"`
-    pip install $pre --no-index --find-links ${GALAXY_WHEELS_INDEX_URL}/pip --upgrade "pip==${GXPIP_VERSION}"
+    method=`python - << EOF
+from pkg_resources import parse_version
+from sys import stdout
+if parse_version('$pip_version') >= parse_version('1.6'):
+    stdout.write('req')
+elif parse_version('$pip_version') >= parse_version('1.5'):
+    stdout.write('wheel')
+else:
+    stdout.write('sdist')
+EOF`
+    case $method in
+        req)
+            pip install --no-index --find-links ${GALAXY_WHEELS_INDEX_URL}/pip --upgrade "pip==${GXPIP_VERSION}"
+            ;;
+        wheel)
+            pip install --upgrade "https://wheels.galaxyproject.org/packages/pip-${GXPIP_VERSION}-py2.py3-none-any.whl"
+            ;;
+        sdist)
+            pip install --upgrade "https://wheels.galaxyproject.org/packages/pip-${GXPIP_VERSION}.tar.gz"
+            ;;
+    esac
+
     # binary-compatibility.cfg may need to be created (e.g. on CentOS)
     [ -n "$VIRTUAL_ENV" -a ! -f ${VIRTUAL_ENV}/binary-compatibility.cfg ] && python ./scripts/binary_compatibility.py -o ${VIRTUAL_ENV}/binary-compatibility.cfg
 fi


### PR DESCRIPTION
Pinning the version should avoid problems related to future pip releases. It does mean that any fixes we need to release for Galaxy pip won't automatically be received, but that's probably the way it should be. This also upgrades from 8.0.0 to 8.0.2. 8.0.2+gx1 wheels are up on wheels.galaxyproject.org.

Fixes #1544 again.

related: galaxyproject/ansible-galaxy#9
