### PR TITLE
Whitelist logging tweaks

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -40,6 +40,7 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
         config.configure_logging( self.config )
         self.configure_fluent_log()
 
+        self.config.reload_sanitize_whitelist(explicit='sanitize_whitelist_file' in kwargs)
         self.amqp_internal_connection_obj = galaxy.queues.connection_from_config(self.config)
         # control_worker *can* be initialized with a queue, but here we don't
         # want to and we'll allow postfork to bind and start it.

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -259,7 +259,7 @@ class Configuration( object ):
         self.log_events = string_as_bool( kwargs.get( 'log_events', 'False' ) )
         self.sanitize_all_html = string_as_bool( kwargs.get( 'sanitize_all_html', True ) )
         self.sanitize_whitelist_file = resolve_path( kwargs.get( 'sanitize_whitelist_file', "config/sanitize_whitelist.txt" ), self.root )
-        self.reload_sanitize_whitelist()
+        self.reload_sanitize_whitelist(explicit='sanitize_whitelist_file' in kwargs)
         self.serve_xss_vulnerable_mimetypes = string_as_bool( kwargs.get( 'serve_xss_vulnerable_mimetypes', False ) )
         self.trust_ipython_notebook_conversion = string_as_bool( kwargs.get( 'trust_ipython_notebook_conversion', False ) )
         self.enable_old_display_applications = string_as_bool( kwargs.get( "enable_old_display_applications", "True" ) )
@@ -473,7 +473,7 @@ class Configuration( object ):
         else:
             return None
 
-    def reload_sanitize_whitelist( self ):
+    def reload_sanitize_whitelist( self, explicit=True ):
         self.sanitize_whitelist = []
         try:
             with open(self.sanitize_whitelist_file, 'rt') as f:
@@ -481,7 +481,8 @@ class Configuration( object ):
                     if not line.startswith("#"):
                         self.sanitize_whitelist.append(line.strip())
         except IOError:
-            log.warning("Sanitize log file %s does not exist, continuing with no tools whitelisted.", self.sanitize_whitelist_file)
+            if explicit:
+                log.warning("Sanitize log file explicitly specified as '%s' but does not exist, continuing with no tools whitelisted.", self.sanitize_whitelist_file)
 
     def __parse_config_file_options( self, kwargs ):
         """

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -259,7 +259,6 @@ class Configuration( object ):
         self.log_events = string_as_bool( kwargs.get( 'log_events', 'False' ) )
         self.sanitize_all_html = string_as_bool( kwargs.get( 'sanitize_all_html', True ) )
         self.sanitize_whitelist_file = resolve_path( kwargs.get( 'sanitize_whitelist_file', "config/sanitize_whitelist.txt" ), self.root )
-        self.reload_sanitize_whitelist(explicit='sanitize_whitelist_file' in kwargs)
         self.serve_xss_vulnerable_mimetypes = string_as_bool( kwargs.get( 'serve_xss_vulnerable_mimetypes', False ) )
         self.trust_ipython_notebook_conversion = string_as_bool( kwargs.get( 'trust_ipython_notebook_conversion', False ) )
         self.enable_old_display_applications = string_as_bool( kwargs.get( "enable_old_display_applications", "True" ) )


### PR DESCRIPTION
Silences warnings when whitelist display isn't explicitly defined, and only attempt to load it when running an actual galaxy application.

@nsoranzo This should cover the changes we'd talked about and is good to go now.  I'm going to follow up with more logging tweaks in a separate PR, because right now logging during config init or config.check doesn't work at all.
