### PR TITLE
Add sample supervisor config

### DIFF
--- a/contrib/galaxy_supervisor.conf
+++ b/contrib/galaxy_supervisor.conf
@@ -1,0 +1,45 @@
+# This is a sample supervisor config file.
+# In this configuration, 2 handlers and 1 uwsgi (uwsgi is more performant than the default Paste) instance with 2 processes and 2 threads will be started.
+# In order for this to work, you will need to have a [uwsgi] section in galaxy.ini, as such:
+#
+# [uwsgi]
+# master = True
+#
+# Further, this assumes uwsgi has been installed through pip into a virtualenv (/home/galaxy/galaxy/.venv/, in this example). 
+# If this is not the case, adjust the path to uwsgi accordingly.
+# If uwsgi was not installed through pip, include "--plugin python" in the uwsgi command.
+# This configuration has been tested with galaxy release_16.01 and uWSGI==2.0.12.
+# This assumes galaxy is installed in /home/galaxy/galaxy, so change occurences of /home/galaxy/galaxy accordingly.
+# If you want to run galaxy under a different username, change "user = galaxy" to "user = <your user>".
+# You will probably want to proxy uwsgi (you can't connect with a browser to uwsgi port 4001) with nginx or apache, 
+# see https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#uWSGI-1
+# or https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#uWSGI-2 . 
+
+[program:uwsgi]
+command         = /home/galaxy/galaxy/.venv/bin/uwsgi --virtualenv /home/galaxy/galaxy/.venv --ini-paste /home/galaxy/galaxy/config/galaxy.ini --logdate --master --processes 2 --threads 2 --logto /home/galaxy/galaxy/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
+directory       = /home/galaxy/galaxy
+umask           = 022
+autostart       = true
+autorestart     = true
+startsecs       = 20
+user            = galaxy
+environment     = PATH=/home/galaxy/galaxy/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,PYTHONHOME=/home/galaxy/galaxy/.venv
+numprocs        = 1
+stopsignal      = INT
+startretries    = 15
+
+[program:handler]
+command         = /home/galaxy/galaxy/.venv/bin/python ./lib/galaxy/main.py -c /home/galaxy/galaxy/config/galaxy.ini --server-name=handler%(process_num)s --log-file=/home/galaxy/galaxy/handler%(process_num)s.log
+directory       = /home/galaxy/galaxy
+process_name    = handler%(process_num)s
+numprocs        = 2
+umask           = 022
+autostart       = true
+autorestart     = true
+startsecs       = 20
+user            = galaxy
+environment     = PYTHONHOME=/home/galaxy/galaxy/.venv
+startretries    = 15
+
+[group:galaxy]
+programs = handler, galaxy_web

--- a/contrib/galaxy_supervisor.conf
+++ b/contrib/galaxy_supervisor.conf
@@ -15,7 +15,7 @@
 # see https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#uWSGI-1
 # or https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#uWSGI-2 . 
 
-[program:uwsgi]
+[program:galaxy_web]
 command         = /home/galaxy/galaxy/.venv/bin/uwsgi --virtualenv /home/galaxy/galaxy/.venv --ini-paste /home/galaxy/galaxy/config/galaxy.ini --logdate --master --processes 2 --threads 2 --logto /home/galaxy/galaxy/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191
 directory       = /home/galaxy/galaxy
 umask           = 022


### PR DESCRIPTION
for galaxy served by uwsgi, with separate handlers.

There was some confusion as to how to start uwsgi correctly on IRC yesterday, I hope this will help people struggling with this. Also, supervisor is a common way to start galaxy, so I guess it would be a good idea to have a sample. Ping @dannon 
