### PR TITLE
Create a new trans method for getting the most recently touched history.

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -487,7 +487,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
             history = self.history_manager.get_accessible( self.decode_id( id ), trans.user,
                 current_history=trans.history )
         else:
-            history = trans.get_history( create=True )
+            history = trans.get_history( most_recent=True, create=True )
 
         trans.response.set_content_type( 'text/xml' )
         return trans.fill_template_mako(
@@ -1351,7 +1351,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
         """Return the current user's current history in a serialized, dictionary form."""
         # Prevent IE11 from caching this
         trans.response.headers[ 'Cache-Control' ] = ["max-age=0", "no-cache", "no-store"]
-        history = trans.get_history( create=True )
+        history = trans.get_history( most_recent=True, create=True )
         return self.history_data( trans, history )
 
     @web.json

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -955,7 +955,7 @@ class VisualizationController( BaseUIController, SharableMixin, UsesVisualizatio
         """
         regions = regions or '{}'
         # Need to create history if necessary in order to create tool form.
-        trans.get_history( create=True )
+        trans.get_history( most_recent=True, create=True )
 
         if id:
             # Loading a shared visualization.

--- a/templates/webapps/galaxy/workflow/display.mako
+++ b/templates/webapps/galaxy/workflow/display.mako
@@ -90,7 +90,7 @@
     <%
         # HACK: Rendering workflow steps requires that trans have a history; however, if its user's first visit to Galaxy is here, he won't have a history
         # and an error will occur. To prevent this error, make sure user has a history. 
-        trans.get_history( create=True ) 
+        trans.get_history( most_recent=True, create=True )
     %>
     <table class="annotated-item">
         <tr><th>Step</th><th class="annotation">Annotation</th></tr>


### PR DESCRIPTION
Swap several uses of get_history (with create=True, only), to use this new functionality where it makes sense.

One main goal here was to change the behavior where, when creating new sessions (say, because of REMOTE_USER login on multiple browsers) there was a more consistent history on initial login (instead of defaulting to a new/default one every time).
