### PR TITLE
UI, datasets: show hid in 'view details' page

### DIFF
--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -140,6 +140,7 @@
         encoded_hda_id = trans.security.encode_id( hda.id )
         encoded_history_id = trans.security.encode_id( hda.history_id )
         %>
+        <tr><td>Number:</td><td>${hda.hid | h}</td></tr>
         <tr><td>Name:</td><td>${hda.name | h}</td></tr>
         <tr><td>Created:</td><td>${unicodify(hda.create_time.strftime(trans.app.config.pretty_datetime_format))}</td></tr>
         ##      <tr><td>Copied from another history?</td><td>${hda.source_library_dataset}</td></tr>


### PR DESCRIPTION
Adds the hid to the list of dataset/job information on the show_params/
view details/info page.

<img width="454" alt="screen shot 2016-05-25 at 1 00 12 pm" src="https://cloud.githubusercontent.com/assets/5102959/15549027/bd5440a8-2278-11e6-9f33-16249b747f2f.png">

@jennaj Will that work?
