### PR TITLE
Simplify RC creation in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,8 +148,6 @@ release-create-rc: release-ensure-upstream ## Create a release-candidate branch
 	git push $(MY_UPSTREAM) version-$(RELEASE_CURR):version-$(RELEASE_CURR)
 	git push $(MY_UPSTREAM) version-$(RELEASE_NEXT).dev:version-$(RELEASE_NEXT).dev
 	git checkout dev
-	git branch -d version-$(RELEASE_CURR)
-	git branch -d version-$(RELEASE_NEXT).dev
 	# TODO: Use hub to automate these PR creations or push directly.
 	@echo "Open a PR from version-$(RELEASE_CURR) of your fork to release_$(RELEASE_CURR)"
 	@echo "Open a PR from version-$(RELEASE_NEXT).dev of your fork to dev"


### PR DESCRIPTION
These commands fail without any harm and then prevent the important echo statements from printing that follow them.