### PR TITLE
[16.01] Attempt to fix transiently failing test due to objectstore makedirs …

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -12,7 +12,7 @@ import logging
 import threading
 from xml.etree import ElementTree
 
-from galaxy.util import umask_fix_perms, force_symlink
+from galaxy.util import umask_fix_perms, force_symlink, safe_makedirs
 from galaxy.exceptions import ObjectInvalid, ObjectNotFound
 from galaxy.util.sleeper import Sleeper
 from galaxy.util.directory_hash import directory_hash_id
@@ -331,8 +331,7 @@ class DiskObjectStore(ObjectStore):
             dir_only = kwargs.get('dir_only', False)
             # Create directory if it does not exist
             dir = path if dir_only else os.path.dirname(path)
-            if not os.path.exists(dir):
-                os.makedirs(dir)
+            safe_makedirs(dir)
             # Create the file if it does not exist
             if not dir_only:
                 open(path, 'w').close()  # Should be rb?

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -568,6 +568,21 @@ def which(file):
     return None
 
 
+def safe_makedirs(path):
+    """ Safely make a directory, do not fail if it already exist or
+    is created during execution.
+    """
+    if not os.path.exists(path):
+        try:
+            os.makedirs(path)
+        except OSError as e:
+            # review source for Python 2.7 this would only ever happen
+            # for the last path anyway so need to recurse - this exception
+            # means the last part of the path was already in existence.
+            if e.errno != errno.EEXIST:
+                raise
+
+
 def in_directory( file, directory, local_path_module=os.path ):
     """
     Return true, if the common prefix of both is equal to directory


### PR DESCRIPTION
…call.

Failing test - https://jenkins.galaxyproject.org/job/docker-api/2421/testReport/junit/api.test_workflows/WorkflowsApiTestCase/test_workflow_metadata_validation_0/.

If you look at the actual source code for os.makedirs - it does inconsistently handle errno.EEXIST - this is probably a better approach than raw os.makedirs for most cases.

xref #1617
