### PR TITLE
[17.05] Fix for Data Tables loaded from a URL.

### DIFF
--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -312,7 +312,7 @@ class TabularToolDataTable( ToolDataTable, Dictifiable ):
         super( TabularToolDataTable, self ).__init__( config_element, tool_data_path, from_shed_config, filename, tool_data_path_files)
         self.config_element = config_element
         self.data = []
-        self.configure_and_load( config_element, tool_data_path, from_shed_config, self.tool_data_path_files)
+        self.configure_and_load( config_element, tool_data_path, from_shed_config )
 
     def configure_and_load( self, config_element, tool_data_path, from_shed_config=False, url_timeout=10 ):
         """


### PR DESCRIPTION
@mvdbeek: looks like the deleted `self.tool_data_path_files` argument was left behind accidentally?

xref: https://github.com/galaxyproject/galaxy/pull/3909

@nekrut should fix the IGV issue