### PR TITLE
Fix docker command_list

### DIFF
--- a/lib/galaxy/tools/deps/docker_util.py
+++ b/lib/galaxy/tools/deps/docker_util.py
@@ -185,7 +185,8 @@ def build_docker_run_command(
 def command_list(command, command_args=[], **kwds):
     """Return Docker command as an argv list."""
     command_parts = _docker_prefix(**kwds)
-    command_parts.extend(command_parts)
+    command_parts.append(command)
+    command_parts.extend(command_args)
     return command_parts
 
 


### PR DESCRIPTION
command_list always generates _docker_prefix twice.
(ex. **_docker docker**_ )

My job_conf.xml has

```
            <param id="embed_metadata_in_job">False</param>
            <param id="docker_enabled">true</param>
            <param id="docker_sudo">false</param>
            <param id="docker_volumes">$defaults</param>
```

```
mkdir -p working; cd working; docker docker > /dev/null 2>&1
[ $? -ne 0 ] && docker docker > /dev/null 2>&1
```

Without fix , docker runs new image which doesn't exist ,
docker fetch it in **_docker run**_ command and it generates progress information to stderr.
It will end galaxy job as fail.

But rerun same job, it will be success , because of the image is already exists , fetch process never happens.
