### PR TITLE
[16.07] Create a uWSGI postfork function registry and start the tool conf watcher thread post-fork

### DIFF
--- a/.ci/flake8_lint_include_list.txt
+++ b/.ci/flake8_lint_include_list.txt
@@ -292,6 +292,7 @@ lib/galaxy/util/multi_byte.py
 lib/galaxy/util/odict.py
 lib/galaxy/util/pastescript/__init__.py
 lib/galaxy/util/plugin_config.py
+lib/galaxy/util/postfork.py
 lib/galaxy/util/simplegraph.py
 lib/galaxy_utils/__init__.py
 lib/galaxy/util/sleeper.py

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -28,17 +28,6 @@ from .version import VERSION_MAJOR
 
 log = logging.getLogger( __name__ )
 
-# The uwsgi module is automatically injected by the parent uwsgi
-# process and only exists that way.  If anything works, this is a
-# uwsgi-managed process.
-try:
-    import uwsgi
-    if uwsgi.numproc:
-        process_is_uwsgi = True
-except ImportError:
-    # This is not a uwsgi process, or something went horribly wrong.
-    process_is_uwsgi = False
-
 
 def resolve_path( path, root ):
     """If 'path' is relative make absolute by prepending 'root'"""

--- a/lib/galaxy/queues.py
+++ b/lib/galaxy/queues.py
@@ -4,7 +4,7 @@ All message queues used by Galaxy
 
 """
 
-from galaxy.config import process_is_uwsgi
+from galaxy.util.postfork import process_is_uwsgi
 
 from kombu import Exchange, Queue, Connection
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -15,6 +15,7 @@ from galaxy.util import listify
 from galaxy.util import parse_xml
 from galaxy.util import string_as_bool
 from galaxy.util.bunch import Bunch
+from galaxy.util.postfork import register_postfork_function
 
 from .parser import get_toolbox_parser, ensure_tool_conf_item
 
@@ -103,6 +104,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
                 self._init_tools_from_config( config_filename )
             except:
                 log.exception( "Error loading tools defined in config %s", config_filename )
+        register_postfork_function(self._tool_conf_watcher.start)
 
     def _init_tools_from_config( self, config_filename ):
         """

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -65,7 +65,7 @@ class ToolConfWatcher(object):
         self.paths = {}
         self._active = False
         self._lock = threading.Lock()
-        self.thread = threading.Thread(target=self.check)
+        self.thread = threading.Thread(target=self.check, name="ToolConfWatcher.thread")
         self.thread.daemon = True
         self.event_handler = ToolConfFileEventHandler(reload_callback)
 
@@ -107,7 +107,6 @@ class ToolConfWatcher(object):
             mod_time = time.ctime(os.path.getmtime(path))
         with self._lock:
             self.paths[path] = mod_time
-        self.start()
 
     def watch_file(self, tool_conf_file):
         self.monitor(tool_conf_file)

--- a/lib/galaxy/util/postfork.py
+++ b/lib/galaxy/util/postfork.py
@@ -22,7 +22,7 @@ except:
     if process_is_uwsgi:
         print("WARNING: This is a uwsgi process but the uwsgidecorators library"
               " is unavailable.  This is likely due to using an external (not"
-              " in Galaxy's .venv) uwsgi and you may experience errors.")
+              " in Galaxy's virtualenv) uwsgi and you may experience errors.")
 
 
 postfork_functions = []

--- a/lib/galaxy/util/postfork.py
+++ b/lib/galaxy/util/postfork.py
@@ -19,6 +19,10 @@ except:
     def pf_dec(func):
         return func
     postfork = pf_dec
+    if process_is_uwsgi:
+        print("WARNING: This is a uwsgi process but the uwsgidecorators library"
+              " is unavailable.  This is likely due to using an external (not"
+              " in Galaxy's .venv) uwsgi and you may experience errors.")
 
 
 postfork_functions = []

--- a/lib/galaxy/util/postfork.py
+++ b/lib/galaxy/util/postfork.py
@@ -1,0 +1,35 @@
+"""
+Handle postfork functions under uWSGI
+"""
+
+# The uwsgi module is automatically injected by the parent uwsgi
+# process and only exists that way.  If anything works, this is a
+# uwsgi-managed process.
+try:
+    import uwsgi
+    from uwsgidecorators import postfork
+    if uwsgi.numproc:
+        process_is_uwsgi = True
+except ImportError:
+    # This is not a uwsgi process, or something went horribly wrong.
+    process_is_uwsgi = False
+
+    def pf_dec(func):
+        return func
+    postfork = pf_dec
+
+
+postfork_functions = []
+
+
+@postfork
+def do_postfork():
+    for f, args, kwargs in [ t for t in postfork_functions ]:
+        f(*args, **kwargs)
+
+
+def register_postfork_function(f, *args, **kwargs):
+    if process_is_uwsgi:
+        postfork_functions.append((f, args, kwargs))
+    else:
+        f(*args, **kwargs)

--- a/lib/galaxy/util/postfork.py
+++ b/lib/galaxy/util/postfork.py
@@ -7,13 +7,15 @@ Handle postfork functions under uWSGI
 # uwsgi-managed process.
 try:
     import uwsgi
-    from uwsgidecorators import postfork
     if uwsgi.numproc:
         process_is_uwsgi = True
 except ImportError:
     # This is not a uwsgi process, or something went horribly wrong.
     process_is_uwsgi = False
 
+try:
+    from uwsgidecorators import postfork
+except:
     def pf_dec(func):
         return func
     postfork = pf_dec

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -13,7 +13,6 @@ except:
 
 
 import galaxy.app
-from galaxy.config import process_is_uwsgi
 import galaxy.model
 import galaxy.model.mapping
 import galaxy.datatypes.registry
@@ -22,21 +21,13 @@ import galaxy.web.framework.webapp
 from galaxy.webapps.util import build_template_error_formatters
 from galaxy import util
 from galaxy.util import asbool
+from galaxy.util.postfork import process_is_uwsgi, register_postfork_function
 from galaxy.util.properties import load_app_properties
 
 from paste import httpexceptions
 
 import logging
 log = logging.getLogger( __name__ )
-
-try:
-    from uwsgidecorators import postfork
-except:
-    # TODO:  Make this function more like flask's @before_first_request w/
-    # registered methods etc.
-    def pf_dec(func):
-        return func
-    postfork = pf_dec
 
 
 class GalaxyWebApplication( galaxy.web.framework.webapp.WebApplication ):
@@ -135,8 +126,7 @@ def paste_app_factory( global_conf, **kwargs ):
     except:
         log.exception("Unable to dispose of pooled toolshed install model database connections.")
 
-    if not process_is_uwsgi:
-        postfork_setup()
+    register_postfork_function(postfork_setup)
 
     # Return
     return webapp
@@ -158,7 +148,6 @@ def uwsgi_app_factory():
     return app_factory(global_conf, **kwargs)
 
 
-@postfork
 def postfork_setup():
     from galaxy.app import app
     if process_is_uwsgi:

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -4,6 +4,7 @@ Provides factory methods to assemble the Galaxy web application
 
 import os
 import sys
+import threading
 import atexit
 
 try:
@@ -128,6 +129,9 @@ def paste_app_factory( global_conf, **kwargs ):
 
     register_postfork_function(postfork_setup)
 
+    for th in threading.enumerate():
+        if th.is_alive():
+            log.debug("Prior to webapp return, Galaxy thread %s is alive.", th)
     # Return
     return webapp
 

--- a/lib/galaxy/webapps/reports/buildapp.py
+++ b/lib/galaxy/webapps/reports/buildapp.py
@@ -10,8 +10,8 @@ from inspect import isclass
 
 from paste import httpexceptions
 
-from galaxy.config import process_is_uwsgi
 from galaxy.util import asbool
+from galaxy.util.postfork import process_is_uwsgi
 from galaxy.webapps.util import build_template_error_formatters
 
 import galaxy.model

--- a/lib/galaxy/webapps/tool_shed/buildapp.py
+++ b/lib/galaxy/webapps/tool_shed/buildapp.py
@@ -15,7 +15,7 @@ import galaxy.web.framework.webapp
 from galaxy.webapps.util import build_template_error_formatters
 from galaxy.webapps.tool_shed.framework.middleware import hg
 from galaxy import util
-from galaxy.config import process_is_uwsgi
+from galaxy.util.postfork import process_is_uwsgi
 from galaxy.util.properties import load_app_properties
 
 log = logging.getLogger( __name__ )

--- a/lib/tool_shed/galaxy_install/update_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/update_repository_manager.py
@@ -11,6 +11,7 @@ from tool_shed.util import common_util
 from tool_shed.util import encoding_util
 from tool_shed.util import repository_util
 from galaxy import util
+from galaxy.util.postfork import register_postfork_function
 
 log = logging.getLogger( __name__ )
 
@@ -26,7 +27,7 @@ class UpdateRepositoryManager( object ):
             self.sleeper = Sleeper()
             self.restarter = threading.Thread( target=self.__restarter )
             self.restarter.daemon = True
-            self.restarter.start()
+            register_postfork_function(self.restarter.start)
             self.seconds_to_sleep = int( app.config.hours_between_check * 3600 )
 
     def get_update_to_changeset_revision_and_ctx_rev( self, repository ):


### PR DESCRIPTION
`process_is_uwsgi` being in `galaxy.util.postfork` is maybe not the best place, but it's not any worse than in `galaxy.config` where it was.

This will hopefully fix the dead uWSGI worker issue we've been having on Main.

xref unbit/uwsgi#1149
