### PR TITLE
[16.04] Undo #1714

### DIFF
--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -157,7 +157,6 @@ class ToolEvaluator( object ):
                 elif isinstance( input, Conditional ):
                     values = input_values[ input.name ]
                     current = values["__current_case__"]
-                    func( values, input.test_param )
                     do_walk( input.cases[current].inputs, values )
                 elif isinstance( input, Section ):
                     values = input_values[ input.name ]

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -71,16 +71,6 @@ class InputValueWrapper( ToolParameterValueWrapper ):
         self.value = value
         self._other_values = other_values
 
-    def __eq__( self, other ):
-        if isinstance( other, basestring ):
-            return str( self ) == other
-        elif isinstance( other, int ):
-            return int( self ) == other
-        elif isinstance( other, float ):
-            return float( self ) == other
-        else:
-            return super( InputValueWrapper, self ) == other
-
     def __str__( self ):
         to_param_dict_string = self.input.to_param_dict_string( self.value, self._other_values )
         if isinstance( to_param_dict_string, list ):
@@ -139,12 +129,6 @@ class SelectToolParameterWrapper( ToolParameterValueWrapper ):
         self._other_values = other_values
         self._path_rewriter = path_rewriter or DEFAULT_PATH_REWRITER
         self.fields = self.SelectToolParameterFieldWrapper( input, value, other_values, self._path_rewriter )
-
-    def __eq__( self, other ):
-        if isinstance( other, basestring ):
-            return str( self ) == other
-        else:
-            return super( SelectToolParameterWrapper, self ) == other
 
     def __str__( self ):
         # Assuming value is never a path - otherwise would need to pass


### PR DESCRIPTION
In #1714, we started to wrap conditional test parameters and overloaded `__eq__` operators. This seems to have some unexpected effects. I suggest this PR to fix #2155 and to revisit the consistent wrapping of parsed parameters again later. ping @jmchilton.
