### PR TITLE
Allow nest param in the dynamic_tool rule -> argument

### DIFF
--- a/config/tool_destinations.yml.sample
+++ b/config/tool_destinations.yml.sample
@@ -121,7 +121,9 @@
 #         destination: fail
 #         fail_message: Don't do that
 #         arguments:
-#           careful: true
+#           my_section:
+#             my_condition:
+#               careful: true
 #     default_destination: cluster_low
 # default_destination: cluster
 # verbose: False

--- a/lib/galaxy/jobs/dynamic_tool_destination.py
+++ b/lib/galaxy/jobs/dynamic_tool_destination.py
@@ -28,6 +28,22 @@ class ScannerError(Exception):
     pass
 
 
+def is_arg_in_options(arg_list,options):
+    """
+    This recursive function check if an argument in the options dictionary
+    The argument can have those shape: input or inputs|input
+    """
+    arg_parent = arg_list[0]
+    log.debug(arg_parent)
+    log.debug(options)
+    if not arg_parent in options:
+        return False
+    else:
+        if len(arg_list) > 1:
+            return(is_arg_in_options(arg_list[1:],options[arg_parent]))
+        else:
+            return options[arg_parent]
+
 class RuleValidator:
     """
     This class is the primary facility for validating configs. It's always called
@@ -1290,18 +1306,18 @@ def map_tool_to_destination(
                             elif rule["rule_type"] == "arguments":
                                 options = job.get_param_values(app)
                                 matched = True
-
                                 # check if the args in the config file are available
                                 for arg in rule["arguments"]:
-                                    if arg in options:
-                                        if rule["arguments"][arg] != options[arg]:
+                                    value = is_arg_in_options(arg.split("|"),options)
+                                    if value:
+                                        if rule["arguments"][arg] != value:
                                             matched = False
                                             options = "test"
                                     else:
                                         matched = False
                                         if verbose:
                                             error = "Argument '" + str(arg)
-                                            error = + "' not recognized!"
+                                            error += "' not recognized!"
                                             log.debug(error)
 
                             # if we matched a rule

--- a/lib/galaxy/jobs/dynamic_tool_destination.py
+++ b/lib/galaxy/jobs/dynamic_tool_destination.py
@@ -11,6 +11,7 @@ import sys
 import copy
 import collections
 import re
+from functools import reduce
 
 
 # log to galaxy's logger
@@ -37,7 +38,6 @@ def get_keys_from_dict(dl, keys_list):
         map(lambda x: get_keys_from_dict(x, keys_list), dl.values())
     elif isinstance(dl, list):
         map(lambda x: get_keys_from_dict(x, keys_list), dl)
-
 
 
 class RuleValidator:
@@ -1306,10 +1306,10 @@ def map_tool_to_destination(
                                 for arg in rule["arguments"]:
                                     arg_dict = {arg : rule["arguments"][arg]}
                                     arg_keys_list = []
-                                    get_keys_from_dict(arg_dict, arg_keys_list) 
+                                    get_keys_from_dict(arg_dict, arg_keys_list)
                                     try:
-                                        options_value=reduce(dict.__getitem__, arg_keys_list, options)
-                                        arg_value=reduce(dict.__getitem__, arg_keys_list, arg_dict)
+                                        options_value = reduce(dict.__getitem__, arg_keys_list, options)
+                                        arg_value = reduce(dict.__getitem__, arg_keys_list, arg_dict)
                                         if (arg_value != options_value):
                                             matched = False
                                     except KeyError:


### PR DESCRIPTION
I'm testing the dynamic tool with rule based on argument.
I failed to manage to use `inputs.input` and `inputs|input`

So, this is an awkwardness PR to allow param which are nest within `<conditional>`
For example:
```
<conditional name="inputs">
            <param name="input" type="select" label="Choose your inputs method" >
                <option value="zip_file" selected="true">Zip file from your history containing your chromatograms</option>
                <option value="single_file">mzXML file from your history</option>
            </param>
            <when value="zip_file">
                <param name="zip_file" type="data" format="no_unzip.zip,zip" label="Zip file" />
            </when>
            <when value="single_file">
                <param name="single_file" type="data" format="mzxml,netcdf" label="Single file" />
            </when>
</conditional>
```
My tool_destinations.yml
```
mytool:
    rules:
      - rule_type: arguments
        nice_value: 0
        arguments:
          "inputs|input": single
        destination: thread1-men_free10
    default_destination: thread4-men_free10
```

I sure that you already have method to browse the option dictionary.