### PR TITLE
Watch tool data table *.loc files, and reload if modified.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -311,7 +311,7 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 
 # Set to True to enable monitoring of the tool_data and shed_tool_data_path
 # directories. If changes in tool data table files are found, the tool data
-# tables for that data manager are automatically reloaded
+# tables for that data manager are automatically reloaded.
 # Watchdog ( https://pypi.python.org/pypi/watchdog ) must be installed and
 # available to Galaxy to use this option. Other options include 'auto'
 # which will attempt to use the watchdog library if it is available but won't

--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -309,6 +309,17 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # when installed from a ToolShed. Defaults to tool_data_path.
 #shed_tool_data_path = tool-data
 
+# Set to True to enable monitoring of the tool_data and shed_tool_data_path
+# directories. If changes in tool data table files are found, the tool data
+# tables for that data manager are automatically reloaded
+# Watchdog ( https://pypi.python.org/pypi/watchdog ) must be installed and
+# available to Galaxy to use this option. Other options include 'auto'
+# which will attempt to use the watchdog library if it is available but won't
+# fail to load Galaxy if it is not and 'polling' which will use a less
+# efficient monitoring scheme that may work in wider range of scenarios
+# than the watchdog default.
+#watch_tool_data_dir = False
+
 # File containing old-style genome builds
 #builds_file_path = tool-data/shared/ucsc/builds.txt
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -378,6 +378,7 @@ class Configuration( object ):
         self.allow_library_path_paste = kwargs.get( 'allow_library_path_paste', False )
         self.disable_library_comptypes = kwargs.get( 'disable_library_comptypes', '' ).lower().split( ',' )
         self.watch_tools = kwargs.get( 'watch_tools', 'false' )
+        self.watch_tool_data_dir = kwargs.get( 'watch_tool_data_dir', 'false' )
         # On can mildly speed up Galaxy startup time by disabling index of help,
         # not needed on production systems but useful if running many functional tests.
         self.index_tool_help = string_as_bool( kwargs.get( "index_tool_help", True ) )

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -159,19 +159,30 @@ class ToolDataTableManager( object ):
             out.write( '</tables>\n' )
         os.chmod( full_path, 0o644 )
 
-    def reload_tables( self, table_names=None ):
+    def reload_tables( self, table_names=None, path=None ):
         """
-        Reload tool data tables.
+        Reload tool data tables. If neither table_names not path is given, reloads all tool data tables.
         """
         tables = self.get_tables()
         if not table_names:
-            table_names = list(tables.keys())
+            if path:
+                table_names = self.get_table_names_by_path(path)
+            else:
+                table_names = list(tables.keys())
         elif not isinstance( table_names, list ):
             table_names = [ table_names ]
         for table_name in table_names:
             tables[ table_name ].reload_from_files()
             log.debug( "Reloaded tool data table '%s' from files.", table_name )
         return table_names
+
+    def get_table_names_by_path(self, path):
+        """Returns a list of table names given a path"""
+        table_names = set()
+        for name, data_table in self.data_tables.items():
+            if path in data_table.filenames:
+                table_names.add(name)
+        return list(table_names)
 
 
 class ToolDataTable( object ):

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -161,7 +161,7 @@ class ToolDataTableManager( object ):
 
     def reload_tables( self, table_names=None, path=None ):
         """
-        Reload tool data tables. If neither table_names not path is given, reloads all tool data tables.
+        Reload tool data tables. If neither table_names nor path is given, reloads all tool data tables.
         """
         tables = self.get_tables()
         if not table_names:

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -12,8 +12,8 @@ from galaxy.queue_worker import (
 )
 from galaxy.tools.data import TabularToolDataTable
 from galaxy.tools.toolbox.watcher import (
-    get_loc_dir_watcher,
-    get_tool_conf_watcher
+    get_tool_conf_watcher,
+    get_tool_data_dir_watcher
 )
 from galaxy.util.odict import odict
 from galaxy.util.template import fill_template
@@ -59,7 +59,7 @@ class DataManagers( object ):
         if self.app.config.shed_data_manager_config_file:
             conf_watchers.append((get_tool_conf_watcher(lambda: reload_data_managers(self.app)), self.app.config.shed_data_manager_config_file))
         [watcher.watch_file(filename) for watcher, filename in conf_watchers]
-        tool_data_watcher = get_loc_dir_watcher(self.app.tool_data_tables, self.app.config)
+        tool_data_watcher = get_tool_data_dir_watcher(self.app.tool_data_tables, self.app.config)
         tool_data_watcher.watch_directory(self.app.config.tool_data_path)
         if self.app.config.shed_tool_data_path:
             tool_data_watcher.watch_directory(self.app.config.shed_tool_data_path)

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -214,7 +214,7 @@ class ToolDataWatcher(object):
         self.observer.join()
 
     def monitor(self, dir):
-        self.observer.schedule(self.event_handler, dir, recursive=False)
+        self.observer.schedule(self.event_handler, dir, recursive=True)
 
     def watch_directory(self, tool_data_dir):
         tool_data_dir = os.path.abspath( tool_data_dir )

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -52,11 +52,11 @@ def get_tool_conf_watcher(reload_callback):
     return ToolConfWatcher(reload_callback)
 
 
-def get_loc_dir_watcher(tool_data_tables, config):
+def get_tool_data_dir_watcher(tool_data_tables, config):
     config_value = getattr(config, "watch_tool_data_dir", None)
     observer_class = get_observer_class(config_value, default="False", monitor_what_str="tool-data directory")
     if observer_class is not None:
-        return LocWatcher(observer_class, tool_data_tables=tool_data_tables)
+        return ToolDataWatcher(observer_class, tool_data_tables=tool_data_tables)
     else:
         return NullWatcher()
 
@@ -196,7 +196,7 @@ class ToolWatcher(object):
             self.monitor( tool_dir )
 
 
-class LocWatcher(object):
+class ToolDataWatcher(object):
 
     def __init__(self, observer_class, tool_data_tables):
         self.tool_data_tables = tool_data_tables
@@ -216,11 +216,11 @@ class LocWatcher(object):
     def monitor(self, dir):
         self.observer.schedule(self.event_handler, dir, recursive=False)
 
-    def watch_directory(self, loc_dir):
-        loc_dir = os.path.abspath( loc_dir )
-        if loc_dir not in self.monitored_dirs:
-            self.monitored_dirs[ loc_dir ] = loc_dir
-            self.monitor( loc_dir )
+    def watch_directory(self, tool_data_dir):
+        tool_data_dir = os.path.abspath( tool_data_dir )
+        if tool_data_dir not in self.monitored_dirs:
+            self.monitored_dirs[ tool_data_dir ] = tool_data_dir
+            self.monitor( tool_data_dir )
 
 
 class LocFileEventHandler(FileSystemEventHandler):

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -52,6 +52,15 @@ def get_tool_conf_watcher(reload_callback):
     return ToolConfWatcher(reload_callback)
 
 
+def get_loc_dir_watcher(tool_data_tables, config):
+    config_value = getattr(config, "watch_tool_data_dir", None)
+    observer_class = get_observer_class(config_value, default="False", monitor_what_str="tool-data directory")
+    if observer_class is not None:
+        return LocWatcher(observer_class, tool_data_tables=tool_data_tables)
+    else:
+        return NullWatcher()
+
+
 def get_tool_watcher(toolbox, config):
     config_value = getattr(config, "watch_tools", None)
     observer_class = get_observer_class(config_value, default="False", monitor_what_str="tools")
@@ -187,6 +196,56 @@ class ToolWatcher(object):
             self.monitor( tool_dir )
 
 
+class LocWatcher(object):
+
+    def __init__(self, observer_class, tool_data_tables):
+        self.tool_data_tables = tool_data_tables
+        self.monitored_dirs = {}
+        self.path_hash = {}
+        self.observer = observer_class()
+        self.event_handler = LocFileEventHandler(self)
+        self.start()
+
+    def start(self):
+        register_postfork_function(self.observer.start)
+
+    def shutdown(self):
+        self.observer.stop()
+        self.observer.join()
+
+    def monitor(self, dir):
+        self.observer.schedule(self.event_handler, dir, recursive=False)
+
+    def watch_directory(self, loc_dir):
+        loc_dir = os.path.abspath( loc_dir )
+        if loc_dir not in self.monitored_dirs:
+            self.monitored_dirs[ loc_dir ] = loc_dir
+            self.monitor( loc_dir )
+
+
+class LocFileEventHandler(FileSystemEventHandler):
+
+    def __init__(self, loc_watcher):
+        self.loc_watcher = loc_watcher
+
+    def on_any_event(self, event):
+        self._handle(event)
+
+    def _handle(self, event):
+        # modified events will only have src path, move events will
+        # have dest_path and src_path but we only care about dest. So
+        # look at dest if it exists else use src.
+        path = getattr( event, 'dest_path', None ) or event.src_path
+        path = os.path.abspath( path )
+        if path.endswith(".loc"):
+            cur_hash = md5_hash_file(path)
+            if self.loc_watcher.path_hash.get(path) == cur_hash:
+                return
+            else:
+                self.loc_watcher.path_hash[path] = cur_hash
+                self.loc_watcher.tool_data_tables.reload_tables(path=path)
+
+
 class ToolFileEventHandler(FileSystemEventHandler):
 
     def __init__(self, tool_watcher):
@@ -228,5 +287,5 @@ class NullWatcher(object):
     def watch_file(self, tool_file, tool_id):
         pass
 
-    def watch_directory(self, tool_dir, callback):
+    def watch_directory(self, tool_dir, callback=None):
         pass


### PR DESCRIPTION
The approach here is quite similar to monitoring a directory of tools. This is optional and requires the watchdog library to be installed. Initial testing on our server that accesses the tool-data folder over sshfs indicate that things are going smooth.

This could be extended to become the default, but I think this is a good first step.