### PR TITLE
Update sqlalchemy to 1.0.15 (from 1.0.8).  This is likely the last 1.…

### DIFF
--- a/lib/galaxy/dependencies/pinned-hashed-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-hashed-requirements.txt
@@ -29,16 +29,12 @@ PyYAML==3.11 --hash:sha256=2912c1fb56c316461d003a8b8f1f41e1ed8387b2e47a4523f8a4e
              --hash:sha256=9b184a4a7d3d383b39cb73429d3798370facaee4263465b575f243c7ede3f9c3 \
              --hash:sha256=f90314e2ed46ea2da980aff88b91c3cc8ce93edd4658011dd462a8f28399533b \
              --hash:sha256=80936dca10b611cd54ca52939aac938d59653830a6a6265bef5d11896de8e249
-SQLAlchemy==1.0.8 --hash:sha256=3c357f36c141205cea2b5ec4c4e9885602452fea06428d6c20596c66c9a43243 \
-                  --hash:sha256=17fad7f37f902dbec37ca2777af3021f9a4ed31079d64f7f888e7b29517240a3 \
-                  --hash:sha256=e177904a384b9bc68914afb32a6ed2cc73ed7787444e3e1fdf85e3b9cfe5f847 \
-                  --hash:sha256=91ed10baf56b6e29665f2b9fcb0c690afc6cc2c2e8e19c7f92b58092a4002e14 \
-                  --hash:sha256=f5d6156d1d7865cd23b76ddad3f53ec07a3009a2cd8082a829cd1f24b366db5c \
-                  --hash:sha256=3c3f3baf07f868c1c3f86d63dc2efa4455e95d76745f1af561f1ccf0fd9e8c81 \
-                  --hash:sha256=a9fb8061aa767ca2ad22983a11e074ac231f44a56709721c60cc1992f2a92350 \
-                  --hash:sha256=884b522d2d067cffd103f4e1a5342c678803cd6903da24a3f757b57b00eb188b \
-                  --hash:sha256=d5dde66c1603853aebbfbbd74d79c60678f7d98c17abce4be4ebbb697dfd7265 \
-                  --hash:sha256=42346d5e91c5e0a5a975352d8af3cfd8b2dad602dd07ec41b6b848ac5205cf5b
+SQLAlchemy==1.0.15 --hash:sha256=7cbac295f87d2af82aac08346b52f72d0b0c007122904951990a53720ad1f820 \
+                   --hash:sha256=bfcef5888031c323407bd924d5718f2f2541867a8dbac87498ea8c2f632a5e1e \
+                   --hash:sha256=0ee07470bc1e64dbceaca4340e6427476d2b03ff3aa069100f3468587f8a973a \
+                   --hash:sha256=f819742f33ae543ca2c48bc43e35bd75372f7c3e379e4881f9040549d3df94b6 \
+                   --hash:sha256=fce29753f720f8a6920185bd5a4d1670fa6b6936819475197b2bce7644243766 \
+                   --hash:sha256=aa8843df6869f6c999400ae32de5480fba1b7711fe535c168a14225ffd1d3de4
 mercurial==3.7.3 --hash:sha256=49f596820f005ac6f94266b89a0dbd815c0ee0aacd3aa86545dc39fb349ea4bf \
                  --hash:sha256=75f5b6b708bec2d6e0e68ec8912725a5dcac42df00b122fa73a8c4bd21495039 \
                  --hash:sha256=8c07cb3404d26641d8829099bd1047582b76def49eca067ba6bea9a73d261775 \

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -2,7 +2,7 @@
 bx-python==0.7.3
 MarkupSafe==0.23
 PyYAML==3.11
-SQLAlchemy==1.0.8
+SQLAlchemy==1.0.15
 mercurial==3.7.3
 numpy==1.9.2
 pycrypto==2.6.1


### PR DESCRIPTION
…0 series release before we'll be able to upgrade to a live 1.1.
