### PR TITLE
Add license and repository information to package.json.  

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,10 @@
   "keywords": [
     "galaxy"
   ],
+  "repository": { "type": "git",
+                  "url": "https://github.com/galaxyproject/galaxy.git"
+  },
+  "license": "AFL-3.0",
   "dependencies": {
     "amdi18n-loader": "^0.2.0",
     "grunt": "^0.4.5",


### PR DESCRIPTION
This seemed like a good idea and silences a couple warnings for recent npm versions.
