### PR TITLE
Fix fluent query log serialization when datetime types are in use.

### DIFF
--- a/lib/galaxy/util/log/fluent_log.py
+++ b/lib/galaxy/util/log/fluent_log.py
@@ -2,6 +2,7 @@
 Provides a `TraceLogger` implementation that logs to a fluentd collector
 """
 
+import json
 import threading
 import time
 
@@ -41,4 +42,4 @@ class FluentTraceLogger( object ):
             kwargs.update( self.thread_local.context )
         self.lock.release()
         event_time = event_time or time.time()
-        self.sender.emit_with_time( label, int(event_time), kwargs )
+        self.sender.emit_with_time( label, int(event_time), json.dumps(kwargs, default=str))


### PR DESCRIPTION
Currently queries which have raw datetime.datetime objects in the context will fail to log and throw an exception -- "Can't serialize datetime.datetime(....)"
