### PR TITLE
[16.01] format_source in workflow editor is too restrictive.

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -983,7 +983,6 @@ class ToolModule( WorkflowModule ):
 
     def get_data_outputs( self ):
         data_outputs = []
-        data_inputs = None
         for name, tool_output in self.tool.outputs.iteritems():
             extra_kwds = {}
             if tool_output.collection:
@@ -992,14 +991,6 @@ class ToolModule( WorkflowModule ):
                 formats = [ 'input' ]  # TODO: fix
             elif tool_output.format_source is not None:
                 formats = [ 'input' ]  # default to special name "input" which remove restrictions on connections
-                if data_inputs is None:
-                    data_inputs = self.get_data_inputs()
-                # find the input parameter referenced by format_source
-                for di in data_inputs:
-                    # input names come prefixed with conditional and repeat names separated by '|'
-                    # remove prefixes when comparing with format_source
-                    if di['name'] is not None and di['name'].split('|')[-1] == tool_output.format_source:
-                        formats = di['extensions']
             else:
                 formats = [ tool_output.format ]
             for change_elem in tool_output.change_format:

--- a/test/functional/tools/output_format.xml
+++ b/test/functional/tools/output_format.xml
@@ -7,9 +7,9 @@
     echo "test" > 5;
   </command>
   <inputs>
-    <param name="input_data_1" type="data" format="data" />
-    <param name="input_data_2" type="data" format="data" />
-    <param name="input_text" type="text" value="1" />
+    <param name="input_data_1" type="data" format="data" label="input_data_1" />
+    <param name="input_data_2" type="data" format="data" label="input_data_2" />
+    <param name="input_text" type="text" value="1"  label="input_text" />
   </inputs>
   <outputs>
     <data format="txt" from_work_dir="1" name="direct_output" />


### PR DESCRIPTION
Case made well by @erasche on #1746, fixes #1746.

To resolve this more correctly (and many other potential type problems) - the workflow editor should be significantly reworked to track the datatype (or a range of datatypes) on each terminal (the way it does for collection mapping information). The change would be a weeks worth of development effort and inappropriate to apply to a release branch.
