### PR TITLE
Remove print of non-existent attribute 'content'

### DIFF
--- a/scripts/api/upload_to_history.py
+++ b/scripts/api/upload_to_history.py
@@ -52,4 +52,3 @@ if __name__ == '__main__':
 
     response = upload_file( base_url, api_key, history_id, filepath, **kwargs )
     print(response, file=sys.stderr)
-    print(response.content)


### PR DESCRIPTION
Which was giving me:
```
Traceback (most recent call last):
  File "scripts/api/upload_to_history.py", line 55, in <module>
    print(response.content)
AttributeError: 'dict' object has no attribute 'content'
```