### PR TITLE
Fix container resolution.

### DIFF
--- a/lib/galaxy/tools/deps/container_resolvers/__init__.py
+++ b/lib/galaxy/tools/deps/container_resolvers/__init__.py
@@ -10,8 +10,8 @@ import six
 from galaxy.util.dictifiable import Dictifiable
 
 
-@six.add_metaclass(ABCMeta)
 @six.python_2_unicode_compatible
+@six.add_metaclass(ABCMeta)
 class ContainerResolver(Dictifiable, object):
     """Description of a technique for resolving container images for tool execution."""
 


### PR DESCRIPTION
Without these decorators swapped - resolving containers results in the following Exception:

```
TypeError: unbound method __str__() must be called with ContainerResolver instance as first argument (got nothing instead)
```

I think this recent merge commit 3ed60db5ce9bf2acb954c843c14f8983b11ffbd9 introduced this problem as it merged the two decorators together.