### PR TITLE
Add the ability to control job conf plugin loading from environment variables.

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -283,7 +283,13 @@
             <param id="insecure">true</param>
             <!-- True to communicate with Chronos over HTTPS; false otherwise-->
         </plugin>
-
+        <!-- Additionally any plugin or destination (below) may define an "enabled" parameter that should
+             evaluate to True or False. When setup using
+                <param id="enabled" from_environ="<VAR>">True|False</param>
+             plugins and destinations can be conditionally loaded using environment variables.
+             Setting the param body above to True or False is required and specifies the default
+             used by Galaxy is no environment variable of the specified name is found.
+        -->
     </plugins>
     <handlers default="handlers">
         <!-- Additional job handlers - the id should match the name of a

--- a/test/unit/jobs/conditional_runners_job_conf.xml
+++ b/test/unit/jobs/conditional_runners_job_conf.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!-- A sample job config that explicitly configures job running the way it is configured by default (if there is no explicit config). -->
+<job_conf>
+    <plugins>
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4"/>
+        <plugin id="local2" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4">
+            <param id="enabled" from_environ="LOCAL2_ENABLED">True</param>
+        </plugin>
+        <plugin id="local3" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4">
+            <param id="enabled" from_environ="LOCAL3_ENABLED">False</param>
+        </plugin>
+    </plugins>
+    <handlers>
+        <handler id="main"/>
+    </handlers>
+    <destinations default="local">
+        <destination id="local" runner="local"/>
+        <destination id="local2_dest" runner="local2">
+            <param id="enabled" from_environ="LOCAL2_ENABLED">True</param>
+        </destination>
+        <destination id="local3_dest" runner="local3">
+            <param id="enabled" from_environ="LOCAL3_ENABLED">False</param>
+        </destination>
+    </destinations>
+</job_conf>

--- a/test/unit/jobs/test_job_configuration.py
+++ b/test/unit/jobs/test_job_configuration.py
@@ -11,6 +11,7 @@ from galaxy.util import bunch
 # there are advantages to testing the documentation/examples.
 SIMPLE_JOB_CONF = os.path.join( os.path.dirname( __file__ ), "..", "..", "..", "config", "job_conf.xml.sample_basic" )
 ADVANCED_JOB_CONF = os.path.join( os.path.dirname( __file__ ), "..", "..", "..", "config", "job_conf.xml.sample_advanced" )
+CONDITIONAL_RUNNER_JOB_CONF = os.path.join( os.path.dirname( __file__ ), "conditional_runners_job_conf.xml" )
 
 
 class JobConfXmlParserTestCase( unittest.TestCase ):
@@ -136,6 +137,30 @@ class JobConfXmlParserTestCase( unittest.TestCase ):
         self.__with_advanced_config()
         for name in ["foo_small", "foo_medium", "foo_large", "foo_longrunning"]:
             assert self.job_config.destinations[ name ]
+
+    def test_conditional_runners( self ):
+        self.__write_config_from( CONDITIONAL_RUNNER_JOB_CONF )
+        runner_ids = [ r[ "id" ] for r in self.job_config.runner_plugins ]
+        assert "local2" in runner_ids
+        assert "local3" not in runner_ids
+
+        assert "local2_dest" in self.job_config.destinations
+        assert "local3_dest" not in self.job_config.destinations
+
+    def test_conditional_runners_from_environ( self ):
+        self.__write_config_from( CONDITIONAL_RUNNER_JOB_CONF )
+        os.environ["LOCAL2_ENABLED"] = "False"
+        os.environ["LOCAL3_ENABLED"] = "True"
+        try:
+            runner_ids = [ r[ "id" ] for r in self.job_config.runner_plugins ]
+            assert "local2" not in runner_ids
+            assert "local3" in runner_ids
+
+            assert "local2_dest" not in self.job_config.destinations
+            assert "local3_dest" in self.job_config.destinations
+        finally:
+            del os.environ["LOCAL2_ENABLED"]
+            del os.environ["LOCAL3_ENABLED"]
 
     # TODO: Add job metrics parsing test.
 


### PR DESCRIPTION
All job configuration parameters can be set using environment variables but currently the actual loading of the plugins and destinations cannot. This is problematic for setting up single job confs for multiple environments (like done with docker-galaxy-stable) when using plugins that may hang waiting for resources (such as Kubernetes for the K8 runner or a MQ for Pulsar for instance) or may require library dependencies not be setup in every environment the job configuration is deployed in.

xref https://github.com/bgruening/docker-galaxy-stable/pull/328