### PR TITLE
Change to sentry middleware to work with modern raven clients. 

### DIFF
--- a/lib/galaxy/web/framework/middleware/sentry.py
+++ b/lib/galaxy/web/framework/middleware/sentry.py
@@ -87,6 +87,6 @@ class Sentry(object):
             }
         )
         # Galaxy: store event_id in environment so we can show it to the user
-        environ['sentry_event_id'] = event_id[0]
+        environ['sentry_event_id'] = event_id
 
         return event_id


### PR DESCRIPTION
This allows us to upgrade raven and actually show the entire event_id to
users on the guru meditation page, instead of just the first character.
