### PR TITLE
[17.05] Fix tool version switching because of uncaught JS bug

### DIFF
--- a/client/galaxy/scripts/mvc/tool/tool-form-base.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-base.js
@@ -148,7 +148,7 @@ define( [ 'utils/utils', 'utils/deferred', 'mvc/ui/ui-misc', 'mvc/form/form-view
                                 // queue model request
                                 self.deferred.reset();
                                 self.deferred.execute( function( process ) {
-                                    self._buildModel( process, { id : id, version : version } )
+                                    self._buildModel( process, { 'id' : id, 'version' : version } )
                                 });
                             }
                         });


### PR DESCRIPTION
I suppose that is what this should be, but total JS noob here. Without this the version switching button would have no effect and/or always load up the latest version.