### PR TITLE
Paramiko based shell runner

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -63,8 +63,8 @@ svgwrite==1.1.6
 pyparsing==2.1.1
 
 # Fabric and dependencies
-Fabric==1.10.2
-paramiko==1.15.2
+Fabric==1.13.2
+paramiko==2.2.1
 ecdsa==0.13
 
 # Flexible BAM index naming

--- a/lib/galaxy/jobs/runners/util/cli/__init__.py
+++ b/lib/galaxy/jobs/runners/util/cli/__init__.py
@@ -39,6 +39,7 @@ class CliInterface(object):
 
         self.cli_shells = {}
         self.cli_job_interfaces = {}
+        self.active_cli_shells = {}
 
         module_prefix = self.__module__
         __load('%s.shell' % module_prefix, self.cli_shells)
@@ -55,8 +56,9 @@ class CliInterface(object):
 
     def get_shell_plugin(self, shell_params):
         shell_plugin = shell_params.get('plugin', DEFAULT_SHELL_PLUGIN)
-        shell = self.cli_shells[shell_plugin](**shell_params)
-        return shell
+        if shell_plugin not in self.active_cli_shells:
+            self.active_cli_shells[shell_plugin] = self.cli_shells[shell_plugin](**shell_params)
+        return self.active_cli_shells[shell_plugin]
 
     def get_job_interface(self, job_params):
         job_plugin = job_params.get('plugin', None)

--- a/lib/galaxy/jobs/runners/util/cli/shell/local.py
+++ b/lib/galaxy/jobs/runners/util/cli/shell/local.py
@@ -48,6 +48,7 @@ class LocalShell(BaseShellExec):
         # poll until timeout
 
         for i in range(int(timeout / timeout_check_interval)):
+            sleep(0.1)  # For fast returning commands
             r = p.poll()
             if r is not None:
                 break

--- a/test/unit/test_remote_shell.py
+++ b/test/unit/test_remote_shell.py
@@ -1,0 +1,57 @@
+import os
+import tempfile
+import unittest
+
+import mockssh
+
+from Crypto.PublicKey import RSA
+
+from galaxy.jobs.runners.cli import CliInterface
+
+
+class TestCliInterface(unittest.TestCase):
+
+
+    @classmethod
+    def tearDownClass(cls):
+       os.remove(cls.private_key)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.private_key = make_private_key()
+        cls.username = 'testuser'
+        cls.shell_params = {'username': cls.username,
+                             'private_key': cls.private_key,
+                             'hostname': 'localhost'}
+        cls.cli_interface = CliInterface()
+
+    def test_secure_shell_plugin_without_strict(self):
+        with mockssh.Server(users={self.username: self.private_key}) as server:
+            self.shell_params['port'] = server.port
+            self.shell_params['plugin'] = 'SecureShell'
+            self.shell_params['strict_host_key_checking'] = False
+            self.shell = self.cli_interface.get_shell_plugin(self.shell_params)
+            result = self.shell.execute(cmd='echo hello')
+        assert result.stdout.strip() == 'hello1'
+
+    def test_get_shell_plugin(self):
+        with mockssh.Server(users={self.username: self.private_key}) as server:
+            self.shell_params['port'] = server.port
+            self.shell_params['plugin'] = 'ParamikoShell'
+            self.shell = self.cli_interface.get_shell_plugin(self.shell_params)
+        assert self.shell.username == self.username
+
+    def test_paramiko_shell_plugin(self):
+        with mockssh.Server(users={self.username: self.private_key}) as server:
+            self.shell_params['port'] = server.port
+            self.shell_params['plugin'] = 'ParamikoShell'
+            self.shell = self.cli_interface.get_shell_plugin(self.shell_params)
+            result = self.shell.execute(cmd='echo hello')
+        assert result.stdout.strip() == 'hello1'
+
+
+def make_private_key():
+    key = RSA.generate(1024)
+    private_fd, private_path = tempfile.mkstemp()
+    open(private_path, 'w').write(key.exportKey('PEM'))
+    return private_path

--- a/test/unit/test_remote_shell.py
+++ b/test/unit/test_remote_shell.py
@@ -2,7 +2,10 @@ import os
 import tempfile
 import unittest
 
-import mockssh
+try:
+    import mockssh
+except ImportError:
+    raise unittest.SkipTest("Skipping tests that require mockssh")
 
 from Crypto.PublicKey import RSA
 
@@ -11,18 +14,17 @@ from galaxy.jobs.runners.cli import CliInterface
 
 class TestCliInterface(unittest.TestCase):
 
-
     @classmethod
     def tearDownClass(cls):
-       os.remove(cls.private_key)
+        os.remove(cls.private_key)
 
     @classmethod
     def setUpClass(cls):
         cls.private_key = make_private_key()
         cls.username = 'testuser'
         cls.shell_params = {'username': cls.username,
-                             'private_key': cls.private_key,
-                             'hostname': 'localhost'}
+                            'private_key': cls.private_key,
+                            'hostname': 'localhost'}
         cls.cli_interface = CliInterface()
 
     def test_secure_shell_plugin_without_strict(self):
@@ -32,7 +34,7 @@ class TestCliInterface(unittest.TestCase):
             self.shell_params['strict_host_key_checking'] = False
             self.shell = self.cli_interface.get_shell_plugin(self.shell_params)
             result = self.shell.execute(cmd='echo hello')
-        assert result.stdout.strip() == 'hello1'
+        assert result.stdout.strip() == 'hello'
 
     def test_get_shell_plugin(self):
         with mockssh.Server(users={self.username: self.private_key}) as server:
@@ -47,7 +49,7 @@ class TestCliInterface(unittest.TestCase):
             self.shell_params['plugin'] = 'ParamikoShell'
             self.shell = self.cli_interface.get_shell_plugin(self.shell_params)
             result = self.shell.execute(cmd='echo hello')
-        assert result.stdout.strip() == 'hello1'
+        assert result.stdout.strip() == 'hello'
 
 
 def make_private_key():

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ deps =
     nose
     NoseHTML
     mock
+    mock-ssh-server
 
 # Setup tox environments for linting all of Galaxy for imports and
 # just a subset we expect to pass (the include import list). Once the


### PR DESCRIPTION
This introduces a new shell runner that uses paramiko for connection handling (and reuse), as well as unit testing for the SecureShell runner and the ParamikoShell runner.

For unit tests to run and pass reliably an update to paramiko is required (which is required by Fabric, which I am also updating to the latest release). Starforge PR is [here](https://github.com/galaxyproject/starforge/pull/137). 
Unit testing also requires an update to [mock-ssh-server](https://github.com/carletes/mock-ssh-server).