### PR TITLE
More warnings, less errors

### DIFF
--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -271,7 +271,7 @@ class MetadataType( JSONType ):
                     sz = total_size(v)
                     if sz > app.app.config.max_metadata_value_size:
                         del value[k]
-                        log.error('Refusing to bind metadata key %s due to size (%s)' % (k, sz))
+                        log.warning('Refusing to bind metadata key %s due to size (%s)' % (k, sz))
             value = json_encoder.encode(value)
         return value
 

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -96,10 +96,11 @@ class RemoteFilesAPIController( BaseAPIController ):
                 if user_ftp_dir is not None:
                     response = self.__load_all_filenames( user_ftp_dir )
                 else:
-                    raise exceptions.ConfigDoesNotAllowException( 'You do not have an FTP directory named as your login at this Galaxy instance.' )
+                    log.warning( 'You do not have an FTP directory named as your login at this Galaxy instance.' )
+                    return None
             except Exception, exception:
-                log.error( 'Could not get ftp files: %s', str( exception ), exc_info=True )
-                raise exceptions.InternalServerError( 'Could not get the files from your FTP folder.' )
+                log.warning( 'Could not get ftp files: %s', str( exception ), exc_info=True )
+                return None
         return response
 
     def __load_all_filenames( self, directory ):
@@ -117,7 +118,8 @@ class RemoteFilesAPIController( BaseAPIController ):
                                            size=statinfo.st_size,
                                            ctime=time.strftime( "%m/%d/%Y %I:%M:%S %p", time.localtime( statinfo.st_ctime ) ) ) )
         else:
-            raise exceptions.ConfigDoesNotAllowException( 'The given directory does not exist.' )
+            log.warning( "The directory \"%s\" does not exist." % directory )
+            return response
         # sort by path
         response = sorted(response, key=itemgetter("path"))
         return response


### PR DESCRIPTION
This is as minor as it gets, but I think it is still important to have a clear idea of what is an error, and what is more of a warning.
- 18a4edc when a user hasn't uploaded a file by FTP, the FTP directory (at least in our configuration) doesn't exist and an error is raised. This should be a warning, and the user still sees `Your FTP directory does not contain any files.`
- 5c45746 when the metadata of a file exceeds a limit, the metadata won't be writtten to the database, and an error is raised. I think this should be a warning
