### PR TITLE
Add some test tools for collection job failures.

### DIFF
--- a/test/functional/tools/collection_creates_dynamic_nested_fail.xml
+++ b/test/functional/tools/collection_creates_dynamic_nested_fail.xml
@@ -1,0 +1,29 @@
+<tool id="collection_creates_dynamic_nested_fail" name="collection_creates_dynamic_nested_fail" version="0.1.0">
+  <command detect_errors="exit_code"><![CDATA[
+    echo "A" > oe1_ie1.fq ;
+    echo "B" > oe1_ie2.fq ;
+    echo "C" > oe2_ie1.fq ;
+    echo "D" > oe2_ie2.fq ;
+    echo "E" > oe3_ie1.fq ;
+    echo "F" > oe3_ie2.fq ;
+    exit 1
+  ]]></command>
+  <inputs>
+    <param name="foo" type="text" label="Dummy Parameter" />
+  </inputs>
+  <outputs>
+    <collection name="list_output" type="list:list" label="Duplicate List">
+      <!-- Use named regex group to grab pattern
+           <identifier_0>_<identifier_1>.fq. Here identifier_0 is the list
+           identifier of the outer list and identifier_1 is the list identifier
+           of the inner list (for instance oe1_ie2.fq in above example).
+      -->
+      <discover_datasets pattern="(?P&lt;identifier_0&gt;[^_]+)_(?P&lt;identifier_1&gt;[^_]+)\.fq" ext="fastqsanger" visible="true" />
+    </collection>
+  </outputs>
+  <tests>
+    <test expect_exit_code="1" expect_failure="true">
+      <param name="foo" value="bar" />
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/collection_creates_list_fail.xml
+++ b/test/functional/tools/collection_creates_list_fail.xml
@@ -1,0 +1,28 @@
+<tool id="collection_creates_list_fail" name="collection_creates_list_fail" version="0.1.0">
+  <command detect_errors="exit_code"><![CDATA[
+    #for $key in $list_output.keys()#
+    echo "identifier is $key" > "$list_output[$key]";
+    #end for#
+    echo 'ensure not empty';
+    exit 1;
+  ]]></command>
+  <inputs>
+    <param name="input1" type="data_collection" collection_type="list" label="Input" help="Input collection..." format="txt" />
+  </inputs>
+  <outputs>
+    <collection name="list_output" type="list" label="Duplicate List" structured_like="input1" inherit_format="true">
+      <!-- inherit_format can be used in conjunction with structured_like
+           to perserve format. -->
+    </collection>
+  </outputs>
+  <tests>
+    <test expect_exit_code="1" expect_failure="true">
+      <param name="input1">
+        <collection type="list">
+          <element name="l11" value="simple_line.txt" />
+          <element name="l12" value="simple_line.txt" />
+        </collection>
+      </param>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/collection_creates_list_fail.xml
+++ b/test/functional/tools/collection_creates_list_fail.xml
@@ -1,7 +1,7 @@
 <tool id="collection_creates_list_fail" name="collection_creates_list_fail" version="0.1.0">
   <command detect_errors="exit_code"><![CDATA[
     #for $key in $list_output.keys()#
-    echo "identifier is $key" > "$list_output[$key]";
+      echo "identifier is $key" > "$list_output[$key]";
     #end for#
     echo 'ensure not empty';
     exit 1;

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -100,6 +100,8 @@
   <tool file="collection_creates_dynamic_nested.xml" />
   <tool file="collection_creates_dynamic_list_of_pairs.xml" />
   <tool file="collection_type_source.xml" />
+  <tool file="collection_creates_list_fail.xml" />
+  <tool file="collection_creates_dynamic_nested_fail.xml" />
   <tool file="cheetah_casting.xml" />
 
   <tool file="cheetah_problem_unbound_var.xml" />


### PR DESCRIPTION
xref #4032

These at least verify that jobs are properly failing whether they use dynamic dataset collection or not. In the case of pre-determinable list structures - they properly go red and expose the problems to the user (try running test/functional/tools/collection_creates_list_fail.xml manually). In the case of dynamic dataset collections - this does not occur though - all the resulting datasets are indeed green.