### PR TITLE
[17.01] More CONVERTER fixes for restricting tools' Python environment.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -125,6 +125,7 @@ GALAXY_LIB_TOOLS_UNVERSIONED = [
     # Converters
     "CONVERTER_bed_to_fli_0",
     "CONVERTER_fastq_to_fqtoc0",
+    "CONVERTER_gff_to_fli_0",
     "CONVERTER_gff_to_interval_index_0",
     "CONVERTER_maf_to_fasta_0",
     "CONVERTER_maf_to_interval_0",

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -123,6 +123,7 @@ GALAXY_LIB_TOOLS_UNVERSIONED = [
     "maf_by_block_number1",
     "wiggle2simple1",
     # Converters
+    "CONVERTER_bed_to_fli_0",
     "CONVERTER_fastq_to_fqtoc0",
     "CONVERTER_gff_to_interval_index_0",
     "CONVERTER_maf_to_fasta_0",


### PR DESCRIPTION
Backport of #3822 with another fix for GFF files.