### PR TITLE
[17.05] Sanitize container names sending to Kubernetes.

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -3,6 +3,7 @@ Offload jobs to a Kubernetes cluster.
 """
 
 import logging
+import re
 from os import environ as os_environ
 
 from six import text_type
@@ -208,8 +209,12 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         return k8s_cont_image
 
     def __get_k8s_container_name(self, job_wrapper):
-        # TODO check if this is correct
-        return job_wrapper.job_destination.id
+        # These must follow a specific regex for Kubernetes.
+        raw_id = job_wrapper.job_destination.id
+        cleaned_id = re.sub("[^-a-z0-9]", "-", raw_id)
+        if cleaned_id.startswith("-") or cleaned_id.endswith("-"):
+            cleaned_id = "x%sx" % cleaned_id
+        return cleaned_id
 
     def check_watched_item(self, job_state):
         """Checks the state of a job already submitted on k8s. Job state is a AsynchronousJobState"""


### PR DESCRIPTION
Kubernetes yells at me and refuses to run these jobs without this sanitization.

```
galaxy.jobs.runners ERROR 2017-05-05 17:02:22,175 (2) Unhandled exception calling queue_job
Traceback (most recent call last):
  File "/export/galaxy-central/lib/galaxy/jobs/runners/__init__.py", line 104, in run_next
    method(arg)
  File "/export/galaxy-central/lib/galaxy/jobs/runners/kubernetes.py", line 112, in queue_job
    Job(self._pykube_api, k8s_job_obj).create()
  File "/export/venv/local/lib/python2.7/site-packages/pykube/objects.py", line 97, in create
    self.api.raise_for_status(r)
  File "/export/venv/local/lib/python2.7/site-packages/pykube/http.py", line 106, in raise_for_status
    raise HTTPError(resp.status_code, payload["message"])
HTTPError: Job.batch "galaxy-2" is invalid: spec.template.spec.containers[0].name: Invalid value: "k8_default": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```

Ping @pcm32.
