### PR TITLE
SLURM: when scontrol fails, try to get job state with sacct

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -314,10 +314,6 @@ class BaseJobRunner( object ):
     def write_executable_script( self, path, contents, mode=0o755 ):
         write_script( path, contents, self.app.config, mode=mode )
 
-    def _complete_terminal_job( self, ajs, **kwargs ):
-        if ajs.job_wrapper.get_state() != model.Job.states.DELETED:
-            self.work_queue.put( ( self.finish_job, ajs ) )
-
     def _find_container(
         self,
         job_wrapper,

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -220,6 +220,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
         Handle a job upon its termination in the DRM. This method is meant to
         be overridden by subclasses to improve post-mortem and reporting of
         failures.
+        Returns True if job was not actually terminal, None otherwise.
         """
         if drmaa_state == drmaa.JobState.FAILED:
             if ajs.job_wrapper.get_state() != model.Job.states.DELETED:

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -231,7 +231,8 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
             external_metadata = not asbool( ajs.job_wrapper.job_destination.params.get( "embed_metadata_in_job", True) )
             if external_metadata:
                 self._handle_metadata_externally( ajs.job_wrapper, resolve_requirements=True )
-            super( DRMAAJobRunner, self )._complete_terminal_job( ajs )
+            if ajs.job_wrapper.get_state() != model.Job.states.DELETED:
+                self.work_queue.put( ( self.finish_job, ajs ) )
 
     def check_watched_items( self ):
         """

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -23,42 +23,63 @@ class SlurmJobRunner( DRMAAJobRunner ):
     restrict_job_name_length = False
 
     def _complete_terminal_job( self, ajs, drmaa_state, **kwargs ):
-        def __get_jobinfo():
-            job_id = ajs.job_id
+        def _get_slurm_state_with_sacct(job_id, cluster):
+            cmd = ['sacct', '-n', '-o state']
+            if cluster:
+                cmd.extend( [ '-M', cluster ] )
+            cmd.extend(['-j', "%s.batch" % job_id])
+            p = subprocess.Popen( cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE )
+            stdout, stderr = p.communicate()
+            if p.returncode != 0:
+                if stderr == 'SLURM accounting storage is disabled':
+                    return
+                raise Exception( '`%s` returned %s, stderr: %s' % ( ' '.join( cmd ), p.returncode, stderr ) )
+            return stdout.strip()
+
+        def _get_slurm_state():
             cmd = [ 'scontrol', '-o' ]
             if '.' in ajs.job_id:
                 # custom slurm-drmaa-with-cluster-support job id syntax
-                job_id, cluster = ajs.job_id.split('.', 1)
+                job_id, cluster = ajs.job_id.split('.', maxsplit=1)
                 cmd.extend( [ '-M', cluster ] )
+            else:
+                job_id = ajs.job_id
+                cluster = None
             cmd.extend( [ 'show', 'job', job_id ] )
             p = subprocess.Popen( cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE )
             stdout, stderr = p.communicate()
             if p.returncode != 0:
                 # Will need to be more clever here if this message is not consistent
                 if stderr == 'slurm_load_jobs error: Invalid job id specified\n':
-                    return dict( JobState='NOT_FOUND' )
+                    # The job may be old, try to get its state with sacct
+                    job_state = _get_slurm_state_with_sacct(job_id, cluster)
+                    if job_state:
+                        return job_state
+                    return 'NOT_FOUND'
                 raise Exception( '`%s` returned %s, stderr: %s' % ( ' '.join( cmd ), p.returncode, stderr ) )
-            return dict( [ out_param.split( '=', 1 ) for out_param in stdout.split() ] )
+            job_info_dict = dict( [ out_param.split( '=', 1 ) for out_param in stdout.split() ] )
+            return job_info_dict['JobState']
+
         try:
             if drmaa_state == self.drmaa_job_states.FAILED:
-                job_info = __get_jobinfo()
+                slurm_state = _get_slurm_state()
                 sleep = 1
-                while job_info['JobState'] == 'COMPLETING':
+                while slurm_state == 'COMPLETING':
                     log.debug( '(%s/%s) Waiting %s seconds for failed job to exit COMPLETING state for post-mortem', ajs.job_wrapper.get_id_tag(), ajs.job_id, sleep )
                     time.sleep( sleep )
                     sleep *= 2
                     if sleep > 64:
                         ajs.fail_message = "This job failed and the system timed out while trying to determine the cause of the failure."
                         break
-                    job_info = __get_jobinfo()
-                if job_info['JobState'] == 'NOT_FOUND':
+                    slurm_state = _get_slurm_state()
+                if slurm_state == 'NOT_FOUND':
                     log.warning( '(%s/%s) Job not found, assuming job check exceeded MinJobAge and completing as successful', ajs.job_wrapper.get_id_tag(), ajs.job_id )
                     drmaa_state = self.drmaa_job_states.DONE
-                elif job_info['JobState'] == 'TIMEOUT':
+                elif slurm_state == 'TIMEOUT':
                     log.info( '(%s/%s) Job hit walltime', ajs.job_wrapper.get_id_tag(), ajs.job_id )
                     ajs.fail_message = "This job was terminated because it ran longer than the maximum allowed job run time."
                     ajs.runner_state = ajs.runner_states.WALLTIME_REACHED
-                elif job_info['JobState'] == 'NODE_FAIL':
+                elif slurm_state == 'NODE_FAIL':
                     log.warning( '(%s/%s) Job failed due to node failure, attempting resubmission', ajs.job_wrapper.get_id_tag(), ajs.job_id )
                     ajs.job_wrapper.change_state( model.Job.states.QUEUED, info='Job was resubmitted due to node failure' )
                     try:
@@ -66,7 +87,7 @@ class SlurmJobRunner( DRMAAJobRunner ):
                         return
                     except:
                         ajs.fail_message = "This job failed due to a cluster node failure, and an attempt to resubmit the job failed."
-                elif job_info['JobState'] == 'CANCELLED':
+                elif slurm_state == 'CANCELLED':
                     # Check to see if the job was killed for exceeding memory consumption
                     if self.__check_memory_limit( ajs.error_file ):
                         log.info( '(%s/%s) Job hit memory limit', ajs.job_wrapper.get_id_tag(), ajs.job_id )
@@ -75,11 +96,11 @@ class SlurmJobRunner( DRMAAJobRunner ):
                     else:
                         log.info( '(%s/%s) Job was cancelled via slurm (e.g. with scancel(1))', ajs.job_wrapper.get_id_tag(), ajs.job_id )
                         ajs.fail_message = "This job failed because it was cancelled by an administrator."
-                elif job_info['JobState'] in ('PENDING', 'RUNNING'):
-                    log.warning( '(%s/%s) Job was reported by drmaa as terminal but scontrol(1) JobState is: %s, returning to monitor queue', ajs.job_wrapper.get_id_tag(), ajs.job_id, job_info['JobState'] )
+                elif slurm_state in ('PENDING', 'RUNNING'):
+                    log.warning( '(%s/%s) Job was reported by drmaa as terminal but job state in SLURM is: %s, returning to monitor queue', ajs.job_wrapper.get_id_tag(), ajs.job_id, slurm_state )
                     return True
                 else:
-                    log.warning( '(%s/%s) Job failed due to unknown reasons, JobState was: %s', ajs.job_wrapper.get_id_tag(), ajs.job_id, job_info['JobState'] )
+                    log.warning( '(%s/%s) Job failed due to unknown reasons, job state in SLURM was: %s', ajs.job_wrapper.get_id_tag(), ajs.job_id, slurm_state )
                     ajs.fail_message = "This job failed for reasons that could not be determined."
                 if drmaa_state == self.drmaa_job_states.FAILED:
                     ajs.fail_message += '\nPlease click the bug icon to report this problem if you need help.'

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -32,6 +32,7 @@ class SlurmJobRunner( DRMAAJobRunner ):
             stdout, stderr = p.communicate()
             if p.returncode != 0:
                 if stderr == 'SLURM accounting storage is disabled':
+                    log.warning('SLURM accounting storage is not properly configured, unable to run sacct')
                     return
                 raise Exception( '`%s` returned %s, stderr: %s' % ( ' '.join( cmd ), p.returncode, stderr ) )
             return stdout.strip()


### PR DESCRIPTION
Also:
- Merge `_complete_terminal_job()` from `BaseJobRunner` into `DRMAAJobRunner`
- Clarify `_complete_terminal_job()` return value
