### PR TITLE
Set $HOME to a temp directory rather than conda_prefix because conda_prefix may not be writable either.

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -215,16 +215,19 @@ class CondaContext(installable.InstallableContext):
 
     def exec_command(self, operation, args):
         command = self.command(operation, args)
-        env = {'HOME': self.conda_prefix}  # We don't want to pollute ~/.conda, which may not even be writable
+        env = {}
         condarc_override = self.condarc_override
         if condarc_override:
             env["CONDARC"] = condarc_override
         log.debug("Executing command: %s", command)
+        env['HOME'] = tempfile.mkdtemp(prefix='conda_exec_home_')  # We don't want to pollute ~/.conda, which may not even be writable
         try:
             return self.shell_exec(command, env=env)
         except commands.CommandLineException as e:
             log.warning(e)
             return e.returncode
+        finally:
+            shutil.rmtree(env['HOME'], ignore_errors=True)
 
     def exec_create(self, args):
         create_base_args = [


### PR DESCRIPTION
I assume I didn't run into this before because 3.19 wasn't attempting to create `~/.conda` but 4.3 is?

Ping @mvdbeek