### PR TITLE
Add a password strength evaluation bar

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -29,7 +29,8 @@
     "wymeditor": "~1.0.0-rc.1",
     "jstree": "~3.0.9",
     "jquery-ui": "git://github.com/jquery/jquery-ui.git#~1.11.2",
-    "threedubmedia.jquery.event": "*",
+    "jquery.complexify": "git://github.com/danpalmer/jquery.complexify.js.git#~0.5.1",
+     "threedubmedia.jquery.event": "*",
     "jquery-migrate": "~1.4",
     "requirejs": "~2"
   },

--- a/client/galaxy/style/less/base.less
+++ b/client/galaxy/style/less/base.less
@@ -1719,3 +1719,16 @@ div.toolTitleNoSection
 #for_bears {
     display: none;
 }
+
+// password complexity monitor
+#change_password,#registrationForm {
+    .progress {
+        width:200px;
+        margin-left: 20px;
+    }
+    .progress-bar {
+        color:black;
+        text-align:left;
+    }
+}
+

--- a/client/grunt-tasks/install-libs.js
+++ b/client/grunt-tasks/install-libs.js
@@ -22,6 +22,7 @@ module.exports = function( grunt ){
             'farbtastic':     [ 'src/farbtastic.js', 'farbtastic.js' ],
             'jQTouch':        [ 'src/reference/jqtouch.js', 'jquery/jqtouch.js' ],
             'bootstrap-tour': [ 'build/js/bootstrap-tour.js', 'bootstrap-tour.js' ],
+            'jquery.complexify':     [ 'jquery.complexify.js', 'jquery.complexify.js' ],
 
             // these need to be updated and tested
             //'jquery-form': [ 'jquery.form.js', 'jquery/jquery.form.js' ],

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -20,6 +20,7 @@ var webpack = require( 'webpack' ),
         'libs/jquery/jquery-ui',
         'libs/bootstrap',
         'libs/bootstrap-tour',
+        'libs/jquery.complexify',
         // mvc
         'libs/underscore',
         'libs/backbone',

--- a/templates/user/change_password.mako
+++ b/templates/user/change_password.mako
@@ -16,6 +16,18 @@
     ${render_msg( message, status )}
 %endif
 
+<script>
+$(function() {
+  $("[name='password']").complexify({'minimumChars':6}, function(valid, complexity){
+    var progressBar = $('.progress-bar');
+    var color = valid ? 'lightgreen' : 'red';
+
+    progressBar.css('background-color', color);
+    progressBar.css({'width': complexity + '%'});
+  });
+});
+</script>
+
 <div class="toolForm">
     <form name="change_password" id="change_password" action="${h.url_for( controller='user', action='change_password' )}" method="post" >
         <input type="hidden" name="display_top" value="${display_top}"/>
@@ -31,6 +43,11 @@
         <div class="form-row">
             <label>New password:</label>
             <input type="password" name="password" value="" size="40"/>
+        </div>
+        <div class="progress">
+            <div id="complexity-bar" class="progress-bar" role="progressbar">
+                Strength
+            </div>
         </div>
         <div class="form-row">
             <label>Confirm:</label>

--- a/templates/user/register.mako
+++ b/templates/user/register.mako
@@ -86,7 +86,15 @@ def inherit(context):
     			$(".errormessage").html(message);
     		}
 
-    		$('#registration').bind('submit', function(e) {
+            $("[name='password']").complexify({'minimumChars':6}, function(valid, complexity){
+                var progressBar = $('.progress-bar');
+                var color = valid ? 'lightgreen' : 'red';
+
+                progressBar.css('background-color', color);
+                progressBar.css({'width': complexity + '%'});
+            });
+
+            $('#registration').bind('submit', function(e) {
     			$('#send').attr('disabled', 'disabled');
                 
                 // we need this value to detect submitting at backend
@@ -129,6 +137,11 @@ def inherit(context):
             <div class="form-row">
                 <label>Password:</label>
                 <input id="password_input" type="password" name="password" value="" size="40"/>
+            </div>
+            <div class="progress">
+                <div id="complexity-bar" class="progress-bar" role="progressbar">
+                    Strength
+                </div>
             </div>
             <div class="form-row">
                 <label>Confirm password:</label>


### PR DESCRIPTION
Modify the register and change_password pages to show a bar
evaluating the strength of the password. Bar displays in red
for passwords < 6 chars or below a certain minimum complexity;
green otherwise. Adds a dependency on Complexify, a password
evaluator written by Dan Palmer. Let me know if you'd like any changes!
