### PR TITLE
Fix transiently failing Selenium upload test.

### DIFF
--- a/test/selenium_tests/test_uploads.py
+++ b/test/selenium_tests/test_uploads.py
@@ -12,9 +12,11 @@ class UploadsTestCase(SeleniumTestCase):
 
         histories = self.api_get("histories")
         current_id = histories[0]["id"]
+        self.history_panel_wait_for_hid_ok(1)
 
         history_contents = self.api_get("histories/%s/contents" % current_id)
-        assert len(history_contents) == 1
+        history_count = len(history_contents)
+        assert history_count == 1, "Incorrect number of items in history - expected 1, found %d" % history_count
 
         hda = history_contents[0]
         assert hda["name"] == '1.sam'


### PR DESCRIPTION
Since the merge of #3582 we have had many more completely successful Selenium suite executions.

![selenium_trend](https://cloud.githubusercontent.com/assets/216771/22830306/fd4dbb3a-ef73-11e6-9e9e-0b6124ab1130.png)

A problem with the upload test did just pop up though - I think it is pretty clear what is wrong. I think what happened when this failed is that Galaxy was still processing the upload during the call to the history contents API. Waiting for the box and ensuring it is green in the GUI should definitely prevent that from happening.

I also improved the assertion error message.