### PR TITLE
Various fixes for test image Docker user switching.

### DIFF
--- a/test/docker/base/run_test_wrapper.sh
+++ b/test/docker/base/run_test_wrapper.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 set -e
 
+echo "Deleting galaxy user - it may not exist and this is fine."
 deluser galaxy | true
-groupadd -r galaxy -g "$GALAXY_TEST_UID"
-useradd -u $GALAXY_TEST_UID -r -g galaxy -d /home/galaxy -c "Galaxy User" galaxy -s /bin/bash
-echo "galaxy:galaxy" | chpasswd
-chown -R galaxy:galaxy /galaxy_venv
+
+echo "Creating galaxy group with gid $GALAXY_TEST_UID - it may already exist and this is fine."
+groupadd -r galaxy -g "$GALAXY_TEST_UID" | true
+echo "Creating galaxy user with uid $GALAXY_TEST_UID - it may already exist and this is fine."
+useradd -u $GALAXY_TEST_UID -r -g galaxy -d /home/galaxy -c "Galaxy User" galaxy -s /bin/bash | true
+echo "Setting galaxy user password - the operation may fail."
+echo "galaxy:galaxy" | chpasswd | true
+chown -R "$GALAXY_TEST_UID:$GALAXY_TEST_UID" /galaxy_venv
 
 GALAXY_TEST_DATABASE_TYPE=${GALAXY_TEST_DATABASE_TYPE:-"postgres"}
 if [ "$GALAXY_TEST_DATABASE_TYPE" = "postgres" ];
@@ -26,6 +31,7 @@ then
     GALAXY_TEST_INSTALL_DB_MERGED="true"
     GALAXY_TEST_DBURI="sqlite:////opt/galaxy/galaxy.sqlite"
     TOOL_SHED_TEST_DBURI="sqlite:////opt/galaxy/toolshed.sqlite"
+    chown -R "$GALAXY_TEST_UID:$GALAXY_TEST_UID" /opt/galaxy
 else
 	echo "Unknown database type"
 	exit 1
@@ -42,19 +48,19 @@ export TOOL_SHED_CONFIG_OVERRIDE_DATABASE_CONNECTION
 
 : ${GALAXY_VIRTUAL_ENV:=.venv}
 
-sudo -E -u galaxy ./scripts/common_startup.sh || { echo "common_startup.sh failed"; exit 1; }
+sudo -E -u "#${GALAXY_TEST_UID}" ./scripts/common_startup.sh || { echo "common_startup.sh failed"; exit 1; }
 
 dev_requirements=./lib/galaxy/dependencies/dev-requirements.txt
 [ -f $dev_requirements ] && $GALAXY_VIRTUAL_ENV/bin/pip install -r $dev_requirements
 
 echo "Upgrading test database..."
-sudo -E -u galaxy sh manage_db.sh upgrade
+sudo -E -u "#${GALAXY_TEST_UID}" sh manage_db.sh upgrade
 echo "Upgrading tool shed database... $TOOL_SHED_CONFIG_OVERRIDE_DATABASE_CONNECTION"
-sudo -E -u galaxy sh manage_db.sh upgrade tool_shed
+sudo -E -u "#${GALAXY_TEST_UID}" sh manage_db.sh upgrade tool_shed
 
 if [ -z "$GALAXY_NO_TESTS" ];
 then
-    sudo -E -u galaxy sh run_tests.sh --skip-common-startup $@
+    sudo -E -u "#${GALAXY_TEST_UID}" sh run_tests.sh --skip-common-startup $@
 else
     GALAXY_CONFIG_MASTER_API_KEY=${GALAXY_CONFIG_MASTER_API_KEY:-"testmasterapikey"}
     GALAXY_CONFIG_FILE=${GALAXY_CONFIG_FILE:-config/galaxy.ini.sample}


### PR DESCRIPTION
- Fix if testing as user with GID 109 (fixes #3425).
- Fix if testing as a user with any UID or GID that already exists in the container.
- More logging to indicate the "problems" being printed to standard output in these cases are not problems.
- Fix sqlite being readonly in the container for the test user.