### PR TITLE
Add the Roadmap of the project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,4 +60,4 @@ Please see `CONTRIBUTING.md <CONTRIBUTING.md>`_ .
 Roadmap
 =============================
 
-Interested in what are the next steps for Galaxy? Take a look here: https://github.com/galaxyproject/galaxy/issues/1928
+Interested in the next steps for Galaxy? Take a look here: https://github.com/galaxyproject/galaxy/issues/1928

--- a/README.rst
+++ b/README.rst
@@ -56,3 +56,8 @@ Issues and Galaxy Development
 =============================
 
 Please see `CONTRIBUTING.md <CONTRIBUTING.md>`_ .
+
+Roadmap
+=============================
+
+Interested in what are the next steps for Galaxy? Take a look here: https://github.com/galaxyproject/galaxy/issues/1928


### PR DESCRIPTION
I was reading an article from Trello: http://blog.trello.com/tips-for-making-a-public-roadmap/ and thought it could be useful for people to have direct access to the roadmap instead of looking for it in the issues.

:)
