### PR TITLE
Change Conda channel order

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -204,7 +204,7 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 #conda_debug = False
 # conda channels to enable by default (http://conda.pydata.org/docs/custom-channels.html)
 # the recommended channel order is the one from BioConda (https://github.com/bioconda/bioconda-recipes/blob/master/config.yml#L8)
-#conda_ensure_channels = bioconda,r,defaults,conda-forge,iuc
+#conda_ensure_channels = iuc,bioconda,r,defaults,conda-forge
 # Set to True to instruct Galaxy to look for and install missing tool
 # dependencies before each job runs.
 #conda_auto_install = False

--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -203,7 +203,8 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # Pass debug flag to conda commands.
 #conda_debug = False
 # conda channels to enable by default (http://conda.pydata.org/docs/custom-channels.html)
-#conda_ensure_channels = conda-forge,r,bioconda,iuc
+# the recommended channel order is the one from BioConda (https://github.com/bioconda/bioconda-recipes/blob/master/config.yml#L8)
+#conda_ensure_channels = bioconda,r,defaults,conda-forge,iuc
 # Set to True to instruct Galaxy to look for and install missing tool
 # dependencies before each job runs.
 #conda_auto_install = False

--- a/doc/source/admin/dependency_resolvers.rst
+++ b/doc/source/admin/dependency_resolvers.rst
@@ -182,7 +182,7 @@ debug
 ensure_channels
     conda channels to enable by default. See
     http://conda.pydata.org/docs/custom-channels.html for more
-    information about channels. (default: conda-forge,r,bioconda,iuc).
+    information about channels. (default: bioconda,r,defaults,conda-forge,iuc).
 
 auto_install
     Set to True to instruct Galaxy to look for and install missing tool

--- a/doc/source/admin/dependency_resolvers.rst
+++ b/doc/source/admin/dependency_resolvers.rst
@@ -182,7 +182,7 @@ debug
 ensure_channels
     conda channels to enable by default. See
     http://conda.pydata.org/docs/custom-channels.html for more
-    information about channels. (default: bioconda,r,defaults,conda-forge,iuc).
+    information about channels. (default: iuc,bioconda,r,defaults,conda-forge).
 
 auto_install
     Set to True to instruct Galaxy to look for and install missing tool

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -31,7 +31,7 @@ from ..resolvers import (
 
 DEFAULT_BASE_PATH_DIRECTORY = "_conda"
 DEFAULT_CONDARC_OVERRIDE = "_condarc"
-DEFAULT_ENSURE_CHANNELS = "conda-forge,r,bioconda,iuc"
+DEFAULT_ENSURE_CHANNELS = "bioconda,r,defaults,conda-forge,iuc"
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -31,7 +31,7 @@ from ..resolvers import (
 
 DEFAULT_BASE_PATH_DIRECTORY = "_conda"
 DEFAULT_CONDARC_OVERRIDE = "_condarc"
-DEFAULT_ENSURE_CHANNELS = "bioconda,r,defaults,conda-forge,iuc"
+DEFAULT_ENSURE_CHANNELS = "iuc,bioconda,r,defaults,conda-forge"
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
After some discussions with conda-forge we agreed on this channel order for now. The `r` channel will go away at some point as we will try to get all packages from r into conda-forge.

I think this PR needs to be backported.