### PR TITLE
Fix misleading message when workflow submitted

### DIFF
--- a/templates/webapps/galaxy/workflow/run_complete.mako
+++ b/templates/webapps/galaxy/workflow/run_complete.mako
@@ -3,7 +3,7 @@
 
 <div class="donemessagelarge">
 %if scheduled:
-    Successfully ran workflow "${util.unicodify( workflow.name )}". The following datasets have been added to the queue:
+    Successfully submitted workflow "${util.unicodify( workflow.name )}". The following datasets have been added to the queue:
     %for invocation in invocations:
         <div class="workflow-invocation-complete">
             %if invocation['new_history']:


### PR DESCRIPTION
At this point the workflow has been processed, and jobs submitted to Galaxy (and the cluster). Those jobs have yet to run, and may fail. The workflow has NOT yet been run, meaning the current green message is misleadingly optimistic.
