### PR TITLE
Avoid step duplication when ordering steps on the fly

### DIFF
--- a/lib/galaxy/workflow/steps.py
+++ b/lib/galaxy/workflow/steps.py
@@ -15,10 +15,12 @@ def attach_ordered_steps( workflow, steps ):
     fails - the workflow contains cycles so it mark it as such.
     """
     ordered_steps = order_workflow_steps( steps )
-    workflow.has_cycles = not bool( ordered_steps )
-    for i, step in enumerate( ordered_steps or steps ):
+    workflow.has_cycles = True
+    if ordered_steps:
+        workflow.has_cycles = False
+        workflow.steps = ordered_steps
+    for i, step in enumerate( workflow.steps ):
         step.order_index = i
-        workflow.steps.append( step )
     return workflow.has_cycles
 
 


### PR DESCRIPTION
If steps are ordered twice to identify cycles without relying on the previously stored `has_cycles` flag, workflow steps are duplicated. This PR prevents this duplication and makes it safe to call the cyclic test mulitple times if necessary. To test this load the run workflow form with and without this fix.