### PR TITLE
Graph visualization: add parsers, change datatypes

### DIFF
--- a/config/plugins/visualizations/graphviz/config/graphviz.xml
+++ b/config/plugins/visualizations/graphviz/config/graphviz.xml
@@ -4,7 +4,17 @@
     <data_sources>
         <data_source>
             <model_class>HistoryDatasetAssociation</model_class>
-            <test type="isinstance" test_attr="datatype" result_type="datatype">data.Text</test>
+            <test test_attr="ext" result_type="datatype">json</test>
+            <to_param param_attr="id">dataset_id</to_param>
+        </data_source>
+        <data_source>
+            <model_class>HistoryDatasetAssociation</model_class>
+            <test test_attr="ext" result_type="datatype">txt</test>
+            <to_param param_attr="id">dataset_id</to_param>
+        </data_source>
+        <data_source>
+            <model_class>HistoryDatasetAssociation</model_class>
+            <test type="has_dataprovider" test_attr="datatype">node-edge</test>
             <to_param param_attr="id">dataset_id</to_param>
         </data_source>
     </data_sources>

--- a/config/plugins/visualizations/graphviz/static/js/graphVis.js
+++ b/config/plugins/visualizations/graphviz/static/js/graphVis.js
@@ -1,38 +1,49 @@
- var showNodeLabel;
- var showEdgeLabel;
- var showOut;
- var showIn;
- var demoNodes = [];
- var demoEdges = [];
- var shape;
- var allcy;
- var cy;
+var showNodeLabel;
+var showEdgeLabel;
+var showOut;
+var showIn;
+var demoNodes = [];
+var demoEdges = [];
+var shape;
+var allcy;
+var cy;
+// The key to hold down when brush/box selecting: 16 === shift
+var BRUSH_KEY = 16;
 
+$(function() {
+    // remove horizontal scrollbar
+    $("body").css("overflow-x", "hidden");
 
-
- $(function() { // on dom ready
-
-
- 	$("body").css("overflow-x", "hidden"); //// remove horizontal scrollbar
-
-
- }); // END on dom ready
+    // set up a key that, when held down, allows box selection and turns panning off
+    $( document )
+        .on( 'keydown', function( ev ){
+            if( cy && ev.keyCode === BRUSH_KEY ){
+                cy.panningEnabled( false );
+                cy.boxSelectionEnabled( true );
+            }
+        })
+        .on( 'keyup', function( ev ){
+            if( cy && ev.keyCode === BRUSH_KEY ){
+                cy.panningEnabled( true );
+                cy.boxSelectionEnabled( false );
+            }
+        });
+});
 
 // shape of the graph
- $("select option:selected").each(function() {
- 	shape = $(this).val();
+$("select option:selected").each(function() {
+    shape = $(this).val();
+});
 
- });
- 
- ///////// create graph
- function createGraph(data) {
+///////// create graph
+function createGraph(data) {
+    window.graphData = data;
 
  	allcy = cytoscape({
  		headless: true,
  	});
 
  	cy = cytoscape({
-
  		container: document.getElementById('cy'),
 
  		layout: {
@@ -45,121 +56,131 @@
  		motionBlur: true,
  		textureOnViewport: true,
 
+        // initially have click and drag pan the viewport
+        panningEnabled: true,
+        boxSelectionEnabled: false,
+
  		ready: function() {
 
  			window.cy = this;
  			cy.nodes().on("click", function(e) {
-
  				showNodeInfo(e.cyTarget);
-
  			});
  		},
+
  		style: cytoscape.stylesheet()
  			.selector('node')
  			.css({
- 			'content': showNodeLabel,
- 			'text-valign': 'center',
- 			'background-color': '#888888',
- 			'opacity': 0.8
+     			'content': showNodeLabel,
+     			'text-valign': 'center',
+     			'background-color': '#888888',
+     			'opacity': 0.8
+            })
 
- 		})
  			.selector('edge')
  			.css({
- 			'curve-style': 'unbundled-bezier',
- 			'target-arrow-shape': 'triangle',
- 			'width': 4,
- 			'line-color': '#ddd',
- 			'target-arrow-color': '#ddd',
- 			'content': showEdgeLabel
+     			'curve-style': 'unbundled-bezier',
+     			'target-arrow-shape': 'triangle',
+     			'width': 2,
+     			'line-color': '#ddd',
+     			'target-arrow-color': '#ddd',
+     			'content': showEdgeLabel
+            })
 
-
- 		})
  			.selector(':selected')
  			.css({
- 			'background-color': '#FE2E64',
- 			'line-color': '#FE2E64',
- 			'target-arrow-color': '#FE2E64',
- 			'source-arrow-color': '#FE2E64',
- 			'opacity': 1
- 		})
- 			.selector('core')
- 			.css({
- 			'outside-texture-bg-color': 'white'
+     			'background-color': '#FE2E64',
+     			'line-color': '#FE2E64',
+     			'target-arrow-color': '#FE2E64',
+     			'source-arrow-color': '#FE2E64',
+     			'opacity': 1
+     		})
 
- 		})
+            .selector('core')
+            .css({
+                'outside-texture-bg-color': 'white'
+     		})
  	});
+    window.cy = cy;
  	allcy.load(data);
 
-// if graph contains more than 50 nodes load only root nodes 
- 	if (allcy.nodes().length > 50 && allcy.nodes().roots().length != 0 ) {
-			
-			var toAdd = allcy.nodes().roots().closedNeighborhood();
- 			allcy.nodes().roots().addClass("roots");
- 			
-			showNodesToExpand(toAdd);
-	 		cy.add(toAdd);
- 			cy.load(cy.elements('*').jsons());
+    // if graph contains more than 50 nodes load only root nodes
+ 	if (allcy.nodes().length > 50 && allcy.nodes().roots().length !== 0 ) {
+		var toAdd = allcy.nodes().roots().closedNeighborhood();
+		allcy.nodes().roots().addClass("roots");
+
+		showNodesToExpand(toAdd);
+ 		cy.add(toAdd);
+		cy.load(cy.elements('*').jsons());
 
  		cy.style()
  			.selector('.toBeExpaned')
  			.css({
+     			'width': 50,
+     			'height': 50
+     		})
+ 			.update();
 
- 			'width': 50,
- 			'height': 50
- 		})
- 			.update(); 			
- 			
  	} else {
-
- 		cy.add(data);
- 		cy.load(cy.elements('*').jsons());
+        cy.add(data);
+        cy.load(cy.elements('*').jsons());
  	}
- 	cy.boxSelectionEnabled(true);
-
-
  	checkBoxes();
 
-
- } // END create graph	
-
-
- //// parse function for matrix data
- function parseAndCreate(demoNodes, demoEdges) {
- 	var data = {
- 		nodes: demoNodes,
- 		edges: demoEdges
- 	};
- 	createGraph(data);
- }
+} // END create graph
 
 
- ///// parsing function for json: for link/egde and "" issues
- function parseJson(dataToParse) {
+//// parse function for matrix data
+function parseTextMatrix(data) {
+    var nodes = [],
+        edges = [];
 
- 	if (dataToParse.links == null) {
+    data.split( '\n' ).forEach( function( line ){
+        var columns = line.split( /,?\s+/ ),
+            sourceId = columns[0]; // split by comma or space
 
- 		var links = dataToParse.edges;
- 	} else {
- 		var links = dataToParse.links;
- 		dataToParse.edges = links;
+        nodes.push({
+            data: { id: sourceId }
+        });
 
- 	}
+        for( var i = 1; i < columns.length; i++ ){
+            edges.push({
+                data: {
+                    source  : sourceId,
+                    target  : columns[i]
+                }
+            });
+        }
+    });
 
- 	var nodes = dataToParse.nodes;
+	createGraph({
+        nodes: nodes,
+        edges: edges
+    });
+}
 
- 	for (var i = 0; i < nodes.length; i++) {
+///// parsing function for json: for link/egde and "" issues
+function parseJson( data ) {
 
- 		dataToParse.nodes[i].data = nodes[i];
- 		dataToParse.nodes[i].data.id = '"' + nodes[i].id + '"';
- 	}
-
-
- 	for (var i = 0; i < links.length; i++) {
-
- 		dataToParse.edges[i].data = links[i];
- 		dataToParse.edges[i].data.source = '"' + links[i].source + '"';
- 		dataToParse.edges[i].data.target = '"' + links[i].target + '"';
- 	}
-
- 	createGraph(dataToParse);
- }
+    if( data.hasOwnProperty( 'links' ) ){
+        data.edges = data.links;
+        delete data.links;
+    }
+	data.nodes = data.nodes.map( function _processNode( node ){
+        return {
+            data : $.extend( {}, node.data, {
+                id : node.id + ''
+            })
+        };
+    });
+    data.edges = data.edges.map( function _processEdge( edge ){
+        return {
+            data : $.extend( {}, edge.data, {
+                id      : edge.id || undefined,
+                source  : data.nodes[ edge.source ].data.id,
+                target  : data.nodes[ edge.target ].data.id
+            })
+        };
+    });
+	createGraph( data );
+}

--- a/config/plugins/visualizations/graphviz/static/js/toolPanelFunctions.js
+++ b/config/plugins/visualizations/graphviz/static/js/toolPanelFunctions.js
@@ -34,7 +34,7 @@ $(function() { // on dom ready
 	});
 
 
-	//////// change the shape of the graph 
+	//////// change the shape of the graph
 	$('#selectShape').change(function() {
 
 		$("select option:selected").each(function() {
@@ -54,11 +54,11 @@ $(function() { // on dom ready
 		if ($('#showOutNode').is(":checked")) {
 			showOut = true;
 			cy.nodes().on("tapend", highlightOut);
-			
+
 		} else {
 			showOut = false;
 			cy.nodes().off("tapend", highlightOut);
-			
+
 			resetHighlightOut(showIn, showOut);
 		}
 	});
@@ -71,13 +71,13 @@ $(function() { // on dom ready
 		if ($('#showInNode').is(":checked")) {
 			showIn = true;
 			cy.nodes().on("tapend", highlightIn);
-			
+
 
 		} else {
 			showIn = false;
 			cy.nodes().off("tapend", highlightIn);
 			resetHighlightIn(showIn, showOut);
-			
+
 			cy.nodes().removeClass('connectedNodeIn');
 		}
 
@@ -101,12 +101,12 @@ $(function() { // on dom ready
 
 	});
 
-	//// disable/unable buttons 
+	//// disable/unable buttons
 	$(document).on('click', function() {
 
 		var selectedNode = cy.nodes(':selected');
 
-		if (selectedNode.outgoers().length == 0) {
+		if (selectedNode.outgoers().length === 0) {
 
 			$('.btn.colNode').prop('disabled', true);
 
@@ -149,7 +149,7 @@ $(function() { // on dom ready
 
 		var selectedNode = cy.nodes(':selected');
 
-		if (e.which == 101 && selectedNode.size() != 0) { // 101 for 'e' = expand
+		if (e.which === 101 && selectedNode.size() !== 0) { // 101 for 'e' = expand
 
 			if (selectedNode.hasClass('toBeExpaned')) {
 
@@ -162,20 +162,20 @@ $(function() { // on dom ready
 
 
 		}
-		if (e.which == 99 && selectedNode.size() != 0 && !selectedNode.hasClass('superNode') && selectedNode.outgoers().length != 0) { // 99 for 'c' = collapse
+		if (e.which === 99 && selectedNode.size() !== 0 && !selectedNode.hasClass('superNode') && selectedNode.outgoers().length !== 0) { // 99 for 'c' = collapse
 
 			colNode();
 
 		}
 
-		if (e.which == 100 && selectedNode.size() != 0) { // 100 for 'd' = delete
+		if (e.which === 100 && selectedNode.size() !== 0) { // 100 for 'd' = delete
 			deleteSelectedNodes();
 		}
 
 
 	});
 
-	/////////////// tool Panel movement 
+	/////////////// tool Panel movement
 
 	$(document).on('click', '.slider-arrow.show', function() {
 		$(".slider-arrow, .panel").animate({
@@ -234,13 +234,9 @@ $(function() { // on dom ready
 		// document.getElementById('cy').style.width="100%";
 		cy.resize();
 	});
+}); // on dom ready END
 
-
-
-
-}) // on dom ready END
-
-///////// finding outgoing Nodes		
+///////// finding outgoing Nodes
 function highlightOut() {
 
 	var selectedNode = this;
@@ -259,7 +255,7 @@ function highlightOut() {
 		})
 			.update();
 	} else {
-		
+
 		cy.nodes().not(this).removeClass('connectedNodeOut');
 		cy.nodes().not(this).removeClass('selectedNodeOut');
 		cy.edges().not(this).removeClass('connectedNodeOut');
@@ -290,7 +286,7 @@ function highlightOut() {
 	}
 }
 
-/////// reset highlighting of outgoing nodes 		
+/////// reset highlighting of outgoing nodes
 function resetHighlightOut(showIn, showOut) {
 
 	cy.style()
@@ -370,7 +366,7 @@ function highlightIn() {
 }
 
 
-/////// reset highlighting of incoming nodes 		
+/////// reset highlighting of incoming nodes
 function resetHighlightIn(showIn, showOut) {
 
 	cy.style()
@@ -401,7 +397,7 @@ function resetHighlightIn(showIn, showOut) {
 }
 
 
-////// export PNG 	
+////// export PNG
 function exportFunction() {
 
 	var pngPic = cy.png();
@@ -418,7 +414,6 @@ function downloadURI(uri, fname) {
 	link.click();
 	// Cleanup the DOM
 	document.body.removeChild(link);
-	delete link;
 }
 
 ///// restore Graph structure
@@ -449,7 +444,6 @@ function showNodeInfo(node) {
 	var j = 0;
 
 	for (var key in nodeContent) {
-
 		if (key == 'group' || key == 'data') {
 			continue;
 		}
@@ -458,9 +452,7 @@ function showNodeInfo(node) {
 		i++;
 		values[j] = nodeContent[key];
 		j++;
-
 	}
-
 
 	var childNodes = node.outgoers().nodes();
 	var childNum = childNodes.length;
@@ -472,16 +464,15 @@ function showNodeInfo(node) {
 	var table = createTable(fieldName, values, degree, parentNum, childNum);
 
 	$('#nodeInfoDiv').html("<p><strong>Node Description </p>" + table);
-	for (var i = 0; i < fieldName.length; i++) {
 
-		if (isValidUrl(values[i])) {
+	for (var strIndex = 0; strIndex < fieldName.length; strIndex++) {
 
+		if (isValidUrl(values[strIndex])) {
 			var e = document.createElement("div");
 			e.id = "linkDiv";
 			$('#nodeInfoDiv').append(e);
-			
+
 			var url = values[i];
-			
 			document.getElementById("linkDiv").innerHTML += "<br>" + fieldName[i] + "<br>";
 			$('<iframe id="iframeId" width = "240"/>').appendTo(document.getElementById("linkDiv")).prop('src', url);
 
@@ -490,39 +481,26 @@ function showNodeInfo(node) {
 	}
 }
 
-function isValidUrl(str) {
-	var pattern = new RegExp(/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/); // fragment locater
-	if (!pattern.test(str)) {
-
-		return false;
-	} else {
-		return true;
-	}
-}
-
 function createTable(fieldName, values, degree, parentNum, childNum) {
-
 	var table = "<table class='CSSTableGenerator'>";
-
 	for (var i = 0; i < fieldName.length; i++) {
-
-
 		if (isValidUrl(values[i])) {
 			i++;
 		}
-
 		table += "<tr>" + "<td>" + fieldName[i] + "</td>" + "<td>" + values[i] + "</td>" + "</tr>";
-
 	}
 	table += "<tr>" + "<td>" + "degree" + "</td>" + "<td>" + degree + "</td>" + "</tr>";
 	table += "<tr>" + "<td>" + "number of child nodes" + "</td>" + "<td>" + childNum + "</td>" + "</tr>";
 	table += "<tr>" + "<td>" + "number of parent nodes" + "</td>" + "<td>" + parentNum + "</td>" + "</tr>";
-
-
 	table += "</table>";
 	return table;
-
 }
+
+function isValidUrl(str) {
+	var pattern = new RegExp(/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/); // fragment locater
+	return pattern.test(str);
+}
+
 
 
 /////// delete selected nodes
@@ -539,7 +517,7 @@ function deleteSelectedNodes() {
 	cy.remove(edgesToRemove);
 
 }
-/////// restore Deleted Nodes 
+/////// restore Deleted Nodes
 function restoreDeletedNodes() {
 	nodesToRemove.restore();
 	edgesToRemove.restore();
@@ -550,7 +528,7 @@ function expandNodes(selectedNode) {
 
 	cy.nodes().unbind("tapend");
 	var selectedNodeId = selectedNode.id();
-	selectedNodeId = selectedNodeId.replace(/[^0-9\.]+/g, ""); // removing "" 
+	selectedNodeId = selectedNodeId.replace(/[^0-9\.]+/g, ""); // removing ""
 
 	var eles = allcy.nodes();
 
@@ -559,7 +537,7 @@ function expandNodes(selectedNode) {
 	showNodesToExpand(nodesToAdd);
 	cy.add(eles[selectedNodeId].outgoers());
 
-	selectedNode.removeClass('toBeExpaned'); 
+	selectedNode.removeClass('toBeExpaned');
 
 	$("select option:selected").each(function() {
 		shape = $(this).val();
@@ -583,7 +561,7 @@ function showNodesToExpand(toAdd) {
 
 		if (ele.outdegree() > 0 && !ele.hasClass('roots')) {
 			ele.addClass('toBeExpaned');
-		} 
+		}
 	});
 
 }
@@ -604,7 +582,7 @@ function checkBoxes() {
 		resetHighlightIn(showIn, showOut);
 		cy.nodes().removeClass('connectedNodeIn');
 	}
-	
+
 	if ($('#showOutNode').is(":checked")) {
 		showOut = true;
 		cy.nodes().on("tapend", highlightOut);


### PR DESCRIPTION
- Removes Data.Text and all subclasses from the applicable datatypes
- Adds all datatypes that can provide node-edge data to be applicable
  (xgmll and sif)
- Adds txt and json extensions as applicable
- Minor clean up
- Can use shift key to brush select multiple nodes
