### PR TITLE
Genbank datatype

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -399,7 +399,7 @@
     <datatype extension="embl" type="galaxy.datatypes.data:Text" subclass="True"/>
     <datatype extension="fitch" type="galaxy.datatypes.data:Text" subclass="True"/>
     <datatype extension="gcg" type="galaxy.datatypes.data:Text" subclass="True"/>
-    <datatype extension="genbank" type="galaxy.datatypes.data:Text" subclass="True" edam_format="format_1936"/>
+    <datatype extension="genbank" type="galaxy.datatypes.sequence:Genbank" edam_format="format_1936"/>
     <datatype extension="hennig86" type="galaxy.datatypes.data:Text" subclass="True"/>
     <datatype extension="ig" type="galaxy.datatypes.data:Text" subclass="True"/>
     <datatype extension="jackknifer" type="galaxy.datatypes.data:Text" subclass="True"/>
@@ -626,6 +626,7 @@
     <sniffer type="galaxy.datatypes.text:Html"/>
     <sniffer type="galaxy.datatypes.images:Pdf"/>
     <sniffer type="galaxy.datatypes.sequence:Axt"/>
+    <sniffer type="galaxy.datatypes.sequence:Genbank"/>
     <sniffer type="galaxy.datatypes.interval:Bed"/>
     <sniffer type="galaxy.datatypes.interval:CustomTrack"/>
     <sniffer type="galaxy.datatypes.interval:Gtf"/>

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -1066,3 +1066,22 @@ class DotBracket ( Sequence ):
 
         # Number of lines is less than 3
         return False
+
+class Genbank(data.Text):
+    """Class representing a Genbank sequence"""
+    edam_format = "format_1936"
+    file_ext = "genbank"
+
+    def sniff(self, filename):
+        try:
+            fh = open(filename, 'r')
+            while True:
+                line = fh.readline()
+                if not line:
+                    break  # EOF
+                line = line.strip()
+                return line.startswith('LOCUS ')
+            fh.close()
+        except:
+            pass
+        return False

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -1067,21 +1067,19 @@ class DotBracket ( Sequence ):
         # Number of lines is less than 3
         return False
 
+
 class Genbank(data.Text):
     """Class representing a Genbank sequence"""
     edam_format = "format_1936"
+    edam_data = "data_0849"
     file_ext = "genbank"
 
     def sniff(self, filename):
         try:
-            fh = open(filename, 'r')
-            while True:
-                line = fh.readline()
-                if not line:
-                    break  # EOF
-                line = line.strip()
+            with open(filename, 'r') as handle:
+                line = handle.readline().strip()
                 return line.startswith('LOCUS ')
-            fh.close()
         except:
             pass
+
         return False


### PR DESCRIPTION
This one has been sitting on my computer for a while. Feel free to reject. I'm PRing because:

- We have a datatype for genbank, but no sniffer. If anyone is uploading genbank files they're manually setting the datatype which is sub-optimal.
- Thus if we have a sniffer, there's no need for it to be perfect, as *anything* is an improvement over nothing, with room to make it more lenient in the future.

I have a branch somewhere that uses biopython for this, but it comes with a lot of baggage, so I'm just submitting this simple version as a minor improvement over the status quo.