### PR TITLE
Fix logo image when serving Galaxy from a subdirectory.

### DIFF
--- a/templates/webapps/galaxy/galaxy.masthead.mako
+++ b/templates/webapps/galaxy/galaxy.masthead.mako
@@ -24,7 +24,7 @@
             'terms_url'                 : app.config.get("terms_url", ""),
             'allow_user_creation'       : app.config.allow_user_creation,
             'logo_url'                  : h.url_for(app.config.get( 'logo_url', '/')),
-            'logo_src'                  : h.url_for( app.config.get( 'logo_src', '../../../static/images/galaxyIcon_noText.png' ) ),
+            'logo_src'                  : h.url_for( app.config.get( 'logo_src', '/static/images/galaxyIcon_noText.png' ) ),
             'is_admin_user'             : trans.user_is_admin(),
             'active_view'               : active_view,
             'ftp_upload_dir'            : app.config.get("ftp_upload_dir",  None),


### PR DESCRIPTION
Would link to a dev-list post but http://dev.list.galaxyproject.org/ seems to be down. Ping @shiltemann @pjbriggs