### PR TITLE
Disable transiently failing tour test.

### DIFF
--- a/test/selenium_tests/test_stock_tours.py
+++ b/test/selenium_tests/test_stock_tours.py
@@ -10,16 +10,24 @@ STOCK_TOURS_DIRECTORY = os.path.join(galaxy_root_path, "config", "plugins", "tou
 
 class TestStockToursTestCase(SeleniumTestCase):
 
-    @selenium_test
-    def test_core_galaxy_ui(self):
-        sleep_on_steps = {
-            "Tools": 20,  # Give upload a chance to take so tool form is filled in.
-            "History": 20,
-        }
-        self.run_tour(
-            os.path.join(STOCK_TOURS_DIRECTORY, "core.galaxy_ui.yaml"),
-            sleep_on_steps=sleep_on_steps,
-        )
+    # Test doesn't pass consistently on Jenkins yet, something is wrong is tool panel
+    # interactions. Example problems:
+    # - https://jenkins.galaxyproject.org/view/All/job/selenium/86/testReport/junit/selenium_tests.test_stock_tours/TestStockToursTestCase/test_core_galaxy_ui/
+    # - https://jenkins.galaxyproject.org/view/All/job/selenium/83/testReport/junit/selenium_tests.test_stock_tours/TestStockToursTestCase/test_core_galaxy_ui/
+    # - https://jenkins.galaxyproject.org/view/All/job/selenium/81/testReport/junit/selenium_tests.test_stock_tours/TestStockToursTestCase/test_core_galaxy_ui/
+    # I'd think that just pausing a bit between transitions to allow the tool panel to
+    # settle would fix it but it doesn't seem to in my initial testing. -John
+    # Tracking with https://github.com/galaxyproject/galaxy/issues/3598
+    # @selenium_test
+    # def test_core_galaxy_ui(self):
+    #    sleep_on_steps = {
+    #        "Tools": 20,  # Give upload a chance to take so tool form is filled in.
+    #        "History": 20,
+    #    }
+    #    self.run_tour(
+    #        os.path.join(STOCK_TOURS_DIRECTORY, "core.galaxy_ui.yaml"),
+    #        sleep_on_steps=sleep_on_steps,
+    #    )
 
     @selenium_test
     def test_core_scratchbook(self):


### PR DESCRIPTION
See code comment for more information - I am tracking the issue here https://github.com/galaxyproject/galaxy/issues/3598. I think it is important to resolve that test and fix the usability problems with current tours but I'd like to get the Selenium tests stable and testing against new PRs first.