### PR TITLE
WIP: Include manager in pulsar http request

### DIFF
--- a/lib/pulsar/client/interface.py
+++ b/lib/pulsar/client/interface.py
@@ -89,6 +89,7 @@ class HttpPulsarInterface(PulsarInterface):
             remote_host = "http://%s" % remote_host
         self.remote_host = remote_host
         self.private_token = destination_params.get("private_token", None)
+        self.manager = destination_params.get("manager", None)
 
     def execute(self, command, args={}, data=None, input_path=None, output_path=None):
         url = self.__build_url(command, args)
@@ -100,6 +101,8 @@ class HttpPulsarInterface(PulsarInterface):
         path = COMMAND_TO_PATH.get(command, Template(command)).safe_substitute(args)
         if self.private_token:
             args["private_token"] = self.private_token
+        if self.remote_host:
+            args["manager_name"] = self.manager
         arg_bytes = dict([(k, text_type(args[k]).encode('utf-8')) for k in args])
         data = urlencode(arg_bytes)
         url = self.remote_host + path + "?" + data


### PR DESCRIPTION
This allows the selection of a named manager in Pulsar if galaxy communicated
with Pulsar via http.

This is probably not the best way to do this, but I hope I can get some comments on that.
Other part of this in https://github.com/galaxyproject/pulsar/pull/106
