### PR TITLE
Improve handling of a missing R environment.

### DIFF
--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -1339,7 +1339,7 @@ class SetupREnvironment( Download, RecipeStep ):
         #       <repository name="package_r_3_0_1" owner="bgruening">
         #           <package name="R" version="3.0.1" />
         #       </repository>
-        #       <!-- allow installing an R packages -->
+        #       <!-- allow installing one or more R packages -->
         #       <package sha256sum="7056b06041fd96ebea9c74f445906f1a5cd784b2b1573c02fcaee86a40f3034d">https://github.com/bgruening/download_store/raw/master/DESeq2-1_0_18/BiocGenerics_0.6.0.tar.gz</package>
         # </action>
         dir = None
@@ -1347,10 +1347,14 @@ class SetupREnvironment( Download, RecipeStep ):
             filtered_actions = actions[ 1: ]
         env_shell_file_paths = action_dict.get( 'env_shell_file_paths', None )
         if env_shell_file_paths is None:
-            log.debug( 'Missing R environment. Please check your specified R installation exists.' )
-            if initial_download:
-                return tool_dependency, filtered_actions, dir
-            return tool_dependency, None, None
+            error_message = 'Missing R environment. Please check your specified R installation exists.'
+            log.error( error_message )
+            status = self.app.install_model.ToolDependency.installation_status.ERROR
+            tool_dependency = tool_dependency_util.set_tool_dependency_attributes( self.app,
+                                                                                   tool_dependency,
+                                                                                   status=status,
+                                                                                   error_message=error_message )
+            return tool_dependency, [], None
         else:
             install_environment.add_env_shell_file_paths( env_shell_file_paths )
         log.debug( 'Handling setup_r_environment for tool dependency %s with install_environment.env_shell_file_paths:\n%s' %


### PR DESCRIPTION
Previously, the error message 'Missing R environment. Please check your specified R installation exists.' would be displayed in an obscure location in the paster log. With this change, galaxy will set the tool dependency to Error and display the error message in the admin panel.

The lack of a displayed error led to @nturaga and I spending an extra 30 minutes tracking down a misconfigured dependency on Tuesday. 
