### PR TITLE
Generate metadata in separate conda environment

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1665,7 +1665,7 @@ class JobWrapper( object ):
             if metadata_tool is not None:
                 # Due to tool shed hacks for migrate and installed tool tests...
                 # see (``setup_shed_tools_for_test`` in test/base/driver_util.py).
-                dependency_shell_commands = metadata_tool.build_dependency_shell_commands(job_directory=self.working_directory)
+                dependency_shell_commands = metadata_tool.build_dependency_shell_commands(job_directory=self.working_directory, metadata=True)
                 if dependency_shell_commands:
                     dependency_shell_commands = "; ".join(dependency_shell_commands)
                     command = "%s; %s" % (dependency_shell_commands, command)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1259,7 +1259,7 @@ class Tool( object, Dictifiable ):
             installed_tool_dependencies=self.installed_tool_dependencies,
             tool_dir=self.tool_dir,
             job_directory=job_directory,
-            metadata=metadata
+            metadata=metadata,
         )
 
     @property

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1252,13 +1252,14 @@ class Tool( object, Dictifiable ):
         visit_input_values( self.inputs, values, validate_inputs )
         return messages
 
-    def build_dependency_shell_commands( self, job_directory=None ):
+    def build_dependency_shell_commands( self, job_directory=None, metadata=False ):
         """Return a list of commands to be run to populate the current environment to include this tools requirements."""
         return self.app.toolbox.dependency_manager.dependency_shell_commands(
             self.requirements,
             installed_tool_dependencies=self.installed_tool_dependencies,
             tool_dir=self.tool_dir,
             job_directory=job_directory,
+            metadata=metadata
         )
 
     @property

--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -95,7 +95,7 @@ class DependencyManager( object ):
                 dependency = self.find_dep( name=requirement.name,
                                             version=requirement.version,
                                             type=requirement.type,
-                                            **kwds )
+                                            **kwds)
             dependency_commands = dependency.shell_commands( requirement )
             if not dependency_commands:
                 log.warn( "Failed to resolve dependency on '%s', ignoring", requirement.name )

--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -95,7 +95,7 @@ class DependencyManager( object ):
                 dependency = self.find_dep( name=requirement.name,
                                             version=requirement.version,
                                             type=requirement.type,
-                                            **kwds)
+                                            **kwds )
             dependency_commands = dependency.shell_commands( requirement )
             if not dependency_commands:
                 log.warn( "Failed to resolve dependency on '%s', ignoring", requirement.name )

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -125,7 +125,12 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
             return INDETERMINATE_DEPENDENCY
 
         # Have installed conda_target and job_directory to send it too.
-        conda_environment = os.path.join(job_directory, "conda-env")
+        # If dependency is for metadata generation, store environment in conda-metadata-env
+        if kwds.get("metadata", False):
+            conda_env = "conda-metadata-env"
+        else:
+            conda_env = "conda-env"
+        conda_environment = os.path.join(job_directory, conda_env)
         env_path, exit_code = build_isolated_environment(
             conda_target,
             path=conda_environment,


### PR DESCRIPTION
Galaxy supports generating metadata in a separate command (enable
beta_tool_command_isolation). This command has its own dependency resolution,
that may interfere with thedependency resolution of the actual tool, if the
same environment is being used. With this PR we create a new environment when
resolving metadata dependencies with conda, that will be active only for
metadata generation.

Should solve issue #2247 
