### PR TITLE
[RFC] Link datasets w/ extension into working directory

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -31,8 +31,13 @@ from galaxy.util.bunch import Bunch
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.xml_macros import load
 
-from .datasets import (DatasetPath, NullDatasetPathRewriter,
-    OutputsToWorkingDirectoryPathRewriter, TaskPathRewriter)
+from .datasets import (
+    DatasetPath,
+    InputSymlinkPathRewriter,
+    NullDatasetPathRewriter,
+    OutputsToWorkingDirectoryPathRewriter,
+    TaskPathRewriter
+)
 from .output_checker import check_output
 
 log = logging.getLogger( __name__ )
@@ -793,8 +798,10 @@ class JobWrapper( object ):
         outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
         if outputs_to_working_directory:
             dataset_path_rewriter = OutputsToWorkingDirectoryPathRewriter( working_directory )
+        elif self.tool and not self.tool.parallelism:
+            dataset_path_rewriter = InputSymlinkPathRewriter( working_directory )
         else:
-            dataset_path_rewriter = NullDatasetPathRewriter( )
+            dataset_path_rewriter = NullDatasetPathRewriter()
         return dataset_path_rewriter
 
     @property

--- a/lib/galaxy/jobs/datasets.py
+++ b/lib/galaxy/jobs/datasets.py
@@ -71,15 +71,27 @@ class NullDatasetPathRewriter( object ):
         return None
 
 
-class OutputsToWorkingDirectoryPathRewriter( object ):
+class InputSymlinkPathRewriter( object ):
+    """
+    Rewrites input dataset paths to a path in the working directory
+    """
+    def __init__(self, working_directory):
+        self.working_directory = working_directory
+
+    def rewrite_dataset_path(self, dataset, dataset_type):
+        if dataset_type == 'input':
+            if dataset and dataset.ext and not dataset.datatype.composite_type:
+                return os.path.abspath( os.path.join( self.working_directory, "input_%d.%s" % (dataset.id, dataset.ext) ) )
+            else:
+                return None
+
+
+class OutputsToWorkingDirectoryPathRewriter( InputSymlinkPathRewriter ):
     """ Rewrites all paths to place them in the specified working
     directory for normal jobs when Galaxy is configured with
     app.config.outputs_to_working_directory. Job runner base class
     is responsible for copying these out after job is complete.
     """
-
-    def __init__( self, working_directory ):
-        self.working_directory = working_directory
 
     def rewrite_dataset_path( self, dataset, dataset_type ):
         """ Keep path the same.
@@ -87,6 +99,8 @@ class OutputsToWorkingDirectoryPathRewriter( object ):
         if dataset_type == 'output':
             false_path = os.path.abspath( os.path.join( self.working_directory, "galaxy_dataset_%d.dat" % dataset.id ) )
             return false_path
+        elif dataset_type == 'input':
+            return InputSymlinkPathRewriter.rewrite_dataset_path(self, dataset, dataset_type)
         else:
             return None
 

--- a/test/unit/jobs/test_job_wrapper.py
+++ b/test/unit/jobs/test_job_wrapper.py
@@ -162,6 +162,7 @@ class MockTool(object):
         self.version_string_cmd = TEST_VERSION_COMMAND
         self.tool_dir = "/path/to/tools"
         self.dependencies = []
+        self.parallelism = None
 
     def build_dependency_shell_commands(self, job_directory):
         return TEST_DEPENDENCIES_COMMANDS

--- a/test/unit/tools/test_evaluation.py
+++ b/test/unit/tools/test_evaluation.py
@@ -268,6 +268,7 @@ class MockTool( object ):
         self._params = { "thresh": self.test_thresh_param() }
         self.options = Bunch(sanitize=False)
         self.check_values = True
+        self.parallelism = None
 
     def test_thresh_param( self ):
         elem = XML( '<param name="thresh" type="integer" value="5" />' )

--- a/test/unit/tools/test_wrappers.py
+++ b/test/unit/tools/test_wrappers.py
@@ -175,6 +175,7 @@ class MockTool(object):
     def __init__(self, app):
         self.app = app
         self.options = Bunch(sanitize=False)
+        self.parallelism = None
 
 
 class MockApp(object):


### PR DESCRIPTION
Another PR in the series of "It's possible, but is it a good idea?"

I'd appreciate any feedback (particularly about these points):
  - should we do the symlinking on the framework level at all ?
  - should we do this by default (as in this PR) ?
  - or should we go with a more fine-grained control (i.e. allow tool authors to specify a tag on input files like `suffix="fastq.gz"` based on which we would link files in with a specifc ending) ?
  - Are there situation where we just can't do symlinking (perhaps pulsar with path rewriting -- haven't tested this)?

In the context of #3145, it would be nice if tool wrapper authors could
rely on the datatype extension for their tools. Many tools require a
specific filename extension. Currently, tool authors need to symlink the
input files with the correct extension in the tool wrapper.

With this commit galaxy will symlink input files into the current
working directory as input_<dataset_id>.<datatype_extension>, if an
extension is defined, the datatype is not composite and the tool does
not make use of parallelism.

I believe this makes writing wrappers easier for tool authors, and
should also prevent resorting to cheetah if a tool accepts different
input formats, where each format has a specific extension (e.g fastq,
fastq.gz. fastq.bz2 etc).