### PR TITLE
Automate and clarify more of the release process.

### DIFF
--- a/scripts/bootstrap_history.py
+++ b/scripts/bootstrap_history.py
@@ -162,12 +162,16 @@ RELEASE_ISSUE_TEMPLATE = string.Template("""
       - [ ] Ensure all [blocking milestone PRs](https://github.com/galaxyproject/galaxy/pulls?q=is%3Aopen+is%3Apr+milestone%3A${version}) have been merged, delayed, or closed.
 
             make release-check-blocking-prs RELEASE_CURR=${version}
-      - [ ] Merge the latest release into dev.
+      - [ ] Merge the latest release into dev and push upstream.
 
-            git fetch upstream && git checkout dev && git merge --ff-only upstream dev && git merge upstream release_${previous_version}
+            make release-merge-stable-to-next RELEASE_PREVIOUS=release_${previous_version}
+            make release-push-dev
+
       - [ ] Create and push release branch:
 
             make release-create-rc RELEASE_CURR=${version} RELEASE_NEXT=${next_version}
+
+      - [ ] Open PRs from your fork of branch ``version-${version}`` to upstream ``release_${version}`` and of ``version-${next_version}.dev`` to ``dev``.
 
 - [ ] **Deploy and Test Release**
 


### PR DESCRIPTION
upstream is used repeatedly and just assumed to be a remote - this tests for it and adds it if it doesn't exist before using in make commands now. This also automates the previous release to dev merge in the instructions with a new Make command.

Additionally, two PRs need to be created to update versions. This prints a reminder to do this and adds it to the release checklist. Ideally, these PRs could be avoided with a direct push or automatically created with hub (https://github.com/github/hub).

Update: PR updated with second thing mentioned and to incorporate typo fix noticed by @martenson 
