### PR TITLE
Fix TypeError when uploading large files from ftp to s3

### DIFF
--- a/lib/galaxy/objectstore/s3_multipart_upload.py
+++ b/lib/galaxy/objectstore/s3_multipart_upload.py
@@ -23,8 +23,8 @@ except ImportError:
 
 def map_wrap(f):
     @functools.wraps(f)
-    def wrapper(*args, **kwargs):
-        return f(*args, **kwargs)
+    def wrapper(args):
+        return f(*args)
     return wrapper
 
 


### PR DESCRIPTION
This PR fixed TypeError during multipart upload to s3.

Here are steps to reproduce the issue:

1. Setup `config/object_store_conf.xml` to use s3 bucket as file storage.
2. Upload large file by sftp.
3. Click Get Data->Upload File->Choose FTP file, then click start to upload file.
4. Failed to upload file. Got this error:

```
Traceback (most recent call last):
  File "/galaxy-central/lib/galaxy/jobs/runners/__init__.py", line 630, in finish_job
    job_state.job_wrapper.finish( stdout, stderr, exit_code )
  File "/galaxy-central/lib/galaxy/jobs/__init__.py", line 1232, in finish
    self.app.object_store.update_from_file(dataset.dataset, create=True)
  File "/galaxy-central/lib/galaxy/objectstore/__init__.py", line 502, in update_from_file
    return self._call_method('update_from_file', obj, ObjectNotFound, True, **kwargs)
  File "/galaxy-central/lib/galaxy/objectstore/__init__.py", line 513, in _call_method
    return store.__getattribute__(method)(obj, **kwargs)
  File "/galaxy-central/lib/galaxy/objectstore/s3.py", line 604, in update_from_file
    self._push_to_os(rel_path, source_file)
  File "/galaxy-central/lib/galaxy/objectstore/s3.py", line 384, in _push_to_os
    multipart_upload(self.s3server, self.bucket, key.name, source_file, mb_size)
  File "/galaxy-central/lib/galaxy/objectstore/s3_multipart_upload.py", line 95, in multipart_upload
    for _ in pmap(transfer_part, ((s3server, mp.id, mp.key_name, mp.bucket_name, i, part) for (i, part) in enumerate(split_file(tarball, mb_size, cores)))):
  File "/galaxy-central/lib/galaxy/objectstore/s3_multipart_upload.py", line 112, in wrap
    return func(self, timeout=timeout if timeout is not None else 1e100)
  File "/galaxy-central/lib/galaxy/objectstore/s3_multipart_upload.py", line 112, in wrap
    return func(self, timeout=timeout if timeout is not None else 1e100)
  File "/galaxy-central/lib/galaxy/objectstore/s3_multipart_upload.py", line 112, in wrap
    return func(self, timeout=timeout if timeout is not None else 1e100)
  File "/galaxy-central/lib/galaxy/objectstore/s3_multipart_upload.py", line 112, in wrap
    return func(self, timeout=timeout if timeout is not None else 1e100)
  File "/galaxy-central/lib/galaxy/objectstore/s3_multipart_upload.py", line 112, in wrap
    return func(self, timeout=timeout if timeout is not None else 1e100)
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 659, in next
    raise value
TypeError: transfer_part() takes exactly 6 arguments (1 given)
```
