### PR TITLE
[16.07] Prevent refresh for collection selector in old run workflow form

### DIFF
--- a/templates/webapps/galaxy/workflow/run.mako
+++ b/templates/webapps/galaxy/workflow/run.mako
@@ -159,7 +159,7 @@
             $("#new_history_cbx").click(function(){
                 $("#new_history_input").toggle(this.checked);
             });
-            $('span.multiinput_wrap select[name*="|input"]').removeAttr('multiple').each(function(i, s) {
+            $('span.multiinput_wrap select[name*="|input"]').off('change').removeAttr('multiple').each(function(i, s) {
                 var select = $(s);
                 // The destroy on the following line is temporary and prevents
                 // select2 use on Input Dataset Steps, but allows elsewhere.  We


### PR DESCRIPTION
Fixes #2919, #2835 and #2772. Generally we want changes in data selectors to trigger a form refresh, this works fine in the new run workflow form and the regular tool form, correctly resolving dependent tool parameters. However when refreshing the collection selector or the regular data selector in data input modules in the old run workflow form the page is rebuild and the last state of the multi input selector can not be restored. This PR removes the refresh trigger for input module selection fields in the old run workflow form restoring the previous behavior.
