### PR TITLE
Acquire lock before attempting to install conda

### DIFF
--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -6,6 +6,10 @@ incompatible changes coming.
 
 import os
 
+from galaxy.web.proxy.filelock import (
+    FileLock,
+    FileLockException
+)
 from ..resolvers import (
     DependencyResolver,
     NullDependency,
@@ -25,6 +29,7 @@ from ..conda_util import (
     USE_PATH_EXEC_DEFAULT,
 )
 
+
 DEFAULT_BASE_PATH_DIRECTORY = "_conda"
 DEFAULT_CONDARC_OVERRIDE = "_condarc"
 DEFAULT_ENSURE_CHANNELS = "r,bioconda,iuc"
@@ -39,6 +44,7 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
 
     def __init__(self, dependency_manager, **kwds):
         self.versionless = _string_as_bool(kwds.get('versionless', 'false'))
+        self.dependency_manager = dependency_manager
 
         def get_option(name):
             return self._get_config_option(name, dependency_manager, config_prefix="conda", **kwds)
@@ -84,26 +90,35 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
         self.ensure_channels = ensure_channels
 
         # Conda operations options (these define how resolution will occur)
-        auto_init = _string_as_bool(get_option("auto_init"))
         auto_install = _string_as_bool(get_option("auto_install"))
         copy_dependencies = _string_as_bool(get_option("copy_dependencies"))
-
-        if not conda_context.is_conda_installed():
-            if auto_init:
-                if conda_context.can_install_conda():
-                    if install_conda(conda_context):
-                        self.disabled = True
-                        log.warning("Conda installation requested and failed.")
-                else:
-                    self.disabled = True
-            else:
-                self.disabled = True
-                log.warning("Conda not installed and auto-installation disabled.")
-
+        self.auto_init = _string_as_bool(get_option("auto_init"))
         self.conda_context = conda_context
+        self.ensure_conda_installed()
         self.auto_install = auto_install
         self.copy_dependencies = copy_dependencies
         self.verbose_install_check = verbose_install_check
+
+    def ensure_conda_installed(self):
+        """
+        Make sure that conda is installed, and if conda can't be installed, mark resolver as disabled.
+        We acquire a lock, so that multiple handlers do not attempt to install conda simultaneously.
+        """
+        try:
+            with FileLock(os.path.join(self.dependency_manager.default_base_path, 'conda')):
+                if not self.conda_context.is_conda_installed():
+                    if self.auto_init:
+                        if self.conda_context.can_install_conda():
+                            if install_conda(self.conda_context):
+                                self.disabled = True
+                                log.warning("Conda installation requested and failed.")
+                        else:
+                            self.disabled = True
+                    else:
+                        self.disabled = True
+                        log.warning("Conda not installed and auto-installation disabled.")
+        except FileLockException:
+            self.ensure_conda_installed()
 
     def resolve(self, name, version, type, **kwds):
         # Check for conda just not being there, this way we can enable

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -104,6 +104,8 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
         Make sure that conda is installed, and if conda can't be installed, mark resolver as disabled.
         We acquire a lock, so that multiple handlers do not attempt to install conda simultaneously.
         """
+        if not os.path.exists(self.dependency_manager.default_base_path):
+            os.mkdir(self.dependency_manager.default_base_path)
         try:
             with FileLock(os.path.join(self.dependency_manager.default_base_path, 'conda')):
                 if not self.conda_context.is_conda_installed():


### PR DESCRIPTION
... otherwise in a multi-handler setup handlers will likely attempt to install conda at the same time. This seems really hackish, so if there are better ways to achieve this, let me know!
Ping @bgruening @nsoranzo @jmchilton

I guess that if this is OK it should go to 16.07, but somehow I think it might be better to wait one more release before enabling `conda_auto_init` by default ... after all I think there are some serious and frustrating bugs that are not yet fixed (`activate` sometimes missing when downgrading conda, offline mode bugs, requirement on short paths etc...).
