### PR TITLE
[16.01] Bump gx pip version to fix OSX platform issues.

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-GXPIP_VERSION='8.0.2+gx1'
+GXPIP_VERSION='8.0.2+gx2'
 
 SET_VENV=1
 for arg in "$@"; do


### PR DESCRIPTION
This resolves #1633 and #1640.
