### PR TITLE
More robust workflow invocation testing.

### DIFF
--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -651,8 +651,8 @@ steps:
         inputs = {
             '0': self._ds_entry(hda1),
         }
-        self.__invoke_workflow(history_id, workflow_id, inputs)
-        time.sleep(5)
+        invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
+        self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         self.assertEqual("a\nc\nb\nd\n", self.dataset_populator.get_history_dataset_content(history_id, hid=0))
 
@@ -681,8 +681,8 @@ steps:
         inputs = {
             '0': self._ds_entry(hdca1),
         }
-        self.__invoke_workflow(history_id, workflow_id, inputs)
-        time.sleep(5)
+        invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
+        self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         self.assertEqual("a\nc\nb\nd\ne\ng\nf\nh\n", self.dataset_populator.get_history_dataset_content(history_id, hid=0))
 


### PR DESCRIPTION
Less random sleeping, wait for actual invocation. I think this is likely the cause this transient failure (https://jenkins.galaxyproject.org/job/docker-api/8215/testReport/junit/api.test_workflows/WorkflowsApiTestCase/test_workflow_run_output_collection_mapping/) picking up the input as the last dataset in the history instead of the output - I bet the workflow just hadn't been invoked yet.