### PR TITLE
[16.04] Extend to_json for dataset tool parameters

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1673,13 +1673,16 @@ class BaseDataToolParameter( ToolParameter ):
     def to_json( self, value, app ):
         def single_to_json( value ):
             src = None
-            if isinstance( value, galaxy.model.DatasetCollectionElement ):
+            if isinstance( value, dict ) and 'src' in value and 'id' in value:
+                return value
+            elif isinstance( value, galaxy.model.DatasetCollectionElement ):
                 src = 'dce'
             elif isinstance( value, app.model.HistoryDatasetCollectionAssociation ):
                 src = 'hdca'
-            else:
+            elif hasattr( value, 'id' ):
                 src = 'hda'
-            return { 'id' : app.security.encode_id( value.id ), 'src' : src }
+            if src is not None:
+                return { 'id' : app.security.encode_id( value.id ), 'src' : src }
 
         if value not in [ None, '', 'None' ]:
             if isinstance( value, list ) and len( value ) > 0:


### PR DESCRIPTION
This fixes the log.exception at https://sentry.galaxyproject.org/sentry/main/issues/14394/ by improving the value resolution of the to_json converter for dataset and dataset collection tool parameters.
