### PR TITLE
Remove microseconds when parsing datetimes for MySQL.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ database/citations
 database/community_files
 database/compiled_templates
 database/files
+database/jobs_directory
 database/job_working_directory
 database/pbs
 database/tmp


### PR DESCRIPTION
Fix #2037.

Also add database/jobs_directory to `.gitignore` .
