### PR TITLE
Better Error Summaries for API Tests

### DIFF
--- a/test/base/interactor.py
+++ b/test/base/interactor.py
@@ -352,22 +352,27 @@ class GalaxyInteractorApi( object ):
             print("*TEST FRAMEWORK FAILED TO FETCH HISTORY DETAILS*")
 
         for history_content in history_contents:
-            if history_content[ 'history_content_type'] != 'dataset':
-                continue
 
             dataset = history_content
-            if dataset[ 'state' ] != 'error':
+            if dataset.get( 'state', 'ok' ) != 'error':
                 continue
 
             print(ERROR_MESSAGE_DATASET_SEP)
             dataset_id = dataset.get( 'id', None )
             print("| %d - %s (HID - NAME) " % ( int( dataset['hid'] ), dataset['name'] ))
+            if history_content[ 'history_content_type'] == 'dataset_collection':
+                history_contents_json = self._get( "histories/%s/contents/dataset_collections/%s" % (history_id, history_content["id"] ) ).json()
+                print("| Dataset Collection: %s" % history_contents_json)
+                continue
+
             try:
                 dataset_info = self._dataset_info( history_id, dataset_id )
                 print("| Dataset Blurb:")
                 print(self.format_for_error( dataset_info.get( "misc_blurb", "" ), "Dataset blurb was empty." ))
                 print("| Dataset Info:")
                 print(self.format_for_error( dataset_info.get( "misc_info", "" ), "Dataset info is empty." ))
+                print("| Peek:")
+                print(self.format_for_error( dataset_info.get( "peek", ""), "Peek unavilable."))
             except Exception:
                 print("| *TEST FRAMEWORK ERROR FETCHING DATASET DETAILS*")
             try:

--- a/test/base/interactor.py
+++ b/test/base/interactor.py
@@ -327,7 +327,7 @@ class GalaxyInteractorApi( object ):
             return self._state_ready( state, error_msg="Job in error state." )
         except Exception:
             if VERBOSE_ERRORS:
-                self._summarize_history_errors( history_id )
+                self._summarize_history( history_id )
             raise
 
     def __history_ready( self, history_id ):
@@ -339,13 +339,13 @@ class GalaxyInteractorApi( object ):
             return self._state_ready( state, error_msg="History in error state." )
         except Exception:
             if VERBOSE_ERRORS:
-                self._summarize_history_errors( history_id )
+                self._summarize_history( history_id )
             raise
 
-    def _summarize_history_errors( self, history_id ):
+    def _summarize_history( self, history_id ):
         if history_id is None:
-            raise ValueError("_summarize_history_errors passed empty history_id")
-        print("History with id %s in error - summary of datasets in error below." % history_id)
+            raise ValueError("_summarize_history passed empty history_id")
+        print("Problem in history with id %s - summary of datasets below." % history_id)
         try:
             history_contents = self.__contents( history_id )
         except Exception:
@@ -354,8 +354,6 @@ class GalaxyInteractorApi( object ):
         for history_content in history_contents:
 
             dataset = history_content
-            if dataset.get( 'state', 'ok' ) != 'error':
-                continue
 
             print(ERROR_MESSAGE_DATASET_SEP)
             dataset_id = dataset.get( 'id', None )
@@ -367,26 +365,28 @@ class GalaxyInteractorApi( object ):
 
             try:
                 dataset_info = self._dataset_info( history_id, dataset_id )
+                print("| Dataset State:")
+                print(self.format_for_summary(dataset_info.get("state"), "Dataset state is unknown."))
                 print("| Dataset Blurb:")
-                print(self.format_for_error( dataset_info.get( "misc_blurb", "" ), "Dataset blurb was empty." ))
+                print(self.format_for_summary( dataset_info.get( "misc_blurb", "" ), "Dataset blurb was empty." ))
                 print("| Dataset Info:")
-                print(self.format_for_error( dataset_info.get( "misc_info", "" ), "Dataset info is empty." ))
+                print(self.format_for_summary( dataset_info.get( "misc_info", "" ), "Dataset info is empty." ))
                 print("| Peek:")
-                print(self.format_for_error( dataset_info.get( "peek", ""), "Peek unavilable."))
+                print(self.format_for_summary( dataset_info.get( "peek", ""), "Peek unavilable."))
             except Exception:
                 print("| *TEST FRAMEWORK ERROR FETCHING DATASET DETAILS*")
             try:
                 provenance_info = self._dataset_provenance( history_id, dataset_id )
                 print("| Dataset Job Standard Output:")
-                print(self.format_for_error( provenance_info.get( "stdout", "" ), "Standard output was empty." ))
+                print(self.format_for_summary( provenance_info.get( "stdout", "" ), "Standard output was empty." ))
                 print("| Dataset Job Standard Error:")
-                print(self.format_for_error( provenance_info.get( "stderr", "" ), "Standard error was empty." ))
+                print(self.format_for_summary( provenance_info.get( "stderr", "" ), "Standard error was empty." ))
             except Exception:
                 print("| *TEST FRAMEWORK ERROR FETCHING JOB DETAILS*")
             print("|")
         print(ERROR_MESSAGE_DATASET_SEP)
 
-    def format_for_error( self, blob, empty_message, prefix="|  " ):
+    def format_for_summary( self, blob, empty_message, prefix="|  " ):
         contents = "\n".join([ "%s%s" % (prefix, line.strip()) for line in StringIO(blob).readlines() if line.rstrip("\n\r") ] )
         return contents or "%s*%s*" % ( prefix, empty_message )
 

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import time
 
@@ -102,6 +103,18 @@ class BaseDatasetPopulator( object ):
 
     def _summarize_history_errors( self, history_id ):
         pass
+
+    @contextlib.contextmanager
+    def test_history(self, **kwds):
+        # TODO: In the future allow targetting a specfic history here
+        # and/or deleting everything in the resulting history when done.
+        # These would be cool options for remote Galaxy test execution.
+        try:
+            history_id = self.new_history()
+            yield history_id
+        except Exception:
+            self._summarize_history_errors(history_id)
+            raise
 
     def new_history( self, **kwds ):
         name = kwds.get( "name", "API Test History" )

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -92,7 +92,7 @@ class BaseDatasetPopulator( object ):
         try:
             return wait_on_state( lambda: self._get( "histories/%s" % history_id ), assert_ok=assert_ok, timeout=timeout )
         except AssertionError:
-            self._summarize_history_errors( history_id )
+            self._summarize_history( history_id )
             raise
 
     def wait_for_job( self, job_id, assert_ok=False, timeout=DEFAULT_TIMEOUT ):
@@ -101,7 +101,7 @@ class BaseDatasetPopulator( object ):
     def get_job_details( self, job_id, full=False ):
         return self._get( "jobs/%s?full=%s" % (job_id, full) )
 
-    def _summarize_history_errors( self, history_id ):
+    def _summarize_history( self, history_id ):
         pass
 
     @contextlib.contextmanager
@@ -113,7 +113,7 @@ class BaseDatasetPopulator( object ):
             history_id = self.new_history()
             yield history_id
         except Exception:
-            self._summarize_history_errors(history_id)
+            self._summarize_history(history_id)
             raise
 
     def new_history( self, **kwds ):
@@ -230,8 +230,8 @@ class DatasetPopulator( BaseDatasetPopulator ):
     def _get( self, route ):
         return self.galaxy_interactor.get( route )
 
-    def _summarize_history_errors( self, history_id ):
-        self.galaxy_interactor._summarize_history_errors( history_id )
+    def _summarize_history( self, history_id ):
+        self.galaxy_interactor._summarize_history( history_id )
 
     def wait_for_dataset(self, history_id, dataset_id, assert_ok=False, timeout=DEFAULT_TIMEOUT):
         return wait_on_state(lambda: self._get("histories/%s/contents/%s" % (history_id, dataset_id)), assert_ok=assert_ok, timeout=timeout)


### PR DESCRIPTION
- Modify existing code that would summarize a history in error state to summarize all datasets and dataset collections - include more information. I've found this is much more helpful in debugging problems with tests downstream.
  - The peak is included now which is helpful to see what tools actually generated during tests.
  - Collections are included at least a little bit now which is useful.
  - Non-error datasets are included which makes it easier to debug problems with datasets that are green but shouldn't be.
- Implement a new contextmanager for creating histories that calls this summary code if any exception is thrown inside of the context. Makes this summary code more useful in more settings.
- Update a random assortment of tool API tests to use this new context manager - mostly just as a demonstration - these particular tests aren't particularly interesting. 

Again useful test code stemming from downstream work in the CWL branch.
