### PR TITLE
Update workflow share dropdown width

### DIFF
--- a/templates/ind_share_base.mako
+++ b/templates/ind_share_base.mako
@@ -92,7 +92,7 @@
                         <label>
                             Email address of user to share with
                         </label>
-                        <div style="float: left; width: 250px; margin-right: 10px;">
+                        <div style="float: left; width: 100%;  margin-right: 10px;">
                             <input type="hidden" id="email_select" name="email" >
                             </input>
                         </div>
@@ -131,6 +131,7 @@
 
     $("#email_select").select2({
         placeholder: "Select a user",
+	width: "33%",
         multiple: false,
         initSelection: function(element, callback) {
             var data = [];


### PR DESCRIPTION
Update to make the workflow share dropdown the same width as the impersonate user dropdown. As it was, the dropdown was so narrow as to make the selection of users difficult. I changed the DIV width to be the width of the container so that the width of the dropdown could be adjusted by the same method I used on the impersonate user dialogue.
