### PR TITLE
[16.01] Fix lack of log output when discovering large collections...

### DIFF
--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -120,6 +120,13 @@ class JobContext( object ):
                 filename=filename,
                 metadata_source_name=output_collection_def.metadata_source,
             )
+            log.debug(
+                "(%s) Created dynamic collection dataset for path [%s] with element identifier [%s] for output [%s].",
+                self.job.id,
+                filename,
+                designation,
+                output_collection_def.name,
+            )
             current_builder.add_dataset( element_identifiers[-1], dataset )
 
     def create_dataset(


### PR DESCRIPTION
Example log statement collected for each dataset:

```
galaxy.tools.parameters.output_collect DEBUG 2016-03-03 11:47:31,302 (8) Created dynamic collection dataset for path [/home/john/workspace/galaxy/database/job_working_directory/000/8/oe2_ie2.fq] with element identifier [oe2:ie2] for output [list_output].
```
