### PR TITLE
Use a stricter regexp for microseconds.

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -931,7 +931,7 @@ class ModelFilterParser( HasAModelManager ):
         self.app = app
 
         #: regex for testing/dicing iso8601 date strings, with optional time and ms, but allowing only UTC timezone
-        self.date_string_re = re.compile( r'^(\d{4}\-\d{2}\-\d{2})[T| ]{0,1}(\d{2}:\d{2}:\d{2}\.*\d*)*Z{0,1}$' )
+        self.date_string_re = re.compile( r'^(\d{4}\-\d{2}\-\d{2})[T| ]{0,1}(\d{2}:\d{2}:\d{2}(?:\.\d{1,6}){0,1}){0,1}Z{0,1}$' )
 
         # dictionary containing parsing data for ORM/SQLAlchemy-based filters
         # ..note: although kind of a pain in the ass and verbose, opt-in/whitelisting allows more control

--- a/test/unit/managers/test_HistoryContentsManager.py
+++ b/test/unit/managers/test_HistoryContentsManager.py
@@ -347,6 +347,9 @@ class HistoryContentsFilterParserTestCase( HistoryAsContainerBaseTestCase ):
         self.log( 'should error if locale is used' )
         self.assertRaises( ValueError, self.filter_parser.parse_date, 'Fri Feb 13 18:31:30 2009' )
 
+        self.log( 'should error if wrong milliseconds format is used' )
+        self.assertRaises( ValueError, self.filter_parser.parse_date, '2009-02-13 18:13:00.' )
+        self.assertRaises( ValueError, self.filter_parser.parse_date, '2009-02-13 18:13:00.1234567' )
 
 # =============================================================================
 if __name__ == '__main__':


### PR DESCRIPTION
I did not have time to comment on #2062, @dannon was too fast!
