### PR TITLE
tool run in docker derived from All-in-one-Galaxy-container

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -51,12 +51,7 @@ def build_command(
 
     __handle_version_command(commands_builder, job_wrapper)
     __handle_task_splitting(commands_builder, job_wrapper)
-
-    # One could imagine also allowing dependencies inside of the container but
-    # that is too sophisticated for a first crack at this - build your
-    # containers ready to go!
-    if not container:
-        __handle_dependency_resolution(commands_builder, job_wrapper, remote_command_params)
+    __handle_dependency_resolution(commands_builder, job_wrapper, remote_command_params)
 
     if (container and modify_command_for_container) or job_wrapper.commands_in_new_shell:
         if container and modify_command_for_container:


### PR DESCRIPTION
We create a Galaxy Docker Container which has installed some tool from toolshed.
Some Toolshed tool require other tool.
When we use All-in-one-Galaxy-container as 'docker_default_container_id', it can't resolve 'requirement' tool.

This pullrequest don't care about other situation sorry..

Other solution canditate .
1. Add new flag which is resolve 'requirement' or not.
