### PR TITLE
Webhook plugin: tool_list

### DIFF
--- a/config/plugins/webhooks/demo/tool_list/config/tool_list.yml
+++ b/config/plugins/webhooks/demo/tool_list/config/tool_list.yml
@@ -1,0 +1,35 @@
+name: tool_list
+type: 
+  - masthead
+activate: true
+
+icon: fa-list
+tooltip: Generate tool list
+
+function: >
+  alert('The tool file will be created and opened in a new window. Please ' +
+  'be patient, this might take a moment.');
+
+  $.getJSON("/api/webhooks/tool_list/get_data", function(data) {
+    var popup = window.open('tool_list.html');
+    var html = '<!DOCTYPE html><body><h2>' + 
+      'Create a Docker flavour of this instance:</h2>' + 
+      '<table style="width:100%"><tr><td width="50%">The textarea on ' +
+      'the right shows the list of installed tools on this Galaxy instance.' +
+      'You can use it to build a custom Galaxy flavour based on the same ' +
+      'tools. Keep in mind that this list only contains tools which can be ' +
+      'installed from a toolshed. <br><br> 1. Save this list as a <i>.yaml</i> ' +
+      'file and edit it according to your needs. You might want to add or ' +
+      'remove tools.<br>2. Follow ' +
+      '<a href="https://github.com/bgruening/docker-galaxy-stable' +
+      '#Extending-the-Docker-Image">this guide</a> on how to create a new ' +
+      'Galaxy Docker flavour. Dont forget to add and install the tool list ' +
+      'with <br><br><b>ADD my_tool_list.yml $GALAXY_ROOT/my_tool_list.yml' +
+      '</b> <br><br> and <br><br><b>' +
+      'RUN install-tools $GALAXY_ROOT/my_tool_list.yml</b></td>' +
+      '<td width="50%"><textarea rows="30" cols="78">' + 
+      data.yaml + 
+      '</textarea></td></tr></table></body>';
+
+    popup.document.write(html);
+  });

--- a/config/plugins/webhooks/demo/tool_list/config/tool_list.yml
+++ b/config/plugins/webhooks/demo/tool_list/config/tool_list.yml
@@ -7,8 +7,11 @@ icon: fa-list
 tooltip: Generate tool list
 
 function: >
-  alert('The tool file will be created and opened in a new window. Please ' +
-  'be patient, this might take a moment.');
+
+  setTimeout(function() {
+    alert('The tool file will be created and opened in a new window. Please ' +
+    'be patient, this might take a moment.');
+  }, 1);
 
   $.getJSON("/api/webhooks/tool_list/get_data", function(data) {
     var popup = window.open('tool_list.html');

--- a/config/plugins/webhooks/demo/tool_list/helper/__init__.py
+++ b/config/plugins/webhooks/demo/tool_list/helper/__init__.py
@@ -13,8 +13,8 @@ def main(trans, webhook):
 
             name = str(tool[1].tool_shed_repository.name)
             revision = str(
-                    tool[1].tool_shed_repository.installed_changeset_revision
-                    )
+                tool[1].tool_shed_repository.installed_changeset_revision
+            )
 
             if (name + revision) not in unique_tools:
 

--- a/config/plugins/webhooks/demo/tool_list/helper/__init__.py
+++ b/config/plugins/webhooks/demo/tool_list/helper/__init__.py
@@ -1,5 +1,6 @@
 import yaml
 
+
 def main(trans, webhook):
     data = {}
     data['tools'] = []
@@ -11,7 +12,9 @@ def main(trans, webhook):
         if tool[1].tool_shed_repository is not None:
 
             name = str(tool[1].tool_shed_repository.name)
-            revision = str(tool[1].tool_shed_repository.installed_changeset_revision)
+            revision = str(
+                    tool[1].tool_shed_repository.installed_changeset_revision
+                    )
 
             if (name + revision) not in unique_tools:
 
@@ -29,6 +32,6 @@ def main(trans, webhook):
                 })
                 if tool[1].get_panel_section()[0]:
                     data['tools'][-1]['tool_panel_section_id'] = \
-                    tool[1].get_panel_section()[0]
+                        tool[1].get_panel_section()[0]
 
     return {'yaml': yaml.safe_dump(data, default_flow_style=False)}

--- a/config/plugins/webhooks/demo/tool_list/helper/__init__.py
+++ b/config/plugins/webhooks/demo/tool_list/helper/__init__.py
@@ -10,23 +10,22 @@ def main(trans, webhook):
     for tool in tools:
         if tool[1].tool_shed_repository is not None:
 
-            if (str(tool[1].tool_shed_repository.name) +
-                    str(tool[1].tool_shed_repository.installed_changeset_revision)
-                    not in unique_tools):
+            name = str(tool[1].tool_shed_repository.name)
+            revision = str(tool[1].tool_shed_repository.installed_changeset_revision)
 
-                unique_tools.append(
-                    str(tool[1].tool_shed_repository.name) +
-                    str(tool[1].tool_shed_repository.installed_changeset_revision))
+            if (name + revision) not in unique_tools:
+
+                unique_tools.append(name + revision)
 
                 data['tools'].append({
-                    'name': tool[1].tool_shed_repository.name,
+                    'name': name,
                     'owner': tool[1].tool_shed_repository.owner,
                     'tool_panel_section_label': tool[1].get_panel_section()[1],
                     'tool_shed_url': tool[1].tool_shed_repository.tool_shed,
                     'install_tool_dependencies': True,
                     'install_repository_dependencies': True,
                     'install_resolver_dependencies': True,
-                    'revisions': [str(tool[1].tool_shed_repository.installed_changeset_revision)]
+                    'revisions': [revision]
                 })
                 if tool[1].get_panel_section()[0]:
                     data['tools'][-1]['tool_panel_section_id'] = \

--- a/config/plugins/webhooks/demo/tool_list/helper/__init__.py
+++ b/config/plugins/webhooks/demo/tool_list/helper/__init__.py
@@ -9,29 +9,31 @@ def main(trans, webhook):
     tools = trans.app.toolbox.tools()
 
     for tool in tools:
-        if tool[1].tool_shed_repository is not None:
 
-            name = str(tool[1].tool_shed_repository.name)
-            revision = str(
-                tool[1].tool_shed_repository.installed_changeset_revision
+        try:
+            ts_data = tool[1].tool_shed_repository.to_dict()
+            panel = tool[1].get_panel_section()
+        except AttributeError:
+            continue
+
+        if (ts_data['name'] + ts_data['installed_changeset_revision'] not in
+                unique_tools):
+
+            unique_tools.append(
+                ts_data['name'] + ts_data['installed_changeset_revision']
             )
 
-            if (name + revision) not in unique_tools:
-
-                unique_tools.append(name + revision)
-
-                data['tools'].append({
-                    'name': name,
-                    'owner': tool[1].tool_shed_repository.owner,
-                    'tool_panel_section_label': tool[1].get_panel_section()[1],
-                    'tool_shed_url': tool[1].tool_shed_repository.tool_shed,
-                    'install_tool_dependencies': True,
-                    'install_repository_dependencies': True,
-                    'install_resolver_dependencies': True,
-                    'revisions': [revision]
-                })
-                if tool[1].get_panel_section()[0]:
-                    data['tools'][-1]['tool_panel_section_id'] = \
-                        tool[1].get_panel_section()[0]
+            data['tools'].append({
+                'name': ts_data['name'],
+                'owner': ts_data['owner'],
+                'tool_panel_section_label': panel[1],
+                'tool_shed_url': ts_data['tool_shed'],
+                'install_tool_dependencies': True,
+                'install_repository_dependencies': True,
+                'install_resolver_dependencies': True,
+                'revisions': [ts_data['installed_changeset_revision']]
+            })
+            if panel[0]:
+                data['tools'][-1]['tool_panel_section_id'] = panel[0]
 
     return {'yaml': yaml.safe_dump(data, default_flow_style=False)}

--- a/config/plugins/webhooks/demo/tool_list/helper/__init__.py
+++ b/config/plugins/webhooks/demo/tool_list/helper/__init__.py
@@ -1,0 +1,35 @@
+import yaml
+
+def main(trans, webhook):
+    data = {}
+    data['tools'] = []
+    unique_tools = []
+
+    tools = trans.app.toolbox.tools()
+
+    for tool in tools:
+        if tool[1].tool_shed_repository is not None:
+
+            if (str(tool[1].tool_shed_repository.name) +
+                    str(tool[1].tool_shed_repository.installed_changeset_revision)
+                    not in unique_tools):
+
+                unique_tools.append(
+                    str(tool[1].tool_shed_repository.name) +
+                    str(tool[1].tool_shed_repository.installed_changeset_revision))
+
+                data['tools'].append({
+                    'name': tool[1].tool_shed_repository.name,
+                    'owner': tool[1].tool_shed_repository.owner,
+                    'tool_panel_section_label': tool[1].get_panel_section()[1],
+                    'tool_shed_url': tool[1].tool_shed_repository.tool_shed,
+                    'install_tool_dependencies': True,
+                    'install_repository_dependencies': True,
+                    'install_resolver_dependencies': True,
+                    'revisions': [str(tool[1].tool_shed_repository.installed_changeset_revision)]
+                })
+                if tool[1].get_panel_section()[0]:
+                    data['tools'][-1]['tool_panel_section_id'] = \
+                    tool[1].get_panel_section()[0]
+
+    return {'yaml': yaml.safe_dump(data, default_flow_style=False)}


### PR DESCRIPTION
Add a webhook plugin at masthead which creates a list of installed toolshed tools on this instance in YAML format. Users can then use it to create their own Galaxy instance or Galaxy Docker flavour based on the same tools.