### PR TITLE
Change API path in docstrings to correct /api/dependency_resolvers/*

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
@@ -23,7 +23,7 @@ class ToolDependenciesAPIController( BaseAPIController ):
     @require_admin
     def index(self, trans, **kwd):
         """
-        GET /api/dependencies_resolvers
+        GET /api/dependency_resolvers
         """
         return self._view.index()
 
@@ -31,7 +31,7 @@ class ToolDependenciesAPIController( BaseAPIController ):
     @require_admin
     def show(self, trans, id):
         """
-        GET /api/dependencies_resolver/<id>
+        GET /api/dependency_resolvers/<id>
         """
         return self._view.show(id)
 
@@ -39,7 +39,7 @@ class ToolDependenciesAPIController( BaseAPIController ):
     @require_admin
     def update(self, trans):
         """
-        PUT /api/dependencies_resolvers
+        PUT /api/dependency_resolvers
 
         Reload tool dependency resolution configuration.
         """
@@ -49,7 +49,7 @@ class ToolDependenciesAPIController( BaseAPIController ):
     @require_admin
     def resolver_dependency(self, trans, id, **kwds):
         """
-        GET /api/dependencies_resolver/{index}/dependency
+        GET /api/dependency_resolvers/{index}/dependency
 
         Resolve described requirement against specified dependency resolver.
 
@@ -75,7 +75,7 @@ class ToolDependenciesAPIController( BaseAPIController ):
     @require_admin
     def install_dependency(self, trans, id=None, **kwds):
         """
-        POST /api/dependencies_resolver/{index}/dependency
+        POST /api/dependency_resolvers/{index}/dependency
 
         Install described requirement against specified dependency resolver.
 
@@ -102,7 +102,7 @@ class ToolDependenciesAPIController( BaseAPIController ):
     @require_admin
     def manager_dependency(self, trans, **kwds):
         """
-        GET /api/dependencies_resolvers/dependency
+        GET /api/dependency_resolvers/dependency
 
         Resolve described requirement against all dependency resolvers, returning
         the match with highest priority.
@@ -129,7 +129,7 @@ class ToolDependenciesAPIController( BaseAPIController ):
     @require_admin
     def resolver_requirements(self, trans, id, **kwds):
         """
-        GET /api/dependencies_resolver/{index}/requirements
+        GET /api/dependency_resolvers/{index}/requirements
 
         Find all "simple" requirements that could be resolved "exactly"
         by this dependency resolver. The dependency resolver must implement
@@ -148,7 +148,7 @@ class ToolDependenciesAPIController( BaseAPIController ):
     @require_admin
     def manager_requirements(self, trans, **kwds):
         """
-        GET /api/dependencies_resolver/requirements
+        GET /api/dependency_resolvers/requirements
 
         Find all "simple" requirements that could be resolved "exactly"
         by all dependency resolvers that support this operation.
@@ -167,7 +167,7 @@ class ToolDependenciesAPIController( BaseAPIController ):
     @require_admin
     def clean(self, trans, id=None, **kwds):
         """
-        POST /api/dependencies_resolver/{index}/clean
+        POST /api/dependency_resolvers/{index}/clean
 
         Cleans up intermediate files created by resolvers during the dependency
         installation.


### PR DESCRIPTION
I think this has always been wrong.

I also realized just now that `api/dependency_resolvers` returns the currently used resolver and channel order ... so we should expose that in the UI.