### PR TITLE
Support Docker Engine swarm mode for Interactive Environments

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -355,6 +355,16 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # separated list.
 #interactive_environment_plugins_directory =
 
+# To run interactive environment containers in Docker Swarm mode (on an
+# existing swarm), set this option to True and set `docker_connect_port` in the
+# IE plugin config (ini) file(s) of any IE plugins you have enabled and ensure
+# that you are not using any `docker run`-specific options in your plugins'
+# `command_inject` options (swarm mode services run using `docker service
+# create`, which has a different and more limited set of options). This option
+# can be overridden on a per-plugin basis by using the `swarm_mode` option in
+# the plugin's ini config file.
+#interactive_environment_swarm_mode = False
+
 # Interactive tour directory: where to store interactive tour definition files.
 # Galaxy ships with several basic interface tours enabled, though a different
 # directory with custom tours can be specified here. The path is relative to the

--- a/config/plugins/interactive_environments/bam_iobio/config/bam_iobio.ini.sample
+++ b/config/plugins/interactive_environments/bam_iobio/config/bam_iobio.ini.sample
@@ -41,3 +41,15 @@ image = qiaoy/iobio-bundle.bam-iobio:1.0-ondemand
 # share data between the IE and Galaxy.
 #docker_galaxy_temp_dir = None
 
+# If your Docker container exposes more then one port, Galaxy needs to know to
+# which ports it needs to connect. With this option you can specify the port number
+# inside your container to which Galaxy should connect the UI.
+#docker_connect_port = None
+
+# To run containers in Docker Swarm mode on (an existing swarm), set the
+# following option to True *and*:
+# - set docker_connect_port above. For qiaoy/iobio-bundle.bam-iobio the port
+#   should most likely be 8000.
+# - If command_inject is uncommented and includes `--sig-proxy`, that option should
+#   be removed.
+#swarm_mode = False

--- a/config/plugins/interactive_environments/jupyter/config/jupyter.ini.sample
+++ b/config/plugins/interactive_environments/jupyter/config/jupyter.ini.sample
@@ -18,7 +18,7 @@
 # The image argument was moved to "allowed_images.yml.sample"
 
 # Additional arguments that are passed to the `docker run` command.
-command_inject = --sig-proxy=true -e DEBUG=false -e DEFAULT_CONTAINER_RUNTIME=120
+#command_inject = --sig-proxy=true -e DEBUG=false -e DEFAULT_CONTAINER_RUNTIME=120
 
 # URL to access the Galaxy API with from the spawn Docker containter, if empty
 # this falls back to galaxy.ini's galaxy_infrastructure_url and finally to the
@@ -43,4 +43,12 @@ command_inject = --sig-proxy=true -e DEBUG=false -e DEFAULT_CONTAINER_RUNTIME=12
 # If your Docker container exposes more then one port, Galaxy needs to know to
 # which ports it needs to connect. With this option you can specify the port number
 # inside your container to which Galaxy should connect the UI.
-# docker_connect_port = None
+#docker_connect_port = None
+
+# To run containers in Docker Swarm mode on (an existing swarm), set the
+# following option to True *and*:
+# - set docker_connect_port above. For Jupyter the # port should most likely be
+#   8888.
+# - If command_inject is uncommented and includes `--sig-proxy`, that option should
+#   be removed.
+#swarm_mode = False

--- a/config/plugins/interactive_environments/neo/config/neo.ini.sample
+++ b/config/plugins/interactive_environments/neo/config/neo.ini.sample
@@ -40,3 +40,16 @@ command_inject = --sig-proxy=true -e DEBUG=false -e DEFAULT_CONTAINER_RUNTIME=12
 # you can have a shared sshfs share which you can use as temporary directory to
 # share data between the IE and Galaxy.
 #docker_galaxy_temp_dir = None
+
+# If your Docker container exposes more then one port, Galaxy needs to know to
+# which ports it needs to connect. With this option you can specify the port number
+# inside your container to which Galaxy should connect the UI.
+#docker_connect_port = None
+
+# To run containers in Docker Swarm mode on (an existing swarm), set the
+# following option to True *and*:
+# - set docker_connect_port above. For thoba/neo4j_galaxy_ie the port
+#   should most likely be 7474.
+# - If command_inject is uncommented and includes `--sig-proxy`, that option should
+#   be removed.
+#swarm_mode = False

--- a/config/plugins/interactive_environments/phinch/config/phinch.ini.sample
+++ b/config/plugins/interactive_environments/phinch/config/phinch.ini.sample
@@ -19,3 +19,16 @@ image = shiltemann/docker-phinch-galaxy:16.04
 # The Docker hostname. It can be useful to run the Docker daemon on a different
 # host than Galaxy.
 #docker_hostname = localhost
+
+# If your Docker container exposes more then one port, Galaxy needs to know to
+# which ports it needs to connect. With this option you can specify the port number
+# inside your container to which Galaxy should connect the UI.
+#docker_connect_port = None
+
+# To run containers in Docker Swarm mode on (an existing swarm), set the
+# following option to True *and*:
+# - set docker_connect_port above. For shiltemann/docker-phinch-galaxy the port
+#   should most likely be 80.
+# - If command_inject is uncommented and includes `--sig-proxy`, that option should
+#   be removed.
+#swarm_mode = False

--- a/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
+++ b/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
@@ -41,3 +41,16 @@ password_auth = True
 # you can have a shared sshfs share which you can use as temporary directory to
 # share data between the IE and Galaxy.
 #docker_galaxy_temp_dir = None
+
+# If your Docker container exposes more then one port, Galaxy needs to know to
+# which ports it needs to connect. With this option you can specify the port number
+# inside your container to which Galaxy should connect the UI.
+#docker_connect_port = None
+
+# To run containers in Docker Swarm mode on (an existing swarm), set the
+# following option to True *and*:
+# - set docker_connect_port above. For erasche/docker-rstudio-notebook the port
+#   should most likely be 80.
+# - If command_inject is uncommented and includes `--sig-proxy`, that option should
+#   be removed.
+#swarm_mode = False

--- a/cron/clean_docker_swarm_mode_services.sh
+++ b/cron/clean_docker_swarm_mode_services.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# When running Galaxy Interactive Environments on a swarm (using Docker Engine
+# swarm mode), GIE sessions that have ended will leave behind "shut down"
+# Docker services. These must be removed, which you can do with this script.
+#
+# Note that this is dependent on the specific ordering and output format of
+# `docker service ls` and `docker service ps`. As of the time of writing
+# (Docker version 1.13.1) these formats cannot be controlled as can be done
+# with `docker ps` and the `--format` option, so be careful when upgrading
+# Docker releases.
+
+
+CONTAINER_NAME_PREFIX='galaxy_gie_'
+LOG_PATH=${1:-'/tmp/galaxy_gie_service_clean.log'}
+
+
+{
+    echo "Running cleanup at $(date)"
+    for service_name in $(docker service ls | awk "\$2 ~ /^$CONTAINER_NAME_PREFIX/ {print \$2}"); do
+        docker service ps --no-trunc $service_name | tail -1 | awk '{print $6}' | grep -q '^Shutdown$' && docker service rm $service_name;
+    done
+    echo "Done"
+} >>$LOG_PATH

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -577,6 +577,8 @@ class Configuration( object ):
         elif ie_dirs:
             self.visualization_plugins_directory += ",%s" % ie_dirs
 
+        self.gie_swarm_mode = string_as_bool( kwargs.get( 'interactive_environment_swarm_mode', False ) )
+
         self.proxy_session_map = self.resolve_path( kwargs.get( "dynamic_proxy_session_map", "database/session_map.sqlite" ) )
         self.manage_dynamic_proxy = string_as_bool( kwargs.get( "dynamic_proxy_manage", "True" ) )  # Set to false if being launched externally
         self.dynamic_proxy_debug = string_as_bool( kwargs.get( "dynamic_proxy_debug", "False" ) )

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -6,8 +6,10 @@ import yaml
 import stat
 import random
 import tempfile
+import uuid
 from subprocess import Popen, PIPE
 
+from galaxy.util import string_as_bool_or_none
 from galaxy.util.bunch import Bunch
 from galaxy import web, model
 from galaxy.managers import api_keys
@@ -15,6 +17,9 @@ from galaxy.tools.deps.docker_util import DockerVolume
 
 import logging
 log = logging.getLogger(__name__)
+
+
+CONTAINER_NAME_PREFIX = 'galaxy_gie_'
 
 
 class InteractiveEnvironmentRequest(object):
@@ -43,6 +48,11 @@ class InteractiveEnvironmentRequest(object):
         self.load_allowed_images()
         self.attr.docker_hostname = self.attr.viz_config.get("docker", "docker_hostname")
         self.attr.docker_connect_port = self.attr.viz_config.get("docker", "docker_connect_port") or None
+
+        if string_as_bool_or_none(self.attr.viz_config.get("docker", "swarm_mode")) is not None:
+            self.attr.swarm_mode = string_as_bool_or_none(self.attr.viz_config.get("docker", "swarm_mode"))
+        else:
+            self.attr.swarm_mode = trans.app.config.gie_swarm_mode
 
         # Generate per-request passwords the IE plugin can use to configure
         # the destination container.
@@ -78,6 +88,10 @@ class InteractiveEnvironmentRequest(object):
         if self.attr.proxy_prefix.startswith('/'):
             self.attr.proxy_prefix = '/' + self.attr.proxy_prefix.lstrip('/')
 
+        assert not self.attr.swarm_mode or (self.attr.swarm_mode and
+                                            self.attr.docker_connect_port is not None), \
+            "Error: Docker swarm mode enabled but docker_connect_port is not set"
+
     def load_allowed_images(self):
         if os.path.exists(os.path.join(self.attr.our_config_dir, 'allowed_images.yml')):
             fn = os.path.join(self.attr.our_config_dir, 'allowed_images.yml')
@@ -108,11 +122,12 @@ class InteractiveEnvironmentRequest(object):
         # their defaults dictionary instead.
         default_dict = {
             'command': 'docker {docker_args}',
-            'command_inject': '--sig-proxy=true -e DEBUG=false',
+            'command_inject': '-e DEBUG=false -e DEFAULT_CONTAINER_RUNTIME=120',
             'docker_hostname': 'localhost',
             'wx_tempdir': 'False',
             'docker_galaxy_temp_dir': None,
-            'docker_connect_port': None
+            'docker_connect_port': None,
+            'swarm_mode': None,
         }
         viz_config = ConfigParser.SafeConfigParser(default_dict)
         conf_path = os.path.join( self.attr.our_config_dir, self.attr.viz_id + ".ini" )
@@ -211,32 +226,72 @@ class InteractiveEnvironmentRequest(object):
     def volume(self, host_path, container_path, **kwds):
         return DockerVolume(host_path, container_path, **kwds)
 
-    def docker_cmd(self, image, env_override={}, volumes=[]):
+    def docker_cmd(self, image, env_override=None, volumes=None):
         """
             Generate and return the docker command to execute
         """
+        if env_override is None:
+            env_override = {}
+        if volumes is None:
+            volumes = []
         temp_dir = self.temp_dir
         conf = self.get_conf_dict()
         conf.update(env_override)
         env_str = ' '.join(['-e "%s=%s"' % (key.upper(), item) for key, item in conf.items()])
         volume_str = ' '.join(['-v "%s"' % volume for volume in volumes])
         import_volume_str = '-v "{temp_dir}:/import/"'.format(temp_dir=temp_dir) if self.attr.import_volume else ''
+        name = None
         # This is the basic docker command such as "sudo -u docker docker {docker_args}"
         # or just "docker {docker_args}"
         command = self.attr.viz_config.get("docker", "command")
         # Then we format in the entire docker command in place of
         # {docker_args}, so as to let the admin not worry about which args are
         # getting passed
-        command = command.format(docker_args='run {command_inject} {environment} -d -P {import_volume_str} {volume_str} {image}')
+        command_inject = self.attr.viz_config.get("docker", "command_inject")
+        # --name should really not be set, but we'll try to honor it anyway
+        if '--name' not in command_inject:
+            name = CONTAINER_NAME_PREFIX + uuid.uuid4().hex
+        if not self.attr.swarm_mode:
+            command = command.format(docker_args='run {command_inject} {name} {environment} -d -P {import_volume_str} {volume_str} {image}')
+            # --sig-proxy is not valid in the swarm mode context
+            if '--sig-proxy=' not in command_inject:
+                command_inject = '--sig-proxy=true ' + command_inject
+        else:
+            command = command.format(docker_args='service create --replicas 1 --restart-condition none {command_inject} {name} -p {docker_connect_port} {environment} {image}')
+
         # Once that's available, we format again with all of our arguments
         command = command.format(
-            command_inject=self.attr.viz_config.get("docker", "command_inject"),
+            command_inject=command_inject,
+            name='--name=%s' % name if name is not None else '',
             environment=env_str,
             import_volume_str=import_volume_str,
             volume_str=volume_str,
             image=image,
+            docker_connect_port=self.attr.docker_connect_port,
         )
         return command
+
+    def get_digest_image(self, image):
+        """Get the digest image string for an image.
+
+        :type image: str
+        :param image: image name and optionally, tag
+
+        :returns: digest string, having the format `<name>@<hash_alg>:<digest>`, e.g.:
+                  `'bgruening/docker-jupyter-notebook@sha256:3ec0bc9abc9d511aa602ee4fff2534d80dd9b1564482de52cb5de36cce6debae'`
+        """
+        command = self.attr.viz_config.get("docker", "command")
+        command = command.format(docker_args="image inspect --format '{{{{(index .RepoDigests 0)}}}}' {image}".format(image=image))
+        p = Popen(command, stdout=PIPE, stderr=PIPE, close_fds=True, shell=True)
+        stdout, stderr = p.communicate()
+        digest = None
+        if p.returncode == 0:
+            digest = stdout.strip()
+        elif p.returncode == 1 and stderr.strip() == 'Error: No such image: {image}'.format(image=image):
+            log.warning("%s not pulled, cannot get digest", image)
+        else:
+            log.error( "%s\n%s" % (stdout, stderr) )
+        return digest or image
 
     def _idsToVolumes(self, ids):
         if len(ids.strip()) == 0:
@@ -285,6 +340,11 @@ class InteractiveEnvironmentRequest(object):
             # requesting images we have not specifically allowed.
             raise Exception("Attempting to launch disallowed image! %s not in list of allowed images [%s]"
                             % (image, ', '.join(self.allowed_images)))
+
+        # The digest image is necessary if using swarm mode and the image's
+        # registry (e.g. docker hub, quay.io) is down. See:
+        # https://github.com/docker/docker/issues/31427
+        image = self.get_digest_image(image)
 
         if additional_ids is not None:
             volumes += self._idsToVolumes(additional_ids)
@@ -355,7 +415,10 @@ class InteractiveEnvironmentRequest(object):
         :returns: inspect_data, a dict of docker inspect output
         """
         command = self.attr.viz_config.get("docker", "command")
-        command = command.format(docker_args="inspect %s" % container_id)
+        if not self.attr.swarm_mode:
+            command = command.format(docker_args="inspect %s" % container_id)
+        else:
+            command = command.format(docker_args="service inspect %s" % container_id)
         log.info("Inspecting docker container {0} with command [{1}]".format(
             container_id,
             command
@@ -368,15 +431,6 @@ class InteractiveEnvironmentRequest(object):
             return None
 
         inspect_data = json.loads(stdout)
-        # [{
-        #     "NetworkSettings" : {
-        #         "Ports" : {
-        #             "3306/tcp" : [
-        #                 {
-        #                     "HostIp" : "127.0.0.1",
-        #                     "HostPort" : "3306"
-        #                 }
-        #             ]
         return inspect_data
 
     def get_container_host(self, inspect_data):
@@ -410,13 +464,43 @@ class InteractiveEnvironmentRequest(object):
         Someday code that calls this should be refactored whenever we get
         containers with multiple ports working.
         """
+        # non-swarm:
+        # [{
+        #     "NetworkSettings" : {
+        #         "Ports" : {
+        #             "3306/tcp" : [
+        #                 {
+        #                     "HostIp" : "127.0.0.1",
+        #                     "HostPort" : "3306"
+        #                 }
+        #             ]
+        # swarm:
+        # [{
+        #     "Endpoint": {
+        #         "Ports": [
+        #             {
+        #                 "Protocol": "tcp",
+        #                 "TargetPort": 8888,
+        #                 "PublishedPort": 30000,
+        #                 "PublishMode": "ingress"
+        #             }
+        #         ]
         mappings = []
-        port_mappings = inspect_data[0]['NetworkSettings']['Ports']
-        for port_name in port_mappings:
-            for binding in port_mappings[port_name]:
+        if not self.attr.swarm_mode:
+            port_mappings = inspect_data[0]['NetworkSettings']['Ports']
+            for port_name in port_mappings:
+                for binding in port_mappings[port_name]:
+                    mappings.append((
+                        port_name.replace('/tcp', '').replace('/udp', ''),
+                        binding['HostIp'],
+                        binding['HostPort']
+                    ))
+        else:
+            port_mappings = inspect_data[0]['Endpoint']['Ports']
+            for binding in port_mappings:
                 mappings.append((
-                    port_name.replace('/tcp', '').replace('/udp', ''),
-                    binding['HostIp'],
-                    binding['HostPort']
+                    binding['TargetPort'],
+                    '127.0.0.1',                # use the routing mesh
+                    binding['PublishedPort']
                 ))
         return mappings


### PR DESCRIPTION
Assuming you have already set up a swarm, enabling `swarm_mode` in the GIE config will instruct Galaxy to run GIE containers as Docker services rather than with `docker run`. Note that these services are not cleaned up by Galaxy itself. Rather than creating a thread to clean them up in the background, I recommend we suggest users to set up a cron job e.g.:

```bash
for service_id in $(docker service ls -q); do docker service ps --no-trunc $service_id | tail -1 | awk '{print $5}' | grep -q '^Shutdown$' && docker service rm $service_id; done
```

Note this indiscriminately removes all stopped services on the swarm - perhaps not ideal if the swarm is shared with non-GIE jobs.

If this PR is meeting with approval I'll update the GIE admin documentation and other plugin samples accordingly.

xref original Docker swarm (predecessor to swarm mode) support: #2386