### PR TITLE
Implement more upload testing in Selenium.

### DIFF
--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -211,22 +211,38 @@ class NavigatesGalaxy(HasDriver):
         center_element = self.driver.find_element_by_css_selector("#center")
         action_chains.move_to_element(center_element).click().perform()
 
-    def perform_upload(self, test_path):
+    def perform_upload(self, test_path, ext=None, genome=None, ext_all=None, genome_all=None):
         self.home()
 
-        upload_button = self.wait_for_selector(".upload-button")
+        upload_button = self.wait_for_selector_clickable(".upload-button")
         upload_button.click()
 
-        local_upload_button = self.wait_for_selector("button#btn-local")
+        if ext_all is not None:
+            self.wait_for_selector_visible('.upload-footer-extension')
+            self.select2_set_value(".upload-footer-extension", ext_all)
+
+        if genome_all is not None:
+            self.wait_for_selector_visible('.upload-footer-genome')
+            self.select2_set_value(".upload-footer-genome", genome_all)
+
+        local_upload_button = self.wait_for_selector_clickable("button#btn-local")
         local_upload_button.click()
 
         file_upload = self.wait_for_selector('input[type="file"]')
         file_upload.send_keys(test_path)
 
-        start_button = self.wait_for_selector("button#btn-start")
+        if ext is not None:
+            self.wait_for_selector_visible('.upload-extension')
+            self.select2_set_value(".upload-extension", ext)
+
+        if genome is not None:
+            self.wait_for_selector_visible('.upload-genome')
+            self.select2_set_value(".upload-genome", genome)
+
+        start_button = self.wait_for_selector_clickable("button#btn-start")
         start_button.click()
 
-        close_button = self.wait_for_selector("button#btn-close")
+        close_button = self.wait_for_selector_clickable("button#btn-close")
         close_button.click()
 
     def workflow_index_open(self):

--- a/test/selenium_tests/test_uploads.py
+++ b/test/selenium_tests/test_uploads.py
@@ -1,22 +1,58 @@
-from .framework import SeleniumTestCase
-from .framework import selenium_test
+from .framework import (
+    SeleniumTestCase,
+    selenium_test,
+    UsesHistoryItemAssertions,
+)
 
 
-class UploadsTestCase(SeleniumTestCase):
+class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_test
-    def test_simple_upload(self):
-        self.home()
-        self.register()
+    def test_upload_simplest(self):
         self.perform_upload(self.get_filename("1.sam"))
 
-        histories = self.api_get("histories")
-        current_id = histories[0]["id"]
         self.history_panel_wait_for_hid_ok(1)
-
-        history_contents = self.api_get("histories/%s/contents" % current_id)
+        history_contents = self.current_history_contents()
         history_count = len(history_contents)
         assert history_count == 1, "Incorrect number of items in history - expected 1, found %d" % history_count
 
         hda = history_contents[0]
         assert hda["name"] == '1.sam'
+        assert hda["extension"] == "sam"
+
+        self.history_panel_click_item_title(hid=1, wait=True)
+        self.assert_item_dbkey_displayed_as(1, "?")
+
+    @selenium_test
+    def test_upload_specify_ext(self):
+        self.perform_upload(self.get_filename("1.sam"), ext="txt")
+        self.history_panel_wait_for_hid_ok(1)
+        history_contents = self.current_history_contents()
+        hda = history_contents[0]
+        assert hda["name"] == '1.sam'
+        assert hda["extension"] == "txt", hda
+
+    @selenium_test
+    def test_upload_specify_genome(self):
+        self.perform_upload(self.get_filename("1.sam"), genome="hg18")
+        self.history_panel_wait_for_hid_ok(1)
+
+        self.history_panel_click_item_title(hid=1, wait=True)
+        self.assert_item_dbkey_displayed_as(1, "hg18")
+
+    @selenium_test
+    def test_upload_specify_ext_all(self):
+        self.perform_upload(self.get_filename("1.sam"), ext_all="txt")
+        self.history_panel_wait_for_hid_ok(1)
+        history_contents = self.current_history_contents()
+        hda = history_contents[0]
+        assert hda["name"] == '1.sam'
+        assert hda["extension"] == "txt", hda
+
+    @selenium_test
+    def test_upload_specify_genome_all(self):
+        self.perform_upload(self.get_filename("1.sam"), genome_all="hg18")
+        self.history_panel_wait_for_hid_ok(1)
+
+        self.history_panel_click_item_title(hid=1, wait=True)
+        self.assert_item_dbkey_displayed_as(1, "hg18")


### PR DESCRIPTION
- Use newer abstraction in the simplest upload test - verify the default extension (auto -> sam) and dbkey (?) also.
- Add a test case that explicitly sets the extension of an upload and verifies.
- Add a test case that explicitly sets a genome and verifies.
- Add a test case that tests setting ext for all uploads and verifies.
- Add a test case that tests setting genome for all uploads and verifies.