### PR TITLE
Set allow_duplicate_entries="False" for built-in Tool Data Tables.

### DIFF
--- a/config/tool_data_table_conf.xml.sample
+++ b/config/tool_data_table_conf.xml.sample
@@ -1,27 +1,27 @@
 <!-- Use the file tool_data_table_conf.xml.oldlocstyle if you don't want to update your loc files as changed in revision 4550:535d276c92bc-->
 <tables>
     <!-- Locations of all fasta files under genome directory -->
-    <table name="all_fasta" comment_char="#">
+    <table name="all_fasta" comment_char="#" allow_duplicate_entries="False" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/all_fasta.loc" />
     </table>
     <!-- Locations of indexes in the BFAST mapper format -->
-    <table name="bfast_indexes" comment_char="#">
+    <table name="bfast_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, formats, name, path</columns>
         <file path="tool-data/bfast_indexes.loc" />
     </table>
     <!-- Locations of protein (mega)blast databases -->
-    <table name="blastdb_p" comment_char="#">
+    <table name="blastdb_p" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, path</columns>
         <file path="tool-data/blastdb_p.loc" />
     </table>
     <!-- Locations of indexes in the BWA mapper format -->
-    <table name="bwa_indexes" comment_char="#">
+    <table name="bwa_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/bwa_index.loc" />
     </table>
     <!-- Locations of indexes in the BWA color-space mapper format -->
-    <table name="bwa_indexes_color" comment_char="#">
+    <table name="bwa_indexes_color" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/bwa_index_color.loc" />
     </table>
@@ -31,62 +31,62 @@
         <file path="tool-data/maf_index.loc" />
     </table>
     <!-- Locations of fasta files appropriate for NGS simulation -->
-    <table name="ngs_sim_fasta" comment_char="#">
+    <table name="ngs_sim_fasta" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/ngs_sim_fasta.loc" />
     </table>
     <!-- Locations of PerM base index files -->
-    <table name="perm_base_indexes" comment_char="#">
+    <table name="perm_base_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, path</columns>
         <file path="tool-data/perm_base_index.loc" />
     </table>
     <!-- Locations of PerM color-space index files -->
-    <table name="perm_color_indexes" comment_char="#">
+    <table name="perm_color_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, path</columns>
         <file path="tool-data/perm_color_index.loc" />
     </table>
     <!-- Location of Picard dict file and other files -->
-    <table name="picard_indexes" comment_char="#">
+    <table name="picard_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/picard_index.loc" />
     </table>
     <!-- Location of SRMA dict file and other files -->
-    <table name="srma_indexes" comment_char="#">
+    <table name="srma_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/picard_index.loc" />
     </table>
     <!-- Location of Mosaik files -->
-    <table name="mosaik_indexes" comment_char="#">
+    <table name="mosaik_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/mosaik_index.loc" />
     </table>
     <!-- Locations of indexes in the 2bit format -->
-    <table name="twobit" comment_char="#">
+    <table name="twobit" comment_char="#" allow_duplicate_entries="False">
         <columns>value, path</columns>
         <file path="tool-data/twobit.loc" />
     </table>
     <!-- Available IGV builds, loaded from URL -->
-    <table name="igv_broad_genomes" comment_char="#">
+    <table name="igv_broad_genomes" comment_char="#" allow_duplicate_entries="False">
         <columns>name, url, value</columns>
         <file url="http://igv.broadinstitute.org/genomes/genomes.txt" />
     </table>
     <!-- Available liftOver chain file -->
-    <table name="liftOver" comment_char="#">
+    <table name="liftOver" comment_char="#" allow_duplicate_entries="False">
         <columns>dbkey, name, value</columns>
         <file path="tool-data/liftOver.loc" />
     </table>
     <!-- iobio bam servers -->
-    <table name="bam_iobio" comment_char="#">
+    <table name="bam_iobio" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, url</columns>
         <file path="tool-data/bam_iobio.loc" />
     </table>
     <!-- iobio vcf servers -->
-    <table name="vcf_iobio" comment_char="#">
+    <table name="vcf_iobio" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, url</columns>
         <file path="tool-data/vcf_iobio.loc" />
     </table>
     <!-- simple biom servers -->
-    <table name="biom_simple_display" comment_char="#">
+    <table name="biom_simple_display" comment_char="#" allow_duplicate_entries="False">
         <columns>value, name, url</columns>
         <file path="tool-data/biom_simple_display.loc" />
     </table>

--- a/config/tool_data_table_conf.xml.sample
+++ b/config/tool_data_table_conf.xml.sample
@@ -1,7 +1,7 @@
 <!-- Use the file tool_data_table_conf.xml.oldlocstyle if you don't want to update your loc files as changed in revision 4550:535d276c92bc-->
 <tables>
     <!-- Locations of all fasta files under genome directory -->
-    <table name="all_fasta" comment_char="#" allow_duplicate_entries="False" allow_duplicate_entries="False">
+    <table name="all_fasta" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/all_fasta.loc" />
     </table>


### PR DESCRIPTION
Prevents duplicate entries from appearing in data table when they exist in the files. Prevents cases where a duplicate entry occurs and is then passed as a comma separated list onto the command line (which breaks most tools).
