### PR TITLE
Fix pbs runner file touch.

### DIFF
--- a/lib/galaxy/jobs/runners/pbs.py
+++ b/lib/galaxy/jobs/runners/pbs.py
@@ -272,7 +272,7 @@ class PBSJobRunner( AsynchronousJobRunner ):
         # write the job script
         if self.app.config.pbs_stage_path != '':
             # touch the ecfile so that it gets staged
-            with file(ecfile, 'a'):
+            with open(ecfile, 'a'):
                 os.utime(ecfile, None)
 
             stage_commands = pbs_symlink_template % (


### PR DESCRIPTION
This updates the touch to be py3 compliant, file is no longer a valid alias to open.
