### PR TITLE
Pin pydocstyle to 1.x version.  2.0 has breaking changes w/ flake8-do…

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ commands = bash .ci/flake8_wrapper.sh
 whitelist_externals = bash
 deps =
     flake8
+    pydocstyle==1.1.1
     flake8-docstrings
     # The next dep can be removed when https://gitlab.com/pycqa/flake8-docstrings/issues/19 is fixed
     pydocstyle<2


### PR DESCRIPTION
…cstrings, causing our travis errors.