### PR TITLE
[15.10] Fix installation of Tool Shed repositories containing non-ASCII characters in the description.

### DIFF
--- a/lib/tool_shed/util/encoding_util.py
+++ b/lib/tool_shed/util/encoding_util.py
@@ -3,7 +3,6 @@ import json
 import logging
 
 from galaxy.util.hash_util import hmac_new
-from galaxy.util.json import json_fix
 
 log = logging.getLogger( __name__ )
 
@@ -21,13 +20,8 @@ def tool_shed_decode( value ):
     values = None
     try:
         values = json.loads( value )
-    except Exception, e:
+    except Exception:
         pass
-    if values is not None:
-        try:
-            return json_fix( values )
-        except Exception, e:
-            log.debug( "Fixing decoded json values '%s' from tool shed threw exception: %s" % ( str( values ), str( e ) ) )
     if values is None:
         values = value
     return values


### PR DESCRIPTION
Fix #1702.
