### PR TITLE
Workflow loading speedup

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -73,6 +73,8 @@ class Registry(object):
         self.datatype_elems = []
         self.sniffer_elems = []
         self.xml_filename = None
+        self._edam_formats_mapping = None
+        self._edam_data_mapping = None
         # Build sites
         self.build_sites = {}
         self.display_sites = {}
@@ -853,15 +855,17 @@ class Registry(object):
     def edam_formats(self):
         """
         """
-        mapping = dict((k, v.edam_format) for k, v in self.datatypes_by_extension.items())
-        return mapping
+        if not self._edam_formats_mapping:
+            self._edam_formats_mapping = dict((k, v.edam_format) for k, v in self.datatypes_by_extension.items())
+        return self._edam_formats_mapping
 
     @property
     def edam_data(self):
         """
         """
-        mapping = dict((k, v.edam_data) for k, v in self.datatypes_by_extension.items())
-        return mapping
+        if not self._edam_data_mapping:
+            self._edam_data_mapping = dict((k, v.edam_data) for k, v in self.datatypes_by_extension.items())
+        return self._edam_data_mapping
 
     @property
     def integrated_datatypes_configs(self):

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -596,13 +596,12 @@ class WorkflowContentsManager(UsesAnnotations):
             }
             # Add tool shed repository information and post-job actions to step dict.
             if module.type == 'tool':
-                if module.tool.tool_shed_repository:
-                    tsr = module.tool.tool_shed_repository
+                if module.tool and module.tool.tool_shed:
                     step_dict["tool_shed_repository"] = {
-                        'name': tsr.name,
-                        'owner': tsr.owner,
-                        'changeset_revision': tsr.changeset_revision,
-                        'tool_shed': tsr.tool_shed
+                        'name': module.tool.repository_name,
+                        'owner': module.tool.repository_owner,
+                        'changeset_revision': module.tool.changeset_revision,
+                        'tool_shed': module.tool.tool_shed
                     }
                 pja_dict = {}
                 for pja in step.post_job_actions:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -451,10 +451,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 else:
                     data['upgrade_messages'][step.order_index] = {module.tool.name: "\n".join(module.version_changes)}
             # Get user annotation.
-            step_annotation = self.get_item_annotation_obj(trans.sa_session, trans.user, step)
-            annotation_str = ""
-            if step_annotation:
-                annotation_str = step_annotation.annotation
+            annotation_str = self.get_item_annotation_str(trans.sa_session, trans.user, step) or ''
             config_form = None
             if trans.history:
                 # If in a web session, attach form html. No reason to do
@@ -550,9 +547,7 @@ class WorkflowContentsManager(UsesAnnotations):
 
         annotation_str = ""
         if stored is not None:
-            workflow_annotation = self.get_item_annotation_obj(trans.sa_session, trans.user, stored)
-            if workflow_annotation:
-                annotation_str = workflow_annotation.annotation
+            annotation_str = self.get_item_annotation_str(trans.sa_session, trans.user, stored) or ''
         # Pack workflow data into a dictionary and return
         data = {}
         data['a_galaxy_workflow'] = 'true'  # Placeholder for identifying galaxy workflow
@@ -569,10 +564,7 @@ class WorkflowContentsManager(UsesAnnotations):
             if not module:
                 return None
             # Get user annotation.
-            step_annotation = self.get_item_annotation_obj(trans.sa_session, trans.user, step)
-            annotation_str = ""
-            if step_annotation:
-                annotation_str = step_annotation.annotation
+            annotation_str = self.get_item_annotation_str(trans.sa_session, trans.user, step) or ''
             content_id = module.get_content_id()
             # Export differences for backward compatibility
             if module.type == 'tool':
@@ -744,7 +736,6 @@ class WorkflowContentsManager(UsesAnnotations):
         for step in workflow.steps:
             steps_to_order_index[step.id] = step.order_index
         for step in workflow.steps:
-            step_uuid = str(step.uuid) if step.uuid else None
             step_id = step.id if legacy else step.order_index
             step_type = step.type
             step_dict = {'id': step_id,

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -205,7 +205,7 @@ class WorkflowContentsManager(UsesAnnotations):
         exact_tools=False,
     ):
         # Put parameters in workflow mode
-        trans.workflow_building_mode = True
+        trans.workflow_building_mode = workflow_building_modes.ENABLED
         # If there's a source, put it in the workflow name.
         if source and source != 'API':
             name = "%s (imported from %s)" % (data['name'], source)
@@ -257,7 +257,7 @@ class WorkflowContentsManager(UsesAnnotations):
 
     def update_workflow_from_dict(self, trans, stored_workflow, workflow_data):
         # Put parameters in workflow mode
-        trans.workflow_building_mode = True
+        trans.workflow_building_mode = workflow_building_modes.ENABLED
 
         workflow, missing_tool_tups = self._workflow_from_dict(
             trans,

--- a/lib/galaxy/model/item_attrs.py
+++ b/lib/galaxy/model/item_attrs.py
@@ -100,7 +100,15 @@ class UsesAnnotations:
 
     def get_item_annotation_str(self, db_session, user, item):
         """ Returns a user's annotation string for an item. """
-        annotation_obj = self.get_item_annotation_obj(db_session, user, item)
+        if hasattr(item, 'annotations'):
+            # If we already have an annotations object we use it.
+            annotation_obj = None
+            for annotation in item.annotations:
+                if annotation.user == user:
+                    annotation_obj = annotation
+                    break
+        else:
+            annotation_obj = self.get_item_annotation_obj(db_session, user, item)
         if annotation_obj:
             return galaxy.util.unicodify(annotation_obj.annotation)
         return None

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1805,7 +1805,7 @@ class Tool(object, Dictifiable):
         """
         history_id = kwd.get('history_id', None)
         history = None
-        if not workflow_building_mode or workflow_building_mode is workflow_building_modes.USE_HISTORY:
+        if workflow_building_mode is workflow_building_modes.USE_HISTORY or workflow_building_mode is workflow_building_modes.DISABLED:
             # We don't need a history when exporting a workflow for the workflow editor or when downloading a workflow
             try:
                 if history_id is not None:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -420,6 +420,7 @@ class Tool(object, Dictifiable):
         self.repository_owner = None
         self.changeset_revision = None
         self.installed_changeset_revision = None
+        self.sharable_url = None
         # The tool.id value will be the value of guid, but we'll keep the
         # guid attribute since it is useful to have.
         self.guid = guid
@@ -1104,6 +1105,7 @@ class Tool(object, Dictifiable):
                     self.repository_owner = tool_shed_repository.owner
                     self.changeset_revision = tool_shed_repository.changeset_revision
                     self.installed_changeset_revision = tool_shed_repository.installed_changeset_revision
+                    self.sharable_url = tool_shed_repository.get_sharable_url(self.app)
 
     @property
     def help(self):
@@ -1871,7 +1873,7 @@ class Tool(object, Dictifiable):
             'help'          : tool_help,
             'citations'     : bool(self.citations),
             'biostar_url'   : self.app.config.biostar_url,
-            'sharable_url'  : self.tool_shed_repository.get_sharable_url(self.app) if self.tool_shed_repository else None,
+            'sharable_url'  : self.sharable_url,
             'message'       : tool_message,
             'warnings'      : tool_warnings,
             'versions'      : tool_versions,
@@ -2021,7 +2023,7 @@ class Tool(object, Dictifiable):
                         else:
                             message += 'You can re-run the job with this tool version, which is a different version of the original tool.'
                 else:
-                    new_tool_shed_url = '%s/%s/' % (tool.tool_shed_repository.get_sharable_url(tool.app), tool.tool_shed_repository.changeset_revision)
+                    new_tool_shed_url = '%s/%s/' % (tool.sharable_url, tool.changeset_revision)
                     old_tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry(self.app, tool_id.split('/repos/')[0])
                     old_tool_shed_url = '%s/view/%s/%s/' % (old_tool_shed_url, tool.repository_owner, tool.repository_name)
                     message = 'This job was run with <a href=\"%s\" target=\"_blank\">tool id \"%s\"</a>, version "%s", which is not available.  ' % (old_tool_shed_url, tool_id, tool_version)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -835,7 +835,7 @@ class SelectToolParameter(ToolParameter):
         workflow_building_mode = trans.workflow_building_mode
         for context_value in other_values.values():
             if is_runtime_value(context_value):
-                workflow_building_mode = True
+                workflow_building_mode = workflow_building_modes.ENABLED
                 break
         if len(list(legal_values)) == 0 and workflow_building_mode:
             if self.multiple:

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -1205,10 +1205,8 @@ class UsesStoredWorkflowMixin(SharableItemSecurityMixin, UsesAnnotations):
     def get_stored_workflow(self, trans, id, check_ownership=True, check_accessible=False):
         """ Get a StoredWorkflow from the database by id, verifying ownership. """
         # Load workflow from database
-        try:
-            workflow = trans.sa_session.query(trans.model.StoredWorkflow).get(trans.security.decode_id(id))
-        except TypeError:
-            workflow = None
+        workflow_contents_manager = workflows.WorkflowsManager(self.app)
+        workflow = workflow_contents_manager.get_stored_workflow(trans=trans, workflow_id=id)
 
         if not workflow:
             error("Workflow not found")

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -18,6 +18,7 @@ from galaxy import web
 from galaxy.managers import workflows
 from galaxy.model.item_attrs import UsesItemRatings
 from galaxy.model.mapping import desc
+from galaxy.tools.parameters.basic import workflow_building_modes
 from galaxy.util import unicodify, FILENAME_VALID_CHARS
 from galaxy.util.sanitize_html import sanitize_html
 from galaxy.web import error, url_for
@@ -633,7 +634,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         encode it as a json string that can be read by the workflow editor
         web interface.
         """
-        trans.workflow_building_mode = True
+        trans.workflow_building_mode = workflow_building_modes.ENABLED
         stored = self.get_stored_workflow(trans, id, check_ownership=True, check_accessible=False)
         workflow_contents_manager = workflows.WorkflowContentsManager(trans.app)
         return workflow_contents_manager.workflow_to_dict(trans, stored, style="editor")
@@ -644,7 +645,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         """
         Exports a workflow to myExperiment website.
         """
-        trans.workflow_building_mode = True
+        trans.workflow_building_mode = workflow_building_modes.ENABLED
         stored = self.get_stored_workflow(trans, id, check_ownership=False, check_accessible=True)
 
         # Convert workflow to dict.

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -608,7 +608,7 @@ class ToolModule(WorkflowModule):
                     if not old_tool_shed_url:  # a tool from a different tool_shed has been found, but the original tool shed has been deactivated
                         old_tool_shed_url = "http://" + old_tool_shed  # let's just assume it's either http, or a http is forwarded to https.
                     old_url = old_tool_shed_url + "/view/%s/%s/" % (module.tool.repository_owner, module.tool.repository_name)
-                    new_url = module.tool.tool_shed_repository.get_sharable_url(module.tool.app) + '/%s/' % module.tool.tool_shed_repository.changeset_revision
+                    new_url = module.tool.sharable_url + '/%s/' % module.tool.changeset_revision
                     new_tool_shed_url = new_url.split("/view")[0]
                     message += "The tool \'%s\', version %s by the owner %s installed from <a href=\"%s\" target=\"_blank\">%s</a> is not available. " % (module.tool.name, tool_version, module.tool.repository_owner, old_url, old_tool_shed_url)
                     message += "A derivation of this tool installed from <a href=\"%s\" target=\"_blank\">%s</a> will be used instead. " % (new_url, new_tool_shed_url)


### PR DESCRIPTION
This PR introduces a number of changes to improve the speed with which we iterate over workflows and workflow steps by doing roughly 4 things (see commits for details).

 - Fetch related workflows, steps, tags and annotations when getting the StoredWorkflow instance from the database
 - Avoid accessing tool_shed_repository attributes when these are available in the Tool object
 - Avoid looking up annotations and and tags when they are attached to the StoredWorkflow instance
- Build edam datatypes only once per datatype registry lifetime.

For a sqlite backend this decreases the time needed to download a workflow through the API using the `editor` style about 4 fold. When using a postgresql backend the speed of downloading a single workflow is minor, but profiling the API endpoint directly shows about a 10 fold speedup.