### PR TITLE
[17.01] Use `command -v` rather than `which` when determining Galaxy Python for external set metadata

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -29,7 +29,7 @@ if [ "$GALAXY_VIRTUAL_ENV" != "None" -a -z "$VIRTUAL_ENV" \
      -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" ]; then
     . "$GALAXY_VIRTUAL_ENV/bin/activate"
 fi
-GALAXY_PYTHON=`which python`
+GALAXY_PYTHON=`command -v python`
 """
 
 


### PR DESCRIPTION
A few reasons:

1. `command` is a [POSIX spec](http://pubs.opengroup.org/onlinepubs/009696899/utilities/command.html)
1. `command` is a shell builtin in `dash`, whereas `which` falls back to `/bin/which`
1. In the (unlikely, impossible?) event `python` is not found on `$PATH`, `command -v` outputs nothing (whereas `which` outputs `python not found`), so the later evaluation of `${GALAXY_PYTHON:-python}` will succeed.

In general I shy away from using `which` because (although it's a builtin on bash) it's a shell script itself and this can lead to [weird undesired effects](https://lists.debian.org/debian-user/2002/06/msg03835.html). `type`, `whence` (in zsh) and `command` are all better alternatives in an interactive shell.

xref #3364 