### PR TITLE
Improve ``version_command`` tag.

### DIFF
--- a/doc/schema_template.md
+++ b/doc/schema_template.md
@@ -15,7 +15,7 @@ $toc
 
 $tag:tool://element[@name='tool']
 $tag:tool|description://element[@name='tool']//element[@name='description']
-$tag:tool|version_command://element[@name='tool']//element[@name='version_command']
+$tag:tool|version_command://complexType[@name='VersionCommand']
 $tag:tool|command://element[@name='tool']//element[@name='command'] hide_attributes
 $tag:tool|inputs://complexType[@name='Inputs']
 $tag:tool|inputs|section://complexType[@name='Section']

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -8,6 +8,7 @@ import os
 import pwd
 import random
 import shutil
+import string
 import subprocess
 import sys
 import time
@@ -908,8 +909,10 @@ class JobWrapper( object ):
         self.sa_session.flush()
         # Return list of all extra files
         self.param_dict = tool_evaluator.param_dict
-        version_string_cmd = self.tool.version_string_cmd
-        if version_string_cmd:
+        version_string_cmd_raw = self.tool.version_string_cmd
+        if version_string_cmd_raw:
+            version_command_template = string.Template(version_string_cmd_raw)
+            version_string_cmd = version_command_template.safe_substitute({"__tool_directory__": compute_environment.tool_directory() })
             self.write_version_cmd = "%s > %s 2>&1" % ( version_string_cmd, compute_environment.version_path() )
         else:
             self.write_version_cmd = None

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -61,23 +61,7 @@ the tool menu immediately following the hyperlink for the tool (based on the
           </xs:annotation>
         </xs:element>
         <xs:element name="parallelism" type="Parallelism" minOccurs="0"/>
-        <xs:element name="version_command" type="xs:string" minOccurs="0">
-          <xs:annotation>
-            <xs:documentation xml:lang="en"><![CDATA[Specifies the command to be run in
-order to get the tool's version string. The resulting value will be found in the
-"Info" field of the history dataset.
-
-Unlike the [``command``](#tool|command) tag, this value is taken as a literal and so there is no
-need to escape values like ``$`` and command inputs are not available for variable
-substitution.
-
-### Example
-
-```xml
-<version_command>tophat -version</version_command>
-```
-]]></xs:documentation>
-          </xs:annotation>
+        <xs:element name="version_command" type="VersionCommand" minOccurs="0">
         </xs:element>
         <xs:element name="action" type="ToolAction" minOccurs="0" maxOccurs="1" />
         <xs:element name="environment_variables" type="EnvironmentVariables" minOccurs="0" maxOccurs="1"/>
@@ -4134,7 +4118,6 @@ define.</xs:documentation>
     </xs:simpleContent>
   </xs:complexType>
 
-
   <xs:complexType name="ConfigFiles">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[See
@@ -4264,6 +4247,52 @@ response to this directive.
         <xs:attribute name="filename" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">Path relative to the working directory of the tool for the inputs JSON file created in response to this directive.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="VersionCommand">
+    <xs:annotation>
+      <xs:documentation xml:lang="en"><![CDATA[Specifies the command to be run in
+order to get the tool's version string. The resulting value will be found in the
+"Info" field of the history dataset.
+
+Unlike the [``command``](#tool|command) tag, with the exception of the string
+``$__tool_directory__`` this value is taken as a literal and so there is no
+need to escape values like ``$`` and command inputs are not available for variable
+substitution.
+
+### Examples
+
+A simple example for a [TopHat](https://ccb.jhu.edu/software/tophat/index.shtml)
+tool definition might just be:
+
+```xml
+<version_command>tophat -version</version_command>
+```
+
+An example that leverages a Python script (e.g. ``count_reads.py``) shipped with
+the tool might be:
+
+```xml
+<version_command>python $__tool_directory__/count_reads.py</version_command>
+```
+
+Examples are included in the test tools directory including:
+
+- [version_command_plain.xml](https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/version_command_plain.xml)
+- [version_command_tool_dir.xml](https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/version_tool_dir.xml)
+- [version_command_interpreter.xml](https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/version_command_interpreter.xml) (*deprecated*)
+
+]]></xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="interpreter" type="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en"><![CDATA[*Deprecated*: Prefix the version command with an interpreter and the tool directory in order to execute a script shipped with the tool. It is better to just use ``<interpreter> $__tool_directory__/<script_name>``.]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -1428,7 +1428,7 @@ many of the default assertion tags that come with Galaxy and examples of each
 can be found below.
 
 The implementation of these tags are simply Python functions defined in the
-[``galaxy.tools.verify.asserts``](https://github.com/galaxyproject/galaxy/tree/dev/lib/galaxy/tools/verify/asserts]
+[``galaxy.tools.verify.asserts``](https://github.com/galaxyproject/galaxy/tree/dev/lib/galaxy/tools/verify/asserts)
 module.
 ]]>
       </xs:documentation>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -38,6 +38,9 @@
   <tool file="maxseconds.xml" />
   -->
   <tool file="job_properties.xml" />
+  <tool file="version_command_plain.xml" />
+  <tool file="version_command_interpreter.xml" />
+  <tool file="version_command_tool_dir.xml" />
   <tool file="exit_code_from_file.xml" />
   <tool file="gzipped_inputs.xml" />
   <tool file="output_order.xml" />

--- a/test/functional/tools/version_command.py
+++ b/test/functional/tools/version_command.py
@@ -1,0 +1,2 @@
+from __future__ import print_function
+print("4.0.0")

--- a/test/functional/tools/version_command_interpreter.xml
+++ b/test/functional/tools/version_command_interpreter.xml
@@ -1,0 +1,20 @@
+<tool id="version_command_interpreter" name="version_command_interpreter" version="1.0.0">
+    <version_command interpreter="python">
+        version_command.py
+    </version_command>
+    <command>
+        cp $input $output
+    </command>
+    <inputs>
+        <param name="input" type="data" format="txt" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="simple_line.txt" />
+            <output name="out_file1" checksum="sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041" />
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/version_command_plain.xml
+++ b/test/functional/tools/version_command_plain.xml
@@ -1,0 +1,20 @@
+<tool id="version_command_plain" name="version_command_plain" version="1.0.0">
+    <version_command>
+        echo "4.0.0"
+    </version_command>
+    <command>
+        cp $input $output
+    </command>
+    <inputs>
+        <param name="input" type="data" format="txt" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="simple_line.txt" />
+            <output name="out_file1" checksum="sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041" />
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/version_command_tool_dir.xml
+++ b/test/functional/tools/version_command_tool_dir.xml
@@ -1,0 +1,20 @@
+<tool id="version_command_tool_dir" name="version_command_tool_dir" version="1.0.0">
+    <version_command>
+        python $__tool_directory__/version_command.py
+    </version_command>
+    <command>
+        cp $input $output
+    </command>
+    <inputs>
+        <param name="input" type="data" format="txt" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="simple_line.txt" />
+            <output name="out_file1" checksum="sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041" />
+        </test>
+    </tests>
+</tool>

--- a/test/unit/jobs/test_job_wrapper.py
+++ b/test/unit/jobs/test_job_wrapper.py
@@ -157,6 +157,7 @@ class MockTool(object):
 
     def __init__(self, app):
         self.version_string_cmd = TEST_VERSION_COMMAND
+        self.tool_dir = "/path/to/tools"
         self.dependencies = []
 
     def build_dependency_shell_commands(self, job_directory):


### PR DESCRIPTION
- Include deprecated `interpreter` tag in XSD. (Closes galaxyproject/planemo#574)
- Allow the use of `$__tool_directory__` in `version_command` (so I can actually call `interpreter` deprecated).
- Include sample tools of both of these styles and a plain example that just uses `echo`.
- General improvements to the version command documentation.
