### PR TITLE
Do not recurse in ensure_installed()

### DIFF
--- a/lib/galaxy/tools/deps/installable.py
+++ b/lib/galaxy/tools/deps/installable.py
@@ -67,11 +67,16 @@ def ensure_installed(installable_context, install_func, auto_init):
     if not os.path.lexists(parent_path):
         os.mkdir(parent_path)
 
-    try:
-        if auto_init and os.access(parent_path, os.W_OK):
-            with FileLock(os.path.join(parent_path, desc.lower())):
+    import time
+    MAX_TRIES = 10
+
+    for i in range( MAX_TRIES ):
+        try:
+            if auto_init and os.access(parent_path, os.W_OK):
+                with FileLock(os.path.join(parent_path, desc.lower())):
+                    return _check()
+            else:
                 return _check()
-        else:
-            return _check()
-    except FileLockException:
-        return ensure_installed(installable_context, install_func, auto_init)
+        except FileLockException:
+            time.sleep(1)
+    raise Exception("Failed to get file lock for %s for %s times" % (os.path.join(parent_path, desc.lower()), MAX_TRIES))

--- a/lib/galaxy/tools/deps/installable.py
+++ b/lib/galaxy/tools/deps/installable.py
@@ -69,7 +69,7 @@ def ensure_installed(installable_context, install_func, auto_init):
 
     try:
         if auto_init and os.access(parent_path, os.W_OK):
-            with FileLock(os.path.join(parent_path, desc.lower())):
+            with FileLock(os.path.join(parent_path, desc.lower()), timeout=300):
                 return _check()
         else:
             return _check()

--- a/lib/galaxy/tools/deps/installable.py
+++ b/lib/galaxy/tools/deps/installable.py
@@ -67,16 +67,11 @@ def ensure_installed(installable_context, install_func, auto_init):
     if not os.path.lexists(parent_path):
         os.mkdir(parent_path)
 
-    import time
-    MAX_TRIES = 10
-
-    for i in range( MAX_TRIES ):
-        try:
-            if auto_init and os.access(parent_path, os.W_OK):
-                with FileLock(os.path.join(parent_path, desc.lower())):
-                    return _check()
-            else:
+    try:
+        if auto_init and os.access(parent_path, os.W_OK):
+            with FileLock(os.path.join(parent_path, desc.lower())):
                 return _check()
-        except FileLockException:
-            time.sleep(1)
-    raise Exception("Failed to get file lock for %s for %s times" % (os.path.join(parent_path, desc.lower()), MAX_TRIES))
+        else:
+            return _check()
+    except FileLockException:
+        raise Exception("Failed to get file lock for %s" % os.path.join(parent_path, desc.lower()))

--- a/lib/galaxy/tools/deps/installable.py
+++ b/lib/galaxy/tools/deps/installable.py
@@ -74,4 +74,4 @@ def ensure_installed(installable_context, install_func, auto_init):
         else:
             return _check()
     except FileLockException:
-        return ensure_installed(installable_context, auto_init)
+        return ensure_installed(installable_context, install_func, auto_init)


### PR DESCRIPTION
There was a missing parameter in the recursive function call. 

There are two more places in the galaxy code where the parameter is missing: 
lib/galaxy/tools/deps/container_resolvers/mulled.py
lib/galaxy/tools/deps/mulled/mulled_build.py

I don't know how to fix them. 

Note that, the recursive function call happens when there is a file lock on a conda related file (database/dependencies/conda.lock) which appeared in my case when galaxy crashed / was aborted. It would be nice to write something to the user otherwise he will wait until the max recursion limit and get a confusing exception. 