### PR TITLE
Load whitelist regardless of whether the setting is explicit in config.

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -259,9 +259,7 @@ class Configuration( object ):
         self.log_events = string_as_bool( kwargs.get( 'log_events', 'False' ) )
         self.sanitize_all_html = string_as_bool( kwargs.get( 'sanitize_all_html', True ) )
         self.sanitize_whitelist_file = resolve_path( kwargs.get( 'sanitize_whitelist_file', "config/sanitize_whitelist.txt" ), self.root )
-        self.sanitize_whitelist = []
-        if kwargs.get('sanitize_whitelist_file', None) is not None:
-            self.reload_sanitize_whitelist()
+        self.reload_sanitize_whitelist()
         self.serve_xss_vulnerable_mimetypes = string_as_bool( kwargs.get( 'serve_xss_vulnerable_mimetypes', False ) )
         self.trust_ipython_notebook_conversion = string_as_bool( kwargs.get( 'trust_ipython_notebook_conversion', False ) )
         self.enable_old_display_applications = string_as_bool( kwargs.get( "enable_old_display_applications", "True" ) )


### PR DESCRIPTION
This is a sensible enough default, and requiring the option to be set in
galaxy.ini is cumbersome and unnecessary since it's admin-only
functionality.

Should resolve #1748
