### PR TITLE
Add IUC as a new default bioconda channel

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -191,7 +191,7 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # Pass debug flag to conda commands.
 #conda_debug = False
 # conda channels to enable by default (http://conda.pydata.org/docs/custom-channels.html)
-#conda_ensure_channels = r,bioconda
+#conda_ensure_channels = r,bioconda,iuc
 # Set to True to instruct Galaxy to look for and install missing tool
 # dependencies before each job runs.
 #conda_auto_install = False


### PR DESCRIPTION
This will be needed for all hacks that we don't want to put into bioconda, e.g. old tool deps.
