### PR TITLE
Unicodify has different semantics to str, causing bug reporter bug

### DIFF
--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -209,7 +209,8 @@ class ErrorReporter( object ):
 
         # Escape all of the content  for use in the HTML report
         for parameter in report_variables.keys():
-            report_variables[parameter] = cgi.escape(unicodify(report_variables[parameter]))
+            if report_variables[parameter] is not None:
+                report_variables[parameter] = cgi.escape(unicodify(report_variables[parameter]))
 
         self.html_report = string.Template( error_report_template_html ).safe_substitute( report_variables )
 


### PR DESCRIPTION
Originally my patch was written with str()'s behaviour in mind. If a value is `None`, it gets cast. 

I did not test my patch well enough following @nsoranzo's request to replace with `galaxy.util.unicodify`. Unicodify returns a real `None` instead of a `'None'`, and that gets passed to cgi.escape() which doesn't like Nones.
