### PR TITLE
17.05 rstudio fixes / one small gie fix

### DIFF
--- a/config/plugins/interactive_environments/rstudio/config/allowed_images.yml.sample
+++ b/config/plugins/interactive_environments/rstudio/config/allowed_images.yml.sample
@@ -6,6 +6,13 @@
 # appropriate `apt-get/pip install` statements.
 ---
 -
+    image: erasche/docker-rstudio-notebook:17.01
+    description: |
+        If you've ever done R analysis, you probably used RStudio. This
+        familiar R analysis software suite will let you explore your datasets
+        in depth. Comes with ggplot2, RODBC, maps, shinyapps, knitr, LaTeX,
+        bioconductor, cummeRbund, and many more pre-installed packages.
+-
     image: erasche/docker-rstudio-notebook:16.10
     description: |
         If you've ever done R analysis, you probably used RStudio. This

--- a/config/plugins/interactive_environments/rstudio/config/allowed_images.yml.sample
+++ b/config/plugins/interactive_environments/rstudio/config/allowed_images.yml.sample
@@ -6,7 +6,7 @@
 # appropriate `apt-get/pip install` statements.
 ---
 -
-    image: erasche/docker-rstudio-notebook:17.05
+    image: erasche/docker-rstudio-notebook:17.01
     description: |
         If you've ever done R analysis, you probably used RStudio. This
         familiar R analysis software suite will let you explore your datasets

--- a/config/plugins/interactive_environments/rstudio/config/allowed_images.yml.sample
+++ b/config/plugins/interactive_environments/rstudio/config/allowed_images.yml.sample
@@ -6,14 +6,7 @@
 # appropriate `apt-get/pip install` statements.
 ---
 -
-    image: erasche/docker-rstudio-notebook:17.01
-    description: |
-        If you've ever done R analysis, you probably used RStudio. This
-        familiar R analysis software suite will let you explore your datasets
-        in depth. Comes with ggplot2, RODBC, maps, shinyapps, knitr, LaTeX,
-        bioconductor, cummeRbund, and many more pre-installed packages.
--
-    image: erasche/docker-rstudio-notebook:16.10
+    image: erasche/docker-rstudio-notebook:17.05
     description: |
         If you've ever done R analysis, you probably used RStudio. This
         familiar R analysis software suite will let you explore your datasets

--- a/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
+++ b/config/plugins/interactive_environments/rstudio/config/rstudio.ini.sample
@@ -20,7 +20,7 @@ password_auth = True
 # The image argument was moved to "allowed_images.yml.sample"
 
 # Additional arguments that are passed to the `docker run` command.
-#command_inject = --sig-proxy=true -e DEBUG=false
+#command_inject = --sig-proxy=true -e DEBUG=false -e DEFAULT_CONTAINER_RUNTIME=120
 
 # URL to access the Galaxy API with from the spawn Docker containter, if empty
 # this falls back to galaxy.ini's galaxy_infrastructure_url and finally to the

--- a/config/plugins/interactive_environments/rstudio/static/js/rstudio.js
+++ b/config/plugins/interactive_environments/rstudio/static/js/rstudio.js
@@ -14,11 +14,11 @@ function message_failed_connection(){
  * @param {String} notebook_access_url: the URL embeded in the page and loaded
  *
  */
-function load_notebook(notebook_login_url, notebook_access_url, notebook_pubkey_url, username){
+function load_notebook(notebook_login_url, notebook_access_url, notebook_pubkey_url){
     // Test notebook_login_url for accessibility, executing the login+load function whenever
     // we've successfully connected to the IE.
     test_ie_availability(notebook_pubkey_url, function(){
-        var payload = username + "\n" + ie_password;
+        var payload = "rstudio\nrstudio";
         $.ajax({
             type: 'GET',
             url: notebook_pubkey_url,
@@ -32,7 +32,6 @@ function load_notebook(notebook_login_url, notebook_access_url, notebook_pubkey_
                 console.log("Found " + exp +" and " + mod);
                 var rsa = new RSAKey();
                 rsa.setPublic(mod, exp);
-                console.log("Encrypting '" + username + "', '" + ie_password + "'");
                 var enc_hex = rsa.encrypt(payload);
                 var encrypted = hex2b64(enc_hex);
                 console.log("E: " + encrypted);
@@ -58,7 +57,10 @@ function load_notebook(notebook_login_url, notebook_access_url, notebook_pubkey_
                         append_notebook(notebook_access_url);
                     },
                     error: function(jqxhr, status, error){
-                        message_failed_connection();
+                        // TODO: Uncomment when rstudio / nginx play nicely and
+                        // don't return http when we asked for HTTPS, thereby
+                        // issuing a mixed-content warning.
+                        //message_failed_connection();
                         // Do we want to try and load the notebook anyway? Just in case?
                         append_notebook(notebook_access_url);
                     }

--- a/config/plugins/interactive_environments/rstudio/templates/rstudio.mako
+++ b/config/plugins/interactive_environments/rstudio/templates/rstudio.mako
@@ -1,4 +1,5 @@
-<%namespace file="ie.mako" name="ie"/>
+<%namespace name="ie" file="ie.mako"/>
+
 <%
 import os
 import shutil
@@ -7,46 +8,42 @@ import time
 # Sets ID and sets up a lot of other variables
 ie_request.load_deploy_config()
 ie_request.attr.docker_port = 80
-# Create tempdir in galaxy
-temp_dir = ie_request.temp_dir
 PASSWORD = "rstudio"
 USERNAME = "rstudio"
 # Then override it again
 ie_request.notebook_pw = "rstudio"
 
-# Did the user give us an RData file?
-if hda.datatype.__class__.__name__ == "RData":
-    shutil.copy( hda.file_name, os.path.join(temp_dir, '.RData') )
+DATASET_HID = hda.hid
 
+# Add all environment variables collected from Galaxy's IE infrastructure
 ie_request.launch(
     image=trans.request.params.get('image_tag', None),
     additional_ids=trans.request.params.get('additional_dataset_ids', None),
     env_override={
         'notebook_username': USERNAME,
         'notebook_password': PASSWORD,
+        'dataset_hid': DATASET_HID,
     }
 )
 
 ## General IE specific
 # Access URLs for the notebook from within galaxy.
-# TODO: Make this work without pointing directly to IE. Currently does not work
-# through proxy.
-notebook_pubkey_url = ie_request.url_template('${PROXY_URL}/rstudio/auth-public-key')
 notebook_access_url = ie_request.url_template('${PROXY_URL}/rstudio/')
-notebook_login_url =  ie_request.url_template('${PROXY_URL}/rstudio/auth-do-sign-in')
+notebook_login_url = ie_request.url_template('${PROXY_URL}/rstudio/auth-do-sign-in')
+notebook_pubkey_url = ie_request.url_template('${PROXY_URL}/rstudio/auth-public-key')
 
 %>
 <html>
 <head>
 ${ ie.load_default_js() }
 </head>
-<body style="margin:0px">
+<body style="margin: 0px">
+
 <script type="text/javascript">
 ${ ie.default_javascript_variables() }
 var notebook_login_url = '${ notebook_login_url }';
 var notebook_access_url = '${ notebook_access_url }';
 var notebook_pubkey_url = '${ notebook_pubkey_url }';
-var notebook_username = '${ USERNAME }';
 require.config({
     baseUrl: app_root,
     paths: {
@@ -65,11 +62,11 @@ requirejs([
     'plugin/rstudio'
 ], function(){
     load_when_ready(ie_readiness_url, function(){
-        load_notebook(notebook_login_url, notebook_access_url, notebook_pubkey_url, "${ USERNAME }");
+        load_notebook(notebook_login_url, notebook_access_url, notebook_pubkey_url);
     });
 });
 </script>
-<div id="main">
+<div id="main" width="100%" height="100%">
 </div>
 </body>
 </html>

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -438,6 +438,10 @@ class InteractiveEnvironmentRequest(object):
             raise Exception("Attempting to launch disallowed image! %s not in list of allowed images [%s]"
                             % (image, ', '.join(self.allowed_images)))
 
+        # Do not allow a None volumes
+        if not volumes:
+            volumes = []
+
         if additional_ids is not None:
             volumes += self._idsToVolumes(additional_ids)
 


### PR DESCRIPTION
- rstudio ... <long string of expletives>. I'm disabling the warning on this because it can't be bothered to play nicely with reverse proxies or non-standard ports. Instead it returns a really bad location (http even under https) issuing a security warning despite the fact that rstudio loads and is logged in in the main window. Yay. :|
- disables the default volume mount for rstudio that wasn't very helpful anyway.
- the small gie fix is when no volumes are there but additional_datasets are, it throws an error trying to append a list to None. (How did this ever work? I feel like I'm breaking things even worse by doing this and somehow a default volume was supposed to be specified? Really not sure. But this is a "safe" change in that it can't make things worse at least.)