### PR TITLE
Use "Gateway" from docker inspect as default docker_hostname

### DIFF
--- a/lib/galaxy/visualization/plugins/plugin.py
+++ b/lib/galaxy/visualization/plugins/plugin.py
@@ -246,7 +246,7 @@ class InteractiveEnvironmentPlugin( VisualizationPlugin ):
     """
     Serves web-based REPLs such as IPython and RStudio.
     """
-    INTENV_REQUEST_FACTORY = interactive_environments.InteractiveEnviornmentRequest
+    INTENV_REQUEST_FACTORY = interactive_environments.InteractiveEnvironmentRequest
 
     def __init__( self, app, path, name, config, context=None, **kwargs ):
         # TODO: this is a hack until we can get int envs seperated from the vis reg and into their own framework

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -219,7 +219,9 @@ class InteractiveEnviornmentRequest(object):
             return None
         else:
             log.debug( "Container id: %s" % stdout)
-            port_mappings = self.get_proxied_ports(stdout)
+            port_mappings, gateway_ip = self.get_proxied_ports(stdout)
+            if self.attr.docker_hostname == 'localhost':
+                self.attr.docker_hostname = gateway_ip
             if len(port_mappings) > 1:
                 log.warning("Don't know how to handle proxies to containers with multiple exposed ports. Arbitrarily choosing first")
             elif len(port_mappings) == 0:
@@ -284,6 +286,7 @@ class InteractiveEnviornmentRequest(object):
         #                     "HostPort" : "3306"
         #                 }
         #             ]
+        gateway_ip = inspect_data[0]['NetworkSettings'][Gateway]
         mappings = []
         port_mappings = inspect_data[0]['NetworkSettings']['Ports']
         for port_name in port_mappings:
@@ -293,4 +296,4 @@ class InteractiveEnviornmentRequest(object):
                     binding['HostIp'],
                     binding['HostPort']
                 ))
-        return mappings
+        return mappings, gateway_ip

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -252,12 +252,12 @@ class InteractiveEnvironmentRequest(object):
             # self.attr.PORT = self.attr.proxy_request[ 'proxied_port' ]
 
     def inspect_container(self, container_id):
-        """Run docker inspect on a container and return json response as python dictionary inspect_data.
+        """Runs docker inspect on a container and returns json response as python dictionary inspect_data.
 
         :type container_id: str
         :param container_id: a docker container ID
 
-        :returns: inspect_data: dict
+        :returns: inspect_data, a dict of docker inspect output
         """
         command = self.attr.viz_config.get("docker", "command")
         command = command.format(docker_args="inspect %s" % container_id)
@@ -287,15 +287,17 @@ class InteractiveEnvironmentRequest(object):
     def get_container_gateway_ip(self, inspect_data):
         """
         Returns gateway ip from inspect_data
-        :param inspect_data: dict
-        :returns: gateway_ip: str
+        :type inspect_data: dict
+        :param inspect_data: output of docker inspect
+        :returns: gateway_ip
         """
         gateway_ip = inspect_data[0]['NetworkSettings']['Gateway']
         return gateway_ip
 
     def get_container_port_mapping(self, inspect_data):
         """
-        :param inspect_data: dict
+        :type inspect_data: dict
+        :param inspect_data: output of docker inspect
         :returns: a list of triples containing (internal_port, external_ip,
                   external_port), of which the ports are probably the only
                   useful information.

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -286,7 +286,7 @@ class InteractiveEnviornmentRequest(object):
         #                     "HostPort" : "3306"
         #                 }
         #             ]
-        gateway_ip = inspect_data[0]['NetworkSettings'][Gateway]
+        gateway_ip = inspect_data[0]['NetworkSettings']['Gateway']
         mappings = []
         port_mappings = inspect_data[0]['NetworkSettings']['Ports']
         for port_name in port_mappings:


### PR DESCRIPTION
Communication with containers started by interactive environments happens on a arbitrarily chosen high-number port `nnnn` that maps back into the container. If the container runs on the same machine as galaxy does, the container can be reached at localhost:`nnnn`. This does not work when using "docker-next-to-docker" (`docker run -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker image`), since the newly started container's localhost: `nnnn` does not point to the host's localhost:`nnnn`. An easy solution for this is to instead use the Gateway.
This allows using interactive environments both in docker-in-docker and docker-next-to-docker scenarios.
See [here](https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/) for some background why docker-next-to-docker is preferrable over docker-in-docker.
Normal operation on localhost will work fine as well, and remote communication will not be affected, so I hope this will be an acceptable default setting.
