### PR TITLE
[PROCEDURES] change Nitesh's handle to reflect reality

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -46,7 +46,7 @@ Members
 - Eric Rasche (@erasche)
 - Nicola Soranzo (@nsoranzo)
 - James Taylor (@jxtx)
-- Nitesh Turaga (@nitesh1989)
+- Nitesh Turaga (@nturaga)
 - Marius van den Beek (@mvdbeek)
 
 


### PR DESCRIPTION
the former github handle is now unused, thanks @nsoranzo for noticing