### PR TITLE
Tones down the warning message about tool changes

### DIFF
--- a/templates/webapps/galaxy/workflow/run.mako
+++ b/templates/webapps/galaxy/workflow/run.mako
@@ -576,15 +576,14 @@ if wf_parms:
 
 %if has_upgrade_messages:
 <div class="warningmessage">
-    Problems were encountered when loading this workflow, likely due to tool
-    version changes. Missing parameter values have been replaced with default.
-    Please review the parameter values below.
+    Warning: Some tools in this workflow have been updated. The workflow may still work, but any new inputs will have default values.
+    Please review the parameter values below to make a decision about whether the changes are reasonable for your experiemnt.
 </div>
 %endif
 
 %if step_version_changes:
     <div class="infomessage">
-        The following tools are beinge executed with a different version from
+        The following tools are being executed with a different version from
         what was available when this workflow was last saved because the
         previous version is no longer available for use on this galaxy
         instance.

--- a/templates/webapps/galaxy/workflow/run.mako
+++ b/templates/webapps/galaxy/workflow/run.mako
@@ -576,8 +576,8 @@ if wf_parms:
 
 %if has_upgrade_messages:
 <div class="warningmessage">
-    Warning: Some tools in this workflow have been updated. The workflow may still work, but any new inputs will have default values.
-    Please review the parameter values below to make a decision about whether the changes will affect your experiment.
+    Warning: Some tools in this workflow have changed since it was last saved. The workflow may still run, but any new options will have default values.
+    Please review the messages below to make a decision about whether the changes will affect your analysis.
 </div>
 %endif
 

--- a/templates/webapps/galaxy/workflow/run.mako
+++ b/templates/webapps/galaxy/workflow/run.mako
@@ -577,7 +577,7 @@ if wf_parms:
 %if has_upgrade_messages:
 <div class="warningmessage">
     Warning: Some tools in this workflow have been updated. The workflow may still work, but any new inputs will have default values.
-    Please review the parameter values below to make a decision about whether the changes are reasonable for your experiemnt.
+    Please review the parameter values below to make a decision about whether the changes will affect your experiment.
 </div>
 %endif
 


### PR DESCRIPTION
This looked like an error to people here. I think this proposed language is a bit softer, but still conveys the message that users can proceed  but should review the changes first to make sure their results will not be affected.
