### PR TITLE
[16.01] Ensure chrom, start, end as bytestring in BamDataProvider

### DIFF
--- a/lib/galaxy/visualization/data_providers/genome.py
+++ b/lib/galaxy/visualization/data_providers/genome.py
@@ -888,6 +888,9 @@ class BamDataProvider( GenomeDataProvider, FilterableMixin ):
         """
 
         # Fetch and return data.
+        chrom = str(chrom)
+        start = int(start)
+        end = int(end)
         try:
             data = data_file.fetch( start=start, end=end, reference=chrom )
         except ValueError:


### PR DESCRIPTION
This should fix an error report that just came in on the mailing list by Lubos Klucar

```
galaxy.webapps.galaxy.api.datasets ERROR 2016-03-15 11:44:38,853 Error in dataset API at listing contents: Expected bytes, got unicode: Expected bytes, got unicode
Traceback (most recent call last):
  File "/usr/local/galaxy-prod/lib/galaxy/webapps/galaxy/api/datasets.py", line 66, in show
    rval = self._data( trans, dataset, **kwd )
  File "/usr/local/galaxy-prod/lib/galaxy/webapps/galaxy/api/datasets.py", line 235, in _data
    ref_seq=region, mean_depth=mean_depth, **kwargs )
  File "/usr/local/galaxy-prod/lib/galaxy/visualization/data_providers/genome.py", line 192, in get_data
    iterator = self.get_iterator( data_file, chrom, start, end, **kwargs )
  File "/usr/local/galaxy-prod/lib/galaxy/visualization/data_providers/genome.py", line 892, in get_iterator
    data = data_file.fetch( start=start, end=end, reference=chrom )
  File "pysam/calignmentfile.pyx", line 868, in pysam.calignmentfile.AlignmentFile.fetch (pysam/calignmentfile.c:10170)
  File "pysam/calignmentfile.pyx", line 787, in pysam.calignmentfile.AlignmentFile.parse_region (pysam/calignmentfile.c:9605)
  File "pysam/calignmentfile.pyx", line 1576, in pysam.calignmentfile.AlignmentFile.gettid (pysam/calignmentfile.c:16665)
  File "pysam/calignmentfile.pyx", line 640, in pysam.calignmentfile.AlignmentFile.get_tid (pysam/calignmentfile.c:8208)
  File "pysam/cutils.pyx", line 106, in pysam.cutils.force_bytes (pysam/cutils.c:2170)
TypeError: Expected bytes, got unicode
```

Ping @nsoranzo @dannon, this seems to be the same issue as in PR #1897 
Though I'm very surprised that noone has reported an error before!
