### PR TITLE
Update check_python.py now dropping Python 2.6

### DIFF
--- a/scripts/check_python.py
+++ b/scripts/check_python.py
@@ -1,12 +1,12 @@
 """
-If the current installed python version is not 2.6 to 2.7, prints an error
+If the current installed python version is not 2.7, prints an error
 message to stderr and returns 1
 """
 
 import sys
 
 msg = """ERROR: Your Python version is: %s
-Galaxy is currently supported on Python 2.6 and 2.7.  To run Galaxy,
+Galaxy is currently supported on Python 2.7 only.  To run Galaxy,
 please download and install a supported version from python.org.  If a
 supported version is installed but is not your default, getgalaxy.org
 contains instructions on how to force Galaxy to use a different version.""" % sys.version[:3]
@@ -14,7 +14,7 @@ contains instructions on how to force Galaxy to use a different version.""" % sy
 
 def check_python():
     try:
-        assert sys.version_info[:2] >= ( 2, 6 ) and sys.version_info[:2] <= ( 2, 7 )
+        assert sys.version_info[:2] == ( 2, 7 )
     except AssertionError:
         print >>sys.stderr, msg
         raise


### PR DESCRIPTION
Closes #1596 by actually stopping the use of Python 2.6.

Will prevent further problems like #1882 where the lack of Python 2.6 support is only discovered indirectly.
