### PR TITLE
WIP: add a conda clean function

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -204,6 +204,16 @@ class CondaContext(object):
         install_base_args.extend(args)
         return self.exec_command("install", install_base_args)
 
+    def exec_clean(self, args=[]):
+        """
+        Clean up after conda installation.
+        """
+        clean_base_args = [
+            "--tarballs"
+        ]
+        clean_base_args.extend(args)
+        return self.exec_command("clean", clean_base_args)
+
     def export_list(self, name, path):
         return self.exec_command("list", [
             "--name", name,
@@ -437,6 +447,7 @@ def build_isolated_environment(
 
         return (path or tempdir_name, exit_code)
     finally:
+        conda_context.exec_clean()
         shutil.rmtree(tempdir)
 
 


### PR DESCRIPTION
We should clean up after a conda installation. 
Conda has a convenient function to clean packages and co. At least the downloaded tarballs can be removed after installation. This will greatly reduce the size of Galaxy flavors ... 

```
usage: conda clean [-h] [-y] [--dry-run] [--json] [-a] [-i] [-l] [-t] [-p]
                   [-s]

Remove unused packages and caches.

Options:

optional arguments:
  -h, --help          Show this help message and exit.
  -y, --yes           Do not ask for confirmation.
  --dry-run           Only display what would have been done.
  --json              Report all output as json. Suitable for using conda
                      programmatically.
  -a, --all           Remove index cache, lock files, tarballs, unused cache
                      packages, and source cache.
  -i, --index-cache   Remove index cache.
  -l, --lock          Remove all conda lock files.
  -t, --tarballs      Remove cached package tarballs.
  -p, --packages      Remove unused cached packages. Warning: this does not
                      check for symlinked packages.
  -s, --source-cache  Remove files from the source cache of conda build.

```

It's not yet tested, I hope I have time next week for this.
