### PR TITLE
Fix #3990, don't chown non-galaxy files

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1215,7 +1215,7 @@ class JobWrapper( object, HasResourceParameters ):
             # need to update all associated output hdas, i.e. history was shared with job running
             for dataset in dataset_assoc.dataset.dataset.history_associations + dataset_assoc.dataset.dataset.library_associations:
                 purged = dataset.dataset.purged
-                if not purged:
+                if not purged and dataset.dataset.external_filename is None:
                     trynum = 0
                     while trynum < self.app.config.retry_job_output_collection:
                         try:


### PR DESCRIPTION
This should fix #3990, which is due to Galaxy trying to `chown` files that it may not own. The easy fix is to just ignore linked in files, which I presume will always have `external_filename is not None`.