### PR TITLE
Python3: use log.warning() instead of deprecated log.warn()

### DIFF
--- a/lib/galaxy/auth/providers/ldap_ad.py
+++ b/lib/galaxy/auth/providers/ldap_ad.py
@@ -135,7 +135,7 @@ class LDAP(AuthProvider):
 
                 # parse results
                 if suser is None or len(suser) == 0:
-                    log.warn('LDAP authenticate: search returned no results')
+                    log.warning('LDAP authenticate: search returned no results')
                     return (failure_mode, '', '')
                 dn, attrs = suser[0]
                 log.debug(("LDAP authenticate: dn is %s" % dn))
@@ -169,7 +169,7 @@ class LDAP(AuthProvider):
             if whoami is None:
                 raise RuntimeError('LDAP authenticate: anonymous bind')
         except Exception:
-            log.warn('LDAP authenticate: bind exception', exc_info=True)
+            log.warning('LDAP authenticate: bind exception', exc_info=True)
             return (failure_mode, '', '')
 
         log.debug('LDAP authentication successful')

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -509,7 +509,7 @@ class CRAM( Binary ):
                 header = fh.read(6)
                 return ord( header[4] ), ord( header[5] )
         except Exception as exc:
-            log.warn( '%s, get_cram_version Exception: %s', self, exc )
+            log.warning( '%s, get_cram_version Exception: %s', self, exc )
             return -1, -1
 
     def set_index_file(self, dataset, index_file):
@@ -530,10 +530,10 @@ class CRAM( Binary ):
                 return index_file.file_name
             else:
                 os.unlink( dataset_symlink )
-                log.warn( '%s, expected crai index not created for: %s', self, dataset.file_name )
+                log.warning( '%s, expected crai index not created for: %s', self, dataset.file_name )
                 return False
         except Exception as exc:
-            log.warn( '%s, set_index_file Exception: %s', self, exc )
+            log.warning( '%s, set_index_file Exception: %s', self, exc )
             return False
 
     def set_peek( self, dataset, is_multi_byte=False ):
@@ -821,18 +821,18 @@ class SQlite ( Binary ):
                     cols = [col[0] for col in cur.description]
                     columns[table] = cols
                 except Exception as exc:
-                    log.warn( '%s, set_meta Exception: %s', self, exc )
+                    log.warning( '%s, set_meta Exception: %s', self, exc )
             for table in tables:
                 try:
                     row_query = "SELECT count(*) FROM %s" % table
                     rowcounts[table] = c.execute(row_query).fetchone()[0]
                 except Exception as exc:
-                    log.warn( '%s, set_meta Exception: %s', self, exc )
+                    log.warning( '%s, set_meta Exception: %s', self, exc )
             dataset.metadata.tables = tables
             dataset.metadata.table_columns = columns
             dataset.metadata.table_row_count = rowcounts
         except Exception as exc:
-            log.warn( '%s, set_meta Exception: %s', self, exc )
+            log.warning( '%s, set_meta Exception: %s', self, exc )
 
     def sniff( self, filename ):
         # The first 16 bytes of any SQLite3 database file is 'SQLite format 3\0', and the file is binary. For details
@@ -903,7 +903,7 @@ class GeminiSQLite( SQlite ):
                 dataset.metadata.gemini_version = version
             # TODO: Can/should we detect even more attributes, such as use of PED file, what was input annotation type, etc.
         except Exception as e:
-            log.warn( '%s, set_meta Exception: %s', self, e )
+            log.warning( '%s, set_meta Exception: %s', self, e )
 
     def sniff( self, filename ):
         if super( GeminiSQLite, self ).sniff( filename ):
@@ -920,7 +920,7 @@ class GeminiSQLite( SQlite ):
                         return False
                 return True
             except Exception as e:
-                log.warn( '%s, sniff Exception: %s', self, e )
+                log.warning( '%s, sniff Exception: %s', self, e )
         return False
 
     def set_peek( self, dataset, is_multi_byte=False ):
@@ -959,7 +959,7 @@ class MzSQlite( SQlite ):
                         return False
                 return True
             except Exception as e:
-                log.warn( '%s, sniff Exception: %s', self, e )
+                log.warning( '%s, sniff Exception: %s', self, e )
         return False
 
 
@@ -994,7 +994,7 @@ class IdpDB( SQlite ):
                         return False
                 return True
             except Exception as e:
-                log.warn( '%s, sniff Exception: %s', self, e )
+                log.warning( '%s, sniff Exception: %s', self, e )
         return False
 
     def set_peek( self, dataset, is_multi_byte=False ):
@@ -1274,7 +1274,7 @@ class SearchGuiArchive ( CompressedArchive ):
                     fh.close()
                 tempzip.close()
         except Exception as e:
-            log.warn( '%s, set_meta Exception: %s', self, e )
+            log.warning( '%s, set_meta Exception: %s', self, e )
 
     def sniff( self, filename ):
         try:
@@ -1284,7 +1284,7 @@ class SearchGuiArchive ( CompressedArchive ):
                 tempzip.close()
                 return is_searchgui
         except Exception as e:
-            log.warn( '%s, sniff Exception: %s', self, e )
+            log.warning( '%s, sniff Exception: %s', self, e )
         return False
 
     def set_peek( self, dataset, is_multi_byte=False ):

--- a/lib/galaxy/datatypes/mothur.py
+++ b/lib/galaxy/datatypes/mothur.py
@@ -301,7 +301,7 @@ class DistanceMatrix(Text):
                     dataset.metadata.sequence_count = int(''.join(line))  # seq count sometimes preceded by tab
                     break
                 except Exception as e:
-                    log.warn("DistanceMatrix set_meta %s" % e)
+                    log.warning("DistanceMatrix set_meta %s" % e)
 
 
 class LowerTriangleDistanceMatrix(DistanceMatrix):
@@ -902,7 +902,7 @@ class SffFlow(Tabular):
             flow_values = int(headers[0][0])
             dataset.metadata.flow_values = flow_values
         except Exception as e:
-            log.warn("SffFlow set_meta %s" % e)
+            log.warning("SffFlow set_meta %s" % e)
 
     def make_html_table(self, dataset, skipchars=[]):
         """Create HTML table, used for displaying peek"""

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -129,11 +129,11 @@ class Registry( object ):
                 make_subclass = galaxy.util.string_as_bool( elem.get( 'subclass', False ) )
                 edam_format = elem.get( 'edam_format', None )
                 if edam_format and not make_subclass:
-                    self.log.warn("Cannot specify edam_format without setting subclass to True, skipping datatype.")
+                    self.log.warning("Cannot specify edam_format without setting subclass to True, skipping datatype.")
                     continue
                 edam_data = elem.get( 'edam_data', None )
                 if edam_data and not make_subclass:
-                    self.log.warn("Cannot specify edam_data without setting subclass to True, skipping datatype.")
+                    self.log.warning("Cannot specify edam_data without setting subclass to True, skipping datatype.")
                     continue
                 # Proprietary datatypes included in installed tool shed repositories will include two special attributes
                 # (proprietary_path and proprietary_datatype_module) if they depend on proprietary datatypes classes.

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -528,14 +528,14 @@ class SnpSiftDbNSFP( Text ):
                             headers = lines[0].split('\t')
                             dataset.metadata.annotation = headers[4:]
                         except Exception as e:
-                            log.warn("set_meta fname: %s  %s" % (fname, str(e)))
+                            log.warning("set_meta fname: %s  %s" % (fname, str(e)))
                         finally:
                             fh.close()
                     if fname.endswith('.tbi'):
                         dataset.metadata.index = fname
             self.regenerate_primary_file(dataset)
         except Exception as e:
-            log.warn("set_meta fname: %s  %s" % (dataset.file_name if dataset and dataset.file_name else 'Unkwown', str(e)))
+            log.warning("set_meta fname: %s  %s" % (dataset.file_name if dataset and dataset.file_name else 'Unkwown', str(e)))
 
         def set_peek( self, dataset, is_multi_byte=False ):
             if not dataset.dataset.purged:

--- a/lib/galaxy/jobs/metrics/collectl/processes.py
+++ b/lib/galaxy/jobs/metrics/collectl/processes.py
@@ -185,7 +185,7 @@ class CollectlProcessSummarizer( object ):
             if column == "AccumT":
                 # Only thing that makes sense is sum
                 if statistic_type != "max":
-                    log.warn( "Only statistic max makes sense for AccumT" )
+                    log.warning( "Only statistic max makes sense for AccumT" )
                     continue
 
                 value = sum( [ v.max for v in self.process_accum_statistics.itervalues() ] )

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -107,7 +107,7 @@ class LocalJobRunner( BaseJobRunner ):
             try:
                 exit_code = int( open( exit_code_path, 'r' ).read() )
             except Exception:
-                log.warn( "Failed to read exit code from path %s" % exit_code_path )
+                log.warning( "Failed to read exit code from path %s" % exit_code_path )
                 pass
             stdout_file.seek( 0 )
             stderr_file.seek( 0 )

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -377,7 +377,7 @@ class PulsarJobRunner( AsynchronousJobRunner ):
         for key, value in self.destination_defaults.iteritems():
             if key in params:
                 if value is PARAMETER_SPECIFICATION_IGNORED:
-                    log.warn( "Pulsar runner in selected configuration ignores parameter %s" % key )
+                    log.warning( "Pulsar runner in selected configuration ignores parameter %s" % key )
                 continue
             # if self.runner_params.get( key, None ):
             #    # Let plugin define defaults for some parameters -
@@ -668,7 +668,7 @@ class PulsarJobRunner( AsynchronousJobRunner ):
             if PulsarJobRunner.__use_remote_datatypes_conf( client ):
                 remote_datatypes_config = remote_system_properties.get('galaxy_datatypes_config_file', None)
                 if not remote_datatypes_config:
-                    log.warn(NO_REMOTE_DATATYPES_CONFIG)
+                    log.warning(NO_REMOTE_DATATYPES_CONFIG)
                     remote_datatypes_config = os.path.join(remote_galaxy_home, 'datatypes_conf.xml')
                 metadata_kwds['datatypes_config'] = remote_datatypes_config
             else:

--- a/lib/galaxy/managers/citations.py
+++ b/lib/galaxy/managers/citations.py
@@ -65,7 +65,7 @@ def parse_citation( elem, directory, citation_manager ):
     citation_type = elem.attrib.get( 'type', None )
     citation_class = CITATION_CLASSES.get( citation_type, None )
     if not citation_class:
-        log.warn("Unknown or unspecified citation type: %s" % citation_type)
+        log.warning("Unknown or unspecified citation type: %s" % citation_type)
         return None
     return citation_class( elem, directory, citation_manager )
 

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -136,7 +136,7 @@ class TagManager( object ):
             # Create tag; if None, skip the tag (and log error).
             tag = self._get_or_create_tag( lc_name )
             if not tag:
-                log.warn( "Failed to create tag with name %s" % lc_name )
+                log.warning( "Failed to create tag with name %s" % lc_name )
                 return
             # Create tag association based on item class.
             item_tag_assoc_class = self.get_tag_assoc_class( item.__class__ )

--- a/lib/galaxy/model/migrate/versions/0041_workflow_invocation.py
+++ b/lib/galaxy/model/migrate/versions/0041_workflow_invocation.py
@@ -37,7 +37,7 @@ def upgrade(migrate_engine):
         try:
             table.create()
         except:
-            log.warn( "Failed to create table '%s', ignoring (might result in wrong schema)" % table.name )
+            log.warning( "Failed to create table '%s', ignoring (might result in wrong schema)" % table.name )
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0046_post_job_actions.py
+++ b/lib/galaxy/model/migrate/versions/0046_post_job_actions.py
@@ -37,7 +37,7 @@ def upgrade(migrate_engine):
         try:
             table.create()
         except:
-            log.warn( "Failed to create table '%s', ignoring (might result in wrong schema)" % table.name )
+            log.warning( "Failed to create table '%s', ignoring (might result in wrong schema)" % table.name )
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0056_workflow_outputs.py
+++ b/lib/galaxy/model/migrate/versions/0056_workflow_outputs.py
@@ -26,7 +26,7 @@ def upgrade(migrate_engine):
         try:
             table.create()
         except:
-            log.warn( "Failed to create table '%s', ignoring (might result in wrong schema)" % table.name )
+            log.warning( "Failed to create table '%s', ignoring (might result in wrong schema)" % table.name )
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0061_tasks.py
+++ b/lib/galaxy/model/migrate/versions/0061_tasks.py
@@ -38,7 +38,7 @@ def upgrade(migrate_engine):
         try:
             table.create()
         except:
-            log.warn( "Failed to create table '%s', ignoring (might result in wrong schema)" % table.name )
+            log.warning( "Failed to create table '%s', ignoring (might result in wrong schema)" % table.name )
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -428,7 +428,7 @@ class Tool( object, Dictifiable ):
         if self.profile >= 16.04 and VERSION_MAJOR < self.profile:
             template = "The tool %s targets version %s of Galaxy, you should upgrade Galaxy to ensure proper functioning of this tool."
             message = template % (self.id, self.profile)
-            log.warn(message)
+            log.warning(message)
 
         # Get the (user visible) name of the tool
         self.name = tool_source.parse_name()

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -340,7 +340,7 @@ class TabularToolDataTable( ToolDataTable, Dictifiable ):
                 self._update_version()
             else:
                 self.missing_index_file = filename
-                log.warn( "Cannot find index file '%s' for tool data table '%s'" % ( filename, self.name ) )
+                log.warning( "Cannot find index file '%s' for tool data table '%s'" % ( filename, self.name ) )
 
             if filename not in self.filenames or not self.filenames[ filename ][ 'found' ]:
                 self.filenames[ filename ] = dict( found=found, filename=filename, from_shed_config=from_shed_config, tool_data_path=tool_data_path,
@@ -461,7 +461,7 @@ class TabularToolDataTable( ToolDataTable, Dictifiable ):
                     line_error = "Line %i in tool data table '%s' is invalid (HINT: '%s' characters must be used to separate fields):\n%s" % ( ( i + 1 ), self.name, separator_char, line )
                     if errors is not None:
                         errors.append( line_error )
-                    log.warn( line_error )
+                    log.warning( line_error )
         return rval
 
     def get_column_name_list( self ):
@@ -590,7 +590,7 @@ class TabularToolDataTable( ToolDataTable, Dictifiable ):
                 values = self._replace_field_separators( values )
                 self.filter_file_fields( filename, values )
             else:
-                log.warn( "Cannot find index file '%s' for tool data table '%s'" % ( filename, self.name ) )
+                log.warning( "Cannot find index file '%s' for tool data table '%s'" % ( filename, self.name ) )
 
         self.reload_from_files()
 

--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -78,9 +78,9 @@ class DependencyManager( object ):
         in `base_paths`.  The default base path is app.config.tool_dependency_dir.
         """
         if not os.path.exists( default_base_path ):
-            log.warn( "Path '%s' does not exist, ignoring", default_base_path )
+            log.warning( "Path '%s' does not exist, ignoring", default_base_path )
         if not os.path.isdir( default_base_path ):
-            log.warn( "Path '%s' is not directory, ignoring", default_base_path )
+            log.warning( "Path '%s' is not directory, ignoring", default_base_path )
         self.extra_config = extra_config
         self.default_base_path = os.path.abspath( default_base_path )
         self.resolver_classes = self.__resolvers_dict()
@@ -98,7 +98,7 @@ class DependencyManager( object ):
                                             **kwds )
             dependency_commands = dependency.shell_commands( requirement )
             if not dependency_commands:
-                log.warn( "Failed to resolve dependency on '%s', ignoring", requirement.name )
+                log.warning( "Failed to resolve dependency on '%s', ignoring", requirement.name )
             else:
                 commands.append( dependency_commands )
         return commands

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -102,7 +102,7 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
 
         job_directory = kwds.get("job_directory", None)
         if job_directory is None:
-            log.warn("Conda dependency resolver not sent job directory.")
+            log.warning("Conda dependency resolver not sent job directory.")
             return INDETERMINATE_DEPENDENCY
 
         exact = not self.versionless or version is None

--- a/lib/galaxy/tools/deps/resolvers/galaxy_packages.py
+++ b/lib/galaxy/tools/deps/resolvers/galaxy_packages.py
@@ -97,7 +97,7 @@ class GalaxyPackageDependency(Dependency):
     def shell_commands( self, requirement ):
         base_path = self.path
         if self.script is None and base_path is None:
-            log.warn( "Failed to resolve dependency on '%s', ignoring", requirement.name )
+            log.warning( "Failed to resolve dependency on '%s', ignoring", requirement.name )
             commands = None
         elif requirement.type == 'package' and self.script is None:
             commands = 'PACKAGE_BASE=%s; export PACKAGE_BASE; PATH="%s/bin:$PATH"; export PATH' % ( base_path, base_path )

--- a/lib/galaxy/tools/deps/resolvers/modules.py
+++ b/lib/galaxy/tools/deps/resolvers/modules.py
@@ -74,7 +74,7 @@ class DirectoryModuleChecker(object):
         self.module_dependency_resolver = module_dependency_resolver
         self.directories = modulepath.split(pathsep)
         if prefetch:
-            log.warn("Created module dependency resolver with prefetch enabled, but directory module checker does not support this.")
+            log.warning("Created module dependency resolver with prefetch enabled, but directory module checker does not support this.")
 
     def has_module(self, module, version):
         has_module = False

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -109,7 +109,7 @@ class ToolExecutionTracker( object ):
     def record_error( self, error ):
         self.failed_jobs += 1
         message = "There was a failure executing a job for tool [%s] - %s"
-        log.warn(message, self.tool.id, error)
+        log.warning(message, self.tool.id, error)
         self.execution_errors.append( error )
 
     def create_output_collections( self, trans, history, params ):
@@ -137,7 +137,7 @@ class ToolExecutionTracker( object ):
             if not len( structure ) == len( outputs ):
                 # Output does not have the same structure, if all jobs were
                 # successfully submitted this shouldn't have happened.
-                log.warn( "Problem matching up datasets while attempting to create implicit dataset collections")
+                log.warning( "Problem matching up datasets while attempting to create implicit dataset collections")
                 continue
             output = self.tool.outputs[ output_name ]
             element_identifiers = structure.element_identifiers_for_outputs( trans, outputs )

--- a/lib/galaxy/tools/loader_directory.py
+++ b/lib/galaxy/tools/loader_directory.py
@@ -26,7 +26,7 @@ CWL_EXTENSIONS = YAML_EXTENSIONS + [".cwl"]
 
 def load_exception_handler(path, exc_info):
     """Default exception handler for use by load_tool_elements_from_path."""
-    log.warn(LOAD_FAILURE_ERROR % path, exc_info=exc_info)
+    log.warning(LOAD_FAILURE_ERROR % path, exc_info=exc_info)
 
 
 def find_possible_tools_from_path(

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -491,7 +491,7 @@ class DynamicOptions( object ):
                     self.missing_index_file = self.tool_data_table.missing_index_file
             else:
                 self.missing_tool_data_table_name = tool_data_table_name
-                log.warn( "Data table named '%s' is required by tool but not configured" % tool_data_table_name )
+                log.warning( "Data table named '%s' is required by tool but not configured" % tool_data_table_name )
         # Options are defined by parsing tabular text data from a data file
         # on disk, a dataset, or the value of another parameter
         elif data_file is not None or dataset_file is not None or from_parameter is not None:
@@ -556,7 +556,7 @@ class DynamicOptions( object ):
                         except AttributeError:
                             name = "a configuration file"
                         # Perhaps this should be an error, but even a warning is useful.
-                        log.warn( "Inconsistent number of fields (%i vs %i) in %s using separator %r, check line: %r" %
+                        log.warning( "Inconsistent number of fields (%i vs %i) in %s using separator %r, check line: %r" %
                                   ( field_count, len( fields ), name, self.separator, line ) )
                     rval.append( fields )
         return rval
@@ -587,7 +587,7 @@ class DynamicOptions( object ):
             else:
                 # Pass just the first megabyte to parse_file_fields.
                 import StringIO
-                log.warn( "Attempting to load options from large file, reading just first megabyte" )
+                log.warning( "Attempting to load options from large file, reading just first megabyte" )
                 contents = open( path, 'r' ).read( 1048576 )
                 options = self.parse_file_fields( StringIO.StringIO( contents ) )
         elif self.tool_data_table:

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -129,7 +129,7 @@ class XmlToolSource(ToolSource):
         command_el = self._command_el
         interpreter = (command_el is not None) and command_el.get("interpreter", None)
         if not self.legacy_defaults:
-            log.warn("Deprecated interpeter attribute on command element is now ignored.")
+            log.warning("Deprecated interpeter attribute on command element is now ignored.")
             interpreter = None
 
         return interpreter

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -729,7 +729,7 @@ def rst_to_html( s ):
     class FakeStream( object ):
         def write( self, str ):
             if len( str ) > 0 and not str.isspace():
-                log.warn( str )
+                log.warning( str )
 
     settings_overrides = {
         "embed_stylesheet": False,
@@ -1351,7 +1351,7 @@ def config_directories_from_setting( directories_setting, galaxy_root=galaxy_roo
         if not directory.startswith( '/' ):
             directory = os.path.join( galaxy_root, directory )
         if not os.path.exists( directory ):
-            log.warn( 'directory not found: %s', directory )
+            log.warning( 'directory not found: %s', directory )
             continue
         directories.append( directory )
     return directories

--- a/lib/galaxy/visualization/plugins/config_parser.py
+++ b/lib/galaxy/visualization/plugins/config_parser.py
@@ -283,7 +283,7 @@ class DataSourceParser( object ):
             test_type = test_elem.get( 'type', 'eq' )
             test_result = test_elem.text.strip() if test_elem.text else None
             if not test_type or not test_result:
-                log.warn( 'Skipping test. Needs both type attribute and text node to be parsed: ' +
+                log.warning( 'Skipping test. Needs both type attribute and text node to be parsed: ' +
                           '%s, %s' % ( test_type, test_elem.text ) )
                 continue
             test_result = test_result.strip()

--- a/lib/galaxy/visualization/plugins/registry.py
+++ b/lib/galaxy/visualization/plugins/registry.py
@@ -203,7 +203,7 @@ class VisualizationsRegistry( pluginframework.PageServingPluginManager ):
                     if not test_result:
                         # but continue (with other tests) if can't find class by that name
                         # if self.debug:
-                        #    log.warn( 'visualizations_registry cannot find class (%s)' +
+                        #    log.warning( 'visualizations_registry cannot find class (%s)' +
                         #              ' for applicability test on: %s, id: %s', datatype_class_name,
                         #              target_object, getattr( target_object, 'id', '' ) )
                         continue

--- a/lib/galaxy/visualization/plugins/resource_parser.py
+++ b/lib/galaxy/visualization/plugins/resource_parser.py
@@ -78,7 +78,7 @@ class ResourceParser( object ):
                     if trans.debug:
                         raise
                     else:
-                        log.warn( 'Exception parsing visualization param from query: %s, %s, (%s) %s',
+                        log.warning( 'Exception parsing visualization param from query: %s, %s, (%s) %s',
                                   param_name, query_val, str( type( exception ) ), str( exception ) )
                     resource = None
 
@@ -109,7 +109,7 @@ class ResourceParser( object ):
                     config_val = self.parse_parameter( trans, param_config, config_val )
 
                 except Exception as exception:
-                    log.warn( 'Exception parsing visualization param from query: ' +
+                    log.warning( 'Exception parsing visualization param from query: ' +
                               '%s, %s, (%s) %s' % ( param_name, config_val, str( type( exception ) ), str( exception ) ))
                     config_val = None
 

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -80,7 +80,7 @@ class BaseController( object ):
     # this should be here - but catching errors from sharable item controllers that *should* have SharableItemMixin
     #   but *don't* then becomes difficult
     # def security_check( self, trans, item, check_ownership=False, check_accessible=False ):
-    #    log.warn( 'BaseController.security_check: %s, %b, %b', str( item ), check_ownership, check_accessible )
+    #    log.warning( 'BaseController.security_check: %s, %b, %b', str( item ), check_ownership, check_accessible )
     #    # meant to be overridden in SharableSecurityMixin
     #    return item
 

--- a/lib/galaxy/web/base/pluginframework.py
+++ b/lib/galaxy/web/base/pluginframework.py
@@ -93,7 +93,7 @@ class PluginManager( object ):
                 # NOTE: prevent silent, implicit overwrite here (two plugins in two diff directories)
                 # TODO: overwriting may be desired
                 elif plugin and plugin.name in self.plugins:
-                    log.warn( '%s, plugin with name already exists: %s. Skipping...', self, plugin.name )
+                    log.warning( '%s, plugin with name already exists: %s. Skipping...', self, plugin.name )
 
             except Exception:
                 if not self.skip_bad_plugins:

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -473,7 +473,7 @@ class DatasetInterface( BaseUIController, UsesAnnotations, UsesItemRatings, Uses
                         assert trans.user.id == hda.history.user_id, "HistoryDatasetAssocation does not belong to current user"
                     hdas.append( hda )
                 else:
-                    log.warn( "Invalid history_dataset_association id '%r' passed to list", hda_id )
+                    log.warning( "Invalid history_dataset_association id '%r' passed to list", hda_id )
 
             if hdas:
                 if operation == "switch" or operation == "switch_history":

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -283,7 +283,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
                         assert trans.user.id == history.user_id, "History does not belong to current user"
                     histories.append( history )
                 else:
-                    log.warn( "Invalid history id '%r' passed to list", history_id )
+                    log.warning( "Invalid history id '%r' passed to list", history_id )
             if histories:
                 if operation == "switch":
                     status, message = self._list_switch( trans, histories )

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -97,7 +97,7 @@ def extract_steps( trans, history=None, job_ids=None, dataset_ids=None, dataset_
     # Tool steps
     for job_id in job_ids:
         if job_id not in jobs_by_id:
-            log.warn( "job_id %s not found in jobs_by_id %s" % ( job_id, jobs_by_id ) )
+            log.warning( "job_id %s not found in jobs_by_id %s" % ( job_id, jobs_by_id ) )
             raise AssertionError( "Attempt to create workflow with job not connected to current history" )
         job = jobs_by_id[ job_id ]
         tool_inputs, associations = step_inputs( trans, job )
@@ -141,7 +141,7 @@ def extract_steps( trans, history=None, job_ids=None, dataset_ids=None, dataset_
                 if hid is None:
                     template = "Failed to find matching implicit job - job is %s, jobs are %s, assoc_name is %s."
                     message = template % ( job.id, jobs, assoc.name )
-                    log.warn( message )
+                    log.warning( message )
                     raise Exception( "Failed to extract job." )
             else:
                 if hasattr( assoc, "dataset" ):
@@ -241,7 +241,7 @@ class WorkflowSummary( object ):
 
             job_hda = self.__original_hda( dataset_instance )
             if not job_hda.creating_job_associations:
-                log.warn( "An implicitly create output dataset collection doesn't have a creating_job_association, should not happen!" )
+                log.warning( "An implicitly create output dataset collection doesn't have a creating_job_association, should not happen!" )
                 job = DatasetCollectionCreationJob( dataset_collection )
                 self.jobs[ job ] = [ ( None, dataset_collection ) ]
 

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -465,7 +465,7 @@ class InstallRepositoryManager( object ):
             message = "Error attempting to retrieve installation information from tool shed "
             message += "%s for revision %s of repository %s owned by %s: %s" % \
                 ( str( tool_shed_url ), str( changeset_revision ), str( name ), str( owner ), str( e ) )
-            log.warn( message )
+            log.warning( message )
             raise exceptions.InternalServerError( message )
         if raw_text:
             # If successful, the response from get_repository_revision_install_info will be 3
@@ -478,7 +478,7 @@ class InstallRepositoryManager( object ):
         else:
             message = "Unable to retrieve installation information from tool shed %s for revision %s of repository %s owned by %s: %s" % \
                 ( str( tool_shed_url ), str( changeset_revision ), str( name ), str( owner ), str( e ) )
-            log.warn( message )
+            log.warning( message )
             raise exceptions.InternalServerError( message )
         # Make sure the tool shed returned everything we need for installing the repository.
         if not repository_revision_dict or not repo_info_dict:

--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/install_environment.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/install_environment.py
@@ -119,10 +119,10 @@ class InstallEnvironment( object ):
         stdout = output.stdout
         stderr = output.stderr
         if len( stdout ) > DATABASE_MAX_STRING_SIZE:
-            log.warn( "Length of stdout > %s, so only a portion will be saved in the database." % str( DATABASE_MAX_STRING_SIZE_PRETTY ) )
+            log.warning( "Length of stdout > %s, so only a portion will be saved in the database." % str( DATABASE_MAX_STRING_SIZE_PRETTY ) )
             stdout = shrink_string_by_size( stdout, DATABASE_MAX_STRING_SIZE, join_by="\n..\n", left_larger=True, beginning_on_size_error=True )
         if len( stderr ) > DATABASE_MAX_STRING_SIZE:
-            log.warn( "Length of stderr > %s, so only a portion will be saved in the database." % str( DATABASE_MAX_STRING_SIZE_PRETTY ) )
+            log.warning( "Length of stderr > %s, so only a portion will be saved in the database." % str( DATABASE_MAX_STRING_SIZE_PRETTY ) )
             stderr = shrink_string_by_size( stderr, DATABASE_MAX_STRING_SIZE, join_by="\n..\n", left_larger=True, beginning_on_size_error=True )
         if output.return_code not in [ 0 ]:
             status = self.app.install_model.ToolDependency.installation_status.ERROR

--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -82,7 +82,7 @@ class CompressedFile( object ):
                     if os.path.exists( absolute_filepath ):
                         os.chmod( absolute_filepath, unix_permissions )
                     else:
-                        log.warn("Unable to change permission on extracted file '%s' as it does not exist" % absolute_filepath)
+                        log.warning("Unable to change permission on extracted file '%s' as it does not exist" % absolute_filepath)
         return os.path.abspath( os.path.join( extraction_path, common_prefix ) )
 
     def getmembers_tar( self ):

--- a/lib/tool_shed/util/common_util.py
+++ b/lib/tool_shed/util/common_util.py
@@ -161,7 +161,7 @@ def get_repository_dependencies( app, tool_shed_url, repository_name, repository
         tool_shed_accessible = True
     except Exception as e:
         tool_shed_accessible = False
-        log.warn( "The URL\n%s\nraised the exception:\n%s\n", util.build_url( tool_shed_url, pathspec=pathspec, params=params ), e )
+        log.warning( "The URL\n%s\nraised the exception:\n%s\n", util.build_url( tool_shed_url, pathspec=pathspec, params=params ), e )
     if tool_shed_accessible:
         if len( raw_text ) > 2:
             encoded_text = json.loads( raw_text )
@@ -193,7 +193,7 @@ def get_tool_dependencies( app, tool_shed_url, repository_name, repository_owner
         tool_shed_accessible = True
     except Exception as e:
         tool_shed_accessible = False
-        log.warn( "The URL\n%s\nraised the exception:\n%s\n", util.build_url( tool_shed_url, pathspec=pathspec, params=params ), e )
+        log.warning( "The URL\n%s\nraised the exception:\n%s\n", util.build_url( tool_shed_url, pathspec=pathspec, params=params ), e )
     if tool_shed_accessible:
         if text:
             tool_dependencies_dict = encoding_util.tool_shed_decode( text )

--- a/lib/tool_shed/util/tool_dependency_util.py
+++ b/lib/tool_shed/util/tool_dependency_util.py
@@ -366,7 +366,7 @@ def remove_tool_dependency_installation_directory( dependency_install_dir ):
         except Exception as e:
             removed = False
             error_message = "Error removing tool dependency installation directory %s: %s" % ( str( dependency_install_dir ), str( e ) )
-            log.warn( error_message )
+            log.warning( error_message )
     else:
         removed = True
         error_message = ''


### PR DESCRIPTION
```
$ python3 -Wd -c 'import logging; logging.warn("foo")'
-c:1: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
WARNING:root:foo
```
