### PR TITLE
[WIP][16.04] Add example of regressed 16.04 behavior related to dbkey output actions.

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -628,7 +628,7 @@ class DefaultToolAction( object ):
         """
         if output.actions:
             for action in output.actions.actions:
-                if action.tag == "metadata":
+                if action.tag == "metadata" and action.default:
                     metadata_new_value = fill_template( action.default, context=params ).split(",")
                     dataset.metadata.__setattr__(str(action.name), metadata_new_value)
 

--- a/test/functional/tools/dbkey_output_action.xml
+++ b/test/functional/tools/dbkey_output_action.xml
@@ -1,0 +1,24 @@
+<tool id="dbkey_output_action" name="dbkey_output_action" version="0.1.0">
+    <command>echo foo > $mapped_reads</command>
+    <inputs>
+        <param name="input" type="data" />
+        <param name="index" type="select" label="Using reference genome">
+          <options from_data_table="test_fasta_indexes">
+            <filter type="data_meta" ref="input" key="dbkey" column="1" />
+            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+          </options>
+        </param>
+    </inputs>
+    <outputs>
+        <data format="txt" name="mapped_reads">
+            <actions>
+                <action type="metadata" name="dbkey">
+                    <option type="from_data_table" name="test_fasta_indexes" column="1" offset="0">
+                        <filter type="param_value" column="0" value="#" compare="startswith" keep="False"/>
+                        <filter type="param_value" ref="index" column="0"/>
+                    </option>
+                </action>
+            </actions>
+        </data>
+    </outputs>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -18,6 +18,7 @@
   <tool file="inputs_as_json.xml" />
   <tool file="dbkey_filter_input.xml" />
   <tool file="dbkey_filter_multi_input.xml" />
+  <tool file="dbkey_output_action.xml" />
   <tool file="composite_output.xml" />
   <tool file="unicode_stream.xml" />
   <tool file="metadata.xml" />


### PR DESCRIPTION
Example tool that demonstrates behavior in 16.04 reported by Hans here http://dev.list.galaxyproject.org/problems-with-action-type-quot-metadata-quot-name-quot-dbkey-quot-in-tool-xml-td4669886.html.

The tool works fine in 16.01.

I'll take this out of WIP once I have a fix.
