### PR TITLE
Implement Singularity Support

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -440,6 +440,46 @@
                the deployer. -->
           <!-- <param id="require_container">true</param> -->
         </destination>
+        <destination id="singularity_local" runner="local">
+          <param id="singularity_enabled">true</param>
+          <!-- See the above documentation for docker_volumes, singularity_volumes works
+               the same way.
+          -->
+          <!--
+          <param id="singularity_volumes">$defaults,/mnt/galaxyData/libraries:ro,/mnt/galaxyData/indices:ro</param>
+          -->
+          <!-- You can configure singularity to run using sudo - this probably should not
+               be set and may be removed in the future.
+          -->
+          <!-- <param id="singularity_sudo">false</param> -->
+          <!-- Following option can be used to tweak sudo command used by
+               default. -->
+          <!-- <param id="singularity_sudo_cmd">/usr/bin/sudo -extra_param</param> -->
+          <!-- Pass extra arguments to the singularity exec command not covered by the
+               above options. -->
+          <!-- <param id="singularity_run_extra_arguments"></param> -->
+          <!-- Following command can be used to tweak singularity command. -->
+          <!-- <param id="singularity_cmd">/usr/local/custom_docker/docker</param> -->
+
+          <!-- If deployer wants to use singularity for isolation, but does not
+               trust tool's specified container - a destination wide override
+               can be set. This will cause all jobs on this destination to use
+               that singularity image. -->
+          <!-- <param id="singularity_container_id_override">/path/to/singularity/image</param> -->
+
+          <!-- Likewise, if deployer wants to use singularity for isolation and
+               does trust tool's specified container - but also wants tool's not
+               configured to run in a container the following option can provide
+               a fallback. -->
+          <!-- <param id="singularity_default_container_id">/path/to/singularity/image</param> -->
+
+          <!-- If the destination should be secured to only allow containerized jobs
+               the following parameter may be set for the job destination. Not all,
+               or even most, tools available in Galaxy core or in the Tool Shed
+               support Docker yet so this option may require a lot of extra work for
+               the deployer. -->
+          <!-- <param id="require_container">true</param> -->
+        </destination>
         <destination id="pbs" runner="pbs" tags="mycluster"/>
         <destination id="pbs_longjobs" runner="pbs" tags="mycluster,longjobs">
             <!-- Define parameters that are native to the job runner plugin. -->

--- a/lib/galaxy/tools/deps/singularity_util.py
+++ b/lib/galaxy/tools/deps/singularity_util.py
@@ -1,0 +1,58 @@
+from six.moves import shlex_quote
+
+
+DEFAULT_WORKING_DIRECTORY = None
+DEFAULT_SINGULARITY_COMMAND = "singularity"
+DEFAULT_SUDO = False
+DEFAULT_SUDO_COMMAND = "sudo"
+DEFAULT_RUN_EXTRA_ARGUMENTS = None
+
+
+def build_singularity_run_command(
+    container_command,
+    image,
+    volumes=[],
+    env=[],
+    working_directory=DEFAULT_WORKING_DIRECTORY,
+    singularity_cmd=DEFAULT_SINGULARITY_COMMAND,
+    run_extra_arguments=DEFAULT_RUN_EXTRA_ARGUMENTS,
+    sudo=DEFAULT_SUDO,
+    sudo_cmd=DEFAULT_SUDO_COMMAND,
+):
+    command_parts = []
+    # http://singularity.lbl.gov/docs-environment-metadata
+    for (key, value) in env:
+        command_parts.extend(["SINGULARITYENV_%s=%s" % (key, value)])
+    command_parts += _singularity_prefix(
+        singularity_cmd=singularity_cmd,
+        sudo=sudo,
+        sudo_cmd=sudo_cmd,
+    )
+    command_parts.append("exec")
+    for volume in volumes:
+        command_parts.extend(["-B", shlex_quote(str(volume))])
+    if working_directory:
+        command_parts.extend(["--pwd", shlex_quote(working_directory)])
+    if run_extra_arguments:
+        command_parts.append(run_extra_arguments)
+    full_image = image
+    command_parts.append(shlex_quote(full_image))
+    command_parts.append(container_command)
+    return " ".join(command_parts)
+
+
+def _singularity_prefix(
+    singularity_cmd=DEFAULT_SINGULARITY_COMMAND,
+    sudo=DEFAULT_SUDO,
+    sudo_cmd=DEFAULT_SUDO_COMMAND,
+    **kwds
+):
+    """Prefix to issue a singularity command."""
+    command_parts = []
+    if sudo:
+        command_parts.append(sudo_cmd)
+    command_parts.append(singularity_cmd)
+    return command_parts
+
+
+__all__ = ("build_singularity_run_command",)


### PR DESCRIPTION
See http://singularity.lbl.gov/ for more information on Singularity and see comments added to job_conf.xml.sample_advanced for information on setting up job runners to exploit singularity.

The biggest current caveat is probably that currently these container images need to be setup manually by the admin and the paths hard-coded for each tool in job_conf.xml. There are people who do such manual setups for Docker (https://github.com/phnmnl/container-galaxy-k8s-runtime/blob/develop/config/job_conf.xml) - so it wouldn't be surprising if someone wanted to set this up for singularity as well. That said I'm sure this will be followed up by magic to fetch and convert Docker containers and leverage published singularity containers (such as mulled can now produce https://github.com/galaxyproject/galaxy-lib/pull/64 - thanks to @bgruening). Work on maintaining singularity image caches would really benefit from completing #3673 for Docker first IMO.
