### PR TITLE
[PROCEDURES] Add Marius van den Beek to Galaxy committer group.

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -48,6 +48,8 @@ Members
 - Nicola Soranzo (@nsoranzo)
 - James Taylor (@jxtx)
 - Nitesh Turaga (@nitesh1989)
+- Marius van den Beek (@mvdbeek)
+
 
 Membership
 ----------


### PR DESCRIPTION
Marius has been an indispensable member of the Galaxy community for a while - his contributions to tools, planemo, and ansible roles have been signficant and invaluable. He is a committer on multiple Galaxy projects outside the core and has done a great job in those roles.

However over the last several months he has taken a very active role on the Galaxy central code base itself. He has worked through a number of very intricate bugs to tool shed, tooling, and workflow code - consistently providing high quality and important bug fixes. Beyond that he has made significant enhancements to the testing of Galaxy and workflow available to tool developers leveraging local tool sheds. He also is very active in the review of issues and pull requests, perhaps the most important role of Galaxy committer group members - so I would propose we make him an official member.
