### PR TITLE
change parameters to samtools sort command (new samtools vers)

### DIFF
--- a/lib/galaxy/datatypes/converters/sam_to_bam.py
+++ b/lib/galaxy/datatypes/converters/sam_to_bam.py
@@ -20,17 +20,16 @@ def cleanup_before_exit( tmp_dir ):
     if tmp_dir and os.path.exists( tmp_dir ):
         shutil.rmtree( tmp_dir )
 
+
 def getSamtoolsVersion():
     cmd = 'samtools --version'
     proc = subprocess.Popen( args=cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True )
     stdout, stderr = proc.communicate()
     if proc.returncode:
-       sys.stderr.write(stderr)
-       return None
+        sys.stderr.write(stderr)
+        return None
     else:
-       return stdout.split("\n")[0].split()[-1]
-
-
+        return stdout.split("\n")[0].split()[-1]
 
 
 def __main__():
@@ -66,11 +65,11 @@ def __main__():
     sorted_stderr_filename = os.path.join( tmp_dir, 'sorted.stderr' )
     sorting_prefix = os.path.join( tmp_dir, 'sorted_bam' )
     # samtools changed sort command arguments (starting from version 1.3)
-    samtools_version =  LooseVersion(getSamtoolsVersion())
-    if samtools_version <  LooseVersion('1.3'):
-      cmd = 'samtools sort -o "%s" "%s" > "%s"' % ( unsorted_bam_filename, sorting_prefix, output_filename )
+    samtools_version = LooseVersion(getSamtoolsVersion())
+    if samtools_version < LooseVersion('1.3'):
+        cmd = 'samtools sort -o "%s" "%s" > "%s"' % ( unsorted_bam_filename, sorting_prefix, output_filename )
     else:
-      cmd = 'samtools sort -T "%s" "%s" > "%s"' % ( sorting_prefix, unsorted_bam_filename, output_filename )
+        cmd = 'samtools sort -T "%s" "%s" > "%s"' % ( sorting_prefix, unsorted_bam_filename, output_filename )
     proc = subprocess.Popen( args=cmd, stderr=open( sorted_stderr_filename, 'wb' ), shell=True, cwd=tmp_dir )
     return_code = proc.wait()
 


### PR DESCRIPTION
New samtools versions use different arguments for sort (see http://www.htslib.org/doc/samtools.html).
Just added version check and modified the cmd accordingly.
