### PR TITLE
Fix Travix builds which use flake8-docstrings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ whitelist_externals = bash
 deps =
     flake8
     flake8-docstrings
+    # The next dep can be removed when https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed
+    pydocstyle<2
 
 [testenv:py33-lint]
 commands = bash .ci/flake8_py3_wrapper.sh
@@ -80,6 +82,8 @@ skip_install = True
 deps =
     flake8
     flake8-docstrings
+    # The next dep can be removed when https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed
+    pydocstyle<2
 
 [testenv:py27-lint-docstring-include-list]
 commands = bash .ci/flake8_wrapper_docstrings.sh --include
@@ -88,3 +92,5 @@ skip_install = True
 deps =
     flake8
     flake8-docstrings
+    # The next dep can be removed when https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed
+    pydocstyle<2


### PR DESCRIPTION
flake8-docstrings is broken due to the release of pydocstyle 2.0.0 (see https://gitlab.com/pycqa/flake8-docstrings/issues/19 ), so temporarily add an extra dep in `tox.ini` to pin it.