### PR TITLE
[17.01] Pin flake8 and plugins in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ skipsdist = True
 commands = bash .ci/flake8_wrapper.sh
 whitelist_externals = bash
 deps =
-    flake8
-    flake8-docstrings==1.0.2
+    flake8==3.2.1
+    flake8-docstrings==1.0.3
 
 [testenv:py33-lint]
 commands = bash .ci/flake8_py3_wrapper.sh
@@ -17,7 +17,7 @@ deps = flake8
 [testenv:py34-lint]
 commands = bash .ci/flake8_py3_wrapper.sh
 whitelist_externals = bash
-deps = flake8
+deps = flake8==3.2.1
 
 [testenv:py35-lint]
 commands = bash .ci/flake8_py3_wrapper.sh
@@ -43,15 +43,15 @@ whitelist_externals = bash
 skip_install = True
 deps =
     flake8
-    flake8-import-order==0.9
+    flake8-import-order>=0.9
 
 [testenv:py27-lint-imports-include-list]
 commands = bash .ci/flake8_wrapper_imports.sh
 whitelist_externals = bash
 skip_install = True
 deps =
-    flake8
-    flake8-import-order>=0.9
+    flake8==3.2.1
+    flake8-import-order==0.11
 
 [testenv:qunit]
 commands = bash run_tests.sh -q
@@ -79,7 +79,7 @@ whitelist_externals = bash
 skip_install = True
 deps =
     flake8
-    flake8-docstrings==1.0.2
+    flake8-docstrings
 
 [testenv:py27-lint-docstring-include-list]
 commands = bash .ci/flake8_wrapper_docstrings.sh --include
@@ -87,4 +87,4 @@ whitelist_externals = bash
 skip_install = True
 deps =
     flake8
-    flake8-docstrings==1.0.2
+    flake8-docstrings==1.0.3


### PR DESCRIPTION
For all tox environments used in .travis.yml except the ones allowed to fail.

Needs to be merged manually to `dev` because we don't pin them there.