### PR TITLE
Allow NodeJS proxy to do reverse proxying

### DIFF
--- a/lib/galaxy/web/proxy/__init__.py
+++ b/lib/galaxy/web/proxy/__init__.py
@@ -106,6 +106,7 @@ class NodeProxyLauncher(object):
             "--sessions", config.proxy_session_map,
             "--ip", config.dynamic_proxy_bind_ip,
             "--port", str(config.dynamic_proxy_bind_port),
+            "--reverseProxy",
         ]
         if config.dynamic_proxy_debug:
             args.append("--verbose")

--- a/lib/galaxy/web/proxy/js/lib/main.js
+++ b/lib/galaxy/web/proxy/js/lib/main.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
-Inspiration taken from 
+Inspiration taken from
 	https://github.com/jupyter/multiuser-server/blob/master/multiuser/js/main.js
 */
 var fs = require('fs');
@@ -14,6 +14,7 @@ args
     .option('--port <n>', 'Public-facing port of the proxy', parseInt)
     .option('--cookie <cookiename>', 'Cookie proving authentication', 'galaxysession')
     .option('--sessions <file>', 'Routes file to monitor')
+    .option('--reverseProxy', 'Cause the proxy to rewrite location blocks with its own port')
     .option('--verbose')
 
 args.parse(process.argv);
@@ -26,7 +27,12 @@ var sessions = mapFor(args.sessions);
 var dynamic_proxy_options = {
   sessionCookie: args['cookie'],
   sessionMap: sessions,
-  verbose: args.verbose
+  verbose: args.verbose,
+  port: args['port']
+}
+
+if(args.reverseProxy){
+    dynamic_proxy_options.reverseProxy = true;
 }
 
 var dynamic_proxy = new DynamicProxy(dynamic_proxy_options);

--- a/lib/galaxy/web/proxy/js/lib/proxy.js
+++ b/lib/galaxy/web/proxy/js/lib/proxy.js
@@ -14,6 +14,8 @@ var DynamicProxy = function(options) {
     this.sessionCookie = options.sessionCookie;
     this.sessionMap = options.sessionMap;
     this.debug = options.verbose;
+    this.reverseProxy = options.reverseProxy;
+    this.port = options.port;
 
     var log_errors = function(handler) {
         return function (req, res) {
@@ -87,6 +89,7 @@ DynamicProxy.prototype.findSession = function(request) {
 };
 
 DynamicProxy.prototype.handleProxyRequest = function(req, res) {
+    var othis = this;
     var target = this.targetForRequest(req);
     if(this.debug) {
         console.log("PROXY " + req.method + " " + req.url + " to " + target.host + ':' + target.port);
@@ -94,7 +97,21 @@ DynamicProxy.prototype.handleProxyRequest = function(req, res) {
     var origin = req.headers.origin;
     this.rewriteRequest(req);
     res.oldWriteHead = res.writeHead;
+
     res.writeHead = function(statusCode, headers) {
+        if(othis.reverseProxy && statusCode === 302){
+            if(res && res._headers){
+                if(othis.debug){
+                    console.log("Original Location Header: " + res._headers.location);
+                }
+                if(res._headers.location){
+                    res._headers.location = res._headers.location.replace('http://localhost/', 'http://localhost:' + othis.port + '/');
+                }
+                if(othis.debug){
+                    console.log("Rewritten Location Header: " + res._headers.location);
+                }
+            }
+        }
         try {
             if(origin){
                 res.setHeader('Access-Control-Allow-Origin', origin);


### PR DESCRIPTION
Noticed this whilst debugging. Containers with proxies in them return 302s to addresses appropriate for them. E.g. a nodejs reverse proxy running in a docker container will rewrite a 302 to `http://localhost/my-path` since it doesn't know about the external port, but that bug isn't really tractable since there is no way for the nginx proxy inside the container to know the external port and readjust itself appropriate (I mean...there are ways, they just are a bit unappealing and are per-container). So we look at the next place upstream.

Previously the NodeJS proxy takes that 302 Location header and says "sure, that looks great", but really it needs to be reverse proxy aware as well and able to rewrite 302s to a location that's more correct.

With this patch, the nodejs proxy will correct a 302 like `http://localhost/my-path` to `http://localhost:8800/my-path` which will actually go through itself, rather than hitting the host webserver and 404ing.

This is activated if you do not say that you're using an external proxy, which is the only case you'd hit this, if you can talk to `:8800` directly. If you're using an external proxy, you're probably accessing galaxy at `https://fqdn/...` anyway, and that maps to URLs inside the container properly.
