### PR TITLE
Update README to remove 2.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ The latest information about Galaxy is available via `https://galaxyproject.org/
 Galaxy Quickstart
 =================
 
-Galaxy requires Python 2.6 or 2.7. To check your python version, run:
+Galaxy requires Python 2.7 To check your python version, run:
 
 .. code:: console
 


### PR DESCRIPTION
Hi :),

Galaxy is not compatible with Python 2.6 since 16.01, right? What do we think about removing it from this README?

We could also say 2.6 for Galaxy version under 16.01, and 2.7 for upper.
