### PR TITLE
Avoid pointless lambda function

### DIFF
--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -448,7 +448,7 @@ class TabularToolDataTable( ToolDataTable, Dictifiable ):
 
         TODO: Allow named access to fields using the column names.
         """
-        separator_char = (lambda c: '<TAB>' if c == '\t' else c)(self.separator)
+        separator_char = "<TAB>" if self.separator == "\t" else self.separator
 
         rval = []
         for i, line in enumerate( reader ):


### PR DESCRIPTION
The lambda function used a ternary if/else anyway, just do this directly - its shorter and clearer.
