### PR TITLE
Ignore W503 (line break before binary operator) as PEP 8 has reversed its position on this.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,5 @@
 # 203 whitespace before ':'
 # 402 module level import not at top of file # TODO, we would like to improve this.
 # 501 is line length
-ignore = E128,E201,E202,E203,E501,E402
+# W503 is line breaks before binary operators, which has been reversed in PEP 8.
+ignore = E128,E201,E202,E203,E501,E402,W503


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator

It is now ignored by default in pycodestyle (see PyCQA/pycodestyle#498 and PyCQA/pycodestyle#499) but our ignore option overrides this default.
