### PR TITLE
Implicitly set use_volumes = False if using Docker swarm

### DIFF
--- a/lib/galaxy/containers/__init__.py
+++ b/lib/galaxy/containers/__init__.py
@@ -115,6 +115,7 @@ class ContainerInterface(with_metaclass(ABCMeta, object)):
     }
     option_map = {}
     publish_port_list_required = False
+    supports_volumes = True
 
     def __init__(self, conf, key, containers_config_file):
         self._key = key

--- a/lib/galaxy/containers/docker_swarm.py
+++ b/lib/galaxy/containers/docker_swarm.py
@@ -34,6 +34,7 @@ class DockerSwarmInterface(DockerInterface):
         'manager_autostart': True,
     }
     publish_port_list_required = True
+    supports_volumes = False
 
     def validate_config(self):
         super(DockerSwarmInterface, self).validate_config()

--- a/lib/galaxy/web/base/interactive_environments.py
+++ b/lib/galaxy/web/base/interactive_environments.py
@@ -300,7 +300,9 @@ class InteractiveEnvironmentRequest(object):
 
     @property
     def use_volumes(self):
-        if self.attr.viz_config.has_option("docker", "use_volumes"):
+        if self.attr.container_interface and not self.attr.container_interface.supports_volumes:
+            return False
+        elif self.attr.viz_config.has_option("docker", "use_volumes"):
             return string_as_bool_or_none(self.attr.viz_config.get("docker", "use_volumes"))
         else:
             return True


### PR DESCRIPTION
Don't require use_volumes to be explicitly set (see: #3980) when running containers on a swarm, since volumes are not supported on swarm mode.