### PR TITLE
[16.04] Relax default value acceptance condition

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1174,7 +1174,7 @@ class ColumnListParameter( SelectToolParameter ):
                 value = ColumnListParameter._strip_c( value )
             else:
                 value = None
-        if not value and not self.get_legal_values( trans, other_values ) and self.accept_default:
+        if not value and self.accept_default:
             value = self.default_value or '1'
             return [ value ] if self.multiple else value
         return super( ColumnListParameter, self ).from_json( value, trans, other_values )


### PR DESCRIPTION
Parameters should default to accepted values in a more robust fashion, independent of the availability of legal values. To reproduce, execute the `Sort` tool with a valid tabular dataset and leave the 'on column' field empty with/without applying this fix.
