### PR TITLE
Fix auto creation of XUnit reports for Jenkins.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -252,7 +252,7 @@ then
 fi
 
 # If in Jenkins environment, create xunit-${BUILD_NUMBER}.xml by default.
-if [ -z "$BUILD_NUMBER" ];
+if [ -n "$BUILD_NUMBER" ];
 then
     xunit_report_file="xunit-${BUILD_NUMBER}.xml"
 fi


### PR DESCRIPTION
This is why Jenkins isn't picking up reports for integration and Selenium tests automatically.