### PR TITLE
Speedup startup and toolbox operations

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -120,6 +120,8 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
         self.datatypes_registry.load_datatype_converters( self.toolbox )
         # Load external metadata tool
         self.datatypes_registry.load_external_metadata_tool( self.toolbox )
+        # Reset Tool Cache after all tools (regular, tool shed, converters, special ... are loaded)
+        self.tool_cache.reset_status()
         # Load history import/export tools.
         load_lib_tools( self.toolbox )
         # visualizations registry: associates resources with visualizations, controls how to render

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -123,7 +123,6 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
         # Load datatype converters defined in local datatypes_conf.xml
         self.datatypes_registry.load_datatype_converters( self.toolbox )
         # Load external metadata tool
-        self.datatypes_registry.to_xml_file()
         self.datatypes_registry.load_external_metadata_tool( self.toolbox )
         # Load history import/export tools.
         load_lib_tools( self.toolbox )

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -22,7 +22,10 @@ from galaxy.webhooks import WebhooksRegistry
 from galaxy.sample_tracking import external_service_types
 from galaxy.openid.providers import OpenIDProviders
 from galaxy.tools.data_manager.manager import DataManagers
-from galaxy.tools.toolbox.cache import ToolCache
+from galaxy.tools.toolbox.cache import (
+    ToolCache,
+    ToolShedRepositoryCache
+)
 from galaxy.jobs import metrics as job_metrics
 from galaxy.web.proxy import ProxyManager
 from galaxy.web.stack import application_stack_instance
@@ -100,6 +103,7 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
 
         # Setup a Tool Cache
         self.tool_cache = ToolCache()
+        self.tool_shed_repository_cache = ToolShedRepositoryCache(self)
         # Watch various config files for immediate reload
         self.watchers = ConfigWatchers(self)
         self._configure_toolbox()

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -48,6 +48,7 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
             logging.basicConfig(level=logging.DEBUG)
         log.debug( "python path is: %s", ", ".join( sys.path ) )
         self.name = 'galaxy'
+        self.start_time = time.time()
         self.new_installation = False
         self.application_stack = application_stack_instance()
         # Read config file and check for errors
@@ -203,6 +204,7 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
 
         self.model.engine.dispose()
         self.server_starttime = int(time.time())  # used for cachebusting
+        log.info("Server startup took %f seconds" % (time.time() - self.start_time))
 
     def shutdown( self ):
         self.workflow_scheduling_manager.shutdown()

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -123,6 +123,7 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
         # Load datatype converters defined in local datatypes_conf.xml
         self.datatypes_registry.load_datatype_converters( self.toolbox )
         # Load external metadata tool
+        self.datatypes_registry.to_xml_file()
         self.datatypes_registry.load_external_metadata_tool( self.toolbox )
         # Load history import/export tools.
         load_lib_tools( self.toolbox )

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -30,7 +30,10 @@ from galaxy.jobs import metrics as job_metrics
 from galaxy.web.proxy import ProxyManager
 from galaxy.web.stack import application_stack_instance
 from galaxy.queue_worker import GalaxyQueueWorker
-from galaxy.util import heartbeat
+from galaxy.util import (
+    ExecutionTimer,
+    heartbeat
+)
 from tool_shed.galaxy_install import update_repository_manager
 
 
@@ -48,7 +51,7 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
             logging.basicConfig(level=logging.DEBUG)
         log.debug( "python path is: %s", ", ".join( sys.path ) )
         self.name = 'galaxy'
-        self.start_time = time.time()
+        self.startup_timer = ExecutionTimer()
         self.new_installation = False
         self.application_stack = application_stack_instance()
         # Read config file and check for errors
@@ -204,7 +207,7 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
 
         self.model.engine.dispose()
         self.server_starttime = int(time.time())  # used for cachebusting
-        log.info("Server startup took %f seconds" % (time.time() - self.start_time))
+        log.info("Galaxy app startup finished %s" % self.startup_timer)
 
     def shutdown( self ):
         self.workflow_scheduling_manager.shutdown()

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -124,8 +124,6 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
         self.datatypes_registry.load_datatype_converters( self.toolbox )
         # Load external metadata tool
         self.datatypes_registry.load_external_metadata_tool( self.toolbox )
-        # Reset Tool Cache after all tools (regular, tool shed, converters, special ... are loaded)
-        self.tool_cache.reset_status()
         # Load history import/export tools.
         load_lib_tools( self.toolbox )
         # visualizations registry: associates resources with visualizations, controls how to render

--- a/lib/galaxy/auth/__init__.py
+++ b/lib/galaxy/auth/__init__.py
@@ -25,7 +25,7 @@ class AuthManager(object):
 
         authenticators = []
         # process authenticators
-        for auth_elem in conf_root.getchildren():
+        for auth_elem in conf_root:
             type_elem = auth_elem.find('type')
             plugin = self.__plugins_dict.get(type_elem.text)()
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -23,9 +23,9 @@ from six.moves import configparser
 
 from galaxy.containers import parse_containers_config
 from galaxy.exceptions import ConfigurationError
+from galaxy.util import ExecutionTimer
 from galaxy.util import listify
 from galaxy.util import string_as_bool
-from galaxy.util import ExecutionTimer
 from galaxy.util.dbkeys import GenomeBuilds
 from galaxy.web.formatting import expand_pretty_datetime_format
 from galaxy.web.stack import register_postfork_function

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -913,8 +913,7 @@ class ConfiguresGalaxyMixin:
             # and make sure toolbox has finished reloading)
             if self.toolbox.has_reloaded(old_toolbox):
                 break
-
-            time.sleep(1)
+            time.sleep(0.1)
 
     def _configure_toolbox( self ):
         from galaxy import tools
@@ -948,13 +947,16 @@ class ConfiguresGalaxyMixin:
         )
         self.container_finder = containers.ContainerFinder(app_info)
 
-    def reindex_tool_search( self, toolbox=None ):
+    def reindex_tool_search( self ):
         # Call this when tools are added or removed.
         import galaxy.tools.search
         index_help = getattr( self.config, "index_tool_help", True )
-        if not toolbox:
-            toolbox = self.toolbox
-        self.toolbox_search = galaxy.tools.search.ToolBoxSearch( toolbox, index_help )
+        toolbox = self.toolbox
+        if not hasattr(self, 'toolbox_search'):
+            self.toolbox_search = galaxy.tools.search.ToolBoxSearch( toolbox, index_help )
+        else:
+            self.toolbox_search.update_index(tool_cache=self.tool_cache)
+        self.tool_cache.reset_status()
 
     def _configure_tool_data_tables( self, from_shed_config ):
         from galaxy.tools.data import ToolDataTableManager

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -956,7 +956,6 @@ class ConfiguresGalaxyMixin:
             self.toolbox_search = galaxy.tools.search.ToolBoxSearch( toolbox, index_help )
         else:
             self.toolbox_search.update_index(tool_cache=self.tool_cache)
-        self.tool_cache.reset_status()
 
     def _configure_tool_data_tables( self, from_shed_config ):
         from galaxy.tools.data import ToolDataTableManager

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -931,7 +931,6 @@ class ConfiguresGalaxyMixin:
             tool_configs.append( self.config.migrated_tools_config )
         self.toolbox = tools.ToolBox( tool_configs, self.config.tool_path, self )
         self.reindex_tool_search()
-        self.tool_cache.reset_status()
 
         galaxy_root_dir = os.path.abspath(self.config.root)
         file_path = os.path.abspath(getattr(self.config, "file_path"))

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -25,6 +25,7 @@ from galaxy.containers import parse_containers_config
 from galaxy.exceptions import ConfigurationError
 from galaxy.util import listify
 from galaxy.util import string_as_bool
+from galaxy.util import ExecutionTimer
 from galaxy.util.dbkeys import GenomeBuilds
 from galaxy.web.formatting import expand_pretty_datetime_format
 from galaxy.web.stack import register_postfork_function
@@ -908,10 +909,11 @@ class ConfiguresGalaxyMixin:
         self.genome_builds = GenomeBuilds( self, data_table_name=data_table_name, load_old_style=load_old_style )
 
     def wait_for_toolbox_reload(self, old_toolbox):
+        timer = ExecutionTimer()
         while True:
             # Wait till toolbox reload has been triggered
-            # and make sure toolbox has finished reloading)
-            if self.toolbox.has_reloaded(old_toolbox):
+            # (or more than 60 seconds have passed)
+            if self.toolbox.has_reloaded(old_toolbox) or timer.elapsed > 60:
                 break
             time.sleep(0.1)
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -931,6 +931,7 @@ class ConfiguresGalaxyMixin:
             tool_configs.append( self.config.migrated_tools_config )
         self.toolbox = tools.ToolBox( tool_configs, self.config.tool_path, self )
         self.reindex_tool_search()
+        self.tool_cache.reset_status()
 
         galaxy_root_dir = os.path.abspath(self.config.root)
         file_path = os.path.abspath(getattr(self.config, "file_path"))

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -936,7 +936,7 @@ class ConfiguresGalaxyMixin:
         self.toolbox = tools.ToolBox( tool_configs, self.config.tool_path, self )
         # Since indexing the toolbox search index can take a while we
         # send it as a local control task and do not block here.
-        send_local_control_task(self, 'rebuild_toolbox_search_index')
+        register_postfork_function(send_local_control_task, self, 'rebuild_toolbox_search_index')
 
         galaxy_root_dir = os.path.abspath(self.config.root)
         file_path = os.path.abspath(getattr(self.config, "file_path"))

--- a/lib/galaxy/datatypes/dataproviders/hierarchy.py
+++ b/lib/galaxy/datatypes/dataproviders/hierarchy.py
@@ -88,7 +88,7 @@ class XMLDataProvider( HierarchalDataProvider ):
         :param  max_depth:  the number of generations of descendents to return
         """
         if not isinstance( max_depth, int ) or max_depth >= 1:
-            for child in element.getchildren():
+            for child in element:
                 child_data = self.element_as_dict( child )
 
                 next_depth = max_depth - 1 if isinstance( max_depth, int ) else None

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -560,6 +560,8 @@ class Registry( object ):
                         self.datatype_converters[ source_datatype ] = odict()
                     self.datatype_converters[ source_datatype ][ target_datatype ] = converter
                     self.log.debug( "Loaded converter: %s", converter.id )
+                    if converter.id in toolbox.app.tool_cache._new_tool_ids:
+                        self.log.debug( "Loaded converter: %s", converter.id )
             except Exception:
                 if deactivate:
                     self.log.exception( "Error deactivating converter from (%s)" % converter_path )

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -663,6 +663,7 @@ class Registry( object ):
         # We need to be able to add a job to the queue to set metadata. The queue will currently only accept jobs with an associated
         # tool.  We'll load a special tool to be used for Auto-Detecting metadata; this is less than ideal, but effective
         # Properly building a tool without relying on parsing an XML file is near difficult...so we bundle with Galaxy.
+        self.to_xml_file()
         set_meta_tool = toolbox.load_hidden_lib_tool( "galaxy/datatypes/set_metadata_tool.xml" )
         self.set_external_metadata_tool = set_meta_tool
         self.log.debug( "Loaded external metadata tool: %s", self.set_external_metadata_tool.id )
@@ -856,7 +857,6 @@ class Registry( object ):
     def integrated_datatypes_configs( self ):
         if self.xml_filename and os.path.isfile( self.xml_filename ):
             return self.xml_filename
-        self.to_xml_file()
         return self.xml_filename
 
     def to_xml_file( self ):

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -559,8 +559,7 @@ class Registry( object ):
                     if source_datatype not in self.datatype_converters:
                         self.datatype_converters[ source_datatype ] = odict()
                     self.datatype_converters[ source_datatype ][ target_datatype ] = converter
-                    self.log.debug( "Loaded converter: %s", converter.id )
-                    if converter.id in toolbox.app.tool_cache._new_tool_ids:
+                    if not hasattr(toolbox.app, 'tool_cache') or converter.id in toolbox.app.tool_cache._new_tool_ids:
                         self.log.debug( "Loaded converter: %s", converter.id )
             except Exception:
                 if deactivate:

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -10,6 +10,7 @@ import tempfile
 
 import yaml
 from collections import OrderedDict as odict
+from xml.etree.ElementTree import Element
 
 import galaxy.util
 
@@ -98,14 +99,17 @@ class Registry( object ):
             #           proprietary_path="[cloned repository path]"
             #           type="galaxy.datatypes.blast:BlastXml" />
             handling_proprietary_datatypes = False
-            # Parse datatypes_conf.xml
-            tree = galaxy.util.parse_xml( config )
-            root = tree.getroot()
-            # Load datatypes and converters from config
-            if deactivate:
-                self.log.debug( 'Deactivating datatypes from %s' % config )
+            if not isinstance(config, Element):
+                # Parse datatypes_conf.xml
+                tree = galaxy.util.parse_xml( config )
+                root = tree.getroot()
+                # Load datatypes and converters from config
+                if deactivate:
+                    self.log.debug('Deactivating datatypes from %s' % config)
+                else:
+                    self.log.debug('Loading datatypes from %s' % config)
             else:
-                self.log.debug( 'Loading datatypes from %s' % config )
+                root = config
             registration = root.find( 'registration' )
             # Set default paths defined in local datatypes_conf.xml.
             if not self.converters_path:

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -9,6 +9,7 @@ import logging
 import tempfile
 
 import yaml
+from collections import OrderedDict as odict
 
 import galaxy.util
 
@@ -23,7 +24,6 @@ from . import coverage
 from . import tracks
 from . import binary
 from . import text
-from galaxy.util.odict import odict
 from .display_applications.application import DisplayApplication
 
 
@@ -301,15 +301,11 @@ class Registry( object ):
             self.upload_file_formats.sort()
             # Load build sites
             self._load_build_sites( root )
-            # Persist the xml form of the registry into a temporary file so that it can be loaded from the command line by tools and
-            # set_metadata processing.
-            self.to_xml_file()
         self.set_default_values()
 
         def append_to_sniff_order():
             # Just in case any supported data types are not included in the config's sniff_order section.
-            for ext in self.datatypes_by_extension:
-                datatype = self.datatypes_by_extension[ ext ]
+            for ext, datatype in self.datatypes_by_extension.items():
                 included = False
                 for atype in self.sniff_order:
                     if isinstance( atype, datatype.__class__ ):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -120,6 +120,7 @@ def _get_new_toolbox(app):
 
 
 def reload_data_managers(app, **kwargs):
+    start = time.time()
     from galaxy.tools.data_manager.manager import DataManagers
     from galaxy.tools.toolbox.lineages.tool_shed import ToolVersionCache
     log.debug("Executing data managers reload on '%s'", app.config.server_name)
@@ -129,6 +130,8 @@ def reload_data_managers(app, **kwargs):
     app.data_managers = DataManagers(app)
     app.data_managers._reload_count = reload_count + 1
     app.tool_version_cache = ToolVersionCache(app)
+    end = time.time() - start
+    log.debug("Data Manager reload took %f seconds", end)
 
 
 def reload_display_application(app, **kwargs):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -114,9 +114,7 @@ def _get_new_toolbox(app):
     new_toolbox.load_hidden_lib_tool( "galaxy/datatypes/set_metadata_tool.xml" )
     [new_toolbox.register_tool(tool) for tool in new_toolbox.data_manager_tools.values()]
     app.toolbox = new_toolbox
-    app.reindex_tool_search()
-    if hasattr(app, 'tool_cache'):
-        app.tool_cache.reset_status()
+    send_local_control_task(app, 'rebuild_toolbox_search_index')
 
 
 def reload_data_managers(app, **kwargs):
@@ -166,6 +164,10 @@ def reload_tool_data_tables(app, **kwargs):
     log.debug("Finished data table reload for %s" % table_names)
 
 
+def rebuild_toolbox_search_index(app, **kwargs):
+    app.reindex_tool_search()
+
+
 def admin_job_lock(app, **kwargs):
     job_lock = kwargs.get('job_lock', False)
     # job_queue is exposed in the root app, but this will be 'fixed' at some
@@ -183,7 +185,8 @@ control_message_to_task = { 'create_panel_section': create_panel_section,
                             'reload_tool_data_tables': reload_tool_data_tables,
                             'admin_job_lock': admin_job_lock,
                             'reload_sanitize_whitelist': reload_sanitize_whitelist,
-                            'recalculate_user_disk_usage': recalculate_user_disk_usage}
+                            'recalculate_user_disk_usage': recalculate_user_disk_usage,
+                            'rebuild_toolbox_search_index': rebuild_toolbox_search_index}
 
 
 class GalaxyQueueWorker(ConsumerMixin, threading.Thread):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -110,8 +110,8 @@ def _get_new_toolbox(app):
     new_toolbox = tools.ToolBox(tool_configs, app.config.tool_path, app)
     new_toolbox.data_manager_tools = app.toolbox.data_manager_tools
     app.datatypes_registry.load_datatype_converters(new_toolbox, use_cached=True)
+    app.datatypes_registry.load_external_metadata_tool(new_toolbox)
     load_lib_tools(new_toolbox)
-    new_toolbox.load_hidden_lib_tool( "galaxy/datatypes/set_metadata_tool.xml" )
     [new_toolbox.register_tool(tool) for tool in new_toolbox.data_manager_tools.values()]
     app.toolbox = new_toolbox
     send_local_control_task(app, 'rebuild_toolbox_search_index')

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -115,7 +115,7 @@ def _get_new_toolbox(app):
     load_lib_tools(new_toolbox)
     new_toolbox.load_hidden_lib_tool( "galaxy/datatypes/set_metadata_tool.xml" )
     [new_toolbox.register_tool(tool) for tool in new_toolbox.data_manager_tools.values()]
-    app.reindex_tool_search(new_toolbox)
+    app.reindex_tool_search()
     return new_toolbox
 
 

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -85,15 +85,14 @@ def reload_tool(app, **kwargs):
 
 
 def reload_toolbox(app, **kwargs):
-    start = time.time()
+    reload_timer = util.ExecutionTimer()
     log.debug("Executing toolbox reload on '%s'", app.config.server_name)
     reload_count = app.toolbox._reload_count
     if app.tool_cache:
         app.tool_cache.cleanup()
     _get_new_toolbox(app)
     app.toolbox._reload_count = reload_count + 1
-    end = time.time() - start
-    log.debug("Toolbox reload took %f seconds", end)
+    log.debug("Toolbox reload %s", reload_timer)
 
 
 def _get_new_toolbox(app):
@@ -122,7 +121,7 @@ def _get_new_toolbox(app):
 
 
 def reload_data_managers(app, **kwargs):
-    start = time.time()
+    reload_timer = util.ExecutionTimer()
     from galaxy.tools.data_manager.manager import DataManagers
     from galaxy.tools.toolbox.lineages.tool_shed import ToolVersionCache
     log.debug("Executing data managers reload on '%s'", app.config.server_name)
@@ -133,8 +132,7 @@ def reload_data_managers(app, **kwargs):
     app.data_managers._reload_count = reload_count + 1
     app.tool_version_cache = ToolVersionCache(app)
     app.tool_cache.reset_status()
-    end = time.time() - start
-    log.debug("Data Manager reload took %f seconds", end)
+    log.debug("Data managers reloaded %s", reload_timer)
 
 
 def reload_display_application(app, **kwargs):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -90,7 +90,7 @@ def reload_toolbox(app, **kwargs):
     reload_count = app.toolbox._reload_count
     if app.tool_cache:
         app.tool_cache.cleanup()
-    app.toolbox = _get_new_toolbox(app)
+    _get_new_toolbox(app)
     app.toolbox._reload_count = reload_count + 1
     end = time.time() - start
     log.debug("Toolbox reload took %f seconds", end)
@@ -115,6 +115,7 @@ def _get_new_toolbox(app):
     load_lib_tools(new_toolbox)
     new_toolbox.load_hidden_lib_tool( "galaxy/datatypes/set_metadata_tool.xml" )
     [new_toolbox.register_tool(tool) for tool in new_toolbox.data_manager_tools.values()]
+    app.toolbox = new_toolbox
     app.reindex_tool_search()
     app.tool_cache.reset_status()
     return new_toolbox

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -5,7 +5,6 @@ reloading the toolbox, etc., across multiple processes.
 
 import logging
 import threading
-import time
 
 import galaxy.queues
 from galaxy import util

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -116,6 +116,7 @@ def _get_new_toolbox(app):
     new_toolbox.load_hidden_lib_tool( "galaxy/datatypes/set_metadata_tool.xml" )
     [new_toolbox.register_tool(tool) for tool in new_toolbox.data_manager_tools.values()]
     app.reindex_tool_search()
+    app.tool_cache.reset_status()
     return new_toolbox
 
 
@@ -130,6 +131,7 @@ def reload_data_managers(app, **kwargs):
     app.data_managers = DataManagers(app)
     app.data_managers._reload_count = reload_count + 1
     app.tool_version_cache = ToolVersionCache(app)
+    app.tool_cache.reset_status()
     end = time.time() - start
     log.debug("Data Manager reload took %f seconds", end)
 

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -87,7 +87,7 @@ def reload_toolbox(app, **kwargs):
     reload_timer = util.ExecutionTimer()
     log.debug("Executing toolbox reload on '%s'", app.config.server_name)
     reload_count = app.toolbox._reload_count
-    if app.tool_cache:
+    if hasattr(app, 'tool_cache'):
         app.tool_cache.cleanup()
     _get_new_toolbox(app)
     app.toolbox._reload_count = reload_count + 1
@@ -115,7 +115,8 @@ def _get_new_toolbox(app):
     [new_toolbox.register_tool(tool) for tool in new_toolbox.data_manager_tools.values()]
     app.toolbox = new_toolbox
     app.reindex_tool_search()
-    app.tool_cache.reset_status()
+    if hasattr(app, 'tool_cache'):
+        app.tool_cache.reset_status()
 
 
 def reload_data_managers(app, **kwargs):
@@ -129,7 +130,8 @@ def reload_data_managers(app, **kwargs):
     app.data_managers = DataManagers(app)
     app.data_managers._reload_count = reload_count + 1
     app.tool_version_cache = ToolVersionCache(app)
-    app.tool_cache.reset_status()
+    if hasattr(app, 'tool_cache'):
+        app.tool_cache.reset_status()
     log.debug("Data managers reloaded %s", reload_timer)
 
 

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -117,7 +117,6 @@ def _get_new_toolbox(app):
     app.toolbox = new_toolbox
     app.reindex_tool_search()
     app.tool_cache.reset_status()
-    return new_toolbox
 
 
 def reload_data_managers(app, **kwargs):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -190,7 +190,7 @@ class ToolBox( BaseGalaxyToolBox ):
     how to construct them, action types, dependency management, etc....
     """
 
-    def __init__( self, config_filenames, tool_root_dir, app, tool_conf_watcher=None ):
+    def __init__( self, config_filenames, tool_root_dir, app ):
         self._reload_count = 0
         self.tool_location_fetcher = ToolLocationFetcher()
         super( ToolBox, self ).__init__(
@@ -443,9 +443,7 @@ class Tool( object, Dictifiable ):
     @property
     def tool_version( self ):
         """Return a ToolVersion if one exists for our id"""
-        return self.app.install_model.context.query( self.app.install_model.ToolVersion ) \
-                                             .filter( self.app.install_model.ToolVersion.table.c.tool_id == self.id ) \
-                                             .first()
+        return self.app.tool_version_cache.tool_version_by_tool_id.get(self.id)
 
     @property
     def tool_versions( self ):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1068,13 +1068,14 @@ class Tool( object, Dictifiable ):
     def populate_tool_shed_info( self ):
         if self.repository_id is not None and self.app.name == 'galaxy':
             repository_id = self.app.security.decode_id( self.repository_id )
-            tool_shed_repository = self.app.install_model.context.query( self.app.install_model.ToolShedRepository ).get( repository_id )
-            if tool_shed_repository:
-                self.tool_shed = tool_shed_repository.tool_shed
-                self.repository_name = tool_shed_repository.name
-                self.repository_owner = tool_shed_repository.owner
-                self.changeset_revision = tool_shed_repository.changeset_revision
-                self.installed_changeset_revision = tool_shed_repository.installed_changeset_revision
+            if hasattr(self.app, 'tool_shed_repository_cache'):
+                tool_shed_repository = self.app.tool_shed_repository_cache.get_installed_repository( repository_id=repository_id )
+                if tool_shed_repository:
+                    self.tool_shed = tool_shed_repository.tool_shed
+                    self.repository_name = tool_shed_repository.name
+                    self.repository_owner = tool_shed_repository.owner
+                    self.changeset_revision = tool_shed_repository.changeset_revision
+                    self.installed_changeset_revision = tool_shed_repository.installed_changeset_revision
 
     @property
     def help(self):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -34,7 +34,6 @@ from galaxy.tools.actions import DefaultToolAction
 from galaxy.tools.actions.data_manager import DataManagerToolAction
 from galaxy.tools.actions.data_source import DataSourceToolAction
 from galaxy.tools.actions.model_operations import ModelOperationToolAction
-from galaxy.tools.actions.upload import UploadToolAction
 from galaxy.tools.deps import (
     CachedDependencyManager,
     views
@@ -248,13 +247,6 @@ class ToolBox( BaseGalaxyToolBox ):
             ToolClass = Tool
         tool = ToolClass( config_file, tool_source, self.app, guid=guid, repository_id=repository_id, **kwds )
         return tool
-
-    def handle_datatypes_changed( self ):
-        """ Refresh upload tools when new datatypes are added. """
-        for tool_id in self._tools_by_id:
-            tool = self._tools_by_id[ tool_id ]
-            if isinstance( tool.tool_action, UploadToolAction ):
-                self.reload_tool_by_id( tool_id )
 
     def get_tool_components( self, tool_id, tool_version=None, get_loaded_tools_by_lineage=False, set_selected=False ):
         """

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -38,7 +38,7 @@ class ToolDataPathFiles(object):
         if time.time() - self.update_time > 1:
             content = os.walk(self.tool_data_path)
             try:
-                self._tool_data_path_files = set([os.path.join(dirpath, fn) for dirpath, _, fn_list in content for fn in fn_list if fn and fn.endswith('.loc') or fn.endswith('.loc.sample')])
+                self._tool_data_path_files = set(os.path.join(dirpath, fn) for dirpath, _, fn_list in content for fn in fn_list if fn and fn.endswith('.loc') or fn.endswith('.loc.sample'))
             except Exception:
                 self._tool_data_path_files = []
             self.update_time = time.time()

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -12,9 +12,9 @@ import os
 import os.path
 import re
 import string
+import time
 from glob import glob
 from tempfile import NamedTemporaryFile
-import time
 
 from six.moves.urllib.request import urlopen
 

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -48,8 +48,8 @@ class ToolDataPathFiles(object):
         path = os.path.abspath(path)
         if path in self.tool_data_path_files:
             return True
-        else:
-            return False
+        elif self.tool_data_path not in path:
+            return os.path.exists(path)
 
 
 class ToolDataTableManager( object ):

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -14,6 +14,7 @@ import re
 import string
 from glob import glob
 from tempfile import NamedTemporaryFile
+import time
 
 from six.moves.urllib.request import urlopen
 
@@ -26,6 +27,31 @@ log = logging.getLogger( __name__ )
 DEFAULT_TABLE_TYPE = 'tabular'
 
 
+class ToolDataPathFiles(object):
+
+    def __init__(self, tool_data_path):
+        self.tool_data_path = tool_data_path
+        self.update_time = 0
+
+    @property
+    def tool_data_path_files(self):
+        if time.time() - self.update_time > 1:
+            content = os.walk(self.tool_data_path)
+            try:
+                self._tool_data_path_files = set([os.path.join(dirpath, fn) for dirpath, _, fn_list in content for fn in fn_list if fn and fn.endswith('.loc') or fn.endswith('.loc.sample')])
+            except Exception:
+                self._tool_data_path_files = []
+            self.update_time = time.time()
+        return self._tool_data_path_files
+
+    def exists(self, path):
+        path = os.path.abspath(path)
+        if path in self.tool_data_path_files:
+            return True
+        else:
+            return False
+
+
 class ToolDataTableManager( object ):
     """Manages a collection of tool data tables"""
 
@@ -35,6 +61,7 @@ class ToolDataTableManager( object ):
         # at server startup. If tool shed repositories are installed that contain a valid file named tool_data_table_conf.xml.sample, entries
         # from that file are inserted into this dict at the time of installation.
         self.data_tables = {}
+        self.tool_data_path_files = ToolDataPathFiles(self.tool_data_path)
         for single_config_filename in util.listify( config_filename ):
             if not single_config_filename:
                 continue
@@ -61,7 +88,7 @@ class ToolDataTableManager( object ):
     def get_tables( self ):
         return self.data_tables
 
-    def load_from_config_file( self, config_filename, tool_data_path, from_shed_config=False ):
+    def load_from_config_file( self, config_filename, tool_data_path, from_shed_config=False):
         """
         This method is called under 3 conditions:
 
@@ -78,7 +105,7 @@ class ToolDataTableManager( object ):
             tree = util.parse_xml( filename )
             root = tree.getroot()
             for table_elem in root.findall( 'table' ):
-                table = ToolDataTable.from_elem( table_elem, tool_data_path, from_shed_config, filename=filename )
+                table = ToolDataTable.from_elem( table_elem, tool_data_path, from_shed_config, filename=filename, tool_data_path_files=self.tool_data_path_files )
                 table_elems.append( table_elem )
                 if table.name not in self.data_tables:
                     self.data_tables[ table.name ] = table
@@ -188,12 +215,12 @@ class ToolDataTableManager( object ):
 class ToolDataTable( object ):
 
     @classmethod
-    def from_elem( cls, table_elem, tool_data_path, from_shed_config, filename ):
+    def from_elem( cls, table_elem, tool_data_path, from_shed_config, filename, tool_data_path_files ):
         table_type = table_elem.get( 'type', 'tabular' )
         assert table_type in tool_data_table_types, "Unknown data table type '%s'" % type
-        return tool_data_table_types[ table_type ]( table_elem, tool_data_path, from_shed_config=from_shed_config, filename=filename )
+        return tool_data_table_types[ table_type ]( table_elem, tool_data_path, from_shed_config=from_shed_config, filename=filename, tool_data_path_files=tool_data_path_files )
 
-    def __init__( self, config_element, tool_data_path, from_shed_config=False, filename=None ):
+    def __init__( self, config_element, tool_data_path, from_shed_config=False, filename=None, tool_data_path_files=None ):
         self.name = config_element.get( 'name' )
         self.comment_char = config_element.get( 'comment_char' )
         self.empty_field_value = config_element.get( 'empty_field_value', '' )
@@ -202,11 +229,12 @@ class ToolDataTable( object ):
         self.here = filename and os.path.dirname(filename)
         self.filenames = odict()
         self.tool_data_path = tool_data_path
+        self.tool_data_path_files = tool_data_path_files
         self.missing_index_file = None
         # increment this variable any time a new entry is added, or when the table is totally reloaded
         # This value has no external meaning, and does not represent an abstract version of the underlying data
         self._loaded_content_version = 1
-        self._load_info = ( [ config_element, tool_data_path ], { 'from_shed_config': from_shed_config } )
+        self._load_info = ( [ config_element, tool_data_path ], { 'from_shed_config': from_shed_config, 'tool_data_path_files': self.tool_data_path_files } )
         self._merged_load_info = []
 
     def _update_version( self, version=None ):
@@ -271,11 +299,11 @@ class TabularToolDataTable( ToolDataTable, Dictifiable ):
 
     type_key = 'tabular'
 
-    def __init__( self, config_element, tool_data_path, from_shed_config=False, filename=None ):
-        super( TabularToolDataTable, self ).__init__( config_element, tool_data_path, from_shed_config, filename)
+    def __init__( self, config_element, tool_data_path, from_shed_config=False, filename=None, tool_data_path_files=None ):
+        super( TabularToolDataTable, self ).__init__( config_element, tool_data_path, from_shed_config, filename, tool_data_path_files)
         self.config_element = config_element
         self.data = []
-        self.configure_and_load( config_element, tool_data_path, from_shed_config)
+        self.configure_and_load( config_element, tool_data_path, from_shed_config, self.tool_data_path_files)
 
     def configure_and_load( self, config_element, tool_data_path, from_shed_config=False, url_timeout=10 ):
         """
@@ -329,9 +357,9 @@ class TabularToolDataTable( ToolDataTable, Dictifiable ):
                 # directory which is hard-coded into the tool_data_table_conf.xml entries.
                 filename = os.path.split( file_path )[ 1 ]
                 filename = os.path.join( tool_data_path, filename )
-            if os.path.exists( filename ):
+            if self.tool_data_path_files.exists( filename ):
                 found = True
-            elif os.path.exists( "%s.sample" % filename ) and not from_shed_config:
+            elif self.tool_data_path_files.exists( "%s.sample" % filename ) and not from_shed_config:
                 log.info("Could not find tool data %s, reading sample" % filename)
                 filename = "%s.sample" % filename
                 found = True
@@ -343,7 +371,7 @@ class TabularToolDataTable( ToolDataTable, Dictifiable ):
                 file_path, file_name = os.path.split( filename )
                 if file_path and file_path != self.tool_data_path:
                     corrected_filename = os.path.join( self.tool_data_path, file_name )
-                    if os.path.exists( corrected_filename ):
+                    if self.tool_data_path_files.exists( corrected_filename ):
                         filename = corrected_filename
                         found = True
 

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -37,9 +37,9 @@ class DataManagers( object ):
                 continue
             self.load_from_xml( filename )
         if self.app.config.shed_data_manager_config_file:
-            self.load_from_xml( self.app.config.shed_data_manager_config_file, store_tool_path=True, replace_existing=True )
+            self.load_from_xml( self.app.config.shed_data_manager_config_file, store_tool_path=True )
 
-    def load_from_xml( self, xml_filename, store_tool_path=True, replace_existing=False ):
+    def load_from_xml( self, xml_filename, store_tool_path=True ):
         try:
             tree = util.parse_xml( xml_filename )
         except Exception as e:
@@ -57,26 +57,22 @@ class DataManagers( object ):
                 tool_path = '.'
             self.tool_path = tool_path
         for data_manager_elem in root.findall( 'data_manager' ):
-            self.load_manager_from_elem( data_manager_elem, tool_path=self.tool_path, replace_existing=replace_existing )
+            self.load_manager_from_elem( data_manager_elem, tool_path=self.tool_path )
 
-    def load_manager_from_elem( self, data_manager_elem, tool_path=None, add_manager=True, replace_existing=False ):
+    def load_manager_from_elem( self, data_manager_elem, tool_path=None, add_manager=True ):
         try:
             data_manager = DataManager( self, data_manager_elem, tool_path=tool_path )
         except Exception as e:
             log.error( "Error loading data_manager '%s':\n%s" % ( e, util.xml_to_string( data_manager_elem ) ) )
             return None
         if add_manager:
-            self.add_manager( data_manager, replace_existing=replace_existing )
+            self.add_manager( data_manager )
         log.debug( 'Loaded Data Manager: %s' % ( data_manager.id ) )
         return data_manager
 
-    def add_manager( self, data_manager, replace_existing=False ):
-        if not replace_existing:
-            assert data_manager.id not in self.data_managers, "A data manager has been defined twice: %s" % ( data_manager.id )
-        elif data_manager.id in self.data_managers:
-            # Data Manager already exists, remove first one and replace with new one
-            log.warning( "A data manager has been defined twice and will be replaced with the last loaded version: %s" % ( data_manager.id ) )
-            self.remove_manager( data_manager.id  )
+    def add_manager( self, data_manager ):
+        if data_manager.id in self.data_managers:
+            log.warning( "A data manager has been defined twice: %s " % ( data_manager.id ) )
         self.data_managers[ data_manager.id ] = data_manager
         for data_table_name in data_manager.data_tables.keys():
             if data_table_name not in self.managed_data_tables:

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -139,7 +139,7 @@ class DataManager( object ):
             path = tool_elem.get( "file", None )
             tool_guid = tool_elem.get( "guid", None )
             # need to determine repository info so that dependencies will work correctly
-            if tool_guid in self.data_managers.app.tool_cache._tool_paths_by_id:
+            if hasattr(self.data_managers.app, 'tool_cache') and tool_guid in self.data_managers.app.tool_cache._tool_paths_by_id:
                 path = self.data_managers.app.tool_cache._tool_paths_by_id[tool_guid]
                 tool = self.data_managers.app.tool_cache.get_tool(path)
                 tool_shed_repository = tool.tool_shed_repository

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -594,7 +594,7 @@ def __parse_param_elem( param_elem, i=0 ):
     else:
         value = None
     attrib['children'] = param_elem
-    if attrib['children']:
+    if attrib['children'] is not None:
         # At this time, we can assume having children only
         # occurs on DataToolParameter test items but this could
         # change and would cause the below parsing to change

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -496,9 +496,8 @@ def __parse_assert_list_from_elem( assert_elem ):
         """ Converts and XML element to a dictionary format, used by assertion checking code. """
         tag = elem.tag
         attributes = dict( elem.attrib )
-        child_elems = list( elem.getchildren() )
         converted_children = []
-        for child_elem in child_elems:
+        for child_elem in elem:
             converted_children.append( convert_elem(child_elem) )
         return {"tag": tag, "attributes": attributes, "children": converted_children}
     if assert_elem is not None:
@@ -594,7 +593,7 @@ def __parse_param_elem( param_elem, i=0 ):
         value = attrib['value']
     else:
         value = None
-    attrib['children'] = list( param_elem.getchildren() )
+    attrib['children'] = param_elem
     if attrib['children']:
         # At this time, we can assume having children only
         # occurs on DataToolParameter test items but this could

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -104,8 +104,9 @@ class ToolBoxSearch( object ):
             writer.delete_by_term('id', tool_id)
         for tool_id in tool_cache._new_tool_ids:
             tool = tool_cache.get_tool_by_id(tool_id)
-            add_doc_kwds = self._create_doc(tool_id=tool_id, tool=tool, index_help=index_help)
-            writer.add_document(**add_doc_kwds)
+            if tool:
+                add_doc_kwds = self._create_doc(tool_id=tool_id, tool=tool, index_help=index_help)
+                writer.add_document(**add_doc_kwds)
         writer.commit()
 
     def search( self, q, tool_name_boost, tool_section_boost, tool_description_boost, tool_label_boost, tool_stub_boost, tool_help_boost, tool_search_limit, tool_enable_ngram_search, tool_ngram_minsize, tool_ngram_maxsize ):

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -47,6 +47,11 @@ class ToolBoxSearch( object ):
         self.rex = analysis.RegexTokenizer()
         self.toolbox = toolbox
         self.storage, self.index = self._index_setup()
+        # We keep track of how many times the tool index has been rebuilt.
+        # We start at -1, so that after the first index the count is at 0,
+        # which is the same is the toolbox reload count. This way we can skip
+        # reindexing if the index count is equal to the toolbox reload count.
+        self.index_count = -1
 
     def _index_setup(self):
         RamStorage.temp_storage = _temp_storage
@@ -61,6 +66,7 @@ class ToolBoxSearch( object ):
         Use `tool_cache` to determine which tools need indexing and which tools should be expired.
         """
         log.debug('Starting to build toolbox index.')
+        self.index_count += 1
         execution_timer = ExecutionTimer()
         writer = self.index.writer()
         for tool_id in tool_cache._removed_tool_ids:

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -14,6 +14,7 @@ from galaxy.exceptions import MessageException, ObjectNotFound
 from galaxy.tools.deps import build_dependency_manager
 from galaxy.tools.loader_directory import looks_like_a_tool
 from galaxy.util import (
+    ExecutionTimer,
     listify,
     parse_xml,
     string_as_bool
@@ -97,7 +98,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
         """ Read through all tool config files and initialize tools in each
         with init_tools_from_config below.
         """
-        start = time.time()
+        execution_timer = ExecutionTimer()
         self._tool_tag_manager.reset_tags()
         config_filenames = listify( config_filenames )
         for config_filename in config_filenames:
@@ -120,7 +121,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
                     raise
             except Exception:
                 log.exception( "Error loading tools defined in config %s", config_filename )
-        log.debug("Reading tools from config files took %f seconds", time.time() - start)
+        log.debug("Reading tools from config files finshed %s", execution_timer)
 
     def _init_tools_from_config( self, config_filename ):
         """
@@ -323,7 +324,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
             log.debug(log_msg)
 
     def _load_tool_panel( self ):
-        start = time.time()
+        execution_timer = ExecutionTimer()
         for key, item_type, val in self._integrated_tool_panel.panel_items_iter():
             if item_type == panel_item_types.TOOL:
                 tool_id = key.replace( 'tool_', '', 1 )
@@ -363,7 +364,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
                             section.elems[ section_key ] = section_val
                             log.debug( "Loaded label: %s" % ( section_val.text ) )
                 self._tool_panel[ key ] = section
-        log.debug("loading tool panel took %d seconds", time.time() - start)
+        log.debug("Loading tool panel finished %s", execution_timer)
 
     def _load_integrated_tool_panel_keys( self ):
         """

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -319,9 +319,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
                             # If the tool is not defined in integrated_tool_panel.xml, append it to the tool panel.
                             panel_dict.append_tool(tool)
                             log_msg = "Loaded tool id: %s, version: %s into tool panel...." % (tool.id, tool.version)
-        if not hasattr(self.app, 'tool_cache'):
-            log.debug(log_msg)
-        elif tool_id in self.app.tool_cache._new_tool_ids:
+        if tool_id in self.app.tool_cache._new_tool_ids:
             log.debug(log_msg)
 
     def _load_tool_panel( self ):

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -319,7 +319,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
                             # If the tool is not defined in integrated_tool_panel.xml, append it to the tool panel.
                             panel_dict.append_tool(tool)
                             log_msg = "Loaded tool id: %s, version: %s into tool panel...." % (tool.id, tool.version)
-        if tool_id in self.app.tool_cache._new_tool_ids:
+        if not hasattr(self.app, 'tool_cache') or tool_id in self.app.tool_cache._new_tool_ids:
             log.debug(log_msg)
 
     def _load_tool_panel( self ):

--- a/lib/galaxy/tools/toolbox/cache.py
+++ b/lib/galaxy/tools/toolbox/cache.py
@@ -101,9 +101,13 @@ class ToolShedRepositoryCache(object):
 
     @property
     def tool_shed_repositories(self):
-        if time.time() - self.time > 1 or not hasattr(self.cache, 'repositories '):  # If cache is older than 1 second we refresh
+        if time.time() - self.time > 1:  # If cache is older than 1 second we refresh
             self.rebuild()
-        return self.cache.repositories
+        try:
+            return self.cache.repositories
+        except AttributeError:
+            self.rebuild()
+            return self.cache.repositories
 
     def rebuild(self):
         self.cache.repositories = self.app.install_model.context.current.query(self.app.install_model.ToolShedRepository).all()

--- a/lib/galaxy/tools/toolbox/cache.py
+++ b/lib/galaxy/tools/toolbox/cache.py
@@ -104,10 +104,14 @@ class ToolShedRepositoryCache(object):
         if time.time() - self.time > 1:  # If cache is older than 1 second we refresh
             self.rebuild()
         try:
-            return self.cache.repositories
+            repositories =  self.cache.repositories
         except AttributeError:
             self.rebuild()
-            return self.cache.repositories
+            repositories = self.cache.repositories
+        if repositories and not repositories[0]._sa_instance_state._attached:
+            self.rebuild()
+            repositories = self.cache.repositories
+        return repositories
 
     def rebuild(self):
         self.cache.repositories = self.app.install_model.context.current.query(self.app.install_model.ToolShedRepository).all()

--- a/lib/galaxy/tools/toolbox/cache.py
+++ b/lib/galaxy/tools/toolbox/cache.py
@@ -101,12 +101,12 @@ class ToolShedRepositoryCache(object):
 
     @property
     def tool_shed_repositories(self):
-        if time.time() - self.time > 1 or not hasattr(self.cache, 'repositories'):  # If cache is older than 1 second we refresh
+        if time.time() - self.time > 1 or not hasattr(self.cache, 'repositories '):  # If cache is older than 1 second we refresh
             self.rebuild()
         return self.cache.repositories
 
     def rebuild(self):
-        self.cache.repositories = self.app.install_model.context.query(self.app.install_model.ToolShedRepository).all()
+        self.cache.repositories = self.app.install_model.context.current.query(self.app.install_model.ToolShedRepository).all()
         self.time = time.time()
 
     def get_installed_repository(self, tool_shed=None, name=None, owner=None, installed_changeset_revision=None, changeset_revision=None, repository_id=None):

--- a/lib/galaxy/tools/toolbox/cache.py
+++ b/lib/galaxy/tools/toolbox/cache.py
@@ -95,10 +95,12 @@ class ToolShedRepositoryCache(object):
     @property
     def tool_shed_repositories(self):
         if time.time() - self.time > 1:  # If cache is older than 1 second we refresh
-            repositories = self.app.install_model.context.query(self.app.install_model.ToolShedRepository).all()
-            self._tool_shed_repositories = repositories
-            self.time = time.time()
+            self.rebuild()
         return self._tool_shed_repositories
+
+    def rebuild(self):
+        self._tool_shed_repositories = self.app.install_model.context.query(self.app.install_model.ToolShedRepository).all()
+        self.time = time.time()
 
     def get_installed_repository(self, tool_shed, name, owner, installed_changeset_revision=None, changeset_revision=None):
         repos = [repo for repo in self.tool_shed_repositories if repo.tool_shed == tool_shed and repo.owner == owner and repo.name == name]

--- a/lib/galaxy/tools/toolbox/cache.py
+++ b/lib/galaxy/tools/toolbox/cache.py
@@ -107,7 +107,13 @@ class ToolShedRepositoryCache(object):
         self._tool_shed_repositories = self.app.install_model.context.query(self.app.install_model.ToolShedRepository).all()
         self.time = time.time()
 
-    def get_installed_repository(self, tool_shed, name, owner, installed_changeset_revision=None, changeset_revision=None):
+    def get_installed_repository(self, tool_shed=None, name=None, owner=None, installed_changeset_revision=None, changeset_revision=None, repository_id=None):
+        if repository_id:
+            repos = [repo for repo in self.tool_shed_repositories if repo.id == repository_id]
+            if repos:
+                return repos[0]
+            else:
+                return None
         repos = [repo for repo in self.tool_shed_repositories if repo.tool_shed == tool_shed and repo.owner == owner and repo.name == name]
         if installed_changeset_revision:
             repos = [repo for repo in repos if repo.installed_changeset_revision == installed_changeset_revision]

--- a/lib/galaxy/tools/toolbox/lineages/tool_shed.py
+++ b/lib/galaxy/tools/toolbox/lineages/tool_shed.py
@@ -61,6 +61,7 @@ class ToolShedLineage(ToolLineage):
             tool_version = ToolVersion( tool_id=tool.id, tool_shed_repository=tool.tool_shed_repository )
             app.install_model.context.add( tool_version )
             app.install_model.context.flush()
+            app.tool_version_cache = ToolVersionCache(app)
         return ToolShedLineage( app, tool.tool_version )
 
     @staticmethod

--- a/lib/galaxy/tools/toolbox/parser.py
+++ b/lib/galaxy/tools/toolbox/parser.py
@@ -44,7 +44,7 @@ class XmlToolConfSource(ToolConfSource):
         return self.root.get('tool_path')
 
     def parse_items(self):
-        return [ensure_tool_conf_item(_) for _ in self.root.getchildren()]
+        return [ensure_tool_conf_item(_) for _ in self.root]
 
     def is_shed_tool_conf(self):
         has_tool_path = self.parse_tool_path() is not None
@@ -140,7 +140,7 @@ def ensure_tool_conf_item(xml_or_item):
         if type != "section":
             return ToolConfItem(type, attributes, elem)
         else:
-            items = [ensure_tool_conf_item(_) for _ in elem.getchildren()]
+            items = [ensure_tool_conf_item(_) for _ in elem]
             return ToolConfSection(attributes, items, elem=elem)
 
 

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -215,7 +215,7 @@ def parse_xml( fname ):
     except ParseError:
         log.exception("Error parsing file %s", fname)
         raise
-    ElementInclude.include( root )
+    ElementInclude.include(root)
     return tree
 
 

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -31,8 +31,8 @@ from datetime import datetime
 from hashlib import md5
 from os.path import normpath, relpath
 from xml.etree import (
+    cElementTree,
     ElementInclude,
-    cElementTree as ElementTree
 )
 from xml.etree.ElementTree import ParseError
 
@@ -208,9 +208,9 @@ def unique_id(KEY_SIZE=128):
 
 def parse_xml( fname ):
     """Returns a parsed xml tree"""
-    tree = ElementTree.ElementTree()
+    tree = cElementTree.ElementTree()
     try:
-        root = tree.parse( fname, parser=ElementTree.XMLParser( ) )
+        root = tree.parse( fname, parser=cElementTree.XMLParser( ) )
     except ParseError:
         log.exception("Error parsing file %s", fname)
         raise
@@ -219,7 +219,7 @@ def parse_xml( fname ):
 
 
 def parse_xml_string(xml_string):
-    tree = ElementTree.fromstring(xml_string)
+    tree = cElementTree.fromstring(xml_string)
     return tree
 
 
@@ -228,7 +228,7 @@ def xml_to_string( elem, pretty=False ):
     if pretty:
         elem = pretty_print_xml( elem )
     try:
-        return ElementTree.tostring( elem )
+        return cElementTree.tostring( elem )
     except TypeError as e:
         # we assume this is a comment
         if hasattr( elem, 'text' ):

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1523,8 +1523,11 @@ class ExecutionTimer(object):
         self.begin = time.time()
 
     def __str__(self):
-        elapsed = (time.time() - self.begin) * 1000.0
-        return "(%0.3f ms)" % elapsed
+        return "(%0.3f ms)" % (self.elapsed * 1000)
+
+    @property
+    def elapsed(self):
+        return (time.time() - self.begin)
 
 
 if __name__ == '__main__':

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -31,8 +31,8 @@ from datetime import datetime
 from hashlib import md5
 from os.path import normpath, relpath
 from xml.etree import (
-    cElementTree,
     ElementInclude,
+    cElementTree as ElementTree
 )
 from xml.etree.ElementTree import ParseError
 
@@ -208,9 +208,9 @@ def unique_id(KEY_SIZE=128):
 
 def parse_xml( fname ):
     """Returns a parsed xml tree"""
-    tree = cElementTree.ElementTree()
+    tree = ElementTree.ElementTree()
     try:
-        root = tree.parse( fname, parser=cElementTree.XMLParser( ) )
+        root = tree.parse( fname, parser=ElementTree.XMLParser( ) )
     except ParseError:
         log.exception("Error parsing file %s", fname)
         raise
@@ -219,7 +219,7 @@ def parse_xml( fname ):
 
 
 def parse_xml_string(xml_string):
-    tree = cElementTree.fromstring(xml_string)
+    tree = ElementTree.fromstring(xml_string)
     return tree
 
 
@@ -228,7 +228,7 @@ def xml_to_string( elem, pretty=False ):
     if pretty:
         elem = pretty_print_xml( elem )
     try:
-        return cElementTree.tostring( elem )
+        return ElementTree.tostring( elem )
     except TypeError as e:
         # we assume this is a comment
         if hasattr( elem, 'text' ):

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -30,7 +30,10 @@ except ImportError:
 from datetime import datetime
 from hashlib import md5
 from os.path import normpath, relpath
-from xml.etree import ElementInclude, ElementTree
+from xml.etree import (
+    ElementInclude,
+    cElementTree as ElementTree
+)
 from xml.etree.ElementTree import ParseError
 
 from six import binary_type, iteritems, string_types, text_type
@@ -205,13 +208,9 @@ def unique_id(KEY_SIZE=128):
 
 def parse_xml( fname ):
     """Returns a parsed xml tree"""
-    # handle deprecation warning for XMLParsing a file with DOCTYPE
-    class DoctypeSafeCallbackTarget( ElementTree.TreeBuilder ):
-        def doctype( *args ):
-            pass
     tree = ElementTree.ElementTree()
     try:
-        root = tree.parse( fname, parser=ElementTree.XMLParser( target=DoctypeSafeCallbackTarget() ) )
+        root = tree.parse( fname, parser=ElementTree.XMLParser( ) )
     except ParseError:
         log.exception("Error parsing file %s", fname)
         raise

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -30,10 +30,7 @@ except ImportError:
 from datetime import datetime
 from hashlib import md5
 from os.path import normpath, relpath
-from xml.etree import (
-    ElementInclude,
-    cElementTree as ElementTree
-)
+from xml.etree import ElementInclude, ElementTree
 from xml.etree.ElementTree import ParseError
 
 from six import binary_type, iteritems, string_types, text_type
@@ -208,9 +205,13 @@ def unique_id(KEY_SIZE=128):
 
 def parse_xml( fname ):
     """Returns a parsed xml tree"""
+    # handle deprecation warning for XMLParsing a file with DOCTYPE
+    class DoctypeSafeCallbackTarget( ElementTree.TreeBuilder ):
+        def doctype( *args ):
+            pass
     tree = ElementTree.ElementTree()
     try:
-        root = tree.parse( fname, parser=ElementTree.XMLParser( ) )
+        root = tree.parse( fname, parser=ElementTree.XMLParser( target=DoctypeSafeCallbackTarget() ) )
     except ParseError:
         log.exception("Error parsing file %s", fname)
         raise

--- a/lib/galaxy/util/plugin_config.py
+++ b/lib/galaxy/util/plugin_config.py
@@ -41,7 +41,7 @@ def load_plugins(plugins_dict, plugin_source, extra_kwds={}):
 def __load_plugins_from_element(plugins_dict, plugins_element, extra_kwds):
     plugins = []
 
-    for plugin_element in plugins_element.getchildren():
+    for plugin_element in plugins_element:
         plugin_type = plugin_element.tag
         plugin_kwds = dict( plugin_element.items() )
         plugin_kwds.update( extra_kwds )

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -1,7 +1,7 @@
 import os
 
 from copy import deepcopy
-from xml.etree import cElementTree, ElementInclude
+from xml.etree import ElementInclude, cElementTree
 
 
 REQUIRED_PARAMETER = object()

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -1,7 +1,7 @@
 import os
 
 from copy import deepcopy
-from xml.etree import ElementInclude, cElementTree
+from xml.etree import cElementTree, ElementInclude
 
 
 REQUIRED_PARAMETER = object()

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -1,7 +1,7 @@
 import os
 
 from copy import deepcopy
-from xml.etree import ElementInclude, cElementTree
+from xml.etree import ElementInclude, ElementTree
 
 
 REQUIRED_PARAMETER = object()
@@ -286,7 +286,7 @@ class XmlMacroDef(object):
 
 
 def _parse_xml(fname):
-    tree = cElementTree.parse(fname)
+    tree = ElementTree.parse(fname)
     root = tree.getroot()
     ElementInclude.include(root)
     return tree

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -1,7 +1,7 @@
 import os
 
 from copy import deepcopy
-from xml.etree import ElementInclude, ElementTree
+from xml.etree import ElementInclude, cElementTree
 
 
 REQUIRED_PARAMETER = object()
@@ -286,7 +286,7 @@ class XmlMacroDef(object):
 
 
 def _parse_xml(fname):
-    tree = ElementTree.parse(fname)
+    tree = cElementTree.parse(fname)
     root = tree.getroot()
     ElementInclude.include(root)
     return tree

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -312,8 +312,8 @@ class AdminToolshed( AdminGalaxy ):
                         trans.app.installed_repository_manager.handle_repository_uninstall( tool_shed_repository )
                 else:
                     tool_shed_repository.status = trans.install_model.ToolShedRepository.installation_status.DEACTIVATED
-                trans.install_model.context.add( tool_shed_repository )
-                trans.install_model.context.flush()
+                trans.install_model.context.current.add( tool_shed_repository )
+                trans.install_model.context.current.flush()
                 if remove_from_disk_checked:
                     message += 'The repository named <b>%s</b> has been uninstalled.  ' % escape( tool_shed_repository.name )
                     if errors:

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -312,7 +312,6 @@ class AdminToolshed( AdminGalaxy ):
                         trans.app.installed_repository_manager.handle_repository_uninstall( tool_shed_repository )
                 else:
                     tool_shed_repository.status = trans.install_model.ToolShedRepository.installation_status.DEACTIVATED
-                trans.install_model.context.add( tool_shed_repository )
                 trans.install_model.context.flush()
                 if remove_from_disk_checked:
                     message += 'The repository named <b>%s</b> has been uninstalled.  ' % escape( tool_shed_repository.name )

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -312,6 +312,7 @@ class AdminToolshed( AdminGalaxy ):
                         trans.app.installed_repository_manager.handle_repository_uninstall( tool_shed_repository )
                 else:
                     tool_shed_repository.status = trans.install_model.ToolShedRepository.installation_status.DEACTIVATED
+                trans.install_model.context.add( tool_shed_repository )
                 trans.install_model.context.flush()
                 if remove_from_disk_checked:
                     message += 'The repository named <b>%s</b> has been uninstalled.  ' % escape( tool_shed_repository.name )

--- a/lib/tool_shed/galaxy_install/datatypes/custom_datatype_manager.py
+++ b/lib/tool_shed/galaxy_install/datatypes/custom_datatype_manager.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import tempfile
 
 from galaxy.util import asbool
 from tool_shed.util import basic_util, hg_util, shed_util_common as suc
@@ -33,7 +32,6 @@ class CustomDatatypeLoader( object ):
         if registration is None:
             # We have valid XML, but not a valid custom datatypes definition.
             return None, None
-        sniffers = datatypes_config_root.find( 'sniffers' )
         converter_path, display_path = self.get_converter_and_display_paths( registration,
                                                                              relative_install_dir )
         if converter_path:
@@ -81,20 +79,9 @@ class CustomDatatypeLoader( object ):
                             # The value of proprietary_path must be an absolute path due to job_working_directory.
                             elem.attrib[ 'proprietary_path' ] = os.path.abspath( datatype_file_name_path )
                             elem.attrib[ 'proprietary_datatype_module' ] = proprietary_datatype_module
-        # Temporarily persist the custom datatypes configuration file so it can be loaded into the
-        # datatypes registry.
-        fd, proprietary_datatypes_config = tempfile.mkstemp( prefix="tmp-toolshed-acalpd" )
-        os.write( fd, '<?xml version="1.0"?>\n' )
-        os.write( fd, '<datatypes>\n' )
-        os.write( fd, '%s' % xml_util.xml_to_string( registration ) )
-        if sniffers is not None:
-            os.write( fd, '%s' % xml_util.xml_to_string( sniffers ) )
-        os.write( fd, '</datatypes>\n' )
-        os.close( fd )
-        os.chmod( proprietary_datatypes_config, 0o644 )
         # Load custom datatypes
         self.app.datatypes_registry.load_datatypes( root_dir=self.app.config.root,
-                                                    config=proprietary_datatypes_config,
+                                                    config=datatypes_config_root,
                                                     deactivate=deactivate,
                                                     override=override )
         if deactivate:
@@ -104,11 +91,6 @@ class CustomDatatypeLoader( object ):
         else:
             self.append_to_datatypes_registry_upload_file_formats( registration )
             tool_util.reload_upload_tools( self.app )
-        if datatype_files is not None:
-            try:
-                os.unlink( proprietary_datatypes_config )
-            except:
-                pass
         return converter_path, display_path
 
     def append_to_datatypes_registry_upload_file_formats( self, elem ):

--- a/lib/tool_shed/galaxy_install/datatypes/custom_datatype_manager.py
+++ b/lib/tool_shed/galaxy_install/datatypes/custom_datatype_manager.py
@@ -1,9 +1,8 @@
 import logging
 import os
 
-from galaxy.util import asbool
 from tool_shed.util import basic_util, hg_util, shed_util_common as suc
-from tool_shed.util import tool_util, xml_util
+from tool_shed.util import xml_util
 
 log = logging.getLogger( __name__ )
 
@@ -84,24 +83,7 @@ class CustomDatatypeLoader( object ):
                                                     config=datatypes_config_root,
                                                     deactivate=deactivate,
                                                     override=override )
-        if deactivate:
-            # Reload the upload tool to eliminate deactivated datatype extensions from the file_type
-            # select list.
-            tool_util.reload_upload_tools( self.app )
-        else:
-            self.append_to_datatypes_registry_upload_file_formats( registration )
-            tool_util.reload_upload_tools( self.app )
         return converter_path, display_path
-
-    def append_to_datatypes_registry_upload_file_formats( self, elem ):
-        # See if we have any datatypes that should be displayed in the upload tool's file_type select list.
-        for datatype_elem in elem.findall( 'datatype' ):
-            extension = datatype_elem.get( 'extension', None )
-            display_in_upload = datatype_elem.get( 'display_in_upload', None )
-            if extension is not None and display_in_upload is not None:
-                display_in_upload = asbool( str( display_in_upload ) )
-                if display_in_upload and extension not in self.app.datatypes_registry.upload_file_formats:
-                    self.app.datatypes_registry.upload_file_formats.append( extension )
 
     def create_repository_dict_for_proprietary_datatypes( self, tool_shed, name, owner, installed_changeset_revision,
                                                           tool_dicts, converter_path=None, display_path=None ):

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -609,7 +609,7 @@ class InstallRepositoryManager( object ):
                                                                           display_path=display_path )
             if converter_path:
                 # Load proprietary datatype converters
-                self.app.datatypes_registry.load_datatype_converters( self.app.toolbox, installed_repository_dict=repository_dict )
+                self.app.datatypes_registry.load_datatype_converters( self.app.toolbox, installed_repository_dict=repository_dict, use_cached=True)
             if display_path:
                 # Load proprietary datatype display applications
                 self.app.datatypes_registry.load_display_applications( self.app, installed_repository_dict=repository_dict )

--- a/lib/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/installed_repository_manager.py
@@ -111,8 +111,8 @@ class InstalledRepositoryManager( object ):
                                            data_manager_relative_install_dir,
                                            repository,
                                            repository_tools_tups )
-        self.install_model.context.add( repository )
-        self.install_model.context.flush()
+        self.install_model.context.current.add( repository )
+        self.install_model.context.current.flush()
         if repository.includes_datatypes:
             if tool_path:
                 repository_install_dir = os.path.abspath( os.path.join( tool_path, relative_install_dir ) )

--- a/lib/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/installed_repository_manager.py
@@ -129,6 +129,7 @@ class InstalledRepositoryManager( object ):
                 display_path = installed_repository_dict.get( 'display_path' )
                 if display_path is not None:
                     cdl.load_installed_display_applications( installed_repository_dict, deactivate=False )
+                self.app.datatypes_registry.to_xml_file()
 
     def add_entry_to_installed_repository_dependencies_of_installed_repositories( self, repository ):
         """
@@ -739,6 +740,7 @@ class InstalledRepositoryManager( object ):
                 installed_repository_dict = cdl.load_installed_datatypes( tool_shed_repository, relative_install_dir )
                 if installed_repository_dict:
                     self.installed_repository_dicts.append( installed_repository_dict )
+        self.app.datatypes_registry.to_xml_file()
 
     def load_proprietary_converters_and_display_applications( self, deactivate=False ):
         cdl = custom_datatype_manager.CustomDatatypeLoader( self.app )

--- a/lib/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/installed_repository_manager.py
@@ -111,7 +111,6 @@ class InstalledRepositoryManager( object ):
                                            data_manager_relative_install_dir,
                                            repository,
                                            repository_tools_tups )
-        self.install_model.context.add( repository )
         self.install_model.context.flush()
         if repository.includes_datatypes:
             if tool_path:

--- a/lib/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/installed_repository_manager.py
@@ -111,6 +111,7 @@ class InstalledRepositoryManager( object ):
                                            data_manager_relative_install_dir,
                                            repository,
                                            repository_tools_tups )
+        self.install_model.context.add( repository )
         self.install_model.context.flush()
         if repository.includes_datatypes:
             if tool_path:

--- a/lib/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/installed_repository_manager.py
@@ -129,7 +129,6 @@ class InstalledRepositoryManager( object ):
                 display_path = installed_repository_dict.get( 'display_path' )
                 if display_path is not None:
                     cdl.load_installed_display_applications( installed_repository_dict, deactivate=False )
-                self.app.datatypes_registry.to_xml_file()
 
     def add_entry_to_installed_repository_dependencies_of_installed_repositories( self, repository ):
         """
@@ -740,7 +739,6 @@ class InstalledRepositoryManager( object ):
                 installed_repository_dict = cdl.load_installed_datatypes( tool_shed_repository, relative_install_dir )
                 if installed_repository_dict:
                     self.installed_repository_dicts.append( installed_repository_dict )
-        self.app.datatypes_registry.to_xml_file()
 
     def load_proprietary_converters_and_display_applications( self, deactivate=False ):
         cdl = custom_datatype_manager.CustomDatatypeLoader( self.app )

--- a/lib/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
+++ b/lib/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
@@ -90,6 +90,7 @@ class InstalledRepositoryMetadataManager( metadata_generator.MetadataGenerator )
                 self.update_in_shed_tool_config()
                 self.app.install_model.context.add( self.repository )
                 self.app.install_model.context.flush()
+                self.app.tool_shed_repository_cache.rebuild()
                 log.debug( 'Metadata has been reset on repository %s.' % self.repository.name )
             else:
                 log.debug( 'Metadata did not need to be reset on repository %s.' % self.repository.name )

--- a/lib/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/data_manager.py
@@ -116,8 +116,7 @@ class DataManagerHandler( object ):
                     elem.insert( 0, tool_elem )
                     data_manager = \
                         self.app.data_managers.load_manager_from_elem( elem,
-                                                                       tool_path=shed_config_dict.get( 'tool_path', '' ),
-                                                                       replace_existing=True )
+                                                                       tool_path=shed_config_dict.get( 'tool_path', '' ))
                     if data_manager:
                         rval.append( data_manager )
                 else:
@@ -129,7 +128,7 @@ class DataManagerHandler( object ):
                 reload_count = self.app.data_managers._reload_count
                 self.data_manager_config_elems_to_xml_file( config_elems, shed_data_manager_conf_filename )
                 while self.app.data_managers._reload_count <= reload_count:
-                    time.sleep(1)  # Wait for shed_data_manager watcher thread to pick up changes
+                    time.sleep(0.1)  # Wait for shed_data_manager watcher thread to pick up changes
         return rval
 
     def remove_from_data_manager( self, repository ):

--- a/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 
-from xml.etree import ElementTree as XmlET
+from xml.etree import cElementTree as XmlET
 
 from tool_shed.util import basic_util
 from tool_shed.util import common_util
@@ -27,6 +27,7 @@ class ToolPanelManager( object ):
             # We may have an empty elem_list in case a data manager is being installed.
             # In that case we don't want to wait for a toolbox reload that will never happen.
             return
+        old_toolbox = self.app.toolbox
         shed_tool_conf = shed_tool_conf_dict[ 'config_filename' ]
         tool_path = shed_tool_conf_dict[ 'tool_path' ]
         config_elems = []
@@ -39,9 +40,8 @@ class ToolPanelManager( object ):
             for elem_entry in elem_list:
                 config_elems.append( elem_entry )
             # Persist the altered shed_tool_config file.
-            toolbox = self.app.toolbox
             self.config_elems_to_xml_file( config_elems, shed_tool_conf, tool_path )
-            self.app.wait_for_toolbox_reload(toolbox)
+            self.app.wait_for_toolbox_reload(old_toolbox)
 
     def add_to_tool_panel( self, repository_name, repository_clone_url, changeset_revision, repository_tools_tups, owner,
                            shed_tool_conf, tool_panel_dict, new_install=True, tool_panel_section_mapping={} ):

--- a/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -439,7 +439,8 @@ class ToolPanelManager( object ):
             toolbox.remove_tool_by_id( guid_to_remove, remove_from_panel=False )
         shed_tool_conf_dict = self.get_shed_tool_conf_dict( shed_tool_conf )
         # Always remove from the shed_tool_conf file on disk. Used to test for uninstall, not sure there is a legitimate use for this?!
-        self.remove_from_shed_tool_config( shed_tool_conf_dict, guids_to_remove )
+        if uninstall:
+            self.remove_from_shed_tool_config( shed_tool_conf_dict, guids_to_remove )
 
     def update_tool_panel_dict( self, tool_panel_dict, tool_panel_section_mapping, repository_tools_tups ):
         for tool_guid in tool_panel_dict:

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -127,7 +127,7 @@ def create_or_update_tool_shed_repository( app, name, description, installed_cha
         deleted = False
         uninstalled = False
     tool_shed_repository = \
-        get_installed_repository( app, tool_shed=tool_shed, name=name, owner=owner, installed_changeset_revision=installed_changeset_revision )
+        get_installed_repository( app, tool_shed=tool_shed, name=name, owner=owner, installed_changeset_revision=installed_changeset_revision, refresh=True )
     if tool_shed_repository:
         log.debug( "Updating an existing row for repository '%s' in the tool_shed_repository table, status set to '%s'." %
                    ( str( name ), str( status ) ) )
@@ -371,13 +371,15 @@ def get_ids_of_tool_shed_repositories_being_installed( app, as_string=False ):
     return installing_repository_ids
 
 
-def get_installed_repository( app, tool_shed, name, owner, changeset_revision=None, installed_changeset_revision=None ):
+def get_installed_repository( app, tool_shed, name, owner, changeset_revision=None, installed_changeset_revision=None, refresh=False ):
     """
     Return a tool shed repository database record defined by the combination of a toolshed, repository name,
     repository owner and either current or originally installed changeset_revision.
     """
     tool_shed = common_util.remove_protocol_from_tool_shed_url( tool_shed )
     if hasattr(app, 'tool_shed_repository_cache'):
+        if refresh:
+            app.tool_shed_repository_cache.rebuild()
         return app.tool_shed_repository_cache.get_installed_repository(tool_shed=tool_shed,
                                                                        name=name,
                                                                        owner=owner,

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -405,6 +405,8 @@ def get_installed_tool_shed_repository( app, id ):
     else:
         id = [ id ]
         return_list = False
+    if hasattr(app, 'tool_shed_repository_cache'):
+        app.tool_shed_repository_cache.rebuild()
     for i in id:
         rval.append( app.install_model.context.query( app.install_model.ToolShedRepository ).get( app.security.decode_id( i ) ) )
     if return_list:

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -376,9 +376,15 @@ def get_installed_repository( app, tool_shed, name, owner, changeset_revision=No
     Return a tool shed repository database record defined by the combination of a toolshed, repository name,
     repository owner and either current or originally installed changeset_revision.
     """
+    tool_shed = common_util.remove_protocol_from_tool_shed_url( tool_shed )
+    if hasattr(app, 'tool_shed_repository_cache'):
+        return app.tool_shed_repository_cache.get_installed_repository(tool_shed=tool_shed,
+                                                                       name=name,
+                                                                       owner=owner,
+                                                                       installed_changeset_revision=installed_changeset_revision,
+                                                                       changeset_revision=changeset_revision)
     query = app.install_model.context.query( app.install_model.ToolShedRepository )
     # We store the port, if one exists, in the database.
-    tool_shed = common_util.remove_protocol_from_tool_shed_url( tool_shed )
     clause_list = [ app.install_model.ToolShedRepository.table.c.tool_shed == tool_shed,
                     app.install_model.ToolShedRepository.table.c.name == name,
                     app.install_model.ToolShedRepository.table.c.owner == owner ]

--- a/lib/tool_shed/util/tool_dependency_util.py
+++ b/lib/tool_shed/util/tool_dependency_util.py
@@ -388,4 +388,5 @@ def set_tool_dependency_attributes( app, tool_dependency, status, error_message=
     tool_dependency.status = status
     sa_session.add( tool_dependency )
     sa_session.flush()
+    app.tool_shed_repository_cache.rebuild()
     return tool_dependency

--- a/lib/tool_shed/util/tool_util.py
+++ b/lib/tool_shed/util/tool_util.py
@@ -272,8 +272,3 @@ def panel_entry_per_tool( tool_section_dict ):
         if k not in [ 'id', 'version', 'name' ]:
             return True
     return False
-
-
-def reload_upload_tools( app ):
-    if hasattr( app, 'toolbox' ):
-        app.toolbox.handle_datatypes_changed()

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -271,7 +271,12 @@ def copy_database_template( source, db_path ):
         shutil.copy(source, db_path)
         assert os.path.exists(db_path)
     elif source.lower().startswith(("http://", "https://", "ftp://")):
-        download_to_file(source, db_path)
+        try:
+            download_to_file(source, db_path)
+        except Exception as e:
+            # We log the exception but don't fail startup, since we can
+            # do all migration steps instead of downloading a template.
+            log.exception(e)
     else:
         raise Exception( "Failed to copy database template from source %s" % source )
 

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -11,6 +11,7 @@ from galaxy import model
 from galaxy.model import tool_shed_install
 from galaxy.model.tool_shed_install import mapping
 from galaxy.tools import ToolBox
+from galaxy.tools.toolbox.cache import ToolCache
 from galaxy.tools.toolbox.lineages.tool_shed import ToolVersionCache
 from galaxy.tools.toolbox.watcher import get_tool_conf_watcher
 from galaxy.webapps.galaxy.config_watchers import ConfigWatchers
@@ -58,7 +59,7 @@ class BaseToolBoxTestCase(  unittest.TestCase, tools_support.UsesApp, tools_supp
         self.reindexed = False
         self.setup_app( mock_model=False )
         install_model = mapping.init( "sqlite:///:memory:", create_tables=True )
-        self.app.tool_cache = None
+        self.app.tool_cache = ToolCache()
         self.app.install_model = install_model
         self.app.reindex_tool_search = self.__reindex
         itp_config = os.path.join(self.test_directory, "integrated_tool_panel.xml")
@@ -432,7 +433,7 @@ class SimplifiedToolBox( ToolBox ):
     def __init__( self, test_case ):
         app = test_case.app
         # Handle app/config stuff needed by toolbox but not by tools.
-        app.tool_cache = None
+        app.tool_cache = ToolCache()
         app.job_config.get_tool_resource_parameters = lambda tool_id: None
         app.config.update_integrated_tool_panel = True
         config_files = test_case.config_files


### PR DESCRIPTION
@bgruening mentioned slow toolbox reloading in gitter a while back, so I had a look at what where major things that could be sped up.

The most effective speedup for reloading the toolbox on my dev instance is rebuilding the search index only for the tools that have changed since the toolbox reloads. The speedup varies with how many tools are installed of course, for me this went from ~2-3 seconds to 0.4 seconds.

In terms of startup times the most effective change is caching the ToolShedRepositories for 1 second in 1b6da123f82e2e603f173aeb1b81ef0124ce6276 and always fetching the ToolVersion objects from the cache  in 4d5dd2d. This should be long enough to be able to load the complete toolbox with just a single emitted db query. This reduced the time to build the full galaxy app object from ~ 7.7 seconds to ~ 4.7 seconds. The more tools you have the better the speedup, I guess.

Data table reloading was also quite slow. It turns out there were hundreds of `os.path.exists()` calls, that even on my SSD were taking quite a while to finish. I addressed that in 12f7dcaf4eec0f20b3400783fb9ce1532401f934

I think this may even speedup other areas in galaxy, just running the unittests went from 140 seconds to 80 seconds locally. I guess everything that accesses a bunch of tools sequentially will benefit from this. 