### PR TITLE
[16.04] Do not pollute param_dict with a non JSONifiable dict

### DIFF
--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -224,7 +224,7 @@ class ToolEvaluator( object ):
                     real_path = dataset.file_name
                     if real_path in input_dataset_paths:
                         wrapper_kwds[ "dataset_path" ] = input_dataset_paths[ real_path ]
-                identifier_key = param_dict[ "identifier_key" ].get( dataset, None )
+                identifier_key = identifier_key_dict.get(dataset, None)
                 if identifier_key:
                     element_identifier = param_dict.get(identifier_key, None)
                     if element_identifier:
@@ -256,7 +256,7 @@ class ToolEvaluator( object ):
         #       tools where the inputs don't even get passed through. These
         #       tools (e.g. UCSC) should really be handled in a special way.
         if self.tool.check_values:
-            param_dict[ "identifier_key" ] = dict((v, "%s|__identifier__" % k) for k, v in input_datasets.iteritems())  # allows lookup of identifier through HDA.
+            identifier_key_dict = dict((v, "%s|__identifier__" % k) for k, v in input_datasets.iteritems())  # allows lookup of identifier through HDA.
             self.__walk_inputs( self.tool.inputs, param_dict, wrap_input )
 
     def __populate_input_dataset_wrappers(self, param_dict, input_datasets, input_dataset_paths):


### PR DESCRIPTION
When running a data manager with a dataset parameter, the job fails with the following backtrace:

```
Traceback (most recent call last):
  File "/opt/galaxy/lib/galaxy/jobs/runners/__init__.py", line 166, in prepare_job
    job_wrapper.prepare()
  File "/opt/galaxy/lib/galaxy/jobs/__init__.py", line 885, in prepare
    tool_evaluator.set_compute_environment( compute_environment, get_special=get_special )
  File "/opt/galaxy/lib/galaxy/tools/evaluation.py", line 107, in set_compute_environment
    self.tool.exec_before_job( self.app, inp_data, out_data, param_dict )
  File "/opt/galaxy/lib/galaxy/tools/__init__.py", line 1956, in exec_before_job
    out.write( json.dumps( (json_params) ).encode('utf8') )
  File "/usr/lib/python2.7/json/__init__.py", line 243, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
TypeError: keys must be a string
```

The bug was introduced in PR #2029.

This fix is an alternative to PR #2337.
