### PR TITLE
Multi-data collection reductions in repeat blocks are broken.

### DIFF
--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -931,6 +931,38 @@ class ToolsTestCase( api.ApiTestCase ):
         }
         self._check_simple_reduce_job( history_id, inputs )
 
+    @skip_without_tool( "multi_data_repeat" )
+    def test_reduce_collections_in_repeat( self ):
+        history_id = self.dataset_populator.new_history()
+        hdca1_id = self.__build_pair( history_id, [ "123", "456" ] )
+        inputs = {
+            "outer_repeat_0|f1": { 'src': 'hdca', 'id': hdca1_id },
+        }
+        create = self._run( "multi_data_repeat", history_id, inputs, assert_ok=True )
+        outputs = create[ 'outputs' ]
+        jobs = create[ 'jobs' ]
+        self.assertEquals( len( jobs ), 1 )
+        self.assertEquals( len( outputs ), 1 )
+        output1 = outputs[0]
+        output1_content = self.dataset_populator.get_history_dataset_content( history_id, dataset=output1 )
+        assert output1_content.strip() == "123\n456", output1_content
+
+    @skip_without_tool( "multi_data_repeat" )
+    def test_reduce_collections_in_repeat_legacy( self ):
+        history_id = self.dataset_populator.new_history()
+        hdca1_id = self.__build_pair( history_id, [ "123", "456" ] )
+        inputs = {
+            "outer_repeat_0|f1": "__collection_reduce__|%s" % hdca1_id,
+        }
+        create = self._run( "multi_data_repeat", history_id, inputs, assert_ok=True )
+        outputs = create[ 'outputs' ]
+        jobs = create[ 'jobs' ]
+        self.assertEquals( len( jobs ), 1 )
+        self.assertEquals( len( outputs ), 1 )
+        output1 = outputs[0]
+        output1_content = self.dataset_populator.get_history_dataset_content( history_id, dataset=output1 )
+        assert output1_content.strip() == "123\n456", output1_content
+
     @skip_without_tool( "multi_data_param" )
     def test_reduce_multiple_lists_on_multi_data( self ):
         history_id = self.dataset_populator.new_history()

--- a/test/functional/tools/multi_data_repeat.xml
+++ b/test/functional/tools/multi_data_repeat.xml
@@ -1,0 +1,13 @@
+<tool id="multi_data_repeat" name="multi_data_repeat" version="0.1.0">
+  <command>
+    cat #for o in $outer_repeat# #for $f in $o.f1# ${f} #end for# #end for# >> $out1;
+  </command>
+  <inputs>
+    <repeat name="outer_repeat" title="Outer Repeat" min="1">
+      <param name="f1" type="data" format="txt" multiple="true" label="Data 1" min="1" max="1235" />
+    </repeat>
+  </inputs>
+  <outputs>
+    <data format="txt" name="out1" />
+  </outputs>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -46,6 +46,7 @@
   <tool file="parallelism_optional.xml" />
   <tool file="implicit_default_conds.xml" />
   <tool file="multi_data_param.xml" />
+  <tool file="multi_data_repeat.xml" />
   <tool file="paths_as_file.xml" />
   <tool file="column_param.xml" />
   <tool file="column_multi_param.xml" />


### PR DESCRIPTION
I've added test cases to demonstrates this, they can be executed with 

```
./run_tests.sh -api test/api/test_tools.py:ToolsTestCase.test_reduce_collections_in_repeat
./run_tests.sh -api test/api/test_tools.py:ToolsTestCase.test_reduce_collections_in_repeat_legacy
```

Or the tool can be executed on a collection interactively by starting Galaxy with the command:

```
GALAXY_RUN_WITH_TEST_TOOLS=1 sh run.sh
```

These tests are both working in a 16.01 as demonstrated by this branch https://github.com/galaxyproject/galaxy/compare/dev...jmchilton:repeat_multidata_16.01.

Once these test cases pass, this will fix #2224.
