### PR TITLE
Users API: add the update endpoint

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -736,7 +736,7 @@ class ModelDeserializer( HasAModelManager ):
     """
     # TODO:?? a larger question is: which should be first? Deserialize then validate - or - validate then deserialize?
 
-    def __init__( self, app, **kwargs ):
+    def __init__( self, app, validator=None, **kwargs ):
         """
         Set up deserializers and validator.
         """
@@ -747,7 +747,7 @@ class ModelDeserializer( HasAModelManager ):
         self.deserializable_keyset = set([])
         self.add_deserializers()
         # a sub object that can validate incoming values
-        self.validate = ModelValidator( self.app )
+        self.validate = validator or ModelValidator( self.app )
 
     def add_deserializers( self ):
         """

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -307,7 +307,7 @@ class UserDeserializer( base.ModelDeserializer ):
         validation_error = validate_user_input.validate_publicname( trans, username, user=user )
         if validation_error:
             raise base.ModelDeserializingError( validation_error )
-        return username
+        return self.default_deserializer( user, key, username, trans=trans, **context )
 
 
 class CurrentUserSerializer( UserSerializer ):

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -301,13 +301,13 @@ class UserDeserializer( base.ModelDeserializer ):
             'username'  : self.deserialize_username,
         })
 
-    def deserialize_username( self, user, key, username, trans=None, **context ):
+    def deserialize_username( self, item, key, username, trans=None, **context ):
         # TODO: validate_user_input requires trans and should(?) raise exceptions
-        # move validation to UserValidator and use self.app/exceptions instead
-        validation_error = validate_user_input.validate_publicname( trans, username, user=user )
+        # move validation to UserValidator and use self.app, exceptions instead
+        validation_error = validate_user_input.validate_publicname( trans, username, user=item )
         if validation_error:
             raise base.ModelDeserializingError( validation_error )
-        return self.default_deserializer( user, key, username, trans=trans, **context )
+        return self.default_deserializer( item, key, username, trans=trans, **context )
 
 
 class CurrentUserSerializer( UserSerializer ):

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -11,6 +11,9 @@ log = logging.getLogger( __name__ )
 
 VALID_PUBLICNAME_RE = re.compile( "^[a-z0-9\-]+$" )
 VALID_PUBLICNAME_SUB = re.compile( "[^a-z0-9\-]" )
+PUBLICNAME_MIN_LEN = 3
+PUBLICNAME_MAX_LEN = 255
+
 #  Basic regular expression to check email validity.
 VALID_EMAIL_RE = re.compile( "[^@]+@[^@]+\.[^@]+" )
 FILL_CHAR = '-'
@@ -41,16 +44,10 @@ def validate_publicname( trans, publicname, user=None ):
     # letters, numbers, and the '-' character.
     if user and user.username == publicname:
         return ''
-    if trans.webapp.name == 'tool_shed':
-        if len( publicname ) < 3:
-            return "Public name must be at least 3 characters in length"
-    else:
-        # DCT - TODO - Simplify logic if 3 chars is okay for publicname for
-        # galaxy as well as toolshed
-        if len( publicname ) < 3:
-            return "Public name must be at least 3 characters in length"
-    if len( publicname ) > 255:
-        return "Public name cannot be more than 255 characters in length"
+    if len( publicname ) < PUBLICNAME_MIN_LEN:
+        return "Public name must be at least %d characters in length" % ( PUBLICNAME_MIN_LEN )
+    if len( publicname ) > PUBLICNAME_MAX_LEN:
+        return "Public name cannot be more than %d characters in length" % ( PUBLICNAME_MAX_LEN )
     if not( VALID_PUBLICNAME_RE.match( publicname ) ):
         return "Public name must contain only lower-case letters, numbers and '-'"
     if trans.sa_session.query( trans.app.model.User ).filter_by( username=publicname ).first():

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -194,11 +194,10 @@ class UserAPIController( BaseAPIController, UsesTagsMixin, CreatesUsersMixin, Cr
         current_user = trans.user
         user_to_update = self.user_manager.by_id( self.decode_id( id ) )
 
-        # if they're not admin, only allow updating themselves
-        log.info( 'is admin? %s', self.user_manager.is_admin( current_user ) )
-        log.info( 'is admin? %s', trans.user_is_admin() )
-        editing_themselves = current_user == user_to_update
-        if not self.user_manager.is_admin( current_user ) and not editing_themselves:
+        # only allow updating other users if they're admin
+        editing_someone_else = current_user != user_to_update
+        is_admin = trans.api_inherit_admin or self.user_manager.is_admin( current_user )
+        if editing_someone_else and not is_admin:
             raise exceptions.InsufficientPermissionsException( 'you are not allowed to update that user', id=id )
 
         self.user_deserializer.deserialize( user_to_update, payload, user=current_user, trans=trans )

--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -18,7 +18,22 @@ class UsersApiTestCase( api.ApiTestCase ):
 
     def test_index_only_self_for_nonadmins( self ):
         self._setup_user( TEST_USER_EMAIL )
-        with self._different_user( ):
+        with self._different_user():
             all_users_response = self._get( "users" )
             # Non admin users can only see themselves
             assert len( all_users_response.json() ) == 1
+
+    def test_show( self ):
+        user = self._setup_user( TEST_USER_EMAIL )
+        with self._different_user( email=TEST_USER_EMAIL ):
+            show_response = self.__show( user )
+            self._assert_status_code_is( show_response, 200 )
+            self.__assert_matches_user( user, show_response.json() )
+
+    def __show( self, user ):
+        return self._get( "users/%s" % ( user[ 'id' ] ) )
+
+    def __assert_matches_user( self, userA, userB ):
+        self._assert_has_keys( userB, "id", "username" )
+        assert userA[ "id" ] == userB[ "id" ]
+        assert userA[ "username" ] == userB[ "username" ]

--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -1,4 +1,9 @@
+import logging
+import json
+from requests import put
 from base import api
+
+log = logging.getLogger(__name__)
 
 TEST_USER_EMAIL = "user_for_users_index_test@bx.psu.edu"
 
@@ -30,10 +35,25 @@ class UsersApiTestCase( api.ApiTestCase ):
             self._assert_status_code_is( show_response, 200 )
             self.__assert_matches_user( user, show_response.json() )
 
+    def test_update( self ):
+        user = self._setup_user( TEST_USER_EMAIL )
+        with self._different_user( email=TEST_USER_EMAIL ):
+            update_response = self.__update( user, username='noob' )
+            self._assert_status_code_is( update_response, 200 )
+            update_json = update_response.json()
+            log.info( update_json )
+            assert update_json[ 'username' ] == 'noob'
+
     def __show( self, user ):
         return self._get( "users/%s" % ( user[ 'id' ] ) )
 
+    def __update( self, user, **new_data ):
+        update_url = self._api_url( "users/%s" % ( user[ "id" ] ), use_key=True )
+        # TODO: Awkward json.dumps required here because of https://trello.com/c/CQwmCeG6
+        body = json.dumps( new_data )
+        return put( update_url, data=body )
+
     def __assert_matches_user( self, userA, userB ):
-        self._assert_has_keys( userB, "id", "username" )
+        self._assert_has_keys( userB, "id", "username", "total_disk_usage" )
         assert userA[ "id" ] == userB[ "id" ]
         assert userA[ "username" ] == userB[ "username" ]

--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -36,13 +36,14 @@ class UsersApiTestCase( api.ApiTestCase ):
             self.__assert_matches_user( user, show_response.json() )
 
     def test_update( self ):
+        new_name = 'mu'
         user = self._setup_user( TEST_USER_EMAIL )
         with self._different_user( email=TEST_USER_EMAIL ):
-            update_response = self.__update( user, username='noob' )
+            update_response = self.__update( user, username=new_name )
             self._assert_status_code_is( update_response, 200 )
             update_json = update_response.json()
             log.info( update_json )
-            assert update_json[ 'username' ] == 'noob'
+            assert update_json[ 'username' ] == new_name
 
     def __show( self, user ):
         return self._get( "users/%s" % ( user[ 'id' ] ) )

--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -1,9 +1,6 @@
-import logging
 import json
 from requests import put
 from base import api
-
-log = logging.getLogger(__name__)
 
 TEST_USER_EMAIL = "user_for_users_index_test@bx.psu.edu"
 
@@ -45,7 +42,7 @@ class UsersApiTestCase( api.ApiTestCase ):
             update_response = self.__update( user, username=new_name )
             self._assert_status_code_is( update_response, 200 )
             update_json = update_response.json()
-            assert update_json[ 'username' ] == new_name
+            self.assertEqual( update_json[ 'username' ], new_name )
 
             # too short
             update_response = self.__update( user, username='mu' )
@@ -69,8 +66,7 @@ class UsersApiTestCase( api.ApiTestCase ):
         update_response = put( update_url, data=json.dumps( dict( username=new_name ) ) )
         self._assert_status_code_is( update_response, 200 )
         update_json = update_response.json()
-        log.info( update_json )
-        assert update_json[ 'username' ] == new_name
+        self.assertEqual( update_json[ 'username' ], new_name )
 
     def __show( self, user ):
         return self._get( "users/%s" % ( user[ 'id' ] ) )

--- a/test/unit/managers/test_UserManager.py
+++ b/test/unit/managers/test_UserManager.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 """
+User Manager testing.
+
+Executable directly using: python -m test.unit.managers.test_UserManager
 """
 import imp
 import os
@@ -15,7 +18,7 @@ from galaxy import exceptions, model
 from galaxy.managers import base as base_manager
 from galaxy.managers import histories, users
 
-from base import BaseTestCase
+from .base import BaseTestCase
 
 
 # =============================================================================
@@ -226,7 +229,7 @@ class UserDeserializerTestCase( BaseTestCase ):
     def _assertRaises_and_return_raised( self, exception_class, fn, *args, **kwargs ):
         try:
             fn( *args, **kwargs )
-        except exception_class, exception:
+        except exception_class as exception:
             self.assertTrue( True )
             return exception
         assert False, '%s not raised' % ( exception_class.__name__ )
@@ -277,5 +280,4 @@ class AdminUserFilterParserTestCase( BaseTestCase ):
 
 # =============================================================================
 if __name__ == '__main__':
-    # or more generally, nosetests test_resourcemanagers.py -s -v
     unittest.main()

--- a/test/unit/managers/test_UserManager.py
+++ b/test/unit/managers/test_UserManager.py
@@ -249,6 +249,11 @@ class UserDeserializerTestCase( BaseTestCase ):
         self.assertRaises( base_manager.ModelDeserializingError, self.deserializer.deserialize,
             user, { 'username': 'user3' }, trans=self.trans )
 
+        self.log( "username should be updatable" )
+        new_name = 'double-plus-good'
+        self.deserializer.deserialize( user, { 'username': new_name }, trans=self.trans )
+        self.assertEqual( self.user_manager.by_id( user.id ).username, new_name )
+
 
 # =============================================================================
 class AdminUserFilterParserTestCase( BaseTestCase ):


### PR DESCRIPTION
Implements update for the users API. Currently only username is deserialized but it should be easier to add more now.
- tests for both the deserializer and the API endpoint were added
- fixes some magic numbers and removes some TODOs

The user deserializer could be improved in the future by bypassing `validate_user_input` and removing the need to pass `trans` for the session.

Should close: #1992
