### PR TITLE
Fix inconsistency in update state handling for tool modules

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1661,12 +1661,6 @@ class Tool( object, Dictifiable ):
         tool_model[ 'inputs' ] = {}
         populate_model( self.inputs, state_inputs, tool_model[ 'inputs' ] )
 
-        # sanitize tool state
-        def value_to_basic( input, value, parent, **kwargs ):
-            parent[ input.name ] = input.value_to_basic( value, self.app )
-
-        visit_input_values( self.inputs, state_inputs, value_to_basic )
-
         # create tool help
         tool_help = ''
         if self.help:
@@ -1692,7 +1686,7 @@ class Tool( object, Dictifiable ):
             'versions'      : tool_versions,
             'requirements'  : [ { 'name' : r.name, 'version' : r.version } for r in self.requirements ],
             'errors'        : state_errors,
-            'state_inputs'  : state_inputs,
+            'state_inputs'  : params_to_strings( self.inputs, state_inputs, self.app ),
             'job_id'        : trans.security.encode_id( job.id ) if job else None,
             'job_remap'     : self._get_job_remap( job ),
             'history_id'    : trans.security.encode_id( history.id ),

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -24,7 +24,7 @@ def visit_input_values( inputs, input_values, callback, name_prefix='', label_pr
     >>> from xml.etree.ElementTree import XML
     >>> from galaxy.util.bunch import Bunch
     >>> from galaxy.util.odict import odict
-    >>> from galaxy.tools.parameters.basic import TextToolParameter
+    >>> from galaxy.tools.parameters.basic import TextToolParameter, BooleanToolParameter
     >>> from galaxy.tools.parameters.grouping import Repeat
     >>> a = TextToolParameter( None, XML( '<param name="a"/>' ) )
     >>> b = Repeat()
@@ -32,7 +32,7 @@ def visit_input_values( inputs, input_values, callback, name_prefix='', label_pr
     >>> d = Repeat()
     >>> e = TextToolParameter( None, XML( '<param name="e"/>' ) )
     >>> f = Conditional()
-    >>> g = TextToolParameter( None, XML( '<param name="g"/>' ) )
+    >>> g = BooleanToolParameter( None, XML( '<param name="g"/>' ) )
     >>> h = TextToolParameter( None, XML( '<param name="h"/>' ) )
     >>> i = TextToolParameter( None, XML( '<param name="i"/>' ) )
     >>> b.name = 'b'
@@ -45,12 +45,16 @@ def visit_input_values( inputs, input_values, callback, name_prefix='', label_pr
     >>>
     >>> def visitor( input, value, prefix, prefixed_name, **kwargs ):
     ...     print 'name=%s, prefix=%s, prefixed_name=%s, value=%s' % ( input.name, prefix, prefixed_name, value )
-    >>> visit_input_values( odict([('a',a),('b',b)]), odict([ ('a', 1), ('b', [ odict([('c', 3), ( 'd', [odict([ ('e',5), ('f', odict([ ('g','true'), ('h',7) ])) ]) ])]) ]) ]), visitor )
+    >>> inputs = odict([('a',a),('b',b)])
+    >>> nested = odict([ ('a', 1), ('b', [ odict([('c', 3), ( 'd', [odict([ ('e', 5), ('f', odict([ ('g', True), ('h', 7) ])) ]) ])]) ]) ])
+    >>> visit_input_values( inputs, nested, visitor )
     name=a, prefix=, prefixed_name=a, value=1
     name=c, prefix=b_0|, prefixed_name=b_0|c, value=3
     name=e, prefix=b_0|d_0|, prefixed_name=b_0|d_0|e, value=5
-    name=g, prefix=b_0|d_0|, prefixed_name=b_0|d_0|f|g, value=true
+    name=g, prefix=b_0|d_0|, prefixed_name=b_0|d_0|f|g, value=True
     name=h, prefix=b_0|d_0|, prefixed_name=b_0|d_0|f|h, value=7
+    >>> params_from_strings( inputs, params_to_strings( inputs, nested, None ), None )[ 'b' ][ 0 ][ 'd' ][ 0 ][ 'f' ][ 'g' ] is True
+    True
     """
     def callback_helper( input, input_values, name_prefix, label_prefix, parent_prefix, context=None, error=None ):
         args = {

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1,7 +1,6 @@
 """
 Modules used in building workflows
 """
-import copy
 import logging
 from json import dumps, loads
 from xml.etree.ElementTree import Element
@@ -965,11 +964,8 @@ class ToolModule( WorkflowModule ):
                         input_dicts.append( { "name": name, "description": "runtime parameter for tool %s" % self.get_name() } )
         return input_dicts
 
-    def get_post_job_actions( self, incoming=None):
-        if incoming is None:
-            return self.post_job_actions
-        else:
-            return ActionBox.handle_incoming(incoming)
+    def get_post_job_actions( self, incoming ):
+        return ActionBox.handle_incoming( incoming )
 
     def get_config_form( self ):
         self.add_dummy_datasets()
@@ -977,8 +973,7 @@ class ToolModule( WorkflowModule ):
                                          tool=self.tool, values=self.state.inputs, errors=( self.errors or {} ) )
 
     def update_state( self, incoming ):
-        self.label = incoming.get( 'label' )
-        self.state.inputs = copy.deepcopy( incoming )
+        self.recover_state( incoming )
 
     def check_and_update_state( self ):
         inputs = self.state.inputs


### PR DESCRIPTION
This fixes an inconsistency in the tool parameter handling. The update state function is supposed to receive a conventionally encoded tool state (produced with `params_to_string`) which is then used to populate a fully expanded tool state (using `params_from_string`). If this does not happen the `to_json` function is called a second time on an already jsonified value when using workflow editor to modify a step state, which can have adverse side effects in the future.
