### PR TITLE
[17.01] Fix container resolver log statements exposing pointers.

### DIFF
--- a/lib/galaxy/tools/deps/container_resolvers/__init__.py
+++ b/lib/galaxy/tools/deps/container_resolvers/__init__.py
@@ -5,9 +5,12 @@ from abc import (
     abstractproperty,
 )
 
+import six
+
 from galaxy.util.dictifiable import Dictifiable
 
 
+@six.python_2_unicode_compatible
 class ContainerResolver(Dictifiable, object):
     """Description of a technique for resolving container images for tool execution."""
 
@@ -48,3 +51,6 @@ class ContainerResolver(Dictifiable, object):
     def _container_type_enabled(self, container_description, enabled_container_types):
         """Return a boolean indicating if the specified container type is enabled."""
         return container_description.type in enabled_container_types
+
+    def __str__(self):
+        return "%s[]" % self.__class__.__name__

--- a/lib/galaxy/tools/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tools/deps/container_resolvers/mulled.py
@@ -3,6 +3,8 @@
 import collections
 import logging
 
+import six
+
 from ..container_resolvers import (
     ContainerResolver,
 )
@@ -102,6 +104,7 @@ def cached_container_description(targets, namespace):
     return container
 
 
+@six.python_2_unicode_compatible
 class CachedMulledContainerResolver(ContainerResolver):
 
     resolver_type = "cached_mulled"
@@ -114,7 +117,11 @@ class CachedMulledContainerResolver(ContainerResolver):
         targets = mulled_targets(tool_info)
         return cached_container_description(targets, self.namespace)
 
+    def __str__(self):
+        return "CachedMulledContainerResolver[namespace=%s]" % self.namespace
 
+
+@six.python_2_unicode_compatible
 class MulledContainerResolver(ContainerResolver):
     """Look for mulled images matching tool dependencies."""
 
@@ -160,7 +167,11 @@ class MulledContainerResolver(ContainerResolver):
                 type="docker",
             )
 
+    def __str__(self):
+        return "MulledContainerResolver[namespace=%s]" % self.namespace
 
+
+@six.python_2_unicode_compatible
 class BuildMulledContainerResolver(ContainerResolver):
     """Look for mulled images matching tool dependencies."""
 
@@ -194,6 +205,9 @@ class BuildMulledContainerResolver(ContainerResolver):
         involucro_context = InvolucroContext(**self._involucro_context_kwds)
         self.enabled = ensure_installed(involucro_context, self.auto_init)
         return involucro_context
+
+    def __str__(self):
+        return "BuildContainerResolver[namespace=%s]" % self.namespace
 
 
 def mulled_targets(tool_info):

--- a/lib/galaxy/tools/deps/requirements.py
+++ b/lib/galaxy/tools/deps/requirements.py
@@ -1,5 +1,7 @@
 import copy
 
+import six
+
 from galaxy.util import (
     asbool,
     xml_text,
@@ -143,6 +145,7 @@ DEFAULT_CONTAINER_RESOLVE_DEPENDENCIES = False
 DEFAULT_CONTAINER_SHELL = "/bin/sh"  # Galaxy assumes bash, but containers are usually thinner.
 
 
+@six.python_2_unicode_compatible
 class ContainerDescription( object ):
 
     def __init__(
@@ -177,6 +180,9 @@ class ContainerDescription( object ):
             resolve_dependencies=resolve_dependencies,
             shell=shell,
         )
+
+    def __str__(self):
+        return "ContainerDescription[identifier=%s,type=%s]" % (self.identifier, self.type)
 
 
 def parse_requirements_from_dict( root_dict ):


### PR DESCRIPTION
These log statements:

```
2017-02-27 12:11:50,959 INFO  [galaxy.tools.deps.containers] Checking with container resolver [<galaxy.tools.deps.container_resolvers.explicit.ExplicitContainerResolver object at 0x10b211590>] found description [None]
2017-02-27 12:11:51,062 INFO  [galaxy.tools.deps.containers] Checking with container resolver [<galaxy.tools.deps.container_resolvers.mulled.CachedMulledContainerResolver object at 0x10b2115d0>] found description [None]
2017-02-27 12:11:51,490 INFO  [galaxy.tools.deps.containers] Checking with container resolver [<galaxy.tools.deps.container_resolvers.mulled.MulledContainerResolver object at 0x10b211610>] found description [<galaxy.tools.deps.requirements.ContainerDescription object at 0x10d6f1550>]
```

Become:

```
2017-02-27 13:19:06,201 INFO  [galaxy.tools.deps.containers] Checking with container resolver [ExplicitContainerResolver[]] found description [None]
2017-02-27 13:19:06,251 INFO  [galaxy.tools.deps.containers] Checking with container resolver [CachedMulledContainerResolver[namespace=None]] found description [None]
2017-02-27 13:19:06,679 INFO  [galaxy.tools.deps.containers] Checking with container resolver [MulledContainerResolver[namespace=biocontainers]] found description [ContainerDescription[identifier=quay.io/biocontainers/seqtk:1.2--0,type=docker]]
```