### PR TITLE
Nicer bug report emails

### DIFF
--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -210,7 +210,6 @@ class ErrorReporter( object ):
         for parameter in report_variables.keys():
             report_variables[parameter] = cgi.escape(report_variables[parameter])
 
-        report_variables['message'] = cgi.escape(report_variables['message'])
         self.html_report = string.Template( error_report_template_html ).safe_substitute( report_variables )
 
     def _send_report( self, user, email=None, message=None, **kwd ):

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -205,7 +205,11 @@ class ErrorReporter( object ):
         )
 
         self.report = string.Template( error_report_template ).safe_substitute( report_variables )
-        # Escape the message for use in the HTML report
+
+        # Escape all of the content  for use in the HTML report
+        for parameter in report_variables.keys():
+            report_variables[parameter] = cgi.escape(report_variables[parameter])
+
         report_variables['message'] = cgi.escape(report_variables['message'])
         self.html_report = string.Template( error_report_template_html ).safe_substitute( report_variables )
 

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -3,6 +3,7 @@ Functionality for dealing with tool errors.
 """
 import string
 from galaxy import model, util, web
+from galaxy.util.sanitize_html import sanitize_html
 
 error_report_template = """
 GALAXY TOOL ERROR REPORT
@@ -51,6 +52,91 @@ ${job_traceback}
 (This is an automated message).
 """
 
+error_report_template_html = """
+<html><head></head>
+    <body>
+<style type="text/css">
+tr:nth-child(even) {background-color: #f2f2f2}
+table{margin: 1em;}
+.mono{font-family: monospace;}
+pre {
+white-space: pre-wrap;
+white-space: -moz-pre-wrap;
+white-space: -pre-wrap;
+white-space: -o-pre-wrap;
+word-wrap: break-word;
+background: #eee;
+border:1px solid black;
+padding:10px;
+}
+</style>
+
+<h1>Galaxy Tool Error Report</h1>
+<span class="sub"><i>from</i> <span class="mono"><a href="${host}">${host}</a></span>
+
+<h3>Error Localization</h3>
+<table>
+    <tbody>
+        <tr><td>Dataset</td><td>${dataset_id} (${dataset_id_encoded})</td></tr>
+        <tr><td>History</td><td><a href="${history_view_link}">${history_id} (${history_id_encoded})</a></td></tr>
+        <tr><td>Failed Job</td><td>${hid}: ${history_item_name}</td></tr>
+    </tbody>
+</table>
+
+<h3>User Provided Information</h3>
+
+The user <a href="mailto:${email_str}"><span class="mono">${email_str}</span></a> provided the following information:
+
+<pre>
+${message}
+</pre>
+
+
+<h3>Detailed Job Information</h3>
+
+Job environment and execution information is available at the job <a href="${hda_show_params_link}">Info Page</a>.
+
+<table>
+    <tbody>
+        <tr><td>Job ID</td><td>${job_id} (${job_id_encoded})</td></tr>
+        <tr><td>Tool ID</td><td>${job_tool_id}</td></tr>
+        <tr><td>Tool Version</td><td>${tool_version}</td></tr>
+        <tr><td>Job PID or DRM id</td><td>${job_runner_external_id}</td></tr>
+        <tr><td>Job Tool Version</td><td>${job_tool_version}</td></tr>
+    </tbody>
+</table>
+
+<h3>Job Execution and Failure Information</h3>
+
+<h4>Command Line</h4>
+<pre>
+${job_command_line}
+</pre>
+
+<h4>stderr</h4>
+<pre>
+${job_stderr}
+</pre>
+
+<h4>stdout</h4>
+<pre>
+${job_stdout}
+</pre>
+
+<h4>Job Information</h4>
+<pre>
+${job_info}
+</pre>
+
+<h4>Job Traceback</h4>
+<pre>
+${job_traceback}
+</pre>
+
+This is an automated message. Do not reply to this address.
+</body></html>
+"""
+
 
 class ErrorReporter( object ):
     def __init__( self, hda, app ):
@@ -91,30 +177,37 @@ class ErrorReporter( object ):
             email_str = "'%s' (providing preferred contact email '%s')" % (user.email, email)
         else:
             email_str = "'%s'" % (email or 'anonymously')
+
+        report_variables = dict(
+            host=host,
+            dataset_id_encoded=self.app.security.encode_id( hda.dataset_id ),
+            dataset_id=hda.dataset_id,
+            history_id_encoded=history_id_encoded,
+            history_id=hda.history_id,
+            hda_id_encoded=hda_id_encoded,
+            hid=hda.hid,
+            history_item_name=hda.get_display_name(),
+            history_view_link=history_view_link,
+            hda_show_params_link=hda_show_params_link,
+            job_id_encoded=self.app.security.encode_id( job.id ),
+            job_id=job.id,
+            tool_version=job.tool_version,
+            job_tool_id=job.tool_id,
+            job_tool_version=hda.tool_version,
+            job_runner_external_id=job.job_runner_external_id,
+            job_command_line=job.command_line,
+            job_stderr=util.unicodify( job.stderr ),
+            job_stdout=util.unicodify( job.stdout ),
+            job_info=util.unicodify( job.info ),
+            job_traceback=util.unicodify( job.traceback ),
+            email_str=email_str,
+            message=sanitize_html( util.unicodify( message ), 'utf-8', 'text/html'  )
+        )
+
         self.report = string.Template( error_report_template ) \
-            .safe_substitute( host=host,
-                              dataset_id_encoded=self.app.security.encode_id( hda.dataset_id ),
-                              dataset_id=hda.dataset_id,
-                              history_id_encoded=history_id_encoded,
-                              history_id=hda.history_id,
-                              hda_id_encoded=hda_id_encoded,
-                              hid=hda.hid,
-                              history_item_name=hda.get_display_name(),
-                              history_view_link=history_view_link,
-                              hda_show_params_link=hda_show_params_link,
-                              job_id_encoded=self.app.security.encode_id( job.id ),
-                              job_id=job.id,
-                              tool_version=job.tool_version,
-                              job_tool_id=job.tool_id,
-                              job_tool_version=hda.tool_version,
-                              job_runner_external_id=job.job_runner_external_id,
-                              job_command_line=job.command_line,
-                              job_stderr=util.unicodify( job.stderr ),
-                              job_stdout=util.unicodify( job.stdout ),
-                              job_info=util.unicodify( job.info ),
-                              job_traceback=util.unicodify( job.traceback ),
-                              email_str=email_str,
-                              message=util.unicodify( message ) )
+            .safe_substitute( report_variables )
+        self.html_report = string.Template( error_report_template_html ) \
+            .safe_substitute( report_variables )
 
     def _send_report( self, user, email=None, message=None, **kwd ):
         return self.report
@@ -146,5 +239,6 @@ class EmailErrorReporter( ErrorReporter ):
             subject = "%s (%s)" % ( subject, self.app.toolbox.get_tool( self.job.tool_id, self.job.tool_version ).old_id )
         except Exception:
             pass
+
         # Send it
-        return util.send_mail( frm, to, subject, self.report, self.app.config )
+        return util.send_mail( frm, to, subject, self.report, self.app.config, html=self.html_report )

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -4,6 +4,7 @@ Functionality for dealing with tool errors.
 import string
 from galaxy import model, util, web
 from galaxy.util.sanitize_html import sanitize_html
+import cgi
 
 error_report_template = """
 GALAXY TOOL ERROR REPORT
@@ -204,10 +205,8 @@ class ErrorReporter( object ):
             message=sanitize_html( util.unicodify( message ), 'utf-8', 'text/html'  )
         )
 
-        self.report = string.Template( error_report_template ) \
-            .safe_substitute( report_variables )
-        self.html_report = string.Template( error_report_template_html ) \
-            .safe_substitute( report_variables )
+        self.report = string.Template( error_report_template ).safe_substitute( report_variables )
+        self.html_report = cgi.escape( string.Template( error_report_template_html ).safe_substitute( report_variables ) )
 
     def _send_report( self, user, email=None, message=None, **kwd ):
         return self.report

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -202,11 +202,13 @@ class ErrorReporter( object ):
             job_info=util.unicodify( job.info ),
             job_traceback=util.unicodify( job.traceback ),
             email_str=email_str,
-            message=sanitize_html( util.unicodify( message ), 'utf-8', 'text/html'  )
+            message=util.unicodify( message )
         )
 
         self.report = string.Template( error_report_template ).safe_substitute( report_variables )
-        self.html_report = cgi.escape( string.Template( error_report_template_html ).safe_substitute( report_variables ) )
+        # Escape the message for use in the HTML report
+        report_variables['message'] = cgi.escape(report_variables['message'])
+        self.html_report = string.Template( error_report_template_html ).safe_substitute( report_variables )
 
     def _send_report( self, user, email=None, message=None, **kwd ):
         return self.report

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -79,7 +79,7 @@ padding:10px;
     <tbody>
         <tr><td>Dataset</td><td>${dataset_id} (${dataset_id_encoded})</td></tr>
         <tr><td>History</td><td><a href="${history_view_link}">${history_id} (${history_id_encoded})</a></td></tr>
-        <tr><td>Failed Job</td><td>${hid}: ${history_item_name}</td></tr>
+        <tr><td>Failed Job</td><td>${hid}: ${history_item_name} (${hda_id_encoded})</td></tr>
     </tbody>
 </table>
 

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -3,7 +3,6 @@ Functionality for dealing with tool errors.
 """
 import string
 from galaxy import model, util, web
-from galaxy.util.sanitize_html import sanitize_html
 import cgi
 
 error_report_template = """

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1230,10 +1230,10 @@ def send_mail( frm, to, subject, body, config, html=None ):
     """
 
     to = listify( to )
-    if html is None:
-        msg = email_mime_text.MIMEText(  body.encode( 'ascii', 'replace' ) )
-    else:
+    if html:
         msg = email_mime_multipart.MIMEMultipart('alternative')
+    else:
+        msg = email_mime_text.MIMEText(  body.encode( 'ascii', 'replace' ) )
 
     msg[ 'To' ] = ', '.join( to )
     msg[ 'From' ] = frm

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1244,7 +1244,7 @@ def send_mail( frm, to, subject, body, config, html=None ):
         log.info( msg )
         return
 
-    if not html:
+    if html:
         mp_text = email_mime_text.MIMEText( body.encode( 'ascii', 'replace' ), 'plain' )
         mp_html = email_mime_text.MIMEText( html.encode( 'ascii', 'replace' ), 'html' )
         msg.attach(mp_text)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1209,15 +1209,16 @@ def send_mail( frm, to, subject, body, config ):
     """
     Sends an email.
     """
+    if config.smtp_server is None:
+        log.error( "Mail is not configured for this Galaxy instance." )
+        log.info( msg )
+        return
+
     to = listify( to )
     msg = email_mime_text.MIMEText(  body.encode( 'ascii', 'replace' ) )
     msg[ 'To' ] = ', '.join( to )
     msg[ 'From' ] = frm
     msg[ 'Subject' ] = subject
-    if config.smtp_server is None:
-        log.error( "Mail is not configured for this Galaxy instance." )
-        log.info( msg )
-        return
     smtp_ssl = asbool( getattr(config, 'smtp_ssl', False ) )
     if smtp_ssl:
         s = smtplib.SMTP_SSL()

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -28,7 +28,7 @@ from os.path import normpath, relpath
 from xml.etree import ElementInclude, ElementTree
 
 from six import binary_type, iteritems, PY3, string_types, text_type
-from six.moves import email_mime_text, xrange, zip
+from six.moves import email_mime_text, email_mime_multipart, xrange, zip
 from six.moves.urllib import parse as urlparse
 from six.moves.urllib import request as urlrequest
 
@@ -1205,9 +1205,28 @@ def size_to_bytes( size ):
         return int( size )
 
 
-def send_mail( frm, to, subject, body, config ):
+def send_mail( frm, to, subject, body, config, html=None ):
     """
     Sends an email.
+
+    :type  frm: str
+    :param frm: from address
+
+    :type  to: str
+    :param to: to address
+
+    :type  subject: str
+    :param subject: Subject line
+
+    :type  body: str
+    :param body: Body text (should be plain text)
+
+    :type  config: object
+    :param config: Galaxy configuration object
+
+    :type  html: str
+    :param html: Alternative HTML representation of the body content. If
+                 provided will convert the message to a MIMEMultipart. (Default 'None')
     """
     if config.smtp_server is None:
         log.error( "Mail is not configured for this Galaxy instance." )
@@ -1215,10 +1234,21 @@ def send_mail( frm, to, subject, body, config ):
         return
 
     to = listify( to )
-    msg = email_mime_text.MIMEText(  body.encode( 'ascii', 'replace' ) )
+    if html is None:
+        msg = email_mime_text.MIMEText(  body.encode( 'ascii', 'replace' ) )
+    else:
+        msg = email_mime_multipart.MIMEMultipart('alternative')
+
     msg[ 'To' ] = ', '.join( to )
     msg[ 'From' ] = frm
     msg[ 'Subject' ] = subject
+
+    if html is not None:
+        mp_text = email_mime_text.MIMEText( body.encode( 'ascii', 'replace' ), 'plain' )
+        mp_html = email_mime_text.MIMEText( html.encode( 'ascii', 'replace' ), 'html' )
+        msg.attach(mp_text)
+        msg.attach(mp_html)
+
     smtp_ssl = asbool( getattr(config, 'smtp_ssl', False ) )
     if smtp_ssl:
         s = smtplib.SMTP_SSL()

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1228,10 +1228,6 @@ def send_mail( frm, to, subject, body, config, html=None ):
     :param html: Alternative HTML representation of the body content. If
                  provided will convert the message to a MIMEMultipart. (Default 'None')
     """
-    if config.smtp_server is None:
-        log.error( "Mail is not configured for this Galaxy instance." )
-        log.info( msg )
-        return
 
     to = listify( to )
     if html is None:
@@ -1242,6 +1238,11 @@ def send_mail( frm, to, subject, body, config, html=None ):
     msg[ 'To' ] = ', '.join( to )
     msg[ 'From' ] = frm
     msg[ 'Subject' ] = subject
+
+    if config.smtp_server is None:
+        log.error( "Mail is not configured for this Galaxy instance." )
+        log.info( msg )
+        return
 
     if html is not None:
         mp_text = email_mime_text.MIMEText( body.encode( 'ascii', 'replace' ), 'plain' )

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1244,7 +1244,7 @@ def send_mail( frm, to, subject, body, config, html=None ):
         log.info( msg )
         return
 
-    if html is not None:
+    if not html:
         mp_text = email_mime_text.MIMEText( body.encode( 'ascii', 'replace' ), 'plain' )
         mp_html = email_mime_text.MIMEText( html.encode( 'ascii', 'replace' ), 'html' )
         msg.attach(mp_text)


### PR DESCRIPTION
The current bug report emails are pretty dull, which is really totally OK. My client recently tried to render them as HTML. I realised that I might actually like HTML bug report emails. This was not a good use of my time, probably. ;)
- [x] HTML support to the email function
- [x] fancier HTML bug reports
- [x] properly sanitized (all HTML characters are URL encoded with cgi.escape, this is enough, right?)

Images:

![utvalg_703](https://cloud.githubusercontent.com/assets/458683/14479691/c90c7c1e-0110-11e6-9933-2ba7498c9a46.png)
![utvalg_704](https://cloud.githubusercontent.com/assets/458683/14479693/cad76ab8-0110-11e6-80b3-906d5be0977e.png)
![utvalg_705](https://cloud.githubusercontent.com/assets/458683/14479696/cc40eff0-0110-11e6-88ad-e6ee5f6344f3.png)
