### PR TITLE
[16.10] Backport #3324

### DIFF
--- a/tools/filters/gff/gff_filter_by_attribute.py
+++ b/tools/filters/gff/gff_filter_by_attribute.py
@@ -6,8 +6,9 @@
 from __future__ import division, print_function
 
 import sys
-from json import loads
+
 from ast import Module, parse, walk
+from json import loads
 
 AST_NODE_TYPE_WHITELIST = [
     'Expr', 'Load', 'Str', 'Num', 'BoolOp', 'Compare', 'And', 'Eq', 'NotEq',
@@ -151,6 +152,7 @@ def check_expression( text ):
             return False
 
     return True
+
 
 #
 # Helper functions.

--- a/tools/filters/gff/gff_filter_by_feature_count.py
+++ b/tools/filters/gff/gff_filter_by_feature_count.py
@@ -9,10 +9,11 @@ from __future__ import print_function
 
 import sys
 
+from ast import Module, parse, walk
+
 from bx.intervals.io import GenomicInterval
 
 from galaxy.datatypes.util.gff_util import GFFReaderWrapper
-from ast import Module, parse, walk
 
 AST_NODE_TYPE_WHITELIST = [
     'Expr', 'Load', 'Str', 'Num', 'BoolOp', 'Compare', 'And', 'Eq', 'NotEq',


### PR DESCRIPTION
Fix linting of `gff_filter_by_attribute.py` and `gff_filter_by_feature_count.py` .

Broken during security patching - Travis tests are failing now against release_16.10 .