### PR TITLE
Add cached dependency manager

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -219,11 +219,10 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 
 # Certain dependency resolvers (namely Conda) take a considerable amount of
 # time to build an isolated job environment in the job_working_directory if the
-# job working diretory is on a network share.  Set the following option to True
+# job working directory is on a network share.  Set the following option to True
 # to cache the dependencies in a folder. This option is beta and should only be
 # used if you experience long waiting times before a job is actually submitted
-# to your cluster. If you activate this option and install or remove dependencies,
-# you may need to clear out old cached environments
+# to your cluster.
 #use_cached_dependency_manager = False
 
 # By default the tool_dependency_cache_dir is the _cache directory

--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -217,18 +217,18 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # of extra disk space usage and extra time spent copying packages.
 #conda_copy_dependencies = False
 
-# Certain dependency resolvers (namely conda) take a considerable amount of
-# time to build an isolated job environment in the job_working_directory.  Set
-# the following option to true to cache the dependencies in a folder. This
-# option is beta and should only be used if you experience long waiting times
-# before a job is actually submitted to your cluster. If you activate this
-# option, and you install new dependencies you may need to clear out old cached
-# environments
+# Certain dependency resolvers (namely Conda) take a considerable amount of
+# time to build an isolated job environment in the job_working_directory if the
+# job working diretory is on a network share.  Set the following option to True
+# to cache the dependencies in a folder. This option is beta and should only be
+# used if you experience long waiting times before a job is actually submitted
+# to your cluster. If you activate this option and install or remove dependencies,
+# you may need to clear out old cached environments
 #use_cached_dependency_manager = False
 
 # By default the tool_dependency_cache_dir is the _cache directory
 # of the tool dependency directory
-#tool_dependency_cache_dir = tool_dependency_dir/_cache
+#tool_dependency_cache_dir = <tool_dependency_dir>/_cache
 
 # File containing the Galaxy Tool Sheds that should be made available to
 # install from in the admin interface (.sample used if default does not exist).

--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -217,6 +217,19 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # of extra disk space usage and extra time spent copying packages.
 #conda_copy_dependencies = False
 
+# Certain dependency resolvers (namely conda) take a considerable amount of
+# time to build an isolated job environment in the job_working_directory.  Set
+# the following option to true to cache the dependencies in a folder. This
+# option is beta and should only be used if you experience long waiting times
+# before a job is actually submitted to your cluster. If you activate this
+# option, and you install new dependencies you may need to clear out old cached
+# environments
+#use_cached_dependency_manager = False
+
+# By default the tool_dependency_cache_dir is the _cache directory
+# of the tool dependency directory
+#tool_dependency_cache_dir = tool_dependency_dir/_cache
+
 # File containing the Galaxy Tool Sheds that should be made available to
 # install from in the admin interface (.sample used if default does not exist).
 #tool_sheds_config_file = config/tool_sheds_conf.xml

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -325,6 +325,8 @@ class Configuration( object ):
         else:
             self.tool_dependency_dir = None
             self.use_tool_dependencies = os.path.exists(self.dependency_resolvers_config_file)
+        self.use_cached_dependency_manager = string_as_bool(kwargs.get("use_cached_dependency_manager", 'False'))
+        self.tool_dependency_cache_dir = kwargs.get( 'tool_dependency_cache_dir', os.path.join(self.tool_dependency_dir, '_cache'))
 
         self.enable_beta_mulled_containers = string_as_bool( kwargs.get( 'enable_beta_mulled_containers', 'False' ) )
         containers_resolvers_config_file = kwargs.get( 'containers_resolvers_config_file', None )

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1306,16 +1306,17 @@ class Tool( object, Dictifiable ):
         return messages
 
     def build_dependency_shell_commands( self, job_directory=None, metadata=False ):
-        """Return a list of commands to be run to populate the current environment to include this tools requirements."""
-        requirements_to_dependencies = self.app.toolbox.dependency_manager.requirements_to_dependencies(
-            self.requirements,
+        """
+        Return a list of commands to be run to populate the current environment to include this tools requirements.
+        """
+        return self.app.toolbox.dependency_manager.dependency_shell_commands(
+            requirements=self.requirements,
             installed_tool_dependencies=self.installed_tool_dependencies,
             tool_dir=self.tool_dir,
             job_directory=job_directory,
             metadata=metadata,
+            tool_instance=self
         )
-        self.dependencies = [dep.to_dict() for dep in requirements_to_dependencies.values()]
-        return [dep.shell_commands(req) for req, dep in requirements_to_dependencies.items()]
 
     @property
     def installed_tool_dependencies(self):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -34,6 +34,7 @@ from galaxy.tools.actions.data_source import DataSourceToolAction
 from galaxy.tools.actions.data_manager import DataManagerToolAction
 from galaxy.tools.actions.model_operations import ModelOperationToolAction
 from galaxy.tools.deps import views
+from galaxy.tools.deps import CachedDependencyManager
 from galaxy.tools.parameters import params_to_incoming, check_param, params_from_strings, params_to_strings, visit_input_values
 from galaxy.tools.parameters import output_collect
 from galaxy.tools.parameters.basic import (BaseURLToolParameter,
@@ -1304,6 +1305,17 @@ class Tool( object, Dictifiable ):
 
         visit_input_values( self.inputs, values, validate_inputs )
         return messages
+
+    def build_dependency_cache(self):
+        if isinstance(self.app.toolbox.dependency_manager, CachedDependencyManager):
+            self.app.toolbox.dependency_manager.build_cache(
+                requirements=self.requirements,
+                installed_tool_dependencies=self.installed_tool_dependencies,
+                tool_dir=self.tool_dir,
+                job_directory=None,
+                metadata=False,
+                tool_instance=self
+            )
 
     def build_dependency_shell_commands( self, job_directory=None, metadata=False ):
         """

--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -54,7 +54,7 @@ class CondaContext(installable.InstallableContext):
 
     def __init__(self, conda_prefix=None, conda_exec=None,
                  shell_exec=None, debug=False, ensure_channels='',
-                 condarc_override=None, use_path_exec=USE_PATH_EXEC_DEFAULT):
+                 condarc_override=None, use_path_exec=USE_PATH_EXEC_DEFAULT, copy_dependencies=False):
         self.condarc_override = condarc_override
         if not conda_exec and use_path_exec:
             conda_exec = commands.which("conda")
@@ -63,6 +63,7 @@ class CondaContext(installable.InstallableContext):
         self.conda_exec = conda_exec
         self.debug = debug
         self.shell_exec = shell_exec or commands.shell
+        self.copy_dependencies = copy_dependencies
 
         if conda_prefix is None:
             info = self.conda_info()

--- a/lib/galaxy/tools/deps/requirements.py
+++ b/lib/galaxy/tools/deps/requirements.py
@@ -25,6 +25,9 @@ class ToolRequirement( object ):
         type = dict.get("type", None)
         return ToolRequirement( name=name, type=type, version=version )
 
+    def __eq__(self, other):
+        return self.name == other.name and self.type == other.type and self.version == other.version
+
 
 DEFAULT_CONTAINER_TYPE = "docker"
 DEFAULT_CONTAINER_RESOLVE_DEPENDENCIES = False

--- a/lib/galaxy/tools/deps/resolvers/__init__.py
+++ b/lib/galaxy/tools/deps/resolvers/__init__.py
@@ -122,3 +122,7 @@ class NullDependency( Dependency ):
 
     def shell_commands( self, requirement ):
         return None
+
+
+class DependencyException(Exception):
+    pass

--- a/lib/galaxy/tools/deps/resolvers/__init__.py
+++ b/lib/galaxy/tools/deps/resolvers/__init__.py
@@ -81,8 +81,9 @@ class InstallableDependencyResolver:
 
 
 class Dependency(Dictifiable, object):
-    dict_collection_visible_keys = ['dependency_type', 'exact', 'name', 'version']
+    dict_collection_visible_keys = ['dependency_type', 'exact', 'name', 'version', 'cacheable']
     __metaclass__ = ABCMeta
+    cacheable = False
 
     @abstractmethod
     def shell_commands( self, requirement ):

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -67,6 +67,7 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
                 dependency_manager.default_base_path, DEFAULT_CONDARC_OVERRIDE
             )
 
+        copy_dependencies = _string_as_bool(get_option("copy_dependencies"))
         conda_exec = get_option("exec")
         debug = _string_as_bool(get_option("debug"))
         ensure_channels = get_option("ensure_channels")
@@ -85,7 +86,7 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
             ensure_channels=ensure_channels,
             condarc_override=condarc_override,
             use_path_exec=use_path_exec,
-            copy_dependencies=_string_as_bool(get_option("copy_dependencies"))
+            copy_dependencies=copy_dependencies
         )
         self.ensure_channels = ensure_channels
 

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -136,11 +136,15 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
 
         # Have installed conda_target and job_directory to send it to.
         # If dependency is for metadata generation, store environment in conda-metadata-env
-        if kwds.get("metadata", False):
-            conda_env = "conda-metadata-env"
+
+        if kwds.get('conda_env', False):
+            conda_environment = kwds.get('conda_env')
         else:
-            conda_env = "conda-env"
-        conda_environment = os.path.join(job_directory, conda_env)
+            if kwds.get("metadata", False):
+                conda_env = "conda-metadata-env"
+            else:
+                conda_env = "conda-env"
+            conda_environment = os.path.join(job_directory, conda_env)
         env_path, exit_code = build_isolated_environment(
             conda_target,
             path=conda_environment,

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -907,9 +907,11 @@ class InstallRepositoryManager( object ):
                 if install_resolver_dependencies:
                     requirements = suc.get_unique_requirements_from_repository(tool_shed_repository)
                     [self._view.install_dependency(id=None, **req) for req in requirements]
+                    cached_requirements = []
                     for tool_d in metadata['tools']:
                         tool = self.app.toolbox._tools_by_id.get(tool_d['guid'], None)
-                        if tool:
+                        if tool and tool.requirements not in cached_requirements:
+                            cached_requirements.append(tool.requirements)
                             tool.build_dependency_cache()
                 # Get the tool_versions from the tool shed for each tool in the installed change set.
                 self.update_tool_shed_repository_status( tool_shed_repository,

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -904,6 +904,13 @@ class InstallRepositoryManager( object ):
             self.install_model.context.refresh( tool_shed_repository )
             metadata = tool_shed_repository.metadata
             if 'tools' in metadata:
+                if install_resolver_dependencies:
+                    requirements = suc.get_unique_requirements_from_repository(tool_shed_repository)
+                    [self._view.install_dependency(id=None, **req) for req in requirements]
+                    for tool_d in metadata['tools']:
+                        tool = self.app.toolbox._tools_by_id.get(tool_d['guid'], None)
+                        if tool:
+                            tool.build_dependency_cache()
                 # Get the tool_versions from the tool shed for each tool in the installed change set.
                 self.update_tool_shed_repository_status( tool_shed_repository,
                                                          self.install_model.ToolShedRepository.installation_status.SETTING_TOOL_VERSIONS )
@@ -913,9 +920,6 @@ class InstallRepositoryManager( object ):
                     error_message += "Version information for the tools included in the <b>%s</b> repository is missing.  " % tool_shed_repository.name
                     error_message += "Reset all of this repository's metadata in the tool shed, then set the installed tool versions "
                     error_message += "from the installed repository's <b>Repository Actions</b> menu.  "
-                if install_resolver_dependencies:
-                    requirements = suc.get_unique_requirements_from_repository(tool_shed_repository)
-                    [self._view.install_dependency(id=None, **req) for req in requirements]
             if install_tool_dependencies and tool_shed_repository.tool_dependencies and 'tool_dependencies' in metadata:
                 work_dir = tempfile.mkdtemp( prefix="tmp-toolshed-itsr" )
                 # Install tool dependencies.


### PR DESCRIPTION
Similar to https://github.com/galaxyproject/galaxy/pull/2986, implements a mechanism that allows tool dependencies to be cached.

If the `use_cached_dependency_manager` option is set to True in `galaxy.ini`, we build a hash of the combination of a tools' requirements, and store the resulting environment in a directory specified by the
`tool_dependency_cache_dir` option in `galaxy.ini`.

The approach here is only caching (combinations of) conda dependencies when installing new tools through the ToolShed.
When a dependency combination is not yet cached, `conda create` will be invoked with `tool_dependency_cache_dir/<hash>` folder, and otherwise  `conda install` with `tool_dependency_cache_dir/<hash>`.

If a `__name@version` dependency exists, but not a cached environment at job runtime, that environment will be used. So to benefit from cached environments for already installed tools, those cached environment need to be created. Currently this can only be done by (re-)installing tools.

ping @abretaud @jmchilton 
