### PR TITLE
Cache fix

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -533,7 +533,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
                     can_load_into_panel_dict = not tool_shed_repository.deleted
                     repository_id = self.app.security.encode_id(tool_shed_repository.id)
                     tool = self.load_tool(os.path.join( tool_path, path ), guid=guid, repository_id=repository_id, use_cached=False)
-            else:  # tool was not in cache and is not a tool shed tool.
+            if not tool:  # tool was not in cache and is not a tool shed tool.
                 tool = self.load_tool(os.path.join(tool_path, path), use_cached=False)
             if string_as_bool(item.get( 'hidden', False )):
                 tool.hidden = True

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -520,8 +520,13 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
             tool = self.load_tool_from_cache(os.path.join(tool_path, path))
             from_cache = tool
             if from_cache:
-                log.debug("Loading tool %s from cache", str(tool.id))
-            elif guid:  # tool was not in cache and is a tool shed tool
+                if guid and tool.id != guid:
+                    # In rare cases a tool shed tool is loaded into the cache without guid.
+                    # In that case recreating the tool will correct the cached version.
+                    from_cache = False
+                else:
+                    log.debug("Loading tool %s from cache", str(tool.id))
+            if guid and not from_cache:  # tool was not in cache and is a tool shed tool
                 tool_shed_repository = self.get_tool_repository_from_xml_item(item, path)
                 if tool_shed_repository:
                     # Only load tools if the repository is not deactivated or uninstalled.


### PR DESCRIPTION
I hope this fixes #3017 for @blankenberg.
The diagnosis so far is that when a tool gets installed, it can happen that a tool instance gets loaded into the toolbox from the cache that does not have an attached guid. When installing a repository that contains tools, the tools will be loaded multiple times at different places in the code during the install process to check the metadata and copy required tool sample files. Usually this does not get registered in the cache, but it appears that this can happen. In this case we check that the primary tool id is the guid, and it it is not, load the tool from scratch.
