### PR TITLE
Improve history copying UI

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -227,6 +227,7 @@ class HistorySerializer( sharable.SharableModelSerializer, deletable.PurgableSer
             # 'contents_states',
             'contents_active',
             'hid_counter',
+            'importing',
         ], include_keys_from='summary' )
 
     # assumes: outgoing to json.dumps and sanitized


### PR DESCRIPTION
Just a spike for now.
- [ ] set the `importing` flag during a history copy. 
- [ ] use the importing flag when rendering histories: if importing, warn the user ('not ready') and show an abbreviated version of the history
- [ ] ? poll the histories and inform the user when the importing is done

Addresses (half of) #2804 
