### PR TITLE
[17.01] Upgrade six to 1.10.0.

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -27,7 +27,7 @@ Beaker==1.7.0
 dictobj==0.3.1
 nose==1.3.7
 Parsley==1.3
-six==1.9.0
+six==1.10.0
 Whoosh==2.7.4
 testfixtures==4.10.0
 


### PR DESCRIPTION
This is required by the setuptools release released today. So if anything uses setuptools (e.g. it seems we get twill from PyPI instead of wheels.galaxyproject.org) it will fail because we have downgraded six it seems.