### PR TITLE
[16.01] Backport #2146 #2145

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
@@ -15,6 +15,8 @@ elif [ -n "$SLURM_NTASKS" ] || [ -n "$SLURM_CPUS_PER_TASK" ]; then
     GALAXY_SLOTS=`expr "${SLURM_NTASKS:-1}" \* "${SLURM_CPUS_PER_TASK:-1}"`
 elif [ -n "$NSLOTS" ]; then
     GALAXY_SLOTS="$NSLOTS"
+elif [ -n "$NCPUS" ]; then
+    GALAXY_SLOTS="$NCPUS"
 elif [ -n "$PBS_NCPUS" ]; then
     GALAXY_SLOTS="$PBS_NCPUS"
 elif [ -f "$PBS_NODEFILE" ]; then

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -1,7 +1,7 @@
 #!$shell
 
-$integrity_injection
 $headers
+$integrity_injection
 $slots_statement
 export GALAXY_SLOTS
 GALAXY_LIB="$galaxy_lib"


### PR DESCRIPTION
- #2145 Use "$NCPUS" if defined to set GALAXY_SLOTS
- #2146 Place $headers before integrity_check
