### PR TITLE
Remove broken tour step.

### DIFF
--- a/config/plugins/tours/core.history.yaml
+++ b/config/plugins/tours/core.history.yaml
@@ -107,13 +107,6 @@ steps:
       postclick:
         - "#current-history-panel > ul.list-items > div:nth-child(1) > div.warnings > div > a"
 
-    - element: "#current-history-panel > div.controls > .subtitle .toggle-deleted-link"
-      title: "Hiding all deleted datasets"
-      intro: "Hiding datasets that were previously deleted works in the same way."
-      position: "bottom"
-      preclick:
-        - "#current-history-panel > div.controls > .subtitle .toggle-deleted-link"
-
     - element: "#current-history-panel > div.controls > div.title > div"
       title: "Change your History name"
       intro: "You can change the history name clicking on the title."


### PR DESCRIPTION
This causes the Selenium tests to fail under various conditions - but legitimately so. The referenced target link disappears pretty quickly after the step in the previous click. When I run them in the web browser and this step is "disconnected" and in the center of the screen and as a result it isn't clear what links are being referred to.

I'm open to other fixes - removing this step was just the most obvious things. Let me know. 