### PR TITLE
[16.01] Prepass on remote user header based on maildomain and normalize confi…

### DIFF
--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -382,8 +382,6 @@ class GalaxyWebTransaction( base.DefaultWebTransaction,
             assert self.app.config.remote_user_header in self.environ, \
                 "use_remote_user is set but %s header was not provided" % self.app.config.remote_user_header
             remote_user_email = self.environ[ self.app.config.remote_user_header ]
-            if getattr( self.app.config, "normalize_remote_user_email", False ):
-                remote_user_email = remote_user_email.lower()
             if galaxy_session:
                 # An existing session, make sure correct association exists
                 if galaxy_session.user is None:

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -688,7 +688,8 @@ def wrap_in_middleware( app, global_conf, **local_conf ):
                           display_servers=util.listify( conf.get( 'display_servers', '' ) ),
                           admin_users=conf.get( 'admin_users', '' ).split( ',' ),
                           remote_user_header=conf.get( 'remote_user_header', 'HTTP_REMOTE_USER' ),
-                          remote_user_secret_header=conf.get('remote_user_secret', None) )
+                          remote_user_secret_header=conf.get('remote_user_secret', None),
+                          normalize_remote_user_email=conf.get('normalize_remote_user_email', False))
     # The recursive middleware allows for including requests in other
     # requests or forwarding of requests, all on the server side.
     if asbool(conf.get('use_recursive', True)):


### PR DESCRIPTION
…g.  This resolves an error reported on -dev with maildomain and user being set incorrectly due to changes in #1801 

Refactoring and cleanup to come in current branch, not applicable to 16.01.
