### PR TITLE
[17.05] Correct webhooks to use Galaxy.root and be compatible with proxy_prefix

### DIFF
--- a/config/plugins/webhooks/demo/search/config/searchover.yaml
+++ b/config/plugins/webhooks/demo/search/config/searchover.yaml
@@ -7,7 +7,7 @@ icon: fa-search
 tooltip: Click to activate search and press Ctrl + Alt + q to open the overlay
 
 function: >
-  $.getJSON("/api/webhooks", function( data ) {
+  $.getJSON(Galaxy.root + "/api/webhooks", function( data ) {
       for( var item in data ) {
           var webhook = data[item];
           if( webhook.name === "searchover" ) {

--- a/config/plugins/webhooks/demo/tool_list/config/tool_list.yml
+++ b/config/plugins/webhooks/demo/tool_list/config/tool_list.yml
@@ -13,7 +13,7 @@ function: >
     'be patient, this might take a moment.');
   }, 1);
 
-  $.getJSON("/api/webhooks/tool_list/get_data", function(data) {
+  $.getJSON(Galaxy.root + "/api/webhooks/tool_list/get_data", function(data) {
     var popup = window.open('tool_list.html');
     var html = '<!DOCTYPE html><body><h2>' + 
       'Create a Docker flavour of this instance:</h2>' + 

--- a/doc/source/admin/special_topics/webhooks.rst
+++ b/doc/source/admin/special_topics/webhooks.rst
@@ -110,7 +110,7 @@ helper/__init__.py
          error = str(e)
       return {'success': not error, 'error': error, 'data': data}
 
-As an example please take a look at the *phdcomics* example plugin: https://github.com/bgruening/galaxy/blob/feature/plugin-system/config/plugins/webhooks/phdcomics/helper/__init__.py
+As an example please take a look at the *phdcomics* example plugin: https://github.com/galaxyproject/galaxy/blob/release_17.05/test/functional/webhooks/phdcomics/helper/__init__.py
 
 
 static

--- a/doc/source/admin/special_topics/webhooks.rst
+++ b/doc/source/admin/special_topics/webhooks.rst
@@ -81,6 +81,9 @@ The configuration file is just a .yml (or .yaml) file with a few options. The fo
 - **name** - must be the same as the plugin's root directory name
 - **type** (see Entry points) - can be combined with others
 - **activate** - *true* or *false* - whether show the plugin on a page or not
+- **icon** Icon to show (if masthead)
+- **tooltip** - Tooltip to show on hover
+- **function** - A javascript function to be executed. Any calls to Galaxy APIs should be sure to use Galaxy.root when constructing the URL to ensure compatability across Galaxy deployments.
 
 All other options can be anything used by the plugin and accessed later via *webhook.config['...']*.
 

--- a/test/functional/webhooks/trans_object/config/trans_object.yaml
+++ b/test/functional/webhooks/trans_object/config/trans_object.yaml
@@ -7,6 +7,6 @@ icon: fa-user
 tooltip: Show Username
 
 function: >
-  $.getJSON("/api/webhooks/trans_object/get_data", function(data) {
+  $.getJSON(Galaxy.root + "/api/webhooks/trans_object/get_data", function(data) {
     alert('Username: ' + data.username);
   });


### PR DESCRIPTION
Fix #4064

Should this target 17.05? Not sure where the team is on release process there.