### PR TITLE
Don't load tools from paths that start with `.` or `_`

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -714,6 +714,9 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
 
         tool_loaded = False
         for name in os.listdir( directory ):
+            if name.startswith('.' or '_'):
+                # Very unlikely that we want to load tools from a hidden or private folder
+                continue
             child_path = os.path.join(directory, name)
             if os.path.isdir(child_path) and recursive:
                 self.__watch_directory(child_path, elems, integrated_elems, load_panel_dict, recursive)


### PR DESCRIPTION
If planemo descends into `.venv` or `_conda` folders, startup can easily take 10-20 minutes.

Ran into this while developing a tool for which I also had a local .conda and .venv environment.