### PR TITLE
[PROCEDURES] Security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ opened using [this form](https://github.com/galaxyproject/galaxy/issues/new).
 
   * Serious security problems should not be fixed via pull request - please
     see [the Galaxy security policies](SECURITY_POLICY.md) for information
-    about responsibly disclosing any security issues.
+    about responsibly disclosing security issues.
 
 * If your changes modify code - please ensure the resulting files
   conform to Galaxy [style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,11 +66,8 @@ opened using [this form](https://github.com/galaxyproject/galaxy/issues/new).
     should be made against the recent `release_XX.XX` branch (`git checkout release_XX.XX`).
 
   * Serious security problems should not be fixed via pull request - please
-    responsibly disclose these by e-mailing them (with or without patches) to
-    galaxy-committers@lists.galaxyproject.org . The Galaxy core development team will
-    issue patches to public servers before announcing the issue to ensure there
-    is time to patch and highlight these fixes widely. We will provide you
-    credit for the discovery when publicly disclosing the issue.
+    see [the Galaxy security policies](SECURITY_POLICY.md) for information
+    about responsibly disclosing any security issues.
 
 * If your changes modify code - please ensure the resulting files
   conform to Galaxy [style

--- a/SECURITY_POLICY.md
+++ b/SECURITY_POLICY.md
@@ -1,0 +1,60 @@
+# Security
+
+[Generic copy indicating how much Galaxy project cares about security]
+
+## Reporting Security Issues
+
+If you believe you have discovered a security issue, please email security@galaxyproject.org We ask that you not disclose the issues on the public issue tracker. [Should we commit to an ACK response within N hours? Would be nice from a vuln reporting perspective]
+
+Security issues which affect a pre-release version of Galaxy (i.e. the dev branch in GitHub) do not need to go through this process, you may open issues and PRs publicly.
+
+[Is there a pubkey it should be encrypted against?]
+
+## Supported versions
+
+The following branches or releases receive security support:
+
+- Development on the `dev` branch, hosted on GitHub, which will become the next release of Galaxy
+- Releases within the past 12 months.
+  - E.g. 16.04 will receive support until 2017-04. As the month changes to 2017-05 it will become unsupported.
+- [LTS Releases?]
+
+Older versions of Galaxy may be affected by security issues, but we do not investigate that, nor will we issue patches or new releases of unsupported versions.
+
+## Issue Severity
+
+Galaxy takes a very conservative stance on issue severity as individual Galaxies often install tools and make customizations that might increase their risk in the face of otherwise less-serious vulnerabilities. As a result, issues that would be considered less-severe issues in other projects are treated as relatively higher risk.
+
+### Issue Classification
+
+Severity | Examples
+--- | ---
+High | RCE, SQL Injection, Sensitive Data Exposure, *Any issue allowing user impersonation*
+Medium | XSS, CSRF [Should this be merged into high? Per @jmchilton's comments out-of-band, this seems plausible. Just remove medium class entirely?]
+Low | Unvalidated redirects/forwards, Issues due to uncommon configuration options 
+
+## Notification of Vulnerabilities
+
+For high severity issues, we will notify a list of Galaxy instance administrators with:
+
+- a description of the issue
+- the precise steps to remedy the issue
+- the set of patch(es), if any, that need to be applied to their instance
+ 
+and embargo the issue for three (3) days. For medium and low severity issues, or high severity issues after the embargo, we will:
+
+- Patch the oldest release within the 12 month support window, and merge that fix forward.
+  - Updates will be available on the `release_XX.YY` branches.
+- Create new point release tags for each release branch [??? I've never understood point release tags in Galaxy]
+- Post a notice to the galaxy-dev mailing list with:  [ER: Should be galaxy-announce?]
+  - The issue description
+  - List of affected/patched versions 
+  - Steps to update / remedy
+
+If an issue is deemed to be time-sensitive – e.g. due to active and ongoing exploits in the wild – the embargo may be shortened considerably.
+
+If we believe that the reported issue affects other Galaxy Project components or projects outside of the Galaxy ecosystem, we may discuss the issue with those projects and coordinate disclosure and resolution with them.
+
+## Advance Notification
+
+[Ok, stopping writing for now since I need to do my real job. But someone should rewrite (or heck, copy-paste + quote the django docs) on https://docs.djangoproject.com/en/dev/internals/security/#who-receives-advance-notification I rather like their section / explanation and it's probably better than I could do.]

--- a/SECURITY_POLICY.md
+++ b/SECURITY_POLICY.md
@@ -4,7 +4,7 @@ The Galaxy project is strongly committed to security and responsible disclosure.
 
 ## Reporting Security Issues
 
-If you believe you have discovered a security issue, please email [galaxy-committers@lists.galaxyproject.org](galaxy-committers@lists.galaxyproject.org). Someone on that list will acknowledge your email within 2 US business days. We ask that you not disclose the issues on the public issue tracker. We will provide you credit for the discovery when publicly disclosing the issue.
+If you believe you have discovered a security issue, please email [galaxy-committers@lists.galaxyproject.org](galaxy-committers@lists.galaxyproject.org). Please use `[SECURITY]` in the email title. Someone on that list will acknowledge your email within 2 US business days. We ask that you not disclose the issues on the public issue tracker. We will provide you credit for the discovery when publicly disclosing the issue.
 
 Security issues which *only* affect a pre-release version of Galaxy (i.e. the `dev` branch in GitHub) do not need to go through this process, so you may open issues and pull requests publicly.
 
@@ -15,18 +15,18 @@ The following branches or releases receive security support:
 - Development on the `dev` branch, hosted on GitHub, which will become the next release of Galaxy
 - Releases within the past 12 months.
   - E.g. 16.04 will receive support until 2017-04. As the month changes to 2017-05 it will become unsupported.
-- There are currently no plans for LTS releases.
+- There are currently no plans for Long Term Support (LTS) releases.
 
 For unsupported branches:
 
 - Older versions of Galaxy may be affected by security issues.
 - Security patches *may* apply
-- The security team will not investigate issues that pertain to unsupported releases.
-- The security team will not issue patches or new releases of unsupported versions.
+- The security team does not commit to investigating issues that pertain to unsupported releases.
+- The security team does not commit to issuing patches or new releases of unsupported versions.
 
 ## Issue Severity
 
-Galaxy takes a very conservative stance on issue severity as individual Galaxy instances often install tools and make customizations that might increase their risk in the face of otherwise less-serious vulnerabilities. As a result, issues that would be considered less-severe in other projects are treated as higher risk here.
+Galaxy takes a very conservative stance on issue severity as individual Galaxy instances often install tools and make customizations that might increase their risk in the face of otherwise less-serious vulnerabilities. As a result, issues that would be considered less-severe in other projects may be treated as higher risk here.
 
 ### Issue Classification
 

--- a/SECURITY_POLICY.md
+++ b/SECURITY_POLICY.md
@@ -4,7 +4,7 @@
 
 ## Reporting Security Issues
 
-If you believe you have discovered a security issue, please email security@galaxyproject.org We ask that you not disclose the issues on the public issue tracker. [Should we commit to an ACK response within N hours? Would be nice from a vuln reporting perspective]
+If you believe you have discovered a security issue, please email galaxy-committers@lists.galaxyproject.org. We ask that you not disclose the issues on the public issue tracker. [Should we commit to an ACK response within N hours? Would be nice from a vuln reporting perspective]
 
 Security issues which affect a pre-release version of Galaxy (i.e. the dev branch in GitHub) do not need to go through this process, you may open issues and PRs publicly.
 
@@ -29,13 +29,14 @@ Galaxy takes a very conservative stance on issue severity as individual Galaxies
 
 Severity | Examples
 --- | ---
-High | RCE, SQL Injection, Sensitive Data Exposure, *Any issue allowing user impersonation*
-Medium | XSS, CSRF [Should this be merged into high? Per @jmchilton's comments out-of-band, this seems plausible. Just remove medium class entirely?]
-Low | Unvalidated redirects/forwards, Issues due to uncommon configuration options 
+High | RCE, SQL Injection, Sensitive Data Exposure, XSS, CSRF, and *any issue allowing user impersonation*.
+Medium / Low | Unvalidated redirects/forwards, Issues due to uncommon configuration options.
+
+These are only examples. The security team will provide a severity classification based on its impact on the average Galaxy instance. However, Galaxy administrators should take it upon themselves to evaluate the impact for their instance(s).
 
 ## Notification of Vulnerabilities
 
-For high severity issues, we will notify a list of Galaxy instance administrators with:
+For high severity issues, we will notify [the list of public Galaxy owners](https://lists.galaxyproject.org/listinfo/galaxy-public-servers) with:
 
 - a description of the issue
 - the precise steps to remedy the issue
@@ -46,7 +47,7 @@ and embargo the issue for three (3) days. For medium and low severity issues, or
 - Patch the oldest release within the 12 month support window, and merge that fix forward.
   - Updates will be available on the `release_XX.YY` branches.
 - Create new point release tags for each release branch [??? I've never understood point release tags in Galaxy]
-- Post a notice to the galaxy-dev mailing list with:  [ER: Should be galaxy-announce?]
+- Post a notice to the [galaxy-announce mailing list](https://lists.galaxyproject.org/listinfo/galaxy-announce) with:
   - The issue description
   - List of affected/patched versions 
   - Steps to update / remedy

--- a/SECURITY_POLICY.md
+++ b/SECURITY_POLICY.md
@@ -32,7 +32,7 @@ Galaxy takes a very conservative stance on issue severity as individual Galaxy i
 
 Severity     | Examples
 ------------ | ---------
-High         | Remote code execution (RCE), SQL Injection, Sensitive Data Exposure, Cross-site scripting (XSS), Cross-site request forgery (CSRF), and *any issue allowing user impersonation*.
+High         | Remote code execution (RCE), SQL Injection, Cross-site scripting (XSS), and *any issue allowing user impersonation*.
 Medium / Low | Unvalidated redirects/forwards, Issues due to uncommon configuration options.
 
 These are only examples. The security team will provide a severity classification based on its impact on the average Galaxy instance. However, Galaxy administrators should take it upon themselves to evaluate the impact for their instance(s).
@@ -51,7 +51,7 @@ embargo, we will:
 
 - Patch the oldest release within the 12 month support window, and merge that fix forward.
   - Updates will be available on the `release_XX.YY` branches.
-- Create new point release tags for each release branch [??? I've never understood point release tags in Galaxy]
+- Update each release branch
 - Post a notice to the [galaxy-announce mailing list](https://lists.galaxyproject.org/listinfo/galaxy-announce) with:
   - A description of the issue
   - List of supported versions that are affected

--- a/SECURITY_POLICY.md
+++ b/SECURITY_POLICY.md
@@ -4,7 +4,7 @@
 
 ## Reporting Security Issues
 
-If you believe you have discovered a security issue, please email galaxy-committers@lists.galaxyproject.org. We ask that you not disclose the issues on the public issue tracker. [Should we commit to an ACK response within N hours? Would be nice from a vuln reporting perspective]
+If you believe you have discovered a security issue, please email [galaxy-committers@lists.galaxyproject.org](galaxy-committers@lists.galaxyproject.org). We ask that you not disclose the issues on the public issue tracker. Someone on that list will acknowledge your email within 2 US business days.
 
 Security issues which affect a pre-release version of Galaxy (i.e. the dev branch in GitHub) do not need to go through this process, you may open issues and PRs publicly.
 
@@ -17,19 +17,24 @@ The following branches or releases receive security support:
 - Development on the `dev` branch, hosted on GitHub, which will become the next release of Galaxy
 - Releases within the past 12 months.
   - E.g. 16.04 will receive support until 2017-04. As the month changes to 2017-05 it will become unsupported.
-- [LTS Releases?]
+- There are currently no plans for LTS releases.
 
-Older versions of Galaxy may be affected by security issues, but we do not investigate that, nor will we issue patches or new releases of unsupported versions.
+For unsupported branches:
+
+- Older versions of Galaxy may be affected by security issues.
+- Security patches *may* apply
+- The security team will not investigate issues that pertain to unsupported releases.
+- The security team will not issue patches or new releases of unsupported versions.
 
 ## Issue Severity
 
-Galaxy takes a very conservative stance on issue severity as individual Galaxies often install tools and make customizations that might increase their risk in the face of otherwise less-serious vulnerabilities. As a result, issues that would be considered less-severe issues in other projects are treated as relatively higher risk.
+Galaxy takes a very conservative stance on issue severity as individual Galaxies often install tools and make customizations that might increase their risk in the face of otherwise less-serious vulnerabilities. As a result, issues that would be considered less-severe issues in other projects are treated as higher risk here.
 
 ### Issue Classification
 
-Severity | Examples
---- | ---
-High | RCE, SQL Injection, Sensitive Data Exposure, XSS, CSRF, and *any issue allowing user impersonation*.
+Severity     | Examples
+------------ | ---------
+High         | RCE, SQL Injection, Sensitive Data Exposure, XSS, CSRF, and *any issue allowing user impersonation*.
 Medium / Low | Unvalidated redirects/forwards, Issues due to uncommon configuration options.
 
 These are only examples. The security team will provide a severity classification based on its impact on the average Galaxy instance. However, Galaxy administrators should take it upon themselves to evaluate the impact for their instance(s).
@@ -38,24 +43,22 @@ These are only examples. The security team will provide a severity classificatio
 
 For high severity issues, we will notify [the list of public Galaxy owners](https://lists.galaxyproject.org/listinfo/galaxy-public-servers) with:
 
-- a description of the issue
-- the precise steps to remedy the issue
-- the set of patch(es), if any, that need to be applied to their instance
- 
-and embargo the issue for three (3) days. For medium and low severity issues, or high severity issues after the embargo, we will:
+- A description of the issue
+- List of supported versions that are affected
+- Steps to update or patch your Galaxy
+
+The issue will then be embargoed for three (3) days. For medium and low
+severity issues, or for publicly announcing high severity issues after the
+embargo, we will:
 
 - Patch the oldest release within the 12 month support window, and merge that fix forward.
   - Updates will be available on the `release_XX.YY` branches.
 - Create new point release tags for each release branch [??? I've never understood point release tags in Galaxy]
 - Post a notice to the [galaxy-announce mailing list](https://lists.galaxyproject.org/listinfo/galaxy-announce) with:
-  - The issue description
-  - List of affected/patched versions 
-  - Steps to update / remedy
+  - A description of the issue
+  - List of supported versions that are affected
+  - Steps to update or patch your Galaxy
 
 If an issue is deemed to be time-sensitive – e.g. due to active and ongoing exploits in the wild – the embargo may be shortened considerably.
 
 If we believe that the reported issue affects other Galaxy Project components or projects outside of the Galaxy ecosystem, we may discuss the issue with those projects and coordinate disclosure and resolution with them.
-
-## Advance Notification
-
-[Ok, stopping writing for now since I need to do my real job. But someone should rewrite (or heck, copy-paste + quote the django docs) on https://docs.djangoproject.com/en/dev/internals/security/#who-receives-advance-notification I rather like their section / explanation and it's probably better than I could do.]

--- a/SECURITY_POLICY.md
+++ b/SECURITY_POLICY.md
@@ -1,14 +1,12 @@
 # Security
 
-[Generic copy indicating how much Galaxy project cares about security]
+The Galaxy project is strongly committed to security and responsible disclosure. We have adopted and published a set of policies specifying how we will act in response to reported security issues, in order to ensure timely updates are made available to all affected parties.
 
 ## Reporting Security Issues
 
 If you believe you have discovered a security issue, please email [galaxy-committers@lists.galaxyproject.org](galaxy-committers@lists.galaxyproject.org). We ask that you not disclose the issues on the public issue tracker. Someone on that list will acknowledge your email within 2 US business days.
 
 Security issues which affect a pre-release version of Galaxy (i.e. the dev branch in GitHub) do not need to go through this process, you may open issues and PRs publicly.
-
-[Is there a pubkey it should be encrypted against?]
 
 ## Supported versions
 

--- a/SECURITY_POLICY.md
+++ b/SECURITY_POLICY.md
@@ -4,9 +4,9 @@ The Galaxy project is strongly committed to security and responsible disclosure.
 
 ## Reporting Security Issues
 
-If you believe you have discovered a security issue, please email [galaxy-committers@lists.galaxyproject.org](galaxy-committers@lists.galaxyproject.org). We ask that you not disclose the issues on the public issue tracker. Someone on that list will acknowledge your email within 2 US business days.
+If you believe you have discovered a security issue, please email [galaxy-committers@lists.galaxyproject.org](galaxy-committers@lists.galaxyproject.org). Someone on that list will acknowledge your email within 2 US business days. We ask that you not disclose the issues on the public issue tracker. We will provide you credit for the discovery when publicly disclosing the issue.
 
-Security issues which affect a pre-release version of Galaxy (i.e. the dev branch in GitHub) do not need to go through this process, you may open issues and PRs publicly.
+Security issues which *only* affect a pre-release version of Galaxy (i.e. the `dev` branch in GitHub) do not need to go through this process, so you may open issues and pull requests publicly.
 
 ## Supported versions
 
@@ -26,13 +26,13 @@ For unsupported branches:
 
 ## Issue Severity
 
-Galaxy takes a very conservative stance on issue severity as individual Galaxies often install tools and make customizations that might increase their risk in the face of otherwise less-serious vulnerabilities. As a result, issues that would be considered less-severe issues in other projects are treated as higher risk here.
+Galaxy takes a very conservative stance on issue severity as individual Galaxy instances often install tools and make customizations that might increase their risk in the face of otherwise less-serious vulnerabilities. As a result, issues that would be considered less-severe in other projects are treated as higher risk here.
 
 ### Issue Classification
 
 Severity     | Examples
 ------------ | ---------
-High         | RCE, SQL Injection, Sensitive Data Exposure, XSS, CSRF, and *any issue allowing user impersonation*.
+High         | Remote code execution (RCE), SQL Injection, Sensitive Data Exposure, Cross-site scripting (XSS), Cross-site request forgery (CSRF), and *any issue allowing user impersonation*.
 Medium / Low | Unvalidated redirects/forwards, Issues due to uncommon configuration options.
 
 These are only examples. The security team will provide a severity classification based on its impact on the average Galaxy instance. However, Galaxy administrators should take it upon themselves to evaluate the impact for their instance(s).

--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -18,6 +18,7 @@ are:
 
 - this document
 - CODE_OF_CONDUCT_.
+- SECURITY_POLICY_.
 
 
 Committers
@@ -215,5 +216,6 @@ handling of issues follows the procedures described in ISSUES_.
 
 .. _LICENSE: https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt
 .. _CODE_OF_CONDUCT: https://github.com/galaxyproject/galaxy/blob/dev/CODE_OF_CONDUCT.md
+.. _SECURITY_POLICY: https://github.com/galaxyproject/galaxy/blob/dev/SECURITY_POLICY.md
 .. _ISSUES: https://github.com/galaxyproject/galaxy/blob/dev/doc/source/project/issues.rst
 .. _ISSUE_REPORT: https://github.com/galaxyproject/galaxy/issues/


### PR DESCRIPTION
FAQ:

- Who has time for this?
  - I volunteer as tribute.
  - @jmchilton would as well, if there was support from the PIs. xref https://github.com/galaxyproject/galaxy/pull/4071#issuecomment-301909868
  - I'm sure that we are not alone in this.
- This is a big commitment
  - Indeed! Time to build a security sub-team who can share duties.
  - The biggest time commitment is testing against old versions of galaxy and ensuring patches work. Hopefully his can be atmeliorated by jenkins (or travis) test matricies and spending time build reported security faults into PoC exploits that can be run and tested automatically.
- 17.09:
  - Unless there is just overwhelming support, I'll be available at GCC to defend this as useful and necessary.
- "we're already short on time, why is this worth devoting time to?
  - my (initial) counters are, in brief:
    - deployers and their universities care (see automated scan reports people send)
    - based on committers mailing list traffic this will be low commitment unless the individuals are enthusiastic about adding more features
    - we're constantly adding new <s>attack vectors</s> features like GIEs. If there's a team of security minded folks, we have some points of contact for "hey would this make things worse in terms of security? How can we make this feature more palatable for admins and security folks? Is there documentation we should add that people should be aware of?"

This is being opened as a procedures PR because it really needs buy in from stakeholders. @jmchilton said it better than I can:

> I'd also not merge this until a few people who actually fund Galaxy development sign off on it - perhaps we could ping the three PIs on the final real [PROCEDURES] PR and get at least a couple :+1:s from them.

From my various hats:

- As a developer, we should have an aggressive security posture and attack our own infrastructure regularly to ensure we're not shipping exploits to unsuspecting administrators.
- As an admin, I want the sort of transparency and accountability described in this document.
- As a white hat, I like the assurances that the team will respond to my vulnerability reports efficiently.