### PR TITLE
Enhancements for Pulsar Embedded Runner

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -114,7 +114,7 @@
                https://github.com/galaxyproject/pulsar/blob/master/app.yml.sample
                http://pulsar.readthedocs.org/en/latest/configure.html
           -->
-          <!-- <param id="pulsar_conf">path/to/pulsar/app.yml</param> -->
+          <!-- <param id="pulsar_config">path/to/pulsar/app.yml</param> -->
         </plugin>
 
     </plugins>

--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -103,13 +103,12 @@
                internal to Galaxy and communicates it directly.
                This maybe be useful for instance when Pulsar
                staging is important but a Pulsar server is
-               unneeded (most obviously for instance if compute
-               servers cannot mount Galaxy's files but Galaxy
-               can mount a scratch directory available on
-               compute). -->
+               unneeded (for instance if compute servers cannot
+               mount Galaxy's files but Galaxy can mount a
+               scratch directory available on compute). -->
           <!-- Specify a complete description of the Pulsar app
                to create. Currently this configuration (if set)
-               must create exactly on job manager. For more
+               must create exactly one job manager. For more
                information on configuring a Pulsar app see:
 
                https://github.com/galaxyproject/pulsar/blob/master/app.yml.sample

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -173,7 +173,7 @@ class PulsarJobRunner( AsynchronousJobRunner ):
         self._init_monitor_thread()
 
     def __init_client_manager( self ):
-        pulsar_conf = self.runner_params.get('pulsar_conf', None)
+        pulsar_conf = self.runner_params.get('pulsar_config', None)
         self.__init_pulsar_app(pulsar_conf)
 
         client_manager_kwargs = {}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -91,6 +91,7 @@ GALAXY_TEST_TMP_DIR             Temp directory used for files required by
 GALAXY_TEST_SAVE                Location to save certain test files (such as
                                 tool outputs).
 GALAXY_TEST_EXTERNAL            Target an external Galaxy as part of testing.
+GALAXY_TEST_JOB_CONFIG_FILE     Job config file to use for the test.
 GALAXY_CONFIG_MASTER_KEY        Master or admin API key to use as part of
                                 testing with GALAXY_TEST_EXTERNAL.
 GALAXY_TEST_USER_API_KEY        User API key to use as part of testing with

--- a/scripts/functional_tests.py
+++ b/scripts/functional_tests.py
@@ -59,8 +59,7 @@ class DefaultGalaxyTestDriver(driver_util.GalaxyTestDriver):
 class FrameworkToolsGalaxyTestDriver(DefaultGalaxyTestDriver):
     """Galaxy-style nose TestDriver for testing framework Galaxy tools."""
 
-    default_tool_conf = driver_util.FRAMEWORK_SAMPLE_TOOLS_CONF
-    datatypes_conf_override = driver_util.FRAMEWORK_DATATYPES_CONF
+    framework_tool_and_types = True
 
 
 class DataManagersGalaxyTestDriver(driver_util.GalaxyTestDriver):

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -97,6 +97,7 @@ def setup_galaxy_config(
     default_install_db_merged=True,
     default_tool_data_table_config_path=None,
     default_shed_tool_data_table_config=None,
+    default_job_config_file=None,
     enable_tool_shed_check=False,
     default_tool_conf=None,
     shed_tool_conf=None,
@@ -126,6 +127,7 @@ def setup_galaxy_config(
     else:
         user_library_import_dir = None
         library_import_dir = None
+    job_config_file = os.environ.get('GALAXY_TEST_JOB_CONFIG_FILE', default_job_config_file)
     tool_path = os.environ.get('GALAXY_TEST_TOOL_PATH', 'tools')
     tool_dependency_dir = os.environ.get('GALAXY_TOOL_DEPENDENCY_DIR', None)
     if tool_dependency_dir is None:
@@ -168,8 +170,9 @@ def setup_galaxy_config(
         file_path=file_path,
         galaxy_data_manager_data_path=galaxy_data_manager_data_path,
         id_secret='changethisinproductiontoo',
-        job_working_directory=job_working_directory,
+        job_config_file=job_config_file,
         job_queue_workers=5,
+        job_working_directory=job_working_directory,
         library_import_dir=library_import_dir,
         log_destination="stdout",
         new_file_path=new_file_path,

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -453,7 +453,7 @@ def build_galaxy_app(simple_kwargs):
     Galaxy override variables are respected. Also setup "global" references
     to sqlalchemy database context for Galaxy and install databases.
     """
-    log.info("Galaxy database connection:", simple_kwargs["database_connection"])
+    log.info("Galaxy database connection: %s", simple_kwargs["database_connection"])
     simple_kwargs['global_conf'] = get_webapp_global_conf()
     simple_kwargs['global_conf']['__file__'] = "config/galaxy.ini.sample"
     simple_kwargs = load_app_properties(
@@ -473,7 +473,7 @@ def build_shed_app(simple_kwargs):
     Construct paste style complex dictionary. Also setup "global" reference
     to sqlalchemy database context for tool shed database.
     """
-    log.info("Tool shed database connection:", simple_kwargs["database_connection"])
+    log.info("Tool shed database connection: %s", simple_kwargs["database_connection"])
     # TODO: Simplify global_conf to match Galaxy above...
     simple_kwargs['__file__'] = 'tool_shed_wsgi.ini.sample'
     simple_kwargs['global_conf'] = get_webapp_global_conf()
@@ -584,27 +584,54 @@ class GalaxyTestDriver(TestDriver):
 
     testing_shed_tools = False
 
-    def setup(self):
-        """Setup a Galaxy server for functional test (if needed)."""
+    def setup(self, config_object=None):
+        """Setup a Galaxy server for functional test (if needed).
+
+        Configuration options can be specified as attributes on the supplied
+        ```config_object``` (defaults to self).
+        """
+        if config_object is None:
+            config_object = self
         self.external_galaxy = os.environ.get('GALAXY_TEST_EXTERNAL', None)
         self.galaxy_test_tmp_dir = get_galaxy_test_tmp_dir()
         self.temp_directories.append(self.galaxy_test_tmp_dir)
 
-        testing_shed_tools = getattr(self, "testing_shed_tools", False)
-        default_tool_conf = getattr(self, "default_tool_conf", None)
-        datatypes_conf_override = getattr(self, "datatypes_conf_override", None)
+        testing_shed_tools = getattr(config_object, "testing_shed_tools", False)
+
+        if getattr(config_object, "framework_tool_and_types", False):
+            default_tool_conf = FRAMEWORK_SAMPLE_TOOLS_CONF
+            datatypes_conf_override = FRAMEWORK_DATATYPES_CONF
+        else:
+            default_tool_conf = getattr(config_object, "default_tool_conf", None)
+            datatypes_conf_override = getattr(config_object, "datatypes_conf_override", None)
 
         if self.external_galaxy is None:
             tempdir = tempfile.mkdtemp(dir=self.galaxy_test_tmp_dir)
             # Configure the database path.
             galaxy_db_path = database_files_path(tempdir)
-            galaxy_config = setup_galaxy_config(
-                galaxy_db_path,
-                use_test_file_dir=not testing_shed_tools,
-                default_install_db_merged=True,
-                default_tool_conf=default_tool_conf,
-                datatypes_conf=datatypes_conf_override,
-            )
+            # Allow config object to specify a config dict or a method to produce
+            # one - other just read the properties above and use the default
+            # implementation from this file.
+            galaxy_config = getattr(config_object, "galaxy_config", None)
+            if hasattr(galaxy_config, '__call__'):
+                galaxy_config = galaxy_config()
+            if galaxy_config is None:
+                setup_galaxy_config_kwds = dict(
+                    use_test_file_dir=not testing_shed_tools,
+                    default_install_db_merged=True,
+                    default_tool_conf=default_tool_conf,
+                    datatypes_conf=datatypes_conf_override,
+                )
+                galaxy_config = setup_galaxy_config(
+                    galaxy_db_path,
+                    **setup_galaxy_config_kwds
+                )
+
+                handle_galaxy_config_kwds = getattr(
+                    config_object, "handle_galaxy_config_kwds", None
+                )
+                if handle_galaxy_config_kwds is not None:
+                    handle_galaxy_config_kwds(galaxy_config)
 
             # ---- Build Application --------------------------------------------------
             self.app = build_galaxy_app(galaxy_config)
@@ -626,9 +653,12 @@ class GalaxyTestDriver(TestDriver):
             testing_installed_tools
         )
 
-    def build_tool_tests(self):
+    def build_tool_tests(self, testing_shed_tools=None):
         if self.app is None:
             return
+
+        if testing_shed_tools is None:
+            testing_shed_tools = getattr(self, "testing_shed_tools", False)
 
         # We must make sure that functional.test_toolbox is always imported after
         # database_contexts.galaxy_content is set (which occurs in this method above).
@@ -639,10 +669,24 @@ class GalaxyTestDriver(TestDriver):
         # When testing data managers, do not test toolbox.
         functional.test_toolbox.build_tests(
             app=self.app,
-            testing_shed_tools=self.testing_shed_tools,
+            testing_shed_tools=testing_shed_tools,
             master_api_key=get_master_api_key(),
             user_api_key=get_user_api_key(),
         )
+        return functional.test_toolbox
+
+    def run_tool_test(self, tool_id, index=0):
+        import functional.test_toolbox
+        functional.test_toolbox.toolbox = self.app.toolbox
+        tool = self.app.toolbox.get_tool(tool_id)
+        testdef = tool.tests[index]
+        test_case_cls = functional.test_toolbox.ToolTestCase
+        test_case = test_case_cls(methodName="setUp")  # NO-OP
+        test_case.shed_tool_id = None
+        test_case.master_api_key = get_master_api_key()
+        test_case.user_api_key = get_user_api_key()
+        test_case.setUp()
+        test_case.do_it(testdef)
 
 
 def drive_test(test_driver_class):

--- a/test/base/integration_util.py
+++ b/test/base/integration_util.py
@@ -1,0 +1,63 @@
+"""Utilities for constructing Galaxy integration tests.
+
+Tests that start an actual Galaxy server with a particular configuration in
+order to test something that cannot be tested with the default functional/api
+tessting configuration.
+"""
+
+from .driver_util import GalaxyTestDriver
+from unittest import TestCase
+
+NO_APP_MESSAGE = "test_case._app called though no Galaxy has been configured."
+
+
+class IntegrationTestCase(TestCase):
+    """Unit test case with utilities for spinning up Galaxy."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Configure and start Galaxy for a test."""
+        cls._app_available = False
+        cls._test_driver = GalaxyTestDriver()
+        cls._prepare_galaxy()
+        cls._test_driver.setup(config_object=cls)
+        cls._app_available = True
+        cls._configure_app()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Shutdown Galaxy server and cleanup temp directory."""
+        cls._test_driver.tear_down()
+        cls._app_available = False
+
+    @property
+    def _app(self):
+        assert self._app_available, NO_APP_MESSAGE
+        return self._test_driver.app
+
+    @property
+    def _tempdir(self):
+        return self._test_driver.galaxy_test_tmp_dir
+
+    @classmethod
+    def _prepare_galaxy(cls):
+        """Extension point for subclasses called before Galaxy is launched."""
+
+    @classmethod
+    def _configure_app(cls):
+        """Extension point for subclasses called after Galaxy is launched.
+
+        ```self._app``` can be used to access Galaxy core app.
+        """
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, galaxy_config_kwds):
+        """Extension point for subclasses to modify arguments used to configure Galaxy.
+
+        This method will be passed the keyword argument pairs used to call
+        Galaxy Config object and can modify the Galaxy instance created for
+        the test as needed.
+        """
+
+    def _run_tool_test(self, *args, **kwargs):
+        return self._test_driver.run_tool_test(*args, **kwargs)

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -1,0 +1,6 @@
+"""This module contains Galaxy integration tests.
+
+Tests that start an actual Galaxy server with a particular configuration in
+order to test something that cannot be tested with the default functional/api
+tessting configuration.
+"""

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -2,5 +2,5 @@
 
 Tests that start an actual Galaxy server with a particular configuration in
 order to test something that cannot be tested with the default functional/api
-tessting configuration.
+testing configuration.
 """

--- a/test/integration/embedded_pulsar_job_conf.xml
+++ b/test/integration/embedded_pulsar_job_conf.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!-- A sample job config that explicitly configures job running the way it is configured by default (if there is no explicit config). -->
+<job_conf>
+    <plugins>
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4"/>
+        <plugin id="pulsar_embed" type="runner" load="galaxy.jobs.runners.pulsar:PulsarEmbeddedJobRunner">
+        </plugin>
+    </plugins>
+    <handlers>
+        <handler id="main"/>
+    </handlers>
+    <destinations default="pulsar_embed">
+        <destination id="local" runner="local">
+        </destination>
+        <destination id="pulsar_embed" runner="pulsar_embed">
+        </destination>
+    </destinations>
+    <tools>
+        <tool id="upload1" destination="local" />
+    </tools>
+</job_conf>

--- a/test/integration/embedded_pulsar_job_conf.xml
+++ b/test/integration/embedded_pulsar_job_conf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!-- A sample job config that explicitly configures job running the way it is configured by default (if there is no explicit config). -->
+<!-- A job config for testing the Pulsar embedded runner -->
 <job_conf>
     <plugins>
         <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4"/>

--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -1,0 +1,24 @@
+"""Integration tests for the Pulsar embedded runner."""
+
+import os
+
+from base import integration_util
+
+SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+EMBEDDED_PULSAR_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "embedded_pulsar_job_conf.xml")
+
+
+class EmbeddedPulsarIntegrationTestCase(integration_util.IntegrationTestCase):
+    """Start a Pulsar job."""
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["job_config_file"] = EMBEDDED_PULSAR_JOB_CONFIG_FILE
+
+    def test_tool_simple_constructs(self):
+        self._run_tool_test("simple_constructs")
+
+    def test_multi_data_param(self):
+        self._run_tool_test("multi_data_param")


### PR DESCRIPTION
Added with #2057 - this features several enhancements.
- a74cda6 (along with framework upgrade in 53f1782) introduces the concept of an integration test and uses it to configure and run a Galaxy test with a Pulsar embedded runner.
- 7f418c2 Updates the job conf sample comments based on edits by @mvdbeek 
- ff20072 Allow configuration of the Pulsar job manager and app - in case one wants to do something esoteric like configure staging or target a cluster.
