### PR TITLE
[16.01] Fixes to subworkflow migration 0131

### DIFF
--- a/lib/galaxy/model/migrate/versions/0131_subworkflow_and_input_parameter_modules.py
+++ b/lib/galaxy/model/migrate/versions/0131_subworkflow_and_input_parameter_modules.py
@@ -78,7 +78,7 @@ def downgrade(migrate_engine):
     metadata.reflect()
 
     __drop_column( "subworkflow_id", "workflow_step", metadata )
-    __drop_column( "parent_workflow_id", "workflow_step", metadata )
+    __drop_column( "parent_workflow_id", "workflow", metadata )
 
     __drop_column( "input_subworkflow_step_id", "workflow_step_connection", metadata )
 

--- a/lib/galaxy/model/migrate/versions/0131_subworkflow_and_input_parameter_modules.py
+++ b/lib/galaxy/model/migrate/versions/0131_subworkflow_and_input_parameter_modules.py
@@ -18,9 +18,9 @@ WorkflowInvocationToSubworkflowInvocationAssociation_table = Table(
     Column( "workflow_invocation_id", Integer ),
     Column( "subworkflow_invocation_id", Integer ),
     Column( "workflow_step_id", Integer ),
-    ForeignKeyConstraint(['workflow_invocation_id'], ['workflow_invocation.id'], name='fk_dannontest1'),
-    ForeignKeyConstraint(['subworkflow_invocation_id'], ['workflow_invocation.id'], name='fk_dannontest2'),
-    ForeignKeyConstraint(['workflow_step_id'], ['workflow_step.id'], name='fk_dannontest3')
+    ForeignKeyConstraint(['workflow_invocation_id'], ['workflow_invocation.id'], name='fk_wfi_swi_wfi'),
+    ForeignKeyConstraint(['subworkflow_invocation_id'], ['workflow_invocation.id'], name='fk_wfi_swi_swi'),
+    ForeignKeyConstraint(['workflow_step_id'], ['workflow_step.id'], name='fk_wfi_swi_ws')
 )
 
 WorkflowRequestInputStepParameter_table = Table(
@@ -29,8 +29,8 @@ WorkflowRequestInputStepParameter_table = Table(
     Column( "workflow_invocation_id", Integer ),
     Column( "workflow_step_id", Integer ),
     Column( "parameter_value", JSONType ),
-    ForeignKeyConstraint(['workflow_invocation_id'], ['workflow_invocation.id'], name='fk_dannontest4'),
-    ForeignKeyConstraint(['workflow_step_id'], ['workflow_step.id'], name='fk_dannontest5')
+    ForeignKeyConstraint(['workflow_invocation_id'], ['workflow_invocation.id'], name='fk_wfreq_isp_wfi'),
+    ForeignKeyConstraint(['workflow_step_id'], ['workflow_step.id'], name='fk_wfreq_isp_ws')
 )
 
 TABLES = [

--- a/lib/galaxy/model/migrate/versions/0131_subworkflow_and_input_parameter_modules.py
+++ b/lib/galaxy/model/migrate/versions/0131_subworkflow_and_input_parameter_modules.py
@@ -49,16 +49,17 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     print __doc__
     metadata.reflect()
-
-    subworkflow_id_column = Column( "subworkflow_id", Integer, ForeignKey("workflow.id"), nullable=True )
+    if migrate_engine.name in ['postgres', 'postgresql']:
+        subworkflow_id_column = Column( "subworkflow_id", Integer, ForeignKey("workflow.id"), nullable=True )
+        input_subworkflow_step_id_column = Column( "input_subworkflow_step_id", Integer, ForeignKey("workflow_step.id"), nullable=True )
+        parent_workflow_id_column = Column( "parent_workflow_id", Integer, ForeignKey("workflow.id"), nullable=True )
+    else:
+        subworkflow_id_column = Column( "subworkflow_id", Integer, nullable=True )
+        input_subworkflow_step_id_column = Column( "input_subworkflow_step_id", Integer, nullable=True )
+        parent_workflow_id_column = Column( "parent_workflow_id", Integer, nullable=True )
     __add_column( subworkflow_id_column, "workflow_step", metadata )
-
-    input_subworkflow_step_id_column = Column( "input_subworkflow_step_id", Integer, ForeignKey("workflow_step.id"), nullable=True )
     __add_column( input_subworkflow_step_id_column, "workflow_step_connection", metadata )
-
-    parent_workflow_id_column = Column( "parent_workflow_id", Integer, ForeignKey("workflow.id"), nullable=True )
     __add_column( parent_workflow_id_column, "workflow", metadata )
-
     workflow_output_label_column = Column( "label", TrimmedString(255) )
     workflow_output_uuid_column = Column( "uuid", UUIDType, nullable=True )
     __add_column( workflow_output_label_column, "workflow_output", metadata )

--- a/lib/galaxy/model/migrate/versions/0131_subworkflow_and_input_parameter_modules.py
+++ b/lib/galaxy/model/migrate/versions/0131_subworkflow_and_input_parameter_modules.py
@@ -85,8 +85,6 @@ def downgrade(migrate_engine):
     __drop_column( "label", "workflow_output", metadata )
     __drop_column( "uuid", "workflow_output", metadata )
 
-    __alter_column("workflow", "stored_workflow_id", metadata, nullable=False)
-
     for table in TABLES:
         __drop(table)
 


### PR DESCRIPTION
This addresses two issues with the subworkflow migration.  

It uses explicit index and foreign key names (short ones), which fit within the 64 character limit imposed by mysql.  Previously mysql users would simply have the migration fail on upgrade.

It also fixes the downgrade() step, which previously was attempting to drop the parent_workflow_id column from the wrong table.

Testing in different database configurations (upgrade and downgrade) would be much appreciated.

It also fixes spelling errors.
