### PR TITLE
Install missing tool when workflow upload from web.

### DIFF
--- a/templates/webapps/galaxy/workflow/import.mako
+++ b/templates/webapps/galaxy/workflow/import.mako
@@ -48,6 +48,14 @@
                     <div style="clear: both"></div>
                 </div>
                 <div class="form-row">
+                    <label>Install missing tool:</label>
+                    <input type='checkbox' name='import_tools' />
+                    <div class="toolParamHelp" style="clear: both;">
+                        Install missing tool which workflow has.
+                    </div>
+                    <div style="clear: both"></div>
+                </div>
+                <div class="form-row">
                     <input type="submit" class="primary-button" name="import_button" value="Import">
                 </div>
             </form>


### PR DESCRIPTION
Install missing tool when workflow upload from web

Add Install missing tool button on web (default: false)

Currently this is work if user is admin.

Message is needed to update.