### PR TITLE
Prefer existing .venv over conda, when both are available.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -60,16 +60,6 @@ done
 
 ./scripts/common_startup.sh $common_startup_args || exit 1
 
-# If there is a .venv/ directory, assume it contains a virtualenv that we
-# should run this instance in.
-GALAXY_VIRTUAL_ENV="${GALAXY_VIRTUAL_ENV:-.venv}"
-if [ -d "$GALAXY_VIRTUAL_ENV" -a -z "$skip_venv" ];
-then
-    [ -n "$PYTHONPATH" ] && { echo 'Unsetting $PYTHONPATH'; unset PYTHONPATH; }
-    echo "Activating virtualenv at $GALAXY_VIRTUAL_ENV"
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
-fi
-
 # If you are using --skip-venv we assume you know what you are doing but warn
 # in case you don't.
 [ -n "$PYTHONPATH" ] && echo 'WARNING: $PYTHONPATH is set, this can cause problems importing Galaxy dependencies'

--- a/run.sh
+++ b/run.sh
@@ -60,6 +60,16 @@ done
 
 ./scripts/common_startup.sh $common_startup_args || exit 1
 
+# If there is a .venv/ directory, assume it contains a virtualenv that we
+# should run this instance in.
+GALAXY_VIRTUAL_ENV="${GALAXY_VIRTUAL_ENV:-.venv}"
+if [ -d "$GALAXY_VIRTUAL_ENV" -a -z "$skip_venv" ];
+then
+    [ -n "$PYTHONPATH" ] && { echo 'Unsetting $PYTHONPATH'; unset PYTHONPATH; }
+    echo "Activating virtualenv at $GALAXY_VIRTUAL_ENV"
+    . "$GALAXY_VIRTUAL_ENV/bin/activate"
+fi
+
 # If you are using --skip-venv we assume you know what you are doing but warn
 # in case you don't.
 [ -n "$PYTHONPATH" ] && echo 'WARNING: $PYTHONPATH is set, this can cause problems importing Galaxy dependencies'

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -74,36 +74,41 @@ fi
 
 : ${GALAXY_VIRTUAL_ENV:=.venv}
 
-if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 -a $CONDA_ALREADY_INSTALLED -eq 0]; then
-    # If .venv does not exist, and there is no conda available, attempt to create it.
+if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 ]; then
     if [ ! -d "$GALAXY_VIRTUAL_ENV" ]
     then
-        # Ensure Python is a supported version before creating .venv
-        python ./scripts/check_python.py || exit 1
-        if command -v virtualenv >/dev/null; then
-            virtualenv -p python2.7 "$GALAXY_VIRTUAL_ENV"
+        if [ $CONDA_ALREADY_INSTALLED -eq 1 ]; then
+            echo "There is no existing Galaxy virtualenv and Conda is available, so we are skipping virtualenv creation."
+            SET_VENV=0
         else
-            vvers=13.1.2
-            vurl="https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${vvers}.tar.gz"
-            vsha="aabc8ef18cddbd8a2a9c7f92bc43e2fea54b1147330d65db920ef3ce9812e3dc"
-            vtmp=$(mktemp -d -t galaxy-virtualenv-XXXXXX)
-            vsrc="$vtmp/$(basename $vurl)"
-            # SSL certificates are not checked to prevent problems with messed
-            # up client cert environments. We verify the download using a known
-            # good sha256 sum instead.
-            echo "Fetching $vurl"
-            if command -v curl >/dev/null; then
-                curl --insecure -L -o "$vsrc" "$vurl"
-            elif command -v wget >/dev/null; then
-                wget --no-check-certificate -O "$vsrc" "$vurl"
+            # If .venv does not exist, and there is no conda available, attempt to create it.
+            # Ensure Python is a supported version before creating .venv
+            python ./scripts/check_python.py || exit 1
+            if command -v virtualenv >/dev/null; then
+                virtualenv -p python2.7 "$GALAXY_VIRTUAL_ENV"
             else
-                python -c "import urllib; urllib.urlretrieve('$vurl', '$vsrc')"
+                vvers=13.1.2
+                vurl="https://pypi.python.org/packages/source/v/virtualenv/virtualenv-${vvers}.tar.gz"
+                vsha="aabc8ef18cddbd8a2a9c7f92bc43e2fea54b1147330d65db920ef3ce9812e3dc"
+                vtmp=$(mktemp -d -t galaxy-virtualenv-XXXXXX)
+                vsrc="$vtmp/$(basename $vurl)"
+                # SSL certificates are not checked to prevent problems with messed
+                # up client cert environments. We verify the download using a known
+                # good sha256 sum instead.
+                echo "Fetching $vurl"
+                if command -v curl >/dev/null; then
+                    curl --insecure -L -o "$vsrc" "$vurl"
+                elif command -v wget >/dev/null; then
+                    wget --no-check-certificate -O "$vsrc" "$vurl"
+                else
+                    python -c "import urllib; urllib.urlretrieve('$vurl', '$vsrc')"
+                fi
+                echo "Verifying $vsrc checksum is $vsha"
+                python -c "import hashlib; assert hashlib.sha256(open('$vsrc', 'rb').read()).hexdigest() == '$vsha', '$vsrc: invalid checksum'"
+                tar zxf "$vsrc" -C "$vtmp"
+                python "$vtmp/virtualenv-$vvers/virtualenv.py" "$GALAXY_VIRTUAL_ENV"
+                rm -rf "$vtmp"
             fi
-            echo "Verifying $vsrc checksum is $vsha"
-            python -c "import hashlib; assert hashlib.sha256(open('$vsrc', 'rb').read()).hexdigest() == '$vsha', '$vsrc: invalid checksum'"
-            tar zxf "$vsrc" -C "$vtmp"
-            python "$vtmp/virtualenv-$vvers/virtualenv.py" "$GALAXY_VIRTUAL_ENV"
-            rm -rf "$vtmp"
         fi
     fi
 fi

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -8,7 +8,6 @@ done
 
 # Conda Python is in use, do not use virtualenv
 if python -V 2>&1 | grep -q -e 'Anaconda' -e 'Continuum Analytics' ; then
-    SET_VENV=0
     CONDA_ALREADY_INSTALLED=1
 else
     CONDA_ALREADY_INSTALLED=0
@@ -75,8 +74,8 @@ fi
 
 : ${GALAXY_VIRTUAL_ENV:=.venv}
 
-if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 ]; then
-    # If .venv does not exist, attempt to create it.
+if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 -a $CONDA_ALREADY_INSTALLED -eq 0]; then
+    # If .venv does not exist, and there is no conda available, attempt to create it.
     if [ ! -d "$GALAXY_VIRTUAL_ENV" ]
     then
         # Ensure Python is a supported version before creating .venv


### PR DESCRIPTION
Prior to this change, if a local conda was available, Galaxy was skipping using its own .venv.  The order or priority should be local .venv, then conda if available, and lastly create a new .venv.