### PR TITLE
[16.01] API, history: fix order in most_recently_used

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -81,7 +81,7 @@ class HistoryManager( sharable.SharableModelManager, deletable.PurgableManagerMi
         """
         if self.user_manager.is_anonymous( user ):
             return None if ( not current_history or current_history.deleted ) else current_history
-        desc_update_time = self.model_class.table.c.update_time
+        desc_update_time = desc( self.model_class.table.c.update_time )
         filters = self._munge_filters( filters, self.model_class.user_id == user.id )
         # TODO: normalize this return value
         return self.query( filters=filters, order_by=desc_update_time, limit=1, **kwargs ).first()

--- a/test/unit/managers/test_HistoryManager.py
+++ b/test/unit/managers/test_HistoryManager.py
@@ -337,6 +337,19 @@ class HistoryManagerTestCase( BaseTestCase ):
         self.assertEqual( self.history_manager.set_current_by_id( self.trans, history1.id ), history1 )
         self.assertEqual( self.history_manager.get_current( self.trans ), history1 )
 
+    def test_most_recently_used( self ):
+        user2 = self.user_manager.create( **user2_data )
+        self.trans.set_user( user2 )
+
+        history1 = self.history_manager.create( name='history1', user=user2 )
+        self.trans.set_history( history1 )
+        history2 = self.history_manager.create( name='history2', user=user2 )
+
+        self.log( "should be able to get the most recently used (updated) history for a given user" )
+        self.assertEqual( self.history_manager.most_recent( user2 ), history2 )
+        self.history_manager.update( history1, { 'name': 'new name' })
+        self.assertEqual( self.history_manager.most_recent( user2 ), history1 )
+
 
 # =============================================================================
 # web.url_for doesn't work well in the framework


### PR DESCRIPTION
- Fix ascending order used in HistoryManager.most_recent to descending
- Slightly update the docs to reflect actual value better
- Add tests
