### PR TITLE
Use a newer conda version by default

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -29,7 +29,7 @@ CONDA_LICENSE = "http://docs.continuum.io/anaconda/eula"
 VERSIONED_ENV_DIR_NAME = re.compile(r"__(.*)@(.*)")
 UNVERSIONED_ENV_DIR_NAME = re.compile(r"__(.*)@_uv_")
 USE_PATH_EXEC_DEFAULT = False
-CONDA_VERSION = "3.19.3"
+CONDA_VERSION = "4.2.13"
 
 
 def conda_link():


### PR DESCRIPTION
We were able to test most of the IUC and devteam tools as indicated here: https://github.com/galaxyproject/tools-iuc/issues/1071

This PR also seem to work with latest conda:
https://github.com/galaxyproject/tools-devteam/pull/375

So maybe we can upgrade dev and test it in the next month more extensively.