### PR TITLE
[16.04] Re-fix the bug with multiple preceding '/' characters in the GIE proxy prefix

### DIFF
--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -71,6 +71,11 @@ class InteractiveEnvironmentRequest(object):
             )
         else:
             self.attr.proxy_prefix = ''
+        # If cookie_path is unset (thus '/'), the proxy prefix ends up with
+        # multiple leading '/' characters, which will cause the client to
+        # request resources from http://dynamic_proxy_prefix
+        if self.attr.proxy_prefix.startswith('/'):
+            self.attr.proxy_prefix = '/' + self.attr.proxy_prefix.lstrip('/')
 
     def load_allowed_images(self):
         if os.path.exists(os.path.join(self.attr.our_config_dir, 'allowed_images.yml')):


### PR DESCRIPTION
It was previously fixed in d824cca31fcebe97b8c7cfd1040eecbb9e5f03d3 but that fix was lost during some later work. Hopefully the comment will prevent it in the future.
