### PR TITLE
[16.07] Fix loading of collection operations

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -67,7 +67,7 @@ import galaxy.jobs
 log = logging.getLogger( __name__ )
 
 HELP_UNINITIALIZED = threading.Lock()
-MODEL_TOOLS_PATH = os.path.dirname(__file__)
+MODEL_TOOLS_PATH = os.path.abspath(os.path.dirname(__file__))
 
 
 class ToolErrorLog:

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -615,7 +615,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
             if labels is not None:
                 tool.labels = labels
         except IOError:
-            log.error( "Error reading tool configuration file from path: %s." % path )
+            log.error( "Error reading tool configuration file from path: %s" % path )
         except Exception:
             log.exception( "Error reading tool from path: %s" % path )
 


### PR DESCRIPTION
If `MODEL_TOOLS_PATH` is not absolute, it will be joined with `tool_path` (i.e. './tools' ) inside `_load_tool_tag_set()`, so Galaxy will try to load e.g. './tools/lib/galaxy/tools/unzip_collection.xml'

Ping @jmchilton 