### PR TITLE
Remove decryption/encryption of tool states

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -271,11 +271,7 @@ class WorkflowContentsManager(UsesAnnotations):
         return workflow, errors
 
     def _workflow_from_dict(self, trans, data, name):
-        # If coming from the editor it will be a flat a string,
-        # we need parse it and handle tool start differently.
-        from_editor = isinstance(data, string_types)
-        if from_editor:
-            # If coming from the editor...
+        if isinstance(data, string_types):
             data = json.loads(data)
 
         # Create new workflow from source data
@@ -297,7 +293,7 @@ class WorkflowContentsManager(UsesAnnotations):
         missing_tool_tups = []
 
         for step_dict in self.__walk_step_dicts( data ):
-            module, step = self.__track_module_from_dict( trans, steps, steps_by_external_id, step_dict, secure=from_editor )
+            module, step = self.__track_module_from_dict( trans, steps, steps_by_external_id, step_dict )
             is_tool = is_tool_module_type( module.type )
             if is_tool and module.tool is None:
                 # A required tool is not available in the local Galaxy instance.
@@ -529,7 +525,7 @@ class WorkflowContentsManager(UsesAnnotations):
                                         # eliminate after a few years...
                 'tool_version': step.tool_version,
                 'name': module.get_name(),
-                'tool_state': module.get_state( secure=False ),
+                'tool_state': module.get_state(),
                 'tool_errors': module.get_errors(),
                 'uuid': str(step.uuid),
                 'label': step.label or None,
@@ -759,8 +755,8 @@ class WorkflowContentsManager(UsesAnnotations):
 
             yield step_dict
 
-    def __track_module_from_dict( self, trans, steps, steps_by_external_id, step_dict, secure ):
-        module, step = self.__module_from_dict( trans, step_dict, secure=secure )
+    def __track_module_from_dict( self, trans, steps, steps_by_external_id, step_dict ):
+        module, step = self.__module_from_dict( trans, step_dict )
         # Create the model class for the step
         steps.append( step )
         steps_by_external_id[ step_dict['id' ] ] = step
@@ -787,7 +783,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 trans.sa_session.add(m)
         return module, step
 
-    def __module_from_dict( self, trans, step_dict, secure ):
+    def __module_from_dict( self, trans, step_dict ):
         """ Create a WorkflowStep model object and corresponding module
         representing type-specific functionality from the incoming dictionary.
         """
@@ -806,7 +802,7 @@ class WorkflowContentsManager(UsesAnnotations):
             )
             step_dict["subworkflow"] = subworkflow
 
-        module = module_factory.from_dict( trans, step_dict, secure=secure )
+        module = module_factory.from_dict( trans, step_dict )
         module.save_to_step( step )
 
         annotation = step_dict[ 'annotation' ]

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -325,8 +325,7 @@ def workflow_run_config_to_request( trans, run_config, workflow ):
     steps_by_id = {}
     for step in workflow.steps:
         steps_by_id[step.id] = step
-        state = step.state
-        serializable_runtime_state = step.module.encode_runtime_state( state )
+        serializable_runtime_state = step.module.get_state( step.state )
         step_state = model.WorkflowRequestStepState()
         step_state.workflow_step = step
         log.info("Creating a step_state for step.id %s" % step.id)

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -326,7 +326,7 @@ def workflow_run_config_to_request( trans, run_config, workflow ):
     for step in workflow.steps:
         steps_by_id[step.id] = step
         state = step.state
-        serializable_runtime_state = step.module.normalize_runtime_state( state )
+        serializable_runtime_state = step.module.encode_runtime_state( state )
         step_state = model.WorkflowRequestStepState()
         step_state.workflow_step = step
         log.info("Creating a step_state for step.id %s" % step.id)

--- a/lib/tool_shed/util/workflow_util.py
+++ b/lib/tool_shed/util/workflow_util.py
@@ -59,7 +59,7 @@ class RepoToolModule( ToolModule ):
         module = Class( trans, repository_id, changeset_revision, tools_metadata, tool_id )
         module.state = galaxy.tools.DefaultToolState()
         if module.tool is not None:
-            module.state.decode( step_dict[ "tool_state" ], module.tool, module.trans.app, secure=secure )
+            module.state.decode( step_dict[ "tool_state" ], module.tool, module.trans.app )
         module.errors = step_dict.get( "tool_errors", None )
         return module
 
@@ -270,7 +270,7 @@ def get_workflow_from_dict( trans, workflow_dict, tools_metadata, repository_id,
         step.label = step_dict.get('label', None)
         step.name = step_dict[ 'name' ]
         step.position = step_dict[ 'position' ]
-        module = module_factory.from_dict( trans, repository_id, changeset_revision, step_dict, tools_metadata=tools_metadata, secure=False )
+        module = module_factory.from_dict( trans, repository_id, changeset_revision, step_dict, tools_metadata=tools_metadata )
         if module.type == 'tool' and module.tool is None:
             # A required tool is not available in the current repository.
             step.tool_errors = 'unavailable'

--- a/templates/webapps/galaxy/workflow/run.mako
+++ b/templates/webapps/galaxy/workflow/run.mako
@@ -644,7 +644,7 @@ if wf_parms:
          that would cause missing_tools.mako to render instead of this
          template. -->
     <% module = step.module %>
-    <input type="hidden" name="${step.id}|tool_state" value="${module.encode_runtime_state( step.state )}">
+    <input type="hidden" name="${step.id}|tool_state" value="${module.get_state( step.state )}">
     %if step.type == 'tool' or step.type is None:
       <%
         tool = trans.app.toolbox.get_tool( step.tool_id )

--- a/templates/webapps/galaxy/workflow/run.mako
+++ b/templates/webapps/galaxy/workflow/run.mako
@@ -644,7 +644,7 @@ if wf_parms:
          that would cause missing_tools.mako to render instead of this
          template. -->
     <% module = step.module %>
-    <input type="hidden" name="${step.id}|tool_state" value="${module.encode_runtime_state( t, step.state )}">
+    <input type="hidden" name="${step.id}|tool_state" value="${module.encode_runtime_state( step.state )}">
     %if step.type == 'tool' or step.type is None:
       <%
         tool = trans.app.toolbox.get_tool( step.tool_id )

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -61,7 +61,7 @@ def test_data_input_compute_runtime_state_args():
     module = __from_step(
         type="data_input",
     )
-    tool_state = module.encode_runtime_state( module.trans, module.test_step.state )
+    tool_state = module.encode_runtime_state( module.test_step.state )
 
     hda = model.HistoryDatasetAssociation()
     with mock.patch('galaxy.workflow.modules.check_param') as check_method:

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -61,7 +61,7 @@ def test_data_input_compute_runtime_state_args():
     module = __from_step(
         type="data_input",
     )
-    tool_state = module.encode_runtime_state( module.test_step.state )
+    tool_state = module.get_state()
 
     hda = model.HistoryDatasetAssociation()
     with mock.patch('galaxy.workflow.modules.check_param') as check_method:


### PR DESCRIPTION
Removes decryption and encryption of tool states and some code duplications. This cleanup is not complete yet, there are still remaining redundancies e.g. it is probably not necessary to use two different string encoded formats, i.e.  `dumps()` and `state.encode()`, but there are other issues of higher priority.
