### PR TITLE
Prefer local npm and fix `client` README.

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,8 +1,9 @@
 Client Build System
 ===================
 
-Builds and moves the client-side scripts necessary for running the Galaxy webapps. There's no need to use this system
-unless you are modifying or developing client-side scripts.
+Builds and moves the client-side scripts necessary for running the Galaxy
+webapps. There's no need to use this system unless you are modifying or
+developing client-side scripts.
 
 The base dependencies you'll need are Node.js and the Node Package Manager
 (npm).  See nodejs.org for more information.
@@ -21,11 +22,8 @@ root.  This will also ensure any local node modules are installed.
 Detailed Build Instructions
 ===========================
 
-Once npm is installed, install the grunt task manager and its command line into your global scope:
-
-    npm install -g grunt grunt-cli
-
-Next, from within this directory, install the local build dependencies:
+Once npm is installed, use it to install the local build dependencies in the
+`client` directory:
 
     cd client
     npm install
@@ -36,11 +34,13 @@ You're now ready to re-build the client scripts after modifying them.
 Rebuilding
 ==========
 
-There are two methods for rebuilding: a complete rebuild and automatic, partial rebuilds while you develop.
+There are two methods for rebuilding: a complete rebuild and automatic,
+partial rebuilds while you develop.
 
-A complete rebuild can be done with the following (from the `client` directory):
+A complete rebuild can be done with the following (from the `client`
+directory):
 
-    grunt
+    npm run all
 
 This will:
 
@@ -54,7 +54,7 @@ Rebuilding Scripts Only
 
 To re-minify all the individual javascript files:
 
-    grunt scripts
+    npm run scripts
 
 
 Rebuilding Webpack Apps
@@ -62,15 +62,15 @@ Rebuilding Webpack Apps
 
 To rebuild the webpack bundles for apps (compressed for production):
 
-    grunt webpack
+    npm run webpack
 
 To rebuild the apps without compression:
 
-    grunt webpack-dev
+    npm run webpack-dev
 
 To rebuild without compression and watch and rebuild when scripts change:
 
-    grunt webpack-watch
+    npm run webpack-watch
 
 
 Changing Styles/CSS
@@ -81,7 +81,7 @@ compiles to CSS, for its styling. LESS files are kept in client/galaxy/style/les
 
 Use grunt to recompile the LESS in into CSS (from the `client` directory):
 
-    grunt style
+    npm run style
 
 
 Grunt watch
@@ -92,8 +92,8 @@ Grunt can also do an automatic, partial rebuild of any files you change *as you 
 1. opening a new terminal session
 2. `cd client`
 3. Watch with:
-    1. `grunt watch` to watch the *scripts/* folder
-    2. `grunt watch-style` to watch the *style/* folder
+    1. `npm run watch` to watch the *scripts/* folder
+    2. `npm run watch-style` to watch the *style/* folder
 
 This starts a new grunt watch process that will monitor the files, in the corresponding folder, for changes and copy and
 rebuild them when they change.
@@ -102,22 +102,11 @@ You can stop the watch task by pressing `Ctrl+C`. Note: you should also be able 
 if you prefer.
 
 
-Using a Locally Installed Version of Grunt
-==========================================
-
-A non-global version of grunt and the grunt-cli are installed when using 'npm install'. If you'd rather build with that
-version, you'll need to use the full, local path when calling it:
-
-    ./node_modules/.bin/grunt
-    # or
-    ./node_modules/.bin/grunt watch
-
-
 The Toolshed Client Build
 =========================
 
 The commands mentioned above in 'Rebuilding' and 'Grunt watch' also can be applied to toolshed scripts by using the
 `--app=toolshed` option:
 
-	grunt watch --app=toolshed
-	grunt --app=toolshed
+	npm run grunt watch --app=toolshed
+	npm run grunt --app=toolshed

--- a/client/package.json
+++ b/client/package.json
@@ -28,5 +28,15 @@
     "i18n-webpack-plugin": "^0.2.7",
     "webpack": "^1.10.1",
     "webpack-dev-server": "^1.7.0"
+  },
+  "scripts": {
+    "grunt": "grunt",
+    "all": "grunt",
+    "style": "grunt style",
+    "scripts": "grunt uglify",
+    "webpack": "grunt webpack",
+    "webpack-dev": "grunt webpack-dev",
+    "webpack-watch": "grunt webpack-watch",
+    "watch": "grunt watch"
   }
 }


### PR DESCRIPTION
Add npm scripts to `package.json` for all of the client build targets,
preferring the locally installed `grunt-cli`. Eliminates the need to
install globally. ally installed `grunt-cli`. Eliminates the need to