### PR TITLE
[16.07] Update python-ldap module

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -11,4 +11,4 @@ drmaa
 statsd
 azure-storage==0.32.0
 # PyRods not in PyPI
-python-ldap==2.4.25
+python-ldap==2.4.27


### PR DESCRIPTION
Backport of #2738.

Updating to the same version as galaxyproject/starforge#97, 2.4.25 was never available on wheels.galaxyproject.org .
