### PR TITLE
[17.01] Fix setting UUID on steps when copying steps from another workflow.

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -881,7 +881,7 @@ class WorkflowContentsManager(UsesAnnotations):
         step = model.WorkflowStep()
         # TODO: Consider handling position inside module.
         step.position = step_dict['position']
-        if "uuid" in step_dict and step_dict['uuid'] != "None":
+        if step_dict.get("uuid", None) and step_dict['uuid'] != "None":
             step.uuid = step_dict["uuid"]
         if "label" in step_dict:
             step.label = step_dict["label"]


### PR DESCRIPTION
It seems like the client is correctly setting the UUID to None when cloning the step, but the backend is treating the None as a UUID because it was (incorrectly IMO) making a distinction between ``uuid`` being absent and being set to ``None``.

Fixes #3845.