### PR TITLE
[16.04] Remove travis-ci python installation, since python2.7 is preinstalled…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ matrix:
     env: TOX_ENV=py27-unit
     language: generic
 
-before_install:
-  - if [ `uname` == "Darwin"  ]; then bash -c "brew update && brew install python"; fi
-
 install:
   - pip install tox
   - if [ "$TOX_ENV" == "qunit" ]; then bash -c 'cd test/qunit && npm install'; fi


### PR DESCRIPTION
… on OSX images now.

ping @martenson @nsoranzo 
