### PR TITLE
Ethercalc Interactive Environment

### DIFF
--- a/config/plugins/interactive_environments/ethercalc/config/ethercalc.ini.sample
+++ b/config/plugins/interactive_environments/ethercalc/config/ethercalc.ini.sample
@@ -1,0 +1,44 @@
+[main]
+# Unused
+
+[docker]
+# Command to launch docker container. For example `sudo docker` or `docker-lxc`.
+# If you need to use a command like `sg` you can do that here, just be sure to
+# wrap all of the docker portion in single quotes. E.g. `sg 'docker' 'docker {docker_args}'`
+#
+# It is recommended that you use command_inject if you need to inject
+# additional parameters. This command string is re-used for a `docker inspect`
+# command and will likely cause errors if it is extensively modified, past the
+# usual group/sudo changes.
+#command = docker {docker_args}
+
+# The docker image name that should be started.
+image = shiltemann/ethercalc-galaxy-ie:17.05
+
+# Additional arguments that are passed to the `docker run` command.
+#command_inject = --sig-proxy=true -e DEBUG=false
+
+# URL to access the Galaxy API with from the spawn Docker containter, if empty
+# this falls back to galaxy.ini's galaxy_infrastructure_url and finally to the
+# Docker host of the spawned container if that is also not set.
+#galaxy_url =
+
+# The Docker hostname. It can be useful to run the Docker daemon on a different
+# host than Galaxy.
+#docker_hostname = localhost
+
+# Try to set the tempdirectory to world execute - this can fix the issue
+# where 'sudo docker' is not able to mount the folder otherwise.
+# "finalize namespace chdir to /import permission denied"
+#wx_tempdir = False
+
+# Overwride the IE tempdirectory. This can be useful if you regular tempdir is
+# located on an NFS share, which does not work well as Docker volume. In this case
+# you can have a shared sshfs share which you can use as temporary directory to
+# share data between the IE and Galaxy.
+#docker_galaxy_temp_dir = None
+
+# If your Docker container exposes more then one port, Galaxy needs to know to
+# which ports it needs to connect. With this option you can specify the port number
+# inside your container to which Galaxy should connect the UI.
+docker_connect_port = 80

--- a/config/plugins/interactive_environments/ethercalc/config/ethercalc.xml
+++ b/config/plugins/interactive_environments/ethercalc/config/ethercalc.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE interactive_environment SYSTEM "../../interactive_environments.dtd">
+<interactive_environment name="Ethercalc">
+    <data_sources>
+        <data_source>
+            <model_class>HistoryDatasetAssociation</model_class>
+            <test type="isinstance" test_attr="datatype" result_type="datatype">tabular.Tabular</test>
+            <test type="isinstance" test_attr="datatype" result_type="datatype">tabular.CSV</test>
+            <to_param param_attr="id">dataset_id</to_param>
+        </data_source>
+    </data_sources>
+    <params>
+        <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
+    </params>
+    <entry_point entry_point_type="mako">ethercalc.mako</entry_point>
+</interactive_environment>

--- a/config/plugins/interactive_environments/ethercalc/static/js/ethercalc.js
+++ b/config/plugins/interactive_environments/ethercalc/static/js/ethercalc.js
@@ -1,0 +1,43 @@
+function load_notebook(url){
+    $( document ).ready(function() {
+        test_ie_availability(url, function(){
+            append_notebook(url)
+        });
+    });
+}
+
+function keep_alive(notebook_access_url){
+    /**
+    * This is needed to keep the container alive. If the user leaves this site
+    * this function is not constantly pinging the container, the container will
+    * terminate itself.
+    */
+
+    var request_count = 0;
+    interval = setInterval(function(){
+        $.ajax({
+            url: notebook_access_url,
+            xhrFields: {
+                withCredentials: true
+            },
+            type: "GET",
+            timeout: 500,
+            success: function(){
+                console.log("Connected to IE, returning");
+            },
+            error: function(jqxhr, status, error){
+                request_count++;
+                console.log("Request " + request_count);
+                if(request_count > 30){
+                    clearInterval(interval);
+                    clear_main_area();
+                    toastr.error(
+                        "Could not connect to IE, contact your administrator",
+                        "Error",
+                        {'closeButton': true, 'timeOut': 20000, 'tapToDismiss': false}
+                    );
+                }
+            }
+        });
+    }, 10000);
+}

--- a/config/plugins/interactive_environments/ethercalc/templates/ethercalc.mako
+++ b/config/plugins/interactive_environments/ethercalc/templates/ethercalc.mako
@@ -1,0 +1,45 @@
+<%namespace name="ie" file="ie.mako" />
+<%
+# Sets ID and sets up a lot of other variables
+ie_request.load_deploy_config()
+
+# Define a volume that will be mounted into the container.
+# This is a useful way to provide access to large files in the container,
+# if the user knows ahead of time that they will need it.
+#user_file = ie_request.volume(
+#    hda.file_name, '/import/file.dat', how='ro')
+
+# Launch the IE. This builds and runs the docker command in the background.
+ie_request.launch(
+    env_override={
+        'dataset_hid': hda.hid
+    }
+)
+
+# Only once the container is launched can we template our URLs. The ie_request
+# doesn't have all of the information needed until the container is running.
+url = ie_request.url_template('${PROXY_URL}/ethercalc/')
+%>
+<html>
+<head>
+${ ie.load_default_js() }
+</head>
+<body>
+<script type="text/javascript">
+${ ie.default_javascript_variables() }
+var url = '${ url }';
+${ ie.plugin_require_config() }
+
+// Keep container running
+requirejs(['interactive_environments', 'plugin/ethercalc'], function(){
+    keep_alive(url);
+});
+
+requirejs(['interactive_environments', 'plugin/ethercalc'], function(){
+    load_notebook(url);
+});
+</script>
+<div id="main" width="100%" height="100%">
+</div>
+</body>
+</html>

--- a/config/plugins/interactive_environments/ethercalc/templates/ethercalc.mako
+++ b/config/plugins/interactive_environments/ethercalc/templates/ethercalc.mako
@@ -3,11 +3,6 @@
 # Sets ID and sets up a lot of other variables
 ie_request.load_deploy_config()
 
-# Define a volume that will be mounted into the container.
-# This is a useful way to provide access to large files in the container,
-# if the user knows ahead of time that they will need it.
-#user_file = ie_request.volume(
-#    hda.file_name, '/import/file.dat', how='ro')
 
 # Launch the IE. This builds and runs the docker command in the background.
 ie_request.launch(


### PR DESCRIPTION
Hi All,

I've made an interactive environment for the [Ethercalc](https://ethercalc.org/) spreadsheet application.

The corresponding docker definition can be found here: https://github.com/shiltemann/ethercalc-galaxy-ie

This will run on any tabular or csv file, load this dataset into Ethercalc, and upon save will give the option of saving in either of those two formats, and will automatically save an audit trail to the history as well,  recording all the edits made.

Let me know what you think, and any comments/suggestions :)

ping @bgruening @erasche 

![image](https://cloud.githubusercontent.com/assets/2563865/23524853/b542c10e-ff8c-11e6-9df3-15b7c521a1cf.png)

![image](https://cloud.githubusercontent.com/assets/2563865/23524951/122f0760-ff8d-11e6-82f9-9e94fd11d710.png)

![image](https://cloud.githubusercontent.com/assets/2563865/23525015/4c690106-ff8d-11e6-9fa0-1263762c4098.png)



