### PR TITLE
[16.01] Disable command isolation for Pulsar...

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -768,6 +768,7 @@ class JobWrapper( object ):
         if use_persisted_destination:
             self.job_runner_mapper.cached_job_destination = JobDestination( from_job=job )
 
+        self.__commands_in_new_shell = self.app.config.commands_in_new_shell
         self.__user_system_pwent = None
         self.__galaxy_system_pwent = None
 
@@ -793,9 +794,15 @@ class JobWrapper( object ):
     def shell(self):
         return self.job_destination.shell or getattr(self.app.config, 'default_job_shell', DEFAULT_JOB_SHELL)
 
+    def disable_commands_in_new_shell(self):
+        """Provide an extension point to disable this isolation,
+        Pulsar builds its own job script so this is not needed for
+        remote jobs."""
+        self.__commands_in_new_shell = False
+
     @property
     def commands_in_new_shell(self):
-        return self.app.config.commands_in_new_shell
+        return self.__commands_in_new_shell
 
     @property
     def galaxy_lib_dir(self):

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -278,6 +278,7 @@ class PulsarJobRunner( AsynchronousJobRunner ):
                 compute_tool_directory=remote_tool_directory,
                 compute_job_directory=remote_job_directory,
             )
+            job_wrapper.disable_commands_in_new_shell()
             command_line = build_command(
                 self,
                 job_wrapper=job_wrapper,

--- a/test/unit/jobs/test_job_wrapper.py
+++ b/test/unit/jobs/test_job_wrapper.py
@@ -12,9 +12,6 @@ from galaxy.util.bunch import Bunch
 from galaxy.tools import evaluation
 
 from tools_support import UsesApp
-# from tools_support import MockTool
-
-# from ..tools_and_jobs_helpers import MockApp
 
 TEST_TOOL_ID = "cufftest"
 TEST_VERSION_COMMAND = "bwa --version"
@@ -121,26 +118,6 @@ class MockJobDispatcher(object):
 
     def url_to_destination(self):
         pass
-
-
-class MockApp(object):
-
-    def __init__(self, object_store, test_directory, model_objects):
-        self.object_store = object_store
-        self.toolbox = MockToolbox(MockTool(self))
-        self.config = Bunch(
-            outputs_to_working_directory=False,
-            new_file_path=os.path.join(test_directory, "new_files"),
-            tool_data_path=os.path.join(test_directory, "tools"),
-            root=os.path.join(test_directory, "galaxy"),
-            datatypes_registry=Bunch(
-                integrated_datatypes_configs=os.path.join(test_directory, "datatypes_conf.xml"),
-            ),
-        )
-        self.job_config = Bunch(
-            dynamic_params=None,
-        )
-        self.model = Bunch(context=MockContext(model_objects))
 
 
 class MockContext(object):

--- a/test/unit/tools_support.py
+++ b/test/unit/tools_support.py
@@ -106,6 +106,7 @@ class MockApp( object ):
 
         self.config = Bunch(
             outputs_to_working_directory=False,
+            commands_in_new_shell=True,
             new_file_path=os.path.join(test_directory, "new_files"),
             tool_data_path=os.path.join(test_directory, "tools"),
             root=os.path.join(test_directory, "galaxy"),


### PR DESCRIPTION
... it builds its own job script - no need to have Galaxy do this isolation on the Galaxy end. The more Pulsar can handle the better.

Fixes https://github.com/galaxyproject/galaxy/issues/1811
