### PR TITLE
Two Small Config Tweaks

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -125,6 +125,11 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # but prefixed with install_ are also available).
 #install_database_connection = sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE
 
+# Setting the following option to true will cause Galaxy to automatically
+# migrate the database forward after updates. This is not recommended for production
+# use.
+#database_auto_migrate = False
+
 # -- Files and directories
 
 # Dataset files are stored in this directory.

--- a/lib/galaxy/model/migrate/check.py
+++ b/lib/galaxy/model/migrate/check.py
@@ -89,7 +89,7 @@ def create_or_verify_database( url, galaxy_config_file, engine_options={}, app=N
     db_schema = schema.ControlledSchema( engine, migrate_repository )
     if migrate_repository.versions.latest != db_schema.version:
         config_arg = ''
-        if os.path.abspath( os.path.join( os.getcwd(), 'config', 'galaxy.ini' ) ) != galaxy_config_file:
+        if galaxy_config_file and os.path.abspath( os.path.join( os.getcwd(), 'config', 'galaxy.ini' ) ) != galaxy_config_file:
             config_arg = ' -c %s' % galaxy_config_file.replace( os.path.abspath( os.getcwd() ), '.' )
         raise Exception( "Your database has version '%d' but this code expects version '%d'.  Please backup your database and then migrate the schema by running 'sh manage_db.sh%s upgrade'."
                          % ( db_schema.version, migrate_repository.versions.latest, config_arg ) )


### PR DESCRIPTION
- Document undocumented `database_auto_migrate` procedure.
- Fix poor assumption of file parameter being non-null - would cause misleading error messages.
