### PR TITLE
Update common_startup.sh to require python2.7

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -81,7 +81,7 @@ if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 ]; then
         # Ensure Python is a supported version before creating .venv
         python ./scripts/check_python.py || exit 1
         if command -v virtualenv >/dev/null; then
-            virtualenv "$GALAXY_VIRTUAL_ENV"
+            virtualenv -p python2.7 "$GALAXY_VIRTUAL_ENV"
         else
             vvers=13.1.2
             vurl="https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${vvers}.tar.gz"


### PR DESCRIPTION
As this hack is untenable: https://wiki.galaxyproject.org/Admin/Python

`% mkdir ~/galaxy-python
% ln -s /path/to/python2.7 ~/galaxy-python/python
% export PATH=~/galaxy-python:$PATH`

I edited line 84 to: virtualenv -p python2.7

This will require that python 2.7 used in the virtual environment, and prevent breakage from multi-python deployed hosts.

I know editing 'master' is not preferred but this simple change makes the software more accesible.

This edit built fine on OS X  10.10.5
python installed: 2.6, 2.7, 3.2, 3.5
