### PR TITLE
[17.01] Fix step name display for 17.01

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -398,8 +398,12 @@ class WorkflowContentsManager(UsesAnnotations):
                 step_model["name"] = step_title(step, step_model.get("name"))
             else:
                 inputs = step.module.get_runtime_inputs( connections=step.output_connections )
+                step_name = step.module.name
+                if hasattr( step, 'tool_inputs' ):
+                    if isinstance( step.tool_inputs, dict ):
+                        step_name = step.tool_inputs.get( 'name' ) or step_name
                 step_model = {
-                    'name'   : step_title(step, step.module.name),
+                    'name'   : step_title(step, step_name),
                     'inputs' : [ input.to_dict( trans ) for input in inputs.itervalues() ]
                 }
             step_model[ 'step_type' ] = step.type


### PR DESCRIPTION
Fixes #3672. This a fix for 17.01 only, in dev labels and names have been unified. In 17.01 only input modules provide a user editable name, subworkflow modules do not have a tool state and tool modules have a fixed name only. This PR compensates for these variations. The preference order of displaying step titles is 1. label, 2. (custom) name and 3. (default/fixed) name. 