### PR TITLE
[16.07] Remove verbose_install_check option

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -202,8 +202,6 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # Set to True to instruct Galaxy to look for and install missing tool
 # dependencies before each job runs.
 #conda_auto_install = False
-# Set to True to perform additional checking of installed Conda environment
-#conda_verbose_install_check=False
 # Set to True to instruct Galaxy to install Conda from the web automatically
 # if it cannot find a local copy and conda_exec is not configured.
 #conda_auto_init = False

--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -359,34 +359,20 @@ def is_target_available(conda_target, conda_context=None):
         return False
 
 
-def is_conda_target_installed(conda_target, conda_context=None, verbose_install_check=False):
+def is_conda_target_installed(conda_target, conda_context=None):
     conda_context = _ensure_conda_context(conda_context)
     # fail by default
-    success = False
     if conda_context.has_env(conda_target.install_environment):
-        if not verbose_install_check:
-            return True
-        # because export_list directs output to a file we
-        # need to make a temporary file, not use StringIO
-        f, package_list_file = tempfile.mkstemp(suffix='.env_packages')
-        os.close(f)
-        conda_context.export_list(conda_target.install_environment, package_list_file)
-        search_pattern = conda_target.package_specifier + '='
-        with open(package_list_file) as input_file:
-            for line in input_file:
-                if line.startswith(search_pattern):
-                    success = True
-                    break
-        os.remove(package_list_file)
-    return success
+        return True
+    else:
+        return False
 
 
-def filter_installed_targets(conda_targets, conda_context=None, verbose_install_check=False):
+def filter_installed_targets(conda_targets, conda_context=None):
     conda_context = _ensure_conda_context(conda_context)
     installed = functools.partial(is_conda_target_installed,
-                                  conda_context=conda_context,
-                                  verbose_install_check=verbose_install_check)
-    return filter(installed, conda_targets)
+                                  conda_context=conda_context)
+    return list(filter(installed, conda_targets))
 
 
 def build_isolated_environment(

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -71,7 +71,6 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
 
         conda_exec = get_option("exec")
         debug = _string_as_bool(get_option("debug"))
-        verbose_install_check = _string_as_bool(get_option("verbose_install_check"))
         ensure_channels = get_option("ensure_channels")
         use_path_exec = get_option("use_path_exec")
         if use_path_exec is None:
@@ -99,7 +98,6 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
         self.ensure_conda_installed()
         self.auto_install = auto_install
         self.copy_dependencies = copy_dependencies
-        self.verbose_install_check = verbose_install_check
 
     def ensure_conda_installed(self):
         """
@@ -149,7 +147,7 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
 
         conda_target = CondaTarget(name, version=version)
         is_installed = is_conda_target_installed(
-            conda_target, conda_context=self.conda_context, verbose_install_check=self.verbose_install_check
+            conda_target, conda_context=self.conda_context
         )
 
         job_directory = kwds.get("job_directory", None)
@@ -220,7 +218,7 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
         conda_target = CondaTarget(name, version=version)
 
         is_installed = is_conda_target_installed(
-            conda_target, conda_context=self.conda_context, verbose_install_check=self.verbose_install_check
+            conda_target, conda_context=self.conda_context
         )
 
         if is_installed:
@@ -232,7 +230,7 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
         else:
             # Recheck if installed
             is_installed = is_conda_target_installed(
-                conda_target, conda_context=self.conda_context, verbose_install_check=self.verbose_install_check
+                conda_target, conda_context=self.conda_context
             )
         if not is_installed:
             log.debug("Removing failed conda install of {}, version '{}'".format(name, version))


### PR DESCRIPTION
This option was introduced with #2554 and #2538, in reponse to a false
positive conda install.  This would have been caught by simply checking
the exit code, which we are doing by default now. The additional
verification is too stringent and not in line with the conda resolver.
Activating this option will report perfectly well installed conda
environments as having failed and will cause them to be uninstalled.