### PR TITLE
Fix installation of repository suites outside of tool panel section

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -220,6 +220,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
             tool_section = ToolSection( section_dict )
             self._tool_panel.append_section( tool_panel_section_key, tool_section )
             log.debug( "Loading new tool panel section: %s" % str( tool_section.name ) )
+            self._save_integrated_tool_panel()
         else:
             tool_section = None
         return tool_panel_section_key, tool_section

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -834,6 +834,7 @@ class InstallRepositoryManager( object ):
 
     def install_tool_shed_repository( self, tool_shed_repository, repo_info_dict, tool_panel_section_key, shed_tool_conf, tool_path,
                                       install_tool_dependencies, reinstalling=False ):
+        self.app.install_model.context.flush()
         if tool_panel_section_key:
             _, tool_section = self.app.toolbox.get_section( tool_panel_section_key )
             if tool_section is None:


### PR DESCRIPTION
This fixes issue #1600 for me, but I'm not sure if this is the right way to do this.
I tried flushing and getting the section again when `tool_section is None`, but that didn't work ... .
