### PR TITLE
Test cases & small enhancement to workflow renaming PJAs.

### DIFF
--- a/lib/galaxy/jobs/actions/post.py
+++ b/lib/galaxy/jobs/actions/post.py
@@ -142,6 +142,15 @@ class RenameDatasetAction(DefaultJobAction):
                     if input_assoc.name == input_file_var:
                         replacement = input_assoc.dataset.name
 
+                # Ditto for collections...
+                for input_assoc in job.input_dataset_collections:
+                    if input_assoc.name == input_file_var:
+                        if input_assoc.dataset_collection:
+                            hdca = input_assoc.dataset_collection
+                            replacement = hdca.name
+
+                # In case name was None.
+                replacement = replacement or ''
                 #  Do operations on replacement
                 #  Any control that is not defined will be ignored.
                 #  This should be moved out to a class or module function

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -593,8 +593,8 @@ class Job( object, JobLike, Dictifiable ):
     def add_output_dataset( self, name, dataset ):
         self.output_datasets.append( JobToOutputDatasetAssociation( name, dataset ) )
 
-    def add_input_dataset_collection( self, name, dataset ):
-        self.input_dataset_collections.append( JobToInputDatasetCollectionAssociation( name, dataset ) )
+    def add_input_dataset_collection( self, name, dataset_collection ):
+        self.input_dataset_collections.append( JobToInputDatasetCollectionAssociation( name, dataset_collection ) )
 
     def add_output_dataset_collection( self, name, dataset_collection_instance ):
         self.output_dataset_collection_instances.append( JobToOutputDatasetCollectionAssociation( name, dataset_collection_instance ) )
@@ -924,9 +924,9 @@ class JobToOutputDatasetAssociation( object ):
 
 
 class JobToInputDatasetCollectionAssociation( object ):
-    def __init__( self, name, dataset ):
+    def __init__( self, name, dataset_collection ):
         self.name = name
-        self.dataset = dataset
+        self.dataset_collection = dataset_collection
 
 
 # Many jobs may map to one HistoryDatasetCollection using these for a given

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2026,8 +2026,7 @@ mapper( model.JobToOutputDatasetAssociation, model.JobToOutputDatasetAssociation
 mapper( model.JobToInputDatasetCollectionAssociation, model.JobToInputDatasetCollectionAssociation.table, properties=dict(
     job=relation( model.Job ),
     dataset_collection=relation( model.HistoryDatasetCollectionAssociation,
-        lazy=False,
-        backref="dependent_jobs" )
+        lazy=False )
 ) )
 
 mapper( model.JobToOutputDatasetCollectionAssociation, model.JobToOutputDatasetCollectionAssociation.table, properties=dict(

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -320,12 +320,12 @@ class UploadDataset( Group ):
                                 dataset_info = 'uploaded url'
                             yield Bunch( type='url', path=line, name=dataset_name )
                 else:
-                    dataset_name = dataset_info = precreated_name = 'Pasted Entry'  # we need to differentiate between various url pastes here
+                    dataset_name = dataset_info = 'Pasted Entry'  # we need to differentiate between various url pastes here
                     if override_name:
                         dataset_name = override_name
                     if override_info:
                         dataset_info = override_info
-                    yield Bunch( type='file', path=url_paste_file, name=precreated_name )
+                    yield Bunch( type='file', path=url_paste_file, name=dataset_name )
 
         def get_one_filename( context ):
             data_file = context['file_data']

--- a/test/api/helpers.py
+++ b/test/api/helpers.py
@@ -349,7 +349,7 @@ class LibraryPopulator( object ):
 
 class BaseDatasetCollectionPopulator( object ):
 
-    def create_list_from_pairs( self, history_id, pairs ):
+    def create_list_from_pairs( self, history_id, pairs, name="Dataset Collection from pairs" ):
         element_identifiers = []
         for i, pair in enumerate( pairs ):
             element_identifiers.append( dict(
@@ -363,6 +363,7 @@ class BaseDatasetCollectionPopulator( object ):
             history_id=history_id,
             element_identifiers=json.dumps(element_identifiers),
             collection_type="list:paired",
+            name=name,
         )
         return self.__create( payload )
 
@@ -400,6 +401,9 @@ class BaseDatasetCollectionPopulator( object ):
 
         if "element_identifiers" not in kwds:
             kwds[ "element_identifiers" ] = json.dumps( identifiers_func( history_id, contents=contents ) )
+
+        if "name" not in kwds:
+            kwds["name"] = "Test Dataset Collection"
 
         payload = dict(
             history_id=history_id,

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -744,7 +744,7 @@ class ToolsTestCase( api.ApiTestCase ):
     @skip_without_tool( "identifier_single" )
     def test_identifier_outside_map( self ):
         history_id = self.dataset_populator.new_history()
-        new_dataset1 = self.dataset_populator.new_dataset( history_id, content='123' )
+        new_dataset1 = self.dataset_populator.new_dataset( history_id, content='123', name="Plain HDA" )
         inputs = {
             "input1": { 'src': 'hda', 'id': new_dataset1["id"] },
         }
@@ -759,7 +759,7 @@ class ToolsTestCase( api.ApiTestCase ):
         self.assertEquals( len( implicit_collections ), 0 )
         output1 = outputs[ 0 ]
         output1_content = self.dataset_populator.get_history_dataset_content( history_id, dataset=output1 )
-        self.assertEquals( output1_content.strip(), "Pasted Entry" )
+        self.assertEquals( output1_content.strip(), "Plain HDA" )
 
     @skip_without_tool( "identifier_multiple" )
     def test_identifier_in_multiple_reduce( self ):
@@ -784,8 +784,8 @@ class ToolsTestCase( api.ApiTestCase ):
     @skip_without_tool( "identifier_multiple" )
     def test_identifier_with_multiple_normal_datasets( self ):
         history_id = self.dataset_populator.new_history()
-        new_dataset1 = self.dataset_populator.new_dataset( history_id, content='123' )
-        new_dataset2 = self.dataset_populator.new_dataset( history_id, content='456' )
+        new_dataset1 = self.dataset_populator.new_dataset( history_id, content='123', name="Normal HDA1" )
+        new_dataset2 = self.dataset_populator.new_dataset( history_id, content='456', name="Normal HDA2" )
         inputs = {
             "input1": [
                 { 'src': 'hda', 'id': new_dataset1["id"] },
@@ -803,7 +803,7 @@ class ToolsTestCase( api.ApiTestCase ):
         self.assertEquals( len( implicit_collections ), 0 )
         output1 = outputs[ 0 ]
         output1_content = self.dataset_populator.get_history_dataset_content( history_id, dataset=output1 )
-        self.assertEquals( output1_content.strip(), "Pasted Entry\nPasted Entry" )
+        self.assertEquals( output1_content.strip(), "Normal HDA1\nNormal HDA2" )
 
     @skip_without_tool( "identifier_collection" )
     def test_identifier_with_data_collection( self ):

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -214,7 +214,14 @@ class BaseWorkflowsApiTestCase( api.ApiTestCase, ImporterGalaxyInterface ):
                 input_type = value["type"]
                 if input_type == "File":
                     content = read_test_data(value)
-                    hda = self.dataset_populator.new_dataset( history_id, content=content )
+                    new_dataset_kwds = {
+                        "content": content
+                    }
+                    if "name" in value:
+                        new_dataset_kwds["name"] = value["name"]
+                    if "file_type" in value:
+                        new_dataset_kwds["file_type"] = value["file_type"]
+                    hda = self.dataset_populator.new_dataset( history_id, **new_dataset_kwds )
                     label_map[key] = self._ds_entry( hda )
                     has_uploads = True
                 elif input_type == "raw":
@@ -1250,6 +1257,104 @@ test_data:
         self._assert_status_code_is( run_workflow_response, 200 )
         content = self.dataset_populator.get_history_dataset_details( history_id, wait=True, assert_ok=True )
         assert content[ "name" ] == "foo was replaced"
+
+    @skip_without_tool( "cat" )
+    def test_run_rename_based_on_input( self ):
+        history_id = self.dataset_populator.new_history()
+        self._run_jobs("""
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+steps:
+  - tool_id: cat
+    label: first_cat
+    state:
+      input1:
+        $link: input1
+    outputs:
+      out_file1:
+        rename: "#{input1 | basename} suffix"
+test_data:
+  input1:
+    value: 1.fasta
+    type: File
+    name: fasta1
+""", history_id=history_id)
+        content = self.dataset_populator.get_history_dataset_details( history_id, wait=True, assert_ok=True )
+        name = content[ "name" ]
+        assert name == "fasta1 suffix", name
+
+    @skip_without_tool( "cat" )
+    def test_run_rename_based_on_input_repeat( self ):
+        history_id = self.dataset_populator.new_history()
+        self._run_jobs("""
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+  - id: input2
+steps:
+  - tool_id: cat
+    label: first_cat
+    state:
+      input1:
+        $link: input1
+      queries:
+        - input2:
+            $link: input2
+    outputs:
+      out_file1:
+        rename: "#{queries_0.input2| basename} suffix"
+test_data:
+  input1:
+    value: 1.fasta
+    type: File
+    name: fasta1
+  input2:
+    value: 1.fasta
+    type: File
+    name: fasta2
+""", history_id=history_id)
+        content = self.dataset_populator.get_history_dataset_details( history_id, wait=True, assert_ok=True )
+        name = content[ "name" ]
+        assert name == "fasta2 suffix", name
+
+    @skip_without_tool( "mapper2" )
+    def test_run_rename_based_on_input_conditional( self ):
+        history_id = self.dataset_populator.new_history()
+        self._run_jobs("""
+class: GalaxyWorkflow
+inputs:
+  - id: fasta_input
+  - id: fastq_input
+steps:
+  - tool_id: mapper2
+    state:
+      fastq_input:
+        fastq_input_selector: single
+        fastq_input1:
+          $link: fastq_input
+      reference:
+        $link: fasta_input
+    outputs:
+      out_file1:
+        # Wish it was qualified for conditionals but it doesn't seem to be. -John
+        # rename: "#{fastq_input.fastq_input1 | basename} suffix"
+        rename: "#{fastq_input1 | basename} suffix"
+test_data:
+  fasta_input:
+    value: 1.fasta
+    type: File
+    name: fasta1
+    file_type: fasta
+  fastq_input:
+    value: 1.fastqsanger
+    type: File
+    name: fastq1
+    file_type: fastqsanger
+""", history_id=history_id)
+        content = self.dataset_populator.get_history_dataset_details( history_id, wait=True, assert_ok=True )
+        name = content[ "name" ]
+        assert name == "fastq1 suffix", name
 
     @skip_without_tool( "cat1" )
     def test_run_with_runtime_pja( self ):

--- a/test/functional/tools/for_workflows/mapper2.xml
+++ b/test/functional/tools/for_workflows/mapper2.xml
@@ -3,7 +3,7 @@
         cp $__tool_directory__/1.bam $out_file1
     </command>
     <inputs>
-        <!-- Conditional input block from bwa-mem. -->
+        <!-- Conditional input block loosely based on bwa-mem. -->
         <conditional name="fastq_input">
           <param name="fastq_input_selector" type="select" label="Single or Paired-end reads">
             <option value="paired">Paired</option>
@@ -12,17 +12,17 @@
             <option value="paired_iv">Paired Interleaved</option>
           </param>
           <when value="paired">
-            <param name="fastq_input1" type="data" format="fastqsanger" label="Select first set of reads" />
-            <param name="fastq_input2" type="data" format="fastqsanger" label="Select second set of reads" />
+            <param name="fastq_input1" type="data" format="fastq" label="Select first set of reads" />
+            <param name="fastq_input2" type="data" format="fastq" label="Select second set of reads" />
           </when>
           <when value="single">
-            <param name="fastq_input1" type="data" format="fastqsanger" label="Select fastq dataset"/>
+            <param name="fastq_input1" type="data" format="fastq" label="Select fastq dataset"/>
           </when>
           <when value="paired_collection">
-            <param name="fastq_input1" format="fastqsanger" type="data_collection" collection_type="paired" label="Select a paired collection" />
+            <param name="fastq_input1" format="fastq" type="data_collection" collection_type="paired" label="Select a paired collection" />
           </when>
           <when value="paired_iv">
-            <param name="fastq_input1" type="data" format="fastqsanger" label="Select fastq dataset" />
+            <param name="fastq_input1" type="data" format="fastq" label="Select fastq dataset" />
           </when>
         </conditional>
         <param name="reference" type="data" format="fasta" label="Fasta Input"/>

--- a/test/functional/tools/for_workflows/mapper2.xml
+++ b/test/functional/tools/for_workflows/mapper2.xml
@@ -1,0 +1,33 @@
+<tool id="mapper2" name="mapper2" version="0.1.0">
+    <command>
+        cp $__tool_directory__/1.bam $out_file1
+    </command>
+    <inputs>
+        <!-- Conditional input block from bwa-mem. -->
+        <conditional name="fastq_input">
+          <param name="fastq_input_selector" type="select" label="Single or Paired-end reads">
+            <option value="paired">Paired</option>
+            <option value="single">Single</option>
+            <option value="paired_collection">Paired Collection</option>
+            <option value="paired_iv">Paired Interleaved</option>
+          </param>
+          <when value="paired">
+            <param name="fastq_input1" type="data" format="fastqsanger" label="Select first set of reads" />
+            <param name="fastq_input2" type="data" format="fastqsanger" label="Select second set of reads" />
+          </when>
+          <when value="single">
+            <param name="fastq_input1" type="data" format="fastqsanger" label="Select fastq dataset"/>
+          </when>
+          <when value="paired_collection">
+            <param name="fastq_input1" format="fastqsanger" type="data_collection" collection_type="paired" label="Select a paired collection" />
+          </when>
+          <when value="paired_iv">
+            <param name="fastq_input1" type="data" format="fastqsanger" label="Select fastq dataset" />
+          </when>
+        </conditional>
+        <param name="reference" type="data" format="fasta" label="Fasta Input"/>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="bam" />
+    </outputs>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -114,6 +114,7 @@
   <tool file="for_workflows/cat_interleave.xml" />
   <tool file="for_workflows/pileup.xml" />
   <tool file="for_workflows/mapper.xml" />
+  <tool file="for_workflows/mapper2.xml" />
   <tool file="for_workflows/split.xml" />
   <tool file="for_workflows/create_input_collection.xml" />
 


### PR DESCRIPTION
See individual commits for full details but in short:
 - #3377 is included since it is required for the test cases.
 - d9ffbc433ef417c08d5d040b27a6d3d626d54872 includes test cases for existing functionality including #662 and the recently merged #3197.
 - a18b24e0679016da159703a4e6b873f0ae95cf4e implements renaming output datasets based on input collections - this is my reading of #2346 (more work to do in this area but a solid step forward I think) 