### PR TITLE
41% reduction in freiburg galaxy startup time

### DIFF
--- a/lib/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/installed_repository_manager.py
@@ -42,6 +42,13 @@ class InstalledRepositoryManager(object):
         self.tool_configs = self.app.config.tool_configs
         if self.app.config.migrated_tools_config not in self.tool_configs:
             self.tool_configs.append(self.app.config.migrated_tools_config)
+
+        self.tool_trees = []
+        for tool_config in self.tool_configs:
+            tree, error_message = xml_util.parse_xml(tool_config)
+            log.error(error_message)
+            self.tool_trees.append(tree)
+
         self.installed_repository_dicts = []
         # Keep an in-memory dictionary whose keys are tuples defining tool_shed_repository objects (whose status is 'Installed')
         # and whose values are a list of tuples defining tool_shed_repository objects (whose status can be anything) required by
@@ -572,8 +579,7 @@ class InstalledRepositoryManager(object):
                 str(repository.installed_changeset_revision))
 
     def get_repository_install_dir(self, tool_shed_repository):
-        for tool_config in self.tool_configs:
-            tree, error_message = xml_util.parse_xml(tool_config)
+        for tree in self.tool_trees:
             if tree is None:
                 return None
             root = tree.getroot()

--- a/lib/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/installed_repository_manager.py
@@ -46,7 +46,8 @@ class InstalledRepositoryManager(object):
         self.tool_trees = []
         for tool_config in self.tool_configs:
             tree, error_message = xml_util.parse_xml(tool_config)
-            log.error(error_message)
+            if error_message:
+                log.error(error_message)
             self.tool_trees.append(tree)
 
         self.installed_repository_dicts = []

--- a/lib/tool_shed/util/xml_util.py
+++ b/lib/tool_shed/util/xml_util.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 import tempfile
 import xml.etree.ElementTree
@@ -118,6 +119,9 @@ def indent(elem, level=0):
 def parse_xml(file_name):
     """Returns a parsed xml tree with comments intact."""
     error_message = ''
+    if not os.path.exists(file_name):
+        return None, "File does not exist %s" % str(file_name)
+
     fobj = open(file_name, 'r')
     if using_python_27:
         try:


### PR DESCRIPTION
So it turns out the `shed_tool_conf.xml` (and every other tool conf) was being re-parsed ahead of every. single. tool shed repository. For large galaxies with large numbers of installed tools.. this sucks. A single (and therefor unscientific datapoint), boot time was decreased from 12 minutes to 7 minutes.

cc @bgruening 