### PR TITLE
Fixes for Selenium workflow run test case.

### DIFF
--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -79,7 +79,7 @@ class NavigatesGalaxy(HasDriver):
             self.switch_to_main_panel()
             yield
         finally:
-            self.driver.switch_to.default_content
+            self.driver.switch_to.default_content()
 
     def api_get(self, endpoint, data={}, raw=False):
         full_url = self.build_url("api/" + endpoint, for_selenium=False)
@@ -148,7 +148,14 @@ class NavigatesGalaxy(HasDriver):
         contents = self.api_get("histories/%s/contents" % current_history_id)
         history_item = [d for d in contents if d["hid"] == hid][0]
         history_item_selector = "#%s-%s" % (history_item["history_content_type"], history_item["id"])
-        self.wait_for_selector_visible(history_item_selector)
+        try:
+            self.wait_for_selector_visible(history_item_selector)
+        except self.TimeoutException as e:
+            dataset_elements = self.driver.find_elements_by_css_selector("#current-history-panel .list-items div")
+            div_ids = [d.get_attribute('id') for d in dataset_elements]
+            template = "Failed waiting on history item %d to become visible, visible datasets include [%s]."
+            message = template % (hid, ",".join(div_ids))
+            raise self.prepend_timeout_message(e, message)
         return history_item_selector
 
     def history_panel_wait_for_hid_hidden(self, hid, timeout=60):

--- a/test/selenium_tests/test_workflow_run.py
+++ b/test/selenium_tests/test_workflow_run.py
@@ -29,10 +29,8 @@ class WorkflowRunTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         with self.main_panel():
             self.workflow_run_submit()
 
-        time.sleep(.5)
-        self.wait_for_history()
-        self.home()
         self.history_panel_wait_for_hid_ok(2)
+        self.history_panel_wait_for_hid_ok(3)
         self.history_panel_click_item_title(hid=2, wait=True)
         self.assert_item_summary_includes(2, "2 sequences")
 


### PR DESCRIPTION
The ``with self.main_panel():`` construct wasn't cleaning up properly - I've fixed this and eliminated the terrible workarounds in the execution test case that I guess I had added trying to figure out how to make things work. It should be more stable now. (This test case has been failing 1 out 9 times I'd say.)