### PR TITLE
avoids broken version of mercurial in conda

### DIFF
--- a/lib/galaxy/dependencies/conda-environment.txt
+++ b/lib/galaxy/dependencies/conda-environment.txt
@@ -23,7 +23,7 @@ bx-python
 MarkupSafe
 PyYAML
 SQLAlchemy
-mercurial
+mercurial!=4.1.1 #conda's mercurial 4.1.1. is broken
 pycrypto
 
 # Install python_lzo if you want to support indexed access to lzo-compressed


### PR DESCRIPTION
this makes the [install instructions](https://docs.galaxyproject.org/en/master/admin/framework_dependencies.html#conda) work again