### PR TITLE
Slim down testing ``Dockerfile``.

### DIFF
--- a/test/docker/base/Dockerfile
+++ b/test/docker/base/Dockerfile
@@ -27,17 +27,11 @@ RUN apt-get update -y && apt-get install -y software-properties-common curl && \
             mercurial nginx-extras nmon patch postgresql postgresql \
             postgresql-client postgresql-plpython-9.3 python-boto python-dev \
             python-prettytable python-psycopg2 python-virtualenv python-pip \
-            postgresql-server-dev-9.3 rsync slurm-drmaa-dev supervisor swig sysstat unzip \
+            postgresql-server-dev-9.3 rsync slurm-drmaa-dev swig sysstat unzip \
             wget zlib1g-dev nodejs && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-   
-RUN npm install -g grunt-contrib-qunit grunt grunt-cli && \
-    cd /tmp && \
-    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
-    tar xf phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
-    mv phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
-    mkdir -p /opt/casperjs /casperjs && wget https://github.com/n1k0/casperjs/tarball/master -O- | tar -xzf- --strip-components=1 -C /opt/casperjs && \
-    ln -sf /opt/casperjs/bin/casperjs /usr/local/bin/casperjs
+
+RUN npm install -g grunt-contrib-qunit grunt grunt-cli
 
 RUN mkdir -p /tmp/ansible && \
     mkdir -p /opt/galaxy/db && \
@@ -108,4 +102,5 @@ ADD run_test_wrapper.sh /usr/local/bin/run_test_wrapper.sh
 EXPOSE :9009
 EXPOSE :8080
 EXPOSE :80
+
 ENTRYPOINT ["/bin/bash", "/usr/local/bin/run_test_wrapper.sh"]

--- a/test/docker/base/ansible_vars.yml
+++ b/test/docker/base/ansible_vars.yml
@@ -26,16 +26,13 @@ galaxy_web_processes: 1
 galaxy_handler_processes: 2
 galaxy_log_dir: "/root"
 
-supervisor_nodaemon: true
-supervisor_postgres_database_path: "{{ galaxy_db_dir }}"
-
-galaxy_extras_config_nginx: true
+galaxy_extras_config_nginx: false
 galaxy_extras_config_proftpd: false
 galaxy_extras_config_slurm: true
-galaxy_extras_config_supervisor: true
+galaxy_extras_config_supervisor: false
 galaxy_extras_config_galaxy_root: false
 galaxy_extras_config_galaxy_job_metrics: false
-galaxy_extras_config_uwsgi: true
+galaxy_extras_config_uwsgi: false
 
 manage_shed_db: yes
 galaxy_toolshed_manage_static_setup: yes

--- a/test/docker/base/run_test_wrapper.sh
+++ b/test/docker/base/run_test_wrapper.sh
@@ -50,12 +50,7 @@ else
     GALAXY_CONFIG_FILE=${GALAXY_CONFIG_FILE:-config/galaxy.ini.sample}
     TOOL_SHED_CONFIG_FILE=${GALAXY_CONFIG_FILE:-config/tool_shed.ini.sample}
     GALAXY_CONFIG_CHECK_MIGRATE_TOOLS=false
-    if [ -z "$GALAXY_MULTI_PROCESS" ];
-    then
-        GALAXY_CONFIG_JOB_CONFIG_FILE=${GALAXY_CONFIG_JOB_CONFIG_FILE:-config/job_conf.xml.sample}
-    else
-        GALAXY_CONFIG_JOB_CONFIG_FILE=/etc/galaxy/job_conf.xml
-    fi
+    GALAXY_CONFIG_JOB_CONFIG_FILE=${GALAXY_CONFIG_JOB_CONFIG_FILE:-config/job_conf.xml.sample}
     GALAXY_CONFIG_FILE_PATH=${GALAXY_CONFIG_FILE_PATH:-/tmp/gx1}
     GALAXY_CONFIG_NEW_FILE_PATH=${GALAXY_CONFIG_NEW_FILE_PATH:-/tmp/gxtmp}
 
@@ -67,10 +62,5 @@ else
     export GALAXY_CONFIG_FILE_PATH
     export GALAXY_CONFIG_NEW_FILE_PATH
 
-    if [ -z "$GALAXY_MULTI_PROCESS" ];
-    then
-        sh run.sh $@
-    else
-        /usr/bin/supervisord
-    fi
+    sh run.sh $@
 fi


### PR DESCRIPTION
- Remove broken CasperJS from testing Dockerfile.
- Remove multi-process mode.

Multi-process mode was difficult to maintain and the last time I did testing at scale I found docker-galaxy-stable to be much more useful and easy to use. The test framework now supports GALAXY_TEST_EXTERNAL again so it should be easy enough to rig something up with docker-compose that actually uses a best practice container for scaling tests such as those in ``test/manual``.