### PR TITLE
Extended the linter rules to accept a help attribute for sections

### DIFF
--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -1903,7 +1903,11 @@ Further examples can be found in the [test case](https://github.com/galaxyprojec
         <xs:documentation xml:lang="en">Whether the section should be expanded by default or not. If not, the default set values are used.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="help" type="xs:string" />
+    <xs:attribute name="help" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Short help description for section, rendered just below the section.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="Param">

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -1903,6 +1903,7 @@ Further examples can be found in the [test case](https://github.com/galaxyprojec
         <xs:documentation xml:lang="en">Whether the section should be expanded by default or not. If not, the default set values are used.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="help" type="xs:string" />
   </xs:complexType>
 
   <xs:complexType name="Param">


### PR DESCRIPTION
Planemos linter raises an error if the "section"-tag is having a "help"-attribute. I added one line to the linter rules and now the "help"-attribute is accepted. 