### PR TITLE
Conda explicitly checks for .sh in the command as a part of it's logi…

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -270,7 +270,7 @@ def hash_conda_packages(conda_packages, conda_target=None):
 # these commands as Python
 def install_conda(conda_context=None):
     conda_context = _ensure_conda_context(conda_context)
-    f, script_path = tempfile.mkstemp(suffix=".bash", prefix="conda_install")
+    f, script_path = tempfile.mkstemp(suffix=".sh", prefix="conda_install")
     os.close(f)
     download_cmd = " ".join(commands.download_command(conda_link(), to=script_path, quote_url=True))
     install_cmd = "bash '%s' -b -p '%s'" % (script_path, conda_context.conda_prefix)


### PR DESCRIPTION
…c to figure out that the shell is sh or bash compatible.

Without this, you'll see the error:

```
Please run using "bash" or "sh", but not "." or "source"
/Users/yoplait/work/galaxy/database/tmp/conda_install10fb8w.bash: line 17: return: can only 'return' from a function or sourced script
```

The failure to return actually _does_ make the script continue working, so we have here a confluence of bugs (one in Galaxy, one in Conda) actually making things succeed.
