### PR TITLE
Do not allow recursive replacements in PJA renames.

### DIFF
--- a/lib/galaxy/jobs/actions/post.py
+++ b/lib/galaxy/jobs/actions/post.py
@@ -111,11 +111,12 @@ class RenameDatasetAction(DefaultJobAction):
             #      "replace" option so you can replace a portion of the name,
             #      support multiple #{name} in one rename action...
 
-            while new_name.find("#{") > -1:
+            start_pos = 0
+            while new_name.find("#{", start_pos) > -1:
                 to_be_replaced = ""
                 #  This assumes a single instance of #{variable} will exist
-                start_pos = new_name.find("#{") + 2
-                end_pos = new_name.find("}")
+                start_pos = new_name.find("#{", start_pos) + 2
+                end_pos = new_name.find("}", start_pos)
                 to_be_replaced = new_name[start_pos:end_pos]
                 input_file_var = to_be_replaced
                 #  Pull out the piped controls and store them for later

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -1290,6 +1290,32 @@ test_data:
         assert name == "fasta1 suffix", name
 
     @skip_without_tool( "cat" )
+    def test_run_rename_based_on_input_recursive( self ):
+        history_id = self.dataset_populator.new_history()
+        self._run_jobs("""
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+steps:
+  - tool_id: cat
+    label: first_cat
+    state:
+      input1:
+        $link: input1
+    outputs:
+      out_file1:
+        rename: "#{input1} #{input1 | upper} suffix"
+test_data:
+  input1:
+    value: 1.fasta
+    type: File
+    name: '#{input1}'
+""", history_id=history_id)
+        content = self.dataset_populator.get_history_dataset_details( history_id, wait=True, assert_ok=True )
+        name = content[ "name" ]
+        assert name == "#{input1} #{INPUT1} suffix", name
+
+    @skip_without_tool( "cat" )
     def test_run_rename_based_on_input_repeat( self ):
         history_id = self.dataset_populator.new_history()
         self._run_jobs("""


### PR DESCRIPTION
May result in infinite loops.

With test case to demonstrate the problem and ensure the fix.