### PR TITLE
Add the trackhub composite datatype

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -530,6 +530,9 @@
     <datatype extension="mothur.axes" type="galaxy.datatypes.mothur:Axes" display_in_upload="true"/>
     <datatype extension="mothur.sff.flow" type="galaxy.datatypes.mothur:SffFlow" display_in_upload="true"/>
     <datatype extension="mothur.count_table" type="galaxy.datatypes.mothur:CountTable" display_in_upload="true"/>
+    <datatype extension="huba" type="galaxy.datatypes.hubAssembly:HubAssembly" display_in_upload="true">
+    <display file="ucsc/huba.xml" />
+    </datatype>
   </registration>
   <sniffers>
     <!--

--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -530,8 +530,8 @@
     <datatype extension="mothur.axes" type="galaxy.datatypes.mothur:Axes" display_in_upload="true"/>
     <datatype extension="mothur.sff.flow" type="galaxy.datatypes.mothur:SffFlow" display_in_upload="true"/>
     <datatype extension="mothur.count_table" type="galaxy.datatypes.mothur:CountTable" display_in_upload="true"/>
-    <datatype extension="huba" type="galaxy.datatypes.hubAssembly:HubAssembly" display_in_upload="true">
-        <display file="ucsc/huba.xml" />
+    <datatype extension="trakhub" type="galaxy.datatypes.tracks:UCSCTrackHub" display_in_upload="true">
+        <display file="ucsc/trackhub.xml" />
     </datatype>
   </registration>
   <sniffers>

--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -531,7 +531,7 @@
     <datatype extension="mothur.sff.flow" type="galaxy.datatypes.mothur:SffFlow" display_in_upload="true"/>
     <datatype extension="mothur.count_table" type="galaxy.datatypes.mothur:CountTable" display_in_upload="true"/>
     <datatype extension="huba" type="galaxy.datatypes.hubAssembly:HubAssembly" display_in_upload="true">
-    <display file="ucsc/huba.xml" />
+        <display file="ucsc/huba.xml" />
     </datatype>
   </registration>
   <sniffers>

--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -530,7 +530,7 @@
     <datatype extension="mothur.axes" type="galaxy.datatypes.mothur:Axes" display_in_upload="true"/>
     <datatype extension="mothur.sff.flow" type="galaxy.datatypes.mothur:SffFlow" display_in_upload="true"/>
     <datatype extension="mothur.count_table" type="galaxy.datatypes.mothur:CountTable" display_in_upload="true"/>
-    <datatype extension="trakhub" type="galaxy.datatypes.tracks:UCSCTrackHub" display_in_upload="true">
+    <datatype extension="trackhub" type="galaxy.datatypes.tracks:UCSCTrackHub" display_in_upload="true">
         <display file="ucsc/trackhub.xml" />
     </datatype>
   </registration>

--- a/display_applications/ucsc/huba.xml
+++ b/display_applications/ucsc/huba.xml
@@ -1,0 +1,6 @@
+<display id="ucsc_huba" version="1.0.0" name="display at Track Hub UCSC">
+    <link id="main" name="main">
+        <url>https://genome.ucsc.edu/cgi-bin/hgHubConnect?hubUrl=${qp($hub_file.url + '/myHub/hub.txt')}&amp;hgHub_do_firstDb=on&amp;hgHub_do_redirect=on&amp;hgHubConnect.remakeTrackHub=on</url>
+        <param type="data" name="hub_file" url="galaxy_${DATASET_HASH}" allow_extra_files_access="True" strip_https="True"/>
+    </link>
+</display>

--- a/display_applications/ucsc/trackhub.xml
+++ b/display_applications/ucsc/trackhub.xml
@@ -1,4 +1,4 @@
-<display id="ucsc_huba" version="1.0.0" name="display at Track Hub UCSC">
+<display id="ucsc_trackhub" version="1.0.0" name="display at Track Hub UCSC">
     <link id="main" name="main">
         <url>https://genome.ucsc.edu/cgi-bin/hgHubConnect?hubUrl=${qp($hub_file.url + '/myHub/hub.txt')}&amp;hgHub_do_firstDb=on&amp;hgHub_do_redirect=on&amp;hgHubConnect.remakeTrackHub=on</url>
         <param type="data" name="hub_file" url="galaxy_${DATASET_HASH}" allow_extra_files_access="True" strip_https="True"/>

--- a/display_applications/ucsc/trackhub.xml
+++ b/display_applications/ucsc/trackhub.xml
@@ -1,6 +1,6 @@
 <display id="ucsc_trackhub" version="1.0.0" name="display at Track Hub UCSC">
     <link id="main" name="main">
         <url>https://genome.ucsc.edu/cgi-bin/hgHubConnect?hubUrl=${qp($hub_file.url + '/myHub/hub.txt')}&amp;hgHub_do_firstDb=on&amp;hgHub_do_redirect=on&amp;hgHubConnect.remakeTrackHub=on</url>
-        <param type="data" name="hub_file" url="galaxy_${DATASET_HASH}" allow_extra_files_access="True" strip_https="True"/>
+        <param type="data" name="hub_file" url="galaxy_${DATASET_HASH}" allow_extra_files_access="True" />
     </link>
 </display>

--- a/lib/galaxy/datatypes/hubAssembly.py
+++ b/lib/galaxy/datatypes/hubAssembly.py
@@ -1,0 +1,58 @@
+"""
+HubAssembly datatype
+"""
+import logging
+import galaxy.version as version
+
+# Support for Galaxy <= 16.01
+if version.VERSION_MAJOR <= "16.01":
+    from galaxy.datatypes.images import Html
+else:
+    from galaxy.datatypes.text import Html
+
+log = logging.getLogger(__name__)
+
+
+class HubAssembly( Html ):
+    """
+    derived class for BioC data structures in Galaxy
+    """
+
+    file_ext = 'huba'
+    composite_type = 'auto_primary_file'
+
+    def __init__(self, **kwd):
+        Html.__init__(self, **kwd)
+
+    def generate_primary_file( self, dataset=None ):
+        """
+        This is called only at upload to write the html file
+        cannot rename the datasets here - they come with the default unfortunately
+        """
+        rval = [
+            '<html><head><title>Files for Composite Dataset (%s)</title></head><p/>\
+            This composite dataset is composed of the following files:<p/><ul>' % (
+                self.file_ext)]
+        for composite_name, composite_file in self.get_composite_files( dataset=dataset ).iteritems():
+            opt_text = ''
+            if composite_file.optional:
+                opt_text = ' (optional)'
+            rval.append('<li><a href="%s">%s</a>%s' % ( composite_name, composite_name, opt_text) )
+        rval.append('</ul></html>')
+        return "\n".join(rval)
+
+    def set_peek( self, dataset, is_multi_byte=False ):
+        if not dataset.dataset.purged:
+            dataset.peek = "Track Hub structure: Visualization in UCSC Track Hub"
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def display_peek( self, dataset ):
+        try:
+            return dataset.peek
+        except:
+            return "Track Hub structure: Visualization in UCSC Track Hub"
+
+    def sniff( self, filename ):
+        return False

--- a/lib/galaxy/datatypes/hubAssembly.py
+++ b/lib/galaxy/datatypes/hubAssembly.py
@@ -56,4 +56,3 @@ class HubAssembly( Html ):
 
     def sniff( self, filename ):
         return False
-

--- a/lib/galaxy/datatypes/hubAssembly.py
+++ b/lib/galaxy/datatypes/hubAssembly.py
@@ -56,3 +56,4 @@ class HubAssembly( Html ):
 
     def sniff( self, filename ):
         return False
+

--- a/lib/galaxy/datatypes/tracks.py
+++ b/lib/galaxy/datatypes/tracks.py
@@ -90,4 +90,3 @@ class UCSCTrackHub( Html ):
 
     def sniff( self, filename ):
         return False
-

--- a/lib/galaxy/datatypes/tracks.py
+++ b/lib/galaxy/datatypes/tracks.py
@@ -5,6 +5,15 @@ Datatype classes for tracks/track views within galaxy.
 import binary
 import logging
 
+# For UCSCTrackHub
+import galaxy.version as version
+
+# Support for Galaxy <= 16.01
+if version.VERSION_MAJOR <= "16.01":
+    from galaxy.datatypes.images import Html
+else:
+    from galaxy.datatypes.text import Html
+
 log = logging.getLogger(__name__)
 
 # GeneTrack is no longer supported but leaving the datatype since
@@ -36,3 +45,49 @@ class GeneTrack( binary.Binary ):
     #                 link = "%s?filename=%s&hashkey=%s&input=%s&GALAXY_URL=%s" % ( url, encoded, hashkey, data_id, galaxy_url )
     #                 ret_val.append( ( name, link ) )
     #         return ret_val
+
+
+class UCSCTrackHub( Html ):
+    """
+    Datatype for UCSC TrackHub
+    """
+
+    file_ext = 'trackHub'
+    composite_type = 'auto_primary_file'
+
+    def __init__(self, **kwd):
+        Html.__init__(self, **kwd)
+
+    def generate_primary_file( self, dataset=None ):
+        """
+        This is called only at upload to write the html file
+        cannot rename the datasets here - they come with the default unfortunately
+        """
+        rval = [
+            '<html><head><title>Files for Composite Dataset (%s)</title></head><p/>\
+            This composite dataset is composed of the following files:<p/><ul>' % (
+                self.file_ext)]
+        for composite_name, composite_file in self.get_composite_files( dataset=dataset ).items():
+            opt_text = ''
+            if composite_file.optional:
+                opt_text = ' (optional)'
+            rval.append('<li><a href="%s">%s</a>%s' % ( composite_name, composite_name, opt_text) )
+        rval.append('</ul></html>')
+        return "\n".join(rval)
+
+    def set_peek( self, dataset, is_multi_byte=False ):
+        if not dataset.dataset.purged:
+            dataset.peek = "Track Hub structure: Visualization in UCSC Track Hub"
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def display_peek( self, dataset ):
+        try:
+            return dataset.peek
+        except:
+            return "Track Hub structure: Visualization in UCSC Track Hub"
+
+    def sniff( self, filename ):
+        return False
+

--- a/lib/galaxy/datatypes/tracks.py
+++ b/lib/galaxy/datatypes/tracks.py
@@ -52,7 +52,7 @@ class UCSCTrackHub( Html ):
     Datatype for UCSC TrackHub
     """
 
-    file_ext = 'trackHub'
+    file_ext = 'trackhub'
     composite_type = 'auto_primary_file'
 
     def __init__(self, **kwd):

--- a/lib/galaxy/datatypes/tracks.py
+++ b/lib/galaxy/datatypes/tracks.py
@@ -5,14 +5,7 @@ Datatype classes for tracks/track views within galaxy.
 import binary
 import logging
 
-# For UCSCTrackHub
-import galaxy.version as version
-
-# Support for Galaxy <= 16.01
-if version.VERSION_MAJOR <= "16.01":
-    from galaxy.datatypes.images import Html
-else:
-    from galaxy.datatypes.text import Html
+from galaxy.datatypes.text import Html
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Hi!

Some of you are maybe aware we are building, at [goeckslab](http://goeckslab.org/), a workflow for genome annotation which is very tied with Galaxy: [G-OnRamp](http://goeckslab.org/news/2015-12-04-gonramp-bd2kposter/).

One of the tools of G-OnRamp workflow is called [HubArchiveCreator](https://github.com/goeckslab/hub-archive-creator) and allows to visualize tracks generated inside Galaxy, onto [UCSC TrackHub](https://genome.ucsc.edu/goldenpath/help/hgTrackHubHelp.html).

To enable this, I needed to add a datatype, and a display_application.

With @jgoecks, we though it could be really useful to have TrackHub UCSC / G-OnRamp compatibility being directly available on Galaxy installation, so here is the PR :).

Here is a print screen of the result:
<img width="250" alt="screen shot 2016-05-11 at 10 00 45 pm" src="https://cloud.githubusercontent.com/assets/2152858/15201980/36771006-17c4-11e6-9ed5-13b256644ec4.png">

To test the datatype:
- Enable testtoolshed in your Galaxy (config/tool_sheds_conf.xml)
- Install [hubarchivecreator](https://toolshed.g2.bx.psu.edu/view/rmarenco/hubarchivecreator/acc233161f50)
- Upload these files into your history:
  [dbia3_trfBig_sorted.bed.txt](https://github.com/galaxyproject/galaxy/files/260520/dbia3_trfBig_sorted.bed.txt)
  [dbia3.fa.txt](https://github.com/galaxyproject/galaxy/files/260521/dbia3.fa.txt)

(Remove the .txt extension => GitHub does not accept `.fa` or `.bed`)
- Run HubArchiveCreator with `dbia3.fa` as `reference genome` and:
  - Format: BED
  - Bed Choice: BED Simple Repeats
  - Bed Simple Repeats (Bed4+12) File: `trfBig.bed`

This image might help:
<img width="849" alt="screen shot 2016-05-11 at 10 08 45 pm" src="https://cloud.githubusercontent.com/assets/2152858/15202108/5c1f39cc-17c5-11e6-9127-f5bb9fda9adf.png">

And you're done! You have huba datatype installed, and you can visualize:
- BED
- BED simple repeats
- GTF
- GFF3
- BigWig
- Bam

files into UCSC TrackHub :)
