### PR TITLE
Nicer command line display?

### DIFF
--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -47,6 +47,12 @@
         min-width: 40px;
         margin-left: -33px;
         padding-right: 1em;
+        -webkit-user-select: none;
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        -o-user-select: none;
+        user-select: none;
     }
 </style>
 

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -19,10 +19,34 @@
     }
 
     .code {
+        font-family: monospace;
         white-space: pre-wrap;
         background: #1d1f21;
         color: white;
-        padding: 1em;
+        line-height: 0px;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        padding-top: 10px;
+    }
+
+    .code div {
+        padding-left: 55px;
+        margin: 0;
+        min-height: 16px;
+        line-height: 2em;
+    }
+
+    .code div:hover {
+        background: #333;
+    }
+
+    .code div .lineno{
+        color: #aaa;
+        display: inline-block;
+        text-align: right;
+        min-width: 40px;
+        margin-left: -33px;
+        padding-right: 1em;
     }
 </style>
 
@@ -234,8 +258,13 @@
 
 %if job and job.command_line and (trans.user_is_admin() or trans.app.config.expose_dataset_path):
 <h3>Command Line</h3>
-<pre class="code">
-${ job.command_line | h }</pre>
+<div class="code">
+% for idx, line in enumerate(job.command_line.split(';')):
+% for subidx, subline in enumerate(line.split('&&')):
+<div><span class="lineno">${idx + subidx + 1}</span><span>${ subline.strip() | h }</span></div>
+% endfor
+% endfor
+</div>
 %endif
 
 %if job and (trans.user_is_admin() or trans.app.config.expose_potentially_sensitive_job_metrics):


### PR DESCRIPTION
Pro:

- easy to spot places where two things are merged on a single line that shouldn't be (the raison d'être of this PR)
- easy to see what is going on
- more like travis

Cons:

- `&&` and `;` are removed (commands are still copy-able @bgruening mentioned that this is important). This could probably be fixed? Maybe?

Screenshots:

![utvalg_194](https://user-images.githubusercontent.com/458683/26852448-ddff75bc-4afd-11e7-90a3-59e5c0df2c47.png)

Compare with:
![utvalg_196](https://user-images.githubusercontent.com/458683/26852506-04021314-4afe-11e7-8ea4-e5bb62c51638.png)

I had two bash variables which were merged on the same line, it took me a fair bit of debugging to realise this. With this PR, it would have been immediately clear that those were on one line. Thoughts? Discussion?