### PR TITLE
Committing format changes to the user impersonation dropdown.

### DIFF
--- a/templates/admin/impersonate.mako
+++ b/templates/admin/impersonate.mako
@@ -29,6 +29,7 @@
      *  queries (term, below) */
     $("#email_select").select2({
         placeholder: "Select a user",
+	width: "33%",
         ajax: {
             url: "${h.url_for(controller="/api/users", action="index")}",
             dataType: 'json',
@@ -44,7 +45,7 @@
               $.each(data, function(index, item){
                     results.push({
                       id: item.email,
-                      text: item.email
+                      text: item.username + " : " + item.email
                     });
               });
               return {


### PR DESCRIPTION
The user impersonation dropdown is a) very narrow, and hard to read as a result, and b) contains only email addresses, which can be confusing if you don't know how the user you wish to impersonate signed up. Often a user will email from an account other than the one used to register for Galaxy. Also, our system uses LDAP identification, which means that the emails won't match in any case.

I propose changing the width of the dropdown to be 33% of the area width, and adding the user name to the dropdown so that it's easier to identify the user one wishes to impersonate. This required two minor changes to the impersonate.mako file. I've tested this thoroughly on my development system and have encountered no problems.
