### PR TITLE
Cast everything to a string

### DIFF
--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -208,7 +208,7 @@ class ErrorReporter( object ):
 
         # Escape all of the content  for use in the HTML report
         for parameter in report_variables.keys():
-            report_variables[parameter] = cgi.escape(report_variables[parameter])
+            report_variables[parameter] = cgi.escape(str(report_variables[parameter]))
 
         self.html_report = string.Template( error_report_template_html ).safe_substitute( report_variables )
 

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -4,6 +4,7 @@ Functionality for dealing with tool errors.
 import string
 from galaxy import model, util, web
 import cgi
+from galaxy.util import unicodify
 
 error_report_template = """
 GALAXY TOOL ERROR REPORT
@@ -208,7 +209,7 @@ class ErrorReporter( object ):
 
         # Escape all of the content  for use in the HTML report
         for parameter in report_variables.keys():
-            report_variables[parameter] = cgi.escape(str(report_variables[parameter]))
+            report_variables[parameter] = cgi.escape(unicodify(report_variables[parameter]))
 
         self.html_report = string.Template( error_report_template_html ).safe_substitute( report_variables )
 


### PR DESCRIPTION
`cgi.escape` doesn't work on non-strings. Fixes #2251 

cc @martenson 
