### PR TITLE
Properly handle boolean values when parsed to a string-based/default tool parameter

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2,7 +2,6 @@
 Basic tool parameters.
 """
 import logging
-import numbers
 import os
 import os.path
 import re
@@ -131,8 +130,6 @@ class ToolParameter( object, Dictifiable ):
 
     def to_python( self, value, app ):
         """Convert a value created with to_json back to an object representation"""
-        if isinstance( value, numbers.Number ):
-            return unicodify( value )
         return value
 
     def value_to_basic( self, value, app, use_security=False ):

--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -56,10 +56,13 @@ def swap_inf_nan( val ):
 def safe_loads( arg ):
     """
     This is a wrapper around loads that returns the parsed value instead of
-    raising a value error.
+    raising a value error. It also avoids autoconversion of non-iterables
+    such as numeric and boolean.
     """
     try:
         loaded = json.loads( arg )
+        if loaded is not None and not isinstance( loaded, collections.Iterable ):
+            loaded = arg
     except ( TypeError, ValueError ):
         loaded = arg
     return loaded

--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -57,7 +57,7 @@ def safe_loads( arg ):
     """
     This is a wrapper around loads that returns the parsed value instead of
     raising a value error. It also avoids autoconversion of non-iterables
-    such as numeric and boolean.
+    i.e numeric and boolean values.
     """
     try:
         loaded = json.loads( arg )


### PR DESCRIPTION
Fixes #3697. When encoding and decoding a default parameters value, boolean values should not be auto converted through json loads.