### PR TITLE
shorten Conda environment names

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -20,8 +20,8 @@ IS_OS_X = _platform == "darwin"
 
 # BSD 3-clause
 CONDA_LICENSE = "http://docs.continuum.io/anaconda/eula"
-VERSIONED_ENV_DIR_NAME = re.compile(r"__package__(.*)@__version__(.*)")
-UNVERSIONED_ENV_DIR_NAME = re.compile(r"__package__(.*)@__unversioned__")
+VERSIONED_ENV_DIR_NAME = re.compile(r"__(.*)@(.*)")
+UNVERSIONED_ENV_DIR_NAME = re.compile(r"__(.*)@_uv_")
 USE_PATH_EXEC_DEFAULT = False
 CONDA_VERSION = "3.19.3"
 
@@ -251,9 +251,9 @@ class CondaTarget(object):
         a fixed and predictable name given package and version.
         """
         if self.version:
-            return "__package__%s@__version__%s" % (self.package, self.version)
+            return "__%s@%s" % (self.package, self.version)
         else:
-            return "__package__%s@__unversioned__" % (self.package)
+            return "__%s@_uv_" % (self.package)
 
 
 def hash_conda_packages(conda_packages, conda_target=None):


### PR DESCRIPTION
This PR is a proposal to shorten the default environment path length of our Conda installations.

The initial Conda limitation pops up really frequently in the Galaxy universe, whereas it is not so frequent in the Conda community. I think part of the problem is that we waste 20 (1/4) chars in `package__` and `__version__`. I really like the more descriptive way of this long identifier but given the Conda problem and that it is much more to type if you install package by hand I think a shorter prefix would be great.

Moreover, many OS have a max length of a command line and our Galaxy generated command-lines getting larger and larger (collections etc.) so I think it is in general a good idea to keep this things short.

What do you think @jmchilton, @mvdbeek, @nsoranzo, @natefoo?

@gregvonkuster , can you test this patch with your initial environment? If you use planemo you need to find the `conda_util.py` from Galaxy lib and change it manually. 
