### PR TITLE
[16.01] Quota API issue with serialization to JSON of Decimal

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/quotas.py
+++ b/lib/galaxy/webapps/galaxy/api/quotas.py
@@ -50,7 +50,7 @@ class QuotaAPIController( BaseAPIController, Admin, AdminActions, UsesQuotaMixin
         Displays information about a quota.
         """
         quota = self.get_quota( trans, id, deleted=util.string_as_bool( deleted ) )
-        return quota.to_dict( view='element', value_mapper={ 'id': trans.security.encode_id } )
+        return quota.to_dict( view='element', value_mapper={ 'id': trans.security.encode_id, 'total_disk_usage': float } )
 
     @web.expose_api
     @web.require_admin


### PR DESCRIPTION
Applies patch from Fabien Mareuil to resolve json serialization of Decimal error.  For more information see http://dev.list.galaxyproject.org/quota-api-error-td4669081.html
