### PR TITLE
Implement default_identifier_source for outputs and sort input keys by default

### DIFF
--- a/lib/galaxy/dataset_collections/matching.py
+++ b/lib/galaxy/dataset_collections/matching.py
@@ -75,7 +75,7 @@ class MatchingCollections( object ):
             return None
 
         matching_collections = MatchingCollections()
-        for input_key, to_match in collections_to_match.items():
+        for input_key, to_match in sorted(collections_to_match.items()):
             hdca = to_match.hdca
             collection_type_description = collection_type_descriptions.for_collection_type( hdca.collection.collection_type )
             subcollection_type = to_match.subcollection_type

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -158,16 +158,19 @@ class ToolExecutionTracker( object ):
                 continue
             output = self.tool.outputs[ output_name ]
 
-            # Switch the structure for outputs if the output specified a default_identifier_source
-            collection_type_descriptions = trans.app.dataset_collections_service.collection_type_descriptions
-            _structure = None
-            source_collection = self.collection_info.collections.get(output.default_identifier_source)
-            if source_collection:
-                collection_type_description = collection_type_descriptions.for_collection_type(source_collection.collection.collection_type)
-                _structure = structure.for_dataset_collection( source_collection.collection, collection_type_description=collection_type_description)
-            if _structure and structure.can_match(_structure):
-                element_identifiers = _structure.element_identifiers_for_outputs(trans, outputs)
-            else:
+            element_identifiers = None
+            if hasattr(output, "default_identifier_source"):
+                # Switch the structure for outputs if the output specified a default_identifier_source
+                collection_type_descriptions = trans.app.dataset_collections_service.collection_type_descriptions
+
+                source_collection = self.collection_info.collections.get(output.default_identifier_source)
+                if source_collection:
+                    collection_type_description = collection_type_descriptions.for_collection_type(source_collection.collection.collection_type)
+                    _structure = structure.for_dataset_collection( source_collection.collection, collection_type_description=collection_type_description)
+                    if structure.can_match(_structure):
+                        element_identifiers = _structure.element_identifiers_for_outputs(trans, outputs)
+
+            if not element_identifiers:
                 element_identifiers = structure.element_identifiers_for_outputs( trans, outputs )
 
             implicit_collection_info = dict(

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -157,7 +157,18 @@ class ToolExecutionTracker( object ):
                 log.warning( "Problem matching up datasets while attempting to create implicit dataset collections")
                 continue
             output = self.tool.outputs[ output_name ]
-            element_identifiers = structure.element_identifiers_for_outputs( trans, outputs )
+
+            # Switch the structure for outputs if the output specified a default_identifier_source
+            collection_type_descriptions = trans.app.dataset_collections_service.collection_type_descriptions
+            _structure = None
+            source_collection = self.collection_info.collections.get(output.default_identifier_source)
+            if source_collection:
+                collection_type_description = collection_type_descriptions.for_collection_type(source_collection.collection.collection_type)
+                _structure = structure.for_dataset_collection( source_collection.collection, collection_type_description=collection_type_description)
+            if _structure and structure.can_match(_structure):
+                element_identifiers = _structure.element_identifiers_for_outputs(trans, outputs)
+            else:
+                element_identifiers = structure.element_identifiers_for_outputs( trans, outputs )
 
             implicit_collection_info = dict(
                 implicit_inputs=implicit_inputs,

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -289,6 +289,7 @@ class XmlToolSource(ToolSource):
         output.format = output_format
         output.change_format = data_elem.findall("change_format")
         output.format_source = data_elem.get("format_source", default_format_source)
+        output.default_identifier_source = data_elem.get("default_identifier_source", 'None')
         output.metadata_source = data_elem.get("metadata_source", default_metadata_source)
         output.parent = data_elem.get("parent", None)
         output.label = xml_text( data_elem, "label" )

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -113,6 +113,7 @@ class YamlToolSource(ToolSource):
         output.format = output_dict.get("format", "data")
         output.change_format = []
         output.format_source = output_dict.get("format_source", None)
+        output.default_identifier_source = output_dict.get("default_identifier_source", None)
         output.metadata_source = output_dict.get("metadata_source", "")
         output.parent = output_dict.get("parent", None)
         output.label = output_dict.get( "label", None )

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -3693,6 +3693,12 @@ The valid values for format can be found in
         <xs:documentation xml:lang="en">This sets the data type of the output file to be the same format as that of a tool input dataset.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="default_identifier_source" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Sets the source of element identifier to the specified input.
+This only applies to collections that are mapped over a non-collection input and that have equivalent structures.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="metadata_source" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">This copies the metadata information

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -1059,6 +1059,20 @@ class ToolsTestCase( api.ApiTestCase ):
         self.assertEquals( len( response_object[ 'jobs' ] ), 2 )
         self.assertEquals( len( response_object[ 'implicit_collections' ] ), 1 )
 
+    @skip_without_tool( "identifier_source" )
+    def test_default_identifier_source_map_over(self):
+        history_id = self.dataset_populator.new_history()
+        input_a_hdca_id = self.dataset_collection_populator.create_list_in_history( history_id, contents=[("A", "A content")]).json()['id']
+        input_b_hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("B", "B content")]).json()['id']
+        inputs = {
+            "inputA": { 'batch': True, 'values': [ dict( src="hdca", id=input_a_hdca_id ) ] },
+            "inputB": { 'batch': True, 'values': [ dict( src="hdca", id=input_b_hdca_id ) ] },
+        }
+        self.dataset_populator.wait_for_history( history_id, assert_ok=True )
+        create = self._run("identifier_source", history_id, inputs, assert_ok=True)
+        assert create['implicit_collections'][0]['elements'][0]['element_identifier'] == 'B'
+        assert create['implicit_collections'][1]['elements'][0]['element_identifier'] == 'A'
+
     @skip_without_tool( "collection_creates_pair" )
     def test_map_over_collection_output( self ):
         history_id = self.dataset_populator.new_history()

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -78,6 +78,7 @@
   <tool file="validation_empty_dataset.xml" />
   <tool file="implicit_conversion.xml" />
   <tool file="explicit_conversion.xml" />
+  <tool file="identifier_source.xml" />
   <tool file="identifier_single.xml" />
   <tool file="identifier_multiple.xml" />
   <tool file="identifier_multiple_in_conditional.xml" />


### PR DESCRIPTION
 - 9d6a0e82f6f9634981ea96c37f0f48e38e9c5b12: Implement default_identifier_source for output. This allows tool authors to specify an input from which the element identifier can be inherited. This applies only to non-collection output when mapping a collection over an input, since collections have a structured_like attribute

- 35c0a4770336ca82fda7dd3034fd029e3bd474b8: Adds an API test for this functionality

- 46fba6ec1c728125efa1339e7334202487a09e18: sorts the input keys by default so that when 2 collections are mapped over and are equally likely to be the source of element identifiers, the first one will be used.

This solves #4366 (mostly).


