### PR TITLE
fix bedfile display in trackster

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -131,6 +131,7 @@ GALAXY_LIB_TOOLS_UNVERSIONED = [
     "CONVERTER_maf_to_fasta_0",
     "CONVERTER_maf_to_interval_0",
     "CONVERTER_wiggle_to_interval_0",
+    "CONVERTER_bed_to_fli_0",
     # Tools improperly migrated to the tool shed (devteam)
     "lastz_wrapper_2",
     "qualityFilter",

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -126,12 +126,12 @@ GALAXY_LIB_TOOLS_UNVERSIONED = [
     "maf_by_block_number1",
     "wiggle2simple1",
     # Converters
+    "CONVERTER_bed_to_fli_0",
     "CONVERTER_fastq_to_fqtoc0",
     "CONVERTER_gff_to_interval_index_0",
     "CONVERTER_maf_to_fasta_0",
     "CONVERTER_maf_to_interval_0",
     "CONVERTER_wiggle_to_interval_0",
-    "CONVERTER_bed_to_fli_0",
     # Tools improperly migrated to the tool shed (devteam)
     "lastz_wrapper_2",
     "qualityFilter",


### PR DESCRIPTION
using the lagacy python environemnt is also required for "CONVERTER_bed_to_fli_0" when displaying a bed file in trackster