### PR TITLE
fix <is_valid_xml> output test assert check

### DIFF
--- a/lib/galaxy/tools/verify/asserts/xml.py
+++ b/lib/galaxy/tools/verify/asserts/xml.py
@@ -6,7 +6,7 @@ import xml.etree
 
 # Helper functions used to work with XML output.
 def to_xml(output):
-    return xml.etree.fromstring(output)
+    return xml.etree.ElementTree.fromstring(output)
 
 
 def xml_find_text(output, path):

--- a/test-data/simple.xml
+++ b/test-data/simple.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<outer>
+    <inner>Foo</inner>
+    <empty />
+</outer>

--- a/test/functional/tools/is_valid_xml.xml
+++ b/test/functional/tools/is_valid_xml.xml
@@ -1,0 +1,21 @@
+<tool id="is_valid_xml" name="is_valid_xml" version="0.001">
+    <command>
+        cp $input $output
+    </command>
+    <inputs>
+        <param name="input" type="data" format="txt" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="simple.xml" />
+            <output name="output">
+                <assert_contents>
+                    <is_valid_xml />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -35,6 +35,7 @@
   <tool file="detect_errors_aggressive.xml" />
   <tool file="md5sum.xml" />
   <tool file="checksum.xml" />
+  <tool file="is_valid_xml.xml" />
   <!--
   TODO: Figure out why this transiently fails on Jenkins.
   <tool file="maxseconds.xml" />


### PR DESCRIPTION
I tried to use the <is_valid_xml> assertion in a tool test and got a python error:
```
History item  different than expected
Expected valid XML, but could not parse output. 'module' object has no attribute 'fromstring'
```
This commit appears to fix the issue.