### PR TITLE
Fix automatic handling of Jenkins BUILD_NUMBER in Dockerized tests.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -247,7 +247,7 @@ then
        shift
     fi
     echo "Launching docker container for testing..."
-    docker $DOCKER_EXTRA_ARGS run $DOCKER_RUN_EXTRA_ARGS -e "GALAXY_TEST_DATABASE_TYPE=$db_type" --rm -v `pwd`:/galaxy $DOCKER_IMAGE "$@"
+    docker $DOCKER_EXTRA_ARGS run $DOCKER_RUN_EXTRA_ARGS -e "BUILD_NUMBER=$BUILD_NUMBER" -e "GALAXY_TEST_DATABASE_TYPE=$db_type" --rm -v `pwd`:/galaxy $DOCKER_IMAGE "$@"
     exit $?
 fi
 


### PR DESCRIPTION
Follow up on  #3368. That was needed fix, but I think this fix is also needed. We are getting closer...

xref #3199 xref #3360