### PR TITLE
[16.04] Relax validation condition for dynamic parameters

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -894,7 +894,11 @@ class SelectToolParameter( ToolParameter ):
 
     def from_json( self, value, trans, other_values={} ):
         legal_values = self.get_legal_values( trans, other_values )
-        if len(list(legal_values)) == 0 and trans.workflow_building_mode:
+        workflow_building_mode = trans.workflow_building_mode
+        for context_value in other_values.itervalues():
+            if isinstance( context_value, RuntimeValue ):
+                workflow_building_mode = True
+        if len( list( legal_values ) ) == 0 and workflow_building_mode:
             if self.multiple:
                 # While it is generally allowed that a select value can be '',
                 # we do not allow this to be the case in a dynamically

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -898,6 +898,7 @@ class SelectToolParameter( ToolParameter ):
         for context_value in other_values.itervalues():
             if isinstance( context_value, RuntimeValue ):
                 workflow_building_mode = True
+                break
         if len( list( legal_values ) ) == 0 and workflow_building_mode:
             if self.multiple:
                 # While it is generally allowed that a select value can be '',

--- a/test/unit/tools/test_select_parameters.py
+++ b/test/unit/tools/test_select_parameters.py
@@ -33,7 +33,7 @@ class SelectToolParameterTestCase( BaseParameterTestCase ):
     def test_validated_datasets( self ):
         self.options_xml = '''<options><filter type="data_meta" ref="input_bam" key="dbkey"/></options>'''
         try:
-            self.param.from_json( model.HistoryDatasetAssociation(), self.trans, { "input_bam": basic.RuntimeValue() } )
+            self.param.from_json( model.HistoryDatasetAssociation(), self.trans, { "input_bam": None } )
         except ValueError, err:
             assert str(err) == "Parameter my_name requires a value, but has no legal values defined."
             return


### PR DESCRIPTION
Fixes #2435. This PR relaxes the validation condition such that it does not validate dynamic values if the select options are empty and putative reference values are missing from the context state. This issue has to be revisited before 16.07 since the underlying issue is how module states are injected before workflow execution in 16.04 and 15.10.
