### PR TITLE
[16.01] Remove SLURM memory limit warning from stderr if the job was successful

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -13,8 +13,9 @@ log = logging.getLogger( __name__ )
 
 __all__ = [ 'SlurmJobRunner' ]
 
-SLURM_MEMORY_LIMIT_EXCEEDED_MSGS = ['slurmstepd: error: Exceeded job memory limit at some point. Job may have been partially swapped out to disk.',
-                                    'slurmstepd: error: Exceeded step memory limit at some point. Step may have been partially swapped out to disk.']
+SLURM_MEMORY_LIMIT_EXCEEDED_MSG = 'slurmstepd: error: Exceeded job memory limit'
+SLURM_MEMORY_LIMIT_EXCEEDED_PARTIAL_WARNINGS = [': Exceeded job memory limit at some point.',
+                                                ': Exceeded step memory limit at some point.']
 
 
 class SlurmJobRunner( DRMAAJobRunner ):
@@ -85,17 +86,16 @@ class SlurmJobRunner( DRMAAJobRunner ):
                 log.exception( '(%s/%s) Unable to inspect failed slurm job using scontrol, job will be unconditionally failed: %s', ajs.job_wrapper.get_id_tag(), ajs.job_id, e )
                 super( SlurmJobRunner, self )._complete_terminal_job( ajs, drmaa_state=drmaa_state )
         elif drmaa_state == self.drmaa_job_states.DONE:
-            log.debug( '(%s/%s) Job completed, checking for SLURM Exceeded memory warnings', ajs.job_wrapper.get_id_tag(), ajs.job_id )
-            f = open(ajs.error_file,"r+")
-            d = f.readlines()
-            f.seek(0)
-            for i in d:
-                if i.strip() not in SLURM_MEMORY_LIMIT_EXCEEDED_MSGS:
-                    f.write(i)
-                else:
-                    log.debug( '(%s/%s) Job completed, removing SLURM exceeded memory warning: (%s)', ajs.job_wrapper.get_id_tag(), ajs.job_id, i )
-            f.truncate()
-            f.close()
+            with open(ajs.error_file, 'r+') as f:
+                lines = f.readlines()
+                f.seek(0)
+                for line in lines:
+                    stripped_line = line.strip()
+                    if any([_ in stripped_line for _ in SLURM_MEMORY_LIMIT_EXCEEDED_PARTIAL_WARNINGS]):
+                        log.debug( '(%s/%s) Job completed, removing SLURM exceeded memory warning: "%s"', ajs.job_wrapper.get_id_tag(), ajs.job_id, stripped_line )
+                    else:
+                        f.write(line)
+                f.truncate()
         # by default, finish as if the job was successful.
         super( SlurmJobRunner, self )._complete_terminal_job( ajs, drmaa_state=drmaa_state )
 
@@ -117,7 +117,7 @@ class SlurmJobRunner( DRMAAJobRunner ):
                         f.seek(-pos + 1, 2)
                         bof = True
 
-                    if (bof or f.read(1) == '\n') and f.readline().strip() in SLURM_MEMORY_LIMIT_EXCEEDED_MSGS:
+                    if (bof or f.read(1) == '\n') and f.readline().strip() == SLURM_MEMORY_LIMIT_EXCEEDED_MSG:
                         return True
 
                     if bof:

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -85,7 +85,7 @@ class SlurmJobRunner( DRMAAJobRunner ):
             except Exception as e:
                 log.exception( '(%s/%s) Unable to inspect failed slurm job using scontrol, job will be unconditionally failed: %s', ajs.job_wrapper.get_id_tag(), ajs.job_id, e )
                 super( SlurmJobRunner, self )._complete_terminal_job( ajs, drmaa_state=drmaa_state )
-        elif drmaa_state == self.drmaa_job_states.DONE:
+        if drmaa_state == self.drmaa_job_states.DONE:
             with open(ajs.error_file, 'r+') as f:
                 lines = f.readlines()
                 f.seek(0)


### PR DESCRIPTION
Should workaround #1426.
