### PR TITLE
More detailed sentry reports

### DIFF
--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -1,11 +1,26 @@
 """The module describes the ``sentry`` error plugin plugin."""
 import logging
 
-from galaxy.util import string_as_bool
+from galaxy import web
+from galaxy.util import string_as_bool, unicodify
 
 from ..plugins import ErrorPlugin
 
 log = logging.getLogger(__name__)
+
+ERROR_TEMPLATE = u"""Galaxy Job Error: {tool_id} v{tool_version}
+
+Command Line:
+{command_line}
+
+Stderr:
+{stderr}
+
+Stdout:
+{stdout}
+
+The user provided the following information:
+{message}"""
 
 
 class SentryPlugin(ErrorPlugin):
@@ -22,29 +37,60 @@ class SentryPlugin(ErrorPlugin):
         """Submit the error report to sentry
         """
         if self.app.sentry_client:
+            user = job.get_user()
             extra = {
-                'info' : job.info,
-                'id' : job.id,
-                'command_line' : job.command_line,
-                'stderr' : job.stderr,
-                'traceback': job.traceback,
+                'info': job.info,
+                'id': job.id,
+                'command_line': unicodify(job.command_line),
+                'stderr': unicodify(job.stderr),
+                'traceback': unicodify(job.traceback),
                 'exit_code': job.exit_code,
-                'stdout': job.stdout,
-                'handler': job.handler,
-                'user': job.get_user(),
-                'tool_version': job.tool_version,
-                'tool_xml': tool.config_file if tool else None
+                'stdout': unicodify(job.stdout),
+                'handler': unicodify(job.handler),
+                'tool_id': unicodify(job.tool_id),
+                'tool_version': unicodify(job.tool_version),
+                'tool_xml': unicodify(tool.config_file) if tool else None
             }
             if 'email' in kwargs:
-                extra['email'] = kwargs['email']
+                extra['email'] = unicodify(kwargs['email'])
 
+            # User submitted message
             if 'message' in kwargs:
-                extra['message'] = kwargs['message']
+                extra['message'] = unicodify(kwargs['message'])
 
+            # Construct the error message to send to sentry. The first line
+            # will be the issue title, everything after that becomes the
+            # "message"
+            error_message = ERROR_TEMPLATE.format(**extra)
+
+            # Update context with user information in a sentry-specific manner
+            self.app.sentry_client.context.merge({
+                # User information here also places email links + allows seeing
+                # a list of affected users in the tags/filtering.
+                'user': {
+                    'email': user.email,
+                    'id': user.id,
+                },
+                # This allows us to link to the dataset info page in case
+                # anything is missing from this report.
+                'request': {
+                    'url': web.url_for(
+                        controller="dataset", action="show_params",
+                        dataset_id=self.app.security.encode_id(dataset.id),
+                        qualified=True
+                    )
+                }
+            })
+
+            # Send the message, using message because
             response = self.app.sentry_client.capture(
                 'raven.events.Message',
-                message="Galaxy Job Error: %s  v.%s" % (job.tool_id, job.tool_version),
+                tags={
+                    'tool_id': job.tool_id,
+                    'tool_version': job.tool_version,
+                },
                 extra=extra,
+                message=unicodify(error_message),
             )
             return ('Submitted bug report to Sentry. Your guru meditation number is %s' % response, 'success')
 

--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -68,8 +68,8 @@ class SentryPlugin(ErrorPlugin):
                 # User information here also places email links + allows seeing
                 # a list of affected users in the tags/filtering.
                 'user': {
+                    'name': user.username,
                     'email': user.email,
-                    'id': user.id,
                 },
                 # This allows us to link to the dataset info page in case
                 # anything is missing from this report.


### PR DESCRIPTION
# Currently

![auswahl_022](https://user-images.githubusercontent.com/458683/29458714-b52035bc-8420-11e7-9abb-03bd1983c34e.png)

- top right shows "0 users"
- limited info
- only tags are level / server

![auswahl_023](https://user-images.githubusercontent.com/458683/29458716-b7aac630-8420-11e7-934d-ba02bc2a4819.png)

- stderr/stdout/cli are all truncated

# Now! 

![auswahl_019](https://user-images.githubusercontent.com/458683/29458735-ceba6c72-8420-11e7-86b5-3106c499c9d0.png)

- complete messages
- tagged by tool ID / version letting you filter sentry reports on these facets
- filter on bugs affecting specific users (it shows id here, but in latest version of this it will use email)
- includes URL to the show_params route for further investigating (or if this report doesn't include enough)

![auswahl_020](https://user-images.githubusercontent.com/458683/29458734-ceb40062-8420-11e7-80bb-6b2c4ef8c0d1.png)

- clickable URLs to galaxy

![auswahl_021](https://user-images.githubusercontent.com/458683/29458733-ceb347b2-8420-11e7-8b8d-e735fe99d936.png)

- list of affected users functions