### PR TITLE
[16.01] Also check for unique outputs on legacy workflow export

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -566,7 +566,7 @@ class WorkflowContentsManager(UsesAnnotations):
             # User outputs
 
             workflow_outputs_dicts = []
-            for workflow_output in step.workflow_outputs:
+            for workflow_output in step.unique_workflow_outputs:
                 workflow_output_dict = dict(
                     output_name=workflow_output.output_name,
                     label=workflow_output.label,


### PR DESCRIPTION
follow-up to issue #1704 / PR #1718 .
This allows export to work properly with "legacy" workflows.
