### PR TITLE
Another fix for Selenium worklow tests.

### DIFF
--- a/test/selenium_tests/test_workflow_run.py
+++ b/test/selenium_tests/test_workflow_run.py
@@ -42,6 +42,5 @@ class WorkflowRunTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.workflow_index_open()
         self.workflow_index_click_option("Run")
         time.sleep(.5)
-        with self.main_panel():
-            # Check that this tool form contains a warning about different versions.
-            self.assert_warning_message(contains="different versions")
+        # Check that this tool form contains a warning about different versions.
+        self.assert_warning_message(contains="different versions")


### PR DESCRIPTION
This time for the workflow upgrade message test, mirrors the fix in #4524 - the content we are searching for in on this page is no longer in the iframe.