### PR TITLE
[16.01] Core, HDCAs: fix 'copy_item_annotation' error when copying a history …

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3181,7 +3181,7 @@ class DatasetCollectionInstance( object, HasName ):
         return changed
 
 
-class HistoryDatasetCollectionAssociation( DatasetCollectionInstance, Dictifiable ):
+class HistoryDatasetCollectionAssociation( DatasetCollectionInstance, UsesAnnotations, Dictifiable ):
     """ Associates a DatasetCollection with a History. """
     editable_keys = ( 'name', 'deleted', 'visible' )
 


### PR DESCRIPTION
…with an hdca by adding UsesAnnotations mixin to HDCA model

Previous could not copy any history with an hdca in it since hdca did not have copy_item_annotation.

@jmchilton This is a significant change (the mixin) - can you review when you get some time, please?

An alternative would be to not attempt to copy hdca annotations in 16.01 and add the mixin in dev.
