### PR TITLE
Inject HOME, so that conda doens't attempt to write to ~/.conda

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -175,7 +175,7 @@ class CondaContext(object):
 
     def exec_command(self, operation, args):
         command = self.command(operation, args)
-        env = {}
+        env = {'HOME': self.conda_prefix}  # We don't want to pollute ~/.conda, which may not even be writable
         condarc_override = self.condarc_override
         if condarc_override:
             env["CONDARC"] = condarc_override


### PR DESCRIPTION
The "guilty" code on conda's side is [here](https://github.com/conda/conda/blame/master/conda/misc.py#L273)

This is important for the regular supervisor setup that we often recommend for production, where  supervisor runs as root and galaxy is launched with `user = galaxy` (see [here](https://github.com/galaxyproject/galaxy/blob/dev/contrib/galaxy_supervisor.conf#L40) for a complete file), and so HOME points to `/root` which fails when conda attempts to write a list of installed environments to ~/.conda/environemnts.txt.

With this PR we set HOME for all conda commands to `<conda_prefix>`.
