### PR TITLE
Make ToolConfWatcher watch ToolCache

### DIFF
--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -87,7 +87,8 @@ def reload_tool(app, **kwargs):
 def reload_toolbox(app, **kwargs):
     log.debug("Executing toolbox reload on '%s'", app.config.server_name)
     reload_count = app.toolbox._reload_count
-    app.tool_cache.cleanup()
+    if app.tool_cache:
+        app.tool_cache.cleanup()
     app.toolbox = _get_new_toolbox(app)
     app.toolbox._reload_count = reload_count + 1
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -79,7 +79,13 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
         if tool_conf_watcher:
             self._tool_conf_watcher = tool_conf_watcher  # Avoids (re-)starting threads in uwsgi
         else:
-            self._tool_conf_watcher = get_tool_conf_watcher(reload_callback=lambda: self.handle_reload_toolbox(), tool_cache=self.app.tool_cache)
+            if hasattr(self.app, 'tool_cache'):
+                # Normal galaxy instances should have a tool_cache,
+                # but the toolshed does not.
+                tool_cache = self.app.tool_cache
+            else:
+                tool_cache = None
+            self._tool_conf_watcher = get_tool_conf_watcher(reload_callback=lambda: self.handle_reload_toolbox(), tool_cache=tool_cache)
         self._filter_factory = FilterFactory( self )
         self._tool_tag_manager = tool_tag_manager( app )
         self._init_tools_from_configs( config_filenames )

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -79,7 +79,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
         if tool_conf_watcher:
             self._tool_conf_watcher = tool_conf_watcher  # Avoids (re-)starting threads in uwsgi
         else:
-            self._tool_conf_watcher = get_tool_conf_watcher(lambda: self.handle_reload_toolbox())
+            self._tool_conf_watcher = get_tool_conf_watcher(reload_callback=lambda: self.handle_reload_toolbox(), tool_cache=self.app.tool_cache)
         self._filter_factory = FilterFactory( self )
         self._tool_tag_manager = tool_tag_manager( app )
         self._init_tools_from_configs( config_filenames )

--- a/lib/galaxy/tools/toolbox/cache.py
+++ b/lib/galaxy/tools/toolbox/cache.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from galaxy.util.hash_util import md5_hash_file
 
@@ -13,16 +14,34 @@ class ToolCache(object):
         self._hash_by_tool_paths = {}
         self._tools_by_path = {}
         self._tool_paths_by_id = {}
+        self._mod_time_by_path = {}
 
     def cleanup(self):
-        """Remove uninstalled tools from tool cache if they are not on disk anymore or if their content has changed."""
-        paths_to_cleanup = {path: tool.all_ids for path, tool in self._tools_by_path.items() if not os.path.exists(path) or md5_hash_file(path) != self._hash_by_tool_paths[path]}
+        """
+        Remove uninstalled tools from tool cache if they are not on disk anymore or if their content has changed.
+
+        Returns list of tool_ids that have been removed.
+        """
+        paths_to_cleanup = {path: tool.all_ids for path, tool in self._tools_by_path.items() if self._should_cleanup(path)}
+        removed_tool_ids = []
         for config_filename, tool_ids in paths_to_cleanup.items():
+            removed_tool_ids.extend(tool_ids)
             del self._hash_by_tool_paths[config_filename]
             del self._tools_by_path[config_filename]
             for tool_id in tool_ids:
                 if tool_id in self._tool_paths_by_id:
                     del self._tool_paths_by_id[tool_id]
+        return removed_tool_ids
+
+    def _should_cleanup(self, config_filename):
+        """Return True of `config_filename` does not exist or if modtime and hash have changes, else return False."""
+        if not os.path.exists(config_filename):
+            return True
+        new_mtime = time.ctime(os.path.getmtime(config_filename))
+        if self._mod_time_by_path[config_filename] != new_mtime:
+            if md5_hash_file(config_filename) != self._hash_by_tool_paths[config_filename]:
+                return True
+        return False
 
     def get_tool(self, config_filename):
         """ Get the tool from the cache if the tool is up to date.
@@ -35,10 +54,12 @@ class ToolCache(object):
             del self._hash_by_tool_paths[config_filename]
             del self._tool_paths_by_id[tool_id]
             del self._tools_by_path[config_filename]
+            del self._mod_time_by_path[config_filename]
 
     def cache_tool(self, config_filename, tool):
         tool_hash = md5_hash_file(config_filename)
         tool_id = str( tool.id )
         self._hash_by_tool_paths[config_filename] = tool_hash
+        self._mod_time_by_path[config_filename] = time.ctime(os.path.getmtime(config_filename))
         self._tool_paths_by_id[tool_id] = config_filename
         self._tools_by_path[config_filename] = tool

--- a/lib/galaxy/tools/toolbox/cache.py
+++ b/lib/galaxy/tools/toolbox/cache.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 from galaxy.util.hash_util import md5_hash_file
 
@@ -22,28 +21,28 @@ class ToolCache(object):
 
         Returns list of tool_ids that have been removed.
         """
+        removed_tool_ids = []
         try:
             paths_to_cleanup = {path: tool.all_ids for path, tool in self._tools_by_path.items() if self._should_cleanup(path)}
-            removed_tool_ids = []
             for config_filename, tool_ids in paths_to_cleanup.items():
-                removed_tool_ids.extend(tool_ids)
                 del self._hash_by_tool_paths[config_filename]
                 del self._tools_by_path[config_filename]
                 for tool_id in tool_ids:
                     if tool_id in self._tool_paths_by_id:
                         del self._tool_paths_by_id[tool_id]
-            return removed_tool_ids
+                removed_tool_ids.extend(tool_ids)
         except Exception:
             # If by chance the file is being removed while calculating the hash or modtime
             # we don't want the thread to die.
-            return []
+            pass
+        return removed_tool_ids
 
     def _should_cleanup(self, config_filename):
-        """Return True of `config_filename` does not exist or if modtime and hash have changes, else return False."""
+        """Return True if `config_filename` does not exist or if modtime and hash have changes, else return False."""
         if not os.path.exists(config_filename):
             return True
-        new_mtime = time.ctime(os.path.getmtime(config_filename))
-        if self._mod_time_by_path.get(config_filename) != new_mtime:
+        new_mtime = os.path.getmtime(config_filename)
+        if self._mod_time_by_path.get(config_filename) < new_mtime:
             if md5_hash_file(config_filename) != self._hash_by_tool_paths.get(config_filename):
                 return True
         return False
@@ -65,6 +64,6 @@ class ToolCache(object):
         tool_hash = md5_hash_file(config_filename)
         tool_id = str( tool.id )
         self._hash_by_tool_paths[config_filename] = tool_hash
-        self._mod_time_by_path[config_filename] = time.ctime(os.path.getmtime(config_filename))
+        self._mod_time_by_path[config_filename] = os.path.getmtime(config_filename)
         self._tool_paths_by_id[tool_id] = config_filename
         self._tools_by_path[config_filename] = tool

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -430,6 +430,7 @@ class SimplifiedToolBox( ToolBox ):
     def __init__( self, test_case ):
         app = test_case.app
         # Handle app/config stuff needed by toolbox but not by tools.
+        app.tool_cache = None
         app.job_config.get_tool_resource_parameters = lambda tool_id: None
         app.config.update_integrated_tool_panel = True
         config_files = test_case.config_files

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -57,6 +57,7 @@ class BaseToolBoxTestCase(  unittest.TestCase, tools_support.UsesApp, tools_supp
         self.reindexed = False
         self.setup_app( mock_model=False )
         install_model = mapping.init( "sqlite:///:memory:", create_tables=True )
+        self.app.tool_cache = None
         self.app.install_model = install_model
         self.app.reindex_tool_search = self.__reindex
         itp_config = os.path.join(self.test_directory, "integrated_tool_panel.xml")

--- a/test/unit/tools/test_watcher.py
+++ b/test/unit/tools/test_watcher.py
@@ -40,6 +40,7 @@ def test_tool_conf_watcher():
 
     with __test_directory() as t:
         tool_conf_path = path.join(t, "test_conf.xml")
+        open(tool_conf_path, "w").write("a")
         conf_watcher.watch_file(tool_conf_path)
         time.sleep(1)
         open(tool_conf_path, "w").write("b")


### PR DESCRIPTION
If any item in the tool cache has changed (local tool update, repository
update, tool deleted) the toolbox will be reloaded and any tool changes are
applied.

Should fix #3813, ping @blankenberg 

I have tested this with both data managers and regular repository updates. You can also test this by modifying any loaded tool, these will automatically be updated now (Is there any reason left to keep the reload toolbox / reload tool xml file buttons around?).