### PR TITLE
Fix broken toolshed tests with #2554

### DIFF
--- a/test/shed_functional/functional/test_1010_install_repository_with_tool_dependencies.py
+++ b/test/shed_functional/functional/test_1010_install_repository_with_tool_dependencies.py
@@ -103,7 +103,7 @@ class ToolWithToolDependencies( ShedTwillTestCase ):
 
     def test_0015_install_freebayes_repository( self ):
         '''Install the freebayes repository without installing tool dependencies.'''
-        strings_displayed = [ 'Never installed', 'dependencies can be automatically handled', 'Handle', 'tool dependencies' ]
+        strings_displayed = [ 'Never installed', 'dependencies can be automatically handled', 'install tool shed managed', 'tool dependencies' ]
         strings_displayed.extend( [ 'freebayes', '0.9.4_9696d0ce8a9', 'samtools', '0.1.18' ] )
         self.install_repository( repository_name,
                                  common.test_user_1_name,

--- a/test/shed_functional/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
+++ b/test/shed_functional/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
@@ -89,7 +89,7 @@ class UninstallingAndReinstallingRepositories( ShedTwillTestCase ):
     def test_0010_install_freebayes_repository( self ):
         '''Install the freebayes repository into the Galaxy instance.'''
         self.galaxy_login( email=common.admin_email, username=common.admin_username )
-        strings_displayed = [ 'Handle', 'tool dependencies', 'freebayes', '0.9.4_9696d0ce8a9', 'samtools', '0.1.18' ]
+        strings_displayed = [ 'install tool shed managed', 'tool dependencies', 'freebayes', '0.9.4_9696d0ce8a9', 'samtools', '0.1.18' ]
         self.install_repository( 'freebayes_0010',
                                  common.test_user_1_name,
                                  'Test 0010 Repository With Tool Dependencies',


### PR DESCRIPTION
The Change from "Handle tool dependencies?" to "When available, install tool shed managed dependencies?" is breaking some of the toolshed tests, this should fix it.
