### PR TITLE
Remove invalid attribute metadata_name from param examples in XSD docs.

### DIFF
--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -1663,7 +1663,7 @@ the [Bowtie 2](https://github.com/galaxyproject/tools-devteam/blob/master/tools/
     </param>
   </when>
   <when value="history">
-    <param name="own_file" type="data" format="fasta" metadata_name="dbkey" label="Select reference genome" />
+    <param name="own_file" type="data" format="fasta" label="Select reference genome" />
   </when>
 </conditional>
 ```
@@ -2664,7 +2664,7 @@ alternative to local reference data.
     </param>
   </when>
   <when value="history">
-    <param name="own_file" type="data" format="fasta" metadata_name="dbkey" label="Select reference genome" />
+    <param name="own_file" type="data" format="fasta" label="Select reference genome" />
   </when>
 </conditional>
 ```


### PR DESCRIPTION
Pointed out by @peterjc in https://github.com/galaxyproject/tools-iuc/pull/964#issuecomment-249632638.
