### PR TITLE
[16.01] Do not convert spaces to tabs when importing datasets into a library.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/lda_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/lda_datasets.py
@@ -433,8 +433,8 @@ class LibraryDatasetsController( BaseAPIController, UsesVisualizationMixin ):
         """
         if payload:
             kwd.update(payload)
-        kwd[ 'space_to_tab' ] = 'False'
-        kwd[ 'to_posix_lines' ] = 'True'
+        kwd['space_to_tab'] = False
+        kwd['to_posix_lines'] = True
         kwd[ 'dbkey' ] = kwd.get( 'dbkey', '?' )
         kwd[ 'file_type' ] = kwd.get( 'file_type', 'auto' )
         kwd['link_data_only'] = 'link_to_files' if util.string_as_bool( kwd.get( 'link_data', False ) ) else 'copy_files'


### PR DESCRIPTION
Reported (with fix provided) by Fabien Mareuil in
http://dev.list.galaxyproject.org/automatic-adding-of-a-tab-in-a-fastq-header-td4669160.html
