### PR TITLE
[17.01] Logout recalc improvements

### DIFF
--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -131,8 +131,7 @@ def recalculate_user_disk_usage(app, **kwargs):
     user_id = kwargs.get('user_id', None)
     sa_session = app.model.context
     if user_id:
-        # user = sa_session.query( app.model.User ).get( trans.security.decode_id( user_id ) )
-        user = sa_session.query( app.model.User ).get( user_id )
+        user = sa_session.query( app.model.User ).get( app.security.decode_id( user_id ) )
         if user:
             if sa_session.get_bind().dialect.name not in ( 'postgres', 'postgresql' ):
                 new = user.calculate_disk_usage()

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -26,8 +26,9 @@ def queue_async_task(app, task, kwargs={}):
     try:
         c = Connection(app.config.amqp_internal_connection)
         with producers[c].acquire(block=True) as producer:
-            producer.publish(payload, exchange=galaxy.queues.galaxy_exchange,
-                             declare=[galaxy.queues.galaxy_exchange].append(galaxy.queues.control_queue_from_config(app.config)),
+            producer.publish(payload,
+                             exchange=galaxy.queues.galaxy_exchange,
+                             declare=[galaxy.queues.galaxy_exchange] + [galaxy.queues.control_queue_from_config(app.config)],
                              routing_key='control')
     except Exception:
         log.exception("Error queueing async task: %s." % payload)

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -19,7 +19,11 @@ logging.getLogger('kombu').setLevel(logging.WARNING)
 log = logging.getLogger(__name__)
 
 
-def queue_async_task(app, task, kwargs={}):
+def send_local_control_task(app, task, kwargs={}):
+    """
+    This sends a message to the process-local control worker, which is useful
+    for one-time asynchronous tasks like recalculating user disk usage.
+    """
     log.info("Queuing async task %s." % task)
     payload = {'task': task,
                'kwargs': kwargs}
@@ -35,6 +39,11 @@ def queue_async_task(app, task, kwargs={}):
 
 
 def send_control_task(app, task, noop_self=False, kwargs={}):
+    """
+    This sends a control task out to all processes, useful for things like
+    reloading a data table, which needs to happen individually in all
+    processes.
+    """
     log.info("Sending %s control task." % task)
     payload = {'task': task,
                'kwargs': kwargs}

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -629,8 +629,7 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
                 # Send a queue recalculation
                 queue_async_task(trans.app,
                                  'recalculate_user_disk_usage',
-                                 # {'user_id': trans.security.encode_id(trans.user.id)})
-                                 {'user_id': trans.user.id})
+                                 {'user_id': trans.security.encode_id(trans.user.id)})
             # Since logging an event requires a session, we'll log prior to ending the session
             trans.log_event( "User logged out" )
         else:

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -626,10 +626,11 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
             else:
                 refresh_frames = [ 'masthead', 'history' ]
             if trans.user:
-                # Send a queue recalculation
-                queue_async_task(trans.app,
-                                 'recalculate_user_disk_usage',
-                                 {'user_id': trans.security.encode_id(trans.user.id)})
+                # Queue a quota recalculation (async) task -- this takes a
+                # while sometimes, so we don't want to block on logout.
+                queue_async_task( trans.app,
+                                  'recalculate_user_disk_usage',
+                                  {'user_id': trans.security.encode_id(trans.user.id)} )
             # Since logging an event requires a session, we'll log prior to ending the session
             trans.log_event( "User logged out" )
         else:

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -17,7 +17,7 @@ from galaxy import model
 from galaxy import util
 from galaxy import web
 from galaxy.exceptions import ObjectInvalid
-from galaxy.model.util import pgcalc
+from galaxy.queue_worker import queue_async_task
 from galaxy.security.validate_user_input import (transform_publicname,
                                                  validate_email,
                                                  validate_password,
@@ -625,13 +625,12 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
                 refresh_frames = [ 'masthead', 'history', 'tools' ]
             else:
                 refresh_frames = [ 'masthead', 'history' ]
-            # Recalculate user disk usage.
             if trans.user:
-                if trans.sa_session.get_bind().dialect.name not in ( 'postgres', 'postgresql' ):
-                    new = trans.user.calculate_disk_usage()
-                else:
-                    new = pgcalc(trans.sa_session, trans.user.id)
-                trans.user.set_disk_usage(new)
+                # Send a queue recalculation
+                queue_async_task(trans.app,
+                                 'recalculate_user_disk_usage',
+                                 # {'user_id': trans.security.encode_id(trans.user.id)})
+                                 {'user_id': trans.user.id})
             # Since logging an event requires a session, we'll log prior to ending the session
             trans.log_event( "User logged out" )
         else:

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -17,7 +17,7 @@ from galaxy import model
 from galaxy import util
 from galaxy import web
 from galaxy.exceptions import ObjectInvalid
-from galaxy.queue_worker import queue_async_task
+from galaxy.queue_worker import send_local_control_task
 from galaxy.security.validate_user_input import (transform_publicname,
                                                  validate_email,
                                                  validate_password,
@@ -628,9 +628,9 @@ class User( BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Creat
             if trans.user:
                 # Queue a quota recalculation (async) task -- this takes a
                 # while sometimes, so we don't want to block on logout.
-                queue_async_task( trans.app,
-                                  'recalculate_user_disk_usage',
-                                  {'user_id': trans.security.encode_id(trans.user.id)} )
+                send_local_control_task( trans.app,
+                                         'recalculate_user_disk_usage',
+                                         {'user_id': trans.security.encode_id(trans.user.id)} )
             # Since logging an event requires a session, we'll log prior to ending the session
             trans.log_event( "User logged out" )
         else:


### PR DESCRIPTION
Two changes to quota-recalc-on-logout.

1) uses pgcalc where possible for faster postgres updates
2) makes it async, using the built in queues.

Applied to 17.01 because it's basically a bugfix because unlike my dev instance where I first wrote the functionality, on main and other large production instances, it takes years to log out without this :(

xref: #3600 