### PR TITLE
[16.07] Do not instantiate the raven (sentry) client or tool conf watchdog threads until uWSGI postfork

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -149,11 +149,15 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
                 )
                 self.heartbeat.daemon = True
                 register_postfork_function(self.heartbeat.start)
+        self.sentry_client = None
         if self.config.sentry_dsn:
-            import raven
-            self.sentry_client = raven.Client(self.config.sentry_dsn)
-        else:
-            self.sentry_client = None
+
+            def postfork_sentry_client():
+                import raven
+                self.sentry_client = raven.Client(self.config.sentry_dsn)
+
+            register_postfork_function(postfork_sentry_client)
+
         # Transfer manager client
         if self.config.get_bool( 'enable_beta_job_managers', False ):
             from galaxy.jobs import transfer_manager

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -23,8 +23,8 @@ from galaxy.exceptions import ConfigurationError
 from galaxy.util import listify
 from galaxy.util import string_as_bool
 from galaxy.util.dbkeys import GenomeBuilds
-from galaxy.web.formatting import expand_pretty_datetime_format
 from galaxy.util.postfork import register_postfork_function
+from galaxy.web.formatting import expand_pretty_datetime_format
 from .version import VERSION_MAJOR
 
 log = logging.getLogger( __name__ )

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -24,6 +24,7 @@ from galaxy.util import listify
 from galaxy.util import string_as_bool
 from galaxy.util.dbkeys import GenomeBuilds
 from galaxy.web.formatting import expand_pretty_datetime_format
+from galaxy.util.postfork import register_postfork_function
 from .version import VERSION_MAJOR
 
 log = logging.getLogger( __name__ )
@@ -785,7 +786,7 @@ def configure_logging( config ):
         from raven.handlers.logging import SentryHandler
         sentry_handler = SentryHandler( config.sentry_dsn )
         sentry_handler.setLevel( logging.WARN )
-        root.addHandler( sentry_handler )
+        register_postfork_function(root.addHandler, sentry_handler)
 
 
 class ConfiguresGalaxyMixin:

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -14,6 +14,8 @@ except ImportError:
     PollingObserver = None
     can_watch = False
 
+from galaxy.util.postfork import register_postfork_function
+
 log = logging.getLogger( __name__ )
 
 
@@ -151,7 +153,7 @@ class ToolWatcher(object):
         self.start()
 
     def start(self):
-        self.observer.start()
+        register_postfork_function(self.observer.start)
 
     def shutdown(self):
         self.observer.stop()

--- a/lib/galaxy/web/framework/middleware/sentry.py
+++ b/lib/galaxy/web/framework/middleware/sentry.py
@@ -12,6 +12,8 @@ try:
 except:
     Client = None
 
+from galaxy.util.postfork import register_postfork_function
+
 
 RAVEN_IMPORT_MESSAGE = ('The Python raven package is required to use this '
                         'feature, please install it')
@@ -25,7 +27,12 @@ class Sentry(object):
     def __init__(self, application, dsn):
         assert Client is not None, RAVEN_IMPORT_MESSAGE
         self.application = application
-        self.client = Client( dsn )
+        self.client = None
+
+        def postfork_sentry_client():
+            self.client = Client( dsn )
+
+        register_postfork_function(postfork_sentry_client)
 
     def __call__(self, environ, start_response):
         try:


### PR DESCRIPTION
As in #2774. I manually tested all three sentry access methods (log handler, exception handling middleware, explicit client capture) and they all seem to work this way.

The downside is that startup errors will no longer be sent to sentry under uWSGI. raven's `Client` does not give any access to the transport to call its `stop()` method so there's no proper way to start the client prefork, stop it just before forking, and then start it again once forking (if that would even work). Destroying the client object doesn't work either (unless explicit garbage collection is needed). In the end I felt like this is not a huge loss.

xref: getsentry/raven-python#806
