### PR TITLE
Quote added in environment

### DIFF
--- a/contrib/galaxy_supervisor.conf
+++ b/contrib/galaxy_supervisor.conf
@@ -23,7 +23,7 @@ autostart       = true
 autorestart     = true
 startsecs       = 20
 user            = galaxy
-environment     = PATH=/home/galaxy/galaxy/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,PYTHONHOME=/home/galaxy/galaxy/.venv
+environment     = PATH="/home/galaxy/galaxy/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",PYTHONHOME="/home/galaxy/galaxy/.venv"
 numprocs        = 1
 stopsignal      = INT
 startretries    = 15
@@ -38,7 +38,7 @@ autostart       = true
 autorestart     = true
 startsecs       = 20
 user            = galaxy
-environment     = PYTHONHOME=/home/galaxy/galaxy/.venv
+environment     = PYTHONHOME="/home/galaxy/galaxy/.venv"
 startretries    = 15
 
 [group:galaxy]


### PR DESCRIPTION
Apparently supervisor might need to have quotes around values in the environment lines. Without them you would have this error :
"Error: Unexpected end of key/value pairs"
