### PR TITLE
[16.01] Browse library date handling for non-ascii month abbreviations

### DIFF
--- a/templates/webapps/galaxy/library/common/browse_library.mako
+++ b/templates/webapps/galaxy/library/common/browse_library.mako
@@ -300,7 +300,7 @@
                 <td id="libraryItemInfo">${render_library_item_info( ldda )}</td>
                 <td>${ldda.extension | h}</td>
             % endif
-            <td>${ldda.create_time.strftime( trans.app.config.pretty_datetime_format ) | h}</td>
+            <td>${util.unicodify(ldda.create_time.strftime( trans.app.config.pretty_datetime_format )) | h}</td>
             <td>${ldda.get_size( nice_size=True ) | h}</td>
         </tr>
         <%

--- a/templates/webapps/galaxy/library/common/ldda_info.mako
+++ b/templates/webapps/galaxy/library/common/ldda_info.mako
@@ -101,7 +101,7 @@
         </div>
         <div class="form-row">
             <label>Date uploaded:</label>
-            ${ldda.create_time.strftime( trans.app.config.pretty_datetime_format ) | h}
+            ${util.unicodify(ldda.create_time.strftime( trans.app.config.pretty_datetime_format )) | h}
             <div style="clear: both"></div>
         </div>
         <div class="form-row">


### PR DESCRIPTION
In particular locales, month abbreviations have non-ascii characters (févr, août, déc) which were breaking the browse library display.
