### PR TITLE
Dataset metadata should not be cached when building chart visualizations

### DIFF
--- a/config/plugins/visualizations/charts/static/client/app.js
+++ b/config/plugins/visualizations/charts/static/client/app.js
@@ -11,7 +11,6 @@ define( [ 'mvc/ui/ui-modal', 'mvc/ui/ui-portlet', 'mvc/ui/ui-misc', 'utils/utils
                 console.debug( Registry );
                 Utils.get({
                     url     : Galaxy.root + 'api/datasets/' + options.dataset_id,
-                    cache   : true,
                     success : function( dataset ) {
                         self.dataset = dataset;
                         self.types = {};


### PR DESCRIPTION
To reproduce: upload a tabular data file and select a wrong datatype in the upload dialog e.g. asn1. Attempt to visualize the dataset with Charts. Then select the dataset in the history and correct the datatype to tabular by editing its attributes. Finally attempt to visualize the dataset using Charts again. This will fail unless the page has been reloaded.
