### PR TITLE
Clean up old TODO into history tests.

### DIFF
--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -106,9 +106,7 @@ class UsersApiTestCase( api.ApiTestCase ):
 
     def __update( self, user, **new_data ):
         update_url = self._api_url( "users/%s" % ( user[ "id" ] ), use_key=True )
-        # TODO: Awkward json.dumps required here because of https://trello.com/c/CQwmCeG6
-        body = json.dumps( new_data )
-        return put( update_url, data=body )
+        return put( update_url, data=new_data )
 
     def __assert_matches_user( self, userA, userB ):
         self._assert_has_keys( userB, "id", "username", "total_disk_usage" )


### PR DESCRIPTION
We upgraded the module a long time ago now that was referenced in the Trello card and the tests seem to work without this hack now.