### PR TITLE
Fix new history endpoint providing custom builds metadata

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -510,7 +510,7 @@ class HistoriesController( BaseAPIController, ExportsHistoryMixin, ImportsHistor
         for build in glob.glob( os.path.join(trans.app.config.len_file_path, "*.len") ):
             installed_builds.append( os.path.basename(build).split(".len")[0] )
         fasta_hdas = trans.sa_session.query( model.HistoryDatasetAssociation ) \
-            .filter_by( history=trans.history, extension="fasta", deleted=False ) \
+            .filter_by( history=history, extension="fasta", deleted=False ) \
             .order_by( model.HistoryDatasetAssociation.hid.desc() )
         return {
             'installed_builds'  : [ { 'label' : ins, 'value' : ins } for ins in installed_builds ],


### PR DESCRIPTION
Looks like this was always using trans.hsitory instead of the id that was passed to the endpoint.  This was also breaking jenkins, causing other builds to fail.