### PR TITLE
mothur datatypes: don't generate error for pairwise distance matrices

### DIFF
--- a/lib/galaxy/datatypes/mothur.py
+++ b/lib/galaxy/datatypes/mothur.py
@@ -307,7 +307,8 @@ class DistanceMatrix(Text):
                     dataset.metadata.sequence_count = int(''.join(line))  # seq count sometimes preceded by tab
                     break
                 except Exception as e:
-                    log.warning("DistanceMatrix set_meta %s" % e)
+                    if not isinstance(self, PairwiseDistanceMatrix):
+                        log.warning("DistanceMatrix set_meta %s" % e)
 
 
 class LowerTriangleDistanceMatrix(DistanceMatrix):


### PR DESCRIPTION
pairwise distance matrices don't (always) have the number of sequences on the first line, so don't generate an error

ping @bgruening (without this some of the mothur tests will still fail)
