### PR TITLE
Fix linting of <conditional>s

### DIFF
--- a/lib/galaxy/tools/linters/inputs.py
+++ b/lib/galaxy/tools/linters/inputs.py
@@ -1,4 +1,6 @@
 """This module contains a linting functions for tool inputs."""
+from galaxy.util import string_as_bool
+
 from ..lint_util import is_datasource
 
 
@@ -36,8 +38,6 @@ def lint_inputs(tool_xml, lint_ctx):
             if any(['value' not in option.attrib for option in select_options]):
                 lint_ctx.error("Option without value")
 
-            select_option_ids = [option.attrib.get('value', None) for option in select_options]
-
             if dynamic_options is None and len(select_options) == 0:
                 message = "No options defined for select [%s]" % param_name
                 lint_ctx.warn(message)
@@ -46,43 +46,49 @@ def lint_inputs(tool_xml, lint_ctx):
 
     conditional_selects = tool_xml.findall("./inputs//conditional")
     for conditional in conditional_selects:
-        booleans = _find_with_attribute(conditional, "param", "type", "boolean")
-        selects = _find_with_attribute(conditional, "param", "type", "select")
-        # Should conditionals ever not have a select?
-        if not len(selects) and not len(booleans):
-            lint_ctx.warn("Conditional without <param type=\"select\" /> or <param type=\"boolean\" />")
+        conditional_name = conditional.get('name')
+        if not conditional_name:
+            lint_ctx.error("Conditional without a name")
+        if conditional.get("value_from"):
+            # Probably only the upload tool use this, no children elements
+            continue
+        first_param = conditional.find("param")
+        if first_param is None:
+            lint_ctx.error("Conditional '%s' has no child <param>" % conditional_name)
+            continue
+        first_param_type = first_param.get('type')
+        if first_param_type not in ['select', 'boolean']:
+            lint_ctx.warn("Conditional '%s' first param should have type=\"select\" /> or type=\"boolean\"" % conditional_name)
             continue
 
-        test_param_optional = False
-        for select in selects:
-            test_param_optional = test_param_optional or (select.attrib.get('optional', None) is not None)
-            select_options = _find_with_attribute(select, 'option', 'value')
-            select_option_ids = [option.attrib.get('value', None) for option in select_options]
-
-        for boolean in booleans:
-            test_param_optional = test_param_optional or (boolean.attrib.get('optional', None) is not None)
-            select_option_ids = [
-                boolean.attrib.get('truevalue', 'true'),
-                boolean.attrib.get('falsevalue', 'false')
+        if first_param_type == 'select':
+            select_options = _find_with_attribute(first_param, 'option', 'value')
+            option_ids = [option.get('value') for option in select_options]
+        else:  # boolean
+            option_ids = [
+                first_param.get('truevalue', 'true'),
+                first_param.get('falsevalue', 'false')
             ]
 
-        if test_param_optional:
-            lint_ctx.warn("Conditional test parameter declares an invalid optional attribute.")
+        if string_as_bool(first_param.get('optional', False)):
+            lint_ctx.warn("Conditional test parameter cannot be optional")
 
         whens = conditional.findall('./when')
-        if any(['value' not in when.attrib for when in whens]):
+        if any('value' not in when.attrib for when in whens):
             lint_ctx.error("When without value")
 
-        when_ids = [w.attrib.get('value', None) for w in whens]
-        when_ids = [i.lower() if i in ["True", "False"] else i for i in when_ids]
+        when_ids = [w.get('value') for w in whens]
 
-        for select_id in select_option_ids:
-            if select_id not in when_ids:
-                lint_ctx.warn("No <when /> block found for select option '%s'" % select_id)
+        for option_id in option_ids:
+            if option_id not in when_ids:
+                lint_ctx.warn("No <when /> block found for %s option '%s' inside conditional '%s'" % (first_param_type, option_id, conditional_name))
 
         for when_id in when_ids:
-            if when_id not in select_option_ids:
-                lint_ctx.warn("No <option /> block found for when block '%s'" % when_id)
+            if when_id not in option_ids:
+                if first_param_type == 'select':
+                    lint_ctx.warn("No <option /> found for when block '%s' inside conditional '%s'" % (when_id, conditional_name))
+                else:
+                    lint_ctx.warn("No truevalue/falsevalue found for when block '%s' inside conditional '%s'" % (when_id, conditional_name))
 
     if datasource:
         for datasource_tag in ('display', 'uihints'):


### PR DESCRIPTION
If the first param is boolean with `truevalue="True"` or `falsavalue="False"`, or a select with an option having value `True` or `False`, the linter was wrongly complaining with both:
```
No <when /> block found for select option 'True'
```
and:
```
No <option /> block found for when block 'true'
```

Tested on all tools shipped with Galaxy and most of tools-iuc tools.