### PR TITLE
Change many job mapped properties to lazy loads

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2100,16 +2100,16 @@ mapper( model.Job, model.Job.table, properties=dict(
     user=relation( model.User ),
     galaxy_session=relation( model.GalaxySession ),
     history=relation( model.History ),
-    library_folder=relation( model.LibraryFolder ),
-    parameters=relation( model.JobParameter, lazy=False ),
+    library_folder=relation( model.LibraryFolder, lazy=True ),
+    parameters=relation( model.JobParameter, lazy=True ),
     input_datasets=relation( model.JobToInputDatasetAssociation ),
-    output_datasets=relation( model.JobToOutputDatasetAssociation ),
-    output_dataset_collection_instances=relation( model.JobToOutputDatasetCollectionAssociation ),
-    output_dataset_collections=relation( model.JobToImplicitOutputDatasetCollectionAssociation ),
+    output_datasets=relation( model.JobToOutputDatasetAssociation, lazy=True ),
+    output_dataset_collection_instances=relation( model.JobToOutputDatasetCollectionAssociation, lazy=True ),
+    output_dataset_collections=relation( model.JobToImplicitOutputDatasetCollectionAssociation, lazy=True ),
     post_job_actions=relation( model.PostJobActionAssociation, lazy=False ),
     input_library_datasets=relation( model.JobToInputLibraryDatasetAssociation ),
-    output_library_datasets=relation( model.JobToOutputLibraryDatasetAssociation ),
-    external_output_metadata=relation( model.JobExternalOutputMetadata, lazy=False ),
+    output_library_datasets=relation( model.JobToOutputLibraryDatasetAssociation, lazy=True ),
+    external_output_metadata=relation( model.JobExternalOutputMetadata, lazy=True ),
     tasks=relation( model.Task )
 ) )
 


### PR DESCRIPTION
Loading a Job object eagerloads a lot of mappings down to the dataset level. For Jobs with many outputs with large metadata, this can consume many GB of memory.  Attempt to lazy load instead such that only one row should be returned for querying jobs **but this could negatively impact performance in other places**.

For example, Martin had a library on Test wherein one job created 5,001 outputs. This resulted in 40,008 rows being returned by the library dataset info page (which uses ldda.creating_job_associations[0].job to
output the job stdout/stderr).  The original query would have returned ~104GB worth of data (but the process was killed by the OOM killer). With job_parameters lazy loaded this dropped to 5,001 rows and ~13GB used. With all outputs lazy loaded, there is no memory increase. Without this change, search engine crawlers (and anyone else who tries to view library dataset info of one of these 5,001 datasets) crashes Test.

We may also want to apply this to 16.01 if it proves to be a good change.
