### PR TITLE
[17.01] Backport of fix unbounded readline in genbank datatype

### DIFF
--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -1184,8 +1184,7 @@ class Genbank(data.Text):
     def sniff(self, filename):
         try:
             with open(filename, 'r') as handle:
-                line = handle.readline().strip()
-                return line.startswith('LOCUS ')
+                return 'LOCUS ' == handle.read(6)
         except:
             pass
 


### PR DESCRIPTION
Fixes #3529 in 17.01. Backport of #3531.

Also testing new Pull Request triggers for integration tests.