### PR TITLE
New Dependency resolver for the LMOD environment modules system

### DIFF
--- a/config/dependency_resolvers_conf.xml.sample
+++ b/config/dependency_resolvers_conf.xml.sample
@@ -26,6 +26,7 @@
    - All the above attributes are optional
    - The value of the lmodexec attribute can't just be "module" because module is actually a bash function and not the real LMOD binary (see the result of the "type module" command)
    - The value of the modulepath attribute can also be a semicolon separated list of path
+   - In versionless mode, only modules marked as Default will be listed by the "avail" command (The -d option is used)
    - If the config folder of your Galaxy instance contains a file called "lmod_modules_mapping.yml" (based on the lmod_modules_mapping.yml.sample file) it will be taken into consideration automatically
   -->
   <!--

--- a/config/dependency_resolvers_conf.xml.sample
+++ b/config/dependency_resolvers_conf.xml.sample
@@ -20,12 +20,13 @@
   * lmodexec - Path to the lmod executable on your system - Default: value of the "LMOD_CMD" environment variable
   * settargexec - Path to the settarg executable on your system - Default: value of the "LMOD_SETTARG_CMD" environment variable
   * modulepath - Path to the folder that contains the LMOD module files on your system - Default: value of the "MODULEPATH" environment variable
-  * versionless - Set it to true to resolve the dependency based on its name only (the version number is ignored) - Default: false
-  * mapping_files - Path to a Yaml configuration file that can be used to link tools requirements with existing LMOD modules - Default: None
+  * versionless - Set it to true to resolve a dependency based on its name only (the version number is ignored) - Default: false
+  * mapping_files - Path to a Yaml configuration file that can be used to link tools requirements with existing LMOD modules - Default: config/lmod_modules_mapping.yml
   Important notes:
    - All the above attributes are optional
    - The value of the lmodexec attribute can't just be "module" because module is actually a bash function and not the real LMOD binary (see the result of the "type module" command)
    - The value of the modulepath attribute can also be a semicolon separated list of path
+   - If the config folder of your Galaxy instance contains a file called "lmod_modules_mapping.yml" (based on the lmod_modules_mapping.yml.sample file) it will be taken into consideration automatically
   -->
   <!--
   <lmod />

--- a/config/dependency_resolvers_conf.xml.sample
+++ b/config/dependency_resolvers_conf.xml.sample
@@ -14,6 +14,24 @@
   <!-- look for any version of the dependency installed via conda -->
   <conda versionless="true" />
 
+  <!-- LMOD dependency resolver (For the LMOD environment modules system - https://github.com/TACC/Lmod) -->
+  <!--
+  The LMOD dependency resolver attributes are:
+  * lmodexec - Path to the lmod executable on your system - Default: value of the "LMOD_CMD" environment variable
+  * settargexec - Path to the settarg executable on your system - Default: value of the "LMOD_SETTARG_CMD" environment variable
+  * modulepath - Path to the folder that contains the LMOD module files on your system - Default: value of the "MODULEPATH" environment variable
+  * versionless - Set it to true to resolve the dependency based on its name only (the version number is ignored) - Default: false
+  * mapping_files - Path to a Yaml configuration file that can be used to link tools requirements with existing LMOD modules - Default: None
+  Important notes:
+   - All the above attributes are optional
+   - The value of the lmodexec attribute can't just be "module" because module is actually a bash function and not the real LMOD binary (see the result of the "type module" command)
+   - The value of the modulepath attribute can also be a semicolon separated list of path
+  -->
+  <!--
+  <lmod />
+  <lmod versionless="true" />
+  -->
+
   <!-- Example configuration of modules dependency resolver, uses Environment Modules -->
   <!--
   <modules modulecmd="/opt/Modules/3.2.9/bin/modulecmd" />
@@ -25,6 +43,7 @@
   * prefetch - default: true - in the AvailModuleChecker prefetch module info with 'module avail'
   * default_indicator - default: '(default)' - what indicate to the AvailModuleChecker that a module is the default version
   -->
+
   <!-- other resolvers
   <tool_shed_tap />
   <homebrew />

--- a/config/lmod_modules_mapping.yml.sample
+++ b/config/lmod_modules_mapping.yml.sample
@@ -1,0 +1,47 @@
+# This is an example mapping file for the LMOD Dependency resolver (in YAML format)
+#
+# The goal of this file is to map tool's requirements to existing LMOD modules available on your system
+# Of course, if the name of a requirement and the name of a module match perfectly, there is no need to map them together through this mapping file.
+#
+# This is a sample file so the first thing to do to activate the mapping system is to create a copy of this file called "lmod_modules_mapping.yml".
+# The Lmod dependency resolver is programmed to search and use this YAML file automatically if it exists in the "config" folder of your Galaxy instance.
+# Alternatively, you can also use the "mapping_files" attribute of the <lmod /> resolver in the dependency_resolvers_conf.xml file to specify a custom mapping file
+#
+# Example 1:
+#
+# Let's say that one of the wrapper installed on your Galaxy instance has the following requirement:
+#
+#	<requirements>
+#		<requirement type="package" version="1.5.0">PIPITS</requirement>
+#	</requirements>
+#
+# But unfortunately, the name of the corresponding module file on your system is "pipits_pipeline/1.5.0"
+#
+# Then, to make Galaxy load/unload the appropriate module, you just have to add the following lines (without to the #) to the "lmod_modules_mapping.yml" file:
+#
+#- from:
+#    name: PIPITS
+#    version: 1.5.0
+#  to:
+#    name: pipits_pipeline
+#    version: 1.5.0.6
+#
+#
+# Example 2:
+#
+# The requirements section specify a requirement on the PIPITS tool but do not ask for a specific version of it:
+#
+#	<requirements>
+#		<requirement type="package">PIPITS</requirement>
+#	</requirements>
+#
+# Although, there is no version required you may want to force the loading of a version that is known to run well on your system.
+#
+# In that case you can add the following lines to the "lmod_modules_mapping.yml" file:
+#
+#- from:
+#    name: PIPITS
+#    unversioned: true
+#  to:
+#    name: pipits_pipeline
+#    version: 1.4.0

--- a/lib/galaxy/tools/deps/resolvers/lmod.py
+++ b/lib/galaxy/tools/deps/resolvers/lmod.py
@@ -167,11 +167,11 @@ class LmodDependency(Dependency):
         # - Set the MODULEPATH environment variable
         command = 'MODULEPATH=%s; ' % (self.lmod_dependency_resolver.modulepath)
         command += 'export MODULEPATH; '
-        # - Execute the "module load" command
-        command += 'eval `%s load %s`; ' % (self.lmod_dependency_resolver.lmodexec, module_to_load)
+        # - Execute the "module load" command (or rather the "/path/to/lmod load" command)
+        command += 'eval `%s load %s` ' % (self.lmod_dependency_resolver.lmodexec, module_to_load)
         # - Execute the "settarg" command in addition if needed
         if self.lmod_dependency_resolver.settargexec is not None:
-            command += 'eval `%s -s sh`' % (self.lmod_dependency_resolver.settargexec)
+            command += '&& eval `%s -s sh`' % (self.lmod_dependency_resolver.settargexec)
 
         return command
 

--- a/lib/galaxy/tools/deps/resolvers/lmod.py
+++ b/lib/galaxy/tools/deps/resolvers/lmod.py
@@ -25,6 +25,7 @@ log = logging.getLogger(__name__)
 DEFAULT_LMOD_PATH = getenv('LMOD_CMD')
 DEFAULT_SETTARG_PATH = getenv('LMOD_SETTARG_CMD')
 DEFAULT_MODULEPATH = getenv('MODULEPATH')
+DEFAULT_MAPPING_FILE = 'config/lmod_modules_mapping.yml'
 INVALID_LMOD_PATH_MSG = "The following LMOD executable could not be found: %s. Either your LMOD Dependency Resolver is misconfigured or LMOD is improperly installed on your system !"
 EMPTY_MODULEPATH_MSG = "No valid LMOD MODULEPATH defined ! Either your LMOD Dependency Resolver is misconfigured or LMOD is improperly installed on your system !"
 
@@ -35,12 +36,21 @@ class LmodDependencyResolver(DependencyResolver, MappableDependencyResolver):
     resolver_type = "lmod"
 
     def __init__(self, dependency_manager, **kwds):
+        # Mapping file management
+        self._set_default_mapping_file(kwds)
         self._setup_mapping(dependency_manager, **kwds)
+
+        # Other attributes
         self.versionless = _string_as_bool(kwds.get('versionless', 'false'))
         self.lmodexec = kwds.get('lmodexec', DEFAULT_LMOD_PATH)
         self.settargexec = kwds.get('settargexec', DEFAULT_SETTARG_PATH)
         self.modulepath = kwds.get('modulepath', DEFAULT_MODULEPATH)
         self.module_checker = AvailModuleChecker(self, self.modulepath)
+
+    def _set_default_mapping_file(self, resolver_attributes):
+        if not resolver_attributes.has_key('mapping_files'):
+            if exists(DEFAULT_MAPPING_FILE):
+                resolver_attributes['mapping_files'] = DEFAULT_MAPPING_FILE
 
     def resolve(self, requirement, **kwds):
         requirement = self._expand_mappings(requirement)

--- a/lib/galaxy/tools/deps/resolvers/lmod.py
+++ b/lib/galaxy/tools/deps/resolvers/lmod.py
@@ -29,6 +29,7 @@ DEFAULT_MAPPING_FILE = 'config/lmod_modules_mapping.yml'
 INVALID_LMOD_PATH_MSG = "The following LMOD executable could not be found: %s. Either your LMOD Dependency Resolver is misconfigured or LMOD is improperly installed on your system !"
 EMPTY_MODULEPATH_MSG = "No valid LMOD MODULEPATH defined ! Either your LMOD Dependency Resolver is misconfigured or LMOD is improperly installed on your system !"
 
+
 class LmodDependencyResolver(DependencyResolver, MappableDependencyResolver):
     """Dependency resolver based on the LMOD environment modules system"""
 
@@ -48,7 +49,7 @@ class LmodDependencyResolver(DependencyResolver, MappableDependencyResolver):
         self.module_checker = AvailModuleChecker(self, self.modulepath)
 
     def _set_default_mapping_file(self, resolver_attributes):
-        if not resolver_attributes.has_key('mapping_files'):
+        if 'mapping_files' not in resolver_attributes:
             if exists(DEFAULT_MAPPING_FILE):
                 resolver_attributes['mapping_files'] = DEFAULT_MAPPING_FILE
 
@@ -76,7 +77,6 @@ class AvailModuleChecker(object):
     def __init__(self, lmod_dependency_resolver, modulepath):
         self.lmod_dependency_resolver = lmod_dependency_resolver
         self.modulepath = modulepath
-
 
     def has_module(self, module, version):
         # In versionless mode we only get the list of default modules

--- a/lib/galaxy/tools/deps/resolvers/lmod.py
+++ b/lib/galaxy/tools/deps/resolvers/lmod.py
@@ -1,0 +1,173 @@
+"""
+This is a prototype dependency resolver to be able to use the "LMOD environment modules system" from TACC to solve package requirements
+
+LMOD official website: https://www.tacc.utexas.edu/research-development/tacc-projects/lmod
+
+LMOD @ Github: https://github.com/TACC/Lmod
+
+"""
+import logging
+from os import getenv
+from os.path import exists
+from subprocess import PIPE, Popen
+
+from six import StringIO
+
+from ..resolvers import (
+    Dependency,
+    DependencyResolver,
+    MappableDependencyResolver,
+    NullDependency,
+)
+
+log = logging.getLogger(__name__)
+
+DEFAULT_LMOD_PATH = getenv('LMOD_CMD')
+DEFAULT_SETTARG_PATH = getenv('LMOD_SETTARG_CMD')
+DEFAULT_MODULEPATH = getenv('MODULEPATH')
+INVALID_LMOD_PATH_MSG = "The following LMOD executable could not be found: %s. Either your LMOD Dependency Resolver is misconfigured or LMOD is improperly installed on your system !"
+EMPTY_MODULEPATH_MSG = "No valid LMOD MODULEPATH defined ! Either your LMOD Dependency Resolver is misconfigured or LMOD is improperly installed on your system !"
+
+class LmodDependencyResolver(DependencyResolver, MappableDependencyResolver):
+    """Dependency resolver based on the LMOD environment modules system"""
+
+    dict_collection_visible_keys = DependencyResolver.dict_collection_visible_keys + ['base_path', 'modulepath']
+    resolver_type = "lmod"
+
+    def __init__(self, dependency_manager, **kwds):
+        self._setup_mapping(dependency_manager, **kwds)
+        self.versionless = _string_as_bool(kwds.get('versionless', 'false'))
+        self.lmodexec = kwds.get('lmodexec', DEFAULT_LMOD_PATH)
+        self.settargexec = kwds.get('settargexec', DEFAULT_SETTARG_PATH)
+        self.modulepath = kwds.get('modulepath', DEFAULT_MODULEPATH)
+        self.module_checker = AvailModuleChecker(self, self.modulepath)
+
+    def resolve(self, requirement, **kwds):
+        requirement = self._expand_mappings(requirement)
+        name, version, type = requirement.name, requirement.version, requirement.type
+
+        if type != "package":
+            return NullDependency(version=version, name=name)
+
+        if self.__has_module(name, version):
+            return LmodDependency(self, name, version, exact=True)
+        elif self.versionless and self.__has_module(name, None):
+            return LmodDependency(self, name, None, exact=False)
+
+        return NullDependency(version=version, name=name)
+
+    def __has_module(self, name, version):
+        return self.module_checker.has_module(name, version)
+
+
+class AvailModuleChecker(object):
+    """Parses the output of Lmod 'module avail' command to get the list of available modules."""
+
+    def __init__(self, lmod_dependency_resolver, modulepath):
+        self.lmod_dependency_resolver = lmod_dependency_resolver
+        self.modulepath = modulepath
+
+
+    def has_module(self, module, version):
+        # In versionless mode we only get the list of default modules
+        # We get the full module list otherwise
+        if version is None:
+            available_modules = self.__get_list_of_available_modules(True)
+        else:
+            available_modules = self.__get_list_of_available_modules(False)
+
+        # Is the required module in the list of avaialable modules ?
+        for module_name, module_version in available_modules:
+            names_match = module == module_name
+            module_match = names_match and (version is None or module_version == version)
+            if module_match:
+                return True
+        return False
+
+    def __get_list_of_available_modules(self, default_version_only=False):
+        # Get the results of the "module avail" command in an easy to parse format
+        # Note that since "module" is actually a bash function, we are directy executing the underlying executable instead
+        raw_output = self.__get_module_avail_command_output(default_version_only).decode("utf-8")
+
+        # Parse the result
+        for line in StringIO(raw_output):
+            # Clean line and discard non-module lines
+            line = line and line.strip()
+            if not line or line.startswith("/"):
+                continue
+
+            # Split module lines by / to separate the module name from the module version
+            # Module without version are discarded
+            module_parts = line.split('/')
+            if len(module_parts) == 2:
+                yield module_parts[0], module_parts[1]
+
+    def __get_module_avail_command_output(self, default_version_only=False):
+        # Check if the LMOD executable is available (ie. if both LMOD and the lmod dependency resolver are both setup properly)
+        lmodexec = self.lmod_dependency_resolver.lmodexec
+        if not exists(lmodexec):
+            raise Exception(INVALID_LMOD_PATH_MSG % lmodexec)
+
+        # Check if the MODULEPATH environment
+        if self.modulepath == "" or self.modulepath is None:
+            raise Exception(EMPTY_MODULEPATH_MSG)
+
+        # Build command line
+        if default_version_only:
+            module_avail_command = [lmodexec, '-t', '-d', 'avail']
+        else:
+            module_avail_command = [lmodexec, '-t', 'avail']
+
+        # The list of avaialable modules is actually printed on stderr and not stdout for module commands
+        return Popen(module_avail_command, stdout=PIPE, stderr=PIPE, env={'MODULEPATH': self.modulepath}, close_fds=True).communicate()[1]
+
+
+class LmodDependency(Dependency):
+    """Prepare the commands required to solve the dependency and add them to the script used to run a tool in Galaxy."""
+
+    dict_collection_visible_keys = Dependency.dict_collection_visible_keys + ['module_name', 'module_version']
+    dependency_type = 'lmod'
+
+    def __init__(self, lmod_dependency_resolver, module_name, module_version=None, exact=True):
+        self.lmod_dependency_resolver = lmod_dependency_resolver
+        self.module_name = module_name
+        self.module_version = module_version
+        self._exact = exact
+
+    @property
+    def name(self):
+        return self.module_name
+
+    @property
+    def version(self):
+        return self.module_version
+
+    @property
+    def exact(self):
+        return self._exact
+
+    def shell_commands(self, requirement):
+        # Get the full module name in the form "tool_name/tool_version"
+        module_to_load = self.module_name
+        if self.module_version:
+            module_to_load = '%s/%s' % (self.module_name, self.module_version)
+
+        # Build the list of command to add to run script
+        # Note that since "module" is actually a bash function, we are directy executing the underlying executable instead
+        # - Set the MODULEPATH environment variable
+        command = 'MODULEPATH=%s; ' % (self.lmod_dependency_resolver.modulepath)
+        command += 'export MODULEPATH; '
+        # - Execute the "module load" command
+        command += 'eval `%s load %s`; ' % (self.lmod_dependency_resolver.lmodexec, module_to_load)
+        # - Execute the "settarg" command in addition if needed
+        if self.lmod_dependency_resolver.settargexec is not None:
+            command += 'eval `%s -s sh`' % (self.lmod_dependency_resolver.settargexec)
+
+        return command
+
+
+def _string_as_bool(value):
+    return str(value).lower() == "true"
+
+
+__all__ = ('LmodDependencyResolver', )

--- a/lib/galaxy/tools/deps/resolvers/lmod.py
+++ b/lib/galaxy/tools/deps/resolvers/lmod.py
@@ -79,8 +79,8 @@ class AvailModuleChecker(object):
         self.modulepath = modulepath
 
     def has_module(self, module, version):
-        # In versionless mode we only get the list of default modules
-        # We get the full module list otherwise
+        # When version is None (No specific version required by the wrapper -or- versionless is set to 'true'), we only get the list of default modules
+        # We get the full list of modules otherwise
         if version is None:
             available_modules = self.__get_list_of_available_modules(True)
         else:

--- a/test/unit/tools/test_tool_deps.py
+++ b/test/unit/tools/test_tool_deps.py
@@ -304,7 +304,7 @@ Mothur/1.33.3
 Mothur/1.36.1
 Mothur/1.38.1.1
 ''')
-        resolver = LmodDependencyResolver(_SimpleDependencyManager(), lmodexec=lmod_script)
+        resolver = LmodDependencyResolver(_SimpleDependencyManager(), lmodexec=lmod_script, modulepath='/path/to/modulefiles')
 
         lmod = resolver.resolve(ToolRequirement(name="Infernal", version=None, type="package"))
         assert lmod.module_name == "Infernal"
@@ -326,7 +326,7 @@ BlastPlus/2.4.0+
 Infernal/1.1.2
 Mothur/1.36.1
 ''')
-        resolver = LmodDependencyResolver(_SimpleDependencyManager(), lmodexec=lmod_script, versionless='true')
+        resolver = LmodDependencyResolver(_SimpleDependencyManager(), lmodexec=lmod_script, versionless='true', modulepath='/path/to/modulefiles')
 
         lmod = resolver.resolve(ToolRequirement(name="Infernal", version=None, type="package"))
         assert lmod.module_name == "Infernal"
@@ -374,7 +374,7 @@ Mothur/1.38.1.1
     version: 1.38.1.1
 ''')
 
-        resolver = LmodDependencyResolver(_SimpleDependencyManager(), lmodexec=lmod_script, mapping_files=mapping_file)
+        resolver = LmodDependencyResolver(_SimpleDependencyManager(), lmodexec=lmod_script, mapping_files=mapping_file, modulepath='/path/to/modulefiles')
 
         lmod = resolver.resolve(ToolRequirement(name="BlastPlus", version="2.2.31+", type="package"))
         assert lmod.module_name == "BlastPlus"
@@ -418,7 +418,7 @@ if [ "$2" != "foomodule/1.0" ]; then
 fi
 echo 'FOO="bar"'
 ''')
-        resolver = Bunch(lmodexec=mock_lmodexec, settargexec=None, modulepath='/something')
+        resolver = Bunch(lmodexec=mock_lmodexec, settargexec=None, modulepath='/path/to/modulefiles')
         dependency = LmodDependency(resolver, "foomodule", "1.0")
         __assert_foo_exported(dependency.shell_commands(Bunch(type="package")))
 

--- a/test/unit/tools/test_tool_deps.py
+++ b/test/unit/tools/test_tool_deps.py
@@ -20,8 +20,8 @@ from galaxy.tools.deps.requirements import (
 )
 from galaxy.tools.deps.resolvers import NullDependency
 from galaxy.tools.deps.resolvers.galaxy_packages import GalaxyPackageDependency
-from galaxy.tools.deps.resolvers.modules import ModuleDependency, ModuleDependencyResolver
 from galaxy.tools.deps.resolvers.lmod import LmodDependency, LmodDependencyResolver
+from galaxy.tools.deps.resolvers.modules import ModuleDependency, ModuleDependencyResolver
 from galaxy.util.bunch import Bunch
 
 

--- a/test/unit/tools/test_tool_deps.py
+++ b/test/unit/tools/test_tool_deps.py
@@ -21,6 +21,7 @@ from galaxy.tools.deps.requirements import (
 from galaxy.tools.deps.resolvers import NullDependency
 from galaxy.tools.deps.resolvers.galaxy_packages import GalaxyPackageDependency
 from galaxy.tools.deps.resolvers.modules import ModuleDependency, ModuleDependencyResolver
+from galaxy.tools.deps.resolvers.lmod import LmodDependency, LmodDependencyResolver
 from galaxy.util.bunch import Bunch
 
 
@@ -286,6 +287,139 @@ echo 'FOO="bar"'
 ''')
         resolver = Bunch(modulecmd=mock_modulecmd, modulepath='/something')
         dependency = ModuleDependency(resolver, "foomodule", "1.0")
+        __assert_foo_exported(dependency.shell_commands(Bunch(type="package")))
+
+
+def test_lmod_dependency_resolver():
+    with __test_base_path() as temp_directory:
+        lmod_script = _setup_lmod_command(temp_directory, '''
+/opt/apps/modulefiles:
+BlastPlus/
+BlastPlus/2.2.31+
+BlastPlus/2.4.0+
+Infernal/
+Infernal/1.1.2
+Mothur/
+Mothur/1.33.3
+Mothur/1.36.1
+Mothur/1.38.1.1
+''')
+        resolver = LmodDependencyResolver(_SimpleDependencyManager(), lmodexec=lmod_script)
+
+        lmod = resolver.resolve(ToolRequirement(name="Infernal", version=None, type="package"))
+        assert lmod.module_name == "Infernal"
+        assert lmod.module_version is None
+
+        lmod = resolver.resolve(ToolRequirement(name="BlastPlus", version="2.4.0+", type="package"))
+        assert lmod.module_name == "BlastPlus"
+        assert lmod.module_version == "2.4.0+"
+
+        lmod = resolver.resolve(ToolRequirement(name="Mothur", version="1.39", type="package"))
+        assert isinstance(lmod, NullDependency)
+
+
+def test_lmod_dependency_resolver_versionless():
+    with __test_base_path() as temp_directory:
+        lmod_script = _setup_lmod_command(temp_directory, '''
+/opt/apps/modulefiles:
+BlastPlus/2.4.0+
+Infernal/1.1.2
+Mothur/1.36.1
+''')
+        resolver = LmodDependencyResolver(_SimpleDependencyManager(), lmodexec=lmod_script, versionless='true')
+
+        lmod = resolver.resolve(ToolRequirement(name="Infernal", version=None, type="package"))
+        assert lmod.module_name == "Infernal"
+        assert lmod.module_version is None
+
+        lmod = resolver.resolve(ToolRequirement(name="Mothur", version="1.36.1", type="package"))
+        assert lmod.module_name == "Mothur"
+        assert lmod.module_version == "1.36.1"
+
+        lmod = resolver.resolve(ToolRequirement(name="BlastPlus", version="2.3", type="package"))
+        assert lmod.module_name == "BlastPlus"
+        assert lmod.module_version is None
+
+        lmod = resolver.resolve(ToolRequirement(name="Foo", version="0.1", type="package"))
+        assert isinstance(lmod, NullDependency)
+
+
+def test_lmod_dependency_resolver_with_mapping_file():
+    with __test_base_path() as temp_directory:
+        lmod_script = _setup_lmod_command(temp_directory, '''
+/opt/apps/modulefiles:
+BlastPlus/
+BlastPlus/2.2.31+
+BlastPlus/2.4.0+
+Infernal/
+Infernal/1.1.2
+Mothur/
+Mothur/1.33.3
+Mothur/1.36.1
+Mothur/1.38.1.1
+''')
+        mapping_file = os.path.join(temp_directory, "mapping")
+        with open(mapping_file, "w") as f:
+            f.write('''
+- from:
+    name: blast+
+    unversioned: true
+  to:
+    name: BlastPlus
+    version: 2.4.0+
+- from:
+    name: Mothur
+    version: 1.38
+  to:
+    version: 1.38.1.1
+''')
+
+        resolver = LmodDependencyResolver(_SimpleDependencyManager(), lmodexec=lmod_script, mapping_files=mapping_file)
+
+        lmod = resolver.resolve(ToolRequirement(name="BlastPlus", version="2.2.31+", type="package"))
+        assert lmod.module_name == "BlastPlus"
+        assert lmod.module_version == "2.2.31+", lmod.module_version
+
+        lmod = resolver.resolve(ToolRequirement(name="blast+", type="package"))
+        assert lmod.module_name == "BlastPlus"
+        assert lmod.module_version == "2.4.0+", lmod.module_version
+
+        lmod = resolver.resolve(ToolRequirement(name="blast+", version="2.23", type="package"))
+        assert isinstance(lmod, NullDependency)
+
+        lmod = resolver.resolve(ToolRequirement(name="Infernal", version="1.2", type="package"))
+        assert isinstance(lmod, NullDependency)
+
+        lmod = resolver.resolve(ToolRequirement(name="Mothur", version="1.38", type="package"))
+        assert lmod.module_name == "Mothur"
+        assert lmod.module_version == "1.38.1.1", lmod.module_version
+
+
+def _setup_lmod_command(temp_directory, contents):
+    lmod_script = os.path.join(temp_directory, "lmod")
+    __write_script(lmod_script, '''#!/bin/sh
+cat %s/lmod_example_output 1>&2;
+''' % temp_directory)
+    with open(os.path.join(temp_directory, "lmod_example_output"), "w") as f:
+        # Subset of a "lmod -t avail" command of the LMOD environment module system.
+        f.write(contents)
+    return lmod_script
+
+
+def test_lmod_dependency():
+    with __test_base_path() as temp_directory:
+        # Create mock lmod script that just exports a variable
+        # the way "lmod load" would, but also validate correct
+        # module name and version are coming through.
+        mock_lmodexec = os.path.join(temp_directory, 'pouet')
+        __write_script(mock_lmodexec, '''#!/bin/sh
+if [ "$2" != "foomodule/1.0" ]; then
+    exit 1
+fi
+echo 'FOO="bar"'
+''')
+        resolver = Bunch(lmodexec=mock_lmodexec, settargexec=None, modulepath='/something')
+        dependency = LmodDependency(resolver, "foomodule", "1.0")
         __assert_foo_exported(dependency.shell_commands(Bunch(type="package")))
 
 


### PR DESCRIPTION
Hi everyone,

This Pull Request concern the integration of a new Dependency resolver (with mapping file support) for the LMOD environment modules system.

This new resolver is inspired by the "modules" resolver but takes into account the differences between LMOD and the legacy module system.

I tried to make the commit messages as detailed as possible.

With this PR, 2 new files are included and 2 existing files are modified:
- (NEW) lib/galaxy/tools/deps/resolvers/lmod.py
- (NEW) config/lmod_modules_mapping.yml.sample
- (MOD) config/dependency_resolvers_conf.xml.sample (with explanations on the resolver attributes)
- (MOD) test/unit/tools/test_tool_deps.py

I've setup the resolver so that it automatically use the lmod_modules_mapping.yml file if it exists in the config folder. Is that the proper way to manage default mapping files in resolvers ?

Since there was no adapted tests for this resolver in test_tool_deps.py script I tried to write some.
However, since I'm defintily not an expert in that matter, feel free to comment them :)

Travis is activated for my fork of the galaxyproject repository and the last build passed without errors (except the .11 build that is in the _Allowed Failures_ section).