### PR TITLE
Return empty tool_version when tool is not loaded into tool panel

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1831,7 +1831,7 @@ class Tool( object, Dictifiable ):
             tool_help = unicodify( tool_help, 'utf-8' )
 
         # create tool versions
-        tool_versions = self.lineage.tool_versions
+        tool_versions = self.lineage.tool_versions if self.lineage else []  # lineage may be `None` if tool is not loaded into tool panel
 
         # update tool model
         tool_model.update({


### PR DESCRIPTION
This is necessary for displaying workflows that reference tools that are not installed.
Reported by @guerler in https://github.com/galaxyproject/galaxy/pull/4119#issuecomment-313370231
This is effectively how missing tool_versions would be handled in 17.05.