### PR TITLE
Display an error message when IE loading raises an exception

### DIFF
--- a/lib/galaxy/visualization/plugins/plugin.py
+++ b/lib/galaxy/visualization/plugins/plugin.py
@@ -274,7 +274,16 @@ class InteractiveEnvironmentPlugin( VisualizationPlugin ):
             render_vars[ 'plugin_path' ] = os.path.abspath( self.path )
 
         if self.config.get( 'plugin_type', 'visualization' ) == "interactive_environment":
-            request = self.INTENV_REQUEST_FACTORY( trans, self )
+            try:
+                request = self.INTENV_REQUEST_FACTORY( trans, self )
+            except:
+                log.exception("IE plugin request handling failed")
+                return trans.fill_template( 'message.mako',
+                    message='Loading the interactive environment failed, please contact the {admin_tag} for assistance'.format(
+                        admin_tag='<a href="mailto:{admin_mail}">Galaxy administrator</a>'.format(
+                            admin_mail=trans.app.config.error_email_to)
+                        if trans.app.config.error_email_to else 'Galaxy administrator'),
+                    status='error')
             render_vars[ "ie_request" ] = request
 
         template_filename = self.config[ 'entry_point' ][ 'file' ]


### PR DESCRIPTION
Not sure how people feel about the use of the message mako here but otherwise you just get an empty middle panel or scratchbook window with no indication that anything has failed, and so you sit there assuming something will eventually happen if you wait long enough.