### PR TITLE
Ensure Galaxy's python binary is used for metadata generation.

### DIFF
--- a/lib/galaxy/datatypes/set_metadata_tool.xml
+++ b/lib/galaxy/datatypes/set_metadata_tool.xml
@@ -4,7 +4,7 @@
       <requirement type="package">samtools</requirement>
   </requirements>
   <action module="galaxy.tools.actions.metadata" class="SetMetadataToolAction"/>
-  <command>python "${set_metadata}" ${__SET_EXTERNAL_METADATA_COMMAND_LINE__}</command>
+  <command>"\${GALAXY_PYTHON:-python}" "${set_metadata}" ${__SET_EXTERNAL_METADATA_COMMAND_LINE__}</command>
   <inputs>
     <param format="data" name="input1" type="data" label="File to set metadata on."/>
     <param name="__ORIGINAL_DATASET_STATE__" type="hidden" value=""/>

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -19,6 +19,7 @@ if [ "$GALAXY_VIRTUAL_ENV" != "None" -a -z "$VIRTUAL_ENV" \
      -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" ]; then
     . "$GALAXY_VIRTUAL_ENV/bin/activate"
 fi
+GALAXY_PYTHON=`which python`
 $instrument_pre_commands
 cd $working_directory
 $command


### PR DESCRIPTION
Might solve problems where resolve samtools requirement could potentially change the Python used by Galaxy when setting metadata. https://github.com/galaxyproject/galaxy/issues/2541#issuecomment-235334397

Can anyone tell me if this fixes https://github.com/galaxyproject/galaxy/issues/2541?
