### PR TITLE
Addition of IGV display for genome fasta file 

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -62,8 +62,7 @@
     <datatype extension="data" type="galaxy.datatypes.data:Data" mimetype="application/octet-stream" max_optional_metadata_filesize="1048576" />
     <datatype extension="data_manager_json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="True" display_in_upload="False"/>
     <datatype extension="dbn" type="galaxy.datatypes.sequence:DotBracket" display_in_upload="true" description="Dot-Bracket format is a text-based format for storing both an RNA sequence and its corresponding 2D structure." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Dbn"/>
-    <datatype extension="fai" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" subclass="True" description="A Fasta Index File is a text file consisting of lines each with five TAB-delimited columns : Name, Length, offset, linebases, Linewidth" description_url="http://www.htslib.org/doc/faidx.html">
-    </datatype>
+    <datatype extension="fai" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" subclass="True" description="A Fasta Index File is a text file consisting of lines each with five TAB-delimited columns : Name, Length, offset, linebases, Linewidth" description_url="http://www.htslib.org/doc/faidx.html" />
     <datatype extension="fasta" type="galaxy.datatypes.sequence:Fasta" display_in_upload="true" description="A sequence in FASTA format consists of a single-line description, followed by lines of sequence data. The first character of the description line is a greater-than ('>') symbol in the first column. All lines should be shorter than 80 characters." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Fasta">
       <converter file="fasta_to_tabular_converter.xml" target_datatype="tabular"/>
       <converter file="fasta_to_bowtie_base_index_converter.xml" target_datatype="bowtie_base_index"/>

--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -62,12 +62,16 @@
     <datatype extension="data" type="galaxy.datatypes.data:Data" mimetype="application/octet-stream" max_optional_metadata_filesize="1048576" />
     <datatype extension="data_manager_json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="True" display_in_upload="False"/>
     <datatype extension="dbn" type="galaxy.datatypes.sequence:DotBracket" display_in_upload="true" description="Dot-Bracket format is a text-based format for storing both an RNA sequence and its corresponding 2D structure." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Dbn"/>
+    <datatype extension="fai" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" subclass="True" description="A Fasta Index File is a text file consisting of lines each with five TAB-delimited columns : Name, Length, offset, linebases, Linewidth" description_url="http://www.htslib.org/doc/faidx.html">
+    </datatype>
     <datatype extension="fasta" type="galaxy.datatypes.sequence:Fasta" display_in_upload="true" description="A sequence in FASTA format consists of a single-line description, followed by lines of sequence data. The first character of the description line is a greater-than ('>') symbol in the first column. All lines should be shorter than 80 characters." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Fasta">
       <converter file="fasta_to_tabular_converter.xml" target_datatype="tabular"/>
       <converter file="fasta_to_bowtie_base_index_converter.xml" target_datatype="bowtie_base_index"/>
       <converter file="fasta_to_bowtie_color_index_converter.xml" target_datatype="bowtie_color_index"/>
       <converter file="fasta_to_2bit.xml" target_datatype="twobit"/>
       <converter file="fasta_to_len.xml" target_datatype="len"/>
+      <converter file="fasta_to_fai.xml" target_datatype="fai"/>
+      <display file="igv/genome_fasta.xml" inherit="True"/>
     </datatype>
     <datatype extension="fastq" type="galaxy.datatypes.sequence:Fastq" display_in_upload="true" description="FASTQ format is a text-based format for storing both a biological sequence (usually nucleotide sequence) and its corresponding quality scores." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Fastq">
         <converter file="fastq_to_fqtoc.xml" target_datatype="fqtoc"/>

--- a/display_applications/igv/genome_fasta.xml
+++ b/display_applications/igv/genome_fasta.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<display id="igv_fasta" version="1.0.0" name="display with IGV">
+    <!-- Load links from file: one line to one link -->
+    <dynamic_links site_type="igv" skip_startswith="#" id="0" name="1">
+        <!-- Define parameters by column from file, allow splitting on builds -->
+        <dynamic_param name="site_id" value="0"/>
+        <dynamic_param name="site_name" value="1"/>
+        <dynamic_param name="site_link" value="2"/>
+        <dynamic_param name="site_dbkeys" value="3" split="True" separator="," />
+        <dynamic_param name="site_organisms" value="4" split="True" separator="," />
+        <!-- Filter out some of the links based upon matching site_dbkeys to dataset dbkey -->
+        <filter>${$site_id.startswith( 'local_' ) or $dataset.dbkey in $site_dbkeys}</filter>
+        <!-- We define url and params as normal, but values defined in dynamic_param are available by specified name -->
+        <url>${redirect_url}</url>
+        <param type="data" name="fasta_file" url="galaxy_${DATASET_HASH}.${dataset.ext}" />
+        <param type="template" name="site_organism" strip="True" >
+            #if ($dataset.dbkey in $site_dbkeys)
+                $site_organisms[ $site_dbkeys.index( $fasta_file.dbkey ) ]
+            #else:
+                $fasta_file.dbkey
+            #end if
+        </param>
+        <param type="template" name="jnlp" url="galaxy_${DATASET_HASH}.jnlp" viewable="True" mimetype="application/x-java-jnlp-file"><![CDATA[
+<?xml version="1.0" encoding="utf-8"?>
+<jnlp
+  spec="1.0+"
+  codebase="${site_link}">
+  <information>
+    <title>IGV 1.5</title>
+    <vendor>The Broad Institute</vendor>
+    <homepage href="http://www.broadinstitute.org/igv"/>
+    <description>IGV Software</description>
+    <description kind="short">IGV</description>
+  </information>
+  <security>
+      <all-permissions/>
+  </security>
+  <resources>
+<j2se version="1.5+" initial-heap-size="256m" max-heap-size="1100m"/>
+    <jar href="igv.jar" download="eager" main="true"/>
+    <jar href="batik-codec.jar" download="eager"/>
+    <property name="apple.laf.useScreenMenuBar" value="true"/>
+    <property name="com.apple.mrj.application.growbox.intrudes" value="false"/>
+    <property name="com.apple.mrj.application.live-resize" value="true"/>
+    <property name="com.apple.macos.smallTabs" value="true"/>
+  </resources>
+    <resources os="Mac" arch="i386">
+        <property name="apple.awt.graphics.UseQuartz" value="false"/>
+        <nativelib href="hdfnative-macintel.jar"/>
+    </resources>
+    <resources os="Mac" arch="ppc">
+        <property name="apple.awt.graphics.UseQuartz" value="false"/>
+        <nativelib href="hdfnative-macppc.jar"/>
+    </resources>
+    <resources os="Mac" arch="PowerPC">
+        <property name="apple.awt.graphics.UseQuartz" value="false"/>
+        <nativelib href="hdfnative-macppc.jar"/>
+    </resources>
+    <resources os="Windows">
+        <property name="sun.java2d.noddraw" value="true"/>
+        <nativelib href="hdfnative-win.jar"/>
+    </resources>
+    <resources os="Linux">
+        <nativelib href="hdfnative-linux64.jar"/>
+    </resources>
+  <application-desc main-class="org.broad.igv.ui.IGVMainFrame">
+     <argument>-g</argument>
+     <argument>${fasta_file.url}</argument>
+  </application-desc>
+</jnlp>
+]]>
+        </param>
+        <param type="data" name="fai_file" dataset="fasta_file" url="galaxy_${DATASET_HASH}.fasta.fai" format="fai" />
+        <param type="template" name="redirect_url" strip="True" >
+            #if $site_id.startswith( 'local_' )
+                ${site_link}?genome=${fasta_file.qp}&amp;merge=true&amp;name=name=${qp( ( $fasta_file.name or $DATASET_HASH ).replace( ',', ';' ) )}
+            #elif $site_id.startswith( 'web_link_' ):
+${site_link}?sessionURL=${fasta_file.qp}&amp;genome=${fasta_file.qp}&amp;merge=true&amp;name=${qp( ( $fasta_file.name or $DATASET_HASH ).replace( ',', ';' ) )}
+            #else:
+                ${jnlp.url}
+            #end if
+        </param>
+    </dynamic_links>
+    <dynamic_links from_data_table="igv_broad_genomes" skip_startswith="#" id="value" name="name">
+        <!-- Our input data table is one line per dbkey -->
+        <filter>${ $dataset.dbkey == $value }</filter>
+        <!-- We define url and params as normal, but values defined in dynamic_param are available by specified name -->
+        <url>http://www.broadinstitute.org/igv/projects/current/igv.php?sessionURL=${fasta_file.qp}&amp;genome=${fasta_file.dbkey}&amp;merge=true&amp;name=${qp( ( $fasta_file.name or $DATASET_HASH ).replace( ',', ';' ) )}</url>
+        <param type="data" name="fasta_file" url="galaxy_${DATASET_HASH}.${dataset.ext}" />
+    </dynamic_links>
+</display>
+<!-- Dan Blankenberg -->

--- a/display_applications/igv/genome_fasta.xml
+++ b/display_applications/igv/genome_fasta.xml
@@ -89,4 +89,4 @@ ${site_link}?sessionURL=${fasta_file.qp}&amp;genome=${fasta_file.qp}&amp;merge=t
         <param type="data" name="fasta_file" url="galaxy_${DATASET_HASH}.${dataset.ext}" />
     </dynamic_links>
 </display>
-<!-- Dan Blankenberg -->
+<!-- Delphine Lariviere - Dan Blankenberg -->

--- a/lib/galaxy/datatypes/converters/fasta_to_fai.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_fai.xml
@@ -2,7 +2,6 @@
     <requirements>
         <requirement type="package" version="0.1.19">samtools</requirement>
     </requirements>
-    <!--<command>samtools faidx '$input' &amp;&amp; mv '${input}.fai' '$output' </command> -->
     <command><![CDATA[ln -s '$input' temp.fasta && samtools faidx temp.fasta && mv temp.fasta.fai '$output' && rm temp.fasta ]]></command>
     <inputs>
         <param name="input" type="data" format="fasta" label="Fasta file"/>

--- a/lib/galaxy/datatypes/converters/fasta_to_fai.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_fai.xml
@@ -1,0 +1,15 @@
+<tool id="CONVERTER_fasta_to_fai" name="Convert FASTA to fai file" version="1.0.0">
+    <requirements>
+        <requirement type="package" version="0.1.19">samtools</requirement>
+    </requirements>
+    <!--<command>samtools faidx '$input' &amp;&amp; mv '${input}.fai' '$output' </command> -->
+    <command><![CDATA[ln -s '$input' temp.fasta && samtools faidx temp.fasta && mv temp.fasta.fai '$output' && rm temp.fasta ]]></command>
+    <inputs>
+        <param name="input" type="data" format="fasta" label="Fasta file"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="fai"/>
+    </outputs>
+    <help>
+    </help>
+</tool>


### PR DESCRIPTION
Addition of IGV view for fasta files, allowing to load it as a genome in IGV display. In order to do that, implementation of the fai datatype and the fasta to fai converter