### PR TITLE
Standardize usage of log.exception

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -129,7 +129,7 @@ class Data( object ):
         try:
             return open(dataset.file_name, 'rb').read(-1)
         except OSError:
-            log.exception('%s reading a file that does not exist %s' % (self.__class__.__name__, dataset.file_name))
+            log.exception('%s reading a file that does not exist %s', self.__class__.__name__, dataset.file_name)
             return ''
 
     def dataset_content_needs_grooming( self, file_name ):
@@ -229,7 +229,7 @@ class Data( object ):
             archive.add(data_filename, archname)
         except IOError:
             error = True
-            log.exception("Unable to add composite parent %s to temporary library download archive" % data_filename)
+            log.exception("Unable to add composite parent %s to temporary library download archive", data_filename)
             msg = "Unable to create archive for download, please report this error"
             messagetype = "error"
         return error, msg, messagetype
@@ -284,7 +284,7 @@ class Data( object ):
                                 archive.add( fpath, rpath )
                             except IOError:
                                 error = True
-                                log.exception( "Unable to add %s to temporary library download archive" % rpath)
+                                log.exception( "Unable to add %s to temporary library download archive", rpath)
                                 msg = "Unable to create archive for download, please report this error"
                                 continue
                 if not error:
@@ -439,7 +439,7 @@ class Data( object ):
         try:
             del self.supported_display_apps[app_id]
         except:
-            log.exception('Tried to remove display app %s from datatype %s, but this display app is not declared.' % ( type, self.__class__.__name__ ) )
+            log.exception('Tried to remove display app %s from datatype %s, but this display app is not declared.', type, self.__class__.__name__ )
 
     def clear_display_apps( self ):
         self.supported_display_apps = {}
@@ -477,7 +477,7 @@ class Data( object ):
             if type in self.get_display_types():
                 return getattr(self, self.supported_display_apps[type]['file_function'])(dataset, **kwd)
         except:
-            log.exception('Function %s is referred to in datatype %s for displaying as type %s, but is not accessible' % (self.supported_display_apps[type]['file_function'], self.__class__.__name__, type) )
+            log.exception('Function %s is referred to in datatype %s for displaying as type %s, but is not accessible',  self.supported_display_apps[type]['file_function'], self.__class__.__name__, type )
         return "This display type (%s) is not implemented for this datatype (%s)." % ( type, dataset.ext)
 
     def get_display_links( self, dataset, type, app, base_url, target_frame='_blank', **kwd ):
@@ -491,8 +491,8 @@ class Data( object ):
             if app.config.enable_old_display_applications and type in self.get_display_types():
                 return target_frame, getattr( self, self.supported_display_apps[type]['links_function'] )( dataset, type, app, base_url, **kwd )
         except:
-            log.exception( 'Function %s is referred to in datatype %s for generating links for type %s, but is not accessible'
-                           % ( self.supported_display_apps[type]['links_function'], self.__class__.__name__, type ) )
+            log.exception( 'Function %s is referred to in datatype %s for generating links for type %s, but is not accessible',
+                           self.supported_display_apps[type]['links_function'], self.__class__.__name__, type )
         return target_frame, []
 
     def get_converter_types(self, original_dataset, datatypes_registry):

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -477,7 +477,7 @@ class Data( object ):
             if type in self.get_display_types():
                 return getattr(self, self.supported_display_apps[type]['file_function'])(dataset, **kwd)
         except:
-            log.exception('Function %s is referred to in datatype %s for displaying as type %s, but is not accessible',  self.supported_display_apps[type]['file_function'], self.__class__.__name__, type )
+            log.exception('Function %s is referred to in datatype %s for displaying as type %s, but is not accessible', self.supported_display_apps[type]['file_function'], self.__class__.__name__, type )
         return "This display type (%s) is not implemented for this datatype (%s)." % ( type, dataset.ext)
 
     def get_display_links( self, dataset, type, app, base_url, target_frame='_blank', **kwd ):

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -187,7 +187,7 @@ class Registry( object ):
                                 datatype_module = fields[ 0 ]
                                 datatype_class_name = fields[ 1 ]
                             except Exception as e:
-                                self.log.exception( 'Error parsing datatype definition for dtype %s' % str( dtype ) )
+                                self.log.exception( 'Error parsing datatype definition for dtype %s', str( dtype ) )
                                 ok = False
                             if ok:
                                 datatype_class = None
@@ -217,13 +217,13 @@ class Registry( object ):
                                         datatype_class = getattr( module, datatype_class_name )
                                         self.log.debug( 'Retrieved datatype module %s:%s from the datatype registry.' % ( str( datatype_module ), datatype_class_name ) )
                                     except Exception as e:
-                                        self.log.exception( 'Error importing datatype module %s' % str( datatype_module ) )
+                                        self.log.exception( 'Error importing datatype module %s', str( datatype_module ) )
                                         ok = False
                         elif type_extension is not None:
                             try:
                                 datatype_class = self.datatypes_by_extension[ type_extension ].__class__
                             except Exception as e:
-                                self.log.exception( 'Error determining datatype_class for type_extension %s' % str( type_extension ) )
+                                self.log.exception( 'Error determining datatype_class for type_extension %s', str( type_extension ) )
                                 ok = False
                         if ok:
                             if not deactivate:
@@ -397,7 +397,7 @@ class Registry( object ):
                         datatype_class_name = fields[ 1 ]
                         module = None
                     except Exception as e:
-                        self.log.exception( 'Error determining datatype class or module for dtype %s' % str( dtype ) )
+                        self.log.exception( 'Error determining datatype class or module for dtype %s', str( dtype ) )
                         ok = False
                     if ok:
                         if handling_proprietary_datatypes:
@@ -413,7 +413,7 @@ class Registry( object ):
                                 for comp in datatype_module.split( '.' )[ 1: ]:
                                     module = getattr( module, comp )
                             except Exception as e:
-                                self.log.exception( "Error importing datatype class for '%s'" % str( dtype ) )
+                                self.log.exception( "Error importing datatype class for '%s'", str( dtype ) )
                                 ok = False
                         if ok:
                             try:

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -560,7 +560,7 @@ class Registry( object ):
                         self.datatype_converters[ source_datatype ] = odict()
                     self.datatype_converters[ source_datatype ][ target_datatype ] = converter
                     self.log.debug( "Loaded converter: %s", converter.id )
-            except Exception as e:
+            except Exception:
                 if deactivate:
                     self.log.exception( "Error deactivating converter from (%s)" % converter_path )
                 else:
@@ -628,7 +628,7 @@ class Registry( object ):
                             if inherit and ( self.datatypes_by_extension[ extension ], display_app ) not in self.inherit_display_application_by_class:
                                 self.inherit_display_application_by_class.append( ( self.datatypes_by_extension[ extension ], display_app ) )
                             self.log.debug( "Loaded display application '%s' for datatype '%s', inherit=%s." % ( display_app.id, extension, inherit ) )
-                except Exception as e:
+                except Exception:
                     if deactivate:
                         self.log.exception( "Error deactivating display application (%s)" % config_path )
                     else:

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -187,7 +187,7 @@ class Registry( object ):
                                 datatype_module = fields[ 0 ]
                                 datatype_class_name = fields[ 1 ]
                             except Exception as e:
-                                self.log.exception( 'Error parsing datatype definition for dtype %s: %s' % ( str( dtype ), str( e ) ) )
+                                self.log.exception( 'Error parsing datatype definition for dtype %s' % str( dtype ) )
                                 ok = False
                             if ok:
                                 datatype_class = None
@@ -217,13 +217,13 @@ class Registry( object ):
                                         datatype_class = getattr( module, datatype_class_name )
                                         self.log.debug( 'Retrieved datatype module %s:%s from the datatype registry.' % ( str( datatype_module ), datatype_class_name ) )
                                     except Exception as e:
-                                        self.log.exception( 'Error importing datatype module %s: %s' % ( str( datatype_module ), str( e ) ) )
+                                        self.log.exception( 'Error importing datatype module %s' % str( datatype_module ) )
                                         ok = False
                         elif type_extension is not None:
                             try:
                                 datatype_class = self.datatypes_by_extension[ type_extension ].__class__
                             except Exception as e:
-                                self.log.exception( 'Error determining datatype_class for type_extension %s: %s' % ( str( type_extension ), str( e ) ) )
+                                self.log.exception( 'Error determining datatype_class for type_extension %s' % str( type_extension ) )
                                 ok = False
                         if ok:
                             if not deactivate:
@@ -324,7 +324,7 @@ class Registry( object ):
         def load_build_site( build_site_config ):
             # Take in either an XML element or simple dictionary from YAML and add build site for this.
             if not (build_site_config.get( 'type' ) and build_site_config.get( 'file' )):
-                self.log.exception( "Site is missing required 'type' and 'file' attributes: %s" )
+                self.log.exception( "Site is missing required 'type' and 'file' attributes" )
                 return
 
             site_type = build_site_config.get( 'type' )
@@ -397,7 +397,7 @@ class Registry( object ):
                         datatype_class_name = fields[ 1 ]
                         module = None
                     except Exception as e:
-                        self.log.exception( 'Error determining datatype class or module for dtype %s: %s' % ( str( dtype ), str( e ) ) )
+                        self.log.exception( 'Error determining datatype class or module for dtype %s' % str( dtype ) )
                         ok = False
                     if ok:
                         if handling_proprietary_datatypes:
@@ -413,13 +413,13 @@ class Registry( object ):
                                 for comp in datatype_module.split( '.' )[ 1: ]:
                                     module = getattr( module, comp )
                             except Exception as e:
-                                self.log.exception( "Error importing datatype class for '%s': %s" % ( str( dtype ), str( e ) ) )
+                                self.log.exception( "Error importing datatype class for '%s'" % str( dtype ) )
                                 ok = False
                         if ok:
                             try:
                                 aclass = getattr( module, datatype_class_name )()
                             except Exception as e:
-                                self.log.exception( 'Error calling method %s from class %s: %s', str( datatype_class_name ), str( module ), str( e ) )
+                                self.log.exception( 'Error calling method %s from class %s', str( datatype_class_name ), str( module ) )
                                 ok = False
                             if ok:
                                 if deactivate:
@@ -562,9 +562,9 @@ class Registry( object ):
                     self.log.debug( "Loaded converter: %s", converter.id )
             except Exception as e:
                 if deactivate:
-                    self.log.exception( "Error deactivating converter from (%s): %s" % ( converter_path, str( e ) ) )
+                    self.log.exception( "Error deactivating converter from (%s)" % converter_path )
                 else:
-                    self.log.exception( "Error loading converter (%s): %s" % ( converter_path, str( e ) ) )
+                    self.log.exception( "Error loading converter (%s)" % converter_path )
 
     def load_display_applications( self, app, installed_repository_dict=None, deactivate=False ):
         """
@@ -630,9 +630,9 @@ class Registry( object ):
                             self.log.debug( "Loaded display application '%s' for datatype '%s', inherit=%s." % ( display_app.id, extension, inherit ) )
                 except Exception as e:
                     if deactivate:
-                        self.log.exception( "Error deactivating display application (%s): %s" % ( config_path, str( e ) ) )
+                        self.log.exception( "Error deactivating display application (%s)" % config_path )
                     else:
-                        self.log.exception( "Error loading display application (%s): %s" % ( config_path, str( e ) ) )
+                        self.log.exception( "Error loading display application (%s)" % config_path )
         # Handle display_application subclass inheritance.
         for extension, d_type1 in self.datatypes_by_extension.iteritems():
             for d_type2, display_app in self.inherit_display_application_by_class:

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -167,7 +167,7 @@ class TabularData( data.Text ):
                 out.append( '</th>' )
             out.append( '</tr>' )
         except Exception as exc:
-            log.exception( 'make_html_peek_header failed on HDA %s' % dataset.id )
+            log.exception( 'make_html_peek_header failed on HDA %s', dataset.id )
             raise Exception( "Can't create peek header %s" % str( exc ) )
         return "".join( out )
 
@@ -198,7 +198,7 @@ class TabularData( data.Text ):
                             out.append( '<td>%s</td>' % escape( elem ) )
                         out.append( '</tr>' )
         except Exception as exc:
-            log.exception( 'make_html_peek_rows failed on HDA %s' % dataset.id )
+            log.exception( 'make_html_peek_rows failed on HDA %s', dataset.id )
             raise Exception( "Can't create peek rows %s" % str( exc ) )
         return "".join( out )
 

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -150,7 +150,7 @@ class Ipynb( Json ):
                 ofilename = '%s.html' % ofilename
             except:
                 ofilename = dataset.file_name
-                log.exception( 'Command "%s" failed. Could not convert the Jupyter Notebook to HTML, defaulting to plain text.' % cmd )
+                log.exception( 'Command "%s" failed. Could not convert the Jupyter Notebook to HTML, defaulting to plain text.', cmd )
             return open( ofilename )
 
     def set_meta( self, dataset, **kwd ):

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -726,8 +726,8 @@ class JobConfiguration( object ):
                 try:
                     rval[id] = runner_class( self.app, runner[ 'workers' ], **runner.get( 'kwds', {} ) )
                 except TypeError:
-                    log.exception( "Job runner '%s:%s' has not been converted to a new-style runner or encountered TypeError on load"
-                                   % ( module_name, class_name ) )
+                    log.exception( "Job runner '%s:%s' has not been converted to a new-style runner or encountered TypeError on load",
+                                   module_name, class_name )
                     rval[id] = runner_class( self.app )
                 log.debug( "Loaded job runner '%s:%s' as '%s'" % ( module_name, class_name, id ) )
         return rval
@@ -1551,7 +1551,7 @@ class JobWrapper( object, HasResourceParameters ):
             if delete_files:
                 self.app.object_store.delete(self.get_job(), base_dir='job_work', entire_dir=True, dir_only=True, obj_dir=True)
         except:
-            log.exception( "Unable to cleanup job %d" % self.job_id )
+            log.exception( "Unable to cleanup job %d", self.job_id )
 
     def _collect_extra_files(self, dataset, job_working_directory):
         temp_file_path = os.path.join( job_working_directory, "dataset_%s_files" % ( dataset.id ) )

--- a/lib/galaxy/jobs/deferred/__init__.py
+++ b/lib/galaxy/jobs/deferred/__init__.py
@@ -105,14 +105,14 @@ class DeferredJobQueue( object ):
             if job.is_check_time:
                 try:
                     job_state = self.plugins[job.plugin].check_job( job )
-                except Exception as e:
+                except Exception:
                     self.__fail_job( job )
                     log.exception( 'Set deferred job %s to error because of an exception in check_job()' % job.id )
                     continue
                 if job_state == self.job_states.READY:
                     try:
                         self.plugins[job.plugin].run_job( job )
-                    except Exception as e:
+                    except Exception:
                         self.__fail_job( job )
                         log.exception( 'Set deferred job %s to error because of an exception in run_job()' % job.id )
                         continue

--- a/lib/galaxy/jobs/deferred/__init__.py
+++ b/lib/galaxy/jobs/deferred/__init__.py
@@ -40,7 +40,7 @@ class DeferredJobQueue( object ):
                 try:
                     module = __import__( module_name )
                 except:
-                    log.exception( 'Deferred job plugin appears to exist but is not loadable: %s' % module_name )
+                    log.exception( 'Deferred job plugin appears to exist but is not loadable: %s', module_name )
                     continue
                 for comp in module_name.split( "." )[1:]:
                     module = getattr( module, comp )

--- a/lib/galaxy/jobs/deferred/__init__.py
+++ b/lib/galaxy/jobs/deferred/__init__.py
@@ -107,14 +107,14 @@ class DeferredJobQueue( object ):
                     job_state = self.plugins[job.plugin].check_job( job )
                 except Exception as e:
                     self.__fail_job( job )
-                    log.exception( 'Set deferred job %s to error because of an exception in check_job(): %s' % ( job.id, str( e ) ) )
+                    log.exception( 'Set deferred job %s to error because of an exception in check_job()' % job.id )
                     continue
                 if job_state == self.job_states.READY:
                     try:
                         self.plugins[job.plugin].run_job( job )
                     except Exception as e:
                         self.__fail_job( job )
-                        log.exception( 'Set deferred job %s to error because of an exception in run_job(): %s' % ( job.id, str( e ) ) )
+                        log.exception( 'Set deferred job %s to error because of an exception in run_job()' % job.id )
                         continue
                 elif job_state == self.job_states.INVALID:
                     self.__fail_job( job )

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -309,7 +309,7 @@ class JobHandlerQueue( object ):
                     log.error( "(%d) Job in unknown state '%s'" % ( job.id, job_state ) )
                     new_waiting_jobs.append( job.id )
             except Exception:
-                log.exception( "failure running job %d" % job.id )
+                log.exception( "failure running job %d", job.id )
         # Update the waiting list
         if not self.track_jobs_in_database:
             self.waiting_jobs = new_waiting_jobs
@@ -785,7 +785,7 @@ class DefaultJobDispatcher( object ):
         try:
             return self.job_runners[runner_name].url_to_destination(url)
         except Exception as e:
-            log.exception("Unable to convert legacy job runner URL '%s' to job destination, destination will be the '%s' runner with no params" % (url, runner_name))
+            log.exception("Unable to convert legacy job runner URL '%s' to job destination, destination will be the '%s' runner with no params", url, runner_name)
             return JobDestination(runner=runner_name)
 
     def put( self, job_wrapper ):

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -784,7 +784,7 @@ class DefaultJobDispatcher( object ):
         runner_name = url.split(':', 1)[0]
         try:
             return self.job_runners[runner_name].url_to_destination(url)
-        except Exception as e:
+        except Exception:
             log.exception("Unable to convert legacy job runner URL '%s' to job destination, destination will be the '%s' runner with no params", url, runner_name)
             return JobDestination(runner=runner_name)
 

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -785,7 +785,7 @@ class DefaultJobDispatcher( object ):
         try:
             return self.job_runners[runner_name].url_to_destination(url)
         except Exception as e:
-            log.exception("Unable to convert legacy job runner URL '%s' to job destination, destination will be the '%s' runner with no params: %s" % (url, runner_name, e))
+            log.exception("Unable to convert legacy job runner URL '%s' to job destination, destination will be the '%s' runner with no params" % (url, runner_name))
             return JobDestination(runner=runner_name)
 
     def put( self, job_wrapper ):

--- a/lib/galaxy/jobs/metrics/__init__.py
+++ b/lib/galaxy/jobs/metrics/__init__.py
@@ -94,7 +94,7 @@ class JobInstrumenter(object):
                 if plugin_commands:
                     commands.extend(util.listify(plugin_commands))
             except Exception:
-                log.exception("Failed to generate pre-execute commands for plugin %s" % plugin)
+                log.exception("Failed to generate pre-execute commands for plugin %s", plugin)
         return "\n".join([ c for c in commands if c ])
 
     def post_execute_commands(self, job_directory):
@@ -105,7 +105,7 @@ class JobInstrumenter(object):
                 if plugin_commands:
                     commands.extend(util.listify(plugin_commands))
             except Exception:
-                log.exception("Failed to generate post-execute commands for plugin %s" % plugin)
+                log.exception("Failed to generate post-execute commands for plugin %s", plugin)
         return "\n".join([ c for c in commands if c ])
 
     def collect_properties(self, job_id, job_directory):
@@ -116,7 +116,7 @@ class JobInstrumenter(object):
                 if properties:
                     per_plugin_properites[ plugin.plugin_type ] = properties
             except Exception:
-                log.exception("Failed to collect job properties for plugin %s" % plugin)
+                log.exception("Failed to collect job properties for plugin %s", plugin)
         return per_plugin_properites
 
     def __plugins_from_source(self, plugins_source):

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -247,7 +247,7 @@ class BaseJobRunner( object ):
                         output_pairs.append( ( source_file, destination ) )
                     else:
                         # Security violation.
-                        log.exception( "from_work_dir specified a location not in the working directory: %s, %s" % ( source_file, job_wrapper.working_directory ) )
+                        log.exception( "from_work_dir specified a location not in the working directory: %s, %s", source_file, job_wrapper.working_directory )
         return output_pairs
 
     def _walk_dataset_outputs( self, job ):

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -120,7 +120,7 @@ class LocalJobRunner( BaseJobRunner ):
             stderr_file.close()
             log.debug('execution finished: %s' % command_line)
         except Exception:
-            log.exception("failure running job %d" % job_wrapper.job_id)
+            log.exception("failure running job %d", job_wrapper.job_id)
             self._fail_job_local(job_wrapper, "failure running job")
             return
 

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -299,7 +299,7 @@ class PulsarJobRunner( AsynchronousJobRunner ):
             job_wrapper.change_state( model.Job.states.QUEUED )
         except Exception:
             job_wrapper.fail( "failure running job", exception=True )
-            log.exception("failure running job %d" % job_wrapper.job_id)
+            log.exception("failure running job %d", job_wrapper.job_id)
             return
 
         pulsar_job_state = AsynchronousJobState()
@@ -366,10 +366,10 @@ class PulsarJobRunner( AsynchronousJobRunner ):
             )
         except UnsupportedPulsarException as e:
             job_wrapper.fail( e.message, exception=False )
-            log.exception("failure running job %d" % job_wrapper.job_id)
+            log.exception("failure running job %d", job_wrapper.job_id)
         except Exception:
             job_wrapper.fail( "failure preparing job", exception=True )
-            log.exception("failure running job %d" % job_wrapper.job_id)
+            log.exception("failure running job %d", job_wrapper.job_id)
 
         # If we were able to get a command line, run the job
         if not command_line:
@@ -488,7 +488,7 @@ class PulsarJobRunner( AsynchronousJobRunner ):
         except Exception:
             message = GENERIC_REMOTE_ERROR
             job_wrapper.fail( message, exception=True )
-            log.exception("failure finishing job %d" % job_wrapper.job_id)
+            log.exception("failure finishing job %d", job_wrapper.job_id)
             return
         if not PulsarJobRunner.__remote_metadata( client ):
             self._handle_metadata_externally( job_wrapper, resolve_requirements=True )
@@ -730,7 +730,7 @@ class PulsarMQJobRunner( PulsarJobRunner ):
             job_state = self._job_state( job, job_wrapper )
             self._update_job_state_for_status(job_state, full_status[ "status" ] )
         except Exception:
-            log.exception( "Failed to update Pulsar job status for job_id %s" % job_id )
+            log.exception( "Failed to update Pulsar job status for job_id %s", job_id )
             raise
             # Nothing else to do? - Attempt to fail the job?
 

--- a/lib/galaxy/jobs/runners/tasks.py
+++ b/lib/galaxy/jobs/runners/tasks.py
@@ -115,7 +115,7 @@ class TaskedJobRunner( BaseJobRunner ):
             stdout, stderr = splitter.do_merge(job_wrapper, task_wrappers)
         except Exception:
             job_wrapper.fail( "failure running job", exception=True )
-            log.exception("failure running job %d" % job_wrapper.job_id)
+            log.exception("failure running job %d", job_wrapper.job_id)
             return
 
         # run the metadata setting script here

--- a/lib/galaxy/managers/citations.py
+++ b/lib/galaxy/managers/citations.py
@@ -150,7 +150,7 @@ class DoiCitation( BaseCitation ):
             try:
                 self.raw_bibtex = self.doi_cache.get_bibtex(self.__doi)
             except Exception:
-                log.exception("Failed to fetch bibtex for DOI %s" % self.__doi)
+                log.exception("Failed to fetch bibtex for DOI %s", self.__doi)
 
         if self.raw_bibtex is DoiCitation.BIBTEX_UNSET:
             return """@MISC{%s,

--- a/lib/galaxy/model/migrate/versions/0048_dataset_instance_state_column.py
+++ b/lib/galaxy/model/migrate/versions/0048_dataset_instance_state_column.py
@@ -42,7 +42,7 @@ def upgrade(migrate_engine):
                 col.create( dataset_instance_table, index_name=index_name)
                 assert col is dataset_instance_table.c.state
             except Exception:
-                log.exception("Adding column 'state' to %s table failed." % table_name)
+                log.exception("Adding column 'state' to %s table failed.", table_name)
 
 
 def downgrade(migrate_engine):
@@ -60,4 +60,4 @@ def downgrade(migrate_engine):
                 col = dataset_instance_table.c.state
                 col.drop()
             except Exception:
-                log.exception("Dropping column 'state' from %s table failed." % table_name)
+                log.exception("Dropping column 'state' from %s table failed.", table_name)

--- a/lib/galaxy/model/migrate/versions/0062_user_openid_table.py
+++ b/lib/galaxy/model/migrate/versions/0062_user_openid_table.py
@@ -44,7 +44,7 @@ def upgrade(migrate_engine):
         try:
             i.create()
         except Exception:
-            log.exception("Adding index '%s' failed." % ix_name)
+            log.exception("Adding index '%s' failed.", ix_name)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0068_rename_sequencer_to_external_services.py
+++ b/lib/galaxy/model/migrate/versions/0068_rename_sequencer_to_external_services.py
@@ -73,7 +73,7 @@ def upgrade(migrate_engine):
         cmd = "ALTER TABLE sequencer RENAME TO external_service"
         migrate_engine.execute( cmd )
     except Exception:
-        log.exception("Exception executing SQL command: %s" % cmd)
+        log.exception("Exception executing SQL command: %s", cmd)
     # if running postgres then rename the primary key sequence too
     if migrate_engine.name in ['postgres', 'postgresql']:
         cmd = "ALTER TABLE sequencer_id_seq RENAME TO external_service_id_seq"

--- a/lib/galaxy/model/migrate/versions/0089_add_object_store_id_columns.py
+++ b/lib/galaxy/model/migrate/versions/0089_add_object_store_id_columns.py
@@ -24,7 +24,7 @@ def upgrade(migrate_engine):
             c.create( t, index_name="ix_%s_object_store_id" % t_name)
             assert c is t.c.object_store_id
         except Exception:
-            log.exception("Adding object_store_id column to %s table failed." % t_name)
+            log.exception("Adding object_store_id column to %s table failed.", t_name)
 
 
 def downgrade(migrate_engine):
@@ -35,4 +35,4 @@ def downgrade(migrate_engine):
         try:
             t.c.object_store_id.drop()
         except Exception:
-            log.exception("Dropping object_store_id column from %s table failed." % t_name)
+            log.exception("Dropping object_store_id column from %s table failed.", t_name)

--- a/lib/galaxy/model/migrate/versions/0103_add_tool_shed_repository_status_columns.py
+++ b/lib/galaxy/model/migrate/versions/0103_add_tool_shed_repository_status_columns.py
@@ -36,19 +36,19 @@ def upgrade(migrate_engine):
     try:
         migrate_engine.execute( cmd )
     except Exception:
-        log.exception("Exception executing SQL command: %s" % cmd)
+        log.exception("Exception executing SQL command: %s", cmd)
     # Update the status column for tool_shed_repositories that have been uninstalled.
     cmd = "UPDATE tool_shed_repository SET status = 'Uninstalled' WHERE uninstalled;"
     try:
         migrate_engine.execute( cmd )
     except Exception:
-        log.exception("Exception executing SQL command: %s" % cmd)
+        log.exception("Exception executing SQL command: %s", cmd)
     # Update the status column for tool_shed_repositories that have been deactivated.
     cmd = "UPDATE tool_shed_repository SET status = 'Deactivated' where deleted and not uninstalled;"
     try:
         migrate_engine.execute( cmd )
     except Exception:
-        log.exception("Exception executing SQL command: %s" % cmd)
+        log.exception("Exception executing SQL command: %s", cmd)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0106_add_missing_indexes.py
+++ b/lib/galaxy/model/migrate/versions/0106_add_missing_indexes.py
@@ -65,7 +65,7 @@ def upgrade(migrate_engine):
             else:
                 pass  # Index already exists, don't recreate.
         except Exception:
-            log.exception("Unable to create index '%s'." % ix)
+            log.exception("Unable to create index '%s'.", ix)
 
 
 def downgrade(migrate_engine):
@@ -78,4 +78,4 @@ def downgrade(migrate_engine):
             t = Table( table, metadata, autoload=True )
             Index( ix, t.c[col] ).drop()
         except Exception:
-            log.exception("Unable to drop index '%s'." % ix)
+            log.exception("Unable to drop index '%s'.", ix)

--- a/lib/galaxy/model/migrate/versions/0119_job_metrics.py
+++ b/lib/galaxy/model/migrate/versions/0119_job_metrics.py
@@ -85,11 +85,11 @@ def __create(table):
     try:
         table.create()
     except Exception:
-        log.exception("Creating %s table failed." % table.name)
+        log.exception("Creating %s table failed.", table.name)
 
 
 def __drop(table):
     try:
         table.drop()
     except Exception:
-        log.exception("Dropping %s table failed." % table.name)
+        log.exception("Dropping %s table failed.", table.name)

--- a/lib/galaxy/model/migrate/versions/0120_dataset_collections.py
+++ b/lib/galaxy/model/migrate/versions/0120_dataset_collections.py
@@ -162,11 +162,11 @@ def __create(table):
     try:
         table.create()
     except Exception:
-        log.exception("Creating %s table failed." % table.name)
+        log.exception("Creating %s table failed.", table.name)
 
 
 def __drop(table):
     try:
         table.drop()
     except Exception:
-        log.exception("Dropping %s table failed." % table.name)
+        log.exception("Dropping %s table failed.", table.name)

--- a/lib/galaxy/model/migrate/versions/0122_grow_mysql_blobs.py
+++ b/lib/galaxy/model/migrate/versions/0122_grow_mysql_blobs.py
@@ -45,7 +45,7 @@ def upgrade(migrate_engine):
         try:
             migrate_engine.execute( cmd )
         except Exception:
-            log.exception("Failed to grow column %s.%s" % (table, column))
+            log.exception("Failed to grow column %s.%s", table, column)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0123_add_workflow_request_tables.py
+++ b/lib/galaxy/model/migrate/versions/0123_add_workflow_request_tables.py
@@ -112,7 +112,7 @@ def __add_column(column, table_name, metadata, **kwds):
         table = Table( table_name, metadata, autoload=True )
         column.create( table, **kwds )
     except Exception:
-        log.exception("Adding column %s column failed." % column)
+        log.exception("Adding column %s column failed.", column)
 
 
 def __drop_column( column_name, table_name, metadata ):
@@ -120,18 +120,18 @@ def __drop_column( column_name, table_name, metadata ):
         table = Table( table_name, metadata, autoload=True )
         getattr( table.c, column_name ).drop()
     except Exception:
-        log.exception("Dropping column %s failed." % column_name)
+        log.exception("Dropping column %s failed.", column_name)
 
 
 def __create(table):
     try:
         table.create()
     except Exception:
-        log.exception("Creating %s table failed." % table.name)
+        log.exception("Creating %s table failed.", table.name)
 
 
 def __drop(table):
     try:
         table.drop()
     except Exception:
-        log.exception("Dropping %s table failed." % table.name)
+        log.exception("Dropping %s table failed.", table.name)

--- a/lib/galaxy/model/migrate/versions/0124_job_state_history.py
+++ b/lib/galaxy/model/migrate/versions/0124_job_state_history.py
@@ -31,7 +31,7 @@ def upgrade(migrate_engine):
     try:
         JobStateHistory_table.create()
     except Exception:
-        log.exception("Creating %s table failed." % JobStateHistory_table.name)
+        log.exception("Creating %s table failed.", JobStateHistory_table.name)
 
 
 def downgrade(migrate_engine):
@@ -41,4 +41,4 @@ def downgrade(migrate_engine):
     try:
         JobStateHistory_table.drop()
     except Exception:
-        log.exception("Dropping %s table failed." % JobStateHistory_table.name)
+        log.exception("Dropping %s table failed.", JobStateHistory_table.name)

--- a/lib/galaxy/model/migrate/versions/0125_workflow_step_tracking.py
+++ b/lib/galaxy/model/migrate/versions/0125_workflow_step_tracking.py
@@ -37,7 +37,7 @@ def __add_column(column, table_name, metadata, **kwds):
         table = Table( table_name, metadata, autoload=True )
         column.create( table, **kwds )
     except Exception:
-        log.exception("Adding column %s failed." % column)
+        log.exception("Adding column %s failed.", column)
 
 
 def __drop_column( column_name, table_name, metadata ):
@@ -45,4 +45,4 @@ def __drop_column( column_name, table_name, metadata ):
         table = Table( table_name, metadata, autoload=True )
         getattr( table.c, column_name ).drop()
     except Exception:
-        log.exception("Dropping column %s failed." % column_name)
+        log.exception("Dropping column %s failed.", column_name)

--- a/lib/galaxy/model/migrate/versions/0126_password_reset.py
+++ b/lib/galaxy/model/migrate/versions/0126_password_reset.py
@@ -23,7 +23,7 @@ def upgrade(migrate_engine):
     try:
         PasswordResetToken_table.create()
     except Exception:
-        log.exception("Creating %s table failed." % PasswordResetToken_table.name)
+        log.exception("Creating %s table failed.", PasswordResetToken_table.name)
 
 
 def downgrade(migrate_engine):
@@ -32,4 +32,4 @@ def downgrade(migrate_engine):
     try:
         PasswordResetToken_table.drop()
     except Exception:
-        log.exception("Dropping %s table failed." % PasswordResetToken_table.name)
+        log.exception("Dropping %s table failed.", PasswordResetToken_table.name)

--- a/lib/galaxy/model/migrate/versions/0127_output_collection_adjustments.py
+++ b/lib/galaxy/model/migrate/versions/0127_output_collection_adjustments.py
@@ -67,11 +67,11 @@ def __create(table):
     try:
         table.create()
     except Exception:
-        log.exception("Creating %s table failed." % table.name)
+        log.exception("Creating %s table failed.", table.name)
 
 
 def __drop(table):
     try:
         table.drop()
     except Exception:
-        log.exception("Dropping %s table failed." % table.name)
+        log.exception("Dropping %s table failed.", table.name)

--- a/lib/galaxy/model/migrate/versions/0128_session_timeout.py
+++ b/lib/galaxy/model/migrate/versions/0128_session_timeout.py
@@ -32,7 +32,7 @@ def __add_column(column, table_name, metadata, **kwds):
         table = Table( table_name, metadata, autoload=True )
         column.create( table, **kwds )
     except Exception:
-        log.exception("Adding column %s failed." % column)
+        log.exception("Adding column %s failed.", column)
 
 
 def __drop_column( column_name, table_name, metadata ):
@@ -40,4 +40,4 @@ def __drop_column( column_name, table_name, metadata ):
         table = Table( table_name, metadata, autoload=True )
         getattr( table.c, column_name ).drop()
     except Exception:
-        log.exception("Dropping column %s failed." % column_name)
+        log.exception("Dropping column %s failed.", column_name)

--- a/lib/galaxy/model/migrate/versions/0129_job_external_output_metadata_validity.py
+++ b/lib/galaxy/model/migrate/versions/0129_job_external_output_metadata_validity.py
@@ -33,7 +33,7 @@ def __add_column(column, table_name, metadata, **kwds):
         table = Table( table_name, metadata, autoload=True )
         column.create( table, **kwds )
     except Exception:
-        log.exception("Adding column %s failed." % column)
+        log.exception("Adding column %s failed.", column)
 
 
 def __drop_column( column_name, table_name, metadata ):
@@ -41,4 +41,4 @@ def __drop_column( column_name, table_name, metadata ):
         table = Table( table_name, metadata, autoload=True )
         getattr( table.c, column_name ).drop()
     except Exception:
-        log.exception("Dropping column %s failed." % column_name)
+        log.exception("Dropping column %s failed.", column_name)

--- a/lib/galaxy/model/migrate/versions/0131_subworkflow_and_input_parameter_modules.py
+++ b/lib/galaxy/model/migrate/versions/0131_subworkflow_and_input_parameter_modules.py
@@ -95,7 +95,7 @@ def __alter_column(table_name, column_name, metadata, **kwds):
         table = Table( table_name, metadata, autoload=True )
         getattr( table.c, column_name ).alter(**kwds)
     except Exception:
-        log.exception("Adding column %s failed." % column_name)
+        log.exception("Adding column %s failed.", column_name)
 
 
 def __add_column(column, table_name, metadata, **kwds):
@@ -103,7 +103,7 @@ def __add_column(column, table_name, metadata, **kwds):
         table = Table( table_name, metadata, autoload=True )
         column.create( table, **kwds )
     except Exception:
-        log.exception("Adding column %s failed." % column)
+        log.exception("Adding column %s failed.", column)
 
 
 def __drop_column( column_name, table_name, metadata ):
@@ -111,18 +111,18 @@ def __drop_column( column_name, table_name, metadata ):
         table = Table( table_name, metadata, autoload=True )
         getattr( table.c, column_name ).drop()
     except Exception:
-        log.exception("Dropping column %s failed." % column_name)
+        log.exception("Dropping column %s failed.", column_name)
 
 
 def __create(table):
     try:
         table.create()
     except Exception:
-        log.exception("Creating %s table failed." % table.name)
+        log.exception("Creating %s table failed.", table.name)
 
 
 def __drop(table):
     try:
         table.drop()
     except Exception:
-        log.exception("Dropping %s table failed." % table.name)
+        log.exception("Dropping %s table failed.", table.name)

--- a/lib/galaxy/model/migrate/versions/0134_hda_set_deleted_if_purged.py
+++ b/lib/galaxy/model/migrate/versions/0134_hda_set_deleted_if_purged.py
@@ -24,7 +24,7 @@ def upgrade(migrate_engine):
     try:
         migrate_engine.execute(cmd)
     except Exception:
-        log.exception("Exception executing SQL command: %s" % cmd)
+        log.exception("Exception executing SQL command: %s", cmd)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -34,7 +34,7 @@ def send_local_control_task(app, task, kwargs={}):
                              declare=[galaxy.queues.galaxy_exchange] + [galaxy.queues.control_queue_from_config(app.config)],
                              routing_key='control.%s' % app.config.server_name)
     except Exception:
-        log.exception("Error queueing async task: %s." % payload)
+        log.exception("Error queueing async task: %s.", payload)
 
 
 def send_control_task(app, task, noop_self=False, kwargs={}):
@@ -58,7 +58,7 @@ def send_control_task(app, task, noop_self=False, kwargs={}):
     except Exception:
         # This is likely connection refused.
         # TODO Use the specific Exception above.
-        log.exception("Error sending control task: %s." % payload)
+        log.exception("Error sending control task: %s.", payload)
 
 
 # Tasks -- to be reorganized into a separate module as appropriate.  This is
@@ -232,7 +232,7 @@ class GalaxyQueueWorker(ConsumerMixin, threading.Thread):
                     f(self.app, **body['kwargs'])
                 except Exception:
                     # this shouldn't ever throw an exception, but...
-                    log.exception("Error running control task type: %s" % body['task'])
+                    log.exception("Error running control task type: %s", body['task'])
         else:
             log.warning("Received a malformed task message:\n%s" % body)
         message.ack()

--- a/lib/galaxy/sample_tracking/external_service_types.py
+++ b/lib/galaxy/sample_tracking/external_service_types.py
@@ -38,7 +38,7 @@ class ExternalServiceTypesCollection( object ):
                     if visible:
                         self.visible_external_service_types.append( external_service_type.id )
             except:
-                log.exception( "error reading external_service_type from path: %s" % file_path )
+                log.exception( "error reading external_service_type from path: %s", file_path )
 
     def load_external_service_type( self, config_file, visible=True ):
         # Parse XML configuration file and get the root element

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1102,7 +1102,7 @@ class Tool( object, Dictifiable ):
                 # Handle tool help image display for tools that are contained in repositories in the tool shed or installed into Galaxy.
                 try:
                     help_text = tool_shed.util.shed_util_common.set_image_paths( self.app, self.repository_id, help_text )
-                except Exception as e:
+                except Exception:
                     log.exception( "Exception in parse_help, so images may not be properly displayed" )
             try:
                 self.__help = Template( rst_to_html(help_text), input_encoding='utf-8',

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1103,7 +1103,7 @@ class Tool( object, Dictifiable ):
                 try:
                     help_text = tool_shed.util.shed_util_common.set_image_paths( self.app, self.repository_id, help_text )
                 except Exception as e:
-                    log.exception( "Exception in parse_help, so images may not be properly displayed:\n%s" % str( e ) )
+                    log.exception( "Exception in parse_help, so images may not be properly displayed" )
             try:
                 self.__help = Template( rst_to_html(help_text), input_encoding='utf-8',
                                         output_encoding='utf-8', default_filters=[ 'decode.utf8' ],

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1109,7 +1109,7 @@ class Tool( object, Dictifiable ):
                                         output_encoding='utf-8', default_filters=[ 'decode.utf8' ],
                                         encoding_errors='replace' )
             except:
-                log.exception( "error in help for tool %s" % self.name )
+                log.exception( "error in help for tool %s", self.name )
 
             # Handle deprecated multi-page help text in XML case.
             if hasattr(tool_source, "root"):
@@ -1129,7 +1129,7 @@ class Tool( object, Dictifiable ):
                                                       encoding_errors='replace' )
                                             for x in self.__help_by_page ]
                 except:
-                    log.exception( "error in multi-page help for tool %s" % self.name )
+                    log.exception( "error in multi-page help for tool %s", self.name )
         # Pad out help pages to match npages ... could this be done better?
         while len( self.__help_by_page ) < self.npages:
             self.__help_by_page.append( self.__help )

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -567,7 +567,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
         except IOError:
             log.error( "Error reading tool configuration file from path: %s" % path )
         except Exception:
-            log.exception( "Error reading tool from path: %s" % path )
+            log.exception( "Error reading tool from path: %s", path )
 
     def get_tool_repository_from_xml_item(self, item, path):
         tool_shed = item.elem.find("tool_shed").text
@@ -630,7 +630,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
             # Always load workflows into the integrated_panel_dict.
             integrated_panel_dict.update_or_append( index, key, workflow )
         except:
-            log.exception( "Error loading workflow: %s" % workflow_id )
+            log.exception( "Error loading workflow: %s", workflow_id )
 
     def _load_label_tag_set( self, item, panel_dict, integrated_panel_dict, load_panel_dict, index=None ):
         label = ToolSectionLabel( item )
@@ -697,7 +697,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
                     self._save_integrated_tool_panel()
                 return tool.id
             except Exception:
-                log.exception("Failed to load potential tool %s." % tool_file)
+                log.exception("Failed to load potential tool %s.", tool_file)
                 return None
 
         tool_loaded = False

--- a/lib/galaxy/tools/verify/asserts/__init__.py
+++ b/lib/galaxy/tools/verify/asserts/__init__.py
@@ -20,7 +20,7 @@ for assertion_module_name in assertion_module_names:
         assertion_module = sys.modules[full_assertion_module_name]
         assertion_modules.append(assertion_module)
     except Exception as e:
-        log.exception('Failed to load assertion module: %s' % (assertion_module_name))
+        log.exception('Failed to load assertion module: %s', assertion_module_name)
 
 
 def verify_assertions(data, assertion_description_list):

--- a/lib/galaxy/tools/verify/asserts/__init__.py
+++ b/lib/galaxy/tools/verify/asserts/__init__.py
@@ -20,7 +20,7 @@ for assertion_module_name in assertion_module_names:
         assertion_module = sys.modules[full_assertion_module_name]
         assertion_modules.append(assertion_module)
     except Exception as e:
-        log.exception('Failed to load assertion module: %s %s' % (assertion_module_name, str(e)))
+        log.exception('Failed to load assertion module: %s' % (assertion_module_name))
 
 
 def verify_assertions(data, assertion_description_list):

--- a/lib/galaxy/tours/__init__.py
+++ b/lib/galaxy/tours/__init__.py
@@ -74,7 +74,7 @@ class ToursRegistry(object):
                 log.info("Loaded tour '%s'" % tour_id)
                 return tour
         except IOError:
-            log.exception("Tour '%s' could not be loaded, error reading file." % tour_id)
+            log.exception("Tour '%s' could not be loaded, error reading file.", tour_id)
         except yaml.error.YAMLError:
-            log.exception("Tour '%s' could not be loaded, error within file.  Please check your yaml syntax." % tour_id)
+            log.exception("Tour '%s' could not be loaded, error within file.  Please check your yaml syntax.", tour_id)
         return None

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -899,7 +899,7 @@ def unicodify(value, encoding=DEFAULT_ENCODING, error='replace', default=None):
         if not isinstance(value, text_type):
             value = text_type(value, encoding, error)
     except Exception:
-        log.exception("value %s could not be coerced to unicode" % value)
+        log.exception("value %s could not be coerced to unicode", value)
         return default
     return value
 
@@ -1139,7 +1139,7 @@ def umask_fix_perms( path, umask, unmasked_perms, gid=None ):
     try:
         st = os.stat( path )
     except OSError as e:
-        log.exception( 'Unable to set permissions or group on %s' % path )
+        log.exception( 'Unable to set permissions or group on %s', path )
         return
     # fix modes
     if stat.S_IMODE( st.st_mode ) != perms:

--- a/lib/galaxy/visualization/genomes.py
+++ b/lib/galaxy/visualization/genomes.py
@@ -214,7 +214,7 @@ class Genomes( object ):
                     if len( val ) == 2:
                         key, path = val
                         twobit_fields[ key ] = path
-            except IOError as e:
+            except IOError:
                 # Thrown if twobit.loc does not exist.
                 log.exception( "Error reading twobit.loc" )
         for key, description in self.app.genome_builds.get_genome_build_names():

--- a/lib/galaxy/visualization/genomes.py
+++ b/lib/galaxy/visualization/genomes.py
@@ -329,7 +329,7 @@ class Genomes( object ):
         if genome:
             rval = genome.to_dict( num=num, chrom=chrom, low=low )
         else:
-            log.exception( 'genome not found for key %s' % dbkey )
+            log.exception( 'genome not found for key %s', dbkey )
 
         return rval
 

--- a/lib/galaxy/visualization/genomes.py
+++ b/lib/galaxy/visualization/genomes.py
@@ -216,7 +216,7 @@ class Genomes( object ):
                         twobit_fields[ key ] = path
             except IOError as e:
                 # Thrown if twobit.loc does not exist.
-                log.exception( "Error reading twobit.loc: %s", e )
+                log.exception( "Error reading twobit.loc" )
         for key, description in self.app.genome_builds.get_genome_build_names():
             self.genomes[ key ] = Genome( key, description )
             # Add len files to genomes.

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -164,7 +164,7 @@ class BaseUIController( BaseController ):
         except exceptions.MessageException:
             raise       # handled in the caller
         except:
-            log.exception( "Exception in get_object check for %s %s:" % ( class_name, str( id ) ) )
+            log.exception( "Exception in get_object check for %s %s:", class_name, str( id ) )
             raise Exception( 'Server error retrieving %s id ( %s ).' % ( class_name, str( id ) ) )
 
 
@@ -180,7 +180,7 @@ class BaseAPIController( BaseController ):
         except exceptions.MessageException as e:
             raise HTTPBadRequest( detail=e.err_msg )
         except Exception as e:
-            log.exception( "Exception in get_object check for %s %s." % ( class_name, str( id ) ) )
+            log.exception( "Exception in get_object check for %s %s.", class_name, str( id ) )
             raise HTTPInternalServerError( comment=str( e ) )
 
     def validate_in_users_and_groups( self, trans, payload ):

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -162,7 +162,7 @@ class HistoryContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrar
             )
             return self.__collection_dict( trans, dataset_collection_instance, view="element" )
         except Exception as e:
-            log.exception( "Error in history API at listing dataset collection: %s", e )
+            log.exception( "Error in history API at listing dataset collection" )
             trans.response.status = 500
             return { 'error': str( e ) }
 

--- a/lib/galaxy/webapps/galaxy/api/lda_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/lda_datasets.py
@@ -607,7 +607,7 @@ class LibraryDatasetsController( BaseAPIController, UsesVisualizationMixin ):
                 log.exception( "Unable to create archive for download" )
                 raise exceptions.InternalServerError( "Unable to create archive for download." )
             except Exception:
-                log.exception( "Unexpected error %s in create archive for download" % sys.exc_info()[ 0 ] )
+                log.exception( "Unexpected error %s in create archive for download", sys.exc_info()[ 0 ] )
                 raise exceptions.InternalServerError( "Unable to create archive for download." )
             composite_extensions = trans.app.datatypes_registry.get_composite_extensions()
             seen = []
@@ -640,13 +640,13 @@ class LibraryDatasetsController( BaseAPIController, UsesVisualizationMixin ):
                         else:
                             archive.add( ldda.dataset.file_name, zpath, check_file=True )  # add the primary of a composite set
                     except IOError:
-                        log.exception( "Unable to add composite parent %s to temporary library download archive" % ldda.dataset.file_name )
+                        log.exception( "Unable to add composite parent %s to temporary library download archive", ldda.dataset.file_name )
                         raise exceptions.InternalServerError( "Unable to create archive for download." )
                     except ObjectNotFound:
-                        log.exception( "Requested dataset %s does not exist on the host." % ldda.dataset.file_name )
+                        log.exception( "Requested dataset %s does not exist on the host.", ldda.dataset.file_name )
                         raise exceptions.ObjectNotFound( "Requested dataset not found. " )
                     except Exception as e:
-                        log.exception( "Unable to add composite parent %s to temporary library download archive" % ldda.dataset.file_name )
+                        log.exception( "Unable to add composite parent %s to temporary library download archive", ldda.dataset.file_name )
                         raise exceptions.InternalServerError( "Unable to add composite parent to temporary library download archive. " + str( e ) )
 
                     flist = glob.glob(os.path.join(ldda.dataset.extra_files_path, '*.*'))  # glob returns full paths
@@ -660,13 +660,13 @@ class LibraryDatasetsController( BaseAPIController, UsesVisualizationMixin ):
                             else:
                                 archive.add( fpath, fname, check_file=True )
                         except IOError:
-                            log.exception( "Unable to add %s to temporary library download archive %s" % ( fname, outfname) )
+                            log.exception( "Unable to add %s to temporary library download archive %s", fname, outfname )
                             raise exceptions.InternalServerError( "Unable to create archive for download." )
                         except ObjectNotFound:
-                            log.exception( "Requested dataset %s does not exist on the host." % fpath )
+                            log.exception( "Requested dataset %s does not exist on the host.", fpath )
                             raise exceptions.ObjectNotFound( "Requested dataset not found." )
                         except Exception as e:
-                            log.exception( "Unable to add %s to temporary library download archive %s" % ( fname, outfname ) )
+                            log.exception( "Unable to add %s to temporary library download archive %s", fname, outfname )
                             raise exceptions.InternalServerError( "Unable to add dataset to temporary library download archive . " + str( e ) )
 
                 else:  # simple case
@@ -676,13 +676,13 @@ class LibraryDatasetsController( BaseAPIController, UsesVisualizationMixin ):
                         else:
                             archive.add( ldda.dataset.file_name, path, check_file=True )
                     except IOError:
-                        log.exception( "Unable to write %s to temporary library download archive" % ldda.dataset.file_name )
+                        log.exception( "Unable to write %s to temporary library download archive", ldda.dataset.file_name )
                         raise exceptions.InternalServerError( "Unable to create archive for download" )
                     except ObjectNotFound:
-                        log.exception( "Requested dataset %s does not exist on the host." % ldda.dataset.file_name )
+                        log.exception( "Requested dataset %s does not exist on the host.", ldda.dataset.file_name )
                         raise exceptions.ObjectNotFound( "Requested dataset not found." )
                     except Exception as e:
-                        log.exception( "Unable to add %s to temporary library download archive %s" % ( fname, outfname ) )
+                        log.exception( "Unable to add %s to temporary library download archive %s", fname, outfname )
                         raise exceptions.InternalServerError( "Unknown error. " + str( e ) )
             lname = 'selected_dataset'
             fname = lname.replace( ' ', '_' ) + '_files'

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -390,7 +390,7 @@ class LibraryContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrar
             trans.sa_session.flush()
             rval[ 'deleted' ] = True
 
-        except exceptions.httpexceptions.HTTPInternalServerError as http_server_err:
+        except exceptions.httpexceptions.HTTPInternalServerError:
             log.exception( 'Library_contents API, delete: uncaught HTTPInternalServerError: %s, %s',
                            id, str( kwd ) )
             raise

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -391,14 +391,14 @@ class LibraryContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrar
             rval[ 'deleted' ] = True
 
         except exceptions.httpexceptions.HTTPInternalServerError as http_server_err:
-            log.exception( 'Library_contents API, delete: uncaught HTTPInternalServerError: %s, %s\n%s',
-                           id, str( kwd ), str( http_server_err ) )
+            log.exception( 'Library_contents API, delete: uncaught HTTPInternalServerError: %s, %s',
+                           id, str( kwd ) )
             raise
         except exceptions.httpexceptions.HTTPException:
             raise
         except Exception as exc:
-            log.exception( 'library_contents API, delete: uncaught exception: %s, %s\n%s',
-                           id, str( kwd ), str( exc ) )
+            log.exception( 'library_contents API, delete: uncaught exception: %s, %s',
+                           id, str( kwd ) )
             trans.response.status = 500
             rval.update({ 'error': str( exc ) })
         return rval

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -630,7 +630,7 @@ class HistoryController( BaseUIController, SharableMixin, UsesAnnotations, UsesI
 
         except Exception as exc:
             user_id = str( trans.user.id ) if trans.user else '(anonymous)'
-            log.exception( 'Error bootstrapping history for user %s: %s', user_id, exc )
+            log.exception( 'Error bootstrapping history for user %s', user_id )
             if isinstance( exc, exceptions.ItemAccessibilityException ):
                 error_msg = 'You do not have permission to view this history.'
             else:

--- a/lib/galaxy/webapps/galaxy/controllers/library_common.py
+++ b/lib/galaxy/webapps/galaxy/controllers/library_common.py
@@ -51,7 +51,7 @@ for comptype in ( 'gz', 'bz2' ):
         archive.close()
         comptypes.append( comptype )
     except tarfile.CompressionError:
-        log.exception( "Compression error when testing %s compression.  This option will be disabled for library downloads." % comptype )
+        log.exception( "Compression error when testing %s compression.  This option will be disabled for library downloads.", comptype )
     try:
         os.unlink( tmpf )
     except OSError:
@@ -1863,7 +1863,7 @@ class LibraryCommon( BaseUIController, UsesFormDefinitionsMixin, UsesExtendedMet
                     status = 'error'
                 except:
                     error = True
-                    log.exception( "Unexpected error %s in create archive for download" % sys.exc_info()[0] )
+                    log.exception( "Unexpected error %s in create archive for download", sys.exc_info()[0] )
                     message = "Unable to create archive for download, please report - %s" % sys.exc_info()[0]
                     status = 'error'
                 if not error:
@@ -1897,7 +1897,7 @@ class LibraryCommon( BaseUIController, UsesFormDefinitionsMixin, UsesExtendedMet
                                 archive.add(ldda.dataset.file_name, zpath)  # add the primary of a composite set
                             except IOError:
                                 error = True
-                                log.exception( "Unable to add composite parent %s to temporary library download archive" % ldda.dataset.file_name)
+                                log.exception( "Unable to add composite parent %s to temporary library download archive", ldda.dataset.file_name)
                                 message = "Unable to create archive for download, please report this error"
                                 status = 'error'
                                 continue
@@ -1910,7 +1910,7 @@ class LibraryCommon( BaseUIController, UsesFormDefinitionsMixin, UsesExtendedMet
                                     archive.add( fpath, fname )
                                 except IOError:
                                     error = True
-                                    log.exception( "Unable to add %s to temporary library download archive %s" % (fname, outfname))
+                                    log.exception( "Unable to add %s to temporary library download archive %s", fname, outfname)
                                     message = "Unable to create archive for download, please report this error"
                                     status = 'error'
                                     continue
@@ -1919,7 +1919,7 @@ class LibraryCommon( BaseUIController, UsesFormDefinitionsMixin, UsesExtendedMet
                                 archive.add( ldda.dataset.file_name, path )
                             except IOError:
                                 error = True
-                                log.exception( "Unable to write %s to temporary library download archive" % ldda.dataset.file_name)
+                                log.exception( "Unable to write %s to temporary library download archive", ldda.dataset.file_name)
                                 message = "Unable to create archive for download, please report this error"
                                 status = 'error'
                     if not error:

--- a/lib/galaxy/webapps/tool_shed/model/migrate/versions/0024_password_reset.py
+++ b/lib/galaxy/webapps/tool_shed/model/migrate/versions/0024_password_reset.py
@@ -24,7 +24,7 @@ def upgrade(migrate_engine):
         PasswordResetToken_table.create()
     except Exception as e:
         print str(e)
-        log.exception("Creating %s table failed" % PasswordResetToken_table.name )
+        log.exception("Creating %s table failed", PasswordResetToken_table.name )
 
 
 def downgrade(migrate_engine):
@@ -34,4 +34,4 @@ def downgrade(migrate_engine):
         PasswordResetToken_table.drop()
     except Exception as e:
         print str(e)
-        log.exception("Dropping %s table failed" % PasswordResetToken_table.name )
+        log.exception("Dropping %s table failed", PasswordResetToken_table.name )

--- a/lib/galaxy/webapps/tool_shed/model/migrate/versions/0024_password_reset.py
+++ b/lib/galaxy/webapps/tool_shed/model/migrate/versions/0024_password_reset.py
@@ -24,7 +24,7 @@ def upgrade(migrate_engine):
         PasswordResetToken_table.create()
     except Exception as e:
         print str(e)
-        log.exception("Creating %s table failed: %s" % (PasswordResetToken_table.name, str( e ) ) )
+        log.exception("Creating %s table failed" % PasswordResetToken_table.name )
 
 
 def downgrade(migrate_engine):
@@ -34,4 +34,4 @@ def downgrade(migrate_engine):
         PasswordResetToken_table.drop()
     except Exception as e:
         print str(e)
-        log.exception("Dropping %s table failed: %s" % (PasswordResetToken_table.name, str( e ) ) )
+        log.exception("Dropping %s table failed" % PasswordResetToken_table.name )

--- a/lib/galaxy/webapps/tool_shed/model/migrate/versions/0025_session_timeout.py
+++ b/lib/galaxy/webapps/tool_shed/model/migrate/versions/0025_session_timeout.py
@@ -33,7 +33,7 @@ def __add_column(column, table_name, metadata, **kwds):
         column.create( table, **kwds )
     except Exception as e:
         print str(e)
-        log.exception( "Adding column %s failed." % column)
+        log.exception( "Adding column %s failed.", column)
 
 
 def __drop_column( column_name, table_name, metadata ):
@@ -42,4 +42,4 @@ def __drop_column( column_name, table_name, metadata ):
         getattr( table.c, column_name ).drop()
     except Exception as e:
         print str(e)
-        log.exception( "Dropping column %s failed." % column_name )
+        log.exception( "Dropping column %s failed.", column_name )

--- a/lib/tool_shed/capsule/capsule_manager.py
+++ b/lib/tool_shed/capsule/capsule_manager.py
@@ -507,7 +507,7 @@ class ImportRepositoryManager( object ):
             tar_archive.extractall( path=file_path )
             try:
                 tar_archive.close()
-            except Exception as e:
+            except Exception:
                 log.exception( "Cannot close tar_archive" )
             del return_dict[ 'tar_archive' ]
         return return_dict

--- a/lib/tool_shed/capsule/capsule_manager.py
+++ b/lib/tool_shed/capsule/capsule_manager.py
@@ -508,7 +508,7 @@ class ImportRepositoryManager( object ):
             try:
                 tar_archive.close()
             except Exception as e:
-                log.exception( "Cannot close tar_archive: %s" % str( e ) )
+                log.exception( "Cannot close tar_archive" )
             del return_dict[ 'tar_archive' ]
         return return_dict
 

--- a/lib/tool_shed/galaxy_install/tool_migration_manager.py
+++ b/lib/tool_shed/galaxy_install/tool_migration_manager.py
@@ -412,7 +412,7 @@ class ToolMigrationManager( object ):
                 lock.acquire( True )
                 try:
                     self.filter_and_persist_proprietary_tool_panel_configs( tool_configs_to_filter )
-                except Exception as e:
+                except Exception:
                     log.exception( "Exception attempting to filter and persist non-shed-related tool panel configs" )
                 finally:
                     lock.release()

--- a/lib/tool_shed/galaxy_install/tool_migration_manager.py
+++ b/lib/tool_shed/galaxy_install/tool_migration_manager.py
@@ -413,7 +413,7 @@ class ToolMigrationManager( object ):
                 try:
                     self.filter_and_persist_proprietary_tool_panel_configs( tool_configs_to_filter )
                 except Exception as e:
-                    log.exception( "Exception attempting to filter and persist non-shed-related tool panel configs:\n%s" % str( e ) )
+                    log.exception( "Exception attempting to filter and persist non-shed-related tool panel configs" )
                 finally:
                     lock.release()
         irmm = InstalledRepositoryMetadataManager( app=self.app,

--- a/lib/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/data_manager.py
@@ -28,7 +28,7 @@ class DataManagerHandler( object ):
                 fh.write( xml_util.xml_to_string( elem ) )
             fh.write( '</data_managers>\n' )
             fh.close()
-        except Exception as e:
+        except Exception:
             log.exception( "Exception in DataManagerHandler.data_manager_config_elems_to_xml_file" )
         finally:
             lock.release()

--- a/lib/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/data_manager.py
@@ -29,7 +29,7 @@ class DataManagerHandler( object ):
             fh.write( '</data_managers>\n' )
             fh.close()
         except Exception as e:
-            log.exception( "Exception in DataManagerHandler.data_manager_config_elems_to_xml_file: %s" % str( e ) )
+            log.exception( "Exception in DataManagerHandler.data_manager_config_elems_to_xml_file" )
         finally:
             lock.release()
 

--- a/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -90,7 +90,7 @@ class ToolPanelManager( object ):
             fh.write( '</toolbox>\n' )
             fh.close()
         except Exception as e:
-            log.exception( "Exception in ToolPanelManager.config_elems_to_xml_file: %s" % str( e ) )
+            log.exception( "Exception in ToolPanelManager.config_elems_to_xml_file: %s" )
         finally:
             lock.release()
 

--- a/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -89,7 +89,7 @@ class ToolPanelManager( object ):
                 fh.write( xml_util.xml_to_string( elem, use_indent=True ) )
             fh.write( '</toolbox>\n' )
             fh.close()
-        except Exception as e:
+        except Exception:
             log.exception( "Exception in ToolPanelManager.config_elems_to_xml_file: %s" )
         finally:
             lock.release()

--- a/lib/tool_shed/metadata/metadata_generator.py
+++ b/lib/tool_shed/metadata/metadata_generator.py
@@ -450,7 +450,7 @@ class MetadataGenerator( object ):
                                 valid_exported_galaxy_workflow = True
                                 try:
                                     exported_workflow_dict = json.loads( workflow_text )
-                                except Exception as e:
+                                except Exception:
                                     log.exception( "Skipping file %s since it does not seem to be a valid exported Galaxy workflow",
                                                    str( relative_path ) )
                                     valid_exported_galaxy_workflow = False

--- a/lib/tool_shed/metadata/metadata_generator.py
+++ b/lib/tool_shed/metadata/metadata_generator.py
@@ -451,8 +451,8 @@ class MetadataGenerator( object ):
                                 try:
                                     exported_workflow_dict = json.loads( workflow_text )
                                 except Exception as e:
-                                    log.exception( "Skipping file %s since it does not seem to be a valid exported Galaxy workflow"
-                                                   % str( relative_path ) )
+                                    log.exception( "Skipping file %s since it does not seem to be a valid exported Galaxy workflow",
+                                                   str( relative_path ) )
                                     valid_exported_galaxy_workflow = False
                             if valid_exported_galaxy_workflow and \
                                 'a_galaxy_workflow' in exported_workflow_dict and \

--- a/lib/tool_shed/metadata/metadata_generator.py
+++ b/lib/tool_shed/metadata/metadata_generator.py
@@ -451,8 +451,8 @@ class MetadataGenerator( object ):
                                 try:
                                     exported_workflow_dict = json.loads( workflow_text )
                                 except Exception as e:
-                                    log.exception( "Skipping file %s since it does not seem to be a valid exported Galaxy workflow: %s"
-                                                   % ( str( relative_path ), str( e ) ) )
+                                    log.exception( "Skipping file %s since it does not seem to be a valid exported Galaxy workflow"
+                                                   % str( relative_path ) )
                                     valid_exported_galaxy_workflow = False
                             if valid_exported_galaxy_workflow and \
                                 'a_galaxy_workflow' in exported_workflow_dict and \

--- a/lib/tool_shed/metadata/repository_metadata_manager.py
+++ b/lib/tool_shed/metadata/repository_metadata_manager.py
@@ -885,7 +885,7 @@ class RepositoryMetadataManager( metadata_generator.MetadataGenerator ):
                             ( str( repository.name ), str( repository.user.username ) ) )
                         successful_count += 1
                 except:
-                    log.exception( "Error attempting to reset metadata on repository %s" % str( repository.name ) )
+                    log.exception( "Error attempting to reset metadata on repository %s", str( repository.name ) )
                     unsuccessful_count += 1
             message = "Successfully reset metadata on %d %s.  " % \
                 ( successful_count, inflector.cond_plural( successful_count, "repository" ) )

--- a/lib/tool_shed/repository_registry.py
+++ b/lib/tool_shed/repository_registry.py
@@ -93,7 +93,7 @@ class Registry( object ):
                 self.load_repository_and_suite_tuple( repository )
                 if is_level_one_certified:
                     self.load_certified_level_one_repository_and_suite_tuple( repository )
-        except Exception as e:
+        except Exception:
             # The viewable repository numbers and the categorized (filtered) lists of repository tuples
             # may be slightly skewed, but that is no reason to result in a potential server error.  All
             # will be corrected at next server start.
@@ -341,7 +341,7 @@ class Registry( object ):
                 self.unload_repository_and_suite_tuple( repository )
                 if is_level_one_certified:
                     self.unload_certified_level_one_repository_and_suite_tuple( repository )
-        except Exception as e:
+        except Exception:
             # The viewable repository numbers and the categorized (filtered) lists of repository tuples
             # may be slightly skewed, but that is no reason to result in a potential server error.  All
             # will be corrected at next server start.

--- a/lib/tool_shed/repository_registry.py
+++ b/lib/tool_shed/repository_registry.py
@@ -97,7 +97,7 @@ class Registry( object ):
             # The viewable repository numbers and the categorized (filtered) lists of repository tuples
             # may be slightly skewed, but that is no reason to result in a potential server error.  All
             # will be corrected at next server start.
-            log.exception( "Handled error adding entry to repository registry: %s." % str( e ) )
+            log.exception( "Handled error adding entry to repository registry" )
 
     def edit_category_entry( self, old_name, new_name ):
         if old_name in self.viewable_repositories_and_suites_by_category:
@@ -345,7 +345,7 @@ class Registry( object ):
             # The viewable repository numbers and the categorized (filtered) lists of repository tuples
             # may be slightly skewed, but that is no reason to result in a potential server error.  All
             # will be corrected at next server start.
-            log.exception( "Handled error removing entry from repository registry: %s." % str( e ) )
+            log.exception( "Handled error removing entry from repository registry: %s." )
 
     @property
     def sa_session( self ):

--- a/lib/tool_shed/util/commit_util.py
+++ b/lib/tool_shed/util/commit_util.py
@@ -138,7 +138,7 @@ def handle_bz2( repository, uploaded_file_name ):
         except IOError:
             os.close( fd )
             os.remove( uncompressed )
-            log.exception( 'Problem uncompressing bz2 data "%s"' % uploaded_file_name )
+            log.exception( 'Problem uncompressing bz2 data "%s"', uploaded_file_name )
             return
         if not chunk:
             break
@@ -238,7 +238,7 @@ def handle_gzip( repository, uploaded_file_name ):
         except IOError as e:
             os.close( fd )
             os.remove( uncompressed )
-            log.exception( 'Problem uncompressing gz data "%s"' % uploaded_file_name )
+            log.exception( 'Problem uncompressing gz data "%s"', uploaded_file_name )
             return
         if not chunk:
             break

--- a/lib/tool_shed/util/commit_util.py
+++ b/lib/tool_shed/util/commit_util.py
@@ -235,7 +235,7 @@ def handle_gzip( repository, uploaded_file_name ):
     while 1:
         try:
             chunk = gzipped_file.read( basic_util.CHUNK_SIZE )
-        except IOError as e:
+        except IOError:
             os.close( fd )
             os.remove( uncompressed )
             log.exception( 'Problem uncompressing gz data "%s"', uploaded_file_name )

--- a/lib/tool_shed/util/commit_util.py
+++ b/lib/tool_shed/util/commit_util.py
@@ -238,7 +238,7 @@ def handle_gzip( repository, uploaded_file_name ):
         except IOError as e:
             os.close( fd )
             os.remove( uncompressed )
-            log.exception( 'Problem uncompressing gz data "%s": %s' % ( uploaded_file_name, str( e ) ) )
+            log.exception( 'Problem uncompressing gz data "%s"' % uploaded_file_name )
             return
         if not chunk:
             break

--- a/lib/tool_shed/util/common_util.py
+++ b/lib/tool_shed/util/common_util.py
@@ -174,7 +174,7 @@ def get_protocol_from_tool_shed_url( tool_shed_url ):
     try:
         if tool_shed_url.find( '://' ) > 0:
             return tool_shed_url.split( '://' )[0].lower()
-    except Exception as e:
+    except Exception:
         # We receive a lot of calls here where the tool_shed_url is None.  The container_util uses
         # that value when creating a header row.  If the tool_shed_url is not None, we have a problem.
         if tool_shed_url is not None:
@@ -272,7 +272,7 @@ def handle_tool_shed_url_protocol( app, shed_url ):
         else:
             tool_shed_url = str( url_for( '/', qualified=True ) ).rstrip( '/' )
         return tool_shed_url
-    except Exception as e:
+    except Exception:
         # We receive a lot of calls here where the tool_shed_url is None.  The container_util uses
         # that value when creating a header row.  If the tool_shed_url is not None, we have a problem.
         if shed_url is not None:
@@ -313,7 +313,7 @@ def remove_port_from_tool_shed_url( tool_shed_url ):
         else:
             new_tool_shed_url = tool_shed_url
         return new_tool_shed_url.rstrip( '/' )
-    except Exception as e:
+    except Exception:
         # We receive a lot of calls here where the tool_shed_url is None.  The container_util uses
         # that value when creating a header row.  If the tool_shed_url is not None, we have a problem.
         if tool_shed_url is not None:

--- a/lib/tool_shed/util/common_util.py
+++ b/lib/tool_shed/util/common_util.py
@@ -178,7 +178,7 @@ def get_protocol_from_tool_shed_url( tool_shed_url ):
         # We receive a lot of calls here where the tool_shed_url is None.  The container_util uses
         # that value when creating a header row.  If the tool_shed_url is not None, we have a problem.
         if tool_shed_url is not None:
-            log.exception( "Handled exception getting the protocol from Tool Shed URL %s:\n%s", str( tool_shed_url ), e )
+            log.exception( "Handled exception getting the protocol from Tool Shed URL %s", str( tool_shed_url ) )
         # Default to HTTP protocol.
         return 'http'
 
@@ -276,7 +276,7 @@ def handle_tool_shed_url_protocol( app, shed_url ):
         # We receive a lot of calls here where the tool_shed_url is None.  The container_util uses
         # that value when creating a header row.  If the tool_shed_url is not None, we have a problem.
         if shed_url is not None:
-            log.exception( "Handled exception removing protocol from URL %s:\n%s", str( shed_url ), e )
+            log.exception( "Handled exception removing protocol from URL %s", str( shed_url ) )
         return shed_url
 
 
@@ -317,7 +317,7 @@ def remove_port_from_tool_shed_url( tool_shed_url ):
         # We receive a lot of calls here where the tool_shed_url is None.  The container_util uses
         # that value when creating a header row.  If the tool_shed_url is not None, we have a problem.
         if tool_shed_url is not None:
-            log.exception( "Handled exception removing the port from Tool Shed URL %s:\n%s", str( tool_shed_url ), e )
+            log.exception( "Handled exception removing the port from Tool Shed URL %s", str( tool_shed_url ) )
         return tool_shed_url
 
 

--- a/lib/tool_shed/util/readme_util.py
+++ b/lib/tool_shed/util/readme_util.py
@@ -45,7 +45,7 @@ def build_readme_files_dict( app, repository, changeset_revision, metadata, tool
                         text = unicodify( f.read() )
                         f.close()
                     except Exception as e:
-                        log.exception( "Error reading README file '%s' from disk: %s" % ( str( relative_path_to_readme_file ), str( e ) ) )
+                        log.exception( "Error reading README file '%s' from disk", str( relative_path_to_readme_file ) )
                         text = None
                     if text:
                         text_of_reasonable_length = basic_util.size_string( text )

--- a/lib/tool_shed/util/readme_util.py
+++ b/lib/tool_shed/util/readme_util.py
@@ -58,7 +58,7 @@ def build_readme_files_dict( app, repository, changeset_revision, metadata, tool
                                                                                  app.security.encode_id( repository.id ),
                                                                                  text_of_reasonable_length )
                             except Exception as e:
-                                log.exception( "Exception in build_readme_files_dict, so images may not be properly displayed:\n%s" % str( e ) )
+                                log.exception( "Exception in build_readme_files_dict, so images may not be properly displayed" )
                             finally:
                                 lock.release()
                         if readme_file_name.endswith( '.rst' ):

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -813,7 +813,7 @@ def get_tool_shed_status_for_installed_repository( app, repository ):
             # The required tool shed may be unavailable, so default the revision_update value to 'false'.
             return dict( revision_update='false' )
     except Exception as e:
-        log.exception( "Error attempting to get tool shed status for installed repository %s: %s" % ( str( repository.name ), str( e ) ) )
+        log.exception( "Error attempting to get tool shed status for installed repository %s" % str( repository.name ) )
         return {}
 
 

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -813,7 +813,7 @@ def get_tool_shed_status_for_installed_repository( app, repository ):
             # The required tool shed may be unavailable, so default the revision_update value to 'false'.
             return dict( revision_update='false' )
     except Exception as e:
-        log.exception( "Error attempting to get tool shed status for installed repository %s" % str( repository.name ) )
+        log.exception( "Error attempting to get tool shed status for installed repository %s", str( repository.name ) )
         return {}
 
 

--- a/lib/tool_shed/util/workflow_util.py
+++ b/lib/tool_shed/util/workflow_util.py
@@ -88,7 +88,7 @@ class RepoToolModule( ToolModule ):
             except:
                 # TODO have this actually use default parameters?  Fix at
                 # refactor, needs to be discussed wrt: reproducibility though.
-                log.exception("Tool parse failed for %s -- this indicates incompatibility of local tool version with expected version by the workflow." % self.tool.id)
+                log.exception("Tool parse failed for %s -- this indicates incompatibility of local tool version with expected version by the workflow.", self.tool.id)
         return data_inputs
 
     def get_data_outputs( self ):

--- a/lib/tool_shed/utility_containers/__init__.py
+++ b/lib/tool_shed/utility_containers/__init__.py
@@ -350,7 +350,7 @@ class ToolShedUtilityContainerManager( utility_container_manager.UtilityContaine
                                                                      error_messages,
                                                                      label="Invalid Data Managers" )
                         containers_dict[ 'invalid_data_managers' ] = data_managers_root_folder
-            except Exception as e:
+            except Exception:
                 log.exception( "Exception in build_repository_containers" )
             finally:
                 lock.release()

--- a/lib/tool_shed/utility_containers/__init__.py
+++ b/lib/tool_shed/utility_containers/__init__.py
@@ -351,7 +351,7 @@ class ToolShedUtilityContainerManager( utility_container_manager.UtilityContaine
                                                                      label="Invalid Data Managers" )
                         containers_dict[ 'invalid_data_managers' ] = data_managers_root_folder
             except Exception as e:
-                log.exception( "Exception in build_repository_containers: %s" % str( e ) )
+                log.exception( "Exception in build_repository_containers" )
             finally:
                 lock.release()
         return containers_dict


### PR DESCRIPTION
Standardizes our usage of log.exception to 1) not include the exception in the string, and 2) use log.exception parameters for string templating.