### PR TITLE
[wip] Dynamic proxy using uWSGI. 

### DIFF
--- a/lib/galaxy/web/proxy/uwsgi/uwsgi_proxy.ini
+++ b/lib/galaxy/web/proxy/uwsgi/uwsgi_proxy.ini
@@ -1,0 +1,16 @@
+[uwsgi]
+
+master = true
+
+## http-socket = localhost:8800
+http-websockets = True
+
+python-raw = uwsgi_proxy_funcs.py
+
+route-run = rpcvar:TARGET_HOST dynamic_proxy_mapper ${HTTP_HOST} ${cookie[galaxysession]}
+route-run = log:Proxy ${HTTP_HOST} to ${TARGET_HOST}
+## route-run = addheader:Access-Control-Allow-Origin *
+## route-run = addheader:Access-Control-Allow-Credentials true
+route-run = httpdumb:${TARGET_HOST}
+
+offload-threads = 2

--- a/lib/galaxy/web/proxy/uwsgi/uwsgi_proxy_funcs.py
+++ b/lib/galaxy/web/proxy/uwsgi/uwsgi_proxy_funcs.py
@@ -1,0 +1,17 @@
+import sys
+import uwsgi
+import sqlite3
+
+db_conn = sqlite3.connect( uwsgi.opt[ "sessions" ] )
+
+def dynamic_proxy_mapper(hostname, galaxy_session):
+    """Attempt to lookup downstream host from database"""
+    if galaxy_session:
+        # Order by rowid gives us the last row added
+        row = db_conn.execute( "select key, secret from gxproxy where secret=? order by rowid desc limit 1", ( galaxy_session, ) ).fetchone()
+        if row:
+            return row[0].encode()
+    # No match for session found
+    return None
+
+uwsgi.register_rpc('dynamic_proxy_mapper', dynamic_proxy_mapper)

--- a/lib/galaxy/web/proxy/uwsgi/uwsgi_proxy_funcs.py
+++ b/lib/galaxy/web/proxy/uwsgi/uwsgi_proxy_funcs.py
@@ -1,8 +1,8 @@
-import sys
 import uwsgi
 import sqlite3
 
 db_conn = sqlite3.connect( uwsgi.opt[ "sessions" ] )
+
 
 def dynamic_proxy_mapper(hostname, galaxy_session):
     """Attempt to lookup downstream host from database"""
@@ -13,5 +13,6 @@ def dynamic_proxy_mapper(hostname, galaxy_session):
             return row[0].encode()
     # No match for session found
     return None
+
 
 uwsgi.register_rpc('dynamic_proxy_mapper', dynamic_proxy_mapper)


### PR DESCRIPTION
A dynamic proxy implementation using uWSGI. A RPC function written in python is used to map the session to the appropriate backend.

Why?
1. We use uwsgi for Galaxy main. With this configuration we can proxy directly to interactive environments, no double proxy needed. 
2. We've talked about making uwsgi the default webserver for all Galaxy's. If we do that we can proxy directly without needing additional processes or ports.
3. uwsgi is fast, flexible, and well tested.
4. I was having trouble getting the node based proxy running.

ping @jmchilton @natefoo @bgruening @erasche 
