### PR TITLE
Tool shed install fixes for tool dependencies

### DIFF
--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -352,7 +352,7 @@ class InstallToolDependencyManager( object ):
                                             # Process the next matching <actions> tag, or any defined <actions> tags that do not
                                             # contain platform dependent recipes.
                                             log.debug( 'Error downloading binary for tool dependency %s version %s: %s' %
-                                                       ( str( package_name ), str( package_version ), util.smart_str( tool_dependency.error_message ) ) )
+                                                       ( str( package_name ), str( package_version ), util.unicodify( tool_dependency.error_message ) ) )
                                     else:
                                         if actions_elem.tag == 'actions':
                                             # We've reached an <actions> tag that defines the recipe for installing and compiling from

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -352,7 +352,7 @@ class InstallToolDependencyManager( object ):
                                             # Process the next matching <actions> tag, or any defined <actions> tags that do not
                                             # contain platform dependent recipes.
                                             log.debug( 'Error downloading binary for tool dependency %s version %s: %s' %
-                                                       ( str( package_name ), str( package_version ), str( tool_dependency.error_message ) ) )
+                                                       ( str( package_name ), str( package_version ), util.smart_str( tool_dependency.error_message ) ) )
                                     else:
                                         if actions_elem.tag == 'actions':
                                             # We've reached an <actions> tag that defines the recipe for installing and compiling from

--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -845,23 +845,26 @@ class MoveDirectoryFiles( RecipeStep ):
                                    destination_dir=os.path.join( action_dict[ 'destination_directory' ] ) )
         return tool_dependency, None, None
 
-    def move_directory_files( self, current_dir, source_dir, destination_dir ):
-        source_directory = os.path.abspath( os.path.join( current_dir, source_dir ) )
-        destination_directory = os.path.abspath(os.path.join(destination_dir))
+    def move_directory_files(self, current_dir, source_dir, destination_dir):
+        source_directory = os.path.abspath(os.path.join(current_dir, source_dir))
+        destination_directory = os.path.join(destination_dir)
         if not os.path.isdir(destination_directory):
             os.makedirs(destination_directory)
-        for dir_entry in os.listdir(source_directory):
-            source_entry = os.path.join(source_directory, dir_entry)
-            if os.path.isdir(source_entry):
-                destination_subdir = os.path.join(destination_directory, dir_entry)
-                if not os.path.exists(destination_subdir):
-                    os.makedirs(destination_subdir)
-            elif os.path.islink(source_entry):
-                destination_entry = os.path.join(destination_directory, dir_entry)
-                os.symlink(os.readlink(source_entry), destination_entry)
-                os.remove(source_entry)
+        symlinks = []
+        regular_files = []
+        for file_name in os.listdir(source_directory):
+            source_file = os.path.join(source_directory, file_name)
+            destination_file = os.path.join(destination_directory, file_name)
+            files_tuple = (source_file, destination_file)
+            if os.path.islink(source_file):
+                symlinks.append(files_tuple)
             else:
-                shutil.move(source_entry, destination_directory)
+                regular_files.append(files_tuple)
+        for source_file, destination_file in symlinks:
+            os.symlink(os.readlink(source_file), destination_file)
+            os.remove(source_file)
+        for source_file, destination_file in regular_files:
+            shutil.move(source_file, destination_file)
 
     def prepare_step( self, tool_dependency, action_elem, action_dict, install_environment, is_binary_download ):
         # <action type="move_directory_files">

--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -852,7 +852,11 @@ class MoveDirectoryFiles( RecipeStep ):
             os.makedirs(destination_directory)
         for dir_entry in os.listdir(source_directory):
             source_entry = os.path.join(source_directory, dir_entry)
-            if os.path.islink(source_entry):
+            if os.path.isdir(source_entry):
+                destination_subdir = os.path.join(destination_directory, dir_entry)
+                if not os.path.exists(destination_subdir):
+                    os.makedirs(destination_subdir)
+            elif os.path.islink(source_entry):
                 destination_entry = os.path.join(destination_directory, dir_entry)
                 os.symlink(os.readlink(source_entry), destination_entry)
                 os.remove(source_entry)

--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -847,7 +847,7 @@ class MoveDirectoryFiles( RecipeStep ):
 
     def move_directory_files(self, current_dir, source_dir, destination_dir):
         source_directory = os.path.abspath(os.path.join(current_dir, source_dir))
-        destination_directory = os.path.join(destination_dir)
+        destination_directory = os.path.abspath(os.path.join(destination_dir))
         if not os.path.isdir(destination_directory):
             os.makedirs(destination_directory)
         symlinks = []


### PR DESCRIPTION
1. Better exception handling when logging install errors
2. Fix for handling subdirectories when moving a directory of files
