### PR TITLE
[16.04] Remove stray print left in workflow sharing which actually throws an …

### DIFF
--- a/templates/webapps/galaxy/workflow/sharing.mako
+++ b/templates/webapps/galaxy/workflow/sharing.mako
@@ -99,7 +99,6 @@
 
         # Get item name.
         item_name = get_item_name(item)
-        print item_name
     %>
     ## Require that user have a public username before sharing or publishing an item.
     %if trans.get_user().username is None or trans.get_user().username is "":


### PR DESCRIPTION
…exception and breaks sharing when item_name is unicode.
