### PR TITLE
Allow tool confs with a tool_path to not be interpreted as shed confs.

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -126,13 +126,10 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
         log.info( "Parsing the tool configuration %s" % config_filename )
         tool_conf_source = get_toolbox_parser(config_filename)
         tool_path = tool_conf_source.parse_tool_path()
-        if tool_path:
-            # We're parsing a shed_tool_conf file since we have a tool_path attribute.
-            parsing_shed_tool_conf = True
+        parsing_shed_tool_conf = tool_conf_source.is_shed_tool_conf()
+        if parsing_shed_tool_conf:
             # Keep an in-memory list of xml elements to enable persistence of the changing tool config.
             config_elems = []
-        else:
-            parsing_shed_tool_conf = False
         tool_path = self.__resolve_tool_path(tool_path, config_filename)
         # Only load the panel_dict under certain conditions.
         load_panel_dict = not self._integrated_tool_panel_config_has_contents

--- a/lib/galaxy/tools/toolbox/parser.py
+++ b/lib/galaxy/tools/toolbox/parser.py
@@ -1,3 +1,8 @@
+"""This module is used to parse tool_conf files.
+
+These files define tool lists, sections, labels, etc... the elements of the
+Galaxy tool panel.
+"""
 from abc import ABCMeta
 from abc import abstractmethod
 
@@ -8,15 +13,13 @@ DEFAULT_MONITOR = False
 
 
 class ToolConfSource(object):
-    """ This interface represents an abstract source to parse tool
-    information from.
-    """
+    """Interface represents a container of tool references."""
+
     __metaclass__ = ABCMeta
 
     @abstractmethod
     def parse_items(self):
-        """ Return a list of ToolConfItem
-        """
+        """Return a list of ToolConfItem describing source."""
 
     @abstractmethod
     def parse_tool_path(self):
@@ -24,8 +27,7 @@ class ToolConfSource(object):
         """
 
     def parse_monitor(self):
-        """ Monitor the toolbox configuration source for changes and
-        reload. """
+        """Monitor the toolbox configuration source for changes and reload."""
         return DEFAULT_MONITOR
 
 
@@ -63,8 +65,9 @@ class YamlToolConfSource(ToolConfSource):
 
 
 class ToolConfItem(object):
-    """ This interface represents an abstract source to parse tool
-    information from.
+    """Abstract description of a tool conf item.
+
+    These may include tools, labels, sections, and workflows.
     """
 
     def __init__(self, type, attributes, elem=None):
@@ -136,3 +139,8 @@ def get_toolbox_parser(config_filename):
         return YamlToolConfSource(config_filename)
     else:
         return XmlToolConfSource(config_filename)
+
+__all__ = [
+    "get_toolbox_parser",
+    "ensure_tool_conf_item",
+]

--- a/lib/galaxy/tools/toolbox/parser.py
+++ b/lib/galaxy/tools/toolbox/parser.py
@@ -23,8 +23,11 @@ class ToolConfSource(object):
 
     @abstractmethod
     def parse_tool_path(self):
-        """ Return tool_path for tools in this toolbox.
-        """
+        """Return tool_path for tools in this toolbox or None."""
+
+    @abstractmethod
+    def is_shed_tool_conf(self):
+        """Decide if this tool conf is a shed tool conf."""
 
     def parse_monitor(self):
         """Monitor the toolbox configuration source for changes and reload."""
@@ -42,6 +45,11 @@ class XmlToolConfSource(ToolConfSource):
 
     def parse_items(self):
         return map(ensure_tool_conf_item, self.root.getchildren())
+
+    def is_shed_tool_conf(self):
+        has_tool_path = self.parse_tool_path() is not None
+        shed_conf = string_as_bool(self.root.get("shed_conf", "True"))
+        return has_tool_path and shed_conf
 
     def parse_monitor(self):
         return string_as_bool(self.root.get('monitor', DEFAULT_MONITOR))
@@ -62,6 +70,9 @@ class YamlToolConfSource(ToolConfSource):
 
     def parse_monitor(self):
         return self.as_dict.get('monitor', DEFAULT_MONITOR)
+
+    def is_shed_tool_conf(self):
+        return False
 
 
 class ToolConfItem(object):

--- a/lib/galaxy/tools/toolbox/parser.py
+++ b/lib/galaxy/tools/toolbox/parser.py
@@ -48,8 +48,8 @@ class XmlToolConfSource(ToolConfSource):
 
     def is_shed_tool_conf(self):
         has_tool_path = self.parse_tool_path() is not None
-        shed_conf = string_as_bool(self.root.get("shed_conf", "True"))
-        return has_tool_path and shed_conf
+        is_shed_conf = string_as_bool(self.root.get("is_shed_conf", "True"))
+        return has_tool_path and is_shed_conf
 
     def parse_monitor(self):
         return string_as_bool(self.root.get('monitor', DEFAULT_MONITOR))

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<toolbox tool_path="${tool_conf_dir}">
+<toolbox tool_path="${tool_conf_dir}" shed_conf="false">
   <tool file="upload.xml"/>
   <tool file="simple_constructs.xml" />
   <tool file="inheritance_simple.xml" />

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<toolbox tool_path="${tool_conf_dir}" shed_conf="false">
+<toolbox tool_path="${tool_conf_dir}" is_shed_conf="false">
   <tool file="upload.xml"/>
   <tool file="simple_constructs.xml" />
   <tool file="inheritance_simple.xml" />

--- a/test/functional/tools/upload_tool_conf.xml
+++ b/test/functional/tools/upload_tool_conf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<toolbox tool_path="${tool_conf_dir}">
+<toolbox tool_path="${tool_conf_dir}" shed_conf="false">
   <section id="getext" name="Get Data">
     <tool file="upload.xml"/>
   </section>

--- a/test/functional/tools/upload_tool_conf.xml
+++ b/test/functional/tools/upload_tool_conf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<toolbox tool_path="${tool_conf_dir}" shed_conf="false">
+<toolbox tool_path="${tool_conf_dir}" is_shed_conf="false">
   <section id="getext" name="Get Data">
     <tool file="upload.xml"/>
   </section>


### PR DESCRIPTION
Previously every tool conf file with a `tool_path` attribute would be interpreted as shed tool conf file - which has implications such as allowing the tool shed to modify it and having it appear in various drop downs. @nsoranzo noticed that the new file `test/functional/tools/upload_tool_conf.xml` was modified during a test and I think this must be a result of that.

I'd prefer to require annotation of shed tool conf files explicitly - but that ship has sailed and we don't want to force people to modify their shed_tool_conf.xml files in the wild - so I instead have introduced a `shed_conf` attribute on toolbox files and defaulted it to True if `tool_path` is set. I have explicitly set it to `False` on the distribution tool conf files that specify tool paths that aren't shed tool confs.
