### PR TITLE
Refactor - move filelock.py to galaxy.util.

### DIFF
--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -6,7 +6,7 @@ incompatible changes coming.
 
 import os
 
-from galaxy.web.proxy.filelock import (
+from galaxy.util.filelock import (
     FileLock,
     FileLockException
 )

--- a/lib/galaxy/util/filelock.py
+++ b/lib/galaxy/util/filelock.py
@@ -1,13 +1,13 @@
-""" Code obtained from https://github.com/dmfrey/FileLock
+"""Code obtained from https://github.com/dmfrey/FileLock.
 
 See full license at:
 
 https://github.com/dmfrey/FileLock/blob/master/LICENSE.txt
 
 """
+import errno
 import os
 import time
-import errno
 
 
 class FileLockException(Exception):

--- a/lib/galaxy/web/proxy/__init__.py
+++ b/lib/galaxy/web/proxy/__init__.py
@@ -2,7 +2,7 @@ import logging
 import os
 import json
 
-from .filelock import FileLock
+from galaxy.util.filelock import FileLock
 from galaxy.util import sockets
 from galaxy.util.lazy_process import LazyProcess, NoOpLazyProcess
 from galaxy.util import sqlite


### PR DESCRIPTION
galaxy.tools.deps.resolvers.conda should not depend on galaxy.web.proxy - this is a smell that indicates filelock belongs in galaxy.util IMO.

This is also keeps the modules synchronized with galaxy-lib coherent.
