### PR TITLE
Overhaul of Tools and Jobs for 16.04

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -308,12 +308,11 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 
 
 # Set the default shell used by jobs Galaxy-wide. This defaults to
-# sh and can be overidden at the destination level for
+# bash and can be overidden at the destination level for
 # heterogenous clusters. conda job resolution requires bash or zsh
-# so if this is not switched to /bin/bash for instance - conda resolution
-# should be disabled. (16.01 will likely be the last release with a
-# default of /bin/sh instead of /bin/bash).
-#default_job_shell = /bin/sh
+# so if this is switched to /bin/sh for instance - conda resolution
+# should be disabled.
+#default_job_shell = /bin/bash
 
 # Citation related caching.  Tool citations information maybe fetched from
 # external sources such as http://dx.doi.org/ by Galaxy - the following

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -172,7 +172,7 @@ class Configuration( object ):
         self.job_queue_cleanup_interval = int( kwargs.get("job_queue_cleanup_interval", "5") )
         self.cluster_files_directory = os.path.abspath( kwargs.get( "cluster_files_directory", "database/pbs" ) )
         self.job_working_directory = resolve_path( kwargs.get( "job_working_directory", "database/job_working_directory" ), self.root )
-        self.default_job_shell = kwargs.get( "default_job_shell", "/bin/sh" )
+        self.default_job_shell = kwargs.get( "default_job_shell", "/bin/bash" )
         self.cleanup_job = kwargs.get( "cleanup_job", "always" )
         self.container_image_cache_path = self.resolve_path( kwargs.get( "container_image_cache_path", "database/container_images" ) )
         self.outputs_to_working_directory = string_as_bool( kwargs.get( 'outputs_to_working_directory', False ) )

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -171,7 +171,10 @@ class Configuration( object ):
         self.cluster_job_queue_workers = int( kwargs.get( "cluster_job_queue_workers", "3" ) )
         self.job_queue_cleanup_interval = int( kwargs.get("job_queue_cleanup_interval", "5") )
         self.cluster_files_directory = os.path.abspath( kwargs.get( "cluster_files_directory", "database/pbs" ) )
-        self.job_working_directory = resolve_path( kwargs.get( "job_working_directory", "database/job_working_directory" ), self.root )
+
+        # Fall back to to legacy job_working_directory config variable if set.
+        default_jobs_directory = kwargs.get( "job_working_directory", "database/jobs_directory" )
+        self.jobs_directory = resolve_path( kwargs.get( "jobs_directory", default_jobs_directory ), self.root )
         self.default_job_shell = kwargs.get( "default_job_shell", "/bin/bash" )
         self.cleanup_job = kwargs.get( "cleanup_job", "always" )
         self.container_image_cache_path = self.resolve_path( kwargs.get( "container_image_cache_path", "database/container_images" ) )

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -44,7 +44,7 @@ log = logging.getLogger( __name__ )
 TOOL_PROVIDED_JOB_METADATA_FILE = 'galaxy.json'
 
 # Override with config.default_job_shell.
-DEFAULT_JOB_SHELL = '/bin/sh'
+DEFAULT_JOB_SHELL = '/bin/bash'
 
 
 class JobDestination( Bunch ):

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1232,8 +1232,7 @@ class JobWrapper( object ):
                     # it would be quicker to just copy the metadata from the originating output dataset,
                     # but somewhat trickier (need to recurse up the copied_from tree), for now we'll call set_meta()
                     retry_internally = util.asbool(self.get_destination_configuration("retry_metadata_internally", True))
-                    if ( retry_internally and
-                            not self.external_output_metadata.external_metadata_set_successfully(dataset, self.sa_session ) ):
+                    if retry_internally and not self.external_output_metadata.external_metadata_set_successfully(dataset, self.sa_session ):
                         # If Galaxy was expected to sniff type and didn't - do so.
                         if dataset.ext == "_sniff_":
                             extension = sniff.handle_uploaded_dataset_file( dataset.dataset.file_name, self.app.datatypes_registry )

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -794,6 +794,10 @@ class JobWrapper( object ):
         return self.job_destination.shell or getattr(self.app.config, 'default_job_shell', DEFAULT_JOB_SHELL)
 
     @property
+    def strict_shell(self):
+        return self.tool.strict_shell
+
+    @property
     def commands_in_new_shell(self):
         return self.app.config.commands_in_new_shell
 

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -87,7 +87,15 @@ def __externalize_commands(job_wrapper, shell, commands_builder, remote_command_
     integrity_injection = ""
     if check_script_integrity(config):
         integrity_injection = INTEGRITY_INJECTION
-    script_contents = u"#!%s\n%s%s" % (shell, integrity_injection, tool_commands)
+    set_e = ""
+    if job_wrapper.strict_shell:
+        set_e = "set -e\n"
+    script_contents = u"#!%s\n%s%s%s" % (
+        shell,
+        integrity_injection,
+        set_e,
+        tool_commands
+    )
     write_script(local_container_script, script_contents, config)
     commands = local_container_script
     if 'working_directory' in remote_command_params:

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -71,8 +71,15 @@ def build_command(
         else:
             commands_builder = CommandsBuilder( externalized_commands )
 
+    # usually working will already exist, but it will not for task
+    # split jobs.
+    commands_builder.prepend_command("mkdir -p working; cd working")
+
     if include_work_dir_outputs:
         __handle_work_dir_outputs(commands_builder, job_wrapper, runner, remote_command_params)
+
+    commands_builder.capture_return_code()
+    commands_builder.append_command("cd ..")
 
     if include_metadata and job_wrapper.requires_setting_metadata:
         __handle_metadata(commands_builder, job_wrapper, runner, remote_command_params)

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -196,19 +196,22 @@ class CommandsBuilder(object):
         self.return_code_captured = False
 
     def prepend_command(self, command):
-        self.commands = u"%s; %s" % (command,
-                                     self.commands)
+        if command:
+            self.commands = u"%s; %s" % (command,
+                                         self.commands)
         return self
 
     def prepend_commands(self, commands):
-        return self.prepend_command(u"; ".join(commands))
+        return self.prepend_command(u"; ".join([c for c in commands if c]))
 
     def append_command(self, command):
-        self.commands = u"%s; %s" % (self.commands,
-                                     command)
+        if command:
+            self.commands = u"%s; %s" % (self.commands,
+                                         command)
+        return self
 
     def append_commands(self, commands):
-        self.append_command(u"; ".join(commands))
+        self.append_command(u"; ".join([c for c in commands if c]))
 
     def capture_return_code(self):
         if not self.return_code_captured:

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -583,7 +583,8 @@ class AsynchronousJobRunner( BaseJobRunner ):
             exit_code = 0
 
         # clean up the job files
-        if self.app.config.cleanup_job == "always" or ( not stderr and self.app.config.cleanup_job == "onsuccess" ):
+        cleanup_job = job_state.job_wrapper.cleanup_job
+        if cleanup_job == "always" or ( not stderr and cleanup_job == "onsuccess" ):
             job_state.cleanup()
 
         try:
@@ -600,7 +601,7 @@ class AsynchronousJobRunner( BaseJobRunner ):
         # something necessary
         if not job_state.runner_state_handled:
             job_state.job_wrapper.fail( getattr( job_state, 'fail_message', 'Job failed' ) )
-            if self.app.config.cleanup_job == "always":
+            if job_state.job_wrapper.cleanup_job == "always":
                 job_state.cleanup()
 
     def mark_as_finished(self, job_state):

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -227,7 +227,7 @@ class BaseJobRunner( object ):
                 if hda_tool_output and hda_tool_output.from_work_dir:
                     # Copy from working dir to HDA.
                     # TODO: move instead of copy to save time?
-                    source_file = os.path.join( job_working_directory, hda_tool_output.from_work_dir )
+                    source_file = os.path.join( job_working_directory, 'working', hda_tool_output.from_work_dir )
                     destination = job_wrapper.get_output_destination( output_paths[ dataset.dataset_id ] )
                     if in_directory( source_file, job_working_directory ):
                         output_pairs.append( ( source_file, destination ) )

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -2,7 +2,6 @@
 Job control via a command line interface (e.g. qsub/qstat), possibly over a remote connection (e.g. ssh).
 """
 
-import os
 import logging
 
 from galaxy import model
@@ -175,18 +174,6 @@ class ShellJobRunner( AsynchronousJobRunner ):
             assert cmd_out.returncode == 0, cmd_out.stderr
             job_states.update(job_interface.parse_status(cmd_out.stdout, job_ids))
         return job_states
-
-    def finish_job( self, job_state ):
-        """For recovery of jobs started prior to standardizing the naming of
-        files in the AsychronousJobState object
-        """
-        old_ofile = "%s.gjout" % os.path.join(job_state.job_wrapper.working_directory, job_state.job_wrapper.get_id_tag())
-        if os.path.exists( old_ofile ):
-            job_state.output_file = old_ofile
-            job_state.error_file = "%s.gjerr" % os.path.join(job_state.job_wrapper.working_directory, job_state.job_wrapper.get_id_tag())
-            job_state.exit_code_file = "%s.gjec" % os.path.join(job_state.job_wrapper.working_directory, job_state.job_wrapper.get_id_tag())
-            job_state.job_file = "%s/galaxy_%s.sh" % (self.app.config.cluster_files_directory, job_state.job_wrapper.get_id_tag())
-        super( ShellJobRunner, self ).finish_job( job_state )
 
     def stop_job( self, job ):
         """Attempts to delete a dispatched job"""

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -80,7 +80,7 @@ class ShellJobRunner( AsynchronousJobRunner ):
         # job was deleted while we were preparing it
         if job_wrapper.get_state() == model.Job.states.DELETED:
             log.info("(%s) Job deleted by user before it entered the queue" % galaxy_id_tag )
-            if self.app.config.cleanup_job in ("always", "onsuccess"):
+            if job_wrapper.cleanup_job in ("always", "onsuccess"):
                 job_wrapper.cleanup()
             return
 

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -96,10 +96,11 @@ class CondorJobRunner( AsynchronousJobRunner ):
             log.exception( "(%s) failure preparing job script" % galaxy_id_tag )
             return
 
+        cleanup_job = job_wrapper.cleanup_job
         try:
             open(submit_file, "w").write(submit_file_contents)
-        except:
-            if self.app.config.cleanup_job == "always":
+        except Exception:
+            if cleanup_job == "always":
                 cjs.cleanup()
                 # job_wrapper.fail() calls job_wrapper.cleanup()
             job_wrapper.fail( "failure preparing submit file", exception=True )
@@ -109,7 +110,7 @@ class CondorJobRunner( AsynchronousJobRunner ):
         # job was deleted while we were preparing it
         if job_wrapper.get_state() == model.Job.states.DELETED:
             log.debug( "Job %s deleted by user before it entered the queue" % galaxy_id_tag )
-            if self.app.config.cleanup_job in ( "always", "onsuccess" ):
+            if cleanup_job in ("always", "onsuccess"):
                 os.unlink( submit_file )
                 cjs.cleanup()
                 job_wrapper.cleanup()

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -311,7 +311,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         try:
             ext_id = job.get_job_runner_external_id()
             assert ext_id not in ( None, 'None' ), 'External job id is None'
-            kill_script = job.get_destination_configuration(self.app.config, "external_killJob_script", None)
+            kill_script = job.get_destination_configuration(self.app.config, "drmaa_external_killjob_script", None)
             if kill_script is None:
                 self.ds.control( ext_id, drmaa.JobControlAction.TERMINATE )
             else:

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -84,9 +84,6 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         self.ds = drmaa.Session()
         self.ds.initialize()
 
-        # external_runJob_script can be None, in which case it's not used.
-        self.external_runJob_script = app.config.drmaa_external_runjob_script
-        self.external_killJob_script = app.config.drmaa_external_killjob_script
         self.userid = None
 
         self._init_monitor_thread()
@@ -115,6 +112,10 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
     def queue_job( self, job_wrapper ):
         """Create job script and submit it to the DRM"""
         # prepare the job
+
+        # external_runJob_script can be None, in which case it's not used.
+        external_runjob_script = job_wrapper.get_destination_configuration("drmaa_external_runjob_script", None)
+
         include_metadata = asbool( job_wrapper.job_destination.params.get( "embed_metadata_in_job", True) )
         if not self.prepare_job( job_wrapper, include_metadata=include_metadata):
             return
@@ -129,7 +130,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         job_name = 'g%s' % galaxy_id_tag
         if job_wrapper.tool.old_id:
             job_name += '_%s' % job_wrapper.tool.old_id
-        if self.external_runJob_script is None:
+        if external_runjob_script is None:
             job_name += '_%s' % job_wrapper.user
         job_name = ''.join( map( lambda x: x if x in ( string.letters + string.digits + '_' ) else '_', job_name ) )
         ajs = AsynchronousJobState( files_dir=job_wrapper.working_directory, job_wrapper=job_wrapper, job_name=job_name )
@@ -159,7 +160,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         # job was deleted while we were preparing it
         if job_wrapper.get_state() == model.Job.states.DELETED:
             log.debug( "(%s) Job deleted by user before it entered the queue" % galaxy_id_tag )
-            if self.app.config.cleanup_job in ( "always", "onsuccess" ):
+            if job_wrapper.cleanup_job in ( "always", "onsuccess" ):
                 job_wrapper.cleanup()
             return
 
@@ -168,7 +169,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
             log.debug( "(%s) native specification is: %s", galaxy_id_tag, native_spec )
 
         # runJob will raise if there's a submit problem
-        if self.external_runJob_script is None:
+        if external_runjob_script is None:
             # TODO: create a queue for retrying submission indefinitely
             # TODO: configurable max tries and sleep
             trynum = 0
@@ -208,7 +209,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
             log.debug( '(%s) submitting with credentials: %s [uid: %s]' % ( galaxy_id_tag, pwent[0], pwent[2] ) )
             filename = self.store_jobtemplate(job_wrapper, jt)
             self.userid = pwent[2]
-            external_job_id = self.external_runjob(filename, pwent[2]).strip()
+            external_job_id = self.external_runjob(external_runjob_script, filename, pwent[2]).strip()
         log.info( "(%s) queued as %s" % ( galaxy_id_tag, external_job_id ) )
 
         # store runner information for tracking if Galaxy restarts
@@ -310,11 +311,12 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         try:
             ext_id = job.get_job_runner_external_id()
             assert ext_id not in ( None, 'None' ), 'External job id is None'
-            if self.external_killJob_script is None:
+            kill_script = job.get_destination_configuration(self.app.config, "external_killJob_script", None)
+            if kill_script is None:
                 self.ds.control( ext_id, drmaa.JobControlAction.TERMINATE )
             else:
                 # FIXME: hardcoded path
-                subprocess.Popen( [ '/usr/bin/sudo', '-E', self.external_killJob_script, str( ext_id ), str( self.userid ) ], shell=False )
+                subprocess.Popen( [ '/usr/bin/sudo', '-E', kill_script, str( ext_id ), str( self.userid ) ], shell=False )
             log.debug( "(%s/%s) Removed from DRM queue at user's request" % ( job.get_id(), ext_id ) )
         except drmaa.InvalidJobException:
             log.debug( "(%s/%s) User killed running job, but it was already dead" % ( job.get_id(), ext_id ) )
@@ -361,12 +363,12 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         log.debug( '(%s) Job script for external submission is: %s' % ( job_wrapper.job_id, filename ) )
         return filename
 
-    def external_runjob(self, jobtemplate_filename, username):
+    def external_runjob(self, external_runjob_script, jobtemplate_filename, username):
         """ runs an external script the will QSUB a new job.
         The external script will be run with sudo, and will setuid() to the specified user.
         Effectively, will QSUB as a different user (then the one used by Galaxy).
         """
-        script_parts = self.external_runJob_script.split()
+        script_parts = external_runjob_script.split()
         script = script_parts[0]
         command = [ '/usr/bin/sudo', '-E', script]
         for script_argument in script_parts[1:]:

--- a/lib/galaxy/jobs/runners/pbs.py
+++ b/lib/galaxy/jobs/runners/pbs.py
@@ -291,7 +291,7 @@ class PBSJobRunner( AsynchronousJobRunner ):
         if job_wrapper.get_state() == model.Job.states.DELETED:
             log.debug( "Job %s deleted by user before it entered the PBS queue" % job_wrapper.job_id )
             pbs.pbs_disconnect(c)
-            if self.app.config.cleanup_job in ( "always", "onsuccess" ):
+            if job_wrapper.cleanup_job in ( "always", "onsuccess" ):
                 self.cleanup( ( ofile, efile, ecfile, job_file ) )
                 job_wrapper.cleanup()
             return
@@ -480,7 +480,7 @@ class PBSJobRunner( AsynchronousJobRunner ):
         if pbs_job_state.stop_job:
             self.stop_job( self.sa_session.query( self.app.model.Job ).get( pbs_job_state.job_wrapper.job_id ) )
         pbs_job_state.job_wrapper.fail( pbs_job_state.fail_message )
-        if self.app.config.cleanup_job == "always":
+        if pbs_job_state.job_wrapper.cleanup_job == "always":
             self.cleanup( ( pbs_job_state.output_file, pbs_job_state.error_file, pbs_job_state.exit_code_file, pbs_job_state.job_file ) )
 
     def get_stage_in_out( self, fnames, symlink=False ):

--- a/lib/galaxy/jobs/runners/pbs.py
+++ b/lib/galaxy/jobs/runners/pbs.py
@@ -18,7 +18,6 @@ except ImportError as exc:
 from galaxy import model
 from galaxy import util
 from galaxy.util.bunch import Bunch
-from galaxy.util import DATABASE_MAX_STRING_SIZE, shrink_stream_by_size
 from galaxy.jobs import JobDestination
 from galaxy.jobs.runners import AsynchronousJobState, AsynchronousJobRunner
 
@@ -472,49 +471,6 @@ class PBSJobRunner( AsynchronousJobRunner ):
         pbs.pbs_disconnect( c )
         return jobs[0].attribs[0].value
 
-    def finish_job( self, pbs_job_state ):
-        """
-        Get the output/error for a finished job, pass to `job_wrapper.finish`
-        and cleanup all the PBS temporary files.
-        """
-        ofile = pbs_job_state.output_file
-        efile = pbs_job_state.error_file
-        ecfile = pbs_job_state.exit_code_file
-        job_file = pbs_job_state.job_file
-        # collect the output
-        try:
-            ofh = file(ofile, "r")
-            efh = file(efile, "r")
-            ecfh = file(ecfile, "r")
-            stdout = shrink_stream_by_size( ofh, DATABASE_MAX_STRING_SIZE, join_by="\n..\n", left_larger=True, beginning_on_size_error=True )
-            stderr = shrink_stream_by_size( efh, DATABASE_MAX_STRING_SIZE, join_by="\n..\n", left_larger=True, beginning_on_size_error=True )
-            # This should be an 8-bit exit code, but read ahead anyway:
-            exit_code_str = ecfh.read(32)
-        except:
-            stdout = ''
-            stderr = 'Job output not returned by PBS: the output datasets were deleted while the job was running, the job was manually dequeued or there was a cluster error.'
-            # By default, the exit code is 0, which usually indicates success
-            # (although clearly some error happened).
-            exit_code_str = ""
-
-        # Translate the exit code string to an integer; use 0 on failure.
-        try:
-            exit_code = int( exit_code_str )
-        except:
-            log.warning( "Exit code " + exit_code_str + " was invalid. Using 0." )
-            exit_code = 0
-
-        # Call on the job wrapper to complete the call:
-        try:
-            pbs_job_state.job_wrapper.finish( stdout, stderr, exit_code )
-        except:
-            log.exception("Job wrapper finish method failed")
-            pbs_job_state.job_wrapper.fail("Unable to finish job", exception=True)
-
-        # clean up the pbs files
-        if self.app.config.cleanup_job == "always" or ( not stderr and self.app.config.cleanup_job == "onsuccess" ):
-            self.cleanup( ( ofile, efile, ecfile, job_file ) )
-
     def fail_job( self, pbs_job_state ):
         """
         Separated out so we can use the worker threads for it.
@@ -526,13 +482,6 @@ class PBSJobRunner( AsynchronousJobRunner ):
         pbs_job_state.job_wrapper.fail( pbs_job_state.fail_message )
         if self.app.config.cleanup_job == "always":
             self.cleanup( ( pbs_job_state.output_file, pbs_job_state.error_file, pbs_job_state.exit_code_file, pbs_job_state.job_file ) )
-
-    def cleanup( self, files ):
-        for file in files:
-            try:
-                os.unlink( file )
-            except Exception as e:
-                log.warning( "Unable to cleanup: %s" % str( e ) )
 
     def get_stage_in_out( self, fnames, symlink=False ):
         """Convenience function to create a stagein/stageout list"""

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -393,7 +393,7 @@ class PulsarJobRunner( AsynchronousJobRunner ):
             # and cleanup job if needed.
             completed_normally = \
                 job_wrapper.get_state() not in [ model.Job.states.ERROR, model.Job.states.DELETED ]
-            cleanup_job = self.app.config.cleanup_job
+            cleanup_job = job_wrapper.cleanup_job
             client_outputs = self.__client_outputs(client, job_wrapper)
             finish_args = dict( client=client,
                                 job_completed_normally=completed_normally,

--- a/lib/galaxy/jobs/runners/util/job_script/__init__.py
+++ b/lib/galaxy/jobs/runners/util/job_script/__init__.py
@@ -7,7 +7,7 @@ from pkg_resources import resource_string
 from six import text_type
 from galaxy.util import unicodify
 
-DEFAULT_SHELL = '/bin/sh'
+DEFAULT_SHELL = '/bin/bash'
 
 DEFAULT_JOB_FILE_TEMPLATE = Template(
     resource_string(__name__, 'DEFAULT_JOB_FILE_TEMPLATE.sh').decode('UTF-8')

--- a/lib/galaxy/jobs/runners/util/job_script/__init__.py
+++ b/lib/galaxy/jobs/runners/util/job_script/__init__.py
@@ -96,6 +96,10 @@ def check_script_integrity(config):
 
 
 def write_script(path, contents, config, mode=0o755):
+    dir = os.path.dirname(path)
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+
     with open(path, 'w') as f:
         if isinstance(contents, text_type):
             contents = contents.encode("UTF-8")

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -694,6 +694,18 @@ class Job( object, JobLike, Dictifiable ):
         if self.workflow_invocation_step:
             self.workflow_invocation_step.update()
 
+    def get_destination_configuration(self, config, key, default=None):
+        """ Get a destination parameter that can be defaulted back
+        in specified config if it needs to be applied globally.
+        """
+        param_unspecified = object()
+        config_value = (self.destination_params or {}).get(key, param_unspecified)
+        if config_value is param_unspecified:
+            config_value = getattr(config, key, param_unspecified)
+        if config_value is param_unspecified:
+            config_value = default
+        return config_value
+
 
 class Task( object, JobLike ):
     """

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -51,8 +51,8 @@ class ObjectStore(object):
     :param extra_dir: Append `extra_dir` to the directory structure where the
         dataset identified by `obj` should be located. (e.g.,
         000/extra_dir/obj.id). Valid values include 'job_work' (defaulting to
-        config.job_working_directory =
-        '$GALAXY_ROOT/database/job_working_directory');
+        config.jobs_directory =
+        '$GALAXY_ROOT/database/jobs_directory');
         'temp' (defaulting to config.new_file_path =
         '$GALAXY_ROOT/database/tmp').
 
@@ -79,7 +79,7 @@ class ObjectStore(object):
         populated from `galaxy/config.ini`. The following attributes are
         currently used:
             object_store_check_old_style (only used by the DiskObjectStore)
-            job_working_directory -- Each job is given a unique empty directory
+            jobs_directory -- Each job is given a unique empty directory
                 as its current working directory. This option defines in what
                 parent directory those directories will be created.
         """
@@ -87,7 +87,7 @@ class ObjectStore(object):
         self.extra_dirs = {}
         self.config = config
         self.check_old_style = config.object_store_check_old_style
-        self.extra_dirs['job_work'] = config.job_working_directory
+        self.extra_dirs['job_work'] = config.jobs_directory
         self.extra_dirs['temp'] = config.new_file_path
 
     def shutdown(self):
@@ -207,7 +207,7 @@ class DiskObjectStore(ObjectStore):
     >>> import tempfile
     >>> file_path=tempfile.mkdtemp()
     >>> obj = Bunch(id=1)
-    >>> s = DiskObjectStore(Bunch(umask=0o077, job_working_directory=file_path, new_file_path=file_path, object_store_check_old_style=False), file_path=file_path)
+    >>> s = DiskObjectStore(Bunch(umask=0o077, jobs_directory=file_path, new_file_path=file_path, object_store_check_old_style=False), file_path=file_path)
     >>> s.create(obj)
     >>> s.exists(obj)
     True
@@ -221,7 +221,7 @@ class DiskObjectStore(ObjectStore):
             populated from `galaxy/config.ini`. The DiskObjectStore specific
             attributes are:
                 object_store_check_old_style
-                job_working_directory -- Each job is given a unique empty
+                job_directory -- Each job is given a unique empty
                     directory as its current working directory. This option
                     defines in what parent directory those directories will be
                     created.

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -557,8 +557,10 @@ class Tool( object, Dictifiable ):
         self.__parse_legacy_features(tool_source)
 
         # Load any tool specific options (optional)
-        self.options = dict( sanitize=True, refresh=False )
-        self.__update_options_dict( tool_source )
+        self.options = dict(
+            sanitize=tool_source.parse_sanitize(),
+            refresh=tool_source.parse_refresh(),
+        )
         self.options = Bunch(** self.options)
 
         # Parse tool inputs (if there are any required)
@@ -627,19 +629,6 @@ class Tool( object, Dictifiable ):
         if uihints_elem is not None:
             for key, value in uihints_elem.attrib.iteritems():
                 self.uihints[ key ] = value
-
-    def __update_options_dict(self, tool_source):
-        # TODO: Move following logic into ToolSource abstraction.
-        if not hasattr(tool_source, 'root'):
-            return
-
-        root = tool_source.root
-        for option_elem in root.findall("options"):
-            for option, value in self.options.copy().items():
-                if isinstance(value, type(False)):
-                    self.options[option] = string_as_bool(option_elem.get(option, str(value)))
-                else:
-                    self.options[option] = option_elem.get(option, str(value))
 
     def __parse_tests(self, tool_source):
         self.__tests_source = tool_source

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -344,7 +344,6 @@ class Tool( object, Dictifiable ):
         except Exception, e:
             global_tool_errors.add_error(config_file, "Tool Loading", e)
             raise e
-        self.external_runJob_script = app.config.drmaa_external_runjob_script
         self.history_manager = histories.HistoryManager( app )
 
     @property

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -562,6 +562,9 @@ class Tool( object, Dictifiable ):
 
         # Parse result handling for tool exit codes and stdout/stderr messages:
         self.parse_stdio( tool_source )
+
+        self.strict_shell = tool_source.parse_strict_shell()
+
         # Any extra generated config files for the tool
         self.__parse_config_files(tool_source)
         # Action

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -469,7 +469,7 @@ class Tool( object, Dictifiable ):
         else:
             self.id = guid
         if not self.id:
-            raise Exception( "Missing tool 'id'" )
+            raise Exception( "Missing tool 'id' for tool at '%s'" % tool_source )
 
         if not self.legacy_defaults and VERSION_MAJOR < tool_profile:
             template = "The tool %s targets version %s of Galaxy, you should upgrade Galaxy to ensure proper functioning of this tool."
@@ -479,7 +479,7 @@ class Tool( object, Dictifiable ):
         # Get the (user visible) name of the tool
         self.name = tool_source.parse_name()
         if not self.name:
-            raise Exception( "Missing tool 'name'" )
+            raise Exception( "Missing tool 'name' for tool with id '%s' at '%s'" % (self.id, tool_source) )
 
         self.version = tool_source.parse_version()
         if not self.version:
@@ -487,7 +487,7 @@ class Tool( object, Dictifiable ):
                 # For backward compatibility, some tools may not have versions yet.
                 self.version = "1.0.0"
             else:
-                raise Exception( "Missing tool version.")
+                raise Exception( "Missing tool 'version' for tool with id '%s' at '%s'" % (self.id, tool_source) )
 
         # Support multi-byte tools
         self.is_multi_byte = tool_source.parse_is_multi_byte()

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -460,8 +460,7 @@ class Tool( object, Dictifiable ):
         """
         Read tool configuration from the element `root` and fill in `self`.
         """
-        self.legacy_defaults = tool_source.legacy_defaults
-        tool_profile = tool_source.parse_profile()
+        self.profile = float( tool_source.parse_profile() )
         # Get the UNIQUE id for the tool
         self.old_id = tool_source.parse_id()
         if guid is None:
@@ -471,9 +470,9 @@ class Tool( object, Dictifiable ):
         if not self.id:
             raise Exception( "Missing tool 'id' for tool at '%s'" % tool_source )
 
-        if not self.legacy_defaults and VERSION_MAJOR < tool_profile:
+        if self.profile >= 16.04 and VERSION_MAJOR < self.profile:
             template = "The tool %s targets version %s of Galaxy, you should upgrade Galaxy to ensure proper functioning of this tool."
-            message = template % (self.id, tool_profile)
+            message = template % (self.id, self.profile)
             log.warn(message)
 
         # Get the (user visible) name of the tool
@@ -483,7 +482,7 @@ class Tool( object, Dictifiable ):
 
         self.version = tool_source.parse_version()
         if not self.version:
-            if self.legacy_defaults:
+            if self.profile < 16.04:
                 # For backward compatibility, some tools may not have versions yet.
                 self.version = "1.0.0"
             else:

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -224,7 +224,10 @@ class DefaultToolAction( object ):
 
         # Deal with input dataset names, 'dbkey' and types
         input_names = []
-        input_ext = 'data'
+        # format='input" previously would give you a random extension from
+        # the input extensions, now it should just give "input" as the output
+        # format.
+        input_ext = 'data' if tool.legacy_defaults else "input"
         input_dbkey = incoming.get( "dbkey", "?" )
         for name, data in reversed(inp_data.items()):
             if not data:
@@ -239,7 +242,8 @@ class DefaultToolAction( object ):
             else:  # HDA
                 if data.hid:
                     input_names.append( 'data %s' % data.hid )
-            input_ext = data.ext
+            if tool.legacy_defaults:
+                input_ext = data.ext
 
             if data.dbkey not in [None, '?']:
                 input_dbkey = data.dbkey

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -227,7 +227,7 @@ class DefaultToolAction( object ):
         # format='input" previously would give you a random extension from
         # the input extensions, now it should just give "input" as the output
         # format.
-        input_ext = 'data' if tool.legacy_defaults else "input"
+        input_ext = 'data' if tool.profile < 16.04 else "input"
         input_dbkey = incoming.get( "dbkey", "?" )
         for name, data in reversed(inp_data.items()):
             if not data:
@@ -242,7 +242,7 @@ class DefaultToolAction( object ):
             else:  # HDA
                 if data.hid:
                     input_names.append( 'data %s' % data.hid )
-            if tool.legacy_defaults:
+            if tool.profile < 16.04:
                 input_ext = data.ext
 
             if data.dbkey not in [None, '?']:

--- a/lib/galaxy/tools/cwl/__init__.py
+++ b/lib/galaxy/tools/cwl/__init__.py
@@ -1,4 +1,5 @@
 from .parser import tool_proxy
+from .parser import workflow_proxy
 from .runtime_actions import handle_outputs
 from .representation import to_cwl_job, to_galaxy_parameters
 
@@ -10,6 +11,7 @@ from .cwltool_deps import (
 
 __all__ = [
     'tool_proxy',
+    'workflow_proxy',
     'handle_outputs',
     'to_cwl_job',
     'to_galaxy_parameters',

--- a/lib/galaxy/tools/cwl/parser.py
+++ b/lib/galaxy/tools/cwl/parser.py
@@ -4,20 +4,38 @@ adapt cwltool to Galaxy features and abstract the library away from the rest
 of the framework.
 """
 from __future__ import absolute_import
-from abc import ABCMeta, abstractmethod
-from galaxy.util.odict import odict
+
 import json
+import logging
 import os
+from abc import ABCMeta, abstractmethod
+
+from galaxy.util import safe_makedirs
+from galaxy.util.bunch import Bunch
+from galaxy.util.odict import odict
 
 from .cwltool_deps import (
+    ensure_cwltool_available,
     main,
     workflow,
-    ensure_cwltool_available,
 )
 
-from galaxy.util.bunch import Bunch
+log = logging.getLogger(__name__)
 
 JOB_JSON_FILE = ".cwl_job.json"
+SECONDARY_FILES_EXTRA_PREFIX = "__secondary_files__"
+
+
+SUPPORTED_TOOL_REQUIREMENTS = [
+    "CreateFileRequirement",
+    "DockerRequirement",
+    "EnvVarRequirement",
+    "InlineJavascriptRequirement",
+]
+
+
+SUPPORTED_WORKFLOW_REQUIREMENTS = SUPPORTED_TOOL_REQUIREMENTS + [
+]
 
 
 def tool_proxy(tool_path):
@@ -29,29 +47,80 @@ def tool_proxy(tool_path):
     return tool
 
 
+def workflow_proxy(workflow_path):
+    ensure_cwltool_available()
+    workflow = to_cwl_workflow_object(workflow_path)
+    return workflow
+
+
 def load_job_proxy(job_directory):
     ensure_cwltool_available()
     job_objects_path = os.path.join(job_directory, JOB_JSON_FILE)
     job_objects = json.load(open(job_objects_path, "r"))
     tool_path = job_objects["tool_path"]
     job_inputs = job_objects["job_inputs"]
+    output_dict = job_objects["output_dict"]
     cwl_tool = tool_proxy(tool_path)
-    cwl_job = cwl_tool.job_proxy(job_inputs, job_directory=job_directory)
+    cwl_job = cwl_tool.job_proxy(job_inputs, output_dict, job_directory=job_directory)
     return cwl_job
 
 
 def to_cwl_tool_object(tool_path):
-    if workflow is None:
-        raise Exception("Using CWL tools requires cwltool module.")
     proxy_class = None
     cwl_tool = None
     make_tool = workflow.defaultMakeTool
     cwl_tool = main.load_tool(tool_path, False, False, make_tool, False)
-    proxy_class = Draft2ToolProxy
-    if proxy_class is None:
-        raise Exception("Unsupported CWL object encountered.")
+    if isinstance(cwl_tool, int):
+        raise Exception("Failed to load tool.")
+
+    raw_tool = cwl_tool.tool
+    check_requirements(raw_tool)
+    if "class" not in raw_tool:
+        raise Exception("File does not declare a class, not a valid Draft 3+ CWL tool.")
+    process_class = raw_tool["class"]
+    if process_class == "CommandLineTool":
+        proxy_class = CommandLineToolProxy
+    elif process_class == "ExpressionTool":
+        proxy_class = ExpressionToolProxy
+    else:
+        raise Exception("File not a CWL CommandLineTool.")
+    if "cwlVersion" not in raw_tool:
+        raise Exception("File does not declare a CWL version, pre-draft 3 CWL tools are not supported.")
+
+    cwl_version = raw_tool["cwlVersion"]
+    if cwl_version != "https://w3id.org/cwl/cwl#draft-3":
+        raise Exception("Only draft 3 CWL tools are supported by Galaxy.")
+
     proxy = proxy_class(cwl_tool, tool_path)
     return proxy
+
+
+def to_cwl_workflow_object(workflow_path):
+    proxy_class = WorkflowProxy
+    make_tool = workflow.defaultMakeTool
+    cwl_workflow = main.load_tool(workflow_path, False, False, make_tool, False)
+    raw_workflow = cwl_workflow.tool
+    check_requirements(raw_workflow, tool=False)
+
+    proxy = proxy_class(cwl_workflow, workflow_path)
+    return proxy
+
+
+def check_requirements(rec, tool=True):
+    if isinstance(rec, dict):
+        if "requirements" in rec:
+            for r in rec["requirements"]:
+                if tool:
+                    possible = SUPPORTED_TOOL_REQUIREMENTS
+                else:
+                    possible = SUPPORTED_WORKFLOW_REQUIREMENTS
+                if r["class"] not in possible:
+                    raise Exception("Unsupported requirement %s" % r["class"])
+        for d in rec:
+            check_requirements(rec[d], tool=tool)
+    if isinstance(rec, list):
+        for d in rec:
+            check_requirements(d, tool=tool)
 
 
 class ToolProxy( object ):
@@ -61,12 +130,12 @@ class ToolProxy( object ):
         self._tool = tool
         self._tool_path = tool_path
 
-    def job_proxy(self, input_dict, job_directory="."):
+    def job_proxy(self, input_dict, output_dict, job_directory="."):
         """ Build a cwltool.job.Job describing computation using a input_json
         Galaxy will generate mapping the Galaxy description of the inputs into
         a cwltool compatible variant.
         """
-        return JobProxy(self, input_dict, job_directory=job_directory)
+        return JobProxy(self, input_dict, output_dict, job_directory=job_directory)
 
     @abstractmethod
     def input_instances(self):
@@ -85,7 +154,7 @@ class ToolProxy( object ):
         """ Return description to tool. """
 
 
-class Draft2ToolProxy(ToolProxy):
+class CommandLineToolProxy(ToolProxy):
 
     def description(self):
         # Feels like I should be getting some abstract namespaced thing
@@ -116,8 +185,6 @@ class Draft2ToolProxy(ToolProxy):
         rval = []
         if not rval and schema["type"] == "record":
             for output in schema["fields"]:
-                # TODO: Handle non-files differently? Make them
-                # JSON maybe?.
                 # output_type = output.get("type", None)
                 # if output_type != "File":
                 #     template = "Unhandled output type [%s] encountered."
@@ -138,87 +205,230 @@ class Draft2ToolProxy(ToolProxy):
         return None
 
 
+class ExpressionToolProxy(CommandLineToolProxy):
+    pass
+
+
 class JobProxy(object):
 
-    def __init__(self, tool_proxy, input_dict, job_directory):
+    def __init__(self, tool_proxy, input_dict, output_dict, job_directory):
         self._tool_proxy = tool_proxy
         self._input_dict = input_dict
+        self._output_dict = output_dict
         self._job_directory = job_directory
 
-    def cwl_job(self):
-        return self._tool_proxy._tool.job(
-            self._input_dict,
-            self._job_directory,
-            self._output_callback,
-            use_container=False
-        ).next()
+        self._final_output = []
+        self._ok = True
+        self._cwl_job = None
+        self._is_command_line_job = None
 
-    def _output_callback(self, out):
-        pass
+    def cwl_job(self):
+        self._ensure_cwl_job_initialized()
+        return self._cwl_job
+
+    @property
+    def is_command_line_job(self):
+        self._ensure_cwl_job_initialized()
+        assert self._is_command_line_job is not None
+
+    def _ensure_cwl_job_initialized(self):
+        if self._cwl_job is None:
+            self._cwl_job = self._tool_proxy._tool.job(
+                self._input_dict,
+                self._job_directory,
+                self._output_callback,
+                use_container=False
+            ).next()
+            self._is_command_line_job = hasattr(self._cwl_job, "command_line")
+
+    @property
+    def command_line(self):
+        if self.is_command_line_job:
+            return self.cwl_job().command_line
+        else:
+            return ["true"]
+
+    @property
+    def stdin(self):
+        if self.is_command_line_job:
+            return self.cwl_job().stdin
+        else:
+            return None
+
+    @property
+    def stdout(self):
+        if self.is_command_line_job:
+            return self.cwl_job().stdout
+        else:
+            return None
+
+    @property
+    def environment(self):
+        if self.is_command_line_job:
+            return self.cwl_job().environment
+        else:
+            return {}
+
+    @property
+    def generate_files(self):
+        if self.is_command_line_job:
+            return self.cwl_job().generatefiles
+        else:
+            return {}
+
+    def _output_callback(self, out, process_status):
+        if process_status == "success":
+            self._final_output = out
+        else:
+            self._ok = False
+
+        log.info("Output are %s, status is %s" % (out, process_status))
+
+    def collect_outputs(self, tool_working_directory):
+        if not self.is_command_line_job:
+            self.cwl_job().run(
+            )
+            return self._final_output
+        else:
+            return self.cwl_job().collect_outputs(tool_working_directory)
 
     def save_job(self):
         job_file = JobProxy._job_file(self._job_directory)
         job_objects = {
             "tool_path": os.path.abspath(self._tool_proxy._tool_path),
             "job_inputs": self._input_dict,
+            "output_dict": self._output_dict,
         }
         json.dump(job_objects, open(job_file, "w"))
 
-    # @staticmethod
-    # def load_job(tool_proxy, job_directory):
-    #     job_file = JobProxy._job_file(job_directory)
-    #     input_dict = json.load(open(job_file, "r"))
-    #     return JobProxy(tool_proxy, input_dict, job_directory)
+    def _output_extra_files_dir(self, output_name):
+        output_id = self.output_id(output_name)
+        return os.path.join(self._job_directory, "dataset_%s_files" % output_id)
+
+    def output_id(self, output_name):
+        output_id = self._output_dict[output_name]["id"]
+        return output_id
+
+    def output_path(self, output_name):
+        output_id = self._output_dict[output_name]["path"]
+        return output_id
+
+    def output_secondary_files_dir(self, output_name, create=False):
+        extra_files_dir = self._output_extra_files_dir(output_name)
+        secondary_files_dir = os.path.join(extra_files_dir, SECONDARY_FILES_EXTRA_PREFIX)
+        if create and not os.path.exists(secondary_files_dir):
+            safe_makedirs(secondary_files_dir)
+        return secondary_files_dir
 
     @staticmethod
     def _job_file(job_directory):
         return os.path.join(job_directory, JOB_JSON_FILE)
 
 
-def _simple_field_union(field):
-    field_type = _field_to_field_type(field)
-    non_null_type = None
-    if len(field_type) == 2:
-        if "null" == field_type[0]:
-            non_null_type = field_type[1]
-        elif "null" == field_type[1]:
-            non_null_type = field_type[1]
+class WorkflowProxy(object):
 
-    if non_null_type is None:
-        raise Exception("General union types not yet implemented (simple).")
+    def __init__(self, workflow, workflow_path):
+        self._workflow = workflow
+        self._workflow_path = workflow_path
+
+    def step_proxies(self):
+        proxies = []
+        for step in self._workflow.steps:
+            proxies.append(StepProxy(self, step))
+        return proxies
+
+    @property
+    def runnables(self):
+        runnables = []
+        for step in self._workflow.steps:
+            print dir(step)
+            if "run" in step.tool:
+                runnables.append(step.tool["run"])
+        return runnables
+
+    def to_dict(self):
+        name = os.path.basename(self._workflow_path)
+        steps = {}
+
+        index = 0
+        for i, input_dict in self._workflow.tool['inputs']:
+            index += 1
+            steps[index] = input_dict
+
+        for i, step_proxy in enumerate(self.step_proxies()):
+            index += 1
+            steps[index] = step_proxy.to_dict()
+
+        return {
+            'name': name,
+            'steps': steps,
+        }
+
+
+class StepProxy(object):
+
+    def __init__(self, workflow_proxy, step):
+        self._workflow_proxy = workflow_proxy
+        self._step = step
+
+    def to_dict(self):
+        return {}
+
+
+def _simple_field_union(field):
+    field_type = _field_to_field_type(field)  # Must be a list if in here?
+
+    def any_of_in_field_type(types):
+        return any([t in field_type for t in types])
 
     name, label, description = _field_metadata(field)
 
     case_name = "_cwl__type_"
-    case_label = "Specify %s" % label
+    case_label = "Specify Parameter %s As" % label
 
-    options = [
-        {"value": "null", "label": "No", "selected": True},
-        {"value": "%s" % non_null_type, "label": "Yes", "selected": False},
-    ]
+    def value_input(**kwds):
+        value_name = "_cwl__value_"
+        value_label = label
+        value_description = description
+        return InputInstance(
+            value_name,
+            value_label,
+            value_description,
+            **kwds
+        )
+
+    select_options = []
+    case_options = []
+    if "null" in field_type:
+        select_options.append({"value": "null", "label": "None", "selected": True})
+        case_options.append(("null", []))
+    if any_of_in_field_type(["Any", "string"]):
+        select_options.append({"value": "string", "label": "Simple String"})
+        case_options.append(("string", [value_input(input_type=INPUT_TYPE.TEXT)]))
+    if any_of_in_field_type(["Any", "boolean"]):
+        select_options.append({"value": "boolean", "label": "Boolean"})
+        case_options.append(("boolean", [value_input(input_type=INPUT_TYPE.BOOLEAN)]))
+    if any_of_in_field_type(["Any", "int"]):
+        select_options.append({"value": "int", "label": "Integer"})
+        case_options.append(("int", [value_input(input_type=INPUT_TYPE.INTEGER)]))
+    if any_of_in_field_type(["Any", "float"]):
+        select_options.append({"value": "float", "label": "Floating Point Number"})
+        case_options.append(("float", [value_input(input_type=INPUT_TYPE.FLOAT)]))
+    if any_of_in_field_type(["Any", "File"]):
+        select_options.append({"value": "data", "label": "Dataset"})
+        case_options.append(("data", [value_input(input_type=INPUT_TYPE.DATA)]))
+    if "Any" in field_type:
+        select_options.append({"value": "json", "label": "JSON Data Structure"})
+        case_options.append(("json", [value_input(input_type=INPUT_TYPE.TEXT, area=True)]))
 
     case_input = SelectInputInstance(
         name=case_name,
         label=case_label,
         description=False,
-        options=options,
+        options=select_options,
     )
 
-    non_null_type_kwds = _simple_field_to_input_type_kwds(field, field_type=non_null_type)
-    non_null_name = "_cwl__value_"
-    non_null_label = label
-    non_null_description = description
-    non_null_input = InputInstance(
-        non_null_name,
-        non_null_label,
-        non_null_description,
-        **non_null_type_kwds
-    )
-    options = [
-        ("null", []),
-        (non_null_type, [non_null_input]),
-    ]
-    return ConditionalInstance(name, case_input, options)
+    return ConditionalInstance(name, case_input, case_options)
 
 
 def _simple_field_to_input(field):
@@ -237,6 +447,9 @@ def _simple_field_to_input_type_kwds(field, field_type=None):
     simple_map_type_map = {
         "File": INPUT_TYPE.DATA,
         "int": INPUT_TYPE.INTEGER,
+        "long": INPUT_TYPE.INTEGER,
+        "float": INPUT_TYPE.INTEGER,
+        "double": INPUT_TYPE.INTEGER,
         "string": INPUT_TYPE.TEXT,
         "boolean": INPUT_TYPE.BOOLEAN,
     }
@@ -270,6 +483,9 @@ def _field_to_field_type(field):
         elif len(field_type) == 1:
             field_type = field_type[0]
 
+    if field_type == "Any":
+        field_type = ["Any"]
+
     return field_type
 
 
@@ -282,13 +498,19 @@ def _field_metadata(field):
 
 def _simple_field_to_output(field):
     name = field["name"]
-    output_instance = OutputInstance(name, output_type=OUTPUT_TYPE.GLOB)
+    output_data_class = field["type"]
+    output_instance = OutputInstance(
+        name,
+        output_data_type=output_data_class,
+        output_type=OUTPUT_TYPE.GLOB
+    )
     return output_instance
 
 
 INPUT_TYPE = Bunch(
     DATA="data",
     INTEGER="integer",
+    FLOAT="float",
     TEXT="text",
     BOOLEAN="boolean",
     SELECT="select",
@@ -341,13 +563,14 @@ class SelectInputInstance(object):
 
 class InputInstance(object):
 
-    def __init__(self, name, label, description, input_type, array=False):
+    def __init__(self, name, label, description, input_type, array=False, area=False):
         self.input_type = input_type
         self.name = name
         self.label = label
         self.description = description
         self.required = True
         self.array = array
+        self.area = area
 
     def to_dict(self, itemwise=True):
         if itemwise and self.array:
@@ -367,8 +590,13 @@ class InputInstance(object):
                 type=self.input_type,
                 optional=not self.required,
             )
+            if self.area:
+                as_dict["area"] = True
+
             if self.input_type == INPUT_TYPE.INTEGER:
                 as_dict["value"] = "0"
+            if self.input_type == INPUT_TYPE.FLOAT:
+                as_dict["value"] = "0.0"
         return as_dict
 
 
@@ -380,8 +608,9 @@ OUTPUT_TYPE = Bunch(
 
 class OutputInstance(object):
 
-    def __init__(self, name, output_type, path=None):
+    def __init__(self, name, output_data_type, output_type, path=None):
         self.name = name
+        self.output_data_type = output_data_type
         self.output_type = output_type
         self.path = path
 

--- a/lib/galaxy/tools/cwl/representation.py
+++ b/lib/galaxy/tools/cwl/representation.py
@@ -1,29 +1,78 @@
 """ This module is responsible for converting between Galaxy's tool
 input description and the CWL description for a job json. """
 
+from six import string_types
+import json
+import os
+
 import logging
 
-from galaxy.util import string_as_bool
+from galaxy.util import string_as_bool, safe_makedirs
+from galaxy.exceptions import RequestParameterInvalidException
 
 log = logging.getLogger(__name__)
 
 NOT_PRESENT = object()
 
+GALAXY_TO_CWL_TYPES = {
+    'integer': 'integer',
+    'float': 'float',
+    'data': 'File',
+    'boolean': 'boolean',
+}
 
-def to_cwl_job(tool, param_dict):
+
+def to_cwl_job(tool, param_dict, local_working_directory):
     """ tool is Galaxy's representation of the tool and param_dict is the
     parameter dictionary with wrapped values.
     """
     inputs = tool.inputs
     input_json = {}
 
-    def simple_value(input, param_dict_value):
-        if input.type == "data":
-            return {"path": str(param_dict_value), "class": "File"}
-        elif input.type == "integer":
+    inputs_dir = os.path.join(local_working_directory, "_inputs")
+
+    def simple_value(input, param_dict_value, cwl_type=None):
+        # Hmm... cwl_type isn't really the cwl type in every case,
+        # like in the case of json for instance.
+        if cwl_type is None:
+            input_type = input.type
+            cwl_type = GALAXY_TO_CWL_TYPES[input_type]
+
+        if cwl_type == "null":
+            assert param_dict_value is None
+            return None
+        if cwl_type == "File":
+            dataset_wrapper = param_dict_value
+            extra_files_path = dataset_wrapper.extra_files_path
+            secondary_files_path = os.path.join(extra_files_path, "__secondary_files__")
+            path = str(dataset_wrapper)
+            if os.path.exists(secondary_files_path):
+                safe_makedirs(inputs_dir)
+                name = os.path.basename(path)
+                new_input_path = os.path.join(inputs_dir, name)
+                os.symlink(path, new_input_path)
+                for secondary_file_name in os.listdir(secondary_files_path):
+                    secondary_file_path = os.path.join(secondary_files_path, secondary_file_name)
+                    os.symlink(secondary_file_path, new_input_path + secondary_file_name)
+                path = new_input_path
+
+            return {"path": path, "class": "File"}
+        elif cwl_type == "integer":
             return int(str(param_dict_value))
-        elif input.type == "boolean":
+        elif cwl_type == "long":
+            return int(str(param_dict_value))
+        elif cwl_type == "float":
+            return float(str(param_dict_value))
+        elif cwl_type == "double":
+            return float(str(param_dict_value))
+        elif cwl_type == "boolean":
             return string_as_bool(param_dict_value)
+        elif cwl_type == "string":
+            return str(param_dict_value)
+        elif cwl_type == "json":
+            raw_value = param_dict_value.value
+            log.info("raw_value is %s (%s)" % (raw_value, type(raw_value)))
+            return json.loads(raw_value)
         else:
             return str(param_dict_value)
 
@@ -37,12 +86,11 @@ def to_cwl_job(tool, param_dict):
         elif input.type == "conditional":
             assert input_name in param_dict, "No value for %s in %s" % (input_name, param_dict)
             current_case = param_dict[input_name]["_cwl__type_"]
-            if current_case != "null":
-                # TODO: make sure trans is not needed here...
+            if str(current_case) != "null":  # str because it is a wrapped...
                 case_index = input.get_current_case( current_case )
-                case_input = input.cases[ case_index ].inputs[ "_cwl__value_"]
+                case_input = input.cases[ case_index ].inputs["_cwl__value_"]
                 case_value = param_dict[input_name]["_cwl__value_"]
-                input_json[input_name] = simple_value(case_input, case_value)
+                input_json[input_name] = simple_value(case_input, case_value, cwl_type=current_case)
         else:
             input_json[input_name] = simple_value(input, param_dict[input_name])
 
@@ -59,13 +107,17 @@ def to_galaxy_parameters(tool, as_dict):
     inputs = tool.inputs
     galaxy_request = {}
 
-    def from_simple_value(input, param_dict_value):
-        return param_dict_value
+    def from_simple_value(input, param_dict_value, cwl_type=None):
+        if cwl_type == "json":
+            return json.dumps(param_dict_value)
+        else:
+            return param_dict_value
 
     for input_name, input in inputs.iteritems():
         as_dict_value = as_dict.get(input_name, NOT_PRESENT)
+        galaxy_input_type = input.type
 
-        if input.type == "repeat":
+        if galaxy_input_type == "repeat":
             if input_name not in as_dict:
                 continue
 
@@ -74,21 +126,46 @@ def to_galaxy_parameters(tool, as_dict):
                 key = "%s_repeat_0|%s" % (input_name, only_input.name)
                 galaxy_value = from_simple_value(only_input, value)
                 galaxy_request[key] = galaxy_value
-        elif input.type == "conditional":
+        elif galaxy_input_type == "conditional":
+            case_strings = input.case_strings
             # TODO: less crazy handling of defaults...
-            if as_dict_value is NOT_PRESENT:
+            if (as_dict_value is NOT_PRESENT or as_dict_value is None) and "null" in case_strings:
                 cwl_type = "null"
-            elif isinstance(as_dict_value, bool):
+            elif (as_dict_value is NOT_PRESENT or as_dict_value is None):
+                raise RequestParameterInvalidException(
+                    "Cannot translate CWL datatype - value [%s] of type [%s] with case_strings [%s]. Non-null property must be set." % (
+                        as_dict_value, type(as_dict_value), case_strings
+                    )
+                )
+            elif isinstance(as_dict_value, bool) and "boolean" in case_strings:
                 cwl_type = "boolean"
-            elif isinstance(as_dict_value, int):
+            elif isinstance(as_dict_value, int) and "integer" in case_strings:
                 cwl_type = "integer"
-            else:
+            elif isinstance(as_dict_value, int) and "long" in case_strings:
+                cwl_type = "long"
+            elif isinstance(as_dict_value, (int, float)) and "float" in case_strings:
+                cwl_type = "float"
+            elif isinstance(as_dict_value, (int, float)) and "double" in case_strings:
+                cwl_type = "double"
+            elif isinstance(as_dict_value, string_types) and "string" in case_strings:
                 cwl_type = "string"
+            elif isinstance(as_dict_value, dict) and "src" in as_dict_value and "id" in as_dict_value:
+                # Bit problematic...
+                cwl_type = "File"
+            elif "json" in case_strings and as_dict_value is not None:
+                cwl_type = "json"
+            else:
+                raise RequestParameterInvalidException(
+                    "Cannot translate CWL datatype - value [%s] of type [%s] with case_strings [%s]." % (
+                        as_dict_value, type(as_dict_value), case_strings
+                    )
+                )
             galaxy_request["%s|_cwl__type_" % input_name] = cwl_type
             if cwl_type != "null":
                 current_case_index = input.get_current_case(cwl_type)
-                current_case_input = input.cases[ current_case_index ].inputs[ "_cwl__value_" ]
-                galaxy_value = from_simple_value(current_case_input, as_dict_value)
+                current_case_inputs = input.cases[ current_case_index ].inputs
+                current_case_input = current_case_inputs[ "_cwl__value_" ]
+                galaxy_value = from_simple_value(current_case_input, as_dict_value, cwl_type)
                 galaxy_request["%s|_cwl__value_" % input_name] = galaxy_value
         elif as_dict_value is NOT_PRESENT:
             continue

--- a/lib/galaxy/tools/cwl/runtime_actions.py
+++ b/lib/galaxy/tools/cwl/runtime_actions.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 
@@ -11,18 +12,42 @@ def handle_outputs(job_directory=None):
     # Relocate dynamically collected files to pre-determined locations
     # registered with ToolOutput objects via from_work_dir handling.
     if job_directory is None:
-        job_directory = os.getcwd()
+        job_directory = os.path.join(os.getcwd(), os.path.pardir)
     cwl_job_file = os.path.join(job_directory, JOB_JSON_FILE)
     if not os.path.exists(cwl_job_file):
         # Not a CWL job, just continue
         return
     job_proxy = load_job_proxy(job_directory)
-    cwl_job = job_proxy.cwl_job()
-    outputs = cwl_job.collect_outputs(job_directory)
+    tool_working_directory = os.path.join(job_directory, "working")
+    outputs = job_proxy.collect_outputs(tool_working_directory)
     for output_name, output in outputs.iteritems():
-        target_path = os.path.join(job_directory, "__cwl_output_%s" % output_name)
-        shutil.move(output["path"], target_path)
-
+        target_path = job_proxy.output_path( output_name )
+        if isinstance(output, dict) and "path" in output:
+            output_path = output["path"]
+            if output["class"] != "File":
+                open("galaxy.json", "w").write(json.dump({
+                    "dataset_id": job_proxy.output_id(output_name),
+                    "type": "dataset",
+                    "ext": "expression.json",
+                }))
+            shutil.move(output_path, target_path)
+            for secondary_file in output.get("secondaryFiles", []):
+                # TODO: handle nested files...
+                secondary_file_path = secondary_file["path"]
+                assert secondary_file_path.startswith(output_path)
+                secondary_file_name = secondary_file_path[len(output_path):]
+                secondary_files_dir = job_proxy.output_secondary_files_dir(
+                    output_name, create=True
+                )
+                extra_target = os.path.join(secondary_files_dir, secondary_file_name)
+                shutil.move(
+                    secondary_file_path,
+                    extra_target,
+                )
+                print extra_target
+        else:
+            with open(target_path, "w") as f:
+                f.write(json.dumps(output))
 
 __all__ = [
     'handle_outputs',

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -526,7 +526,7 @@ class ToolEvaluator( object ):
         param_dict = self.param_dict
         directory = self.local_working_directory
         command = self.tool.command
-        if command and "$param_file" in command:
+        if self.tool.legacy_defaults and command and "$param_file" in command:
             fd, param_filename = tempfile.mkstemp( dir=directory )
             os.close( fd )
             f = open( param_filename, "w" )

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -526,7 +526,7 @@ class ToolEvaluator( object ):
         param_dict = self.param_dict
         directory = self.local_working_directory
         command = self.tool.command
-        if self.tool.legacy_defaults and command and "$param_file" in command:
+        if self.tool.profile < 16.04 and command and "$param_file" in command:
             fd, param_filename = tempfile.mkstemp( dir=directory )
             os.close( fd )
             f = open( param_filename, "w" )

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -191,7 +191,12 @@ def collect_primary_datasets( tool, output, job_working_directory, input_ext, in
     sa_session = tool.sa_session
     new_primary_datasets = {}
     try:
-        json_file = open( os.path.join( job_working_directory, jobs.TOOL_PROVIDED_JOB_METADATA_FILE ), 'r' )
+        galaxy_json_path = os.path.join( job_working_directory, "working", jobs.TOOL_PROVIDED_JOB_METADATA_FILE )
+        # LEGACY: Remove in 17.XX
+        if not os.path.exists( galaxy_json_path ):
+            # Maybe this is a legacy job, use the job working directory instead
+            galaxy_json_path = os.path.join( job_working_directory, jobs.TOOL_PROVIDED_JOB_METADATA_FILE )
+        json_file = open( galaxy_json_path, 'r' )
         for line in json_file:
             line = json.loads( line )
             if line.get( 'type' ) == 'new_primary_dataset':

--- a/lib/galaxy/tools/parser/cwl.py
+++ b/lib/galaxy/tools/parser/cwl.py
@@ -61,6 +61,9 @@ class CwlToolSource(ToolSource):
     def parse_help(self):
         return ""
 
+    def parse_strict_shell(self):
+        return True
+
     def parse_stdio(self):
         # TODO: remove duplication with YAML
         from galaxy.jobs.error_level import StdioErrorLevel

--- a/lib/galaxy/tools/parser/cwl.py
+++ b/lib/galaxy/tools/parser/cwl.py
@@ -24,6 +24,7 @@ class CwlToolSource(ToolSource):
         self._cwl_tool_file = tool_file
         self._id, _ = os.path.splitext(os.path.basename(tool_file))
         self._tool_proxy = tool_proxy(tool_file)
+        self._source_path = tool_file
 
     @property
     def tool_proxy(self):

--- a/lib/galaxy/tools/parser/cwl.py
+++ b/lib/galaxy/tools/parser/cwl.py
@@ -133,6 +133,9 @@ class CwlToolSource(ToolSource):
             containers=containers,
         ))
 
+    def parse_profile(self):
+        return "16.04"
+
 
 class CwlPageSource(PageSource):
 

--- a/lib/galaxy/tools/parser/cwl.py
+++ b/lib/galaxy/tools/parser/cwl.py
@@ -61,6 +61,9 @@ class CwlToolSource(ToolSource):
     def parse_help(self):
         return ""
 
+    def parse_sanitize(self):
+        return False
+
     def parse_strict_shell(self):
         return True
 
@@ -107,7 +110,10 @@ class CwlToolSource(ToolSource):
         name = output_instance.name
         # TODO: handle filters, actions, change_format
         output = ToolOutput( name )
-        output.format = "_sniff_"
+        if "File" in output_instance.output_data_type:
+            output.format = "_sniff_"
+        else:
+            output.format = "expression.json"
         output.change_format = []
         output.format_source = None
         output.metadata_source = ""
@@ -116,9 +122,8 @@ class CwlToolSource(ToolSource):
         output.count = None
         output.filters = []
         output.tool = tool
-        output.from_work_dir = "__cwl_output_%s" % name
         output.hidden = ""
-        output.dataset_collectors = []
+        output.dataset_collector_descriptions = []
         output.actions = ToolOutputActionGroup( output, None )
         return output
 

--- a/lib/galaxy/tools/parser/factory.py
+++ b/lib/galaxy/tools/parser/factory.py
@@ -21,20 +21,20 @@ def get_tool_source(config_file, enable_beta_formats=True):
     if not enable_beta_formats:
         tree = load_tool_xml(config_file)
         root = tree.getroot()
-        return XmlToolSource(root)
+        return XmlToolSource(root, source_path=config_file)
 
     if config_file.endswith(".yml"):
         log.info("Loading tool from YAML - this is experimental - tool will not function in future.")
         with open(config_file, "r") as f:
             as_dict = ordered_load(f)
-            return YamlToolSource(as_dict)
+            return YamlToolSource(as_dict, source_path=config_file)
     elif config_file.endswith(".json") or config_file.endswith(".cwl"):
         log.info("Loading CWL tool - this is experimental - tool likely will not function in future at least in same way.")
         return CwlToolSource(config_file)
     else:
         tree = load_tool_xml(config_file)
         root = tree.getroot()
-        return XmlToolSource(root)
+        return XmlToolSource(root, source_path=config_file)
 
 
 def ordered_load(stream):

--- a/lib/galaxy/tools/parser/interface.py
+++ b/lib/galaxy/tools/parser/interface.py
@@ -130,6 +130,16 @@ class ToolSource(object):
         """
         return False
 
+    def parse_sanitize(self):
+        """ Return boolean indicating whether tool should be sanitized or not.
+        """
+        return True
+
+    def parse_refresh(self):
+        """ Return boolean indicating ... I have no clue...
+        """
+        return False
+
     @abstractmethod
     def parse_requirements_and_containers(self):
         """ Return pair of ToolRequirement and ContainerDescription lists. """

--- a/lib/galaxy/tools/parser/interface.py
+++ b/lib/galaxy/tools/parser/interface.py
@@ -140,6 +140,12 @@ class ToolSource(object):
         """
 
     @abstractmethod
+    def parse_strict_shell(self):
+        """ Return True if tool commands should be executed with
+        set -e.
+        """
+
+    @abstractmethod
     def parse_stdio(self):
         """ Builds lists of ToolStdioExitCode and ToolStdioRegex objects
         to describe tool execution error conditions.

--- a/lib/galaxy/tools/parser/interface.py
+++ b/lib/galaxy/tools/parser/interface.py
@@ -1,9 +1,12 @@
 from abc import ABCMeta
 from abc import abstractmethod
 
+import six
+
 NOT_IMPLEMENTED_MESSAGE = "Galaxy tool format does not yet support this tool feature."
 
 
+@six.python_2_unicode_compatible
 class ToolSource(object):
     """ This interface represents an abstract source to parse tool
     information from.
@@ -181,6 +184,14 @@ class ToolSource(object):
 
     def parse_tests_to_dict(self):
         return {'tests': []}
+
+    def __str__(self):
+        source_path = getattr(self, "_soure_path", None)
+        if source_path:
+            as_str = u'%s[%s]' % (self.__class__.__name__, source_path)
+        else:
+            as_str = u'%s[In-memory]' % (self.__class__.__name__)
+        return as_str
 
 
 class PagesSource(object):

--- a/lib/galaxy/tools/parser/interface.py
+++ b/lib/galaxy/tools/parser/interface.py
@@ -11,6 +11,11 @@ class ToolSource(object):
     __metaclass__ = ABCMeta
     default_is_multi_byte = False
 
+    @property
+    def legacy_defaults(self):
+        # Restore oldest defaults for XML-based tools.
+        return self.parse_profile() == "legacy"
+
     @abstractmethod
     def parse_id(self):
         """ Parse an ID describing the abstract tool. This is not the
@@ -156,6 +161,12 @@ class ToolSource(object):
     def parse_help(self):
         """ Return RST definition of help text for tool or None if the tool
         doesn't define help text.
+        """
+
+    @abstractmethod
+    def parse_profile(self):
+        """ Return tool profile to use, currently this should be a Galaxy
+        version (> 16.04) or 'legacy'.
         """
 
     def parse_tests_to_dict(self):

--- a/lib/galaxy/tools/parser/interface.py
+++ b/lib/galaxy/tools/parser/interface.py
@@ -14,11 +14,6 @@ class ToolSource(object):
     __metaclass__ = ABCMeta
     default_is_multi_byte = False
 
-    @property
-    def legacy_defaults(self):
-        # Restore oldest defaults for XML-based tools.
-        return self.parse_profile() == "legacy"
-
     @abstractmethod
     def parse_id(self):
         """ Parse an ID describing the abstract tool. This is not the
@@ -178,8 +173,7 @@ class ToolSource(object):
 
     @abstractmethod
     def parse_profile(self):
-        """ Return tool profile to use, currently this should be a Galaxy
-        version (> 16.04) or 'legacy'.
+        """ Return tool profile version as Galaxy major e.g. 16.01 or 16.04.
         """
 
     def parse_tests_to_dict(self):

--- a/lib/galaxy/tools/parser/output_collection_def.py
+++ b/lib/galaxy/tools/parser/output_collection_def.py
@@ -23,9 +23,9 @@ INPUT_DBKEY_TOKEN = "__input__"
 LEGACY_DEFAULT_DBKEY = None  # don't use __input__ for legacy default collection
 
 
-def dataset_collector_descriptions_from_elem( elem ):
+def dataset_collector_descriptions_from_elem( elem, legacy=True ):
     primary_dataset_elems = elem.findall( "discover_datasets" )
-    if not primary_dataset_elems:
+    if len(primary_dataset_elems) == 0 and legacy:
         return [ DEFAULT_DATASET_COLLECTOR_DESCRIPTION ]
     else:
         return map( lambda elem: DatasetCollectionDescription( **elem.attrib ), primary_dataset_elems )

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -38,8 +38,9 @@ class XmlToolSource(ToolSource):
     """ Responsible for parsing a tool from classic Galaxy representation.
     """
 
-    def __init__(self, root):
+    def __init__(self, root, source_path=None):
         self.root = root
+        self._source_path = source_path
 
     def parse_version(self):
         return self.root.get("version", None)

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -281,6 +281,13 @@ class XmlToolSource(ToolSource):
             parser = StdioParser(self.root)
             return parser.stdio_exit_codes, parser.stdio_regexes
 
+    def parse_strict_shell(self):
+        command_el = self._command_el
+        if command_el is not None:
+            return string_as_bool(command_el.get("strict", "False"))
+        else:
+            return False
+
     def parse_help(self):
         help_elem = self.root.find( 'help' )
         return help_elem.text if help_elem is not None else None

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -151,6 +151,20 @@ class XmlToolSource(ToolSource):
     def parse_redirect_url_params_elem(self):
         return self.root.find("redirect_url_params")
 
+    def parse_sanitize(self):
+        return self._get_option_value("sanitize", True)
+
+    def parse_refresh(self):
+        return self._get_option_value("refresh", False)
+
+    def _get_option_value(self, key, default):
+        root = self.root
+        for option_elem in root.findall("options"):
+            if key in option_elem.attrib:
+                return string_as_bool(option_elem.get(key))
+
+        return default
+
     @property
     def _command_el(self):
         return self.root.find("command")

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -41,6 +41,7 @@ class XmlToolSource(ToolSource):
     def __init__(self, root, source_path=None):
         self.root = root
         self._source_path = source_path
+        self.legacy_defaults = self.parse_profile() == "16.01"
 
     def parse_version(self):
         return self.root.get("version", None)
@@ -331,19 +332,14 @@ class XmlToolSource(ToolSource):
 
         return rval
 
-    @property
-    def legacy_defaults(self):
+    def parse_profile(self):
         # Pre-16.04 or default XML defaults
         # - Use standard error for error detection.
         # - Don't run shells with -e
         # - Auto-check for implicit multiple outputs.
         # - Auto-check for $param_file.
         # - Enable buggy interpreter attribute.
-        return self.parse_profile() == "legacy"
-
-    def parse_profile(self):
-        profile = self.root.get("profile", "legacy")
-        return profile
+        return self.root.get("profile", "16.01")
 
 
 def _test_elem_to_dict(test_elem, i):

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -30,7 +30,7 @@ class YamlToolSource(ToolSource):
         return self.root_dict.get("name")
 
     def parse_description(self):
-        return self.root_dict.get("description")
+        return self.root_dict.get("description", "")
 
     def parse_is_multi_byte(self):
         return self.root_dict.get("is_multi_byte", self.default_is_multi_byte)

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -168,6 +168,11 @@ class YamlToolSource(ToolSource):
 
         return rval
 
+    def parse_profile(self):
+        """
+        """
+        return self.root_dict.get("profile", "16.04")
+
 
 def _parse_test(i, test_dict):
     inputs = test_dict["inputs"]

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -35,6 +35,9 @@ class YamlToolSource(ToolSource):
     def parse_is_multi_byte(self):
         return self.root_dict.get("is_multi_byte", self.default_is_multi_byte)
 
+    def parse_sanitize(self):
+        return self.root_dict.get("sanitize", True)
+
     def parse_display_interface(self, default):
         return self.root_dict.get('display_interface', default)
 

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -17,8 +17,9 @@ from .output_objects import (
 
 class YamlToolSource(ToolSource):
 
-    def __init__(self, root_dict):
+    def __init__(self, root_dict, source_path=None):
         self.root_dict = root_dict
+        self._source_path = source_path
 
     def parse_id(self):
         return self.root_dict.get("id")

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -64,6 +64,10 @@ class YamlToolSource(ToolSource):
         page_source = YamlPageSource(self.root_dict.get("inputs", {}))
         return PagesSource([page_source])
 
+    def parse_strict_shell(self):
+        # TODO: Add ability to disable this.
+        return True
+
     def parse_stdio(self):
         return error_on_exit_code()
 

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -173,8 +173,6 @@ class YamlToolSource(ToolSource):
         return rval
 
     def parse_profile(self):
-        """
-        """
         return self.root_dict.get("profile", "16.04")
 
 

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -23,6 +23,8 @@
   <tool file="metadata.xml" />
   <tool file="metadata_bam.xml" />
   <tool file="metadata_bcf.xml" />
+  <tool file="strict_shell.xml" />
+  <tool file="strict_shell_default_off.xml" />
   <tool file="detect_errors_aggressive.xml" />
   <tool file="md5sum.xml" />
   <!--

--- a/test/functional/tools/strict_shell.xml
+++ b/test/functional/tools/strict_shell.xml
@@ -1,0 +1,23 @@
+<tool id="strict_shell" name="strict_shell" version="1.0.0">
+    <command strict="true" detect_errors="exit_code">
+        echo "Hello" > $out_file1
+        ; sh -c "exit $exit_code"
+        ; sh -c "exit 0"
+    </command>
+    <inputs>
+        <param name="exit_code" type="integer" value="0" label="exit code"/>
+    </inputs>
+    <outputs>
+        <data name="out_file1" />
+    </outputs>
+    <tests>
+        <test expect_exit_code="0" expect_failure="false">
+            <param name="exit_code" value="0" />
+        </test>
+        <test expect_exit_code="1" expect_failure="true">
+            <param name="exit_code" value="1" />
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/strict_shell_default_off.xml
+++ b/test/functional/tools/strict_shell_default_off.xml
@@ -1,0 +1,20 @@
+<tool id="strict_shell_default_off" name="strict_shell_default_off" version="1.0.0">
+    <command detect_errors="exit_code">
+        echo "Hello" > $out_file1
+        ; sh -c "exit $exit_code"
+        ; sh -c "exit 0"
+    </command>
+    <inputs>
+        <param name="exit_code" type="integer" value="0" label="exit code"/>
+    </inputs>
+    <outputs>
+        <data name="out_file1" />
+    </outputs>
+    <tests>
+        <test expect_exit_code="0" expect_failure="false">
+            <param name="exit_code" value="1" />
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -32,49 +32,49 @@ class TestCommandFactory(TestCase):
 
     def test_simplest_command(self):
         self.include_work_dir_outputs = False
-        self.__assert_command_is( MOCK_COMMAND_LINE )
+        self.__assert_command_is( _surrond_command(MOCK_COMMAND_LINE + "; return_code=$?; cd .." ))
 
     def test_shell_commands(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is( "%s; %s" % (dep_commands[0], MOCK_COMMAND_LINE) )
+        self.__assert_command_is( _surrond_command("%s; %s; return_code=$?; cd .." % (dep_commands[0], MOCK_COMMAND_LINE) ))
 
     def test_shell_commands_external(self):
         self.job_wrapper.commands_in_new_shell = True
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is( "%s/tool_script.sh" % self.job_wrapper.working_directory)
+        self.__assert_command_is( _surrond_command( "%s/tool_script.sh; return_code=$?; cd .." % self.job_wrapper.working_directory)  )
         self.__assert_tool_script_is( "#!/bin/sh\n%s; %s" % (dep_commands[0], MOCK_COMMAND_LINE) )
 
     def test_remote_dependency_resolution(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(MOCK_COMMAND_LINE, remote_command_params=dict(dependency_resolution="remote"))
+        self.__assert_command_is(_surrond_command(MOCK_COMMAND_LINE + "; return_code=$?; cd .."), remote_command_params=dict(dependency_resolution="remote"))
 
     def test_explicit_local_dependency_resolution(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is("%s; %s" % (dep_commands[0], MOCK_COMMAND_LINE),
+        self.__assert_command_is( _surrond_command("%s; %s; return_code=$?; cd .." % (dep_commands[0], MOCK_COMMAND_LINE)),
                                  remote_command_params=dict(dependency_resolution="local"))
 
     def test_task_prepare_inputs(self):
         self.include_work_dir_outputs = False
         self.job_wrapper.prepare_input_files_cmds = ["/opt/split1", "/opt/split2"]
-        self.__assert_command_is( "/opt/split1; /opt/split2; %s" % MOCK_COMMAND_LINE )
+        self.__assert_command_is( _surrond_command("/opt/split1; /opt/split2; %s; return_code=$?; cd ..") % MOCK_COMMAND_LINE )
 
     def test_workdir_outputs(self):
         self.include_work_dir_outputs = True
         self.workdir_outputs = [("foo", "bar")]
-        self.__assert_command_is( '%s; return_code=$?; if [ -f foo ] ; then cp foo bar ; fi; sh -c "exit $return_code"' % MOCK_COMMAND_LINE )
+        self.__assert_command_is( _surrond_command('%s; return_code=$?; if [ -f foo ] ; then cp foo bar ; fi; cd ..' % MOCK_COMMAND_LINE ))
 
     def test_set_metadata_skipped_if_unneeded(self):
         self.include_metadata = True
         self.include_work_dir_outputs = False
-        self.__assert_command_is( MOCK_COMMAND_LINE )
+        self.__assert_command_is( _surrond_command( MOCK_COMMAND_LINE + "; return_code=$?; cd .." ) )
 
     def test_set_metadata(self):
         self._test_set_metadata()
@@ -87,18 +87,18 @@ class TestCommandFactory(TestCase):
         self.include_metadata = True
         self.include_work_dir_outputs = False
         self.job_wrapper.metadata_line = TEST_METADATA_LINE
-        expected_command = '%s; return_code=$?; %s; sh -c "exit $return_code"' % (MOCK_COMMAND_LINE, TEST_METADATA_LINE)
+        expected_command = _surrond_command('%s; return_code=$?; cd ..; %s' % (MOCK_COMMAND_LINE, TEST_METADATA_LINE))
         self.__assert_command_is( expected_command )
 
     def test_empty_metadata(self):
         """
-        As produced by TaskWrapper.
+        Test empty metadata as produced by TaskWrapper.
         """
         self.include_metadata = True
         self.include_work_dir_outputs = False
         self.job_wrapper.metadata_line = ' '
         # Empty metadata command do not touch command line.
-        expected_command = '%s' % (MOCK_COMMAND_LINE)
+        expected_command = _surrond_command('%s; return_code=$?; cd ..' % (MOCK_COMMAND_LINE))
         self.__assert_command_is( expected_command )
 
     def test_metadata_kwd_defaults(self):
@@ -150,6 +150,10 @@ class TestCommandFactory(TestCase):
             **extra_kwds
         )
         return build_command(**kwds)
+
+
+def _surrond_command(command):
+    return '''mkdir -p working; cd working; %s; sh -c "exit $return_code"''' % command
 
 
 class MockJobWrapper(object):

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -155,6 +155,7 @@ class TestCommandFactory(TestCase):
 class MockJobWrapper(object):
 
     def __init__(self, job_dir):
+        self.strict_shell = False
         self.write_version_cmd = None
         self.command_line = MOCK_COMMAND_LINE
         self.dependency_shell_commands = []

--- a/test/unit/test_objectstore.py
+++ b/test/unit/test_objectstore.py
@@ -175,7 +175,7 @@ class MockConfig(object):
         self.file_path = temp_directory
         self.object_store_config_file = os.path.join(temp_directory, "store.xml")
         self.object_store_check_old_style = False
-        self.job_working_directory = temp_directory
+        self.jobs_directory = temp_directory
         self.new_file_path = temp_directory
         self.umask = 0000
 

--- a/test/unit/tools/test_evaluation.py
+++ b/test/unit/tools/test_evaluation.py
@@ -256,6 +256,7 @@ class TestComputeEnviornment( SimpleComputeEnvironment ):
 class MockTool( object ):
 
     def __init__( self, app ):
+        self.legacy_defaults = True
         self.app = app
         self.hooks_called = []
         self.environment_variables = []

--- a/test/unit/tools/test_evaluation.py
+++ b/test/unit/tools/test_evaluation.py
@@ -256,7 +256,7 @@ class TestComputeEnviornment( SimpleComputeEnvironment ):
 class MockTool( object ):
 
     def __init__( self, app ):
-        self.profile=16.01
+        self.profile = 16.01
         self.app = app
         self.hooks_called = []
         self.environment_variables = []

--- a/test/unit/tools/test_evaluation.py
+++ b/test/unit/tools/test_evaluation.py
@@ -256,7 +256,7 @@ class TestComputeEnviornment( SimpleComputeEnvironment ):
 class MockTool( object ):
 
     def __init__( self, app ):
-        self.legacy_defaults = True
+        self.profile=16.01
         self.app = app
         self.hooks_called = []
         self.environment_variables = []

--- a/test/unit/tools/test_parsing.py
+++ b/test/unit/tools/test_parsing.py
@@ -244,6 +244,12 @@ class XmlLoaderTestCase(BaseLoaderTestCase):
         assert len(exit) == 2, exit
         assert len(regexes) == 2, regexes
 
+    def test_sanitize_option(self):
+        assert self._tool_source.parse_sanitize() is True
+
+    def test_refresh_option(self):
+        assert self._tool_source.parse_refresh() is False
+
 
 class YamlLoaderTestCase(BaseLoaderTestCase):
     source_file_name = "bwa.yml"
@@ -363,6 +369,9 @@ class YamlLoaderTestCase(BaseLoaderTestCase):
         assert attributes1["compare"] == "sim_size"
         assert attributes1["lines_diff"] == 4
 
+    def test_sanitize(self):
+        assert self._tool_source.parse_sanitize() is True
+
 
 class DataSourceLoaderTestCase(BaseLoaderTestCase):
     source_file_name = "ds.xml"
@@ -390,6 +399,12 @@ class DataSourceLoaderTestCase(BaseLoaderTestCase):
     <options sanitize="False" refresh="True"/>
 </tool>
 """
+
+    def test_sanitize_option(self):
+        assert self._tool_source.parse_sanitize() is False
+
+    def test_refresh_option(self):
+        assert self._tool_source.parse_refresh() is True
 
     def test_tool_type(self):
         assert self._tool_source.parse_tool_type() == "data_source"

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -68,7 +68,7 @@ class MockAppConfig( Bunch ):
         self.security = security.SecurityHelper( id_secret='bler' )
         self.use_remote_user = kwargs.get( 'use_remote_user', False )
         self.file_path = '/tmp'
-        self.job_working_directory = '/tmp'
+        self.jobs_directory = '/tmp'
         self.new_file_path = '/tmp'
 
         self.object_store_config_file = ''


### PR DESCRIPTION
This is a fairly substantial cleanup of tool and job handling.
- Introduce `profile="16.04"` attribute tools, the resulting tools have all new defaults that should really simplify tool development. https://github.com/galaxyproject/galaxy/issues/1609
  - `#set -e` on tool executions.
  - Use exit code by default for error detection.
  - Eliminate some buggy features - `interpreter` attribute for instance.
- Make bash the default shell with 16.04 so conda will work out of the box.
- Ensure tool execution working directories are empty. https://github.com/galaxyproject/galaxy/issues/1575
- Enable per-destination configuration of many job properties (makes Galaxy much more usable for multi-cluster deployments).  https://github.com/galaxyproject/galaxy/pull/1573, https://trello.com/c/6w8bples
- Small cleanups of legacy features and duplicated job runner code.
