### PR TITLE
wrap bare str raises with generic Exception()

### DIFF
--- a/lib/galaxy/external_services/actions.py
+++ b/lib/galaxy/external_services/actions.py
@@ -80,7 +80,7 @@ class ExternalServiceAction( object ):
         return handled_results
 
     def perform_action( self, param_dict ):
-        raise 'Abstract Method'
+        raise Exception( 'Abstract Method' )
 
 
 class ExternalServiceResult( object ):
@@ -90,7 +90,7 @@ class ExternalServiceResult( object ):
 
     @property
     def content( self ):
-        raise 'Abstract Method'
+        raise Exception( 'Abstract Method' )
 
 
 class ExternalServiceWebAPIActionResult( ExternalServiceResult ):

--- a/lib/galaxy/external_services/parameters.py
+++ b/lib/galaxy/external_services/parameters.py
@@ -21,7 +21,7 @@ class ExternalServiceParameter( object ):
         self.parent = parent
 
     def get_value( self, param_dict ):
-        raise 'Abstract Method'
+        raise Exception( 'Abstract Method' )
 
 
 class ExternalServiceTemplateParameter( ExternalServiceParameter ):

--- a/lib/galaxy/external_services/service.py
+++ b/lib/galaxy/external_services/service.py
@@ -218,7 +218,7 @@ class PopulatedExternalService( object ):
             elif isinstance( item, ExternalServiceActionsGroup ):
                 item.prepare_actions( param_dict, param_dict, action_list )
             else:
-                raise 'unknown item type found'
+                raise Exception( 'unknown item type found' )
         self.param_dict = param_dict
         self.actions = action_list
 

--- a/lib/galaxy/forms/forms.py
+++ b/lib/galaxy/forms/forms.py
@@ -69,7 +69,7 @@ class FormDefinitionFieldFactory( object ):
     type = None
 
     def __get_stored_field_type( self, **kwds ):
-        raise 'not implemented'
+        raise Exception( 'not implemented' )
 
     def new( self, name=None, label=None, required=False, helptext=None, default=None, visible=True, layout=None ):
         """

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1572,7 +1572,7 @@ class LibraryPermissions( object ):
         if isinstance( library_item, Library ):
             self.library = library_item
         else:
-            raise "Invalid Library specified: %s" % library_item.__class__.__name__
+            raise Exception( "Invalid Library specified: %s" % library_item.__class__.__name__ )
         self.role = role
 
 
@@ -1582,7 +1582,7 @@ class LibraryFolderPermissions( object ):
         if isinstance( library_item, LibraryFolder ):
             self.folder = library_item
         else:
-            raise "Invalid LibraryFolder specified: %s" % library_item.__class__.__name__
+            raise Exception( "Invalid LibraryFolder specified: %s" % library_item.__class__.__name__ )
         self.role = role
 
 
@@ -1592,7 +1592,7 @@ class LibraryDatasetPermissions( object ):
         if isinstance( library_item, LibraryDataset ):
             self.library_dataset = library_item
         else:
-            raise "Invalid LibraryDataset specified: %s" % library_item.__class__.__name__
+            raise Exception( "Invalid LibraryDataset specified: %s" % library_item.__class__.__name__ )
         self.role = role
 
 
@@ -1602,7 +1602,7 @@ class LibraryDatasetDatasetAssociationPermissions( object ):
         if isinstance( library_item, LibraryDatasetDatasetAssociation ):
             self.library_dataset_dataset_association = library_item
         else:
-            raise "Invalid LibraryDatasetDatasetAssociation specified: %s" % library_item.__class__.__name__
+            raise Exception( "Invalid LibraryDatasetDatasetAssociation specified: %s" % library_item.__class__.__name__ )
         self.role = role
 
 
@@ -2079,7 +2079,7 @@ class DatasetInstance( object ):
                 return fake_hda
 
     def clear_associated_files( self, metadata_safe=False, purge=False ):
-        raise 'Unimplemented'
+        raise Exception( "Unimplemented" )
 
     def get_child_by_designation(self, designation):
         for child in self.children:

--- a/lib/galaxy/model/migrate/versions/0005_cleanup_datasets_fix.py
+++ b/lib/galaxy/model/migrate/versions/0005_cleanup_datasets_fix.py
@@ -274,7 +274,7 @@ class DatasetInstance( object ):
         return valid
 
     def clear_associated_files( self, metadata_safe=False, purge=False ):
-        raise 'Unimplemented'
+        raise Exception( 'Unimplemented' )
 
     def get_child_by_designation(self, designation):
         for child in self.children:

--- a/lib/galaxy/security/__init__.py
+++ b/lib/galaxy/security/__init__.py
@@ -1300,8 +1300,8 @@ class GalaxyRBACAgent( RBACAgent ):
                         self.sa_session.add( lp )
                         self.sa_session.flush()
             else:
-                raise Exception( 'Invalid class (%s) specified for target_library_item (%s)' % \ )
-                    ( target_library_item.__class__, target_library_item.__class__.__name__ )
+                raise Exception( 'Invalid class (%s) specified for target_library_item (%s)' %
+                                 ( target_library_item.__class__, target_library_item.__class__.__name__ ) )
 
     def get_permitted_libraries( self, trans, user, actions ):
         """

--- a/lib/galaxy/security/__init__.py
+++ b/lib/galaxy/security/__init__.py
@@ -48,97 +48,97 @@ class RBACAgent:
         return self.permitted_actions.__dict__.values()
 
     def get_item_actions( self, action, item ):
-        raise 'No valid method of retrieving action (%s) for item %s.' % ( action, item )
+        raise Exception( 'No valid method of retrieving action (%s) for item %s.' % ( action, item ) )
 
     def guess_derived_permissions_for_datasets( self, datasets=[] ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def can_access_dataset( self, roles, dataset ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def can_manage_dataset( self, roles, dataset ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def can_access_library( self, roles, library ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def can_add_library_item( self, roles, item ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def can_modify_library_item( self, roles, item ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def can_manage_library_item( self, roles, item ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def associate_components( self, **kwd ):
-        raise 'No valid method of associating provided components: %s' % kwd
+        raise Exception( 'No valid method of associating provided components: %s' % kwd )
 
     def create_private_user_role( self, user ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def get_private_user_role( self, user ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def get_accessible_request_types( self, trans, user ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def user_set_default_permissions( self, user, permissions={}, history=False, dataset=False ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def history_set_default_permissions( self, history, permissions=None, dataset=False, bypass_manage_permission=False ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def set_all_dataset_permissions( self, dataset, permissions, new=False ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def set_dataset_permission( self, dataset, permission ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def set_all_library_permissions( self, trans, dataset, permissions ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def set_library_item_permission( self, library_item, permission ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def library_is_public( self, library ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def make_library_public( self, library ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def get_accessible_libraries( self, trans, user ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def get_permitted_libraries( self, trans, user, actions ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def folder_is_public( self, library ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def make_folder_public( self, folder, count=0 ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def dataset_is_public( self, dataset ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def make_dataset_public( self, dataset ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def get_permissions( self, library_dataset ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def get_all_roles( self, trans, cntrller ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def get_legitimate_roles( self, trans, item, cntrller ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def derive_roles_from_access( self, trans, item_id, cntrller, library=False, **kwd ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def get_component_associations( self, **kwd ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def components_are_associated( self, **kwd ):
         return bool( self.get_component_associations( **kwd ) )
@@ -736,7 +736,7 @@ class GalaxyRBACAgent( RBACAgent ):
         if 'action' in kwd:
             if 'dataset' in kwd and 'role' in kwd:
                 return self.associate_action_dataset_role( kwd['action'], kwd['dataset'], kwd['role'] )
-        raise 'No valid method of associating provided components: %s' % kwd
+        raise Exception( 'No valid method of associating provided components: %s' % kwd )
 
     def associate_user_group( self, user, group ):
         assoc = self.model.UserGroupAssociation( user, group )
@@ -1300,7 +1300,7 @@ class GalaxyRBACAgent( RBACAgent ):
                         self.sa_session.add( lp )
                         self.sa_session.flush()
             else:
-                raise 'Invalid class (%s) specified for target_library_item (%s)' % \
+                raise Exception( 'Invalid class (%s) specified for target_library_item (%s)' % \ )
                     ( target_library_item.__class__, target_library_item.__class__.__name__ )
 
     def get_permitted_libraries( self, trans, user, actions ):
@@ -1435,7 +1435,7 @@ class GalaxyRBACAgent( RBACAgent ):
         elif 'group' in kwd:
             if 'role' in kwd:
                 return self.sa_session.query( self.model.GroupRoleAssociation ).filter_by( role_id=kwd['role'].id, group_id=kwd['group'].id ).first()
-        raise 'No valid method of associating provided components: %s' % kwd
+        raise Exception( 'No valid method of associating provided components: %s' % kwd )
 
     def check_folder_contents( self, user, roles, folder, hidden_folder_ids='' ):
         """
@@ -1567,7 +1567,7 @@ class HostAgent( RBACAgent ):
             log.debug( 'Allowing access to private dataset with hda: %i.  Remote server is: %s.' % ( hda.id, server ) )
             return True
         else:
-            raise 'The dataset access permission is the only valid permission in the host security agent.'
+            raise Exception( 'The dataset access permission is the only valid permission in the host security agent.' )
 
     def set_dataset_permissions( self, hda, user, site ):
         hdadaa = self.sa_session.query( self.model.HistoryDatasetAssociationDisplayAtAuthorization ) \

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -78,7 +78,7 @@ class DefaultToolAction( object ):
                             data = new_data
 
                 if not trans.app.security_agent.can_access_dataset( current_user_roles, data.dataset ):
-                    raise "User does not have permission to use a dataset (%s) provided for input." % data.id
+                    raise Exception( "User does not have permission to use a dataset (%s) provided for input." % data.id )
                 return data
             if isinstance( input, DataToolParameter ):
                 if isinstance( value, list ):

--- a/lib/galaxy/visualization/data_providers/genome.py
+++ b/lib/galaxy/visualization/data_providers/genome.py
@@ -1483,7 +1483,7 @@ class ENCODEPeakDataProvider( GenomeDataProvider ):
     """
 
     def get_iterator( self, data_file, chrom, start, end, **kwargs ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def process_data( self, iterator, start_val=0, max_vals=None, **kwargs ):
         """

--- a/lib/galaxy/webapps/galaxy/controllers/external_services.py
+++ b/lib/galaxy/webapps/galaxy/controllers/external_services.py
@@ -24,4 +24,4 @@ class ExternalServiceController( BaseUIController ):
             results = populated_action.handle_results( trans )
             return results
         else:
-            raise 'unknown item class type'
+            raise Exception( 'unknown item class type' )

--- a/lib/galaxy/webapps/tool_shed/security/__init__.py
+++ b/lib/galaxy/webapps/tool_shed/security/__init__.py
@@ -22,10 +22,10 @@ class RBACAgent:
     permitted_actions = Bunch()
 
     def associate_components( self, **kwd ):
-        raise 'No valid method of associating provided components: %s' % kwd
+        raise Exception( 'No valid method of associating provided components: %s' % kwd )
 
     def associate_user_role( self, user, role ):
-        raise 'No valid method of associating a user with a role'
+        raise Exception( 'No valid method of associating a user with a role' )
 
     def convert_permitted_action_strings( self, permitted_action_strings ):
         """
@@ -35,7 +35,7 @@ class RBACAgent:
         return filter( lambda x: x is not None, [ self.permitted_actions.get( action_string ) for action_string in permitted_action_strings ] )
 
     def create_private_user_role( self, user ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
     def get_action( self, name, default=None ):
         """Get a permitted action by its dict key or action name"""
@@ -49,10 +49,10 @@ class RBACAgent:
         return self.permitted_actions.__dict__.values()
 
     def get_item_actions( self, action, item ):
-        raise 'No valid method of retrieving action (%s) for item %s.' % ( action, item )
+        raise Exception( 'No valid method of retrieving action (%s) for item %s.' % ( action, item ) )
 
     def get_private_user_role( self, user ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
 
 class CommunityRBACAgent( RBACAgent ):
@@ -93,7 +93,7 @@ class CommunityRBACAgent( RBACAgent ):
                 return self.associate_group_role( kwd['group'], kwd['role'] )
         elif 'repository' in kwd:
             return self.associate_repository_category( kwd[ 'repository' ], kwd[ 'category' ] )
-        raise 'No valid method of associating provided components: %s' % kwd
+        raise Exception( 'No valid method of associating provided components: %s' % kwd )
 
     def associate_group_role( self, group, role ):
         assoc = self.model.GroupRoleAssociation( group, role )

--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -239,10 +239,10 @@ class RecipeStep( object ):
 
     def execute_step( self, tool_dependency, package_name, actions, action_dict, filtered_actions, env_file_builder,
                       install_environment, work_dir, current_dir=None, initial_download=False ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method")
 
     def prepare_step( self, tool_dependency, action_elem, action_dict, install_environment, is_binary_download ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
 
 class AssertDirectoryExecutable( RecipeStep ):

--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/tag_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/tag_handler.py
@@ -22,7 +22,7 @@ class RecipeTag( object ):
 
     def process_tag_set( self, tool_shed_repository, tool_dependency, package_elem, package_name, package_version,
                          from_tool_migration_manager=False, tool_dependency_db_records=None ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
 
 class SyncDatabase( object ):

--- a/lib/tool_shed/repository_types/metadata.py
+++ b/lib/tool_shed/repository_types/metadata.py
@@ -16,7 +16,7 @@ class Metadata( object ):
         return repo.changelog
 
     def is_valid_for_type( self, app, repository, revisions_to_check=None ):
-        raise "Unimplemented Method"
+        raise Exception( "Unimplemented Method" )
 
 
 class TipOnly( Metadata ):

--- a/tools/filters/axt_to_lav.py
+++ b/tools/filters/axt_to_lav.py
@@ -156,17 +156,16 @@ def read_lengths(fileName):
 
         fields = line.split()
         if len(fields) != 2:
-            raise "bad lengths line (%s:%d): %s" % (fileName, lineNumber, line)
+            raise Exception( "bad lengths line (%s:%d): %s" % (fileName, lineNumber, line) )
 
         chrom = fields[0]
         try:
             length = int(fields[1])
         except:
-            raise "bad lengths line (%s:%d): %s" % (fileName, lineNumber, line)
+            raise Exception( "bad lengths line (%s:%d): %s" % (fileName, lineNumber, line) )
 
         if chrom in chromToLength:
-            raise "%s appears more than once (%s:%d): %s" \
-                % (chrom, fileName, lineNumber)
+            raise Exception( "%s appears more than once (%s:%d): %s" % (chrom, fileName, lineNumber) )
 
         chromToLength[chrom] = length
 


### PR DESCRIPTION
The probable cause is that Python 2.7 does not support raising bare str exceptions anymore.
`TypeError: exceptions must be old-style classes or derived from BaseException, not str`

We might want to backport this to 16.04? Maybe just part of it that affects live code.

Found as a part of https://github.com/galaxyproject/galaxy/issues/2419
Happens on Main: https://sentry.galaxyproject.org/sentry/main/issues/115526/
