### PR TITLE
[16.10] Fix workflow extraction of dataset/collections name.

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -1052,6 +1052,10 @@ class WorkflowController( BaseUIController, SharableMixin, UsesStoredWorkflowMix
                 history=history
             )
         else:
+            # If there is just one dataset name selected or one dataset collection, these
+            # come through as string types instead of lists. xref #3247.
+            dataset_names = util.listify(dataset_names)
+            dataset_collection_names = util.listify(dataset_collection_names)
             stored_workflow = extract_workflow(
                 trans,
                 user=user,


### PR DESCRIPTION
It works fine if multiple names are chosen, but if only one input is selected and named it doesn't work. This is a temporary workaround until that page is replaced by API calls with superior typing.

Fixes #3247 reported by @peterjc.