### PR TITLE
Fix tours pasting content into text area

### DIFF
--- a/config/plugins/tours/core.galaxy_ui.yaml
+++ b/config/plugins/tours/core.galaxy_ui.yaml
@@ -42,7 +42,7 @@ steps:
         - ".upload-button"
 
     - title: "Insert URLs"
-      element: "textarea#text-content"
+      element: ".upload-text-content:first"
       intro: "URLs separated by a line break are automatically downloaded by Galaxy."
       position: "top"
       textinsert: |

--- a/config/plugins/tours/core.history.yaml
+++ b/config/plugins/tours/core.history.yaml
@@ -26,7 +26,7 @@ steps:
       position: "top"
 
     - title: "Insert URLs"
-      element: "textarea#text-content"
+      element: ".upload-text-content:first"
       intro: "URLs separated by a line break are automatically downloaded by Galaxy."
       position: "bottom"
       textinsert: |

--- a/config/plugins/tours/core.scratchbook.yaml
+++ b/config/plugins/tours/core.scratchbook.yaml
@@ -16,7 +16,7 @@ steps:
       postclick:
         - "#btn-new"
 
-    - element: ".text-content:first"
+    - element: ".upload-text-content:first"
       intro: "...and paste content into the text area field."
       position: "top"
       textinsert: |


### PR DESCRIPTION
Fixes tours pasting content into upload dialogs text area which broke with #2711. Sorry.
