### PR TITLE
More workflow test case fixes for #4047.

### DIFF
--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -449,7 +449,8 @@ class NavigatesGalaxy(HasDriver):
         self.click_xpath(self.navigation_data["selectors"]["masthead"]["workflow"])
 
     def click_button_new_workflow(self):
-        self.click_selector(self.navigation_data["selectors"]["workflows"]["new_button"])
+        element = self.wait_for_selector_clickable(self.navigation_data["selectors"]["workflows"]["new_button"])
+        element.click()
 
     def wait_for_sizzle_selector_clickable(self, selector):
         element = self._wait_on(


### PR DESCRIPTION
I think previously this button would be there on page load and now it is loaded after the page in JS.