### PR TITLE
Generalize allow_library_path_paste to allow_path_paste.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -908,12 +908,14 @@ use_interactive = True
 # sub-directories of files contained in their directory.
 #user_library_import_dir = None
 
-# Add an option to the admin library upload tool allowing admins to paste
+# Allow admins to paste filesystem paths during upload. For libraries this
+# adds an option to the admin library upload tool allowing admins to paste
 # filesystem paths to files and directories in a box, and these paths will be
-# added to a library.  Set to True to enable.  Please note the security
+# added to a library.  For history uploads, this allows pasting in paths as URIs.
+# (i.e. prefixed with file://). Set to True to enable.  Please note the security
 # implication that this will give Galaxy Admins access to anything your Galaxy
 # user has access to.
-#allow_library_path_paste = False
+#allow_path_paste = False
 
 # Users may choose to download multiple files from a library in an archive.  By
 # default, Galaxy allows users to select from a few different archive formats

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -393,7 +393,10 @@ class Configuration( object ):
         self.ftp_upload_dir_template = kwargs.get( 'ftp_upload_dir_template', '${ftp_upload_dir}%s${ftp_upload_dir_identifier}' % os.path.sep )
         self.ftp_upload_purge = string_as_bool(  kwargs.get( 'ftp_upload_purge', 'True' ) )
         self.ftp_upload_site = kwargs.get( 'ftp_upload_site', None )
-        self.allow_library_path_paste = kwargs.get( 'allow_library_path_paste', False )
+        self.allow_path_paste = string_as_bool( kwargs.get('allow_path_paste', False ) )
+        # Support older library-specific path paste option but just default to the new
+        # allow_path_paste value.
+        self.allow_library_path_paste = string_as_bool( kwargs.get( 'allow_library_path_paste', self.allow_path_paste ) )
         self.disable_library_comptypes = kwargs.get( 'disable_library_comptypes', '' ).lower().split( ',' )
         self.watch_tools = kwargs.get( 'watch_tools', 'false' )
         self.watch_tool_data_dir = kwargs.get( 'watch_tool_data_dir', 'false' )

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -293,7 +293,6 @@ class UploadDataset( Group ):
     def get_uploaded_datasets( self, trans, context, override_name=None, override_info=None ):
         def get_data_file_filename( data_file, override_name=None, override_info=None, purge=True ):
             dataset_name = override_name
-            dataset_info = override_info
 
             def get_file_name( file_name ):
                 file_name = file_name.split( '\\' )[-1]
@@ -303,8 +302,6 @@ class UploadDataset( Group ):
                 # Use the existing file
                 if not dataset_name and 'filename' in data_file:
                     dataset_name = get_file_name( data_file['filename'] )
-                if not dataset_info:
-                    dataset_info = 'uploaded file'
                 return Bunch( type='file', path=data_file['local_filename'], name=dataset_name, purge_source=purge )
             except:
                 # The uploaded file should've been persisted by the upload tool action
@@ -340,22 +337,16 @@ class UploadDataset( Group ):
                                     raise ConfigDoesNotAllowException()
                                 upload_path = line[len("file://"):]
                                 dataset_name = os.path.basename(upload_path)
-                                dataset_info = "File copied from %s" % upload_path
                             else:
                                 dataset_name = line
-                                dataset_info = 'uploaded_url'
 
                             if override_name:
                                 dataset_name = override_name
-                            if override_info:
-                                dataset_info = override_info
                             yield Bunch( type='url', path=line, name=dataset_name )
                 else:
-                    dataset_name = dataset_info = 'Pasted Entry'  # we need to differentiate between various url pastes here
+                    dataset_name = 'Pasted Entry'  # we need to differentiate between various url pastes here
                     if override_name:
                         dataset_name = override_name
-                    if override_info:
-                        dataset_info = override_info
                     yield Bunch( type='file', path=url_paste_file, name=dataset_name )
 
         def get_one_filename( context ):


### PR DESCRIPTION
Enable pasting paths in the history upload GUI & general purpose tools API for admin users if enabled.