### PR TITLE
Fixes for workflow extraction of mapping collection jobs.

### DIFF
--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -192,6 +192,9 @@ class ToolExecutionTracker( object ):
                 job.add_output_dataset_collection( output_name, collection )
             collections[ output_name ] = collection
 
+        # Needed to flush the association created just above with
+        # job.add_output_dataset_collection.
+        trans.sa_session.flush()
         self.implicit_collections = collections
 
 __all__ = [ execute ]

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -220,15 +220,17 @@ class WorkflowSummary( object ):
         dataset_collection = content
         hid = content.hid
         self.collection_types[ hid ] = content.collection.collection_type
-        if content.creating_job_associations:
-            for assoc in content.creating_job_associations:
-                job = assoc.job
-                if job not in self.jobs or self.jobs[ job ][ 0 ][ 1 ].history_content_type == "dataset":
-                    self.jobs[ job ] = [ ( assoc.name, dataset_collection ) ]
-                    if content.implicit_output_name:
-                        self.implicit_map_jobs.append( job )
-                else:
-                    self.jobs[ job ].append( ( assoc.name, dataset_collection ) )
+        cja = content.creating_job_associations
+        if cja:
+            # Use the first job to represent all mapped jobs.
+            representive_job_assoc = content.creating_job_associations[0]
+            job = representive_job_assoc.job
+            if job not in self.jobs or self.jobs[ job ][ 0 ][ 1 ].history_content_type == "dataset":
+                self.jobs[ job ] = [ ( representive_job_assoc.name, dataset_collection ) ]
+                if content.implicit_output_name:
+                    self.implicit_map_jobs.append( job )
+            else:
+                self.jobs[ job ].append( ( representive_job_assoc.name, dataset_collection ) )
         # This whole elif condition may no longer be needed do to additional
         # tracking with creating_job_associations. Will delete at some point.
         elif content.implicit_output_name:


### PR DESCRIPTION
Extraction might not work on older histories thanks to incorrect flushing fixed with 43523da being persisted incorrectly.

To test:
- GALAXY_RUN_WITH_TEST_TOOLS=1 bash run.sh
- Create a collection.
- Run the "Create 10" tool over the collection.
- Extract a workflow.
- Note the duplicated "Create 10" job - one of those fails.
- Apply the patch.
- Run a new "Create 10" tool over the collection.
- Second run should not be duplicated and workflow extraction should succeed.

Might fix https://github.com/galaxyproject/galaxy/issues/1465?
