### PR TITLE
Assorted Fixes for Dockerized Test Setup

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -276,8 +276,8 @@ then
        DOCKER_RUN_EXTRA_ARGS="-v ${tmp}:/tmp ${DOCKER_RUN_EXTRA_ARGS}"
        shift
     fi
-    UID=$(id -u)
-    DOCKER_RUN_EXTRA_ARGS="-e GALAXY_TEST_UID=${UID} ${DOCKER_RUN_EXTRA_ARGS}"
+    MY_UID=$(id -u)
+    DOCKER_RUN_EXTRA_ARGS="-e GALAXY_TEST_UID=${MY_UID} ${DOCKER_RUN_EXTRA_ARGS}"
     echo "Launching docker container for testing..."
     docker $DOCKER_EXTRA_ARGS run $DOCKER_RUN_EXTRA_ARGS -e "BUILD_NUMBER=$BUILD_NUMBER" -e "GALAXY_TEST_DATABASE_TYPE=$db_type" --rm -v `pwd`:/galaxy $DOCKER_IMAGE "$@"
     exit $?

--- a/test/docker/base/run_test_wrapper.sh
+++ b/test/docker/base/run_test_wrapper.sh
@@ -4,7 +4,7 @@ set -e
 echo "Deleting galaxy user - it may not exist and this is fine."
 deluser galaxy | true
 
-GALAXY_TEST_UID=${GALAXY_TEST_UID:-"1"}
+: ${GALAXY_TEST_UID:-"1"}
 
 echo "Creating galaxy group with gid $GALAXY_TEST_UID - it may already exist and this is fine."
 groupadd -r galaxy -g "$GALAXY_TEST_UID" | true
@@ -14,7 +14,7 @@ echo "Setting galaxy user password - the operation may fail."
 echo "galaxy:galaxy" | chpasswd | true
 chown -R "$GALAXY_TEST_UID:$GALAXY_TEST_UID" /galaxy_venv
 
-GALAXY_TEST_DATABASE_TYPE=${GALAXY_TEST_DATABASE_TYPE:-"postgres"}
+: ${GALAXY_TEST_DATABASE_TYPE:-"postgres"}
 if [ "$GALAXY_TEST_DATABASE_TYPE" = "postgres" ];
 then
     su -c '/usr/lib/postgresql/9.3/bin/pg_ctl -o "-F" start -D /opt/galaxy/db' postgres

--- a/test/docker/base/run_test_wrapper.sh
+++ b/test/docker/base/run_test_wrapper.sh
@@ -4,6 +4,8 @@ set -e
 echo "Deleting galaxy user - it may not exist and this is fine."
 deluser galaxy | true
 
+GALAXY_TEST_UID=${GALAXY_TEST_UID:-"1"}
+
 echo "Creating galaxy group with gid $GALAXY_TEST_UID - it may already exist and this is fine."
 groupadd -r galaxy -g "$GALAXY_TEST_UID" | true
 echo "Creating galaxy user with uid $GALAXY_TEST_UID - it may already exist and this is fine."

--- a/test/docker/base/run_test_wrapper.sh
+++ b/test/docker/base/run_test_wrapper.sh
@@ -50,10 +50,11 @@ export TOOL_SHED_CONFIG_OVERRIDE_DATABASE_CONNECTION
 
 : ${GALAXY_VIRTUAL_ENV:=.venv}
 
+HOME=/galaxy
 sudo -E -u "#${GALAXY_TEST_UID}" ./scripts/common_startup.sh || { echo "common_startup.sh failed"; exit 1; }
 
 dev_requirements=./lib/galaxy/dependencies/dev-requirements.txt
-[ -f $dev_requirements ] && $GALAXY_VIRTUAL_ENV/bin/pip install -r $dev_requirements
+[ -f $dev_requirements ] && sudo -E -u "#${GALAXY_TEST_UID}" $GALAXY_VIRTUAL_ENV/bin/pip install -r $dev_requirements
 
 echo "Upgrading test database..."
 sudo -E -u "#${GALAXY_TEST_UID}" sh manage_db.sh upgrade


### PR DESCRIPTION
- 77b2988 Fixes using ``sh run_tests.sh --dockerzied`` on Mac OS X.
- d1eab26 Provides a slightly improved experience if using the Dockerfile directly.
- d665483 Appears to fix the pip caching issue that currently breaks the tests for #3179.