### PR TITLE
Fix unbounded readline in genbank datatype

### DIFF
--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -1184,8 +1184,7 @@ class Genbank(data.Text):
     def sniff(self, filename):
         try:
             with open(filename, 'r') as handle:
-                line = handle.readline().strip()
-                return line.startswith('LOCUS ')
+                return 'LOCUS ' == handle.read(6)
         except:
             pass
 


### PR DESCRIPTION
Fixes #3529

> martenson edited this and the title for clarity and RN sake