### PR TITLE
[16.04] Fix to mount job directory in Docker for #1688.

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -175,7 +175,7 @@
           <!-- For a stock Galaxy instance and traditional job runner $defaults will
                expand out as:
 
-               $galaxy_root:ro,$tool_directory:ro,$working_directory:rw,$default_file_path:rw
+               $galaxy_root:ro,$tool_directory:ro,$job_directory:ro,$working_directory:rw,$default_file_path:rw
 
                This assumes most of what is needed is available under Galaxy's root directory,
                the tool directory, and the Galaxy's file_path (if using object store creatively
@@ -186,7 +186,7 @@
                galaxy.ini. This will cause $defaults to allow writing to much
                less. It will then expand as follows:
 
-               $galaxy_root:ro,$tool_directory:ro,$working_directory:rw,$default_file_path:ro
+               $galaxy_root:ro,$tool_directory:ro,$job_directory:ro,$working_directory:rw,$default_file_path:ro
 
                If using the Pulsar, defaults will be even further restricted because the
                Pulsar will (by default) stage all needed inputs into the job's job_directory

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -323,10 +323,14 @@ class BaseJobRunner( object ):
         job_wrapper,
         compute_working_directory=None,
         compute_tool_directory=None,
-        compute_job_directory=None
+        compute_job_directory=None,
     ):
+        job_directory_type = "galaxy" if compute_working_directory is None else "pulsar"
         if not compute_working_directory:
             compute_working_directory = job_wrapper.tool_working_directory
+
+        if not compute_job_directory:
+            compute_job_directory = job_wrapper.working_directory
 
         if not compute_tool_directory:
             compute_tool_directory = job_wrapper.tool.tool_dir
@@ -334,7 +338,12 @@ class BaseJobRunner( object ):
         tool = job_wrapper.tool
         from galaxy.tools.deps import containers
         tool_info = containers.ToolInfo(tool.containers, tool.requirements)
-        job_info = containers.JobInfo(compute_working_directory, compute_tool_directory, compute_job_directory)
+        job_info = containers.JobInfo(
+            compute_working_directory,
+            compute_tool_directory,
+            compute_job_directory,
+            job_directory_type,
+        )
 
         destination_info = job_wrapper.job_destination.params
         return self.app.container_finder.find_container(

--- a/lib/galaxy/tools/deps/containers.py
+++ b/lib/galaxy/tools/deps/containers.py
@@ -169,12 +169,13 @@ class ToolInfo(object):
 
 class JobInfo(object):
 
-    def __init__(self, working_directory, tool_directory, job_directory):
+    def __init__(self, working_directory, tool_directory, job_directory, job_directory_type):
         self.working_directory = working_directory
         self.job_directory = job_directory
         # Tool files may be remote staged - so this is unintuitively a property
         # of the job not of the tool.
         self.tool_directory = tool_directory
+        self.job_directory_type = job_directory_type  # "galaxy" or "pulsar"
 
 
 class Container( object ):
@@ -292,16 +293,16 @@ class DockerContainer(Container):
         add_var("galaxy_root", self.app_info.galaxy_root_dir)
         add_var("default_file_path", self.app_info.default_file_path)
 
-        if self.job_info.job_directory:
-            # We have a job directory, so everything needed (excluding index
+        if self.job_info.job_directory and self.job_info.job_directory_type == "pulsar":
+            # We have a Pulsar job directory, so everything needed (excluding index
             # files) should be available in job_directory...
             defaults = "$job_directory:ro,$tool_directory:ro,$job_directory/outputs:rw,$working_directory:rw"
         elif self.app_info.outputs_to_working_directory:
             # Should need default_file_path (which is a course estimate given
             # object stores anyway).
-            defaults = "$galaxy_root:ro,$tool_directory:ro,$working_directory:rw,$default_file_path:ro"
+            defaults = "$galaxy_root:ro,$tool_directory:ro,$job_directory:ro,$working_directory:rw,$default_file_path:ro"
         else:
-            defaults = "$galaxy_root:ro,$tool_directory:ro,$working_directory:rw,$default_file_path:rw"
+            defaults = "$galaxy_root:ro,$tool_directory:ro,$job_directory:ro,$working_directory:rw,$default_file_path:rw"
 
         # Define $defaults that can easily be extended with external library and
         # index data without deployer worrying about above details.


### PR DESCRIPTION
The default for this was including GALAXY_ROOT so in testing (and many deployments) the job directory would have been picked up anyway because it is in `$GALAXY_ROOT/database/` but if job directory was outside of `$GALAXY_ROOT/database/` one needed to add it to the volumes mounted by Docker. This fix mounts just that directory - so no need for instance to mount all job directories which one could have done.

This is an alternative to #2739 (thanks for the contribution @manabuishii)
