### PR TITLE
Added the *.jar datatype

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -148,6 +148,7 @@
     <datatype extension="rna_eps" type="galaxy.datatypes.sequence:RNADotPlotMatrix" mimetype="image/eps" display_in_upload="True"/>
     <datatype extension="zip" type="galaxy.datatypes.binary:CompressedZipArchive" display_in_upload="True"/>
     <datatype extension="tar" type="galaxy.datatypes.binary:CompressedArchive" subclass="True" display_in_upload="True"/>
+    <datatype extension="jar" type="galaxy.datatypes.binary:JarArchive" subclass="True" display_in_upload="True"/>
     <!-- Proteomics Datatypes -->
     <datatype extension="pepxml" type="galaxy.datatypes.proteomics:PepXml" mimetype="application/xml" display_in_upload="True"/>
     <datatype extension="raw_pepxml" type="galaxy.datatypes.proteomics:PepXml" mimetype="application/xml" subclass="True"/>

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -173,6 +173,27 @@ class CompressedZipArchive( CompressedArchive ):
 
 Binary.register_unsniffable_binary_ext("zip")
 
+class JarArchive( CompressedZipArchive ):
+    """
+        Class describing a java jar archive  https://en.wikipedia.org/wiki/JAR_(file_format) 
+    """
+    file_ext = "jar"
+    def set_peek( self, dataset, is_multi_byte=False ):
+        if not dataset.dataset.purged:
+            dataset.peek = "Compressed jar file"
+            dataset.blurb = nice_size( dataset.get_size() )
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def display_peek( self, dataset ):
+        try:
+            return dataset.peek
+        except:
+            return "Jar file (%s)" % ( nice_size( dataset.get_size() ) )
+
+
+Binary.register_unsniffable_binary_ext("jar")
 
 class GenericAsn1Binary( Binary ):
     """Class for generic ASN.1 binary format"""

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -173,11 +173,13 @@ class CompressedZipArchive( CompressedArchive ):
 
 Binary.register_unsniffable_binary_ext("zip")
 
+
 class JarArchive( CompressedZipArchive ):
     """
-        Class describing a java jar archive  https://en.wikipedia.org/wiki/JAR_(file_format) 
+        Class describing a java jar archive  https://en.wikipedia.org/wiki/JAR_(file_format)
     """
     file_ext = "jar"
+
     def set_peek( self, dataset, is_multi_byte=False ):
         if not dataset.dataset.purged:
             dataset.peek = "Compressed jar file"
@@ -194,6 +196,7 @@ class JarArchive( CompressedZipArchive ):
 
 
 Binary.register_unsniffable_binary_ext("jar")
+
 
 class GenericAsn1Binary( Binary ):
     """Class for generic ASN.1 binary format"""


### PR DESCRIPTION
# motivation

As http://gatkforums.broadinstitute.org/gatk/discussion/8402 

>  A simpler option would be to set up your instance so that your users have to upload their own GATK jar to the toolshed

I want the users to be able to upload their private GATK GenomeToolkit.jar
So, this PR introduces the datatype JarArchive , a subclass of *.zip

I've added galaxy.datatypes.binary:JarArchive in `config/datatypes_conf.xml.sample`

and a class JarArchive , subclass of CompressedZipArchive  in `lib/galaxy/datatypes/binary.py`

Pierre, python novice :-P 
