### PR TITLE
Shift asbool handling in datatypes api so that an appropriate error m…

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datatypes.py
+++ b/lib/galaxy/webapps/galaxy/api/datatypes.py
@@ -21,9 +21,9 @@ class DatatypesController( BaseAPIController ):
         Return an object containing upload datatypes.
         """
         datatypes_registry = self._datatypes_registry
-        extension_only = asbool( kwd.get( 'extension_only', True ) )
-        upload_only = asbool( kwd.get( 'upload_only', True ) )
         try:
+            extension_only = asbool( kwd.get( 'extension_only', True ) )
+            upload_only = asbool( kwd.get( 'upload_only', True ) )
             if extension_only:
                 if upload_only:
                     return datatypes_registry.upload_file_formats


### PR DESCRIPTION
…essage is now returned for requests like ?extension_only=LDKFJSLKDFJKLJ

Previously you'd just see "Uncaught exception in exposed API method", now you actually see "String is not true/false".
