### PR TITLE
Fix usage of super() in the mothur datatypes.

### DIFF
--- a/lib/galaxy/datatypes/mothur.py
+++ b/lib/galaxy/datatypes/mothur.py
@@ -136,10 +136,6 @@ class GroupAbund(Otu):
     def __init__(self, **kwd):
         super(GroupAbund, self).__init__(**kwd)
 
-    """
-    def init_meta(self, dataset, copy_from=None):
-        Otu.init_meta(self, dataset, copy_from=copy_from)
-    """
     def init_meta(self, dataset, copy_from=None):
         super(GroupAbund, self).init_meta(dataset, copy_from=copy_from)
 
@@ -299,7 +295,7 @@ class DistanceMatrix(Text):
     MetadataElement(name="sequence_count", default=0, desc="Number of sequences", readonly=True, visible=True, optional=True, no_value='?')
 
     def init_meta(self, dataset, copy_from=None):
-        super(DistanceMatrix, self).init_meta(self, dataset, copy_from=copy_from)
+        super(DistanceMatrix, self).init_meta(dataset, copy_from=copy_from)
 
     def set_meta(self, dataset, overwrite=True, skip=0, **kwd):
         super(DistanceMatrix, self).set_meta(dataset, overwrite=overwrite, skip=skip, **kwd)
@@ -384,7 +380,7 @@ class SquareDistanceMatrix(DistanceMatrix):
         super(SquareDistanceMatrix, self).__init__(**kwd)
 
     def init_meta(self, dataset, copy_from=None):
-        super(SquareDistanceMatrix, self).init_meta(self, dataset, copy_from=copy_from)
+        super(SquareDistanceMatrix, self).init_meta(dataset, copy_from=copy_from)
 
     def sniff(self, filename):
         """


### PR DESCRIPTION
This should fix the few falling test from the mothur wrappers:

```
Traceback (most recent call last):
  File "/home/bag/projects/code/galaxy/lib/galaxy/tools/parameters/output_collect.py", line 63, in collect_dynamic_collections
    output_collection_def,
  File "/home/bag/projects/code/galaxy/lib/galaxy/tools/parameters/output_collect.py", line 131, in populate_collection_elements
    metadata_source_name=output_collection_def.metadata_source,
  File "/home/bag/projects/code/galaxy/lib/galaxy/tools/parameters/output_collect.py", line 206, in create_dataset
    primary_data.init_meta()
  File "/home/bag/projects/code/galaxy/lib/galaxy/model/__init__.py", line 1979, in init_meta
    return self.datatype.init_meta( self, copy_from=copy_from )
  File "/home/bag/projects/code/galaxy/lib/galaxy/datatypes/mothur.py", line 302, in init_meta
    super(DistanceMatrix, self).init_meta(self, dataset, copy_from=copy_from)
TypeError: init_meta() got multiple values for keyword argument 'copy_from'
```
