### PR TITLE
Delete conda_exec_home instead of env['HOME']

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -254,14 +254,14 @@ class CondaContext(installable.InstallableContext):
         if condarc_override:
             env["CONDARC"] = condarc_override
         log.debug("Executing command: %s", command)
-        env['HOME'] = tempfile.mkdtemp(prefix='conda_exec_home_')  # We don't want to pollute ~/.conda, which may not even be writable
+        conda_exec_home = env['HOME'] = tempfile.mkdtemp(prefix='conda_exec_home_')  # We don't want to pollute ~/.conda, which may not even be writable
         try:
             return self.shell_exec(command, env=env)
         except commands.CommandLineException as e:
             log.warning(e)
             return e.returncode
         finally:
-            shutil.rmtree(env['HOME'], ignore_errors=True)
+            shutil.rmtree(conda_exec_home, ignore_errors=True)
 
     def exec_create(self, args, allow_local=True):
         create_base_args = [


### PR DESCRIPTION
This should always be the same as `env['HOME']` in the current code, but this feels a little safer, given that `env` is mutable.