### PR TITLE
Log loading of resources from *.loc files

### DIFF
--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -465,6 +465,8 @@ class TabularToolDataTable( ToolDataTable, Dictifiable ):
                     if errors is not None:
                         errors.append( line_error )
                     log.warning( line_error )
+        if hasattr(reader, "name"):
+            log.debug("Loaded %i lines from '%s' for '%s'", len(rval), reader.name, self.name)
         return rval
 
     def get_column_name_list( self ):


### PR DESCRIPTION
Example output:

```
$ grep "lines from" paster.log
galaxy.tools.data INFO 2016-10-26 10:24:22,742 Loaded 0 lines from 'tool-data/all_fasta.loc' for 'all_fasta'
galaxy.tools.data INFO 2016-10-26 10:24:22,753 Loaded 0 lines from 'tool-data/bfast_indexes.loc' for 'bfast_indexes'
galaxy.tools.data INFO 2016-10-26 10:24:22,848 Loaded 24 lines from 'tool-data/blastdb_p.loc' for 'blastdb_p'
galaxy.tools.data INFO 2016-10-26 10:24:22,859 Loaded 0 lines from 'tool-data/maf_index.loc' for 'indexed_maf_files'
galaxy.tools.data INFO 2016-10-26 10:24:22,865 Loaded 0 lines from 'tool-data/ngs_sim_fasta.loc' for 'ngs_sim_fasta'
galaxy.tools.data INFO 2016-10-26 10:24:22,878 Loaded 0 lines from 'tool-data/perm_base_index.loc' for 'perm_base_indexes'
galaxy.tools.data INFO 2016-10-26 10:24:22,890 Loaded 0 lines from 'tool-data/perm_color_index.loc' for 'perm_color_indexes'
galaxy.tools.data INFO 2016-10-26 10:24:22,895 Loaded 0 lines from 'tool-data/picard_index.loc' for 'picard_indexes'
galaxy.tools.data INFO 2016-10-26 10:24:22,899 Loaded 0 lines from 'tool-data/picard_index.loc' for 'srma_indexes'
galaxy.tools.data INFO 2016-10-26 10:24:22,937 Loaded 0 lines from 'tool-data/mosaik_index.loc' for 'mosaik_indexes'
galaxy.tools.data INFO 2016-10-26 10:24:22,943 Loaded 0 lines from 'tool-data/twobit.loc' for 'twobit'
...
galaxy.tools.data INFO 2016-10-26 10:24:24,036 Loaded 0 lines from '/mnt/shared/galaxy/galaxy-dist/tool-data/toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/7f3c448e119b/blastdb.loc' for 'blastdb'
galaxy.tools.data INFO 2016-10-26 10:24:24,106 Loaded 0 lines from '/mnt/shared/galaxy/galaxy-dist/tool-data/toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/7f3c448e119b/blastdb_p.loc' for 'blastdb_p'
galaxy.tools.data INFO 2016-10-26 10:24:24,112 Loaded 0 lines from '/mnt/shared/galaxy/galaxy-dist/tool-data/toolshed.g2.bx.psu.edu/repos/devteam/ncbi_blast_plus/7f3c448e119b/blastdb_d.loc' for 'blastdb_d'
```

I'm happy to make this a DEBUG log entry, rather than info level as implemented.

The reason for logging this is to help Galaxy administrators struggling with `*.loc` files failing to take effect - in my case `tool-data/blastdb_p.loc` is loading but `tool-data/blastdb.loc` and `tool-data/blastdb_d.loc` appear to be ignored, see also #3095 and #3098
