### PR TITLE
Updated the version requirements

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -22,7 +22,7 @@ WebOb==1.4.1
 WebHelpers==1.3
 Mako==1.0.2
 pytz==2015.4
-Babel==2.1.1
+Babel==2.3.4
 Beaker==1.7.0
 dictobj==0.3.1
 nose==1.3.7
@@ -39,7 +39,7 @@ Markdown==2.6.3
 # BioBlend and dependencies
 bioblend==0.7.0
 boto==2.38.0
-requests==2.8.1
+requests==2.10.0
 requests-toolbelt==0.4.0
 
 # kombu and dependencies

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -22,7 +22,7 @@ WebOb==1.4.1
 WebHelpers==1.3
 Mako==1.0.2
 pytz==2015.4
-Babel==2.3.4
+Babel==2.4.0
 Beaker==1.7.0
 dictobj==0.3.1
 nose==1.3.7


### PR DESCRIPTION
Update the version of `Babel` and `requests` packages to the minimum required versions for `CloudBridge` wheel.