### PR TITLE
Remove unnecessary use of binascii

### DIFF
--- a/.ci/flake8_lint_include_list.txt
+++ b/.ci/flake8_lint_include_list.txt
@@ -13,6 +13,7 @@ lib/galaxy/dataset_collections/structure.py
 lib/galaxy/dataset_collections/subcollections.py
 lib/galaxy/dataset_collections/type_description.py
 lib/galaxy/datatypes/assembly.py
+lib/galaxy/datatypes/binary.py
 lib/galaxy/datatypes/constructive_solid_geometry.py
 lib/galaxy/datatypes/converters/bcf_bgzip_to_bcf_converter.py
 lib/galaxy/datatypes/converters/bcf_to_bcf_bgzip_converter.py
@@ -39,6 +40,7 @@ lib/galaxy/datatypes/converters/maf_to_interval_converter.py
 lib/galaxy/datatypes/converters/pbed_to_lped_converter.py
 lib/galaxy/datatypes/converters/picard_interval_list_to_bed6_converter.py
 lib/galaxy/datatypes/converters/pileup_to_interval_index_converter.py
+lib/galaxy/datatypes/converters/tabular_to_dbnsfp.py
 lib/galaxy/datatypes/converters/vcf_to_vcf_bgzip.py
 lib/galaxy/datatypes/converters/wiggle_to_array_tree_converter.py
 lib/galaxy/datatypes/coverage.py

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -1,7 +1,6 @@
 """
 Proteomics Datatypes
 """
-import binascii
 import logging
 import re
 
@@ -272,10 +271,9 @@ class ThermoRAW(Binary):
         # This combination represents 17 bytes, but to play safe we read 20 bytes from
         # the start of the file.
         try:
-            header = open(filename).read(20)
-            hexheader = binascii.b2a_hex(header)
-            finnigan = binascii.hexlify('F\0i\0n\0n\0i\0g\0a\0n')
-            if hexheader.find(finnigan) != -1:
+            header = open(filename, 'rb').read(20)
+            finnigan = b'F\0i\0n\0n\0i\0g\0a\0n'
+            if header.find(finnigan) != -1:
                 return True
             return False
         except:

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -1,4 +1,3 @@
-import binascii
 import bz2
 import gzip
 import imghdr
@@ -95,7 +94,7 @@ def check_gzip( file_path ):
     # for sff format.
     try:
         header = gzip.open( file_path ).read(4)
-        if binascii.b2a_hex( header ) == binascii.hexlify( '.sff' ):
+        if header == b'.sff':
             return ( True, True )
     except:
         return( False, False )


### PR DESCRIPTION
Also explicitly specify binary mode for file opening and header strings (for Python3). xref. #1715 
Fix import order.
