### PR TITLE
When CONDA_ALREADY_INSTALLED is undefined there's an error due to the…

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -10,6 +10,8 @@ done
 if python -V 2>&1 | grep -q -e 'Anaconda' -e 'Continuum Analytics' ; then
     SET_VENV=0
     CONDA_ALREADY_INSTALLED=1
+else
+    CONDA_ALREADY_INSTALLED=0
 fi
 
 DEV_WHEELS=0
@@ -128,7 +130,7 @@ if [ $SET_VENV -eq 1 ]; then
         echo "ERROR: A virtualenv cannot be found. Please create a virtualenv in $GALAXY_VIRTUAL_ENV, or activate one."
         exit 1
     fi
-elif [ $SET_VENV -eq -0 -a $CONDA_ALREADY_INSTALLED -eq 1 ]; then
+elif [ $SET_VENV -eq 0 -a $CONDA_ALREADY_INSTALLED -eq 1 ]; then
     echo -e "\e[33mWarning: You have Conda installed. Skipping virtualenv activation. This could cause missing dependencies.\e[0m"
 fi
 


### PR DESCRIPTION
… number of arguments in the boolean expression (we actually _do_ always want a 1 or 0 there, never empty).

ping @remimarenco 

I encountered this error when running with --skip-venv
