### PR TITLE
Avoid adding `(imported from API)` to workflows

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -196,7 +196,7 @@ class WorkflowContentsManager(UsesAnnotations):
         # Put parameters in workflow mode
         trans.workflow_building_mode = True
         # If there's a source, put it in the workflow name.
-        if source:
+        if source and source != 'API':
             name = "%s (imported from %s)" % ( data['name'], source )
         else:
             name = data['name']

--- a/test/api/test_search.py
+++ b/test/api/test_search.py
@@ -9,14 +9,14 @@ class SearchApiTestCase( api.ApiTestCase ):
         workflow_populator = WorkflowPopulator( self.galaxy_interactor )
         workflow_id = workflow_populator.simple_workflow( "test_for_search" )
         search_response = self.__search( "select * from workflow" )
-        assert self.__has_result_with_name( search_response, "test_for_search (imported from API)" ), search_response.json()
+        assert self.__has_result_with_name( search_response, "test_for_search" ), search_response.json()
 
         # Deleted
         delete_url = self._api_url( "workflows/%s" % workflow_id, use_key=True )
         delete( delete_url )
 
         search_response = self.__search( "select * from workflow where deleted = False" )
-        assert not self.__has_result_with_name( search_response, "test_for_search (imported from API)" ), search_response.json()
+        assert not self.__has_result_with_name( search_response, "test_for_search" ), search_response.json()
 
     def __search( self, query ):
         data = dict( query=query )

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -349,7 +349,7 @@ class WorkflowsApiTestCase( BaseWorkflowsApiTestCase ):
         upload_response = self._post( route, data=data )
         if assert_ok:
             self._assert_status_code_is( upload_response, 200 )
-            self._assert_user_has_workflow_with_name( "%s (imported from API)" % name )
+            self._assert_user_has_workflow_with_name( name )
         return upload_response
 
     def test_update( self ):


### PR DESCRIPTION
It's kind of pointless and hinders setting up a Galaxy instance (e.g. from Docker) programmatically.