### PR TITLE
[16.10] Backport of 3429, safestringwrapper

### DIFF
--- a/lib/galaxy/util/object_wrapper.py
+++ b/lib/galaxy/util/object_wrapper.py
@@ -184,6 +184,7 @@ def wrap_with_safe_string( value, no_wrap_classes=None ):
                 # Set pickle and copy properties
                 copy_reg.pickle( wrapped_class, pickle_safe_object, do_wrap_func )
         return wrapped_class( value, safe_string_wrapper_function=do_wrap_func )
+
     # Determine classes not to wrap
     if no_wrap_classes:
         if not isinstance( no_wrap_classes, ( tuple, list ) ):
@@ -214,7 +215,7 @@ class SafeStringWrapper( object ):
     will still be sanitized, but not wrapped), and e.g. integers will have neither.
     """
     __UNSANITIZED_ATTRIBUTE_NAME__ = 'unsanitized'
-    __NO_WRAP_NAMES__ = [ '__safe_string_wrapper_function__', __UNSANITIZED_ATTRIBUTE_NAME__]
+    __NO_WRAP_NAMES__ = [ '__safe_string_wrapper_function__', '__class__', __UNSANITIZED_ATTRIBUTE_NAME__]
 
     def __new__( cls, *arg, **kwd ):
         # We need to define a __new__ since, we are subclassing from e.g. immutable str, which internally sets data
@@ -284,7 +285,7 @@ class SafeStringWrapper( object ):
     def __getattr__( self, name ):
         if name in SafeStringWrapper.__NO_WRAP_NAMES__:
             # FIXME: is this ever reached?
-            return object.__getattr__( self, name )
+            return object.__getattribute__( self, name )
         return self.__safe_string_wrapper_function__( getattr( self.unsanitized, name ) )
 
     def __setattr__( self, name, value ):


### PR DESCRIPTION
Reopen of #3429 w/ 16.10 target.

Do not wrap __class__ attribute of SafeStringWrapper
Fix #3353 by not recursing on the parent classes, which may lead to
an abstract class.
Also fix a method name of "object" class.