### PR TITLE
[17.01] Order processing evaluation of workflow invocations when scheduling.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3999,11 +3999,11 @@ class WorkflowInvocation( object, Dictifiable ):
             and_conditions.append( WorkflowInvocation.handler == handler )
 
         query = sa_session.query(
-            WorkflowInvocation
-        ).filter( and_( *and_conditions ) )
+            WorkflowInvocation.id
+        ).filter( and_( *and_conditions ) ).order_by( WorkflowInvocation.table.c.id.asc() )
         # Immediately just load all ids into memory so time slicing logic
         # is relatively intutitive.
-        return [wi.id for wi in query.all()]
+        return [wid for wid in query.all()]
 
     def to_dict( self, view='collection', value_mapper=None, step_details=False ):
         rval = super( WorkflowInvocation, self ).to_dict( view=view, value_mapper=value_mapper )

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -1597,11 +1597,19 @@ test_data:
         history_id = self.dataset_populator.new_history()
         hda1 = self.dataset_populator.new_dataset( history_id, content="1 2 3" )
         hda2 = self.dataset_populator.new_dataset( history_id, content="4 5 6" )
+        hda3 = self.dataset_populator.new_dataset( history_id, content="7 8 9" )
+        hda4 = self.dataset_populator.new_dataset( history_id, content="10 11 12" )
+        parameters = {
+            "0": { "input": { "batch": True, "values": [ { "id" : hda1.get( "id" ), "hid": hda1.get( "hid" ), "src": "hda" },
+                                                         { "id" : hda2.get( "id" ), "hid": hda2.get( "hid" ), "src": "hda" },
+                                                         { "id" : hda3.get( "id" ), "hid": hda2.get( "hid" ), "src": "hda" },
+                                                         { "id" : hda4.get( "id" ), "hid": hda2.get( "hid" ), "src": "hda" } ] } },
+            "1": { "input": { "batch": False, "values": [ { "id" : hda1.get( "id" ), "hid": hda1.get( "hid" ), "src": "hda" } ] }, "exp": "2" } }
         workflow_request = {
             "history_id" : history_id,
             "batch"      : True,
             "parameters_normalized": True,
-            "parameters" : dumps( { "0": { "input": { "batch": True, "values": [ { "id" : hda1.get( "id" ), "hid": hda1.get( "hid" ), "src": "hda" }, { "id" : hda2.get( "id" ), "hid": hda2.get( "hid" ), "src": "hda" } ] } }, "1": { "input": { "batch": False, "values": [ { "id" : hda1.get( "id" ), "hid": hda1.get( "hid" ), "src": "hda" } ] }, "exp": "2" } } )
+            "parameters" : dumps( parameters ),
         }
         invocation_response = self._post( "workflows/%s/usage" % workflow_id, data=workflow_request )
         self._assert_status_code_is( invocation_response, 200 )
@@ -1609,9 +1617,16 @@ test_data:
         self.dataset_populator.wait_for_history( history_id, assert_ok=True )
         r1 = "1 2 3\t1\n1 2 3\t2\n"
         r2 = "4 5 6\t1\n1 2 3\t2\n"
-        t1 = self.dataset_populator.get_history_dataset_content( history_id, hid=5 )
-        t2 = self.dataset_populator.get_history_dataset_content( history_id, hid=8 )
-        assert ( r1 == t1 and r2 == t2 ) or ( r1 == t2 and r2 == t1 )
+        r3 = "7 8 9\t1\n1 2 3\t2\n"
+        r4 = "10 11 12\t1\n1 2 3\t2\n"
+        t1 = self.dataset_populator.get_history_dataset_content( history_id, hid=7 )
+        t2 = self.dataset_populator.get_history_dataset_content( history_id, hid=10 )
+        t3 = self.dataset_populator.get_history_dataset_content( history_id, hid=13 )
+        t4 = self.dataset_populator.get_history_dataset_content( history_id, hid=16 )
+        self.assertEqual(r1, t1)
+        self.assertEqual(r2, t2)
+        self.assertEqual(r3, t3)
+        self.assertEqual(r4, t4)
 
     @skip_without_tool( "validation_default" )
     def test_parameter_substitution_sanitization( self ):


### PR DESCRIPTION
So history maintains more order by default.

xref https://github.com/galaxyproject/galaxy/pull/3820#issuecomment-289725795

I'd say this is a usability bug so I'm targeting 17.01. Happy to switch to dev if this is considered an enhancement instead by anyone.

Ping @bgruening @guerler 