### PR TITLE
[16.04] Cast key to string in _prepare_json_param_dict

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1919,6 +1919,7 @@ class OutputParameterJSONTool( Tool ):
     def _prepare_json_param_dict( self, param_dict ):
         rval = {}
         for key, value in param_dict.iteritems():
+            key = str(key)
             if isinstance( value, dict ):
                 rval[ key ] = self._prepare_json_param_dict( value )
             elif isinstance( value, list ):


### PR DESCRIPTION
Otherwise data manager jobs fail to write out json with

```
TypeError: keys must be a string
```
