### PR TITLE
Avoid user role checks for individual dataset when building the tool form models

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1669,7 +1669,7 @@ class BaseDataToolParameter( ToolParameter ):
             dataset_matcher = DatasetMatcher( trans, self, None, other_values )
             if isinstance( self, DataToolParameter ):
                 for hda in reversed( history.active_datasets_children_and_roles ):
-                    match = dataset_matcher.hda_match( hda )
+                    match = dataset_matcher.hda_match( hda, check_security=trans.workflow_building_mode is workflow_building_modes.DISABLED )
                     if match:
                         return match.hda
             else:
@@ -2038,7 +2038,7 @@ class DataToolParameter( BaseDataToolParameter ):
         visible_hda = other_values.get( self.name )
         has_matched = False
         for hda in history.active_datasets_children_and_roles:
-            match = dataset_matcher.hda_match( hda )
+            match = dataset_matcher.hda_match( hda, check_security=trans.workflow_building_mode is workflow_building_modes.DISABLED )
             if match:
                 m = match.hda
                 has_matched = has_matched or visible_hda == m or visible_hda == hda

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1669,7 +1669,7 @@ class BaseDataToolParameter( ToolParameter ):
             dataset_matcher = DatasetMatcher( trans, self, None, other_values )
             if isinstance( self, DataToolParameter ):
                 for hda in reversed( history.active_datasets_children_and_roles ):
-                    match = dataset_matcher.hda_match( hda, check_security=trans.workflow_building_mode is workflow_building_modes.DISABLED )
+                    match = dataset_matcher.hda_match( hda, check_security=False )
                     if match:
                         return match.hda
             else:
@@ -2038,7 +2038,7 @@ class DataToolParameter( BaseDataToolParameter ):
         visible_hda = other_values.get( self.name )
         has_matched = False
         for hda in history.active_datasets_children_and_roles:
-            match = dataset_matcher.hda_match( hda, check_security=trans.workflow_building_mode is workflow_building_modes.DISABLED )
+            match = dataset_matcher.hda_match( hda, check_security=False )
             if match:
                 m = match.hda
                 has_matched = has_matched or visible_hda == m or visible_hda == hda

--- a/lib/galaxy/tools/parameters/dataset_matcher.py
+++ b/lib/galaxy/tools/parameters/dataset_matcher.py
@@ -70,12 +70,12 @@ class DatasetMatcher( object ):
             return False
         return rval
 
-    def hda_match( self, hda, check_implicit_conversions=True, ensure_visible=True ):
+    def hda_match( self, hda, check_implicit_conversions=True, check_security=True, ensure_visible=True ):
         """ If HDA is accessible, return information about whether it could
         match this parameter and if so how. See valid_hda_match for more
         information.
         """
-        accessible = self.hda_accessible( hda )
+        accessible = self.hda_accessible( hda, check_security=check_security )
         if accessible and ( not ensure_visible or hda.visible or ( self.selected( hda ) and not hda.implicitly_converted_parent_datasets ) ):
             # If we are sending data to an external application, then we need to make sure there are no roles
             # associated with the dataset that restrict its access from "public".


### PR DESCRIPTION
The run workflow form requires datasets and thus the dataset matcher. The dataset matcher is the most time consuming part of the model building process particularly for large histories. One of its slowest components is the security check which is performed for each individual dataset of a given history. Since the security check will be performed for the selected datasets either way upon workflow or job submission, preemptivley checking each dataset upfront seems to be unnecessary. Particularly since all datasets are part of a history to which the user has access to. Currently this PR modifies the workflow and regular tool model building process such that detailed user role checks are disabled when creating the list of available datasets. An alternative strategy might be to cache the security check results somehow. I ran tests with a history of 1k tabular datasets and a workflow of 200 unconnected steps, consisting of 100 `Add column` and 100 `Merge columns` steps, and used the following test script to measure the performance: https://gist.github.com/guerler/05a46da6fdcb446128eebc5f8ad68bbd. The average time to build the workflow model after applying this PR is 8.7s seconds while it takes 22.9s without this modification. These results were obtained locally with a single user registered.
