### PR TITLE
[16.04] Fix for slurm's complete_terminal_job where if unable to inspect the …

### DIFF
--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -247,7 +247,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
                 assert external_job_id not in ( None, 'None' ), '(%s/%s) Invalid job id' % ( galaxy_id_tag, external_job_id )
                 state = self.ds.job_status( external_job_id )
             except ( drmaa.InternalException, drmaa.InvalidJobException ) as e:
-                if isinstance( e , drmaa.InvalidJobException ):
+                if isinstance( e, drmaa.InvalidJobException ):
                     ecn = "InvalidJobException".lower()
                 else:
                     ecn = "InternalException".lower()

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -88,7 +88,7 @@ class SlurmJobRunner( DRMAAJobRunner ):
                     return
             except Exception as e:
                 log.exception( '(%s/%s) Unable to inspect failed slurm job using scontrol, job will be unconditionally failed: %s', ajs.job_wrapper.get_id_tag(), ajs.job_id, e )
-                super( SlurmJobRunner, self )._complete_terminal_job( ajs, drmaa_state=drmaa_state )
+                return super( SlurmJobRunner, self )._complete_terminal_job( ajs, drmaa_state=drmaa_state )
         if drmaa_state == self.drmaa_job_states.DONE:
             with open(ajs.error_file, 'r+') as f:
                 lines = f.readlines()


### PR DESCRIPTION
…failed job with scontrol, drmaajobrunner's _complete_terminal_job was called twice.

Trivial pep8 fix in drmaa.py as well.
