### PR TITLE
Fix private role validation

### DIFF
--- a/lib/galaxy/security/__init__.py
+++ b/lib/galaxy/security/__init__.py
@@ -1391,7 +1391,7 @@ class GalaxyRBACAgent( RBACAgent ):
             self.sa_session.refresh( user )
             for role in roles:
                 # Make sure we are not creating an additional association with a PRIVATE role
-                if role not in user.roles:
+                if role not in [ x.role for x in user.roles ]:
                     self.associate_components( user=user, role=role )
             for group in groups:
                 self.associate_components( user=user, group=group )


### PR DESCRIPTION
User.roles is an array containing role-associations not actual roles. Individual roles are accessible through the .role attribute of the role-association. This change fixes the validation statement.