### PR TITLE
Do not require stored workflow id for subworkflows

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -745,9 +745,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 del step_dict['tool_id']
                 del step_dict['tool_version']
                 del step_dict['tool_inputs']
-                workflow = step.subworkflow
-                step_dict['stored_workflow_id'] = encode(workflow.stored_workflow.id)
-                step_dict['workflow_id'] = encode(workflow.id)
+                step_dict['workflow_id'] = encode(step.subworkflow.id)
 
             for conn in step.input_connections:
                 step_id = step.id if legacy else step.order_index


### PR DESCRIPTION
Editing and saving an imported workflow containing subworkflows triggers an error. The subworkflow does not seem to have an associated stored_workflow. Is this here a reasonable fix? ping @jmchilton.