### PR TITLE
[17.01] Fix import order

### DIFF
--- a/.ci/flake8_lint_include_list.txt
+++ b/.ci/flake8_lint_include_list.txt
@@ -444,7 +444,6 @@ scripts/tools/re_escape_output.py
 test/api/__init__.py
 test/api/test_dataset_collections.py
 test/api/test_datasets.py
-test/api/test_datatypes.py
 test/api/test_framework.py
 test/api/test_history_contents_provenance.py
 test/api/test_jobs.py

--- a/test/api/test_datatypes.py
+++ b/test/api/test_datatypes.py
@@ -1,6 +1,8 @@
 import time
-from base import api
+
 from requests import put
+
+from base import api
 
 HIDDEN_DURING_UPLOAD_DATATYPE = "fli"
 


### PR DESCRIPTION
Broken in commit dd77cdb62576a62ea7e8ce8e31d2d7d78aef7823 .

Need to remove the file from `.ci/flake8_lint_include_list.txt` because `base` is not in application-import-names