### PR TITLE
Toolbox filter fixes

### DIFF
--- a/lib/galaxy/tools/toolbox/filters/__init__.py
+++ b/lib/galaxy/tools/toolbox/filters/__init__.py
@@ -55,13 +55,13 @@ class FilterFactory( object ):
     def __init_filters( self, key, filters, toolbox_filters, validate=None ):
         for filter in filters:
             if validate is None or filter in validate or filter in self.default_filters:
-                filter_function = self.__build_filter_function( filter )
+                filter_function = self._build_filter_function( filter )
                 toolbox_filters[ key ].append( filter_function )
             else:
                 log.warning( "Refusing to load %s filter '%s' which is not defined in config", key, filter )
         return toolbox_filters
 
-    def __build_filter_function( self, filter_name ):
+    def _build_filter_function( self, filter_name ):
         """Obtain python function (importing a submodule if needed)
         corresponding to filter_name.
         """

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -1349,12 +1349,6 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
     def edit_toolbox_filters( self, trans, cntrller, **kwd ):
         params = util.Params( kwd )
         message = util.restore_text( params.get( 'message', '' ) )
-        user_id = params.get( 'user_id', False )
-        if not user_id:
-            # User must be logged in to create a new address
-            return trans.show_error_message( "You must be logged in to change the ToolBox filters." )
-
-        user = trans.sa_session.query( trans.app.model.User ).get( trans.security.decode_id( user_id ) )
 
         if params.get( 'edit_toolbox_filter_button', False ):
             tool_filters = list()
@@ -1368,11 +1362,11 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
                         label_filters.append( name[2:] )
                     elif name.startswith('s_'):
                         section_filters.append( name[2:] )
-            user.preferences['toolbox_tool_filters'] = ','.join( tool_filters )
-            user.preferences['toolbox_section_filters'] = ','.join( section_filters )
-            user.preferences['toolbox_label_filters'] = ','.join( label_filters )
+            trans.user.preferences['toolbox_tool_filters'] = ','.join( tool_filters )
+            trans.user.preferences['toolbox_section_filters'] = ','.join( section_filters )
+            trans.user.preferences['toolbox_label_filters'] = ','.join( label_filters )
 
-            trans.sa_session.add( user )
+            trans.sa_session.add( trans.user )
             trans.sa_session.flush()
             message = 'ToolBox filters has been updated.'
             kwd = dict( message=message, status='done' )


### PR DESCRIPTION
Firstly, fixes the ability for users to toggle their filters -- As far as I can tell there's no reason to require a user_id here since it's locked to trans and require_login is set.  This is not something admins have any interface to toggle on behalf of a user, and nothing seems to set the user_id field.
