### PR TITLE
Refactor the Html Datatype Class into text.py instead of images.py

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -108,7 +108,7 @@
     </datatype>
     <datatype extension="toolshed.gz" type="galaxy.datatypes.binary:Binary" mimetype="multipart/x-gzip" subclass="True" />
     <datatype extension="h5" type="galaxy.datatypes.binary:H5" mimetype="application/octet-stream" display_in_upload="True"/>
-    <datatype extension="html" type="galaxy.datatypes.images:Html" mimetype="text/html"/>
+    <datatype extension="html" type="galaxy.datatypes.text:Html" mimetype="text/html"/>
     <datatype extension="interval" type="galaxy.datatypes.interval:Interval" display_in_upload="true" description="File must start with definition line in the following format (columns may be in any order)." >
       <converter file="interval_to_bed_converter.xml" target_datatype="bed"/>
       <converter file="interval_to_bedstrict_converter.xml" target_datatype="bedstrict"/>
@@ -494,7 +494,7 @@
     <sniffer type="galaxy.datatypes.sequence:Fasta"/>
     <sniffer type="galaxy.datatypes.sequence:Fastq"/>
     <sniffer type="galaxy.datatypes.interval:Wiggle"/>
-    <sniffer type="galaxy.datatypes.images:Html"/>
+    <sniffer type="galaxy.datatypes.text:Html"/>
     <sniffer type="galaxy.datatypes.images:Pdf"/>
     <sniffer type="galaxy.datatypes.sequence:Axt"/>
     <sniffer type="galaxy.datatypes.interval:Bed"/>

--- a/lib/galaxy/datatypes/assembly.py
+++ b/lib/galaxy/datatypes/assembly.py
@@ -11,7 +11,7 @@ import os
 import re
 import sys
 from galaxy.datatypes import sequence
-from galaxy.datatypes.images import Html
+from galaxy.datatypes.text import Html
 from galaxy.datatypes.metadata import MetadataElement
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -364,7 +364,7 @@ class Data( object ):
         if not os.path.exists( data.file_name ):
             raise paste.httpexceptions.HTTPNotFound( "File Not Found (%s)." % data.file_name )
         max_peek_size = 1000000  # 1 MB
-        if isinstance(data.datatype, datatypes.images.Html):
+        if isinstance(data.datatype, datatypes.text.Html):
             max_peek_size = 10000000  # 10 MB for html
         preview = util.string_as_bool( preview )
         if not preview or isinstance(data.datatype, datatypes.images.Image) or os.stat( data.file_name ).st_size < max_peek_size:

--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -19,7 +19,7 @@ import urllib
 from cgi import escape
 
 from galaxy.datatypes import metadata
-from galaxy.datatypes.images import Html
+from galaxy.datatypes.text import Html
 from galaxy.datatypes.metadata import MetadataElement
 from galaxy.datatypes.tabular import Tabular
 from galaxy.util import nice_size

--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -8,6 +8,7 @@ import zipfile
 from urllib import quote_plus
 
 from galaxy.datatypes.binary import Binary
+from galaxy.datatypes.text import Html as HtmlFromText
 from galaxy.datatypes.sniff import get_headers
 from galaxy.datatypes.util.image_util import check_image_type
 from galaxy.util import nice_size
@@ -297,43 +298,9 @@ class Gmaj( data.Data ):
         return True
 
 
-class Html( data.Text ):
-    """Class describing an html file"""
-    edam_format = "format_2331"
-    file_ext = "html"
-
-    def set_peek( self, dataset, is_multi_byte=False ):
-        if not dataset.dataset.purged:
-            dataset.peek = "HTML file"
-            dataset.blurb = nice_size( dataset.get_size() )
-        else:
-            dataset.peek = 'file does not exist'
-            dataset.blurb = 'file purged from disk'
-
-    def get_mime(self):
-        """Returns the mime type of the datatype"""
-        return 'text/html'
-
-    def sniff( self, filename ):
-        """
-        Determines whether the file is in html format
-
-        >>> from galaxy.datatypes.sniff import get_test_fname
-        >>> fname = get_test_fname( 'complete.bed' )
-        >>> Html().sniff( fname )
-        False
-        >>> fname = get_test_fname( 'file.html' )
-        >>> Html().sniff( fname )
-        True
-        """
-        headers = get_headers( filename, None )
-        try:
-            for i, hdr in enumerate(headers):
-                if hdr and hdr[0].lower().find( '<html>' ) >= 0:
-                    return True
-            return False
-        except:
-            return True
+class Html( HtmlFromText ):
+    """Deprecated class. This class should not be used anymore, but the galaxy.datatypes.text:Html one.
+    This is for backwards compatibilities only."""
 
 
 class Laj( data.Text ):

--- a/lib/galaxy/datatypes/ngsindex.py
+++ b/lib/galaxy/datatypes/ngsindex.py
@@ -5,7 +5,7 @@ import os
 import logging
 
 from metadata import MetadataElement
-from images import Html
+from text import Html
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -17,6 +17,7 @@ from . import xml
 from . import coverage
 from . import tracks
 from . import binary
+from . import text
 import galaxy.util
 from galaxy.util.odict import odict
 from .display_applications.application import DisplayApplication
@@ -746,7 +747,7 @@ class Registry( object ):
                 sequence.Fasta(),
                 sequence.Fastq(),
                 interval.Wiggle(),
-                images.Html(),
+                text.Html(),
                 sequence.Axt(),
                 interval.Bed(),
                 interval.CustomTrack(),

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -12,9 +12,49 @@ import tempfile
 
 from galaxy.datatypes.data import get_file_peek, Text
 from galaxy.datatypes.metadata import MetadataElement, MetadataParameter
+from galaxy.datatypes.sniff import get_headers
 from galaxy.util import nice_size, string_as_bool
 
 log = logging.getLogger(__name__)
+
+
+class Html( Text ):
+    """Class describing an html file"""
+    edam_format = "format_2331"
+    file_ext = "html"
+
+    def set_peek( self, dataset, is_multi_byte=False ):
+        if not dataset.dataset.purged:
+            dataset.peek = "HTML file"
+            dataset.blurb = nice_size( dataset.get_size() )
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def get_mime(self):
+        """Returns the mime type of the datatype"""
+        return 'text/html'
+
+    def sniff( self, filename ):
+        """
+        Determines whether the file is in html format
+
+        >>> from galaxy.datatypes.sniff import get_test_fname
+        >>> fname = get_test_fname( 'complete.bed' )
+        >>> Html().sniff( fname )
+        False
+        >>> fname = get_test_fname( 'file.html' )
+        >>> Html().sniff( fname )
+        True
+        """
+        headers = get_headers( filename, None )
+        try:
+            for i, hdr in enumerate(headers):
+                if hdr and hdr[0].lower().find( '<html>' ) >= 0:
+                    return True
+            return False
+        except:
+            return True
 
 
 class Json( Text ):

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -593,7 +593,7 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
 
             # If data is binary or an image, stream without template; otherwise, use display template.
             # TODO: figure out a way to display images in display template.
-            if isinstance(dataset.datatype, datatypes.binary.Binary) or isinstance(dataset.datatype, datatypes.images.Image) or isinstance(dataset.datatype, datatypes.images.Html):
+            if isinstance(dataset.datatype, datatypes.binary.Binary) or isinstance(dataset.datatype, datatypes.images.Image) or isinstance(dataset.datatype, datatypes.text.Html):
                 trans.response.set_content_type( dataset.get_mime() )
                 return open( dataset.file_name )
             else:


### PR DESCRIPTION
Hi :),

Here is a refactoring Pull Request. Below, some details as recommended in `contributing.md`
### A description of why the changes should be made.

The Html class herits from `data.text`, and is located in `galaxy.datatypes.images`. In my point of view, an Html class is not an image but a text so I thought this class should be refactored by moving it into `lib/datatypes/text.py` instead of `lib/datatypes/images.py`.
### A description of the implementation of the changes.
1. I moved the Html class from images.py to text.py.
2. I fixed all the references in the galaxy code:
   - `config/datatypes_conf.xml.sample`
   - `lib/galaxy/datatypes/assembly.py`
   - `lib/galaxy/datatypes/genetics.py`
   - `lib/galaxy/datatypes/ngsindex.py`
   - `lib/galaxy/datatypes/registry.py`
3. I fixed some code calling the Html class directly:
   - `lib/galaxy/webapps/galaxy/controllers/dataset.py`
   - `lib/galaxy/datatypes/data.py`
4. I created an Html class in `images.py` which herits from the Html class in `text.py` for backwards compatibility.
### A description of how to test the changes.

As far as I know, I tested the changes by uploading an Html element and displaying it. But I am sure I could do better tests on this, and will welcome any thoughts about how to test more in-depth this.

I also runned tox as recommended in `contributing.md`
