### PR TITLE
[17.05] Validate workflow step after step argument injection

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1062,14 +1062,16 @@ class WorkflowModuleInjector(object):
         # Populate module.
         module = step.module = module_factory.from_workflow_step( self.trans, step )
 
-        # Fix any missing parameters
-        step.upgrade_messages = module.check_and_update_state()
-
         # Any connected input needs to have value DummyDataset (these
         # are not persisted so we need to do it every time)
         module.add_dummy_datasets( connections=step.input_connections, steps=steps )
         state, step_errors = module.compute_runtime_state( self.trans, step_args )
         step.state = state
+
+        # Fix any missing parameters
+        step.upgrade_messages = module.check_and_update_state()
+
+        # Populate subworkflow components
         if step.type == "subworkflow":
             subworkflow = step.subworkflow
             populate_module_and_state( self.trans, subworkflow, param_map={}, )


### PR DESCRIPTION
Fixes #4481. This PR makes sure that the check and update helper for workflow steps is called after all step arguments have been injected into the step state. Previously the first check was performed before injecting optional user inputs, solely relying on the inputs provided in the database/configuration state. In some cases this could led to a premature upgrade message response before considering the inputs parsed through the step arguments dictionary. There might be still some issues with this PR, particularly with regard to conflicting messages between the validations. I am looking into those now.