### PR TITLE
Swap over all URLs to new wiki location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ done in the ``config/galaxy.ini`` file. Tools can be either installed
 from the Tool Shed or added manually. For details please see the Galaxy
 wiki:
 
-https://wiki.galaxyproject.org/Admin/Tools/AddToolFromToolShedTutorial
+https://galaxyproject.org/admin/tools/add-tool-from-toolshed-tutorial/
 
 Not all dependencies are included for the tools provided in the sample
 ``tool_conf.xml``. A full list of external dependencies is available at:

--- a/contrib/galaxy.debian-init
+++ b/contrib/galaxy.debian-init
@@ -18,7 +18,7 @@ GROUP="nogroup"
 GALAXY_DIR="/home/galaxy/galaxy_dist/"
 # Galaxy releases >= 16.01 installs dependencies by default into a virtualenv in <GALAXY_DIR>/.venv
 # A simple way to activate this virtualenv is to use the python interpreter in <GALAXY_DIR>/.venv
-# See https://wiki.galaxyproject.org/News/2016_01_GalaxyRelease and
+# See https://galaxyproject.org/news/2016-01-galaxy-release/ and
 # https://github.com/galaxyproject/galaxy/blob/dev/doc/source/admin/framework_dependencies.rst
 PYTHON="/home/galaxy/galaxy_dist/.venv/bin/python"
 OPTS="./scripts/paster.py serve --log-file /home/galaxy/galaxy.log config/galaxy.ini"

--- a/contrib/galaxy_supervisor.conf
+++ b/contrib/galaxy_supervisor.conf
@@ -12,8 +12,8 @@
 # This assumes galaxy is installed in /home/galaxy/galaxy, so change occurences of /home/galaxy/galaxy accordingly.
 # If you want to run galaxy under a different username, change "user = galaxy" to "user = <your user>".
 # You will probably want to proxy uwsgi (you can't connect with a browser to uwsgi port 4001) with nginx or apache, 
-# see https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#uWSGI-1
-# or https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#uWSGI-2 . 
+# see https://galaxyproject.org/admin/config/performance/scaling/#apache
+# or https://galaxyproject.org/admin/config/performance/scaling/#nginx
 
 [program:galaxy_web]
 command         = /home/galaxy/galaxy/.venv/bin/uwsgi --virtualenv /home/galaxy/galaxy/.venv --ini-paste /home/galaxy/galaxy/config/galaxy.ini --logdate --master --processes 2 --threads 2 --logto /home/galaxy/galaxy/uwsgi.log --socket 127.0.0.1:4001 --pythonpath lib --stats 127.0.0.1:9191

--- a/doc/source/admin/authentication.md
+++ b/doc/source/admin/authentication.md
@@ -104,7 +104,7 @@ Smtp server takes care of the email sending and the activation_email email is us
 
 You can also set the instance_resource_url which is shown in the activation emails so you can point users to your wiki or other materials.
 ```
-instance_resource_url = http://wiki.galaxyproject.org/
+instance_resource_url = http://galaxyproject.org/
 ```
 
 

--- a/doc/source/admin/special_topics/mulled_containers.rst
+++ b/doc/source/admin/special_topics/mulled_containers.rst
@@ -120,7 +120,7 @@ you could do something along these lines.
 
 
 .. _Galaxy Conda documentation: ./conda_faq.rst
-.. _IUC: https://wiki.galaxyproject.org/IUC
+.. _IUC: https://galaxyproject.org/iuc/
 .. _container annotation:  https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/catDocker.xml#L4
 .. _BioContainers: https://github.com/biocontainers
 .. _bioconda: https://github.com/bioconda/bioconda-recipes

--- a/doc/source/dev/build_a_job_runner.rst
+++ b/doc/source/dev/build_a_job_runner.rst
@@ -11,7 +11,7 @@ components based on their function.
 We assume you are familiar with setting up and managing a local installation of Galaxy.
 
 To learn more about the basics, please refer to:
-https://wiki.galaxyproject.org/Admin/GetGalaxy
+https://galaxyproject.org/admin/get-galaxy/
 
 To explore existing runners, please refer to:
 https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/jobs/runners
@@ -81,7 +81,7 @@ The input params are read from job\_conf.xml and passed to the runner by
 the Galaxy framework. Configuration of where to run jobs and external
 runner configuration is performed in the job\_conf.xml file. More
 information about job\_conf.xml is available
-`here <https://wiki.galaxyproject.org/Admin/Config/Jobs>`__.
+`here <https://galaxyproject.org/admin/config/jobs/>`__.
 
 Have a look at the sample job\_conf.xml:
 

--- a/doc/source/releases/13.01_announce.rst
+++ b/doc/source/releases/13.01_announce.rst
@@ -6,6 +6,6 @@ January 2013 Galaxy Release (v 13.01)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2013_01_11_DistributionNewsBrief
+.. _Galaxy wiki: https://galaxyproject.org/news/2013-01-11-distribution-news-brief/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/13.02_announce.rst
+++ b/doc/source/releases/13.02_announce.rst
@@ -6,6 +6,6 @@ February 2013 Galaxy Release (v 13.02)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2013_02_08_GalaxyNewsBrief
+.. _Galaxy wiki: https://galaxyproject.org/news/2013-02-08-galaxy-news-brief/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/13.04_announce.rst
+++ b/doc/source/releases/13.04_announce.rst
@@ -6,6 +6,6 @@ April 2013 Galaxy Release (v 13.04)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2013_04_01_Galaxy_Distribution
+.. _Galaxy wiki: https://galaxyproject.org/news/2013-04-01-galaxy-distribution/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/13.06_announce.rst
+++ b/doc/source/releases/13.06_announce.rst
@@ -6,6 +6,6 @@ June 2013 Galaxy Release (v 13.06)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2013_06_03_Galaxy_Distribution
+.. _Galaxy wiki: https://galaxyproject.org/news/2013-06-03-galaxy-distribution/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/13.08_announce.rst
+++ b/doc/source/releases/13.08_announce.rst
@@ -6,6 +6,6 @@ August 2013 Galaxy Release (v 13.08)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2013_08_12_Galaxy_Distribution
+.. _Galaxy wiki: https://galaxyproject.org/news/2013-08-12-galaxy-distribution/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/13.11_announce.rst
+++ b/doc/source/releases/13.11_announce.rst
@@ -6,6 +6,6 @@ November 2013 Galaxy Release (v 13.11)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2013_11_04_Galaxy_Distribution
+.. _Galaxy wiki: https://galaxyproject.org/news/2013-11-04-galaxy-distribution/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/14.02_announce.rst
+++ b/doc/source/releases/14.02_announce.rst
@@ -6,6 +6,6 @@ February 2014 Galaxy Release (v 14.02)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2014_02_10_Galaxy_Distribution
+.. _Galaxy wiki: https://galaxyproject.org/news/2014-02-10-galaxy-distribution/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/14.04_announce.rst
+++ b/doc/source/releases/14.04_announce.rst
@@ -6,6 +6,6 @@ April 2014 Galaxy Release (v 14.04)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2014_04_14_Galaxy_Distribution
+.. _Galaxy wiki: https://galaxyproject.org/news/2014-04-14-galaxy-distribution/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/14.06_announce.rst
+++ b/doc/source/releases/14.06_announce.rst
@@ -6,6 +6,6 @@ June 2014 Galaxy Release (v 14.06)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2014_06_02_Galaxy_Distribution
+.. _Galaxy wiki: https://galaxyproject.org/news/2014-06-02-galaxy-distribution/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/14.08_announce.rst
+++ b/doc/source/releases/14.08_announce.rst
@@ -6,6 +6,6 @@ August 2014 Galaxy Release (v 14.08)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2014_08_11_Galaxy_Distribution
+.. _Galaxy wiki: https://galaxyproject.org/news/2014-08-11-galaxy-distribution/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/14.10_announce.rst
+++ b/doc/source/releases/14.10_announce.rst
@@ -6,6 +6,6 @@ October 2014 Galaxy Release (v 14.10)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2014_10_06_Galaxy_Distribution
+.. _Galaxy wiki: https://galaxyproject.org/news/2014-10-06-galaxy-distribution/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/15.01_announce.rst
+++ b/doc/source/releases/15.01_announce.rst
@@ -6,6 +6,6 @@ January 2015 Galaxy Release (v 15.01)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2015_01_13_Galaxy_Distribution
+.. _Galaxy wiki: https://galaxyproject.org/news/2015-01-13-galaxy-distribution/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/15.03_announce.rst
+++ b/doc/source/releases/15.03_announce.rst
@@ -6,6 +6,6 @@ March 2015 Galaxy Release (v 15.03)
 
 Please see the `Galaxy wiki`_ for announcement and release notes.
 
-.. _Galaxy wiki: https://wiki.galaxyproject.org/News/2015_03_GalaxyRelease
+.. _Galaxy wiki: https://galaxyproject.org/news/2015-03-galaxy-release/
 
 .. include:: _thanks.rst

--- a/doc/source/releases/15.05.rst
+++ b/doc/source/releases/15.05.rst
@@ -192,7 +192,7 @@ Fixes
 
 .. _IGV: https://www.broadinstitute.org/igv/
 .. _External Display Application: https://wiki.galaxyproject.org/Admin/Tools/External%20Display%20Applications%20Tutorial
-.. _Interactive Environments: https://wiki.galaxyproject.org/Admin/IEs
+.. _Interactive Environments: https://galaxyproject.org/Admin/IEs
 .. _TravisCI: https://travis-ci.org/
 .. _Tox: https://testrun.org/tox/latest/
 .. _Source Maps: https://developer.chrome.com/devtools/docs/javascript-debugging#source-maps

--- a/doc/source/releases/15.05_announce.rst
+++ b/doc/source/releases/15.05_announce.rst
@@ -47,7 +47,7 @@ Upgrade
       % hg update latest_15.05
 
 
-See `our wiki <https://wiki.galaxyproject.org/Develop/SourceCode>`__ for additional details regarding the source code locations.
+See `our wiki <https://galaxyproject.org/develop/source-code/>`__ for additional details regarding the source code locations.
 
 Release Notes
 ===========================================================

--- a/doc/source/releases/15.07_announce.rst
+++ b/doc/source/releases/15.07_announce.rst
@@ -52,7 +52,7 @@ Upgrade
       % hg update latest_15.07
 
 
-See `our wiki <https://wiki.galaxyproject.org/Develop/SourceCode>`__ for additional details regarding the source code locations.
+See `our wiki <https://galaxyproject.org/develop/source-code/>`__ for additional details regarding the source code locations.
 
 Deprecation Notice
 ===========================================================

--- a/doc/source/releases/15.10_announce.rst
+++ b/doc/source/releases/15.10_announce.rst
@@ -52,7 +52,7 @@ Upgrade
       % hg update latest_15.10
 
 
-See `our wiki <https://wiki.galaxyproject.org/Develop/SourceCode>`__ for additional details regarding the source code locations.
+See `our wiki <https://galaxyproject.org/develop/source-code/>`__ for additional details regarding the source code locations.
 
 
 Deprecation Notices
@@ -61,7 +61,7 @@ Deprecation Notices
 The Mercurial repository at https://bitbucket.org/galaxy/galaxy-dist is deprecated.
 **We recommend deployers to switch their instances to git** and follow the `master`
 branch of GitHub repository https://github.com/galaxyproject/galaxy
-Details are available at https://wiki.galaxyproject.org/Develop/SourceCode
+Details are available at https://galaxyproject.org/develop/source-code/
 *The next few releases will still be available on Bitbucket, but they may be
 less up to date than the corresponding GitHub branches.*
 

--- a/doc/source/releases/16.01_announce.rst
+++ b/doc/source/releases/16.01_announce.rst
@@ -63,7 +63,7 @@ Upgrade
       % hg update latest_16.01
 
 
-See `our wiki <https://wiki.galaxyproject.org/Develop/SourceCode>`__ for additional details regarding the source code locations.
+See `our wiki <https://galaxyproject.org/develop/source-code/>`__ for additional details regarding the source code locations.
 
 Deprecation Notices
 ===========================================================

--- a/doc/source/releases/16.04_announce.rst
+++ b/doc/source/releases/16.04_announce.rst
@@ -61,7 +61,7 @@ Upgrade
       % hg update latest_16.04
 
 
-See `our wiki <https://wiki.galaxyproject.org/Develop/SourceCode>`__ for additional details regarding the source code locations.
+See `our wiki <https://galaxyproject.org/develop/source-code/>`__ for additional details regarding the source code locations.
 
 Security
 ===========================================================

--- a/doc/source/releases/16.07_announce.rst
+++ b/doc/source/releases/16.07_announce.rst
@@ -18,7 +18,7 @@ Highlights
   Our friends from Canada National Microbiology Laboratory enhanced
   Galaxy with feature that allows dynamic mapping of tools to destinations
   based on finer grained admin-specified rules. Please see the
-  `wiki <https://wiki.galaxyproject.org/Admin/Config/Jobs#Dynamic_Destination_Mapping>`__.
+  `wiki <https://galaxyproject.org/admin/config/jobs/#Dynamic_Destination_Mapping>`__.
   Implemented in `PR #2579 <https://github.com/galaxyproject/galaxy/pull/2579>`__
 
 **Galaxy chat**
@@ -41,7 +41,7 @@ Update of existing Galaxy repository
 
       $ git checkout release_16.07 && git pull --ff-only origin release_16.07
 
-See `our wiki <https://wiki.galaxyproject.org/Develop/SourceCode>`__ for additional details regarding the source code locations.
+See `our wiki <https://galaxyproject.org/develop/source-code/>`__ for additional details regarding the source code locations.
 
 Deprecation Notices
 ===========================================================

--- a/doc/source/releases/16.10_announce.rst
+++ b/doc/source/releases/16.10_announce.rst
@@ -41,7 +41,7 @@ To update an existing Galaxy repository run:
 
       $ git checkout release_16.10 && git pull --ff-only origin release_16.10
 
-See `our wiki <https://wiki.galaxyproject.org/Develop/SourceCode>`__ for additional details regarding the source code location.
+See `our wiki <https://galaxyproject.org/develop/source-code/>`__ for additional details regarding the source code location.
 
 Deprecation Notices
 ===================

--- a/doc/source/releases/17.01_announce.rst
+++ b/doc/source/releases/17.01_announce.rst
@@ -44,7 +44,7 @@ To update an existing Galaxy repository run:
 
       $ git checkout release_17.01 && git pull --ff-only origin release_17.01
 
-See `our wiki <https://wiki.galaxyproject.org/Develop/SourceCode>`__ for additional details regarding the source code locations.
+See `our wiki <https://galaxyproject.org/develop/source-code/>`__ for additional details regarding the source code locations.
 
 Deprecation Notices
 ===================

--- a/doc/source/slideshow/architecture/galaxy_architecture.md
+++ b/doc/source/slideshow/architecture/galaxy_architecture.md
@@ -443,7 +443,7 @@ def handle_request(self, environ, start_response):
 
 ### Database Diagram
 
-https://wiki.galaxyproject.org/Admin/Internals/DataModel
+https://galaxyproject.org/admin/internals/data-model/
 
 ---
 

--- a/lib/galaxy/tools/xsd/README.md
+++ b/lib/galaxy/tools/xsd/README.md
@@ -41,5 +41,5 @@ This code is free software released under the terms of the MIT license.
 # See also:
 
 * Galaxy https://usegalaxy.org/
-* Galaxy Tool XML File https://wiki.galaxyproject.org/Admin/Tools/ToolConfigSyntax
+* Galaxy Tool XML File https://galaxyproject.org/admin/tools/tool-config-syntax/
 

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -166,8 +166,8 @@ graphical tool form by setting this to ``false``.</xs:documentation>
           <xs:documentation xml:lang="en">Allows for certain framework
 functionality to be performed on certain types of tools. Normal tools that execute
 typical command-line jobs do not need to specify this, special kinds of tools such
-as [Data Source](https://wiki.galaxyproject.org/Admin/Internals/DataSources) and
-[Data Manager](https://wiki.galaxyproject.org/Admin/Tools/DataManagers) tools should
+as [Data Source](https://galaxyproject.org/admin/internals/data-sources/) and
+[Data Manager](https://galaxyproject.org/admin/tools/data-managers/) tools should
 set this to have values such as ``data_source`` or ``manage_data``.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
@@ -237,7 +237,7 @@ programs or modules that the tool depends upon are included in this tag set.
 When a tool runs, Galaxy attempts to *resolve* these requirements (also called
 dependencies). ``requirement``s are meant to be abstract and resolvable by
 multiple different systems (e.g. [conda](http://conda.pydata.org/docs/), the
-[Galaxy Tool Shed dependency management system](https://wiki.galaxyproject.org/ToolShedToolFeatures#Automatic_third-party_tool_dependency_installation_and_compilation_with_installed_repositories),
+[Galaxy Tool Shed dependency management system](https://galaxyproject.org/toolshed/tool-features/#Automatic_third-party_tool_dependency_installation_and_compilation_with_installed_repositories),
 or [environment modules](http://modules.sourceforge.net/)).
 
 Read more about dependency resolvers in Galaxy on
@@ -251,7 +251,7 @@ discussed in greater detail
 This example shows a tool that requires the samtools 0.0.18 package.
 
 This package is available via the Tool Shed (see
-[Tool Shed dependency management](https://wiki.galaxyproject.org/ToolShedToolFeatures#Automatic_third-party_tool_dependency_installation_and_compilation_with_installed_repositories)
+[Tool Shed dependency management](https://galaxyproject.org/toolshed/tool-features/#Automatic_third-party_tool_dependency_installation_and_compilation_with_installed_repositories)
 ) as well as [Conda](https://docs.galaxyproject.org/en/master/admin/conda_faq.html)
 and can be configured locally to adapt to any other package management system.
 
@@ -301,7 +301,7 @@ this tag allows the tool to suggest possible valid Docker containers for this
 tool.
 
 Read more about configuring Galaxy to run Docker jobs
-[here](https://wiki.galaxyproject.org/Admin/Tools/Docker).
+[here](https://galaxyproject.org/admin/tools/docker/).
 
 ]]></xs:documentation>
     </xs:annotation>
@@ -593,7 +593,7 @@ The documentation contained here is mostly reference documentation, for
 tutorials on writing tool tests please check out Planemo's
 [Test-Driven Development](https://planemo.readthedocs.io/en/latest/writing_advanced.html#test-driven-development)
 documentation or the much older wiki content for
-[WritingTests](https://wiki.galaxyproject.org/Admin/Tools/WritingTests).
+[WritingTests](https://galaxyproject.org/admin/tools/writing-tests/).
 
 ]]></xs:documentation>
     </xs:annotation>
@@ -1717,7 +1717,7 @@ conditionally reference ``${input_type.process_obs_metadata}`` with a Cheetah
 
 A common use of the conditional wrapper is to select between reference data
 managed by the Galaxy admins (for instance via
-[data managers](https://wiki.galaxyproject.org/Admin/Tools/DataManagers)
+[data managers](https://galaxyproject.org/admin/tools/data-managers/)
 ) and
 history files. A good example tool that demonstrates this is
 the [Bowtie 2](https://github.com/galaxyproject/tools-devteam/blob/master/tools/bowtie2/bowtie2_wrapper.xml) wrapper.
@@ -3103,7 +3103,7 @@ specified by the ``skip`` attribute.</xs:documentation>
             <xs:documentation xml:lang="en">Tool data table name to check against
 if ``type`` is ``dataset_metadata_in_tool_data``. See the documentation for
 [tool data tables](https://wiki.galaxyproject.org/Admin/Tools/Data%20Tables)
-and [data managers](https://wiki.galaxyproject.org/Admin/Tools/DataManagers) for
+and [data managers](https://galaxyproject.org/admin/tools/data-managers/) for
 more information.</xs:documentation>
           </xs:annotation>
         </xs:attribute>

--- a/scripts/bootstrap_history.py
+++ b/scripts/bootstrap_history.py
@@ -114,7 +114,7 @@ To update an existing Galaxy repository run:
 
       $$ git checkout release_${release} && git pull --ff-only origin release_${release}
 
-See our community `hub <https://galaxyproject.org/develop/source-code/>`__ for additional details regarding the source code locations.
+See `our wiki <https://galaxyproject.org/develop/source-code/>`__ for additional details regarding the source code locations.
 
 Release Notes
 ===========================================================
@@ -174,7 +174,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template("""
 
 - [ ] **Create Release Notes**
 
-    - [ ] Review merged PRs and ensure they all have a milestones attached. [Link](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+is%3Amerged+no%3Amilestone%20-label%3Amerge)
+    - [ ] Review merged PRs and ensure they all have a milestones attached. [Link](https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+is%3Amerged+no%3Amilestone)
     - [ ] Checkout release branch
 
           git checkout release_${version} -b ${version}_release_notes
@@ -185,9 +185,6 @@ RELEASE_ISSUE_TEMPLATE = string.Template("""
 
           make release-bootstrap-history RELEASE_CURR=${version}
     - [ ] Open newly created files and manually curate major topics and release notes.
-    - [ ] Check ``diff`` of ``galaxy.ini.sample`` against last release and include any important changes.
-    - [ ] Check ``diff`` of ``datatypes_conf.xml.sample`` against last release and include any important changes.
-    - [ ] Check if there were database migrations and include a high-profile note about it if so.
     - [ ] Commit release notes.
 
           git add docs/; git commit -m "Release notes for $version"; git push upstream ${version}_release_notes
@@ -207,7 +204,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template("""
 
           make release-create RELEASE_CURR=${version}
 
-    - [ ] Switch Jenkins documentation build [branch specifier](https://jenkins.galaxyproject.org/job/Sphinx-Docs/configure) to `*/release_${version}`.
+    - [ ] Switch Jenkins documentation build [branch specifier](https://jenkins.galaxyproject.org/job/Sphinx-Docs/configure) to `*/release_{version}`.
     - [ ] Trigger the documentation build.
 
 - [ ] **Do Docker Release**
@@ -225,7 +222,7 @@ RELEASE_ISSUE_TEMPLATE = string.Template("""
     - [ ] Verify release included in https://docs.galaxyproject.org/en/master/releases/index.html
     - [ ] Review announcement in https://github.com/galaxyproject/galaxy/blob/dev/doc/source/releases/${version}_announce.rst
     - [ ] Stage annoucement content (Wiki, Biostars, Bit.ly link) on annouce date to capture date tags. Note: all final content does not need to be completed to do this.
-    - [ ] Create wiki *highlights* and post to http://galaxyproject.org News (w/ RSS) and NewsBriefs. [An Example](https://wiki.galaxyproject.org/News/2016_04_GalaxyRelease).
+    - [ ] Create wiki *highlights* and post to http://galaxyproject.org News (w/ RSS) and NewsBriefs. [An Example](https://galaxyproject.org/news/2016-04-galaxy-release).
     - [ ] Tweet docs news *highlights* via bit.ly link to https://twitter.com/galaxyproject/ (As user ``galaxyproject``, password in Galaxy password store under ``twitter.com / galaxyproject`` ). [An Example](https://twitter.com/galaxyproject/status/733029921316986881).
     - [ ] Post *highlights* type News to Galaxy Biostars https://biostar.usegalaxy.org. [An Example](https://biostar.usegalaxy.org/p/17712/).
     - [ ] Email *highlights* to [galaxy-dev](http://dev.list.galaxyproject.org/) and [galaxy-announce](http://announce.list.galaxyproject.org/) @lists.galaxyproject.org. [An Example](http://dev.list.galaxyproject.org/The-Galaxy-release-16-04-is-out-tp4669419.html)

--- a/static/welcome.html.sample
+++ b/static/welcome.html.sample
@@ -10,8 +10,8 @@
                 <h2>Hello, <strong>Galaxy</strong> is running!</h2>
                 To customize this page edit <code>static/welcome.html</code>
                 <br>
-                <a target="_blank" href="https://wiki.galaxyproject.org/Admin/Config" class="btn btn-primary btn-lg">Configuring Galaxy »</a>
-                <a target="_blank" href="https://wiki.galaxyproject.org/Admin/Tools/AddToolFromToolShedTutorial" class="btn btn-primary btn-lg">Installing Tools »</a>
+                <a target="_blank" href="https://galaxyproject.org/admin/config/" class="btn btn-primary btn-lg">Configuring Galaxy »</a>
+                <a target="_blank" href="https://galaxyproject.org/admin/tools/add-tool-from-toolshed-tutorial/" class="btn btn-primary btn-lg">Installing Tools »</a>
             </div>
             <br>
             <div class="container">
@@ -26,7 +26,7 @@
             <p class="lead">
                 <a target="_blank" class="reference" href="http://galaxyproject.org/">
                 Galaxy</a> is an open platform for supporting data intensive
-                research. Galaxy is developed by <a target="_blank" class="reference" href="http://wiki.galaxyproject.org/GalaxyTeam">The Galaxy Team</a>
+                research. Galaxy is developed by <a target="_blank" class="reference" href="https://galaxyproject.org/galaxy-team/">The Galaxy Team</a>
                 with the support of  <a target="_blank" class="reference" href="https://github.com/galaxyproject/galaxy/blob/dev/CONTRIBUTORS.md">many contributors</a>.
             </p>
             <footer>

--- a/test/functional/tools/sample_datatypes_conf.xml
+++ b/test/functional/tools/sample_datatypes_conf.xml
@@ -15,10 +15,10 @@
     <datatype extension="fastqcssanger" type="galaxy.datatypes.sequence:FastqCSSanger" display_in_upload="true" />
     <datatype extension="fastqillumina" type="galaxy.datatypes.sequence:FastqIllumina" display_in_upload="true" />
     <datatype extension="sam" type="galaxy.datatypes.tabular:Sam" display_in_upload="true" />
-    <datatype extension="bam" type="galaxy.datatypes.binary:Bam" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM" />
-    <datatype extension="bcf" type="galaxy.datatypes.binary:Bcf" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bcf' file extension." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BCF" />
+	<datatype extension="bam" type="galaxy.datatypes.binary:Bam" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension." description_url="https://galaxyproject.org/learn/datatypes/#bam" />
+	<datatype extension="bcf" type="galaxy.datatypes.binary:Bcf" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bcf' file extension." description_url="https://galaxyproject.org/learn/datatypes/#bcf" />
     <datatype extension="biom1" type="galaxy.datatypes.text:Biom1" display_in_upload="True" subclass="True" mimetype="application/json"/>
-    <datatype extension="bed" type="galaxy.datatypes.interval:Bed" display_in_upload="true" description="BED format provides a flexible way to define the data lines that are displayed in an annotation track. BED lines have three required columns and nine additional optional columns. The three required columns are chrom, chromStart and chromEnd." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Bed">
+	<datatype extension="bed" type="galaxy.datatypes.interval:Bed" display_in_upload="true" description="BED format provides a flexible way to define the data lines that are displayed in an annotation track. BED lines have three required columns and nine additional optional columns. The three required columns are chrom, chromStart and chromEnd." description_url="https://galaxyproject.org/learn/datatypes/#bed">
     </datatype>
   </registration>
 </datatypes>

--- a/test/qunit/test-data/bootstrapped.js
+++ b/test/qunit/test-data/bootstrapped.js
@@ -3,9 +3,9 @@ define([], function(){
         config  : {
             "allow_user_deletion": false,
             "allow_user_creation": true,
-            "wiki_url": "https://wiki.galaxyproject.org/",
+            "wiki_url": "https://galaxyproject.org/",
             "ftp_upload_site": null,
-            "support_url": "https://wiki.galaxyproject.org/Support",
+            "support_url": "https://galaxyproject.org/support/",
             "allow_user_dataset_purge": false,
             "allow_library_path_paste": false,
             "user_library_import_dir": null,

--- a/test/qunit/tests/galaxy-app-base.js
+++ b/test/qunit/tests/galaxy-app-base.js
@@ -16,9 +16,9 @@ define([
         config : {
             "allow_user_deletion": false,
             "allow_user_creation": true,
-            "wiki_url": "https://wiki.galaxyproject.org/",
+            "wiki_url": "https://galaxyproject.org/",
             "ftp_upload_site": null,
-            "support_url": "https://wiki.galaxyproject.org/Support",
+            "support_url": "https://galaxyproject.org/support/",
             "allow_user_dataset_purge": false,
             "allow_library_path_paste": false,
             "user_library_import_dir": null,
@@ -96,7 +96,7 @@ define([
         ok( app.hasOwnProperty( 'config' ) && typeof app.config === 'object' );
         equal( app.config.allow_user_deletion,  false );
         equal( app.config.allow_user_creation,  true );
-        equal( app.config.wiki_url,             "https://wiki.galaxyproject.org/" );
+        equal( app.config.wiki_url,             "https://galaxyproject.org/" );
         equal( app.config.ftp_upload_site,      null );
         //...
     });


### PR DESCRIPTION
- maybe one day we can remove redirects (y'all should monitor 301s)
- faster, one fewer round trip
- now grepping for wiki.galaxyproject.org only returns broken links, helps identify what to fix. 