### PR TITLE
Prevent graphite from dying loudly

### DIFF
--- a/lib/galaxy/web/framework/middleware/graphite.py
+++ b/lib/galaxy/web/framework/middleware/graphite.py
@@ -4,6 +4,8 @@ Middleware for sending request statistics to graphite
 from __future__ import absolute_import
 
 import time
+import logging
+log = logging.getLogger(__name__)
 
 try:
     import graphitesend
@@ -28,11 +30,22 @@ class GraphiteMiddleware(object):
             raise ImportError("graphite middleware configured, but no graphite python module found. "
                               "Please install the python graphitesend module to use this functionality.")
         self.application = application
-        self.graphite_client = graphitesend.init(graphite_server=graphite_host, graphite_port=int(graphite_port), prefix=graphite_prefix.rstrip('.'))
+        try:
+            self.graphite_client = graphitesend.init(graphite_server=graphite_host, graphite_port=int(graphite_port), prefix=graphite_prefix.rstrip('.'))
+        except graphitesend.graphitesend.GraphiteSendException:
+            self.graphite_client = None
+            log.exception("Could not instantiate graphite metrics logger. It will be disabled until Galaxy restart")
 
     def __call__(self, environ, start_response):
         start_time = time.time()
         req = self.application(environ, start_response)
+        # If graphite is disabled, exit early.
+        if not self.graphite_client:
+            return req
+
         dt = int((time.time() - start_time) * 1000)
-        self.graphite_client.send(environ.get('controller_action_key', None) or environ.get('PATH_INFO', "NOPATH").strip('/').replace('/', '.'), dt)
+        try:
+            self.graphite_client.send(environ.get('controller_action_key', None) or environ.get('PATH_INFO', "NOPATH").strip('/').replace('/', '.'), dt)
+        except graphitesend.GraphiteSendException:
+            log.exception("Graphite Error")
         return req


### PR DESCRIPTION
If your server is temporarily unavailable, graphitesend will pitch a fit and kill the process, leaving your server stuck in a reboot loop. It is preferable to disable it until manually triaged / rebooted. 