### PR TITLE
[16.04] Sync job_script module with Pulsar to fix doctest.

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/__init__.py
+++ b/lib/galaxy/jobs/runners/util/job_script/__init__.py
@@ -65,7 +65,7 @@ def job_script(template=DEFAULT_JOB_FILE_TEMPLATE, **kwds):
     >>> script.startswith('#!/bin/sh\\n#PBS -test\\n')
     False
     >>> script = job_script(working_directory='wd', command='uptime', exit_code_path='ec', headers='#PBS -test')
-    >>> script.startswith('#!/bin/sh\\n#PBS -test\\n')
+    >>> script.startswith('#!/bin/bash\\n\\n#PBS -test\\n')
     True
     >>> script = job_script(working_directory='wd', command='uptime', exit_code_path='ec', slots_statement='GALAXY_SLOTS="$SLURM_JOB_NUM_NODES"')
     >>> script.find('GALAXY_SLOTS="$SLURM_JOB_NUM_NODES"\\nexport GALAXY_SLOTS\\n') > 0
@@ -76,7 +76,7 @@ def job_script(template=DEFAULT_JOB_FILE_TEMPLATE, **kwds):
     job_instrumenter = kwds.get("job_instrumenter", None)
     if job_instrumenter:
         del kwds["job_instrumenter"]
-        working_directory = kwds["working_directory"]
+        working_directory = kwds.get("metadata_directory", kwds["working_directory"])
         kwds["instrument_pre_commands"] = job_instrumenter.pre_execute_commands(working_directory) or ''
         kwds["instrument_post_commands"] = job_instrumenter.post_execute_commands(working_directory) or ''
 


### PR DESCRIPTION
Following test fails without this change and is fixed by it.

```
nosetests --with-doctest lib/galaxy/jobs/runners/util/job_script
```

I'm not sure why Travis doesn't pick this up - I should figure that out.
