### PR TITLE
[15.10] Fix pretty_print_time_interval for MySQL.

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -352,7 +352,11 @@ def pretty_print_time_interval( time=False, precise=False ):
     elif isinstance( time, datetime ):
         diff = now - time
     elif isinstance( time, basestring ):
-        time = datetime.strptime( time, "%Y-%m-%dT%H:%M:%S.%f" )
+        try:
+            time = datetime.strptime( time, "%Y-%m-%dT%H:%M:%S.%f" )
+        except ValueError:
+            # MySQL may not support microseconds precision
+            time = datetime.strptime( time, "%Y-%m-%dT%H:%M:%S" )
         diff = now - time
     else:
         diff = now - now


### PR DESCRIPTION
Fix #1619.

There are instances of `datetime.strptime()` function which probably have the same problem in `lib/galaxy/webapps/galaxy/api/metrics.py` and `lib/galaxy/tools/imp_exp/__init__.py` .
