### PR TITLE
Increase patience of Galaxy tests throughout.

### DIFF
--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -912,7 +912,7 @@ class ToolsTestCase( api.ApiTestCase ):
         self.assertEquals( len( outputs ), 2 )
         output1 = outputs[ 0 ]
         output2 = outputs[ 1 ]
-        self.dataset_populator.wait_for_history( history_id, timeout=25 )
+        self.dataset_populator.wait_for_history( history_id )
         output1_content = self.dataset_populator.get_history_dataset_content( history_id, dataset=output1 )
         output2_content = self.dataset_populator.get_history_dataset_content( history_id, dataset=output2 )
         self.assertEquals( output1_content.strip(), "123\n789" )

--- a/test/api/test_workflow_extraction.py
+++ b/test/api/test_workflow_extraction.py
@@ -98,7 +98,7 @@ class WorkflowExtractionApiTestCase( BaseWorkflowsApiTestCase ):
             history_id=self.history_id,
         )
         job_id2 = reduction_run_output[ "jobs" ][ 0 ][ "id" ]
-        self.dataset_populator.wait_for_history( self.history_id, assert_ok=True, timeout=20 )
+        self.dataset_populator.wait_for_history( self.history_id, assert_ok=True )
         downloaded_workflow = self._extract_and_download_workflow(
             dataset_collection_ids=[ hdca[ "hid" ] ],
             job_ids=[ job_id1, job_id2 ],
@@ -425,7 +425,7 @@ test_data:
         )
         implicit_hdca = run_output1[ "implicit_collections" ][ 0 ]
         job_id = run_output1[ "jobs" ][ 0 ][ "id" ]
-        self.dataset_populator.wait_for_history( history_id, assert_ok=True, timeout=20 )
+        self.dataset_populator.wait_for_history( history_id, assert_ok=True )
         return implicit_hdca, job_id
 
     def __check_workflow(

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -17,7 +17,7 @@ workflow_str = resource_string( __name__, "data/test_workflow_1.ga" )
 workflow_random_x2_str = resource_string( __name__, "data/test_workflow_2.ga" )
 
 
-DEFAULT_TIMEOUT = 15  # Secs to wait for state to turn ok
+DEFAULT_TIMEOUT = 60  # Secs to wait for state to turn ok
 
 
 def skip_without_tool( tool_id ):

--- a/test/selenium_tests/framework.py
+++ b/test/selenium_tests/framework.py
@@ -33,7 +33,7 @@ from base.workflows_format_2 import (
 
 from galaxy.util import asbool
 
-DEFAULT_WAIT_TIMEOUT = 15
+DEFAULT_WAIT_TIMEOUT = 60
 DEFAULT_TEST_ERRORS_DIRECTORY = os.path.abspath("database/test_errors")
 DEFAULT_SELENIUM_BROWSER = "auto"
 DEFAULT_SELENIUM_REMOTE = False


### PR DESCRIPTION
This should help reduce various API and Selenium transient failures.