### PR TITLE
[17.05] Open Babel update for datatype converters

### DIFF
--- a/lib/galaxy/datatypes/converters/cml_to_inchi_converter.xml
+++ b/lib/galaxy/datatypes/converters/cml_to_inchi_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_cml_to_inchi" name="CML to InChI" version="1.0.0">
+<tool id="CONVERTER_cml_to_inchi" name="CML to InChI" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/cml_to_mol2_converter.xml
+++ b/lib/galaxy/datatypes/converters/cml_to_mol2_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_cml_to_mol2" name="CML to mol2" version="1.0.0">
+<tool id="CONVERTER_cml_to_mol2" name="CML to mol2" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/cml_to_sdf_converter.xml
+++ b/lib/galaxy/datatypes/converters/cml_to_sdf_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_cml_to_sdf" name="CML to SDF" version="1.0.0">
+<tool id="CONVERTER_cml_to_sdf" name="CML to SDF" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/cml_to_smi_converter.xml
+++ b/lib/galaxy/datatypes/converters/cml_to_smi_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_cml_to_smiles" name="CML to SMILES" version="1.0.0">
+<tool id="CONVERTER_cml_to_smiles" name="CML to SMILES" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command >
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/inchi_to_cml_converter.xml
+++ b/lib/galaxy/datatypes/converters/inchi_to_cml_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_inchi_to_cml" name="InChI to CML" version="1.0.0">
+<tool id="CONVERTER_inchi_to_cml" name="InChI to CML" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/inchi_to_mol2_converter.xml
+++ b/lib/galaxy/datatypes/converters/inchi_to_mol2_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_inchi_to_mol2" name="InChI to MOL2" version="1.0.0">
+<tool id="CONVERTER_inchi_to_mol2" name="InChI to MOL2" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/inchi_to_mol_converter.xml
+++ b/lib/galaxy/datatypes/converters/inchi_to_mol_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_inchi_to_mol" name="InChI to MOL" version="1.0.0">
+<tool id="CONVERTER_inchi_to_mol" name="InChI to MOL" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/inchi_to_sdf_converter.xml
+++ b/lib/galaxy/datatypes/converters/inchi_to_sdf_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_inchi_to_sdf" name="InChI to SDF" version="1.0.0">
+<tool id="CONVERTER_inchi_to_sdf" name="InChI to SDF" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/inchi_to_smi_converter.xml
+++ b/lib/galaxy/datatypes/converters/inchi_to_smi_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_inchi_to_smi" name="InChI to SMILES" version="1.0.0">
+<tool id="CONVERTER_inchi_to_smi" name="InChI to SMILES" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/mol2_to_cml_converter.xml
+++ b/lib/galaxy/datatypes/converters/mol2_to_cml_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_mol2_to_cml" name="MOL2 to CML" version="1.0.0">
+<tool id="CONVERTER_mol2_to_cml" name="MOL2 to CML" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/mol2_to_inchi_converter.xml
+++ b/lib/galaxy/datatypes/converters/mol2_to_inchi_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_mol2_to_inchi" name="MOL2 to InChI" version="1.0.0">
+<tool id="CONVERTER_mol2_to_inchi" name="MOL2 to InChI" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/mol2_to_mol_converter.xml
+++ b/lib/galaxy/datatypes/converters/mol2_to_mol_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_mol2_to_mol" name="MOL2 to MOL" version="1.0.0">
+<tool id="CONVERTER_mol2_to_mol" name="MOL2 to MOL" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/mol2_to_sdf_converter.xml
+++ b/lib/galaxy/datatypes/converters/mol2_to_sdf_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_mol2_to_sdf" name="MOL2 to SDF" version="1.0.0">
+<tool id="CONVERTER_mol2_to_sdf" name="MOL2 to SDF" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/mol2_to_smi_converter.xml
+++ b/lib/galaxy/datatypes/converters/mol2_to_smi_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_mol2_to_smi" name="MOL2 to SMILES" version="1.0.0">
+<tool id="CONVERTER_mol2_to_smi" name="MOL2 to SMILES" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/mol_to_cml_converter.xml
+++ b/lib/galaxy/datatypes/converters/mol_to_cml_converter.xml
@@ -1,7 +1,7 @@
-<tool id="CONVERTER_mol_to_cml" name="MOL to CML" version="1.0.0">
+<tool id="CONVERTER_mol_to_cml" name="MOL to CML" version="2.4.1">
     <description></description>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/mol_to_inchi_converter.xml
+++ b/lib/galaxy/datatypes/converters/mol_to_inchi_converter.xml
@@ -1,7 +1,7 @@
-<tool id="CONVERTER_mol_to_mol2" name="MOL to MOL2" version="1.0.0">
+<tool id="CONVERTER_mol_to_mol2" name="MOL to MOL2" version="2.4.1">
     <description></description>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/mol_to_mol2_converter.xml
+++ b/lib/galaxy/datatypes/converters/mol_to_mol2_converter.xml
@@ -1,7 +1,7 @@
-<tool id="CONVERTER_mol_to_mol2" name="MOL to MOL2" version="1.0.0">
+<tool id="CONVERTER_mol_to_mol2" name="MOL to MOL2" version="2.4.1">
     <description></description>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/mol_to_smi_converter.xml
+++ b/lib/galaxy/datatypes/converters/mol_to_smi_converter.xml
@@ -1,7 +1,7 @@
-<tool id="CONVERTER_mol_to_smi" name="MOL to SMILES" version="1.0.0">
+<tool id="CONVERTER_mol_to_smi" name="MOL to SMILES" version="2.4.1">
     <description></description>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/sdf_to_cml_converter.xml
+++ b/lib/galaxy/datatypes/converters/sdf_to_cml_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_sdf_to_cml" name="SDF to CML" version="1.0.0">
+<tool id="CONVERTER_sdf_to_cml" name="SDF to CML" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/sdf_to_inchi_converter.xml
+++ b/lib/galaxy/datatypes/converters/sdf_to_inchi_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_sdf_to_inchi" name="SDF to InChI" version="1.0.0">
+<tool id="CONVERTER_sdf_to_inchi" name="SDF to InChI" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/sdf_to_mol2_converter.xml
+++ b/lib/galaxy/datatypes/converters/sdf_to_mol2_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_sdf_to_mol2" name="SDF to mol2" version="1.0.0">
+<tool id="CONVERTER_sdf_to_mol2" name="SDF to mol2" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/sdf_to_smi_converter.xml
+++ b/lib/galaxy/datatypes/converters/sdf_to_smi_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_sdf_to_smiles" name="SDF to SMILES" version="1.0.1">
+<tool id="CONVERTER_sdf_to_smiles" name="SDF to SMILES" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command >
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/smi_to_cml_converter.xml
+++ b/lib/galaxy/datatypes/converters/smi_to_cml_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_SMILES_to_cml" name="SMILES to CML" version="1.0.0">
+<tool id="CONVERTER_SMILES_to_cml" name="SMILES to CML" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/smi_to_inchi_converter.xml
+++ b/lib/galaxy/datatypes/converters/smi_to_inchi_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_SMILES_to_inchi" name="SMILES to InChI" version="1.0.0">
+<tool id="CONVERTER_SMILES_to_inchi" name="SMILES to InChI" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/smi_to_mol2_converter.xml
+++ b/lib/galaxy/datatypes/converters/smi_to_mol2_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_SMILES_to_MOL2" name="SMILES to MOL2" version="1.0.0">
+<tool id="CONVERTER_SMILES_to_MOL2" name="SMILES to MOL2" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/smi_to_mol_converter.xml
+++ b/lib/galaxy/datatypes/converters/smi_to_mol_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_SMILES_to_MOL" name="SMILES to MOL" version="1.0.0">
+<tool id="CONVERTER_SMILES_to_MOL" name="SMILES to MOL" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/smi_to_sdf_converter.xml
+++ b/lib/galaxy/datatypes/converters/smi_to_sdf_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_SMILES_to_sdf" name="SMILES to SDF" version="1.0.0">
+<tool id="CONVERTER_SMILES_to_sdf" name="SMILES to SDF" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/smi_to_smi_converter.xml
+++ b/lib/galaxy/datatypes/converters/smi_to_smi_converter.xml
@@ -1,8 +1,8 @@
-<tool id="CONVERTER_smiles_to_smiles" name="SMILES to SMILES" version="1.0.0">
+<tool id="CONVERTER_smiles_to_smiles" name="SMILES to SMILES" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>
-        <requirement type="package" version="2.3.2">openbabel</requirement>
+        <requirement type="package" version="2.4.1">openbabel</requirement>
     </requirements>
     <command >
 <![CDATA[


### PR DESCRIPTION
The old Open Babel version had some bugs and this one is way more up-to-date.