### PR TITLE
Further tighten up GG format.

### DIFF
--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -353,6 +353,9 @@ def guess_ext( fname, sniff_order, is_multi_byte=False ):
     >>> fname = get_test_fname('mothur_datatypetest_true.mothur.otu')
     >>> guess_ext(fname, sniff_order)
     'mothur.otu'
+    >>> fname = get_test_fname('1.gg')
+    >>> guess_ext(fname, sniff_order)
+    'gg'
     """
     file_ext = None
     for datatype in sniff_order:


### PR DESCRIPTION
I encountered similar input problems to #864 - this helps a little.

- Ensure first column is a valid marker as outlined on https://genome.ucsc.edu/goldenpath/help/hgGenomeHelp.html.
- Avoid readlines() since it may allocate huge amounts on memory on certain inputs.
- Eliminate bare exception.