### PR TITLE
[16.10] Backport #3106 and #3222: Cached conda environments and API to manage them

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -219,11 +219,10 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 
 # Certain dependency resolvers (namely Conda) take a considerable amount of
 # time to build an isolated job environment in the job_working_directory if the
-# job working diretory is on a network share.  Set the following option to True
+# job working directory is on a network share.  Set the following option to True
 # to cache the dependencies in a folder. This option is beta and should only be
 # used if you experience long waiting times before a job is actually submitted
-# to your cluster. If you activate this option and install or remove dependencies,
-# you may need to clear out old cached environments
+# to your cluster.
 #use_cached_dependency_manager = False
 
 # By default the tool_dependency_cache_dir is the _cache directory

--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -217,18 +217,18 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # of extra disk space usage and extra time spent copying packages.
 #conda_copy_dependencies = False
 
-# Certain dependency resolvers (namely conda) take a considerable amount of
-# time to build an isolated job environment in the job_working_directory.  Set
-# the following option to true to cache the dependencies in a folder. This
-# option is beta and should only be used if you experience long waiting times
-# before a job is actually submitted to your cluster. If you activate this
-# option, and you install new dependencies you may need to clear out old cached
-# environments
+# Certain dependency resolvers (namely Conda) take a considerable amount of
+# time to build an isolated job environment in the job_working_directory if the
+# job working diretory is on a network share.  Set the following option to True
+# to cache the dependencies in a folder. This option is beta and should only be
+# used if you experience long waiting times before a job is actually submitted
+# to your cluster. If you activate this option and install or remove dependencies,
+# you may need to clear out old cached environments
 #use_cached_dependency_manager = False
 
 # By default the tool_dependency_cache_dir is the _cache directory
 # of the tool dependency directory
-#tool_dependency_cache_dir = tool_dependency_dir/_cache
+#tool_dependency_cache_dir = <tool_dependency_dir>/_cache
 
 # File containing the Galaxy Tool Sheds that should be made available to
 # install from in the admin interface (.sample used if default does not exist).

--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -217,6 +217,19 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # of extra disk space usage and extra time spent copying packages.
 #conda_copy_dependencies = False
 
+# Certain dependency resolvers (namely conda) take a considerable amount of
+# time to build an isolated job environment in the job_working_directory.  Set
+# the following option to true to cache the dependencies in a folder. This
+# option is beta and should only be used if you experience long waiting times
+# before a job is actually submitted to your cluster. If you activate this
+# option, and you install new dependencies you may need to clear out old cached
+# environments
+#use_cached_dependency_manager = False
+
+# By default the tool_dependency_cache_dir is the _cache directory
+# of the tool dependency directory
+#tool_dependency_cache_dir = tool_dependency_dir/_cache
+
 # File containing the Galaxy Tool Sheds that should be made available to
 # install from in the admin interface (.sample used if default does not exist).
 #tool_sheds_config_file = config/tool_sheds_conf.xml

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -325,6 +325,8 @@ class Configuration( object ):
         else:
             self.tool_dependency_dir = None
             self.use_tool_dependencies = os.path.exists(self.dependency_resolvers_config_file)
+        self.use_cached_dependency_manager = string_as_bool(kwargs.get("use_cached_dependency_manager", 'False'))
+        self.tool_dependency_cache_dir = kwargs.get( 'tool_dependency_cache_dir', os.path.join(self.tool_dependency_dir, '_cache'))
 
         self.enable_beta_mulled_containers = string_as_bool( kwargs.get( 'enable_beta_mulled_containers', 'False' ) )
         containers_resolvers_config_file = kwargs.get( 'containers_resolvers_config_file', None )

--- a/lib/galaxy/datatypes/converters/fasta_to_2bit.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_2bit.xml
@@ -2,6 +2,7 @@
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <!-- Used on the metadata edit page. -->
     <requirements>
+        <requirement type="package" version="332">ucsc-twobittofa</requirement>
         <requirement type="package">ucsc_tools</requirement>
     </requirements>
     <command>faToTwoBit '$input' '$output'</command>

--- a/lib/galaxy/datatypes/converters/fasta_to_2bit.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_2bit.xml
@@ -2,7 +2,7 @@
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <!-- Used on the metadata edit page. -->
     <requirements>
-        <requirement type="package" version="332">ucsc-twobittofa</requirement>
+        <requirement type="package" version="332">ucsc-fatotwobit</requirement>
         <requirement type="package">ucsc_tools</requirement>
     </requirements>
     <command>faToTwoBit '$input' '$output'</command>

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1306,7 +1306,7 @@ class Tool( object, Dictifiable ):
         visit_input_values( self.inputs, values, validate_inputs )
         return messages
 
-    def build_dependency_cache(self):
+    def build_dependency_cache(self, **kwds):
         if isinstance(self.app.toolbox.dependency_manager, CachedDependencyManager):
             self.app.toolbox.dependency_manager.build_cache(
                 requirements=self.requirements,
@@ -1314,7 +1314,8 @@ class Tool( object, Dictifiable ):
                 tool_dir=self.tool_dir,
                 job_directory=None,
                 metadata=False,
-                tool_instance=self
+                tool_instance=self,
+                **kwds
             )
 
     def build_dependency_shell_commands( self, job_directory=None, metadata=False ):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1306,16 +1306,17 @@ class Tool( object, Dictifiable ):
         return messages
 
     def build_dependency_shell_commands( self, job_directory=None, metadata=False ):
-        """Return a list of commands to be run to populate the current environment to include this tools requirements."""
-        requirements_to_dependencies = self.app.toolbox.dependency_manager.requirements_to_dependencies(
-            self.requirements,
+        """
+        Return a list of commands to be run to populate the current environment to include this tools requirements.
+        """
+        return self.app.toolbox.dependency_manager.dependency_shell_commands(
+            requirements=self.requirements,
             installed_tool_dependencies=self.installed_tool_dependencies,
             tool_dir=self.tool_dir,
             job_directory=job_directory,
             metadata=metadata,
+            tool_instance=self
         )
-        self.dependencies = [dep.to_dict() for dep in requirements_to_dependencies.values()]
-        return [dep.shell_commands(req) for req, dep in requirements_to_dependencies.items()]
 
     @property
     def installed_tool_dependencies(self):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -34,6 +34,7 @@ from galaxy.tools.actions.data_source import DataSourceToolAction
 from galaxy.tools.actions.data_manager import DataManagerToolAction
 from galaxy.tools.actions.model_operations import ModelOperationToolAction
 from galaxy.tools.deps import views
+from galaxy.tools.deps import CachedDependencyManager
 from galaxy.tools.parameters import params_to_incoming, check_param, params_from_strings, params_to_strings, visit_input_values
 from galaxy.tools.parameters import output_collect
 from galaxy.tools.parameters.basic import (BaseURLToolParameter,
@@ -1304,6 +1305,17 @@ class Tool( object, Dictifiable ):
 
         visit_input_values( self.inputs, values, validate_inputs )
         return messages
+
+    def build_dependency_cache(self):
+        if isinstance(self.app.toolbox.dependency_manager, CachedDependencyManager):
+            self.app.toolbox.dependency_manager.build_cache(
+                requirements=self.requirements,
+                installed_tool_dependencies=self.installed_tool_dependencies,
+                tool_dir=self.tool_dir,
+                job_directory=None,
+                metadata=False,
+                tool_instance=self
+            )
 
     def build_dependency_shell_commands( self, job_directory=None, metadata=False ):
         """

--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -5,6 +5,7 @@ Dependency management for tools.
 import json
 import logging
 import os.path
+import shutil
 
 from collections import OrderedDict
 
@@ -175,6 +176,12 @@ class CachedDependencyManager(DependencyManager):
         resolved_dependencies = self.requirements_to_dependencies(requirements, **kwds)
         cacheable_dependencies = [dep for req, dep in resolved_dependencies.items() if dep.cacheable]
         hashed_requirements_dir = self.get_hashed_requirements_path(cacheable_dependencies)
+        if kwds.get('force_rebuild', False) and os.path.exists(hashed_requirements_dir):
+            try:
+                shutil.rmtree(hashed_requirements_dir)
+            except Exception:
+                log.warning("Could not delete cached requirements directory '%s'" % hashed_requirements_dir)
+                pass
         [dep.build_cache(hashed_requirements_dir) for dep in cacheable_dependencies]
 
     def dependency_shell_commands( self, requirements, **kwds ):

--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -54,7 +54,7 @@ class CondaContext(installable.InstallableContext):
 
     def __init__(self, conda_prefix=None, conda_exec=None,
                  shell_exec=None, debug=False, ensure_channels='',
-                 condarc_override=None, use_path_exec=USE_PATH_EXEC_DEFAULT):
+                 condarc_override=None, use_path_exec=USE_PATH_EXEC_DEFAULT, copy_dependencies=False):
         self.condarc_override = condarc_override
         if not conda_exec and use_path_exec:
             conda_exec = commands.which("conda")
@@ -63,6 +63,7 @@ class CondaContext(installable.InstallableContext):
         self.conda_exec = conda_exec
         self.debug = debug
         self.shell_exec = shell_exec or commands.shell
+        self.copy_dependencies = copy_dependencies
 
         if conda_prefix is None:
             info = self.conda_info()

--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -214,6 +214,16 @@ class CondaContext(installable.InstallableContext):
         install_base_args.extend(args)
         return self.exec_command("install", install_base_args)
 
+    def exec_clean(self, args=[]):
+        """
+        Clean up after conda installation.
+        """
+        clean_base_args = [
+            "--tarballs"
+        ]
+        clean_base_args.extend(args)
+        return self.exec_command("clean", clean_base_args)
+
     def export_list(self, name, path):
         return self.exec_command("list", [
             "--name", name,
@@ -488,6 +498,7 @@ def build_isolated_environment(
 
         return (path or tempdir_name, exit_code)
     finally:
+        conda_context.exec_clean()
         shutil.rmtree(tempdir)
 
 

--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -219,7 +219,8 @@ class CondaContext(installable.InstallableContext):
         Clean up after conda installation.
         """
         clean_base_args = [
-            "--tarballs"
+            "--tarballs",
+            "-y"
         ]
         clean_base_args.extend(args)
         return self.exec_command("clean", clean_base_args)

--- a/lib/galaxy/tools/deps/requirements.py
+++ b/lib/galaxy/tools/deps/requirements.py
@@ -25,6 +25,9 @@ class ToolRequirement( object ):
         type = dict.get("type", None)
         return ToolRequirement( name=name, type=type, version=version )
 
+    def __eq__(self, other):
+        return self.name == other.name and self.type == other.type and self.version == other.version
+
 
 DEFAULT_CONTAINER_TYPE = "docker"
 DEFAULT_CONTAINER_RESOLVE_DEPENDENCIES = False

--- a/lib/galaxy/tools/deps/resolvers/__init__.py
+++ b/lib/galaxy/tools/deps/resolvers/__init__.py
@@ -122,3 +122,7 @@ class NullDependency( Dependency ):
 
     def shell_commands( self, requirement ):
         return None
+
+
+class DependencyException(Exception):
+    pass

--- a/lib/galaxy/tools/deps/resolvers/__init__.py
+++ b/lib/galaxy/tools/deps/resolvers/__init__.py
@@ -81,8 +81,9 @@ class InstallableDependencyResolver:
 
 
 class Dependency(Dictifiable, object):
-    dict_collection_visible_keys = ['dependency_type', 'exact', 'name', 'version']
+    dict_collection_visible_keys = ['dependency_type', 'exact', 'name', 'version', 'cacheable']
     __metaclass__ = ABCMeta
+    cacheable = False
 
     @abstractmethod
     def shell_commands( self, requirement ):

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -67,6 +67,7 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
                 dependency_manager.default_base_path, DEFAULT_CONDARC_OVERRIDE
             )
 
+        copy_dependencies = _string_as_bool(get_option("copy_dependencies"))
         conda_exec = get_option("exec")
         debug = _string_as_bool(get_option("debug"))
         ensure_channels = get_option("ensure_channels")
@@ -85,7 +86,7 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
             ensure_channels=ensure_channels,
             condarc_override=condarc_override,
             use_path_exec=use_path_exec,
-            copy_dependencies=_string_as_bool(get_option("copy_dependencies"))
+            copy_dependencies=copy_dependencies
         )
         self.ensure_channels = ensure_channels
 

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -11,7 +11,6 @@ import galaxy.tools.deps.installable
 from ..conda_util import (
     build_isolated_environment,
     cleanup_failed_install,
-    exec_clean,
     CondaContext,
     CondaTarget,
     install_conda,
@@ -100,7 +99,7 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
         self.copy_dependencies = copy_dependencies
 
     def clean(self, **kwds):
-        return exec_clean()
+        return self.conda_context.exec_clean()
 
     def resolve(self, name, version, type, **kwds):
         # Check for conda just not being there, this way we can enable

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -136,11 +136,15 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
 
         # Have installed conda_target and job_directory to send it to.
         # If dependency is for metadata generation, store environment in conda-metadata-env
-        if kwds.get("metadata", False):
-            conda_env = "conda-metadata-env"
+
+        if kwds.get('conda_env', False):
+            conda_environment = kwds.get('conda_env')
         else:
-            conda_env = "conda-env"
-        conda_environment = os.path.join(job_directory, conda_env)
+            if kwds.get("metadata", False):
+                conda_env = "conda-metadata-env"
+            else:
+                conda_env = "conda-env"
+            conda_environment = os.path.join(job_directory, conda_env)
         env_path, exit_code = build_isolated_environment(
             conda_target,
             path=conda_environment,

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -11,6 +11,7 @@ import galaxy.tools.deps.installable
 from ..conda_util import (
     build_isolated_environment,
     cleanup_failed_install,
+    exec_clean,
     CondaContext,
     CondaTarget,
     install_conda,
@@ -97,6 +98,9 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
         self.disabled = not galaxy.tools.deps.installable.ensure_installed(conda_context, install_conda, self.auto_init)
         self.auto_install = auto_install
         self.copy_dependencies = copy_dependencies
+
+    def clean(self, **kwds):
+        return exec_clean()
 
     def resolve(self, name, version, type, **kwds):
         # Check for conda just not being there, this way we can enable

--- a/lib/galaxy/tools/deps/views.py
+++ b/lib/galaxy/tools/deps/views.py
@@ -125,7 +125,6 @@ class DependencyResolversView(object):
         """
         return [index for index, resolver in enumerate(self._dependency_resolvers) if hasattr(resolver, "install_dependency") and not resolver.disabled ]
 
-
     def get_requirements_status(self, requested_requirements, installed_tool_dependencies=None):
         return [self.manager_dependency(installed_tool_dependencies=installed_tool_dependencies, **req) for req in requested_requirements]
 
@@ -140,4 +139,3 @@ class DependencyResolversView(object):
         else:
             [resolver.clean(**kwds) for resolver in self._dependency_resolvers if hasattr(resolver, 'clean')]
             return "OK"
-

--- a/lib/galaxy/tools/deps/views.py
+++ b/lib/galaxy/tools/deps/views.py
@@ -125,5 +125,19 @@ class DependencyResolversView(object):
         """
         return [index for index, resolver in enumerate(self._dependency_resolvers) if hasattr(resolver, "install_dependency") and not resolver.disabled ]
 
+
     def get_requirements_status(self, requested_requirements, installed_tool_dependencies=None):
         return [self.manager_dependency(installed_tool_dependencies=installed_tool_dependencies, **req) for req in requested_requirements]
+
+    def clean(self, index=None, **kwds):
+        if index:
+            resolver = self._dependency_resolver(index)
+            if not hasattr(resolver, "clean"):
+                raise NotImplemented()
+            else:
+                resolver.clean()
+                return "OK"
+        else:
+            [resolver.clean(**kwds) for resolver in self._dependency_resolvers if hasattr(resolver, 'clean')]
+            return "OK"
+

--- a/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
@@ -162,3 +162,22 @@ class ToolDependenciesAPIController( BaseAPIController ):
                     the corresponding resolver (keyed on 'index').
         """
         return self._view.manager_requirements()
+
+    @expose_api
+    @require_admin
+    def clean(self, trans, id=None, **kwds):
+        """
+        POST /api/dependencies_resolver/clean
+
+        Cleans up intermediate files created by resolvers during the dependency
+        installation.
+
+        :type   index:    int
+        :param  index:    index of the dependency resolver
+
+        :rtype:     dict
+        :returns:   a dictified description of the requirement that could
+                    be resolved (keyed on 'requirement') and the index of
+                    the corresponding resolver (keyed on 'index').
+        """
+        return self._view.clean(id, **kwds)

--- a/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
@@ -167,7 +167,7 @@ class ToolDependenciesAPIController( BaseAPIController ):
     @require_admin
     def clean(self, trans, id=None, **kwds):
         """
-        POST /api/dependencies_resolver/clean
+        POST /api/dependencies_resolver/{index}/clean
 
         Cleans up intermediate files created by resolvers during the dependency
         installation.

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -131,6 +131,33 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
 
     @expose_api
     @web.require_admin
+    def install_dependencies(self, trans, id, **kwds):
+        """
+        POST /api/tools/{tool_id}/install_dependencies
+        Attempts to install requirements via the dependency resolver
+        """
+        tool = self._get_tool(id)
+        [tool._view.install_dependency(id=None, **req.to_dict()) for req in tool.requirements]
+        if kwds.get('build_dependency_cache'):
+            tool.build_dependency_cache()
+        # TODO: rework resolver install system to log and report what has been done.
+        # _view.install_dependency should return a dict with stdout, stderr and success status
+        return tool.tool_requirements_status
+
+    @expose_api
+    @web.require_admin
+    def build_dependency_cache(self, trans, id, **kwds):
+        """
+        POST /api/tools/{tool_id}/build_dependency_cache
+        Attempts to cache installed dependencies.
+        """
+        tool = self._get_tool(id)
+        tool.build_dependency_cache()
+        # TODO: Should also have a more meaningful return.
+        return tool.tool_requirements_status
+
+    @expose_api
+    @web.require_admin
     def diagnostics( self, trans, id, **kwd ):
         """
         GET /api/tools/{tool_id}/diagnostics

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -135,11 +135,15 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
         """
         POST /api/tools/{tool_id}/install_dependencies
         Attempts to install requirements via the dependency resolver
+
+        parameters:
+            build_dependency_cache:  If true, attempts to cache dependencies for this tool
+            force_rebuild:           If true and chache dir exists, attempts to delete cache dir
         """
         tool = self._get_tool(id)
         [tool._view.install_dependency(id=None, **req.to_dict()) for req in tool.requirements]
         if kwds.get('build_dependency_cache'):
-            tool.build_dependency_cache()
+            tool.build_dependency_cache(**kwds)
         # TODO: rework resolver install system to log and report what has been done.
         # _view.install_dependency should return a dict with stdout, stderr and success status
         return tool.tool_requirements_status
@@ -150,9 +154,12 @@ class ToolsController( BaseAPIController, UsesVisualizationMixin ):
         """
         POST /api/tools/{tool_id}/build_dependency_cache
         Attempts to cache installed dependencies.
+
+        parameters:
+            force_rebuild:           If true and chache dir exists, attempts to delete cache dir
         """
         tool = self._get_tool(id)
-        tool.build_dependency_cache()
+        tool.build_dependency_cache(**kwds)
         # TODO: Should also have a more meaningful return.
         return tool.tool_requirements_status
 

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -262,6 +262,8 @@ def populate_api_routes( webapp, app ):
     webapp.mapper.connect( '/api/tools/{id:.+?}/citations', action='citations', controller="tools" )
     webapp.mapper.connect( '/api/tools/{id:.+?}/download', action='download', controller="tools" )
     webapp.mapper.connect( '/api/tools/{id:.+?}/requirements', action='requirements', controller="tools")
+    webapp.mapper.connect( '/api/tools/{id:.+?}/install_dependencies', action='install_dependencies', controller="tools", conditions=dict( method=[ "POST" ] ))
+    webapp.mapper.connect( '/api/tools/{id:.+?}/build_dependency_cache', action='build_dependency_cache', controller="tools", conditions=dict( method=[ "POST" ] ))
     webapp.mapper.connect( '/api/tools/{id:.+?}', action='show', controller="tools" )
     webapp.mapper.resource( 'tool', 'tools', path_prefix='/api' )
 

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -270,6 +270,7 @@ def populate_api_routes( webapp, app ):
     webapp.mapper.connect( '/api/dependency_resolvers/dependency', action="manager_dependency", controller="tool_dependencies", conditions=dict( method=[ "GET" ] ) )
     webapp.mapper.connect( '/api/dependency_resolvers/dependency', action="install_dependency", controller="tool_dependencies", conditions=dict( method=[ "POST" ] ) )
     webapp.mapper.connect( '/api/dependency_resolvers/requirements', action="manager_requirements", controller="tool_dependencies" )
+    webapp.mapper.connect('/api/dependency_resolvers/clean', action="clean", controller="tool_dependencies", conditions=dict(method=["POST"]))
     webapp.mapper.connect( '/api/dependency_resolvers/{id}/dependency', action="resolver_dependency", controller="tool_dependencies", conditions=dict( method=[ "GET" ] ) )
     webapp.mapper.connect( '/api/dependency_resolvers/{id}/dependency', action="install_dependency", controller="tool_dependencies", conditions=dict( method=[ "POST" ] ) )
     webapp.mapper.connect( '/api/dependency_resolvers/{id}/requirements', action="resolver_requirements", controller="tool_dependencies" )

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -267,10 +267,11 @@ def populate_api_routes( webapp, app ):
     webapp.mapper.connect( '/api/tools/{id:.+?}', action='show', controller="tools" )
     webapp.mapper.resource( 'tool', 'tools', path_prefix='/api' )
 
+    webapp.mapper.connect( '/api/dependency_resolvers/clean', action="clean", controller="tool_dependencies", conditions=dict( method=[ "POST" ]) )
     webapp.mapper.connect( '/api/dependency_resolvers/dependency', action="manager_dependency", controller="tool_dependencies", conditions=dict( method=[ "GET" ] ) )
     webapp.mapper.connect( '/api/dependency_resolvers/dependency', action="install_dependency", controller="tool_dependencies", conditions=dict( method=[ "POST" ] ) )
     webapp.mapper.connect( '/api/dependency_resolvers/requirements', action="manager_requirements", controller="tool_dependencies" )
-    webapp.mapper.connect('/api/dependency_resolvers/clean', action="clean", controller="tool_dependencies", conditions=dict(method=["POST"]))
+    webapp.mapper.connect( '/api/dependency_resolvers/{id}/clean', action="clean", controller="tool_dependencies", conditions=dict( method=[ "POST" ]) )
     webapp.mapper.connect( '/api/dependency_resolvers/{id}/dependency', action="resolver_dependency", controller="tool_dependencies", conditions=dict( method=[ "GET" ] ) )
     webapp.mapper.connect( '/api/dependency_resolvers/{id}/dependency', action="install_dependency", controller="tool_dependencies", conditions=dict( method=[ "POST" ] ) )
     webapp.mapper.connect( '/api/dependency_resolvers/{id}/requirements', action="resolver_requirements", controller="tool_dependencies" )

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -907,9 +907,11 @@ class InstallRepositoryManager( object ):
                 if install_resolver_dependencies:
                     requirements = suc.get_unique_requirements_from_repository(tool_shed_repository)
                     [self._view.install_dependency(id=None, **req) for req in requirements]
+                    cached_requirements = []
                     for tool_d in metadata['tools']:
                         tool = self.app.toolbox._tools_by_id.get(tool_d['guid'], None)
-                        if tool:
+                        if tool and tool.requirements not in cached_requirements:
+                            cached_requirements.append(tool.requirements)
                             tool.build_dependency_cache()
                 # Get the tool_versions from the tool shed for each tool in the installed change set.
                 self.update_tool_shed_repository_status( tool_shed_repository,

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -904,6 +904,13 @@ class InstallRepositoryManager( object ):
             self.install_model.context.refresh( tool_shed_repository )
             metadata = tool_shed_repository.metadata
             if 'tools' in metadata:
+                if install_resolver_dependencies:
+                    requirements = suc.get_unique_requirements_from_repository(tool_shed_repository)
+                    [self._view.install_dependency(id=None, **req) for req in requirements]
+                    for tool_d in metadata['tools']:
+                        tool = self.app.toolbox._tools_by_id.get(tool_d['guid'], None)
+                        if tool:
+                            tool.build_dependency_cache()
                 # Get the tool_versions from the tool shed for each tool in the installed change set.
                 self.update_tool_shed_repository_status( tool_shed_repository,
                                                          self.install_model.ToolShedRepository.installation_status.SETTING_TOOL_VERSIONS )
@@ -913,9 +920,6 @@ class InstallRepositoryManager( object ):
                     error_message += "Version information for the tools included in the <b>%s</b> repository is missing.  " % tool_shed_repository.name
                     error_message += "Reset all of this repository's metadata in the tool shed, then set the installed tool versions "
                     error_message += "from the installed repository's <b>Repository Actions</b> menu.  "
-                if install_resolver_dependencies:
-                    requirements = suc.get_unique_requirements_from_repository(tool_shed_repository)
-                    [self._view.install_dependency(id=None, **req) for req in requirements]
             if install_tool_dependencies and tool_shed_repository.tool_dependencies and 'tool_dependencies' in metadata:
                 work_dir = tempfile.mkdtemp( prefix="tmp-toolshed-itsr" )
                 # Install tool dependencies.

--- a/test/integration/test_resolvers.py
+++ b/test/integration/test_resolvers.py
@@ -97,7 +97,7 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase, A
         self._assert_status_code_is( create_response, 200 )
 
     def test_conda_clean( self ):
-        endpoint = 'dependencies_resolvers/clean'
+        endpoint = 'dependency_resolvers/clean'
         create_response = self._post(endpoint, data={}, admin=True)
         self._assert_status_code_is(create_response, 200)
         response = create_response.json()

--- a/test/integration/test_resolvers.py
+++ b/test/integration/test_resolvers.py
@@ -17,6 +17,7 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase, A
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         cls.conda_tmp_prefix = mkdtemp()
+        config["use_cached_dep_manager"] = True
         config["conda_auto_init"] = True
         config["conda_prefix"] = os.path.join(cls.conda_tmp_prefix, 'conda')
 
@@ -82,3 +83,15 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase, A
         self._assert_status_code_is( create_response, 200 )
         response = create_response.json()
         assert response['dependency_type'] == 'conda' and not response['exact']
+
+    def test_conda_install_through_tools_api( self ):
+        tool_id = 'mulled_example_multi_1'
+        endpoint = "tools/%s/install_dependencies" % tool_id
+        data = {'id': tool_id}
+        create_response = self._post(endpoint, data=data, admin=True)
+        self._assert_status_code_is( create_response, 200 )
+        response = create_response.json()
+        assert any([True for d in response if d['dependency_type'] == 'conda'])
+        endpoint = "tools/%s/build_dependency_cache" % tool_id
+        create_response = self._post(endpoint, data=data, admin=True)
+        self._assert_status_code_is( create_response, 200 )

--- a/test/integration/test_resolvers.py
+++ b/test/integration/test_resolvers.py
@@ -95,3 +95,10 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase, A
         endpoint = "tools/%s/build_dependency_cache" % tool_id
         create_response = self._post(endpoint, data=data, admin=True)
         self._assert_status_code_is( create_response, 200 )
+
+    def test_conda_clean( self ):
+        endpoint = 'dependencies_resolvers/clean'
+        create_response = self._post(endpoint, data={}, admin=True)
+        self._assert_status_code_is(create_response, 200)
+        response = create_response.json()
+        assert response == "OK"


### PR DESCRIPTION
Backport #3106 and #3222.

It appears that building conda environments in the job directory is problematic in some larger production environments (true for @lecorguille @lparsons and myself ).
Since that seriously cripples Conda usage I think we should backport this to `release_16.10`.

Ping @bgruening @jmchilton 