### PR TITLE
tool lineage for versionless toolshed tool_ids

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -400,6 +400,8 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
             # exact tool id match not found, or all versions requested, search for other options, e.g. migrated tools or different versions
             rval = []
             tool_lineage = self._lineage_map.get( tool_id )
+            if not tool_lineage:
+                tool_lineage = self._lineage_map.get_versionless( tool_id )
             if tool_lineage:
                 lineage_tool_versions = tool_lineage.get_versions( )
                 for lineage_tool_version in lineage_tool_versions:

--- a/lib/galaxy/tools/toolbox/lineages/factory.py
+++ b/lib/galaxy/tools/toolbox/lineages/factory.py
@@ -2,6 +2,16 @@ from .tool_shed import ToolShedLineage
 from .stock import StockLineage
 
 
+def remove_version_from_guid( guid ):
+    """
+    Removes version from toolshed-derived tool_id(=guid).
+    """
+    if "/repos/" not in guid:
+        return None
+    tool_version = guid.split("/")[-1]
+    return guid.split(tool_version)[0]
+
+
 class LineageMap(object):
     """ Map each unique tool id to a lineage object.
     """
@@ -12,8 +22,11 @@ class LineageMap(object):
 
     def register(self, tool, **kwds):
         tool_id = tool.id
+        versionless_tool_id = remove_version_from_guid( tool_id )
+        tool_shed_repository = kwds.get("tool_shed_repository", None)
+        if versionless_tool_id and versionless_tool_id not in self.lineage_map:
+            self.lineage_map[versionless_tool_id] = ToolShedLineage.from_tool(self.app, tool, tool_shed_repository)
         if tool_id not in self.lineage_map:
-            tool_shed_repository = kwds.get("tool_shed_repository", None)
             if tool_shed_repository:
                 lineage = ToolShedLineage.from_tool(self.app, tool, tool_shed_repository)
             else:
@@ -28,5 +41,9 @@ class LineageMap(object):
                 self.lineage_map[tool_id] = lineage
 
         return self.lineage_map.get(tool_id, None)
+
+    def get_versionless(self, tool_id):
+        versionless_tool_id = remove_version_from_guid(tool_id)
+        return self.lineage_map.get(versionless_tool_id, None)
 
 __all__ = ["LineageMap"]

--- a/lib/galaxy/tools/toolbox/lineages/factory.py
+++ b/lib/galaxy/tools/toolbox/lineages/factory.py
@@ -8,8 +8,8 @@ def remove_version_from_guid( guid ):
     """
     if "/repos/" not in guid:
         return None
-    tool_version = guid.split("/")[-1]
-    return guid.split(tool_version)[0]
+    last_slash = guid.rfind('/')
+    return guid[:last_slash]
 
 
 class LineageMap(object):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -772,7 +772,7 @@ class ToolModule( WorkflowModule ):
             if tool_id != module.tool_id:
                 message += "The tool (id '%s') specified in this step is not available. Using the tool with id %s instead." % (tool_id, module.tool_id)
             if d.get('tool_version', 'Unspecified') != module.get_tool_version():
-                message += "%s: using version '%s' instead of version '%s' specified in this workflow." % ( tool_id, d.get( 'tool_version', 'Unspecified' ), module.get_tool_version() )
+                message += "%s: using version '%s' instead of version '%s' specified in this workflow." % ( tool_id, module.get_tool_version(), d.get( 'tool_version', 'Unspecified' ) )
             if message:
                 log.debug(message)
                 module.version_changes.append(message)


### PR DESCRIPTION
- 9b7be814b34494a4705cb19c44ce2039931f610f allows running/importing workflows and re-running tools from different toolsheds, where tools with the same owner and name, but different version are installed. (The functionality was introduced with #818, but in its current implementation requires that the same tool version is installed)
- 99cb275 fixes #2058
