### PR TITLE
Add compressed fastq peek and preview

### DIFF
--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -2,8 +2,6 @@
 Sequence classes
 """
 
-import bz2
-import gzip
 import json
 import logging
 import os

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -18,7 +18,10 @@ from six import text_type
 
 from galaxy import util
 from galaxy.util import multi_byte
-from galaxy.util import unicodify
+from galaxy.util import (
+    compression_utils,
+    unicodify
+)
 from galaxy.util.checkers import (
     check_binary,
     check_html,
@@ -204,15 +207,8 @@ def get_headers( fname, sep, count=60, is_multi_byte=False ):
     [['chr7', '127475281', '127491632', 'NM_000230', '0', '+', '127486022', '127488767', '0', '3', '29,172,3225,', '0,10713,13126,'], ['chr7', '127486011', '127488900', 'D49487', '0', '+', '127486022', '127488767', '0', '2', '155,490,', '0,2399']]
     """
     headers = []
-    compressed_gzip = is_gzip(fname)
-    compressed_bzip2 = is_bz2(fname)
+    in_file = compression_utils.get_fileobj(fname)
     try:
-        if compressed_gzip:
-            in_file = gzip.GzipFile(fname, 'r')
-        elif compressed_bzip2:
-            in_file = bz2.BZ2File(fname, 'r')
-        else:
-            in_file = open(fname, 'rt')
         for idx, line in enumerate(in_file):
             line = line.rstrip('\n\r')
             if is_multi_byte:
@@ -490,9 +486,9 @@ def handle_uploaded_dataset_file( filename, datatypes_registry, ext='auto', is_m
 
 
 AUTO_DETECT_EXTENSIONS = [ 'auto' ]  # should 'data' also cause auto detect?
-DECOMPRESSION_FUNCTIONS = dict( gzip=gzip.GzipFile )
-COMPRESSION_CHECK_FUNCTIONS = [ ( 'gzip', is_gzip ) ]
-COMPRESSION_DATATYPES = dict( gzip=[ 'bam', 'fastq.gz', 'fastqsanger.gz', 'fastqillumina.gz', 'fastqsolexa.gz', 'fastqcssanger.gz', 'fastq.bz2', 'fastqsanger.bz2', 'fastqillumina.bz2', 'fastqsolexa.bz2', 'fastqcssanger.bz2' ] )
+DECOMPRESSION_FUNCTIONS = dict( gzip=gzip.GzipFile, bz2=bz2.BZ2File )
+COMPRESSION_CHECK_FUNCTIONS = [ ( 'gzip', is_gzip ), ('bz2', is_bz2) ]
+COMPRESSION_DATATYPES = dict( gzip=[ 'bam', 'fastq.gz', 'fastqsanger.gz', 'fastqillumina.gz', 'fastqsolexa.gz', 'fastqcssanger.gz'], bz2=['fastq.bz2', 'fastqsanger.bz2', 'fastqillumina.bz2', 'fastqsolexa.bz2', 'fastqcssanger.bz2' ] )
 COMPRESSED_EXTENSIONS = []
 for exts in COMPRESSION_DATATYPES.values():
     COMPRESSED_EXTENSIONS.extend( exts )

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import abc
 import csv
-import gzip
 import logging
 import os
 import re
@@ -19,7 +18,7 @@ from galaxy import util
 from galaxy.datatypes import data, metadata
 from galaxy.datatypes.metadata import MetadataElement
 from galaxy.datatypes.sniff import get_headers
-from galaxy.util.checkers import is_gzip
+from galaxy.util import compression_utils
 
 from . import dataproviders
 
@@ -789,11 +788,7 @@ class Eland( Tabular ):
             - We will only check that up to the first 5 alignments are correctly formatted.
         """
         try:
-            compress = is_gzip(filename)
-            if compress:
-                fh = gzip.GzipFile(filename, 'r')
-            else:
-                fh = open( filename )
+            fh = compression_utils.get_fileobj(filename, gzip_only=True)
             count = 0
             while True:
                 line = fh.readline()
@@ -830,33 +825,31 @@ class Eland( Tabular ):
 
     def set_meta( self, dataset, overwrite=True, skip=None, max_data_lines=5, **kwd ):
         if dataset.has_data():
-            compress = is_gzip(dataset.file_name)
-            if compress:
-                dataset_fh = gzip.GzipFile(dataset.file_name, 'r')
-            else:
-                dataset_fh = open( dataset.file_name )
-            lanes = {}
-            tiles = {}
-            barcodes = {}
-            reads = {}
-            # Should always read the entire file (until we devise a more clever way to pass metadata on)
-            # if self.max_optional_metadata_filesize >= 0 and dataset.get_size() > self.max_optional_metadata_filesize:
-            # If the dataset is larger than optional_metadata, just count comment lines.
-            #     dataset.metadata.data_lines = None
-            # else:
-            # Otherwise, read the whole thing and set num data lines.
-            for i, line in enumerate(dataset_fh):
-                if line:
-                    line_pieces = line.split('\t')
-                    if len(line_pieces) != 22:
-                        raise Exception('%s:%d:Corrupt line!' % (dataset.file_name, i))
-                    lanes[line_pieces[2]] = 1
-                    tiles[line_pieces[3]] = 1
-                    barcodes[line_pieces[6]] = 1
-                    reads[line_pieces[7]] = 1
-                pass
-            dataset.metadata.data_lines = i + 1
-            dataset_fh.close()
+            dataset_fh = compression_utils.get_fileobj(dataset.file_name, gzip_only=True)
+            try:
+                lanes = {}
+                tiles = {}
+                barcodes = {}
+                reads = {}
+                # Should always read the entire file (until we devise a more clever way to pass metadata on)
+                # if self.max_optional_metadata_filesize >= 0 and dataset.get_size() > self.max_optional_metadata_filesize:
+                # If the dataset is larger than optional_metadata, just count comment lines.
+                #     dataset.metadata.data_lines = None
+                # else:
+                # Otherwise, read the whole thing and set num data lines.
+                for i, line in enumerate(dataset_fh):
+                    if line:
+                        line_pieces = line.split('\t')
+                        if len(line_pieces) != 22:
+                            raise Exception('%s:%d:Corrupt line!' % (dataset.file_name, i))
+                        lanes[line_pieces[2]] = 1
+                        tiles[line_pieces[3]] = 1
+                        barcodes[line_pieces[6]] = 1
+                        reads[line_pieces[7]] = 1
+                    pass
+                dataset.metadata.data_lines = i + 1
+            finally:
+                dataset_fh.close()
             dataset.metadata.comment_lines = 0
             dataset.metadata.columns = 21
             dataset.metadata.column_types = ['str', 'int', 'int', 'int', 'int', 'int', 'str', 'int', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str', 'str']

--- a/lib/galaxy/util/compression_utils.py
+++ b/lib/galaxy/util/compression_utils.py
@@ -1,0 +1,33 @@
+import bz2
+import gzip
+import zipfile
+
+from .checkers import (
+    is_bz2,
+    is_gzip
+)
+
+
+def get_fileobj(filename, mode="r", gzip_only=False, bz2_only=False, zip_only=False):
+    """
+    Returns a fileobj. If the file is compressed, return appropriate file reader.
+
+    :param filename: path to file that should be opened
+    :param mode: mode to pass to opener
+    :param gzip_only: only open file if file is gzip compressed or not compressed
+    :param bz2_only: only open file if file is bz2 compressed or not compressed
+    :param zip_only: only open file if file is zip compressed or not compressed
+    """
+    # the various compression readers don't support 'U' mode,
+    # so we open in 'r'.
+    if mode == 'U':
+        cmode = 'r'
+    else:
+        cmode = mode
+    if not bz2_only and not zip_only and is_gzip(filename):
+        return gzip.GzipFile(filename, cmode)
+    if not gzip_only and not zip_only and is_bz2(filename):
+        return bz2.BZ2File(filename, cmode)
+    if not bz2_only and not gzip_only and zipfile.is_zipfile(filename):
+        return zipfile.os_zipfile(filename, cmode)
+    return open(filename, mode)


### PR DESCRIPTION
and unify various places in the code that open optionally compressed files.
This addresses `provide 'peak' of gzipped contents` of #3498.