### PR TITLE
Align and improve validation errors and value to text conversions

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1240,9 +1240,10 @@ class Tool( object, Dictifiable ):
             if error:
                 if update_values:
                     try:
+                        previous_value = value
                         value = input.get_initial_value( request_context, context )
                         if not prefixed_name.startswith( '__' ):
-                            messages[ prefixed_name ] = '%s Using default: \'%s\'.' % ( error, value )
+                            messages[ prefixed_name ] = error if previous_value == value else '%s Using default: \'%s\'.' % ( error, value )
                         parent[ input.name ] = value
                     except:
                         messages[ prefixed_name ] = 'Attempt to replace invalid value for \'%s\' failed.' % ( prefixed_label )

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1943,8 +1943,11 @@ class DataToolParameter( BaseDataToolParameter ):
                     raise ValueError( "The previously selected dataset has entered an unusable state" )
         if not self.multiple:
             if len( values ) > 1:
-                raise ValueError( "More than one dataset supplied to single input dataset parameter.")
-            rval = values[ 0 ]
+                raise ValueError( "More than one dataset supplied to single input dataset parameter." )
+            if len( values ) > 0:
+                rval = values[ 0 ]
+            else:
+                raise ValueError( "Invalid dataset supplied to single input dataset parameter." )
         return rval
 
     def to_param_dict_string( self, value, other_values={} ):

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1484,7 +1484,7 @@ class DrillDownSelectToolParameter( SelectToolParameter ):
                     value = value.split( "\n" )
             return value
         if not value and not self.optional:
-            raise ValueError( "An invalid option was selected for %s, 'None', please verify" % (self.name) )
+            raise ValueError( "An invalid option was selected for %s, please verify." % (self.name) )
         if not value:
             return None
         if not isinstance( value, list ):

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -171,7 +171,9 @@ class ToolParameter( object, Dictifiable ):
         Convert a value to a text representation suitable for displaying to
         the user
         """
-        return unicodify( value )
+        if value:
+            return unicodify( value )
+        return "Not available."
 
     def to_param_dict_string( self, value, other_values={} ):
         """Called via __str__ when used in the Cheetah template"""
@@ -986,7 +988,9 @@ class SelectToolParameter( ToolParameter ):
             for t, v, s in options:
                 if v in value:
                     rval.append( t )
-        return "\n".join( rval )
+        if rval:
+            return "\n".join( rval )
+        return "Nothing selected."
 
     def get_dependencies( self ):
         """
@@ -1583,7 +1587,9 @@ class DrillDownSelectToolParameter( SelectToolParameter ):
             rval = []
             for val in value:
                 rval.append( get_option_display( val, self.options ) or val )
-        return "\n".join( map( str, rval ) )
+        if rval:
+            return "\n".join( map( str, rval ) )
+        return "Nothing selected."
 
     def get_dependencies( self ):
         """
@@ -1954,7 +1960,7 @@ class DataToolParameter( BaseDataToolParameter ):
                 return ", ".join( [ "%s: %s" % ( item.hid, item.name ) for item in value ] )
             except:
                 pass
-        return "No dataset"
+        return "No dataset."
 
     def validate( self, value, trans=None ):
         dataset_count = 0


### PR DESCRIPTION
In some cases, values are converted into empty strings when displayed to the user through `value_to_display_text`. This PR prevents this by returning a proper text message instead.
