### PR TITLE
[16.04] Fix.published history long titles have to be truncated

### DIFF
--- a/templates/display_base.mako
+++ b/templates/display_base.mako
@@ -124,8 +124,11 @@
         href_to_user_items = href_to_user_items.replace( 'xxx', 'f-username')
     %>
 
-    <div class="unified-panel-header" unselectable="on">
+    <div class="unified-panel-header" unselectable="on" style="overflow: hidden">
         <div class="unified-panel-header-inner">
+            <div style="float: right">
+                ${self.render_item_links( item )}
+            </div>
             %if item.published:
                     <a href="${href_to_all_items}">Published ${item_plural}</a> |
                     <a href="${href_to_user_items}">${item.user.username}</a>
@@ -137,10 +140,6 @@
                 Private ${get_class_display_name( item.__class__ )}
             %endif
             | ${get_item_name( item ) | h}
-
-            <div style="float: right">
-                ${self.render_item_links( item )}
-            </div>
         </div>
     </div>
 

--- a/templates/webapps/galaxy/history/display.mako
+++ b/templates/webapps/galaxy/history/display.mako
@@ -13,28 +13,6 @@
 <%def name="stylesheets()">
     ${parent.stylesheets()}
     <style type="text/css">
-/*        #center,
-        .unified-panel-header,
-        div.unified-panel-body {
-            position: static;
-            top: auto;
-            bottom: auto;
-            width: 100%;
-            height: auto;
-            margin: 0;
-            padding 0;
-            overflow: auto;
-        }
-        #center {
-            margin-top: 34px;
-            margin-right: 250px;
-        }
-        .unified-panel-header {
-        }
-        .unified-panel-header-inner {
-        }
-        div.unified-panel-body {
-        }*/
     </style>
 </%def>
 

--- a/templates/webapps/galaxy/history/display.mako
+++ b/templates/webapps/galaxy/history/display.mako
@@ -13,9 +13,28 @@
 <%def name="stylesheets()">
     ${parent.stylesheets()}
     <style type="text/css">
-        .history-panel {
-            margin-top: 8px;
+/*        #center,
+        .unified-panel-header,
+        div.unified-panel-body {
+            position: static;
+            top: auto;
+            bottom: auto;
+            width: 100%;
+            height: auto;
+            margin: 0;
+            padding 0;
+            overflow: auto;
         }
+        #center {
+            margin-top: 34px;
+            margin-right: 250px;
+        }
+        .unified-panel-header {
+        }
+        .unified-panel-header-inner {
+        }
+        div.unified-panel-body {
+        }*/
     </style>
 </%def>
 
@@ -41,9 +60,7 @@
 </%def>
 
 <%def name="render_item( history, datasets )">
-
-<div id="history-${ history_dict[ 'id' ] }" class="history-panel">
-</div>
+<div id="history-${ history_dict[ 'id' ] }" class="history-panel"></div>
 <script type="text/javascript">
     var historyJSON  = ${h.dumps( history_dict )},
         contentsJSON = ${h.dumps( content_dicts )};


### PR DESCRIPTION
Render links first in upanel-header - this allows text to flow around them and for them to be positioned at/near the top (and remain clickable).

This is a stop-gap/kludge and what we'd really want to do is move away
from absolutely positoned panels/layouts so elements like this can
stretch more naturally around their contents.

Fixes #2172

<img width="1003" alt="screen shot 2016-04-18 at 2 04 39 pm" src="https://cloud.githubusercontent.com/assets/5102959/14614566/c15ef6e6-056f-11e6-844e-f0746e36024f.png">
