### PR TITLE
Update Jupyter IE name to be shorter and consistent with other names.…

### DIFF
--- a/config/plugins/interactive_environments/jupyter/config/jupyter.xml
+++ b/config/plugins/interactive_environments/jupyter/config/jupyter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE interactive_environment SYSTEM "../../interactive_environments.dtd">
-<interactive_environment name="Jupyter (Programming Environment)">
+<interactive_environment name="Jupyter">
     <data_sources>
         <data_source>
             <model_class>HistoryDatasetAssociation</model_class>


### PR DESCRIPTION
…  Makes menu entries look correct.   Is this name used in linking IEs to content?  (I hope not)

Before: 
![image](https://cloud.githubusercontent.com/assets/155398/22710556/c13889f6-ed4b-11e6-960c-13bf7b3a748b.png)

After:
![image](https://cloud.githubusercontent.com/assets/155398/22710596/df346376-ed4b-11e6-99ec-edadf3f72455.png)
