### PR TITLE
Fix import order in containers.py

### DIFF
--- a/lib/galaxy/tools/deps/containers.py
+++ b/lib/galaxy/tools/deps/containers.py
@@ -11,9 +11,9 @@ import six
 
 from galaxy.util import asbool
 
-from ..deps import docker_util
 from .requirements import ContainerDescription
 from .requirements import DEFAULT_CONTAINER_RESOLVE_DEPENDENCIES, DEFAULT_CONTAINER_SHELL
+from ..deps import docker_util
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Broken in cad4002efed5547ccc1f89a3a45d2d4b9b12f76d.
