### PR TITLE
Using node 5.7, 'grunt style' fails with the error:

### DIFF
--- a/client/grunt-tasks/style.js
+++ b/client/grunt-tasks/style.js
@@ -67,6 +67,9 @@ module.exports = function( grunt ){
 
     // remove tmp files
     grunt.config( 'clean', {
+        options : {
+            force: true
+        },
         clean : [
             fmt( '%s/tmp-site-config.less', lessPath )
         ]


### PR DESCRIPTION
"ERROR
Warning: Cannot delete files outside the current working directory. Use
--force to continue.
"
This re-enables deletion of the temporary file, and seems perfectly safe since it's a single non-globbed and very specifically named file.
