### PR TITLE
Include filenames in loc file DEBUG lines

### DIFF
--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -83,9 +83,9 @@ class ToolDataTableManager( object ):
                 table_elems.append( table_elem )
                 if table.name not in self.data_tables:
                     self.data_tables[ table.name ] = table
-                    log.debug( "Loaded tool data table '%s'", table.name )
+                    log.debug( "Loaded tool data table '%s' from file '%s'", table.name, filename )
                 else:
-                    log.debug( "Loading another instance of data table '%s', attempting to merge content.", table.name )
+                    log.debug( "Loading another instance of data table '%s' from file '%s', attempting to merge content.", table.name, filename )
                     self.data_tables[ table.name ].merge_tool_data_table( table, allow_duplicates=False )  # only merge content, do not persist to disk, do not allow duplicate rows when merging
                     # FIXME: This does not account for an entry with the same unique build ID, but a different path.
         return table_elems


### PR DESCRIPTION
This will help debugging where multiple (possibly conflicting) `*.loc` files come from, e.g.

```
$ grep blastdb paster.log
...
galaxy.tools.data DEBUG 2016-10-25 18:34:50,841 Loaded tool data table 'blastdb_p'
galaxy.tools.data DEBUG 2016-10-25 18:34:51,356 Loaded tool data table 'blastdb'
galaxy.tools.data DEBUG 2016-10-25 18:34:51,359 Loading another instance of data table 'blastdb_p', attempting to merge content.
galaxy.tools.data DEBUG 2016-10-25 18:34:51,375 Loaded tool data table 'blastdb_d'
...
```

Evidently I may have at least two copies of `blastdb_p.loc`, but where are they?

With the patch:

```
$ grep blastdb paster.log
...
galaxy.tools.data DEBUG 2016-10-25 18:43:48,947 Loaded tool data table 'blastdb_p' from file './config/tool_data_table_conf.xml.sample'
galaxy.tools.data DEBUG 2016-10-25 18:43:49,729 Loaded tool data table 'blastdb' from file './config/shed_tool_data_table_conf.xml'
galaxy.tools.data DEBUG 2016-10-25 18:43:49,733 Loading another instance of data table 'blastdb_p' from file './config/shed_tool_data_table_conf.xml', attempting to merge content.
galaxy.tools.data DEBUG 2016-10-25 18:43:49,736 Loaded tool data table 'blastdb_d' from file './config/shed_tool_data_table_conf.xml'
...
```

I am now puzzled about why `blastdb_p` gets loaded twice from the XML:

```
$ grep blastdb config/shed_tool_data_table_conf.xml
<table comment_char="#" name="blastdb">
        <file path="/mnt/shared/galaxy/galaxy-dist/tool-data/toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/7f3c448e119b/blastdb.loc" />
<table comment_char="#" name="blastdb_p">
        <file path="/mnt/shared/galaxy/galaxy-dist/tool-data/toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/7f3c448e119b/blastdb_p.loc" />
<table comment_char="#" name="blastdb_d">
        <file path="/mnt/shared/galaxy/galaxy-dist/tool-data/toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/7f3c448e119b/blastdb_d.loc" />
```
