### PR TITLE
[16.10] port Fix tour URLs in welcome

### DIFF
--- a/static/welcome.html.sample
+++ b/static/welcome.html.sample
@@ -16,9 +16,9 @@
             <br>
             <div class="container">
                 <p>Take an interactive tour:
-                    <a target="_parent" href="tours/core.galaxy_ui" class="btn btn-default btn-xs">Galaxy UI</a>
-                    <a target="_parent" href="tours/core.history" class="btn btn-default btn-xs">History</a>
-                    <a target="_parent" href="tours/core.scratchbook" class="btn btn-default btn-xs">Scratchbook</a>
+                    <a target="_parent" href="../tours/core.galaxy_ui" class="btn btn-default btn-xs">Galaxy UI</a>
+                    <a target="_parent" href="../tours/core.history" class="btn btn-default btn-xs">History</a>
+                    <a target="_parent" href="../tours/core.scratchbook" class="btn btn-default btn-xs">Scratchbook</a>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
This was merged earlier as #3273, but I probably should have opened that against 16.10 instead.  This fixes that.