### PR TITLE
[16.07] Revert str.split() syntax for Python 2 compatibility

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -43,7 +43,7 @@ class SlurmJobRunner( DRMAAJobRunner ):
             cmd = [ 'scontrol', '-o' ]
             if '.' in ajs.job_id:
                 # custom slurm-drmaa-with-cluster-support job id syntax
-                job_id, cluster = ajs.job_id.split('.', maxsplit=1)
+                job_id, cluster = ajs.job_id.split('.', 1)
                 cmd.extend( [ '-M', cluster ] )
             else:
                 job_id = ajs.job_id


### PR DESCRIPTION
See 301f7dbbda272da764f3796b02e35a6eab587df2 for discussion
