### PR TITLE
3 enhancements for the SLURM job runner

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -86,6 +86,8 @@ class SlurmJobRunner( DRMAAJobRunner ):
                 if slurm_state == 'NOT_FOUND':
                     log.warning( '(%s/%s) Job not found, assuming job check exceeded MinJobAge and completing as successful', ajs.job_wrapper.get_id_tag(), ajs.job_id )
                     drmaa_state = self.drmaa_job_states.DONE
+                elif slurm_state == 'COMPLETED':
+                    drmaa_state = self.drmaa_job_states.DONE
                 elif slurm_state == 'TIMEOUT':
                     log.info( '(%s/%s) Job hit walltime', ajs.job_wrapper.get_id_tag(), ajs.job_id )
                     ajs.fail_message = "This job was terminated because it ran longer than the maximum allowed job run time."

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -92,6 +92,7 @@ class SlurmJobRunner( DRMAAJobRunner ):
                     log.warning( '(%s/%s) Job not found, assuming job check exceeded MinJobAge and completing as successful', ajs.job_wrapper.get_id_tag(), ajs.job_id )
                     drmaa_state = self.drmaa_job_states.DONE
                 elif slurm_state == 'COMPLETED':
+                    log.debug("(%s/%s) SLURM reported job success, assuming job check exceeded MinJobAge and completing as successful", ajs.job_wrapper.get_id_tag(), ajs.job_id)
                     drmaa_state = self.drmaa_job_states.DONE
                 elif slurm_state == 'TIMEOUT':
                     log.info( '(%s/%s) Job hit walltime', ajs.job_wrapper.get_id_tag(), ajs.job_id )
@@ -113,7 +114,7 @@ class SlurmJobRunner( DRMAAJobRunner ):
                         ajs.fail_message = check_memory_limit_msg
                         ajs.runner_state = ajs.runner_states.MEMORY_LIMIT_REACHED
                     else:
-                        log.info( '(%s/%s) Job was cancelled via slurm (e.g. with scancel(1))', ajs.job_wrapper.get_id_tag(), ajs.job_id )
+                        log.info( '(%s/%s) Job was cancelled via SLURM (e.g. with scancel(1))', ajs.job_wrapper.get_id_tag(), ajs.job_id )
                         ajs.fail_message = "This job failed because it was cancelled by an administrator."
                 elif slurm_state in ('PENDING', 'RUNNING'):
                     log.warning( '(%s/%s) Job was reported by drmaa as terminal but job state in SLURM is: %s, returning to monitor queue', ajs.job_wrapper.get_id_tag(), ajs.job_id, slurm_state )
@@ -152,7 +153,7 @@ class SlurmJobRunner( DRMAAJobRunner ):
         since we are only searching the last 2K
         """
         try:
-            log.debug( 'Checking %s for exceeded memory message from slurm', efile_path )
+            log.debug( 'Checking %s for exceeded memory message from SLURM', efile_path )
             with open( efile_path ) as f:
                 if os.path.getsize(efile_path) > 2048:
                     f.seek(-2048, os.SEEK_END)


### PR DESCRIPTION
- Fix `_get_slurm_state_with_sacct()` for not completed jobs
- Handle also `COMPLETED` state in `_complete_terminal_job`
- Fix `_get_slurm_state_with_sacct()` for not completed jobs

Ping @natefoo and @lparsons.