### PR TITLE
Update datatype converter tools

### DIFF
--- a/lib/galaxy/datatypes/converters/bam_to_bai.xml
+++ b/lib/galaxy/datatypes/converters/bam_to_bai.xml
@@ -1,16 +1,14 @@
-<tool id="CONVERTER_Bam_Bai_0" name="Bam to Bai" hidden="true">
-  <requirements>
-      <requirement type="package">samtools</requirement>
-  </requirements>
-  <command>samtools index $input1 $output1</command>
-  <inputs>
-    <page>
-      <param format="bam" name="input1" type="data" label="Choose BAM"/>
-    </page>
-   </inputs>
-   <outputs>
-      <data format="bai" name="output1"/>
-   </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_Bam_Bai_0" name="Bam to Bai" version="1.0.0" hidden="true">
+    <requirements>
+        <requirement type="package">samtools</requirement>
+    </requirements>
+    <command>samtools index '$input1' '$output1'</command>
+    <inputs>
+        <param format="bam" name="input1" type="data" label="Choose BAM"/>
+    </inputs>
+    <outputs>
+        <data format="bai" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/bcf_bgzip_to_bcf_converter.xml
+++ b/lib/galaxy/datatypes/converters/bcf_bgzip_to_bcf_converter.xml
@@ -1,14 +1,12 @@
 <tool id="CONVERTER_bcf_bgzip_to_bcf" name="Convert BCF_BGZIP to BCF" version="0.0.1" hidden="false">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">bcf_bgzip_to_bcf_converter.py '$input1' '$output1'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/bcf_bgzip_to_bcf_converter.py' '$input1' '$output1'</command>
+    <inputs>
         <param format="bcf_bgzip" name="input1" type="data" label="Choose bcf_bgzip file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bcf" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="bcf" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/bcf_to_bcf_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/bcf_to_bcf_bgzip_converter.xml
@@ -1,14 +1,12 @@
 <tool id="CONVERTER_bcf_to_bcf_bgzip" name="Convert BCF to BCF_BGZIP" version="0.0.1" hidden="false">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">bcf_to_bcf_bgzip_converter.py '$input1' '$output1'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/bcf_to_bcf_bgzip_converter.py' '$input1' '$output1'</command>
+    <inputs>
         <param format="bcf" name="input1" type="data" label="Choose bcf file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bcf_bgzip" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="bcf_bgzip" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/bed_gff_or_vcf_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bed_gff_or_vcf_to_bigwig_converter.xml
@@ -5,11 +5,12 @@
         <requirement type="package">bedtools</requirement>
     </requirements>
     <command>
+<![CDATA[
         ## Remove comments and sort by chromosome.
-        grep -v '^#' $input | sort -k1,1 | 
+        grep -v '^#' '$input' | sort -k1,1 |
 
         ## Generate coverage bedgraph.
-        bedtools genomecov -bg -i stdin -g $chromInfo
+        bedtools genomecov -bg -i stdin -g '$chromInfo'
 
         ## Only use split option for bed and gff/gff3/gtf.
         #if $input.ext in [ 'bed', 'gff', 'gff3', 'gtf' ]:
@@ -18,10 +19,11 @@
 
         ## Streaming the bedgraph file to wigToBigWig is fast but very memory intensive; hence, this
         ## should only be used on systems with large RAM.
-        ## | wigToBigWig stdin $chromInfo $output
+        ## | wigToBigWig stdin '$chromInfo' '$output'
 
         ## This can be used anywhere.
-        > temp.bg ; bedGraphToBigWig temp.bg $chromInfo $output
+        > temp.bg && bedGraphToBigWig temp.bg '$chromInfo' '$output'
+]]>
     </command>
     <inputs>
         <param format="bed,gff,vcf" name="input" type="data" label="Choose input file"/>

--- a/lib/galaxy/datatypes/converters/bed_to_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/bed_to_bgzip_converter.xml
@@ -1,14 +1,12 @@
 <tool id="CONVERTER_bed_to_bgzip_0" name="Convert BED to BGZIP" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">bgzip.py -P bed $input1 $output1</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/bgzip.py' -P bed '$input1' '$output1'</command>
+    <inputs>
         <param format="bed" name="input1" type="data" label="Choose BED file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bgzip" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="bgzip" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/bed_to_fli_converter.xml
+++ b/lib/galaxy/datatypes/converters/bed_to_fli_converter.xml
@@ -1,13 +1,13 @@
-<tool id="CONVERTER_bed_to_fli_0" name="Convert BED to Feature Location Index">
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">interval_to_fli.py -F bed '$input1' '$output1'</command>
-  <inputs>
-    <param format="bed" name="input1" type="data" label="Choose BED file"/>
-  </inputs>
-  <outputs>
-    <data format="fli" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_bed_to_fli_0" name="Convert BED to Feature Location Index" version="1.0.0">
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <!-- Used on the metadata edit page. -->
+    <command>python '$__tool_directory__/interval_to_fli.py' -F bed '$input1' '$output1'</command>
+    <inputs>
+        <param format="bed" name="input1" type="data" label="Choose BED file"/>
+    </inputs>
+    <outputs>
+        <data format="fli" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/bed_to_gff_converter.xml
+++ b/lib/galaxy/datatypes/converters/bed_to_gff_converter.xml
@@ -1,13 +1,13 @@
 <tool id="CONVERTER_bed_to_gff_0" name="Convert BED to GFF" version="2.0.0">
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">bed_to_gff_converter.py '$input1' '$output1'</command>
-  <inputs>
-    <param format="bed" name="input1" type="data" label="Choose BED file"/>
-  </inputs>
-  <outputs>
-    <data format="gff" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <!-- Used on the metadata edit page. -->
+    <command>python '$__tool_directory__/bed_to_gff_converter.py' '$input1' '$output1'</command>
+    <inputs>
+        <param format="bed" name="input1" type="data" label="Choose BED file"/>
+    </inputs>
+    <outputs>
+        <data format="gff" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/bed_to_interval_index_converter.xml
+++ b/lib/galaxy/datatypes/converters/bed_to_interval_index_converter.xml
@@ -1,14 +1,12 @@
 <tool id="CONVERTER_bed_to_interval_index_0" name="Convert BED to Interval Index" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">interval_to_interval_index_converter.py $input1 $output1</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/interval_to_interval_index_converter.py' '$input1' '$output1'</command>
+    <inputs>
         <param format="bed" name="input1" type="data" label="Choose BED file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="interval_index" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="interval_index" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/bed_to_tabix_converter.xml
+++ b/lib/galaxy/datatypes/converters/bed_to_tabix_converter.xml
@@ -1,15 +1,13 @@
 <tool id="CONVERTER_bed_to_tabix_0" name="Convert BED to tabix" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">interval_to_tabix_converter.py -P bed '$input1' '$bgzip' '$output1'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/interval_to_tabix_converter.py' -P bed '$input1' '$bgzip' '$output1'</command>
+    <inputs>
         <param format="bed" name="input1" type="data" label="Choose BED file"/>
         <param format="bgzip" name="bgzip" type="data" label="BGZIP file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="tabix" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="tabix" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/bedgraph_to_array_tree_converter.xml
+++ b/lib/galaxy/datatypes/converters/bedgraph_to_array_tree_converter.xml
@@ -1,14 +1,12 @@
-<tool id="CONVERTER_BedGraph_0" name="Index BedGraph for Track Viewer" hidden="true">
-  <!-- Used internally to generate track indexes -->
-  <command interpreter="python">bedgraph_to_array_tree_converter.py '$input' '$output'</command>
-  <inputs>
-    <page>
-      <param format="bedgraph" name="input" type="data" label="Choose BedGraph"/>
-    </page>
-   </inputs>
-   <outputs>
-      <data format="array_tree" name="output"/>
-   </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_BedGraph_0" name="Index BedGraph for Track Viewer" version="1.0.0" hidden="true">
+    <!-- Used internally to generate track indexes -->
+    <command>python '$__tool_directory__/bedgraph_to_array_tree_converter.py' '$input' '$output'</command>
+    <inputs>
+        <param format="bedgraph" name="input" type="data" label="Choose BedGraph"/>
+    </inputs>
+    <outputs>
+        <data format="array_tree" name="output"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/bedgraph_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bedgraph_to_bigwig_converter.xml
@@ -3,7 +3,7 @@
     <requirements>
         <requirement type="package">ucsc_tools</requirement>
     </requirements>
-    <command>grep -v "^track" '$input' | wigToBigWig -clip stdin $chromInfo '$output'</command>
+    <command>grep -v "^track" '$input' | wigToBigWig -clip stdin '$chromInfo' '$output'</command>
     <inputs>
         <param format="bedgraph" name="input" type="data" label="Choose wiggle"/>
     </inputs>

--- a/lib/galaxy/datatypes/converters/bedgraph_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bedgraph_to_bigwig_converter.xml
@@ -1,15 +1,15 @@
-<tool id="CONVERTER_bedgraph_to_bigwig" name="Convert BedGraph to BigWig" hidden="true">
-  <!-- Used internally to generate track indexes -->
-  <requirements>
-      <requirement type="package">ucsc_tools</requirement>
-  </requirements>
-  <command>grep -v "^track" '$input' | wigToBigWig -clip stdin $chromInfo '$output'</command>
-  <inputs>
-      <param format="bedgraph" name="input" type="data" label="Choose wiggle"/>
-   </inputs>
-   <outputs>
-      <data format="bigwig" name="output"/>
-   </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_bedgraph_to_bigwig" name="Convert BedGraph to BigWig" version="1.0.0" hidden="true">
+    <!-- Used internally to generate track indexes -->
+    <requirements>
+        <requirement type="package">ucsc_tools</requirement>
+    </requirements>
+    <command>grep -v "^track" '$input' | wigToBigWig -clip stdin $chromInfo '$output'</command>
+    <inputs>
+        <param format="bedgraph" name="input" type="data" label="Choose wiggle"/>
+    </inputs>
+    <outputs>
+        <data format="bigwig" name="output"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/encodepeak_to_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/encodepeak_to_bgzip_converter.xml
@@ -1,19 +1,18 @@
 <tool id="CONVERTER_encodepeak_to_bgzip_0" name="Convert ENCODEPeak to BGZIP" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">bgzip.py 
-                                  -c ${input1.metadata.chromCol} 
-                                  -s ${input1.metadata.startCol} 
-                                  -e ${input1.metadata.endCol} 
-                                  '$input1' '$output1'
-  </command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>
+        python '$__tool_directory__/bgzip.py'
+        -c ${input1.metadata.chromCol}
+        -s ${input1.metadata.startCol}
+        -e ${input1.metadata.endCol}
+        '$input1' '$output1'
+    </command>
+    <inputs>
         <param format="ENCODEPeak" name="input1" type="data" label="Choose ENCODEPeak file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bgzip" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="bgzip" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/encodepeak_to_tabix_converter.xml
+++ b/lib/galaxy/datatypes/converters/encodepeak_to_tabix_converter.xml
@@ -1,20 +1,19 @@
 <tool id="CONVERTER_encodepeak_to_tabix_0" name="Convert ENCODEPeak to tabix" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">interval_to_tabix_converter.py
-                                  -c ${input1.metadata.chromCol} 
-                                  -s ${input1.metadata.startCol} 
-                                  -e ${input1.metadata.endCol} 
-                                  '$input1' '$bgzip' '$output1'
-  </command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>
+        python '$__tool_directory__/interval_to_tabix_converter.py'
+        -c ${input1.metadata.chromCol}
+        -s ${input1.metadata.startCol}
+        -e ${input1.metadata.endCol}
+        '$input1' '$bgzip' '$output1'
+    </command>
+    <inputs>
         <param format="encodepeak" name="input1" type="data" label="Choose ENCODEPeak file"/>
         <param format="bgzip" name="bgzip" type="data" label="BGZIP file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="tabix" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="tabix" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/fasta_to_bowtie_base_index_converter.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_bowtie_base_index_converter.xml
@@ -1,22 +1,21 @@
 <tool id="CONVERTER_fasta_to_bowtie_base_index" name="Convert FASTA to Bowtie base space Index" version="1.0.0">
-  <requirements><requirement type='package'>bowtie</requirement></requirements>
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <requirements>
-      <requirement type="package">bowtie</requirement>
-  </requirements>
-  <command>
-  mkdir '${output.files_path}'
-  &amp;&amp; bowtie-build --quiet
-  -f 
-  '$input'  '${output.files_path}/${output.metadata.base_name}'
-  </command>
-  <inputs>
-    <param name="input" type="data" format="fasta" label="Fasta file"/>
-  </inputs>
-  <outputs>
-    <data name="output" format="bowtie_base_index"/>
-  </outputs>
-  <help>
-  </help>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <!-- Used on the metadata edit page. -->
+    <requirements>
+        <requirement type="package">bowtie</requirement>
+    </requirements>
+    <command>
+        mkdir '${output.files_path}'
+        &amp;&amp; bowtie-build --quiet
+        -f
+        '$input' '${output.files_path}/${output.metadata.base_name}'
+    </command>
+    <inputs>
+        <param name="input" type="data" format="fasta" label="Fasta file"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="bowtie_base_index"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/fasta_to_bowtie_base_index_converter.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_bowtie_base_index_converter.xml
@@ -5,10 +5,12 @@
         <requirement type="package">bowtie</requirement>
     </requirements>
     <command>
+<![CDATA[
         mkdir '${output.files_path}'
-        &amp;&amp; bowtie-build --quiet
+        && bowtie-build --quiet
         -f
         '$input' '${output.files_path}/${output.metadata.base_name}'
+]]>
     </command>
     <inputs>
         <param name="input" type="data" format="fasta" label="Fasta file"/>

--- a/lib/galaxy/datatypes/converters/fasta_to_bowtie_color_index_converter.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_bowtie_color_index_converter.xml
@@ -1,23 +1,22 @@
 <tool id="CONVERTER_fasta_to_bowtie_color_index" name="Convert FASTA to Bowtie color space Index" version="1.0.0">
-  <requirements><requirement type='package'>bowtie</requirement></requirements>
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <requirements>
-      <requirement type="package">bowtie</requirement>
-  </requirements>
-  <command>
-  mkdir '${output.files_path}'
-  &amp;&amp; bowtie-build --quiet
-  --color
-  -f 
-  '$input'  '${output.files_path}/${output.metadata.base_name}'
-  </command>
-  <inputs>
-    <param name="input" type="data" format="fasta" label="Fasta file"/>
-  </inputs>
-  <outputs>
-    <data name="output" format="bowtie_color_index"/>
-  </outputs>
-  <help>
-  </help>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <!-- Used on the metadata edit page. -->
+    <requirements>
+        <requirement type="package">bowtie</requirement>
+    </requirements>
+    <command>
+        mkdir '${output.files_path}'
+        &amp;&amp; bowtie-build --quiet
+        --color
+        -f
+        '$input' '${output.files_path}/${output.metadata.base_name}'
+    </command>
+    <inputs>
+        <param name="input" type="data" format="fasta" label="Fasta file"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="bowtie_color_index"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/fasta_to_bowtie_color_index_converter.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_bowtie_color_index_converter.xml
@@ -5,11 +5,13 @@
         <requirement type="package">bowtie</requirement>
     </requirements>
     <command>
+<![CDATA[
         mkdir '${output.files_path}'
-        &amp;&amp; bowtie-build --quiet
+        && bowtie-build --quiet
         --color
         -f
         '$input' '${output.files_path}/${output.metadata.base_name}'
+]]>
     </command>
     <inputs>
         <param name="input" type="data" format="fasta" label="Fasta file"/>

--- a/lib/galaxy/datatypes/converters/fasta_to_len.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_len.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_fasta_to_len" name="Convert FASTA to len file" version="1.0.0">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <!-- Used on the metadata edit page. -->
-    <command interpreter="python">fasta_to_len.py '$input' '$output' 0</command>
+    <command>python '$__tool_directory__/fasta_to_len.py' '$input' '$output' 0</command>
     <inputs>
         <param name="input" type="data" format="fasta" label="Fasta file"/>
     </inputs>

--- a/lib/galaxy/datatypes/converters/fasta_to_tabular_converter.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_tabular_converter.xml
@@ -1,13 +1,13 @@
 <tool id="CONVERTER_fasta_to_tabular" name="Convert FASTA to Tabular" version="1.0.1">
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">fasta_to_tabular_converter.py '$input' '$output'</command>
-  <inputs>
-    <param name="input" type="data" format="fasta" label="Fasta file"/>
-  </inputs>
-  <outputs>
-    <data name="output" format="tabular"/>
-  </outputs>
-  <help>
-  </help>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <!-- Used on the metadata edit page. -->
+    <command>python '$__tool_directory__/fasta_to_tabular_converter.py' '$input' '$output'</command>
+    <inputs>
+        <param name="input" type="data" format="fasta" label="Fasta file"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="tabular"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/fastq_to_fqtoc.xml
+++ b/lib/galaxy/datatypes/converters/fastq_to_fqtoc.xml
@@ -1,13 +1,11 @@
 <tool id="CONVERTER_fastq_to_fqtoc0" name="Convert FASTQ files to seek locations" version="1.0.0" hidden="true">
-  <command interpreter="python">fastq_to_fqtoc.py '$input1' '$output1'</command>
-  <inputs>
-    <page>
+    <command>python '$__tool_directory__/fastq_to_fqtoc.py' '$input1' '$output1'</command>
+    <inputs>
         <param format="fastq" name="input1" type="data" label="Choose FASTQ file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="fqtoc" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="fqtoc" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/fastqsolexa_to_fasta_converter.xml
+++ b/lib/galaxy/datatypes/converters/fastqsolexa_to_fasta_converter.xml
@@ -1,12 +1,12 @@
 <tool id="CONVERTER_fastqsolexa_to_fasta_0" name="Convert Fastqsolexa to Fasta" version="1.0.0">
-  <description>converts Fastqsolexa file to Fasta format</description>
-  <command interpreter="python">fastqsolexa_to_fasta_converter.py '$input' '$output'</command>
-  <inputs>
-    <param name="input" type="data" format="fastqsolexa" label="Choose Fastqsolexa file"/>
-  </inputs>
-  <outputs>
-    <data name="output" format="fasta"/>
-  </outputs>
-  <help>
-  </help>
+    <description>converts Fastqsolexa file to Fasta format</description>
+    <command>python '$__tool_directory__/fastqsolexa_to_fasta_converter.py' '$input' '$output'</command>
+    <inputs>
+        <param name="input" type="data" format="fastqsolexa" label="Choose Fastqsolexa file"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="fasta"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/fastqsolexa_to_qual_converter.xml
+++ b/lib/galaxy/datatypes/converters/fastqsolexa_to_qual_converter.xml
@@ -1,11 +1,11 @@
-<tool id="CONVERTER_fastqsolexa_to_qual_0" name="Convert Fastqsolexa to Qual">
-  <command interpreter="python">fastqsolexa_to_qual_converter.py '$input1' '$output1' ${input1.extension}</command>
-  <inputs>
-    <param format="fastqsolexa" name="input1" type="data" label="Choose Fastqsolexa file"/>
-  </inputs>
-  <outputs>
-    <data format="qualsolexa" name="output1" />
-  </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_fastqsolexa_to_qual_0" name="Convert Fastqsolexa to Qual" version="1.0.0">
+    <command>python '$__tool_directory__/fastqsolexa_to_qual_converter.py' '$input1' '$output1' ${input1.extension}</command>
+    <inputs>
+        <param format="fastqsolexa" name="input1" type="data" label="Choose Fastqsolexa file"/>
+    </inputs>
+    <outputs>
+        <data format="qualsolexa" name="output1" />
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/gff_to_bed_converter.xml
+++ b/lib/galaxy/datatypes/converters/gff_to_bed_converter.xml
@@ -1,13 +1,13 @@
-<tool id="CONVERTER_gff_to_bed_0" name="Convert GFF to BED">
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">gff_to_bed_converter.py '$input1' '$output1'</command>
-  <inputs>
-    <param format="gff" name="input1" type="data" label="Choose GFF file"/>
-  </inputs>
-  <outputs>
-    <data format="bed" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_gff_to_bed_0" name="Convert GFF to BED" version="1.0.0">
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <!-- Used on the metadata edit page. -->
+    <command>python '$__tool_directory__/gff_to_bed_converter.py' '$input1' '$output1'</command>
+    <inputs>
+        <param format="gff" name="input1" type="data" label="Choose GFF file"/>
+    </inputs>
+    <outputs>
+        <data format="bed" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/gff_to_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/gff_to_bgzip_converter.xml
@@ -1,14 +1,12 @@
 <tool id="CONVERTER_gff_to_bgzip_0" name="Convert GFF to BGZIP" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">bgzip.py -P gff '$input1' '$output1'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/bgzip.py' -P gff '$input1' '$output1'</command>
+    <inputs>
         <param format="gff" name="input1" type="data" label="Choose GFF file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bgzip" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="bgzip" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/gff_to_fli_converter.xml
+++ b/lib/galaxy/datatypes/converters/gff_to_fli_converter.xml
@@ -1,13 +1,13 @@
-<tool id="CONVERTER_gff_to_fli_0" name="Convert GFF to Feature Location Index">
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">interval_to_fli.py -F $input1.extension '$input1' '$output1'</command>
-  <inputs>
-    <param format="gff" name="input1" type="data" label="Choose GFF file"/>
-  </inputs>
-  <outputs>
-    <data format="fli" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_gff_to_fli_0" name="Convert GFF to Feature Location Index" version="1.0.0">
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <!-- Used on the metadata edit page. -->
+    <command>python '$__tool_directory__/interval_to_fli.py' -F $input1.extension '$input1' '$output1'</command>
+    <inputs>
+        <param format="gff" name="input1" type="data" label="Choose GFF file"/>
+    </inputs>
+    <outputs>
+        <data format="fli" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/gff_to_interval_index_converter.xml
+++ b/lib/galaxy/datatypes/converters/gff_to_interval_index_converter.xml
@@ -1,14 +1,12 @@
 <tool id="CONVERTER_gff_to_interval_index_0" name="Convert GFF to Interval Index" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">gff_to_interval_index_converter.py '$input1' '$output1'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/gff_to_interval_index_converter.py' '$input1' '$output1'</command>
+    <inputs>
         <param format="gff" name="input1" type="data" label="Choose GFF file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="interval_index" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="interval_index" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/gff_to_tabix_converter.xml
+++ b/lib/galaxy/datatypes/converters/gff_to_tabix_converter.xml
@@ -1,15 +1,13 @@
 <tool id="CONVERTER_gff_to_tabix_0" name="Convert GFF to tabix" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">interval_to_tabix_converter.py -P gff '$input1' '$bgzip' '$output1'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/interval_to_tabix_converter.py' -P gff '$input1' '$bgzip' '$output1'</command>
+    <inputs>
         <param format="gff" name="input1" type="data" label="Choose GFF file"/>
         <param format="bgzip" name="bgzip" type="data" label="BGZIP file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="tabix" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="tabix" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/interval_to_bed12_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bed12_converter.xml
@@ -1,15 +1,12 @@
-<tool id="CONVERTER_interval_to_bed12_0" name="Convert Genomic Intervals To Strict BED12">
-  <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">interval_to_bedstrict_converter.py '$output1' '$input1' ${input1.metadata.chromCol} ${input1.metadata.startCol} ${input1.metadata.endCol} ${input1.metadata.strandCol} ${input1.metadata.nameCol} ${input1.extension} 12</command>
-  <inputs>
-    <page>
-      <param format="interval" name="input1" type="data" label="Choose intervals"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bed12" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_interval_to_bed12_0" name="Convert Genomic Intervals To Strict BED12" version="1.0.0">
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/interval_to_bedstrict_converter.py' '$output1' '$input1' ${input1.metadata.chromCol} ${input1.metadata.startCol} ${input1.metadata.endCol} ${input1.metadata.strandCol} ${input1.metadata.nameCol} ${input1.extension} 12</command>
+    <inputs>
+        <param format="interval" name="input1" type="data" label="Choose intervals"/>
+    </inputs>
+    <outputs>
+        <data format="bed12" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/interval_to_bed12_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bed12_converter.xml
@@ -1,6 +1,12 @@
 <tool id="CONVERTER_interval_to_bed12_0" name="Convert Genomic Intervals To Strict BED12" version="1.0.0">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-    <command>python '$__tool_directory__/interval_to_bedstrict_converter.py' '$output1' '$input1' ${input1.metadata.chromCol} ${input1.metadata.startCol} ${input1.metadata.endCol} ${input1.metadata.strandCol} ${input1.metadata.nameCol} ${input1.extension} 12</command>
+    <command>
+        python '$__tool_directory__/interval_to_bedstrict_converter.py'
+        '$output1' '$input1' ${input1.metadata.chromCol}
+        ${input1.metadata.startCol} ${input1.metadata.endCol}
+        ${input1.metadata.strandCol} ${input1.metadata.nameCol}
+        ${input1.extension} 12
+    </command>
     <inputs>
         <param format="interval" name="input1" type="data" label="Choose intervals"/>
     </inputs>

--- a/lib/galaxy/datatypes/converters/interval_to_bed6_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bed6_converter.xml
@@ -1,15 +1,12 @@
-<tool id="CONVERTER_interval_to_bed6_0" name="Convert Genomic Intervals To Strict BED6">
-  <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">interval_to_bedstrict_converter.py '$output1' '$input1' ${input1.metadata.chromCol} ${input1.metadata.startCol} ${input1.metadata.endCol} ${input1.metadata.strandCol} ${input1.metadata.nameCol} ${input1.extension} 6</command>
-  <inputs>
-    <page>
-      <param format="interval" name="input1" type="data" label="Choose intervals"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bed6" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_interval_to_bed6_0" name="Convert Genomic Intervals To Strict BED6" version="1.0.0">
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/interval_to_bedstrict_converter.py' '$output1' '$input1' ${input1.metadata.chromCol} ${input1.metadata.startCol} ${input1.metadata.endCol} ${input1.metadata.strandCol} ${input1.metadata.nameCol} ${input1.extension} 6</command>
+    <inputs>
+        <param format="interval" name="input1" type="data" label="Choose intervals"/>
+    </inputs>
+    <outputs>
+        <data format="bed6" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/interval_to_bed_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bed_converter.xml
@@ -1,15 +1,12 @@
-<tool id="CONVERTER_interval_to_bed_0" name="Convert Genomic Intervals To BED">
-  <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">interval_to_bed_converter.py '$output1' '$input1' ${input1.metadata.chromCol} ${input1.metadata.startCol} ${input1.metadata.endCol} ${input1.metadata.strandCol} ${input1.metadata.nameCol}</command>
-  <inputs>
-    <page>
-      <param format="interval" name="input1" type="data" label="Choose intervals"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bed" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_interval_to_bed_0" name="Convert Genomic Intervals To BED" version="1.0.0">
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/interval_to_bed_converter.py' '$output1' '$input1' ${input1.metadata.chromCol} ${input1.metadata.startCol} ${input1.metadata.endCol} ${input1.metadata.strandCol} ${input1.metadata.nameCol}</command>
+    <inputs>
+        <param format="interval" name="input1" type="data" label="Choose intervals"/>
+    </inputs>
+    <outputs>
+        <data format="bed" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/interval_to_bedstrict_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bedstrict_converter.xml
@@ -1,15 +1,12 @@
-<tool id="CONVERTER_interval_to_bedstrict_0" name="Convert Genomic Intervals To Strict BED">
-  <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">interval_to_bedstrict_converter.py '$output1' '$input1' ${input1.metadata.chromCol} ${input1.metadata.startCol} ${input1.metadata.endCol} ${input1.metadata.strandCol} ${input1.metadata.nameCol} ${input1.extension}</command>
-  <inputs>
-    <page>
-      <param format="interval" name="input1" type="data" label="Choose intervals"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bedstrict" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_interval_to_bedstrict_0" name="Convert Genomic Intervals To Strict BED" version="1.0.0">
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/interval_to_bedstrict_converter.py' '$output1' '$input1' ${input1.metadata.chromCol} ${input1.metadata.startCol} ${input1.metadata.endCol} ${input1.metadata.strandCol} ${input1.metadata.nameCol} ${input1.extension}</command>
+    <inputs>
+        <param format="interval" name="input1" type="data" label="Choose intervals"/>
+    </inputs>
+    <outputs>
+        <data format="bedstrict" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
@@ -1,19 +1,18 @@
 <tool id="CONVERTER_interval_to_bgzip_0" name="Convert Interval to BGZIP" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">bgzip.py 
-                                  -c ${input1.metadata.chromCol} 
-                                  -s ${input1.metadata.startCol} 
-                                  -e ${input1.metadata.endCol} 
-                                  '$input1' '$output1'
-  </command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>
+        python '$__tool_directory__/bgzip.py'
+        -c ${input1.metadata.chromCol}
+        -s ${input1.metadata.startCol}
+        -e ${input1.metadata.endCol}
+        '$input1' '$output1'
+    </command>
+    <inputs>
         <param format="interval" name="input1" type="data" label="Choose Interval file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bgzip" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="bgzip" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/interval_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bigwig_converter.xml
@@ -1,37 +1,32 @@
-<tool id="CONVERTER_interval_to_bigwig_0" name="Convert Genomic Intervals To Coverage">
-  <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
+<tool id="CONVERTER_interval_to_bigwig_0" name="Convert Genomic Intervals To Coverage" version="1.0.0">
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
         <requirement type="package">ucsc_tools</requirement>
         <requirement type="package">bedtools</requirement>
     </requirements>
-  <command>
+    <command>
+        ## Remove comments and sort by chromosome.
+        grep -v '^#' '$input1' | sort -k${input1.metadata.chromCol},${input1.metadata.chromCol} |
 
-    ## Remove comments and sort by chromosome.
-    grep -v '^#' '$input1' | sort -k${input1.metadata.chromCol},${input1.metadata.chromCol} |
+        ## Create simple BED by cutting chrom, start, and end columns.
+        awk -v OFS='	' '{print $${input1.metadata.chromCol},$${input1.metadata.startCol},$${input1.metadata.endCol} }' |
 
-    ## Create simple BED by cutting chrom, start, and end columns.
-    awk -v OFS='	' '{print $${input1.metadata.chromCol},$${input1.metadata.startCol},$${input1.metadata.endCol} }' |
+        ## Generate coverage bedgraph.
+        bedtools genomecov -bg -split -i stdin -g $chromInfo
 
-    ## Generate coverage bedgraph.
-    bedtools genomecov -bg -split -i stdin -g $chromInfo 
+        ## Streaming the bedgraph file to wigToBigWig is fast but very memory intensive; hence, this
+        ## should only be used on systems with large RAM.
+        ## | wigToBigWig stdin $chromInfo '$output'
 
-    ## Streaming the bedgraph file to wigToBigWig is fast but very memory intensive; hence, this
-    ## should only be used on systems with large RAM.
-    ## | wigToBigWig stdin $chromInfo '$output'
-
-    ## This can be used anywhere.
-    > temp.bg ; bedGraphToBigWig temp.bg $chromInfo '$output'
-
-  </command>
-  <inputs>
-    <page>
-      <param format="interval" name="input1" type="data" label="Choose intervals"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bigwig" name="output"/>
-  </outputs>
-  <help>
-  </help>
+        ## This can be used anywhere.
+        > temp.bg ; bedGraphToBigWig temp.bg $chromInfo '$output'
+    </command>
+    <inputs>
+        <param format="interval" name="input1" type="data" label="Choose intervals"/>
+    </inputs>
+    <outputs>
+        <data format="bigwig" name="output"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/interval_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bigwig_converter.xml
@@ -5,6 +5,7 @@
         <requirement type="package">bedtools</requirement>
     </requirements>
     <command>
+<![CDATA[
         ## Remove comments and sort by chromosome.
         grep -v '^#' '$input1' | sort -k${input1.metadata.chromCol},${input1.metadata.chromCol} |
 
@@ -12,14 +13,15 @@
         awk -v OFS='	' '{print $${input1.metadata.chromCol},$${input1.metadata.startCol},$${input1.metadata.endCol} }' |
 
         ## Generate coverage bedgraph.
-        bedtools genomecov -bg -split -i stdin -g $chromInfo
+        bedtools genomecov -bg -split -i stdin -g '$chromInfo'
 
         ## Streaming the bedgraph file to wigToBigWig is fast but very memory intensive; hence, this
         ## should only be used on systems with large RAM.
-        ## | wigToBigWig stdin $chromInfo '$output'
+        ## | wigToBigWig stdin '$chromInfo' '$output'
 
         ## This can be used anywhere.
-        > temp.bg ; bedGraphToBigWig temp.bg $chromInfo '$output'
+        > temp.bg && bedGraphToBigWig temp.bg '$chromInfo' '$output'
+]]>
     </command>
     <inputs>
         <param format="interval" name="input1" type="data" label="Choose intervals"/>

--- a/lib/galaxy/datatypes/converters/interval_to_coverage.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_coverage.xml
@@ -1,18 +1,16 @@
-<tool id="CONVERTER_interval_to_coverage_0" name="Convert Genomic Intervals To COVERAGE">
-  <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">interval_to_coverage.py '$input1' '$output1'
-  -1 ${input1.metadata.chromCol},${input1.metadata.startCol},${input1.metadata.endCol},${input1.metadata.strandCol}
-  -2 ${output1.metadata.chromCol},${output1.metadata.positionCol},${output1.metadata.forwardCol},${output1.metadata.reverseCol}
-  </command>
-  <inputs>
-    <page>
-      <param format="interval" name="input1" type="data" label="Choose intervals"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="coverage" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_interval_to_coverage_0" name="Convert Genomic Intervals To COVERAGE" version="1.0.0">
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>
+        python '$__tool_directory__/interval_to_coverage.py' '$input1' '$output1'
+        -1 ${input1.metadata.chromCol},${input1.metadata.startCol},${input1.metadata.endCol},${input1.metadata.strandCol}
+        -2 ${output1.metadata.chromCol},${output1.metadata.positionCol},${output1.metadata.forwardCol},${output1.metadata.reverseCol}
+    </command>
+    <inputs>
+        <param format="interval" name="input1" type="data" label="Choose intervals"/>
+    </inputs>
+    <outputs>
+        <data format="coverage" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/interval_to_interval_index_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_interval_index_converter.xml
@@ -1,19 +1,18 @@
 <tool id="CONVERTER_interval_to_interval_index_0" name="Convert Interval to Interval Index" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">interval_to_interval_index_converter.py 
-                                -c ${input1.metadata.chromCol} 
-                                -s ${input1.metadata.startCol} 
-                                -e ${input1.metadata.endCol} 
-                                '$input1' '$output1'
-  </command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>
+        python '$__tool_directory__/interval_to_interval_index_converter.py'
+        -c ${input1.metadata.chromCol}
+        -s ${input1.metadata.startCol}
+        -e ${input1.metadata.endCol}
+        '$input1' '$output1'
+    </command>
+    <inputs>
         <param format="interval" name="input1" type="data" label="Choose Interval file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="interval_index" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="interval_index" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/interval_to_tabix_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_tabix_converter.xml
@@ -1,20 +1,19 @@
 <tool id="CONVERTER_interval_to_tabix_0" name="Convert Interval to tabix" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">interval_to_tabix_converter.py
-                                  -c ${input1.metadata.chromCol} 
-                                  -s ${input1.metadata.startCol} 
-                                  -e ${input1.metadata.endCol} 
-                                  '$input1' '$bgzip' '$output1'
-  </command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>
+        python '$__tool_directory__/interval_to_tabix_converter.py'
+        -c ${input1.metadata.chromCol}
+        -s ${input1.metadata.startCol}
+        -e ${input1.metadata.endCol}
+        '$input1' '$bgzip' '$output1'
+    </command>
+    <inputs>
         <param format="interval" name="input1" type="data" label="Choose Interval file"/>
         <param format="bgzip" name="bgzip" type="data" label="BGZIP file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="tabix" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="tabix" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/len_to_linecount.xml
+++ b/lib/galaxy/datatypes/converters/len_to_linecount.xml
@@ -1,7 +1,11 @@
 <tool id="CONVERTER_len_to_linecount" name="Convert Len file to Linecount" version="1.0.0">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <!-- Used on the metadata edit page. -->
-    <command>wc -l '$input' | awk '{print $1}' &gt; '$output' </command>
+    <command>
+<![CDATA[
+        wc -l '$input' | awk '{print $1}' > '$output'
+]]>
+    </command>
     <inputs>
         <param name="input" type="data" format="len" label="Fasta file"/>
     </inputs>

--- a/lib/galaxy/datatypes/converters/lped_to_fped_converter.py
+++ b/lib/galaxy/datatypes/converters/lped_to_fped_converter.py
@@ -81,7 +81,7 @@ def main():
     """call fbater
     need to work with rgenetics composite datatypes
     so in and out are html files with data in extrafiles path
-    <command interpreter="python">rg_convert_lped_fped.py '$input1/$input1.metadata.base_name'
+    <command>python '$__tool_directory__/rg_convert_lped_fped.py' '$input1/$input1.metadata.base_name'
     '$output1' '$output1.extra_files_path'
     </command>
     """

--- a/lib/galaxy/datatypes/converters/lped_to_fped_converter.xml
+++ b/lib/galaxy/datatypes/converters/lped_to_fped_converter.xml
@@ -1,15 +1,15 @@
 <tool id="lped2fpedconvert" name="Convert lped to fped" version="0.01">
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">
-   lped_to_fped_converter.py '$input1.extra_files_path/$input1.metadata.base_name' '$output1' '$output1.files_path'
-  </command>
-  <inputs>
-    <param format="lped" name="input1" type="data" label="Choose linkage pedigree file"/>
-  </inputs>
-  <outputs>
-    <data format="fped" name="output1" metadata_source="input1"/>
-  </outputs>
-  <help>
-  </help>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <!-- Used on the metadata edit page. -->
+    <command>
+        python '$__tool_directory__/lped_to_fped_converter.py' '$input1.extra_files_path/$input1.metadata.base_name' '$output1' '$output1.files_path'
+    </command>
+    <inputs>
+        <param format="lped" name="input1" type="data" label="Choose linkage pedigree file"/>
+    </inputs>
+    <outputs>
+        <data format="fped" name="output1" metadata_source="input1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/lped_to_pbed_converter.py
+++ b/lib/galaxy/datatypes/converters/lped_to_pbed_converter.py
@@ -81,7 +81,7 @@ def main():
     """
     need to work with rgenetics composite datatypes
     so in and out are html files with data in extrafiles path
-    <command interpreter="python">lped_to_pbed_converter.py '$input1/$input1.metadata.base_name'
+    <command>python '$__tool_directory__/lped_to_pbed_converter.py' '$input1/$input1.metadata.base_name'
     '$output1' '$output1.extra_files_path' '${GALAXY_DATA_INDEX_DIR}/rg/bin/plink'
     </command>
     """

--- a/lib/galaxy/datatypes/converters/lped_to_pbed_converter.xml
+++ b/lib/galaxy/datatypes/converters/lped_to_pbed_converter.xml
@@ -1,16 +1,16 @@
 <tool id="lped2pbedconvert" name="Convert lped to plink pbed" version="0.01">
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">
-   lped_to_pbed_converter.py '$input1.extra_files_path/$input1.metadata.base_name'
-   '$output1' '$output1.files_path' 'plink'
-  </command>
-  <inputs>
-    <param format="lped" name="input1" type="data" label="Choose linkage pedigree file"/>
-  </inputs>
-  <outputs>
-    <data format="pbed" name="output1" metadata_source="input1"/>
-  </outputs>
-  <help>
-  </help>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <!-- Used on the metadata edit page. -->
+    <command>
+        python '$__tool_directory__/lped_to_pbed_converter.py' '$input1.extra_files_path/$input1.metadata.base_name'
+        '$output1' '$output1.files_path' 'plink'
+    </command>
+    <inputs>
+        <param format="lped" name="input1" type="data" label="Choose linkage pedigree file"/>
+    </inputs>
+    <outputs>
+        <data format="pbed" name="output1" metadata_source="input1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/maf_to_fasta_converter.xml
+++ b/lib/galaxy/datatypes/converters/maf_to_fasta_converter.xml
@@ -1,15 +1,12 @@
 <tool id="CONVERTER_maf_to_fasta_0" name="Convert MAF to Fasta" version="1.0.1">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">maf_to_fasta_converter.py '$output1' '$input1'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/maf_to_fasta_converter.py' '$output1' '$input1'</command>
+    <inputs>
         <param format="maf" name="input1" type="data" label="Choose MAF file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="fasta" name="output1"/>
-  </outputs>
-  <help>
-  </help>
-<!--  <code file="maf_to_fasta_converter_code.py"/>-->
+    </inputs>
+    <outputs>
+        <data format="fasta" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/maf_to_interval_converter.xml
+++ b/lib/galaxy/datatypes/converters/maf_to_interval_converter.xml
@@ -1,15 +1,12 @@
 <tool id="CONVERTER_maf_to_interval_0" name="Convert MAF to Genomic Intervals" version="1.0.2">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">maf_to_interval_converter.py '$output1' '$input1' '${input1.metadata.dbkey}'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/maf_to_interval_converter.py' '$output1' '$input1' '${input1.metadata.dbkey}'</command>
+    <inputs>
         <param format="maf" name="input1" type="data" label="Choose MAF file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="interval" name="output1"/>
-  </outputs>
-  <help>
-  </help>
-<!--  <code file="maf_to_interval_converter_code.py"/> -->
+    </inputs>
+    <outputs>
+        <data format="interval" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/pbed_ldreduced_converter.py
+++ b/lib/galaxy/datatypes/converters/pbed_ldreduced_converter.py
@@ -75,11 +75,10 @@ def main():
 
     .. raw:: xml
 
-        <command interpreter="python">
-            pbed_ldreduced_converter.py '$input1.extra_files_path/$input1.metadata.base_name' '$winsize' '$winmove' '$r2thresh'
+        <command>
+            python '$__tool_directory__/pbed_ldreduced_converter.py' '$input1.extra_files_path/$input1.metadata.base_name' '$winsize' '$winmove' '$r2thresh'
             '$output1' '$output1.files_path' 'plink'
         </command>
-
     """
     nparm = 7
     if len(sys.argv) < nparm:

--- a/lib/galaxy/datatypes/converters/pbed_ldreduced_converter.xml
+++ b/lib/galaxy/datatypes/converters/pbed_ldreduced_converter.xml
@@ -1,18 +1,14 @@
 <tool id="pbed2ldindepconvert" name="Convert plink pbed to ld reduced format" version="0.01">
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">
-   pbed_ldreduced_converter.py '$input1.extra_files_path/$input1.metadata.base_name' '60' '55' '0.1' '$output1' '$output1.files_path' 'plink'
-  </command>
-  <inputs>
-   <page>
-     <param format="pbed" name="input1" type="data" label="Choose a compressed Plink binary format genotype file"/>
-   </page>
-  </inputs>
-  <outputs>
-    <data format="ldindep" name="output1" metadata_source="input1"/>
-  </outputs>
-  <help>
-  </help>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>
+        python '$__tool_directory__/pbed_ldreduced_converter.py' '$input1.extra_files_path/$input1.metadata.base_name' '60' '55' '0.1' '$output1' '$output1.files_path' 'plink'
+    </command>
+    <inputs>
+        <param format="pbed" name="input1" type="data" label="Choose a compressed Plink binary format genotype file"/>
+    </inputs>
+    <outputs>
+        <data format="ldindep" name="output1" metadata_source="input1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>
- 

--- a/lib/galaxy/datatypes/converters/pbed_to_lped_converter.py
+++ b/lib/galaxy/datatypes/converters/pbed_to_lped_converter.py
@@ -49,7 +49,7 @@ def main():
     """
     need to work with rgenetics composite datatypes
     so in and out are html files with data in extrafiles path
-    <command interpreter="python">pbed_to_lped_converter.py '$input1/$input1.metadata.base_name'
+    <command>python '$__tool_directory__/pbed_to_lped_converter.py' '$input1/$input1.metadata.base_name'
     '$output1' '$output1.extra_files_path' '${GALAXY_DATA_INDEX_DIR}/rg/bin/plink'
     </command>
     """

--- a/lib/galaxy/datatypes/converters/pbed_to_lped_converter.xml
+++ b/lib/galaxy/datatypes/converters/pbed_to_lped_converter.xml
@@ -1,16 +1,16 @@
 <tool id="pbed2lpedconvert" name="Convert plink pbed to linkage lped" version="0.01">
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">
-   pbed_to_lped_converter.py '$input1.extra_files_path/$input1.metadata.base_name'
-   '$output1' '$output1.files_path' 'plink'
-  </command>
-  <inputs>
-    <param format="pbed" name="input1" type="data" label="Choose compressed Plink binary format genotype file"/>
-  </inputs>
-  <outputs>
-    <data format="lped" name="output1" metadata_source="input1"/>
-  </outputs>
-  <help>
-  </help>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <!-- Used on the metadata edit page. -->
+    <command>
+        python '$__tool_directory__/pbed_to_lped_converter.py' '$input1.extra_files_path/$input1.metadata.base_name'
+        '$output1' '$output1.files_path' plink
+    </command>
+    <inputs>
+        <param format="pbed" name="input1" type="data" label="Choose compressed Plink binary format genotype file"/>
+    </inputs>
+    <outputs>
+        <data format="lped" name="output1" metadata_source="input1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/picard_interval_list_to_bed6_converter.xml
+++ b/lib/galaxy/datatypes/converters/picard_interval_list_to_bed6_converter.xml
@@ -1,6 +1,6 @@
 <tool id="CONVERTER_picard_interval_list_to_bed6" name="Convert Picard Interval List to BED6" version="1.0.0">
     <description>converter</description>
-    <command interpreter="python">picard_interval_list_to_bed6_converter.py '$input' '$output'</command>
+    <command>python '$__tool_directory__/picard_interval_list_to_bed6_converter.py' '$input' '$output'</command>
     <inputs>
         <param name="input" type="data" format="picard_interval_list" label="Picard Interval List file"/>
     </inputs>

--- a/lib/galaxy/datatypes/converters/pileup_to_interval_index_converter.xml
+++ b/lib/galaxy/datatypes/converters/pileup_to_interval_index_converter.xml
@@ -1,15 +1,15 @@
 <tool id="CONVERTER_pileup_to_interval_index_0" name="Convert Pileup to Interval Index" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">pileup_to_interval_index_converter.py '$input' '$output'
-  </command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>
+        python '$__tool_directory__/pileup_to_interval_index_converter.py'
+        '$input' '$output'
+    </command>
+    <inputs>
         <param format="pileup" name="input" type="data" label="Choose Pileup file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="interval_index" name="output"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="interval_index" name="output"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/sam_to_bam.xml
+++ b/lib/galaxy/datatypes/converters/sam_to_bam.xml
@@ -8,7 +8,7 @@
     <requirements>
         <requirement type="package">samtools</requirement>
     </requirements>
-    <command interpreter="python">sam_to_bam.py '$input1' '$output'</command>
+    <command>python '$__tool_directory__/sam_to_bam.py' '$input1' '$output'</command>
     <inputs>
         <param name="input1" type="data" format="sam" label="SAM file"/>
     </inputs>

--- a/lib/galaxy/datatypes/converters/sam_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/sam_to_bigwig_converter.xml
@@ -5,14 +5,16 @@
         <requirement type="package">bedtools</requirement>
     </requirements>
     <command>
-        samtools view -bh '$input' | bedtools genomecov -bg -split -ibam stdin -g $chromInfo
+<![CDATA[
+        samtools view -bh '$input' | bedtools genomecov -bg -split -ibam stdin -g '$chromInfo'
 
         ## Streaming the bedgraph file to wigToBigWig is fast but very memory intensive; hence, this
         ## should only be used on systems with large RAM.
-        ## | wigToBigWig stdin $chromInfo '$output'
+        ## | wigToBigWig stdin '$chromInfo' '$output'
 
         ## This can be used anywhere.
-        > temp.bg ; bedGraphToBigWig temp.bg $chromInfo '$output'
+        > temp.bg && bedGraphToBigWig temp.bg '$chromInfo' '$output'
+]]>
     </command>
     <inputs>
         <param format="bam" name="input" type="data" label="Choose BAM file"/>

--- a/lib/galaxy/datatypes/converters/tabular_to_dbnsfp.xml
+++ b/lib/galaxy/datatypes/converters/tabular_to_dbnsfp.xml
@@ -1,12 +1,12 @@
 <tool id="tabular_to_dbnsfp" name="Convert tabular to dbnsfp" version="1.0.0">
-  <description></description> 
-  <command interpreter="python">tabular_to_dbnsfp.py '$input' '$dbnsfp.extra_files_path/dbNSFP.gz'</command>
-  <inputs>
-      <param format="tabular" name="input" type="data" label="Choose a dbnsfp tabular file"/>
-   </inputs>
-  <outputs>
-    <data format="snpsiftdbnsfp" name="dbnsfp"/>
-  </outputs>
-  <help>
-  </help>
+    <description></description>
+    <command>python '$__tool_directory__/tabular_to_dbnsfp.py' '$input' '$dbnsfp.extra_files_path/dbNSFP.gz'</command>
+    <inputs>
+        <param format="tabular" name="input" type="data" label="Choose a dbnsfp tabular file"/>
+    </inputs>
+    <outputs>
+        <data format="snpsiftdbnsfp" name="dbnsfp"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/vcf_bgzip_to_tabix_converter.xml
+++ b/lib/galaxy/datatypes/converters/vcf_bgzip_to_tabix_converter.xml
@@ -1,14 +1,12 @@
 <tool id="CONVERTER_vcf_bgzip_to_tabix_0" name="Convert BGZ VCF to tabix" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">interval_to_tabix_converter.py -P 'vcf' '' '$input1' '$output1'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/interval_to_tabix_converter.py' -P 'vcf' '' '$input1' '$output1'</command>
+    <inputs>
         <param format="vcf_bgzip" name="input1" type="data" label="Choose BGZIP'd VCF file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="tabix" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="tabix" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/vcf_to_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/vcf_to_bgzip_converter.xml
@@ -1,14 +1,12 @@
 <tool id="CONVERTER_vcf_to_bgzip_0" name="Convert VCF to BGZIP" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">bgzip.py -P vcf '$input1' '$output1'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/bgzip.py' -P vcf '$input1' '$output1'</command>
+    <inputs>
         <param format="vcf" name="input1" type="data" label="Choose Vcf file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="bgzip" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="bgzip" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/vcf_to_interval_index_converter.xml
+++ b/lib/galaxy/datatypes/converters/vcf_to_interval_index_converter.xml
@@ -1,14 +1,12 @@
 <tool id="CONVERTER_vcf_to_interval_index_0" name="Convert VCF to Interval Index" version="1.0.0" hidden="true">
-  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description>
-  <command interpreter="python">vcf_to_interval_index_converter.py '$input1' '$output1'</command>
-  <inputs>
-    <page>
+    <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description>
+    <command>python '$__tool_directory__/vcf_to_interval_index_converter.py' '$input1' '$output1'</command>
+    <inputs>
         <param format="vcf" name="input1" type="data" label="Choose VCF file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="interval_index" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="interval_index" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/vcf_to_tabix_converter.xml
+++ b/lib/galaxy/datatypes/converters/vcf_to_tabix_converter.xml
@@ -1,15 +1,13 @@
 <tool id="CONVERTER_vcf_to_tabix_0" name="Convert Vcf to tabix" version="1.0.0" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">interval_to_tabix_converter.py -P vcf '$input1' '$bgzip' '$output1'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/interval_to_tabix_converter.py' -P vcf '$input1' '$bgzip' '$output1'</command>
+    <inputs>
         <param format="vcf" name="input1" type="data" label="Choose Vcf file"/>
         <param format="bgzip" name="bgzip" type="data" label="BGZIP file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="tabix" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="tabix" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/vcf_to_vcf_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/vcf_to_vcf_bgzip_converter.xml
@@ -1,14 +1,12 @@
 <tool id="CONVERTER_vcf_to_vcf_bgzip_0" name="Convert VCF to VCF_BGZIP" version="1.0.1" hidden="true">
-<!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <command interpreter="python">vcf_to_vcf_bgzip.py '$input1' '$output1'</command>
-  <inputs>
-    <page>
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <command>python '$__tool_directory__/vcf_to_vcf_bgzip.py' '$input1' '$output1'</command>
+    <inputs>
         <param format="vcf" name="input1" type="data" label="Choose Vcf file"/>
-    </page>
-   </inputs>
-  <outputs>
-    <data format="vcf_bgzip" name="output1"/>
-  </outputs>
-  <help>
-  </help>
+    </inputs>
+    <outputs>
+        <data format="vcf_bgzip" name="output1"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/wig_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/wig_to_bigwig_converter.xml
@@ -4,8 +4,10 @@
         <requirement type="package">ucsc_tools</requirement>
     </requirements>
     <command>
-        grep -v "^track" '$input' | wigToBigWig -clip stdin $chromInfo '$output'
-        2&gt;&amp;1 || echo "Error running Wiggle to BigWig converter." >&amp;2
+<![CDATA[
+        grep -v "^track" '$input' | wigToBigWig -clip stdin '$chromInfo' '$output'
+        2>&1 || echo "Error running Wiggle to BigWig converter." >&2
+]]>
     </command>
     <inputs>
         <param format="wig" name="input" type="data" label="Choose wiggle"/>

--- a/lib/galaxy/datatypes/converters/wig_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/wig_to_bigwig_converter.xml
@@ -1,20 +1,18 @@
-<tool id="CONVERTER_wig_to_bigwig" name="Convert Wiggle to BigWig" hidden="true">
-  <!-- Used internally to generate track indexes -->
-  <requirements>
-      <requirement type="package">ucsc_tools</requirement>
-  </requirements>
-  <command>
-      grep -v "^track" '$input' | wigToBigWig -clip stdin $chromInfo '$output'
-      2&gt;&amp;1 || echo "Error running wiggle to bigwig converter." >&amp;2
-  </command>
-  <inputs>
-    <page>
-      <param format="wig" name="input" type="data" label="Choose wiggle"/>
-    </page>
-   </inputs>
-   <outputs>
-      <data format="bigwig" name="output"/>
-   </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_wig_to_bigwig" name="Convert Wiggle to BigWig" version="1.0.0" hidden="true">
+    <!-- Used internally to generate track indexes -->
+    <requirements>
+        <requirement type="package">ucsc_tools</requirement>
+    </requirements>
+    <command>
+        grep -v "^track" '$input' | wigToBigWig -clip stdin $chromInfo '$output'
+        2&gt;&amp;1 || echo "Error running Wiggle to BigWig converter." >&amp;2
+    </command>
+    <inputs>
+        <param format="wig" name="input" type="data" label="Choose wiggle"/>
+    </inputs>
+    <outputs>
+        <data format="bigwig" name="output"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/wiggle_to_array_tree_converter.xml
+++ b/lib/galaxy/datatypes/converters/wiggle_to_array_tree_converter.xml
@@ -1,14 +1,12 @@
-<tool id="CONVERTER_Wiggle_0" name="Index Wiggle for Track Viewer" hidden="true">
-  <!-- Used internally to generate track indexes -->
-  <command interpreter="python">wiggle_to_array_tree_converter.py '$input' '$output'</command>
-  <inputs>
-    <page>
-      <param format="wiggle" name="input" type="data" label="Choose wiggle"/>
-    </page>
-   </inputs>
-   <outputs>
-      <data format="array_tree" name="output"/>
-   </outputs>
-  <help>
-  </help>
+<tool id="CONVERTER_Wiggle_0" name="Index Wiggle for Track Viewer" version="1.0.0" hidden="true">
+    <!-- Used internally to generate track indexes -->
+    <command>python '$__tool_directory__/wiggle_to_array_tree_converter.py' '$input' '$output'</command>
+    <inputs>
+        <param format="wiggle" name="input" type="data" label="Choose wiggle"/>
+    </inputs>
+    <outputs>
+        <data format="array_tree" name="output"/>
+    </outputs>
+    <help>
+    </help>
 </tool>

--- a/lib/galaxy/datatypes/converters/wiggle_to_simple_converter.xml
+++ b/lib/galaxy/datatypes/converters/wiggle_to_simple_converter.xml
@@ -1,11 +1,11 @@
-<tool id="CONVERTER_wiggle_to_interval_0" name="Wiggle to Interval">
-  <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
-  <!-- Used on the metadata edit page. -->
-  <command interpreter="python">wiggle_to_simple_converter.py '$input' '$out_file1' </command>
-  <inputs>
-    <param format="wig" name="input" type="data" label="Convert"/>
-  </inputs>
-  <outputs>
-    <data format="interval" name="out_file1" />
-  </outputs>
+<tool id="CONVERTER_wiggle_to_interval_0" name="Wiggle to Interval" version="1.0.0">
+    <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <!-- Used on the metadata edit page. -->
+    <command>python '$__tool_directory__/wiggle_to_simple_converter.py' '$input' '$out_file1'</command>
+    <inputs>
+        <param format="wig" name="input" type="data" label="Convert"/>
+    </inputs>
+    <outputs>
+        <data format="interval" name="out_file1" />
+    </outputs>
 </tool>


### PR DESCRIPTION
- dos2unix
- Fix indentation
- Add missing tool version
- Remove deprecated `<page>` elements
- Remove deprecated `interpreter` attribute of `<command>`
- Quote some data parameters in `<command>`
- Remove some duplicated requirement
- Add CDATA
- Use `&&` to concatenate commands
- Quote `$chromInfo` (it's a file)