### PR TITLE
HTCondor Docker Integration

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -434,6 +434,25 @@
                  <param> tags.
             -->
             <param id="request_cpus">8</param>
+
+            <!-- Recent version of HTCondor do have a `docker` universe to handle containers.
+                 Activate this feature by explicitly specifying the `docker` universe.
+            -->
+            <!-- <param id="universe">docker</param> -->
+
+            <!-- If the tool has a container specified this one is used.
+
+                <requirements>
+                    <container type="docker">bgruening/galaxy-stable</container>
+                </requirements>
+
+                If not the container specified with id="docker_image" is used and as last resort
+                id="docker_default_container_id" is considered.
+            -->
+
+            <!-- <param id="docker_image">busybox:ubuntu-14.04</param> -->
+            <!-- <param id="docker_default_container_id">busybox:ubuntu-14.04</param> -->
+
         </destination>
 
         <!-- Jobs that hit the walltime on one destination can be automatically

--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -446,13 +446,14 @@
                     <container type="docker">bgruening/galaxy-stable</container>
                 </requirements>
 
-                If not the container specified with id="docker_image" is used and as last resort
-                id="docker_default_container_id" is considered.
+            Unless the job destination specifies an override 
+            with docker_container_id_override. If neither of 
+            these is set a default container can be specified
+            with docker_default_container_id. The resolved
+            container ID will be passed along to condor as
+            the docker_image submission parameter.
             -->
-
-            <!-- <param id="docker_image">busybox:ubuntu-14.04</param> -->
             <!-- <param id="docker_default_container_id">busybox:ubuntu-14.04</param> -->
-
         </destination>
 
         <!-- Jobs that hit the walltime on one destination can be automatically

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -413,7 +413,15 @@ class JobConfiguration( object ):
 
         :returns: str -- id or tag representing the default.
         """
+
         rval = parent.get('default')
+        if 'default_from_environ' in parent.attrib:
+            environ_var = parent.attrib['default_from_environ']
+            rval = os.environ.get(environ_var, rval)
+        elif 'default_from_config' in parent.attrib:
+            config_val = parent.attrib['default_from_config']
+            rval = self.app.config.config_dict.get(config_val, rval)
+
         if rval is not None:
             # If the parent element has a 'default' attribute, use the id or tag in that attribute
             if rval not in names:

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -57,6 +57,19 @@ class CondorJobRunner( AsynchronousJobRunner ):
 
         # get destination params
         query_params = submission_params(prefix="", **job_destination.params)
+        container = None
+        universe = query_params.get('universe', False)
+        if universe.strip().lower() == 'docker':
+            if job_wrapper.tool.containers:
+                # Try to extract the container (1) from the Tool, (2) from 'docker_image'
+                # and (3) from 'docker_default_container_id'. The last two can be specified in job_conf.xml
+                container = job_wrapper.tool.containers[0].identifier or \
+                    query_params.get('docker_image', False) or \
+                    query_params.get('docker_default_container_id', False)
+            if container:
+                # HTCondor needs the image as 'docker_image'
+                query_params.update({'docker_image': container})
+
         galaxy_slots = query_params.get('request_cpus', None)
         if galaxy_slots:
             galaxy_slots_statement = 'GALAXY_SLOTS="%s"; export GALAXY_SLOTS_CONFIGURED="1"' % galaxy_slots

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -60,12 +60,7 @@ class CondorJobRunner( AsynchronousJobRunner ):
         container = None
         universe = query_params.get('universe', False)
         if universe.strip().lower() == 'docker':
-            if job_wrapper.tool.containers:
-                # Try to extract the container (1) from the Tool, (2) from 'docker_image'
-                # and (3) from 'docker_default_container_id'. The last two can be specified in job_conf.xml
-                container = job_wrapper.tool.containers[0].identifier or \
-                    query_params.get('docker_image', False) or \
-                    query_params.get('docker_default_container_id', False)
+            container = self.find_container( job_wrapper )
             if container:
                 # HTCondor needs the image as 'docker_image'
                 query_params.update({'docker_image': container})

--- a/lib/galaxy/tools/deps/containers.py
+++ b/lib/galaxy/tools/deps/containers.py
@@ -107,7 +107,11 @@ class ContainerFinder(object):
     def __default_container_id(self, container_type, destination_info):
         if not self.__container_type_enabled(container_type, destination_info):
             return None
-        return destination_info.get("%s_default_container_id" % container_type)
+        key = "%s_default_container_id" % container_type
+        # Also allow docker_image...
+        if key not in destination_info:
+            key = "%s_image" % container_type
+        return destination_info.get(key)
 
     def __destination_container(self, container_id, container_type, tool_info, destination_info, job_info):
         # TODO: ensure destination_info is dict-like

--- a/test/functional/tools/catDocker.xml
+++ b/test/functional/tools/catDocker.xml
@@ -1,9 +1,9 @@
 <tool id="catdc" name="Concatenate datasets (in docker)">
     <description>tail-to-head</description>
     <requirements>
-      <container type="docker">bgruening/busybox-bash:0.1</container>
+      <container type="docker">busybox:ubuntu-14.04</container>
     </requirements>
-    <command detect_errors="exit_code">
+    <command>
       echo "Galaxy slots passed through contain as \$GALAXY_SLOTS";
       cat $input1
       #for $q in $queries

--- a/test/functional/tools/catDocker.xml
+++ b/test/functional/tools/catDocker.xml
@@ -1,9 +1,9 @@
 <tool id="catdc" name="Concatenate datasets (in docker)">
     <description>tail-to-head</description>
     <requirements>
-      <container type="docker">busybox:ubuntu-14.04</container>
+      <container type="docker">bgruening/busybox-bash:0.1</container>
     </requirements>
-    <command>
+    <command detect_errors="exit_code">
       echo "Galaxy slots passed through contain as \$GALAXY_SLOTS";
       cat $input1
       #for $q in $queries


### PR DESCRIPTION
The latest release of HTCondor supports the [`docker` universe](https://research.cs.wisc.edu/htcondor/manual/v8.5/2_12Docker_Universe.html) to encapsulate jobs into a containers.

This PR enables Galaxy to submit containers via the HTCondor job runner to your cluster.
An alternative approach would be [kubernetes](http://kubernetes.io/) which @pcm32 is working on in https://github.com/galaxyproject/galaxy/issues/1902.

@abdulrahmanazab: this needs proper testing. Would be great if you can look at it.
