### PR TITLE
[16.01] Add the `scientific` platform (Scientific Linux) as binary compatible with RHEL

### DIFF
--- a/scripts/binary_compatibility.py
+++ b/scripts/binary_compatibility.py
@@ -34,7 +34,8 @@ from pip.platform import get_specific_platform
 
 
 compatible_platforms = {
-    'centos': 'rhel'
+    'centos': 'rhel',
+    'scientific': 'rhel',
 }
 
 


### PR DESCRIPTION
Fixes #1662.
