### PR TITLE
Selenium test fixes and improvements.

### DIFF
--- a/test/galaxy_selenium/driver_factory.py
+++ b/test/galaxy_selenium/driver_factory.py
@@ -42,7 +42,7 @@ def get_remote_driver(
         browser = "CHROME"
     assert browser in ["CHROME", "EDGE", "ANDROID", "FIREFOX", "INTERNETEXPLORER", "IPAD", "IPHONE", "OPERA", "PHANTOMJS", "SAFARI"]
     desired_capabilities = getattr(DesiredCapabilities, browser)
-
+    desired_capabilities['loggingPrefs'] = {"browser": "all"}
     executor = 'http://%s:%s/wd/hub' % (host, port)
     driver = webdriver.Remote(
         command_executor=executor,

--- a/test/galaxy_selenium/sizzle.py
+++ b/test/galaxy_selenium/sizzle.py
@@ -95,12 +95,18 @@ def find_elements_by_sizzle(driver, sizzle_selector):
 
 def _inject_sizzle(driver, sizzle_url, timeout):
     script = """
-        var _s = document.createElement("script");
-        _s.type = "text/javascript";
-        _s.src = "{src}";
-        var _h = document.getElementsByTagName("head")[0];
-        _h.appendChild(_s);
-    """.format(src=sizzle_url)
+        if(typeof(window.$) != "undefined") {
+            // Just reuse jQuery if it is available, avoids potential amd problems
+            // that have cropped up with Galaxy for instance.
+            window.Sizzle = window.$;
+        } else {
+            var _s = document.createElement("script");
+            _s.type = "text/javascript";
+            _s.src = "%s";
+            var _h = document.getElementsByTagName("head")[0];
+            _h.appendChild(_s);
+        }
+    """ % sizzle_url
     driver.execute_script(script)
     wait = WebDriverWait(driver, timeout)
     wait.until(lambda d: _is_sizzle_loaded(d),
@@ -121,8 +127,8 @@ def _make_sizzle_string(sizzle_selector):
 
 
 __all__ = (
-    "sizzle_selector_clickable",
-    "sizzle_presence_of_selector",
     "find_element_by_sizzle",
     "find_elements_by_sizzle",
+    "sizzle_selector_clickable",
+    "sizzle_presence_of_selector",
 )

--- a/test/selenium_tests/framework.py
+++ b/test/selenium_tests/framework.py
@@ -91,6 +91,11 @@ def selenium_test(f):
                     write_file("page_source.txt", self.driver.page_source)
                     write_file("DOM.txt", self.driver.execute_script("return document.documentElement.outerHTML"))
                     write_file("stacktrace.txt", traceback.format_exc())
+                    for log_type in ["browser", "driver"]:
+                        try:
+                            write_file("%s.log.json" % log_type, json.dumps(self.driver.get_log(log_type)))
+                        except Exception:
+                            continue
                     iframes = self.driver.find_elements_by_css_selector("iframe")
                     for iframe in iframes:
                         pass

--- a/test/selenium_tests/test_sizzle_loading.py
+++ b/test/selenium_tests/test_sizzle_loading.py
@@ -1,0 +1,10 @@
+from .framework import SeleniumTestCase
+from .framework import selenium_test
+
+
+class SizzleLoadingTestCase(SeleniumTestCase):
+
+    @selenium_test
+    def test_sizzle_loads(self):
+        self.home()
+        self.wait_for_sizzle_selector_clickable("div")


### PR DESCRIPTION
## More logging for selenium tests.

Dump the browser log and the driver log out as JSON to the test error directory for that test.

## Fix and Improve setting up Sizzle for Selenium tests.

Something related to AMD broke our way of injecting Sizzle into Galaxy for Selenium tests. This is a much better way that seems to work - just use jQuery (``$``) as ``Sizzle`` if it is available. Avoids an external dependency and another page fetch per test as well as fixing the problem.

Add a test case that just tests the sizzle stuff works on its own. It will be a clear indication what is broken if there are related regressions in the future.
