### PR TITLE
Added proxy to handler environment line

### DIFF
--- a/contrib/galaxy_supervisor.conf
+++ b/contrib/galaxy_supervisor.conf
@@ -38,7 +38,7 @@ autostart       = true
 autorestart     = true
 startsecs       = 20
 user            = galaxy
-environment     = PYTHONHOME=/home/galaxy/galaxy/.venv
+environment     = PYTHONHOME=/home/galaxy/galaxy/.venv,http_proxy="http://proxy_url:port",https_proxy="http://proxy_url:port"
 startretries    = 15
 
 [group:galaxy]


### PR DESCRIPTION
You need to set the http_proxy environment variable to supervisor since it does not use the environment variable of the user launching the command.This is required when you are working in a place where every connexion run behind a proxy.
