### PR TITLE
[16.01] UI, history: replace copy dialog on grid refresh

### DIFF
--- a/templates/webapps/galaxy/history/grid.mako
+++ b/templates/webapps/galaxy/history/grid.mako
@@ -15,11 +15,25 @@
                 return ( $link.attr( 'href' ).match( /id=(\w+)/ ) || [] )[1];
             }
 
-            // wait for page ready and set it all up
+            // wait for page ready and set it all up, do it again when the grid refreshes
             $(function(){
-                var $buttons = $( '.popup.menubutton' ).each( function( i ){
-                    copyDialogHack.call( this, i, findHistoryId );
-                });
+                if( !gridView ){
+                    console.warn( 'no grid' );
+                    return;
+                }
+
+                function replaceCopyFunction(){
+                    gridView.$( '.popup.menubutton' ).each( function( i ){
+                        copyDialogHack.call( this, i, findHistoryId );
+                    });
+                }
+                replaceCopyFunction();
+
+                var originalInitGrid = gridView.init_grid;
+                gridView.init_grid = function __patched_init_grid( json ){
+                    originalInitGrid.call( gridView, json );
+                    replaceCopyFunction();
+                };
             });
         });
     </script>


### PR DESCRIPTION
Fixes #2624

init_grid is called from update_grid to rebuild the grid. This patches
that call to replace the copy links with the dialog.

Note:
- related to #1303 which was an effort to make a single code path
  for copying histories.
- Uses monkey patching to keep from porting build artifacts.
