### PR TITLE
Improve composite output tool test.

### DIFF
--- a/test-data/composite_output_expected_log
+++ b/test-data/composite_output_expected_log
@@ -1,0 +1,2 @@
+Fri May 28 13:27:22 2010
+ ./velveth /Users/jj/src/wf/galaxy/galaxy-central/test-data/velveth_test1 21 -shortPaired /Users/jj/src/wf/galaxy/galaxy-central/test-data/velvet_test_reads.fa

--- a/test/functional/tools/composite_output.xml
+++ b/test/functional/tools/composite_output.xml
@@ -1,5 +1,5 @@
 <tool id="composite_output" name="composite_output" version="1.0.0">
-  <command>mkdir $output.extra_files_path; cp $input.extra_files_path/* $output.extra_files_path</command>
+  <command>mkdir $output.extra_files_path; cp $input.extra_files_path/* $output.extra_files_path; cp $input.extra_files_path/Log $output.extra_files_path/second_log; mkdir $output.extra_files_path/nested; cp $input.extra_files_path/Log $output.extra_files_path/nested/nested_log</command>
   <inputs>
     <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth."/>
   </inputs>
@@ -17,7 +17,9 @@
       <output name="output" file="velveth_test1/output.html">
         <extra_files type="file" name="Sequences" value="velveth_test1/Sequences" />
         <extra_files type="file" name="Roadmaps" value="velveth_test1/Roadmaps" />
-        <extra_files type="file" name="Log" value="velveth_test1/Log" />
+        <extra_files type="file" name="Log" value="composite_output_expected_log" />
+        <extra_files type="file" name="second_log" value="composite_output_expected_log" />
+        <extra_files type="file" name="nested/nested_log" value="composite_output_expected_log" />
       </output>
     </test>
   </tests>


### PR DESCRIPTION
- Rename expected output Log from input Log. This relieves a concern I had that the tests were just working because the inputs and outputs match.
- Add another "unregistered" output file to the output directory and add a test for it. This verifies that such files are in fact tested.
- Add a nested "unregistered" output file to the output directory and add a test for it. This verifies that nested files are tested.

Ping @remimarenco 
