### PR TITLE
Log the resolved dependency type

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -755,6 +755,7 @@ class JobWrapper( object ):
         self.sa_session = self.app.model.context
         self.extra_filenames = []
         self.command_line = None
+        self.dependencies = []
         # Tool versioning variables
         self.write_version_cmd = None
         self.version_string = ""
@@ -902,6 +903,7 @@ class JobWrapper( object ):
         # We need command_line persisted to the db in order for Galaxy to re-queue the job
         # if the server was stopped and restarted before the job finished
         job.command_line = unicodify(self.command_line)
+        job.dependencies = self.tool.dependencies
         self.sa_session.add( job )
         self.sa_session.flush()
         # Return list of all extra files

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -393,6 +393,7 @@ class Job( object, JobLike, Dictifiable ):
         self.tool_id = None
         self.tool_version = None
         self.command_line = None
+        self.dependencies = []
         self.param_filename = None
         self.parameters = []
         self.input_datasets = []
@@ -449,6 +450,9 @@ class Job( object, JobLike, Dictifiable ):
 
     def get_command_line( self ):
         return self.command_line
+
+    def get_dependencies(self):
+        return self.dependencies
 
     def get_param_filename( self ):
         return self.param_filename
@@ -529,6 +533,9 @@ class Job( object, JobLike, Dictifiable ):
 
     def set_command_line( self, command_line ):
         self.command_line = command_line
+
+    def set_dependencies( self, dependencies ):
+        self.dependencies = dependencies
 
     def set_param_filename( self, param_filename ):
         self.param_filename = param_filename

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -445,6 +445,7 @@ model.Job.table = Table(
     Column( "state", String( 64 ), index=True ),
     Column( "info", TrimmedString( 255 ) ),
     Column( "command_line", TEXT ),
+    Column( "dependencies", JSONType, nullable=True),
     Column( "param_filename", String( 1024 ) ),
     Column( "runner_name", String( 255 ) ),
     Column( "stdout", TEXT ),

--- a/lib/galaxy/model/migrate/versions/0133_add_dependency_column_to_job.py
+++ b/lib/galaxy/model/migrate/versions/0133_add_dependency_column_to_job.py
@@ -1,0 +1,49 @@
+"""
+Add dependencies column to jobs table
+"""
+from __future__ import print_function
+
+import logging
+
+from sqlalchemy import Column, MetaData, Table
+
+from galaxy.model.custom_types import JSONType
+
+log = logging.getLogger( __name__ )
+jobs_dependencies_column = Column( "dependencies", JSONType, nullable=True )
+
+
+def display_migration_details():
+    print("")
+    print("This migration adds dependencies column to job table")
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata = MetaData()
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    # Add the uuid colum to the dataset table
+    try:
+        jobs_table = Table( "job", metadata, autoload=True )
+        jobs_dependencies_column.create( jobs_table )
+        assert jobs_dependencies_column is jobs_table.c.dependencies
+    except Exception as e:
+        print(str(e))
+        log.error( "Adding column 'dependencies' to job table failed: %s" % str( e ) )
+        return
+
+
+def downgrade(migrate_engine):
+    metadata = MetaData()
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    # Drop the dataset table's uuid column.
+    try:
+        jobs_table = Table( "job", metadata, autoload=True )
+        jobs_dependencies = jobs_table.c.dependencies
+        jobs_dependencies.drop()
+    except Exception as e:
+        log.debug( "Dropping 'dependencies' column from job table failed: %s" % ( str( e ) ) )

--- a/lib/galaxy/model/migrate/versions/0133_add_dependency_column_to_job.py
+++ b/lib/galaxy/model/migrate/versions/0133_add_dependency_column_to_job.py
@@ -24,7 +24,7 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    # Add the uuid colum to the dataset table
+    # Add the dependencies column to the job table
     try:
         jobs_table = Table( "job", metadata, autoload=True )
         jobs_dependencies_column.create( jobs_table )
@@ -40,7 +40,7 @@ def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    # Drop the dataset table's uuid column.
+    # Drop the job table's dependencies column.
     try:
         jobs_table = Table( "job", metadata, autoload=True )
         jobs_dependencies = jobs_table.c.dependencies

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -304,6 +304,7 @@ class Tool( object, Dictifiable ):
         self.guid = guid
         self.old_id = None
         self.version = None
+        self.dependencies = []
         # Enable easy access to this tool's version lineage.
         self.lineage_ids = []
         # populate toolshed repository info, if available
@@ -1284,13 +1285,15 @@ class Tool( object, Dictifiable ):
 
     def build_dependency_shell_commands( self, job_directory=None, metadata=False ):
         """Return a list of commands to be run to populate the current environment to include this tools requirements."""
-        return self.app.toolbox.dependency_manager.dependency_shell_commands(
+        requirements_to_dependencies = self.app.toolbox.dependency_manager.requirements_to_dependencies(
             self.requirements,
             installed_tool_dependencies=self.installed_tool_dependencies,
             tool_dir=self.tool_dir,
             job_directory=job_directory,
             metadata=metadata,
         )
+        self.dependencies = [dep.to_dict() for dep in requirements_to_dependencies.values()]
+        return [dep.shell_commands(req) for req, dep in requirements_to_dependencies.items()]
 
     @property
     def installed_tool_dependencies(self):

--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -97,6 +97,7 @@ class DependencyManager( object ):
                                             version=requirement.version,
                                             type=requirement.type,
                                             **kwds )
+                log.debug(dependency.resolver_msg)
             dependency_commands = dependency.shell_commands( requirement )
             if not dependency_commands:
                 log.warning( "Failed to resolve dependency on '%s', ignoring", requirement.name )

--- a/lib/galaxy/tools/deps/resolvers/__init__.py
+++ b/lib/galaxy/tools/deps/resolvers/__init__.py
@@ -91,6 +91,13 @@ class Dependency(Dictifiable, object):
         the dependency.
         """
 
+    @property
+    def resolver_msg(self):
+        """
+        Return a message describing this dependency
+        """
+        return "Using dependency %s version %s of type %s" % (self.name, self.version, self.dependency_type)
+
 
 class NullDependency( Dependency ):
     dependency_type = None
@@ -99,6 +106,13 @@ class NullDependency( Dependency ):
     def __init__(self, version=None, name=None):
         self.version = version
         self.name = name
+
+    @property
+    def resolver_msg(self):
+        """
+        Return a message describing this dependency
+        """
+        return "Dependency %s not found." % self.name
 
     def shell_commands( self, requirement ):
         return None

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -205,6 +205,30 @@
     ${ render_msg( 'One or more of your original parameters may no longer be valid or displayed properly.', status='warning' ) }
 %endif
 
+%if job and job.dependencies:
+    <br>
+    <table class="tabletip">
+        <thead>
+        <tr>
+            <th>Dependency</th>
+            <th>Dependency Type</th>
+            <th>Version</th>
+        </tr>
+        </thead>
+        <tbody>
+
+            %for dependency in job.dependencies:
+                <tr><td>${ dependency['name'] | h }</td>
+                    <td>${ dependency['dependency_type'] | h }</td>
+                    <td>${ dependency['version'] | h }</td>
+                </tr>
+            %endfor
+
+        </tbody>
+    </table>
+    <br />
+%endif
+
 <script type="text/javascript">
 $(function(){
     $( '.input-dataset-show-params' ).on( 'click', function( ev ){

--- a/test/unit/jobs/test_job_wrapper.py
+++ b/test/unit/jobs/test_job_wrapper.py
@@ -157,6 +157,7 @@ class MockTool(object):
 
     def __init__(self, app):
         self.version_string_cmd = TEST_VERSION_COMMAND
+        self.dependencies = []
 
     def build_dependency_shell_commands(self, job_directory):
         return TEST_DEPENDENCIES_COMMANDS


### PR DESCRIPTION
This is addressing https://github.com/galaxyproject/galaxy/issues/2914 by logging which dependency has been used. 
- 85c1a8f is pretty straightforward, ~~for logging the job metadata I'll have to look around some more~~. This one we may want to include in release_16.07
- 167286a additionally stores that information in the job table and display it with the show_params.mako and requires a DB migration, so that should probably go to 16.10

Ping @martenson 
