### PR TITLE
[16.04] Delay import of DrmaaSessionFactory after runner initialization

### DIFF
--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -15,7 +15,6 @@ from galaxy.jobs import JobDestination
 from galaxy.jobs.handler import DEFAULT_JOB_PUT_FAILURE_MESSAGE
 from galaxy.jobs.runners import AsynchronousJobState, AsynchronousJobRunner
 from galaxy.util import asbool
-from pulsar.managers.util.drmaa import DrmaaSessionFactory
 
 drmaa = None
 
@@ -62,6 +61,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
                                 'feature, please install it or correct the '
                                 'following error:\n%s: %s' %
                                 (exc.__class__.__name__, str(exc)))
+        from pulsar.managers.util.drmaa import DrmaaSessionFactory
 
         # Subclasses may need access to state constants
         self.drmaa_job_states = drmaa.JobState


### PR DESCRIPTION
Fix issue #2463, i.e. the regression introduced in #2102 by which Galaxy no longer respects `<param id="drmaa_library_path">` in `config/job_conf.xml` , preventing the use of multiple drmaa runners.

Ping @natefoo @jmchilton.
