### PR TITLE
Add Warning when Conda is installed 

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -129,7 +129,7 @@ if [ $SET_VENV -eq 1 ]; then
         exit 1
     fi
 elif [ $SET_VENV -eq -0 -a $CONDA_ALREADY_INSTALLED -eq 1 ]; then
-    echo -e "\e[33mWarning: You have Conda installed. Skipping virtualenv creation. This could cause missing dependencies.\e[0m"
+    echo -e "\e[33mWarning: You have Conda installed. Skipping virtualenv activation. This could cause missing dependencies.\e[0m"
 fi
 
 : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -9,6 +9,7 @@ done
 # Conda Python is in use, do not use virtualenv
 if python -V 2>&1 | grep -q -e 'Anaconda' -e 'Continuum Analytics' ; then
     SET_VENV=0
+    CONDA_ALREADY_INSTALLED=1
 fi
 
 DEV_WHEELS=0
@@ -127,6 +128,8 @@ if [ $SET_VENV -eq 1 ]; then
         echo "ERROR: A virtualenv cannot be found. Please create a virtualenv in $GALAXY_VIRTUAL_ENV, or activate one."
         exit 1
     fi
+elif [ $SET_VENV -eq -0 -a $CONDA_ALREADY_INSTALLED -eq 1 ]; then
+    echo -e "\e[33mWarning: You have Conda installed. Skipping virtualenv creation. This could cause missing dependencies.\e[0m"
 fi
 
 : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}


### PR DESCRIPTION
because we skip the virtualenv activation.

Here is a potential help for people having Conda installed, but then have issues because of missing dependencies (https://github.com/galaxyproject/galaxy/issues/1633).

A few problematics still exist:
- Is it normal to have failed dependencies? Do we expect people to have them because they installed Conda?
- Will people be able to see the Warning? The `run.sh` / `common_startup.sh` are pretty verbose. I don't expect everybody to check every line of code trying to find a Warning. So what can we do to help people find this errors, in your opinion?

xref: https://github.com/galaxyproject/galaxy/issues/1633#issuecomment-231082404
