### PR TITLE
Fix UX problem when sharing objects with users.

### DIFF
--- a/templates/ind_share_base.mako
+++ b/templates/ind_share_base.mako
@@ -93,9 +93,15 @@
                             Email address of user to share with
                         </label>
                         <div style="float: left; width: 100%;  margin-right: 10px;">
+                            %if trans.app.config.expose_user_email or trans.app.config.expose_user_name:
                             <input type="hidden" id="email_select" name="email" >
                             </input>
+                            %else:
+                            <input type="text" name="email" value="${email | h}" size="40">
+                            </input>
+                            %endif
                         </div>
+
                         <div style="clear: both"></div>
                     </div>
                     <div class="form-row">


### PR DESCRIPTION
The problem is that by default Galaxy doesn't expose usernames and user e-mails via this form but a select2 + search is used anyway making it appear that any selection matches an actual user. It is confusing.

Fixes #3250 reported by @peterjc.

xref #1111