### PR TITLE
[17.01] Add missing chemical formats to datatypes_conf.xml.sample

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python: 2.7
 os:
@@ -24,9 +25,13 @@ matrix:
   allow_failures:
   - env: TOX_ENV=py27-lint-imports
 
+addons:
+  apt:
+    packages:
+      - libxml2-utils
+
 install:
   - pip install tox
-  - if [ "$TOX_ENV" == "validate-test-tools" ]; then sudo apt-get install libxml2-utils; fi
   - if [ "$TOX_ENV" == "qunit" ]; then bash -c 'cd test/qunit && npm install'; fi
   - if [ "$TOX_ENV" == "first_startup" ]; then bash -c "bash scripts/common_startup.sh && wget -q https://github.com/jmchilton/galaxy-downloads/raw/master/db_gx_rev_0127.sqlite && mv db_gx_rev_0127.sqlite database/universe.sqlite && bash manage_db.sh -c ./config/galaxy.ini.sample upgrade"; fi
 

--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -542,8 +542,12 @@
         </datatype>
     <datatype extension="fps" type="galaxy.datatypes.molecules:FPS" mimetype="text/html" display_in_upload="true" />
     <datatype extension="obfs" type="galaxy.datatypes.molecules:OBFS" mimetype="text/html" display_in_upload="true" />
+    <datatype extension="drf" type="galaxy.datatypes.molecules:DRF" display_in_upload="true" />
     <datatype extension="phar" type="galaxy.datatypes.molecules:PHAR" display_in_upload="false" />
     <datatype extension="pdb" type="galaxy.datatypes.molecules:PDB" display_in_upload="true" />
+    <datatype extension="pdbqt" type="galaxy.datatypes.molecules:PDBQT" display_in_upload="true" />
+    <datatype extension="grd" type="galaxy.datatypes.molecules:grd" display_in_upload="true" />
+    <datatype extension="grd.tgz" type="galaxy.datatypes.molecules:grdtgz" display_in_upload="true" />
     <!-- mothur formats -->
     <datatype extension="mothur.otu" type="galaxy.datatypes.mothur:Otu" display_in_upload="true"/>
     <datatype extension="mothur.list" type="galaxy.datatypes.mothur:Otu" subclass="true" display_in_upload="true"/>

--- a/lib/galaxy/datatypes/molecules.py
+++ b/lib/galaxy/datatypes/molecules.py
@@ -350,7 +350,7 @@ class FPS(GenericMolFile):
 
 class OBFS(Binary):
     """OpenBabel Fastsearch format (fs)."""
-    file_ext = 'fs'
+    file_ext = 'obfs'
     composite_type = 'basic'
     allow_datatype_change = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@
 # 501 is line length
 # W503 is line breaks before binary operators, which has been reversed in PEP 8.
 # D** are docstring linting - which we mostly ignore except D302. (Hopefully we will solve more over time).
-ignore = E128,E201,E202,E203,E501,E402,W503,D100,D101,D102,D103,D104,D105,D200,D201,D202,D204,D205,D206,D207,D208,D209,D210,D211,D300,D301,D400,D401,D402,D403
+ignore = E128,E201,E202,E203,E501,E402,W503,D100,D101,D102,D103,D104,D105,D200,D201,D202,D204,D205,D206,D207,D208,D209,D210,D211,D300,D301,D400,D401,D402,D403,D412,D413
 exclude = lib/galaxy/util/jstree.py
 # For flake8-import-order
 # https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_smarkets.py

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ commands = bash .ci/flake8_wrapper.sh
 whitelist_externals = bash
 deps =
     flake8==3.2.1
-    flake8-docstrings==1.0.3
+    flake8-docstrings==1.1.0
 
 [testenv:py33-lint]
 commands = bash .ci/flake8_py3_wrapper.sh
@@ -86,5 +86,5 @@ commands = bash .ci/flake8_wrapper_docstrings.sh --include
 whitelist_externals = bash
 skip_install = True
 deps =
-    flake8
-    flake8-docstrings==1.0.3
+    flake8==3.2.1
+    flake8-docstrings==1.1.0


### PR DESCRIPTION
Missed in https://github.com/galaxyproject/galaxy/pull/1941 and https://github.com/galaxyproject/galaxy/pull/2452 .