### PR TITLE
[16.04] If a Slurm post-mortem determines that a job is in a non-terminal state, return the job to the monitor queue

### DIFF
--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -285,8 +285,11 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
                 ajs.running = True
                 ajs.job_wrapper.change_state( model.Job.states.RUNNING )
             if state in ( drmaa.JobState.FAILED, drmaa.JobState.DONE ):
-                self._complete_terminal_job( ajs, drmaa_state=state )
-                continue
+                if self._complete_terminal_job( ajs, drmaa_state=state ) is not None:
+                    # job was not actually terminal
+                    state = ajs.old_state
+                else:
+                    continue
             if ajs.check_limits():
                 self.work_queue.put( ( self.fail_job, ajs ) )
                 continue

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -73,6 +73,9 @@ class SlurmJobRunner( DRMAAJobRunner ):
                     else:
                         log.info( '(%s/%s) Job was cancelled via slurm (e.g. with scancel(1))', ajs.job_wrapper.get_id_tag(), ajs.job_id )
                         ajs.fail_message = "This job failed because it was cancelled by an administrator."
+                elif job_info['JobState'] in ('PENDING', 'RUNNING'):
+                    log.warning( '(%s/%s) Job was reported by drmaa as terminal but scontrol(1) JobState is: %s, returning to monitor queue', ajs.job_wrapper.get_id_tag(), ajs.job_id, job_info['JobState'] )
+                    return True
                 else:
                     log.warning( '(%s/%s) Job failed due to unknown reasons, JobState was: %s', ajs.job_wrapper.get_id_tag(), ajs.job_id, job_info['JobState'] )
                     ajs.fail_message = "This job failed for reasons that could not be determined."


### PR DESCRIPTION
Since we started using the Pulsar embedded runner with a DRMAA manager in the handler process as Galaxy native drmaa runners (where all share a single global DRMAA session) we have started having state checks occasionally return the failed state when jobs are still actually in the Slurm queue. This works around that issue.

I suspect we might be able to fix this by putting locking around the state checks as we do with submitting and deleting, but this workaround certainly can't hurt.
