### PR TITLE
[16.01] Allow admin to serialize/deserialize dataset permissions

### DIFF
--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -199,8 +199,7 @@ class DatasetSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin
     def serialize_permissions( self, dataset, key, user=None, **context ):
         """
         """
-        is_admin = self.user_manager.is_admin( user )
-        if not is_admin and not self.dataset_manager.permissions.manage.is_permitted( dataset, user ):
+        if not self.dataset_manager.permissions.manage.is_permitted( dataset, user ):
             self.skip()
 
         management_permissions = self.dataset_manager.permissions.manage.by_dataset( dataset )

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -199,7 +199,8 @@ class DatasetSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin
     def serialize_permissions( self, dataset, key, user=None, **context ):
         """
         """
-        if not self.dataset_manager.permissions.manage.is_permitted( dataset, user ):
+        is_admin = self.user_manager.is_admin( user )
+        if not is_admin and not self.dataset_manager.permissions.manage.is_permitted( dataset, user ):
             self.skip()
 
         management_permissions = self.dataset_manager.permissions.manage.by_dataset( dataset )

--- a/lib/galaxy/managers/rbac_secured.py
+++ b/lib/galaxy/managers/rbac_secured.py
@@ -173,6 +173,9 @@ class ManageDatasetRBACPermission( DatasetRBACPermission ):
         # anonymous users cannot manage permissions on datasets
         if self.user_manager.is_anonymous( user ):
             return False
+        # admin can always manager permissions
+        if self.user_manager.is_admin( user ):
+            return True
         for role in user.all_roles():
             if self._role_is_permitted( dataset, role ):
                 return True
@@ -225,7 +228,9 @@ class AccessDatasetRBACPermission( DatasetRBACPermission ):
         current_roles = self._roles( dataset )
         # NOTE: that because of short circuiting this allows
         #   anonymous access to public datasets
-        return ( self._is_public_from_roles( current_roles ) or
+        return ( self._is_public_based_on_roles( current_roles ) or
+                 # admin can always manager permissions
+                 self.user_manager.is_admin( user ) or
                  self._user_has_all_roles( user, current_roles ) )
 
     def grant( self, item, user ):
@@ -241,14 +246,14 @@ class AccessDatasetRBACPermission( DatasetRBACPermission ):
     # TODO: these are a lil off message
     def is_public( self, dataset ):
         current_roles = self._roles( dataset )
-        return self._is_public_from_roles( current_roles )
+        return self._is_public_based_on_roles( current_roles )
 
     def set_private( self, dataset, user, flush=True ):
         private_role = self.user_manager.private_role( user )
         return self.set( dataset, [ private_role ], flush=flush )
 
     # ---- private
-    def _is_public_from_roles( self, roles ):
+    def _is_public_based_on_roles( self, roles ):
         return len( roles ) == 0
 
     def _user_has_all_roles( self, user, roles ):
@@ -259,6 +264,6 @@ class AccessDatasetRBACPermission( DatasetRBACPermission ):
 
     def _role_is_permitted( self, dataset, role ):
         current_roles = self._roles( dataset )
-        return ( self._is_public_from_roles( current_roles ) or
+        return ( self._is_public_based_on_roles( current_roles ) or
                  # if there's only one role and this is it, let em in
                  ( ( len( current_roles ) == 1 ) and ( role == current_roles[0] ) ) )

--- a/lib/galaxy/managers/rbac_secured.py
+++ b/lib/galaxy/managers/rbac_secured.py
@@ -173,7 +173,8 @@ class ManageDatasetRBACPermission( DatasetRBACPermission ):
         # anonymous users cannot manage permissions on datasets
         if self.user_manager.is_anonymous( user ):
             return False
-        # admin can always manager permissions
+        # admin is always permitted
+        # TODO: could probably move this into RBACPermission and call that first
         if self.user_manager.is_admin( user ):
             return True
         for role in user.all_roles():
@@ -229,7 +230,7 @@ class AccessDatasetRBACPermission( DatasetRBACPermission ):
         # NOTE: that because of short circuiting this allows
         #   anonymous access to public datasets
         return ( self._is_public_based_on_roles( current_roles ) or
-                 # admin can always manager permissions
+                 # admin is always permitted
                  self.user_manager.is_admin( user ) or
                  self._user_has_all_roles( user, current_roles ) )
 

--- a/test/unit/managers/test_DatasetManager.py
+++ b/test/unit/managers/test_DatasetManager.py
@@ -117,6 +117,11 @@ class DatasetManagerTestCase( BaseTestCase ):
         self.log( "a dataset without permissions should be accessible by an admin" )
         self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, self.admin_user ) )
 
+        self.log( "a dataset without permissions shouldn't be manageable by an anonymous user" )
+        self.assertFalse( self.dataset_manager.permissions.manage.is_permitted( dataset, None ) )
+        self.log( "a dataset without permissions should be accessible by an anonymous user" )
+        self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, None ) )
+
     def test_create_public_dataset( self ):
         self.log( "should be able to create a new Dataset and give it some permissions that actually, you know, "
             "might work if there's any justice in this universe" )
@@ -144,6 +149,11 @@ class DatasetManagerTestCase( BaseTestCase ):
         self.assertTrue( self.dataset_manager.permissions.manage.is_permitted( dataset, self.admin_user ) )
         self.log( "a public dataset should be accessible by an admin" )
         self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, self.admin_user ) )
+
+        self.log( "a public dataset shouldn't be manageable by an anonymous user" )
+        self.assertFalse( self.dataset_manager.permissions.manage.is_permitted( dataset, None ) )
+        self.log( "a public dataset should be accessible by an anonymous user" )
+        self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, None ) )
 
     def test_create_private_dataset( self ):
         self.log( "should be able to create a new Dataset and give it private permissions" )
@@ -176,6 +186,11 @@ class DatasetManagerTestCase( BaseTestCase ):
         self.assertTrue( self.dataset_manager.permissions.manage.is_permitted( dataset, self.admin_user ) )
         self.log( "a private dataset should be accessible by an admin" )
         self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, self.admin_user ) )
+
+        self.log( "a private dataset shouldn't be manageable by an anonymous user" )
+        self.assertFalse( self.dataset_manager.permissions.manage.is_permitted( dataset, None ) )
+        self.log( "a private dataset shouldn't be accessible by an anonymous user" )
+        self.assertFalse( self.dataset_manager.permissions.access.is_permitted( dataset, None ) )
 
 
 # =============================================================================

--- a/test/unit/managers/test_DatasetManager.py
+++ b/test/unit/managers/test_DatasetManager.py
@@ -162,6 +162,11 @@ class DatasetManagerTestCase( BaseTestCase ):
         self.log( "a private dataset shouldn't be accessible to just anyone" )
         self.assertFalse( self.dataset_manager.permissions.access.is_permitted( dataset, user3 ) )
 
+        self.log( "a private dataset shouldn be manageable by an admin" )
+        self.assertFalse( self.dataset_manager.permissions.manage.is_permitted( dataset, self.admin_user ) )
+        self.log( "a private dataset shouldn be accessible by an admin" )
+        self.assertFalse( self.dataset_manager.permissions.access.is_permitted( dataset, self.admin_user ) )
+
 
 # =============================================================================
 class DatasetRBACPermissionsTestCase( BaseTestCase ):
@@ -248,7 +253,6 @@ class DatasetSerializerTestCase( BaseTestCase ):
         role_id = self.app.security.decode_id( role_id )
         role = self.role_manager.get( self.trans, role_id )
         self.assertTrue( who_manages in [ user_role.user for user_role in role.users ])
-        # wat
 
         self.log( 'permissions should be not returned for non-managing users' )
         not_my_supervisor = self.user_manager.create( **user3_data )
@@ -258,6 +262,11 @@ class DatasetSerializerTestCase( BaseTestCase ):
         self.log( 'permissions should not be returned for anon users' )
         self.assertRaises( SkipAttribute, self.dataset_serializer.serialize_permissions,
             dataset, 'perms', user=None )
+
+        self.log( 'permissions should be returned for admin users' )
+        permissions = self.dataset_serializer.serialize_permissions( dataset, 'perms', user=self.admin_user )
+        self.assertIsInstance( permissions, dict )
+        self.assertKeys( permissions, [ 'manage', 'access' ] )
 
     def test_serializers( self ):
         # self.user_manager.create( **user2_data )

--- a/test/unit/managers/test_DatasetManager.py
+++ b/test/unit/managers/test_DatasetManager.py
@@ -112,6 +112,11 @@ class DatasetManagerTestCase( BaseTestCase ):
         self.log( "a dataset without permissions should be accessible" )
         self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, user3 ) )
 
+        self.log( "a dataset without permissions should be manageable by an admin" )
+        self.assertTrue( self.dataset_manager.permissions.manage.is_permitted( dataset, self.admin_user ) )
+        self.log( "a dataset without permissions should be accessible by an admin" )
+        self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, self.admin_user ) )
+
     def test_create_public_dataset( self ):
         self.log( "should be able to create a new Dataset and give it some permissions that actually, you know, "
             "might work if there's any justice in this universe" )
@@ -134,6 +139,11 @@ class DatasetManagerTestCase( BaseTestCase ):
         self.assertFalse( self.dataset_manager.permissions.manage.is_permitted( dataset, user3 ) )
         self.log( "a public dataset should be accessible" )
         self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, user3 ) )
+
+        self.log( "a public dataset should be manageable by an admin" )
+        self.assertTrue( self.dataset_manager.permissions.manage.is_permitted( dataset, self.admin_user ) )
+        self.log( "a public dataset should be accessible by an admin" )
+        self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, self.admin_user ) )
 
     def test_create_private_dataset( self ):
         self.log( "should be able to create a new Dataset and give it private permissions" )
@@ -162,10 +172,10 @@ class DatasetManagerTestCase( BaseTestCase ):
         self.log( "a private dataset shouldn't be accessible to just anyone" )
         self.assertFalse( self.dataset_manager.permissions.access.is_permitted( dataset, user3 ) )
 
-        self.log( "a private dataset shouldn be manageable by an admin" )
-        self.assertFalse( self.dataset_manager.permissions.manage.is_permitted( dataset, self.admin_user ) )
-        self.log( "a private dataset shouldn be accessible by an admin" )
-        self.assertFalse( self.dataset_manager.permissions.access.is_permitted( dataset, self.admin_user ) )
+        self.log( "a private dataset should be manageable by an admin" )
+        self.assertTrue( self.dataset_manager.permissions.manage.is_permitted( dataset, self.admin_user ) )
+        self.log( "a private dataset should be accessible by an admin" )
+        self.assertTrue( self.dataset_manager.permissions.access.is_permitted( dataset, self.admin_user ) )
 
 
 # =============================================================================

--- a/test/unit/managers/test_DatasetManager.py
+++ b/test/unit/managers/test_DatasetManager.py
@@ -384,6 +384,10 @@ class DatasetDeserializerTestCase( BaseTestCase ):
         self.assertRaises( rbac_secured.DatasetManagePermissionFailedException, self.dataset_deserializer.deserialize,
             dataset, user=user3, data={ 'permissions': existing_permissions })
 
+        self.log( 'deserializing permissions using an anon user should error' )
+        self.assertRaises( rbac_secured.DatasetManagePermissionFailedException, self.dataset_deserializer.deserialize,
+            dataset, user=None, data={ 'permissions': existing_permissions })
+
         self.log( 'deserializing permissions with a single access should make the dataset private' )
         private_role = self.user_manager.private_role( who_manages )
         private_role = private_role.to_dict( value_mapper={ 'id' : self.app.security.encode_id } )


### PR DESCRIPTION
Upshot: admin can now (16.01) properly get and set permissions over the API.
- Adds `unit/manager/test_DatasetManager` tests for serialization and deserialization by admin users. 
- Updates `managers/datasets.py` to add `is_admin` check to `serialize_permissions`
- (deserialization for admin has been possible (`error_unless_permitted`), but unwise if you can't get the serialized form in the first place.

**getting**:
    // GET https://galaxy/api/histories/:history_id/contents/:hda_id?keys=id,permissions

```
{
  "id": "0778472e8df1f331",
  "permissions": {
    //public
    "access": [

    ],
    //role id of private role for me
    "manage": [
      "54d6187b0652a2a1"
    ]
  }
}
```

**setting**: POST (add/subtract role ids from the `access` and `manage` arrays above.)
    // POST https://galaxy/api/histories/:history_id/contents/:hda_id?keys=id,permissions

```
// post body
{
  "permissions": {
    //will now be private to me
    "access": [
      "54d6187b0652a2a1"
    ],
    //role id of private role for me
    "manage": [
      "54d6187b0652a2a1"
    ]
  }
}
```
