### PR TITLE
Fix two errors in sff_extract.py detected by flake8

### DIFF
--- a/tools/filters/sff_extract.py
+++ b/tools/filters/sff_extract.py
@@ -231,7 +231,7 @@ def sequences(fileh, header):
     while True:
         if fposition == header['index_offset']:
             # we have to skip the index section
-            fposition += index_length
+            fposition += header['index_length']
             continue
         else:
             bytes_read, seq_data = read_sequence(header=header, fileh=fileh,
@@ -276,7 +276,7 @@ def remove_last_xmltag_in_file(fname, tag=None):
 
     # we check that we're removing the asked tag
     if tag is not None and tag != last_tag:
-        etxt = join('The given xml tag (', tag, ') was not the last one in the file')
+        etxt = 'The given xml tag (%s) was not the last one in the file' % tag
         raise RuntimeError(etxt)
 
     # while we are at it: also remove all white spaces in that line :-)


### PR DESCRIPTION
Either of these code paths would have thrown an exception and failed prior to this.

I'm not 100% confident on the index_length intent, but it seems reasonable (and certainly doesn't break any worse)
