### PR TITLE
extend API version information

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -10,6 +10,9 @@ from galaxy.web.base.controller import BaseAPIController
 from galaxy.managers import configuration
 from galaxy.queue_worker import send_control_task
 
+import json
+import os
+
 import logging
 log = logging.getLogger( __name__ )
 
@@ -42,7 +45,16 @@ class ConfigurationController( BaseAPIController ):
         :rtype:     dict
         :returns:   dictionary with major version keyed on 'version_major'
         """
-        return {"version_major": self.app.config.version_major }
+        extra={}
+        try:
+            version_file=os.environ.get("GALAXY_VERSION_JSON_FILE",self.app.container_finder.app_info.galaxy_root_dir+"/version.json")
+            f=open(version_file)
+            extra = json.load(f)
+            f.close()
+        except:
+            pass
+        return {"version_major": self.app.config.version_major , "extra": extra}
+
 
     def get_config_dict( self, trans, return_admin=False, view=None, keys=None, default_view='all' ):
         """

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -47,7 +47,7 @@ class ConfigurationController( BaseAPIController ):
         """
         extra = {}
         try:
-            version_file = os.environ.get("GALAXY_VERSION_JSON_FILE", self.app.container_finder.app_info.galaxy_root_dir+"/version.json")
+            version_file = os.environ.get("GALAXY_VERSION_JSON_FILE", self.app.container_finder.app_info.galaxy_root_dir + "/version.json")
             f = open(version_file)
             extra = json.load(f)
             f.close()

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -45,16 +45,15 @@ class ConfigurationController( BaseAPIController ):
         :rtype:     dict
         :returns:   dictionary with major version keyed on 'version_major'
         """
-        extra={}
+        extra = {}
         try:
-            version_file=os.environ.get("GALAXY_VERSION_JSON_FILE",self.app.container_finder.app_info.galaxy_root_dir+"/version.json")
-            f=open(version_file)
+            version_file = os.environ.get("GALAXY_VERSION_JSON_FILE", self.app.container_finder.app_info.galaxy_root_dir+"/version.json")
+            f = open(version_file)
             extra = json.load(f)
             f.close()
         except:
             pass
-        return {"version_major": self.app.config.version_major , "extra": extra}
-
+        return {"version_major": self.app.config.version_major, "extra": extra}
 
     def get_config_dict( self, trans, return_admin=False, view=None, keys=None, default_view='all' ):
         """

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -48,10 +48,9 @@ class ConfigurationController( BaseAPIController ):
         extra = {}
         try:
             version_file = os.environ.get("GALAXY_VERSION_JSON_FILE", self.app.container_finder.app_info.galaxy_root_dir + "/version.json")
-            f = open(version_file)
-            extra = json.load(f)
-            f.close()
-        except:
+            with open(version_file, "r") as f:
+                extra = json.load(f)
+        except Exception:
             pass
         return {"version_major": self.app.config.version_major, "extra": extra}
 


### PR DESCRIPTION
extend API version information #1907
https://github.com/galaxyproject/galaxy/issues/1907

extend /api/version

output json file contents with version_major

```json
{
  "extra": {
    "user_tag": "_fix_job_runner_issue",
    "commit-id": "abcde123"
  },
  "version_major": "16.10"
}
```

First check environment value GALAXY_VERSION_JSON_FILE.
if it's not set, try "galaxy root direcotory"/version.json.

if json file is not find, extra set empty.