### PR TITLE
[16.01] Always use the python hashlib method for verifying the virtualenv download

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -101,11 +101,7 @@ if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 ]; then
                 python -c "import urllib; urllib.urlretrieve('$vurl', '$vsrc')"
             fi
             echo "Verifying $vsrc checksum is $vsha"
-            if command -v sha256sum >/dev/null; then
-                echo "$vsha $vsrc" | sha256sum -c --strict
-            else
-                python -c "import hashlib; assert hashlib.sha256(open('$vsrc', 'rb').read()).hexdigest() == '$vsha', '$vsrc: invalid checksum'"
-            fi
+            python -c "import hashlib; assert hashlib.sha256(open('$vsrc', 'rb').read()).hexdigest() == '$vsha', '$vsrc: invalid checksum'"
             tar zxf $vsrc -C $vtmp
             python $vtmp/virtualenv-$vvers/virtualenv.py "$GALAXY_VIRTUAL_ENV"
             rm -rf $vtmp


### PR DESCRIPTION
...in common_startup.sh rather than attempting to use sha256sum. Older versions of coreutils (such as in RHEL 6) did not include the `--strict` argument to `sha256sum`.

Fixes #1563.
