### PR TITLE
Add download_to_file function to galaxy.util

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -38,6 +38,7 @@ from six.moves.urllib import (
     parse as urlparse,
     request as urlrequest
 )
+from six.moves.urllib.request import urlopen
 
 try:
     import docutils.core as docutils_core
@@ -1479,6 +1480,17 @@ def url_get( base_url, password_mgr=None, pathspec=None, params=None ):
     content = response.read()
     response.close()
     return content
+
+
+def download_to_file(url, dest_file_path, timeout=30, chunk_size=2 ** 20):
+    """Download a URL to a file in chunks."""
+    src = urlopen(url, timeout=timeout)
+    with open(dest_file_path, 'wb') as f:
+        while True:
+            chunk = src.read(chunk_size)
+            if not chunk:
+                break
+            f.write(chunk)
 
 
 def safe_relpath(path):

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -17,12 +17,11 @@ import nose.config
 import nose.core
 import nose.loader
 import nose.plugins.manager
-import requests
 from paste import httpserver
 
 from functional import database_contexts
 from galaxy.app import UniverseApplication as GalaxyUniverseApplication
-from galaxy.util import asbool
+from galaxy.util import asbool, download_to_file
 from galaxy.util.properties import load_app_properties
 from galaxy.web import buildapp
 from galaxy.webapps.tool_shed.app import UniverseApplication as ToolshedUniverseApplication
@@ -254,9 +253,7 @@ def copy_database_template( source, db_path ):
         shutil.copy(source, db_path)
         assert os.path.exists(db_path)
     elif source.lower().startswith(("http://", "https://", "ftp://")):
-        r = requests.get(source)
-        with open(db_path, 'w') as f:
-            f.write(r.content)
+        download_to_file(source, db_path)
     else:
         raise Exception( "Failed to copy database template from source %s" % source )
 


### PR DESCRIPTION
Use it in 2 places:
- `test/base/driver_util.py` (thus adding timeout and chunking)
- `lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py` where the total download timeout is substituted with the usual `urllib` timeout.

I've used `urllib2.urlopen` because the TS tests use `file://` URI which are not supported by  `requests`.

Follow-up on #3013, ping @mvdbeek.
