### PR TITLE
Remove outdated warning on ID_SECRET

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -886,8 +886,7 @@ use_interactive = True
 # Galaxy encodes various internal values when these values will be output in
 # some format (for example, in a URL or cookie).  You should set a key to be
 # used by the algorithm that encodes and decodes these values.  It can be any
-# string.  If left unchanged, anyone could construct a cookie that would grant
-# them access to others' sessions.
+# string.
 # One simple way to generate a value for this is with the shell command:
 #   python -c 'import time; print time.time()' | md5sum | cut -f 1 -d ' '
 #id_secret = USING THE DEFAULT IS NOT SECURE!


### PR DESCRIPTION
After digging through the code I am not finding evidence that this was ever possible to do, at least not since sometime pre-2010.

xref https://github.com/galaxyproject/galaxy/commit/3443e25e066b597a63cef483ea1e7ae026aa3286
