### PR TITLE
[17.01] Fix collection operations in workflows.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3485,6 +3485,14 @@ class DatasetCollectionElement( object, Dictifiable ):
         else:
             return element_object
 
+    @property
+    def dataset_instances( self ):
+        element_object = self.element_object
+        if isinstance( element_object, DatasetCollection ):
+            return element_object.dataset_instances
+        else:
+            return [element_object]
+
     def copy_to_collection( self, collection, destination=None, element_destination=None ):
         element_object = self.element_object
         if element_destination:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2384,9 +2384,10 @@ class DatabaseOperationTool( Tool ):
         for input_dataset in input_datasets.values():
             check_dataset_instance( input_dataset )
 
-        for input_dataset_collection in input_dataset_collections.values():
-            if not input_dataset_collection.collection.populated:
-                raise ToolInputsNotReadyException()
+        for input_dataset_collection_pairs in input_dataset_collections.values():
+            for input_dataset_collection, is_mapped in input_dataset_collection_pairs:
+                if not input_dataset_collection.collection.populated:
+                    raise ToolInputsNotReadyException()
 
             map( check_dataset_instance, input_dataset_collection.dataset_instances )
 

--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -12,8 +12,12 @@ log = logging.getLogger( __name__ )
 
 class ModelOperationToolAction( DefaultToolAction ):
 
-    def check_inputs_ready( self, tool, trans, incoming, history ):
-        history, inp_data, inp_dataset_collections = self._collect_inputs(tool, trans, incoming, history)
+    def check_inputs_ready( self, tool, trans, incoming, history, execution_cache=None ):
+        if execution_cache is None:
+            execution_cache = ToolExecutionCache(trans)
+
+        current_user_roles = execution_cache.current_user_roles
+        history, inp_data, inp_dataset_collections = self._collect_inputs(tool, trans, incoming, history, current_user_roles)
 
         tool.check_inputs_ready( inp_data, inp_dataset_collections )
 

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -48,7 +48,7 @@ def execute( trans, tool, param_combinations, history, rerun_remap_job_id=None, 
     burst_at = getattr( config, 'tool_submission_burst_at', 10 )
     burst_threads = getattr( config, 'tool_submission_burst_threads', 1 )
 
-    tool_action = tool.action
+    tool_action = tool.tool_action
     if hasattr( tool_action, "check_inputs_ready" ):
         for params in execution_tracker.param_combinations:
             # This will throw an exception if the tool is not ready.


### PR DESCRIPTION
Due to a couple bugs things weren't being delayed correctly for some of these tools in some workflows.

Adds a test case that previously would have failed. The test workflow uses the "filter failed" collection operation tool in the middle of the workflow to kill off dead branches of computation - and continue the workflow only with the OK datasets in the collection.