### PR TITLE
[16.04] Improve error message for data source tools, executed through the tool_runner controller

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1120,7 +1120,7 @@ class Tool( object, Dictifiable ):
         log.debug( 'Validated and populated state for tool request %s' % validation_timer )
         # If there were errors, we stay on the same page and display them
         if any( all_errors ):
-            raise exceptions.MessageException( err_data=all_errors[ 0 ] )
+            raise exceptions.MessageException( ', '.join( [ msg for msg in all_errors[ 0 ].itervalues() ] ), err_data=all_errors[ 0 ] )
         else:
             execution_tracker = execute_job( trans, self, all_params, history=request_context.history, rerun_remap_job_id=rerun_remap_job_id, collection_info=collection_info )
             if execution_tracker.successful_jobs:


### PR DESCRIPTION
Tool parameter validation errors which are encountered when running `data_source` tools through the `tool_runner.py` controller show a generic error message only. This PR fixes that by displaying the specific validation notification e.g. `You must provide a URL to this tool.`. It can be tested by running a `data_source` tool with a parameter validation tag `<validator>` as described in #2200.
