### PR TITLE
Escape section name when writing to xml

### DIFF
--- a/lib/galaxy/tools/toolbox/integrated_panel.py
+++ b/lib/galaxy/tools/toolbox/integrated_panel.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import time
 import traceback
+from xml.sax.saxutils import escape
 
 from .panel import ToolPanelElements
 from .panel import panel_item_types
@@ -78,7 +79,7 @@ class ManagesIntegratedToolPanelMixin:
                     section_id = item.id or ''
                     section_name = item.name or ''
                     section_version = item.version or ''
-                    os.write( fd, '    <section id="%s" name="%s" version="%s">\n' % ( section_id, section_name, section_version ) )
+                    os.write( fd, '    <section id="%s" name="%s" version="%s">\n' % ( escape(section_id), escape(section_name), section_version ) )
                     for section_key, section_item_type, section_item in item.panel_items_iter():
                         if section_item_type == panel_item_types.TOOL:
                             if section_item:


### PR DESCRIPTION
unescape when building ToolSection.
Should hopefully fix #3084 and the problem Miuki reported on the Mailing List.

This allows to have "beautiful" section like that:
![screenshot from 2016-11-03 16-57-31](https://cloud.githubusercontent.com/assets/6804901/19974279/34782cfa-a1e8-11e6-8817-7e356a44354c.png)

Ping @peterjc @nsoranzo
