### PR TITLE
[17.01] Fix for uploading rdata datasets when explicitly declaring datatype.

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -478,7 +478,7 @@
     <datatype extension="stockholm" type="galaxy.datatypes.msa:Stockholm_1_0" display_in_upload="true" />
     <datatype extension="xmfa" type="galaxy.datatypes.msa:MauveXmfa" display_in_upload="true" />
     <datatype extension="cel" type="galaxy.datatypes.binary:Cel" display_in_upload="true" />
-    <datatype extension="RData" type="galaxy.datatypes.binary:RData" display_in_upload="true" description="Stored data from an R session"/>
+    <datatype extension="rdata" type="galaxy.datatypes.binary:RData" display_in_upload="true" description="Stored data from an R session"/>
     <datatype extension="oxlicg" type="galaxy.datatypes.binary:OxliCountGraph" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="oxling" type="galaxy.datatypes.binary:OxliNodeGraph" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="oxlits" type="galaxy.datatypes.binary:OxliTagSet" mimetype="application/octet-stream" display_in_upload="true"/>

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1148,7 +1148,7 @@ Binary.register_sniffable_binary_format('sra', 'sra', Sra)
 
 class RData( Binary ):
     """Generic R Data file datatype implementation"""
-    file_ext = 'RData'
+    file_ext = 'rdata'
 
     def sniff( self, filename ):
         rdata_header = b'RDX2\nX\n'


### PR DESCRIPTION
Now that ext's are forced to be all lowercase, you cannot upload a dataset with any uppercase characters in the extension.

TODO: An additional fix directly for the upload tool/datatype widget should be pursued that will prevent these issues.