### PR TITLE
Add grunt watcher on the .less files

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -91,12 +91,13 @@ Grunt can also do an automatic, partial rebuild of any files you change *as you 
 
 1. opening a new terminal session
 2. `cd client`
-3. `grunt watch`
+    1. `grunt watch` to watch the *scripts/* folder
+    2. `grunt watch-style` to watch the *style/* folder
 
-This starts a new grunt watch process that will monitor the files in `client/galaxy/scripts` for changes and copy and
-pack them when they change.
+This starts a new grunt watch process that will monitor the files the corresponding folder for changes and copy and
+rebuild them when they change.
 
-You can stop the `grunt watch` task by pressing `Ctrl+C`. Note: you should also be able to background that task if you
+You can stop the `grunt watch*` task by pressing `Ctrl+C`. Note: you should also be able to background that task if you
 prefer.
 
 

--- a/client/README.md
+++ b/client/README.md
@@ -91,13 +91,14 @@ Grunt can also do an automatic, partial rebuild of any files you change *as you 
 
 1. opening a new terminal session
 2. `cd client`
-3. `grunt watch`
+    1. `grunt watch` to watch the *scripts/* folder
+    2. `grunt watch-style` to watch the *style/* folder
 
-This starts a new grunt watch process that will monitor the files in `client/galaxy/scripts` for changes and copy and
-pack them when they change.
+This starts a new grunt watch process that will monitor the files, in the corresponding folder, for changes and copy and
+rebuild them when they change.
 
-You can stop the `grunt watch` task by pressing `Ctrl+C`. Note: you should also be able to background that task if you
-prefer.
+You can stop the watch task by pressing `Ctrl+C`. Note: you should also be able to background that task
+if you prefer.
 
 
 Using a Locally Installed Version of Grunt

--- a/client/README.md
+++ b/client/README.md
@@ -91,6 +91,7 @@ Grunt can also do an automatic, partial rebuild of any files you change *as you 
 
 1. opening a new terminal session
 2. `cd client`
+3. Watch with:
     1. `grunt watch` to watch the *scripts/* folder
     2. `grunt watch-style` to watch the *style/* folder
 

--- a/client/grunt-tasks/style.js
+++ b/client/grunt-tasks/style.js
@@ -75,15 +75,30 @@ module.exports = function( grunt ){
         ]
     });
 
+
+    // -------------------------------------------------------------------------- watch & rebuild less files
+    // use 'grunt watch-style' (from a new tab in your terminal) to have grunt re-copy changed files automatically
+    grunt.config( 'watch', {
+        watch: {
+            // watch for changes in the src dir
+            files: [ lessPath + '/**' ],
+            tasks: ['check-modules', 'sprite', 'less-site-config', 'less', 'clean'],
+            options: {
+                spawn: false
+            }
+        }
+    });
+
     grunt.loadNpmTasks( 'grunt-contrib-less' );
     grunt.loadNpmTasks( 'grunt-spritesmith' );
     grunt.loadNpmTasks( 'grunt-contrib-clean' );
-
+    grunt.loadNpmTasks( 'grunt-contrib-watch' );
 
     // Write theme variable for less
     grunt.registerTask( 'less-site-config', 'Write site configuration for less', function() {
         grunt.file.write( fmt( '%s/tmp-site-config.less', lessPath ), fmt( "@theme-name: %s;", theme ) );
     });
 
+    grunt.registerTask( 'watch-style', [ 'watch' ] );
     grunt.registerTask( 'style', [  'check-modules', 'sprite', 'less-site-config', 'less', 'clean' ] );
 };


### PR DESCRIPTION
Hi!

I wanted to work on cleaning a bit the less files, but did not want to recompile manually the .less files. So, with the kickstart of @dannon, I added it!

In terminal, Go to `client/` and type `grunt watch-style`.
Change a .less file in `client/galaxy/style/less`, are **watch** it recompile :)

TODO:
- [x] Add documentation of it
- [ ] Less bruteforce recompilation
