### PR TITLE
Use "$NCPUS" if defined to set GALAXY_SLOTS

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
@@ -15,6 +15,8 @@ elif [ -n "$SLURM_NTASKS" ] || [ -n "$SLURM_CPUS_PER_TASK" ]; then
     GALAXY_SLOTS=`expr "${SLURM_NTASKS:-1}" \* "${SLURM_CPUS_PER_TASK:-1}"`
 elif [ -n "$NSLOTS" ]; then
     GALAXY_SLOTS="$NSLOTS"
+elif [ -n "$NCPUS" ]; then
+    GALAXY_SLOTS="$NCPUS"
 elif [ -n "$PBS_NCPUS" ]; then
     GALAXY_SLOTS="$PBS_NCPUS"
 elif [ -f "$PBS_NODEFILE" ]; then


### PR DESCRIPTION
On our PBS cluster we do not have $PBS_NCPUS, and $PBS_NODEFILE contains the
hostname of the nodes the task runs on. But we do have "$NCPUS" with the
correct number of CPUS.
