### PR TITLE
[16.04] Only scan the last 16 MB of a job's stderr for slurm memory warning messages

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -17,7 +17,7 @@ __all__ = [ 'SlurmJobRunner' ]
 SLURM_MEMORY_LIMIT_EXCEEDED_MSG = 'slurmstepd: error: Exceeded job memory limit'
 SLURM_MEMORY_LIMIT_EXCEEDED_PARTIAL_WARNINGS = [': Exceeded job memory limit at some point.',
                                                 ': Exceeded step memory limit at some point.']
-SLURM_MEMORY_LIMIT_SCAN_SIZE = 16 * 1024 * 1024 # 16MB
+SLURM_MEMORY_LIMIT_SCAN_SIZE = 16 * 1024 * 1024  # 16MB
 
 
 class SlurmJobRunner( DRMAAJobRunner ):


### PR DESCRIPTION
Otherwise the entire stderr is loaded into memory. This is a problem on Main where we have stderr files in excess of 100 GB (tools with malformed inputs that output an error message for every line of the input).

Ping @nsoranzo and @lparsons 
