### PR TITLE
[17.05] Fix for returning a fileobject in compression_utils.py when handling a zipfile.

### DIFF
--- a/lib/galaxy/util/compression_utils.py
+++ b/lib/galaxy/util/compression_utils.py
@@ -29,5 +29,7 @@ def get_fileobj(filename, mode="r", gzip_only=False, bz2_only=False, zip_only=Fa
     if not gzip_only and not zip_only and is_bz2(filename):
         return bz2.BZ2File(filename, cmode)
     if not bz2_only and not gzip_only and zipfile.is_zipfile(filename):
-        return zipfile.os_zipfile(filename, cmode)
+        # Return fileobj for the first file in a zip file.
+        with zipfile.ZipFile(filename, cmode) as zh:
+            return zh.open(zh.namelist()[0], cmode)
     return open(filename, mode)


### PR DESCRIPTION
Will return the first named object in the archive. zipfile.os_zipfile does not exist...

xref: #3512
xref: https://biostar.usegalaxy.org/p/23349/
ping @mvdbeek