### PR TITLE
Allow explicit configuration of handlers for workflow scheduling.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -203,7 +203,7 @@ class JobConfiguration( object, ConfiguresHandlers ):
         if not self.handlers:
             raise ValueError("Job configuration file defines no valid handler elements.")
         # Determine the default handler(s)
-        self.default_handler_id = self._get_default(self.app, handlers_conf, list(self.handlers.keys()))
+        self.default_handler_id = self._get_default(self.app.config, handlers_conf, list(self.handlers.keys()))
 
         # Parse destinations
         destinations = root.find('destinations')
@@ -240,7 +240,7 @@ class JobConfiguration( object, ConfiguresHandlers ):
                     self.destinations[tag].append(job_destination)
 
         # Determine the default destination
-        self.default_destination_id = self._get_default(self.app, destinations, list(self.destinations.keys()))
+        self.default_destination_id = self._get_default(self.app.config, destinations, list(self.destinations.keys()))
 
         # Parse resources...
         resources = root.find('resources')
@@ -313,11 +313,11 @@ class JobConfiguration( object, ConfiguresHandlers ):
 
         log.debug('Done loading job configuration')
 
-    def _parse_handler(self, handler_element):
+    def _parse_handler(self, handler_id, handler_element):
         for plugin in handler_element.findall('plugin'):
-            if id not in self.handler_runner_plugins:
-                self.handler_runner_plugins[id] = []
-            self.handler_runner_plugins[id].append( plugin.get('id') )
+            if handler_id not in self.handler_runner_plugins:
+                self.handler_runner_plugins[handler_id] = []
+            self.handler_runner_plugins[handler_id].append( plugin.get('id') )
 
     def __parse_job_conf_legacy(self):
         """Loads the old-style job configuration from options in the galaxy config file (by default, config/galaxy.ini).

--- a/lib/galaxy/util/handlers.py
+++ b/lib/galaxy/util/handlers.py
@@ -17,24 +17,24 @@ class ConfiguresHandlers:
         # Parse handlers
         if config_element is not None:
             for handler in self._findall_with_required(config_element, 'handler'):
-                id = handler.get('id')
-                if id in self.handlers:
-                    log.error("Handler '%s' overlaps handler with the same name, ignoring" % id)
+                handler_id = handler.get('id')
+                if handler_id in self.handlers:
+                    log.error("Handler '%s' overlaps handler with the same name, ignoring" % handler_id)
                 else:
-                    log.debug("Read definition for handler '%s'" % id)
-                    self.handlers[id] = (id,)
-                    self._parse_handler(handler)
+                    log.debug("Read definition for handler '%s'" % handler_id)
+                    self.handlers[handler_id] = (handler_id,)
+                    self._parse_handler(handler_id, handler)
                     if handler.get('tags', None) is not None:
                         for tag in [ x.strip() for x in handler.get('tags').split(',') ]:
                             if tag in self.handlers:
-                                self.handlers[tag].append(id)
+                                self.handlers[tag].append(handler_id)
                             else:
-                                self.handlers[tag] = [id]
+                                self.handlers[tag] = [handler_id]
 
-    def _parse_handler(self, handler_def):
+    def _parse_handler(self, handler_id, handler_def):
         pass
 
-    def _get_default(self, app, parent, names):
+    def _get_default(self, config, parent, names):
         """
         Returns the default attribute set in a parent tag like <handlers> or
         <destinations>, or return the ID of the child, if there is no explicit
@@ -54,7 +54,7 @@ class ConfiguresHandlers:
             rval = os.environ.get(environ_var, rval)
         elif 'default_from_config' in parent.attrib:
             config_val = parent.attrib['default_from_config']
-            rval = app.config.config_dict.get(config_val, rval)
+            rval = config.config_dict.get(config_val, rval)
 
         if rval is not None:
             # If the parent element has a 'default' attribute, use the id or tag in that attribute

--- a/lib/galaxy/util/handlers.py
+++ b/lib/galaxy/util/handlers.py
@@ -1,0 +1,132 @@
+"""Utilities for dealing with the Galaxy 'handler' process pattern.
+
+A 'handler' is a named Python process running the Galaxy application responsible
+for some activity such as queuing up jobs or scheduling workflows.
+"""
+
+import logging
+import os
+import random
+
+log = logging.getLogger( __name__ )
+
+
+class ConfiguresHandlers:
+
+    def _init_handlers(self, config_element):
+        # Parse handlers
+        if config_element is not None:
+            for handler in self._findall_with_required(config_element, 'handler'):
+                id = handler.get('id')
+                if id in self.handlers:
+                    log.error("Handler '%s' overlaps handler with the same name, ignoring" % id)
+                else:
+                    log.debug("Read definition for handler '%s'" % id)
+                    self.handlers[id] = (id,)
+                    self._parse_handler(handler)
+                    if handler.get('tags', None) is not None:
+                        for tag in [ x.strip() for x in handler.get('tags').split(',') ]:
+                            if tag in self.handlers:
+                                self.handlers[tag].append(id)
+                            else:
+                                self.handlers[tag] = [id]
+
+    def _parse_handler(self, handler_def):
+        pass
+
+    def _get_default(self, app, parent, names):
+        """
+        Returns the default attribute set in a parent tag like <handlers> or
+        <destinations>, or return the ID of the child, if there is no explicit
+        default and only one child.
+
+        :param parent: Object representing a tag that may or may not have a 'default' attribute.
+        :type parent: ``xml.etree.ElementTree.Element``
+        :param names: The list of destination or handler IDs or tags that were loaded.
+        :type names: list of str
+
+        :returns: str -- id or tag representing the default.
+        """
+
+        rval = parent.get('default')
+        if 'default_from_environ' in parent.attrib:
+            environ_var = parent.attrib['default_from_environ']
+            rval = os.environ.get(environ_var, rval)
+        elif 'default_from_config' in parent.attrib:
+            config_val = parent.attrib['default_from_config']
+            rval = app.config.config_dict.get(config_val, rval)
+
+        if rval is not None:
+            # If the parent element has a 'default' attribute, use the id or tag in that attribute
+            if rval not in names:
+                raise Exception("<%s> default attribute '%s' does not match a defined id or tag in a child element" % (parent.tag, rval))
+            log.debug("<%s> default set to child with id or tag '%s'" % (parent.tag, rval))
+        elif len(names) == 1:
+            log.info("Setting <%s> default to child with id '%s'" % (parent.tag, names[0]))
+            rval = names[0]
+        else:
+            raise Exception("No <%s> default specified, please specify a valid id or tag with the 'default' attribute" % parent.tag)
+        return rval
+
+    def _findall_with_required(self, parent, match, attribs=None):
+        """Like ``xml.etree.ElementTree.Element.findall()``, except only returns children that have the specified attribs.
+
+        :param parent: Parent element in which to find.
+        :type parent: ``xml.etree.ElementTree.Element``
+        :param match: Name of child elements to find.
+        :type match: str
+        :param attribs: List of required attributes in children elements.
+        :type attribs: list of str
+
+        :returns: list of ``xml.etree.ElementTree.Element``
+        """
+        rval = []
+        if attribs is None:
+            attribs = ('id',)
+        for elem in parent.findall(match):
+            for attrib in attribs:
+                if attrib not in elem.attrib:
+                    log.warning("required '%s' attribute is missing from <%s> element" % (attrib, match))
+                    break
+            else:
+                rval.append(elem)
+        return rval
+
+    def is_handler(self, server_name):
+        """Given a server name, indicate whether the server is a handler.
+
+        :param server_name: The name to check
+        :type server_name: str
+
+        :return: bool
+        """
+        for collection in self.handlers.values():
+            if server_name in collection:
+                return True
+        return False
+
+    def _get_single_item(self, collection, index=None):
+        """Given a collection of handlers or destinations, return one item from the collection at random.
+        """
+        # Done like this to avoid random under the assumption it's faster to avoid it
+        if len(collection) == 1:
+            return collection[0]
+        elif index is None:
+            return random.choice(collection)
+        else:
+            return collection[index % len(collection)]
+
+    # This is called by Tool.get_job_handler()
+    def get_handler(self, id_or_tag, index=None):
+        """Given a handler ID or tag, return a handler matching it.
+
+        :param id_or_tag: A handler ID or tag.
+        :type id_or_tag: str
+        :param index: Generate "consistent" "random" handlers with this index if specified.
+        :type index: int
+
+        :returns: str -- A valid job handler ID.
+        """
+        if id_or_tag is None:
+            id_or_tag = self.default_handler_id
+        return self._get_single_item(self.handlers[id_or_tag], index=index)

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -7,6 +7,7 @@ from xml.etree import ElementTree
 
 from galaxy import model
 from galaxy.util import plugin_config
+from galaxy.util.handlers import ConfiguresHandlers
 
 import galaxy.workflow.schedulers
 
@@ -21,7 +22,7 @@ EXCEPTION_MESSAGE_NO_DEFAULT_SCHEDULER = "Failed to defined workflow schedulers 
 EXCEPTION_MESSAGE_DUPLICATE_SCHEDULERS = "Failed to defined workflow schedulers - workflow scheduling plugin id '%s' duplicated."
 
 
-class WorkflowSchedulingManager( object ):
+class WorkflowSchedulingManager( object, ConfiguresHandlers ):
     """ A workflow scheduling manager based loosely on pattern established by
     ``galaxy.manager.JobManager``. Only schedules workflows on handler
     processes.
@@ -29,12 +30,14 @@ class WorkflowSchedulingManager( object ):
 
     def __init__( self, app ):
         self.app = app
-        self.__job_config = app.job_config
+        self.__handlers_configured = False
         self.workflow_schedulers = {}
         self.active_workflow_schedulers = {}
         # Passive workflow schedulers won't need to be monitored I guess.
 
         self.request_monitor = None
+
+        self.handlers = {}
 
         self.__plugin_classes = self.__plugins_dict()
         self.__init_schedulers()
@@ -48,11 +51,22 @@ class WorkflowSchedulingManager( object ):
             # Process should not schedule workflows - do nothing.
             pass
 
-    # Provide a handler config-like interface by delegating to job handler
-    # config. Perhaps it makes sense to let there be explicit workflow
-    # handlers?
+        # When assinging handlers to workflows being queued - use job_conf
+        # if not explicit workflow scheduling handlers have be specified or
+        # else use those explicit workflow scheduling handlers (on self).
+        if self.__handlers_configured:
+            self.__has_handlers = self
+        else:
+            self.__has_handlers = app.job_config
+
     def _is_workflow_handler( self ):
-        return self.app.is_job_handler()
+        # If we have explicitly configured handlers, check them.
+        # Else just make sure we are a job handler.
+        if self.__handlers_configured:
+            is_handler = self.is_handler(self.app.config.server_name)
+        else:
+            is_handler = self.app.is_job_handler()
+        return is_handler
 
     def _get_handler( self, history_id ):
         # Use random-ish integer history_id to produce a consistent index to pick
@@ -60,7 +74,7 @@ class WorkflowSchedulingManager( object ):
         random_index = history_id
         if self.app.config.parallelize_workflow_scheduling_within_histories:
             random_index = None
-        return self.__job_config.get_handler( None, index=random_index )
+        return self.__has_handlers.get_handler( None, index=random_index )
 
     def shutdown( self ):
         for workflow_scheduler in self.workflow_schedulers.itervalues():
@@ -118,16 +132,30 @@ class WorkflowSchedulingManager( object ):
     def __init_schedulers_for_element( self, plugins_element ):
         plugins_kwds = dict( plugins_element.items() )
         self.default_scheduler_id = plugins_kwds.get( 'default', DEFAULT_SCHEDULER_ID )
-        for plugin_element in plugins_element:
-            plugin_type = plugin_element.tag
-            plugin_kwds = dict( plugin_element.items() )
-            workflow_scheduler_id = plugin_kwds.get( 'id', None )
-            self.__init_plugin( plugin_type, workflow_scheduler_id, **plugin_kwds )
+        for config_element in plugins_element:
+            config_element_tag = config_element.tag
+            if config_element_tag == "handlers":
+                self.__init_handlers(config_element)
+
+                # Determine the default handler(s)
+                self.default_handler_id = self._get_default(self.app, config_element, list(self.handlers.keys()))
+            else:
+                plugin_type = config_element_tag
+                plugin_element = config_element
+                # Configuring a scheduling plugin...
+                plugin_kwds = dict( plugin_element.items() )
+                workflow_scheduler_id = plugin_kwds.get( 'id', None )
+                self.__init_plugin( plugin_type, workflow_scheduler_id, **plugin_kwds )
 
         if not self.workflow_schedulers:
             raise Exception( EXCEPTION_MESSAGE_NO_SCHEDULERS )
         if self.default_scheduler_id not in self.workflow_schedulers:
             raise Exception( EXCEPTION_MESSAGE_NO_DEFAULT_SCHEDULER % self.default_scheduler_id )
+
+    def __init_handlers(self, config_element):
+        assert not self.__handlers_configured
+        self._init_handlers(config_element)
+        self.__handlers_configured = True
 
     def __init_plugin( self, plugin_type, workflow_scheduler_id=None, **kwds ):
         workflow_scheduler_id = workflow_scheduler_id or self.default_scheduler_id

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -138,7 +138,7 @@ class WorkflowSchedulingManager( object, ConfiguresHandlers ):
                 self.__init_handlers(config_element)
 
                 # Determine the default handler(s)
-                self.default_handler_id = self._get_default(self.app, config_element, list(self.handlers.keys()))
+                self.default_handler_id = self._get_default(self.app.config, config_element, list(self.handlers.keys()))
             else:
                 plugin_type = config_element_tag
                 plugin_element = config_element

--- a/test/integration/workflow_handler_configuration_workflow_scheduler_conf.xml
+++ b/test/integration/workflow_handler_configuration_workflow_scheduler_conf.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<workflow_schedulers default="core">
+  <core id="core" />
+  <handlers default="workflow_handlers">
+    <handler id="work1" tags="workflow_handlers" />
+    <handler id="work2" tags="workflow_handlers" />
+  </handlers>
+</workflow_schedulers>


### PR DESCRIPTION
Currently every job handler is a workflow scheduler handler and vice versa. This (in particular bb1bb67) allow specifying a separate (or potentially overlapping) pool of workflow schedulers. Includes lots of testing for figuring out if the current process is a workflow handler and for determining what handler should be assigned for queued workflows.

Builds on the testing from #3820 so it includes that PR and a merge forward of everything into dev.

A long discussion of how this may potentially improve performance, robustness, and quality of logs for workflow scheduling can be found as part of https://github.com/galaxyproject/galaxy/issues/3816#issuecomment-289323288.