### PR TITLE
[16.10] Remoteuser Logout Fix.

### DIFF
--- a/lib/galaxy/web/framework/middleware/remoteuser.py
+++ b/lib/galaxy/web/framework/middleware/remoteuser.py
@@ -150,6 +150,7 @@ class RemoteUser( object ):
                 '/user/api_keys',
                 '/user/edit_username',
                 '/user/dbkeys',
+                '/user/logout',
                 '/user/toolbox_filters',
                 '/user/set_default_permissions',
                 '/user/change_communication',


### PR DESCRIPTION
The /user/logout endpoint is now used for both remote and internal users to handle logout logic, and should be accessible here