### PR TITLE
Fix directory of local_container_script

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -100,7 +100,7 @@ def build_command(
 
 
 def __externalize_commands(job_wrapper, shell, commands_builder, remote_command_params, script_name="tool_script.sh"):
-    local_container_script = join( job_wrapper.working_directory, script_name )
+    local_container_script = join( job_wrapper.tool_working_directory, script_name )
     tool_commands = commands_builder.build()
     config = job_wrapper.app.config
     integrity_injection = ""


### PR DESCRIPTION
When docker jobs is run, it try to execute script in working directory.
I think this related #1688 and 975937ec9d18287fe89a7ee9eda0952e22284ac7
