### PR TITLE
[17.05] CONTRIBUTORS update 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,10 +12,13 @@ The following individuals have contributed code to Galaxy:
 * Abdulrahman Azab <eng.azab@gmail.com>
 * Finn Bacall <finn.bacall@cs.man.ac.uk>
 * Dannon Baker <dannon.baker@gmail.com>
+* balto <balto_59@hotmail.fr>
 * Christopher Bare <christopherbare@gmail.com>
 * Bérénice Batut <berenice.batut@gmail.com>
 * Marius van den Beek <m.vandenbeek@gmail.com>
+* Maria Bernard <maria.bernard@jouy.inra.fr>
 * Jean-Frédéric Berthelot <jean-frederic.berthelot@lifl.fr>
+* Léo Biscassi <leo.biscassi@gmail.com>
 * Dan Blanchard <dan.blanchard@gmail.com>
 * Clemens Blank <blankclemens@gmail.com>
 * Daniel Blankenberg <dan.blankenberg@gmail.com> <dan@bx.psu.edu>
@@ -32,6 +35,7 @@ The following individuals have contributed code to Galaxy:
 * Jennifer Cabral <jencabral@gmail.com>
 * Martin Čech <marten@bx.psu.edu>
 * Ramkrishna Chakrabarty <rc@bx.psu.edu>
+* Matt Chambers <matt.chambers42@gmail.com>
 * Brad Chapman <chapmanb@50mail.com>
 * John Chilton <jmchilton@gmail.com>
 * Saket Choudhary <saketkc@gmail.com>
@@ -59,6 +63,7 @@ The following individuals have contributed code to Galaxy:
 * Jean-Frédéric (@JeanFred on Github)
 * Maximilian Friedersdorff <max@friedersdorff.com>
 * Jaime Frey <jfrey@cs.wisc.edu>
+* Ben Fulton <benmarkfulton@gmail.com>
 * Carrie Ganote <cganote@iu.edu>
 * Ryan Golhar <ngsbioinformatics@gmail.com>
 * Jeremy Goecks <jeremy.goecks@emory.edu> <jgoecks@gwu.edu>
@@ -75,10 +80,13 @@ The following individuals have contributed code to Galaxy:
 * Hans-Rudolf Hotz <hrhotz@users.noreply.github.com>
 * Jian-Long Huang <jlh@pyhub.org>
 * Gert Hulselmans <gert.hulselmans@med.kuleuven.be>
+* Manabu Ishii <manabu.ishii.rb@gmail.com>
 * Jennifer Jackson <jen@bx.psu.edu>
 * Joachim Jacob <joachim.jacob@gmail.com>
+* Xiaoqian Jiang <jxq198409@hotmail.com>
 * Jim Johnson <jj@umn.edu> <jj@msi.umn.edu>
 * Radhesh Kamath <radhesh@bx.psu.edu>
+* Iyad Kandalaft <ik@iyadk.com>
 * Jan Kanis <jan.code@jankanis.nl>
 * David King <dcking@bx.psu.edu>
 * Rory Kirchner <roryk@mit.edu>
@@ -90,17 +98,20 @@ The following individuals have contributed code to Galaxy:
 * Ross Lazarus <ross.lazarus@gmail.com> <rossl@bx.psu.edu>
 * Yvan Le Bras <yvan.le_bras@irisa.fr>
 * Gildas Le Corguillé @lecorguille
+* Alexander Lenail <alexander.lenail@tufts.edu>
 * Simone Leo <simone.leo@gmail.com>
 * Kanwei Li <kanwei@gmail.com>
 * Michael Li <michael.li@uwaterloo.ca>
 * Pierre Lindenbaum <plindenbaum@yahoo.fr>
 * Mikael Loaec <mikael.loaec@versailles.inra.fr>
+* Thoba Lose <thobalose@users.noreply.github.com>
 * Philip Mabon <philipmabon@gmail.com>
 * Remi Marenco <remi.marenco@gmail.com> <remimarenco@gmail.com>
 * Zipho Mashologu <zipho@trustpay.biz>
 * Thomas McGowan <mcgo0092@msi.umn.edu>
 * Scott McManus <scottmcmanus@emory.edu> <scottmcmanus@gatech.edu>
 * Hervé Ménager <herve.menager@pasteur.fr>
+* Pablo Moreno <pablo.a.moreno@gmail.com>
 * Hunter Moseley <hunter.moseley@louisville.edu>
 * Takao Nakaguchi <takao.nakaguchi@gmail.com>
 * Arjun Nath <arjun@bx.psu.edu>
@@ -108,22 +119,26 @@ The following individuals have contributed code to Galaxy:
 * Eric Paniagua <paniagua.cshl@gmail.com>
 * Richard Park <rpark@bu.edu>
 * Lance Parsons <lparsons@princeton.edu>
+* Balthazar Pavot <balthazar.pavot@hotmail.fr>
 * Chinmay Rao <chinmay@bx.psu.edu>
 * Matt Ralston <mrals89@gmail.com>
 * ramezrawas <ramezrawas@gmail.com>
 * Eric Rasche <esr@tamu.edu> <rasche.eric@gmail.com> <rasche.eric@yandex.ru>
 * Athos Ribeiro <athoscr@fedoraproject.org>
 * Andrew Robinson <Andrew.Robinson@latrobe.edu.au>
+* Devon Ryan <dpryan79@gmail.com>
 * Michael Sauria <crockopotamus@gmail.com>
 * Andrea Sbardellati <andrea.sbardellati@crs4.it>
 * Ian Schenck <ian@bx.psu.edu>
 * Nick Semenkovich <semenko@alum.mit.edu>
 * Varun Shankar <varunshankar55@gmail.com>
 * Matthew Shirley <mdshw5@gmail.com>
+* Timur Shtatland <shtatland@neb.com>
 * Sourav Singh <ssouravsingh12@gmail.com>
 * Clare Sloggett <sloc@unimelb.edu.au>
 * Eteri Sokhoyan @Sokhoyan
 * Nicola Soranzo <nicola.soranzo@tgac.ac.uk> <nsoranzo@tiscali.it> <soranzo@crs4.it>
+* Nick Stoler <nick@nstoler.com>
 * Roy Storey <kiwiroy@gmail.com>
 * Hanfei Sun <ad9075@gmail.com>
 * Ilya Sytchev <hackdna@gmail.com>
@@ -142,6 +157,7 @@ The following individuals have contributed code to Galaxy:
 * Greg Von Kuster <greg@bx.psu.edu>
 * Pavan Videm <videmp@informatik.uni-freiburg.de>
 * Hiral Vora <hvora1@uncc.edu>
+* Junzhou Wang <junzhouwang@gmail.com>
 * Andrew Warren <anwarren@vbi.vt.edu>
 * Trevor Wennblom <trevor@well.com>
 * Joachim Wolff <wolffj@informatik.uni-freiburg.de>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -77,7 +77,7 @@ The following individuals have contributed code to Galaxy:
 * Saskia Hiltemann <zazkia@gmail.com>
 * Rob Hooft <rob.hooft@nbic.nl>
 * Y. Hoogstrate <y.hoogstrate@erasmusmc.nl>
-* Hans-Rudolf Hotz <hrhotz@users.noreply.github.com>
+* Hans-Rudolf Hotz @hrhotz
 * Jian-Long Huang <jlh@pyhub.org>
 * Gert Hulselmans <gert.hulselmans@med.kuleuven.be>
 * Manabu Ishii <manabu.ishii.rb@gmail.com>
@@ -104,7 +104,7 @@ The following individuals have contributed code to Galaxy:
 * Michael Li <michael.li@uwaterloo.ca>
 * Pierre Lindenbaum <plindenbaum@yahoo.fr>
 * Mikael Loaec <mikael.loaec@versailles.inra.fr>
-* Thoba Lose <thobalose@users.noreply.github.com>
+* Thoba Lose @thobalose
 * Philip Mabon <philipmabon@gmail.com>
 * Remi Marenco <remi.marenco@gmail.com> <remimarenco@gmail.com>
 * Zipho Mashologu <zipho@trustpay.biz>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ The following individuals have contributed code to Galaxy:
 * Guruprasad Ananda <gua110@bx.psu.edu>
 * Florent Angly <florent.angly@gmail.com>
 * Raj Ayyampalayam <raj76@uga.edu>
+* Abdulrahman Azab <eng.azab@gmail.com>
 * Finn Bacall <finn.bacall@cs.man.ac.uk>
 * Dannon Baker <dannon.baker@gmail.com>
 * Christopher Bare <christopherbare@gmail.com>
@@ -50,8 +51,10 @@ The following individuals have contributed code to Galaxy:
 * Kyle Ellrott <kellrott@gmail.com> <kellrott@soe.ucsc.edu>
 * Eric Enns <eric.enns@gmail.com>
 * fescudie <fescudie@toulouse.inra.fr>
+* Anne Fouilloux <annefou@uio.no>
 * Dorine Francheteau <dorine@bx.psu.edu>
 * Jean-Frédéric (@JeanFred on Github)
+* Maximilian Friedersdorff <max@friedersdorff.com>
 * Jaime Frey <jfrey@cs.wisc.edu>
 * Carrie Ganote <cganote@iu.edu>
 * Ryan Golhar <ngsbioinformatics@gmail.com>
@@ -66,6 +69,7 @@ The following individuals have contributed code to Galaxy:
 * Saskia Hiltemann <zazkia@gmail.com>
 * Rob Hooft <rob.hooft@nbic.nl>
 * Y. Hoogstrate <y.hoogstrate@erasmusmc.nl>
+* Hans-Rudolf Hotz <hrhotz@users.noreply.github.com>
 * Jian-Long Huang <jlh@pyhub.org>
 * Gert Hulselmans <gert.hulselmans@med.kuleuven.be>
 * Jennifer Jackson <jen@bx.psu.edu>
@@ -76,7 +80,9 @@ The following individuals have contributed code to Galaxy:
 * David King <dcking@bx.psu.edu>
 * Rory Kirchner <roryk@mit.edu>
 * Edward Kirton <eskirton@lbl.gov>
+* Anup Kumar <anup.rulez@gmail.com>
 * Brad Langhorst <langhorst@neb.com>
+* Delphine Lariviere <lariviere.delphine@gmail.com>
 * Ross Lazarus <ross.lazarus@gmail.com> <rossl@bx.psu.edu>
 * Yvan Le Bras <yvan.le_bras@irisa.fr>
 * Gildas Le Corguillé @lecorguille
@@ -90,6 +96,7 @@ The following individuals have contributed code to Galaxy:
 * Zipho Mashologu <zipho@trustpay.biz>
 * Thomas McGowan <mcgo0092@msi.umn.edu>
 * Scott McManus <scottmcmanus@emory.edu> <scottmcmanus@gatech.edu>
+* Hervé Ménager <herve.menager@pasteur.fr>
 * Hunter Moseley <hunter.moseley@louisville.edu>
 * Takao Nakaguchi <takao.nakaguchi@gmail.com>
 * Arjun Nath <arjun@bx.psu.edu>
@@ -120,9 +127,11 @@ The following individuals have contributed code to Galaxy:
 * Nitesh Turaga <nitesh.turaga@gmail.com>
 * Clayton Turner <clayclay911@gmail.com>
 * Jesse c j van Dam <jesse.vandam@wur.nl>
+* Ashok Varadharajan <ashvark@gmail.com>
 * Marek Vavruša <marek@vavrusa.com>
 * Martijn Vermaat <m.vermaat.hg@lumc.nl>
 * Kelly Vincent <kpvincent@bx.psu.edu>
+* Jeremy Volkening <jdv@base2bio.com>
 * Greg Von Kuster <greg@bx.psu.edu>
 * Pavan Videm <videmp@informatik.uni-freiburg.de>
 * Hiral Vora <hvora1@uncc.edu>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,9 +11,12 @@ The following individuals have contributed code to Galaxy:
 * Finn Bacall <finn.bacall@cs.man.ac.uk>
 * Dannon Baker <dannon.baker@gmail.com>
 * Christopher Bare <christopherbare@gmail.com>
+* Bérénice Batut <berenice.batut@gmail.com>
 * Marius van den Beek <m.vandenbeek@gmail.com>
 * Dan Blanchard <dan.blanchard@gmail.com>
+* Clemens Blank <blankclemens@gmail.com>
 * Daniel Blankenberg <dan.blankenberg@gmail.com> <dan@bx.psu.edu>
+* Jorrit Boekel <jorrit.boekel@scilifelab.se>
 * James Boocock <sfk2001@gmail.com>
 * Carlos Borroto <carlos.borroto@gmail.com>
 * Daniel Bouchard <dbouchard@corefacility.ca> <daniel.bouchard@phac-aspc.gc.ca>
@@ -75,6 +78,7 @@ The following individuals have contributed code to Galaxy:
 * Edward Kirton <eskirton@lbl.gov>
 * Brad Langhorst <langhorst@neb.com>
 * Ross Lazarus <ross.lazarus@gmail.com> <rossl@bx.psu.edu>
+* Yvan Le Bras <yvan.le_bras@irisa.fr>
 * Gildas Le Corguillé @lecorguille
 * Simone Leo <simone.leo@gmail.com>
 * Kanwei Li <kanwei@gmail.com>
@@ -96,6 +100,7 @@ The following individuals have contributed code to Galaxy:
 * Chinmay Rao <chinmay@bx.psu.edu>
 * Matt Ralston <mrals89@gmail.com>
 * Eric Rasche <esr@tamu.edu> <rasche.eric@gmail.com> <rasche.eric@yandex.ru>
+* Athos Ribeiro <athoscr@fedoraproject.org>
 * Andrew Robinson <Andrew.Robinson@latrobe.edu.au>
 * Michael Sauria <crockopotamus@gmail.com>
 * Andrea Sbardellati <andrea.sbardellati@crs4.it>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ The following individuals have contributed code to Galaxy:
 * Istvan Albert <istvan.albert@gmail.com>
 * Renato Alves <alves.rjc@gmail.com> <rjalves@igc.gulbenkian.pt>
 * Guruprasad Ananda <gua110@bx.psu.edu>
+* Evgeny Anatskiy <evgeny.anatskiy@gmail.com>
 * Florent Angly <florent.angly@gmail.com>
 * Raj Ayyampalayam <raj76@uga.edu>
 * Abdulrahman Azab <eng.azab@gmail.com>
@@ -14,6 +15,7 @@ The following individuals have contributed code to Galaxy:
 * Christopher Bare <christopherbare@gmail.com>
 * Bérénice Batut <berenice.batut@gmail.com>
 * Marius van den Beek <m.vandenbeek@gmail.com>
+* Jean-Frédéric Berthelot <jean-frederic.berthelot@lifl.fr>
 * Dan Blanchard <dan.blanchard@gmail.com>
 * Clemens Blank <blankclemens@gmail.com>
 * Daniel Blankenberg <dan.blankenberg@gmail.com> <dan@bx.psu.edu>
@@ -47,6 +49,7 @@ The following individuals have contributed code to Galaxy:
 * Shane Dowling <shane@shanedowling.com>
 * John Duddy <jduddy@illumina.com>
 * Carl Eberhard <carlfeberhard@gmail.com>
+* Ignacio Eguinoa <ignacio.eguinoa@gmail.com>
 * Mark Einon <mark.einon@gmail.com>
 * Kyle Ellrott <kellrott@gmail.com> <kellrott@soe.ucsc.edu>
 * Eric Enns <eric.enns@gmail.com>
@@ -80,6 +83,7 @@ The following individuals have contributed code to Galaxy:
 * David King <dcking@bx.psu.edu>
 * Rory Kirchner <roryk@mit.edu>
 * Edward Kirton <eskirton@lbl.gov>
+* Jasper Koehorst <jasperkoehorst@gmail.com>
 * Anup Kumar <anup.rulez@gmail.com>
 * Brad Langhorst <langhorst@neb.com>
 * Delphine Lariviere <lariviere.delphine@gmail.com>
@@ -106,6 +110,7 @@ The following individuals have contributed code to Galaxy:
 * Lance Parsons <lparsons@princeton.edu>
 * Chinmay Rao <chinmay@bx.psu.edu>
 * Matt Ralston <mrals89@gmail.com>
+* ramezrawas <ramezrawas@gmail.com>
 * Eric Rasche <esr@tamu.edu> <rasche.eric@gmail.com> <rasche.eric@yandex.ru>
 * Athos Ribeiro <athoscr@fedoraproject.org>
 * Andrew Robinson <Andrew.Robinson@latrobe.edu.au>
@@ -113,6 +118,7 @@ The following individuals have contributed code to Galaxy:
 * Andrea Sbardellati <andrea.sbardellati@crs4.it>
 * Ian Schenck <ian@bx.psu.edu>
 * Nick Semenkovich <semenko@alum.mit.edu>
+* Varun Shankar <varunshankar55@gmail.com>
 * Matthew Shirley <mdshw5@gmail.com>
 * Sourav Singh <ssouravsingh12@gmail.com>
 * Clare Sloggett <sloc@unimelb.edu.au>
@@ -121,6 +127,7 @@ The following individuals have contributed code to Galaxy:
 * Roy Storey <kiwiroy@gmail.com>
 * Hanfei Sun <ad9075@gmail.com>
 * Ilya Sytchev <hackdna@gmail.com>
+* Scott Szakonyi <sszakony@nd.edu>
 * James Taylor <james@jamestaylor.org>
 * Tomithy Too <tomithy.too@gmail.com>
 * David Trudgian <dave@trudgian.net> <david.trudgian@utsouthwestern.edu>
@@ -137,6 +144,7 @@ The following individuals have contributed code to Galaxy:
 * Hiral Vora <hvora1@uncc.edu>
 * Andrew Warren <anwarren@vbi.vt.edu>
 * Trevor Wennblom <trevor@well.com>
+* Joachim Wolff <wolffj@informatik.uni-freiburg.de>
 * Thomas Wollmann <thomas.s.wollmann@gmail.com> <thomas.wollmann@bioquant.uni-heidelberg.de>
 * Jay Young <xiaojay@gmail.com>
 * Yi Zhang <yizhang@bx.psu.edu>


### PR DESCRIPTION
WIP, currently only 17.01->17.05, backtracking to the previous few releases to make sure we haven't missed anyone.

For anyone curious, these are generated with something like: 
```colordiff =(git shortlog -se -b upstream/release_16.07 | awk '{print substr($0, index($0, $2))}') =(git shortlog -se -b upstream/release_16.10 | awk '{print substr($0, index($0, $2))}') | less -r```