### PR TITLE
Uniform titles

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/library.py
+++ b/lib/galaxy/webapps/galaxy/controllers/library.py
@@ -87,7 +87,7 @@ class Library( BaseUIController ):
         }
         return trans.fill_template( 'galaxy.panels.mako',
                                     config={
-                                        'title': 'Galaxy Data Libraries',
+                                        'title': 'Data Libraries',
                                         'app': app } )
 
     @web.expose

--- a/templates/base.mako
+++ b/templates/base.mako
@@ -13,7 +13,13 @@
         ## Force IE to standards mode, and prefer Google Chrome Frame if the user has already installed it
         <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 
-        <title>${self.title()}</title>
+        <title>
+            Galaxy
+            %if app.config.brand:
+            | ${app.config.brand}
+            %endif
+            | ${self.title()}
+        </title>
         ## relative href for site root
         <link rel="index" href="${ h.url_for( '/' ) }"/>
         ${self.metas()}

--- a/templates/base/base_panels.mako
+++ b/templates/base/base_panels.mako
@@ -166,11 +166,13 @@
         ## Force IE to standards mode, and prefer Google Chrome Frame if the user has already installed it
         <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 
-        %if app.config.brand:
-            <title>${self.title()} / ${app.config.brand}</title>
-        %else:
-            <title>${self.title()}</title>
-        %endif
+        <title>
+            Galaxy
+            %if app.config.brand:
+            | ${app.config.brand}
+            %endif
+            | ${self.title()}
+        </title>
         ## relative href for site root
         <link rel="index" href="${ h.url_for( '/' ) }"/>
         ${self.stylesheets()}

--- a/templates/display_base.mako
+++ b/templates/display_base.mako
@@ -17,7 +17,7 @@
 ##
 
 <%def name="title()">
-    Galaxy | ${iff( item.published, "Published ", iff( item.importable , "Accessible ", iff( item.users_shared_with, "Shared ", "Private " ) ) ) + get_class_display_name( item.__class__ )} | ${get_item_name( item ) | h}
+    ${iff( item.published, "Published ", iff( item.importable , "Accessible ", iff( item.users_shared_with, "Shared ", "Private " ) ) ) + get_class_display_name( item.__class__ )} | ${get_item_name( item ) | h}
 </%def>
 
 <%def name="init()">

--- a/templates/js-app.mako
+++ b/templates/js-app.mako
@@ -9,7 +9,13 @@
         ## Force IE to standards mode, and prefer Google Chrome Frame if the user has already installed it
         <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 
-        <title>Galaxy</title>
+        <title>
+            Galaxy
+            %if app.config.brand:
+            | ${app.config.brand}
+            %endif
+            | ${self.title()}
+        </title>
         ## relative href for site root
         <link rel="index" href="${ h.url_for( '/' ) }"/>
         ## TODO: use loaders to move everything but the essentials below the fold

--- a/templates/js-app.mako
+++ b/templates/js-app.mako
@@ -14,7 +14,6 @@
             %if app.config.brand:
             | ${app.config.brand}
             %endif
-            | ${self.title()}
         </title>
         ## relative href for site root
         <link rel="index" href="${ h.url_for( '/' ) }"/>

--- a/templates/user/logout.mako
+++ b/templates/user/logout.mako
@@ -32,7 +32,7 @@ def inherit(context):
     </style>
 </%def>
 
-<%def name="title()">Galaxy :: Logout</%def>
+<%def name="title()">Logout</%def>
 
 <%def name="center_panel()">
     ${self.body()}

--- a/templates/webapps/galaxy/admin/center.mako
+++ b/templates/webapps/galaxy/admin/center.mako
@@ -1,7 +1,7 @@
 <%inherit file="/base.mako"/>
 <%namespace file="/message.mako" import="render_msg" />
 
-<%def name="title()">Galaxy Administration</%def>
+<%def name="title()">Administration</%def>
 
 <h2>Administration</h2>
 Please visit <a href="https://galaxyproject.org/admin" target="_blank">the Galaxy administration hub</a> to learn how to keep your Galaxy in best shape.

--- a/templates/webapps/galaxy/base_panels.mako
+++ b/templates/webapps/galaxy/base_panels.mako
@@ -3,7 +3,7 @@
 <%namespace name="mod_masthead" file="/webapps/galaxy/galaxy.masthead.mako"/>
 
 ## Default title
-<%def name="title()">Galaxy</%def>
+<%def name="title()"></%def>
 
 <%def name="javascripts()">
 ${parent.javascripts()}

--- a/templates/webapps/galaxy/dataset/display.mako
+++ b/templates/webapps/galaxy/dataset/display.mako
@@ -44,7 +44,7 @@
 </%def>
 
 <%def name="title()">
-    Galaxy | ${get_class_display_name( item.__class__ )} | ${get_item_name( item ) | h}
+    ${get_class_display_name( item.__class__ )} | ${get_item_name( item ) | h}
 </%def>
 
 <%def name="render_item_links( data )">

--- a/templates/webapps/galaxy/dataset/errors.mako
+++ b/templates/webapps/galaxy/dataset/errors.mako
@@ -1,7 +1,13 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
     <head>
-        <title>Dataset generation errors</title>
+        <title>
+            Galaxy
+            %if app.config.brand:
+            | ${app.config.brand}
+            %endif
+            | Dataset generation errors
+        </title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link href="/static/style/base.css" rel="stylesheet" type="text/css" />
         <style>

--- a/templates/webapps/galaxy/galaxy.panels.mako
+++ b/templates/webapps/galaxy/galaxy.panels.mako
@@ -159,9 +159,13 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge,chrome=1">
 
         <title>
-        %if self.galaxy_config['title']:
-            ${self.galaxy_config['title']}
-        %endif
+            Galaxy
+            %if app.config.brand:
+            | ${app.config.brand}
+            %endif
+            %if self.galaxy_config['title']:
+            | ${self.galaxy_config['title']}
+            %endif
         </title>
 
         ${self.stylesheets()}

--- a/templates/webapps/galaxy/history/list_published.mako
+++ b/templates/webapps/galaxy/history/list_published.mako
@@ -10,7 +10,7 @@
 </%def>
 
 <%def name="title()">
-    Galaxy | Published Histories
+    Published Histories
 </%def>
 
 <%def name="stylesheets()">

--- a/templates/webapps/galaxy/mobile/form.mako
+++ b/templates/webapps/galaxy/mobile/form.mako
@@ -3,7 +3,13 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <title>${form.title}</title>
+  <title>
+    Galaxy
+    %if app.config.brand:
+    | ${app.config.brand}
+    %endif
+    ${form.title}
+  </title>
   <meta name="viewport" content="width=devicewidth; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;"/>
   <link rel="apple-touch-icon" href="${h.url_for('/static/iui/iui-logo-touch-icon.png')}" />
   <meta name="apple-touch-fullscreen" content="YES" />

--- a/templates/webapps/galaxy/mobile/index.mako
+++ b/templates/webapps/galaxy/mobile/index.mako
@@ -2,7 +2,12 @@
          "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-    <title>Galaxy</title>
+    <title>
+        Galaxy
+        %if app.config.brand:
+        | ${app.config.brand}
+        %endif
+    </title>
     
     <style>
     li > a > div {

--- a/templates/webapps/galaxy/root/tool_runner.mako
+++ b/templates/webapps/galaxy/root/tool_runner.mako
@@ -1,7 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
     <head>
-        <title>Galaxy</title>
+        <title>
+            Galaxy
+            %if app.config.brand:
+            | ${app.config.brand}
+            %endif
+        </title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link href="${h.url_for('/static/style/base.css')}" rel="stylesheet" type="text/css" />
         <script type="text/javascript">

--- a/templates/webapps/reports/base_panels.mako
+++ b/templates/webapps/reports/base_panels.mako
@@ -7,7 +7,7 @@
 
 
 ## Default title
-<%def name="title()">Galaxy Reports</%def>
+<%def name="title()">Reports</%def>
 
 ## Masthead
 <%def name="masthead()">

--- a/templates/webapps/tool_shed/admin/center.mako
+++ b/templates/webapps/tool_shed/admin/center.mako
@@ -2,7 +2,7 @@
 <%namespace file="/message.mako" import="render_msg" />
 
 
-<%def name="title()">Galaxy Administration</%def>
+<%def name="title()">Administration</%def>
 
 %if message:
     ${render_msg( message, status )}

--- a/templates/webapps/tool_shed/base_panels.mako
+++ b/templates/webapps/tool_shed/base_panels.mako
@@ -1,7 +1,7 @@
 <%inherit file="/base/base_panels.mako"/>
 
 ## Default title
-<%def name="title()">Galaxy Tool Shed</%def>
+<%def name="title()">Tool Shed</%def>
 
 <%def name="javascripts()">
     ${parent.javascripts()}

--- a/templates/webapps/tool_shed/repository/tool_form.mako
+++ b/templates/webapps/tool_shed/repository/tool_form.mako
@@ -11,7 +11,13 @@
 
 <html>
     <head>
-        <title>Galaxy tool preview</title>
+        <title>
+            Galaxy
+            %if app.config.brand:
+            | ${app.config.brand}
+            %endif
+            | Tool Preview
+        </title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         ${h.css( "base" )}
     </head>


### PR DESCRIPTION
Found myself mildly annoyed by the inability to get to the home page based on title search, so this fixes that by including the app brand in a more uniform manner.

![utvalg_014](https://user-images.githubusercontent.com/458683/27767559-8810c146-5eea-11e7-8fe2-aedb7668678b.png)
