### PR TITLE
[WIP] Persist and expose workflow invocation outputs

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -904,6 +904,24 @@ model.WorkflowInvocationStep.table = Table(
     Column("job_id", Integer, ForeignKey("job.id"), index=True, nullable=True),
     Column("action", JSONType, nullable=True))
 
+model.WorkflowInvocationOutputDatasetAssociation.table = Table(
+    "workflow_invocation_output_dataset_association", metadata,
+    Column( "id", Integer, primary_key=True ),
+    Column( "workflow_invocation_id", Integer, ForeignKey( "workflow_invocation.id" ), index=True ),
+    Column( "workflow_step_id", Integer, ForeignKey( "workflow_step.id" ), index=True ),
+    Column( "dataset_id", Integer, ForeignKey( "history_dataset_association.id" ), index=True ),
+    Column( "workflow_output_id", Integer, ForeignKey( "workflow_output.id" ), index=True ),
+)
+
+model.WorkflowInvocationOutputDatasetCollectionAssociation.table = Table(
+    "workflow_invocation_output_dataset_collection_association", metadata,
+    Column( "id", Integer, primary_key=True ),
+    Column( "workflow_invocation_id", Integer, ForeignKey( "workflow_invocation.id" ), index=True ),
+    Column( "workflow_step_id", Integer, ForeignKey( "workflow_step.id" ), index=True ),
+    Column( "dataset_collection_id", Integer, ForeignKey( "history_dataset_collection_association.id" ), index=True ),
+    Column( "workflow_output_id", Integer, ForeignKey( "workflow_output.id" ), index=True ),
+)
+
 model.WorkflowInvocationToSubworkflowInvocationAssociation.table = Table(
     "workflow_invocation_to_subworkflow_invocation_association", metadata,
     Column("id", Integer, primary_key=True),
@@ -2381,6 +2399,21 @@ mapper(model.MetadataFile, model.MetadataFile.table, properties=dict(
     history_dataset=relation(model.HistoryDatasetAssociation),
     library_dataset=relation(model.LibraryDatasetDatasetAssociation)
 ))
+
+
+simple_mapping(model.WorkflowInvocationOutputDatasetAssociation,
+    workflow_invocation=relation(model.WorkflowInvocation, backref="output_datasets"),
+    workflow_step=relation(model.WorkflowStep),
+    dataset=relation(model.HistoryDatasetAssociation),
+    workflow_output=relation(model.WorkflowOutput),)
+
+
+simple_mapping(model.WorkflowInvocationOutputDatasetCollectionAssociation,
+    workflow_invocation=relation(model.WorkflowInvocation, backref="output_dataset_collections"),
+    workflow_step=relation(model.WorkflowStep),
+    dataset_collection=relation(model.HistoryDatasetCollectionAssociation),
+    workflow_output=relation(model.WorkflowOutput),)
+
 
 mapper(model.PageRevision, model.PageRevision.table)
 

--- a/lib/galaxy/model/migrate/versions/0135_record_workflow_outputs.py
+++ b/lib/galaxy/model/migrate/versions/0135_record_workflow_outputs.py
@@ -1,0 +1,68 @@
+"""
+Migration script for workflow request tables.
+"""
+from __future__ import print_function
+
+import logging
+
+from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table
+
+log = logging.getLogger( __name__ )
+metadata = MetaData()
+
+
+WorkflowInvocationOutputDatasetAssociation_table = Table(
+    "workflow_invocation_output_dataset_association", metadata,
+    Column( "id", Integer, primary_key=True ),
+    Column( "workflow_invocation_id", Integer, ForeignKey( "workflow_invocation.id" ), index=True ),
+    Column( "workflow_step_id", Integer, ForeignKey("workflow_step.id") ),
+    Column( "dataset_id", Integer, ForeignKey( "history_dataset_association.id" ), index=True ),
+    Column( "workflow_output_id", Integer, ForeignKey("workflow_output.id") ),
+)
+
+
+WorkflowInvocationOutputDatasetCollectionAssociation_table = Table(
+    "workflow_invocation_output_dataset_collection_association", metadata,
+    Column( "id", Integer, primary_key=True ),
+    Column( "workflow_invocation_id", Integer, ForeignKey( "workflow_invocation.id" ), index=True ),
+    Column( "workflow_step_id", Integer, ForeignKey("workflow_step.id") ),
+    Column( "dataset_collection_id", Integer, ForeignKey( "history_dataset_collection_association.id" ), index=True ),
+    Column( "workflow_output_id", Integer, ForeignKey("workflow_output.id") ),
+)
+
+
+TABLES = [
+    WorkflowInvocationOutputDatasetAssociation_table,
+    WorkflowInvocationOutputDatasetCollectionAssociation_table,
+]
+
+
+def upgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    print(__doc__)
+    metadata.reflect()
+
+    for table in TABLES:
+        __create(table)
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    for table in TABLES:
+        __drop(table)
+
+
+def __create(table):
+    try:
+        table.create()
+    except Exception:
+        log.exception("Creating %s table failed.", table.name)
+
+
+def __drop(table):
+    try:
+        table.drop()
+    except Exception:
+        log.exception("Dropping %s table failed.", table.name)

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -352,6 +352,19 @@ class WorkflowProgress(object):
 
     def set_step_outputs(self, step, outputs):
         self.outputs[step.id] = outputs
+        for workflow_output in step.workflow_outputs:
+            output_name = workflow_output.output_name
+            if output_name not in outputs:
+                raise KeyError("Failed to find [%s] in step outputs [%s]" % (output_name, outputs))
+            output = outputs[output_name]
+            self._record_workflow_output(
+                step,
+                workflow_output,
+                output=output,
+            )
+
+    def _record_workflow_output(self, step, workflow_output, output):
+        self.workflow_invocation.add_output(workflow_output, step, output)
 
     def mark_step_outputs_delayed(self, step, why=None):
         if why:

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -963,6 +963,77 @@ test_data:
         time.sleep(5)
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
 
+    def test_workflow_output_dataset(self):
+        history_id = self.dataset_populator.new_history()
+        summary = self._run_jobs("""
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+outputs:
+  - id: wf_output_1
+    source: first_cat#out_file1
+steps:
+  - tool_id: cat1
+    label: first_cat
+    state:
+      input1:
+        $link: input1
+
+test_data:
+  input1: "hello world"
+""", history_id=history_id)
+        workflow_id = summary.workflow_id
+        invocation_id = summary.invocation_id
+        invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
+        self._assert_status_code_is(invocation_response, 200)
+        invocation = invocation_response.json()
+        self._assert_has_keys(invocation , "id", "outputs", "output_collections")
+        assert len(invocation["output_collections"]) == 0
+        assert len(invocation["outputs"]) == 1
+        output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=invocation["outputs"]["wf_output_1"]["id"])
+        assert "hello world" == output_content.strip()
+
+    def test_workflow_output_dataset_collection(self):
+        history_id = self.dataset_populator.new_history()
+        summary = self._run_jobs("""
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+    type: data_collection_input
+    collection_type: list
+outputs:
+  - id: wf_output_1
+    source: first_cat#out_file1
+steps:
+  - tool_id: cat
+    label: first_cat
+    state:
+      input1:
+        $link: input1
+test_data:
+  input1:
+    type: list
+    name: the_dataset_list
+    elements:
+      - identifier: el1
+        value: 1.fastq
+        type: File
+""", history_id=history_id)
+        workflow_id = summary.workflow_id
+        invocation_id = summary.invocation_id
+        invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
+        self._assert_status_code_is(invocation_response, 200)
+        invocation = invocation_response.json()
+        self._assert_has_keys(invocation , "id", "outputs", "output_collections")
+        assert len(invocation["output_collections"]) == 1
+        assert len(invocation["outputs"]) == 0
+        output_content = self.dataset_populator.get_history_collection_details(history_id, content_id=invocation["output_collections"]["wf_output_1"]["id"])
+        self._assert_has_keys(output_content , "id", "elements")
+        elements = output_content["elements"]
+        assert len(elements) == 1
+        elements0 = elements[0]
+        assert elements0["element_identifier"] == "el1"
+
     @skip_without_tool("cat")
     def test_workflow_pause(self):
         workflow = self.workflow_populator.load_workflow_from_resource("test_workflow_pause")

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -24,6 +24,9 @@ SIMPLE_NESTED_WORKFLOW_YAML = """
 class: GalaxyWorkflow
 inputs:
   - id: outer_input
+outputs:
+  - id: outer_output
+    source: second_cat#out_file1
 steps:
   - tool_id: cat1
     label: first_cat
@@ -58,11 +61,6 @@ steps:
       queries:
         - input2:
             $link: nested_workflow#workflow_output
-
-test_data:
-  outer_input:
-    value: 1.bed
-    type: File
 """
 
 
@@ -861,7 +859,14 @@ test_data:
 
     def test_run_subworkflow_simple(self):
         history_id = self.dataset_populator.new_history()
-        self._run_jobs(SIMPLE_NESTED_WORKFLOW_YAML, history_id=history_id)
+        workflow_run_description = """%s
+
+test_data:
+  outer_input:
+    value: 1.bed
+    type: File
+""" % SIMPLE_NESTED_WORKFLOW_YAML
+        self._run_jobs(workflow_run_description, history_id=history_id)
 
         content = self.dataset_populator.get_history_dataset_content(history_id)
         self.assertEqual("chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\nchr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n", content)
@@ -1029,10 +1034,131 @@ test_data:
         assert len(invocation["outputs"]) == 0
         output_content = self.dataset_populator.get_history_collection_details(history_id, content_id=invocation["output_collections"]["wf_output_1"]["id"])
         self._assert_has_keys(output_content , "id", "elements")
+        assert output_content["collection_type"] == "list"
         elements = output_content["elements"]
         assert len(elements) == 1
         elements0 = elements[0]
         assert elements0["element_identifier"] == "el1"
+
+    def test_worklfow_input_mapping(self ):
+        history_id = self.dataset_populator.new_history()
+        summary = self._run_jobs("""
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+outputs:
+  - id: wf_output_1
+    source: first_cat#out_file1
+steps:
+  - tool_id: cat
+    label: first_cat
+    state:
+      input1:
+        $link: input1
+test_data:
+  input1:
+    type: list
+    name: the_dataset_list
+    elements:
+      - identifier: el1
+        value: 1.fastq
+        type: File
+      - identifier: el2
+        value: 1.fastq
+        type: File
+""", history_id=history_id)
+        workflow_id = summary.workflow_id
+        invocation_id = summary.invocation_id
+        invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id ) )
+        self._assert_status_code_is(invocation_response, 200 )
+        invocation = invocation_response.json()
+        self._assert_has_keys(invocation , "id", "outputs", "output_collections" )
+        assert len(invocation["output_collections"]) == 1
+        assert len(invocation["outputs"]) == 0
+        output_content = self.dataset_populator.get_history_collection_details(history_id, content_id=invocation["output_collections"]["wf_output_1"]["id"])
+        self._assert_has_keys(output_content , "id", "elements" )
+        elements = output_content["elements"]
+        assert len(elements) == 2
+        elements0 = elements[0]
+        assert elements0["element_identifier"] == "el1"
+
+    @skip_without_tool("collection_creates_pair")
+    def test_workflow_run_input_mapping_with_output_collections(self):
+        history_id = self.dataset_populator.new_history()
+        summary = self._run_jobs("""
+class: GalaxyWorkflow
+outputs:
+  - id: wf_output_1
+    source: split_up#paired_output
+steps:
+  - label: text_input
+    type: input
+  - label: split_up
+    tool_id: collection_creates_pair
+    state:
+      input1:
+        $link: text_input
+test_data:
+  text_input:
+    type: list
+    name: the_dataset_list
+    elements:
+      - identifier: el1
+        value: 1.fastq
+        type: File
+      - identifier: el2
+        value: 1.fastq
+        type: File
+""", history_id=history_id)
+        workflow_id = summary.workflow_id
+        invocation_id = summary.invocation_id
+        invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
+        self._assert_status_code_is(invocation_response, 200)
+        invocation = invocation_response.json()
+        self._assert_has_keys(invocation , "id", "outputs", "output_collections")
+        assert len(invocation["output_collections"]) == 1
+        assert len(invocation["outputs"]) == 0
+        output_content = self.dataset_populator.get_history_collection_details(history_id, content_id=invocation["output_collections"]["wf_output_1"]["id"])
+        self._assert_has_keys(output_content , "id", "elements")
+        assert output_content["collection_type"] == "list:paired", output_content
+        elements = output_content["elements"]
+        assert len(elements) == 2
+        elements0 = elements[0]
+        assert elements0["element_identifier"] == "el1"
+
+    def test_workflow_run_input_mapping_with_subworkflows(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_jobs("""%s
+
+test_data:
+  outer_input:
+    type: list
+    name: the_dataset_list
+    elements:
+      - identifier: el1
+        value: 1.fastq
+        type: File
+      - identifier: el2
+        value: 1.fastq
+        type: File
+""" % SIMPLE_NESTED_WORKFLOW_YAML, history_id=history_id)
+            workflow_id = summary.workflow_id
+            invocation_id = summary.invocation_id
+            invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
+            self._assert_status_code_is(invocation_response, 200)
+            invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
+            self._assert_status_code_is(invocation_response, 200)
+            invocation = invocation_response.json()
+            self._assert_has_keys(invocation , "id", "outputs", "output_collections")
+            assert len(invocation["output_collections"]) == 1, invocation
+            assert len(invocation["outputs"]) == 0
+            output_content = self.dataset_populator.get_history_collection_details(history_id, content_id=invocation["output_collections"]["outer_output"]["id"])
+            self._assert_has_keys(output_content , "id", "elements")
+            assert output_content["collection_type"] == "list", output_content
+            elements = output_content["elements"]
+            assert len(elements) == 2
+            elements0 = elements[0]
+            assert elements0["element_identifier"] == "el1"
 
     @skip_without_tool("cat")
     def test_workflow_pause(self):

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -241,6 +241,8 @@ class BaseDatasetPopulator(object):
         # the last dataset in the history will be fetched.
         if "dataset_id" in kwds:
             history_content_id = kwds["dataset_id"]
+        elif "content_id" in kwds:
+            history_content_id = kwds["content_id"]
         elif "dataset" in kwds:
             history_content_id = kwds["dataset"]["id"]
         else:


### PR DESCRIPTION
This pull request persists the outputs of workflow invocations and exposes them via the invocation API. This is useful for downstream workflow testing in Planemo as well as the downstream work on CWL.

This PR adds tests of this functionality as well as new tests for mapping collections over workflows that are much easier to implement using this functionality.

I'm pretty sure these are the tables and endpoints we want - but I'm going to keep this in WIP for sometime because of the database changes - I don't want to get those wrong.