### PR TITLE
Remove Google from OpenID providers in the sample. 

### DIFF
--- a/config/openid_conf.xml.sample
+++ b/config/openid_conf.xml.sample
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <openid>
+    <provider file="genomespace.xml" />
     <provider file="yahoo.xml" />
     <provider file="aol.xml" />
     <provider file="launchpad.xml" />
-    <provider file="genomespace.xml" />
 </openid>

--- a/config/openid_conf.xml.sample
+++ b/config/openid_conf.xml.sample
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <openid>
-    <provider file="google.xml" />
     <provider file="yahoo.xml" />
     <provider file="aol.xml" />
     <provider file="launchpad.xml" />

--- a/openid/google.xml
+++ b/openid/google.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0"?>
-<provider id="google" name="Google">
-    <op_endpoint_url>https://www.google.com/accounts/o8/id</op_endpoint_url>
-</provider>


### PR DESCRIPTION
 Google dropped OpenID support a while back.