### PR TITLE
Cache depencencies on the fly when first used

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -230,6 +230,10 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # of the tool dependency directory
 #tool_dependency_cache_dir = <tool_dependency_dir>/_cache
 
+# By default the dependencies are cached only when installing tools.
+# Set this to True to allow dependencies to be cached the first time they are used
+#build_cache_on_first_run = False
+
 # File containing the Galaxy Tool Sheds that should be made available to
 # install from in the admin interface (.sample used if default does not exist).
 #tool_sheds_config_file = config/tool_sheds_conf.xml

--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -230,9 +230,10 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # of the tool dependency directory
 #tool_dependency_cache_dir = <tool_dependency_dir>/_cache
 
-# By default the dependencies are cached only when installing tools.
-# Set this to True to allow dependencies to be cached the first time they are used
-#build_cache_on_first_run = False
+# By default, when using a cached dependency manager, the dependencies are cached
+# when installing new tools and when using tools for the first time.
+# Set this to False if you prefer dependencies to be cached only when installing new tools.
+#precache_dependencies = True
 
 # File containing the Galaxy Tool Sheds that should be made available to
 # install from in the admin interface (.sample used if default does not exist).

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -334,6 +334,7 @@ class Configuration( object ):
             self.use_tool_dependencies = os.path.exists(self.dependency_resolvers_config_file)
         self.use_cached_dependency_manager = string_as_bool(kwargs.get("use_cached_dependency_manager", 'False'))
         self.tool_dependency_cache_dir = kwargs.get( 'tool_dependency_cache_dir', os.path.join(self.tool_dependency_dir, '_cache'))
+        self.build_cache_on_first_run = string_as_bool(kwargs.get("build_cache_on_first_run", 'False'))
 
         self.enable_beta_mulled_containers = string_as_bool( kwargs.get( 'enable_beta_mulled_containers', 'False' ) )
         containers_resolvers_config_file = kwargs.get( 'containers_resolvers_config_file', None )

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -334,7 +334,7 @@ class Configuration( object ):
             self.use_tool_dependencies = os.path.exists(self.dependency_resolvers_config_file)
         self.use_cached_dependency_manager = string_as_bool(kwargs.get("use_cached_dependency_manager", 'False'))
         self.tool_dependency_cache_dir = kwargs.get( 'tool_dependency_cache_dir', os.path.join(self.tool_dependency_dir, '_cache'))
-        self.build_cache_on_first_run = string_as_bool(kwargs.get("build_cache_on_first_run", 'False'))
+        self.precache_dependencies = string_as_bool(kwargs.get("precache_dependencies", 'True'))
 
         self.enable_beta_mulled_containers = string_as_bool( kwargs.get( 'enable_beta_mulled_containers', 'False' ) )
         containers_resolvers_config_file = kwargs.get( 'containers_resolvers_config_file', None )

--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -32,6 +32,7 @@ EXTRA_CONFIG_KWDS = {
     'conda_auto_install': False,
     'conda_auto_init': False,
     'conda_copy_dependencies': False,
+    'build_cache_on_first_run': False,
 }
 
 CONFIG_VAL_NOT_FOUND = object()
@@ -199,10 +200,10 @@ class CachedDependencyManager(DependencyManager):
         resolved_dependencies = self.requirements_to_dependencies(requirements, **kwds)
         cacheable_dependencies = [dep for dep in resolved_dependencies.values() if dep.cacheable]
         hashed_dependencies_dir = self.get_hashed_dependencies_path(cacheable_dependencies)
-        if not os.path.exists(hashed_dependencies_dir):
+        if not os.path.exists(hashed_dependencies_dir) and self.extra_config['build_cache_on_first_run'] == True:
             # Cache not present, try to create it
             self.build_cache(requirements, **kwds)
-        if os.path.exists(hashed_dependencies_dir): # Check caching was successfull
+        if os.path.exists(hashed_dependencies_dir):
             [dep.set_cache_path(hashed_dependencies_dir) for dep in cacheable_dependencies]
         commands = [dep.shell_commands(req) for req, dep in resolved_dependencies.items()]
         return commands

--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -32,7 +32,7 @@ EXTRA_CONFIG_KWDS = {
     'conda_auto_install': False,
     'conda_auto_init': False,
     'conda_copy_dependencies': False,
-    'build_cache_on_first_run': False,
+    'precache_dependencies': True,
 }
 
 CONFIG_VAL_NOT_FOUND = object()
@@ -200,7 +200,7 @@ class CachedDependencyManager(DependencyManager):
         resolved_dependencies = self.requirements_to_dependencies(requirements, **kwds)
         cacheable_dependencies = [dep for dep in resolved_dependencies.values() if dep.cacheable]
         hashed_dependencies_dir = self.get_hashed_dependencies_path(cacheable_dependencies)
-        if not os.path.exists(hashed_dependencies_dir) and self.extra_config['build_cache_on_first_run']:
+        if not os.path.exists(hashed_dependencies_dir) and self.extra_config['precache_dependencies']:
             # Cache not present, try to create it
             self.build_cache(requirements, **kwds)
         if os.path.exists(hashed_dependencies_dir):

--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -200,7 +200,7 @@ class CachedDependencyManager(DependencyManager):
         resolved_dependencies = self.requirements_to_dependencies(requirements, **kwds)
         cacheable_dependencies = [dep for dep in resolved_dependencies.values() if dep.cacheable]
         hashed_dependencies_dir = self.get_hashed_dependencies_path(cacheable_dependencies)
-        if not os.path.exists(hashed_dependencies_dir) and self.extra_config['build_cache_on_first_run'] == True:
+        if not os.path.exists(hashed_dependencies_dir) and self.extra_config['build_cache_on_first_run']:
             # Cache not present, try to create it
             self.build_cache(requirements, **kwds)
         if os.path.exists(hashed_dependencies_dir):


### PR DESCRIPTION
Hi,
A tiny patch to allow caching (conda) dependencies on the fly when a tool is executed the first time (well, anytime the cache is not found in fact).

There is some discussion about this in https://github.com/galaxyproject/planemo/pull/612

Just tested it with planemo, it seems to work fine

ping @mvdbeek @jmchilton 

🎅 🎅 🎅 