### PR TITLE
[16.01] revert ts repo long desc escaping 

### DIFF
--- a/templates/webapps/tool_shed/repository/view_repository.mako
+++ b/templates/webapps/tool_shed/repository/view_repository.mako
@@ -25,7 +25,7 @@
         tip_str = ''
         sharable_link_label = 'Link to this repository revision:'
         sharable_link_changeset_revision = changeset_revision
-    
+
     if heads:
         multiple_heads = len( heads ) > 1
     else:
@@ -119,8 +119,7 @@
         </div>
         %if repository.long_description:
             <div class="form-row">
-                <p>${repository.long_description|h}</p>
-                ## ${render_long_description( to_html_string( repository.long_description ) )}
+                ${render_long_description( to_html_string( repository.long_description ) )}
             </div>
         %endif
         %if repository.homepage_url:


### PR DESCRIPTION
added in a24e206ff7762d5b86d3dc7240190f043dc532b5 - it prevented line endings and spaces to be rendered properly

probably added due to over-cautiousness in escaping
