### PR TITLE
[16.04] Switch Dockerized commands to use sh instead of bash.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -307,11 +307,12 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 #check_job_script_integrity_sleep = .25
 
 
-# Set the default shell used by jobs Galaxy-wide. This defaults to
-# bash and can be overidden at the destination level for
-# heterogenous clusters. conda job resolution requires bash or zsh
+# Set the default shell used by non-containerized jobs Galaxy-wide. This
+# defaults to bash for all jobs and can be overidden at the destination
+# level for heterogenous clusters. conda job resolution requires bash or zsh
 # so if this is switched to /bin/sh for instance - conda resolution
-# should be disabled.
+# should be disabled. Containerized jobs always use /bin/sh - so more maximum
+# portability tool authors should assume generated commands run in sh.
 #default_job_shell = /bin/bash
 
 # Citation related caching.  Tool citations information maybe fetched from

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -58,7 +58,12 @@ def build_command(
         __handle_dependency_resolution(commands_builder, job_wrapper, remote_command_params)
 
     if container or job_wrapper.commands_in_new_shell:
-        externalized_commands = __externalize_commands(job_wrapper, shell, commands_builder, remote_command_params)
+        if container:
+            # Many Docker containers do not have /bin/bash.
+            external_command_shell = "/bin/sh"
+        else:
+            external_command_shell = shell
+        externalized_commands = __externalize_commands(job_wrapper, external_command_shell, commands_builder, remote_command_params)
         if container:
             # Stop now and build command before handling metadata and copying
             # working directory files back. These should always happen outside


### PR DESCRIPTION
We switched to bash for the conda and that doesn't get sourced in containers - so we should be a bit pragmatic about this and switch back to /bin/sh for containers which is more common than /bin/bash. To illustrate this point, our own example tool `catDocker.xml` doesn't work with 16.04.

xref https://github.com/galaxyproject/galaxy/pull/2278

Ping @bgruening 
