### PR TITLE
Add a new workflow building mode variation which does access the history

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1573,7 +1573,7 @@ class Tool( object, Dictifiable ):
 
         return tool_dict
 
-    def to_json( self, trans, kwd={}, job=None, workflow_mode=False ):
+    def to_json( self, trans, kwd={}, job=None, workflow_building_mode=False ):
         """
         Recursively creates a tool dictionary containing repeats, dynamic options and updated states.
         """
@@ -1590,7 +1590,7 @@ class Tool( object, Dictifiable ):
             raise exceptions.MessageException( '[history_id=%s] Failed to retrieve history. %s.' % ( history_id, str( e ) ) )
 
         # build request context
-        request_context = WorkRequestContext( app=trans.app, user=trans.user, history=history, workflow_building_mode=workflow_mode )
+        request_context = WorkRequestContext( app=trans.app, user=trans.user, history=history, workflow_building_mode=workflow_building_mode )
 
         # load job parameters into incoming
         tool_message = ''

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -334,7 +334,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         } )
 
         # create tool model and default tool state (if missing)
-        tool_model = module.tool.to_json( trans, tool_inputs, workflow_mode=True )
+        tool_model = module.tool.to_json( trans, tool_inputs, workflow_building_mode=True )
         module.update_state( tool_model[ 'state_inputs' ] )
         return {
             'tool_model'        : tool_model,

--- a/templates/webapps/galaxy/workflow/editor_tool_form.mako
+++ b/templates/webapps/galaxy/workflow/editor_tool_form.mako
@@ -4,7 +4,7 @@
     from galaxy.tools.parameters import params_to_incoming
     incoming = {}
     params_to_incoming( incoming, tool.inputs, module.state.inputs, trans.app )
-    self.form_config = tool.to_json(trans, incoming, workflow_mode=True)
+    self.form_config = tool.to_json(trans, incoming, workflow_building_mode=True)
     self.form_config.update({
         'id'                : tool.id,
         'job_id'            : trans.security.encode_id( job.id ) if job else None,


### PR DESCRIPTION
This PR adds a new workflow building mode variation to the tool framework. In contrast to the regular workflow building mode used in the workflow editor, this 2nd variation accesses the history which is necessary when building a workflow form for execution. This PR also relabels the flag name in `to_json` from `workflow_mode` to `workflow_building_mode` for consistency.
