### PR TITLE
Added python-ldap by default

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -72,3 +72,6 @@ pysam==0.8.4+gx5
 
 # Chronos client
 chronos-python==0.38.0
+
+#LDAP authentication
+python-ldap==2.4.27


### PR DESCRIPTION
Useful for LDAP authentication. Users only have to install an auth.conf.xml file now to enable the LDAP authentication, no need anymore to manually install this dependency.