### PR TITLE
Small improvements for driving Qunit tests.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -235,11 +235,16 @@ exists() {
     type "$1" >/dev/null 2>/dev/null
 }
 
-ensure_grunt() {
+ensure_grunt_for_qunit() {
     if ! exists "grunt";
     then
-        echo "Grunt not on path, cannot run these tests."
-        exit 1
+        PATH="$PATH:./test/qunit/node_modules/grunt/bin"
+        export PATH
+        if ! exists "grunt";
+        then
+            echo "Grunt not on path, cannot run these tests."
+            exit 1
+        fi
     fi
 }
 
@@ -616,7 +621,7 @@ if [ "$driver" = "python" ]; then
     echo "Testing complete. HTML report is in \"$report_file\"." 1>&2
     exit ${exit_status}
 else
-    ensure_grunt
+    ensure_grunt_for_qunit
     if [ -n "$watch" ]; then
         grunt_task="watch"
     else

--- a/test/qunit/package.json
+++ b/test/qunit/package.json
@@ -5,7 +5,6 @@
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-qunit": "^1.2.0",
-    "grunt-contrib-watch": "^1.0.0",
-    "phantomjs-prebuilt": "^2.1.13"
+    "grunt-contrib-watch": "^1.0.0"
   }
 }


### PR DESCRIPTION
- Drop explicit requirement on phantomjs since we are moving away from explicit phantomjs testing (it is still pulled in by QUnit which is fine).
- If ``npm install .`` has previously been executed from the ``test/qunit``, don't require globally available grunt to run the tests via ``run_tests.sh -q``.