### PR TITLE
[16.04] Add conditional statsd requirement

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -66,6 +66,9 @@ class ConditionalDependencies( object ):
     def check_raven( self ):
         return self.config.get("sentry_dsn", None) is not None
 
+    def check_statsd( self ):
+        return self.config.get("statsd_host", None) is not None
+
     def check_weberror( self ):
         return ( asbool( self.config["debug"] ) and
                  asbool( self.config["use_interactive"] ) )

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -10,4 +10,5 @@ fluent-logger
 raven
 pbs_python
 drmaa
+statsd
 # PyRods not in PyPI


### PR DESCRIPTION
Cherrypick of 44a337ab to 16.04 since without it, statsd isn't installed and just blows up once configured.
