### PR TITLE
Fix default output labels for subworkflows

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -284,7 +284,7 @@ class SubWorkflowModule( WorkflowModule ):
                 name = step.label
                 if not name:
                     step_module = module_factory.from_workflow_step( self.trans, step )
-                    name = step_module.get_name()
+                    name = "%s:%s" % (step.order_index, step_module.get_name())
                 step_type = step.type
                 assert step_type in step_to_input_type
                 input = dict(

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -302,6 +302,9 @@ class SubWorkflowModule( WorkflowModule ):
         outputs = []
         if hasattr( self.subworkflow, 'workflow_outputs' ):
             for workflow_output in self.subworkflow.workflow_outputs:
+                if workflow_output.workflow_step.type in {'data_input', 'data_collection_input'}:
+                    # It is just confusing to display the input data as output data in subworkflows
+                    continue
                 output_step = workflow_output.workflow_step
                 label = workflow_output.label
                 if label is None:
@@ -328,7 +331,7 @@ class SubWorkflowModule( WorkflowModule ):
         subworkflow_progress = subworkflow_invoker.progress
         outputs = {}
         for workflow_output in subworkflow.workflow_outputs:
-            workflow_output_label = workflow_output.label
+            workflow_output_label = workflow_output.label or "%s:%s" % (step.order_index, workflow_output.output_name)
             replacement = subworkflow_progress.get_replacement_workflow_output( workflow_output )
             outputs[ workflow_output_label ] = replacement
         progress.set_step_outputs( step, outputs )

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -397,7 +397,7 @@ class InputDataModule( InputModule ):
         if connections:
             for oc in connections:
                 for ic in oc.input_step.module.get_data_inputs():
-                    if 'extensions' in ic and ic[ 'name' ] == oc.input_name:
+                    if 'extensions' in ic and ic[ 'extensions' ] != 'input' and ic[ 'name' ] == oc.input_name:
                         filter_set += ic[ 'extensions' ]
         if not filter_set:
             filter_set = [ 'data' ]

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -307,7 +307,7 @@ class SubWorkflowModule( WorkflowModule ):
                     continue
                 output_step = workflow_output.workflow_step
                 label = workflow_output.label
-                if label is None:
+                if not label:
                     label = "%s:%s" % (output_step.order_index, workflow_output.output_name)
                 output = dict(
                     name=label,


### PR DESCRIPTION
And do not display input or input_collection modules as child workflow outputs.

Also allows to use child workflows with input modules that do not contain a label.
With these changes labels are not mandatory anymore. 
This should fix https://github.com/galaxyproject/galaxy/issues/3120

I hope this makes it easier for users to get started with subworkflows.