### PR TITLE
Don't try to get the file name of purged files

### DIFF
--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -186,9 +186,10 @@ class DatasetSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin
         of the file that contains this dataset's data.
         """
         is_admin = self.user_manager.is_admin( user )
-        # expensive: allow conifg option due to cost of operation
+        # expensive: allow config option due to cost of operation
         if is_admin or self.app.config.expose_dataset_path:
-            return dataset.file_name
+            if not dataset.purged:
+                return dataset.file_name
         self.skip()
 
     def serialize_extra_files_path( self, dataset, key, user=None, **context ):
@@ -196,9 +197,10 @@ class DatasetSerializer( base.ModelSerializer, deletable.PurgableSerializerMixin
         If the config allows or the user is admin, return the file path.
         """
         is_admin = self.user_manager.is_admin( user )
-        # expensive: allow conifg option due to cost of operation
+        # expensive: allow config option due to cost of operation
         if is_admin or self.app.config.expose_dataset_path:
-            return dataset.extra_files_path
+            if not dataset.purged:
+                return dataset.extra_files_path
         self.skip()
 
     def serialize_permissions( self, dataset, key, user=None, **context ):

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -188,7 +188,9 @@
         <tr><td>UUID:</td><td>${hda.dataset.uuid}</td></tr>
         %endif
         %if trans.user_is_admin() or trans.app.config.expose_dataset_path:
-            <tr><td>Full Path:</td><td>${hda.file_name | h}</td></tr>
+            %if not hda.purged:
+                <tr><td>Full Path:</td><td>${hda.file_name | h}</td></tr>
+            %endif
         %endif
     </tbody>
 </table>


### PR DESCRIPTION
This has been bugging me for a while, but I only just now had a chance to track down the causes.

If one allows users to purge their data then they can often run into problems if they then try to (1) display deleted (including purged in this case) items in a history or (2) click on the information button on a deleted and purged item. The errors are displayed via javascript on the user end, an example of which is below:

    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:45.0) Gecko/20100101 Firefox/45.0",
    "onLine": true,
    "version": "17.01",
      "xhr": {
        "readyState": 4,
        "responseText": "{\"err_msg\": \"objectstore, _call_method failed: get_filename on <galaxy.model.Dataset object at 0x7f7ecfe7b710>, kwargs: {}\", \"err_code\": 404001}",
        "responseJSON": {
          "err_msg": "objectstore, _call_method failed: get_filename on <galaxy.model.Dataset object at 0x7f7ecfe7b710>, kwargs: {}",
          "err_code": 404001
        },
        "status": 404,
        "statusText": "Not Found"
      },
      "options": {
        "parse": true,
        "silent": true,
        "limit": 500,
        "offset": 0,
        "details": "bbedde4931a34160,bf1fc87dfb22ab7b,c060d876360b529c,239de9509e5f2ad5,031ac30ff5ede248,8a614701a0f1b6a2,3a4220c205f26e2c,17abf85b2306c490,28eb2b64ae0059de,078ee83f6a81d187,487ef6b7ce257489,a0f3c3eaddadcc06,87833dc316faf4b6,910f5492ec37eb15,d895a91075d8a8ce,20f5fb4fc6089119,654b16c6f6aa34ce,d41ff3ffbb639bb5,8682b451162603de,fa448058b8ac2a47,302ddcb06e18bc43,72c46c8eb9871f99,a78e2601656e62e9,915b8d6cc740513a",
        "traditional": true,
        "data": {
          "limit": 500,
          "offset": 0,
          "details":    "bbedde4931a34160,bf1fc87dfb22ab7b,c060d876360b529c,239de9509e5f2ad5,031ac30ff5ede248,8a614701a0f1b6a2,3a4220c205f26e2c,17abf85b2306c490,28eb2b64ae0059de,078ee83f6a81d187,487ef6b7ce257489,a0f3c3eaddadcc06,87833dc316faf4b6,910f5492ec37eb15,d895a91075d8a8ce,20f5fb4fc6089119,654b16c6f6aa34ce,d41ff3ffbb639bb5,8682b451162603de,fa448058b8ac2a47,302ddcb06e18bc43,72c46c8eb9871f99,a78e2601656e62e9,915b8d6cc740513a",
          "order": "hid",
          "v": "dev",
          "q": [
            "visible"
          ],
          "qv": [
            "True"
          ]
        },
        "emulateHTTP": false,
        "emulateJSON": false,
        "textStatus": "error",
        "errorThrown": "Not Found"
      },
      "url": "http://galaxy.ie-freiburg.mpg.de/api/histories/63edcbc9511f9a4c/contents?limit=500&offset=0&details=bbedde4931a34160%2Cbf1fc87dfb22ab7b%2Cc060d876360b529c%2C239de9509e5f2ad5%2C031ac30ff5ede248%2C8a614701a0f1b6a2%2C3a4220c205f26e2c%2C17abf85b2306c490%2C28eb2b64ae0059de%2C078ee83f6a81d187%2C487ef6b7ce257489%2Ca0f3c3eaddadcc06%2C87833dc316faf4b6%2C910f5492ec37eb15%2Cd895a91075d8a8ce%2C20f5fb4fc6089119%2C654b16c6f6aa3    4ce%2Cd41ff3ffbb639bb5%2C8682b451162603de%2Cfa448058b8ac2a47%2C302ddcb06e18bc43%2C72c46c8eb9871f99%2Ca78e2601656e62e9%2C915b8d6cc740513a&order=hid&v=dev&q=visible&    qv=True",
      "model": [],
      "user": {
        "id": "fc24ff678cc48b4e",
        "username": "aline",
        "total_disk_usage": 121603913933,
        "nice_total_disk_usage": "113.3 GB",
        "quota_percent": 56,
        "is_admin": false,
        "preferences": {
          "selected_tool_tags": ""
        },
        "tags_used": [],
        "deleted": false,
        "purged": false,
        "quota": "200.0 GB"
      }
    }

In my local instance, I was able to find a few places where this can occur. The simplest is to modify `show_params.mako` to check for purged files and not attempt to display their paths. I've additionally set some of the `Dataset` class methods to not try to get file names for purged datasets. At least for my local instance, this allows people to view deleted items (and their parameters) in histories containing purged datasets.