### PR TITLE
Improvements to workflow scaling performance testing scripts.

### DIFF
--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -73,6 +73,7 @@ class WorkflowSchedulingManager( object ):
         workflow_invocation.state = model.WorkflowInvocation.states.NEW
         scheduler = request_params.get( "scheduler", None ) or self.default_scheduler_id
         handler = self._get_handler()
+        log.info("Queueing workflow invocation for handler [%s]" % handler)
 
         workflow_invocation.scheduler = scheduler
         workflow_invocation.handler = handler

--- a/scripts/summarize_timings.py
+++ b/scripts/summarize_timings.py
@@ -1,9 +1,7 @@
+"""Script to parse timings out of a Galaxy log and summarize."""
 from __future__ import print_function
 
-try:
-    from argparse import ArgumentParser
-except ImportError:
-    ArgumentParser = None
+from argparse import ArgumentParser
 import re
 
 import numpy
@@ -15,19 +13,19 @@ TIMING_LINE_PATTERN = re.compile("\((\d+.\d+) ms\)")
 
 
 def main(argv=None):
-    if ArgumentParser is None:
-        raise Exception("Test requires Python 2.7")
+    """Entry point for script."""
     arg_parser = ArgumentParser(description=DESCRIPTION)
     arg_parser.add_argument("--file", default="paster.log")
     arg_parser.add_argument("--print_lines", default=False, action="store_true")
-    arg_parser.add_argument("--pattern")
+    arg_parser.add_argument("--pattern", default=None)
 
     args = arg_parser.parse_args(argv)
     print_lines = args.print_lines
-    filter_pattern = re.compile(args.pattern)
+    pattern_str = args.pattern
+    filter_pattern = re.compile(pattern_str) if pattern_str is not None else None
     times = []
     for line in open(args.file, "r"):
-        if not filter_pattern.search(line):
+        if filter_pattern and not filter_pattern.search(line):
             continue
 
         match = TIMING_LINE_PATTERN.search(line)

--- a/test/functional/tools/for_workflows/create_input_collection.xml
+++ b/test/functional/tools/for_workflows/create_input_collection.xml
@@ -1,0 +1,42 @@
+<tool id="create_input_collection" name="create_input_collection" version="0.1.0">
+  <description>This tool is used to create a collection of text files.</description>
+  <command detect_errors="exit_code">
+    mkdir outputs; cd outputs; python $script
+  </command>
+  <configfiles>
+    <configfile name="script">
+import os
+
+for i in range($collection_size):
+    template = "File number %s\n"
+    contents = template % i
+    with open(str(i), "w") as f:
+        f.write(contents)
+</configfile>
+  </configfiles>
+  <inputs>
+    <param name="collection_size" type="integer" format="txt" label="Collection Size" value="1" />
+  </inputs>
+  <outputs>
+    <collection name="output" type="list" label="lines">
+      <discover_datasets pattern="__name__" directory="outputs" format="txt" />
+    </collection>
+  </outputs>
+  <tests>
+    <test>
+      <param name="collection_size" value="2" />
+      <output_collection name="output" type="list">
+        <element name="0">
+          <assert_contents>
+            <has_line line="File number 0" />
+          </assert_contents>
+        </element>
+        <element name="1">
+          <assert_contents>
+            <has_line line="File number 1" />
+          </assert_contents>
+        </element>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/for_workflows/create_input_collection.xml
+++ b/test/functional/tools/for_workflows/create_input_collection.xml
@@ -5,8 +5,6 @@
   </command>
   <configfiles>
     <configfile name="script">
-import os
-
 for i in range($collection_size):
     template = "File number %s\n"
     contents = template % i
@@ -25,7 +23,7 @@ for i in range($collection_size):
   <tests>
     <test>
       <param name="collection_size" value="2" />
-      <output_collection name="output" type="list">
+      <output_collection name="output" type="list" count="2">
         <element name="0">
           <assert_contents>
             <has_line line="File number 0" />

--- a/test/functional/tools/for_workflows/split.xml
+++ b/test/functional/tools/for_workflows/split.xml
@@ -1,0 +1,33 @@
+<tool id="split" name="split" version="0.1.0">
+  <command detect_errors="exit_code">
+    bash $script
+  </command>
+  <configfiles>
+    <configfile name="script">
+      mkdir outputs;
+      cd outputs;
+      i=1;
+      while read -r line || [[ -n "\$line" ]]; do
+        printf "\$line\n" &gt; \$i ;
+        i=\$[\$i +1];
+      done &lt; "$input1";
+    </configfile>
+  </configfiles>
+  <inputs>
+    <param name="input1" type="data" format="txt" label="Input Text" />
+  </inputs>
+  <outputs>
+    <collection name="output" type="list" label="lines">
+      <discover_datasets pattern="__name__" directory="outputs" />
+    </collection>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input1" value="simple_lines_both.txt" />
+      <output_collection name="output" type="list">
+        <element name="1" file="simple_line.txt" />
+        <element name="2" file="simple_line_alternative.txt" />
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -96,6 +96,8 @@
   <tool file="for_workflows/cat_interleave.xml" />
   <tool file="for_workflows/pileup.xml" />
   <tool file="for_workflows/mapper.xml" />
+  <tool file="for_workflows/split.xml" />
+  <tool file="for_workflows/create_input_collection.xml" />
 
   <tool file="simple_constructs.yml" />
 

--- a/test/manual/launch_and_run.sh
+++ b/test/manual/launch_and_run.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#set -e
+
+# Open and few the contents of a docker-galaxy-stable container.
+# docker run --rm -i -t bgruening/galaxy-stable /bin/bash
+
+pwd_dir=$(pwd)
+GALAXY_ROOT=`dirname $0`/../..
+cd $GALAXY_ROOT
+GALAXY_ROOT=$(pwd)
+SCRIPT_DIR="$GALAXY_ROOT/test/manual"
+
+manual_test_script=$1
+shift
+manual_test_script_args="$@"
+
+GALAXY_VIRTUAL_ENV="${GALAXY_VIRTUAL_ENV:-.venv}"
+
+# Docker options defined to reflect run_tests.sh names and behavior.
+DOCKER_DEFAULT_IMAGE='bgruening/galaxy-stable'
+
+DOCKER_EXTRA_ARGS=${DOCKER_ARGS:-""}
+DOCKER_RUN_EXTRA_ARGS=${DOCKER_RUN_EXTRA_ARGS:-""}
+DOCKER_IMAGE=${DOCKER_IMAGE:-${DOCKER_DEFAULT_IMAGE}}
+# Root for Galaxy in the docker container
+DOCKER_GALAXY_ROOT=${DOCKER_GALAXY_ROOT:-/galaxy-central}
+
+# Location of this script's directory when mounted into the container.
+DOCKER_SCRIPT_DIR=/etc/galaxy/manual
+
+GALAXY_PORT=${GALAXY_PORT:-"any_free"}
+if [ "$GALAXY_PORT" == "any_free" ];
+then
+    GALAXY_PORT=`python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()'`
+fi
+
+GALAXY_URL=${GALAXY_URL:-http://localhost:${GALAXY_PORT}}
+GALAXY_MASTER_API_KEY=${GALAXY_MASTER_API_KEY:-HSNiugRFvgT574F43jZ7N9F3}
+
+LOGS_DIR=`cd "$LOGS_DIR"; pwd`
+WORK_DIR=`mktemp --tmpdir=$LOGS_DIR -d -t gxperfXXXX`
+echo "WORK_DIR is ${WORK_DIR}"
+NAME=`basename $WORK_DIR`
+
+GALAXY_HANDLER_NUMPROCS=${GALAXY_HANDLER_NUMPROCS:-1}
+
+DOCKER_ENVIRONMENT="\
+-e NONUSE=nodejs,proftp,reports \
+-e GALAXY_HANDLER_NUMPROCS=$GALAXY_HANDLER_NUMPROCS \
+-e GALAXY_CONFIG_OVERRIDE_TOOL_CONFIG_FILE=$DOCKER_GALAXY_ROOT/test/functional/tools/samples_tool_conf.xml \
+-e GALAXY_CONFIG_ENABLE_BETA_WORKFLOW_MODULES=true \
+-e GALAXY_CONFIG_OVERRIDE_ENABLE_BETA_TOOL_FORMATS=true \
+"
+
+if [ $manual_test_script == "workflows_scaling" ];
+then
+    DOCKER_ENVIRONMENT="$DOCKER_ENVIRONMENT -e GALAXY_CONFIG_JOB_CONFIG_FILE=$DOCKER_SCRIPT_DIR/workflow_job_conf.xml "
+fi
+
+# Mount logs, local galaxy changes, and local galaxy config.
+DOCKER_VOLUMES="\
+-v $WORK_DIR:/galaxy_logs \
+-v $GALAXY_ROOT/lib:$DOCKER_GALAXY_ROOT/lib \
+-v $GALAXY_ROOT/test:/galaxy-central/test \
+-v $SCRIPT_DIR:$DOCKER_SCRIPT_DIR \
+"
+DOCKER_RUN_ARGS="$DOCKER_RUN_EXTRA_ARGS -d -p ${GALAXY_PORT}:80 -i -t $DOCKER_VOLUMES $DOCKER_ENVIRONMENT"
+
+docker_image_id=`docker $DOCKER_EXTRA_ARGS run $DOCKER_RUN_ARGS ${DOCKER_IMAGE}`
+
+echo "Docker container with id $docker_image_id launched. Inspect with 'docker exec -i -t $docker_image_id /bin/bash'."
+
+# Wait for Galaxy to be available
+for i in {1..40}; do curl --silent --fail ${GALAXY_URL}/api/version && break || sleep 5; done
+
+${GALAXY_VIRTUAL_ENV}/bin/python test/manual/$manual_test_script.py --api_key ${GALAXY_MASTER_API_KEY} --host ${GALAXY_URL} $manual_test_script_args
+docker exec -i -t $docker_image_id /bin/bash -c "cp /home/galaxy/*log /galaxy_logs"
+docker kill $docker_image_id

--- a/test/manual/workflow_job_conf.xml
+++ b/test/manual/workflow_job_conf.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<job_conf>
+    <plugins workers="2">
+        <plugin id="slurm" type="runner" load="galaxy.jobs.runners.slurm:SlurmJobRunner">
+            <param id="drmaa_library_path">/usr/lib/slurm-drmaa/lib/libdrmaa.so</param>
+        </plugin>
+    </plugins>
+    <handlers default="handlers">
+        <handler id="handler0" tags="handlers"/>
+        <handler id="noophandler" />
+    </handlers>
+    <destinations default="noopcluster">
+        <destination id="cluster" runner="slurm" handler="handlers">
+        </destination>
+        <destination id="noopcluster" runner="slurm" handler="noophandler">
+        </destination>
+    </destinations>
+    <limits>
+    </limits>
+    <tools>
+        <tool id="upload1" destination="cluster" />
+        <tool id="create_input_collection" destination="cluster" />
+        <tool id="split" destination="cluster" />
+        <tool id="cat" destination="noopcluster" handler="noophandler" />
+    </tools>
+</job_conf>


### PR DESCRIPTION
- Implement a wrapper script for launching a docker-galaxy-stable setup a many ways for this task including:
  - Configure container's Galaxy with outer Galaxy's lib and test directory.
  - Collect log files.
  - Log a statement for interacting with the container easily while the test is running.
  - Disable unneeded services.
- Implement a fan-in-fan-out style workflow for performance testing.
- Add an option to test performance of scheduling workflows without actually running jobs.
- Sample tool for creating large collections easily at beginning of tests (much faster than uploads).
- Sample tool for splitting a file into a collection for fan in and out workflow test.
- Assume Python 2.7 in scripts to simplify things.
- Add documentation.
