### PR TITLE
Importing old exported histories failing

### DIFF
--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -71,14 +71,16 @@ class JobImportHistoryArchiveWrapper( object, UsesAnnotations ):
                 archive_dir = jiha.archive_dir
                 user = jiha.job.user
 
+                # Bioblend previous to 17.01 exported histories with an extra subdir.
+                if not os.path.exists( os.path.join( archive_dir, 'history_attrs.txt' ) ):
+                    for d in os.listdir( archive_dir ):
+                        if os.path.isdir( os.path.join( archive_dir, d ) ):
+                            archive_dir = os.path.join( archive_dir, d )
+                            break
+
                 #
                 # Create history.
                 #
-                if not os.path.exists(os.path.join( archive_dir, 'history_attrs.txt')):
-                    for d in os.listdir(archive_dir):
-                        if os.path.isdir(os.path.join(archive_dir, d)):
-                            archive_dir = os.path.join(archive_dir, d)
-                            break
                 history_attr_file_name = os.path.join( archive_dir, 'history_attrs.txt')
                 history_attr_str = read_file_contents( history_attr_file_name )
                 history_attrs = loads( history_attr_str )

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -74,6 +74,11 @@ class JobImportHistoryArchiveWrapper( object, UsesAnnotations ):
                 #
                 # Create history.
                 #
+                if not os.path.exists(os.path.join( archive_dir, 'history_attrs.txt')):
+                    dirs = os.listdir(archive_dir)
+                    for d in dirs:
+                        if os.path.isdir(os.path.join(archive_dir, d)):
+                                archive_dir = os.path.join(archive_dir, d)
                 history_attr_file_name = os.path.join( archive_dir, 'history_attrs.txt')
                 history_attr_str = read_file_contents( history_attr_file_name )
                 history_attrs = loads( history_attr_str )

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -75,10 +75,10 @@ class JobImportHistoryArchiveWrapper( object, UsesAnnotations ):
                 # Create history.
                 #
                 if not os.path.exists(os.path.join( archive_dir, 'history_attrs.txt')):
-                    dirs = os.listdir(archive_dir)
-                    for d in dirs:
+                    for d in os.listdir(archive_dir):
                         if os.path.isdir(os.path.join(archive_dir, d)):
-                                archive_dir = os.path.join(archive_dir, d)
+                            archive_dir = os.path.join(archive_dir, d)
+                            break
                 history_attr_file_name = os.path.join( archive_dir, 'history_attrs.txt')
                 history_attr_str = read_file_contents( history_attr_file_name )
                 history_attrs = loads( history_attr_str )


### PR DESCRIPTION
I have exported histories on older versions of galaxy (<17.01) in order to keep them as backup. I can not import them anymore in newer version.

While exporting histories on older versions of galaxy (using the bioblend API) there was a subdirectory created at the base of the archive (Galaxy-History-<name-of-history>). This is not the format expected by the import history tool which expects all the data to be found on the base of the archive and the datasets in a 'datasets' subdirectory. This produces a 'history_attrs.txt' file not found error and the import fails.

The workaround implemented is to check for the existence of 'history_attrs.txt' on the base of the archive and if not found check for the existence in the subdirectory of the archive.

Cheers,
Cristian