### PR TITLE
Tool execution dependency resolution already contains the relevant

### DIFF
--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -113,10 +113,7 @@ class DependencyManager( object ):
         for i, resolver in enumerate(self.dependency_resolvers):
             if index is not None and i != index:
                 continue
-
             dependency = resolver.resolve( name, version, type, **kwds )
-            log.debug('Resolver %s returned %s (isnull? %s)' % (resolver.resolver_type, dependency,
-                                                                dependency == INDETERMINATE_DEPENDENCY))
             if require_exact and not dependency.exact:
                 dependency = INDETERMINATE_DEPENDENCY
             if dependency != INDETERMINATE_DEPENDENCY:


### PR DESCRIPTION
information for viewing dependency resolution attempts and warns when
the dependency isn't found (Null resolver).  Pretty sure this was just a
stray extra debugging statement that got unintentionally left in, and
it's pretty chatty.
