### PR TITLE
Use sed instead of pandoc to insert TOC in schema doc

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -48,8 +48,10 @@ schema.md: parse_gx_xsd.py schema_template.md ../lib/galaxy/tools/xsd/galaxy.xsd
 	python parse_gx_xsd.py schema_template.md ../lib/galaxy/tools/xsd/galaxy.xsd > $@
 
 source/dev/schema.rst: schema.md ## Convert Galaxy Tool XSD Markdown docs into reStructuredText (expects pandoc in environment)
-	pandoc schema.md -f markdown_github-hard_line_breaks -s --toc --toc-depth=2 -o $@
+	pandoc schema.md -f markdown_github-hard_line_breaks -s -o $@
 	sed -i -e 's|.. code:: xml|.. code-block:: xml|g' $@
+	# Insert table of contents
+	sed -i -e '/^``tool``$$/i .. contents:: Table of contents\n   :local:\n   :depth: 1\n..\n' $@
 
 # might also want to do
 # cd source/lib; hg revert; rm *.rst.orig;  or not.


### PR DESCRIPTION
pandoc < 1.14 adds the TOC depth as a float, which is not recognised by Sphinx.
Also, move the TOC after the introduction, which looks nicer.