### PR TITLE
[17.05] Fixes for containerized job executions.

### DIFF
--- a/lib/galaxy/jobs/rule_helper.py
+++ b/lib/galaxy/jobs/rule_helper.py
@@ -40,7 +40,11 @@ class RuleHelper( object ):
         else:
             # Have a Job object.
             tool = self.app.toolbox.get_tool( job_or_tool.tool_id )
-        return any( [ c.type == "docker" for c in tool.containers ] )
+        # Can't import at top because circular import between galaxy.tools and galaxy.jobs.
+        import galaxy.tools.deps.containers
+        tool_info = galaxy.tools.deps.containers.ToolInfo(tool.containers, tool.requirements)
+        container_description = self.app.container_finder.find_best_container_description(["docker"], tool_info)
+        return container_description is not None
 
     def job_count(
         self,

--- a/lib/galaxy/jobs/rule_helper.py
+++ b/lib/galaxy/jobs/rule_helper.py
@@ -42,7 +42,7 @@ class RuleHelper( object ):
             tool = self.app.toolbox.get_tool( job_or_tool.tool_id )
         # Can't import at top because circular import between galaxy.tools and galaxy.jobs.
         import galaxy.tools.deps.containers
-        tool_info = galaxy.tools.deps.containers.ToolInfo(tool.containers, tool.requirements)
+        tool_info = galaxy.tools.deps.containers.ToolInfo(tool.containers, tool.requirements, tool.requires_galaxy_python_environment)
         container_description = self.app.container_finder.find_best_container_description(["docker"], tool_info)
         return container_description is not None
 

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -345,7 +345,7 @@ class BaseJobRunner( object ):
 
         tool = job_wrapper.tool
         from galaxy.tools.deps import containers
-        tool_info = containers.ToolInfo(tool.containers, tool.requirements)
+        tool_info = containers.ToolInfo(tool.containers, tool.requirements, tool.requires_galaxy_python_environment)
         job_info = containers.JobInfo(
             compute_working_directory,
             compute_tool_directory,

--- a/lib/galaxy/tools/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tools/deps/container_resolvers/mulled.py
@@ -114,6 +114,9 @@ class CachedMulledContainerResolver(ContainerResolver):
         self.namespace = namespace
 
     def resolve(self, enabled_container_types, tool_info):
+        if tool_info.requires_galaxy_python_environment:
+            return None
+
         targets = mulled_targets(tool_info)
         return cached_container_description(targets, self.namespace)
 
@@ -132,6 +135,9 @@ class MulledContainerResolver(ContainerResolver):
         self.namespace = namespace
 
     def resolve(self, enabled_container_types, tool_info):
+        if tool_info.requires_galaxy_python_environment:
+            return None
+
         targets = mulled_targets(tool_info)
         if len(targets) == 0:
             return None
@@ -190,6 +196,9 @@ class BuildMulledContainerResolver(ContainerResolver):
         self.auto_init = self._get_config_option("auto_init", DEFAULT_CHANNELS, prefix="involucro")
 
     def resolve(self, enabled_container_types, tool_info):
+        if tool_info.requires_galaxy_python_environment:
+            return None
+
         targets = mulled_targets(tool_info)
         if len(targets) == 0:
             return None

--- a/lib/galaxy/tools/deps/containers.py
+++ b/lib/galaxy/tools/deps/containers.py
@@ -61,6 +61,13 @@ class ContainerFinder(object):
     def __enabled_container_types(self, destination_info):
         return [t for t in ALL_CONTAINER_TYPES if self.__container_type_enabled(t, destination_info)]
 
+    def find_best_container_description(self, enabled_container_types, tool_info):
+        """Regardless of destination properties - find best container for tool.
+
+        Given container types and container.ToolInfo description of the tool."""
+        container_description = self.container_registry.find_best_container_description(enabled_container_types, tool_info)
+        return container_description
+
     def find_container(self, tool_info, destination_info, job_info):
         enabled_container_types = self.__enabled_container_types(destination_info)
 
@@ -89,7 +96,7 @@ class ContainerFinder(object):
                 if container:
                     return container
 
-        # Is destination forcing Galaxy to use a particular container do it,
+        # If destination forcing Galaxy to use a particular container do it,
         # this is likely kind of a corner case. For instance if deployers
         # do not trust the containers annotated in tools.
         for container_type in CONTAINER_CLASSES.keys():
@@ -100,7 +107,7 @@ class ContainerFinder(object):
                     return container
 
         # Otherwise lets see if we can find container for the tool.
-        container_description = self.container_registry.find_best_container_description(enabled_container_types, tool_info)
+        container_description = self.find_best_container_description(enabled_container_types, tool_info)
         container = __destination_container(container_description)
         if container:
             return container

--- a/lib/galaxy/tools/deps/containers.py
+++ b/lib/galaxy/tools/deps/containers.py
@@ -269,9 +269,10 @@ class ToolInfo(object):
     # variables they can consume (e.g. JVM options, license keys, etc..)
     # and add these to env_path_through
 
-    def __init__(self, container_descriptions=[], requirements=[]):
+    def __init__(self, container_descriptions=[], requirements=[], requires_galaxy_python_environment=False):
         self.container_descriptions = container_descriptions
         self.requirements = requirements
+        self.requires_galaxy_python_environment = requires_galaxy_python_environment
         self.env_pass_through = ["GALAXY_SLOTS"]
 
 


### PR DESCRIPTION
A pair of framework related commits from my exploits in getting Kubernetes to run biocontainer jobs.

- One commit fixes the ``docker_dispatch`` dynamic rule to respect BioContainers. It should have been updated with #2986 but wasn't and so would only detect containers explicitly annotated in tools.
- Other commit prevents tools that require the legacy Python environment from being executed in BioContainers - at least for now. Galaxy isn't available in these Docker containers - there is no assurance Python is even available.
 
