### PR TITLE
Stop loading tools that require a newer galaxy

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -582,10 +582,11 @@ class Tool( object, Dictifiable ):
         if not self.id:
             raise Exception( "Missing tool 'id' for tool at '%s'" % tool_source )
 
-        if self.profile >= 16.04 and VERSION_MAJOR < self.profile:
+        profile = LooseVersion(str(self.profile))
+        if profile >= LooseVersion("16.04") and LooseVersion(VERSION_MAJOR) < profile:
             template = "The tool %s targets version %s of Galaxy, you should upgrade Galaxy to ensure proper functioning of this tool."
             message = template % (self.id, self.profile)
-            log.warning(message)
+            raise Exception(message)
 
         # Get the (user visible) name of the tool
         self.name = tool_source.parse_name()

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -397,7 +397,7 @@ class AbstractToolBox( Dictifiable, ManagesIntegratedToolPanelMixin, object ):
                 self._integrated_tool_panel.stub_label( key )
 
     def get_tool( self, tool_id, tool_version=None, get_all_versions=False, exact=False ):
-        """Attempt to locate a tool in the tool box."""
+        """Attempt to locate a tool in the tool box. Note that `exact` only refers to the `tool_id`, not the `tool_version`."""
         if tool_version:
             tool_version = str( tool_version )
 

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -163,6 +163,14 @@ class ToolBoxTestCase( BaseToolBoxTestCase ):
         assert toolbox.get_tool( "test_tool" ) is not None
         assert toolbox.get_tool( "not_a_test_tool" ) is None
 
+    def test_enforce_tool_profile(self):
+        self._init_tool(filename="old_tool.xml", version="1.0", profile="17.01", tool_id="test_old_tool_profile")
+        self._init_tool(filename="new_tool.xml", version="2.0", profile="27.01", tool_id="test_new_tool_profile")
+        self._add_config("""<toolbox><tool file="old_tool.xml"/><tool file="new_tool.xml"/></toolbox>""")
+        toolbox = self.toolbox
+        assert toolbox.get_tool("test_old_tool_profile") is not None
+        assert toolbox.get_tool("test_new_tool_profile") is None
+
     def test_to_dict_in_panel( self ):
         for json_conf in [True, False]:
             self._init_tool_in_section(json=json_conf)

--- a/test/unit/tools_support.py
+++ b/test/unit/tools_support.py
@@ -36,7 +36,7 @@ class UsesApp( object ):
 
 
 # Simple tool with just one text parameter and output.
-SIMPLE_TOOL_CONTENTS = '''<tool id="test_tool" name="Test Tool" version="$version">
+SIMPLE_TOOL_CONTENTS = '''<tool id="${tool_id}" name="Test Tool" version="$version" profile="$profile">
     <command>echo "$param1" &lt; $out1</command>
     <inputs>
         <param type="text" name="param1" value="" />
@@ -49,7 +49,7 @@ SIMPLE_TOOL_CONTENTS = '''<tool id="test_tool" name="Test Tool" version="$versio
 
 
 # A tool with data parameters (kind of like cat1) my favorite test tool :)
-SIMPLE_CAT_TOOL_CONTENTS = '''<tool id="test_tool" name="Test Tool" version="$version">
+SIMPLE_CAT_TOOL_CONTENTS = '''<tool id="${tool_id}" name="Test Tool" version="$version" profile="$profile">
     <command>cat "$param1" #for $r in $repeat# "$r.param2" #end for# &lt; $out1</command>
     <inputs>
         <param type="data" format="tabular" name="param1" value="" />
@@ -70,12 +70,14 @@ class UsesTools( object ):
         self,
         tool_contents=SIMPLE_TOOL_CONTENTS,
         filename="tool.xml",
-        version="1.0"
+        version="1.0",
+        profile="16.01",
+        tool_id="test_tool",
     ):
         self._init_app_for_tools()
         self.tool_file = os.path.join( self.test_directory, filename )
         contents_template = string.Template( tool_contents )
-        tool_contents = contents_template.safe_substitute( dict( version=version ) )
+        tool_contents = contents_template.safe_substitute( dict( version=version, profile=profile, tool_id=tool_id ) )
         self.__write_tool( tool_contents )
         return self.__setup_tool( )
 
@@ -87,8 +89,11 @@ class UsesTools( object ):
 
     def __setup_tool( self ):
         tool_source = get_tool_source( self.tool_file )
-        self.tool = Tool( self.tool_file, tool_source, self.app )
-        if getattr( self, "tool_action", None ):
+        try:
+            self.tool = Tool( self.tool_file, tool_source, self.app )
+        except Exception:
+            self.tool = None
+        if getattr( self, "tool_action", None and self.tool):
             self.tool.tool_action = self.tool_action
         return self.tool
 


### PR DESCRIPTION
We look at a tools profile attribute, and if it is too new we will not load the tool. This is a first step towards https://github.com/galaxyproject/galaxy/issues/2086

We should also warn admins prominently that these tools will not load into the tool panel when installing from the tool shed (which is the harder part ...).