### PR TITLE
Docker swarm support for interactive environments

### DIFF
--- a/config/plugins/interactive_environments/jupyter/config/jupyter.ini.sample
+++ b/config/plugins/interactive_environments/jupyter/config/jupyter.ini.sample
@@ -29,10 +29,6 @@ command_inject = --sig-proxy=true -e DEBUG=false -e DEFAULT_CONTAINER_RUNTIME=12
 # host than Galaxy.
 #docker_hostname = localhost
 
-# If set, will assume Docker Swarm is being used and look for the appropriate
-# worker host to connect to.
-#docker_swarm=False
-
 # Try to set the tempdirectory to world execute - this can fix the issue 
 # where 'sudo docker' is not able to mount the folder otherwise.
 # "finalize namespace chdir to /import permission denied"

--- a/config/plugins/interactive_environments/jupyter/config/jupyter.ini.sample
+++ b/config/plugins/interactive_environments/jupyter/config/jupyter.ini.sample
@@ -29,6 +29,10 @@ command_inject = --sig-proxy=true -e DEBUG=false -e DEFAULT_CONTAINER_RUNTIME=12
 # host than Galaxy.
 #docker_hostname = localhost
 
+# If set, will assume Docker Swarm is being used and look for the appropriate
+# worker host to connect to.
+#docker_swarm=False
+
 # Try to set the tempdirectory to world execute - this can fix the issue 
 # where 'sudo docker' is not able to mount the folder otherwise.
 # "finalize namespace chdir to /import permission denied"


### PR DESCRIPTION
Pretty simple as it turns out. If running swarm, the Docker inspect output contains information on the node that the container is actually running on. We extract that and use it. 

ping @natefoo @bgruening 
