### PR TITLE
Update galaxy.xsd

### DIFF
--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -486,6 +486,11 @@ def get_field_components_options( dataset, field_name ):
     <xs:annotation>
       <xs:documentation xml:lang="en"></xs:documentation>
     </xs:annotation>
+    <xs:attribute name="type" type="TracksterActionType" use="required">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Type of action (at least ``set_param`` currently).</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="name" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en"></xs:documentation>
@@ -5114,6 +5119,14 @@ and ``contains``.</xs:documentation>
       <xs:enumeration value="False"/>
       <xs:enumeration value="yes"/>
       <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TracksterActionType">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Documentation for TracksterActionType</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="set_param"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
Add `type` for `trackster_conf`.`action`

Context [cufflinks](https://github.com/galaxyproject/tools-devteam/blob/master/tool_collections/cufflinks/cufflinks/cufflinks_wrapper.xml#L188)
```xml
<trackster_conf>
        <action type="set_param" name="global_model" output_name="total_map_mass"/>
</trackster_conf>
```

```
Applying linter tool_xsd... FAIL
.. ERROR: Invalid tmpHdMIet found. Errors [/tmp/tmpHdMIet:190:0:ERROR:SCHEMASV:SCHEMAV_CVC_COMPLEX_TYPE_3_2_1: Element 'action', attribute 'type': The attribute 'type' is not allowed.]
```

I rather don't know anythink about this tag ... so I only add `set_param` in the `type` enumerate