### PR TITLE
Place $headers before integrity_check

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -1,7 +1,7 @@
 #!$shell
 
-$integrity_injection
 $headers
+$integrity_injection
 $slots_statement
 export GALAXY_SLOTS
 GALAXY_LIB="$galaxy_lib"


### PR DESCRIPTION
PBS needs the resource selection (which will be filled in place of $headers) to
appear before anything else (except the shebang), so this changes the order.
