### PR TITLE
Expose more user properties to admins via the API.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -152,9 +152,9 @@ class User( object, Dictifiable ):
     histories, credentials, and roles.
     """
     # attributes that will be accessed and returned when calling to_dict( view='collection' )
-    dict_collection_visible_keys = ( 'id', 'email', 'username', 'deleted', 'purged', 'active', 'last_password_change' )
+    dict_collection_visible_keys = ( 'id', 'email', 'username', 'deleted', 'active', 'last_password_change' )
     # attributes that will be accessed and returned when calling to_dict( view='element' )
-    dict_element_visible_keys = ( 'id', 'email', 'username', 'total_disk_usage', 'nice_total_disk_usage' )
+    dict_element_visible_keys = ( 'id', 'email', 'username', 'total_disk_usage', 'nice_total_disk_usage', 'deleted', 'active', 'last_password_change' )
 
     def __init__( self, email=None, password=None ):
         self.email = email

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -152,7 +152,7 @@ class User( object, Dictifiable ):
     histories, credentials, and roles.
     """
     # attributes that will be accessed and returned when calling to_dict( view='collection' )
-    dict_collection_visible_keys = ( 'id', 'email', 'username' )
+    dict_collection_visible_keys = ( 'id', 'email', 'username', 'deleted', 'purged', 'active', 'last_password_change' )
     # attributes that will be accessed and returned when calling to_dict( view='element' )
     dict_element_visible_keys = ( 'id', 'email', 'username', 'total_disk_usage', 'nice_total_disk_usage' )
 

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -113,10 +113,18 @@ class UserAPIController( BaseAPIController, UsesTagsMixin, CreatesUsersMixin, Cr
             item = user.to_dict( value_mapper={ 'id': trans.security.encode_id } )
             # If NOT configured to expose_email, do not expose email UNLESS the user is self, or
             # the user is an admin
-            if not trans.app.config.expose_user_name and user is not trans.user and not trans.user_is_admin():
-                del item['username']
-            if not trans.app.config.expose_user_email and user is not trans.user and not trans.user_is_admin():
-                del item['email']
+            if user is not trans.user and not trans.user_is_admin():
+                expose_keys = ["id"]
+                if trans.app.config.expose_user_name:
+                    expose_keys.append("username")
+                if trans.app.config.expose_user_email:
+                    expose_keys.append("email")
+                new_item = {}
+                for key, value in item.items():
+                    if key in expose_keys:
+                        new_item[key] = value
+                item = new_item
+
             # TODO: move into api_values
             rval.append( item )
         return rval

--- a/test/integration/test_config_options_users.py
+++ b/test/integration/test_config_options_users.py
@@ -1,0 +1,58 @@
+"""Integration tests for user config options."""
+
+from base import integration_util
+
+
+class _BaseUserExposeIntegerationTestCase(integration_util.IntegrationTestCase):
+
+    def original_user_ids(self):
+        return [u["id"] for u in self.galaxy_interactor.get("users").json()]
+
+    def new_users(self, original_ids):
+        users = [u for u in self.galaxy_interactor.get("users").json() if u["id"] not in original_ids]
+        return users
+
+
+class DefaultUserExposeIntegrationTestCase(_BaseUserExposeIntegerationTestCase):
+
+    def test_defaults(self):
+        original_user_ids = self.original_user_ids()
+        self.galaxy_interactor.ensure_user_with_email("defaultuserexposetest@galaxyproject.org")
+        new_users = self.new_users(original_user_ids)
+        # If expose username or expose email isn't enabled - user indexing is
+        # empty by default for non-admin users.
+        assert len(new_users) == 0
+
+
+class EmailUserExposeIntegrationTestCase(_BaseUserExposeIntegerationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["expose_user_email"] = True
+
+    def test_only_email_exposed(self):
+        original_user_ids = self.original_user_ids()
+        self.galaxy_interactor.ensure_user_with_email("emailuserexposetest@galaxyproject.org")
+        new_users = self.new_users(original_user_ids)
+        assert len(new_users) > 0
+        user = new_users[0]
+        assert "email" in user
+        assert "username" not in user
+        assert "last_password_change" not in user
+
+
+class UsernameUserExposeIntegrationTestCase(_BaseUserExposeIntegerationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["expose_user_name"] = True
+
+    def test_only_username_exposed(self):
+        original_user_ids = self.original_user_ids()
+        self.galaxy_interactor.ensure_user_with_email("usernameuserexposetest@galaxyproject.org")
+        new_users = self.new_users(original_user_ids)
+        assert len(new_users) > 0
+        user = new_users[0]
+        assert "email" not in user
+        assert "username" in user
+        assert "last_password_change" not in user


### PR DESCRIPTION
This is an extension of #4255 - merging this PR will merge that one. See that PR for details.

This PR extends it to include a test case regarding what we are exposing via the API for non-admin users and it tweaks the users API endpoint to not expose the new attributes in #4255 to non-admin users.