### PR TITLE
Add import order linting using tox and flake8-import-order.

### DIFF
--- a/.ci/flake8_lint_include_list.txt
+++ b/.ci/flake8_lint_include_list.txt
@@ -1,0 +1,2 @@
+lib/galaxy/jobs/runners/util/external.py
+lib/galaxy/util/bunch.py

--- a/.ci/flake8_wrapper_imports.sh
+++ b/.ci/flake8_wrapper_imports.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+flake8 `paste .ci/flake8_lint_include_list.txt`

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ env:
   - TOX_ENV=py27-unit
   - TOX_ENV=qunit
   - TOX_ENV=first_startup
+  - TOX_ENV=py27-lint-imports
+  - TOX_ENV=py27-lint-imports-include-list
+
 matrix:
   include:
   - os: osx
@@ -16,6 +19,8 @@ matrix:
   - os: osx
     env: TOX_ENV=py27-unit
     language: generic
+  allow_failures:
+  - env: TOX_ENV=py27-lint-imports
 
 before_install:
   - if [ `uname` == "Darwin"  ]; then bash -c "brew update && brew install python"; fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,8 @@
 # 501 is line length
 # W503 is line breaks before binary operators, which has been reversed in PEP 8.
 ignore = E128,E201,E202,E203,E501,E402,W503
+
+# For flake8-import-order
+# https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_smarkets.py
+import-order-style = smarkets
+application-import-names = galaxy

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
-envlist = py27-lint, py27-unit, qunit, mako-count, web-controller-line-count, py33-lint, py34-lint, py35-lint
+envlist = py27-lint, py27-lint-imports, py27-lint-imports-include-list, py27-unit, qunit, mako-count, web-controller-line-count, py33-lint, py34-lint, py35-lint
 skipsdist = True
-
 
 [testenv:py27-lint]
 commands = bash .ci/flake8_wrapper.sh
@@ -30,6 +29,27 @@ deps =
     nose
     NoseHTML
     mock
+
+# Setup tox environments for linting all of Galaxy for imports and
+# just a subset we expect to pass (the include import list). Once the
+# include list is reduced to just the inverse of Galaxy's linting
+# blacklist these can both just be removed and flake8-import-order can
+# be added as a dependency to Galaxy's main linting task.
+[testenv:py27-lint-imports] 
+commands = bash .ci/flake8_wrapper.sh
+whitelist_externals = bash
+skip_install = True
+deps =
+    flake8<3
+    flake8-import-order
+
+[testenv:py27-lint-imports-include-list]
+commands = bash .ci/flake8_wrapper_imports.sh
+whitelist_externals = bash
+skip_install = True
+deps =
+    flake8<3
+    flake8-import-order
 
 [testenv:qunit]
 commands = bash run_tests.sh -q


### PR DESCRIPTION
Adds two tasks:
- Add a task that just lints everything the way Galaxy's default linting is (py27-lint-imports) and don't enforce it passes on Travis.
- Add a task that just lints a subset we expect to pass, hopefully we can grow this subset over time.

Once the inverse of the subset we are testing is just the blacklist, we can eliminate both tasks and just wrap this into Galaxy's default linting.

These tasks require an older flake8 until https://github.com/PyCQA/flake8-import-order/issues/79#issuecomment-235052270 is part of a released version of flake8.
