### PR TITLE
[17.01] Drop children from query that prefetches data for dataset matching.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1406,20 +1406,19 @@ class History( object, Dictifiable, UsesAnnotations, HasName ):
         return galaxy.util.nice_size( self.disk_size )
 
     @property
-    def active_datasets_children_and_roles( self ):
-        if not hasattr(self, '_active_datasets_children_and_roles'):
+    def active_datasets_and_roles( self ):
+        if not hasattr(self, '_active_datasets_and_roles'):
             db_session = object_session( self )
             query = ( db_session.query( HistoryDatasetAssociation )
                       .filter( HistoryDatasetAssociation.table.c.history_id == self.id )
                       .filter( not_( HistoryDatasetAssociation.deleted ) )
                       .order_by( HistoryDatasetAssociation.table.c.hid.asc() )
-                      .options( joinedload("children"),
-                                joinedload("dataset"),
+                      .options( joinedload("dataset"),
                                 joinedload("dataset.actions"),
                                 joinedload("dataset.actions.role"),
                                 ))
-            self._active_datasets_children_and_roles = query.all()
-        return self._active_datasets_children_and_roles
+            self._active_datasets_and_roles = query.all()
+        return self._active_datasets_and_roles
 
     @property
     def active_contents( self ):

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1461,7 +1461,7 @@ class BaseDataToolParameter( ToolParameter ):
         if history is not None:
             dataset_matcher = DatasetMatcher( trans, self, None, other_values )
             if isinstance( self, DataToolParameter ):
-                for hda in reversed( history.active_datasets_children_and_roles ):
+                for hda in reversed( history.active_datasets_and_roles ):
                     match = dataset_matcher.hda_match( hda, check_security=False )
                     if match:
                         return match.hda
@@ -1581,25 +1581,6 @@ class DataToolParameter( BaseDataToolParameter ):
         for history_dataset_collection in history.active_dataset_collections:
             if dataset_collection_matcher.hdca_match( history_dataset_collection, reduction=reduction ):
                 yield history_dataset_collection
-
-    def match_datasets( self, history, dataset_matcher ):
-
-        def dataset_collector( hdas, parent_hid ):
-            for i, hda in enumerate( hdas ):
-                if parent_hid is not None:
-                    hid = "%s.%d" % ( parent_hid, i + 1 )
-                else:
-                    hid = str( hda.hid )
-                hda_match = dataset_matcher.hda_match( hda )
-                if not hda_match:
-                    continue
-                yield (hda_match, hid)
-                # Also collect children via association object
-                for item in dataset_collector( hda.children, hid ):
-                    yield item
-
-        for item in dataset_collector( history.active_datasets_children_and_roles, None ):
-            yield item
 
     def from_json( self, value, trans, other_values={} ):
         if trans.workflow_building_mode is workflow_building_modes.ENABLED:
@@ -1799,7 +1780,7 @@ class DataToolParameter( BaseDataToolParameter ):
         # add datasets
         visible_hda = other_values.get( self.name )
         has_matched = False
-        for hda in history.active_datasets_children_and_roles:
+        for hda in history.active_datasets_and_roles:
             match = dataset_matcher.hda_match( hda, check_security=False )
             if match:
                 m = match.hda

--- a/test/unit/tools/test_data_parameters.py
+++ b/test/unit/tools/test_data_parameters.py
@@ -163,7 +163,7 @@ class DataToolParameterTestCase( BaseParameterTestCase ):
         self._param = None
 
     def stub_active_datasets( self, *hdas ):
-        self.test_history._active_datasets_children_and_roles = [ h for h in hdas if not h.deleted ]
+        self.test_history._active_datasets_and_roles = [ h for h in hdas if not h.deleted ]
 
     def _simple_field( self, **kwds ):
         return self.param.to_dict( trans=self.trans, **kwds )

--- a/test/unit/tools/test_execution.py
+++ b/test/unit/tools/test_execution.py
@@ -199,7 +199,7 @@ class MockTrans( object ):
         self.app = app
         self.history = history
         self.user = None
-        self.history._active_datasets_children_and_roles = [hda for hda in self.app.model.context.model_objects[ galaxy.model.HistoryDatasetAssociation ] if hda.active and hda.history == history]
+        self.history._active_datasets_and_roles = [hda for hda in self.app.model.context.model_objects[ galaxy.model.HistoryDatasetAssociation ] if hda.active and hda.history == history]
         self.workflow_building_mode = False
         self.webapp = Bunch( name="galaxy" )
         self.sa_session = self.app.model.context


### PR DESCRIPTION
I guess somewhere in the tool building process we eliminated children from appearing the form. Remove unused code that used the children selector in the tool form.