### PR TITLE
Implement ``single_user = <email>`` config option.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -881,6 +881,13 @@ use_interactive = True
 # to True to force these to lower case.
 #normalize_remote_user_email = False
 
+# If an e-mail address is specified here, it will hijack remote user mechanics
+# (``use_remote_user``) and have the webapp inject a single fixed user. This
+# has the effect of turning Galaxy into a single user application with no
+# login or external proxy required. Such applications should not be exposed to
+# the world.
+#single_user =
+
 # Administrative users - set this to a comma-separated list of valid Galaxy
 # users (email addresses).  These users will have access to the Admin section
 # of the server, and will have access to create users, groups, roles,

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -153,6 +153,7 @@ class Configuration( object ):
         self.max_metadata_value_size = int( kwargs.get( "max_metadata_value_size", 5242880 ) )
         self.use_remote_user = string_as_bool( kwargs.get( "use_remote_user", "False" ) )
         self.normalize_remote_user_email = string_as_bool( kwargs.get( "normalize_remote_user_email", "False" ) )
+        self.single_user = kwargs.get( "single_user", None )
         self.remote_user_maildomain = kwargs.get( "remote_user_maildomain", None )
         self.remote_user_header = kwargs.get( "remote_user_header", 'HTTP_REMOTE_USER' )
         self.remote_user_logout_href = kwargs.get( "remote_user_logout_href", None )

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -151,9 +151,9 @@ class Configuration( object ):
         self.id_secret = kwargs.get( "id_secret", "USING THE DEFAULT IS NOT SECURE!" )
         self.retry_metadata_internally = string_as_bool( kwargs.get( "retry_metadata_internally", "True" ) )
         self.max_metadata_value_size = int( kwargs.get( "max_metadata_value_size", 5242880 ) )
-        self.use_remote_user = string_as_bool( kwargs.get( "use_remote_user", "False" ) )
-        self.normalize_remote_user_email = string_as_bool( kwargs.get( "normalize_remote_user_email", "False" ) )
         self.single_user = kwargs.get( "single_user", None )
+        self.use_remote_user = string_as_bool( kwargs.get( "use_remote_user", "False" ) ) or self.single_user
+        self.normalize_remote_user_email = string_as_bool( kwargs.get( "normalize_remote_user_email", "False" ) )
         self.remote_user_maildomain = kwargs.get( "remote_user_maildomain", None )
         self.remote_user_header = kwargs.get( "remote_user_header", 'HTTP_REMOTE_USER' )
         self.remote_user_logout_href = kwargs.get( "remote_user_logout_href", None )

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -720,6 +720,7 @@ def wrap_in_middleware( app, global_conf, **local_conf ):
         from galaxy.web.framework.middleware.remoteuser import RemoteUser
         app = RemoteUser( app, maildomain=conf.get( 'remote_user_maildomain', None ),
                           display_servers=util.listify( conf.get( 'display_servers', '' ) ),
+                          single_user=conf.get( 'single_user', None ),
                           admin_users=conf.get( 'admin_users', '' ).split( ',' ),
                           remote_user_header=conf.get( 'remote_user_header', 'HTTP_REMOTE_USER' ),
                           remote_user_secret_header=conf.get('remote_user_secret', None) )

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -716,11 +716,13 @@ def wrap_in_middleware( app, global_conf, **local_conf ):
     # If we're using remote_user authentication, add middleware that
     # protects Galaxy from improperly configured authentication in the
     # upstream server
-    if asbool(conf.get( 'use_remote_user', False )):
+    single_user = conf.get( 'single_user', None )
+    use_remote_user = asbool(conf.get( 'use_remote_user', False )) or single_user
+    if use_remote_user:
         from galaxy.web.framework.middleware.remoteuser import RemoteUser
         app = RemoteUser( app, maildomain=conf.get( 'remote_user_maildomain', None ),
                           display_servers=util.listify( conf.get( 'display_servers', '' ) ),
-                          single_user=conf.get( 'single_user', None ),
+                          single_user=single_user,
                           admin_users=conf.get( 'admin_users', '' ).split( ',' ),
                           remote_user_header=conf.get( 'remote_user_header', 'HTTP_REMOTE_USER' ),
                           remote_user_secret_header=conf.get('remote_user_secret', None) )


### PR DESCRIPTION
Let Planemo and other such applications serve a full-fledged, personalized Galaxy instance without having to worry about logins, etc....
