### PR TITLE
[16.10] Ensure toolbox conf watcher updates cached hash when config change is detected

### DIFF
--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -98,8 +98,10 @@ class ToolConfWatcher(object):
                 if os.path.exists(path):
                     new_mod_time = time.ctime(os.path.getmtime(path))
                 if new_mod_time != mod_time:
-                    if hashes[path] != md5_hash_file(path):
+                    new_hash = md5_hash_file(path)
+                    if hashes[path] != new_hash:
                         self.paths[path] = new_mod_time
+                        hashes[path] = new_hash
                         log.debug("The file '%s' has changes.", path)
                         do_reload = True
 


### PR DESCRIPTION
Otherwise, if you uninstall a tool and reinstall it in the same run of the Galaxy server, the web thread servicing the transaction will go into an infinite loop on `self.app.wait_for_toolbox_reload()`.