### PR TITLE
Fix parameter expansion for empty collections

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1645,7 +1645,8 @@ class Tool( object, Dictifiable ):
         # expand incoming parameters (parameters might trigger multiple tool executions,
         # here we select the first execution only in order to resolve dynamic parameters)
         expanded_incomings, _ = expand_meta_parameters( trans, self, params.__dict__ )
-        params.__dict__ = expanded_incomings[ 0 ]
+        if expanded_incomings:
+            params.__dict__ = expanded_incomings[ 0 ]
 
         # do param translation here, used by datasource tools
         if self.input_translator:

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1874,6 +1874,8 @@ class DataToolParameter( BaseDataToolParameter ):
             raise ValueError( "History does not include a dataset of the required format / build" )
         if value in [ None, "None", '' ]:
             return None
+        if isinstance( value, dict ) and 'values' in value:
+            value = self.to_python( value, trans.app )
         if isinstance( value, string_types ) and value.find( "," ) > 0:
             value = [ int( value_part ) for value_part in value.split( "," ) ]
         if isinstance( value, list ):
@@ -1955,7 +1957,7 @@ class DataToolParameter( BaseDataToolParameter ):
         dataset_count = 0
         for validator in self.validators:
             def do_validate( v ):
-                if validator.requires_dataset_metadata and v and v.dataset.state != galaxy.model.Dataset.states.OK:
+                if validator.requires_dataset_metadata and v and hasattr( v, 'dataset' ) and v.dataset.state != galaxy.model.Dataset.states.OK:
                     return
                 else:
                     validator.validate( v, trans )


### PR DESCRIPTION
If an empty collection is selected in the tool form, the parameter expansion fails. In this case dynamic parameters are not properly updated in the tool form.
