### PR TITLE
Fixes `<param argument="--set" />` not working when `help=""` is not set

### DIFF
--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -109,9 +109,9 @@ define([], function() {
             tmp +=              '<div class="ui-form-info">';
             if (options.help) {
                 tmp +=              options.help;
-                if (options.argument && options.help.indexOf('(' + options.argument + ')') == -1) {
-                    tmp += ' (' + options.argument + ')';
-                }
+            }
+            if (options.argument && options.help.indexOf('(' + options.argument + ')') == -1) {
+                tmp += ' (' + options.argument + ')';
             }
             tmp +=              '</div>' +
                                 '<div class="ui-form-backdrop"/>' +

--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -111,7 +111,7 @@ define([], function() {
                 tmp +=              options.help;
             }
             if (options.argument && options.help.indexOf('(' + options.argument + ')') == -1) {
-                tmp += ' (' + options.argument + ')';
+                tmp +=              ' (' + options.argument + ')';
             }
             tmp +=              '</div>' +
                                 '<div class="ui-form-backdrop"/>' +


### PR DESCRIPTION
Fixes that `<param argument="--set" />` is not working when `help=""` is not set

ref:
https://github.com/galaxyproject/galaxy/pull/346#issuecomment-178555758
https://github.com/galaxyproject/tools-iuc/pull/575#issuecomment-178069191

After running grunt quite some files had changed. I didn't dare to put them in the commit.
