### PR TITLE
[17.01] Disable conda_auto_init by default for most tests.

### DIFF
--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -172,6 +172,7 @@ def setup_galaxy_config(
         api_allow_run_as='test@bx.psu.edu',
         auto_configure_logging=logging_config_file is None,
         check_migrate_tools=False,
+        conda_auto_init=False,
         cleanup_job='onsuccess',
         data_manager_config_file=data_manager_config_file,
         enable_beta_tool_formats=True,


### PR DESCRIPTION
Executing framework, API, and/or selenium tests was causing Conda to be installed for each execution of run_tests.sh into a temp directory. This isn't needed - the only tests that test Conda dependencies are unit tests and integration tests that explicitly configure this Conda installation.

xref  #3444 312f941e46fdbbe6198b6b0e6a3f00867946a6bd
