### PR TITLE
[16.04] Fix path in run_tool_shed.sh

### DIFF
--- a/run_tool_shed.sh
+++ b/run_tool_shed.sh
@@ -23,7 +23,7 @@ tool_shed=`./scripts/tool_shed/bootstrap_tool_shed/parse_run_sh_args.sh $@`
 args=$@
 
 if [ $? -eq 0 ] ; then
-	bash ./scripts/tool_shed/bootstrap_tool_shed/parse_run_sh_args.sh $@
+	bash ./scripts/tool_shed/bootstrap_tool_shed/bootstrap_tool_shed.sh $@
 	args=`echo $@ | sed "s#-\?-bootstrap_from_tool_shed $tool_shed##"`
 fi
 


### PR DESCRIPTION
Broken in #2131.

Reported by @dnbenso at https://github.com/galaxyproject/galaxy/commit/f2bd242a2c28954215fb84d289d19e35a6460c65#commitcomment-19642191

Ping @nturaga @martenson 