### PR TITLE
Ensure tool.changeset_revision is set...

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -327,6 +327,7 @@ class Tool( object, Dictifiable ):
         self.tool_shed = None
         self.repository_name = None
         self.repository_owner = None
+        self.changeset_revision = None
         self.installed_changeset_revision = None
         # The tool.id value will be the value of guid, but we'll keep the
         # guid attribute since it is useful to have.


### PR DESCRIPTION
... in some cases tool.tool_shed will be non-null but changeset_revision will be absent. This is my development instance so it is easy to imagine my database doesn't match my tool panel config.

xref https://github.com/galaxyproject/galaxy/pull/1802
