### PR TITLE
Fix handling main_panel switching in various Selenium tests.

### DIFF
--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -666,10 +666,13 @@ class NavigatesGalaxy(HasDriver):
         return self._assert_message("warning", contains=contains)
 
     def _assert_message(self, type, contains=None):
-        element = self.wait_for_selector(self.test_data["selectors"]["messages"][type])
+        element = self.wait_for_selector_visible(self.test_data["selectors"]["messages"][type])
         assert element, "No error message found, one expected."
         if contains is not None:
-            assert contains in element.text
+            text = element.text
+            if contains not in text:
+                message = "Text [%s] expected inside of [%s] but not found." % (contains, text)
+                raise AssertionError(message)
 
     def assert_no_error_message(self):
         self.assert_selector_absent(self.test_data["selectors"]["messages"]["error"])

--- a/test/selenium_tests/test_history_sharing.py
+++ b/test/selenium_tests/test_history_sharing.py
@@ -59,14 +59,16 @@ class HistorySharingTestCase(SeleniumTestCase):
         user1_email = self._get_random_email()
         self.register(user1_email)
         self.share_history_with_user("invalid_user@test.com")
-        self.assert_error_message(contains='is not a valid Galaxy user')
+        with self.main_panel():
+            self.assert_error_message(contains='is not a valid Galaxy user')
 
     @selenium_test
     def test_sharing_with_self(self):
         user1_email = self._get_random_email()
         self.register(user1_email)
         self.share_history_with_user(user1_email)
-        self.assert_error_message(contains='You cannot send histories to yourself')
+        with self.main_panel():
+            self.assert_error_message(contains='You cannot send histories to yourself')
 
     def setup_two_users_with_one_shared_history(self, share_by_id=False):
         user1_email = self._get_random_email()
@@ -88,7 +90,8 @@ class HistorySharingTestCase(SeleniumTestCase):
             self.share_history_with_user(user2_email)
         else:
             self.share_history_with_user(user2_id)
-        self.assert_no_error_message()
+        with self.main_panel():
+            self.assert_no_error_message()
         self.logout_if_needed()
 
         return user1_email, user2_email, history_id
@@ -106,10 +109,11 @@ class HistorySharingTestCase(SeleniumTestCase):
 
     def share_history_with_user(self, email):
         self.navigate_to_history_user_share_page()
-        form_selector = "form#share"
-        form = self.wait_for_selector(form_selector)
-        # If expose_user_info is on would fill form out with this
-        # line, in future dispatch on actual select2 div present or not.
-        # self.select2_set_value(form_selector, email)
-        self.fill(form, {"email": email})
-        self.click_submit(form)
+        with self.main_panel():
+            form_selector = "form#share"
+            form = self.wait_for_selector(form_selector)
+            # If expose_user_info is on would fill form out with this
+            # line, in future dispatch on actual select2 div present or not.
+            # self.select2_set_value(form_selector, email)
+            self.fill(form, {"email": email})
+            self.click_submit(form)

--- a/test/selenium_tests/test_login.py
+++ b/test/selenium_tests/test_login.py
@@ -11,7 +11,8 @@ class LoginTestCase(SeleniumTestCase):
         self.logout_if_needed()
         self.home()
         self.submit_login(email)
-        self.assert_no_error_message()
+        with self.main_panel():
+            self.assert_no_error_message()
         assert self.is_logged_in()
 
     @selenium_test
@@ -20,7 +21,8 @@ class LoginTestCase(SeleniumTestCase):
         for bad_email in bad_emails:
             self.home()
             self.submit_login(bad_email)
-            self.assert_error_message()
+            with self.main_panel():
+                self.assert_error_message()
 
     @selenium_test
     def test_invalid_passwords(self):
@@ -28,7 +30,8 @@ class LoginTestCase(SeleniumTestCase):
         for bad_password in bad_passwords:
             self.home()
             self.submit_login(self._get_random_email(), password=bad_password)
-            self.assert_error_message()
+            with self.main_panel():
+                self.assert_error_message()
 
     @selenium_test
     def test_wrong_password(self):
@@ -37,4 +40,5 @@ class LoginTestCase(SeleniumTestCase):
         self.logout_if_needed()
         self.home()
         self.submit_login(email, password="12345678")
-        self.assert_error_message()
+        with self.main_panel():
+            self.assert_error_message()

--- a/test/selenium_tests/test_registration.py
+++ b/test/selenium_tests/test_registration.py
@@ -39,7 +39,8 @@ class RegistrationTestCase(SeleniumTestCase):
         self.register(email, password, username, confirm)
         self.logout_if_needed()
         self.register(email, password, username, confirm, assert_valid=False)
-        self.assert_error_message()
+        with self.main_panel():
+            self.assert_error_message()
 
     @selenium_test
     def test_reregister_username_fails(self):
@@ -52,7 +53,8 @@ class RegistrationTestCase(SeleniumTestCase):
         self.register(email1, password, username, confirm)
         self.logout_if_needed()
         self.register(email2, password, username, confirm, assert_valid=False)
-        self.assert_error_message(contains='Public name is taken; please choose another')
+        with self.main_panel():
+            self.assert_error_message(contains='Public name is taken; please choose another')
 
     @selenium_test
     def test_bad_emails(self):
@@ -64,23 +66,27 @@ class RegistrationTestCase(SeleniumTestCase):
 
         for bad_email in bad_emails:
             self.register(bad_email, password, username, confirm, assert_valid=False)
-            self.assert_error_message(contains='The format of the email address is not correct.')
+            with self.main_panel():
+                self.assert_error_message(contains='The format of the email address is not correct.')
 
     @selenium_test
     def test_short_password(self):
         self.register(password="1234", assert_valid=False)
-        self.assert_error_message(contains='Use a password of at least 6 characters')
+        with self.main_panel():
+            self.assert_error_message(contains='Use a password of at least 6 characters')
 
     @selenium_test
     def test_password_confirmation(self):
         bad_confirms = ['1234', '12345678', '123456 7', '']
         for bad_confirm in bad_confirms:
             self.register(confirm=bad_confirm, assert_valid=False)
-            self.assert_error_message(contains='Passwords don\'t match')
+            with self.main_panel():
+                self.assert_error_message(contains='Passwords don\'t match')
 
     @selenium_test
     def test_bad_usernames(self):
         bad_usernames = ['BOBERT', 'Robert Paulson', 'bobert!']
         for bad_username in bad_usernames:
             self.register(username=bad_username, assert_valid=False)
-            self.assert_error_message(contains='Public name must contain only ')
+            with self.main_panel():
+                self.assert_error_message(contains='Public name must contain only ')


### PR DESCRIPTION
PR #3992 fixed "with self.main_panel()" so that leaving the context actually restore the Selenium context back to the top level page. This surfaced a bunch of bugs related to assertions that were operating in the main panel without declaring it. This fixes those and makes the assertions a bit stronger - such as verifying error messages being asserted about are visible.