### PR TITLE
Prettier Job Information Page

### DIFF
--- a/lib/galaxy/jobs/metrics/instrumenters/env.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/env.py
@@ -9,9 +9,7 @@ log = logging.getLogger( __name__ )
 
 
 class EnvFormatter( formatting.JobMetricFormatter ):
-
-    def format( self, key, value ):
-        return ( "%s (runtime environment variable)" % key, value )
+    pass
 
 
 class EnvPlugin( InstrumentPlugin ):

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -126,16 +126,16 @@
     </td>
 </%def>
 
+<h2>
+% if tool:
+    ${tool.name | h}
+% else:
+    Unknown Tool
+% endif
+</h2>
+
+<h3>Dataset Information</h3>
 <table class="tabletip">
-    <thead>
-        <tr><th colspan="2" style="font-size: 120%;">
-            % if tool:
-                Tool: ${tool.name | h}
-            % else:
-                Unknown Tool
-            % endif
-        </th></tr>
-    </thead>
     <tbody>
         <%
         encoded_hda_id = trans.security.encode_id( hda.id )
@@ -148,6 +148,12 @@
         <tr><td>Filesize:</td><td>${nice_size(hda.dataset.file_size)}</td></tr>
         <tr><td>Dbkey:</td><td>${hda.dbkey | h}</td></tr>
         <tr><td>Format:</td><td>${hda.ext | h}</td></tr>
+    </tbody>
+</table>
+
+<h3>Job Information</h3>
+<table class="tabletip">
+    <tbody>
         %if job:
             <tr><td>Galaxy Tool ID:</td><td>${ job.tool_id | h }</td></tr>
             <tr><td>Galaxy Tool Version:</td><td>${ job.tool_version | h }</td></tr>
@@ -169,19 +175,10 @@
         %if trans.user_is_admin() or trans.app.config.expose_dataset_path:
             <tr><td>Full Path:</td><td>${hda.file_name | h}</td></tr>
         %endif
-        %if job and job.command_line and trans.user_is_admin():
-            <tr><td>Job Command-Line:</td><td>${ job.command_line | h }</td></tr>
-        %endif
-        %if job and trans.user_is_admin():
-            <% job_metrics = trans.app.job_metrics %>
-            %for metric in sorted(job.metrics, key=lambda x:x.metric_name):
-                <% metric_title, metric_value = job_metrics.format( metric.plugin, metric.metric_name, metric.metric_value ) %>
-                <tr><td>${ metric_title | h }</td><td>${ metric_value | h }</td></tr>
-            %endfor
-        %endif
+    </tbody>
 </table>
-<br />
 
+<h3>Tool Parameters</h3>
 <table class="tabletip">
     <thead>
         <tr>
@@ -205,8 +202,51 @@
     ${ render_msg( 'One or more of your original parameters may no longer be valid or displayed properly.', status='warning' ) }
 %endif
 
+
+<h3>Inheritance Chain</h3>
+<div class="inherit" style="background-color: #fff; font-weight:bold;">${hda.name | h}</div>
+
+% for dep in inherit_chain:
+    <div style="font-size: 36px; text-align: center; position: relative; top: 3px">&uarr;</div>
+    <div class="inherit">
+        '${dep[0].name | h}' in ${dep[1]}<br/>
+    </div>
+% endfor
+
+
+
+<h3>Command Line</h3>
+%if job and job.command_line and trans.user_is_admin():
+<pre style="white-space: pre-wrap; background: #1d1f21; color: white; padding: 1em;">
+${ job.command_line | h }</pre>
+%endif
+
+<style type="text/css">
+table.info_data_table {
+    table-layout: fixed;
+    word-break: break-word;
+}
+table.info_data_table td:nth-child(1) {
+    width: 25%;
+}
+</style>
+
+%if job and trans.user_is_admin():
+<h3>Job Metrics</h3>
+<table class="tabletip info_data_table">
+    <tbody>
+        <% job_metrics = trans.app.job_metrics %>
+        %for metric in sorted(job.metrics, key=lambda x:x.metric_name):
+            <% metric_title, metric_value = job_metrics.format( metric.plugin, metric.metric_name, metric.metric_value ) %>
+            <% metric_title = metric_title.replace(' (runtime environment variable)', '') %>
+            <tr><td>${ metric_title | h }</td><td>${ metric_value | h }</td></tr>
+        %endfor
+    </tbody>
+</table>
+%endif
+
 %if job and job.dependencies:
-    <br>
+<h3>Job Dependencies</h3>
     <table class="tabletip">
         <thead>
         <tr>
@@ -226,8 +266,9 @@
 
         </tbody>
     </table>
-    <br />
 %endif
+
+
 
 <script type="text/javascript">
 $(function(){
@@ -239,13 +280,3 @@ $(function(){
     })
 });
 </script>
-
-    <h3>Inheritance Chain</h3>
-    <div class="inherit" style="background-color: #fff; font-weight:bold;">${hda.name | h}</div>
-
-    % for dep in inherit_chain:
-        <div style="font-size: 36px; text-align: center; position: relative; top: 3px">&uarr;</div>
-        <div class="inherit">
-            '${dep[0].name | h}' in ${dep[1]}<br/>
-        </div>
-    % endfor

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -9,6 +9,21 @@
         text-align: center;
         background-color: #eee;
     }
+
+    table.info_data_table {
+        table-layout: fixed;
+        word-break: break-word;
+    }
+    table.info_data_table td:nth-child(1) {
+        width: 25%;
+    }
+
+    .code {
+        white-space: pre-wrap;
+        background: #1d1f21;
+        color: white;
+        padding: 1em;
+    }
 </style>
 
 <%def name="inputs_recursive( input_params, param_values, depth=1, upgrade_messages=None )">
@@ -217,19 +232,9 @@
 
 %if job and job.command_line and trans.user_is_admin():
 <h3>Command Line</h3>
-<pre style="white-space: pre-wrap; background: #1d1f21; color: white; padding: 1em;">
+<pre class="code">
 ${ job.command_line | h }</pre>
 %endif
-
-<style type="text/css">
-table.info_data_table {
-    table-layout: fixed;
-    word-break: break-word;
-}
-table.info_data_table td:nth-child(1) {
-    width: 25%;
-}
-</style>
 
 %if job and trans.user_is_admin():
 <h3>Job Metrics</h3>

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -215,8 +215,8 @@
 
 
 
-<h3>Command Line</h3>
 %if job and job.command_line and trans.user_is_admin():
+<h3>Command Line</h3>
 <pre style="white-space: pre-wrap; background: #1d1f21; color: white; padding: 1em;">
 ${ job.command_line | h }</pre>
 %endif

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -150,7 +150,16 @@
 </h2>
 
 <h3>Dataset Information</h3>
-<table class="tabletip">
+<table class="tabletip" id="dataset-details">
+    <thead>
+        <tr><th colspan="2" style="font-size: 120%;">
+            % if tool:
+                Tool: ${tool.name | h}
+            % else:
+                Unknown Tool
+            % endif
+        </th></tr>
+    </thead>
     <tbody>
         <%
         encoded_hda_id = trans.security.encode_id( hda.id )
@@ -194,7 +203,7 @@
 </table>
 
 <h3>Tool Parameters</h3>
-<table class="tabletip">
+<table class="tabletip" id="tool-parameters">
     <thead>
         <tr>
             <th>Input Parameter</th>

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -226,6 +226,9 @@ table.info_data_table {
     table-layout: fixed;
     word-break: break-word;
 }
+table.info_data_table td:nth-child(1) {
+    width: 25%;
+}
 </style>
 
 %if job and trans.user_is_admin():
@@ -233,14 +236,8 @@ table.info_data_table {
 <% job_metrics = trans.app.job_metrics %>
 <% plugins = set([metric.plugin for metric in job.metrics]) %>
     %for plugin in sorted(plugins):
-    <h4>Plugin: ${ plugin | h }</h4>
+    <h4>${ plugin | h }</h4>
     <table class="tabletip info_data_table">
-        <thead>
-            <tr>
-                <th style="width: 25%">Metric Name</th>
-                <th>Metric Value</th>
-            </tr>
-        </thead>
         <tbody>
             %for metric in sorted(filter(lambda x: x.plugin == plugin, job.metrics), key=lambda x:x.metric_name):
                 <% metric_title, metric_value = job_metrics.format( metric.plugin, metric.metric_name, metric.metric_value ) %>

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -238,7 +238,6 @@ table.info_data_table td:nth-child(1) {
         <% job_metrics = trans.app.job_metrics %>
         %for metric in sorted(job.metrics, key=lambda x:x.metric_name):
             <% metric_title, metric_value = job_metrics.format( metric.plugin, metric.metric_name, metric.metric_value ) %>
-            <% metric_title = metric_title.replace(' (runtime environment variable)', '') %>
             <tr><td>${ metric_title | h }</td><td>${ metric_value | h }</td></tr>
         %endfor
     </tbody>

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -151,15 +151,6 @@
 
 <h3>Dataset Information</h3>
 <table class="tabletip" id="dataset-details">
-    <thead>
-        <tr><th colspan="2" style="font-size: 120%;">
-            % if tool:
-                Tool: ${tool.name | h}
-            % else:
-                Unknown Tool
-            % endif
-        </th></tr>
-    </thead>
     <tbody>
         <%
         encoded_hda_id = trans.security.encode_id( hda.id )

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -253,8 +253,12 @@ ${ job.command_line | h }</pre>
     <h4>${ plugin | h }</h4>
     <table class="tabletip info_data_table">
         <tbody>
-            %for metric in sorted(filter(lambda x: x.plugin == plugin, job.metrics), key=lambda x:x.metric_name):
-                <% metric_title, metric_value = job_metrics.format( metric.plugin, metric.metric_name, metric.metric_value ) %>
+        <%
+            plugin_metrics = filter(lambda x: x.plugin == plugin, job.metrics)
+            plugin_metric_displays = [job_metrics.format( metric.plugin, metric.metric_name, metric.metric_value ) for metric in plugin_metrics]
+            plugin_metric_displays = sorted(plugin_metric_displays, key=lambda pair: pair[0])  # Sort on displayed title
+        %>
+            %for metric_title, metric_value in plugin_metric_displays:
                 <tr><td>${ metric_title | h }</td><td>${ metric_value | h }</td></tr>
             %endfor
         </tbody>

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -226,22 +226,29 @@ table.info_data_table {
     table-layout: fixed;
     word-break: break-word;
 }
-table.info_data_table td:nth-child(1) {
-    width: 25%;
-}
 </style>
 
 %if job and trans.user_is_admin():
 <h3>Job Metrics</h3>
-<table class="tabletip info_data_table">
-    <tbody>
-        <% job_metrics = trans.app.job_metrics %>
-        %for metric in sorted(job.metrics, key=lambda x:x.metric_name):
-            <% metric_title, metric_value = job_metrics.format( metric.plugin, metric.metric_name, metric.metric_value ) %>
-            <tr><td>${ metric_title | h }</td><td>${ metric_value | h }</td></tr>
-        %endfor
-    </tbody>
-</table>
+<% job_metrics = trans.app.job_metrics %>
+<% plugins = set([metric.plugin for metric in job.metrics]) %>
+    %for plugin in sorted(plugins):
+    <h4>Plugin: ${ plugin | h }</h4>
+    <table class="tabletip info_data_table">
+        <thead>
+            <tr>
+                <th style="width: 25%">Metric Name</th>
+                <th>Metric Value</th>
+            </tr>
+        </thead>
+        <tbody>
+            %for metric in sorted(filter(lambda x: x.plugin == plugin, job.metrics), key=lambda x:x.metric_name):
+                <% metric_title, metric_value = job_metrics.format( metric.plugin, metric.metric_name, metric.metric_value ) %>
+                <tr><td>${ metric_title | h }</td><td>${ metric_value | h }</td></tr>
+            %endfor
+        </tbody>
+    </table>
+    %endfor
 %endif
 
 %if job and job.dependencies:

--- a/test/selenium_tests/test_history_dataset_state.py
+++ b/test/selenium_tests/test_history_dataset_state.py
@@ -4,28 +4,7 @@ from .framework import SeleniumTestCase
 from .framework import selenium_test
 
 
-class HistoryDatasetStateTestCase(SeleniumTestCase):
-
-    @selenium_test
-    def test_dataset_state(self):
-        self.register()
-        self.perform_upload(self.get_filename("1.fasta"))
-        self.wait_for_history()
-        hda_id = self.latest_history_item()["id"]
-        item_selector = self.hda_div_selector(hda_id)
-        self.assert_item_name(item_selector, "1.fasta")
-        self.assert_item_hid(item_selector, "1")
-        self.assert_title_buttons(item_selector)
-
-        self.click_hda_title(hda_id, wait=True)
-        hda_body_selector = self.hda_body_selector(hda_id)
-        self.wait_for_selector_visible(hda_body_selector)
-
-        self.assert_item_summary_includes(hda_body_selector, "1 sequence")
-        self.assert_dbkey_display_as(hda_body_selector, "?")
-        self.assert_info_includes(hda_body_selector, 'uploaded fasta file')
-        self.assert_action_buttons(hda_body_selector)
-        self.assert_peek_includes(hda_body_selector, ">hg17")
+class UsesHistoryItemAssertions:
 
     def assert_action_buttons(self, body_selector, expected_buttons=["info", "download"]):
         buttons_selector = body_selector + " " + self.test_data["historyPanel"]["selectors"]["hda"]["primaryActionButtons"]
@@ -80,3 +59,27 @@ class HistoryDatasetStateTestCase(SeleniumTestCase):
         button_item = self.wait_for_selector_visible("%s %s" % (buttons_area, selector))
         expected_tooltip = button_def.get("tooltip")
         self.assert_tooltip_text(button_item, expected_tooltip)
+
+
+class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
+
+    @selenium_test
+    def test_dataset_state(self):
+        self.register()
+        self.perform_upload(self.get_filename("1.fasta"))
+        self.wait_for_history()
+        hda_id = self.latest_history_item()["id"]
+        item_selector = self.hda_div_selector(hda_id)
+        self.assert_item_name(item_selector, "1.fasta")
+        self.assert_item_hid(item_selector, "1")
+        self.assert_title_buttons(item_selector)
+
+        self.click_hda_title(hda_id, wait=True)
+        hda_body_selector = self.hda_body_selector(hda_id)
+        self.wait_for_selector_visible(hda_body_selector)
+
+        self.assert_item_summary_includes(hda_body_selector, "1 sequence")
+        self.assert_dbkey_display_as(hda_body_selector, "?")
+        self.assert_info_includes(hda_body_selector, 'uploaded fasta file')
+        self.assert_action_buttons(hda_body_selector)
+        self.assert_peek_includes(hda_body_selector, ">hg17")

--- a/test/selenium_tests/test_history_sharing.py
+++ b/test/selenium_tests/test_history_sharing.py
@@ -1,5 +1,3 @@
-import time
-
 from .framework import SeleniumTestCase
 from .framework import selenium_test
 
@@ -108,10 +106,7 @@ class HistorySharingTestCase(SeleniumTestCase):
 
     def share_history_with_user(self, email):
         self.navigate_to_history_user_share_page()
-        form = self.wait_for_selector("form#share")
-        text_element = form.find_element_by_css_selector("input[type='text']")
-        text_element.send_keys(email)
-        # Wait for select2 options to load and then click to add this one.
-        time.sleep(2)
-        self.send_enter(text_element)
+        form_selector = "form#share"
+        form = self.wait_for_selector(form_selector)
+        self.select2_set_value(form_selector, email)
         self.click_submit(form)

--- a/test/selenium_tests/test_tool_form.py
+++ b/test/selenium_tests/test_tool_form.py
@@ -37,7 +37,6 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         dataset_details_key_value_pairs = self._table_to_key_value_elements("table#dataset-details")
         number_found = name_found = format_found = False
         for key, value in dataset_details_key_value_pairs:
-            print hda
             if "Number:" in key.text:
                 assert str(hda["hid"]) in value.text
                 number_found = True

--- a/test/selenium_tests/test_tool_form.py
+++ b/test/selenium_tests/test_tool_form.py
@@ -1,0 +1,121 @@
+from .framework import SeleniumTestCase
+from .framework import selenium_test
+
+from .test_history_dataset_state import UsesHistoryItemAssertions
+
+
+class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
+
+    @selenium_test
+    def test_run_tool_verify_contents_by_peek(self):
+        self._run_environment_test_tool()
+
+        self.wait_for_history()
+        hda_id = self.latest_history_item()["id"]
+        self.click_hda_title(hda_id, wait=True)
+        hda_body_selector = self.hda_body_selector(hda_id)
+        self.wait_for_selector_visible(hda_body_selector)
+        self.assert_peek_includes(hda_body_selector, "42")
+
+    @selenium_test
+    def test_run_tool_verify_dataset_details(self):
+        self._run_environment_test_tool()
+        self.wait_for_history()
+
+        hda_id = self.latest_history_item()["id"]
+        self._check_dataset_details_for_inttest_value(hda_id)
+
+    @selenium_test
+    def test_verify_dataset_details_tables(self):
+        self._run_environment_test_tool()
+        self.wait_for_history()
+
+        hda = self.latest_history_item()
+        hda_id = hda["id"]
+        self._check_dataset_details_for_inttest_value(hda_id)
+
+        dataset_details_key_value_pairs = self._table_to_key_value_elements("table#dataset-details")
+        number_found = name_found = format_found = False
+        for key, value in dataset_details_key_value_pairs:
+            print hda
+            if "Number:" in key.text:
+                assert str(hda["hid"]) in value.text
+                number_found = True
+            if "Name:" in key.text:
+                assert hda["name"] in value.text
+                name_found = True
+            if "Format:" in key.text:
+                assert hda["extension"] in value.text
+                format_found = True
+
+        assert number_found
+        assert name_found
+        assert format_found
+
+    def _table_to_key_value_elements(self, table_selector):
+        tool_parameters_table = self.wait_for_selector_visible(table_selector)
+        tbody_element = tool_parameters_table.find_element_by_css_selector("tbody")
+        trs = tbody_element.find_elements_by_css_selector("tr")
+        assert trs
+        key_value_pairs = []
+        for tr in trs:
+            tds = tr.find_elements_by_css_selector("td")
+            assert tds
+            key_value_pairs.append((tds[0], tds[1]))
+
+        return key_value_pairs
+
+    @selenium_test
+    def test_rerun(self):
+        self._run_environment_test_tool()
+        self.wait_for_history()
+        hda_id = self.latest_history_item()["id"]
+        self.hda_click_primary_action_button(hda_id, "rerun")
+
+        inttest_div_element = self.tool_parameter_div("inttest")
+        inttest_input_element = inttest_div_element.find_element_by_css_selector("input")
+        recorded_val = inttest_input_element.get_attribute("value")
+        # Assert form re-rendered with correct value in textbox.
+        assert recorded_val == "42", recorded_val
+        self.tool_execute()
+
+        self.wait_for_history()
+        new_hda_id = self.latest_history_item()["id"]
+
+        assert new_hda_id != hda_id  # We do indeed have a new dataset for the re-run
+        self._check_dataset_details_for_inttest_value(new_hda_id)
+
+    @selenium_test
+    def test_run_data(self):
+        test_path = self.get_filename("1.fasta")
+        test_path_decoy = self.get_filename("1.txt")
+        self.perform_upload(test_path)
+        self.perform_upload(test_path_decoy)
+        self.wait_for_history()
+
+        self.home()
+        self.tool_open("head")
+        self.tool_set_value("input", "1.fasta", expected_type="data")
+        self.tool_execute()
+        self.wait_for_history()
+
+        latest_hda = self.latest_history_item()
+        assert latest_hda["hid"] == 3
+        assert latest_hda["name"] == "Select first on data 1"
+
+    def _check_dataset_details_for_inttest_value(self, hda_id, expected_value="42"):
+        self.hda_click_primary_action_button(hda_id, "info")
+
+        with self.main_panel():
+            self.wait_for_selector_visible("table#dataset-details")
+            tool_parameters_table = self.wait_for_selector_visible("table#tool-parameters")
+            tbody_element = tool_parameters_table.find_element_by_css_selector("tbody")
+            tds = tbody_element.find_elements_by_css_selector("td")
+            assert tds
+            assert any([expected_value in td.text for td in tds])
+
+    def _run_environment_test_tool(self, inttest_value="42"):
+        self.home()
+        self.tool_open("environment_variables")
+        self.tool_set_value("inttest", inttest_value)
+        self.tool_execute()


### PR DESCRIPTION
Changes:

- split one giant table into multiple tables based on section
- nicer headers (using h2/h3s for semantic meaning)
- terminal themed command line block to allow for easy visual acquisition by admins
- moved giant job metrics section down a bit
- Fixed left column width of metrics table and removed redundant `(runtime environment variable)`
- `word-break: break-word;` all the things

![First half of job info page](https://cloud.githubusercontent.com/assets/458683/21328820/99bc1978-c62d-11e6-9793-e665910eb7d5.png)
![Second half of job info page](https://cloud.githubusercontent.com/assets/458683/21328830/a4c194c4-c62d-11e6-9519-b14e9170ca98.png)
