### PR TITLE
[16.04] Pages parser fix

### DIFF
--- a/lib/galaxy/util/sanitize_html.py
+++ b/lib/galaxy/util/sanitize_html.py
@@ -194,7 +194,7 @@ class _BaseHTMLProcessor(sgmllib.SGMLParser):
 
     def output(self):
         '''Return processed HTML as a single string'''
-        return ''.join([str(p) for p in self.pieces])
+        return ''.join([unicodify(p) for p in self.pieces])
 
 
 class _HTMLSanitizer(_BaseHTMLProcessor):

--- a/lib/galaxy/util/sanitize_html.py
+++ b/lib/galaxy/util/sanitize_html.py
@@ -194,7 +194,7 @@ class _BaseHTMLProcessor(sgmllib.SGMLParser):
 
     def output(self):
         '''Return processed HTML as a single string'''
-        return ''.join([unicodify(p) for p in self.pieces])
+        return ''.join(self.pieces)
 
 
 class _HTMLSanitizer(_BaseHTMLProcessor):

--- a/lib/galaxy/util/validation.py
+++ b/lib/galaxy/util/validation.py
@@ -3,23 +3,22 @@
 TODO: Refactor BaseController references to similar methods to use this module.
 """
 from galaxy import exceptions
-from galaxy.util import unicodify
 from galaxy.util.sanitize_html import sanitize_html
 
-from six import string_types, text_type
+from six import string_types
 
 
 def validate_and_sanitize_basestring( key, val ):
     if not isinstance( val, string_types ):
         raise exceptions.RequestParameterInvalidException( '%s must be a string or unicode: %s'
                                                            % ( key, str( type( val ) ) ) )
-    return unicodify( sanitize_html( val, 'utf-8', 'text/html' ), 'utf-8' )
+    return sanitize_html( val, 'utf-8', 'text/html' )
 
 
 def validate_and_sanitize_basestring_list( key, val ):
     try:
         assert isinstance( val, list )
-        return [ text_type( sanitize_html( t, 'utf-8', 'text/html' ), 'utf-8' ) for t in val ]
+        return [ sanitize_html( t, 'utf-8', 'text/html' ) for t in val ]
     except ( AssertionError, TypeError ):
         raise exceptions.RequestParameterInvalidException( '%s must be a list of strings: %s'
                                                            % ( key, str( type( val ) ) ) )

--- a/lib/galaxy/util/validation.py
+++ b/lib/galaxy/util/validation.py
@@ -3,6 +3,7 @@
 TODO: Refactor BaseController references to similar methods to use this module.
 """
 from galaxy import exceptions
+from galaxy.util import unicodify
 from galaxy.util.sanitize_html import sanitize_html
 
 from six import string_types, text_type
@@ -12,7 +13,7 @@ def validate_and_sanitize_basestring( key, val ):
     if not isinstance( val, string_types ):
         raise exceptions.RequestParameterInvalidException( '%s must be a string or unicode: %s'
                                                            % ( key, str( type( val ) ) ) )
-    return text_type( sanitize_html( val, 'utf-8', 'text/html' ), 'utf-8' )
+    return unicodify( sanitize_html( val, 'utf-8', 'text/html' ), 'utf-8' )
 
 
 def validate_and_sanitize_basestring_list( key, val ):


### PR DESCRIPTION
Using str on previously unicodify'd non-ascii values throws the exception.  This caused Galaxy pages with non-ascii values to cease working with #1731.

This should resolve the issue you reported @jgoecks 

Example of the encoding failure:

```
In [2]: str("Blah blah blah, this breaks the page: ಠ_ಠ")
Out[2]: 'Blah blah blah, this breaks the page:
\xe0\xb2\xa0_\xe0\xb2\xa0'

In [3]: str(unicodify("Blah blah blah, this breaks the page: ಠ_ಠ"))
---------------------------------------------------------------------------
UnicodeEncodeError                        Traceback (most recent call
last)
<ipython-input-3-4a83f5e5f5c8> in <module>()
----> 1 str(unicodify("Blah blah blah, this breaks the page: ಠ_ಠ"))

UnicodeEncodeError: 'ascii' codec can't encode character u'\u0ca0' in
position 38: ordinal not in range(128)
```
