### PR TITLE
Fixes for core.galaxy_ui.yaml.

### DIFF
--- a/config/plugins/tours/core.galaxy_ui.yaml
+++ b/config/plugins/tours/core.galaxy_ui.yaml
@@ -38,8 +38,6 @@ steps:
       element: "button#btn-new"
       intro: "Copy and paste data directly into Galaxy or include URLs that lead to your data"
       position: "top"
-      preclick:
-        - ".upload-button"
 
     - title: "Insert URLs"
       element: ".upload-text-content:first"
@@ -97,7 +95,7 @@ steps:
       #backdrop: true
 
     - title: "Tool parameters"
-      element: '#uid-0'
+      element: '#center-panel .ui-portlet-limited'
       intro: "Here you can choose your tool parameters. Select your input dataset from your history and specify parameters for your analysis."
       position: "right"
 


### PR DESCRIPTION
Neither of these prevent the tour from working but I think they are bugs. The extra click isn't an elemment that is clickable at that point in the tour and the referenced id isn't available so nothing in particular is tagged in the UI at that point.