### PR TITLE
Set a default for tool_dependencies_dir.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -168,9 +168,10 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # the tool shed to install dependencies and can also be used by administrators
 # to manually install or link to dependencies.  For details, see:
 #   https://wiki.galaxyproject.org/Admin/Config/ToolDependencies
-# If this option is not set to a valid path, installing tools with dependencies
-# from the Tool Shed will fail.
-#tool_dependency_dir = None
+# Set to the string none to explicitly disable tool dependency handling.
+# If this option is set to none or an invalid path, installing tools with dependencies
+# from the Tool Shed will fail. 
+#tool_dependency_dir = database/dependencies
 
 # The dependency resolves config file specifies an ordering and options for how
 # Galaxy resolves tool dependencies (requirement tags in Tool XML). The default

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -311,8 +311,13 @@ class Configuration( object ):
         self.tool_help_boost = kwargs.get( "tool_help_boost", 0.5 )
         self.tool_search_limit = kwargs.get( "tool_search_limit", 20 )
         # Location for tool dependencies.
-        if 'tool_dependency_dir' in kwargs:
-            self.tool_dependency_dir = resolve_path( kwargs.get( "tool_dependency_dir" ), self.root )
+        # Location for tool dependencies.
+        tool_dependency_dir = kwargs.get( "tool_dependency_dir", "database/dependencies" )
+        if tool_dependency_dir.lower() == "none":
+            tool_dependency_dir = None
+
+        if tool_dependency_dir is not None:
+            self.tool_dependency_dir = resolve_path( tool_dependency_dir, self.root )
             # Setting the following flag to true will ultimately cause tool dependencies
             # to be located in the shell environment and used by the job that is executing
             # the tool.


### PR DESCRIPTION
This should make some obsecure errors less easy to encounter and makes it less work to get going with conda or the Tool Shed.
