### PR TITLE
[16.04] Fix missing pulsar-galaxy-lib update

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -43,7 +43,7 @@ anyjson==0.3.3
 
 # Pulsar requirements
 psutil==4.1.0
-pulsar-galaxy-lib==0.7.0.dev2
+pulsar-galaxy-lib==0.7.0.dev3
 
 # sqlalchemy-migrate and dependencies
 sqlalchemy-migrate==0.10.0


### PR DESCRIPTION
It was updated in requirements.txt in #2122, but pinned-requirements.txt was missed.
