### PR TITLE
[16.01] Fix move_directory_files tool dependency action when destination is not empty

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/__init__.py
+++ b/lib/galaxy/jobs/runners/util/job_script/__init__.py
@@ -4,6 +4,7 @@ import subprocess
 import time
 from pkg_resources import resource_string
 
+from six import text_type
 from galaxy.util import unicodify
 
 DEFAULT_SHELL = '/bin/sh'
@@ -96,7 +97,7 @@ def check_script_integrity(config):
 
 def write_script(path, contents, config, mode=0o755):
     with open(path, 'w') as f:
-        if isinstance(contents, unicode):
+        if isinstance(contents, text_type):
             contents = contents.encode("UTF-8")
         f.write(contents)
     os.chmod(path, mode)

--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -847,11 +847,17 @@ class MoveDirectoryFiles( RecipeStep ):
 
     def move_directory_files( self, current_dir, source_dir, destination_dir ):
         source_directory = os.path.abspath( os.path.join( current_dir, source_dir ) )
-        destination_directory = os.path.join( destination_dir )
-        destination_parent_directory = os.path.dirname(destination_directory)
-        if not os.path.isdir( destination_parent_directory ):
-            os.makedirs( destination_parent_directory )
-        shutil.move( source_directory, destination_directory )
+        destination_directory = os.path.abspath(os.path.join(destination_dir))
+        if not os.path.isdir(destination_directory):
+            os.makedirs(destination_directory)
+        for dir_entry in os.listdir(source_directory):
+            source_entry = os.path.join(source_directory, dir_entry)
+            if os.path.islink(source_entry):
+                destination_entry = os.path.join(destination_directory, dir_entry)
+                os.symlink(os.readlink(source_entry), destination_entry)
+                os.remove(source_entry)
+            else:
+                shutil.move(source_entry, destination_directory)
 
     def prepare_step( self, tool_dependency, action_elem, action_dict, install_environment, is_binary_download ):
         # <action type="move_directory_files">


### PR DESCRIPTION
Historically this action moves the contents of the source directory to the destination directory. Commit d38936b broke the install when e.g. the destination is `$INSTALL_DIR`, which is created by Galaxy and is not empty (contains `INSTALLATION.log` after first action).

Thanks @lparsons for reporting. Can you please test this?
