### PR TITLE
[15.10] Checks for api_key before checking for header from SSO.

### DIFF
--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -79,8 +79,7 @@ class RemoteUser( object ):
             # Check for API key before checking for header
             return self.app( environ, start_response )
         elif self.config_secret_header is not None:
-            gxSecretIsNone = environ.get('HTTP_GX_SECRET') is None
-            if gxSecretIsNone or not safe_str_cmp(environ.get('HTTP_GX_SECRET'), self.config_secret_header):
+            if not safe_str_cmp(environ.get('HTTP_GX_SECRET',''), self.config_secret_header):
                 title = "Access to Galaxy is denied"
                 message = """
                 Galaxy is configured to authenticate users via an external

--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -79,7 +79,7 @@ class RemoteUser( object ):
             # Check for API key before checking for header
             return self.app( environ, start_response )
         elif self.config_secret_header is not None:
-            if not safe_str_cmp(environ.get('HTTP_GX_SECRET',''), self.config_secret_header):
+            if not safe_str_cmp(environ.get('HTTP_GX_SECRET', ''), self.config_secret_header):
                 title = "Access to Galaxy is denied"
                 message = """
                 Galaxy is configured to authenticate users via an external


### PR DESCRIPTION
This pull request addresses an issue #972  found when using the Galaxy API and bioblend when also using an SSO. The principle issue was that SSO headers are checked before API keys are authenticated. This led to API/bioblend requests failing, as no headers are passed through bioblend. The solution was to check if the request was API-related before headers are checked; API-key validation is done downstream of this process. In the process, another issue was found when Galaxy receives no headers (i.e. accessing the port directly: http://server.example.com:1234, instead of the appropriate url http://galaxy.example.com). When no headers are passed, the `Remoteuser` class compares `None` to the GX_SECRET defined in the config. The received error is reported below. This is also handled by this patch.

``` python
File '.../galaxy-v15.05-production/eggs/WebError-0.8a-py2.7.egg/weberror/evalexception/middleware.py', line 364 in respond
  app_iter = self.application(environ, detect_start_response)
File '.../galaxy_env/lib/python2.7/site-packages/paste/recursive.py', line 84 in __call__
  return self.application(environ, start_response)
File '.../galaxy-v15.05-staging/lib/galaxy/web/framework/middleware/remoteuser.py', line 78 in __call__
  if not safe_str_cmp(environ.get('HTTP_GX_SECRET'), self.config_secret_header):
File '.../galaxy-v15.05-staging/lib/galaxy/util/__init__.py', line 1244 in safe_str_cmp
  if len(a) != len(b):
TypeError: object of type 'NoneType' has no len()
```
