### PR TITLE
Bring Galaxy, reports, and shed run scripts in sync.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,18 @@ open-project: ## open project on github
 lint: ## check style using tox and flake8 for Python 2 and Python 3
 	$(IN_VENV) tox -e py27-lint && tox -e py34-lint
 
+uwsgi-rebuild-validation:
+	$(IN_VENV) python scripts/config_ini_to_yaml.py build_uwsgi_yaml
+
+tool-shed-config-validate:
+	$(IN_VENV) python scripts/config_ini_to_yaml.py validate tool_shed
+
+tool-shed-config-convert:
+	$(IN_VENV) python scripts/config_ini_to_yaml.py convert tool_shed
+
+tool-shed-config-rebuild-sample:
+	$(IN_VENV) python scripts/config_ini_to_yaml.py build_sample_yaml tool_shed --add_comments
+
 release-ensure-upstream: ## Ensure upstream branch for release commands setup
 ifeq (shell git remote -v | grep $(RELEASE_UPSTREAM), )
 	git remote add $(RELEASE_UPSTREAM) git@github.com:galaxyproject/galaxy.git

--- a/config/reports.ini.sample
+++ b/config/reports.ini.sample
@@ -55,13 +55,6 @@ log_level = DEBUG
 # used for the cache
 #template_cache_path = database/compiled_templates/reports
 
-# Session support (beaker)
-use_beaker_session = True
-session_type = memory
-session_data_dir = %(here)s/database/beaker_sessions
-session_key = galaxysessions
-session_secret = changethisinproduction
-
 # Configuration for debugging middleware
 #debug = False
 

--- a/config/reports.ini.sample
+++ b/config/reports.ini.sample
@@ -39,12 +39,16 @@ prefix = /reports
 
 # Specifies the factory for the universe WSGI application
 paste.app_factory = galaxy.webapps.reports.buildapp:app_factory
-log_level = DEBUG
+
+# Verbosity of console log messages.  Acceptable values can be found here:
+# https://docs.python.org/2/library/logging.html#logging-levels
+#log_level = DEBUG
 
 # Database connection
-# Galaxy reports are intended for production Galaxy instances, so sqlite is not supported.
-# You may use a SQLAlchemy connection string to specify an external database.
-#database_connection = postgres:///galaxy_test?user=postgres&password=postgres
+# Galaxy reports are intended for production Galaxy instances, so sqlite (and the default value
+# below) is not supported. An SQLAlchemy connection string should be used specify an external
+# database.
+#database_connection = sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE
 
 # Where dataset files are saved
 #file_path = database/files

--- a/config/tool_shed.ini.sample
+++ b/config/tool_shed.ini.sample
@@ -53,13 +53,6 @@ new_file_path = database/tmp
 #   standard).
 #pretty_datetime_format = $locale (UTC)
 
-# Session support (beaker)
-use_beaker_session = True
-session_type = memory
-session_data_dir = %(here)s/database/beaker_sessions
-session_key = galaxysessions
-session_secret = changethisinproduction
-
 # -- Repository and Tool search
 # Using the script located at scripts/build_ts_whoosh_index.py
 # you can generate search index and allow full text API searching over

--- a/config/tool_shed.ini.sample
+++ b/config/tool_shed.ini.sample
@@ -23,23 +23,27 @@ threadpool_kill_thread_limit = 10800
 
 # Specifies the factory for the universe WSGI application
 paste.app_factory = galaxy.webapps.tool_shed.buildapp:app_factory
+
+# Verbosity of console log messages.  Acceptable values can be found here:
+# https://docs.python.org/2/library/logging.html#logging-levels
 #log_level = DEBUG
 
-# Database connection
-database_file = database/community.sqlite
-# You may use a SQLAlchemy connection string to specify
-# an external database instead
-#database_connection = postgres:///community_test?host=/var/run/postgresql
+# By default, the Tool Shed uses a SQLite database at 'database/community.sqlite'.  You
+# may use a SQLAlchemy connection string to specify an external database
+# instead.  This string takes many options which are explained in detail in the
+# config file documentation.
+#database_connection = sqlite:///./database/community.sqlite?isolation_level=IMMEDIATE
 
 # Where the hgweb.config file is stored.
 # The default is the Galaxy installation directory.
 #hgweb_config_dir = None
 
 # Where tool shed repositories are stored.
-file_path = database/community_files
+#file_path = database/community_files
+
 # Temporary storage for additional datasets,
 # this should be shared through the cluster
-new_file_path = database/tmp
+#new_file_path = database/tmp
 
 # File containing old-style genome builds
 #builds_file_path = tool-data/shared/ucsc/builds.txt
@@ -87,12 +91,14 @@ new_file_path = database/tmp
 
 # -- Users and Security
 
-# Galaxy encodes various internal values when these values will be output in
+# The Tool Shed encodes various internal values when these values will be output in
 # some format (for example, in a URL or cookie).  You should set a key to be
 # used by the algorithm that encodes and decodes these values.  It can be any
 # string.  If left unchanged, anyone could construct a cookie that would grant
 # them access to others' sessions.
-id_secret = changethisinproductiontoo
+# One simple way to generate a value for this is with the shell command:
+#   python -c 'import time; print time.time()' | md5sum | cut -f 1 -d ' '
+#id_secret = changethisinproductiontoo
 
 # User authentication can be delegated to an upstream proxy server (usually
 # Apache).  The upstream proxy should set a REMOTE_USER header in the request.
@@ -119,8 +125,11 @@ id_secret = changethisinproductiontoo
 # NEVER enable this on a public site (even test or QA)
 #use_interactive = true
 
-# this should be a comma-separated list of valid Galaxy users
-#admin_users = user1@example.org,user2@example.org
+# Administrative users - set this to a comma-separated list of valid Tool Shed
+# users (email addresses).  These users will have access to the Admin section
+# of the server, and will have access to create users, groups, roles,
+# libraries, and more.
+#admin_users = None
 
 # Force everyone to log in (disable anonymous access)
 #require_login = False

--- a/lib/galaxy/util/postfork.py
+++ b/lib/galaxy/util/postfork.py
@@ -7,8 +7,10 @@ Handle postfork functions under uWSGI
 # uwsgi-managed process.
 try:
     import uwsgi
-    if uwsgi.numproc:
+    if hasattr(uwsgi, "numproc"):
         process_is_uwsgi = True
+    else:
+        process_is_uwsgi = False
 except ImportError:
     # This is not a uwsgi process, or something went horribly wrong.
     process_is_uwsgi = False

--- a/lib/galaxy/webapps/tool_shed/config.py
+++ b/lib/galaxy/webapps/tool_shed/config.py
@@ -66,7 +66,7 @@ class Configuration( object ):
         self.new_file_path = resolve_path( kwargs.get( "new_file_path", "database/tmp" ), self.root )
         self.cookie_path = kwargs.get( "cookie_path", "/" )
         self.enable_quotas = string_as_bool( kwargs.get( 'enable_quotas', False ) )
-        self.id_secret = kwargs.get( "id_secret", "USING THE DEFAULT IS NOT SECURE!" )
+        self.id_secret = kwargs.get( "id_secret", "changethisinproductiontoo")
         # Tool stuff
         self.tool_path = resolve_path( kwargs.get( "tool_path", "tools" ), self.root )
         self.tool_secret = kwargs.get( "tool_secret", "" )

--- a/lib/galaxy/webapps/tool_shed/config_schema.yml
+++ b/lib/galaxy/webapps/tool_shed/config_schema.yml
@@ -1,0 +1,387 @@
+type: map
+mapping:
+  uwsgi: !include uwsgi_schema.yml
+  tool_shed:
+    type: map
+    required: true
+    desc: |
+      Tool Shed configuration options.
+    mapping:
+      log_level:
+        type: str
+        default: DEBUG
+        required: false
+        desc: |
+          Verbosity of console log messages.  Acceptable values can be found here:
+          https://docs.python.org/2/library/logging.html#logging-levels
+      
+      database_connection:
+        type: str
+        default: sqlite:///./database/community.sqlite?isolation_level=IMMEDIATE
+        required: false
+        desc: |
+          By default, the Tool Shed uses a SQLite database at 'database/community.sqlite'.  You
+          may use a SQLAlchemy connection string to specify an external database
+          instead.  This string takes many options which are explained in detail in the
+          config file documentation.
+      
+      hgweb_config_dir:
+        type: str
+        required: false
+        desc: |
+          Where the hgweb.config file is stored.
+          The default is the Galaxy installation directory.
+      
+      file_path:
+        type: str
+        default: database/community_files
+        required: false
+        desc: |
+          Where tool shed repositories are stored.
+      
+      new_file_path:
+        type: str
+        default: database/tmp
+        required: false
+        desc: |
+          Temporary storage for additional datasets,
+          this should be shared through the cluster
+      
+      builds_file_path:
+        type: str
+        default: tool-data/shared/ucsc/builds.txt
+        required: false
+        desc: |
+          File containing old-style genome builds
+      
+      pretty_datetime_format:
+        type: str
+        default: $locale (UTC)
+        required: false
+        desc: |
+          Format string used when showing date and time information.
+          The string may contain:
+          - the directives used by Python time.strftime() function (see
+            https://docs.python.org/2/library/time.html#time.strftime ),
+          - $locale (complete format string for the server locale),
+          - $iso8601 (complete format string as specified by ISO 8601 international
+            standard).
+      
+      toolshed_search_on:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          -- Repository and Tool search
+          Using the script located at scripts/build_ts_whoosh_index.py
+          you can generate search index and allow full text API searching over
+          the repositories and tools within the Tool Shed given that you specify
+          the following two config options.
+      
+      whoosh_index_dir:
+        type: str
+        default: database/toolshed_whoosh_indexes
+        required: false
+        desc: |
+          -- Repository and Tool search
+          Using the script located at scripts/build_ts_whoosh_index.py
+          you can generate search index and allow full text API searching over
+          the repositories and tools within the Tool Shed given that you specify
+          the following two config options.
+      
+      repo_name_boost:
+        type: float
+        default: 0.9
+        required: false
+        desc: |
+          For searching repositories at /api/repositories:
+      
+      repo_description_boost:
+        type: float
+        default: 0.6
+        required: false
+        desc: |
+          For searching repositories at /api/repositories:
+      
+      repo_long_description_boost:
+        type: float
+        default: 0.5
+        required: false
+        desc: |
+          For searching repositories at /api/repositories:
+      
+      repo_homepage_url_boost:
+        type: float
+        default: 0.3
+        required: false
+        desc: |
+          For searching repositories at /api/repositories:
+      
+      repo_remote_repository_url_boost:
+        type: float
+        default: 0.2
+        required: false
+        desc: |
+          For searching repositories at /api/repositories:
+      
+      repo_owner_username_boost:
+        type: float
+        default: 0.3
+        required: false
+        desc: |
+          For searching repositories at /api/repositories:
+      
+      tool_name_boost:
+        type: float
+        default: 1.2
+        required: false
+        desc: |
+          For searching tools at /api/tools
+      
+      tool_description_boost:
+        type: float
+        default: 0.6
+        required: false
+        desc: |
+          For searching tools at /api/tools
+      
+      tool_help_boost:
+        type: float
+        default: 0.4
+        required: false
+        desc: |
+          For searching tools at /api/tools
+      
+      tool_repo_owner_username:
+        type: float
+        default: 0.3
+        required: false
+        desc: |
+          For searching tools at /api/tools
+      
+      ga_code:
+        type: str
+        required: false
+        desc: |
+          You can enter tracking code here to track visitor's behavior
+          through your Google Analytics account. Example: UA-XXXXXXXX-Y
+      
+      id_secret:
+        type: str
+        default: changethisinproductiontoo
+        required: false
+        desc: |
+          The Tool Shed encodes various internal values when these values will be output in
+          some format (for example, in a URL or cookie).  You should set a key to be
+          used by the algorithm that encodes and decodes these values.  It can be any
+          string.  If left unchanged, anyone could construct a cookie that would grant
+          them access to others' sessions.
+          One simple way to generate a value for this is with the shell command:
+            python -c 'import time; print time.time()' | md5sum | cut -f 1 -d ' '
+      
+      use_remote_user:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          User authentication can be delegated to an upstream proxy server (usually
+          Apache).  The upstream proxy should set a REMOTE_USER header in the request.
+          Enabling remote user disables regular logins.  For more information, see:
+          https://wiki.galaxyproject.org/Admin/Config/ApacheProxy
+      
+      remote_user_secret:
+        type: str
+        default: changethisinproductiontoo
+        required: false
+        desc: |
+          If use_remote_user is enabled, anyone who can log in to the Galaxy host may
+          impersonate any other user by simply sending the appropriate header. Thus a
+          secret shared between the upstream proxy server, and Galaxy is required.
+          If anyone other than the Galaxy user is using the server, then apache/nginx
+          should pass a value in the header 'GX_SECRET' that is identical the one below
+      
+      debug:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Configuration for debugging middleware
+      
+      use_lint:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Check for WSGI compliance.
+      
+      use_printdebug:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          Intercept print statements and show them on the returned page.
+      
+      use_interactive:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          NEVER enable this on a public site (even test or QA)
+      
+      admin_users:
+        type: str
+        required: false
+        desc: |
+          Administrative users - set this to a comma-separated list of valid Tool Shed
+          users (email addresses).  These users will have access to the Admin section
+          of the server, and will have access to create users, groups, roles,
+          libraries, and more.
+      
+      require_login:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Force everyone to log in (disable anonymous access)
+      
+      smtp_server:
+        type: str
+        default: smtp.your_tool_shed_server
+        required: false
+        desc: |
+          For use by email messages sent from the tool shed
+      
+      email_from:
+        type: str
+        default: your_tool_shed_email@server
+        required: false
+        desc: |
+          For use by email messages sent from the tool shed
+      
+      smtp_username:
+        type: str
+        required: false
+        desc: |
+          If your SMTP server requires a username and password, you can provide them
+          here (password in cleartext here, but if your server supports STARTTLS it
+          will be sent over the network encrypted).
+      
+      smtp_password:
+        type: str
+        required: false
+        desc: |
+          If your SMTP server requires a username and password, you can provide them
+          here (password in cleartext here, but if your server supports STARTTLS it
+          will be sent over the network encrypted).
+      
+      smtp_ssl:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          If your SMTP server requires SSL from the beginning of the connection
+      
+      support_url:
+        type: str
+        default: https://wiki.galaxyproject.org/Support
+        required: false
+        desc: |
+          The URL linked by the "Support" link in the "Help" menu.
+      
+      mailing_join_addr:
+        type: str
+        default: galaxy-announce-join@bx.psu.edu
+        required: false
+        desc: |
+          Address to join mailing list
+      
+      use_heartbeat:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          Write thread status periodically to 'heartbeat.log' (careful, uses disk
+           space rapidly!)
+      
+      use_profile:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          Profiling middleware (cProfile based)
+      
+      enable_galaxy_flavor_docker_image:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Enable creation of Galaxy flavor Docker Image
+      
+      message_box_visible:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Show a message box under the masthead.
+      
+      message_box_content:
+        type: str
+        required: false
+        desc: |
+          Show a message box under the masthead.
+      
+      message_box_class:
+        type: str
+        default: info
+        required: false
+        desc: |
+          Show a message box under the masthead.
+      
+      static_enabled:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          Serving static files (needed if running standalone)
+      
+      static_cache_time:
+        type: int
+        default: 360
+        required: false
+        desc: |
+          Serving static files (needed if running standalone)
+      
+      static_dir:
+        type: str
+        default: static/
+        required: false
+        desc: |
+          Serving static files (needed if running standalone)
+      
+      static_images_dir:
+        type: str
+        default: static/images
+        required: false
+        desc: |
+          Serving static files (needed if running standalone)
+      
+      static_favicon_dir:
+        type: str
+        default: static/favicon.ico
+        required: false
+        desc: |
+          Serving static files (needed if running standalone)
+      
+      static_scripts_dir:
+        type: str
+        default: static/scripts/
+        required: false
+        desc: |
+          Serving static files (needed if running standalone)
+      
+      static_style_dir:
+        type: str
+        default: static/style/blue
+        required: false
+        desc: |
+          Serving static files (needed if running standalone)

--- a/lib/galaxy/webapps/tool_shed/uwsgi_schema.yml
+++ b/lib/galaxy/webapps/tool_shed/uwsgi_schema.yml
@@ -1,0 +1,17 @@
+type: map
+required: false
+desc: |
+  uwsgi definition, see http://uwsgi-docs.readthedocs.io/en/latest/Options.html
+mapping:
+  http:
+    desc: Host and port to bind to.
+    type: str
+    required: true
+  offload-threads:
+    type: int
+    required: false
+    desc: |
+      http://uwsgi-docs.readthedocs.io/en/latest/Options.html#offload-threads
+  regex;(.*):
+    type: any
+    desc: Other potential uwsgi option.

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,8 @@
 
 cd "$(dirname "$0")"
 
+. ./scripts/common_startup_functions.sh
+
 # If there is a file that defines a shell environment specific to this
 # instance of Galaxy, source the file.
 if [ -z "$GALAXY_LOCAL_ENV_FILE" ];
@@ -14,67 +16,11 @@ then
     . $GALAXY_LOCAL_ENV_FILE
 fi
 
-# Pop args meant for common_startup.sh
-while :
-do
-    case "$1" in
-        --skip-eggs|--skip-wheels|--skip-samples|--dev-wheels|--no-create-venv|--no-replace-pip|--replace-pip)
-            common_startup_args="$common_startup_args $1"
-            shift
-            ;;
-        --skip-venv)
-            skip_venv=1
-            common_startup_args="$common_startup_args $1"
-            shift
-            ;;
-        --stop-daemon)
-            common_startup_args="$common_startup_args $1"
-            paster_args="$paster_args $1"
-            stop_daemon_arg_set=1
-            shift
-            ;;
-        --daemon|--restart|restart)
-            if [ "$1" = "--restart" ]
-            then
-                paster_args="$paster_args restart"
-            else
-                paster_args="$paster_args $1"
-            fi
+parse_common_args
 
-            daemon_or_restart_arg_set=1
-            shift
-            ;;
-        --wait)
-            wait_arg_set=1
-            shift
-            ;;
-        "")
-            break
-            ;;
-        *)
-            paster_args="$paster_args $1"
-            shift
-            ;;
-    esac
-done
+run_common_start_up
 
-./scripts/common_startup.sh $common_startup_args || exit 1
-
-# If there is a .venv/ directory, assume it contains a virtualenv that we
-# should run this instance in.
-GALAXY_VIRTUAL_ENV="${GALAXY_VIRTUAL_ENV:-.venv}"
-if [ -d "$GALAXY_VIRTUAL_ENV" -a -z "$skip_venv" ];
-then
-    [ -n "$PYTHONPATH" ] && { echo 'Unsetting $PYTHONPATH'; unset PYTHONPATH; }
-    echo "Activating virtualenv at $GALAXY_VIRTUAL_ENV"
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
-fi
-
-# If you are using --skip-venv we assume you know what you are doing but warn
-# in case you don't.
-[ -n "$PYTHONPATH" ] && echo 'WARNING: $PYTHONPATH is set, this can cause problems importing Galaxy dependencies'
-
-python ./scripts/check_python.py || exit 1
+setup_python
 
 if [ ! -z "$GALAXY_RUN_WITH_TEST_TOOLS" ];
 then

--- a/run_reports.sh
+++ b/run_reports.sh
@@ -9,16 +9,21 @@
 # argument to this will cause Galaxy's database and path parameters
 # from galaxy.ini to be copied over into reports.ini.
 
-cd `dirname $0`
+cd "$(dirname "$0")"
 
-./scripts/common_startup.sh --skip-samples
+. ./scripts/common_startup_functions.sh
 
-: ${GALAXY_VIRTUAL_ENV:=.venv}
-
-if [ -d "$GALAXY_VIRTUAL_ENV" ];
+if [ "$1" = "--sync-config" ];
 then
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
+    python ./scripts/sync_reports_config.py
+    shift
 fi
+
+parse_common_args
+
+run_common_start_up
+
+setup_python
 
 if [ -z "$GALAXY_REPORTS_CONFIG" ]; then
     if [ -f reports_wsgi.ini ]; then
@@ -40,11 +45,4 @@ if [ -n "$GALAXY_REPORTS_CONFIG_DIR" ]; then
     python ./scripts/build_universe_config.py "$GALAXY_REPORTS_CONFIG_DIR" "$GALAXY_REPORTS_CONFIG"
 fi
 
-
-if [ "$1" = "--sync-config" ];
-then
-    python ./scripts/sync_reports_config.py
-    shift
-fi
-
-python ./scripts/paster.py serve "$GALAXY_REPORTS_CONFIG" --pid-file="$GALAXY_REPORTS_PID" --log-file="$GALAXY_REPORTS_LOG" $@
+python ./scripts/paster.py serve "$GALAXY_REPORTS_CONFIG" --pid-file="$GALAXY_REPORTS_PID" --log-file="$GALAXY_REPORTS_LOG"  $paster_args

--- a/run_reports.sh
+++ b/run_reports.sh
@@ -11,6 +11,11 @@
 
 cd "$(dirname "$0")"
 
+GALAXY_REPORTS_PID=${GALAXY_REPORTS_PID:-reports_webapp.pid}
+GALAXY_REPORTS_LOG=${GALAXY_REPORTS_LOG:-reports_webapp.log}
+PID_FILE=$GALAXY_REPORTS_PID
+LOG_FILE=$GALAXY_REPORTS_LOG
+
 . ./scripts/common_startup_functions.sh
 
 if [ "$1" = "--sync-config" ];
@@ -38,11 +43,9 @@ if [ -z "$GALAXY_REPORTS_CONFIG" ]; then
     export GALAXY_REPORTS_CONFIG
 fi
 
-GALAXY_REPORTS_PID=${GALAXY_REPORTS_PID:-reports_webapp.pid}
-GALAXY_REPORTS_LOG=${GALAXY_REPORTS_LOG:-reports_webapp.log}
-
 if [ -n "$GALAXY_REPORTS_CONFIG_DIR" ]; then
     python ./scripts/build_universe_config.py "$GALAXY_REPORTS_CONFIG_DIR" "$GALAXY_REPORTS_CONFIG"
 fi
 
-python ./scripts/paster.py serve "$GALAXY_REPORTS_CONFIG" --pid-file="$GALAXY_REPORTS_PID" --log-file="$GALAXY_REPORTS_LOG"  $paster_args
+find_server $GALAXY_REPORTS_CONFIG
+$RUN_SERVER $SERVER_ARGS

--- a/run_tool_shed.sh
+++ b/run_tool_shed.sh
@@ -2,6 +2,12 @@
 
 cd "$(dirname "$0")"
 
+
+TOOL_SHED_PID=${TOOL_SHED_PID:-tool_shed_webapp.pid}
+TOOL_SHED_LOG=${TOOL_SHED_LOG:-tool_shed_webapp.log}
+PID_FILE=$TOOL_SHED_PID
+LOG_FILE=$TOOL_SHED_LOG
+
 . ./scripts/common_startup_functions.sh
 
 parse_common_args
@@ -30,4 +36,5 @@ if [ -z "$TOOL_SHED_CONFIG_FILE" ]; then
     export TOOL_SHED_CONFIG_FILE
 fi
 
-python ./scripts/paster.py serve $TOOL_SHED_CONFIG_FILE --pid-file=tool_shed_webapp.pid --log-file=tool_shed_webapp.log $args
+find_server $TOOL_SHED_CONFIG_FILE
+$RUN_SERVER $SERVER_ARGS

--- a/run_tool_shed.sh
+++ b/run_tool_shed.sh
@@ -1,29 +1,21 @@
 #!/bin/sh
 
-cd `dirname $0`
+cd "$(dirname "$0")"
 
-: ${GALAXY_VIRTUAL_ENV:=.venv}
+. ./scripts/common_startup_functions.sh
 
-if [ -d "$GALAXY_VIRTUAL_ENV" ];
-then
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
-fi
+parse_common_args
 
-./scripts/common_startup.sh
+run_common_start_up
 
-: ${GALAXY_VIRTUAL_ENV:=.venv}
-
-if [ -d "$GALAXY_VIRTUAL_ENV" ];
-then
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
-fi
+setup_python
 
 
-tool_shed=`./scripts/tool_shed/bootstrap_tool_shed/parse_run_sh_args.sh $@`
-args=$@
+tool_shed=`./scripts/tool_shed/bootstrap_tool_shed/parse_run_sh_args.sh $parser_args`
+args=$parser_args
 
 if [ $? -eq 0 ] ; then
-	bash ./scripts/tool_shed/bootstrap_tool_shed/parse_run_sh_args.sh $@
+	bash ./scripts/tool_shed/bootstrap_tool_shed/parse_run_sh_args.sh $parser_args
 	args=`echo $@ | sed "s#-\?-bootstrap_from_tool_shed $tool_shed##"`
 fi
 

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+parse_common_args() {
+    # Pop args meant for common_startup.sh
+    while :
+    do
+        case "$1" in
+            --skip-eggs|--skip-wheels|--skip-samples|--dev-wheels|--no-create-venv|--no-replace-pip|--replace-pip)
+                common_startup_args="$common_startup_args $1"
+                shift
+                ;;
+            --skip-venv)
+                skip_venv=1
+                common_startup_args="$common_startup_args $1"
+                shift
+                ;;
+            --stop-daemon)
+                common_startup_args="$common_startup_args $1"
+                paster_args="$paster_args $1"
+                stop_daemon_arg_set=1
+                shift
+                ;;
+            --daemon|--restart|restart)
+                if [ "$1" = "--restart" ]
+                then
+                    paster_args="$paster_args restart"
+                else
+                    paster_args="$paster_args $1"
+                fi
+
+                daemon_or_restart_arg_set=1
+                shift
+                ;;
+            --wait)
+                wait_arg_set=1
+                shift
+                ;;
+            "")
+                break
+                ;;
+            *)
+                paster_args="$paster_args $1"
+                shift
+                ;;
+        esac
+    done
+}
+
+run_common_start_up() {
+    ./scripts/common_startup.sh $common_startup_args || exit 1
+}
+
+setup_python() {
+    # If there is a .venv/ directory, assume it contains a virtualenv that we
+    # should run this instance in.
+    GALAXY_VIRTUAL_ENV="${GALAXY_VIRTUAL_ENV:-.venv}"
+    if [ -d "$GALAXY_VIRTUAL_ENV" -a -z "$skip_venv" ];
+    then
+        [ -n "$PYTHONPATH" ] && { echo 'Unsetting $PYTHONPATH'; unset PYTHONPATH; }
+        echo "Activating virtualenv at $GALAXY_VIRTUAL_ENV"
+        . "$GALAXY_VIRTUAL_ENV/bin/activate"
+    fi
+
+    # If you are using --skip-venv we assume you know what you are doing but warn
+    # in case you don't.
+    [ -n "$PYTHONPATH" ] && echo 'WARNING: $PYTHONPATH is set, this can cause problems importing Galaxy dependencies'
+
+    python ./scripts/check_python.py || exit 1
+}

--- a/scripts/config_ini_to_yaml.py
+++ b/scripts/config_ini_to_yaml.py
@@ -1,0 +1,332 @@
+from __future__ import print_function
+
+import argparse
+from collections import namedtuple
+from collections import OrderedDict
+import os
+import sys
+import tempfile
+from textwrap import TextWrapper
+import urllib2
+
+from six.moves.configparser import SafeConfigParser
+from six import StringIO
+
+import yaml
+
+try:
+    from pykwalify.core import Core
+except ImportError:
+    Core = None
+
+DESCRIPTION = "Convert configuration files."
+UNKNOWN_OPTION_MESSAGE = "Option [%s] not found in schema - either it is invalid or the Galaxy team hasn't documented it. If invalid, you should manually remove it. If the option is valid but undocumented, please file an issue with the Galaxy team."
+YAML_COMMENT_WRAPPER = TextWrapper(initial_indent="# ", subsequent_indent="# ")
+
+App = namedtuple(
+    "App",
+    ["config_paths", "default_port", "expected_app_factories", "destination", "schema_path"]
+)
+
+
+def _app_name(self):
+    return os.path.splitext(os.path.basename(self.destination))[0]
+
+
+def _sample_destination(self):
+    return self.destination + ".sample"
+
+
+def _schema(self):
+    return AppSchema(self)
+
+
+App.app_name = property(_app_name)
+App.sample_destination = property(_sample_destination)
+App.schema = property(_schema)
+
+OptionValue = namedtuple("OptionValue", ["name", "value", "option"] )
+
+
+UNKNOWN_OPTION = {
+    "type": "str",
+    "required": False,
+    "unknown_option": True,
+    "desc": "Unknown option, may want to remove or report to Galaxy team."
+}
+
+OPTION_DEFAULTS = {
+    "type": "str",
+    "unknown_option": False,
+    "default": None,
+    "desc": None,
+}
+
+
+class AppSchema(object):
+
+    def __init__(self, app_desc):
+        schema_path = app_desc.schema_path
+        app_name = app_desc.app_name
+        with open(schema_path, "r") as f:
+            config_all = _ordered_load(f)
+        self.raw_schema = config_all
+        app_schema = config_all["mapping"][app_name]
+        self.app_schema = app_schema["mapping"]
+
+    def get_app_option(self, name):
+        try:
+            raw_option = self.app_schema[name]
+        except KeyError:
+            raw_option = UNKNOWN_OPTION
+        option = OPTION_DEFAULTS.copy()
+        option.update(raw_option)
+        return option
+
+
+GALAXY_APP = App(
+    ["universe_wsgi.ini", "config/galaxy.ini"],
+    "8080",
+    ["galaxy.web.buildapp:app_factory"],  # TODO: Galaxy could call factory a few different things and they'd all be fine.
+    "config/galaxy.yml",
+    None,  # TODO
+)
+SHED_APP = App(
+    ["tool_shed_wsgi.ini", "config/tool_shed.ini"],
+    "9009",
+    ["galaxy.webapps.tool_shed.buildapp:app_factory"],
+    "config/tool_shed.yml",
+    "lib/galaxy/webapps/tool_shed/config_schema.yml",  # TODO
+)
+REPORTS_APP = App(
+    ["reports_wsgi.ini", "config/reports.ini"],
+    "9001",
+    ["galaxy.webapps.reports.buildapp:app_factory"],
+    "config/reports.yml",
+    None,  # TODO
+)
+APPS = {"galaxy": GALAXY_APP, "tool_shed": SHED_APP, "reports": REPORTS_APP}
+
+
+def main():
+    """Entry point for conversion process."""
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument('action', metavar='ACTION', type=str,
+                        help='action (convert, build_sample_yaml, validate))')
+    parser.add_argument('app', metavar='APP', type=str, nargs="?",
+                        help='app (galaxy, tool_shed, or reports))')
+    parser.add_argument('--add_comments', default=False, action="store_true")
+    args = parser.parse_args()
+    app_name = args.app
+    app_desc = APPS.get(app_name, None)
+    action = args.action
+    if action == "convert":
+        _run_conversion(args, app_desc)
+    elif action == "build_sample_yaml":
+        _build_sample_yaml(args, app_desc)
+    elif action == "validate":
+        _validate(args, app_desc)
+    elif action == "build_uwsgi_yaml":
+        _build_uwsgi_schema(args, app_desc)
+    else:
+        raise Exception("Unknown config action [%s]" % action)
+
+
+def _build_uwsgi_schema(args, app_desc):
+    req = urllib2.Request('https://raw.githubusercontent.com/unbit/uwsgi-docs/master/Options.rst')
+    response = urllib2.urlopen(req)
+    rst_options = response.read()
+    last_line = None
+    current_opt = None
+    current_parser = None
+    current_help = None
+    for line in rst_options.splitlines():
+        line = line.strip()
+        dots = "*" * len(line)
+        if line and (line == dots):
+            current_opt = last_line
+            print("New opt %s" % current_opt)
+            if line.startswith("``parser``"):
+                current_parser = line.split(":", 1)[1]
+            elif line.startswith("``help``"):
+                current_help = line.split(":", 1)[1]
+        last_line = line
+
+
+
+def _validate(args, app_desc):
+    path = app_desc.destination
+    if not os.path.exists(path):
+        _warn("Path [%s] not a file, using sample.")
+        path = app_desc.sample_destination
+    fp = tempfile.NamedTemporaryFile(delete=False, suffix=".yml")
+    _ordered_dump(app_desc.schema.raw_schema, fp)
+    print(_ordered_dump(app_desc.schema.raw_schema))
+    fp.flush()
+    name = fp.name
+    c = Core(
+        source_file=path,
+        schema_files=[name],
+    )
+    c.validate()
+
+
+def _run_conversion(args, app_desc):
+    ini_config = None
+    for possible_ini_config in app_desc.config_paths:
+        if os.path.exists(possible_ini_config):
+            ini_config = possible_ini_config
+
+    if not ini_config:
+        _warn("Failed to find a config to convert - exiting without changes.")
+        sys.exit(1)
+
+    p = SafeConfigParser()
+    p.read(ini_config)
+
+    server_section = None
+    app_main_found = False
+
+    for section in p.sections():
+        if section.startswith("server:"):
+            if server_section:
+                message = "Additional sever section after [%s] encountered [%s], will be ignored."
+                _warn(message % (server_section, section))
+            else:
+                server_section = section
+        elif section == "app:main":
+            app_main_found = True
+
+    if not server_section:
+        _warn("No server section found, using default uwsgi server definition.")
+        server_config = OrderedDict()
+    else:
+        server_config = OrderedDict(p.items(server_section))
+
+    uwsgi_dict = _server_paste_to_uwsgi(app_desc, server_config)
+
+    app_items = OrderedDict(p.items("app:main"))
+    app_dict = OrderedDict({})
+    schema = app_desc.schema
+    for key, value in app_items.items():
+        if key == "paste.app_factory":
+            assert value in app_desc.expected_app_factories
+            continue
+
+        option = schema.get_app_option(key)
+        if option["unknown_option"]:
+            _warn(UNKNOWN_OPTION_MESSAGE % key)
+
+        option_value = OptionValue(key, value, option)
+        app_dict[key] = option_value
+
+    f = StringIO()
+    _write_section(args, f, "uwsgi", uwsgi_dict)
+    _write_section(args, f, app_desc.app_name, app_dict)
+    print(f.getvalue())
+
+
+def _build_sample_yaml(args, app_desc):
+    schema = app_desc.schema
+    f = StringIO()
+    _write_sample_section(args, f, app_desc.app_name, schema)
+    print(f.getvalue())
+
+
+def _write_sample_section(args, f, section_header, schema):
+    _write_header(f, section_header)
+    for key, value in schema.app_schema.items():
+        default = value["default"]
+        option = schema.get_app_option(key)
+        option_value = OptionValue(key, default, option)
+        _write_option(args, f, key, option_value, as_comment=True)
+
+
+def _write_section(args, f, section_header, section_dict):
+    _write_header(f, section_header)
+    for key, option_value in section_dict.items():
+        _write_option(args, f, key, option_value)
+
+
+def _write_header(f, section_header):
+    f.write("%s:\n\n" % section_header)
+
+
+def _write_option(args, f, key, option_value, as_comment=False):
+    if isinstance(option_value, OptionValue):
+        option = option_value.option
+        value = option_value.value
+    else:
+        value = option_value
+        option = OPTION_DEFAULTS
+    desc = option["desc"]
+    comment = ""
+    if desc and args.add_comments:
+        comment = "\n".join(YAML_COMMENT_WRAPPER.wrap(desc))
+        comment += "\n"
+    as_comment_str = "#" if as_comment else ""
+    lines = "%s%s%s: %s" % (comment, as_comment_str, key, value)
+    lines_idented = "\n".join([("  %s" % l) for l in lines.split("\n")])
+    f.write("%s\n\n" % lines_idented)
+
+
+def _server_paste_to_uwsgi(app_desc, server_config):
+    uwsgi_dict = OrderedDict()
+    port = server_config.get("port", app_desc.default_port)
+    host = server_config.get("host", "127.0.0.1")
+
+    if server_config.get("use", "egg:Paste#http") != "egg:Paste#http":
+        raise Exception("Unhandled paste server 'use' value [%s], file must be manually migrate.")
+
+    uwsgi_dict["http"] = "%s:%s" % (host, port)
+    # default changing from 10 to 8
+    uwsgi_dict["threads"] = server_config.get("threadpool_workers", "8")
+    # required for static...
+    uwsgi_dict["http-raw-body"] = True
+    uwsgi_dict["offload-threads"] = 8
+    return uwsgi_dict
+
+
+def _warn(message):
+    print("WARNING: %s" % message)
+
+
+def _ordered_load(stream):
+
+    class OrderedLoader(yaml.Loader):
+
+        def __init__(self, stream):
+            self._root = os.path.split(stream.name)[0]
+            super(OrderedLoader, self).__init__(stream)
+
+        def include(self, node):
+            filename = os.path.join(self._root, self.construct_scalar(node))
+            with open(filename, 'r') as f:
+                return yaml.load(f, OrderedLoader)
+
+    def construct_mapping(loader, node):
+        loader.flatten_mapping(node)
+        return OrderedDict(loader.construct_pairs(node))
+
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping)
+    OrderedLoader.add_constructor('!include', OrderedLoader.include)
+
+    return yaml.load(stream, OrderedLoader)
+
+
+def _ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
+    class OrderedDumper(Dumper):
+        pass
+
+    def _dict_representer(dumper, data):
+        return dumper.represent_mapping(
+            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+            data.items())
+    OrderedDumper.add_representer(OrderedDict, _dict_representer)
+    return yaml.dump(data, stream, OrderedDumper, **kwds)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/config_sample_to_kwalify.py
+++ b/scripts/config_sample_to_kwalify.py
@@ -1,0 +1,71 @@
+from __future__ import print_function
+
+import sys
+
+
+def main():
+    """Entry point for conversion procedure."""
+    found_app_main = False
+    current_section_desc = []
+    current_section_options = []
+    try:
+        sample = sys.argv[1]
+    except KeyError:
+        sample = "config/galaxy.ini.sample"
+
+    for line in open(sample, "r"):
+        is_app_main = line.startswith('[app:main]')
+        if not found_app_main and not is_app_main:
+            continue
+        if is_app_main:
+            found_app_main = True
+            continue
+
+        line = line.strip()
+        if not line.startswith("#"):
+            for section_option in current_section_options:
+                _dump_option(section_option, current_section_desc)
+            current_section_desc = []
+            current_section_options = []
+        if line.startswith("[galaxy_amqp]"):
+            break
+
+        if line.startswith("# ") or "#" == line:
+            current_section_desc.append(line[2:])
+        elif line.startswith("#"):
+            current_section_options.append(line)
+
+
+def _dump_option(option, current_section_desc):
+    def print_line(line):
+        print((" " * 6) + line)
+    if "=" not in option:
+        print(option)
+    key, default = [s.strip() for s in option.split("=", 1)]
+    key = key[1:]  # strip #
+    if default.strip().lower() in ["true", "false"]:
+        default = default.lower()
+        type = "bool"
+    elif default.isdigit():
+        type = "int"
+    else:
+        try:
+            float(default)
+            type = "float"
+        except ValueError:
+            type = "str"
+    if default == "None":
+        default = None
+    print_line("%s:" % key)
+    print_line("  type: %s" % type)
+    if default is not None:
+        print_line("  default: %s" % default)
+    print_line("  required: false")
+    print_line("  desc: |")
+    for line in current_section_desc:
+        print_line("    %s" % line)
+    print_line("")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- They now uniformly handle server option processing.
- Reports and Tool Shed now respect many important options such as `--skip_venv`.
- Reports and Tool Shed now do extra checking around Python version that Galaxy does.

In addition to improving the reports and tool shed startup scripts and reducing cognative load with respect to option handling, this is an important precondition to us being able us to switch on uwsgi by default for all three services simultaneously without a bunch of copy and pasting.
