### PR TITLE
Allow decompressing tool test outputs.

### DIFF
--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -446,6 +446,7 @@ def __parse_test_attributes( output_elem, attrib, parse_elements=False, parse_di
     # Allow a file size to vary if sim_size compare
     attributes['delta'] = int( attrib.pop( 'delta', '10000' ) )
     attributes['sort'] = string_as_bool( attrib.pop( 'sort', False ) )
+    attributes['decompress'] = string_as_bool( attrib.pop( 'decompress', False ) )
     extra_files = []
     if 'ftype' in attrib:
         attributes['ftype'] = attrib['ftype']

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -10,6 +10,8 @@ import shutil
 import subprocess
 import tempfile
 
+from galaxy.util.compression_utils import get_fileobj
+
 from .asserts import verify_assertions
 from .test_data import TestDataResolver
 
@@ -173,10 +175,15 @@ def files_diff(file1, file2, attributes=None):
         return count
     if not filecmp.cmp( file1, file2 ):
         files_differ = False
-        local_file = open( file1, 'U' ).readlines()
-        history_data = open( file2, 'U' ).readlines()
         if attributes is None:
             attributes = {}
+        decompress = attributes.get("decompress", None)
+        if not decompress:
+            local_file = open( file1, 'U' ).readlines()
+            history_data = open( file2, 'U' ).readlines()
+        else:
+            local_file = get_fileobj( file1, 'U' ).readlines()
+            history_data = get_fileobj( file2, 'U' ).readlines()
         if attributes.get( 'sort', False ):
             history_data.sort()
         # Why even bother with the check loop below, why not just use the diff output? This seems wasteful.


### PR DESCRIPTION
This seems to be needed to test fastq outputs from tools. Gzipped files seem to depend on the file name before compression - so diff compares (even binary ones) do not work. This allows comparing compressed outputs (and it will magically work if the expected file in test-data is compressed or not).

Builds on the awesome work from @mvdbeek in #3512.