### PR TITLE
[17.01] Properly label hidden datasets in dataset selectors

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1805,7 +1805,7 @@ class DataToolParameter( BaseDataToolParameter ):
                 m = match.hda
                 has_matched = has_matched or visible_hda == m or visible_hda == hda
                 m_name = '%s (as %s)' % ( match.original_hda.name, match.target_ext ) if match.implicit_conversion else m.name
-                append( d[ 'options' ][ 'hda' ], m.id, m.hid, m_name if m.visible else '(hidden) %s' % m_name, 'hda' )
+                append( d[ 'options' ][ 'hda' ], m.id, m.hid, m_name, 'hda' )
         if not has_matched and hasattr( visible_hda, 'id' ) and hasattr( visible_hda, 'hid' ) and hasattr( visible_hda, 'name' ):
             if visible_hda.deleted:
                 hda_state = 'deleted'

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1806,7 +1806,7 @@ class DataToolParameter( BaseDataToolParameter ):
                 has_matched = has_matched or visible_hda == m or visible_hda == hda
                 m_name = '%s (as %s)' % ( match.original_hda.name, match.target_ext ) if match.implicit_conversion else m.name
                 append( d[ 'options' ][ 'hda' ], m.id, m.hid, m_name, 'hda' )
-        if not has_matched and hasattr( visible_hda, 'id' ) and hasattr( visible_hda, 'hid' ) and hasattr( visible_hda, 'name' ):
+        if not has_matched and hasattr( visible_hda, 'hid' ):
             if visible_hda.deleted:
                 hda_state = 'deleted'
             elif not visible_hda.visible:

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1807,7 +1807,13 @@ class DataToolParameter( BaseDataToolParameter ):
                 m_name = '%s (as %s)' % ( match.original_hda.name, match.target_ext ) if match.implicit_conversion else m.name
                 append( d[ 'options' ][ 'hda' ], m.id, m.hid, m_name if m.visible else '(hidden) %s' % m_name, 'hda' )
         if not has_matched and hasattr( visible_hda, 'id' ) and hasattr( visible_hda, 'hid' ) and hasattr( visible_hda, 'name' ):
-            append( d[ 'options' ][ 'hda' ], visible_hda.id, visible_hda.hid, '(unavailable) %s' % visible_hda.name, 'hda', True )
+            if visible_hda.deleted:
+                hda_state = 'deleted'
+            elif not visible_hda.visible:
+                hda_state = 'hidden'
+            else:
+                hda_state = 'unavailable'
+            append( d[ 'options' ][ 'hda' ], visible_hda.id, visible_hda.hid, '(%s) %s' % ( hda_state, visible_hda.name ), 'hda', True )
 
         # add dataset collections
         dataset_collection_matcher = DatasetCollectionMatcher( dataset_matcher )

--- a/test/unit/tools/test_data_parameters.py
+++ b/test/unit/tools/test_data_parameters.py
@@ -59,7 +59,7 @@ class DataToolParameterTestCase( BaseParameterTestCase ):
         hda2.visible = False
         field = self._simple_field( other_values={ "data2" : hda2 } )
         self.assertEquals( len( field[ 'options' ][ 'hda' ] ), 1 )  # hda1 not an option, not visible or selected
-        assert field[ 'options' ][ 'hda' ][ 0 ][ 'name' ] == "(unavailable) hda2"
+        assert field[ 'options' ][ 'hda' ][ 0 ][ 'name' ] == "(hidden) hda2"
 
     def test_field_implicit_conversion_new( self ):
         hda1 = MockHistoryDatasetAssociation( name="hda1", id=1 )

--- a/test/unit/tools/test_data_parameters.py
+++ b/test/unit/tools/test_data_parameters.py
@@ -54,12 +54,22 @@ class DataToolParameterTestCase( BaseParameterTestCase ):
     def test_field_display_hidden_hdas_only_if_selected( self ):
         hda1 = MockHistoryDatasetAssociation( name="hda1", id=1 )
         hda2 = MockHistoryDatasetAssociation( name="hda2", id=2 )
-        self.stub_active_datasets( hda1, hda2 )
         hda1.visible = False
         hda2.visible = False
+        self.stub_active_datasets( hda1, hda2 )
         field = self._simple_field( other_values={ "data2" : hda2 } )
-        self.assertEquals( len( field[ 'options' ][ 'hda' ] ), 1 )  # hda1 not an option, not visible or selected
+        assert len( field[ 'options' ][ 'hda' ] ) == 1  # hda1 not an option, not visible or selected
         assert field[ 'options' ][ 'hda' ][ 0 ][ 'name' ] == "(hidden) hda2"
+
+    def test_field_display_deleted_hdas_only_if_selected( self ):
+        hda1 = MockHistoryDatasetAssociation( name="hda1", id=1 )
+        hda2 = MockHistoryDatasetAssociation( name="hda2", id=2 )
+        hda1.visible = False
+        hda2.deleted = True
+        self.stub_active_datasets( hda1, hda2 )
+        field = self._simple_field( other_values={ "data2" : hda2 } )
+        assert len( field[ 'options' ][ 'hda' ] ) == 1  # hda1 not an option, not visible or selected
+        assert field[ 'options' ][ 'hda' ][ 0 ][ 'name' ] == "(deleted) hda2"
 
     def test_field_implicit_conversion_new( self ):
         hda1 = MockHistoryDatasetAssociation( name="hda1", id=1 )
@@ -153,7 +163,7 @@ class DataToolParameterTestCase( BaseParameterTestCase ):
         self._param = None
 
     def stub_active_datasets( self, *hdas ):
-        self.test_history._active_datasets_children_and_roles = hdas
+        self.test_history._active_datasets_children_and_roles = [ h for h in hdas if not h.deleted ]
 
     def _simple_field( self, **kwds ):
         return self.param.to_dict( trans=self.trans, **kwds )


### PR DESCRIPTION
This PR improves the label annotation for selected datasets in the tool form. Fixes #3487.