### PR TITLE
Visualization plugins: add routes that more closely match potential s…

### DIFF
--- a/lib/galaxy/visualization/plugins/registry.py
+++ b/lib/galaxy/visualization/plugins/registry.py
@@ -227,7 +227,6 @@ class VisualizationsRegistry( pluginframework.PageServingPluginManager ):
 
         # we want existing visualizations to work as normal but still be part of the registry (without mod'ing)
         #   so generate their urls differently
-        print visualization.name, param_data
         url = None
         if visualization.name in self.BUILT_IN_VISUALIZATIONS:
             url = url_for( controller='visualization', action=visualization.name, **params )

--- a/lib/galaxy/visualization/plugins/registry.py
+++ b/lib/galaxy/visualization/plugins/registry.py
@@ -31,6 +31,7 @@ class VisualizationsRegistry( pluginframework.PageServingPluginManager ):
         - validating and parsing params into resources (based on a context)
             used in the visualization template
     """
+    NAMED_ROUTE = 'visualization_plugin'
     DEFAULT_BASE_URL = 'visualizations'
     # these should be handled somewhat differently - and be passed onto their resp. methods in ctrl.visualization
     # TODO: change/remove if/when they can be updated to use this system
@@ -165,7 +166,7 @@ class VisualizationsRegistry( pluginframework.PageServingPluginManager ):
             # log.debug( '\t passed tests' )
 
             param_data = data_source[ 'to_params' ]
-            url = self.get_visualization_url( trans, target_object, visualization_name, param_data )
+            url = self.get_visualization_url( trans, target_object, visualization, param_data )
             display_name = visualization.config.get( 'name', None )
             render_target = visualization.config.get( 'render_target', 'galaxy_main' )
             embeddable = visualization.config.get( 'embeddable', False )
@@ -214,9 +215,9 @@ class VisualizationsRegistry( pluginframework.PageServingPluginManager ):
 
         return False
 
-    def get_visualization_url( self, trans, target_object, visualization_name, param_data ):
+    def get_visualization_url( self, trans, target_object, visualization, param_data ):
         """
-        Generates a url for the visualization with `visualization_name`
+        Generates a url for the visualization with `visualization`
         for use with the given `target_object` with a query string built
         from the configuration data in `param_data`.
         """
@@ -226,12 +227,15 @@ class VisualizationsRegistry( pluginframework.PageServingPluginManager ):
 
         # we want existing visualizations to work as normal but still be part of the registry (without mod'ing)
         #   so generate their urls differently
+        print visualization.name, param_data
         url = None
-        if visualization_name in self.BUILT_IN_VISUALIZATIONS:
-            url = url_for( controller='visualization', action=visualization_name, **params )
+        if visualization.name in self.BUILT_IN_VISUALIZATIONS:
+            url = url_for( controller='visualization', action=visualization.name, **params )
+        # TODO: needs to be split off as it's own registry
+        elif isinstance( visualization, vis_plugins.InteractiveEnvironmentPlugin ):
+            url = url_for( 'interactive_environment_plugin', visualization_name=visualization.name, **params )
         else:
-            url = url_for( controller='visualization', action='render',
-                           visualization_name=visualization_name, **params )
+            url = url_for( self.NAMED_ROUTE, visualization_name=visualization.name, **params )
 
         # TODO:?? not sure if embedded would fit/used here? or added in client...
         return url

--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -252,15 +252,12 @@ class Grid( object ):
 
         # Render grid.
         def url( *args, **kwargs ):
-            new_args = kwargs.pop( '__args', () )
-            print 'new_args:', new_args
-            print 'url:', args, kwargs
+            route_name = kwargs.pop( '__route_name__', None )
             # Only include sort/filter arguments if not linking to another
             # page. This is a bit of a hack.
             if 'action' in kwargs:
                 new_kwargs = dict()
             else:
-                print 'extra_url_args:', extra_url_args
                 new_kwargs = dict( extra_url_args )
             # Extend new_kwargs with first argument if found
             if len(args) > 0:
@@ -278,8 +275,8 @@ class Grid( object ):
                 new_kwargs['controller'] = trans.controller
             if 'action' not in new_kwargs:
                 new_kwargs['action'] = trans.action
-            if new_args:
-                return url_for( *new_args, **new_kwargs )
+            if route_name:
+                return url_for( route_name, **new_kwargs )
             return url_for( **new_kwargs )
 
         self.use_panels = ( kwargs.get( 'use_panels', False ) in [ True, 'True', 'true' ] )

--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -252,11 +252,15 @@ class Grid( object ):
 
         # Render grid.
         def url( *args, **kwargs ):
+            new_args = kwargs.pop( '__args', () )
+            print 'new_args:', new_args
+            print 'url:', args, kwargs
             # Only include sort/filter arguments if not linking to another
             # page. This is a bit of a hack.
             if 'action' in kwargs:
                 new_kwargs = dict()
             else:
+                print 'extra_url_args:', extra_url_args
                 new_kwargs = dict( extra_url_args )
             # Extend new_kwargs with first argument if found
             if len(args) > 0:
@@ -274,7 +278,9 @@ class Grid( object ):
                 new_kwargs['controller'] = trans.controller
             if 'action' not in new_kwargs:
                 new_kwargs['action'] = trans.action
-            return url_for( **new_kwargs)
+            if new_args:
+                return url_for( *new_args, **new_kwargs )
+            return url_for( **new_kwargs )
 
         self.use_panels = ( kwargs.get( 'use_panels', False ) in [ True, 'True', 'true' ] )
         self.advanced_search = ( kwargs.get( 'advanced_search', False ) in [ True, 'True', 'true' ] )

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -312,6 +312,10 @@ def populate_api_routes( webapp, app ):
 
     # visualizations registry generic template renderer
     webapp.add_route( '/visualization/show/{visualization_name}', controller='visualization', action='render', visualization_name=None )
+    # provide an alternate route to visualization plugins that's closer to their static assets
+    # (/plugins/visualizations/{visualization_name}/static) and allow them to use relative urls to those
+    webapp.add_route( '/plugins/visualizations/{visualization_name}/show', controller='visualization', action='render' )
+    webapp.mapper.connect( 'saved_visualization', '/plugins/visualizations/{visualization_name}/saved', controller='visualization', action='saved' )
 
     # Deprecated in favor of POST /api/workflows with 'workflow' in payload.
     webapp.mapper.connect( 'import_workflow_deprecated',

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -310,12 +310,21 @@ def populate_api_routes( webapp, app ):
                            controller="users", action="api_key", user_id=None,
                            conditions=dict( method=["POST"] ) )
 
-    # visualizations registry generic template renderer
+    # ---- visualizations registry ---- generic template renderer
+    # @deprecated: this route should be considered deprecated
     webapp.add_route( '/visualization/show/{visualization_name}', controller='visualization', action='render', visualization_name=None )
+
     # provide an alternate route to visualization plugins that's closer to their static assets
     # (/plugins/visualizations/{visualization_name}/static) and allow them to use relative urls to those
-    webapp.add_route( '/plugins/visualizations/{visualization_name}/show', controller='visualization', action='render' )
-    webapp.mapper.connect( 'saved_visualization', '/plugins/visualizations/{visualization_name}/saved', controller='visualization', action='saved' )
+    webapp.mapper.connect( 'visualization_plugin', '/plugins/visualizations/{visualization_name}/show',
+        controller='visualization', action='render' )
+    webapp.mapper.connect( 'saved_visualization', '/plugins/visualizations/{visualization_name}/saved',
+        controller='visualization', action='saved' )
+    # same with IE's
+    webapp.mapper.connect( 'interactive_environment_plugin', '/plugins/interactive_environments/{visualization_name}/show',
+        controller='visualization', action='render' )
+    webapp.mapper.connect( 'saved_interactive_environment', '/plugins/interactive_environments/{visualization_name}/saved',
+        controller='visualization', action='saved' )
 
     # Deprecated in favor of POST /api/workflows with 'workflow' in payload.
     webapp.mapper.connect( 'import_workflow_deprecated',

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -191,6 +191,8 @@ class VisualizationListGrid( grids.Grid ):
         if item.type in registry.VisualizationsRegistry.BUILT_IN_VISUALIZATIONS:
             url_kwargs[ 'action' ] = item.type
         else:
+            url_kwargs[ '__route_name__' ] = 'saved_visualization'
+            url_kwargs[ 'visualization_name' ] = item.type
             url_kwargs[ 'action' ] = 'saved'
         return url_kwargs
 


### PR DESCRIPTION
…tatic assets in order to allow easier, relative hrefs (for both new and saved visualizations); Grids: allow operations to use named routes by adding kwarg '__route_name__'

Plugins will now render from:
`/plugins/visualizations/{visualization_name}/show`
and saved will render from:
`/plugins/visualizations/{visualization_name}/saved`

This means loading **local, static assets** in the base html/mako goes from:

``` html
<script src="${ h.url_for( '/' ) + 'plugins/visualizations/scatterplot/static/scatterplot-edit.js' }"></script>
```

to:

``` html
<script src="static/scatterplot-edit.js"></script>
```

The older urls are still there and work.
