### PR TITLE
fixed ui bugs in tours

### DIFF
--- a/config/plugins/tours/core.galaxy_ui.yaml
+++ b/config/plugins/tours/core.galaxy_ui.yaml
@@ -103,7 +103,7 @@ steps:
 
     - title: "Tool help"
       element: 'div.ui-form-help'
-      intro: "Every Galaxy tool has a help section with detailed information about the tool and its parameters. 
+      intro: "Every Galaxy tool has a help section with detailed information about the tool and its parameters.
               Have a look and study your tool in depth by reading it."
       position: "top"
 
@@ -130,25 +130,25 @@ steps:
         - "#current-history-panel > div.controls > div.title > div"
 
     - title: "View dataset"
-      element: ".fa-eye:eq(0)"
+      element: "#current-history-panel .fa-eye:eq(0)"
       intro: "View your dataset by clicking the eye button."
       position: "left"
       #preclick:
-      #  - ".fa-eye:eq(0)"
+      #  - "#current-history-panel .fa-eye:eq(0)"
 
     - title: "Rename dataset"
-      element: ".fa-pencil:eq(0)"
+      element: "#current-history-panel .fa-pencil:eq(0)"
       intro: "Rename your dataset by clicking the pencil button."
       position: "left"
       #preclick:
-      #  - ".fa-pencil:eq(0)"
+      #  - "#current-history-panel .fa-pencil:eq(0)"
 
     - title: "Remove dataset"
-      element: ".fa-times:eq(0)"
+      element: "#current-history-panel .fa-times:eq(0)"
       intro: "Delete your dataset by clicking the x-button."
       position: "left"
       #postclick:
-      #  - ".fa-times:eq(0)"
+      #  - "#current-history-panel .fa-times:eq(0)"
 
     - title: "Dataset information"
       element: "div.title-bar.clear:eq(0)"

--- a/config/plugins/tours/core.scratchbook.yaml
+++ b/config/plugins/tours/core.scratchbook.yaml
@@ -63,11 +63,11 @@ steps:
       intro: "This is your history. It contains all datasets you are currently working with including our uploaded table."
       position: "left"
 
-    - element: ".fa-eye:first"
+    - element: "#current-history-panel .fa-eye:first"
       intro: "Clicking the eye-icon usually displays a dataset in the center panel."
       position: "left"
       postclick:
-        - ".fa-eye:first"
+        - "#current-history-panel .fa-eye:first"
 
     - element: "#frame-0"
       intro: "However while in Scratchbook mode, the dataset will be shown as resizable window."


### PR DESCRIPTION
Since the scratchbook icon also has the class "fa-eye" I narrowed some queries to "#current-history-panel".
