### PR TITLE
[16.07] Do not allow Conda to replace Galaxy's Python environment for select tools.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -375,6 +375,16 @@ class Tool( object, Dictifiable ):
     def valid_input_states( self ):
         return model.Dataset.valid_input_states
 
+    @property
+    def requires_galaxy_python_environment(self):
+        """Indicates this tool's runtime requires Galaxy's Python environment."""
+        # All special tool types (data source, history import/export, etc...)
+        # seem to require Galaxy's Python.
+        return self.tool_type != "default" or self.id in [
+            "__SET_METADATA__",
+            "upload1",
+        ]
+
     def __get_job_tool_configuration(self, job_params=None):
         """Generalized method for getting this tool's job configuration.
 
@@ -1288,6 +1298,7 @@ class Tool( object, Dictifiable ):
             installed_tool_dependencies=self.installed_tool_dependencies,
             tool_dir=self.tool_dir,
             job_directory=job_directory,
+            preserve_python_environment=self.requires_galaxy_python_environment,
             metadata=metadata,
         )
 


### PR DESCRIPTION
This has never happened in my testing, but there have been multiple reports of Conda crafting environments for the set metadata tool that include Python. When this happens Galaxy's Python environment is lost and the tool cannot function properly.

For these tools, simply add the Conda's bin directory to the jobs ``PATH`` - certainly a hack but it covers ``samtools`` and any other use case I can readily conceive of. Datatypes or tools that require new Python libraries beside Galaxy's own - need to be added to our requirements.txt - that is how virtualenvs should work.

Fixes #3238.
Fixes #3224.
Fixes https://biostar.usegalaxy.org/p/20865/.

Ping @bgruening @mvdbeek.