### PR TITLE
Fix qunit local testing install -- now runs on modern node (v6.9.1) w…

### DIFF
--- a/test/qunit/package.json
+++ b/test/qunit/package.json
@@ -1,10 +1,11 @@
 {
   "name": "galaxy-qunit-tests",
   "version": "1.0.0",
-  "devDependencies": {
-    "grunt": "^0.4.4",
-    "grunt-contrib-qunit": "^0.4.0",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-cli": "^0.1.13"
+  "dependencies": {
+    "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-qunit": "^1.2.0",
+    "grunt-contrib-watch": "^1.0.0",
+    "phantomjs-prebuilt": "^2.1.13"
   }
 }


### PR DESCRIPTION
…ith no system packages, just 'npm install', 'grunt'.

Upgrades dependencies, continues to work fine for me.  Pursued this while tracking down what in #3040 broke qunit tests (another PR forthcoming for that).
