### PR TITLE
[16.01] Backport print fix.

### DIFF
--- a/scripts/binary_compatibility.py
+++ b/scripts/binary_compatibility.py
@@ -46,7 +46,7 @@ def install_compat():
     compat_plat = compatible_platforms.get(this_plat, None)
     rval = {}
     if compat_plat:
-        print('{} is binary compatible with {} (and can install {} wheels)'
+        print('{0} is binary compatible with {1} (and can install {2} wheels)'
               .format(this_plat, compat_plat, compat_plat),
               file=sys.stderr)
         for py, abi, plat in get_supported():


### PR DESCRIPTION
Change python print() format to be backward compatible with older versions

In python versions prior to 3.1, the print("{}", .format(x)) form throws
an error, use the more compatible print("{0}", .format(x)) form
instead.

xref https://github.com/galaxyproject/galaxy/pull/1520
