### PR TITLE
Mirror galaxy-lib changes to allow local Conda and Docker Development

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -30,6 +30,10 @@ VERSIONED_ENV_DIR_NAME = re.compile(r"__(.*)@(.*)")
 UNVERSIONED_ENV_DIR_NAME = re.compile(r"__(.*)@_uv_")
 USE_PATH_EXEC_DEFAULT = False
 CONDA_VERSION = "4.2.13"
+# 2.1.5 is incompatible with 4.2 Conda because of
+# https://github.com/conda/conda-build/pull/1766
+CONDA_BUILD_VERSION = "2.1.4"
+USE_LOCAL_DEFAULT = False
 
 
 def conda_link():
@@ -45,7 +49,16 @@ def find_conda_prefix(conda_prefix=None):
     for Miniconda installs.
     """
     if conda_prefix is None:
-        return os.path.join(os.path.expanduser("~"), "miniconda2")
+        home = os.path.expanduser("~")
+        miniconda_2_dest = os.path.join(home, "miniconda2")
+        miniconda_3_dest = os.path.join(home, "miniconda3")
+        # Prefer miniconda3 install if both available
+        if os.path.exists(miniconda_3_dest):
+            return miniconda_3_dest
+        elif os.path.exists(miniconda_2_dest):
+            return miniconda_2_dest
+        else:
+            return miniconda_3_dest
     return conda_prefix
 
 
@@ -54,7 +67,8 @@ class CondaContext(installable.InstallableContext):
 
     def __init__(self, conda_prefix=None, conda_exec=None,
                  shell_exec=None, debug=False, ensure_channels='',
-                 condarc_override=None, use_path_exec=USE_PATH_EXEC_DEFAULT, copy_dependencies=False):
+                 condarc_override=None, use_path_exec=USE_PATH_EXEC_DEFAULT,
+                 copy_dependencies=False, use_local=USE_LOCAL_DEFAULT):
         self.condarc_override = condarc_override
         if not conda_exec and use_path_exec:
             conda_exec = commands.which("conda")
@@ -84,18 +98,31 @@ class CondaContext(installable.InstallableContext):
         self.ensured_channels = False
         self._conda_version = None
         self._miniconda_version = None
+        self._conda_build_available = None
+        self._use_local = use_local
 
     @property
     def conda_version(self):
         if self._conda_version is None:
-            self._guess_conda_version()
+            self._guess_conda_properties()
         return self._conda_version
 
-    def _guess_conda_version(self):
+    @property
+    def conda_build_available(self):
+        if self._conda_build_available is None:
+            self._guess_conda_properties()
+        return self._conda_build_available
+
+    @property
+    def use_local(self):
+        return self._use_local
+
+    def _guess_conda_properties(self):
         conda_meta_path = self._conda_meta_path
         # Perhaps we should call "conda info --json" and parse it but for now we are going
         # to assume the default.
         conda_version = LooseVersion(CONDA_VERSION)
+        conda_build_available = False
         miniconda_version = "3"
 
         if os.path.exists(conda_meta_path):
@@ -110,9 +137,12 @@ class CondaContext(installable.InstallableContext):
                     conda_version = LooseVersion(version)
                 if package == "python" and version.startswith("2"):
                     miniconda_version = "2"
+                if package == "conda-build":
+                    conda_build_available = True
 
         self._conda_version = conda_version
         self._miniconda_version = miniconda_version
+        self._conda_build_available = conda_build_available
 
     @property
     def _conda_meta_path(self):
@@ -134,6 +164,14 @@ class CondaContext(installable.InstallableContext):
 
             if changed:
                 self.save_condarc(conda_conf)
+
+    def ensure_conda_build_installed_if_needed(self):
+        if self.use_local and not self.conda_build_available:
+            conda_targets = [CondaTarget("conda-build", version=CONDA_BUILD_VERSION)]
+            # Cannot use --use-local during installation fo conda-build.
+            return install_conda_targets(conda_targets, env_name=None, conda_context=self, allow_local=False)
+        else:
+            return 0
 
     def conda_info(self):
         if self.conda_exec is not None:
@@ -229,10 +267,12 @@ class CondaContext(installable.InstallableContext):
         finally:
             shutil.rmtree(env['HOME'], ignore_errors=True)
 
-    def exec_create(self, args):
+    def exec_create(self, args, allow_local=True):
         create_base_args = [
             "-y"
         ]
+        if allow_local and self._use_local:
+            create_base_args.extend(["--use-local"])
         create_base_args.extend(args)
         return self.exec_command("create", create_base_args)
 
@@ -245,10 +285,12 @@ class CondaContext(installable.InstallableContext):
         remove_base_args.extend(args)
         return self.exec_command("env", remove_base_args)
 
-    def exec_install(self, args):
+    def exec_install(self, args, allow_local=True):
         install_base_args = [
             "-y"
         ]
+        if allow_local and self._use_local:
+            install_base_args.extend(["--use-local"])
         install_base_args.extend(args)
         return self.exec_command("install", install_base_args)
 
@@ -389,13 +431,18 @@ def hash_conda_packages(conda_packages, conda_target=None):
 
 # shell makes sense for planemo, in Galaxy this should just execute
 # these commands as Python
-def install_conda(conda_context=None):
+def install_conda(conda_context=None, force_conda_build=False):
     conda_context = _ensure_conda_context(conda_context)
     f, script_path = tempfile.mkstemp(suffix=".sh", prefix="conda_install")
     os.close(f)
     download_cmd = " ".join(commands.download_command(conda_link(), to=script_path, quote_url=True))
     install_cmd = "bash '%s' -b -p '%s'" % (script_path, conda_context.conda_prefix)
-    fix_version_cmd = "%s install -y -q conda=%s " % (os.path.join(conda_context.conda_prefix, 'bin/conda'), CONDA_VERSION)
+    package_targets = [
+        "conda=%s" % CONDA_VERSION,
+    ]
+    if force_conda_build or conda_context.use_local:
+        package_targets.append("conda-build=%s" % CONDA_BUILD_VERSION)
+    fix_version_cmd = "%s install -y -q %s " % (os.path.join(conda_context.conda_prefix, 'bin/conda'), " ".join(package_targets))
     full_command = "%s && %s && %s" % (download_cmd, install_cmd, fix_version_cmd)
     try:
         log.info("Installing Conda, this may take several minutes.")
@@ -405,7 +452,7 @@ def install_conda(conda_context=None):
             os.remove(script_path)
 
 
-def install_conda_targets(conda_targets, env_name=None, conda_context=None):
+def install_conda_targets(conda_targets, env_name=None, conda_context=None, allow_local=True):
     conda_context = _ensure_conda_context(conda_context)
     conda_context.ensure_channels_configured()
     if env_name is not None:
@@ -414,9 +461,9 @@ def install_conda_targets(conda_targets, env_name=None, conda_context=None):
         ]
         for conda_target in conda_targets:
             create_args.append(conda_target.package_specifier)
-        return conda_context.exec_create(create_args)
+        return conda_context.exec_create(create_args, allow_local=allow_local)
     else:
-        return conda_context.exec_install([t.package_specifier for t in conda_targets])
+        return conda_context.exec_install([t.package_specifier for t in conda_targets], allow_local=allow_local)
 
 
 def install_conda_target(conda_target, conda_context=None, skip_environment=False):

--- a/lib/galaxy/tools/deps/mulled/invfile.lua
+++ b/lib/galaxy/tools/deps/mulled/invfile.lua
@@ -40,19 +40,49 @@ for i = 1, #test_binds_table do
     table.insert(test_bind_args, test_binds_table[i])
 end
 
+local conda_image = VAR.CONDA_IMAGE
+if conda_image == '' then
+    conda_image = 'continuumio/miniconda:latest'
+end
+
+local destination_base_image = VAR.DEST_BASE_IMAGE
+if destination_base_image == '' then
+    destination_base_image = 'bgruening/busybox-bash:0.1'
+end
+
+local verbose = VAR.VERBOSE
+if verbose == '' then
+    verbose = '--quiet'
+else
+    verbose = '--verbose'
+end
+
+local preinstall = VAR.PREINSTALL
+if preinstall ~= '' then
+    preinstall = preinstall .. ' && '
+end
+
+local postinstall = VAR.POSTINSTALL
+if postinstall ~= '' then
+    postinstall = '&&' .. postinstall
+end
+
 inv.task('build')
-    .using('continuumio/miniconda:latest')
+    .using(conda_image)
         .withHostConfig({binds = {"build:/data"}})
         .run('rm', '-rf', '/data/dist')
-    .using('continuumio/miniconda:latest')
+    .using(conda_image)
         .withHostConfig({binds = bind_args})
-        .run('/bin/sh', '-c', 'conda install '
+        .run('/bin/sh', '-c', preinstall
+            .. 'conda install '
             .. channel_args .. ' '
             .. target_args
-            .. ' -p /usr/local --copy --yes --quiet')
+            .. ' -p /usr/local --copy --yes '
+            .. verbose
+            .. postinstall)
     .wrap('build/dist')
         .at('/usr/local')
-        .inImage('bgruening/busybox-bash:0.1')
+        .inImage(destination_base_image)
         .as(repo)
 
 if VAR.TEST_BINDS == '' then

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -55,6 +55,7 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
         'auto_install': False,
         'auto_init': True,
         'copy_dependencies': False,
+        'use_local': False,
     }
     _specification_pattern = re.compile(r"https\:\/\/anaconda.org\/\w+\/\w+")
 
@@ -83,6 +84,7 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
             )
 
         copy_dependencies = _string_as_bool(get_option("copy_dependencies"))
+        use_local = _string_as_bool(get_option("use_local"))
         conda_exec = get_option("exec")
         debug = _string_as_bool(get_option("debug"))
         ensure_channels = get_option("ensure_channels")
@@ -101,7 +103,8 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
             ensure_channels=ensure_channels,
             condarc_override=condarc_override,
             use_path_exec=use_path_exec,
-            copy_dependencies=copy_dependencies
+            copy_dependencies=copy_dependencies,
+            use_local=use_local,
         )
         self.ensure_channels = ensure_channels
 
@@ -110,6 +113,8 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
         self.auto_init = _string_as_bool(get_option("auto_init"))
         self.conda_context = conda_context
         self.disabled = not galaxy.tools.deps.installable.ensure_installed(conda_context, install_conda, self.auto_init)
+        if self.auto_init and not self.disabled:
+            self.conda_context.ensure_conda_build_installed_if_needed()
         self.auto_install = auto_install
         self.copy_dependencies = copy_dependencies
 


### PR DESCRIPTION
- I added more flexibility to mulled operations to work around bugs on OS X (https://github.com/galaxyproject/galaxy-lib/pull/50).
- I added the ability to use local packages with the Conda resolver (https://github.com/galaxyproject/galaxy-lib/pull/47) - this allows Galaxy when used with Planemo to use locally built packages. Check out planemo docs on how to do this at http://planemo.readthedocs.io/en/latest/writing_advanced.html#building-new-conda-packages.
- I switched the default Conda prefix to miniconda3 so the name matches what Galaxy is actually installing. https://github.com/galaxyproject/galaxy-lib/pull/48. This would never actually be used with Galaxy since we decided it should maintain its own prefix rather than using the default - it is important for Planemo though.

There are some other bug fixes outside of these three main PRs related to the second point - minor refinements to get conda-build dependencies working and working automatically.
 - https://github.com/galaxyproject/galaxy-lib/commit/bdacc4d98245411786533bd5c37d5dfa74340e1b
 - https://github.com/galaxyproject/galaxy-lib/commit/1b7bca6a379e1859001a9ba73afeeccc9fece0a3
 - https://github.com/galaxyproject/galaxy-lib/commit/36b2e656160f3489bc924768b6c9c37fef5557c7