### PR TITLE
[16.04] Provide backward compatible galaxy.datatypes.checkers module...

### DIFF
--- a/lib/galaxy/datatypes/checkers.py
+++ b/lib/galaxy/datatypes/checkers.py
@@ -1,0 +1,27 @@
+"""Module proxies :module:`galaxy.util.checkers` for backward compatibility.
+
+External datatypes may make use of these functions.
+"""
+from galaxy.util.checkers import (
+    check_binary,
+    check_bz2,
+    check_gzip,
+    check_html,
+    check_image,
+    check_zip,
+    HTML_CHECK_LINES,
+    is_gzip,
+    is_bz2,
+)
+
+__all__ = [
+    'check_binary',
+    'check_bz2',
+    'check_gzip',
+    'check_html',
+    'check_image',
+    'check_zip',
+    'HTML_CHECK_LINES',
+    'is_gzip',
+    'is_bz2',
+]

--- a/lib/galaxy/datatypes/checkers.py
+++ b/lib/galaxy/datatypes/checkers.py
@@ -9,7 +9,6 @@ from galaxy.util.checkers import (
     check_html,
     check_image,
     check_zip,
-    HTML_CHECK_LINES,
     is_gzip,
     is_bz2,
 )
@@ -21,7 +20,6 @@ __all__ = [
     'check_html',
     'check_image',
     'check_zip',
-    'HTML_CHECK_LINES',
     'is_gzip',
     'is_bz2',
 ]

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -140,3 +140,16 @@ def is_bz2( file_path ):
 def is_gzip( file_path ):
     is_gzipped, is_valid = check_gzip( file_path )
     return is_gzipped
+
+
+__all__ = [
+    'check_binary',
+    'check_bz2',
+    'check_gzip',
+    'check_html',
+    'check_image',
+    'check_zip',
+    'HTML_CHECK_LINES',
+    'is_gzip',
+    'is_bz2',
+]

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -149,7 +149,6 @@ __all__ = [
     'check_html',
     'check_image',
     'check_zip',
-    'HTML_CHECK_LINES',
     'is_gzip',
     'is_bz2',
 ]


### PR DESCRIPTION
... for external datatypes.

xref http://dev.list.galaxyproject.org/STACKS-error-td4669428.html
