### PR TITLE
Optimize object store interaction during job creation.

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -115,6 +115,14 @@ class ObjectStore(object):
         """
         raise NotImplementedError()
 
+    def set_object_store_id(self, obj):
+        """
+        Set an object store identifier (``object_store_id``) for the supplied object.
+
+        For simple object stores this may no be needed and so a no-op default
+        method is provided by this class.
+        """
+
     def empty(self, obj, base_dir=None, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False):
         """
         Test if the object identified by `obj` has content.
@@ -464,7 +472,13 @@ class NestedObjectStore(ObjectStore):
 
     def create(self, obj, **kwargs):
         """Create a backing file in a random backend."""
-        random.choice(self.backends.values()).create(obj, **kwargs)
+        self.set_object_store_id(obj)
+        return self._call_method('create', obj, **kwargs)
+
+    def set_object_store_id(self, obj):
+        """Set the object store ID (backend) to use."""
+        if obj.object_store_id is None:
+            self._random_backend().set_object_store_id(obj)
 
     def empty(self, obj, **kwargs):
         """For the first backend that has this `obj`, determine if it is empty."""
@@ -496,6 +510,9 @@ class NestedObjectStore(ObjectStore):
     def get_object_url(self, obj, **kwargs):
         """For the first backend that has this `obj`, get its URL."""
         return self._call_method('get_object_url', obj, None, False, **kwargs)
+
+    def _random_backend(self):
+        return random.choice(self.backends.values())
 
     def _call_method(self, method, obj, default, default_is_exception,
             **kwargs):
@@ -609,21 +626,26 @@ class DistributedObjectStore(NestedObjectStore):
 
     def create(self, obj, **kwargs):
         """The only method in which obj.object_store_id may be None."""
-        if obj.object_store_id is None or not self.exists(obj, **kwargs):
-            if obj.object_store_id is None or obj.object_store_id not in self.weighted_backend_ids:
-                try:
-                    obj.object_store_id = random.choice(self.weighted_backend_ids)
-                except IndexError:
-                    raise ObjectInvalid('objectstore.create, could not generate '
-                                        'obj.object_store_id: %s, kwargs: %s'
-                                        % ( str( obj ), str( kwargs ) ) )
+        object_store_id = obj.object_store_id
+        if object_store_id is None or not self.exists(obj, **kwargs):
+            if object_store_id is None or object_store_id not in self.weighted_backend_ids:
+                self.set_object_store_id(obj, **kwargs)
                 _create_object_in_session( obj )
                 log.debug("Selected backend '%s' for creation of %s %s"
                           % (obj.object_store_id, obj.__class__.__name__, obj.id))
             else:
                 log.debug("Using preferred backend '%s' for creation of %s %s"
-                          % (obj.object_store_id, obj.__class__.__name__, obj.id))
+                          % (object_store_id, obj.__class__.__name__, obj.id))
             self.backends[obj.object_store_id].create(obj, **kwargs)
+
+    def set_object_store_id(self, obj, **kwargs):
+        if obj.object_store_id is None:
+            try:
+                obj.object_store_id = random.choice(self.weighted_backend_ids)
+            except IndexError:
+                raise ObjectInvalid('objectstore.create, could not generate '
+                                    'obj.object_store_id: %s, kwargs: %s'
+                                    % ( str( obj ), str( kwargs ) ) )
 
     def _call_method(self, method, obj, default, default_is_exception, **kwargs):
         object_store_id = self.__get_store_id_for(obj, **kwargs)
@@ -679,7 +701,13 @@ class HierarchicalObjectStore(NestedObjectStore):
 
     def create(self, obj, **kwargs):
         """Call the primary object store."""
-        self.backends[0].create(obj, **kwargs)
+        self._primary_backend().create(obj, **kwargs)
+
+    def set_object_store_id(self, obj, **kwargs):
+        self._primary_backend().set_object_store_id(obj, **kwargs)
+
+    def _primary_backend(self):
+        return self.backends[0]
 
 
 def build_object_store_from_config(config, fsmon=False, config_xml=None):

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -305,10 +305,7 @@ class DefaultToolAction( object ):
                 trans.sa_session.add( data )
                 trans.app.security_agent.set_all_dataset_permissions( data.dataset, output_permissions, new=True )
 
-            # Must flush before setting object store id currently.
-            # TODO: optimize this.
-            trans.sa_session.flush()
-            object_store_populator.set_object_store_id( data )
+            object_store_populator.register( data )
 
             # This may not be neccesary with the new parent/child associations
             data.designation = name
@@ -463,6 +460,15 @@ class DefaultToolAction( object ):
             parent_dataset.children.append( child_dataset )
 
         log.info("Added output datasets to history %s" % add_datasets_timer)
+
+        create_files_timer = ExecutionTimer()
+        # TODO: Further optimize by moving this down to after the flush
+        # for the job. Would probably want to clean up the job if there
+        # are problems before making this change.
+        trans.sa_session.flush()
+        object_store_populator.create_datasets()
+        log.info("Created output datasets in object store %s" % create_files_timer)
+
         job_setup_timer = ExecutionTimer()
         # Create the job object
         job, galaxy_session = self._new_job_for_session( trans, tool, history )
@@ -647,17 +653,24 @@ class ObjectStorePopulator( object ):
     def __init__( self, app ):
         self.object_store = app.object_store
         self.object_store_id = None
+        self.objects = []
 
-    def set_object_store_id( self, data ):
+    def register( self, data ):
         # Create an empty file immediately.  The first dataset will be
         # created in the "default" store, all others will be created in
         # the same store as the first.
-        data.dataset.object_store_id = self.object_store_id
+        dataset = data.dataset
+        dataset.object_store_id = self.object_store_id
+        self.objects.append(dataset)
         try:
-            self.object_store.create( data.dataset )
+            self.object_store.set_object_store_id( dataset )
         except ObjectInvalid:
-            raise Exception('Unable to create output dataset: object store is full')
-        self.object_store_id = data.dataset.object_store_id  # these will be the same thing after the first output
+            raise Exception('Unable to set object store id for output dataset: object store is full')
+        self.object_store_id = dataset.object_store_id  # these will be the same thing after the first output
+
+    def create_datasets(self):
+        for obj in self.objects:
+            self.object_store.create(obj)
 
 
 def on_text_for_names( input_names ):

--- a/test/unit/tools/test_actions.py
+++ b/test/unit/tools/test_actions.py
@@ -260,9 +260,12 @@ class MockObjectStore( object ):
 
     def create( self, dataset ):
         self.created_datasets.append( dataset )
+        if hasattr( dataset, "object_store_id" ) and dataset.object_store_id:
+            assert dataset.object_store_id == self.object_store_id
         if self.first_create:
             self.first_create = False
             assert dataset.object_store_id is None
-            dataset.object_store_id = self.object_store_id
-        else:
-            assert dataset.object_store_id == self.object_store_id
+            self.set_object_store_id( dataset )
+
+    def set_object_store_id( self, dataset ):
+        self.object_store_id = self.object_store_id


### PR DESCRIPTION
Previously object_store_id on datasets was set as part of create - and create requires an object ID and therefore by extension a database flush. Together, this required a flush per output dataset while creating jobs.

This commit splits the object_store_id setting out from create - so that datasets can set an object_store_id during dataset creation and before flushing. The upshot is that flushing the database can now be done once for all datasets instead of once per dataset.

This optimization will in particular help executing tools with many outputs. For instance, the time to create a job for the sample tool create_10.xml which has 10 outputs dropped from 1086.074 ms to 230.539 ms with this change.

Before:

```
galaxy.tools DEBUG 2016-03-21 01:28:51,785 Validated and populated state for tool request (37.990 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:51,885 Handled output named out_file1 for tool create_10 (85.515 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:51,972 Handled output named out_file2 for tool create_10 (86.611 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,045 Handled output named out_file3 for tool create_10 (72.657 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,135 Handled output named out_file4 for tool create_10 (90.179 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,210 Handled output named out_file5 for tool create_10 (74.831 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,277 Handled output named out_file6 for tool create_10 (66.720 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,349 Handled output named out_file7 for tool create_10 (71.524 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,429 Handled output named out_file8 for tool create_10 (79.768 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,517 Handled output named out_file9 for tool create_10 (87.794 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,627 Handled output named out_file10 for tool create_10 (110.615 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,720 Verified access to datasets for Job[unflushed,tool_id=create_10] (7.573 ms)
galaxy.tools.execute DEBUG 2016-03-21 01:28:52,845 Tool [create_10] created job [19] (1060.070 ms)
galaxy.tools.execute DEBUG 2016-03-21 01:28:52,871 Executed 1 job(s) for tool create_10 request: (1086.074 ms)
```

After:

```
galaxy.tools DEBUG 2016-03-21 01:30:05,284 Validated and populated state for tool request (44.121 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,299 Handled output named out_file1 for tool create_10 (1.674 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,301 Handled output named out_file2 for tool create_10 (0.983 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,302 Handled output named out_file3 for tool create_10 (1.046 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,302 Handled output named out_file4 for tool create_10 (0.490 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,303 Handled output named out_file5 for tool create_10 (0.469 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,304 Handled output named out_file6 for tool create_10 (0.512 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,304 Handled output named out_file7 for tool create_10 (0.465 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,305 Handled output named out_file8 for tool create_10 (0.462 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,305 Handled output named out_file9 for tool create_10 (0.488 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,306 Handled output named out_file10 for tool create_10 (0.446 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,393 Created output datasets in object store (0.958 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,395 Verified access to datasets for Job[unflushed,tool_id=create_10] (0.359 ms)
galaxy.tools.execute DEBUG 2016-03-21 01:30:05,491 Tool [create_10] created job [20] (207.226 ms)
galaxy.tools.execute DEBUG 2016-03-21 01:30:05,515 Executed 1 job(s) for tool create_10 request: (230.539 ms)
```
