### PR TITLE
[16.04] Truncate job name in DRMAA runner by default for PBSPro.

### DIFF
--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -29,6 +29,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
     Job runner backed by a finite pool of worker threads. FIFO scheduling
     """
     runner_name = "DRMAARunner"
+    restrict_job_name_length = 15
 
     def __init__( self, app, nworkers, **kwargs ):
         """Start the job runner"""
@@ -124,13 +125,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         # wrapper.get_id_tag() instead of job_id for compatibility with TaskWrappers.
         galaxy_id_tag = job_wrapper.get_id_tag()
 
-        # define job attributes
-        job_name = 'g%s' % galaxy_id_tag
-        if job_wrapper.tool.old_id:
-            job_name += '_%s' % job_wrapper.tool.old_id
-        if external_runjob_script is None:
-            job_name += '_%s' % job_wrapper.user
-        job_name = ''.join( map( lambda x: x if x in ( string.letters + string.digits + '_' ) else '_', job_name ) )
+        job_name = self._job_name(job_wrapper)
         ajs = AsynchronousJobState( files_dir=job_wrapper.working_directory, job_wrapper=job_wrapper, job_name=job_name )
 
         # set up the drmaa job template
@@ -377,3 +372,18 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         # the DRMAA job-ID. If not the case, will throw an error.
         jobId = stdoutdata
         return jobId
+
+    def _job_name(self, job_wrapper):
+        external_runjob_script = job_wrapper.get_destination_configuration("drmaa_external_runjob_script", None)
+        galaxy_id_tag = job_wrapper.get_id_tag()
+
+        # define job attributes
+        job_name = 'g%s' % galaxy_id_tag
+        if job_wrapper.tool.old_id:
+            job_name += '_%s' % job_wrapper.tool.old_id
+        if external_runjob_script is None:
+            job_name += '_%s' % job_wrapper.user
+        job_name = ''.join( map( lambda x: x if x in ( string.letters + string.digits + '_' ) else '_', job_name ) )
+        if self.restrict_job_name_length:
+            job_name = job_name[:self.restrict_job_name_length]
+        return job_name

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -18,6 +18,7 @@ SLURM_MEMORY_LIMIT_EXCEEDED_MSG = 'slurmstepd: error: Exceeded job memory limit'
 
 class SlurmJobRunner( DRMAAJobRunner ):
     runner_name = "SlurmRunner"
+    restrict_job_name_length = False
 
     def _complete_terminal_job( self, ajs, drmaa_state, **kwargs ):
         def __get_jobinfo():


### PR DESCRIPTION
We don't really have a clean way to tell if the DRMAA runner is serving to PBSPro so we make this truncation the default for the DRMAA runner but in the case of the SLURM runner we continue to not truncate.

Issue has been brought up a couple times on -dev lately...
- http://dev.list.galaxyproject.org/Problem-with-DRMAA-and-Pbs-Pro-td4669338.html
- http://dev.list.galaxyproject.org/If-you-need-to-use-PBS-Pro-with-Galaxy-16-01-td4669229.html

I'm not sure if this is the result of changes in PBS Pro, the PBS library, or Galaxy. It really seems like DRMAA has worked this way for years.
