### PR TITLE
refactors tag manager to use only what it needs…

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -84,7 +84,7 @@ class UniverseApplication( object, config.ConfiguresGalaxyMixin ):
         # Security helper
         self._configure_security()
         # Tag handler
-        self.tag_handler = GalaxyTagManager( self )
+        self.tag_handler = GalaxyTagManager( self.model.context )
         # Dataset Collection Plugins
         self.dataset_collections_service = DatasetCollectionManager(self)
 

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -36,7 +36,7 @@ class DatasetCollectionManager( object ):
 
         self.hda_manager = hdas.HDAManager( app )
         self.history_manager = histories.HistoryManager( app )
-        self.tag_manager = tags.GalaxyTagManager( app )
+        self.tag_manager = tags.GalaxyTagManager( app.model.context )
         self.ldda_manager = lddas.LDDAManager( app )
 
     def create( self, trans, parent, name, collection_type, element_identifiers=None,

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -85,8 +85,9 @@ class TagManager( object ):
         return community_tags
 
     def get_tool_tags( self ):
-        result_set = self.sa_session.execute( select( columns=[ galaxy.model.ToolTagAssociation.table.c.tag_id ],
-                                                             from_obj=galaxy.model.ToolTagAssociation.table ).distinct() )
+        query = select( columns=[ galaxy.model.ToolTagAssociation.table.c.tag_id ],
+                        from_obj=galaxy.model.ToolTagAssociation.table ).distinct()
+        result_set = self.sa_session.execute( query )
 
         tags = []
         for row in result_set:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2910,6 +2910,7 @@ class LibraryDatasetDatasetAssociation( DatasetInstance, HasName ):
         self.user = user
 
     def to_history_dataset_association( self, target_history, parent_id=None, add_to_history=False ):
+        sa_session = object_session( self )
         hda = HistoryDatasetAssociation( name=self.name,
                                          info=self.info,
                                          blurb=self.blurb,
@@ -2923,8 +2924,8 @@ class LibraryDatasetDatasetAssociation( DatasetInstance, HasName ):
                                          parent_id=parent_id,
                                          copied_from_library_dataset_dataset_association=self,
                                          history=target_history )
-        object_session( self ).add( hda )
-        object_session( self ).flush()
+        sa_session.add( hda )
+        sa_session.flush()
         hda.metadata = self.metadata  # need to set after flushed, as MetadataFiles require dataset.id
         if add_to_history and target_history:
             target_history.add_dataset( hda )
@@ -2932,10 +2933,11 @@ class LibraryDatasetDatasetAssociation( DatasetInstance, HasName ):
             child.to_history_dataset_association( target_history=target_history, parent_id=hda.id, add_to_history=False )
         if not self.datatype.copy_safe_peek:
             hda.set_peek()  # in some instances peek relies on dataset_id, i.e. gmaj.zip for viewing MAFs
-        object_session( self ).flush()
+        sa_session.flush()
         return hda
 
     def copy( self, copy_children=False, parent_id=None, target_folder=None ):
+        sa_session = object_session( self )
         ldda = LibraryDatasetDatasetAssociation( name=self.name,
                                                  info=self.info,
                                                  blurb=self.blurb,
@@ -2949,8 +2951,8 @@ class LibraryDatasetDatasetAssociation( DatasetInstance, HasName ):
                                                  parent_id=parent_id,
                                                  copied_from_library_dataset_dataset_association=self,
                                                  folder=target_folder )
-        object_session( self ).add( ldda )
-        object_session( self ).flush()
+        sa_session.add( ldda )
+        sa_session.flush()
         # Need to set after flushed, as MetadataFiles require dataset.id
         ldda.metadata = self.metadata
         if copy_children:
@@ -2959,7 +2961,7 @@ class LibraryDatasetDatasetAssociation( DatasetInstance, HasName ):
         if not self.datatype.copy_safe_peek:
             # In some instances peek relies on dataset_id, i.e. gmaj.zip for viewing MAFs
             ldda.set_peek()
-        object_session( self ).flush()
+        sa_session.flush()
         return ldda
 
     def clear_associated_files( self, metadata_safe=False, purge=False ):

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -2165,7 +2165,7 @@ class UsesTagsMixin( SharableItemSecurityMixin ):
 
     def set_tags_from_list( self, trans, item, new_tags_list, user=None ):
         # Method deprecated - try to use TagsHandler instead.
-        tags_manager = tags.GalaxyTagManager( trans.app )
+        tags_manager = tags.GalaxyTagManager( trans.app.model.context )
         return tags_manager.set_tags_from_list( user, item, new_tags_list )
 
     def get_user_tags_used( self, trans, user=None ):

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -143,7 +143,7 @@ class InstallToolDependencyManager( object ):
         """
         attr_tups_of_dependencies_for_install = [ ( td.name, td.version, td.type ) for td in tool_dependencies ]
         installed_packages = []
-        tag_manager = TagManager( self.app )
+        tag_manager = TagManager( self.app.model.context )
         # Parse the tool_dependencies.xml config.
         tree, error_message = xml_util.parse_xml( tool_dependencies_config )
         if tree is None:
@@ -277,7 +277,7 @@ class InstallToolDependencyManager( object ):
         Install a tool dependency package defined by the XML element elem.  The value of tool_dependencies is
         a partial or full list of ToolDependency records associated with the tool_shed_repository.
         """
-        tag_manager = TagManager( self.app )
+        tag_manager = TagManager( self.app.model.context )
         # The value of package_name should match the value of the "package" type in the tool config's
         # <requirements> tag set, but it's not required.
         package_name = elem.get( 'name', None )

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -143,7 +143,7 @@ class InstallToolDependencyManager( object ):
         """
         attr_tups_of_dependencies_for_install = [ ( td.name, td.version, td.type ) for td in tool_dependencies ]
         installed_packages = []
-        tag_manager = TagManager( self.app.model.context )
+        tag_manager = TagManager( self.app )
         # Parse the tool_dependencies.xml config.
         tree, error_message = xml_util.parse_xml( tool_dependencies_config )
         if tree is None:
@@ -277,7 +277,7 @@ class InstallToolDependencyManager( object ):
         Install a tool dependency package defined by the XML element elem.  The value of tool_dependencies is
         a partial or full list of ToolDependency records associated with the tool_shed_repository.
         """
-        tag_manager = TagManager( self.app.model.context )
+        tag_manager = TagManager( self.app )
         # The value of package_name should match the value of the "package" type in the tool config's
         # <requirements> tag set, but it's not required.
         package_name = elem.get( 'name', None )

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -60,7 +60,7 @@ class MockApp( object ):
         self.model = mapping.init( "/tmp", "sqlite:///:memory:", create_tables=True, object_store=self.object_store )
         self.security_agent = self.model.security_agent
         self.visualizations_registry = MockVisualizationsRegistry()
-        self.tag_handler = tags.GalaxyTagManager( self )
+        self.tag_handler = tags.GalaxyTagManager( self.model.context )
         self.quota_agent = quota.QuotaAgent( self.model )
         self.init_datatypes()
 


### PR DESCRIPTION
an sql_alchemy session, not the full app.
This makes it possible to use the tag manager from
the model.
