### PR TITLE
Sort bedtools output in bam_to_bigwig conversion

### DIFF
--- a/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
@@ -4,15 +4,17 @@
         <requirement type="package">ucsc_tools</requirement>
         <requirement type="package">bedtools</requirement>
     </requirements>
-    <command>
-        bedtools genomecov -bg -split -ibam $input -g $chromInfo 
+    <command><![CDATA[
+        bedtools genomecov -bg -split -ibam '$input' -g '$chromInfo'
+
+        | LC_COLLATE=C sort -k1,1 -k2,2n
 
         ## Streaming the bedgraph file to wigToBigWig is fast but very memory intensive; hence, this
         ## should only be used on systems with large RAM.
-        ## | wigToBigWig stdin $chromInfo $output
+        ## | wigToBigWig stdin '$chromInfo' '$output'
 
         ## This can be used anywhere.
-        > temp.bg ; bedGraphToBigWig temp.bg $chromInfo $output
+        > temp.bg && bedGraphToBigWig temp.bg '$chromInfo' '$output']]>
     </command>
     <inputs>
         <param format="bam" name="input" type="data" label="Choose BAM file"/>


### PR DESCRIPTION
Bedtools genomecov seems to output bedgraph files with chromosomes
sorted in the order given in the chromInfo file. This can cause issues
with bedGraphToBigWig which requires them sorted in a specific way.

Fixes #2582.
