### PR TITLE
[17.01] Fix tools that use Galaxy sequence utilities for #3364.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -136,6 +136,13 @@ GALAXY_LIB_TOOLS = [
     "sam_to_bam",  # This was fixed with version 1.1.3 of the tool - TODO add Galaxy to PYTHONPATH only for older versions
     # Tools improperly migrated to the tool shed (iuc)
     "tabular_to_dbnsfp",
+    # From peterjc and others seq utils
+    "venn_list",
+    "seq_rename",
+    "seq_primer_clip",
+    "fastq_groomer_parallel",
+    "fasta_filter_by_id",
+    "fastq_filter_by_id",
 ]
 
 


### PR DESCRIPTION
Thanks to @peterjc for reporting and @martenson for grepping.

xref #minor #3364

- [x] ~000/repo_830/fastq_paired_end_splitter.py:3:from galaxy_utils.sequence.fastq import fastqReader, fastqWriter, fastqSplitter~ has tool dep
- [x] ~000/repo_816/fastq_filter.py:3:from galaxy_utils.sequence.fastq import fastqReader, fastqWriter~ has tool dep
- [x] ~000/repo_794/fastq_paired_end_joiner.py:7:import galaxy_utils.sequence.fastq as fq~ has tool dep
- [x] ~000/repo_820/fastq_to_tabular.py:3:from galaxy_utils.sequence.fastq import fastqReader~ has tool dep
- [x] ~000/repo_813/fastq_trimmer.py:3:from galaxy_utils.sequence.fastq import fastqReader, fastqWriter~ has tool dep
- [x] ~000/repo_810/fastq_paired_end_deinterlacer.py:3:from galaxy_utils.sequence.fastq import fastqReader, fastqWriter, fastqNamedReader, fastqJoiner~ has tool dep
- [x] 000/repo_54/tools/venn_list/venn_list.py:59:        from galaxy_utils.sequence.fastq import fastqReader (opened PR)
- [x] ~000/repo_797/fastq_manipulation.py:4:from galaxy_utils.sequence.fastq import fastqReader, fastqWriter~ has tool dep
- [x] ~000/repo_220/cgatools/lib/galaxy/datatypes/completegenomics.py:17:import galaxy_utils.sequence.vcf~ datatype
- [x] ~000/repo_811/fastq_to_fasta.py:3:from galaxy_utils.sequence.fastq import fastqReader~ has tool deps
- [x] ~000/repo_811/fastq_to_fasta.py:4:from galaxy_utils.sequence.fasta import fastaWriter~ has tool deps
- [x] 000/repo_41/tools/seq_rename/seq_rename.py:112:        from galaxy_utils.sequence.fasta import fastaReader, fastaWriter (opened PR)
- [x] 000/repo_349/deseq/fonctionsNGS/differential_expression_analysis_pipeline_for_rnaseq_data/DiffExpAnal/fastq_groomer_parallel.py:8:from galaxy_utils.sequence.fastq import fastqReader, fastqVerboseErrorReader, fastqAggregator, fastqWriter (opened PR)
- [x] ~000/repo_827/fastq_stats.py:3:from galaxy_utils.sequence.fastq import fastqReader, fastqAggregator~ has tool deps
- [x] 000/repo_16/tools/fasta_tools/fasta_filter_by_id.py:22:from galaxy_utils.sequence.fasta import fastaReader, fastaWriter (opened PR) 
- [x] ~000/repo_805/fastq_trimmer_by_quality.py:3:from galaxy_utils.sequence.fastq import fastqReader, fastqWriter~ (has tool deps)
- [x] ~000/repo_823/fastq_combiner.py:3:from galaxy_utils.sequence.fastq import fastqWriter, fastqSequencingRead, fastqCombiner, fastqFakeFastaScoreReader~
- [x] ~000/repo_823/fastq_combiner.py:4:from galaxy_utils.sequence.fasta import fastaReader, fastaNamedReader~ (has tool deps)
- [x] 000/repo_396/tools/seq_primer_clip/seq_primer_clip.py:34:from galaxy_utils.sequence.fasta import fastaReader, fastaWriter (opened PR)
- [x] ~000/repo_793/fastq_masker_by_quality.py:4:from galaxy_utils.sequence.fastq import fastqReader, fastqWriter~ (has tool deps)
- [x] ~000/repo_219/cgatools/lib/galaxy/datatypes/completegenomics.py:17:import galaxy_utils.sequence.vcf~ datatype
- [x] 000/repo_250/fastq_groomer_parallel.py:13:from galaxy_utils.sequence.fastq import fastqReader, fastqVerboseErrorReader, fastqAggregator, fastqWriter (opend PR)
- [x] ~000/repo_250/README:34:    from galaxy_utils.sequence.fastq import fastqReader, fastqVerboseErrorReader, fastqAggregator, fastqWriter~
- [x] ~000/repo_817/fastq_groomer.py:3:from galaxy_utils.sequence.fastq import fastqReader, fastqVerboseErrorReader, fastqAggregator, fastqWriter~ has tool deps
- [x] 000/repo_17/tools/fastq/fastq_filter_by_id.py:25:from galaxy_utils.sequence.fastq import fastqReader, fastqWriter opened PR
- [x] ~000/repo_804/fastq_paired_end_interlacer.py:3:from galaxy_utils.sequence.fastq import fastqReader, fastqWriter, fastqNamedReader, fastqJoiner~ has tool deps
- [x] ~001/repo_1876/lib/galaxy/datatypes/completegenomics.py:18:import galaxy_utils.sequence.vcf~ datatype