### PR TITLE
[17.01] Fix conda resolver when conda_auto_install = True and install = False

### DIFF
--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -160,7 +160,12 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
         dependencies = []
 
         is_installed = self.conda_context.has_env(env)
-        if not is_installed and (self.auto_install or kwds.get('install', False)):
+        install = kwds.get('install', None)
+        if install is None:
+            install = not is_installed and self.auto_install
+        elif install:
+            install = not is_installed
+        if install:
             is_installed = self.install_all(conda_targets)
 
         if is_installed:
@@ -209,7 +214,12 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
         preserve_python_environment = kwds.get("preserve_python_environment", False)
 
         job_directory = kwds.get("job_directory", None)
-        if not is_installed and (self.auto_install or kwds.get('install', False)):
+        install = kwds.get('install', None)
+        if install is None:
+            install = not is_installed and self.auto_install
+        elif install:
+            install = not is_installed
+        if install:
             is_installed = self.install_dependency(name=name, version=version, type=type)
 
         if not is_installed:

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -162,8 +162,10 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
         is_installed = self.conda_context.has_env(env)
         install = kwds.get('install', None)
         if install is None:
+            # Default behavior, install dependencies if conda_auto_install is active.
             install = not is_installed and self.auto_install
         elif install:
+            # Install has been set to True, install if not yet installed.
             install = not is_installed
         if install:
             is_installed = self.install_all(conda_targets)


### PR DESCRIPTION
Conda dependencies were being prematurely installed during installation of repositories from the ToolShed (at the point where we are just trying to list already installed dependencies).