### PR TITLE
More items per page in saved history and directly show tags

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -120,7 +120,7 @@ class HistoryListGrid(grids.Grid):
         grids.GridColumnFilter("All", args=dict(deleted='All')),
     ]
     default_filter = dict(name="All", deleted="False", tags="All", sharing="All")
-    num_rows_per_page = 10
+    num_rows_per_page = 15
     preserve_state = False
     use_async = True
     use_paging = True

--- a/templates/tagging_common.mako
+++ b/templates/tagging_common.mako
@@ -132,7 +132,14 @@
     %>
 
     ## Build HTML.
-    ${self.render_tagging_element_html(elt_id=elt_id, tags=item_tags, editable=editable, use_toggle_link=use_toggle_link, input_size=input_size, in_form=in_form, render_add_tag_button=render_add_tag_button)}
+    <%
+    if len(item_tags) > 3:
+        # If item has more than 3 tags show a link to see tags instead of displaying them all
+        use_toggle_link = True
+    else:
+        use_toggle_link = False
+    %>
+    ${self.render_tagging_element_html(elt_id=elt_id, tags=item_tags, editable=editable, use_toggle_link=use_toggle_link,  input_size=input_size, in_form=in_form, render_add_tag_button=render_add_tag_button)}
 
     ## Build script that augments tags using progressive javascript.
     <script type="text/javascript">


### PR DESCRIPTION
This PR increases the amount of histories shown per page to 15 and if there are less than 4 tags we show them directly instead of hiding them.

<img width="1024" alt="screen shot 2017-08-20 at 5 29 00 pm" src="https://user-images.githubusercontent.com/6804901/29496278-9e9ffe8e-85cf-11e7-9d6d-034b8c6b4769.png">
