### PR TITLE
Simplify required conditional spec. in .ga workflows.

### DIFF
--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -575,7 +575,7 @@ class Conditional( Group ):
     def value_from_basic( self, value, app, ignore_errors=False ):
         rval = dict()
         try:
-            current_case = rval['__current_case__'] = value['__current_case__']
+            current_case = rval['__current_case__'] = self._current_case_from_basic(value, app)
             # Test param
             if ignore_errors and self.test_param.name not in value:
                 # If ignoring errors, do nothing. However this is potentially very
@@ -636,6 +636,19 @@ class Conditional( Group ):
     @property
     def is_job_resource_conditional(self):
         return self.name == "__job_resource"
+
+    def _current_case_from_basic(self, value, app):
+        if '__current_case__' in value:
+            return value['__current_case__']
+        else:
+            # For hand-crafted workflow and tool API requests, don't require
+            # __current_case__ to be set.
+            test_param_name = self.test_param.name
+            if test_param_name not in value:
+                raise Exception("Conditional value '%s' must specify __current_case__ or param value for '%s'" % (value, test_param_name))
+            raw_value = value[test_param_name]
+            test_value = self.test_param.value_from_basic(raw_value, app)
+            return self.get_current_case(test_value)
 
 
 class ConditionalWhen( object, Dictifiable ):

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -46,7 +46,6 @@ steps:
             seed_source:
               seed_source_selector: set_seed
               seed: asdf
-              __current_case__: 1
     label: nested_workflow
     connect:
       inner_input: first_cat#out_file1
@@ -951,7 +950,6 @@ steps:
     seed_source:
       seed_source_selector: set_seed
       seed: asdf
-      __current_case__: 1
 test_data:
   test_input: "hello world"
 """, history_id=history_id, wait=False)
@@ -1035,7 +1033,6 @@ steps:
       seed_source_selector: set_seed
       seed:
         $link: text_input
-      __current_case__: 1
 test_data:
   data_input:
     value: 1.bed

--- a/test/api/test_workflows_from_yaml.py
+++ b/test/api/test_workflows_from_yaml.py
@@ -33,7 +33,6 @@ steps:
       seed_source:
         seed_source_selector: set_seed
         seed: asdf
-        __current_case__: 1
 """)
         workflow = self._get("workflows/%s/download" % workflow_id).json()
 
@@ -180,7 +179,6 @@ steps:
             seed_source:
               seed_source_selector: set_seed
               seed: asdf
-              __current_case__: 1
     label: nested_workflow
     connect:
       inner_input: first_cat#out_file1


### PR DESCRIPTION
Don't force these to have `__current_case__` values specified, infer from the conditional input value if these are specified.

Probably there are better ways to do this - since the default value should be inferred if it is not there and I'm not sure it works with booleans exactly - but I think this is a step forward.

Ping @guerler - you've been looking at this code a lot lately, what do you think?

The clearest test to verify the workflows are still working is probably:

```
./run_tests.sh -api test/api/test_workflows.py:WorkflowsApiTestCase.test_run_with_text_connection
```
