### PR TITLE
[16.10] Display tool requirements for conda-only tools

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -1112,6 +1112,9 @@ class AdminToolshed( AdminGalaxy ):
         shed_tool_conf_select_field = tool_util.build_shed_tool_conf_select_field( trans.app )
         tool_path = suc.get_tool_path_by_shed_tool_conf_filename( trans.app, shed_tool_conf )
         tool_panel_section_select_field = tool_util.build_tool_panel_section_select_field( trans.app )
+        tool_requirements = suc.get_tool_shed_repo_requirements(app=trans.app,
+                                                                tool_shed_url=tool_shed_url,
+                                                                repo_info_dicts=repo_info_dicts)
         if len( repo_info_dicts ) == 1:
             # If we're installing or updating a single repository, see if it contains a readme or
             # dependencies that we can display.

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -1115,6 +1115,8 @@ class AdminToolshed( AdminGalaxy ):
         tool_requirements = suc.get_tool_shed_repo_requirements(app=trans.app,
                                                                 tool_shed_url=tool_shed_url,
                                                                 repo_info_dicts=repo_info_dicts)
+        view = views.DependencyResolversView(self.app)
+        requirements_status = view.get_requirements_status(tool_requirements)
         if len( repo_info_dicts ) == 1:
             # If we're installing or updating a single repository, see if it contains a readme or
             # dependencies that we can display.
@@ -1233,6 +1235,7 @@ class AdminToolshed( AdminGalaxy ):
                                         shed_tool_conf_select_field=shed_tool_conf_select_field,
                                         tool_panel_section_select_field=tool_panel_section_select_field,
                                         tool_shed_url=tool_shed_url,
+                                        requirements_status=requirements_status,
                                         message=message,
                                         status=status )
         else:
@@ -1259,6 +1262,7 @@ class AdminToolshed( AdminGalaxy ):
                                         shed_tool_conf_select_field=shed_tool_conf_select_field,
                                         tool_panel_section_select_field=tool_panel_section_select_field,
                                         tool_shed_url=tool_shed_url,
+                                        tool_requirements=tool_requirements,
                                         message=message,
                                         status=status )
 

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -8,11 +8,15 @@ import string
 import sqlalchemy.orm.exc
 from sqlalchemy import and_, false, true
 
-import tool_shed.util.repository_util
 from galaxy import util
 from galaxy.util import checkers
 from galaxy.web import url_for
-from tool_shed.util import basic_util, common_util, hg_util
+from tool_shed.util import (
+    basic_util,
+    common_util,
+    hg_util,
+    repository_util
+)
 
 log = logging.getLogger( __name__ )
 
@@ -178,21 +182,34 @@ def get_category_by_name( app, name ):
         return None
 
 
-def get_tool_shed_repo_requirements(app, tool_shed_url, repository):
+def get_tool_shed_repo_requirements(app, tool_shed_url, repositories=None, repo_info_dicts=None):
     """
     Contact tool_shed_url for a list of requirements for a repository or a list of repositories.
     Returns a list of requirements, where each requirement is a dictionary with name and version as keys.
     """
-    if not isinstance(repository, list):
-        repositories = [repository]
+    if not repositories and not repo_info_dicts:
+        raise Exception("Need to pass either repository or repo_info_dicts")
+    if repositories:
+        if not isinstance(repositories, list):
+            repositories = [repositories]
+        repository_params = [{'name': repository.name,
+                             'owner': repository.owner,
+                             'changeset_revision': repository.changeset_revision} for repository in repositories]
     else:
-        repositories = repository
+        if not isinstance(repo_info_dicts, list):
+            repo_info_dicts = [repo_info_dicts]
+        repository_params = []
+        for repo_info_dict in repo_info_dicts:
+            for name, repo_info_tuple in repo_info_dict.items():
+                # repo_info_tuple is a list, but keep terminology
+                owner = repo_info_tuple[4]
+                changeset_revision = repo_info_tuple[2]
+                repository_params.append({'name': name,
+                                          'owner': owner,
+                                          'changeset_revision': changeset_revision})
     pathspec = ["api", "repositories", "get_repository_revision_install_info"]
     tools = []
-    for repository in repositories:
-        params = {"name": repository.name,
-                  "owner": repository.owner,
-                  "changeset_revision": repository.changeset_revision}
+    for params in repository_params:
         response = util.url_get(tool_shed_url,
                                 password_mgr=app.tool_shed_registry.url_auth( tool_shed_url ),
                                 pathspec=pathspec,
@@ -355,7 +372,7 @@ def get_repository_from_refresh_on_change( app, **kwd ):
         changeset_revision_str = 'changeset_revision_'
         if k.startswith( changeset_revision_str ):
             repository_id = app.security.encode_id( int( k.lstrip( changeset_revision_str ) ) )
-            repository = tool_shed.util.repository_util.get_repository_in_tool_shed( app, repository_id )
+            repository = repository_util.get_repository_in_tool_shed( app, repository_id )
             if repository.tip( app ) != v:
                 return v, repository
     # This should never be reached - raise an exception?
@@ -458,7 +475,7 @@ def handle_email_alerts( app, host, repository, content_alert_str='', new_repo_a
     """
     sa_session = app.model.context.current
     repo = hg_util.get_repo_for_repository( app, repository=repository, repo_path=None, create=False )
-    sharable_link = tool_shed.util.repository_util.generate_sharable_link_for_repository_in_tool_shed( repository, changeset_revision=None )
+    sharable_link = repository_util.generate_sharable_link_for_repository_in_tool_shed( repository, changeset_revision=None )
     smtp_server = app.config.smtp_server
     if smtp_server and ( new_repo_alert or repository.email_alerts ):
         # Send email alert to users that want them.
@@ -560,7 +577,7 @@ def is_path_within_repo( app, path, repository_id ):
     Detect whether the given path is within the repository folder on the disk.
     Use to filter malicious symlinks targeting outside paths.
     """
-    repo_path = os.path.abspath( tool_shed.util.repository_util.get_repository_by_id( app, repository_id ).repo_path( app ) )
+    repo_path = os.path.abspath( repository_util.get_repository_by_id( app, repository_id ).repo_path( app ) )
     resolved_path = os.path.realpath( path )
     return os.path.commonprefix( [ repo_path, resolved_path ] ) == repo_path
 
@@ -610,7 +627,7 @@ def set_image_paths( app, encoded_repository_id, text ):
     return the path to it that will enable the caller to open the file.
     """
     if text:
-        if tool_shed.util.repository_util.is_tool_shed_client( app ):
+        if repository_util.is_tool_shed_client( app ):
             route_to_images = 'admin_toolshed/static/images/%s' % encoded_repository_id
         else:
             # We're in the tool shed.

--- a/templates/admin/tool_shed_repository/common.mako
+++ b/templates/admin/tool_shed_repository/common.mako
@@ -65,7 +65,7 @@
     </script>
 </%def>
 
-<%def name="render_dependencies_section( install_resolver_dependencies_check_box, repository_dependencies_check_box, install_tool_dependencies_check_box, containers_dict, revision_label=None, export=False )">
+<%def name="render_dependencies_section( install_resolver_dependencies_check_box, repository_dependencies_check_box, install_tool_dependencies_check_box, containers_dict, revision_label=None, export=False, requirements_status=None )">
     <style type="text/css">
         #dependency_table{ table-layout:fixed;
                            width:100%;
@@ -125,6 +125,8 @@
             <button class="toggle-detail-section">
                 Display Details
             </button>
+        </p>
+        <p>
         </p>
      </div>
    %if export:
@@ -216,7 +218,7 @@
     </div>
     %endif
     <div style="clear: both"></div>
-    %if install_resolver_dependencies_check_box:
+    %if requirements_status and install_resolver_dependencies_check_box:
     <div class="form-row">
         <label>When available, install <a href="https://docs.galaxyproject.org/en/master/admin/conda_faq.html" target="_blank">Conda</a> managed tool dependencies?</label>
         ${install_resolver_dependencies_check_box.get_html()}

--- a/templates/admin/tool_shed_repository/select_tool_panel_section.mako
+++ b/templates/admin/tool_shed_repository/select_tool_panel_section.mako
@@ -65,6 +65,7 @@
             <div class="form-row">
                 <input type="hidden" name="includes_tools" value="${includes_tools}" />
                 <input type="hidden" name="includes_tool_dependencies" value="${includes_tool_dependencies}" />
+                <input type="hidden" name="requirements_status" value="${requirements_status}" />
                 <input type="hidden" name="includes_tools_for_display_in_tool_panel" value="${includes_tools_for_display_in_tool_panel}" />
                 <input type="hidden" name="tool_shed_url" value="${tool_shed_url}" />
                 <input type="hidden" name="encoded_repo_info_dicts" value="${encoded_repo_info_dicts}" />
@@ -85,13 +86,48 @@
                 ${render_readme_section( containers_dict )}
                 <div style="clear: both"></div>
             %endif
-            %if can_display_repository_dependencies or can_display_tool_dependencies or can_display_resolver_installation:
+            <%
+                if requirements_status and install_resolver_dependencies_check_box or includes_tool_dependencies:
+                    display_dependency_confirmation = True
+                else:
+                    display_dependency_confirmation = False
+            %>
+            %if requirements_status:
+                %if not install_resolver_dependencies_check_box and not includes_tool_dependencies:
+                <div class="form-row">
+                    <table class="colored" width="100%">
+                        <head>
+                            <th>
+                                <img src="${h.url_for('/static')}/images/icon_error_sml.gif" title='Cannot install dependencies'/>
+                                This repository requires dependencies that cannot be installed through the toolshed
+                            </th>
+                        </head>
+                    </table>
+                </div>
+                <div class="form-row">
+                     <p>This repository defines tool requirements that cannot be installed through the Tool Shed.</p>
+                     <p>Please activate Conda dependency resolution, activate Docker dependency resolution, setup Environment Modules
+or manually satisfy the dependencies listed below.</p>
+                     <p>For details see <a target="_blank" href="https://docs.galaxyproject.org/en/latest/admin/dependency_resolvers.html">the dependency resolver documentation.</a></p>
+                </div>
+                %endif
+                <div class="form-row">
+                    <table class="colored" width="100%">
+                        <th bgcolor="#EBD9B2">The following tool dependencies are required by the current repository</th>
+                    </table>
+                </div>
+                <div class="form-row">
+                    ${render_tool_dependency_resolver( requirements_status, prepare_for_install=True )}
+                </div>
+                <div style="clear: both"></div>
+            %endif
+            %if can_display_repository_dependencies or display_dependency_confirmation:
                 <div class="form-row">
                     <table class="colored" width="100%">
                         <th bgcolor="#EBD9B2">Confirm dependency installation</th>
                     </table>
                 </div>
-                ${render_dependencies_section( install_resolver_dependencies_check_box, install_repository_dependencies_check_box, install_tool_dependencies_check_box, containers_dict, revision_label=None, export=False )}
+                ${render_dependencies_section( install_resolver_dependencies_check_box, install_repository_dependencies_check_box, install_tool_dependencies_check_box, containers_dict, revision_label=None, export=False, requirements_status=requirements_status )}
                 <div style="clear: both"></div>
             %endif
             %if shed_tool_conf_select_field:

--- a/templates/admin/tool_shed_repository/select_tool_panel_section.mako
+++ b/templates/admin/tool_shed_repository/select_tool_panel_section.mako
@@ -99,7 +99,7 @@
                         <head>
                             <th>
                                 <img src="${h.url_for('/static')}/images/icon_error_sml.gif" title='Cannot install dependencies'/>
-                                This repository requires dependencies that cannot be installed through the toolshed
+                                This repository requires dependencies that cannot be installed through the Tool Shed
                             </th>
                         </head>
                     </table>

--- a/templates/webapps/tool_shed/repository/common.mako
+++ b/templates/webapps/tool_shed/repository/common.mako
@@ -1026,7 +1026,7 @@
     %>
 </%def>
 
-<%def name="render_tool_dependency_resolver( requirements_status )">
+<%def name="render_tool_dependency_resolver( requirements_status, prepare_for_install=False )">
     <tr class="datasetRow">
         <td style="padding-left: 20 px;">
             <table class="grid" id="module_resolver_environment">
@@ -1034,9 +1034,11 @@
                     <tr>
                         <th>Dependency</th>
                         <th>Version</th>
-                        <th>Resolver</th>
-                        <th>Exact version</th>
-                        <th>Status<th>
+                        %if not prepare_for_install:
+                            <th>Resolver</th>
+                            <th>Exact version</th>
+                        %endif
+                        <th>Current Installation Status<th>
                     </tr>
                 </head>
                 <body>
@@ -1044,18 +1046,32 @@
                         <tr>
                             <td>${dependency['name'] | h}</td>
                             <td>${dependency['version'] | h}</td>
-                            <td>${dependency['dependency_type'] | h}</td>
-                            <td>${dependency['exact'] | h}</td>
+                            %if not prepare_for_install:
+                                %if dependency['dependency_type']:
+                                    <td>${dependency['dependency_type'].title() | h}</td>
+                                %else:
+                                    <td>${dependency['dependency_type'] | h}</td>
+                                %endif
+                                <td>${dependency['exact'] | h}</td>
+                            %endif
                         %if dependency['dependency_type'] == None:
                             <td>
                                <img src="${h.url_for('/static')}/images/icon_error_sml.gif" title='Dependency not resolved'/>
+                               %if prepare_for_install:
+                                   Not Installed
+                               %endif
                             </td>
                         %elif not dependency['exact']:
                             <td>
                                 <img src="${h.url_for('/static')}/images/icon_warning_sml.gif" title='Dependency resolved, but version ${dependency['version']} not found'/>
                             </td>
                         %else:
-                            <td><img src="${h.url_for('/static')}/june_2007_style/blue/ok_small.png"/></td>
+                            <td>
+                                <img src="${h.url_for('/static')}/june_2007_style/blue/ok_small.png"/>
+                                %if prepare_for_install:
+                                    Installed through ${dependency['dependency_type'].title() | h}
+                                %endif
+                            </td>
                         %endif
                         </tr>
                     %endfor


### PR DESCRIPTION
With this PR we display tool requirements as defined in the tool xml during
the install confirmation dialog. If a tool dependency is defined in the
tool XML, but not in a tool_dependencies.xml, a warning is shown if
conda is not activated.
This should close #3257.

Ping @martenson 