### PR TITLE
Parse internal parameters such as job resource selections when data converter tools are executed implicitly

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -520,6 +520,7 @@ class Data( object ):
                 params[value.name] = deps[value.name]
             elif value.type == 'data':
                 input_name = key
+        # add potentially required/common internal tool parameters e.g. '__job_resource'
         if target_context:
             for key, value in target_context.items():
                 if key.startsWith( '__' ):

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -505,7 +505,7 @@ class Data( object ):
         """Returns ( target_ext, existing converted dataset )"""
         return datatypes_registry.find_conversion_destination_for_dataset_by_extensions( dataset, accepted_formats, **kwd )
 
-    def convert_dataset(self, trans, original_dataset, target_type, return_output=False, visible=True, deps=None, set_output_history=True):
+    def convert_dataset(self, trans, original_dataset, target_type, return_output=False, visible=True, deps=None, set_output_history=True, target_context=None):
         """This function adds a job to the queue to convert a dataset to another type. Returns a message about success/failure."""
         converter = trans.app.datatypes_registry.get_converter_by_target_type( original_dataset.ext, target_type )
 
@@ -520,8 +520,12 @@ class Data( object ):
                 params[value.name] = deps[value.name]
             elif value.type == 'data':
                 input_name = key
-
+        if target_context:
+            for key, value in target_context.items():
+                if key.startsWith( '__' ):
+                    params[ key ] = value
         params[input_name] = original_dataset
+
         # Run converter, job is dispatched through Queue
         converted_dataset = converter.execute( trans, incoming=params, set_output_hid=visible, set_output_history=set_output_history)[1]
         if len(params) > 0:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2034,7 +2034,7 @@ class DatasetInstance( object ):
             depends_list = []
         return dict([ (dep, self.get_converted_dataset(trans, dep)) for dep in depends_list ])
 
-    def get_converted_dataset(self, trans, target_ext):
+    def get_converted_dataset(self, trans, target_ext, target_context=None):
         """
         Return converted dataset(s) if they exist, along with a dict of dependencies.
         If not converted yet, do so and return None (the first time). If unconvertible, raise exception.
@@ -2073,13 +2073,15 @@ class DatasetInstance( object ):
             raise NoConverterException("A dependency (%s) is missing a converter." % dependency)
         except KeyError:
             pass  # No deps
-        new_dataset = next(iter(self.datatype.convert_dataset( trans, self, target_ext, return_output=True, visible=False, deps=deps, set_output_history=True ).values()))
+        new_dataset = next(iter(self.datatype.convert_dataset( trans, self, target_ext, return_output=True, visible=False, deps=deps, set_output_history=True, target_context=target_context ).values()))
+        new_dataset.hid = self.hid
+        new_dataset.name = self.name
         assoc = ImplicitlyConvertedDatasetAssociation( parent=self, file_type=target_ext, dataset=new_dataset, metadata_safe=False )
         session = trans.sa_session
         session.add( new_dataset )
         session.add( assoc )
         session.flush()
-        return None
+        return new_dataset
 
     def get_metadata_dataset( self, dataset_ext ):
         """

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -66,16 +66,7 @@ class DefaultToolAction( object ):
                         if converted_dataset:
                             data = converted_dataset
                         else:
-                            # FIXME: merge with hda.get_converted_dataset() mode as it's nearly identical.
-                            # run converter here
-                            new_data = data.datatype.convert_dataset( trans, data, target_ext, return_output=True, visible=False ).values()[0]
-                            new_data.hid = data.hid
-                            new_data.name = data.name
-                            trans.sa_session.add( new_data )
-                            assoc = trans.app.model.ImplicitlyConvertedDatasetAssociation( parent=data, file_type=target_ext, dataset=new_data, metadata_safe=False )
-                            trans.sa_session.add( assoc )
-                            trans.sa_session.flush()
-                            data = new_data
+                            data = data.get_converted_dataset( trans, target_ext, target_context=parent )
 
                 if not trans.app.security_agent.can_access_dataset( current_user_roles, data.dataset ):
                     raise Exception( "User does not have permission to use a dataset (%s) provided for input." % data.id )


### PR DESCRIPTION
Fixes #2760. Suggestions are welcome. Can be tested by converting a tabular file into fasta and then executing the Add Column tool.
