### PR TITLE
[16.01] Fix move_directory_files tool dependency action when new_file_path is on a different filesystem

### DIFF
--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -848,22 +848,10 @@ class MoveDirectoryFiles( RecipeStep ):
     def move_directory_files( self, current_dir, source_dir, destination_dir ):
         source_directory = os.path.abspath( os.path.join( current_dir, source_dir ) )
         destination_directory = os.path.join( destination_dir )
-        if not os.path.isdir( destination_directory ):
-            os.makedirs( destination_directory )
-        symlinks = []
-        regular_files = []
-        for file_name in os.listdir( source_directory ):
-            source_file = os.path.join( source_directory, file_name )
-            destination_file = os.path.join( destination_directory, file_name )
-            files_tuple = ( source_file, destination_file )
-            if os.path.islink( source_file ):
-                symlinks.append( files_tuple )
-            else:
-                regular_files.append( files_tuple )
-        for source_file, destination_file in symlinks:
-            shutil.move( source_file, destination_file )
-        for source_file, destination_file in regular_files:
-            shutil.move( source_file, destination_file )
+        destination_parent_directory = os.path.dirname(destination_directory)
+        if not os.path.isdir( destination_parent_directory ):
+            os.makedirs( destination_parent_directory )
+        shutil.move( source_directory, destination_directory )
 
     def prepare_step( self, tool_dependency, action_elem, action_dict, install_environment, is_binary_download ):
         # <action type="move_directory_files">

--- a/lib/tool_shed/util/basic_util.py
+++ b/lib/tool_shed/util/basic_util.py
@@ -89,13 +89,11 @@ def get_file_type_str( changeset_revision, file_type ):
 
 def move_file( current_dir, source, destination, rename_to=None ):
     source_path = os.path.abspath( os.path.join( current_dir, source ) )
-    source_file = os.path.basename( source_path )
+    destination_directory = os.path.join( destination )
     if rename_to is not None:
-        destination_file = rename_to
-        destination_directory = os.path.join( destination )
-        destination_path = os.path.join( destination_directory, destination_file )
+        destination_path = os.path.join( destination_directory, rename_to )
     else:
-        destination_directory = os.path.join( destination )
+        source_file = os.path.basename( source_path )
         destination_path = os.path.join( destination_directory, source_file )
     if not os.path.exists( destination_directory ):
         os.makedirs( destination_directory )


### PR DESCRIPTION
Move the whole directory instead of element by element. Fix #1947.
Also refactor `move_file()` method.

Ping @lparsons and @JJAlmagro, can you please test this patch (the changes to `lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py` are enough)?
