### PR TITLE
Fix tabular display chunking

### DIFF
--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -56,13 +56,16 @@ class TabularData( data.Text ):
     def get_chunk(self, trans, dataset, chunk):
         ck_index = int(chunk)
         f = open(dataset.file_name)
+        t_start = (ck_index * trans.app.config.display_chunk_size)
         f.seek(ck_index * trans.app.config.display_chunk_size)
         # If we aren't at the start of the file, seek to next newline.  Do this better eventually.
         if f.tell() != 0:
             cursor = f.read(1)
             while cursor and cursor != '\n':
                 cursor = f.read(1)
-        ck_data = f.read(trans.app.config.display_chunk_size)
+        t_firstnewline = f.tell()
+        t_skipped = t_firstnewline - t_start
+        ck_data = f.read(trans.app.config.display_chunk_size - (t_skipped))
         cursor = f.read(1)
         while cursor and ck_data[-1] != '\n':
             ck_data += cursor

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -56,16 +56,18 @@ class TabularData( data.Text ):
     def get_chunk(self, trans, dataset, chunk):
         ck_index = int(chunk)
         f = open(dataset.file_name)
-        t_start = (ck_index * trans.app.config.display_chunk_size)
-        f.seek(ck_index * trans.app.config.display_chunk_size)
+        initial_offset = (ck_index * trans.app.config.display_chunk_size)
+        f.seek(initial_offset)
         # If we aren't at the start of the file, seek to next newline.  Do this better eventually.
         if f.tell() != 0:
             cursor = f.read(1)
             while cursor and cursor != '\n':
                 cursor = f.read(1)
-        t_firstnewline = f.tell()
-        t_skipped = t_firstnewline - t_start
-        ck_data = f.read(trans.app.config.display_chunk_size - (t_skipped))
+        read_start_offset = f.tell()
+        prechunk_skip = read_start_offset - initial_offset
+        # We subtract the prechunk skip out of the primary chunk read to avoid
+        # shifting the chunk tail onto a line it shouldn't have.
+        ck_data = f.read(trans.app.config.display_chunk_size - prechunk_skip)
         cursor = f.read(1)
         while cursor and ck_data[-1] != '\n':
             ck_data += cursor


### PR DESCRIPTION
…Skipping to the newline previously shifted the chunk past where it should read, so we subtract the skip difference from the chunk size.

This resolves https://biostar.usegalaxy.org/p/18001/
