### PR TITLE
[16.01] Fix job splitting functionallity

### DIFF
--- a/extract_dataset_parts.sh
+++ b/extract_dataset_parts.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+: ${GALAXY_VIRTUAL_ENV:=.venv}
+printf "Activating virtualenv at $GALAXY_VIRTUAL_ENV\n"
+. "$GALAXY_VIRTUAL_ENV/bin/activate"
+
 cd `dirname $0`
 for file in $1/split_info*.json
 do


### PR DESCRIPTION
Currently, tools that specify the parallelism-tag will result in the following error: 

https://travis-ci.org/bgruening/galaxytools/builds/112478615#L3818

This PR will source the Galaxy virtual-env before trying to split tasks into smaller chunks.
@dannon what is the correct way of defining tests for this?
