### PR TITLE
Refactor recent toolbox changes for galaxy-lib.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -24,6 +24,7 @@ from galaxy import model
 from galaxy.managers import histories
 from galaxy.datatypes.metadata import JobExternalOutputMetadataWrapper
 from galaxy import exceptions
+from galaxy.queue_worker import reload_toolbox
 from galaxy.tools.actions import DefaultToolAction
 from galaxy.tools.actions.upload import UploadToolAction
 from galaxy.tools.actions.data_source import DataSourceToolAction
@@ -103,12 +104,19 @@ class ToolBox( BaseGalaxyToolBox ):
     """
 
     def __init__( self, config_filenames, tool_root_dir, app, tool_conf_watcher=None ):
+        self._reload_count = 0
         super( ToolBox, self ).__init__(
             config_filenames=config_filenames,
             tool_root_dir=tool_root_dir,
             app=app,
             tool_conf_watcher=tool_conf_watcher
         )
+
+    def handle_reload_toolbox(self):
+        reload_toolbox(self.app)
+
+    def has_reloaded(self, other_toolbox):
+        return self._reload_count != other_toolbox._reload_count
 
     @property
     def all_requirements(self):


### PR DESCRIPTION
The abstracttoolbox class is supposed to shield Galaxy from the internals of the toolbox organization and vice versa, so having a reload method that uses Galaxy-specific queueing stuff is less than ideal. The concrete toolbox class is where I have been putting such functionality.

In addition to this being the abstract design I prefer, it is definitely needed for galaxy-lib which contains the abstracttoolbox but not the concrete toolbox or the queue worker functionality.

xref #2840
