### PR TITLE
Stricter checks for GFF/GFF3/GTF sniffing

### DIFF
--- a/.ci/flake8_lint_include_list.txt
+++ b/.ci/flake8_lint_include_list.txt
@@ -66,8 +66,7 @@ lib/galaxy/datatypes/sequence.py
 lib/galaxy/datatypes/tabular.py
 lib/galaxy/datatypes/text.py
 lib/galaxy/datatypes/tracks.py
-lib/galaxy/datatypes/util/generic_util.py
-lib/galaxy/datatypes/util/__init__.py
+lib/galaxy/datatypes/util/
 lib/galaxy/eggs/
 lib/galaxy/exceptions/__init__.py
 lib/galaxy/external_services/__init__.py

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -16,7 +16,7 @@ from galaxy.datatypes import metadata
 from galaxy.datatypes.metadata import MetadataElement
 from galaxy.datatypes.sniff import get_headers
 from galaxy.datatypes.tabular import Tabular
-from galaxy.datatypes.util.gff_util import parse_gff_attributes
+from galaxy.datatypes.util.gff_util import parse_gff3_attributes, parse_gff_attributes
 from galaxy.web import url_for
 
 from . import (
@@ -649,6 +649,7 @@ class Gff( Tabular, _RemoteCallMixin ):
     edam_data = "data_1255"
     edam_format = "format_2305"
     file_ext = "gff"
+    valid_gff_frame = ['.', '0', '1', '2']
     column_names = [ 'Seqname', 'Source', 'Feature', 'Start', 'End', 'Score', 'Strand', 'Frame', 'Group' ]
     data_sources = { "data": "interval_index", "index": "bigwig", "feature_search": "fli" }
     track_type = Interval.track_type
@@ -868,6 +869,8 @@ class Gff( Tabular, _RemoteCallMixin ):
                             return False
                     if hdr[6] not in data.valid_strand:
                         return False
+                    if hdr[7] not in self.valid_gff_frame:
+                        return False
             return True
         except:
             return False
@@ -902,7 +905,7 @@ class Gff3( Gff ):
     edam_format = "format_1975"
     file_ext = "gff3"
     valid_gff3_strand = ['+', '-', '.', '?']
-    valid_gff3_phase = ['.', '0', '1', '2']
+    valid_gff3_phase = Gff.valid_gff_frame
     column_names = [ 'Seqid', 'Source', 'Type', 'Start', 'End', 'Score', 'Strand', 'Phase', 'Attributes' ]
     track_type = Interval.track_type
 
@@ -945,7 +948,7 @@ class Gff3( Gff ):
 
     def sniff( self, filename ):
         """
-        Determines whether the file is in gff version 3 format
+        Determines whether the file is in GFF version 3 format
 
         GFF 3 format:
 
@@ -967,6 +970,9 @@ class Gff3( Gff ):
 
         >>> from galaxy.datatypes.sniff import get_test_fname
         >>> fname = get_test_fname( 'test.gff' )
+        >>> Gff3().sniff( fname )
+        False
+        >>> fname = get_test_fname( 'test.gtf' )
         >>> Gff3().sniff( fname )
         False
         >>> fname = get_test_fname('gff_version_3.gff')
@@ -1005,6 +1011,7 @@ class Gff3( Gff ):
                         return False
                     if hdr[7] not in self.valid_gff3_phase:
                         return False
+                    parse_gff3_attributes(hdr[8])
             return True
         except:
             return False
@@ -1068,6 +1075,8 @@ class Gtf( Gff ):
                         except:
                             return False
                     if hdr[6] not in data.valid_strand:
+                        return False
+                    if hdr[7] not in self.valid_gff_frame:
                         return False
 
                     # Check attributes for gene_id, transcript_id

--- a/lib/galaxy/datatypes/util/gff_util.py
+++ b/lib/galaxy/datatypes/util/gff_util.py
@@ -3,8 +3,8 @@ Provides utilities for working with GFF files.
 """
 import copy
 
-from bx.intervals.io import GenomicInterval, MissingFieldError, NiceReaderWrapper, ParseError, GenomicIntervalReader
-from bx.tabular.io import Header, Comment
+from bx.intervals.io import GenomicInterval, GenomicIntervalReader, MissingFieldError, NiceReaderWrapper, ParseError
+from bx.tabular.io import Comment, Header
 
 from galaxy.util.odict import odict
 

--- a/lib/galaxy/datatypes/util/gff_util.py
+++ b/lib/galaxy/datatypes/util/gff_util.py
@@ -347,6 +347,29 @@ def parse_gff_attributes( attr_str ):
     return attributes
 
 
+def parse_gff3_attributes( attr_str ):
+    """
+    Parses a GFF3 attribute string and returns a dictionary of name-value
+    pairs. The general format for a GFF3 attributes string is
+
+        name1=value1;name2=value2
+    """
+    attributes_list = attr_str.split(";")
+    attributes = {}
+    for tag_value_pair in attributes_list:
+        pair = tag_value_pair.strip().split("=")
+        if len(pair) == 1:
+            raise Exception("Attribute '%s' does not contain a '='" % tag_value_pair)
+        if pair == '':
+            continue
+        tag = pair[0].strip()
+        if tag == '':
+            raise Exception("Empty tag in attribute '%s'" % tag_value_pair)
+        value = pair[1].strip()
+        attributes[tag] = value
+    return attributes
+
+
 def gff_attributes_to_str( attrs, gff_format ):
     """
     Convert GFF attributes to string. Supported formats are GFF3, GTF.


### PR DESCRIPTION
- Check frame column in `Gff.sniff()` and `Gtf.sniff()` .
- Parse attributes column in `Gff3.sniff()` with a specific function to prevent non-compliant GTF files being recognised as GFF3.
 - Fix import order for `lib/galaxy/datatypes/util/gff_util.py` .