### PR TITLE
Build mulled images for Singularity on demand...

### DIFF
--- a/lib/galaxy/tools/deps/containers.py
+++ b/lib/galaxy/tools/deps/containers.py
@@ -16,6 +16,7 @@ from galaxy.util import plugin_config
 from .container_resolvers.explicit import ExplicitContainerResolver
 from .container_resolvers.mulled import (
     BuildMulledDockerContainerResolver,
+    BuildMulledSingularityContainerResolver,
     CachedMulledDockerContainerResolver,
     CachedMulledSingularityContainerResolver,
     MulledDockerContainerResolver,
@@ -224,6 +225,7 @@ class ContainerRegistry(object):
                 MulledDockerContainerResolver(self.app_info, namespace="biocontainers"),
                 BuildMulledDockerContainerResolver(self.app_info),
                 CachedMulledSingularityContainerResolver(self.app_info),
+                BuildMulledSingularityContainerResolver(self.app_info),
             ])
         return default_resolvers
 

--- a/lib/galaxy/tools/deps/mulled/invfile.lua
+++ b/lib/galaxy/tools/deps/mulled/invfile.lua
@@ -51,6 +51,12 @@ if singularity_image == '' then
     singularity_image = 'quay.io/biocontainers/singularity:2.3--0'
 end
 
+local singularity_image_dir = VAR.SINGULARITY_IMAGE_DIR
+if singularity_image_dir == '' then
+    singularity_image_dir = 'singularity_import'
+end
+
+
 
 local destination_base_image = VAR.DEST_BASE_IMAGE
 if destination_base_image == '' then
@@ -95,7 +101,7 @@ inv.task('build')
 if VAR.SINGULARITY ~= '' then
     inv.task('singularity')
         .using(singularity_image)
-        .withHostConfig({binds = {"build:/data","singularity_import:/import"}, privileged = true})
+        .withHostConfig({binds = {"build:/data",singularity_image_dir .. ":/import"}, privileged = true})
         .withConfig({entrypoint = {'/bin/sh', '-c'}})
         -- this will create a container that is the size of our conda dependencies + 20MiB
         -- The 20 MiB can be improved at some point, but this seems to work for now.

--- a/lib/galaxy/tools/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tools/deps/mulled/mulled_build.py
@@ -25,6 +25,8 @@ except ImportError:
 
 from galaxy.tools.deps import commands, installable
 
+from galaxy.util import safe_makedirs
+
 from ._cli import arg_parser
 from .util import (
     build_target,
@@ -152,13 +154,14 @@ def mull_targets(
     repository_template=DEFAULT_REPOSITORY_TEMPLATE, dry_run=False,
     conda_version=None, verbose=False, binds=DEFAULT_BINDS, rebuild=True,
     oauth_token=None, hash_func="v2", singularity=False,
+    singularity_image_dir="singularity_import",
 ):
     targets = list(targets)
     if involucro_context is None:
         involucro_context = InvolucroContext()
 
     image_function = v1_image_name if hash_func == "v1" else v2_image_name
-    if len(targets) > 2 and image_build is None:
+    if len(targets) > 1 and image_build is None:
         # Force an image build in this case - this seems hacky probably
         # shouldn't work this way but single case broken else wise.
         image_build = "0"
@@ -212,6 +215,7 @@ def mull_targets(
         singularity_image_name = repo_template_kwds['image']
         involucro_args.extend(["-set", "SINGULARITY='1'"])
         involucro_args.extend(["-set", "SINGULARITY_IMAGE_NAME='%s'" % singularity_image_name])
+        involucro_args.extend(["-set", "SINGULARITY_IMAGE_DIR='%s'" % singularity_image_dir])
         involucro_args.extend(["-set", "USER_ID='%s:%s'" % (os.getuid(), os.getgid() )])
     if conda_version is not None:
         verbose = "--verbose" if verbose else "--quiet"
@@ -233,9 +237,9 @@ def mull_targets(
     if not dry_run:
         ensure_installed(involucro_context, True)
         if singularity:
-            if not os.path.exists('./singularity_import'):
-                os.mkdir('./singularity_import')
-            with open('./singularity_import/Singularity', 'w+') as sin_def:
+            if not os.path.exists(singularity_image_dir):
+                safe_makedirs(singularity_image_dir)
+            with open(os.path.join(singularity_image_dir, 'Singularity'), 'w+') as sin_def:
                 fill_template = SINGULARITY_TEMPLATE % {'container_test': test}
                 sin_def.write(fill_template)
         ret = involucro_context.exec_command(involucro_args)
@@ -314,6 +318,8 @@ def add_build_arguments(parser):
                         help='Cause process to be verbose.')
     parser.add_argument('--singularity', action="store_true",
                         help='Additionally build a singularity image.')
+    parser.add_argument('--singularity-image-dir', dest="singularity_image_dir",
+                        help="Directory to write singularity images too.")
     parser.add_argument('-n', '--namespace', dest='namespace', default="biocontainers",
                         help='quay.io namespace.')
     parser.add_argument('-r', '--repository_template', dest='repository_template', default=DEFAULT_REPOSITORY_TEMPLATE,
@@ -387,6 +393,8 @@ def args_to_mull_targets_kwds(args):
         kwds["rebuild"] = args.rebuild
     if hasattr(args, "hash"):
         kwds["hash_func"] = args.hash
+    if hasattr(args, "singularity_image_dir"):
+        kwds["singularity_image_dir"] = args.singularity_image_dir
 
     kwds["involucro_context"] = context_from_args(args)
 

--- a/lib/galaxy/tools/deps/mulled/mulled_build_files.py
+++ b/lib/galaxy/tools/deps/mulled/mulled_build_files.py
@@ -35,9 +35,6 @@ def main(argv=None):
                         help="Path to directory (or single file) of TSV files describing composite recipes.")
     args = parser.parse_args()
     for (targets, image_build, name_override) in generate_targets(args.files):
-        if not image_build and len(targets) > 1:
-            # Specify an explict tag in this case.
-            image_build = "0"
         try:
             mull_targets(
                 targets,

--- a/lib/galaxy/tools/deps/mulled/mulled_build_tool.py
+++ b/lib/galaxy/tools/deps/mulled/mulled_build_tool.py
@@ -32,7 +32,8 @@ def main(argv=None):
     tool_source = get_tool_source(args.tool)
     requirements, _ = tool_source.parse_requirements_and_containers()
     targets = requirements_to_mulled_targets(requirements)
-    mull_targets(targets, **args_to_mull_targets_kwds(args))
+    kwds = args_to_mull_targets_kwds(args)
+    mull_targets(targets, **kwds)
 
 
 def requirements_to_mulled_targets(requirements):


### PR DESCRIPTION
... if a cached container for the tool in question cannot be found. This mirrors behavior for Docker and can be disabled by setting up a custom containers resolution file.

This should also enable easy testing of tools with Planemo using Singularity.

xref #4179 (cached mulled support)
xref #4182 (the issue)
xref https://github.com/galaxyproject/galaxy-lib/pull/66 (singularity changes in this PR added to galaxy-lib allowing this)
