### PR TITLE
Update Galaxy testing to target latest galaxy-lib.

### DIFF
--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -461,16 +461,19 @@ def __parse_test_attributes( output_elem, attrib, parse_elements=False ):
     for metadata_elem in output_elem.findall( 'metadata' ):
         metadata[ metadata_elem.get('name') ] = metadata_elem.get( 'value' )
     md5sum = attrib.get("md5", None)
+    checksum = attrib.get("checksum", None)
     element_tests = {}
     if parse_elements:
         element_tests = __parse_element_tests( output_elem )
 
-    if not (assert_list or file or extra_files or metadata or md5sum or element_tests):
-        raise Exception( "Test output defines nothing to check (e.g. must have a 'file' check against, assertions to check, metadata or md5 tests, etc...)")
+    has_checksum = md5sum or checksum
+    if not (assert_list or file or extra_files or metadata or has_checksum or element_tests):
+        raise Exception( "Test output defines nothing to check (e.g. must have a 'file' check against, assertions to check, metadata or checksum tests, etc...)")
     attributes['assert_list'] = assert_list
     attributes['extra_files'] = extra_files
     attributes['metadata'] = metadata
     attributes['md5'] = md5sum
+    attributes['checksum'] = checksum
     attributes['elements'] = element_tests
     return file, attributes
 

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -2,6 +2,7 @@
 
 import difflib
 import filecmp
+import hashlib
 import logging
 import os
 import re
@@ -18,15 +19,18 @@ DEFAULT_TEST_DATA_RESOLVER = TestDataResolver()
 
 
 def verify(
+    item_label,
     output_content,
     attributes,
     filename=None,
-    hid=None,
     get_filename=None,
     keep_outputs_dir=None,
     verify_extra_files=None,
 ):
-    """Verify the content of a test output using test definitions described by attributes."""
+    """Verify the content of a test output using test definitions described by attributes.
+
+    Throw an informative assertion error if any of these tests fail.
+    """
     if get_filename is None:
         get_filename = DEFAULT_TEST_DATA_RESOLVER.get_filename
 
@@ -36,17 +40,27 @@ def verify(
         try:
             verify_assertions(output_content, attributes["assert_list"])
         except AssertionError as err:
-            errmsg = 'History item %s different than expected\n' % (hid)
+            errmsg = '%s different than expected\n' % (item_label)
             errmsg += str( err )
             raise AssertionError( errmsg )
 
-    # Check md5sum...
+    # Verify checksum attributes...
+    # works with older Galaxy style md5=<expected_sum> or cwltest
+    # style checksum=<hash_type>$<hash>.
+    expected_checksum_type = None
+    expected_checksum = None
     if attributes is not None and attributes.get("md5", None) is not None:
-        md5 = attributes.get("md5")
+        expected_checksum_type = "md5"
+        expected_checksum = attributes.get("md5")
+    elif attributes is not None and attributes.get("checksum", None) is not None:
+        checksum_value = attributes.get("checksum", None)
+        expected_checksum_type, expected_checksum = checksum_value.split("$", 1)
+
+    if expected_checksum_type:
         try:
-            _verify_md5(output_content, md5)
+            _verify_checksum(output_content, expected_checksum_type, expected_checksum)
         except AssertionError as err:
-            errmsg = 'History item %s different than expected\n' % (hid)
+            errmsg = '%s different than expected\n' % (item_label)
             errmsg += str( err )
             raise AssertionError( errmsg )
 
@@ -86,7 +100,7 @@ def verify(
                 s1 = len(output_content)
                 s2 = os.path.getsize(local_name)
                 if abs(s1 - s2) > int(delta):
-                    raise Exception( 'Files %s=%db but %s=%db - compare (delta=%s) failed' % (temp_name, s1, local_name, s2, delta) )
+                    raise AssertionError( 'Files %s=%db but %s=%db - compare by size (delta=%s) failed' % (temp_name, s1, local_name, s2, delta) )
             elif compare == "contains":
                 files_contains( local_name, temp_name, attributes=attributes )
             else:
@@ -96,7 +110,7 @@ def verify(
                 if extra_files:
                     verify_extra_files(extra_files)
         except AssertionError as err:
-            errmsg = 'History item %s different than expected, difference (using %s):\n' % ( hid, compare )
+            errmsg = '%s different than expected, difference (using %s):\n' % ( item_label, compare )
             errmsg += "( %s v. %s )\n" % ( local_name, temp_name )
             errmsg += str( err )
             raise AssertionError( errmsg )
@@ -124,15 +138,17 @@ def _bam_to_sam(local_name, temp_name):
     return temp_local, temp_temp
 
 
-def _verify_md5(data, expected_md5):
-    import md5
-    m = md5.new()
-    m.update( data )
-    actual_md5 = m.hexdigest()
-    if expected_md5 != actual_md5:
-        template = "Output md5sum [%s] does not match expected [%s]."
-        message = template % (actual_md5, expected_md5)
-        assert False, message
+def _verify_checksum(data, checksum_type, expected_checksum_value):
+    if checksum_type not in ["md5", "sha1", "sha256", "sha512"]:
+        raise Exception("Unimplemented hash algorithm [%s] encountered." % checksum_type)
+
+    h = hashlib.new(checksum_type)
+    h.update( data )
+    actual_checksum_value = h.hexdigest()
+    if expected_checksum_value != actual_checksum_value:
+        template = "Output checksum [%s] does not match expected [%s] (using hash algorithm %s)."
+        message = template % (actual_checksum_value, expected_checksum_value, checksum_type)
+        raise AssertionError(message)
 
 
 def check_command(command, description):

--- a/test/base/twilltestcase.py
+++ b/test/base/twilltestcase.py
@@ -2073,17 +2073,18 @@ class TwillTestCase( unittest.TestCase ):
             return self.get_filename(test_filename, shed_tool_id=shed_tool_id)
 
         data = dataset_fetcher( hda_id, base_name )
+        item_label = "History item %s" % hda_id
         try:
             verify(
+                item_label,
                 data,
                 attributes=attributes,
                 filename=file_name,
-                hid=hda_id,
                 get_filename=get_filename,
                 keep_outputs_dir=self.keepOutdir,
             )
         except AssertionError, err:
-            errmsg = 'Composite file (%s) of History item %s different than expected, difference:\n' % ( base_name, hda_id )
+            errmsg = 'Composite file (%s) of %s different than expected, difference:\n' % ( base_name, item_label )
             errmsg += str( err )
             raise AssertionError( errmsg )
 
@@ -2142,11 +2143,12 @@ class TwillTestCase( unittest.TestCase ):
             self.verify_extra_files_content(extra_files, hda_id, shed_tool_id=shed_tool_id, dataset_fetcher=dataset_fetcher)
 
         data = dataset_fetcher( hda_id )
+        item_label = "History item %s" % hid
         verify(
+            item_label,
             data,
             attributes=attributes,
             filename=filename,
-            hid=hid,
             get_filename=get_filename,
             keep_outputs_dir=self.keepOutdir,
             verify_extra_files=verify_extra_files,

--- a/test/functional/tools/checksum.xml
+++ b/test/functional/tools/checksum.xml
@@ -1,0 +1,17 @@
+<tool id="checksum" name="checksum" version="1.0.0">
+    <command>
+        cp $input $output
+    </command>
+    <inputs>
+        <param name="input" type="data" format="txt" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="simple_line.txt" />
+            <output name="out_file1" checksum="sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041" />
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -28,6 +28,7 @@
   <tool file="strict_shell_default_off.xml" />
   <tool file="detect_errors_aggressive.xml" />
   <tool file="md5sum.xml" />
+  <tool file="checksum.xml" />
   <!--
   TODO: Figure out why this transiently fails on Jenkins.
   <tool file="maxseconds.xml" />


### PR DESCRIPTION
Incorporates https://github.com/galaxyproject/galaxy-lib/pull/10 which modifies the interface to the test output verification code to allow reuse from within Planemo in both non-tool and non-Galaxy contexts. I also think this represents a better separation of concerns.

One upshot of this is that CWL-style checksum verification is now possible from within Galaxy tools - a test case of this is included.
