### PR TITLE
Kubernetes runner: improves handling of failed jobs

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -73,7 +73,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         job_destination = job_wrapper.job_destination
 
         # Construction of the Kubernetes Job object follows: http://kubernetes.io/docs/user-guide/persistent-volumes/
-        k8s_job_name = self.__produce_unique_k8s_job_name(job_wrapper)
+        k8s_job_name = self.__produce_unique_k8s_job_name(job_wrapper.get_id_tag())
         k8s_job_obj = {
             "apiVersion": "extensions/v1beta1",
             "kind": "Job",
@@ -108,9 +108,9 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         external_runjob_script = None
         return external_runjob_script
 
-    def __produce_unique_k8s_job_name(self, job_wrapper):
+    def __produce_unique_k8s_job_name(self, galaxy_internal_job_id):
         # wrapper.get_id_tag() instead of job_id for compatibility with TaskWrappers.
-        return "galaxy-" + job_wrapper.get_id_tag()
+        return "galaxy-" + galaxy_internal_job_id
 
     def __get_k8s_job_spec(self, job_wrapper):
         """Creates the k8s Job spec. For a Job spec, the only requirement is to have a .spec.template."""
@@ -123,7 +123,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         (see pod selector) and an appropriate restart policy."""
         k8s_spec_template = {
             "metadata": {
-                "labels": {"app": self.__produce_unique_k8s_job_name(job_wrapper)}
+                "labels": {"app": self.__produce_unique_k8s_job_name(job_wrapper.get_id_tag())}
             },
             "spec": {
                 "volumes": self.__get_k8s_mountable_volumes(job_wrapper),

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -284,8 +284,9 @@ class KubernetesJobRunner(AsynchronousJobRunner):
     def stop_job(self, job):
         """Attempts to delete a dispatched job to the k8s cluster"""
         try:
-            jobs = Job.objects(self._pykube_api).filter(selector="app=" + job.job_runner_external_id)
-            if jobs.response['items'].len() >= 0:
+            jobs = Job.objects(self._pykube_api).filter(selector="app=" +
+                                                                 self.__produce_unique_k8s_job_name(job.get_id_tag()))
+            if len(jobs.response['items']) >= 0:
                 job_to_delete = Job(self._pykube_api, jobs.response['items'][0])
                 job_to_delete.scale(replicas=0)
             # TODO assert whether job parallelism == 0

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -4,8 +4,6 @@ Offload jobs to a Kubernetes cluster.
 
 import logging
 
-from pykube.exceptions import HTTPError
-
 from galaxy import model
 from galaxy.jobs.runners import AsynchronousJobState, AsynchronousJobRunner
 from os import environ as os_environ
@@ -285,7 +283,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 logs += pod.logs(timestamps=True)
                 logs += "\n\n==== Pod " + pod.name + " log end   ===="
             except Exception as detail:
-                log.info("Could not write pods "+job_state.job_id+" log file due to HTTPError "+str(detail))
+                log.info("Could not write pod\'s " + pod_obj['metadata']['name'] +
+                         " log file due to HTTPError "+str(detail))
 
         logs_file_path = job_state.output_file
         logs_file = open(logs_file_path, mode="w")

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -311,7 +311,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 logs += "\n\n==== Pod " + pod.name + " log end   ===="
             except Exception as detail:
                 log.info("Could not write pod\'s " + pod_obj['metadata']['name'] +
-                         " log file due to HTTPError "+str(detail))
+                         " log file due to HTTPError " + str(detail))
 
         logs_file_path = job_state.output_file
         logs_file = open(logs_file_path, mode="w")

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -89,7 +89,14 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             "spec": self.__get_k8s_job_spec(job_wrapper)
         }
 
+        # Checks if job exists
+        job = Job(self._pykube_api, k8s_job_obj)
+        if job.exists():
+            job.delete()
         # Creates the Kubernetes Job
+        # TODO if a job with that ID exists, what should we do?
+        # TODO do we trust that this is the same job and use that?
+        # TODO or create a new job as we cannot make sure
         Job(self._pykube_api, k8s_job_obj).create()
 
         # define job attributes in the AsyncronousJobState for follow-up

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -7,6 +7,7 @@ import logging
 from galaxy import model
 from galaxy.jobs.runners import AsynchronousJobState, AsynchronousJobRunner
 from os import environ as os_environ
+from six import text_type
 
 # pykube imports:
 try:
@@ -267,7 +268,9 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             logs += "\n\n==== Pod " + pod.name + " log end   ===="
         logs_file_path = job_state.output_file
         logs_file = open(logs_file_path, mode="w")
-        logs_file.write(logs.encode('utf8'))
+        if isinstance(logs, text_type):
+            logs = logs.encode('utf8')
+        logs_file.write(logs)
         logs_file.close()
         return logs_file_path
 

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -267,7 +267,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             logs += "\n\n==== Pod " + pod.name + " log end   ===="
         logs_file_path = job_state.output_file
         logs_file = open(logs_file_path, mode="w")
-        logs_file.write(logs)
+        logs_file.write(logs.encode('utf8'))
         logs_file.close()
         return logs_file_path
 


### PR DESCRIPTION
This pull requests addresses some original issues related to jobs failure within the Kubernetes runner. This PR fixes:
- Parameters for pod retrials set in the job_conf.xml not being used.
- Handles exception when pod is no longer available or its logs are not longer available.
- Kubernetes jobs now get correctly down-scaled to zero when terminating a job, without errors.
- Overrides parent fail_job method in the Kubernetes runner to save the stderr/stdout of the pods (the result of `kubectl logs pods/<pod-id>`), which is lost when the job fails. Previous behaviour didn't allow the user to see the reason why the pod failed (ie, the error of the program running inside the container).

On the last point, unfortunately, Kubernetes currently doesn't allow to tell the difference between stderr and stdout, and galaxy rightly limits to 32k the amount of data that is will save on the database for this purpose, so we still might end up in scenarios in which we lose the reason of the failure.

I have tested this functionality extensively with pipelines that have jobs failing, current version on the dev branch doesn't work well on this respect.

I didn't realise that pull #2528 wasn't merged yet, so unfortunately this pull includes 2 commits from that other pull.
