### PR TITLE
Show minimum required galaxy version in tool shed and galaxy installation process

### DIFF
--- a/lib/tool_shed/metadata/metadata_generator.py
+++ b/lib/tool_shed/metadata/metadata_generator.py
@@ -680,6 +680,7 @@ class MetadataGenerator( object ):
                           guid=guid,
                           name=tool.name,
                           version=tool.version,
+                          profile=tool.profile,
                           description=tool.description,
                           version_string_cmd=tool.version_string_cmd,
                           tool_config=tool_config,

--- a/lib/tool_shed/utility_containers/utility_container_manager.py
+++ b/lib/tool_shed/utility_containers/utility_container_manager.py
@@ -136,7 +136,7 @@ class RepositoryDependency( object ):
 class Tool( object ):
     """Tool object"""
 
-    def __init__( self, id=None, tool_config=None, tool_id=None, name=None, description=None, version=None, requirements=None,
+    def __init__( self, id=None, tool_config=None, tool_id=None, name=None, description=None, version=None, profile=None, requirements=None,
                   repository_id=None, changeset_revision=None, repository_installation_status=None ):
         self.id = id
         self.tool_config = tool_config
@@ -144,6 +144,7 @@ class Tool( object ):
         self.name = name
         self.description = description
         self.version = version
+        self.profile = profile
         self.requirements = requirements
         self.repository_id = repository_id
         self.changeset_revision = changeset_revision
@@ -438,6 +439,7 @@ class UtilityContainerManager( object ):
                          name='Name',
                          description='Description',
                          version='Version',
+                         profile='Minimum required Galaxy version',
                          requirements='',
                          repository_id='',
                          changeset_revision='' )
@@ -479,6 +481,7 @@ class UtilityContainerManager( object ):
                     name = str( tool_dict.get( 'name', 'unknown' ) )
                     description = str( tool_dict.get( 'description', '' ) )
                     version = str( tool_dict.get( 'version', 'unknown' ) )
+                    profile = str( tool_dict.get('profile', 'any'))
                 except Exception as e:
                     tool_config = str( e )
                     tool_id = 'unknown'
@@ -491,6 +494,7 @@ class UtilityContainerManager( object ):
                              name=name,
                              description=description,
                              version=version,
+                             profile=profile,
                              requirements=requirements_str,
                              repository_id=repository_id,
                              changeset_revision=changeset_revision,

--- a/lib/tool_shed/utility_containers/utility_container_manager.py
+++ b/lib/tool_shed/utility_containers/utility_container_manager.py
@@ -439,7 +439,7 @@ class UtilityContainerManager( object ):
                          name='Name',
                          description='Description',
                          version='Version',
-                         profile='Minimum required Galaxy version',
+                         profile='Minimum Galaxy Version',
                          requirements='',
                          repository_id='',
                          changeset_revision='' )

--- a/templates/webapps/tool_shed/repository/common.mako
+++ b/templates/webapps/tool_shed/repository/common.mako
@@ -280,7 +280,7 @@
                 elif folder.label == 'Invalid tool dependencies':
                     folder_label = "%s<i> - click the tool dependency to see why it is invalid</i>" % folder_label
                 elif folder.label == 'Valid tools':
-                    col_span_str = 'colspan="3"'
+                    col_span_str = 'colspan="4"'
                     if folder.description:
                         folder_label = "%s<i> - %s</i>" % ( folder_label, folder.description )
                     else:
@@ -870,6 +870,7 @@
         %endif
         <${cell_type}>${tool.description | h}</${cell_type}>
         <${cell_type}>${tool.version | h}</${cell_type}>
+        <${cell_type}>${tool.profile | h}</${cell_type}>
         ##<${cell_type}>${tool.requirements | h}</${cell_type}>
     </tr>
     <%


### PR DESCRIPTION
This requires a metadata reset on the toolshed side (or updating a repository by uploading a new revision). This doesn't prevent an admin from installing the tools, but at least the information is clearly visible.