### PR TITLE
Fix output tests for checksum example tools.

### DIFF
--- a/test/functional/tools/checksum.xml
+++ b/test/functional/tools/checksum.xml
@@ -11,7 +11,7 @@
     <tests>
         <test>
             <param name="input" value="simple_line.txt" />
-            <output name="out_file1" checksum="sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041" />
+            <output name="output" checksum="sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041" />
         </test>
     </tests>
 </tool>

--- a/test/functional/tools/md5sum.xml
+++ b/test/functional/tools/md5sum.xml
@@ -11,7 +11,7 @@
     <tests>
         <test>
             <param name="input" value="simple_line.txt" />
-            <output name="out_file1" md5="ac94233685713ce99d1e712b0023c381" />
+            <output name="output" md5="ac94233685713ce99d1e712b0023c381" />
         </test>
     </tests>
 </tool>


### PR DESCRIPTION
Fixes #3544 - thanks to @jvolkening for the heads up.

Since these tests passed before - you can verify the change is needed by checking this out and just modifying the checksums and rerunning the tests to verify they now fail.