### PR TITLE
[WIP] Make uwsgi the default web server in Galaxy.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -26,7 +26,7 @@
 # The address and port on which to listen.  By default, only listen to
 # localhost (Galaxy will not be accessible over the network).  Use '0.0.0.0' to
 # listen on all available network interfaces.
-http = 127.0.0.1:8080
+http-socket = 127.0.0.1:8080
 
 # Number of threads in the web server thread pool.
 threads = 8
@@ -35,8 +35,19 @@ threads = 8
 static-map = /static=./static
 static-map = /static/style=./static/style/blue
 
-[server:main]
+# Routing for proxy (e.g. interactive environments)
+route-uri = ^/proxy/ goto:proxy
+route = .* last: 
 
+route-label = proxy 
+route-run = rpcvar:TARGET_HOST galaxy_dynamic_proxy_mapper ${HTTP_HOST} ${cookie[galaxysession]}
+route-run = log:Proxy ${HTTP_HOST} to ${TARGET_HOST}
+## route-run = addheader:Access-Control-Allow-Origin *
+## route-run = addheader:Access-Control-Allow-Credentials true
+route-run = httpdumb:${TARGET_HOST}
+
+http-websockets = True
+offload-threads = 8
 
 # ---- Filters --------------------------------------------------------------
 

--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -21,30 +21,22 @@
 
 # Configuration of the internal HTTP server.
 
-[server:main]
+[uwsgi]
 
-# The internal HTTP server to use.  Currently only Paste is provided.  This
-# option is required.
-use = egg:Paste#http
-
-# The port on which to listen.
-#port = 8080
-
-# The address on which to listen.  By default, only listen to localhost (Galaxy
-# will not be accessible over the network).  Use '0.0.0.0' to listen on all
-# available network interfaces.
-#host = 127.0.0.1
-
-# Use a threadpool for the web server instead of creating a thread for each
-# request.
-use_threadpool = True
+# The address and port on which to listen.  By default, only listen to
+# localhost (Galaxy will not be accessible over the network).  Use '0.0.0.0' to
+# listen on all available network interfaces.
+http = 127.0.0.1:8080
 
 # Number of threads in the web server thread pool.
-#threadpool_workers = 10
+threads = 8
 
-# Set the number of seconds a thread can work before you should kill it
-# (assuming it will never finish) to 3 hours.  Default is 600 (10 minutes).
-threadpool_kill_thread_limit = 10800
+# Locations of static files, can be modified, e.g. to use custom styles. 
+static-map = /static=./static
+static-map = /static/style=./static/style/blue
+
+[server:main]
+
 
 # ---- Filters --------------------------------------------------------------
 

--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -26,7 +26,7 @@
 # The address and port on which to listen.  By default, only listen to
 # localhost (Galaxy will not be accessible over the network).  Use '0.0.0.0' to
 # listen on all available network interfaces.
-http-socket = 127.0.0.1:8080
+http = 127.0.0.1:8080
 
 # Number of threads in the web server thread pool.
 threads = 8
@@ -46,7 +46,8 @@ route-run = log:Proxy ${HTTP_HOST} to ${TARGET_HOST}
 ## route-run = addheader:Access-Control-Allow-Credentials true
 route-run = httpdumb:${TARGET_HOST}
 
-http-websockets = True
+# Required for websockets / proxy
+http-raw-body = True
 offload-threads = 8
 
 # ---- Filters --------------------------------------------------------------

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -30,13 +30,14 @@ log = logging.getLogger( __name__ )
 # The uwsgi module is automatically injected by the parent uwsgi
 # process and only exists that way.  If anything works, this is a
 # uwsgi-managed process.
+process_is_uwsgi = False
 try:
     import uwsgi
-    if uwsgi.numproc:
+    if hasattr( uwsgi, "numproc" ):
         process_is_uwsgi = True
 except ImportError:
     # This is not a uwsgi process, or something went horribly wrong.
-    process_is_uwsgi = False
+    pass
 
 
 def resolve_path( path, root ):

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -6,7 +6,7 @@ SQLAlchemy==1.0.8
 mercurial==3.7.3
 numpy==1.9.2
 pycrypto==2.6.1
-## pyuwsgi==2.0.13.1
+pyuwsgi==2.1.dev0+gx1.c6ee1f6
 
 # Install python_lzo if you want to support indexed access to lzo-compressed
 # locally cached maf files via bx-python

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -6,6 +6,7 @@ SQLAlchemy==1.0.8
 mercurial==3.7.3
 numpy==1.9.2
 pycrypto==2.6.1
+## pyuwsgi==2.0.13.1
 
 # Install python_lzo if you want to support indexed access to lzo-compressed
 # locally cached maf files via bx-python

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -59,23 +59,9 @@ class InteractiveEnvironmentRequest(object):
                 log.error( "Could not change permissions of tmpdir %s" % self.temp_dir )
                 # continue anyway
 
-        # This duplicates the logic in the proxy manager
-        if self.attr.galaxy_config.dynamic_proxy_external_proxy:
-            self.attr.proxy_prefix = '/'.join(
-                (
-                    '',
-                    self.attr.galaxy_config.cookie_path.strip('/'),
-                    self.attr.galaxy_config.dynamic_proxy_prefix.strip('/'),
-                    self.attr.viz_id,
-                )
-            )
-        else:
-            self.attr.proxy_prefix = ''
-        # If cookie_path is unset (thus '/'), the proxy prefix ends up with
-        # multiple leading '/' characters, which will cause the client to
-        # request resources from http://dynamic_proxy_prefix
-        if self.attr.proxy_prefix.startswith('/'):
-            self.attr.proxy_prefix = '/' + self.attr.proxy_prefix.lstrip('/')
+        # This is maybe a HACK, are there circumstances in which this should
+        # be configurable?
+        self.attr.proxy_prefix = "/proxy"
 
     def load_allowed_images(self):
         if os.path.exists(os.path.join(self.attr.our_config_dir, 'allowed_images.yml')):

--- a/lib/galaxy/web/proxy/__init__.py
+++ b/lib/galaxy/web/proxy/__init__.py
@@ -18,46 +18,38 @@ SECURE_COOKIE = "galaxysession"
 # Randomly generate a password every launch
 
 
+# TODO: Use the main Galaxy database or something that scales across nodes, 
+#       not sqlite.
+
 class ProxyManager(object):
 
     def __init__( self, config ):
-        for option in ["manage_dynamic_proxy", "dynamic_proxy_bind_port",
-                       "dynamic_proxy_bind_ip", "dynamic_proxy_debug",
-                       "dynamic_proxy_external_proxy", "dynamic_proxy_prefix",
-                       "proxy_session_map",
-                       "dynamic_proxy", "cookie_path",
-                       "dynamic_proxy_golang_noaccess",
-                       "dynamic_proxy_golang_clean_interval",
-                       "dynamic_proxy_golang_docker_address",
-                       "dynamic_proxy_golang_api_key"]:
-
+        for option in [ "proxy_session_map" ]: 
             setattr( self, option, getattr( config, option ) )
-
-        if self.manage_dynamic_proxy:
-            self.lazy_process = self.__setup_lazy_process( config )
-        else:
-            self.lazy_process = NoOpLazyProcess()
-
-        if self.dynamic_proxy_golang_api_key is None:
-            self.dynamic_proxy_golang_api_key = unique_id()
-
-        self.proxy_ipc = proxy_ipc(config)
+        # Register lookup function with uwsgi (defined here to capture 
+        # configuration)
+        proxy_session_map = self.proxy_session_map
+        def dynamic_proxy_mapper(hostname, galaxy_session):
+            db_conn = sqlite.connect( proxy_session_map )
+            if galaxy_session:
+                # Order by rowid gives us the last row added
+                row = db_conn.execute( "select key, secret from gxproxy where secret=? order by rowid desc limit 1", ( galaxy_session, ) ).fetchone()
+                if row:
+                    return row[0].encode()
+                # No match for session found
+                return None
+        import uwsgi
+        uwsgi.register_rpc('galaxy_dynamic_proxy_mapper', dynamic_proxy_mapper)
 
     def shutdown( self ):
-        self.lazy_process.shutdown()
+        pass
 
     def setup_proxy( self, trans, host=DEFAULT_PROXY_TO_HOST, port=None, proxy_prefix="", route_name="", container_ids=None ):
-        if self.manage_dynamic_proxy:
-            log.info("Attempting to start dynamic proxy process")
-            log.debug("Cmd: " + ' '.join(self.lazy_process.command_and_args))
-            self.lazy_process.start_process()
-
         if container_ids is None:
             container_ids = []
-
         authentication = AuthenticationToken(trans)
         proxy_requests = ProxyRequests(host=host, port=port)
-        self.proxy_ipc.handle_requests(
+        self.handle_requests(
             authentication,
             proxy_requests,
             '/%s' % route_name,
@@ -66,145 +58,15 @@ class ProxyManager(object):
         # TODO: These shouldn't need to be request.host and request.scheme -
         # though they are reasonable defaults.
         host = trans.request.host
-        if ':' in host:
-            host = host[0:host.index(':')]
+        ## if ':' in host:
+        ##     host = host[0:host.index(':')]
         scheme = trans.request.scheme
-        if not self.dynamic_proxy_external_proxy:
-            proxy_url = '%s://%s:%d' % (scheme, host, self.dynamic_proxy_bind_port)
-        else:
-            proxy_url = '%s://%s%s' % (scheme, host, proxy_prefix)
+        proxy_url = '%s://%s%s' % (scheme, host, proxy_prefix)
         return {
             'proxy_url': proxy_url,
             'proxied_port': proxy_requests.port,
             'proxied_host': proxy_requests.host,
         }
-
-    def __setup_lazy_process( self, config ):
-        launcher = self.proxy_launcher()
-        command = launcher.launch_proxy_command(config)
-        return LazyProcess(command)
-
-    def proxy_launcher(self):
-        if self.dynamic_proxy == "node":
-            return NodeProxyLauncher()
-        elif self.dynamic_proxy == "golang":
-            return GolangProxyLauncher()
-        else:
-            raise Exception("Unknown proxy type")
-
-
-class ProxyLauncher(object):
-
-    def launch_proxy_command(self, config):
-        raise NotImplementedError()
-
-
-class NodeProxyLauncher(object):
-
-    def launch_proxy_command(self, config):
-        args = [
-            "--sessions", config.proxy_session_map,
-            "--ip", config.dynamic_proxy_bind_ip,
-            "--port", str(config.dynamic_proxy_bind_port),
-        ]
-        if config.dynamic_proxy_debug:
-            args.append("--verbose")
-
-        parent_directory = os.path.dirname( __file__ )
-        path_to_application = os.path.join( parent_directory, "js", "lib", "main.js" )
-        command = [ path_to_application ] + args
-        return command
-
-
-class GolangProxyLauncher(object):
-
-    def launch_proxy_command(self, config):
-        args = [
-            "gxproxy",  # Must be on path. TODO: wheel?
-            "--listenAddr", '%s:%d' % (
-                config.dynamic_proxy_bind_ip,
-                config.dynamic_proxy_bind_port,
-            ),
-            "--listenPath", "/".join((
-                config.cookie_path,
-                config.dynamic_proxy_prefix
-            )),
-            "--cookieName", "galaxysession",
-            "--storage", config.proxy_session_map.replace('.sqlite', '.xml'),  # just in case.
-            "--apiKey", config.dynamic_proxy_golang_api_key,
-            "--noAccess", config.dynamic_proxy_golang_noaccess,
-            "--cleanInterval", config.dynamic_proxy_golang_clean_interval,
-            "--dockerAddr", config.dynamic_proxy_golang_docker_address,
-        ]
-        if config.dynamic_proxy_debug:
-            args.append("--verbose")
-        return args
-
-
-class AuthenticationToken(object):
-
-    def __init__(self, trans):
-        self.cookie_name = SECURE_COOKIE
-        self.cookie_value = trans.get_cookie( self.cookie_name )
-
-
-class ProxyRequests(object):
-
-    def __init__(self, host=None, port=None):
-        if host is None:
-            host = DEFAULT_PROXY_TO_HOST
-        if port is None:
-            port = sockets.unused_port()
-            log.info("Obtained unused port %d" % port)
-        self.host = host
-        self.port = port
-
-
-def proxy_ipc(config):
-    proxy_session_map = config.proxy_session_map
-    if config.dynamic_proxy == "node":
-        if proxy_session_map.endswith(".sqlite"):
-            return SqliteProxyIpc(proxy_session_map)
-        else:
-            return JsonFileProxyIpc(proxy_session_map)
-    elif config.dynamic_proxy == "golang":
-        return RestGolangProxyIpc(config)
-
-
-class ProxyIpc(object):
-
-    def handle_requests(self, authentication, proxy_requests, route_name, container_ids):
-        raise NotImplementedError()
-
-
-class JsonFileProxyIpc(object):
-
-    def __init__(self, proxy_session_map):
-        self.proxy_session_map = proxy_session_map
-
-    def handle_requests(self, authentication, proxy_requests, route_name, container_ids):
-        key = "%s:%s" % ( proxy_requests.host, proxy_requests.port )
-        secure_id = authentication.cookie_value
-        with FileLock( self.proxy_session_map ):
-            if not os.path.exists( self.proxy_session_map ):
-                open( self.proxy_session_map, "w" ).write( "{}" )
-            json_data = open( self.proxy_session_map, "r" ).read()
-            session_map = json.loads( json_data )
-            to_remove = []
-            for k, value in session_map.items():
-                if value == secure_id:
-                    to_remove.append( k )
-            for k in to_remove:
-                del session_map[ k ]
-            session_map[ key ] = secure_id
-            new_json_data = json.dumps( session_map )
-            open( self.proxy_session_map, "w" ).write( new_json_data )
-
-
-class SqliteProxyIpc(object):
-
-    def __init__(self, proxy_session_map):
-        self.proxy_session_map = proxy_session_map
 
     def handle_requests(self, authentication, proxy_requests, route_name, container_ids):
         key = "%s:%s" % ( proxy_requests.host, proxy_requests.port )
@@ -227,36 +89,20 @@ class SqliteProxyIpc(object):
                 conn.close()
 
 
-class RestGolangProxyIpc(object):
+class AuthenticationToken(object):
 
-    def __init__(self, config):
-        self.config = config
-        self.api_url = 'http://127.0.0.1:%s/api?api_key=%s' % (self.config.dynamic_proxy_bind_port, self.config.dynamic_proxy_golang_api_key)
+    def __init__(self, trans):
+        self.cookie_name = SECURE_COOKIE
+        self.cookie_value = trans.get_cookie( self.cookie_name )
 
-    def handle_requests(self, authentication, proxy_requests, route_name, container_ids, sleep=1):
-        """Make a POST request to the GO proxy to register a route
-        """
-        values = {
-            'FrontendPath': route_name,
-            'BackendAddr': "%s:%s" % ( proxy_requests.host, proxy_requests.port ),
-            'AuthorizedCookie': authentication.cookie_value,
-            'ContainerIds': container_ids,
-        }
 
-        req = urllib2.Request(self.api_url)
-        req.add_header('Content-Type', 'application/json')
+class ProxyRequests(object):
 
-        # Sometimes it takes our poor little proxy a second or two to get
-        # going, so if this fails, re-call ourselves with an increased timeout.
-        try:
-            urllib2.urlopen(req, json.dumps(values))
-        except urllib2.URLError as err:
-            log.debug(err)
-            if sleep > 5:
-                excp = "Could not contact proxy after %s seconds" % sum(range(sleep + 1))
-                raise Exception(excp)
-            time.sleep(sleep)
-            self.handle_requests(authentication, proxy_requests, route_name, container_ids, sleep=sleep + 1)
-        pass
-
-# TODO: MQ diven proxy?
+    def __init__(self, host=None, port=None):
+        if host is None:
+            host = DEFAULT_PROXY_TO_HOST
+        if port is None:
+            port = sockets.unused_port()
+            log.info("Obtained unused port %d" % port)
+        self.host = host
+        self.port = port

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -120,7 +120,10 @@ def paste_app_factory( global_conf, **kwargs ):
         webapp = wrap_in_middleware( webapp, global_conf, **kwargs )
     if asbool( kwargs.get( 'static_enabled', True) ):
         if process_is_uwsgi:
-            log.error("Static middleware is enabled in your configuration but this is a uwsgi process.  Refusing to wrap in static middleware.")
+            ## log.error("Static middleware is enabled in your configuration but this is a uwsgi process.  Refusing to wrap in static middleware except for plugins")
+            ## We need the statics for plugins since they are configured dynamically. 
+            ## TODO: should be possible to configure this dynamically in uWSGI
+            webapp = wrap_in_static( webapp, global_conf, plugin_frameworks=[ app.visualizations_registry ], **kwargs )
         else:
             webapp = wrap_in_static( webapp, global_conf, plugin_frameworks=[ app.visualizations_registry ], **kwargs )
     # Close any pooled database connections before forking

--- a/run.sh
+++ b/run.sh
@@ -30,7 +30,10 @@ then
     . $GALAXY_LOCAL_ENV_FILE
 fi
 
-# Pop args meant for common_startup.sh
+uwsgi_args="--master --pythonpath=lib"
+
+# Pop args meant for common_startup.sh and translate any old paster style 
+# args for uwsgi
 while :
 do
     case "$1" in


### PR DESCRIPTION
This won't pass the travis tests until wheels are built for pyuwsgi. But it will work if you install uwsgi locally either in Galaxy's .venv or the path.

Now includes an modification of what was introduced in #2385. For anything under the path /proxy, uwsgi will look for a registered proxy mapping and use it. Otherwise it will fallback to Galaxy.

I changed as little as possible for now at the interface level, e.g. sqlite is still used for storing the mapping, but much can and will be cleaned up. I did delete a fair bit since _if_ this gets merged it will probably be the only supported approach. I would like to change the scheme so each registered proxy has an ID. So, you would go to /proxy/THEPROXYKEY/... The secret would still get verified, but this allows a user to have multiple IEs going at the same time.

Tested to the point of seeing jupyter work and keep its socket up for a while. Much more testing needed. Many things are likely broken.
