### PR TITLE
also update rrda when repairing or updating a repository

### DIFF
--- a/lib/tool_shed/galaxy_install/update_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/update_repository_manager.py
@@ -108,6 +108,8 @@ class UpdateRepositoryManager( object ):
         Tool Shed.  This happens when updating an installed repository to a new changeset revision.
         """
         repository.metadata = updated_metadata_dict
+        tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry( self.app, repository.tool_shed )
+        suc.clean_dependency_relationships(self.app, updated_metadata_dict, repository, tool_shed_url)
         # Update the repository.changeset_revision column in the database.
         repository.changeset_revision = updated_changeset_revision
         repository.ctx_rev = updated_ctx_rev

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -127,10 +127,16 @@ def clean_dependency_relationships(trans, metadata_dict, tool_shed_repository, t
         rd = rrda.repository_dependency
         r = rd.repository
         if can_eliminate_repository_dependency(metadata_dict, tool_shed_url, r.name, r.owner):
+            message = "Repository dependency %s by owner %s is not required by repository %s, owner %s, "
+            message += "removing from list of repository dependencies."
+            log.debug(message % (r.name, r.owner, tool_shed_repository.name, tool_shed_repository.owner))
             trans.install_model.context.delete(rrda)
             trans.install_model.context.flush()
     for td in tool_shed_repository.tool_dependencies:
         if can_eliminate_tool_dependency(metadata_dict, td.name, td.type, td.version):
+            message = "Tool dependency %s, version %s is not required by repository %s, owner %s, "
+            message += "removing from list of tool dependencies."
+            log.debug(message % (td.name, td.version, tool_shed_repository.name, tool_shed_repository.owner))
             trans.install_model.context.delete(td)
             trans.install_model.context.flush()
 


### PR DESCRIPTION
This is a follow-up to PR #1193. Here I'm using a similar strategy for removing outdated repository-repository dependency associations from the database using the current repository's metadata.
This should fix the situation where an update to a repository dependency update leads to old dependencies being listed as missing (or installed), even if the current version doesn't depend on them anymore.
This came up again in https://github.com/galaxyproject/tools-iuc/issues/631
