### PR TITLE
Update the testing image used with ``--dockerize``ed tests.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -214,7 +214,7 @@ ensure_grunt() {
 }
 
 
-DOCKER_DEFAULT_IMAGE='galaxy/testing-base:15.10.3'
+DOCKER_DEFAULT_IMAGE='galaxy/testing-base:17.01.0'
 
 test_script="./scripts/functional_tests.py"
 report_file="run_functional_tests.html"


### PR DESCRIPTION
Should prevent Jenkins from writing files as root.

I haven't run the tests yet, so it is important to wait on Jenkins for this one.