### PR TITLE
Refactor ToolOutputCollectionStructure...

### DIFF
--- a/lib/galaxy/tools/parser/output_objects.py
+++ b/lib/galaxy/tools/parser/output_objects.py
@@ -178,9 +178,9 @@ class ToolOutputCollectionStructure( object ):
     def __init__(
         self,
         collection_type,
-        collection_type_source,
-        structured_like,
-        dataset_collector_descriptions,
+        collection_type_source=None,
+        structured_like=None,
+        dataset_collector_descriptions=None,
     ):
         self.collection_type = collection_type
         self.collection_type_source = collection_type_source

--- a/lib/galaxy/tools/parser/output_objects.py
+++ b/lib/galaxy/tools/parser/output_objects.py
@@ -118,11 +118,7 @@ class ToolOutputCollection( ToolOutputBase ):
         if len( self.outputs ) > 1:
             output_parts = [ToolOutputCollectionPart(self, k, v) for k, v in self.outputs.items()]
         else:
-            # either must have specified structured_like or something worse
-            if self.structure.structured_like:
-                collection_prototype = inputs[ self.structure.structured_like ].collection
-            else:
-                collection_prototype = type_registry.prototype( self.structure.collection_type )
+            collection_prototype = self.structure.collection_prototype( inputs, type_registry )
 
             def prototype_dataset_element_to_output( element, parent_ids=[] ):
                 name = element.element_identifier
@@ -193,6 +189,14 @@ class ToolOutputCollectionStructure( object ):
         if dataset_collector_descriptions and structured_like:
             raise ValueError( "Cannot specify dynamic structure (discovered_datasets) and structured_like attribute." )
         self.dynamic = dataset_collector_descriptions is not None
+
+    def collection_prototype( self, inputs, type_registry ):
+        # either must have specified structured_like or something worse
+        if self.structured_like:
+            collection_prototype = inputs[ self.structured_like ].collection
+        else:
+            collection_prototype = type_registry.prototype( self.collection_type )
+        return collection_prototype
 
 
 class ToolOutputCollectionPart( object ):


### PR DESCRIPTION
... for easier reuse and better cohesion (now known outputs doesn't need to know about the internals of ToolOutputCollectionStructure to build collection prototypes for outputs).

Makes downstream work on structured record collections a bit cleaner - https://github.com/common-workflow-language/galaxy/pull/47/commits/562ae965eaac0a4d7b56c5ab5eb6fc7fd4aa165c.