### PR TITLE
[16.04] Properly handle AsynchronousJobState objects in the job runner work queue

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -89,8 +89,11 @@ class BaseJobRunner( object ):
                 return
             # id and name are collected first so that the call of method() is the last exception.
             try:
-                # arg should be a JobWrapper/TaskWrapper
-                job_id = arg.get_id_tag()
+                if isinstance(arg, AsynchronousJobState):
+                    job_id = arg.job_wrapper.get_id_tag()
+                else:
+                    # arg should be a JobWrapper/TaskWrapper
+                    job_id = arg.get_id_tag()
             except:
                 job_id = 'unknown'
             try:


### PR DESCRIPTION
Not all objects added to the runner work queue are JobWrappers/TaskWrappers as claimed in the comment. AsynchronousJobStates could also be added, and although these objects would be passed to the accompanying method accordingly without error, if the fail method was called this would result in the AttributeError of attempting to access an AJS' non-existent `get_id_tag` being logged in job.exeception as a red herring, e.g.:

``` pytb
Traceback (most recent call last):
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/runners/__init__.py", line 93, in run_next
    job_id = arg.get_id_tag()
AttributeError: 'AsynchronousJobState' object has no attribute 'get_id_tag'
```
