### PR TITLE
Ensure proper filtering of dataset when injecting input data on workflow initialization

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -21,7 +21,7 @@ from galaxy.tools.parameters.basic import (
 from galaxy.tools.parameters.wrapped import make_dict_copy
 from galaxy.tools import DefaultToolState
 from galaxy.tools import ToolInputsNotReadyException
-from galaxy.util import odict, listify
+from galaxy.util import odict
 from galaxy.util.bunch import Bunch
 from galaxy.web.framework import formbuilder
 from tool_shed.util import common_util
@@ -1152,28 +1152,24 @@ class ToolModule( WorkflowModule ):
 
     def add_dummy_datasets( self, connections=None, steps=None ):
         if connections:
-            # Store onnections by input name
+            # Store connections by input name
             input_connections_by_name = dict( ( conn.input_name, conn ) for conn in connections )
         else:
             input_connections_by_name = {}
 
-        # Any connected input needs to have value RuntimeValue (these
-        # are not persisted so we need to do it every time)
+        # Any input needs to have value RuntimeValue or obtain the value from connected steps
         def callback( input, prefixed_name, context, **kwargs ):
             if isinstance( input, DataToolParameter ) or isinstance( input, DataCollectionToolParameter ):
-                if self.trans.workflow_building_mode is workflow_building_modes.USE_HISTORY:
-                    if connections is None or prefixed_name in input_connections_by_name:
-                        if steps:
-                            connection = input_connections_by_name[ prefixed_name ]
-                            output_step = next( output_step for output_step in steps if connection.output_step_id == output_step.id )
-                            if output_step.type.startswith( 'data' ):
-                                output_inputs = output_step.module.get_runtime_inputs( connections=connections )
-                                output_value = output_inputs[ 'input' ].get_initial_value( self.trans, context )
-                                if isinstance( input, DataToolParameter ):
-                                    for v in listify( output_value ):
-                                        if isinstance( v, self.trans.app.model.HistoryDatasetCollectionAssociation ):
-                                            return v.to_hda_representative()
-                                return output_value
+                if connections is not None and steps is not None and self.trans.workflow_building_mode is workflow_building_modes.USE_HISTORY:
+                    if prefixed_name in input_connections_by_name:
+                        connection = input_connections_by_name[ prefixed_name ]
+                        output_step = next( output_step for output_step in steps if connection.output_step_id == output_step.id )
+                        if output_step.type.startswith( 'data' ):
+                            output_inputs = output_step.module.get_runtime_inputs( connections=connections )
+                            output_value = output_inputs[ 'input' ].get_initial_value( self.trans, context )
+                            if isinstance( input, DataToolParameter ) and isinstance( output_value, self.trans.app.model.HistoryDatasetCollectionAssociation ):
+                                return output_value.to_hda_representative()
+                            return output_value
                         return RuntimeValue()
                     else:
                         return input.get_initial_value( self.trans, context )

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -528,9 +528,20 @@ class InputDataModule( InputModule ):
     def get_data_outputs( self ):
         return [ dict( name='output', extensions=['input'] ) ]
 
-    def get_runtime_inputs( self, filter_set=['data'] ):
+    def get_filter_set( self, connections=None ):
+        filter_set = []
+        if connections:
+            for oc in connections:
+                for ic in oc.input_step.module.get_data_inputs():
+                    if 'extensions' in ic and ic[ 'name' ] == oc.input_name:
+                        filter_set += ic[ 'extensions' ]
+        if not filter_set:
+            filter_set = [ 'data' ]
+        return ', '.join( filter_set )
+
+    def get_runtime_inputs( self, connections=None ):
         label = self.state.get( "name", "Input Dataset" )
-        return dict( input=DataToolParameter( None, Element( "param", name="input", label=label, multiple=False, type="data", format=', '.join(filter_set) ), self.trans ) )
+        return dict( input=DataToolParameter( None, Element( "param", name="input", label=label, multiple=False, type="data", format=self.get_filter_set( connections ) ), self.trans ) )
 
 
 class InputDataCollectionModule( InputModule ):
@@ -545,7 +556,7 @@ class InputDataCollectionModule( InputModule ):
     def default_state( Class ):
         return dict( name=Class.default_name, collection_type=Class.default_collection_type )
 
-    def get_runtime_inputs( self, filter_set=['data'] ):
+    def get_runtime_inputs( self, **kwds ):
         label = self.state.get( "name", self.default_name )
         collection_type = self.state.get( "collection_type", self.default_collection_type )
         input_element = Element( "param", name="input", label=label, type="data_collection", collection_type=collection_type )
@@ -1156,7 +1167,7 @@ class ToolModule( WorkflowModule ):
                             connection = input_connections_by_name[ prefixed_name ]
                             output_step = next( output_step for output_step in steps if connection.output_step_id == output_step.id )
                             if output_step.type.startswith( 'data' ):
-                                output_inputs = output_step.module.get_runtime_inputs()
+                                output_inputs = output_step.module.get_runtime_inputs( connections=connections )
                                 output_value = output_inputs[ 'input' ].get_initial_value( self.trans, context )
                                 if isinstance( input, DataToolParameter ):
                                     for v in listify( output_value ):

--- a/templates/webapps/galaxy/workflow/run.mako
+++ b/templates/webapps/galaxy/workflow/run.mako
@@ -23,14 +23,7 @@
                     'action_arguments'  : pja.action_arguments
                 } for pja in step.post_job_actions ]
             else:
-                type_filter = []
-                for oc in step.output_connections:
-                    for ic in oc.input_step.module.get_data_inputs():
-                        if 'extensions' in ic and ic[ 'name' ] == oc.input_name:
-                            type_filter += ic[ 'extensions' ]
-                if not type_filter:
-                    type_filter = [ 'data' ]
-                inputs = step.module.get_runtime_inputs( filter_set=type_filter )
+                inputs = step.module.get_runtime_inputs( connections=step.output_connections )
                 step_model = {
                     'name'   : step.module.name,
                     'inputs' : [ input.to_dict( trans ) for input in inputs.itervalues() ]

--- a/templates/webapps/galaxy/workflow/run.mako
+++ b/templates/webapps/galaxy/workflow/run.mako
@@ -699,17 +699,7 @@ import base64
                   % endif
           </div>
           <div class="toolFormBody">
-              <%
-              # Filter possible inputs to data types that are valid for subsequent steps
-              type_filter = []
-              for oc in step.output_connections:
-                  for ic in oc.input_step.module.get_data_inputs():
-                      if 'extensions' in ic and ic['name'] == oc.input_name:
-                          type_filter += ic['extensions']
-              if not type_filter:
-                  type_filter = ['data']
-              %>
-              ${do_inputs( module.get_runtime_inputs(filter_set=type_filter), step.state.inputs, errors.get( step.id, dict() ), "", step, None, used_accumulator )}
+              ${do_inputs( module.get_runtime_inputs( connections=step.output_connections ), step.state.inputs, errors.get( step.id, dict() ), "", step, None, used_accumulator )}
           </div>
       </div>
     %endif


### PR DESCRIPTION
This is an addition to: https://github.com/galaxyproject/galaxy/pull/2669. Currently datasets are not properly filtered by datatypes when injected on initialization. As a consequence discrepencies might occur such that the input parameter is initialized with a dataset which is not permitted in the connected step input parameter. In this case a refresh is required. This PR avoids the necessity of a refresh by properly filtering the data types upon initial injection. This can be tested as follows: add a non-tabular file to the history, and select the `Merge columns` tool. The columns will not be resolved unless a refresh has been triggered. Additionally this PR touches up on the injection procedure to simplify it and improve its robustness and consistency.
