### PR TITLE
Fix for splitting dataset collections

### DIFF
--- a/lib/galaxy/dataset_collections/subcollections.py
+++ b/lib/galaxy/dataset_collections/subcollections.py
@@ -20,6 +20,6 @@ def _split_dataset_collection( dataset_collection, collection_type ):
         if child_collection.collection_type == collection_type:
             split_elements.append( element )
         else:
-            split_elements.extend( _split_dataset_collection( element.child_collection ) )
+            split_elements.extend( _split_dataset_collection( element.child_collection, element.child_collection.collection_type ) )
 
     return split_elements


### PR DESCRIPTION
I encountered the following error when attempting to re-run a job that produced a dataset collection, and this PR should correct the error:

```
constructor galaxy.web.framework.decorators ERROR 2016-08-02 22:22:48,425 Uncaught exception in exposed API method:
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 260, in decorator
    rval = func( self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/api/tools.py", line 262, in create
    vars = tool.handle_input( trans, incoming, history=target_history )
  File "lib/galaxy/tools/__init__.py", line 1086, in handle_input
    expanded_incomings, collection_info = expand_meta_parameters( trans, self, incoming )
  File "lib/galaxy/tools/parameters/meta.py", line 53, in expand_meta_parameters
    expanded_incomings = permutations.expand_multi_inputs( incoming_template, classifier )
  File "lib/galaxy/util/permutations.py", line 30, in expand_multi_inputs
    key_filter
  File "lib/galaxy/util/permutations.py", line 49, in __split_inputs
    input_type, expanded_val = classifier( input_key )
  File "lib/galaxy/tools/parameters/meta.py", line 38, in classifier
    values = __expand_collection_parameter( trans, input_key, collection_value, collections_to_match, linked=is_linked )
  File "lib/galaxy/tools/parameters/meta.py", line 81, in __expand_collection_parameter
    subcollection_elements = subcollections.split_dataset_collection_instance( hdc, subcollection_type )
  File "lib/galaxy/dataset_collections/subcollections.py", line 7, in split_dataset_collection_instance
    return _split_dataset_collection( dataset_collection_instance.collection, collection_type )
  File "lib/galaxy/dataset_collections/subcollections.py", line 23, in _split_dataset_collection
    split_elements.extend( _split_dataset_collection( element.child_collection ) )
TypeError: _split_dataset_collection() takes exactly 2 arguments (1 given)
```
