### PR TITLE
Refactor shed tool lineage registration

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -33,7 +33,6 @@ from .tags import tool_tag_manager
 from .watcher import get_tool_watcher
 from .watcher import get_tool_conf_watcher
 
-
 log = logging.getLogger( __name__ )
 
 
@@ -520,8 +519,6 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
             from_cache = tool
             if from_cache:
                 log.debug("Loading tool %s from cache", str(tool.id))
-                if guid:
-                    tool_shed_repository = tool.tool_shed_repository
             elif guid:  # tool was not in cache and is a tool shed tool
                 tool_shed_repository = self.get_tool_repository_from_xml_item(item, path)
                 if tool_shed_repository:
@@ -543,7 +540,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
                     tool.guid = guid
                     tool.version = item.elem.find( "version" ).text
                 # Make sure tools have a tool_version object.
-                tool_lineage = self._lineage_map.register( tool, tool_shed_repository=tool_shed_repository )
+                tool_lineage = self._lineage_map.register( tool, from_toolshed=guid )
                 tool.lineage = tool_lineage
                 if item.has_elem:
                     self._tool_tag_manager.handle_tags( tool.id, item.elem )

--- a/lib/galaxy/tools/toolbox/lineages/factory.py
+++ b/lib/galaxy/tools/toolbox/lineages/factory.py
@@ -20,12 +20,11 @@ class LineageMap(object):
         self.lineage_map = {}
         self.app = app
 
-    def register(self, tool, **kwds):
+    def register(self, tool, from_toolshed=False):
         tool_id = tool.id
         versionless_tool_id = remove_version_from_guid( tool_id )
-        tool_shed_repository = kwds.get("tool_shed_repository", None)
-        if tool_shed_repository:
-            lineage = ToolShedLineage.from_tool(self.app, tool, tool_shed_repository)
+        if from_toolshed:
+            lineage = ToolShedLineage.from_tool(self.app, tool)
         else:
             lineage = StockLineage.from_tool( tool )
         if versionless_tool_id and versionless_tool_id not in self.lineage_map:

--- a/lib/galaxy/tools/toolbox/lineages/tool_shed.py
+++ b/lib/galaxy/tools/toolbox/lineages/tool_shed.py
@@ -56,10 +56,10 @@ class ToolShedLineage(ToolLineage):
         self._tool_shed_repository = tool_shed_repository
 
     @staticmethod
-    def from_tool( app, tool, tool_shed_repository ):
+    def from_tool( app, tool ):
         # Make sure the tool has a tool_version.
         if not get_installed_tool_version( app, tool.id ):
-            tool_version = ToolVersion( tool_id=tool.id, tool_shed_repository=tool_shed_repository )
+            tool_version = ToolVersion( tool_id=tool.id, tool_shed_repository=tool.tool_shed_repository )
             app.install_model.context.add( tool_version )
             app.install_model.context.flush()
         return ToolShedLineage( app, tool.tool_version )


### PR DESCRIPTION
to avoid using tool.tool_shed_repository if possible, since this is a
property of the tool instance, which results in a database query. These
sequential queries slow down reloading a large number of tools.

This is another followup to #2905 that gets the reload speed for ~300 installed repos from 7s back to ~1s.
