### PR TITLE
[16.04] Bump Pulsar client lib version number and add timeout options to Pulsar runner

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -43,7 +43,7 @@ anyjson==0.3.3
 
 # Pulsar requirements
 psutil==4.1.0
-pulsar-galaxy-lib==0.7.0.dev4
+pulsar-galaxy-lib==0.7.0.dev5
 
 # sqlalchemy-migrate and dependencies
 sqlalchemy-migrate==0.10.0


### PR DESCRIPTION
Fixes a timeout bug that kills the handlers on usegalaxy.org. Pulsar side of the fix was at galaxyproject/pulsar#115
