### PR TITLE
[17.05] fix plugin access path

### DIFF
--- a/config/plugins/webhooks/demo/search/config/searchover.yaml
+++ b/config/plugins/webhooks/demo/search/config/searchover.yaml
@@ -7,7 +7,7 @@ icon: fa-search
 tooltip: Click to activate search and press Ctrl + Alt + q to open the overlay
 
 function: >
-  $.getJSON(Galaxy.root + "/api/webhooks", function( data ) {
+  $.getJSON(Galaxy.root + "api/webhooks", function( data ) {
       for( var item in data ) {
           var webhook = data[item];
           if( webhook.name === "searchover" ) {


### PR DESCRIPTION
@dannon @guerler without this fix the webhook is not working. There are other plugins that needs the same fix, I'm just wondering why this happens now and if there is something more serious broken.