### PR TITLE
Uniform indentation of multiline if conditionals

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -718,9 +718,9 @@ class Params(object):
                 # changed to not require this and NEVER_SANITIZE should be
                 # removed.
                 if (value is not None and
-                    key not in self.NEVER_SANITIZE and
-                    True not in [key.endswith("|%s" % nonsanitize_parameter) for
-                                 nonsanitize_parameter in self.NEVER_SANITIZE]):
+                        key not in self.NEVER_SANITIZE and
+                        True not in [key.endswith("|%s" % nonsanitize_parameter) for
+                                     nonsanitize_parameter in self.NEVER_SANITIZE]):
                     self.__dict__[key] = sanitize_param(value)
                 else:
                     self.__dict__[key] = value

--- a/lib/galaxy/util/pastescript/serve.py
+++ b/lib/galaxy/util/pastescript/serve.py
@@ -193,7 +193,7 @@ class Command(object):
         self.simulate = getattr(self.options, 'simulate', False)
 
         # For #! situations:
-        if (os.environ.get('PASTE_CONFIG_FILE') and self.takes_config_file is not None):
+        if os.environ.get('PASTE_CONFIG_FILE') and self.takes_config_file is not None:
             take = self.takes_config_file
             filename = os.environ.get('PASTE_CONFIG_FILE')
             if take == 1:
@@ -205,7 +205,7 @@ class Command(object):
                     "Value takes_config_file must be None, 1, or -1 (not %r)"
                     % take)
 
-        if (os.environ.get('PASTE_DEFAULT_QUIET')):
+        if os.environ.get('PASTE_DEFAULT_QUIET'):
             self.verbose = 0
 
         # Validate:
@@ -315,7 +315,7 @@ class Command(object):
         that case, or on non-Windows systems or an executable with no
         spaces, it just leaves well enough alone.
         """
-        if (sys.platform != 'win32' or ' ' not in arg):
+        if sys.platform != 'win32' or ' ' not in arg:
             # Problem does not apply:
             return arg
         try:
@@ -499,7 +499,7 @@ class ServeCommand(Command):
             if not self.args:
                 raise BadCommand('You must give a config file')
             app_spec = self.args[0]
-            if (len(self.args) > 1 and self.args[1] in self.possible_subcommands):
+            if len(self.args) > 1 and self.args[1] in self.possible_subcommands:
                 cmd = self.args[1]
                 restvars = self.args[2:]
             else:
@@ -507,7 +507,7 @@ class ServeCommand(Command):
                 restvars = self.args[1:]
         else:
             app_spec = ""
-            if (self.args and self.args[0] in self.possible_subcommands):
+            if self.args and self.args[0] in self.possible_subcommands:
                 cmd = self.args[0]
                 restvars = self.args[1:]
             else:
@@ -699,7 +699,7 @@ class ServeCommand(Command):
 
         import resource  # Resource usage information.
         maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-        if (maxfd == resource.RLIM_INFINITY):
+        if maxfd == resource.RLIM_INFINITY:
             maxfd = MAXFD
         # Iterate through and close all file descriptors.
         for fd in range(0, maxfd):
@@ -708,7 +708,7 @@ class ServeCommand(Command):
             except OSError:  # ERROR, fd wasn't open to begin with (ignored)
                 pass
 
-        if (hasattr(os, "devnull")):
+        if hasattr(os, "devnull"):
             REDIRECT_TO = os.devnull
         else:
             REDIRECT_TO = "/dev/null"
@@ -802,8 +802,7 @@ class ServeCommand(Command):
                         raise
                     return 1
             finally:
-                if (proc is not None and
-                        hasattr(os, 'kill')):
+                if proc is not None and hasattr(os, 'kill'):
                     import signal
                     try:
                         os.kill(proc.pid, signal.SIGTERM)
@@ -1039,10 +1038,8 @@ commands = {
 
 
 def run(args=None):
-    if (not args and
-        len(sys.argv) >= 2 and
-            os.environ.get('_') and sys.argv[0] != os.environ['_'] and
-            os.environ['_'] == sys.argv[1]):
+    if (not args and len(sys.argv) >= 2 and os.environ.get('_') and
+            sys.argv[0] != os.environ['_'] and os.environ['_'] == sys.argv[1]):
         # probably it's an exe execution
         args = ['exe', os.environ['_']] + sys.argv[2:]
     if args is None:

--- a/lib/galaxy/util/pastescript/serve.py
+++ b/lib/galaxy/util/pastescript/serve.py
@@ -19,19 +19,20 @@
 from __future__ import print_function
 
 import atexit
-import ConfigParser
 import errno
 import logging
 import optparse
 import os
 import re
+import signal
 import subprocess
 import sys
 import textwrap
 import threading
 import time
-
 from logging.config import fileConfig
+
+from six.moves import configparser
 
 from .loadwsgi import loadapp, loadserver
 
@@ -351,7 +352,7 @@ class Command(object):
         ConfigParser defaults are specified for the special ``__file__``
         and ``here`` variables, similar to PasteDeploy config loading.
         """
-        parser = ConfigParser.ConfigParser()
+        parser = configparser.ConfigParser()
         parser.read([config_file])
         if parser.has_section('loggers'):
             config_file = os.path.abspath(config_file)
@@ -747,7 +748,6 @@ class ServeCommand(Command):
         for j in range(10):
             if not live_pidfile(pid_file):
                 break
-            import signal
             os.kill(pid, signal.SIGTERM)
             time.sleep(1)
         else:
@@ -803,7 +803,6 @@ class ServeCommand(Command):
                     return 1
             finally:
                 if proc is not None and hasattr(os, 'kill'):
-                    import signal
                     try:
                         os.kill(proc.pid, signal.SIGTERM)
                     except (OSError, IOError):
@@ -1005,10 +1004,6 @@ def _turn_sigterm_into_systemexit():
     """
     Attempts to turn a SIGTERM exception into a SystemExit exception.
     """
-    try:
-        import signal
-    except ImportError:
-        return
 
     def handle_term(signo, frame):
         raise SystemExit


### PR DESCRIPTION
Use 8-spaces indentation for the conditional continuation lines of `if`-statements where the conditional part spans multiple lines.

According to PEP-8, using 4-spaces "can produce a visual conflict with the indented suite of code nested inside the `if`-statement", but the PEP "takes no explicit position".

There were only 2 places in the whole codebase where 8 spaces were not used, this will make it uniform.