### PR TITLE
Update common_startup.sh to require python2.7 in .venv

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -82,7 +82,7 @@ if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 ]; then
         # Ensure Python is a supported version before creating .venv
         python ./scripts/check_python.py || exit 1
         if command -v virtualenv >/dev/null; then
-            virtualenv "$GALAXY_VIRTUAL_ENV"
+            virtualenv -p python2.7 "$GALAXY_VIRTUAL_ENV"
         else
             vvers=13.1.2
             vurl="https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${vvers}.tar.gz"


### PR DESCRIPTION
by changing the .venv creation to 'virtualenv -p python2.7' we force the python version we need.

The current suggestion on getgalaxy is: https://wiki.galaxyproject.org/Admin/Python
% mkdir ~/galaxy-python
% ln -s /path/to/python2.7 ~/galaxy-python/python
% export PATH=~/galaxy-python:$PATH

Which break lots of things, since we are working in a virtual environment anyway we can build it from the start with the version we want.

This will require that python 2.7 used in the virtual environment, and prevent breakage from multi-python deployed hosts. This simple change makes the software more accessible.

This edit built fine on OS X  10.10.5
python installed: 2.6, 2.7, 3.2, 3.5

galaxy.queue_worker INFO 2016-08-08 22:14:15,624 Binding and starting galaxy control worker for main
Starting server in PID 69210.
serving on http://127.0.0.1:8080
/Users/benc/Code/github/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/sql/sqltypes.py:565: SAWarning: Dialect sqlite+pysqlite does _not_ support Decimal objects natively, and SQLAlchemy must convert from floating point - rounding errors and other issues may occur. Please consider storing Decimal numbers as strings or integers on this platform for lossless storage.
  'storage.' % (dialect.name, dialect.driver))
127.0.0.1 - - [08/Aug/2016:22:39:18 -0400] "GET / HTTP/1.1" 200 - "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36"
