### PR TITLE
[16.07] Postfork tool conf watcher test fix

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -104,7 +104,6 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
                 self._init_tools_from_config( config_filename )
             except:
                 log.exception( "Error loading tools defined in config %s", config_filename )
-        register_postfork_function(self._tool_conf_watcher.start)
 
     def _init_tools_from_config( self, config_filename ):
         """

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -74,7 +74,7 @@ class ToolConfWatcher(object):
     def start(self):
         if not self._active:
             self._active = True
-            self.thread.start()
+            register_postfork_function(self.thread.start)
 
     def shutdown(self):
         if self._active:
@@ -109,6 +109,7 @@ class ToolConfWatcher(object):
             mod_time = time.ctime(os.path.getmtime(path))
         with self._lock:
             self.paths[path] = mod_time
+        self.start()
 
     def watch_file(self, tool_conf_file):
         self.monitor(tool_conf_file)


### PR DESCRIPTION
Move the registration of the start function into the ToolConfWatcher itself so it doesn't have to be called by things that instantiate it.

Fixes #2831.
