### PR TITLE
Use the configured tool_path when loading data managers

### DIFF
--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -37,7 +37,7 @@ class DataManagers( object ):
                 continue
             self.load_from_xml( filename )
         if self.app.config.shed_data_manager_config_file:
-            self.load_from_xml( self.app.config.shed_data_manager_config_file, store_tool_path=False, replace_existing=True )
+            self.load_from_xml( self.app.config.shed_data_manager_config_file, store_tool_path=True, replace_existing=True )
 
     def load_from_xml( self, xml_filename, store_tool_path=True, replace_existing=False ):
         try:
@@ -57,7 +57,7 @@ class DataManagers( object ):
                 tool_path = '.'
             self.tool_path = tool_path
         for data_manager_elem in root.findall( 'data_manager' ):
-            self.load_manager_from_elem( data_manager_elem, replace_existing=replace_existing )
+            self.load_manager_from_elem( data_manager_elem, tool_path=tool_path, replace_existing=replace_existing )
 
     def load_manager_from_elem( self, data_manager_elem, tool_path=None, add_manager=True, replace_existing=False ):
         try:

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -57,7 +57,7 @@ class DataManagers( object ):
                 tool_path = '.'
             self.tool_path = tool_path
         for data_manager_elem in root.findall( 'data_manager' ):
-            self.load_manager_from_elem( data_manager_elem, tool_path=tool_path, replace_existing=replace_existing )
+            self.load_manager_from_elem( data_manager_elem, tool_path=self.tool_path, replace_existing=replace_existing )
 
     def load_manager_from_elem( self, data_manager_elem, tool_path=None, add_manager=True, replace_existing=False ):
         try:

--- a/lib/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/data_manager.py
@@ -7,6 +7,7 @@ from tool_shed.galaxy_install.tools import tool_panel_manager
 from tool_shed.util import xml_util
 
 log = logging.getLogger( __name__ )
+# <data_managers tool_path="/var/galaxy/data_managers">
 
 
 class DataManagerHandler( object ):
@@ -14,16 +15,29 @@ class DataManagerHandler( object ):
     def __init__( self, app ):
         self.app = app
 
+    @property
+    def data_managers_path( self ):
+        tree, error_message = xml_util.parse_xml( self.app.config.shed_data_manager_config_file )
+        if tree:
+            root = tree.getroot()
+            data_managers_path = root.get( 'tool_path', None )
+        return data_managers_path
+
+
     def data_manager_config_elems_to_xml_file( self, config_elems, config_filename ):
         """
         Persist the current in-memory list of config_elems to a file named by the value
         of config_filename.
         """
+        data_managers_path = self.data_managers_path
         lock = threading.Lock()
         lock.acquire( True )
         try:
             fh = open( config_filename, 'wb' )
-            fh.write( '<?xml version="1.0"?>\n<data_managers>\n' )
+            if data_managers_path is not None:
+                fh.write( '<?xml version="1.0"?>\n<data_managers tool_path="%s">\n    ' % data_managers_path )
+            else:
+                fh.write( '<?xml version="1.0"?>\n<data_managers>\n    ' )
             for elem in config_elems:
                 fh.write( xml_util.xml_to_string( elem ) )
             fh.write( '</data_managers>\n' )
@@ -158,4 +172,4 @@ class DataManagerHandler( object ):
                     self.app.data_managers.load_manager_from_elem( elem )
                 # Persist the altered shed_data_manager_config file.
                 if data_manager_config_has_changes:
-                    self.data_manager_config_elems_to_xml_file( config_elems, shed_data_manager_conf_filename  )
+                    self.data_manager_config_elems_to_xml_file( config_elems, shed_data_manager_conf_filename )

--- a/lib/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/data_manager.py
@@ -19,9 +19,7 @@ class DataManagerHandler( object ):
         tree, error_message = xml_util.parse_xml( self.app.config.shed_data_manager_config_file )
         if tree:
             root = tree.getroot()
-            data_managers_path = root.get( 'tool_path', None )
-        return data_managers_path
-
+            return root.get( 'tool_path', None )
 
     def data_manager_config_elems_to_xml_file( self, config_elems, config_filename ):
         """

--- a/lib/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/data_manager.py
@@ -20,6 +20,7 @@ class DataManagerHandler( object ):
         if tree:
             root = tree.getroot()
             return root.get( 'tool_path', None )
+        return None
 
     def data_manager_config_elems_to_xml_file( self, config_elems, config_filename ):
         """

--- a/lib/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/data_manager.py
@@ -7,7 +7,6 @@ from tool_shed.galaxy_install.tools import tool_panel_manager
 from tool_shed.util import xml_util
 
 log = logging.getLogger( __name__ )
-# <data_managers tool_path="/var/galaxy/data_managers">
 
 
 class DataManagerHandler( object ):


### PR DESCRIPTION
This should address #3606. I've also confirmed that my local instance can still load data managers with these changes.