### PR TITLE
Fix cli runner: use embed_metadata_in_job parameter

### DIFF
--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -17,6 +17,7 @@ __all__ = [ 'ShellJobRunner' ]
 
 DEFAULT_EMBED_METADATA_IN_JOB = True
 
+
 class ShellJobRunner( AsynchronousJobRunner ):
     """
     Job runner backed by a finite pool of worker threads. FIFO scheduling
@@ -53,7 +54,7 @@ class ShellJobRunner( AsynchronousJobRunner ):
         """Create job script and submit it to the DRM"""
         # prepare the job
         include_metadata = asbool( job_wrapper.job_destination.params.get( "embed_metadata_in_job", DEFAULT_EMBED_METADATA_IN_JOB ) )
-        if not self.prepare_job( job_wrapper, include_metadata=include_metadata):
+        if not self.prepare_job( job_wrapper, include_metadata=include_metadata ):
              return
 
         # Get shell and job execution interface

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -8,6 +8,7 @@ import logging
 from galaxy import model
 from galaxy.jobs import JobDestination
 from galaxy.jobs.runners import AsynchronousJobState, AsynchronousJobRunner
+from galaxy.util import asbool
 from .util.cli import CliInterface, split_params
 
 log = logging.getLogger( __name__ )

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -134,7 +134,7 @@ class ShellJobRunner( AsynchronousJobRunner ):
                 if ajs.job_wrapper.get_state() == model.Job.states.DELETED:
                     continue
 
-                external_metadata = not asbool( job_wrapper.job_destination.params.get( "embed_metadata_in_job", DEFAULT_EMBED_METADATA_IN_JOB ) )
+                external_metadata = not asbool( ajs.job_wrapper.job_destination.params.get( "embed_metadata_in_job", DEFAULT_EMBED_METADATA_IN_JOB ) )
                 if external_metadata:
                     self._handle_metadata_externally( ajs.job_wrapper, resolve_requirements=True )
 

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -14,6 +14,7 @@ log = logging.getLogger( __name__ )
 
 __all__ = [ 'ShellJobRunner' ]
 
+DEFAULT_EMBED_METADATA_IN_JOB = True
 
 class ShellJobRunner( AsynchronousJobRunner ):
     """

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -55,7 +55,7 @@ class ShellJobRunner( AsynchronousJobRunner ):
         # prepare the job
         include_metadata = asbool( job_wrapper.job_destination.params.get( "embed_metadata_in_job", DEFAULT_EMBED_METADATA_IN_JOB ) )
         if not self.prepare_job( job_wrapper, include_metadata=include_metadata ):
-             return
+            return
 
         # Get shell and job execution interface
         job_destination = job_wrapper.job_destination

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -50,7 +50,6 @@ class ShellJobRunner( AsynchronousJobRunner ):
     def queue_job( self, job_wrapper ):
         """Create job script and submit it to the DRM"""
         # prepare the job
-        #hack https://github.com/dpryan79/galaxy/commit/3536ff923cf736b2dbefab3e04b7fcd79b909d22
         include_metadata = asbool( job_wrapper.job_destination.params.get( "embed_metadata_in_job", DEFAULT_EMBED_METADATA_IN_JOB ) )
         if not self.prepare_job( job_wrapper, include_metadata=include_metadata):
              return


### PR DESCRIPTION
Added code for reading the DEFAULT_EMBED_METADATA_IN_JOB parameter in jobs/runners/cli.py job submission.
