### PR TITLE
Fix for mapping tools with paired collection input and a structured_like tag over list:paired collections

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -126,7 +126,13 @@ class DatasetCollectionManager( object ):
             if collection_type_description.has_subcollections( ):
                 # Nested collection - recursively create collections and update identifiers.
                 self.__recursively_create_collections( trans, element_identifiers )
-            elements = self.__load_elements( trans, element_identifiers )
+            new_collection = False
+            for element_identifier in element_identifiers:
+                if element_identifier.get("src") == "new_collection" and element_identifier.get('collection_type') == '':
+                    new_collection = True
+                    elements = self.__load_elements(trans, element_identifier['element_identifiers'])
+            if not new_collection:
+                elements = self.__load_elements( trans, element_identifiers )
         # else if elements is set, it better be an ordered dict!
 
         if elements is not self.ELEMENTS_UNINITIALIZED:

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -770,7 +770,15 @@ def determine_output_format(output, parameter_context, input_datasets, input_dat
             if collection_name in input_dataset_collections:
                 try:
                     input_collection = input_dataset_collections[collection_name][0][0]
-                    input_dataset = input_collection.collection[element_index].element_object
+                    input_collection_collection = input_collection.collection
+                    try:
+                        input_element = input_collection_collection[element_index]
+                    except KeyError:
+                        for element in input_collection_collection.dataset_elements:
+                            if element.element_identifier == element_index:
+                                input_element = element
+                                break
+                    input_dataset = input_element.element_object
                     input_extension = input_dataset.ext
                     ext = input_extension
                 except Exception as e:

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -846,6 +846,15 @@ class ToolsTestCase( api.ApiTestCase ):
         }
         self._check_simple_cat1_over_nested_collections( history_id, inputs )
 
+    @skip_without_tool( "paired_collection_map_over_structured_like" )
+    def test_paired_input_map_over_nested_collections( self ):
+        history_id = self.dataset_populator.new_history()
+        hdca_id = self.__build_pair( history_id, ["123", "456"] )
+        inputs = {
+            "input1": { 'batch': True, 'values': [ dict( src="hdca", id=hdca_id ) ] },
+        }
+        create = self._run( "paired_collection_map_over_structured_like", history_id, inputs, assert_ok=True )
+
     def _check_simple_cat1_over_nested_collections( self, history_id, inputs ):
         create = self._run_cat1( history_id, inputs=inputs, assert_ok=True )
         outputs = create[ 'outputs' ]

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -849,11 +849,20 @@ class ToolsTestCase( api.ApiTestCase ):
     @skip_without_tool( "paired_collection_map_over_structured_like" )
     def test_paired_input_map_over_nested_collections( self ):
         history_id = self.dataset_populator.new_history()
-        hdca_id = self.__build_pair( history_id, ["123", "456"] )
+        hdca_id = self.__build_nested_list( history_id )
         inputs = {
-            "input1": { 'batch': True, 'values': [ dict( src="hdca", id=hdca_id ) ] },
+            "input1": { 'batch': True, 'values': [ dict( map_over_type='paired', src="hdca", id=hdca_id ) ] },
         }
+        self.dataset_populator.wait_for_history( history_id, assert_ok=True )
         create = self._run( "paired_collection_map_over_structured_like", history_id, inputs, assert_ok=True )
+        jobs = create[ 'jobs' ]
+        implicit_collections = create[ 'implicit_collections' ]
+        self.assertEquals( len( jobs ), 2 )
+        self.assertEquals( len( implicit_collections ), 1 )
+        implicit_collection = implicit_collections[ 0 ]
+        assert implicit_collection[ "collection_type" ] == "list:paired", implicit_collection
+        outer_elements = implicit_collection[ "elements" ]
+        assert len( outer_elements ) == 2
 
     def _check_simple_cat1_over_nested_collections( self, history_id, inputs ):
         create = self._run_cat1( history_id, inputs=inputs, assert_ok=True )

--- a/test/functional/tools/paired_collection_map_over_structured_like.xml
+++ b/test/functional/tools/paired_collection_map_over_structured_like.xml
@@ -10,7 +10,7 @@
     <param name="input1" type="data_collection" collection_type="paired" label="Input" help="Input collection..." format="txt" />
   </inputs>
   <outputs>
-    <collection name="list_output" structured_like="input1" type="paired" label="Duplicate List">
+    <collection name="list_output" structured_like="input1" type="paired" label="Duplicate List" inherit_format="true">
       <!-- inherit_format can be used in conjunction with structured_like
            to perserve format. -->
     </collection>

--- a/test/functional/tools/paired_collection_map_over_structured_like.xml
+++ b/test/functional/tools/paired_collection_map_over_structured_like.xml
@@ -1,0 +1,44 @@
+<tool id="paired_collection_map_over_structured_like" name="paired_collection_map_over_strcutured_like" version="0.1.0">
+  <!-- You usually wouldn't want to do this - just write the operation for
+       a single dataset and allow the user to map that tool over the whole
+       collection. -->
+  <command>
+        cat '${input1.forward}' > '${list_output.forward}';
+        cat '${input1.reverse}' > '${list_output.reverse}'
+  </command>
+  <inputs>
+    <param name="input1" type="data_collection" collection_type="paired" label="Input" help="Input collection..." format="txt" />
+  </inputs>
+  <outputs>
+    <collection name="list_output" structured_like="input1" type="paired" label="Duplicate List">
+      <!-- inherit_format can be used in conjunction with structured_like
+           to perserve format. -->
+    </collection>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input1">
+        <collection type="list:paired">
+          <element name="i1">
+            <collection type="paired">
+              <element name="forward" value="simple_line.txt" />
+              <element name="reverse" value="simple_line_alternative.txt" />
+            </collection>
+          </element>
+        </collection>
+      </param>
+      <output_collection name="list_output" type="paired">
+          <element name="forward">
+            <assert_contents>
+              <has_text_matching expression="^identifier is i1:forward\n$" />
+            </assert_contents>
+          </element>
+          <element name="reverse">
+            <assert_contents>
+              <has_text_matching expression="^identifier is i1:reverse\n$" />
+            </assert_contents>
+          </element>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/paired_collection_map_over_structured_like.xml
+++ b/test/functional/tools/paired_collection_map_over_structured_like.xml
@@ -18,26 +18,14 @@
   <tests>
     <test>
       <param name="input1">
-        <collection type="list:paired">
-          <element name="i1">
-            <collection type="paired">
-              <element name="forward" value="simple_line.txt" />
-              <element name="reverse" value="simple_line_alternative.txt" />
-            </collection>
-          </element>
+        <collection type="paired">
+          <element name="forward" value="simple_line.txt" />
+          <element name="reverse" value="simple_line_alternative.txt" />
         </collection>
       </param>
       <output_collection name="list_output" type="paired">
-          <element name="forward">
-            <assert_contents>
-              <has_text_matching expression="^identifier is i1:forward\n$" />
-            </assert_contents>
-          </element>
-          <element name="reverse">
-            <assert_contents>
-              <has_text_matching expression="^identifier is i1:reverse\n$" />
-            </assert_contents>
-          </element>
+          <element name="forward" file="simple_line.txt" ftype="txt"/>
+          <element name="reverse" file="simple_line_alternative.txt" ftype="txt"/>
       </output_collection>
     </test>
   </tests>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -78,6 +78,7 @@
   <tool file="tool_directory.xml" />
   <tool file="output_action_change_format.xml" />
   <tool file="collection_paired_test.xml" />
+  <tool file="paired_collection_map_over_structured_like.xml" />
   <tool file="collection_nested_test.xml" />
   <tool file="collection_mixed_param.xml" />
   <tool file="collection_two_paired.xml" />


### PR DESCRIPTION
collection input and a `structured_like` tag over list:paired collections.

I'm trying to fix #3202 here. This currently works, but is most likely a terrible way to do this,
and I can't get the test tool to pass.

@jmchilton do you have any advice here?