### PR TITLE
Replaced boto with cloudbridge in S3ObjectStore

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -108,6 +108,9 @@ class ConditionalDependencies( object ):
 
     def check_azure_storage( self ):
         return 'azure_blob' in self.object_stores
+    
+    def check_cloudbridge( self ):
+        return 's3' in self.object_stores
 
 
 def optional( config_file ):

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -13,4 +13,4 @@ graphitesend
 azure-storage==0.32.0
 # PyRods not in PyPI
 python-ldap==2.4.27
-cloudbridge==0.1.1
+cloudbridge==0.3.1

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -13,3 +13,4 @@ graphitesend
 azure-storage==0.32.0
 # PyRods not in PyPI
 python-ldap==2.4.27
+cloudbridge==0.1.1

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -26,15 +26,13 @@ from ..objectstore import convert_bytes, ObjectStore
 from cloudbridge.cloud.factory import CloudProviderFactory, ProviderList
 
 # TODO: Cloudbridge is not exposing exceptions; however, it is planned in the next release milestone.
-# TODO: Till then we're using temporarily using S3ResponseError, which will be replaced by CloudBridge
-# TODO: error responses, once ready.
+# Till then we're using temporarily using S3ResponseError, which will be replaced by CloudBridge
+# error responses, once ready.
 try:
     # Imports are done this way to allow objectstore code to be used outside of Galaxy.
     import boto
 
     from boto.exception import S3ResponseError
-    # from boto.s3.key import Key
-    # from boto.s3.connection import S3Connection
 except ImportError:
     boto = None
 
@@ -52,8 +50,6 @@ class S3ObjectStore(ObjectStore):
     Galaxy and S3.
     """
     def __init__(self, config, config_xml):
-        # if boto is None:
-        #    raise Exception(NO_BOTO_ERROR_MESSAGE)
         super(S3ObjectStore, self).__init__(config)
         self.staging_path = self.config.file_path
         self.transfer_progress = 0
@@ -378,7 +374,6 @@ class S3ObjectStore(ObjectStore):
         try:
             source_file = source_file if source_file else self._get_cache_path(rel_path)
             if os.path.exists(source_file):
-                # TODO: is it necessary to check for existence of the bucket ?
                 if os.path.getsize(source_file) == 0 and self.bucket.exists(rel_path):
                     log.debug("Wanted to push file '%s' to S3 key '%s' but its size is 0; skipping.", source_file,
                               rel_path)
@@ -386,7 +381,6 @@ class S3ObjectStore(ObjectStore):
                 # TODO: don't need to differenciate between uploading from a string or file,
                 # because CloudBridge handles this internally.
                 if from_string:
-                    # TODO: The upload function of CloudBridge should be updated to accept the following parameters.
                     if not self.bucket.get(rel_path):
                         created_obj = self.bucket.create_object(rel_path)
                         created_obj.upload(source_file)

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -599,8 +599,8 @@ class S3ObjectStore(ObjectStore):
         # even if it does not exist.
         # if dir_only:
         #     return cache_path
-        raise ObjectNotFound('objectstore.get_filename, no cache_path: %s, kwargs: %s'
-                             % (str(obj), str(kwargs)))
+        raise ObjectNotFound( 'objectstore.get_filename, no cache_path: %s, kwargs: %s'
+                              % ( str( obj ), str( kwargs ) ) )
         # return cache_path # Until the upload tool does not explicitly create the dataset, return expected path
 
     def update_from_file(self, obj, file_name=None, create=False, **kwargs):
@@ -625,8 +625,8 @@ class S3ObjectStore(ObjectStore):
             # Update the file on S3
             self._push_to_os(rel_path, source_file)
         else:
-            raise ObjectNotFound('objectstore.update_from_file, object does not exist: %s, kwargs: %s'
-                                 % (str(obj), str(kwargs)))
+            raise ObjectNotFound( 'objectstore.update_from_file, object does not exist: %s, kwargs: %s'
+                                  % ( str( obj ), str( kwargs ) ) )
 
     def get_object_url(self, obj, **kwargs):
         if self.exists(obj, **kwargs):

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -23,14 +23,18 @@ from galaxy.util.sleeper import Sleeper
 
 from .s3_multipart_upload import multipart_upload
 from ..objectstore import convert_bytes, ObjectStore
+from cloudbridge.cloud.factory import CloudProviderFactory, ProviderList
 
+# TODO: Cloudbridge is not exposing exceptions; however, it is planned in the next release milestone.
+# TODO: Till then we're using temporarily using S3ResponseError, which will be replaced by CloudBridge
+# TODO: error responses, once ready.
 try:
     # Imports are done this way to allow objectstore code to be used outside of Galaxy.
     import boto
 
     from boto.exception import S3ResponseError
-    from boto.s3.key import Key
-    from boto.s3.connection import S3Connection
+    # from boto.s3.key import Key
+    # from boto.s3.connection import S3Connection
 except ImportError:
     boto = None
 
@@ -48,13 +52,17 @@ class S3ObjectStore(ObjectStore):
     Galaxy and S3.
     """
     def __init__(self, config, config_xml):
-        if boto is None:
-            raise Exception(NO_BOTO_ERROR_MESSAGE)
+        # if boto is None:
+        #    raise Exception(NO_BOTO_ERROR_MESSAGE)
         super(S3ObjectStore, self).__init__(config)
         self.staging_path = self.config.file_path
         self.transfer_progress = 0
         self._parse_config_xml(config_xml)
         self._configure_connection()
+        # Maybe it would be better if we differentiate between
+        # the "name" of a bucket, and bucket as an "object".
+        # Till this command, self.bucket is bucket "name",
+        # but after this command it becomes a bucket "object".
         self.bucket = self._get_bucket(self.bucket)
         # Clean cache only if value is set in galaxy.ini
         if self.cache_size != -1:
@@ -73,8 +81,15 @@ class S3ObjectStore(ObjectStore):
             self.use_axel = False
 
     def _configure_connection(self):
+        # TODO: in the absence of an internet connection,
+        # this would prevent galaxy from starting.
+        # Maybe it would be better to put a maximum
+        # wait time, and ignore process if fails to
+        # respond within the time frame.
         log.debug("Configuring S3 Connection")
-        self.conn = S3Connection(self.access_key, self.secret_key)
+        aws_config = {'aws_access_key': self.access_key,
+                      'aws_secret_key': self.secret_key}
+        self.conn = CloudProviderFactory().create_provider(ProviderList.AWS, aws_config)
 
     def _parse_config_xml(self, config_xml):
         try:
@@ -185,19 +200,18 @@ class S3ObjectStore(ObjectStore):
 
     def _get_bucket(self, bucket_name):
         """ Sometimes a handle to a bucket is not established right away so try
-        it a few times. Raise error is connection is not established. """
+        it a few times. Raise error if connection is not established. """
         for i in range(5):
             try:
-                bucket = self.conn.get_bucket(bucket_name)
+                bucket = self.conn.object_store.get(bucket_name)
+                if bucket is None:
+                    log.debug("Bucket not found, creating s3 bucket with handle '%s'", bucket_name)
+                    bucket = self.conn.object_store.create(bucket_name)
                 log.debug("Using cloud object store with bucket '%s'", bucket.name)
                 return bucket
             except S3ResponseError:
-                try:
-                    log.debug("Bucket not found, creating s3 bucket with handle '%s'", bucket_name)
-                    self.conn.create_bucket(bucket_name)
-                except S3ResponseError:
-                    log.exception("Could not get bucket '%s', attempt %s/5", bucket_name, i + 1)
-                    time.sleep(2)
+                log.exception("Could not get bucket '%s', attempt %s/5", bucket_name, i + 1)
+                time.sleep(2)
         # All the attempts have been exhausted and connection was not established,
         # raise error
         raise S3ResponseError
@@ -211,9 +225,10 @@ class S3ObjectStore(ObjectStore):
                 # Ignore symlinks
                 if os.path.islink(path):
                     continue
-                umask_fix_perms( path, self.config.umask, 0o666, self.config.gid )
+                umask_fix_perms(path, self.config.umask, 0o666, self.config.gid)
 
-    def _construct_path(self, obj, base_dir=None, dir_only=None, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False, **kwargs):
+    def _construct_path(self, obj, base_dir=None, dir_only=None, extra_dir=None, extra_dir_at_root=False, alt_name=None,
+                        obj_dir=False, **kwargs):
         # extra_dir should never be constructed from provided data but just
         # make sure there are no shenannigans afoot
         if extra_dir and extra_dir != os.path.normpath(extra_dir):
@@ -257,9 +272,9 @@ class S3ObjectStore(ObjectStore):
 
     def _get_size_in_s3(self, rel_path):
         try:
-            key = self.bucket.get_key(rel_path)
-            if key:
-                return key.size
+            obj = self.bucket.get(rel_path)
+            if obj:
+                return obj.size
         except S3ResponseError:
             log.exception("Could not get size of key '%s' from S3", rel_path)
             return -1
@@ -270,14 +285,13 @@ class S3ObjectStore(ObjectStore):
             # A hackish way of testing if the rel_path is a folder vs a file
             is_dir = rel_path[-1] == '/'
             if is_dir:
-                keyresult = self.bucket.get_all_keys(prefix=rel_path)
+                keyresult = self.bucket.list(prefix=rel_path)
                 if len(keyresult) > 0:
                     exists = True
                 else:
                     exists = False
             else:
-                key = Key(self.bucket, rel_path)
-                exists = key.exists()
+                exists = self.bucket.exists(rel_path)
         except S3ResponseError:
             log.exception("Trouble checking existence of S3 key '%s'", rel_path)
             return False
@@ -330,7 +344,7 @@ class S3ObjectStore(ObjectStore):
     def _download(self, rel_path):
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, self._get_cache_path(rel_path))
-            key = self.bucket.get_key(rel_path)
+            key = self.bucket.get(rel_path)
             # Test if cache is large enough to hold the new file
             if self.cache_size > 0 and key.size > self.cache_size:
                 log.critical("File %s is larger (%s) than the cache size (%s). Cannot download.",
@@ -346,7 +360,8 @@ class S3ObjectStore(ObjectStore):
             else:
                 log.debug("Pulled key '%s' into cache to %s", rel_path, self._get_cache_path(rel_path))
                 self.transfer_progress = 0  # Reset transfer progress counter
-                key.get_contents_to_filename(self._get_cache_path(rel_path), cb=self._transfer_cb, num_cb=10)
+                with open(self._get_cache_path(rel_path), "w+") as downloaded_file_handle:
+                    key.save_content(downloaded_file_handle)
                 return True
         except S3ResponseError:
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self.bucket.name)
@@ -363,25 +378,40 @@ class S3ObjectStore(ObjectStore):
         try:
             source_file = source_file if source_file else self._get_cache_path(rel_path)
             if os.path.exists(source_file):
-                key = Key(self.bucket, rel_path)
-                if os.path.getsize(source_file) == 0 and key.exists():
-                    log.debug("Wanted to push file '%s' to S3 key '%s' but its size is 0; skipping.", source_file, rel_path)
+                # TODO: is it necessary to check for existence of the bucket ?
+                if os.path.getsize(source_file) == 0 and self.bucket.exists(rel_path):
+                    log.debug("Wanted to push file '%s' to S3 key '%s' but its size is 0; skipping.", source_file,
+                              rel_path)
                     return True
+                # TODO: don't need to differenciate between uploading from a string or file,
+                # because CloudBridge handles this internally.
                 if from_string:
-                    key.set_contents_from_string(from_string, reduced_redundancy=self.use_rr)
+                    # TODO: The upload function of CloudBridge should be updated to accept the following parameters.
+                    if not self.bucket.get(rel_path):
+                        created_obj = self.bucket.create_object(rel_path)
+                        created_obj.upload(source_file)
+                    else:
+                        self.bucket.get(rel_path).upload(source_file)
                     log.debug("Pushed data from string '%s' to key '%s'", from_string, rel_path)
                 else:
                     start_time = datetime.now()
-                    log.debug("Pushing cache file '%s' of size %s bytes to key '%s'", source_file, os.path.getsize(source_file), rel_path)
+                    log.debug("Pushing cache file '%s' of size %s bytes to key '%s'", source_file,
+                              os.path.getsize(source_file), rel_path)
                     mb_size = os.path.getsize(source_file) / 1e6
                     if mb_size < 10 or (not self.multipart):
                         self.transfer_progress = 0  # Reset transfer progress counter
-                        key.set_contents_from_filename(source_file,
-                                                       reduced_redundancy=self.use_rr,
-                                                       cb=self._transfer_cb,
-                                                       num_cb=10)
+                        # TODO: The upload function of CloudBridge should be updated to accept the following parameters.
+                        # key.set_contents_from_filename(source_file,
+                        #                               reduced_redundancy=self.use_rr,
+                        #                               cb=self._transfer_cb,
+                        #                               num_cb=10)
+                        if not self.bucket.get(rel_path):
+                            created_obj = self.bucket.create_object(rel_path)
+                            created_obj.upload(source_file)
+                        else:
+                            self.bucket.get(rel_path).upload(source_file)
                     else:
-                        multipart_upload(self.s3server, self.bucket, key.name, source_file, mb_size)
+                        multipart_upload(self.s3server, self.bucket, self.bucket.get(rel_path).name, source_file, mb_size)
                     end_time = datetime.now()
                     log.debug("Pushed cache file '%s' to key '%s' (%s bytes transfered in %s sec)",
                               source_file, rel_path, os.path.getsize(source_file), end_time - start_time)
@@ -408,20 +438,20 @@ class S3ObjectStore(ObjectStore):
         return False
 
     def exists(self, obj, **kwargs):
-        in_cache = in_s3 = False
+        in_cache = False
         rel_path = self._construct_path(obj, **kwargs)
 
         # Check cache
         if self._in_cache(rel_path):
             in_cache = True
         # Check S3
-        in_s3 = self._key_exists(rel_path)
+        in_cloud = self._key_exists(rel_path)
         # log.debug("~~~~~~ File '%s' exists in cache: %s; in s3: %s" % (rel_path, in_cache, in_s3))
         # dir_only does not get synced so shortcut the decision
         dir_only = kwargs.get('dir_only', False)
         base_dir = kwargs.get('base_dir', None)
         if dir_only:
-            if in_cache or in_s3:
+            if in_cache or in_cloud:
                 return True
             # for JOB_WORK directory
             elif base_dir:
@@ -432,17 +462,16 @@ class S3ObjectStore(ObjectStore):
                 return False
 
         # TODO: Sync should probably not be done here. Add this to an async upload stack?
-        if in_cache and not in_s3:
+        if in_cache and not in_cloud:
             self._push_to_os(rel_path, source_file=self._get_cache_path(rel_path))
             return True
-        elif in_s3:
+        elif in_cloud:
             return True
         else:
             return False
 
     def create(self, obj, **kwargs):
         if not self.exists(obj, **kwargs):
-
             # Pull out locally used fields
             extra_dir = kwargs.get('extra_dir', None)
             extra_dir_at_root = kwargs.get('extra_dir_at_root', False)
@@ -479,8 +508,8 @@ class S3ObjectStore(ObjectStore):
         if self.exists(obj, **kwargs):
             return bool(self.size(obj, **kwargs) > 0)
         else:
-            raise ObjectNotFound( 'objectstore.empty, object does not exist: %s, kwargs: %s'
-                                  % ( str( obj ), str( kwargs ) ) )
+            raise ObjectNotFound('objectstore.empty, object does not exist: %s, kwargs: %s'
+                                 % (str(obj), str(kwargs)))
 
     def size(self, obj, **kwargs):
         rel_path = self._construct_path(obj, **kwargs)
@@ -505,14 +534,13 @@ class S3ObjectStore(ObjectStore):
             if base_dir and dir_only and obj_dir:
                 shutil.rmtree(os.path.abspath(rel_path))
                 return True
-
             # For the case of extra_files, because we don't have a reference to
             # individual files/keys we need to remove the entire directory structure
             # with all the files in it. This is easy for the local file system,
             # but requires iterating through each individual key in S3 and deleing it.
             if entire_dir and extra_dir:
                 shutil.rmtree(self._get_cache_path(rel_path))
-                results = self.bucket.get_all_keys(prefix=rel_path)
+                results = self.bucket.list(prefix=rel_path)
                 for key in results:
                     log.debug("Deleting key %s", key.name)
                     key.delete()
@@ -522,7 +550,7 @@ class S3ObjectStore(ObjectStore):
                 os.unlink(self._get_cache_path(rel_path))
                 # Delete from S3 as well
                 if self._key_exists(rel_path):
-                    key = Key(self.bucket, rel_path)
+                    key = self.bucket.get(rel_path)
                     log.debug("Deleting key %s", key.name)
                     key.delete()
                     return True
@@ -577,8 +605,8 @@ class S3ObjectStore(ObjectStore):
         # even if it does not exist.
         # if dir_only:
         #     return cache_path
-        raise ObjectNotFound( 'objectstore.get_filename, no cache_path: %s, kwargs: %s'
-                              % ( str( obj ), str( kwargs ) ) )
+        raise ObjectNotFound('objectstore.get_filename, no cache_path: %s, kwargs: %s'
+                             % (str(obj), str(kwargs)))
         # return cache_path # Until the upload tool does not explicitly create the dataset, return expected path
 
     def update_from_file(self, obj, file_name=None, create=False, **kwargs):
@@ -603,14 +631,14 @@ class S3ObjectStore(ObjectStore):
             # Update the file on S3
             self._push_to_os(rel_path, source_file)
         else:
-            raise ObjectNotFound( 'objectstore.update_from_file, object does not exist: %s, kwargs: %s'
-                                  % ( str( obj ), str( kwargs ) ) )
+            raise ObjectNotFound('objectstore.update_from_file, object does not exist: %s, kwargs: %s'
+                                 % (str(obj), str(kwargs)))
 
     def get_object_url(self, obj, **kwargs):
         if self.exists(obj, **kwargs):
             rel_path = self._construct_path(obj, **kwargs)
             try:
-                key = Key(self.bucket, rel_path)
+                key = self.bucket.get(rel_path)
                 return key.generate_url(expires_in=86400)  # 24hrs
             except S3ResponseError:
                 log.exception("Trouble generating URL for dataset '%s'", rel_path)
@@ -628,11 +656,12 @@ class SwiftObjectStore(S3ObjectStore):
     """
 
     def _configure_connection(self):
+        # TODO: Replace with Cloudbridge connection.
         log.debug("Configuring Swift Connection")
-        self.conn = boto.connect_s3(aws_access_key_id=self.access_key,
-                                    aws_secret_access_key=self.secret_key,
-                                    is_secure=self.is_secure,
-                                    host=self.host,
-                                    port=self.port,
-                                    calling_format=boto.s3.connection.OrdinaryCallingFormat(),
-                                    path=self.conn_path)
+        # self.conn = boto.connect_s3(aws_access_key_id=self.access_key,
+        #                            aws_secret_access_key=self.secret_key,
+        #                            is_secure=self.is_secure,
+        #                            host=self.host,
+        #                            port=self.port,
+        #                            calling_format=boto.s3.connection.OrdinaryCallingFormat(),
+        #                            path=self.conn_path)


### PR DESCRIPTION
In general, all calls to `boto` are replaced with their equivalents from [cloudbridge](https://github.com/gvlproject/cloudbridge). This makes `S3ObjectStore` implementation agnostic to cloud storage providers, and makes it easily extendable to different providers.

There are few missing functionalities here (e.g., switching between the providers) which will be added in future PRs. Additionally, since `cloudbridge` is not exposing all parameters of `boto` functions (and similarly other provider adapters), few parameters are ignored in this PR. Also, since `cloudbridge` is not exposing `boto` exceptions, therefore, to prevent crashes, `boto` class is temporarily used to catch exception. All such exception handles should be updated once `cloudbridge` exposes `boto` exceptions. 

Few necessary improvements are marked with `todos`, which will be addressed in next PRs.