### PR TITLE
[PROCEDURES] Drop Ross from the committers group.

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -42,7 +42,6 @@ Members
 - Björn Grüning (@bgruening)
 - Aysam Guerler (@guerler)
 - Jennifer Hillman Jackson (@jennaj)
-- Ross Lazarus (@fubar2)
 - Anton Nekrutenko (@nekrut)
 - Eric Rasche (@erasche)
 - Nicola Soranzo (@nsoranzo)


### PR DESCRIPTION
Ross Lazarus has done a lot for Galaxy for a long time and has been a fantastic presence in the community. He is now retired and has no intention of touching the code or reviewing pull requests so I think it is best to remove him from the committers list. I have contacted him to confirm this and he has no problem with his removal from this group.

Just to reiterate, this isn't a condemnation of any kind, from the organization policies - "Periodically, active members may review this group and request inactive members are removed - this should not be interpreted as a condemnation of these inactive members but merely as a reflection of a desire to keep this group focused enough to remain effective."
