### PR TITLE
update rename dataset action to accept . in repeat input parameters

### DIFF
--- a/lib/galaxy/jobs/actions/post.py
+++ b/lib/galaxy/jobs/actions/post.py
@@ -124,13 +124,16 @@ class RenameDatasetAction(DefaultJobAction):
                 if len(tokens) > 1:
                     input_file_var = tokens[0].strip()
 
-                    # Treat . as special symbol (breaks parameter names anyway)
-                    # to allow access to repeat elements, for instance first
-                    # repeat in cat1 would be something like queries_0.input2.
-                    input_file_var = input_file_var.replace(".", "|")
-
                     for i in range(1, len(tokens)):
                         operations.append(tokens[i].strip())
+
+                # Treat . as special symbol (breaks parameter names anyway)
+                # to allow access to repeat elements, for instance first
+                # repeat in cat1 would be something like queries_0.input2.
+                # TODO: update the help text (input_terminals) on the action to
+                # show correct valid inputs.
+                input_file_var = input_file_var.replace(".", "|")
+
                 replacement = ""
                 #  Lookp through inputs find one with "to_be_replaced" input
                 #  variable name, and get the replacement name


### PR DESCRIPTION
This very minor update allows the "rename dataset action" to accept ``.`` in repeat input parameters, also when not using additional operations like '|basename'.

e.g. 
for "filter bam" 0.0.1: ``#{input_bams_0.input_bam}`` and ``#{input_bams_0.input_bam|basename}`` work.
And for "filter bam" 0.0.2: ``#{input_bams1}`` and ``#{input_bams2|basename}`` work.

This has only been tested tiny workflows and only seems to work on tools/workflow steps not generating collections. See all other open issues for that...
This might help the issue #2346 although that might be more about the proper help_text that lists the available input dataset variable names..
