### PR TITLE
Limit creation of multitudes of default, empty histories. 

### DIFF
--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -482,9 +482,10 @@ class GalaxyWebTransaction( base.DefaultWebTransaction,
             if prev_galaxy_session:
                 self.sa_session.add( prev_galaxy_session )
             self.sa_session.flush()
-        # If the old session was invalid, get a new history with our new session
+        # If the old session was invalid, get a new (or existing default,
+        # unused) history with our new session
         if invalidate_existing_session:
-            self.new_history()
+            self.get_or_create_default_history()
 
     def _ensure_logged_in_user( self, environ, session_cookie ):
         # The value of session_cookie can be one of
@@ -719,7 +720,7 @@ class GalaxyWebTransaction( base.DefaultWebTransaction,
             if hasattr( self.galaxy_session, 'current_history' ):
                 history = self.galaxy_session.current_history
         if not history and util.string_as_bool( create ):
-            history = self.new_history()
+            history = self.get_or_create_default_history()
         return history
 
     def set_history( self, history ):


### PR DESCRIPTION
This was happening for every new session using remote auth.  Does anyone see a reason why we would _not_ want to use the default history in these two spots, if it exists?

Followup PR will address associating new remote_auth sessions with the previously used history correctly, but this is a good step forward.
