### PR TITLE
Various improvements to the heartbeat

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -714,6 +714,15 @@ use_interactive = True
 # lot of CPU.
 #use_heartbeat = False
 
+# Control the period (in seconds) between dumps. Use -1 to disable. Regardless
+# of this setting, if use_heartbeat is enabled, you can send a Galaxy process
+# (unless running with uWSGI) SIGUSR1 (`kill -USR1`) to force a dump.
+#heartbeat_interval = 20
+
+# Heartbeat log filename. Can accept the template variables {server_name} and
+# {pid}
+#heartbeat_log = heartbeat_{server_name}.log
+
 # Log to Sentry
 # Sentry is an open source logging and error aggregation platform.  Setting
 # sentry_dsn will enable the Sentry middleware and errors will be sent to the

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -1,8 +1,17 @@
 from __future__ import absolute_import
+import logging
+import signal
 import sys
+import time
 import os
 
-import time
+try:
+    from uwsgidecorators import postfork
+except:
+    def pf_dec(func):
+        return func
+    postfork = pf_dec
+
 from galaxy import config, jobs
 import galaxy.model
 import galaxy.security
@@ -23,7 +32,7 @@ from galaxy.web.proxy import ProxyManager
 from galaxy.queue_worker import GalaxyQueueWorker
 from tool_shed.galaxy_install import update_repository_manager
 
-import logging
+
 log = logging.getLogger( __name__ )
 app = None
 
@@ -127,15 +136,25 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
             self.openid_providers = OpenIDProviders.from_file( self.config.openid_config_file )
         else:
             self.openid_providers = OpenIDProviders()
-        # Start the heartbeat process if configured and available
         from galaxy import auth
         self.auth_manager = auth.AuthManager( self )
+        # Start the heartbeat process if configured and available (wait until
+        # postfork if using uWSGI)
         if self.config.use_heartbeat:
             from galaxy.util import heartbeat
             if heartbeat.Heartbeat:
-                self.heartbeat = heartbeat.Heartbeat( fname=self.config.heartbeat_log )
+                self.heartbeat = heartbeat.Heartbeat(
+                    self.config,
+                    period=self.config.heartbeat_interval,
+                    fname=self.config.heartbeat_log
+                )
                 self.heartbeat.daemon = True
-                self.heartbeat.start()
+
+                @postfork
+                def _start():
+                    self.heartbeat.start()
+                if not config.process_is_uwsgi:
+                    _start()
         # Transfer manager client
         if self.config.get_bool( 'enable_beta_job_managers', False ):
             from galaxy.jobs import transfer_manager
@@ -156,6 +175,12 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
         from galaxy.workflow import scheduling_manager
         # Must be initialized after job_config.
         self.workflow_scheduling_manager = scheduling_manager.WorkflowSchedulingManager( self )
+
+        # Configure handling of signals
+        handlers = {
+            signal.SIGUSR1: self.heartbeat.dump_signal_handler if self.heartbeat else None
+        }
+        self._configure_signal_handlers( handlers )
 
         self.model.engine.dispose()
         self.server_starttime = int(time.time())  # used for cachebusting

--- a/lib/galaxy/util/heartbeat.py
+++ b/lib/galaxy/util/heartbeat.py
@@ -33,59 +33,77 @@ class Heartbeat( threading.Thread ):
     """
     Thread that periodically dumps the state of all threads to a file
     """
-    def __init__( self, name="Heartbeat Thread", period=20, fname="heartbeat.log" ):
+    def __init__( self, config, name="Heartbeat Thread", period=20, fname="heartbeat.log" ):
         threading.Thread.__init__( self, name=name )
+        self.config = config
         self.should_stop = False
         self.period = period
         self.fname = fname
         self.file = None
-        self.fname_nonsleeping = fname + ".nonsleeping"
+        self.fname_nonsleeping = None
         self.file_nonsleeping = None
+        self.pid = None
         self.nonsleeping_heartbeats = { }
-        # Save process id
-        self.pid = os.getpid()
         # Event to wait on when sleeping, allows us to interrupt for shutdown
         self.wait_event = threading.Event()
 
     def run( self ):
-        self.file = open( self.fname, "a" )
-        print >> self.file, "Heartbeat for pid %d thread started at %s" % ( self.pid, time.asctime() )
-        print >> self.file
-        self.file_nonsleeping = open( self.fname_nonsleeping, "a" )
-        print >> self.file_nonsleeping, "Non-Sleeping-threads for pid %d thread started at %s" % ( self.pid, time.asctime() )
-        print >> self.file_nonsleeping
-        try:
-            while not self.should_stop:
-                # Print separator with timestamp
-                print >> self.file, "Traceback dump for all threads at %s:" % time.asctime()
-                print >> self.file
-                # Print the thread states
-                threads = get_current_thread_object_dict()
-                for thread_id, frame in iteritems(sys._current_frames()):
-                    if thread_id in threads:
-                        object = repr( threads[thread_id] )
-                    else:
-                        object = "<No Thread object>"
-                    print >> self.file, "Thread %s, %s:" % ( thread_id, object )
-                    print >> self.file
-                    traceback.print_stack( frame, file=self.file )
-                    print >> self.file
-                print >> self.file, "End dump"
-                print >> self.file
-                self.file.flush()
-                self.print_nonsleeping(threads)
-                # Sleep for a bit
-                self.wait_event.wait( self.period )
-        finally:
-            print >> self.file, "Heartbeat for pid %d thread stopped at %s" % ( self.pid, time.asctime() )
-            print >> self.file
-            # Cleanup
+        self.pid = os.getpid()
+        self.fname = self.fname.format(
+            server_name=self.config.server_name,
+            pid=self.pid
+        )
+        fname, ext = os.path.splitext(self.fname)
+        self.fname_nonsleeping = fname + '.nonsleeping' + ext
+        wait = self.period
+        if self.period <= 0:
+            wait = 60
+        while not self.should_stop:
+            if self.period > 0:
+                self.dump()
+            self.wait_event.wait( wait )
+
+    def open_logs( self ):
+        if self.file is None or self.file.closed:
+            self.file = open( self.fname, "a" )
+            self.file_nonsleeping = open( self.fname_nonsleeping, "a" )
+            self.file.write( "Heartbeat for pid %d thread started at %s\n\n" % ( self.pid, time.asctime() ) )
+            self.file_nonsleeping.write( "Non-Sleeping-threads for pid %d thread started at %s\n\n" % ( self.pid, time.asctime() ) )
+
+    def close_logs( self ):
+        if self.file is not None and not self.file.closed:
+            self.file.write( "Heartbeat for pid %d thread stopped at %s\n\n" % ( self.pid, time.asctime() ) )
+            self.file_nonsleeping.write( "Non-Sleeping-threads for pid %d thread stopped at %s\n\n" % ( self.pid, time.asctime() ) )
             self.file.close()
             self.file_nonsleeping.close()
+
+    def dump( self ):
+        self.open_logs()
+        try:
+            # Print separator with timestamp
+            self.file.write( "Traceback dump for all threads at %s:\n\n" % time.asctime() )
+            # Print the thread states
+            threads = get_current_thread_object_dict()
+            for thread_id, frame in iteritems(sys._current_frames()):
+                if thread_id in threads:
+                    object = repr( threads[thread_id] )
+                else:
+                    object = "<No Thread object>"
+                self.file.write( "Thread %s, %s:\n\n" % ( thread_id, object ) )
+                traceback.print_stack( frame, file=self.file )
+                self.file.write( "\n" )
+            self.file.write( "End dump\n\n" )
+            self.file.flush()
+            self.print_nonsleeping(threads)
+        except:
+            self.file.write( "Caught exception attempting to dump thread states:" )
+            traceback.print_exc( None, self.file )
+            self.file.write( "\n" )
 
     def shutdown( self ):
         self.should_stop = True
         self.wait_event.set()
+        self.close_logs()
         self.join()
 
     def thread_is_sleeping( self, last_stack_frame ):
@@ -107,7 +125,8 @@ class Heartbeat( threading.Thread ):
             return True
         if _funcname == "accept" and _text[-14:] == "_sock.accept()":
             return True
-        if _funcname == "monitor" and _text.startswith("time.sleep( ") and _text.endswith(" )"):
+        if _funcname in ("monitor", "__monitor", "app_loop", "check") \
+                and _text.startswith("time.sleep(") and _text.endswith(")"):
             return True
         if _funcname == "drain_events" and _text == "sleep(polling_interval)":
             return True
@@ -139,8 +158,7 @@ class Heartbeat( threading.Thread ):
         return stack_frames[-1]
 
     def print_nonsleeping( self, threads_object_dict ):
-        print >> self.file_nonsleeping, "Non-Sleeping threads at %s:" % time.asctime()
-        print >> self.file_nonsleeping
+        self.file_nonsleeping.write( "Non-Sleeping threads at %s:\n\n" % time.asctime() )
         all_threads_are_sleeping = True
         threads = get_current_thread_object_dict()
         for thread_id, frame in iteritems(sys._current_frames()):
@@ -161,11 +179,14 @@ class Heartbeat( threading.Thread ):
                 self.nonsleeping_heartbeats[thread_id] = 1
 
             good_frame = self.get_interesting_stack_frame(tb)
-            print >> self.file_nonsleeping, "Thread %s\t%s\tnon-sleeping for %d heartbeat(s)\n  File %s:%d\n    Function \"%s\"\n      %s" % \
-                ( thread_id, object, self.nonsleeping_heartbeats[thread_id], good_frame[0], good_frame[1], good_frame[2], good_frame[3] )
+            self.file_nonsleeping.write( "Thread %s\t%s\tnon-sleeping for %d heartbeat(s)\n  File %s:%d\n    Function \"%s\"\n      %s\n" %
+                ( thread_id, object, self.nonsleeping_heartbeats[thread_id], good_frame[0], good_frame[1], good_frame[2], good_frame[3] ) )
             all_threads_are_sleeping = False
 
         if all_threads_are_sleeping:
-            print >> self.file_nonsleeping, "All threads are sleeping."
-        print >> self.file_nonsleeping
+            self.file_nonsleeping.write( "All threads are sleeping.\n" )
+        self.file_nonsleeping.write( "\n" )
         self.file_nonsleeping.flush()
+
+    def dump_signal_handler( self, signum, frame ):
+        self.dump()

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -156,7 +156,8 @@ class WorkflowRequestMonitor( object ):
                     return
 
                 self.__schedule( workflow_scheduler_id, workflow_scheduler )
-                time.sleep(1)  # TODO: wake if stopped
+                # TODO: wake if stopped
+                time.sleep(1)
 
     def __schedule( self, workflow_scheduler_id, workflow_scheduler ):
         invocation_ids = self.__active_invocation_ids( workflow_scheduler_id )


### PR DESCRIPTION
- Dump on `SIGUSR1`
- Configurable dump period (including "no periodic dump, signal only")
- Default log filename now includes `server_name` so logs do not clobber eachother
- Configurable/templateable log filename
- Catch more sleeping threads
- Use `write()` instead of `print`

Regarding `SIGUSR1`, this is only one action that Galaxy might take on `SIGUSR1`. Others could be added later. That said, the utility of Galaxy signal handling is somewhat limited by uWSGI claiming every conceivable signal.
