### PR TITLE
Remove print debug option from toolshed.

### DIFF
--- a/config/tool_shed.ini.sample
+++ b/config/tool_shed.ini.sample
@@ -119,9 +119,6 @@ paste.app_factory = galaxy.webapps.tool_shed.buildapp:app_factory
 # Check for WSGI compliance.
 #use_lint = False
 
-# Intercept print statements and show them on the returned page.
-#use_printdebug = True
-
 # NEVER enable this on a public site (even test or QA)
 #use_interactive = true
 

--- a/lib/galaxy/webapps/tool_shed/buildapp.py
+++ b/lib/galaxy/webapps/tool_shed/buildapp.py
@@ -283,10 +283,10 @@ def wrap_in_middleware( app, global_conf, application_stack, **local_conf ):
                 log.warning(str(exc))
                 import galaxy.web.framework.middleware.error
                 app = wrap_if_allowed( app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,) )
-    elif debug and not interactive:
-        # Not in interactive debug mode, just use the regular error middleware
-        import galaxy.web.framework.middleware.error
-        app = wrap_if_allowed( app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,) )
+        else:
+            # Not in interactive debug mode, just use the regular error middleware
+            import galaxy.web.framework.middleware.error
+            app = wrap_if_allowed( app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,) )
     return app
 
 


### PR DESCRIPTION
After investigating, I've determined that it's not worth the effort to fix the print debug middleware, so this will remove the option from buildapp.py and tool_shed.ini.sample

This addresses #4330