### PR TITLE
Include collections in items searched by tag

### DIFF
--- a/client/galaxy/scripts/mvc/collection/collection-model.js
+++ b/client/galaxy/scripts/mvc/collection/collection-model.js
@@ -285,7 +285,7 @@ var DatasetCollection = Backbone.Model
     // ........................................................................ searchable
     /** searchable attributes for collections */
     searchAttributes : [
-        'name'
+        'name', 'tags'
     ],
 
     // ........................................................................ misc


### PR DESCRIPTION
This is a fix for #4243, which simply adds tags as an attribute of dataset collections that is searched.