### PR TITLE
Convert tool_shed response to unicode

### DIFF
--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import os.path
+from six import string_types
 import galaxy.tools.parameters.basic
 import galaxy.tools.parameters.grouping
 from galaxy.util import string_as_bool
@@ -117,7 +118,7 @@ class ToolTestBuilder( object ):
             log.info( msg )
 
     def __split_if_str( self, value ):
-        split = isinstance(value, str)
+        split = isinstance(value, string_types)
         if split:
             value = value.split(",")
         return value

--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -11,6 +11,7 @@ import random
 import string
 
 from six import text_type, string_types, iteritems
+from galaxy.util.string_conversion import to_unicode
 
 dumps = json.dumps
 loads = json.loads
@@ -27,7 +28,7 @@ def json_fix( val ):
     elif isinstance( val, dict ):
         return dict( [ ( json_fix( k ), json_fix( v ) ) for ( k, v ) in iteritems(val) ] )
     elif isinstance( val, text_type ):
-        return val.encode( "utf8" )
+        return to_unicode( val )
     else:
         return val
 

--- a/lib/galaxy/util/string_conversion.py
+++ b/lib/galaxy/util/string_conversion.py
@@ -1,0 +1,10 @@
+"""
+Safe conversion to unicode
+"""
+from six import text_type
+
+
+def to_unicode(a_string):
+    if a_string is None:
+        return None
+    return text_type(a_string)


### PR DESCRIPTION
Addresses issue #1702, where strings returned from the toolshed are causing problems in sqlalchemy.
With this PR unpacked json values will be converted to unicode and downstream code that checks instance type is now using `isinstance(var, text_types)` instead of `str` or `basestring` (which is not available in python3).
