### PR TITLE
[16.01] Fix use_tool_dependencies for non-default dependency_resolver_conf files.

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -305,7 +305,7 @@ class Configuration( object ):
             self.use_tool_dependencies = True
         else:
             self.tool_dependency_dir = None
-            self.use_tool_dependencies = False
+            self.use_tool_dependencies = os.path.exists(self.dependency_resolvers_config_file)
         # Configuration options for taking advantage of nginx features
         self.upstream_gzip = string_as_bool( kwargs.get( 'upstream_gzip', False ) )
         self.apache_xsendfile = string_as_bool( kwargs.get( 'apache_xsendfile', False ) )


### PR DESCRIPTION
This way resolvers like the module resolver work even if tool_dependency_dir is not set.

Ping @pvanheus.
