### PR TITLE
Fix problem in collection download tests related to ID references.

### DIFF
--- a/test/api/test_dataset_collections.py
+++ b/test/api/test_dataset_collections.py
@@ -97,8 +97,9 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
 
     def test_list_download(self):
         dataset_collection = self.dataset_collection_populator.create_list_in_history(self.history_id).json()
-        returned_datasets = dataset_collection["elements"]
-        assert len(returned_datasets) == 3, dataset_collection
+        returned_dce = dataset_collection["elements"]
+        assert len(returned_dce) == 3, dataset_collection
+        returned_datasets = [dce["object"] for dce in returned_dce]
         for element in returned_datasets:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
@@ -107,12 +108,14 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         namelist = tar_contents.getnames()
         assert len(namelist) == 3, "Expected 3 elements in [%s]" % namelist
         collection_name = dataset_collection['name']
-        for element, zip_path in zip(returned_datasets, namelist):
+        for element, zip_path in zip(returned_dce, namelist):
             assert "%s/%s.%s" % (collection_name, element['element_identifier'], element['object']['file_ext']) == zip_path
 
     def test_pair_download(self):
         dataset_collection = self.dataset_collection_populator.create_pair_in_history(self.history_id).json()
-        returned_datasets = dataset_collection["elements"]
+        returned_dce = dataset_collection["elements"]
+        assert len(returned_dce) == 2, dataset_collection
+        returned_datasets = [dce["object"] for dce in returned_dce]
         for element in returned_datasets:
             self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
         hdca_id = dataset_collection['id']
@@ -122,17 +125,17 @@ class DatasetCollectionApiTestCase( api.ApiTestCase ):
         namelist = tar_contents.getnames()
         assert len(namelist) == 2, "Expected 2 elements in [%s]" % namelist
         collection_name = dataset_collection['name']
-        for element, zip_path in zip(returned_datasets, namelist):
+        for element, zip_path in zip(returned_dce, namelist):
             assert "%s/%s.%s" % (collection_name, element['element_identifier'], element['object']['file_ext']) == zip_path
 
     def test_list_pair_download(self):
         dataset_collection = self.dataset_collection_populator.create_list_of_pairs_in_history(self.history_id).json()
-        returned_datasets = dataset_collection["elements"]
-        assert len(returned_datasets) == 1, dataset_collection
+        returned_dce = dataset_collection["elements"]
+        assert len(returned_dce) == 1, dataset_collection
         list_collection_name = dataset_collection['name']
-        pair = returned_datasets[0]
+        pair = returned_dce[0]
         for element in pair['object']['elements']:
-            self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element['id'], assert_ok=True)
+            self.dataset_populator.wait_for_dataset(history_id=self.history_id, dataset_id=element["object"]['id'], assert_ok=True)
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
         self._assert_status_code_is(create_response, 200)
         tar_contents = tarfile.open(fileobj=StringIO(create_response.content))


### PR DESCRIPTION
DatasetsCollectionElement ids were being confused with HDA ids.