### PR TITLE
Do not wrap __class__ attribute of SafeStringWrapper

### DIFF
--- a/lib/galaxy/util/object_wrapper.py
+++ b/lib/galaxy/util/object_wrapper.py
@@ -184,6 +184,7 @@ def wrap_with_safe_string( value, no_wrap_classes=None ):
                 # Set pickle and copy properties
                 copy_reg.pickle( wrapped_class, pickle_safe_object, do_wrap_func )
         return wrapped_class( value, safe_string_wrapper_function=do_wrap_func )
+
     # Determine classes not to wrap
     if no_wrap_classes:
         if not isinstance( no_wrap_classes, ( tuple, list ) ):
@@ -214,7 +215,7 @@ class SafeStringWrapper( object ):
     will still be sanitized, but not wrapped), and e.g. integers will have neither.
     """
     __UNSANITIZED_ATTRIBUTE_NAME__ = 'unsanitized'
-    __NO_WRAP_NAMES__ = [ '__safe_string_wrapper_function__', __UNSANITIZED_ATTRIBUTE_NAME__]
+    __NO_WRAP_NAMES__ = [ '__safe_string_wrapper_function__', '__class__', __UNSANITIZED_ATTRIBUTE_NAME__]
 
     def __new__( cls, *arg, **kwd ):
         # We need to define a __new__ since, we are subclassing from e.g. immutable str, which internally sets data
@@ -284,7 +285,7 @@ class SafeStringWrapper( object ):
     def __getattr__( self, name ):
         if name in SafeStringWrapper.__NO_WRAP_NAMES__:
             # FIXME: is this ever reached?
-            return object.__getattr__( self, name )
+            return object.__getattribute__( self, name )
         return self.__safe_string_wrapper_function__( getattr( self.unsanitized, name ) )
 
     def __setattr__( self, name, value ):


### PR DESCRIPTION
Fix #3353 by not recursing on the parent classes, which may lead to an abstract class.
Also fix a method name of `object` class.

This is an alternative to #3359, which fixes the issue only for the classes derived from `TabularData`, but any datatype derived from an abstract class would exhibit the same problem, e.g. if `samtool_filter2.xml` is modified with this patch:
```patch
diff --git a/tools/samtool_filter2/samtool_filter2.xml b/tools/samtool_filter2/samtool_filter2.xml
index a5d2b9a..bd2f2b2 100644
--- a/tools/samtool_filter2/samtool_filter2.xml
+++ b/tools/samtool_filter2/samtool_filter2.xml
@@ -16,6 +16,9 @@
 #elif isinstance($input1.datatype, $__app__.datatypes_registry.get_datatype_by_extension('sam').__class__):
   #set $input = 'input.sam'
   ln -s "$input1" $input &&
+#elif isinstance($input1.datatype, $__app__.datatypes_registry.get_datatype_by_extension('hmm3').__class__):
+  #set $input = 'input'
+  ln -s "$input1" $input &&
 #end if
 samtools view $possibly_select_inverse "$output1" $header
 
@@ -66,7 +69,7 @@ samtools view $possibly_select_inverse "$output1" $header
 ]]>
   </command>
   <inputs>
-    <param name="input1" type="data" format="sam,bam" label="SAM or BAM file to filter" />
+    <param name="input1" type="data" format="sam,bam,hmm3" label="SAM or BAM file to filter" />
     <param name="header" type="select" label="Header in output">
       <option value="-h">Include Header</option>
       <option value="">Exclude Header</option>
@@ -134,7 +137,7 @@ samtools view $possibly_select_inverse "$output1" $header
   </outputs>
   <tests>
     <test>
-      <param name="input1" value="bam_to_sam_in2.sam" ftype="sam" />
+      <param name="input1" value="bam_to_sam_in2.sam" ftype="hmm3" />
       <param name="header" value=""/>
       <param name="filter" value="yes"/>
       <param name="reqBits" value="0x0080"/>
```
the problem reappears.