### PR TITLE
Fixup circular dependency in #3427.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -20,6 +20,8 @@ from six.moves.urllib.parse import unquote_plus
 
 import galaxy.jobs
 import tool_shed.util.repository_util as repository_util
+import tool_shed.util.shed_util_common
+
 from galaxy import (
     exceptions,
     model
@@ -83,7 +85,6 @@ from galaxy.web import url_for
 from galaxy.web.form_builder import SelectField
 from galaxy.work.context import WorkRequestContext
 from tool_shed.util import common_util
-from tool_shed.util import shed_util_common as suc
 
 from .execute import execute as execute_job
 from .loader import (
@@ -1071,7 +1072,7 @@ class Tool( object, Dictifiable ):
             if self.repository_id and help_text.find( '.. image:: ' ) >= 0:
                 # Handle tool help image display for tools that are contained in repositories in the tool shed or installed into Galaxy.
                 try:
-                    help_text = suc.set_image_paths( self.app, self.repository_id, help_text )
+                    help_text = tool_shed.util.shed_util_common.set_image_paths( self.app, self.repository_id, help_text )
                 except Exception as e:
                     log.exception( "Exception in parse_help, so images may not be properly displayed:\n%s" % str( e ) )
             try:

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -8,8 +8,9 @@ import string
 import sqlalchemy.orm.exc
 from sqlalchemy import and_, false, true
 
+import galaxy.tools.deps.requirements
+
 from galaxy import util
-from galaxy.tools.deps.requirements import ToolRequirement
 from galaxy.util import checkers
 from galaxy.web import url_for
 from tool_shed.util import (
@@ -224,7 +225,7 @@ def get_tool_shed_repo_requirements(app, tool_shed_url, repositories=None, repo_
 
 
 def get_requirements_from_tools(tools):
-    return {tool['id']: [ToolRequirement.from_dict(r) for r in tool['requirements']] for tool in tools}
+    return {tool['id']: [galaxy.tools.deps.requirements.ToolRequirement.from_dict(r) for r in tool['requirements']] for tool in tools}
 
 
 def get_requirements_from_repository(repository):


### PR DESCRIPTION
Unfortunately the "root" of the problem is that galaxy.tools.deps.requirements.ToolRequirement should be importable without importing galaxy.tools - but it cannot be currently just because of the way things are structured.

Reported by @bgruening on Gitter.