### PR TITLE
[16.04] Workflow SVG generation fix

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -29,7 +29,7 @@ from galaxy.workflow.extract import summarize
 from galaxy.workflow.modules import MissingToolException
 from galaxy.workflow.modules import module_factory
 from galaxy.workflow.modules import WorkflowModuleInjector
-from galaxy.workflow.render import WorkflowCanvas
+from galaxy.workflow.render import WorkflowCanvas, STANDALONE_SVG_TEMPLATE
 from galaxy.workflow.run import invoke
 from galaxy.workflow.run import WorkflowRunConfig
 
@@ -519,7 +519,8 @@ class WorkflowController( BaseUIController, SharableMixin, UsesStoredWorkflowMix
             message = 'Galaxy is unable to create the SVG image. Please check your workflow, there might be missing tools.'
             return trans.fill_template( "/workflow/sharing.mako", use_panels=True, item=stored, status=status, message=message )
         trans.response.set_content_type("image/svg+xml")
-        return svg.tostring()
+        s = STANDALONE_SVG_TEMPLATE % svg.tostring()
+        return s.encode('utf-8')
 
     @web.expose
     @web.require_login( "use Galaxy workflows" )

--- a/lib/galaxy/workflow/render.py
+++ b/lib/galaxy/workflow/render.py
@@ -2,6 +2,10 @@ import svgwrite
 
 MARGIN = 5
 LINE_SPACING = 15
+STANDALONE_SVG_TEMPLATE = """<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+%s"""
 
 
 class WorkflowCanvas( object ):


### PR DESCRIPTION
Paste handles encoding automatically when thrown unicode, but uwsgi does
not.  This was resulting in unencoded (unicode) workflow drawings (svg)
not appearing at all when the gen_image was invoked.  Also took the
opportunity to add a correct header for a standalone svg document.

This resolves the core issue in #2465
