### PR TITLE
When using the new slow query logger, include parameters. 

### DIFF
--- a/lib/galaxy/model/orm/engine_factory.py
+++ b/lib/galaxy/model/orm/engine_factory.py
@@ -29,7 +29,7 @@ def build_engine(url, engine_options, database_query_profiling_proxy=False, trac
                                  parameters, context, executemany):
             total = time.time() - conn.info['query_start_time'].pop(-1)
             if total > slow_query_log_threshold:
-                log.debug("Slow query: %f(s) for %s" % (total, statement))
+                log.debug("Slow query: %f(s)\n%s\nParameters: %s" % (total, statement, parameters))
 
     # Create the database engine
     engine = create_engine( url, proxy=proxy, **engine_options )


### PR DESCRIPTION
 Originally left these out, but 1) logs are assumed to be secure, and 2) it's super useful