### PR TITLE
Source common_startup script vs running it so the activated venv appl…

### DIFF
--- a/run_reports.sh
+++ b/run_reports.sh
@@ -11,7 +11,7 @@
 
 cd `dirname $0`
 
-./scripts/common_startup.sh --skip-samples
+. ./scripts/common_startup.sh --skip-samples
 
 if [ -z "$GALAXY_REPORTS_CONFIG" ]; then
     if [ -f reports_wsgi.ini ]; then

--- a/run_tool_shed.sh
+++ b/run_tool_shed.sh
@@ -2,7 +2,7 @@
 
 cd `dirname $0`
 
-./scripts/common_startup.sh
+. ./scripts/common_startup.sh
 
 tool_shed=`./lib/tool_shed/scripts/bootstrap_tool_shed/parse_run_sh_args.sh $@`
 args=$@


### PR DESCRIPTION
…ies to the parent script's shell. Fixes #1847.

My testing resulted in the venv getting and staying activated when starting reports app.
