### PR TITLE
Minor copy datasets dialog improvement.

### DIFF
--- a/templates/webapps/galaxy/dataset/copy_view.mako
+++ b/templates/webapps/galaxy/dataset/copy_view.mako
@@ -102,58 +102,59 @@
             </div>
         </div>
         <div style="float: left; padding-left: 10px; font-size: 36px;">&rarr;</div>
-        <div class="toolForm" style="float: right; width: 45%; padding: 0px;">
-            <div class="toolFormTitle">Destination History:</div>
-            <div class="toolFormBody">
-                <div class="form-row" id="single-destination">
-                    <select id="single-dest-select" name="target_history_id">
-                        %for i, hist in enumerate(target_histories):
-                            <%
-                                encoded_id = trans.security.encode_id(hist.id)
-                                source_history_text = ""
-                                selected = ""
-                                if hist == source_history:
-                                    source_history_text = " (source history)"
-                                if encoded_id == target_history_id:
-                                    selected = " selected='selected'"
-                            %>
-                            <option value="${encoded_id}"${selected}>${i + 1}: ${h.truncate( util.unicodify( hist.name ), 30) | h}${source_history_text}</option>
-                        %endfor
-                    </select><br /><br />
-                    <a style="margin-left: 10px;" href="javascript:void(0);" id="select-multiple">Choose multiple histories</a>
-                </div>
-                <div id="multiple-destination" style="display: none;">
-                    %for i, hist in enumerate( target_histories ):
-                        <%
-                            cur_history_text = ""
-                            encoded_id = trans.security.encode_id(hist.id)
-                            if hist == source_history:
-                                cur_history_text = " <strong>(source history)</strong>"
-                        %>
-                        <div class="form-row">
-                            <input type="checkbox" name="target_history_ids" id="hist_${encoded_id}" value="${encoded_id}"/>
-                            <label for="hist_${encoded_id}" style="display: inline; font-weight:normal;">${i + 1}: ${ util.unicodify( hist.name ) | h }${cur_history_text}</label>
-                        </div>
-                    %endfor
-                </div>
-                %if trans.get_user():
-                    <%
-                        checked = ""
-                        if "create_new_history" in target_history_ids:
-                            checked = " checked='checked'"
-                    %>
-                    <hr />
-                    <div style="text-align: center; color: #888;">&mdash; OR &mdash;</div>
-                    <div class="form-row">
-                        <label for="new_history_name" style="display: inline; font-weight:normal;">New history named:</label>
-                        <input id="new_history_name" type="text" name="new_history_name" />
+        <div style="float: right; width: 45%; padding: 0px;">
+            <div class="toolForm">
+                <div class="toolFormTitle">Destination History:</div>
+                <div class="toolFormBody">
+                    <div class="form-row" id="single-destination">
+                        <select id="single-dest-select" name="target_history_id">
+                            %for i, hist in enumerate(target_histories):
+                                <%
+                                    encoded_id = trans.security.encode_id(hist.id)
+                                    source_history_text = ""
+                                    selected = ""
+                                    if hist == source_history:
+                                        source_history_text = " (source history)"
+                                    if encoded_id == target_history_id:
+                                        selected = " selected='selected'"
+                                %>
+                                <option value="${encoded_id}"${selected}>${i + 1}: ${h.truncate( util.unicodify( hist.name ), 30) | h}${source_history_text}</option>
+                            %endfor
+                        </select><br /><br />
+                        <a style="margin-left: 10px;" href="javascript:void(0);" id="select-multiple">Choose multiple histories</a>
                     </div>
-                %endif
+                    <div id="multiple-destination" style="display: none;">
+                        %for i, hist in enumerate( target_histories ):
+                            <%
+                                cur_history_text = ""
+                                encoded_id = trans.security.encode_id(hist.id)
+                                if hist == source_history:
+                                    cur_history_text = " <strong>(source history)</strong>"
+                            %>
+                            <div class="form-row">
+                                <input type="checkbox" name="target_history_ids" id="hist_${encoded_id}" value="${encoded_id}"/>
+                                <label for="hist_${encoded_id}" style="display: inline; font-weight:normal;">${i + 1}: ${ util.unicodify( hist.name ) | h }${cur_history_text}</label>
+                            </div>
+                        %endfor
+                    </div>
+                    %if trans.get_user():
+                        <%
+                            checked = ""
+                            if "create_new_history" in target_history_ids:
+                                checked = " checked='checked'"
+                        %>
+                        <hr />
+                        <div style="text-align: center; color: #888;">&mdash; OR &mdash;</div>
+                        <div class="form-row">
+                            <label for="new_history_name" style="display: inline; font-weight:normal;">New history named:</label>
+                            <input id="new_history_name" type="text" name="new_history_name" />
+                        </div>
+                    %endif
+                </div>
             </div>
-        </div>
-        <div style="clear: both"></div>
-        <div class="form-row" style="text-align: center;">
-            <input type="submit" class="primary-button" name="do_copy" value="Copy History Items"/>
+            <div class="form-row" style="text-align: center;">
+                <input type="submit" class="primary-button" name="do_copy" value="Copy History Items"/>
+            </div>
         </div>
     </form>
 </div>


### PR DESCRIPTION
I forgot the button for "copy" was way down at the bottom clearing both columns when I went to use this dialog a minute ago on a very large history, and it took me a second to find it.

This whole thing will be rewritten and the mako removed eventually, but this puts "Copy History" in a more obvious place, immediately after the second action on the page.  My thinking is that you pick datasets, scroll up, pick destination histor(ies), and then click the button right there where you're currently active without having to scroll all the way down to the bottom again.