### PR TITLE
Fix dependency display and api

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1401,7 +1401,7 @@ class Tool( object, Dictifiable ):
         """
         Return all requiremens of type package
         """
-        reqs = [req.to_dict() for req in self.requirements if req.type == 'package']
+        reqs = [req for req in self.requirements if req.type == 'package']
         return reqs
 
     @property
@@ -1409,7 +1409,7 @@ class Tool( object, Dictifiable ):
         """
         Return a list of dictionaries for all tool dependencies with their associated status
         """
-        return self._view.get_requirements_status(self.tool_requirements, self.installed_tool_dependencies)
+        return self._view.get_requirements_status({self.id: self.tool_requirements}, self.installed_tool_dependencies)
 
     def build_redirect_url_params( self, param_dict ):
         """

--- a/lib/galaxy/tools/deps/__init__.py
+++ b/lib/galaxy/tools/deps/__init__.py
@@ -123,6 +123,7 @@ class DependencyManager( object ):
         requirement_to_dependency = OrderedDict()
         index = kwds.get('index', None)
         require_exact = kwds.get('exact', False)
+        return_null_dependencies = kwds.get('return_null', False)
 
         resolvable_requirements = []
         for requirement in requirements:
@@ -163,6 +164,8 @@ class DependencyManager( object ):
 
                     log.debug(dependency.resolver_msg)
                     if not isinstance(dependency, NullDependency):
+                        requirement_to_dependency[requirement] = dependency
+                    elif return_null_dependencies and (resolver == self.dependency_resolvers[-1] or i == index):
                         requirement_to_dependency[requirement] = dependency
 
         return requirement_to_dependency

--- a/lib/galaxy/tools/deps/requirements.py
+++ b/lib/galaxy/tools/deps/requirements.py
@@ -28,6 +28,9 @@ class ToolRequirement( object ):
     def __eq__(self, other):
         return self.name == other.name and self.type == other.type and self.version == other.version
 
+    def __hash__(self):
+        return hash((self.name, self.type, self.version))
+
 
 DEFAULT_CONTAINER_TYPE = "docker"
 DEFAULT_CONTAINER_RESOLVE_DEPENDENCIES = False

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -153,7 +153,7 @@ class CondaDependencyResolver(DependencyResolver, ListableDependencyResolver, In
                 dependency = MergedCondaDependency(
                     self.conda_context,
                     self.conda_context.env_path(env),
-                    exact=self.versionless or requirement.version is None,
+                    exact=not self.versionless or requirement.version is None,
                     name=requirement.name,
                     version=requirement.version,
                     preserve_python_environment=preserve_python_environment,

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -781,7 +781,7 @@ class AdminToolshed( AdminGalaxy ):
                                                                                 reinstalling=False,
                                                                                 required_repo_info_dicts=None )
         view = views.DependencyResolversView(self.app)
-        requirements = suc.get_unique_requirements_from_repository(repository)
+        requirements = suc.get_requirements_from_repository(repository)
         requirements_status = view.get_requirements_status(requirements, repository.installed_tool_dependencies)
         return trans.fill_template( '/admin/tool_shed_repository/manage_repository.mako',
                                     repository=repository,

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -9,6 +9,7 @@ import sqlalchemy.orm.exc
 from sqlalchemy import and_, false, true
 
 from galaxy import util
+from galaxy.tools.deps.requirements import ToolRequirement
 from galaxy.util import checkers
 from galaxy.web import url_for
 from tool_shed.util import (
@@ -219,37 +220,18 @@ def get_tool_shed_repo_requirements(app, tool_shed_url, repositories=None, repo_
         valid_tools = json_response[1].get('valid_tools', [])
         if valid_tools:
             tools.extend(valid_tools)
-    return get_unique_requirements_from_tools(tools)
+    return get_requirements_from_tools(tools)
 
 
-def get_unique_requirements_from_tools(tools):
-    requirements = []
-    for tool in tools:
-        if tool['requirements']:
-            requirements.append(tool['requirements'])
-    return get_unique_requirements(requirements)
+def get_requirements_from_tools(tools):
+    return {tool['id']: [ToolRequirement.from_dict(r) for r in tool['requirements']] for tool in tools}
 
 
-def get_unique_requirements(requirements):
-    uniq_reqs = dict()
-    for tool_requirements in requirements:
-        for req in tool_requirements:
-            name = req.get("name", None)
-            if not name:
-                continue  # A requirement without a name can't be resolved, so let's skip those
-            version = req.get("version", "versionless")
-            type = req.get("type", None)
-            if not type == "package":
-                continue
-            uniq_reqs["%s_%s" % (name, version)] = {'name': name, 'version': version, 'type': type}
-    return list(uniq_reqs.values())
-
-
-def get_unique_requirements_from_repository(repository):
+def get_requirements_from_repository(repository):
     if not repository.includes_tools:
-        return []
+        return {}
     else:
-        return get_unique_requirements_from_tools(repository.metadata.get('tools', []))
+        return get_requirements_from_tools(repository.metadata.get('tools', []))
 
 
 def get_ctx_rev( app, tool_shed_url, name, owner, changeset_revision ):


### PR DESCRIPTION
Fix display of repository dependency status that broke with the introduction of the all-at-once dependency resolution in #3391 and addresses in part #3398. I have only restored the (collapsed) display of dependencies for all requirements in a repository, so breaking the information out on a per tool basis remains on the TODO list. The integration API tests are passing for me as well.

I also took the liberty to cherry-pick @jmchilton exact version fix, so this should replace #3424