### PR TITLE
[16.10] BUG: Reload converter tools after toolbox reload

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -478,7 +478,7 @@ class Registry( object ):
             data.init_meta( copy_from=data )
         return data
 
-    def load_datatype_converters( self, toolbox, installed_repository_dict=None, deactivate=False ):
+    def load_datatype_converters( self, toolbox, installed_repository_dict=None, deactivate=False, use_cached=False ):
         """
         If deactivate is False, add datatype converters from self.converters or self.proprietary_converters
         to the calling app's toolbox.  If deactivate is True, eliminates relevant converters from the calling
@@ -500,7 +500,7 @@ class Registry( object ):
                 converter_path = self.converters_path
             try:
                 config_path = os.path.join( converter_path, tool_config )
-                converter = toolbox.load_tool( config_path )
+                converter = toolbox.load_tool( config_path, use_cached=use_cached )
                 if installed_repository_dict:
                     # If the converter is included in an installed tool shed repository, set the tool
                     # shed related tool attributes.

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -81,6 +81,7 @@ def _get_new_toolbox(app):
     start = time.time()
     new_toolbox = tools.ToolBox(tool_configs, app.config.tool_path, app, app.toolbox._tool_conf_watcher)
     new_toolbox.data_manager_tools = app.toolbox.data_manager_tools
+    app.datatypes_registry.load_datatype_converters(new_toolbox, use_cached=True)
     load_lib_tools(new_toolbox)
     new_toolbox.load_hidden_lib_tool( "galaxy/datatypes/set_metadata_tool.xml" )
     [new_toolbox.register_tool(tool) for tool in new_toolbox.data_manager_tools.values()]

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -85,7 +85,7 @@ class ConfigurationController( BaseAPIController ):
 
     @expose_api
     @require_admin
-    def reload_toolbox(self, trans):
+    def reload_toolbox(self, trans, **kwds):
         """
         PUT /api/configuration/toolbox
         Reload the Galaxy toolbox (but not individual tools).

--- a/test/api/test_datatypes.py
+++ b/test/api/test_datatypes.py
@@ -58,7 +58,7 @@ class DatatypesApiTestCase( api.ApiTestCase ):
         assert found_fasta_to_tabular
 
     def test_converter_present_after_toolbox_reload( self ):
-        response = self._get( "tools", data={'tool_id': 'CONVERTER_wiggle_to_interval_0'} )
+        response = self._get( "tools", data={'tool_id': 'CONVERTER_fasta_to_tabular'} )
         self._assert_status_code_is( response, 200 )
         converters = len(response.json())
         assert converters == 1
@@ -66,7 +66,7 @@ class DatatypesApiTestCase( api.ApiTestCase ):
         put_response = put( url, params=dict( key=self.master_api_key ) )
         self._assert_status_code_is( put_response, 200 )
         time.sleep(2)
-        response = self._get( "tools", data={'tool_id': 'CONVERTER_wiggle_to_interval_0'} )
+        response = self._get( "tools", data={'tool_id': 'CONVERTER_fasta_to_tabular'} )
         self._assert_status_code_is( response, 200 )
         assert converters == len(response.json())
 

--- a/test/api/test_datatypes.py
+++ b/test/api/test_datatypes.py
@@ -1,5 +1,6 @@
+import time
 from base import api
-
+from requests import put
 
 HIDDEN_DURING_UPLOAD_DATATYPE = "fli"
 
@@ -55,6 +56,19 @@ class DatatypesApiTestCase( api.ApiTestCase ):
                 found_fasta_to_tabular = True
 
         assert found_fasta_to_tabular
+
+    def test_converter_present_after_toolbox_reload( self ):
+        response = self._get( "tools", data={'tool_id': 'CONVERTER_wiggle_to_interval_0'} )
+        self._assert_status_code_is( response, 200 )
+        converters = len(response.json())
+        assert converters == 1
+        url = self._api_url( 'configuration/toolbox' )
+        put_response = put( url, params=dict( key=self.master_api_key ) )
+        self._assert_status_code_is( put_response, 200 )
+        time.sleep(2)
+        response = self._get( "tools", data={'tool_id': 'CONVERTER_wiggle_to_interval_0'} )
+        self._assert_status_code_is( response, 200 )
+        assert converters == len(response.json())
 
     def _index_datatypes( self, data={} ):
         response = self._get( "datatypes", data=data )


### PR DESCRIPTION
The first commit is a testcase demonstrating the problem.
To solve this we just reload the converter tools (from the tool cache).