### PR TITLE
[16.04] Allow disabling separating tools commands into their own script.

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -87,7 +87,7 @@
                higher value (in seconds) (or `None` to use blocking connections). -->
           <!-- <param id="amqp_consumer_timeout">None</param> -->
         </plugin>
-        <plugin id="pulsar_legacy" type="runner" load="galaxy.jobs.runners.pulsar:PulsarLegacyJobRunner">
+        <plugin id="pulsar_legacy" type="runner" load="galaxy.jobs.runners.pulsar:PulsarLegacyJobRunner" shell="none">
           <!-- Pulsar job runner with default parameters matching those
                of old LWR job runner. If your Pulsar server is running on a
                Windows machine for instance this runner should still be used.

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -104,7 +104,7 @@ def __externalize_commands(job_wrapper, shell, commands_builder, remote_command_
     config = job_wrapper.app.config
     integrity_injection = ""
     # Setting shell to none in job_conf.xml disables creating a tool command script,
-    # set -e doesn't work for composite commands but this is nessecary for Windows jobs
+    # set -e doesn't work for composite commands but this is necessary for Windows jobs
     # for instance.
     if shell and shell.lower() == 'none':
         return tool_commands

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -103,6 +103,11 @@ def __externalize_commands(job_wrapper, shell, commands_builder, remote_command_
     tool_commands = commands_builder.build()
     config = job_wrapper.app.config
     integrity_injection = ""
+    # Setting shell to none in job_conf.xml disables creating a tool command script,
+    # set -e doesn't work for composite commands but this is nessecary for Windows jobs
+    # for instance.
+    if shell and shell.lower() == 'none':
+        return tool_commands
     if check_script_integrity(config):
         integrity_injection = INTEGRITY_INJECTION
     set_e = ""


### PR DESCRIPTION
Forcing them there broke Pulsar-on-Windows functionality - this fix is courtesy of @jj-umn.

This is reopening #2483 against the correct branch (thanks for the catch @martenson).
