### PR TITLE
[16.07] Finish job for Torque SSH/CLI runner

### DIFF
--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -154,13 +154,16 @@ class ShellJobRunner( AsynchronousJobRunner ):
                         ajs.job_wrapper.change_state( state )
             else:
                 if state != old_state:
-                    log.debug("(%s/%s) state change: %s" % ( id_tag, external_job_id, state ) )
+                    log.debug("(%s/%s) state change: %s to %s" % ( id_tag, external_job_id, old_state, state ) )
                     ajs.job_wrapper.change_state( state )
                 if state == model.Job.states.RUNNING and not ajs.running:
                     ajs.running = True
                     ajs.job_wrapper.change_state( model.Job.states.RUNNING )
             ajs.old_state = state
-            new_watched.append( ajs )
+            if state == model.Job.states.OK:
+                self.work_queue.put( ( self.finish_job, ajs ) )
+            else:
+                new_watched.append( ajs )
         # Replace the watch list with the updated version
         self.watched = new_watched
 

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -154,7 +154,7 @@ class ShellJobRunner( AsynchronousJobRunner ):
                         ajs.job_wrapper.change_state( state )
             else:
                 if state != old_state:
-                    log.debug("(%s/%s) state change: %s to %s" % ( id_tag, external_job_id, old_state, state ) )
+                    log.debug("(%s/%s) state change: from %s to %s" % ( id_tag, external_job_id, old_state, state ) )
                     ajs.job_wrapper.change_state( state )
                 if state == model.Job.states.RUNNING and not ajs.running:
                     ajs.running = True


### PR DESCRIPTION
This fixes a problem with jobs frequently not finishing and should affect all CLI job runners that do not rely on parsing single status lines from `qstat` stdout (but it's possible that this is only the torque plugin ... not sure on that).
A closer look revealed that the list of monitored jobs was continuing to grow,
and jobs wouldn't be removed even if the status was OK.
