### PR TITLE
Fixes to get GIEs working on Mac OS X.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -591,6 +591,11 @@ nglims_config_file = tool-data/nglims.yaml
 # URL (with schema http/https) of the Galaxy instance as accessible within your
 # local network - if specified used as a default by pulsar file staging and
 # Jupyter Docker container for communicating back with Galaxy via the API.
+#
+# If you are attempting to setup GIEs on Mac OS X with Docker for Mac - this
+# should likely be the IP address of your machine on the virtualbox network (vboxnet0)
+# setup for the Docker host VM. This can found by running ifconfig and using the
+# IP address of the network vboxnet0.
 #galaxy_infrastructure_url = http://localhost:8080
 
 # If the above URL cannot be determined ahead of time in dynamic environments

--- a/lib/galaxy/web/proxy/js/package.json
+++ b/lib/galaxy/web/proxy/js/package.json
@@ -14,6 +14,6 @@
     "eventemitter3": "0.1.6",
     "http-proxy": "1.6.0",
     "commander": "~2.2",
-    "sqlite3": "3.1.3"
+    "sqlite3": "3.1.8"
   }
 }


### PR DESCRIPTION
One of the upsides of selling out on all of my previous values I guess.

- Fix logic error related to config parsing (OS non-specific).
- Don't trust GatewayAddress from Docker if on Mac OS X - it is probably a Docker host VM specific address.
- Update sqlite dependency for the newest version of Node available from Mac OS X Homebrew.
- Add a little blurb about how to configure galaxy_infrastructure_url in this case.