### PR TITLE
Enable skipping comment lines while sniffing files

### DIFF
--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -314,7 +314,7 @@ class Interval( Tabular ):
         >>> Interval().sniff( fname )
         True
         """
-        headers = get_headers( filename, '\t', commentDesignator='#' )
+        headers = get_headers( filename, '\t', comment_designator='#' )
         try:
             """
             If we got here, we already know the file is_column_based and is not bed,
@@ -504,7 +504,7 @@ class Bed( Interval ):
         >>> Bed().sniff( fname )
         True
         """
-        headers = get_headers( filename, '\t', commentDesignator='#' )
+        headers = get_headers( filename, '\t', comment_designator='#' )
         try:
             if not headers:
                 return False

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -314,14 +314,14 @@ class Interval( Tabular ):
         >>> Interval().sniff( fname )
         True
         """
-        headers = get_headers( filename, '\t' )
+        headers = get_headers( filename, '\t', commentDesignator='#' )
         try:
             """
             If we got here, we already know the file is_column_based and is not bed,
             so we'll just look for some valid data.
             """
             for hdr in headers:
-                if hdr and not hdr[0].startswith( '#' ):
+                if hdr:
                     if len(hdr) < 3:
                         return False
                     try:
@@ -504,12 +504,12 @@ class Bed( Interval ):
         >>> Bed().sniff( fname )
         True
         """
-        headers = get_headers( filename, '\t' )
+        headers = get_headers( filename, '\t', commentDesignator='#' )
         try:
             if not headers:
                 return False
             for hdr in headers:
-                if (hdr[0] == '' or hdr[0].startswith( '#' )):
+                if (hdr[0] == ''):
                     continue
                 valid_col1 = False
                 if len(hdr) < 3 or len(hdr) > 12:

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -509,7 +509,7 @@ class Bed( Interval ):
             if not headers:
                 return False
             for hdr in headers:
-                if (hdr[0] == ''):
+                if hdr[0] == '':
                     continue
                 valid_col1 = False
                 if len(hdr) < 3 or len(hdr) > 12:

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -222,7 +222,7 @@ def get_headers( fname, sep, count=60, is_multi_byte=False, commentDesignator=No
                 sep = sep.encode( 'utf-8' )
                 if commentDesignator is not None:
                     commentDesignator = commentDesignator.encode( 'utf-8' )
-            if commentLine is not None and line.startswith( commentDesignator ):
+            if commentDesignator is not None and line.startswith( commentDesignator ):
                 continue
             headers.append( line.split(sep) )
             idx += 1

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -220,9 +220,9 @@ def get_headers( fname, sep, count=60, is_multi_byte=False, comment_designator=N
                 # TODO: fix this - sep is never found in line
                 line = unicodify( line, 'utf-8' )
                 sep = sep.encode( 'utf-8' )
-                if comment_designator is not None:
+                if comment_designator is not None and comment_designator != '':
                     comment_designator = comment_designator.encode( 'utf-8' )
-            if comment_designator is not None and line.startswith( comment_designator ):
+            if comment_designator is not None and comment_designator != '' and line.startswith( comment_designator ):
                 continue
             headers.append( line.split(sep) )
             idx += 1

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -198,16 +198,16 @@ def convert_newlines_sep2tabs( fname, in_place=True, patt="\\s+", tmp_dir=None, 
         return ( i + 1, temp_name )
 
 
-def get_headers( fname, sep, count=60, is_multi_byte=False, commentDesignator=None ):
+def get_headers( fname, sep, count=60, is_multi_byte=False, comment_designator=None ):
     """
     Returns a list with the first 'count' lines split by 'sep', ignoring lines
-    starting with 'commentDesignator'
+    starting with 'comment_designator'
 
     >>> fname = get_test_fname('complete.bed')
     >>> get_headers(fname,'\\t')
     [['chr7', '127475281', '127491632', 'NM_000230', '0', '+', '127486022', '127488767', '0', '3', '29,172,3225,', '0,10713,13126,'], ['chr7', '127486011', '127488900', 'D49487', '0', '+', '127486022', '127488767', '0', '2', '155,490,', '0,2399']]
     >>> fname = get_test_fname('test.gff')
-    >>> get_headers(fname, '\\t', count=5, commentDesignator='#')
+    >>> get_headers(fname, '\\t', count=5, comment_designator='#')
     [[''], ['chr7', 'bed2gff', 'AR', '26731313', '26731437', '.', '+', '.', 'score'], ['chr7', 'bed2gff', 'AR', '26731491', '26731536', '.', '+', '.', 'score'], ['chr7', 'bed2gff', 'AR', '26731541', '26731649', '.', '+', '.', 'score'], ['chr7', 'bed2gff', 'AR', '26731659', '26731841', '.', '+', '.', 'score']]
     """
     headers = []
@@ -220,9 +220,9 @@ def get_headers( fname, sep, count=60, is_multi_byte=False, commentDesignator=No
                 # TODO: fix this - sep is never found in line
                 line = unicodify( line, 'utf-8' )
                 sep = sep.encode( 'utf-8' )
-                if commentDesignator is not None:
-                    commentDesignator = commentDesignator.encode( 'utf-8' )
-            if commentDesignator is not None and line.startswith( commentDesignator ):
+                if comment_designator is not None:
+                    comment_designator = comment_designator.encode( 'utf-8' )
+            if comment_designator is not None and line.startswith( comment_designator ):
                 continue
             headers.append( line.split(sep) )
             idx += 1


### PR DESCRIPTION
This is related to #3148.

For some data types, sniffing is done after skipping comment lines. That's problematic in cases of files with many comment lines at the beginning, where false assignments can be done (as in #3148). This PR adds a `commentDesignator` option to `get_headers()`, which, if set, causes comment lines starting with the desired character/string to be skipped. This won't solve every issue related to this (e.g., possible confusion of GFF and VCF files if they don't have the file type indicated in the header), but it'll solve at least some of them.

As an aside, this causes the most recent dm6 GFF to sniff as GFF rather than BED :)