### PR TITLE
List resolver toolshed packages

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1312,7 +1312,7 @@ class Tool( object, Dictifiable ):
         """
         Return a list of dictionaries for all tool dependencies with their associated status
         """
-        return self._view.get_requirements_status(self.tool_requirements)
+        return self._view.get_requirements_status(self.tool_requirements, self.installed_tool_dependencies)
 
     def build_redirect_url_params( self, param_dict ):
         """

--- a/lib/galaxy/tools/deps/resolvers/galaxy_packages.py
+++ b/lib/galaxy/tools/deps/resolvers/galaxy_packages.py
@@ -13,8 +13,40 @@ import logging
 log = logging.getLogger( __name__ )
 
 
+class GalaxyPackageDependency(Dependency):
+    dict_collection_visible_keys = Dependency.dict_collection_visible_keys + ['script', 'path', 'version', 'name']
+    dependency_type = 'galaxy_package'
+
+    def __init__( self, script, path, version, name, exact=True ):
+        self.script = script
+        self.path = path
+        self.version = version
+        self.name = name
+        self._exact = exact
+
+    @property
+    def exact(self):
+        return self._exact
+
+    def shell_commands( self, requirement ):
+        base_path = self.path
+        if self.script is None and base_path is None:
+            log.warning( "Failed to resolve dependency on '%s', ignoring", requirement.name )
+            commands = None
+        elif requirement.type == 'package' and self.script is None:
+            commands = 'PACKAGE_BASE=%s; export PACKAGE_BASE; PATH="%s/bin:$PATH"; export PATH' % ( base_path, base_path )
+        else:
+            commands = 'PACKAGE_BASE=%s; export PACKAGE_BASE; . %s' % ( base_path, self.script )
+        return commands
+
+
+class ToolShedDependency(GalaxyPackageDependency):
+    dependency_type = 'tool_shed_package'
+
+
 class BaseGalaxyPackageDependencyResolver(DependencyResolver, UsesToolDependencyDirMixin):
     dict_collection_visible_keys = DependencyResolver.dict_collection_visible_keys + ['base_path', 'versionless']
+    DependencyType = GalaxyPackageDependency
 
     def __init__(self, dependency_manager, **kwds):
         # Galaxy tool shed requires explicit versions on XML elements,
@@ -54,9 +86,9 @@ class BaseGalaxyPackageDependencyResolver(DependencyResolver, UsesToolDependency
     def _galaxy_package_dep( self, path, version, name, exact ):
         script = join( path, 'env.sh' )
         if exists( script ):
-            return GalaxyPackageDependency(script, path, version, name, exact)
+            return self.DependencyType(script, path, version, name, exact)
         elif exists( join( path, 'bin' ) ):
-            return GalaxyPackageDependency(None, path, version, name, exact)
+            return self.DependencyType(None, path, version, name, exact)
         return NullDependency(version=version, name=name)
 
 
@@ -81,30 +113,4 @@ def _is_dependency_directory(directory):
     return exists(join(directory, 'env.sh')) or exists(join(directory, 'bin'))
 
 
-class GalaxyPackageDependency(Dependency):
-    dict_collection_visible_keys = Dependency.dict_collection_visible_keys + ['script', 'path', 'version', 'name']
-    dependency_type = 'galaxy_package'
-
-    def __init__( self, script, path, version, name, exact=True ):
-        self.script = script
-        self.path = path
-        self.version = version
-        self.name = name
-        self._exact = exact
-
-    @property
-    def exact(self):
-        return self._exact
-
-    def shell_commands( self, requirement ):
-        base_path = self.path
-        if self.script is None and base_path is None:
-            log.warning( "Failed to resolve dependency on '%s', ignoring", requirement.name )
-            commands = None
-        elif requirement.type == 'package' and self.script is None:
-            commands = 'PACKAGE_BASE=%s; export PACKAGE_BASE; PATH="%s/bin:$PATH"; export PATH' % ( base_path, base_path )
-        else:
-            commands = 'PACKAGE_BASE=%s; export PACKAGE_BASE; . %s' % ( base_path, self.script )
-        return commands
-
-__all__ = ['GalaxyPackageDependencyResolver', 'GalaxyPackageDependency']
+__all__ = ['GalaxyPackageDependencyResolver', 'GalaxyPackageDependency', 'GalaxyToolShedDependency']

--- a/lib/galaxy/tools/deps/resolvers/galaxy_packages.py
+++ b/lib/galaxy/tools/deps/resolvers/galaxy_packages.py
@@ -46,7 +46,7 @@ class ToolShedDependency(GalaxyPackageDependency):
 
 class BaseGalaxyPackageDependencyResolver(DependencyResolver, UsesToolDependencyDirMixin):
     dict_collection_visible_keys = DependencyResolver.dict_collection_visible_keys + ['base_path', 'versionless']
-    DependencyType = GalaxyPackageDependency
+    dependency_type = GalaxyPackageDependency
 
     def __init__(self, dependency_manager, **kwds):
         # Galaxy tool shed requires explicit versions on XML elements,
@@ -86,9 +86,9 @@ class BaseGalaxyPackageDependencyResolver(DependencyResolver, UsesToolDependency
     def _galaxy_package_dep( self, path, version, name, exact ):
         script = join( path, 'env.sh' )
         if exists( script ):
-            return self.DependencyType(script, path, version, name, exact)
+            return self.dependency_type(script, path, version, name, exact)
         elif exists( join( path, 'bin' ) ):
-            return self.DependencyType(None, path, version, name, exact)
+            return self.dependency_type(None, path, version, name, exact)
         return NullDependency(version=version, name=name)
 
 

--- a/lib/galaxy/tools/deps/resolvers/galaxy_packages.py
+++ b/lib/galaxy/tools/deps/resolvers/galaxy_packages.py
@@ -113,4 +113,4 @@ def _is_dependency_directory(directory):
     return exists(join(directory, 'env.sh')) or exists(join(directory, 'bin'))
 
 
-__all__ = ['GalaxyPackageDependencyResolver', 'GalaxyPackageDependency', 'GalaxyToolShedDependency']
+__all__ = ['GalaxyPackageDependencyResolver', 'GalaxyPackageDependency', 'ToolShedDependency']

--- a/lib/galaxy/tools/deps/resolvers/galaxy_packages.py
+++ b/lib/galaxy/tools/deps/resolvers/galaxy_packages.py
@@ -54,9 +54,9 @@ class BaseGalaxyPackageDependencyResolver(DependencyResolver, UsesToolDependency
     def _galaxy_package_dep( self, path, version, name, exact ):
         script = join( path, 'env.sh' )
         if exists( script ):
-            return GalaxyPackageDependency(script, path, version, exact)
+            return GalaxyPackageDependency(script, path, version, name, exact)
         elif exists( join( path, 'bin' ) ):
-            return GalaxyPackageDependency(None, path, version, exact)
+            return GalaxyPackageDependency(None, path, version, name, exact)
         return NullDependency(version=version, name=name)
 
 
@@ -82,13 +82,14 @@ def _is_dependency_directory(directory):
 
 
 class GalaxyPackageDependency(Dependency):
-    dict_collection_visible_keys = Dependency.dict_collection_visible_keys + ['script', 'path', 'version']
+    dict_collection_visible_keys = Dependency.dict_collection_visible_keys + ['script', 'path', 'version', 'name']
     dependency_type = 'galaxy_package'
 
-    def __init__( self, script, path, version, exact=True ):
+    def __init__( self, script, path, version, name, exact=True ):
         self.script = script
         self.path = path
         self.version = version
+        self.name = name
         self._exact = exact
 
     @property

--- a/lib/galaxy/tools/deps/resolvers/tool_shed_packages.py
+++ b/lib/galaxy/tools/deps/resolvers/tool_shed_packages.py
@@ -32,7 +32,7 @@ class ToolShedPackageDependencyResolver(BaseGalaxyPackageDependencyResolver, Use
                 has_script_dep = is_galaxy_dep and dependency.script and dependency.path
                 if has_script_dep:
                     # Environment settings do not use versions.
-                    return GalaxyPackageDependency(dependency.script, dependency.path, None, True)
+                    return GalaxyPackageDependency(dependency.script, dependency.path, None, name, True)
         return NullDependency(version=None, name=name)
 
     def _get_package_installed_dependency_path( self, installed_tool_dependency, name, version ):
@@ -58,7 +58,7 @@ class ToolShedPackageDependencyResolver(BaseGalaxyPackageDependencyResolver, Use
                               tool_shed_repository.installed_changeset_revision ) )
         if exists( path ):
             script = join( path, 'env.sh' )
-            return GalaxyPackageDependency(script, path, None, True)
+            return GalaxyPackageDependency(script, path, None, name, True)
         return NullDependency(version=None, name=name)
 
 

--- a/lib/galaxy/tools/deps/resolvers/tool_shed_packages.py
+++ b/lib/galaxy/tools/deps/resolvers/tool_shed_packages.py
@@ -1,7 +1,7 @@
 from os.path import abspath, join, exists
 
 from .resolver_mixins import UsesInstalledRepositoriesMixin
-from .galaxy_packages import BaseGalaxyPackageDependencyResolver, GalaxyPackageDependency
+from .galaxy_packages import BaseGalaxyPackageDependencyResolver, ToolShedDependency
 from ..resolvers import NullDependency
 
 
@@ -10,6 +10,7 @@ class ToolShedPackageDependencyResolver(BaseGalaxyPackageDependencyResolver, Use
     # Resolution of these dependencies depends on more than just the requirement
     # tag, it depends on the tool installation context - therefore these are
     # non-simple.
+    DependencyType = ToolShedDependency
     resolves_simple_dependencies = False
 
     def __init__(self, dependency_manager, **kwds):
@@ -28,11 +29,11 @@ class ToolShedPackageDependencyResolver(BaseGalaxyPackageDependencyResolver, Use
             installed_tool_dependency = self._get_installed_dependency( name, type, version=None, **kwds )
             if installed_tool_dependency:
                 dependency = self._get_set_environment_installed_dependency_script_path( installed_tool_dependency, name )
-                is_galaxy_dep = isinstance(dependency, GalaxyPackageDependency)
+                is_galaxy_dep = isinstance(dependency, ToolShedDependency)
                 has_script_dep = is_galaxy_dep and dependency.script and dependency.path
                 if has_script_dep:
                     # Environment settings do not use versions.
-                    return GalaxyPackageDependency(dependency.script, dependency.path, None, name, True)
+                    return ToolShedDependency(dependency.script, dependency.path, None, name, True)
         return NullDependency(version=None, name=name)
 
     def _get_package_installed_dependency_path( self, installed_tool_dependency, name, version ):
@@ -58,7 +59,7 @@ class ToolShedPackageDependencyResolver(BaseGalaxyPackageDependencyResolver, Use
                               tool_shed_repository.installed_changeset_revision ) )
         if exists( path ):
             script = join( path, 'env.sh' )
-            return GalaxyPackageDependency(script, path, None, name, True)
+            return ToolShedDependency(script, path, None, name, True)
         return NullDependency(version=None, name=name)
 
 

--- a/lib/galaxy/tools/deps/resolvers/tool_shed_packages.py
+++ b/lib/galaxy/tools/deps/resolvers/tool_shed_packages.py
@@ -10,7 +10,7 @@ class ToolShedPackageDependencyResolver(BaseGalaxyPackageDependencyResolver, Use
     # Resolution of these dependencies depends on more than just the requirement
     # tag, it depends on the tool installation context - therefore these are
     # non-simple.
-    DependencyType = ToolShedDependency
+    dependency_type = ToolShedDependency
     resolves_simple_dependencies = False
 
     def __init__(self, dependency_manager, **kwds):

--- a/lib/galaxy/tools/deps/views.py
+++ b/lib/galaxy/tools/deps/views.py
@@ -126,4 +126,6 @@ class DependencyResolversView(object):
         return [index for index, resolver in enumerate(self._dependency_resolvers) if hasattr(resolver, "install_dependency") and not resolver.disabled ]
 
     def get_requirements_status(self, requested_requirements, installed_tool_dependencies=None):
+        for req in requested_requirements:
+            req['installed_tool_dependencies'] = installed_tool_dependencies
         return [self.manager_dependency(**req) for req in requested_requirements]

--- a/lib/galaxy/tools/deps/views.py
+++ b/lib/galaxy/tools/deps/views.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from galaxy.exceptions import (
     RequestParameterMissingException,
     NotImplemented
@@ -126,6 +127,7 @@ class DependencyResolversView(object):
         return [index for index, resolver in enumerate(self._dependency_resolvers) if hasattr(resolver, "install_dependency") and not resolver.disabled ]
 
     def get_requirements_status(self, requested_requirements, installed_tool_dependencies=None):
-        for req in requested_requirements:
-            req['installed_tool_dependencies'] = installed_tool_dependencies
-        return [self.manager_dependency(**req) for req in requested_requirements]
+        dependencies = deepcopy(requested_requirements)  # Make a copy to avoid changing contents of requested_requirements
+        for dep in dependencies:
+            dep['installed_tool_dependencies'] = installed_tool_dependencies
+        return [self.manager_dependency(**dep) for dep in dependencies]

--- a/lib/galaxy/tools/deps/views.py
+++ b/lib/galaxy/tools/deps/views.py
@@ -1,7 +1,6 @@
-from copy import deepcopy
 from galaxy.exceptions import (
-    RequestParameterMissingException,
-    NotImplemented
+    NotImplemented,
+    RequestParameterMissingException
 )
 
 
@@ -14,7 +13,7 @@ class DependencyResolversView(object):
         self._app = app
 
     def index(self):
-        return map(lambda r: r.to_dict(), self._dependency_resolvers)
+        return [r.to_dict() for r in self._dependency_resolvers]
 
     def show(self, index):
         return self._dependency_resolver(index).to_dict()
@@ -127,7 +126,4 @@ class DependencyResolversView(object):
         return [index for index, resolver in enumerate(self._dependency_resolvers) if hasattr(resolver, "install_dependency") and not resolver.disabled ]
 
     def get_requirements_status(self, requested_requirements, installed_tool_dependencies=None):
-        dependencies = deepcopy(requested_requirements)  # Make a copy to avoid changing contents of requested_requirements
-        for dep in dependencies:
-            dep['installed_tool_dependencies'] = installed_tool_dependencies
-        return [self.manager_dependency(**dep) for dep in dependencies]
+        return [self.manager_dependency(installed_tool_dependencies=installed_tool_dependencies, **req) for req in requested_requirements]

--- a/lib/galaxy/tools/deps/views.py
+++ b/lib/galaxy/tools/deps/views.py
@@ -125,5 +125,5 @@ class DependencyResolversView(object):
         """
         return [index for index, resolver in enumerate(self._dependency_resolvers) if hasattr(resolver, "install_dependency") and not resolver.disabled ]
 
-    def get_requirements_status(self, requested_requirements):
+    def get_requirements_status(self, requested_requirements, installed_tool_dependencies=None):
         return [self.manager_dependency(**req) for req in requested_requirements]

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -816,7 +816,7 @@ class AdminToolshed( AdminGalaxy ):
                                                                                 required_repo_info_dicts=None )
         view = views.DependencyResolversView(self.app)
         requirements = suc.get_unique_requirements_from_repository(repository)
-        requirements_status = view.get_requirements_status(requirements)
+        requirements_status = view.get_requirements_status(requirements, repository.installed_tool_dependencies)
         return trans.fill_template( '/admin/tool_shed_repository/manage_repository.mako',
                                     repository=repository,
                                     description=description,

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -234,7 +234,10 @@ def get_unique_requirements_from_repository(repository):
     if not repository.includes_tools:
         return []
     else:
-        return get_unique_requirements_from_tools(repository.metadata.get('tools', []))
+        requirements = get_unique_requirements_from_tools(repository.metadata.get('tools', []))
+        for req in requirements:
+            req['installed_tool_dependencies'] = repository.installed_tool_dependencies
+        return requirements
 
 
 def get_ctx_rev( app, tool_shed_url, name, owner, changeset_revision ):

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -234,10 +234,7 @@ def get_unique_requirements_from_repository(repository):
     if not repository.includes_tools:
         return []
     else:
-        requirements = get_unique_requirements_from_tools(repository.metadata.get('tools', []))
-        for req in requirements:
-            req['installed_tool_dependencies'] = repository.installed_tool_dependencies
-        return requirements
+        return get_unique_requirements_from_tools(repository.metadata.get('tools', []))
 
 
 def get_ctx_rev( app, tool_shed_url, name, owner, changeset_revision ):

--- a/test/unit/tools/test_tool_deps.py
+++ b/test/unit/tools/test_tool_deps.py
@@ -175,7 +175,7 @@ def test_galaxy_dependency_object_script():
         # Create env.sh file that just exports variable FOO and verify it
         # shell_commands export it correctly.
         env_path = __setup_galaxy_package_dep(base_path, TEST_REPO_NAME, TEST_VERSION, "export FOO=\"bar\"")
-        dependency = GalaxyPackageDependency(env_path, os.path.dirname(env_path), TEST_VERSION)
+        dependency = GalaxyPackageDependency(env_path, os.path.dirname(env_path), TEST_REPO_NAME, TEST_VERSION)
         __assert_foo_exported( dependency.shell_commands( Bunch( type="package" ) ) )
 
 


### PR DESCRIPTION
This will include installed tool shed packages both in the manage repository UI and in response
to API requests to `/api/tools/{tool_id}/requirements`.
<img width="964" alt="screen shot 2016-08-08 at 15 59 38" src="https://cloud.githubusercontent.com/assets/6804901/17482965/5930697a-5d84-11e6-9a01-e5c69cb54ea8.png">

This should give admins a better idea of which dependency is going to be used (Point 4 in https://github.com/galaxyproject/tools-iuc/issues/905#issuecomment-237320157).

I'm targeting 16.07 since one could say this is a "useability bug fix", let me know if I better target dev.
