### PR TITLE
Fix tools placed outside of panel section

### DIFF
--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -40,6 +40,15 @@ def send_control_task(app, task, noop_self=False, kwargs={}):
 # just an example method.  Ideally this gets pushed into atomic tasks, whether
 # where they're currently invoked, or elsewhere.  (potentially using a dispatch
 # decorator).
+
+def create_panel_section(app, **kwargs):
+    """
+    Updates in memory toolbox dictionary.
+    """
+    log.debug("Updating in-memory tool panel")
+    app.toolbox.create_section(kwargs)
+
+
 def reload_tool(app, **kwargs):
     params = util.Params(kwargs)
     tool_id = params.get('tool_id', None)
@@ -117,7 +126,8 @@ def admin_job_lock(app, **kwargs):
     log.info("Administrative Job Lock is now set to %s. Jobs will %s dispatch."
              % (job_lock, "not" if job_lock else "now"))
 
-control_message_to_task = { 'reload_tool': reload_tool,
+control_message_to_task = { 'create_panel_section': create_panel_section,
+                            'reload_tool': reload_tool,
                             'reload_toolbox': reload_toolbox,
                             'reload_data_managers': reload_data_managers,
                             'reload_display_application': reload_display_application,

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -95,6 +95,13 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
         interacting with the rest of the Galaxy app or message queues, etc....
         """
 
+    def handle_panel_update(self, section_dict):
+        """Extension-point for Galaxy-app specific reload logic.
+
+        This abstract representation of the toolbox shouldn't have details about
+        interacting with the rest of the Galaxy app or message queues, etc....
+        """
+
     def create_tool( self, config_file, repository_id=None, guid=None, **kwds ):
         raise NotImplementedError()
 
@@ -236,13 +243,18 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
                 'id': section_id,
                 'version': '',
             }
-            tool_section = ToolSection( section_dict )
-            self._tool_panel.append_section( tool_panel_section_key, tool_section )
-            log.debug( "Loading new tool panel section: %s" % str( tool_section.name ) )
+            self.handle_panel_update(section_dict)
+            tool_section = self._tool_panel[ tool_panel_section_key ]
             self._save_integrated_tool_panel()
         else:
             tool_section = None
         return tool_panel_section_key, tool_section
+
+    def create_section(self, section_dict):
+        tool_section = ToolSection(section_dict)
+        self._tool_panel.append_section(tool_section.id, tool_section)
+        log.debug("Loading new tool panel section: %s" % str(tool_section.name))
+        return tool_section
 
     def get_integrated_section_for_tool( self, tool ):
         tool_id = tool.id

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -443,6 +443,9 @@ class SimplifiedToolBox( ToolBox ):
         )
         self._tool_conf_watcher = get_tool_conf_watcher(dummy_callback)
 
+    def handle_panel_update(self, section_dict):
+        self.create_section(section_dict)
+
 
 def dummy_callback():
     pass


### PR DESCRIPTION
Occasionally tools were being installed outside of the selected too panel
section. In the log one would find contradicting messages such as
```

tool_shed.util.repository_util DEBUG 2016-11-04 11:06:17,854 Adding new row for repository 'sra_tools' in the tool_shed_repository table, status set to 'New'.
galaxy.tools.toolbox.base DEBUG 2016-11-04 11:06:17,886 Appending to tool panel section: NCBI SRA Tools
172.17.0.1 - - [04/Nov/2016:11:06:15 +0000] "POST
/admin_toolshed/prepare_for_install HTTP/1.1" 200 -
"http://localhost/admin_toolshed/prepare_for_install?changeset_revisions=62e4d56ebb6f&repository_ids=cb2d31dfab58ee88&tool_shed_url=https%3A%2F%2Ftoolshed.g2.bx.psu.edu%2F"
"
Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)
Chrome/54.0.2840.71 Safari/537.36
nvalid tool_panel_section_key "ncbi_sra_tools" specified.  Tools will be
loaded outside of sections in the tool panel.
```
The intermittent POST is picked up by a different thread, that didn't
have its toolbox updated with the new section.
To circumvent this, we send the `create_panel_section` task to all
threads.