### PR TITLE
Import pyparsing in testing so twill's older version doesn't get loaded.

### DIFF
--- a/test/base/twilltestcase.py
+++ b/test/base/twilltestcase.py
@@ -12,6 +12,10 @@ import zipfile
 from json import loads
 from xml.etree import ElementTree
 
+# Be sure to use Galaxy's vanilla pyparsing instead of the older version
+# imported by twill.
+import pyparsing  # noqa: F401
+
 import twill
 import twill.commands as tc
 from markupsafe import escape


### PR DESCRIPTION
There are unintended consequences if not, such as svgwrite not loading properly.
