### PR TITLE
[16.01] Fix shared viz (and other base_panels.mako displays) early URL generation.

### DIFF
--- a/templates/base/base_panels.mako
+++ b/templates/base/base_panels.mako
@@ -39,7 +39,7 @@
 
 ## Default javascripts
 <%def name="javascripts()">
-    ## Send errors to Sntry server if configured
+    ## Send errors to Sentry server if configured
     %if app.config.sentry_dsn:
         ${h.js( "libs/tracekit", "libs/raven" )}
         <script>
@@ -60,6 +60,8 @@
         // configure require
         // due to our using both script tags and require, we need to access the same jq in both for plugin retention
         // source http://www.manuel-strehl.de/dev/load_jquery_before_requirejs.en.html
+        window.Galaxy = window.Galaxy || {};
+        window.Galaxy.root = '${h.url_for( "/" )}';
         define( 'jquery', [], function(){ return jQuery; })
         // TODO: use one system
 


### PR DESCRIPTION
Basepanels don't have Galaxy object, causing failures in views like published tracks, etc., when resource urls are generated incorrectly

This resolves the URL generation part of #1994, commentary here: https://github.com/galaxyproject/galaxy/issues/1994#issuecomment-200496361

Reopen of #1999.  Thanks @blankenberg 
