### PR TITLE
Extend wait for datasets to be ready in transiently failing API tests

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -205,7 +205,10 @@ class HistoryContentsController( BaseAPIController, UsesLibraryMixin, UsesLibrar
         names, hdas = get_hda_and_element_identifiers(dataset_collection_instance)
         for name, hda in zip(names, hdas):
             if hda.state != hda.states.OK:
-                continue
+                trans.sa_session.refresh(hda)
+                if hda.state != hda.states.OK:
+                    log.info("Skipping download of '%s', because its state is '%s'" % (name, hda.state))
+                    continue
             for file_path, relpath in hda.datatype.to_archive(trans=trans, dataset=hda, name=name):
                 archive.add(file=file_path, relpath=relpath)
         archive_name = "%s: %s.%s" % (dataset_collection_instance.hid, dataset_collection_instance.name, archive_ext)

--- a/test/api/test_dataset_collections.py
+++ b/test/api/test_dataset_collections.py
@@ -1,6 +1,5 @@
 import json
 import tarfile
-import time
 
 from base import api
 from base.populators import DatasetCollectionPopulator, DatasetPopulator
@@ -102,7 +101,6 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         assert len(returned_datasets) == 3, dataset_collection
         for element in returned_datasets:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
-        time.sleep(5)
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
         self._assert_status_code_is(create_response, 200)
         tar_contents = tarfile.open(fileobj=StringIO(create_response.content))
@@ -117,7 +115,6 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         returned_datasets = dataset_collection["elements"]
         for element in returned_datasets:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
-        time.sleep(5)
         hdca_id = dataset_collection['id']
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=hdca_id)
         self._assert_status_code_is(create_response, 200)
@@ -136,7 +133,6 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         pair = returned_datasets[0]
         for element in pair['object']['elements']:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
-        time.sleep(5)
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
         self._assert_status_code_is(create_response, 200)
         tar_contents = tarfile.open(fileobj=StringIO(create_response.content))

--- a/test/api/test_dataset_collections.py
+++ b/test/api/test_dataset_collections.py
@@ -102,7 +102,7 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         assert len(returned_datasets) == 3, dataset_collection
         for element in returned_datasets:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
-        time.sleep(1)
+        time.sleep(5)
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
         self._assert_status_code_is(create_response, 200)
         tar_contents = tarfile.open(fileobj=StringIO(create_response.content))
@@ -117,7 +117,7 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         returned_datasets = dataset_collection["elements"]
         for element in returned_datasets:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
-        time.sleep(1)
+        time.sleep(5)
         hdca_id = dataset_collection['id']
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=hdca_id)
         self._assert_status_code_is(create_response, 200)
@@ -136,7 +136,7 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         pair = returned_datasets[0]
         for element in pair['object']['elements']:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
-        time.sleep(1)
+        time.sleep(5)
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
         self._assert_status_code_is(create_response, 200)
         tar_contents = tarfile.open(fileobj=StringIO(create_response.content))

--- a/test/api/test_dataset_collections.py
+++ b/test/api/test_dataset_collections.py
@@ -102,7 +102,7 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         assert len(returned_datasets) == 3, dataset_collection
         for element in returned_datasets:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
-        time.sleep(5)
+        time.sleep(1)
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
         self._assert_status_code_is(create_response, 200)
         tar_contents = tarfile.open(fileobj=StringIO(create_response.content))
@@ -117,7 +117,7 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         returned_datasets = dataset_collection["elements"]
         for element in returned_datasets:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
-        time.sleep(5)
+        time.sleep(1)
         hdca_id = dataset_collection['id']
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=hdca_id)
         self._assert_status_code_is(create_response, 200)
@@ -136,7 +136,7 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         pair = returned_datasets[0]
         for element in pair['object']['elements']:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
-        time.sleep(5)
+        time.sleep(1)
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
         self._assert_status_code_is(create_response, 200)
         tar_contents = tarfile.open(fileobj=StringIO(create_response.content))

--- a/test/api/test_dataset_collections.py
+++ b/test/api/test_dataset_collections.py
@@ -1,5 +1,6 @@
 import json
 import tarfile
+import time
 
 from base import api
 from base.populators import DatasetCollectionPopulator, DatasetPopulator
@@ -101,6 +102,7 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         assert len(returned_datasets) == 3, dataset_collection
         for element in returned_datasets:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
+        time.sleep(5)
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
         self._assert_status_code_is(create_response, 200)
         tar_contents = tarfile.open(fileobj=StringIO(create_response.content))
@@ -115,6 +117,7 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         returned_datasets = dataset_collection["elements"]
         for element in returned_datasets:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
+        time.sleep(5)
         hdca_id = dataset_collection['id']
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=hdca_id)
         self._assert_status_code_is(create_response, 200)
@@ -133,6 +136,7 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         pair = returned_datasets[0]
         for element in pair['object']['elements']:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
+        time.sleep(5)
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
         self._assert_status_code_is(create_response, 200)
         tar_contents = tarfile.open(fileobj=StringIO(create_response.content))


### PR DESCRIPTION
Just testing out if that would fix #4218 ...