### PR TITLE
Touchup .gitignore to not ignore new bundles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,7 +121,7 @@ tool-data/shared/jars/
 sprite-*.less
 
 # JS, Local node_modules, and bower_components directories
-static/scripts/bundled
+static/scripts/bundled/[0-9]*
 node_modules
 bower_components
 


### PR DESCRIPTION
Should prevent issues like #4079. 