### PR TITLE
Fix BLAST database *.loc files inconsistency

### DIFF
--- a/config/tool_data_table_conf.xml.sample
+++ b/config/tool_data_table_conf.xml.sample
@@ -10,11 +10,6 @@
         <columns>value, dbkey, formats, name, path</columns>
         <file path="tool-data/bfast_indexes.loc" />
     </table>
-    <!-- Locations of protein (mega)blast databases -->
-    <table name="blastdb_p" comment_char="#" allow_duplicate_entries="False">
-        <columns>value, name, path</columns>
-        <file path="tool-data/blastdb_p.loc" />
-    </table>
     <!-- Locations of indexes in the BWA mapper format -->
     <table name="bwa_indexes" comment_char="#" allow_duplicate_entries="False">
         <columns>value, dbkey, name, path</columns>


### PR DESCRIPTION
We should have all of the `blast*.loc` files in the sample configuration, or none of them.

Historically Galaxy included only the nucleotide BLAST database `blastdb.loc` file for use with mega-blast, with `blastdb_p.loc` later for protein databases added as part of the BLAST+ suite (which initially was in the main Galaxy repository).

The BLAST+ tools were moved to the Tool Shed in August 2012, later in a3018feb028658fc3a7071803b7b49cb575e7358 the mega-blast tool was also moved to the Tool Shed, and the `blastdb.loc` entry removed. `tool-data/blastdb_p.loc.sample` was removed in f77324d3a33439b617f4ed8fe5932da2972e0687, but the `blastdb_p.loc` entry still remains.

Later (on the Tool Shed only) `blastdb_d.loc`was added for protein domain databases.
