### PR TITLE
Correct license name in nodejs proxy

### DIFF
--- a/lib/galaxy/web/proxy/js/package.json
+++ b/lib/galaxy/web/proxy/js/package.json
@@ -4,7 +4,7 @@
   "description": "A dynamic reverse proxy for use within Galaxy",
   "main": "index.js",
   "author": "John Chilton",
-  "license": "AFL v3",
+  "license": "AFL-3.0",
   "readmeFilename": "README.md",
   "repository": {
     "type": "mercurial",


### PR DESCRIPTION
Should conform to SPDX names
