### PR TITLE
Adds a 'make charts' makefile target to make it more obvious how to build these.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PROJECT_URL?=https://github.com/galaxyproject/galaxy
 GRUNT_DOCKER_NAME:=galaxy/client-builder:16.01
 GRUNT_EXEC?=node_modules/grunt-cli/bin/grunt
 WEBPACK_EXEC?=node_modules/webpack/bin/webpack.js
-NODE_PATH?=client/node_modules
+GXY_NODE_MODULES=client/node_modules
 DOCS_DIR=doc
 DOC_SOURCE_DIR=$(DOCS_DIR)/source
 SLIDESHOW_DIR=$(DOC_SOURCE_DIR)/slideshow
@@ -95,7 +95,7 @@ client-install-libs: npm-deps ## Fetch updated client dependencies using bower.
 client: grunt style ## Rebuild all client-side artifacts
 
 charts: npm-deps ## Rebuild charts
-	NODE_PATH=$(CURDIR)/$(NODE_PATH) client/$(WEBPACK_EXEC) -p --config config/plugins/visualizations/charts/webpack.config.js
+	NODE_PATH=$(GXY_NODE_MODULES) client/$(WEBPACK_EXEC) -p --config config/plugins/visualizations/charts/webpack.config.js
 
 grunt-docker-image: ## Build docker image for running grunt
 	docker build -t ${GRUNT_DOCKER_NAME} client

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ IN_VENV=if [ -f $(VENV)/bin/activate ]; then . $(VENV)/bin/activate; fi;
 PROJECT_URL?=https://github.com/galaxyproject/galaxy
 GRUNT_DOCKER_NAME:=galaxy/client-builder:16.01
 GRUNT_EXEC?=node_modules/grunt-cli/bin/grunt
+WEBPACK_EXEC?=node_modules/webpack/bin/webpack.js
 DOCS_DIR=doc
 DOC_SOURCE_DIR=$(DOCS_DIR)/source
 SLIDESHOW_DIR=$(DOC_SOURCE_DIR)/slideshow
@@ -91,6 +92,9 @@ client-install-libs: npm-deps ## Fetch updated client dependencies using bower.
 	cd client && $(GRUNT_EXEC) install-libs
 
 client: grunt style ## Rebuild all client-side artifacts
+
+charts: npm-deps ## Rebuild charts
+	client/$(WEBPACK_EXEC) -p --config config/plugins/visualizations/charts/webpack.config.js
 
 grunt-docker-image: ## Build docker image for running grunt
 	docker build -t ${GRUNT_DOCKER_NAME} client

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ PROJECT_URL?=https://github.com/galaxyproject/galaxy
 GRUNT_DOCKER_NAME:=galaxy/client-builder:16.01
 GRUNT_EXEC?=node_modules/grunt-cli/bin/grunt
 WEBPACK_EXEC?=node_modules/webpack/bin/webpack.js
+NODE_PATH?=node_modules
 DOCS_DIR=doc
 DOC_SOURCE_DIR=$(DOCS_DIR)/source
 SLIDESHOW_DIR=$(DOC_SOURCE_DIR)/slideshow
@@ -94,7 +95,7 @@ client-install-libs: npm-deps ## Fetch updated client dependencies using bower.
 client: grunt style ## Rebuild all client-side artifacts
 
 charts: npm-deps ## Rebuild charts
-	client/$(WEBPACK_EXEC) -p --config config/plugins/visualizations/charts/webpack.config.js
+	NODE_PATH=client/$(NODE_PATH) client/$(WEBPACK_EXEC) -p --config config/plugins/visualizations/charts/webpack.config.js
 
 grunt-docker-image: ## Build docker image for running grunt
 	docker build -t ${GRUNT_DOCKER_NAME} client

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PROJECT_URL?=https://github.com/galaxyproject/galaxy
 GRUNT_DOCKER_NAME:=galaxy/client-builder:16.01
 GRUNT_EXEC?=node_modules/grunt-cli/bin/grunt
 WEBPACK_EXEC?=node_modules/webpack/bin/webpack.js
-NODE_PATH?=node_modules
+NODE_PATH?=client/node_modules
 DOCS_DIR=doc
 DOC_SOURCE_DIR=$(DOCS_DIR)/source
 SLIDESHOW_DIR=$(DOC_SOURCE_DIR)/slideshow
@@ -95,7 +95,7 @@ client-install-libs: npm-deps ## Fetch updated client dependencies using bower.
 client: grunt style ## Rebuild all client-side artifacts
 
 charts: npm-deps ## Rebuild charts
-	NODE_PATH=client/$(NODE_PATH) client/$(WEBPACK_EXEC) -p --config config/plugins/visualizations/charts/webpack.config.js
+	NODE_PATH=$(CURDIR)/$(NODE_PATH) client/$(WEBPACK_EXEC) -p --config config/plugins/visualizations/charts/webpack.config.js
 
 grunt-docker-image: ## Build docker image for running grunt
 	docker build -t ${GRUNT_DOCKER_NAME} client

--- a/config/plugins/visualizations/charts/webpack.config.js
+++ b/config/plugins/visualizations/charts/webpack.config.js
@@ -1,4 +1,3 @@
-var webpack = require( 'webpack' );
 var path = require( 'path' );
 var root = path.join( __dirname, 'static/repository' );
 var grunt = require( 'grunt' );


### PR DESCRIPTION
Not invoked automatically though, since these should very
rarely conflict and we don't want to have version build difference
conflicts (harmless) all the time.

@nsoranzo, @guerler, does this handle it?