### PR TITLE
Properly initialize datasets when workflow is loaded for execution

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1838,7 +1838,7 @@ class DataToolParameter( BaseDataToolParameter ):
               happens twice (here and when generating HTML).
         """
         # Can't look at history in workflow mode. Tool shed has no histories.
-        if trans.workflow_building_mode or trans.app.name == 'tool_shed':
+        if trans.workflow_building_mode is workflow_building_modes.ENABLED or trans.app.name == 'tool_shed':
             return RuntimeValue()
         history = self._get_history( trans )
         dataset_matcher = DatasetMatcher( trans, self, None, other_values )

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -32,6 +32,7 @@ from galaxy.workflow.modules import WorkflowModuleInjector
 from galaxy.workflow.render import WorkflowCanvas
 from galaxy.workflow.run import invoke
 from galaxy.workflow.run import WorkflowRunConfig
+from galaxy.tools.parameters.basic import workflow_building_modes
 
 log = logging.getLogger( __name__ )
 
@@ -1130,6 +1131,7 @@ class WorkflowController( BaseUIController, SharableMixin, UsesStoredWorkflowMix
             else:
                 # Prepare each step
                 missing_tools = []
+                trans.workflow_building_mode = workflow_building_modes.USE_HISTORY
                 for step in workflow.steps:
                     try:
                         module_injector.inject( step )

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -16,6 +16,7 @@ from galaxy.tools.parameters.basic import (
     DataCollectionToolParameter,
     DataToolParameter,
     RuntimeValue,
+    workflow_building_modes
 )
 from galaxy.tools.parameters.wrapped import make_dict_copy
 from galaxy.tools import DefaultToolState
@@ -1148,10 +1149,12 @@ class ToolModule( WorkflowModule ):
 
         # Any connected input needs to have value RuntimeValue (these
         # are not persisted so we need to do it every time)
-        def callback( input, prefixed_name, **kwargs ):
+        def callback( input, prefixed_name, context, **kwargs ):
             if isinstance( input, DataToolParameter ) or isinstance( input, DataCollectionToolParameter ):
                 if connections is None or prefixed_name in input_connections_by_name:
                     return RuntimeValue()
+                elif self.trans.workflow_building_mode is workflow_building_modes.USE_HISTORY:
+                    return input.get_initial_value( self.trans, context )
 
         visit_input_values( self.tool.inputs, self.state.inputs, callback )
 


### PR DESCRIPTION
When loading the workflow form, datasets are not initialized on module injection instead they are served as `RuntimeValues` formely as `DummyDatasets`. As a consequence data dependent input parameters such as e.g. data columns are not resolved i.e. no options are shown unless refreshed. This PR fixes the issue and ensures that unlinked datasets are initialized properly on load such that these dynamic option fields are resolved on start up without the need for an additional refresh. It can be tested by loading a single step workflow containing the `merge` tool without modifying any parameters with and without this fix.

![columnyesno](https://cloud.githubusercontent.com/assets/2105447/16963087/acc81366-4dc2-11e6-9606-f933ff976cf5.png)
