### PR TITLE
Remove logout hack

### DIFF
--- a/templates/user/logout.mako
+++ b/templates/user/logout.mako
@@ -39,14 +39,6 @@ def inherit(context):
 </%def>
 
 <%def name="body()">
-    <script type="text/javascript">
-        $(function(){
-            //HACK: should happen before we get to this page - _before_ logged out of session
-            if( top.Galaxy && top.Galaxy.user ){
-                top.Galaxy.user.clearSessionStorage();
-            }
-        });
-    </script>
     %if message:
         ${render_msg( message, status )}
     %endif


### PR DESCRIPTION
This removes an old hack that was causing impersonation to break things and Galaxy to have a 'null' user on the client side afterwards.

I can't think of a reason we actually need this, since the logout action is always a full page refresh -- there should be no context to wipe out here.

xref #3581 and #3906