### PR TITLE
Setup framework for retrying failed Selenium tests.

### DIFF
--- a/.ci/jenkins/selenium/run_tests.sh
+++ b/.ci/jenkins/selenium/run_tests.sh
@@ -97,6 +97,12 @@ done;
 export GALAXY_TEST_SELENIUM_REMOTE=1
 export GALAXY_TEST_SELENIUM_REMOTE_PORT="${SELENIUM_PORT}"
 
+# Retry all failed Selenium tests a second time to deal
+# with transiently failing tests. Failure information for
+# first tests is still populated in database/test_errors
+# and available at the top of the Jenkins test report.
+export GALAXY_TEST_SELENIUM_RETRIES=1
+
 # Access Galaxy on localhost via port $GALAXY_PORT
 export GALAXY_TEST_PORT="${GALAXY_PORT}"
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -112,6 +112,20 @@ address Docker exposes localhost on to its child containers. This trick
 doesn't work on Mac OS X and so GALAXY_TEST_HOST will need to be crafted
 carefully ahead of time.
 
+For Selenium test cases a stack trace is usually insufficient to diagnose
+problems. For this reason, GALAXY_TEST_ERRORS_DIRECTORY is populated with
+a new directory of information for each failing test case. This information
+includes a screenshot, a stack trace, and the DOM of the currently rendered
+Galaxy instance. The new directories are created with names that include
+information about the failed test method name and the timestamp. By default,
+GALAXY_TEST_ERRORS_DIRECTORY will be set to database/errors.
+
+The Selenium tests seem to be subject to transient failures at a higher
+rate than the rest of the tests in Galaxy. Though this is unfortunate,
+they have more moving pieces so this is perhaps not surprising. One can
+set the GALAXY_TEST_SELENIUM_RETRIES to a number greater than 0 to
+automatically retry every failed test case the specified number of times.
+
 External Tests:
 
 A small subset of tests can be run against an existing Galaxy


### PR DESCRIPTION
- By default this won't occur locally, but you can set GALAXY_TEST_SELENIUM_RETRIES to a non-zero number to enable auto retrying tests that many times.
- Capture the stack trace in the Selenium test error report directory - this will be useful for debugging problems that may fail once but pass on a subsequence attempt. Jenkins now captures these directories and includes their content in the test reports.
- Document the Selenium test error report directory in run_tests.sh as well as this new retry variable.
- Update the Jenkins test script to set this new variable to 1 so transient failures break the build much less frequently.