### PR TITLE
adding contrib init for reports and modifying status check to have ou…

### DIFF
--- a/contrib/galaxy.fedora-init
+++ b/contrib/galaxy.fedora-init
@@ -65,7 +65,9 @@ galaxy_status() {
 		do
 			status -p $RUN_IN/${proc}.pid ${proc}
 		done
-	fi																			}
+	fi
+}
+
 notsupported() {
 	echo "*** ERROR*** $SERVICE_NAME: operation [$1] not supported"
 }

--- a/contrib/galaxy.fedora-init
+++ b/contrib/galaxy.fedora-init
@@ -24,11 +24,9 @@ start() {
 	case "$(id -un)" in
 		$RUN_AS)
 			eval "$cmd"
-			touch /var/lock/subsys/galaxy
 			;;
 		root)
 			su - $RUN_AS -c "$cmd"
-			touch /var/lock/subsys/galaxy
 			;;
 		*)
 			echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
@@ -45,11 +43,9 @@ stop() {
 	case "$(id -un)" in
 		$RUN_AS)
 			eval "$cmd"
-			rm -f /var/lock/subsys/galaxy
 			;;
 		root)
 			su - $RUN_AS -c "$cmd"
-			rm -f /var/lock/subsys/galaxy
 			;;
 		*)
 			echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2

--- a/contrib/galaxy_reports.fedora-init
+++ b/contrib/galaxy_reports.fedora-init
@@ -24,11 +24,9 @@ start() {
 	case "$(id -un)" in
 		$RUN_AS)
 			eval "$cmd"
-			touch /var/lock/subsys/galaxy-reports
 			;;
 		root)
 			su - $RUN_AS -c "$cmd"
-			touch /var/lock/subsys/galaxy-reports
 			;;
 		*)
 			echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
@@ -45,12 +43,9 @@ stop() {
 	case "$(id -un)" in
 		$RUN_AS)
 			eval "$cmd"
-			rm -f /var/lock/subsys/galaxy-reports
 			;;
 		root)
 			su - $RUN_AS -c "$cmd"
-			rm -f /var/lock/subsys/galaxy-reports
-			;;
 		*)
 			echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
 			exit 1

--- a/contrib/galaxy_reports.fedora-init
+++ b/contrib/galaxy_reports.fedora-init
@@ -12,7 +12,7 @@
 . /etc/init.d/functions
 #--- config
 
-SERVICE_NAME="galaxy"
+SERVICE_NAME="galaxy-reports"
 RUN_AS="galaxy"
 RUN_IN="/path/to/galaxy-dist"
 
@@ -20,15 +20,15 @@ RUN_IN="/path/to/galaxy-dist"
 
 start() {
 	echo "Starting $SERVICE_NAME... "
-	cmd="cd $RUN_IN && sh run.sh --daemon"
+	cmd="cd $RUN_IN && sh run_reports.sh --daemon"
 	case "$(id -un)" in
 		$RUN_AS)
 			eval "$cmd"
-			touch /var/lock/subsys/galaxy
+			touch /var/lock/subsys/galaxy-reports
 			;;
 		root)
 			su - $RUN_AS -c "$cmd"
-			touch /var/lock/subsys/galaxy
+			touch /var/lock/subsys/galaxy-reports
 			;;
 		*)
 			echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
@@ -40,16 +40,16 @@ start() {
 stop() {
 	echo -n "Stopping $SERVICE_NAME... "
 	
-	cmd="cd $RUN_IN && sh run.sh --stop-daemon"
+	cmd="cd $RUN_IN && sh run_reports.sh --stop-daemon"
 
 	case "$(id -un)" in
 		$RUN_AS)
 			eval "$cmd"
-			rm -f /var/lock/subsys/galaxy
+			rm -f /var/lock/subsys/galaxy-reports
 			;;
 		root)
 			su - $RUN_AS -c "$cmd"
-			rm -f /var/lock/subsys/galaxy
+			rm -f /var/lock/subsys/galaxy-reports
 			;;
 		*)
 			echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
@@ -59,17 +59,6 @@ stop() {
 	echo "done."
 }
 
-galaxy_status() {
-	if [[ $(grep '\[server:' $RUN_IN/config/galaxy.ini|awk -F'(:)|(])' '{ print $2 }') == 'main' ]]
-	then
-		echo -n "$SERVICE_NAME status: "
-		status -p $RUN_IN/paster.pid galaxy
-	else
-		for proc in $(grep '\[server:' $RUN_IN/config/galaxy.ini|awk -F'(:)|(])' '{ print $2 }')
-		do
-			status -p $RUN_IN/${proc}.pid ${proc}
-		done
-	fi																			}
 notsupported() {
 	echo "*** ERROR*** $SERVICE_NAME: operation [$1] not supported"
 }
@@ -94,7 +83,8 @@ case "$1" in
 		;;
 	status)
 		set +e
-		galaxy_status
+		echo -n "$SERVICE_NAME status: "
+		status -p $RUN_IN/reports_webapp.pid $SERVICE_NAME
 		exit $?
 		;;
 	'')

--- a/contrib/galaxy_reports.fedora-init
+++ b/contrib/galaxy_reports.fedora-init
@@ -46,6 +46,7 @@ stop() {
 			;;
 		root)
 			su - $RUN_AS -c "$cmd"
+			;;
 		*)
 			echo "*** ERROR *** must be $RUN_AS or root in order to control this service" >&2
 			exit 1


### PR DESCRIPTION
I add an init.d file for the reports and change the status check in order to print out each process status (ie web0, handler0, handler1..)

/etc/init.d/galaxy status

web0 (pid  28038) running...
handler0 (pid  28041) running...
handler1 (pid  28044) running...
