### PR TITLE
Optimize get_file_peek()

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -974,29 +974,24 @@ def get_file_peek( file_name, is_multi_byte=False, WIDTH=256, LINE_COUNT=5, skip
     file_type = None
     data_checked = False
     temp = open( file_name, "U" )
-    last_line = ''
     while count < LINE_COUNT:
-        line = last_line + temp.readline( WIDTH - len( last_line ) )
+        line = temp.readline( WIDTH )
         if line and not is_multi_byte and not data_checked:
             # See if we have a compressed or binary file
             if line[0:2] == util.gzip_magic:
                 file_type = 'gzipped'
-                break
             else:
                 for char in line:
                     if ord( char ) > 128:
                         file_type = 'binary'
                         break
             data_checked = True
-        if file_type in [ 'gzipped', 'binary' ]:
-            break
+            if file_type in [ 'gzipped', 'binary' ]:
+                break
         if not line_wrap:
-            if '\n' in line:
-                i = line.index( '\n' )
-                last_line = line[i + 1:]
-                line = line[:i]
+            if line.endswith('\n'):
+                line = line[:-1]
             else:
-                last_line = ''
                 while True:
                     i = temp.read(1)
                     if not i or i == '\n':

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -892,7 +892,7 @@ def unicodify(value, encoding=DEFAULT_ENCODING, error='replace', default=None):
 
 
 def smart_str(s, encoding=DEFAULT_ENCODING, strings_only=False, errors='strict'):
-    """
+    u"""
     Returns a bytestring version of 's', encoded as specified in 'encoding'.
 
     If strings_only is True, don't convert (some) non-string-like objects.
@@ -905,8 +905,8 @@ def smart_str(s, encoding=DEFAULT_ENCODING, strings_only=False, errors='strict')
     >>> assert smart_str(3, strings_only=True) == 3
     >>> assert smart_str(b'a bytes string') == b'a bytes string'
     >>> assert smart_str(u'a simple unicode string') == b'a simple unicode string'
-    >>> assert smart_str(u'à strange ünicode ڃtring') == b'\xc3\xa0 strange \xc3\xbcnicode \xda\x83tring'
-    >>> assert smart_str(b'\xc3\xa0n \xc3\xabncoded utf-8 string', encoding='latin-1') == b'\xe0n \xebncoded utf-8 string'
+    >>> assert smart_str(u'à strange ünicode ڃtring') == b'\\xc3\\xa0 strange \\xc3\\xbcnicode \\xda\\x83tring'
+    >>> assert smart_str(b'\\xc3\\xa0n \\xc3\\xabncoded utf-8 string', encoding='latin-1') == b'\\xe0n \\xebncoded utf-8 string'
     """
     if strings_only and isinstance(s, (type(None), int)):
         return s


### PR DESCRIPTION
`last_line` was always the empty string because `line` is read with `readline()` and therefore `'\n'` is always its last character (if it is present). This is a follow-up to #2556.

Also fix `smart_str()` doctests which were silently failing.
