### PR TITLE
dev

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -300,13 +300,9 @@ class Configuration( object ):
         # Location for tool dependencies.
         if 'tool_dependency_dir' in kwargs:
             self.tool_dependency_dir = resolve_path( kwargs.get( "tool_dependency_dir" ), self.root )
-            # Setting the following flag to true will ultimately cause tool dependencies
-            # to be located in the shell environment and used by the job that is executing
-            # the tool.
-            self.use_tool_dependencies = True
+
         else:
             self.tool_dependency_dir = None
-            self.use_tool_dependencies = False
         # Configuration options for taking advantage of nginx features
         self.upstream_gzip = string_as_bool( kwargs.get( 'upstream_gzip', False ) )
         self.apache_xsendfile = string_as_bool( kwargs.get( 'apache_xsendfile', False ) )

--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -29,21 +29,18 @@ CONFIG_VAL_NOT_FOUND = object()
 
 
 def build_dependency_manager( config ):
-    if getattr( config, "use_tool_dependencies", False ):
-        dependency_manager_kwds = {
-            'default_base_path': config.tool_dependency_dir,
-            'conf_file': config.dependency_resolvers_config_file,
-        }
-        for key, default_value in EXTRA_CONFIG_KWDS.items():
-            value = getattr(config, key, CONFIG_VAL_NOT_FOUND)
-            if value is CONFIG_VAL_NOT_FOUND and hasattr(config, "config_dict"):
-                value = config.config_dict.get(key, CONFIG_VAL_NOT_FOUND)
-            if value is CONFIG_VAL_NOT_FOUND:
-                value = default_value
-            dependency_manager_kwds[key] = value
-        dependency_manager = DependencyManager( **dependency_manager_kwds )
-    else:
-        dependency_manager = NullDependencyManager()
+    dependency_manager_kwds = {
+        'default_base_path': getattr( config, "tool_dependency_dir", config.root ),
+        'conf_file': config.dependency_resolvers_config_file,
+    }
+    for key, default_value in EXTRA_CONFIG_KWDS.items():
+        value = getattr(config, key, CONFIG_VAL_NOT_FOUND)
+        if value is CONFIG_VAL_NOT_FOUND and hasattr(config, "config_dict"):
+            value = config.config_dict.get(key, CONFIG_VAL_NOT_FOUND)
+        if value is CONFIG_VAL_NOT_FOUND:
+            value = default_value
+        dependency_manager_kwds[key] = value
+    dependency_manager = DependencyManager( **dependency_manager_kwds )
 
     return dependency_manager
 

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -806,7 +806,7 @@ class AdminToolshed( AdminGalaxy ):
                     message = 'No selected tool dependencies can be uninstalled, you may need to use the <b>Repair repository</b> feature.'
                     status = 'error'
             elif operation == "install":
-                if trans.app.config.tool_dependency_dir:
+                if trans.app.config.tool_dependency_dir is not None:
                     tool_dependencies_for_installation = []
                     for tool_dependency_id in tool_dependency_ids:
                         tool_dependency = tool_dependency_util.get_tool_dependency( trans.app, tool_dependency_id )
@@ -875,7 +875,7 @@ class AdminToolshed( AdminGalaxy ):
                                                                   action='browse_tool_dependency',
                                                                   **kwd ) )
             elif operation == "install":
-                if trans.app.config.tool_dependency_dir:
+                if trans.app.config.tool_dependency_dir is not None:
                     tool_dependencies_for_installation = []
                     for tool_dependency_id in tool_dependency_ids:
                         tool_dependency = tool_dependency_util.get_tool_dependency( trans.app, tool_dependency_id )

--- a/lib/tool_shed/galaxy_install/dependency_display.py
+++ b/lib/tool_shed/galaxy_install/dependency_display.py
@@ -34,7 +34,7 @@ class DependencyDisplayer( object ):
             changeset_revision = requirements_dict.get( 'changeset_revision', 'unknown' )
             dependency_name = requirements_dict[ 'name' ]
             version = requirements_dict[ 'version' ]
-            if self.app.config.tool_dependency_dir:
+            if self.app.config.tool_dependency_dir is not None:
                 root_dir = self.app.config.tool_dependency_dir
             else:
                 root_dir = '<set your tool_dependency_dir in your Galaxy configuration file>'


### PR DESCRIPTION
- Remove requirement that tool_dependency_dir is set before dependency resolver modules are used.
  - if tool_dependency_dir is not set, use the Galaxy root directory as the default_base_path for resolvers
    Rationale: Not all dependency resolvers rely on the tool_dependency_dir (e.g. the modules resolver does not need this), so making the use of resolvers dependent on this setting does not make sense.
