### PR TITLE
Undo dataset renaming for URL uploads

### DIFF
--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -95,7 +95,6 @@ def add_file( dataset, registry, json_file, output_path ):
             file_err( 'Unable to fetch %s\n%s' % ( dataset.path, str( e ) ), dataset, json_file )
             return
         dataset.path = temp_name
-        dataset.name = os.path.basename( dataset.name )
     # See if we have an empty file
     if not os.path.exists( dataset.path ):
         file_err( 'Uploaded temporary file (%s) does not exist.' % dataset.path, dataset, json_file )


### PR DESCRIPTION
As discussed, here is the suggestion to undo this for the release and revisit it later with ideas provided in #3695. ping @natefoo 