### PR TITLE
add option to send API key in header

### DIFF
--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -362,7 +362,7 @@ class GalaxyWebTransaction( base.DefaultWebTransaction,
         """
         Authenticate for the API via key or session (if available).
         """
-        api_key = self.request.params.get('key', None)
+        api_key = self.request.params.get('key', None) or self.request.headers.get( 'x-api-key', None )
         secure_id = self.get_cookie( name=session_cookie )
         api_key_supplied = self.environ.get('is_api_request', False) and api_key
         if api_key_supplied and self._check_master_api_key( api_key ):


### PR DESCRIPTION
There are arguments to be made security-wise for putting a REST API key in the HTTP header rather than in the URL, even over an encrypted connection. This PR provides the option to new consumers of the API to put the key in an `x-api-key` header without (I hope) breaking existing implementations. Please review to see if this makes sense to incorporate.