### PR TITLE
Created alphabetic and numerical sort tool for collection operations

### DIFF
--- a/config/tool_conf.xml.sample
+++ b/config/tool_conf.xml.sample
@@ -38,6 +38,7 @@
     <tool file="${model_tools_path}/merge_collection.xml" />
     <tool file="${model_tools_path}/relabel_from_file.xml" />
     <tool file="${model_tools_path}/filter_from_file.xml" />
+    <tool file="${model_tools_path}/sort_collection_list.xml" />
   </section>
   <section id="liftOver" name="Lift-Over">
     <tool file="extract/liftOver_wrapper.xml" />

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2509,6 +2509,30 @@ class FlattenTool( DatabaseOperationTool ):
         )
 
 
+class SortTool( DatabaseOperationTool ):
+    tool_type = 'sort_collection'
+
+    def produce_outputs( self, trans, out_data, output_collections, incoming, history ):
+        hdca = incoming[ "input" ]
+        sorttype = incoming["sort_type"]
+        new_elements = odict()
+        elements = hdca.collection.elements
+        if sorttype == 'alpha':
+            presort_elements = [(dce.element_identifier, dce) for dce in elements]
+        elif sorttype == 'numeric':
+            presort_elements = [(int(re.sub('[^0-9]', '', dce.element_identifier)), dce) for dce in elements]
+        sorted_elements = [x[1] for x in sorted(presort_elements, key=lambda x: x[0])]
+
+        for dce in sorted_elements:
+            dce_object = dce.element_object
+            copied_dataset = dce_object.copy()
+            history.add_dataset(copied_dataset, set_hid=False)
+            new_elements[dce.element_identifier] = copied_dataset
+        output_collections.create_collection(
+            next(iter(self.outputs.values())), "output", elements=new_elements
+        )
+
+
 class RelabelFromFileTool(DatabaseOperationTool):
     tool_type = 'relabel_from_file'
 

--- a/lib/galaxy/tools/sort_collection_list.xml
+++ b/lib/galaxy/tools/sort_collection_list.xml
@@ -1,0 +1,73 @@
+<tool id="__SORTLIST__"
+      name="Sort Collection"
+      version="1.0.0"
+      tool_type="sort_collection">
+    <description>of list of datasets</description>
+    <type class="SortTool" module="galaxy.tools" />
+    <action module="galaxy.tools.actions.model_operations"
+            class="ModelOperationToolAction"/>
+    <inputs>
+        <param type="data_collection" collection_type="list" name="input" label="Input Collection" />
+        <param type="select" name="sort_type" label="Sort collection identifiers" help="">
+            <option value="alpha">alphabetically</option>
+            <option value="numeric">numerically (strips all characters except numbers)</option>
+        </param>
+    </inputs>
+    <outputs>
+        <collection name="output" format_source="input" type="list" label="${on_string} (sorted)" >
+        </collection>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input">
+                <collection type="list">
+		    <element name="def" value="simple_line_alternative.txt" />
+		    <element name="abc" value="simple_line.txt" />
+                </collection>
+            </param>
+	    <param name="sort_type" value="alpha" />
+            <output_collection name="output" type="list">
+              <element name="abc">
+                <assert_contents>
+                  <has_text_matching expression="^This is a line of text.\n$" />
+                </assert_contents>
+              </element>
+              <element name="def">
+                <assert_contents>
+                  <has_text_matching expression="^This is a different line of text.\n$" />
+                </assert_contents>
+              </element>
+            </output_collection>
+        </test>
+        <test>
+            <param name="input">
+                <collection type="list">
+		    <element name="def0123400" value="simple_line_alternative.txt" />
+		    <element name="abc5678" value="simple_line.txt" />
+                </collection>
+            </param>
+	    <param name="sort_type" value="numeric" />
+            <output_collection name="output" type="list">
+              <element name="abc5678">
+                <assert_contents>
+                  <has_text_matching expression="^This is a line of text.\n$" />
+                </assert_contents>
+              </element>
+              <element name="def0123400">
+                <assert_contents>
+                  <has_text_matching expression="^This is a different line of text.\n$" />
+                </assert_contents>
+              </element>
+            </output_collection>
+        </test>
+    </tests>
+    <help><![CDATA[
+
+This tool takes list-type collections - and produces a sorted ist from the inputs. The collection identifiers are sorted either alphabetically or numerically (where the characters other than 0-9 are stripped before sorting).
+
+.. class:: infomark
+
+This tool will create new history datasets from your collection but your quota usage will not increase.
+
+     ]]></help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -148,6 +148,7 @@
   <tool file="${model_tools_path}/zip_collection.xml" />
   <tool file="${model_tools_path}/filter_failed_collection.xml" />
   <tool file="${model_tools_path}/flatten_collection.xml" />
+  <tool file="${model_tools_path}/sort_collection_list.xml" />
   <tool file="${model_tools_path}/merge_collection.xml" />
   <tool file="${model_tools_path}/relabel_from_file.xml" />
   <tool file="${model_tools_path}/filter_from_file.xml" />


### PR DESCRIPTION
This PR creates a new tool in collection operations, which can sort a collection of the list type on its element identifiers. Referred to in gitter: https://gitter.im/galaxyproject/Lobby?at=5971d67b1c8697534a47166c

It scratches an itch I have, because I have a lot of collection work and two collections sometimes need to be in sync with eachother e.g. when pairing them. When they are not sorted problems ensue (i.e. I have to do that via the API creating a new collection). Also when creating new collections the standard order I sometimes find backwards (file highest in history is first).

The tool is implemented as other collection operation tools, I more or less ripped the `flatten_collection.xml` and the functionality is in `lib/galaxy/tools`, so there is no impact on user quota.

I included two tests, which can be run using the functional framework tests: `sh run_tests.sh -framework -id __SORTLIST__`. Tests pass on my box (famous last words).

Hoping this is useful stuff for other people too.