### PR TITLE
Preliminary fix for displaying raw text/html 

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -373,7 +373,10 @@ class Data( object ):
                 # We cannot currently trust imported datasets for rendering.
                 if not data.creating_job.imported and data.creating_job.tool_id in trans.app.config.sanitize_whitelist:
                     return open(data.file_name).read()
-                return sanitize_html(open( data.file_name ).read())
+                # This is returning to the browser, it needs to be encoded.
+                # TODO Ideally this happens a layer higher, but this is a bad
+                # issue affecting many tools
+                return sanitize_html(open( data.file_name ).read()).encode('utf-8')
             return open( data.file_name )
         else:
             trans.response.set_content_type( "text/html" )


### PR DESCRIPTION
Raw unicode return here was being dropped by the webapp or proxy.  Encoding the output here is appropriate, but as a TODO I'm going to try to push this logic up into the framework so inside the webapp it's all unicode all the time.
