### PR TITLE
API routes for dataset stdout/stderr

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -88,6 +88,36 @@ class DatasetsController( BaseAPIController, UsesVisualizationMixin ):
             trans.response.status = 500
         return rval
 
+    @web.expose_api
+    def stdout( self, trans, dataset_id, hda_ldda='hda', **kwd ):
+        """
+        * GET /api/dataset/{dataset_id}/stdout
+            returns stdout of dataset's job
+
+        :type   dataset_id: string
+        :param  dataset_id: Encoded dataset id
+
+        :rtype:     dictionary
+        :returns:   dictionary containing dataset stdout
+        """
+        dataset = self.get_hda_or_ldda( trans, hda_ldda=hda_ldda, dataset_id=dataset_id )
+        return {'stdout': dataset.creating_job.stdout}
+
+    @web.expose_api
+    def stderr( self, trans, dataset_id, hda_ldda='hda', **kwd ):
+        """
+        * GET /api/dataset/{dataset_id}/stderr
+            returns stderr of dataset's job
+
+        :type   dataset_id: string
+        :param  dataset_id: Encoded dataset id
+
+        :rtype:     dictionary
+        :returns:   dictionary containing dataset stderr
+        """
+        dataset = self.get_hda_or_ldda( trans, hda_ldda=hda_ldda, dataset_id=dataset_id )
+        return {'stderr': dataset.creating_job.stderr}
+
     def _dataset_state( self, trans, dataset, **kwargs ):
         """
         Returns state of dataset.

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -384,6 +384,8 @@ def populate_api_routes( webapp, app ):
     # route for creating/getting converted datasets
     webapp.mapper.connect( '/api/datasets/{dataset_id}/converted', controller='datasets', action='converted', ext=None )
     webapp.mapper.connect( '/api/datasets/{dataset_id}/converted/{ext}', controller='datasets', action='converted' )
+    webapp.mapper.connect( '/api/datasets/{dataset_id}/stdout', controller='datasets', action='stdout' )
+    webapp.mapper.connect( '/api/datasets/{dataset_id}/stderr', controller='datasets', action='stderr' )
 
     # API refers to usages and invocations - these mean the same thing but the
     # usage routes should be considered deprecated.


### PR DESCRIPTION
These are essentially duplicates of the normal routes for accessing, but 1) return json, 2) is under /api so is accessible without adding extra proxy rules for us remote_user folks.

example json returned:

```json
{"stderr": "this is on stderr\n"}
```

xref https://github.com/galaxyproject/bioblend/issues/221