### PR TITLE
API: add server_starttime to api/configuration

### DIFF
--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -8,13 +8,13 @@ Used by both the API and bootstrapped data.
 #   but doesn't have a model like them. It might be better in config.py or a
 #   totally new area, but I'm leaving it in managers for now for class consistency.
 
+from galaxy.web.framework.base import server_starttime
 from galaxy.managers import base
 
 import logging
 log = logging.getLogger( __name__ )
 
 
-# TODO: for lack of a manager file for the config. May well be better in config.py? Circ imports?
 class ConfigSerializer( base.ModelSerializer ):
     """Configuration (galaxy.ini) settings viewable by all users"""
 
@@ -73,6 +73,7 @@ class ConfigSerializer( base.ModelSerializer ):
             'message_box_content'       : _defaults_to( None ),
             'message_box_visible'       : _defaults_to( False ),
             'message_box_class'         : _defaults_to( 'info' ),
+            'server_startttime'         : lambda i, k, **c: server_starttime,
         }
 
 

--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -9,6 +9,7 @@ import socket
 import tarfile
 import tempfile
 import types
+import time
 
 import routes
 import webob
@@ -23,6 +24,9 @@ from paste.response import HeaderDict
 
 
 log = logging.getLogger( __name__ )
+
+#: time of the most recent server startup
+server_starttime = int( time.time() )
 
 
 def __resource_with_deleted( self, member_name, collection_name, **kwargs ):

--- a/lib/galaxy/web/framework/helpers/__init__.py
+++ b/lib/galaxy/web/framework/helpers/__init__.py
@@ -2,7 +2,7 @@
 Galaxy web framework helpers
 """
 
-import time
+from ..base import server_starttime
 from datetime import datetime, timedelta
 
 from galaxy.util import hash_util
@@ -12,8 +12,6 @@ from webhelpers import date
 from webhelpers.html.tags import stylesheet_link, javascript_link
 
 from routes import url_for
-
-server_starttime = int(time.time())
 
 
 def time_ago( x ):


### PR DESCRIPTION
Adds key `server_starttime` to the JSON returned from `api/configuration`.
This is the epoch time since the last server restart and may be
convenient for use in client-side caching.

This moves `server_starttime` from `web/framework/helpers/__init__.py`
(for use in script cache-busting) to `web/framework/base.py`.

On the client, this should be available to all pages as:
`Galaxy.config.server_starttime`.
