### PR TITLE
Add sam_to_bam to list of tools requiring Galaxy's environment.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -133,6 +133,7 @@ GALAXY_LIB_TOOLS = [
     "sam_pileup",
     "find_diag_hits",
     "cufflinks",
+    "sam_to_bam",  # This was fixed with version 1.1.3 of the tool - TODO add Galaxy to PYTHONPATH only for older versions
     # Tools improperly migrated to the tool shed (iuc)
     "tabular_to_dbnsfp",
 ]


### PR DESCRIPTION
Only a very old version of sam_to_bam required this - but I guess it is actively used on usegalaxy.org since there was a bug report on IRC from @jennaj.

I'll follow up with a fix to dev that makes this apply only to the old version of the tool - it shouldn't hurt anything for these particular tools but I feel it would be better to be precise.