### PR TITLE
Add `database/dependencies` gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ database/pbs
 database/tmp
 database/*.sqlite
 database/openid_consumer_cache
+database/dependencies
 
 # Python bytecode
 *.pyc


### PR DESCRIPTION
Since the galaxy.ini.sample file is shipped with `#tool_dependency_dir = database/dependencies` as default, and we don't want anyone commiting dependencies.
