### PR TITLE
[17.05] Don't cast tool_version to string if tool_version is None-type

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -560,7 +560,9 @@ class ToolModule( WorkflowModule ):
         tool_id = d.get( 'content_id' ) or d.get( 'tool_id' )
         if tool_id is None:
             raise exceptions.RequestParameterInvalidException( "No tool id could be located for step [%s]." % d )
-        tool_version = str( d.get( 'tool_version' ) )
+        tool_version = d.get( 'tool_version' )
+        if tool_version:
+            tool_version = str(tool_version)
         module = super( ToolModule, Class ).from_dict( trans, d, tool_id=tool_id, tool_version=tool_version, exact_tools=exact_tools )
         module.post_job_actions = d.get( 'post_job_actions', {} )
         module.workflow_outputs = d.get( 'workflow_outputs', [] )


### PR DESCRIPTION
If a version is not specifically requested a wrong version (`None` cast to
`'None'`) of a tool will be loaded in the workflow editor instead of the
latest version.

That should address @martenson's remark in
https://github.com/galaxyproject/galaxy/pull/4373#issuecomment-321896674
(and maybe also
https://github.com/galaxyproject/galaxy/issues/557#issuecomment-213498153).