### PR TITLE
GRT Update (Coordinates, Contacts & More Metadata)

### DIFF
--- a/scripts/grt.py
+++ b/scripts/grt.py
@@ -89,7 +89,8 @@ def _init(config_path):
             object_store=object_store
         ),
         object_store,
-        config.database_connection.split(':')[0]
+        config.database_connection.split(':')[0],
+        config.version_major
     )
 
 
@@ -182,7 +183,7 @@ def main(argv):
         exit(1)
 
     log.info('Loading Galaxy...')
-    model, object_store, engine = _init(config_dict['galaxy_config'])
+    model, object_store, engine, gx_version = _init(config_dict['galaxy_config'])
 
     sa_session = model.context.current
 
@@ -247,6 +248,7 @@ def main(argv):
     grt_report_data = {
         'meta': {
             'version': 1,
+            'galaxy_version': gx_version,
             'uuid': config_dict['grt_server']['instance_id'],
             'api_key': config_dict['grt_server']['api_key'],
             'name': config_dict['instance']['name'],
@@ -273,7 +275,7 @@ def main(argv):
         exit(0)
 
     try:
-        urllib2.urlopen(config_dict['grt_url'], data=json.dumps(grt_report_data))
+        urllib2.urlopen(config_dict['grt_server']['grt_url'], data=json.dumps(grt_report_data))
     except urllib2.HTTPError as htpe:
         print(htpe.read())
         exit(1)

--- a/scripts/grt.py
+++ b/scripts/grt.py
@@ -13,6 +13,9 @@ import argparse
 import sqlalchemy as sa
 import yaml
 import re
+import logging
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(name="grt")
 
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, 'lib')))
 
@@ -23,6 +26,45 @@ from galaxy.model import mapping
 
 sample_config = os.path.abspath(os.path.join(os.path.dirname(__file__), 'grt.yml.sample'))
 default_config = os.path.abspath(os.path.join(os.path.dirname(__file__), 'grt.yml'))
+
+
+def resolve_location(config):
+    """
+    resolve_location takes in a dict with autodetect (bool) and hardcoded
+    latitude and longitude values (floats). The function calls a number of
+    external websites in order to resolve the host's IP address, and their
+    geographic location.
+    """
+    if config['autodetect']:
+        # Get public IP
+        try:
+            ip_address = urllib2.urlopen('https://icanhazip.com').read()
+        except (urllib2.HTTPError, urllib2.URLError) as err:
+            log.error("Could not contact IP detection service. %s", err)
+            return None
+
+        geolocation_api = 'http://ip-api.com/json/{0}'.format(ip_address)
+
+        try:
+            response = urllib2.urlopen(geolocation_api).read()
+        except (urllib2.HTTPError, urllib2.URLError) as err:
+            log.error("Could not contact location detection service. %s", err)
+            return None
+
+        # Construct or get the Location
+        json_geoloc = json.loads(response)
+        return {
+            'lat': json_geoloc['lat'],
+            'lon': json_geoloc['lon'],
+        }
+    else:
+        if str(config['latitude']) == '0.0' and str(config['longitude']) == '0.0':
+            return None
+        else:
+            return {
+                'lat': config['latitude'],
+                'lon': config['longitude'],
+            }
 
 
 def _init(config):
@@ -100,15 +142,15 @@ def _sanitize_value(unsanitized_value):
 def main(argv):
     """Entry point for GRT statistics collection."""
     parser = argparse.ArgumentParser()
-    parser.add_argument('instance_id', help='Galactic Radio Telescope Instance ID')
-    parser.add_argument('api_key', help='Galactic Radio Telescope API Key')
+    parser.add_argument('--instance_id', help='Galactic Radio Telescope Instance ID')
+    parser.add_argument('--api_key', help='Galactic Radio Telescope API Key')
 
     parser.add_argument('-c', '--config', dest='config', help='Path to GRT config file (scripts/grt.ini)', default=default_config)
     parser.add_argument('--dry-run', dest='dryrun', help='Dry run (show data to be sent, but do not send)', action='store_true', default=False)
     parser.add_argument('--grt-url', dest='grt_url', help='GRT Server (You can run your own!)')
     args = parser.parse_args(argv[1:])
 
-    print('Loading GRT ini...')
+    log.info('Loading GRT ini...')
     try:
         with open(args.config) as f:
             config_dict = yaml.load(f)
@@ -121,13 +163,17 @@ def main(argv):
         config_dict['last_job_id_sent'] = 0
 
     if args.instance_id:
-        config_dict['instance_id'] = args.instance_id
+        config_dict['grt_server']['instance_id'] = args.instance_id
     if args.api_key:
-        config_dict['api_key'] = args.api_key
+        config_dict['grt_server']['api_key'] = args.api_key
     if args.grt_url:
-        config_dict['grt_url'] = args.grt_url
+        config_dict['grt_server']['grt_url'] = args.grt_url
 
-    print('Loading Galaxy...')
+
+    import pprint; pprint.pprint(resolve_location(config_dict['location']))
+    exit(0)
+
+    log.info('Loading Galaxy...')
     model, object_store, engine = _init(config_dict['galaxy_config'])
     sa_session = model.context.current
 
@@ -192,8 +238,12 @@ def main(argv):
     grt_report_data = {
         'meta': {
             'version': 1,
-            'instance_uuid': config_dict['instance_id'],
-            'instance_api_key': config_dict['api_key'],
+            'uuid': config_dict['grt_server']['instance_id'],
+            'api_key': config_dict['grt_server']['api_key'],
+            'name': config_dict['instance']['name'],
+            'description': config_dict['instance']['description'],
+            'tags': config_dict['instance']['tags'],
+            'location': resolve_location(config_dict['location']),
             # We do not record ANYTHING about your users other than count.
             'active_users': len(set(active_users)),
             'total_users': sa_session.query(model.User).count(),
@@ -211,16 +261,17 @@ def main(argv):
 
     if args.dryrun:
         print(json.dumps(grt_report_data, indent=2))
-    else:
-        try:
-            urllib2.urlopen(config_dict['grt_url'], data=json.dumps(grt_report_data))
-        except urllib2.HTTPError as htpe:
-            print(htpe.read())
-            exit(1)
+        exit(0)
 
-        # Update grt.ini with last id of job (prevent duplicates from being sent)
-        with open(args.config, 'w') as f:
-            yaml.dump(config_dict, f, default_flow_style=False)
+    try:
+        urllib2.urlopen(config_dict['grt_url'], data=json.dumps(grt_report_data))
+    except urllib2.HTTPError as htpe:
+        print(htpe.read())
+        exit(1)
+
+    # Update grt.ini with last id of job (prevent duplicates from being sent)
+    with open(args.config, 'w') as f:
+        yaml.dump(config_dict, f, default_flow_style=False)
 
 if __name__ == '__main__':
     main(sys.argv)

--- a/scripts/grt.py
+++ b/scripts/grt.py
@@ -173,6 +173,14 @@ def main(argv):
     if args.grt_url:
         config_dict['grt_server']['grt_url'] = args.grt_url
 
+    if config_dict['grt_server']['instance_id'] == '':
+        print("No Instance ID was provdied. One is required and may be obtained at https://telescope.galaxyproject.org")
+        exit(1)
+
+    if config_dict['grt_server']['api_key'] == '':
+        print("No API Key was provdied. One is required and may be obtained at https://telescope.galaxyproject.org")
+        exit(1)
+
     log.info('Loading Galaxy...')
     model, object_store, engine = _init(config_dict['galaxy_config'])
 

--- a/scripts/grt.py
+++ b/scripts/grt.py
@@ -2,6 +2,11 @@
 """Script for uploading Galaxy statistics to the Galactic radio telescope.
 
 See doc/source/admin/grt.rst for more detailed usage information.
+
+TODO:
+    - toolbox
+    - job runners
+    - check if GIEs are enabled
 """
 from __future__ import print_function
 
@@ -255,10 +260,12 @@ def main(argv):
             'description': config_dict['instance']['description'],
             'tags': config_dict['instance']['tags'],
             'location': resolve_location(config_dict['location']),
+            'latest_job': config_dict.get('last_job_id_sent', 0),
             # We do not record ANYTHING about your users other than count.
             'active_users': len(set(active_users)),
             'total_users': sa_session.query(model.User).count(),
             'recent_jobs': len(jobs),
+            'url': config_dict['instance']['url'],
         },
         'tools': [
             {

--- a/scripts/grt.yml.sample
+++ b/scripts/grt.yml.sample
@@ -22,12 +22,12 @@ instance:
 location:
     # If autodetect is set to true, then an attempt will be made to
     # automatically detect your location using a third party service
-    # (http://ip-api.com).
+    # (http://ip-api.com, https://icanhazip.com).
     autodetect: false
     # If you still wish to share the location of your Galaxy server
     # (great for helping people find local resources for Galaxy)
-    latitude: 30
-    longitude: -96
+    latitude: 0.0
+    longitude: 0.0
 
 
 tool_blacklist:

--- a/scripts/grt.yml.sample
+++ b/scripts/grt.yml.sample
@@ -3,22 +3,36 @@ galaxy_config: config/galaxy.ini
 
 grt_server:
     ## URL to your GRT server
-    grt_url: https://telescope.galaxyproject.org/api/v1/upload
+    #grt_url: https://telescope.galaxyproject.org/api/v1/upload
+    grt_url: http://localhost:8000/grt/api/v1/upload
     ## An instance ID uniquely identifies your Galaxy instance
-    instance_id: ""
+    instance_id: "80b800b4-5507-4f19-8222-c81bbb630563"
     ## An API key is required to submit data to GRT
-    api_key: ""
+    api_key: "4f3c15e9-c054-4548-a135-7acc2fc2ea92"
 
 ## The public name and description of your Galaxy instance
 instance:
-    name: "A Galaxy Server"
+    ## The publicly accessible URL of your galaxy instance. E.g. https://fqdn/galaxy
+    url: ""
+    name: "Testing Galaxy instance"
     description: |
         Galaxy server providing tools for private use
     tags:
-        # As of now "public" and "private" are the only recognised
-        # tags. We will work on this ontology going forward.
-        - public
-
+        #- public
+        - private
+        ## If this is a cloudlaunch server, you could indicate that here
+        #- cloudlaunch
+        ## If you wish to share what infrastucture you're running on, there are
+        #tags for this:
+        #- infra/aws
+        #- infra/gcp
+        #- infra/azure
+        #- infra/other_cloud
+        #- infra/private
+        ## Additionally if you wish to share a bit about your job runners we
+        #would be interested to hear who is using which runners.
+        #- cluster/condor
+        #- cluster/slurm
 location:
     # If autodetect is set to true, then an attempt will be made to
     # automatically detect your location using a third party service
@@ -26,8 +40,8 @@ location:
     autodetect: false
     # If you still wish to share the location of your Galaxy server
     # (great for helping people find local resources for Galaxy)
-    latitude: 0.0
-    longitude: 0.0
+    latitude: 51
+    longitude: 4
 
 
 tool_blacklist:

--- a/scripts/grt.yml.sample
+++ b/scripts/grt.yml.sample
@@ -1,7 +1,35 @@
+---
 galaxy_config: config/galaxy.ini
-#instance_id: blah
-#api_key: blah
-grt_url: https://radio-telescope.galaxyproject.org/api/v1/upload
+
+grt_server:
+    ## URL to your GRT server
+    grt_url: https://radio-telescope.galaxyproject.org/api/v1/upload
+    ## An instance ID uniquely identifies your Galaxy instance
+    #instance_id: none
+    ## An API key is required to submit data to GRT
+    #api_key: none
+
+## The public name and description of your Galaxy instance
+instance:
+    name: "A Galaxy Server"
+    description: |
+        Galaxy server providing tools for private use
+    tags:
+        # As of now "public" and "private" are the only recognised
+        # tags. We will work on this ontology going forward.
+        - public
+
+location:
+    # If autodetect is set to true, then an attempt will be made to
+    # automatically detect your location using a third party service
+    # (http://ip-api.com).
+    autodetect: false
+    # If you still wish to share the location of your Galaxy server
+    # (great for helping people find local resources for Galaxy)
+    latitude: 30
+    longitude: -96
+
+
 tool_blacklist:
   - __SET_METADATA__
   - upload1

--- a/scripts/grt.yml.sample
+++ b/scripts/grt.yml.sample
@@ -3,11 +3,11 @@ galaxy_config: config/galaxy.ini
 
 grt_server:
     ## URL to your GRT server
-    grt_url: https://radio-telescope.galaxyproject.org/api/v1/upload
+    grt_url: https://telescope.galaxyproject.org/api/v1/upload
     ## An instance ID uniquely identifies your Galaxy instance
-    #instance_id: none
+    instance_id: ""
     ## An API key is required to submit data to GRT
-    #api_key: none
+    api_key: ""
 
 ## The public name and description of your Galaxy instance
 instance:


### PR DESCRIPTION
The backend portion of this is still in development.
- This follows cloudlaunch's example and uses some external web services to obtain a guess at latitude and longitude. This is completely opt-in and disabled by default.
- Additionally updates for a requested DNS record change by @martenson.
- Additionally supports updating the registered name, description, and adding tags to a galaxy instance. Previously this was done via the web interface but moving this into configuration seems like a good choice :) 

This is really to support https://github.com/bgruening/galaxy-maps/issues/6 as I think GRT is the right place to do this.

TODO:
- [x] backend support
- [x] global map (GeoJSON)
  - [x] Local map
- [ ] toolbox
- [ ] optionally expose the point of contact on the backend
- [ ] tag runs based on being done inside a workflow. xref https://github.com/galaxyproject/galaxy/issues/2798#issuecomment-240139535
- [ ] https://botbot.me/freenode/galaxyproject/2017-02-15/?msg=81020936&page=3