### PR TITLE
[17.01] Fix another tool (GeneBed_Maf_Fasta2) requiring the legacy Galaxy environment.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -112,6 +112,7 @@ GALAXY_LIB_TOOLS_UNVERSIONED = [
     "Extract genomic DNA 1",
     "aggregate_scores_in_intervals2",
     "Interval_Maf_Merged_Fasta2",
+    "GeneBed_Maf_Fasta2",
     "maf_stats1",
     "Interval2Maf1",
     "MAF_To_Interval1",


### PR DESCRIPTION
Sorry about that... again... for the 32nd time.

Thanks to @blankenberg for pointing me at this and @jennaj for reporting it.