### PR TITLE
Allow Galaxy to use cached mulled containers for Singularity.

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -247,7 +247,11 @@ class Configuration( object ):
             log.warn("preserve_python_environment set to unknown value [%s], defaulting to legacy_only")
             preserve_python_environment = "legacy_only"
         self.preserve_python_environment = preserve_python_environment
+        # Older default container cache path, I don't think anyone is using it anymore and it wasn't documented - we
+        # should probably drop the backward compatiblity to save the path check.
         self.container_image_cache_path = self.resolve_path( kwargs.get( "container_image_cache_path", "database/container_images" ) )
+        if not os.path.exists( self.container_image_cache_path ):
+            self.container_image_cache_path = self.resolve_path( kwargs.get( "container_image_cache_path", "database/container_cache" ) )
         self.outputs_to_working_directory = string_as_bool( kwargs.get( 'outputs_to_working_directory', False ) )
         self.output_size_limit = int( kwargs.get( 'output_size_limit', 0 ) )
         self.retry_job_output_collection = int( kwargs.get( 'retry_job_output_collection', 0 ) )

--- a/lib/galaxy/tools/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tools/deps/container_resolvers/mulled.py
@@ -54,6 +54,7 @@ def list_docker_cached_mulled_images(namespace=None, hash_func="v2"):
     raw_images = [output_line_to_image(_) for _ in filter(name_filter, images_and_versions.splitlines())]
     return [i for i in raw_images if i is not None]
 
+
 def identifier_to_cached_target(identifier, hash_func):
     image_name, version = identifier.rsplit(":", 1)
     if not version or version == "latest":


### PR DESCRIPTION
~This builds on #4173 and so that open PR is included here.~ (That has been merged.)

- Change undocumented (and probably unused) config option ``container_image_cache_path`` default to ``database/contianer_cache``.
- Update container resolver framework to let plugins assert they only produce containers of a single type.
- Update existing mulled container resolvers to indicate they produce Docker containers only - update names also.
- Refactor mulled caching stuff to allow reuse with Singularity (where the names come from is different - but a lot of the logic is the same).
- Add a cached singularity container resolver - that searches ``<config.container_image_cache_path>/singularity/mulled`` for an image with the correct name. This mirrors the cached Docker which looks for similar image names for Docker but just in the output for ``docker images``.

These cached images can be built with the mulled tooling included with galaxy-lib - it should be as easy as `mulled-build-tool --singularity <tool_path> build` to produce such images.

Future work includes a subsequent PR will allow Galaxy to build these images and populate that cache automatically and a longer term open infrastructure project is to build these and publish them to depot.galaxyproject.org (or Singularity hub).
