### PR TITLE
disable conda_auto_init

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -206,7 +206,7 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 #conda_verbose_install_check=False
 # Set to True to instruct Galaxy to install Conda from the web automatically
 # if it cannot find a local copy and conda_exec is not configured.
-#conda_auto_init = True
+#conda_auto_init = False
 
 # File containing the Galaxy Tool Sheds that should be made available to
 # install from in the admin interface (.sample used if default does not exist).

--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -22,7 +22,7 @@ EXTRA_CONFIG_KWDS = {
     'conda_debug': None,
     'conda_ensure_channels': 'r,bioconda,iuc',
     'conda_auto_install': False,
-    'conda_auto_init': True,
+    'conda_auto_init': False,
 }
 
 CONFIG_VAL_NOT_FOUND = object()


### PR DESCRIPTION
Based on discussion at https://github.com/galaxyproject/galaxy/pull/2826 it will be better to mark Conda as a beta feature and make it opt-in. 

@mvdbeek @jmchilton @bgruening

edit: also see https://github.com/galaxyproject/galaxy/pull/2794
