### PR TITLE
add a zip datatype which won't be extracted

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -145,6 +145,7 @@
     <datatype extension="pbm" type="galaxy.datatypes.images:Pbm" mimetype="image/pbm"/>
     <datatype extension="pgm" type="galaxy.datatypes.images:Pgm" mimetype="image/pgm"/>
     <datatype extension="rna_eps" type="galaxy.datatypes.sequence:RNADotPlotMatrix" mimetype="image/eps" display_in_upload="True"/>
+    <datatype extension="zip" type="galaxy.datatypes.binary:CompressedArchive" subclass="True" display_in_upload="True"/>
     <!-- Proteomics Datatypes -->
     <datatype extension="pepxml" type="galaxy.datatypes.proteomics:PepXml" mimetype="application/xml" display_in_upload="True"/>
     <datatype extension="raw_pepxml" type="galaxy.datatypes.proteomics:PepXml" mimetype="application/xml" subclass="True"/>

--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -145,7 +145,7 @@
     <datatype extension="pbm" type="galaxy.datatypes.images:Pbm" mimetype="image/pbm"/>
     <datatype extension="pgm" type="galaxy.datatypes.images:Pgm" mimetype="image/pgm"/>
     <datatype extension="rna_eps" type="galaxy.datatypes.sequence:RNADotPlotMatrix" mimetype="image/eps" display_in_upload="True"/>
-    <datatype extension="zip" type="galaxy.datatypes.binary:CompressedArchive" subclass="True" display_in_upload="True"/>
+    <datatype extension="zip" type="galaxy.datatypes.binary:CompressedZipArchive" display_in_upload="True"/>
     <!-- Proteomics Datatypes -->
     <datatype extension="pepxml" type="galaxy.datatypes.proteomics:PepXml" mimetype="application/xml" display_in_upload="True"/>
     <datatype extension="raw_pepxml" type="galaxy.datatypes.proteomics:PepXml" mimetype="application/xml" subclass="True"/>

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -146,6 +146,31 @@ class CompressedArchive( Binary ):
 Binary.register_unsniffable_binary_ext("compressed_archive")
 
 
+class CompressedZipArchive( CompressedArchive ):
+    """
+        Class describing an compressed binary file
+        This class can be sublass'ed to implement archive filetypes that will not be unpacked by upload.py.
+    """
+    file_ext = "zip"
+
+    def set_peek( self, dataset, is_multi_byte=False ):
+        if not dataset.dataset.purged:
+            dataset.peek = "Compressed zip file"
+            dataset.blurb = nice_size( dataset.get_size() )
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def display_peek( self, dataset ):
+        try:
+            return dataset.peek
+        except:
+            return "Compressed zip file (%s)" % ( nice_size( dataset.get_size() ) )
+
+
+Binary.register_unsniffable_binary_ext("zip")
+
+
 class GenericAsn1Binary( Binary ):
     """Class for generic ASN.1 binary format"""
     file_ext = "asn1-binary"


### PR DESCRIPTION
Him again!

I haven't changed my mind. I think Galaxy need to support archives with multiple files.
The aim is to keep files organized in a directory tree. Some software (or R library in our case) need as input a path so we just need to extract the archive.
Dataset collection is also a good way to organized files per condition. But our user know how to manage directories and zip since years.

And I'm not alone: 
https://github.com/galaxyproject/galaxy/issues/1180

Since three year, I use this datatype: https://toolshed.g2.bx.psu.edu/view/lecorguille/no_unzip_datatype/7800ba9a4c1e
Unfortunatly, it's not in the core of Galaxy, so Planemo have trouble to deal with. Also, I am aware that currently it ignores when the archive contains OS artefacts like __MACOSX/ and desktop.ini

One month ago, I proposed a PR on upload.py and checkers.py
https://github.com/galaxyproject/galaxy/pull/1442
This time, the detection of multi-files zip manages OS artefacts. But I agree that a datatype is a better way to solve my problem.

So I will try to enhance my datatype.

But this time, I will go step by step.

So my first move will be to convince you that Galaxy need a candid zip datatype.

If you are not, I will not waste time with the sniffer :tongue: 
