### PR TITLE
[16.07] Fix metadata collection on workdir outputs for Pulsar.

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -207,13 +207,18 @@ class BaseJobRunner( object ):
             container=container
         )
 
-    def get_work_dir_outputs( self, job_wrapper, job_working_directory=None ):
+    def get_work_dir_outputs( self, job_wrapper, job_working_directory=None, tool_working_directory=None ):
         """
         Returns list of pairs (source_file, destination) describing path
         to work_dir output file and ultimate destination.
         """
-        if not job_working_directory:
-            job_working_directory = os.path.abspath( job_wrapper.working_directory )
+        if tool_working_directory is not None and job_working_directory is not None:
+            raise Exception("get_work_dir_outputs called with both a job and tool working directory, only one may be specified")
+
+        if tool_working_directory is None:
+            if not job_working_directory:
+                job_working_directory = os.path.abspath( job_wrapper.working_directory )
+            tool_working_directory = os.path.join(job_working_directory, "working")
 
         # Set up dict of dataset id --> output path; output path can be real or
         # false depending on outputs_to_working_directory
@@ -234,9 +239,9 @@ class BaseJobRunner( object ):
                 if hda_tool_output and hda_tool_output.from_work_dir:
                     # Copy from working dir to HDA.
                     # TODO: move instead of copy to save time?
-                    source_file = os.path.join( job_working_directory, 'working', hda_tool_output.from_work_dir )
+                    source_file = os.path.join( tool_working_directory, hda_tool_output.from_work_dir )
                     destination = job_wrapper.get_output_destination( output_paths[ dataset.dataset_id ] )
-                    if in_directory( source_file, job_working_directory ):
+                    if in_directory( source_file, tool_working_directory ):
                         output_pairs.append( ( source_file, destination ) )
                     else:
                         # Security violation.

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -661,7 +661,7 @@ class PulsarJobRunner( AsynchronousJobRunner ):
             # each work_dir output substitute the effective path on the Pulsar
             # server relative to the remote working directory as the
             # false_path to send the metadata command generation module.
-            work_dir_outputs = self.get_work_dir_outputs(job_wrapper, job_working_directory=working_directory)
+            work_dir_outputs = self.get_work_dir_outputs(job_wrapper, tool_working_directory=working_directory)
             outputs = [Bunch(false_path=os.path.join(outputs_directory, os.path.basename(path)), real_path=path) for path in self.get_output_files(job_wrapper)]
             for output in outputs:
                 for pulsar_workdir_path, real_path in work_dir_outputs:


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/1688/commits/a2e31403753c407e7f6966b69b157e32f5f3ef8a which gave tool's clean working directories made the function get_workdir_outputs a big sloppy. Pulsar would send it the actual remote working directory for jobs and Galaxy would send it the job directory (expecting it to append 'working').
