### PR TITLE
[16.04] Update `_condarc` automatically

### DIFF
--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -20,7 +20,7 @@ EXTRA_CONFIG_KWDS = {
     'conda_prefix': None,
     'conda_exec': None,
     'conda_debug': None,
-    'conda_channels': 'r,bioconda',
+    'conda_ensure_channels': 'r,bioconda',
     'conda_auto_install': False,
     'conda_auto_init': False,
 }


### PR DESCRIPTION
With this fix the `_condarc` file will be updated if you change the galaxy.ini or the GALAYX_CONFIG_ENSURE_CHANNELS environment variable.

Very useful for flavors with it's own conda channels.

ping @jmchilton, @mvdbeek 
