### PR TITLE
Tagging tweaks to handle multiple 'name'/etc tags on a single object.

### DIFF
--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -131,7 +131,9 @@ class TagManager( object ):
         lc_name = name.lower()
         # Get or create item-tag association.
         item_tag_assoc = self._get_item_tag_assoc( user, item, lc_name )
-        if not item_tag_assoc:
+        # If the association does not exist, or if it has a different value, add another.
+        # We do allow multiple associations with different values.
+        if not item_tag_assoc or (item_tag_assoc and item_tag_assoc.value != value):
             # Create item-tag association.
             # Create tag; if None, skip the tag (and log error).
             tag = self._get_or_create_tag( lc_name )
@@ -159,7 +161,7 @@ class TagManager( object ):
         # Parse tags.
         parsed_tags = self.parse_tags( tags_str )
         # Apply each tag.
-        for name, value in parsed_tags.items():
+        for name, value in parsed_tags:
             self.apply_item_tag( user, item, name, value )
 
     def get_tags_str( self, tags ):
@@ -231,7 +233,7 @@ class TagManager( object ):
     def parse_tags( self, tag_str ):
         """
         Returns a list of raw (tag-name, value) pairs derived from a string; method scrubs tag names and values as well.
-        Return value is a dictionary where tag-names are keys.
+        Return value is a list of (tag_name, tag_value) tuples.
         """
         # Gracefully handle None.
         if not tag_str:
@@ -240,12 +242,13 @@ class TagManager( object ):
         reg_exp = re.compile( '[' + self.tag_separators + ']' )
         raw_tags = reg_exp.split( tag_str )
         # Extract name-value pairs.
-        name_value_pairs = dict()
+        name_value_pairs = []
         for raw_tag in raw_tags:
             nv_pair = self._get_name_value_pair( raw_tag )
             scrubbed_name = self._scrub_tag_name( nv_pair[0] )
             scrubbed_value = self._scrub_tag_value( nv_pair[1] )
-            name_value_pairs[scrubbed_name] = scrubbed_value
+            # Append tag_name, tag_value tuple -- TODO use NamedTuple
+            name_value_pairs.append(( scrubbed_name, scrubbed_value ))
         return name_value_pairs
 
     def _scrub_tag_value( self, value ):

--- a/lib/galaxy/tags/__init__.py
+++ b/lib/galaxy/tags/__init__.py
@@ -1,3 +1,0 @@
-"""
-Galaxy tagging classes and methods.
-"""

--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -603,7 +603,7 @@ class CommunityTagsColumn( TextColumn ):
                 column_filter = ",".join( column_filter )
             raw_tags = trans.app.tag_handler.parse_tags( column_filter.encode( "utf-8" ) )
             clause_list = []
-            for name, value in raw_tags.items():
+            for name, value in raw_tags:
                 if name:
                     # Filter by all tags.
                     clause_list.append( self.model_class.tags.any( func.lower( self.model_tag_association_class.user_tname ).like( "%" + name.lower() + "%" ) ) )
@@ -633,7 +633,7 @@ class IndividualTagsColumn( CommunityTagsColumn ):
                 column_filter = ",".join( column_filter )
             raw_tags = trans.app.tag_handler.parse_tags( column_filter.encode( "utf-8" ) )
             clause_list = []
-            for name, value in raw_tags.items():
+            for name, value in raw_tags:
                 if name:
                     # Filter by individual's tag names.
                     clause_list.append( self.model_class.tags.any( and_( func.lower( self.model_tag_association_class.user_tname ).like( "%" + name.lower() + "%" ), self.model_tag_association_class.user == user ) ) )


### PR DESCRIPTION
The tag manager was preventing multiple tags with the same name (but different values) from being applied to items.  This isn't a database limitation and I can't find a reason for the artificial limitation.  The way it was implemented makes it look a bit like an oversight, to me.