### PR TITLE
Avoid locale specific string.letters for job_name

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -419,7 +419,7 @@ class JobState( object ):
                 job_name += '_%s' % self.job_wrapper.tool.old_id
             if self.job_wrapper.user:
                 job_name += '_%s' % self.job_wrapper.user
-            self.job_name = ''.join( map( lambda x: x if x in ( string.letters + string.digits + '_' ) else '_', job_name ) )
+            self.job_name = ''.join( map( lambda x: x if x in ( string.ascii_letters + string.digits + '_' ) else '_', job_name ) )
 
     @staticmethod
     def default_job_file( files_dir, id_tag ):

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -394,7 +394,7 @@ class DRMAAJobRunner( AsynchronousJobRunner ):
             job_name += '_%s' % job_wrapper.tool.old_id
         if external_runjob_script is None:
             job_name += '_%s' % job_wrapper.user
-        job_name = ''.join( x if x in ( string.letters + string.digits + '_' ) else '_' for x in job_name )
+        job_name = ''.join( x if x in ( string.ascii_letters + string.digits + '_' ) else '_' for x in job_name )
         if self.restrict_job_name_length:
             job_name = job_name[:self.restrict_job_name_length]
         return job_name


### PR DESCRIPTION
The job_name sanitation can fail if the locale specific ``string.letters`` contains unexpected characters. e.g. Saravanaraj Ayyampalayam reported getting the following under locale ``en_US.iso885915``

```
Traceback (most recent call last):
  File /.../galaxy-dist/lib/galaxy/jobs/runners/drmaa.py, line 397, in <genexpr>
    job_name = ''.join( x if x in ( string.letters + string.digits + '_' ) else '_' for x in job_name )
UnicodeDecodeError: 'ascii' codec can't decode byte 0xa6 in position 52: ordinal not in range(128)
```

See http://dev.list.galaxyproject.org/Issue-with-job-name-UnicodeDecodeError-in-drmaa-td4670784.html or https://lists.galaxyproject.org/pipermail/galaxy-dev/2017-May/025687.html

The downside of this proposed change would be to mask reasonable non ASCII letters from the job name on a well defined system with consistent locale settings for both Galaxy and the Cluster. But ASCII only seems safer.