### PR TITLE
[16.01] Backport #2869 Fix initial conda version at 4.0.5

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -27,9 +27,9 @@ USE_PATH_EXEC_DEFAULT = False
 
 def conda_link():
     if IS_OS_X:
-        url = "https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh"
+        url = "https://repo.continuum.io/miniconda/Miniconda2-4.0.5-MacOSX-x86_64.sh"
     else:
-        url = "https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh"
+        url = "https://repo.continuum.io/miniconda/Miniconda2-4.0.5-Linux-x86_64.sh"
     return url
 
 


### PR DESCRIPTION
Backport of #2869

This should prevent missing `activate` in <conda_prefix>/bin when
downgrading to 3.19.3. This is what the conda people use in their CI
environment (
[see](https://github.com/conda/conda/blob/master/utils/travis-run-install.sh#L61)
and perhaps why that bug made it into the release in the first place).

ping @nsoranzo 
