### PR TITLE
add the mzData datatype

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -218,6 +218,7 @@
     <datatype extension="mgf" type="galaxy.datatypes.proteomics:Mgf" display_in_upload="true" />
     <datatype extension="wiff" type="galaxy.datatypes.proteomics:Wiff" display_in_upload="true" />
     <datatype extension="mzxml" type="galaxy.datatypes.proteomics:MzXML" mimetype="application/xml" display_in_upload="true" />
+    <datatype extension="mzdata" type="galaxy.datatypes.proteomics:MzData" mimetype="application/xml" display_in_upload="true" />
     <datatype extension="ms2" type="galaxy.datatypes.proteomics:Ms2" display_in_upload="true" />
     <datatype extension="mzq" type="galaxy.datatypes.proteomics:MzQuantML" mimetype="application/xml" display_in_upload="true" />
     <datatype extension="mz.sqlite" type="galaxy.datatypes.binary:MzSQlite" mimetype="application/octet-stream" display_in_upload="true" />

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -151,6 +151,13 @@ class MzXML(ProteomicsXml):
     blurb = "mzXML Mass Spectrometry data"
     root = "mzXML"
 
+class MzData(ProteomicsXml):
+    """mzData data"""
+    edam_format = "format_3245"
+    file_ext = "mzdata"
+    blurb = "mzData Mass Spectrometry data"
+    root = "mzData"
+
 
 class MzIdentML(ProteomicsXml):
     edam_format = "format_3247"

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -151,6 +151,7 @@ class MzXML(ProteomicsXml):
     blurb = "mzXML Mass Spectrometry data"
     root = "mzXML"
 
+
 class MzData(ProteomicsXml):
     """mzData data"""
     edam_format = "format_3245"


### PR DESCRIPTION
It will be used in our metabolomics workflow (w4m) but I added it into proteomics lib to join its mates

There isn't specific edam format for mzData. I used the upper class `Mass spectrometry data format` id

Thanks