### PR TITLE
Fix various transiently failing Selenium tests.

### DIFF
--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -109,6 +109,12 @@ class NavigatesGalaxy(HasDriver):
 
     def history_panel_wait_for_hid_ok(self, hid, timeout=30):
         current_history_id = self.current_history_id()
+
+        def history_has_hid(driver):
+            contents = self.api_get("histories/%s/contents" % current_history_id)
+            return any([d for d in contents if d["hid"] == hid])
+
+        self.wait(timeout).until(history_has_hid)
         contents = self.api_get("histories/%s/contents" % current_history_id)
         history_item = [d for d in contents if d["hid"] == hid][0]
         history_item_selector_okay = "#%s-%s.state-ok" % (history_item["history_content_type"], history_item["id"])

--- a/test/selenium_tests/test_history_dataset_state.py
+++ b/test/selenium_tests/test_history_dataset_state.py
@@ -11,7 +11,7 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
     def test_dataset_state(self):
         self.register()
         self.perform_upload(self.get_filename("1.fasta"))
-        self.wait_for_history()
+        self.history_panel_wait_for_hid_ok(1)
         self.assert_item_name(1, "1.fasta")
         self.assert_item_hid_text(1)
         self._assert_title_buttons(1)

--- a/test/selenium_tests/test_tool_form.py
+++ b/test/selenium_tests/test_tool_form.py
@@ -11,20 +11,20 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
     def test_run_tool_verify_contents_by_peek(self):
         self._run_environment_test_tool()
 
-        self.wait_for_history()
+        self.history_panel_wait_for_hid_ok(1)
         self.history_panel_click_item_title(hid=1)
         self.assert_item_peek_includes(1, "42")
 
     @selenium_test
     def test_run_tool_verify_dataset_details(self):
         self._run_environment_test_tool()
-        self.wait_for_history()
+        self.history_panel_wait_for_hid_ok(1)
         self._check_dataset_details_for_inttest_value(1)
 
     @selenium_test
     def test_verify_dataset_details_tables(self):
         self._run_environment_test_tool()
-        self.wait_for_history()
+        self.history_panel_wait_for_hid_ok(1)
 
         hda = self.latest_history_item()
         self._check_dataset_details_for_inttest_value(1)
@@ -62,7 +62,7 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
     @selenium_test
     def test_rerun(self):
         self._run_environment_test_tool()
-        self.wait_for_history()
+        self.history_panel_wait_for_hid_ok(1)
         self.hda_click_primary_action_button(1, "rerun")
 
         inttest_div_element = self.tool_parameter_div("inttest")
@@ -72,7 +72,7 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         assert recorded_val == "42", recorded_val
         self.tool_execute()
 
-        self.wait_for_history()
+        self.history_panel_wait_for_hid_ok(2)
         self._check_dataset_details_for_inttest_value(2)
 
     @selenium_test
@@ -81,13 +81,14 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         test_path_decoy = self.get_filename("1.txt")
         self.perform_upload(test_path)
         self.perform_upload(test_path_decoy)
-        self.wait_for_history()
+        self.history_panel_wait_for_hid_ok(1)
+        self.history_panel_wait_for_hid_ok(2)
 
         self.home()
         self.tool_open("head")
         self.tool_set_value("input", "1.fasta", expected_type="data")
         self.tool_execute()
-        self.wait_for_history()
+        self.history_panel_wait_for_hid_ok(3)
 
         latest_hda = self.latest_history_item()
         assert latest_hda["hid"] == 3


### PR DESCRIPTION
I'm pretty sure the problem is that I was waiting on conditions (e.g. datasets to become "ok") using the API and then assuming the state of the GUI elements was the same. Obviously though the GUI is polling the API and there is some lag there. This commit changes things to specifically wait on history panel GUI changes for given HIDs - obviously the better thing to wait on in a GUI test.