### PR TITLE
Fix startswith method spelling

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -521,7 +521,7 @@ class Data( object ):
         # add potentially required/common internal tool parameters e.g. '__job_resource'
         if target_context:
             for key, value in target_context.items():
-                if key.startsWith( '__' ):
+                if key.startswith( '__' ):
                     params[ key ] = value
         params[input_name] = original_dataset
 


### PR DESCRIPTION
Introduced in commit 4b2e0c84e19001c8071b374a8e7daf609bb3aa88
