### PR TITLE
Moved the integrated_tool_panel.xml into config/ 

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -157,7 +157,7 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # files integrated into a single file that defines the tool panel layout.  This
 # file can be changed by the Galaxy administrator to alter the layout of the
 # tool panel.  If not present, Galaxy will create it.
-#integrated_tool_panel_config = integrated_tool_panel.xml
+#integrated_tool_panel_config = config/integrated_tool_panel.xml
 
 # Default path to the directory containing the tools defined in tool_conf.xml.
 # Other tool config files must include the tool_path as an attribute in the

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -22,6 +22,7 @@ from galaxy.exceptions import ConfigurationError
 from galaxy.util import listify
 from galaxy.util import string_as_bool
 from galaxy.util.dbkeys import GenomeBuilds
+from galaxy.util.path_util import resolve_path
 from galaxy.web.formatting import expand_pretty_datetime_format
 from .version import VERSION_MAJOR
 
@@ -37,13 +38,6 @@ try:
 except ImportError:
     # This is not a uwsgi process, or something went horribly wrong.
     process_is_uwsgi = False
-
-
-def resolve_path( path, root ):
-    """If 'path' is relative make absolute by prepending 'root'"""
-    if not os.path.isabs( path ):
-        path = os.path.join( root, path )
-    return path
 
 
 class Configuration( object ):
@@ -95,6 +89,7 @@ class Configuration( object ):
         # The value of migrated_tools_config is the file reserved for containing only those tools that have been eliminated from the distribution
         # and moved to the tool shed.
         self.integrated_tool_panel_config = resolve_path( kwargs.get( 'integrated_tool_panel_config', 'config/integrated_tool_panel.xml' ), self.root )
+
         integrated_tool_panel_tracking_directory = kwargs.get( 'integrated_tool_panel_tracking_directory', None )
         if integrated_tool_panel_tracking_directory:
             self.integrated_tool_panel_tracking_directory = resolve_path( integrated_tool_panel_tracking_directory, self.root )

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -94,7 +94,7 @@ class Configuration( object ):
         self.test_conf = resolve_path( kwargs.get( "test_conf", "" ), self.root )
         # The value of migrated_tools_config is the file reserved for containing only those tools that have been eliminated from the distribution
         # and moved to the tool shed.
-        self.integrated_tool_panel_config = resolve_path( kwargs.get( 'integrated_tool_panel_config', 'integrated_tool_panel.xml' ), self.root )
+        self.integrated_tool_panel_config = resolve_path( kwargs.get( 'integrated_tool_panel_config', 'config/integrated_tool_panel.xml' ), self.root )
         integrated_tool_panel_tracking_directory = kwargs.get( 'integrated_tool_panel_tracking_directory', None )
         if integrated_tool_panel_tracking_directory:
             self.integrated_tool_panel_tracking_directory = resolve_path( integrated_tool_panel_tracking_directory, self.root )

--- a/lib/galaxy/tools/toolbox/integrated_panel.py
+++ b/lib/galaxy/tools/toolbox/integrated_panel.py
@@ -104,10 +104,7 @@ class ManagesIntegratedToolPanelMixin:
 
         old_default = 'integrated_tool_panel.xml'
         # TODO: Get the new_default via a variable into config, and do not repeat it
-        new_default = 'config/integrated_tool_panel.xml'
-
         full_path_old_default = os.path.abspath( resolve_path( old_default, self.root ) )
-        full_path_new_default = os.path.abspath( resolve_path( new_default, self.root ) )
 
         destination = os.path.abspath( self._integrated_tool_panel_config )
 

--- a/lib/galaxy/tools/toolbox/integrated_panel.py
+++ b/lib/galaxy/tools/toolbox/integrated_panel.py
@@ -3,9 +3,12 @@ import shutil
 import tempfile
 import time
 import traceback
+import logging
 
 from .panel import ToolPanelElements
 from .panel import panel_item_types
+
+from galaxy.util.path_util import resolve_path
 
 
 INTEGRATED_TOOL_PANEL_DESCRIPTION = """
@@ -22,6 +25,8 @@ via its API - but if changes are necessary (such as to hide a tool or re-assign
 its section) modify that file and restart Galaxy.
 """
 
+log = logging.getLogger( __name__ )
+
 
 class ManagesIntegratedToolPanelMixin:
 
@@ -34,6 +39,7 @@ class ManagesIntegratedToolPanelMixin:
         self._integrated_tool_panel_config_has_contents = os.path.exists( self._integrated_tool_panel_config ) and os.stat( self._integrated_tool_panel_config ).st_size > 0
         if self._integrated_tool_panel_config_has_contents:
             self._load_integrated_tool_panel_keys()
+        self.root = config.root
 
     def _save_integrated_tool_panel(self):
         if self.update_integrated_tool_panel:
@@ -95,10 +101,29 @@ class ManagesIntegratedToolPanelMixin:
                     os.write( fd, '    </section>\n' )
         os.write( fd, '</toolbox>\n' )
         os.close( fd )
+
+        old_default = 'integrated_tool_panel.xml'
+        new_default = 'config/integrated_tool_panel.xml'
+
+        full_path_old_default = os.path.abspath( resolve_path( old_default, self.root ) )
+        full_path_new_default = os.path.abspath( resolve_path( new_default, self.root ) )
+
         destination = os.path.abspath( self._integrated_tool_panel_config )
+
         if tracking_directory:
             open(filename + ".stack", "w").write(''.join(traceback.format_stack()))
             shutil.copy( filename, filename + ".copy" )
             filename = filename + ".copy"
-        shutil.move( filename, destination )
-        os.chmod( self._integrated_tool_panel_config, 0o644 )
+
+        # Check if the 16.01 and older configuration still exists
+        if os.path.isfile(full_path_old_default) and (full_path_old_default != self._integrated_tool_panel_config):
+            try:
+                os.symlink(full_path_old_default, destination)
+                log.warn( "Old file 'integrated_tool_panel.xml' is now removed from the root directory by default, but "
+                         "you still have it from an older version. Please move it to %s" % destination )
+            except OSError:
+                log.warn( "You have two integrated_tool_conf.xml files. "
+                          "Please remove the one at root location (be careful to not lose your data!)" )
+        else:
+            shutil.move( filename, destination )
+        os.chmod( os.path.realpath( self._integrated_tool_panel_config ), 0o644 )

--- a/lib/galaxy/tools/toolbox/integrated_panel.py
+++ b/lib/galaxy/tools/toolbox/integrated_panel.py
@@ -103,6 +103,7 @@ class ManagesIntegratedToolPanelMixin:
         os.close( fd )
 
         old_default = 'integrated_tool_panel.xml'
+        # TODO: Get the new_default via a variable into config, and do not repeat it
         new_default = 'config/integrated_tool_panel.xml'
 
         full_path_old_default = os.path.abspath( resolve_path( old_default, self.root ) )
@@ -124,6 +125,7 @@ class ManagesIntegratedToolPanelMixin:
             except OSError:
                 log.warn( "You have two integrated_tool_conf.xml files. "
                           "Please remove the one at root location (be careful to not lose your data!)" )
+        # We are in 16.04 configuration or integrated_tool_panel_config is configured
         else:
             shutil.move( filename, destination )
         os.chmod( os.path.realpath( self._integrated_tool_panel_config ), 0o644 )

--- a/lib/galaxy/util/path_util.py
+++ b/lib/galaxy/util/path_util.py
@@ -3,6 +3,7 @@
 import os
 
 
+# TODO: Check if this extracted function from galaxy/config.py and tool_shed/config.py is used somewhere else
 def resolve_path( path, root ):
     """If 'path' is relative make absolute by prepending 'root'"""
     if not( os.path.isabs( path ) ):

--- a/lib/galaxy/util/path_util.py
+++ b/lib/galaxy/util/path_util.py
@@ -1,0 +1,10 @@
+"""This file is here to solve any path mannipulation"""
+
+import os
+
+
+def resolve_path( path, root ):
+    """If 'path' is relative make absolute by prepending 'root'"""
+    if not( os.path.isabs( path ) ):
+        path = os.path.join( root, path )
+    return path

--- a/lib/galaxy/webapps/tool_shed/config.py
+++ b/lib/galaxy/webapps/tool_shed/config.py
@@ -8,17 +8,11 @@ import logging
 import logging.config
 import ConfigParser
 from galaxy.util import string_as_bool, listify
+from galaxy.util.path_util import resolve_path
 from galaxy.web.formatting import expand_pretty_datetime_format
 from galaxy.version import VERSION, VERSION_MAJOR
 
 log = logging.getLogger( __name__ )
-
-
-def resolve_path( path, root ):
-    """If 'path' is relative make absolute by prepending 'root'"""
-    if not( os.path.isabs( path ) ):
-        path = os.path.join( root, path )
-    return path
 
 
 class ConfigurationError( Exception ):

--- a/lib/galaxy/webapps/tool_shed/config.py
+++ b/lib/galaxy/webapps/tool_shed/config.py
@@ -72,7 +72,7 @@ class Configuration( object ):
         self.tool_path = resolve_path( kwargs.get( "tool_path", "tools" ), self.root )
         self.tool_secret = kwargs.get( "tool_secret", "" )
         self.tool_data_path = resolve_path( kwargs.get( "tool_data_path", "shed-tool-data" ), os.getcwd() )
-        self.integrated_tool_panel_config = resolve_path( kwargs.get( 'integrated_tool_panel_config', 'integrated_tool_panel.xml' ), self.root )
+        self.integrated_tool_panel_config = resolve_path( kwargs.get( 'integrated_tool_panel_config', 'config/integrated_tool_panel.xml' ), self.root )
         self.builds_file_path = resolve_path( kwargs.get( "builds_file_path", os.path.join( self.tool_data_path, 'shared', 'ucsc', 'builds.txt') ), self.root )
         self.len_file_path = resolve_path( kwargs.get( "len_file_path", os.path.join( self.tool_data_path, 'shared', 'ucsc', 'chrom') ), self.root )
         self.ftp_upload_dir = kwargs.get( 'ftp_upload_dir', None )


### PR DESCRIPTION
I took the initiative to move the `integrated_tool_panel.xml` into the `config` folder for less pollution in the root directory and better coherence (In my opininion, this is a config file).

The quick story was I wanted to rename some sections. After looking for my sections in the `tool_conf.xml` and renaming them, I was still having the wrong section name.

I looked into all the config files without finding it, then I bruteforced to find my string from root...where it was located in `integrated_tool_panel.xml`.

I thought it could be a good idea to move this file into the `config` folder.
