### PR TITLE
Allow admins to see API keys under REMOTE_USER

### DIFF
--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -161,6 +161,7 @@ class RemoteUser( object ):
                 '/user/manage_user_info',
                 '/user/edit_info',
                 '/userskeys/all_users',
+                '/userskeys/admin_api_keys',
             )
 
             if not path_info.startswith('/user'):


### PR DESCRIPTION
This route is permitted under non-remote-user usage, expose to remote_user admins as well.