### PR TITLE
Neglects interpreter set for tool at the Kubernetes runner.

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -66,6 +66,12 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         # We currently don't need to include_metadata or include_work_dir_outputs, as working directory is the same
         # were galaxy will expect results.
         log.debug("Starting queue_job for job " + job_wrapper.get_id_tag())
+        # For backward compatibility, we set the tool interpreter field to none, so that it doesn't make it to the
+        # command line. We need to avoid the interpreter as Galaxy changes the working directory, and as such we cannot
+        # guarantee the location of a script in the <interpreter> <script> <arguments> scenario. As such, we ask
+        # container developers to add the correct shebang to the <script> file, make it executable and place it on the
+        # $PATH of the container. It is then executable like <script> <arguments> instead.
+        job_wrapper.tool.interpreter = None
         if not self.prepare_job(job_wrapper, include_metadata=False, modify_command_for_container=False):
             return
 


### PR DESCRIPTION
The following PR addresses the scenario of tools that rely on a interpreter and a script on a defined location. Because Galaxy changes the working directory, Kubernetes (k8s) cannot make use of the stated working directory of the container. As such, for an scenario where a tool is wrapped like this:

```
<command intepreter="Rscript">my_R_script.R $input1 $input2</command>
```

To the best of my understanding, the Galaxy wiki encourages not to follow this pattern anymore, yet this is the way many tools are written already.

The k8s runner would need to figure out where in the container the `my_R_script.R` is located and then append that in between the interpreter and the script. This is difficult, and as such our approach is to ask any container developer to make sure that `my_R_script.R` has the correct shebang (in this case, for example, `#!/usr/bin/env Rscript`), the script is set as executable and it is left in the `$PATH` of the container. Having done that, the execution can be done like

```
my_R_script.R arguments..
```

For this to happen, this PR sets the Job Wrapper's `tool.interpreter` variable to `None`. This should allow the runner to work with all the tools that follow this pattern without any tool wrapper modification.
