### PR TITLE
Add API repository uninstall endpoint

### DIFF
--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -827,10 +827,28 @@ def populate_api_routes( webapp, app ):
                            conditions=dict( method=[ "GET" ] ) )
 
     webapp.mapper.connect( 'install_repository',
+                           '/api/tool_shed_repositories',
+                           controller='tool_shed_repositories',
+                           action='install_repository_revision',
+                           conditions=dict( method=[ 'POST' ] ) )
+
+    webapp.mapper.connect( 'install_repository',
                            '/api/tool_shed_repositories/install',
                            controller='tool_shed_repositories',
                            action='install',
                            conditions=dict( method=[ 'POST' ] ) )
+
+    webapp.mapper.connect( 'tool_shed_repository',
+                           '/api/tool_shed_repositories',
+                           controller='tool_shed_repositories',
+                           action='uninstall_repository',
+                           conditions=dict( method=[ "DELETE" ]))
+
+    webapp.mapper.connect( 'tool_shed_repository',
+                           '/api/tool_shed_repositories/{id}',
+                           controller='tool_shed_repositories',
+                           action='uninstall_repository',
+                           conditions=dict( method=[ "DELETE" ]))
 
     # Galaxy API for tool shed features.
     webapp.mapper.resource( 'tool_shed_repository',

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -252,7 +252,7 @@ class AdminToolshed( AdminGalaxy ):
         for tool_shed_repository in tool_shed_repositories:
             if kwd.get( 'deactivate_or_uninstall_repository_button', False ):
                 errors = irm.uninstall_repository(repository=tool_shed_repository, remove_from_disk=remove_from_disk_checked)
-                action = 'removed' if remove_from_disk_checked else 'uninstalled'
+                action = 'uninstalled' if remove_from_disk_checked else 'deactivated'
                 status = max( status, statuses.index( 'done' ) )
                 message += 'The repository named <b>%s</b> has been %s.  ' % (escape( tool_shed_repository.name ), action)
                 if remove_from_disk_checked:

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -252,16 +252,13 @@ class AdminToolshed( AdminGalaxy ):
         for tool_shed_repository in tool_shed_repositories:
             if kwd.get( 'deactivate_or_uninstall_repository_button', False ):
                 errors = irm.uninstall_repository(repository=tool_shed_repository, remove_from_disk=remove_from_disk_checked)
+                action = 'removed' if remove_from_disk_checked else 'uninstalled'
+                status = max( status, statuses.index( 'done' ) )
+                message += 'The repository named <b>%s</b> has been %s.  ' % (escape( tool_shed_repository.name ), action)
                 if remove_from_disk_checked:
-                    message += 'The repository named <b>%s</b> has been uninstalled.  ' % escape( tool_shed_repository.name )
                     if errors:
                         message += 'Attempting to uninstall tool dependencies resulted in errors: %s' % errors
                         status = max( status, statuses.index( 'error' ) )
-                    else:
-                        status = max( status, statuses.index( 'done' ) )
-                else:
-                    message = 'The repository named <b>%s</b> has been deactivated.  ' % escape( tool_shed_repository.name )
-                    status = max( status, statuses.index( 'done' ) )
         status = statuses[ status ]
         if kwd.get( 'deactivate_or_uninstall_repository_button', False ):
             return trans.response.send_redirect( web.url_for( controller='admin_toolshed',

--- a/lib/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/installed_repository_manager.py
@@ -79,11 +79,11 @@ class InstalledRepositoryManager( object ):
 
     def activate_repository( self, repository ):
         """Activate an installed tool shed repository that has been marked as deactivated."""
-        repository_clone_url = common_util.generate_clone_url_for_installed_repository( self.app, repository )
         shed_tool_conf, tool_path, relative_install_dir = suc.get_tool_panel_config_tool_path_install_dir( self.app, repository )
         repository.deleted = False
         repository.status = self.install_model.ToolShedRepository.installation_status.INSTALLED
         if repository.includes_tools_for_display_in_tool_panel:
+            repository_clone_url = common_util.generate_clone_url_for_installed_repository( self.app, repository )
             tpm = tool_panel_manager.ToolPanelManager( self.app )
             irmm = InstalledRepositoryMetadataManager( app=self.app,
                                                        tpm=tpm,

--- a/lib/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/installed_repository_manager.py
@@ -4,6 +4,7 @@ Class encapsulating the management of repositories installed into Galaxy from th
 import copy
 import logging
 import os
+import shutil
 
 from sqlalchemy import and_, false, true
 
@@ -748,6 +749,75 @@ class InstalledRepositoryManager( object ):
                 cdl.load_installed_datatype_converters( installed_repository_dict, deactivate=deactivate )
             if installed_repository_dict[ 'display_path' ]:
                 cdl.load_installed_display_applications( installed_repository_dict, deactivate=deactivate )
+
+    def uninstall_repository(self, repository, remove_from_disk=True):
+        errors = ''
+        shed_tool_conf, tool_path, relative_install_dir = \
+            suc.get_tool_panel_config_tool_path_install_dir( app=self.app, repository=repository )
+        if relative_install_dir:
+            if tool_path:
+                relative_install_dir = os.path.join( tool_path, relative_install_dir )
+            repository_install_dir = os.path.abspath( relative_install_dir )
+        else:
+            repository_install_dir = None
+        if repository.includes_tools_for_display_in_tool_panel:
+            # Handle tool panel alterations.
+            tpm = tool_panel_manager.ToolPanelManager(app=self.app)
+            tpm.remove_repository_contents(repository,
+                                           shed_tool_conf,
+                                           uninstall=remove_from_disk)
+        if repository.includes_data_managers:
+            dmh = data_manager.DataManagerHandler(app=self.app)
+            dmh.remove_from_data_manager(repository)
+        if repository.includes_datatypes:
+            # Deactivate proprietary datatypes.
+            cdl = custom_datatype_manager.CustomDatatypeLoader(app=self.app)
+            installed_repository_dict = cdl.load_installed_datatypes( repository,
+                                                                      repository_install_dir,
+                                                                      deactivate=True )
+            if installed_repository_dict:
+                converter_path = installed_repository_dict.get( 'converter_path' )
+                if converter_path is not None:
+                    cdl.load_installed_datatype_converters( installed_repository_dict, deactivate=True )
+                display_path = installed_repository_dict.get( 'display_path' )
+                if display_path is not None:
+                    cdl.load_installed_display_applications( installed_repository_dict, deactivate=True )
+        if remove_from_disk:
+            try:
+                # Remove the repository from disk.
+                shutil.rmtree( repository_install_dir )
+                log.debug( "Removed repository installation directory: %s" % str( repository_install_dir ) )
+                removed = True
+            except Exception as e:
+                log.debug( "Error removing repository installation directory %s: %s" % ( str( repository_install_dir ), str( e ) ) )
+                if isinstance( e, OSError ) and not os.path.exists( repository_install_dir ):
+                    removed = True
+                    log.debug( "Repository directory does not exist on disk, marking as uninstalled." )
+                else:
+                    removed = False
+            if removed:
+                repository.uninstalled = True
+                # Remove all installed tool dependencies and tool dependencies stuck in the INSTALLING state, but don't touch any
+                # repository dependencies.
+                tool_dependencies_to_uninstall = repository.tool_dependencies_installed_or_in_error
+                tool_dependencies_to_uninstall.extend( repository.tool_dependencies_being_installed )
+                for tool_dependency in tool_dependencies_to_uninstall:
+                    uninstalled, error_message = tool_dependency_util.remove_tool_dependency( self.app, tool_dependency )
+                    if error_message:
+                        errors = '%s  %s' % ( errors, error_message )
+        repository.deleted = True
+        if remove_from_disk:
+            repository.status = self.app.install_model.ToolShedRepository.installation_status.UNINSTALLED
+            repository.error_message = None
+            if self.app.config.manage_dependency_relationships:
+                # Remove the uninstalled repository and any tool dependencies from the in-memory dictionaries in the
+                # installed_repository_manager.
+                self.handle_repository_uninstall( repository )
+        else:
+            repository.status = self.app.install_model.ToolShedRepository.installation_status.DEACTIVATED
+        self.app.install_model.context.current.add( repository )
+        self.app.install_model.context.current.flush()
+        return errors
 
     def purge_repository( self, repository ):
         """Purge a repository with status New (a white ghost) from the database."""

--- a/test/unit/shed_unit/test_installed_repository_manager.py
+++ b/test/unit/shed_unit/test_installed_repository_manager.py
@@ -1,0 +1,36 @@
+from tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager
+from tools.test_toolbox import BaseToolBoxTestCase
+
+
+class InstalledRepositoryManagerTestCase(BaseToolBoxTestCase):
+
+    def test_uninstall_repository(self):
+        repository = self._setup_repository()
+        assert repository.uninstalled is False
+        irm = InstalledRepositoryManager(self.app)
+        irm.uninstall_repository(repository=repository, remove_from_disk=True)
+        assert repository.uninstalled is True
+
+    def test_deactivate_repository(self):
+        self._deactivate_repository()
+
+    def test_activate_repository(self):
+        irm, repository = self._deactivate_repository()
+        irm.activate_repository(repository)
+        assert repository.status == self.app.install_model.ToolShedRepository.installation_status.INSTALLED
+
+    def _deactivate_repository(self):
+        repository = self._setup_repository()
+        assert repository.uninstalled is False
+        irm = InstalledRepositoryManager(self.app)
+        irm.uninstall_repository(repository=repository, remove_from_disk=False)
+        assert repository.uninstalled is False
+        assert repository.status == self.app.install_model.ToolShedRepository.installation_status.DEACTIVATED
+        return irm, repository
+
+    def _setup_repository(self):
+        self._init_dynamic_tool_conf()
+        self.app.config.tool_configs = self.config_files
+        self.app.config.manage_dependency_relationships = False
+        self.app.toolbox = self.toolbox
+        return self._repo_install(changeset='1', config_filename=self.config_files[0])

--- a/test/unit/shed_unit/test_tool_panel_manager.py
+++ b/test/unit/shed_unit/test_tool_panel_manager.py
@@ -188,10 +188,6 @@ class ToolPanelManagerTestCase( BaseToolBoxTestCase ):
             message = message_template % ( filename, open( filename, "r" ).read() )
             raise AssertionError( message )
 
-    def _init_dynamic_tool_conf( self ):
-        # Add a dynamic tool conf (such as a ToolShed managed one) to list of configs.
-        self._add_config( """<toolbox tool_path="%s"></toolbox>""" % self.test_directory )
-
     def _init_ts_tool( self, guid=DEFAULT_GUID, **kwds ):
         tool = self._init_tool( **kwds )
         tool.guid = guid

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -68,8 +68,11 @@ class BaseToolBoxTestCase(  unittest.TestCase, tools_support.UsesApp, tools_supp
         self.__toolbox = None
         self.config_files = []
 
-    def _repo_install( self, changeset ):
-        repository = tool_shed_install.ToolShedRepository()
+    def _repo_install( self, changeset, config_filename=None ):
+        metadata = {}
+        if config_filename:
+            metadata['shed_config_filename'] = config_filename
+        repository = tool_shed_install.ToolShedRepository(metadata=metadata)
         repository.tool_shed = "github.com"
         repository.owner = "galaxyproject"
         repository.name = "example"
@@ -136,6 +139,10 @@ class BaseToolBoxTestCase(  unittest.TestCase, tools_support.UsesApp, tools_supp
             else:
                 json.dump(content, f)
         self.config_files.append( path )
+
+    def _init_dynamic_tool_conf( self ):
+        # Add a dynamic tool conf (such as a ToolShed managed one) to list of configs.
+        self._add_config( """<toolbox tool_path="%s"></toolbox>""" % self.test_directory )
 
     def _tool_conf_path( self, name="tool_conf.xml" ):
         path = os.path.join( self.test_directory, name )


### PR DESCRIPTION
- 58a2cde Refactors deactivate_or_uninstall_repository  - Move code that deals with repository uninstallation into InstalledRepositoryManager, so that this can be reused by the API.
- 67c6686 Adds a new API endpoint to uninstall or deactivate a repository
- 6a8f15ba Adds a basic unittest for the core InstalledRepositoryManager functionality