### PR TITLE
improvements to toolbox search

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -832,6 +832,8 @@ use_interactive = True
 # tool_name_boost = 9
 # tool_section_boost = 3
 # tool_description_boost = 2
+# tool_label_boost = 1
+# tool_stub_boost = 5
 # tool_help_boost = 0.5
 
 # Limits the number of results in toolbox search.  Can be used to tweak how many
@@ -1030,13 +1032,13 @@ use_interactive = True
 # users in the help text.
 #ftp_upload_site = None
 
-# User attribute to use as subdirectory in calculating default ftp_upload_dir 
+# User attribute to use as subdirectory in calculating default ftp_upload_dir
 # pattern. By default this will be email so a user's FTP upload directory will be
 # ${ftp_upload_dir}/${user.email}. Can set this to other attributes such as id or
 # username though.
 #ftp_upload_dir_identifier = email
 
-# Python string template used to determine an FTP upload directory for a 
+# Python string template used to determine an FTP upload directory for a
 # particular user.
 #ftp_upload_dir_template = ${ftp_upload_dir}/${ftp_upload_dir_identifier}
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -305,6 +305,8 @@ class Configuration( object ):
         self.tool_name_boost = kwargs.get( "tool_name_boost", 9 )
         self.tool_section_boost = kwargs.get( "tool_section_boost", 3 )
         self.tool_description_boost = kwargs.get( "tool_description_boost", 2 )
+        self.tool_labels_boost = kwargs.get( "tool_labels_boost", 1 )
+        self.tool_stub_boost = kwargs.get( "tool_stub_boost", 5 )
         self.tool_help_boost = kwargs.get( "tool_help_boost", 0.5 )
         self.tool_search_limit = kwargs.get( "tool_search_limit", 20 )
         # Location for tool dependencies.

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -2,18 +2,16 @@
 Module for building and searching the index of tools
 installed within this Galaxy.
 """
+import re
+
 from galaxy.web.framework.helpers import to_unicode
+from datetime import datetime
 
 from whoosh.filedb.filestore import RamStorage
 from whoosh.fields import KEYWORD, Schema, STORED, TEXT
 from whoosh.scoring import BM25F
 from whoosh.qparser import MultifieldParser
-schema = Schema( id=STORED,
-                 name=TEXT,
-                 description=TEXT,
-                 section=TEXT,
-                 help=TEXT,
-                 labels=KEYWORD )
+from whoosh import analysis
 import logging
 log = logging.getLogger( __name__ )
 
@@ -28,25 +26,46 @@ class ToolBoxSearch( object ):
         """
         Create a searcher for `toolbox`.
         """
+        self.schema = Schema( id=STORED,
+                              stub=KEYWORD,
+                              name=TEXT( analyzer=analysis.SimpleAnalyzer() ),
+                              description=TEXT,
+                              section=TEXT,
+                              help=TEXT,
+                              labels=KEYWORD )
+        self.rex = analysis.RegexTokenizer()
         self.toolbox = toolbox
         self.build_index( index_help )
 
     def build_index( self, index_help=True ):
-        log.debug( 'Starting to build toolbox index.' )
         self.storage = RamStorage()
-        self.index = self.storage.create_index( schema )
+        self.index = self.storage.create_index( self.schema )
         writer = self.index.writer()
+        start_time = datetime.now()
+        log.debug( 'Starting to build toolbox index.' )
         for id, tool in self.toolbox.tools():
             #  Do not add data managers to the public index
             if tool.tool_type == 'manage_data':
                 continue
             add_doc_kwds = {
                 "id": id,
-                "name": to_unicode( tool.name ),
                 "description": to_unicode( tool.description ),
                 "section": to_unicode( tool.get_panel_section()[1] if len( tool.get_panel_section() ) == 2 else '' ),
                 "help": to_unicode( "" )
             }
+            # Hyphens are wildcards in Whoosh causing bad things
+            if tool.name.find( '-' ) != -1:
+                add_doc_kwds['name'] = (' ').join( [ token.text for token in self.rex( to_unicode( tool.name ) ) ] )
+            else:
+                add_doc_kwds['name'] = to_unicode( tool.name )
+            # We do not want to search Tool Shed or version parts
+            # of the long ids
+            if id.find( '/' ) != -1:
+                slash_indexes = [ m.start() for m in re.finditer( '/', id ) ]
+                id_stub = id[ ( slash_indexes[1] + 1 ): slash_indexes[4] ]
+                add_doc_kwds['stub'] = (' ').join( [ token.text for token in self.rex( to_unicode( id_stub ) ) ] )
+            else:
+                add_doc_kwds['stub'] = to_unicode( id )
             if tool.labels:
                 add_doc_kwds['labels'] = to_unicode( " ".join( tool.labels ) )
             if index_help and tool.help:
@@ -58,9 +77,10 @@ class ToolBoxSearch( object ):
                     pass
             writer.add_document( **add_doc_kwds )
         writer.commit()
-        log.debug( 'Toolbox index finished.' )
+        stop_time = datetime.now()
+        log.debug( 'Toolbox index finished. It took: ' + str(stop_time - start_time) )
 
-    def search( self, q, tool_name_boost, tool_section_boost, tool_description_boost, tool_help_boost, tool_search_limit ):
+    def search( self, q, tool_name_boost, tool_section_boost, tool_description_boost, tool_label_boost, tool_stub_boost, tool_help_boost, tool_search_limit ):
         """
         Perform search on the in-memory index. Weight in the given boosts.
         """
@@ -70,11 +90,16 @@ class ToolBoxSearch( object ):
                 field_B={ 'name_B': float( tool_name_boost ),
                           'section_B': float( tool_section_boost ),
                           'description_B': float( tool_description_boost ),
+                          'labels_B': float( tool_label_boost ),
+                          'stub_B': float( tool_stub_boost ),
                           'help_B': float( tool_help_boost ) }
             )
         )
         # Set query to search name, description, section, help, and labels.
-        parser = MultifieldParser( [ 'name', 'description', 'section', 'help', 'labels' ], schema=schema )
+        parser = MultifieldParser( [ 'name', 'description', 'section', 'help', 'labels', 'stub' ], schema=self.schema )
+        # Hyphens are wildcards in Whoosh causing bad things
+        if q.find( '-' ) != -1:
+            q = (' ').join( [ token.text for token in self.rex( to_unicode( q ) ) ] )
         # Perform the search
         hits = searcher.search( parser.parse( '*' + q + '*' ), limit=float( tool_search_limit ) )
         return [ hit[ 'id' ] for hit in hits ]

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -59,6 +59,8 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
                             results.append( tool.id )
                     except exceptions.AuthenticationFailed:
                         pass
+                    except exceptions.ObjectNotFound:
+                        pass
             return results
 
         # Find whether to detect.
@@ -175,6 +177,8 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
         tool_name_boost = self.app.config.get( 'tool_name_boost', 9 )
         tool_section_boost = self.app.config.get( 'tool_section_boost', 3 )
         tool_description_boost = self.app.config.get( 'tool_description_boost', 2 )
+        tool_label_boost = self.app.config.get( 'tool_label_boost', 1 )
+        tool_stub_boost = self.app.config.get( 'tool_stub_boost', 5 )
         tool_help_boost = self.app.config.get( 'tool_help_boost', 0.5 )
         tool_search_limit = self.app.config.get( 'tool_search_limit', 20 )
 
@@ -182,6 +186,8 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
                                                   tool_name_boost=tool_name_boost,
                                                   tool_section_boost=tool_section_boost,
                                                   tool_description_boost=tool_description_boost,
+                                                  tool_label_boost=tool_label_boost,
+                                                  tool_stub_boost=tool_stub_boost,
                                                   tool_help_boost=tool_help_boost,
                                                   tool_search_limit=tool_search_limit )
         return results


### PR DESCRIPTION
fix searching on hyphenated strings; index and search on tool id stub
(tool id stub is a part of a long tool id that does not have the TS
part nor the version i.e. it has owner+repo+toolname)
also introduce config boost for labels and id stubs

part of https://github.com/galaxyproject/galaxy/issues/2272
