### PR TITLE
[16.04] Add fixed validation check for data_source tools URL parameter

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -69,6 +69,8 @@ class ToolRunner( BaseUIController ):
         # do param translation here, used by datasource tools
         if tool.input_translator:
             tool.input_translator.translate( params )
+        if 'runtool_btn' not in params.__dict__ and 'URL' not in params.__dict__:
+            error( 'Tool execution through the `tool_runner` requires a `runtool_btn` flag or `URL` parameter.' )
         # We may be visiting Galaxy for the first time ( e.g., sending data from UCSC ),
         # so make sure to create a new history if we've never had one before.
         history = tool.get_default_history_by_trans( trans, create=True )


### PR DESCRIPTION
As mentioned in #2200, `data_source` tools used to have a `URL` parameter check, preventing job execution when the `URL` parameter was not transmitted to the `tool_runner` controller. This PR re-introduces this check. However, instead of redirecting to the welcome page, the error is displayed. This can be tested by accessing e.g. `http://127.0.0.1:8080/tool_runner?tool_id=genomespace_importer` with and without this fix.
