### PR TITLE
Use shared value serialization for tool model

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -568,7 +568,7 @@ class DefaultToolAction( object ):
                     first_reduction = False
                     incoming[ name ] = []
                 if reduced:
-                    incoming[ name ].append( "__collection_reduce__|%s" % dataset_collection.id )
+                    incoming[ name ].append( dataset_collection )
                 # Should verify security? We check security of individual
                 # datasets below?
                 # TODO: verify can have multiple with same name, don't want to loose tracability

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -58,7 +58,7 @@ class ToolEvaluator( object ):
         request_context = WorkRequestContext( app=self.app, user=job.history and job.history.user, history=job.history )
 
         def validate_inputs( input, value, context, **kwargs ):
-            value = input.from_html( value, request_context, context )
+            value = input.from_json( value, request_context, context )
             input.validate( value, request_context )
         visit_input_values( self.tool.inputs, incoming, validate_inputs )
 

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -120,7 +120,7 @@ def check_param( trans, param, incoming_value, param_values ):
             if isinstance( value, dict ):
                 if value.get( '__class__' ) == 'RuntimeValue':
                     return [ value, None ]
-        value = param.from_html( value, trans, param_values )
+        value = param.from_json( value, trans, param_values )
         param.validate( value, trans )
     except ValueError, e:
         error = str( e )

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1680,7 +1680,7 @@ class BaseDataToolParameter( ToolParameter ):
                 src = 'hda'
             return { 'id' : app.security.encode_id( value.id ), 'src' : src }
 
-        if value is not None:
+        if value not in [ None, '', 'None' ]:
             if isinstance( value, list ) and len( value ) > 0:
                 values = [ single_to_json( v ) for v in value ]
             else:

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1670,7 +1670,6 @@ class BaseDataToolParameter( ToolParameter ):
         self.is_dynamic = self.options is not None
 
     def to_json( self, value, app ):
-
         def single_to_json( value ):
             src = None
             if isinstance( value, galaxy.model.DatasetCollectionElement ):
@@ -1680,7 +1679,6 @@ class BaseDataToolParameter( ToolParameter ):
             else:
                 src = 'hda'
             return { 'id' : app.security.encode_id( value.id ), 'src' : src }
-
         if value is not None:
             if isinstance( value, list ) and len( value ) > 0:
                 values = [ single_to_json( v ) for v in value ]

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -98,7 +98,7 @@ class ToolParameter( object, Dictifiable ):
         """
         return self.get_html_field( trans, value, other_values ).get_html()
 
-    def from_html( self, value, trans=None, other_values={} ):
+    def from_json( self, value, trans=None, other_values={} ):
         """
         Convert a value from an HTML POST into the parameters preferred value
         format.
@@ -284,9 +284,9 @@ class IntegerToolParameter( TextToolParameter ):
     blah
     >>> print p.get_html()
     <input type="text" name="blah" size="4" value="10">
-    >>> type( p.from_html( "10", trans ) )
+    >>> type( p.from_json( "10", trans ) )
     <type 'int'>
-    >>> type( p.from_html( "bleh", trans ) )
+    >>> type( p.from_json( "bleh", trans ) )
     Traceback (most recent call last):
         ...
     ValueError: An integer or workflow parameter e.g. ${name} is required
@@ -324,7 +324,7 @@ class IntegerToolParameter( TextToolParameter ):
             value = str( value )
         return super( IntegerToolParameter, self ).get_html_field( trans=trans, value=value, other_values=other_values )
 
-    def from_html( self, value, trans, other_values={} ):
+    def from_json( self, value, trans, other_values={} ):
         try:
             return int( value )
         except:
@@ -364,9 +364,9 @@ class FloatToolParameter( TextToolParameter ):
     blah
     >>> print p.get_html()
     <input type="text" name="blah" size="4" value="3.141592">
-    >>> type( p.from_html( "36.1", trans ) )
+    >>> type( p.from_json( "36.1", trans ) )
     <type 'float'>
-    >>> type( p.from_html( "bleh", trans ) )
+    >>> type( p.from_json( "bleh", trans ) )
     Traceback (most recent call last):
         ...
     ValueError: A real number or workflow parameter e.g. ${name} is required
@@ -404,7 +404,7 @@ class FloatToolParameter( TextToolParameter ):
             value = str( value )
         return super( FloatToolParameter, self ).get_html_field( trans=trans, value=value, other_values=other_values )
 
-    def from_html( self, value, trans, other_values={} ):
+    def from_json( self, value, trans, other_values={} ):
         try:
             return float( value )
         except:
@@ -443,11 +443,11 @@ class BooleanToolParameter( ToolParameter ):
     blah
     >>> print p.get_html()
     <input type="checkbox" id="blah" name="blah" value="__CHECKED__" checked="checked"><input type="hidden" name="blah" value="__NOTHING__">
-    >>> print p.from_html( ["__CHECKED__","__NOTHING__"] )
+    >>> print p.from_json( ["__CHECKED__","__NOTHING__"] )
     True
     >>> print p.to_param_dict_string( True )
     bulletproof vests
-    >>> print p.from_html( ["__NOTHING__"] )
+    >>> print p.from_json( ["__NOTHING__"] )
     False
     >>> print p.to_param_dict_string( False )
     cellophane chests
@@ -462,10 +462,10 @@ class BooleanToolParameter( ToolParameter ):
     def get_html_field( self, trans=None, value=None, other_values={} ):
         checked = self.checked
         if value is not None:
-            checked = self.from_html( value )
+            checked = self.from_json( value )
         return form_builder.CheckboxField( self.name, checked, refresh_on_change=self.refresh_on_change )
 
-    def from_html( self, value, trans=None, other_values={} ):
+    def from_json( self, value, trans=None, other_values={} ):
         if form_builder.CheckboxField.is_checked( value ):
             return True
         return self.to_python( value )
@@ -518,7 +518,7 @@ class FileToolParameter( ToolParameter ):
     def get_html_field( self, trans=None, value=None, other_values={}  ):
         return form_builder.FileField( self.name, ajax=self.ajax, value=value )
 
-    def from_html( self, value, trans=None, other_values={} ):
+    def from_json( self, value, trans=None, other_values={} ):
         # Middleware or proxies may encode files in special ways (TODO: this
         # should be pluggable)
         if type( value ) == dict:
@@ -609,7 +609,7 @@ class FTPFileToolParameter( ToolParameter ):
         else:
             return lst[ 0 ]
 
-    def from_html( self, value, trans=None, other_values={} ):
+    def from_json( self, value, trans=None, other_values={} ):
         return self.to_python( value, trans.app, validate=True )
 
     def to_string( self, value, app ):
@@ -706,7 +706,7 @@ class BaseURLToolParameter( HiddenToolParameter ):
     def get_html_field( self, trans=None, value=None, other_values={} ):
         return form_builder.HiddenField( self.name, self._get_value() )
 
-    def from_html( self, value=None, trans=None, other_values={} ):
+    def from_json( self, value=None, trans=None, other_values={} ):
         return self._get_value()
 
     def _get_value( self ):
@@ -886,7 +886,7 @@ class SelectToolParameter( ToolParameter ):
             field.add_option( text, optval, selected )
         return field
 
-    def from_html( self, value, trans, other_values={} ):
+    def from_json( self, value, trans, other_values={} ):
         legal_values = self.get_legal_values( trans, other_values )
         if len(list(legal_values)) == 0 and trans.workflow_building_mode:
             if self.multiple:
@@ -1155,7 +1155,7 @@ class ColumnListParameter( SelectToolParameter ):
         self.is_dynamic = True
         self.usecolnames = input_source.get_bool( "use_header_names", False )
 
-    def from_html( self, value, trans, other_values={} ):
+    def from_json( self, value, trans, other_values={} ):
         """
         Label convention prepends column number with a 'c', but tool uses the integer. This
         removes the 'c' when entered into a workflow.
@@ -1182,7 +1182,7 @@ class ColumnListParameter( SelectToolParameter ):
         if not value and not self.get_legal_values( trans, other_values ) and self.accept_default:
             value = self.default_value or '1'
             return [ value ] if self.multiple else value
-        return super( ColumnListParameter, self ).from_html( value, trans, other_values )
+        return super( ColumnListParameter, self ).from_json( value, trans, other_values )
 
     @staticmethod
     def _strip_c(column):
@@ -1479,7 +1479,7 @@ class DrillDownSelectToolParameter( SelectToolParameter ):
                 return form_builder.TextField( self.name, value=(value or "") )
         return form_builder.DrillDownField( self.name, self.multiple, self.display, self.refresh_on_change, options, value, refresh_on_change_values=self.refresh_on_change_values )
 
-    def from_html( self, value, trans, other_values={} ):
+    def from_json( self, value, trans, other_values={} ):
         legal_values = self.get_legal_values( trans, other_values )
         if len( list( legal_values ) ) == 0 and trans.workflow_building_mode:
             if self.multiple:
@@ -1818,7 +1818,7 @@ class DataToolParameter( BaseDataToolParameter ):
             return most_recent_dataset[0]
         return ''
 
-    def from_html( self, value, trans, other_values={} ):
+    def from_json( self, value, trans, other_values={} ):
         if trans.workflow_building_mode:
             return None
         if not value and not self.optional:
@@ -2135,7 +2135,7 @@ class DataCollectionToolParameter( BaseDataToolParameter ):
         self._ensure_selection( field )
         return field
 
-    def from_html( self, value, trans, other_values={} ):
+    def from_json( self, value, trans, other_values={} ):
         if trans.workflow_building_mode:
             return None
         if not value and not self.optional:
@@ -2294,7 +2294,7 @@ class LibraryDatasetToolParameter( ToolParameter ):
     def get_initial_value( self, trans, other_values ):
         return None
 
-    def from_html( self, value, trans, other_values={} ):
+    def from_json( self, value, trans, other_values={} ):
         return self.to_python( value, trans.app, other_values=other_values, validate=True )
 
     def to_param_dict_string( self, value, other_values={} ):

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1679,6 +1679,7 @@ class BaseDataToolParameter( ToolParameter ):
             else:
                 src = 'hda'
             return { 'id' : app.security.encode_id( value.id ), 'src' : src }
+
         if value is not None:
             if isinstance( value, list ) and len( value ) > 0:
                 values = [ single_to_json( v ) for v in value ]

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1139,6 +1139,7 @@ class ToolModule( WorkflowModule ):
                 dict( ( conn.input_name, conn ) for conn in connections )
         else:
             input_connections_by_name = {}
+
         # Any connected input needs to have value RuntimeValue (these
         # are not persisted so we need to do it every time)
         def callback( input, prefixed_name, **kwargs ):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1141,19 +1141,10 @@ class ToolModule( WorkflowModule ):
             input_connections_by_name = {}
         # Any connected input needs to have value RuntimeValue (these
         # are not persisted so we need to do it every time)
-
         def callback( input, prefixed_name, **kwargs ):
-            replacement = None
-            if isinstance( input, DataToolParameter ):
+            if isinstance( input, DataToolParameter ) or isinstance( input, DataCollectionToolParameter ):
                 if connections is None or prefixed_name in input_connections_by_name:
-                    if input.multiple:
-                        replacement = [] if not connections else [RuntimeValue() for conn in connections]
-                    else:
-                        replacement = RuntimeValue()
-            elif isinstance( input, DataCollectionToolParameter ):
-                if connections is None or prefixed_name in input_connections_by_name:
-                    replacement = RuntimeValue()
-            return replacement
+                    return RuntimeValue()
 
         visit_input_values( self.tool.inputs, self.state.inputs, callback )
 

--- a/test/unit/tools/test_column_parameters.py
+++ b/test/unit/tools/test_column_parameters.py
@@ -25,22 +25,22 @@ class DataColumnParameterTestCase( BaseParameterTestCase ):
         # TODO: don't break abstraction, try setting null value instead
         return self.param.optional
 
-    def test_from_html(self):
-        value = self.param.from_html("3", self.trans, { "input_tsv": self.build_ready_hda()  } )
+    def test_from_json(self):
+        value = self.param.from_json("3", self.trans, { "input_tsv": self.build_ready_hda()  } )
         assert value == "3"
 
-    def test_from_html_strips_c(self):
-        value = self.param.from_html("c1", self.trans, { "input_tsv": self.build_ready_hda()  } )
+    def test_from_json_strips_c(self):
+        value = self.param.from_json("c1", self.trans, { "input_tsv": self.build_ready_hda()  } )
         assert value == "1"
 
-    def test_multiple_from_html(self):
+    def test_multiple_from_json(self):
         self.multiple = True
-        value = self.param.from_html("1,2,3", self.trans, { "input_tsv": self.build_ready_hda()  } )
+        value = self.param.from_json("1,2,3", self.trans, { "input_tsv": self.build_ready_hda()  } )
         assert value == ["1", "2", "3"]
 
-    def test_multiple_from_html_with_c(self):
+    def test_multiple_from_json_with_c(self):
         self.multiple = True
-        value = self.param.from_html("c1,c2,c3", self.trans, { "input_tsv": self.build_ready_hda()  } )
+        value = self.param.from_json("c1,c2,c3", self.trans, { "input_tsv": self.build_ready_hda()  } )
         assert value == ["1", "2", "3"]
 
     def test_get_initial_value_default(self):

--- a/test/unit/tools/test_data_parameters.py
+++ b/test/unit/tools/test_data_parameters.py
@@ -8,8 +8,8 @@ class DataToolParameterTestCase( BaseParameterTestCase ):
 
     def test_to_python_none_values( self ):
         assert None is self.param.to_python( None, self.app )
-        assert 'None' == self.param.to_python( 'None', self.app )
-        assert '' == self.param.to_python( '', self.app )
+        assert None is self.param.to_python( 'None', self.app )
+        assert None is self.param.to_python( '', self.app )
 
     def test_to_python_hda( self ):
         hda = self._new_hda()

--- a/test/unit/tools/test_data_parameters.py
+++ b/test/unit/tools/test_data_parameters.py
@@ -7,9 +7,9 @@ from .test_parameter_parsing import BaseParameterTestCase
 class DataToolParameterTestCase( BaseParameterTestCase ):
 
     def test_to_python_none_values( self ):
-        assert None is self.param.to_python( None, self.app )
-        assert None is self.param.to_python( 'None', self.app )
-        assert None is self.param.to_python( '', self.app )
+        assert self.param.to_python( None, self.app ) is None
+        assert self.param.to_python( 'None', self.app ) is None
+        assert self.param.to_python( '', self.app ) is None
 
     def test_to_python_hda( self ):
         hda = self._new_hda()

--- a/test/unit/tools/test_select_parameters.py
+++ b/test/unit/tools/test_select_parameters.py
@@ -10,7 +10,7 @@ class SelectToolParameterTestCase( BaseParameterTestCase ):
     def test_validated_values( self ):
         self.options_xml = '''<options><filter type="data_meta" ref="input_bam" key="dbkey"/></options>'''
         try:
-            self.param.from_html("42", self.trans, { "input_bam": model.HistoryDatasetAssociation() })
+            self.param.from_json("42", self.trans, { "input_bam": model.HistoryDatasetAssociation() })
         except ValueError, err:
             assert str(err) == "An invalid option was selected for my_name, '42', please verify."
             return
@@ -19,7 +19,7 @@ class SelectToolParameterTestCase( BaseParameterTestCase ):
     def test_validated_values_missing_dependency( self ):
         self.options_xml = '''<options><filter type="data_meta" ref="input_bam" key="dbkey"/></options>'''
         try:
-            self.param.from_html("42", self.trans)
+            self.param.from_json("42", self.trans)
         except AssertionError, err:
             assert str(err) == "Required dependency 'input_bam' not found in incoming values"
             return
@@ -28,12 +28,12 @@ class SelectToolParameterTestCase( BaseParameterTestCase ):
     def test_unvalidated_values( self ):
         self.options_xml = '''<options><filter type="data_meta" ref="input_bam" key="dbkey"/></options>'''
         self.trans.workflow_building_mode = True
-        assert self.param.from_html("42", self.trans) == "42"
+        assert self.param.from_json("42", self.trans) == "42"
 
     def test_validated_datasets( self ):
         self.options_xml = '''<options><filter type="data_meta" ref="input_bam" key="dbkey"/></options>'''
         try:
-            self.param.from_html( model.HistoryDatasetAssociation(), self.trans, { "input_bam": basic.RuntimeValue() } )
+            self.param.from_json( model.HistoryDatasetAssociation(), self.trans, { "input_bam": basic.RuntimeValue() } )
         except ValueError, err:
             assert str(err) == "Parameter my_name requires a value, but has no legal values defined."
             return
@@ -42,7 +42,7 @@ class SelectToolParameterTestCase( BaseParameterTestCase ):
     def test_unvalidated_datasets( self ):
         self.options_xml = '''<options><filter type="data_meta" ref="input_bam" key="dbkey"/></options>'''
         self.trans.workflow_building_mode = True
-        assert isinstance( self.param.from_html( model.HistoryDatasetAssociation(), self.trans, { "input_bam": basic.RuntimeValue() } ), model.HistoryDatasetAssociation )
+        assert isinstance( self.param.from_json( model.HistoryDatasetAssociation(), self.trans, { "input_bam": basic.RuntimeValue() } ), model.HistoryDatasetAssociation )
 
     def test_filter_param_value( self ):
         self.options_xml = '''<options from_data_table="test_table"><filter type="param_value" ref="input_bam" column="0" /></options>'''


### PR DESCRIPTION
This PR replaces the custom serialization using `jsonify` with the shared `value_to_basic` caller. It also renames `from_html` to `from_json` and `to_string` to `to_json` to highlight the value transformation pathway (see: https://github.com/galaxyproject/galaxy/pull/1901/files#diff-1bef786a2b2ea704c1748e41cd25dd33L1607). It also removes the collection handling tags `__collection_reduce__|`, `dce:` and `hdca:` while preserving backward compatibility. In total we had to remove five collection legacy tags. Previously removed legacy tags are `__multirun__|` and  `__collection_multirun__|` (see: https://github.com/guerler/galaxy/commit/050adad1ea20f80472fa7f41a301b2d9d4d38d3d#diff-3a53a967fc9b71e9f853f502b64ccba4L49). Now, Datasets and DatasetCollections are serialized in the same fashion. Additionally  we stripped the inconsistent RuntimeValue-Array creation for multiple data tool parameters. This unifies the RuntimeValue handling throughout the parameter processing.
