### PR TITLE
Export collections when exporting an history

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1084,7 +1084,7 @@ class JobExternalOutputMetadata(object):
 class JobExportHistoryArchive(object):
     def __init__(self, job=None, history=None, dataset=None, compressed=False,
                  history_attrs_filename=None, datasets_attrs_filename=None,
-                 jobs_attrs_filename=None):
+                 jobs_attrs_filename=None, collections_attrs_filename=None):
         self.job = job
         self.history = history
         self.dataset = dataset
@@ -1092,6 +1092,7 @@ class JobExportHistoryArchive(object):
         self.history_attrs_filename = history_attrs_filename
         self.datasets_attrs_filename = datasets_attrs_filename
         self.jobs_attrs_filename = jobs_attrs_filename
+        self.collections_attrs_filename = collections_attrs_filename 
 
     @property
     def up_to_date(self):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1092,7 +1092,7 @@ class JobExportHistoryArchive(object):
         self.history_attrs_filename = history_attrs_filename
         self.datasets_attrs_filename = datasets_attrs_filename
         self.jobs_attrs_filename = jobs_attrs_filename
-        self.collections_attrs_filename = collections_attrs_filename 
+        self.collections_attrs_filename = collections_attrs_filename
 
     @property
     def up_to_date(self):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1083,16 +1083,16 @@ class JobExternalOutputMetadata(object):
 
 class JobExportHistoryArchive(object):
     def __init__(self, job=None, history=None, dataset=None, compressed=False,
-                 history_attrs_filename=None, datasets_attrs_filename=None,
-                 jobs_attrs_filename=None, collections_attrs_filename=None):
+                 history_attrs_filename=None):
         self.job = job
         self.history = history
         self.dataset = dataset
         self.compressed = compressed
         self.history_attrs_filename = history_attrs_filename
-        self.datasets_attrs_filename = datasets_attrs_filename
-        self.jobs_attrs_filename = jobs_attrs_filename
-        self.collections_attrs_filename = collections_attrs_filename
+
+    @property
+    def temp_directory(self):
+        return os.path.split(self.history_attrs_filename)[0]
 
     @property
     def up_to_date(self):

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -582,7 +582,8 @@ model.JobExportHistoryArchive.table = Table(
     Column("compressed", Boolean, index=True, default=False),
     Column("history_attrs_filename", TEXT),
     Column("datasets_attrs_filename", TEXT),
-    Column("jobs_attrs_filename", TEXT))
+    Column("jobs_attrs_filename", TEXT,
+    Column("collections_attrs_filename", TEXT))
 
 model.JobImportHistoryArchive.table = Table(
     "job_import_history_archive", metadata,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -582,7 +582,7 @@ model.JobExportHistoryArchive.table = Table(
     Column("compressed", Boolean, index=True, default=False),
     Column("history_attrs_filename", TEXT),
     Column("datasets_attrs_filename", TEXT),
-    Column("jobs_attrs_filename", TEXT,
+    Column("jobs_attrs_filename", TEXT),
     Column("collections_attrs_filename", TEXT))
 
 model.JobImportHistoryArchive.table = Table(

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -580,10 +580,7 @@ model.JobExportHistoryArchive.table = Table(
     Column("history_id", Integer, ForeignKey("history.id"), index=True),
     Column("dataset_id", Integer, ForeignKey("dataset.id"), index=True),
     Column("compressed", Boolean, index=True, default=False),
-    Column("history_attrs_filename", TEXT),
-    Column("datasets_attrs_filename", TEXT),
-    Column("jobs_attrs_filename", TEXT),
-    Column("collections_attrs_filename", TEXT))
+    Column("history_attrs_filename", TEXT))
 
 model.JobImportHistoryArchive.table = Table(
     "job_import_history_archive", metadata,

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -555,6 +555,9 @@ class JobExportHistoryArchiveWrapper(object, UsesAnnotations):
                 break
 
             collections_attrs.append(collection)
+            # export jobs for these datasets
+            for collection_dataset in collection.dataset_instances:
+                included_datasets.append(collection_dataset)
 
         collections_attrs_filename = tempfile.NamedTemporaryFile(dir=temp_output_dir).name
         collections_attrs_out = open(collections_attrs_filename, 'w')

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -29,7 +29,9 @@ class JobImportHistoryArchiveWrapper(object, UsesAnnotations):
         self.sa_session = self.app.model.context
 
     def cleanup_after_job(self):
-        """ Set history, datasets, and jobs' attributes and clean up archive directory. """
+        """ Set history, datasets, collections and jobs' attributes
+            and clean up archive directory.
+        """
 
         #
         # Helper methods.
@@ -410,17 +412,17 @@ class JobExportHistoryArchiveWrapper(object, UsesAnnotations):
             def default(self, obj):
                 """ Encode a collection, default encoding for everything else. """
                 if isinstance(obj, trans.model.HistoryDatasetCollectionAssociation):
-                    #dump attrs of each dataset of this collection
+                    # dump attrs of each dataset of this collection
                     collections_datasets_attrs = []
                     collection_datasets = obj.dataset_instances
                     for collection_dataset in collection_datasets:
                         collections_datasets_attrs.append(collection_dataset)
-                    
+
                     rval = {
                         "display_name": obj.display_name(),
                         "state": obj.state,
                         "populated": obj.populated,
-                        "datasets":dumps(collections_datasets_attrs, cls=HistoryDatasetAssociationEncoder)
+                        "datasets": dumps(collections_datasets_attrs, cls=HistoryDatasetAssociationEncoder)
                     }
                     return rval
                 return json.JSONEncoder.default(self, obj)
@@ -473,18 +475,18 @@ class JobExportHistoryArchiveWrapper(object, UsesAnnotations):
 
         # Write collections' attributes (including datasets list) to file.
         collections = get_history_collections(trans, history)
-    
+
         collections_attrs = []
         included_collections_datasets = []
         collections_datasets_attrs = []
         collections_provenance_attrs = []
         for collection in collections:
-            #filter this ?
-            if collection.populated == False:
+            # filter this ?
+            if not collection.populated:
                 break
             if collection.state != 'ok':
                 break
-        
+
             collections_attrs.append(collection)
 
         collections_attrs_filename = tempfile.NamedTemporaryFile(dir=temp_output_dir).name

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -537,7 +537,6 @@ class JobExportHistoryArchiveWrapper(object, UsesAnnotations):
         datasets_attrs_out = open(datasets_attrs_filename, 'w')
         datasets_attrs_out.write(dumps(datasets_attrs, cls=HistoryDatasetAssociationEncoder))
         datasets_attrs_out.close()
-        jeha.datasets_attrs_filename = datasets_attrs_filename
 
         provenance_attrs_out = open(datasets_attrs_filename + ".provenance", 'w')
         provenance_attrs_out.write(dumps(provenance_attrs, cls=HistoryDatasetAssociationEncoder))
@@ -563,7 +562,6 @@ class JobExportHistoryArchiveWrapper(object, UsesAnnotations):
         collections_attrs_out = open(collections_attrs_filename, 'w')
         collections_attrs_out.write(dumps(collections_attrs, cls=CollectionsEncoder))
         collections_attrs_out.close()
-        jeha.collections_attrs_filename = collections_attrs_filename
 
         #
         # Write jobs attributes file.
@@ -640,7 +638,6 @@ class JobExportHistoryArchiveWrapper(object, UsesAnnotations):
         jobs_attrs_out = open(jobs_attrs_filename, 'w')
         jobs_attrs_out.write(dumps(jobs_attrs, cls=HistoryDatasetAssociationEncoder))
         jobs_attrs_out.close()
-        jeha.jobs_attrs_filename = jobs_attrs_filename
 
         #
         # Create and return command line for running tool.
@@ -658,12 +655,7 @@ class JobExportHistoryArchiveWrapper(object, UsesAnnotations):
         # Get jeha for job.
         jeha = db_session.query(model.JobExportHistoryArchive).filter_by(job_id=self.job_id).first()
         if jeha:
-            for filename in [jeha.history_attrs_filename, jeha.datasets_attrs_filename, jeha.jobs_attrs_filename, jeha.collections_attrs_filename]:
-                try:
-                    os.remove(filename)
-                except Exception as e:
-                    log.debug('Failed to cleanup attributes file (%s): %s' % (filename, e))
-            temp_dir = os.path.split(jeha.history_attrs_filename)[0]
+            temp_dir = jeha.temp_directory
             try:
                 shutil.rmtree(temp_dir)
             except Exception as e:

--- a/lib/galaxy/tools/imp_exp/export_history.py
+++ b/lib/galaxy/tools/imp_exp/export_history.py
@@ -24,7 +24,23 @@ def get_dataset_filename(name, ext, hid):
     return base + "_%s.%s" % (hid, ext)
 
 
-def create_archive(history_attrs_file, datasets_attrs_file, jobs_attrs_file, out_file, gzip=False):
+def read_attributes_from_file(file):
+    """ Read attributes from file and return JSON. """
+    datasets_attr_in = open(file, 'rb')
+    datasets_attr_str = ''
+    buffsize = 1048576
+    try:
+       while True:
+           datasets_attr_str += datasets_attr_in.read(buffsize)
+           if not datasets_attr_str or len(datasets_attr_str) % buffsize != 0:
+               break
+    except OverflowError:
+        pass
+    datasets_attrs = loads(datasets_attr_str)
+    return datasets_attrs
+
+
+def create_archive(history_attrs_file, datasets_attrs_file, jobs_attrs_file, collections_attrs_file, out_file, gzip=False):
     """ Create archive from the given attribute/metadata files and save it to out_file. """
     tarfile_mode = "w"
     if gzip:
@@ -33,19 +49,7 @@ def create_archive(history_attrs_file, datasets_attrs_file, jobs_attrs_file, out
 
         history_archive = tarfile.open(out_file, tarfile_mode)
 
-        # Read datasets attributes from file.
-        datasets_attr_in = open(datasets_attrs_file, 'rb')
-        datasets_attr_str = ''
-        buffsize = 1048576
-        try:
-            while True:
-                datasets_attr_str += datasets_attr_in.read(buffsize)
-                if not datasets_attr_str or len(datasets_attr_str) % buffsize != 0:
-                    break
-        except OverflowError:
-            pass
-        datasets_attr_in.close()
-        datasets_attrs = loads(datasets_attr_str)
+        datasets_attrs = read_attributes_from_file(datasets_attrs_file)
 
         # Add datasets to archive and update dataset attributes.
         # TODO: security check to ensure that files added are in Galaxy dataset directory?
@@ -81,12 +85,49 @@ def create_archive(history_attrs_file, datasets_attrs_file, jobs_attrs_file, out
         datasets_attrs_out = open(datasets_attrs_file, 'w')
         datasets_attrs_out.write(dumps(datasets_attrs))
         datasets_attrs_out.close()
+ 
+        collections_attrs = read_attributes_from_file(collections_attrs_file)
+
+        # Add collections datasets to archive and update dataset attributes.
+        for collection_attrs in collections_attrs:
+            for collection_dataset_attrs in collection_attrs['datasets']:
+                dataset_file_name = collection_dataset_attrs['file_name']  # Full file name.
+                dataset_hid = collection_dataset_attrs['hid']
+                collections_dataset_archive_name = os.path.join('collections_datasets',
+                                                     get_dataset_filename(collection_dataset_attrs['name'], collection_dataset_attrs['extension'], dataset_hid))
+                history_archive.add(dataset_file_name, arcname=collections_dataset_archive_name) 
+                # Include additional files for example, files/images included in HTML output.
+                extra_files_path = collection_dataset_attrs['extra_files_path']
+                if extra_files_path:
+                    try:
+                        file_list = os.listdir(extra_files_path)
+                    except OSError:
+                        file_list = []
+
+                    if len(file_list):
+                        dataset_extra_files_path = 'collections_datasets/extra_files_path_%s' % dataset_hid
+                        for fname in file_list:
+                            history_archive.add(os.path.join(extra_files_path, fname),
+                                                arcname=(os.path.join(dataset_extra_files_path, fname)))
+                        collection_dataset_attrs['extra_files_path'] = dataset_extra_files_path
+                    else:
+                        collection_dataset_attrs['extra_files_path'] = ''
+
+                # Update dataset filename to be archive name.
+                collection_dataset_attrs['file_name'] = collections_dataset_archive_name
+
+        # Rewrite collection attributes file.
+        collections_datasets_attrs_out = open(collections_attrs_file, 'w')
+        collections_datasets_attrs_out.write(dumps(collections_attrs))
+        collections_datasets_attrs_out.close()
 
         # Finish archive.
         history_archive.add(history_attrs_file, arcname="history_attrs.txt")
         history_archive.add(datasets_attrs_file, arcname="datasets_attrs.txt")
         if os.path.exists(datasets_attrs_file + ".provenance"):
             history_archive.add(datasets_attrs_file + ".provenance", arcname="datasets_attrs.txt.provenance")
+        if os.path.exists(collections_attrs_file):
+            history_archive.add(collections_attrs_file, arcname="collections_attrs.txt")
         history_archive.add(jobs_attrs_file, arcname="jobs_attrs.txt")
         history_archive.close()
 
@@ -102,10 +143,10 @@ def main():
     parser.add_option('-G', '--gzip', dest='gzip', action="store_true", help='Compress archive using gzip.')
     (options, args) = parser.parse_args()
     gzip = bool(options.gzip)
-    history_attrs, dataset_attrs, job_attrs, out_file = args
+    history_attrs, dataset_attrs, job_attrs, collection_attrs, out_file = args
 
     # Create archive.
-    status = create_archive(history_attrs, dataset_attrs, job_attrs, out_file, gzip)
+    status = create_archive(history_attrs, dataset_attrs, job_attrs, collection_attrs, out_file, gzip)
     print(status)
 
 

--- a/lib/galaxy/tools/imp_exp/export_history.py
+++ b/lib/galaxy/tools/imp_exp/export_history.py
@@ -30,10 +30,10 @@ def read_attributes_from_file(file):
     datasets_attr_str = ''
     buffsize = 1048576
     try:
-       while True:
-           datasets_attr_str += datasets_attr_in.read(buffsize)
-           if not datasets_attr_str or len(datasets_attr_str) % buffsize != 0:
-               break
+        while True:
+            datasets_attr_str += datasets_attr_in.read(buffsize)
+            if not datasets_attr_str or len(datasets_attr_str) % buffsize != 0:
+                break
     except OverflowError:
         pass
     datasets_attrs = loads(datasets_attr_str)
@@ -85,7 +85,7 @@ def create_archive(history_attrs_file, datasets_attrs_file, jobs_attrs_file, col
         datasets_attrs_out = open(datasets_attrs_file, 'w')
         datasets_attrs_out.write(dumps(datasets_attrs))
         datasets_attrs_out.close()
- 
+
         collections_attrs = read_attributes_from_file(collections_attrs_file)
 
         # Add collections datasets to archive and update dataset attributes.
@@ -94,8 +94,8 @@ def create_archive(history_attrs_file, datasets_attrs_file, jobs_attrs_file, col
                 dataset_file_name = collection_dataset_attrs['file_name']  # Full file name.
                 dataset_hid = collection_dataset_attrs['hid']
                 collections_dataset_archive_name = os.path.join('collections_datasets',
-                                                     get_dataset_filename(collection_dataset_attrs['name'], collection_dataset_attrs['extension'], dataset_hid))
-                history_archive.add(dataset_file_name, arcname=collections_dataset_archive_name) 
+                                                                get_dataset_filename(collection_dataset_attrs['name'], collection_dataset_attrs['extension'], dataset_hid))
+                history_archive.add(dataset_file_name, arcname=collections_dataset_archive_name)
                 # Include additional files for example, files/images included in HTML output.
                 extra_files_path = collection_dataset_attrs['extra_files_path']
                 if extra_files_path:

--- a/lib/galaxy/tools/imp_exp/export_history.py
+++ b/lib/galaxy/tools/imp_exp/export_history.py
@@ -86,47 +86,48 @@ def create_archive(history_attrs_file, datasets_attrs_file, jobs_attrs_file, col
         datasets_attrs_out.write(dumps(datasets_attrs))
         datasets_attrs_out.close()
 
-        collections_attrs = read_attributes_from_file(collections_attrs_file)
+        if collections_attrs_file:
+            collections_attrs = read_attributes_from_file(collections_attrs_file)
 
-        # Add collections datasets to archive and update dataset attributes.
-        for collection_attrs in collections_attrs:
-            for collection_dataset_attrs in collection_attrs['datasets']:
-                dataset_file_name = collection_dataset_attrs['file_name']  # Full file name.
-                dataset_hid = collection_dataset_attrs['hid']
-                collections_dataset_archive_name = os.path.join('collections_datasets',
-                                                                get_dataset_filename(collection_dataset_attrs['name'], collection_dataset_attrs['extension'], dataset_hid))
-                history_archive.add(dataset_file_name, arcname=collections_dataset_archive_name)
-                # Include additional files for example, files/images included in HTML output.
-                extra_files_path = collection_dataset_attrs['extra_files_path']
-                if extra_files_path:
-                    try:
-                        file_list = os.listdir(extra_files_path)
-                    except OSError:
-                        file_list = []
+            # Add collections datasets to archive and update dataset attributes.
+            for collection_attrs in collections_attrs:
+                for collection_dataset_attrs in collection_attrs['datasets']:
+                    dataset_file_name = collection_dataset_attrs['file_name']  # Full file name.
+                    dataset_hid = collection_dataset_attrs['hid']
+                    collections_dataset_archive_name = os.path.join('collections_datasets',
+                                                                    get_dataset_filename(collection_dataset_attrs['name'], collection_dataset_attrs['extension'], dataset_hid))
+                    history_archive.add(dataset_file_name, arcname=collections_dataset_archive_name)
+                    # Include additional files for example, files/images included in HTML output.
+                    extra_files_path = collection_dataset_attrs['extra_files_path']
+                    if extra_files_path:
+                        try:
+                            file_list = os.listdir(extra_files_path)
+                        except OSError:
+                            file_list = []
 
-                    if len(file_list):
-                        dataset_extra_files_path = 'collections_datasets/extra_files_path_%s' % dataset_hid
-                        for fname in file_list:
-                            history_archive.add(os.path.join(extra_files_path, fname),
-                                                arcname=(os.path.join(dataset_extra_files_path, fname)))
-                        collection_dataset_attrs['extra_files_path'] = dataset_extra_files_path
-                    else:
-                        collection_dataset_attrs['extra_files_path'] = ''
+                        if len(file_list):
+                            dataset_extra_files_path = 'collections_datasets/extra_files_path_%s' % dataset_hid
+                            for fname in file_list:
+                                history_archive.add(os.path.join(extra_files_path, fname),
+                                                    arcname=(os.path.join(dataset_extra_files_path, fname)))
+                            collection_dataset_attrs['extra_files_path'] = dataset_extra_files_path
+                        else:
+                            collection_dataset_attrs['extra_files_path'] = ''
 
-                # Update dataset filename to be archive name.
-                collection_dataset_attrs['file_name'] = collections_dataset_archive_name
+                    # Update dataset filename to be archive name.
+                    collection_dataset_attrs['file_name'] = collections_dataset_archive_name
 
-        # Rewrite collection attributes file.
-        collections_datasets_attrs_out = open(collections_attrs_file, 'w')
-        collections_datasets_attrs_out.write(dumps(collections_attrs))
-        collections_datasets_attrs_out.close()
+            # Rewrite collection attributes file.
+            collections_datasets_attrs_out = open(collections_attrs_file, 'w')
+            collections_datasets_attrs_out.write(dumps(collections_attrs))
+            collections_datasets_attrs_out.close()
 
         # Finish archive.
         history_archive.add(history_attrs_file, arcname="history_attrs.txt")
         history_archive.add(datasets_attrs_file, arcname="datasets_attrs.txt")
         if os.path.exists(datasets_attrs_file + ".provenance"):
             history_archive.add(datasets_attrs_file + ".provenance", arcname="datasets_attrs.txt.provenance")
-        if os.path.exists(collections_attrs_file):
+        if collections_attrs_file and os.path.exists(collections_attrs_file):
             history_archive.add(collections_attrs_file, arcname="collections_attrs.txt")
         history_archive.add(jobs_attrs_file, arcname="jobs_attrs.txt")
         history_archive.close()
@@ -143,7 +144,17 @@ def main():
     parser.add_option('-G', '--gzip', dest='gzip', action="store_true", help='Compress archive using gzip.')
     (options, args) = parser.parse_args()
     gzip = bool(options.gzip)
-    history_attrs, dataset_attrs, job_attrs, collection_attrs, out_file = args
+    if len(args) == 2:
+        # We have a 18.0X directory argument instead of individual arguments.
+        temp_directory, out_file = args
+        history_attrs = os.path.join(temp_directory, 'history_attrs.txt')
+        dataset_attrs = os.path.join(temp_directory, 'datasets_attrs.txt')
+        job_attrs = os.path.join(temp_directory, 'jobs_attrs.txt')
+        collection_attrs = os.path.join(temp_directory, 'collections_attrs.txt')
+    else:
+        # This job was created pre 18.0X with old argument style.
+        history_attrs, dataset_attrs, job_attrs, out_file = args
+        collection_attrs = None
 
     # Create archive.
     status = create_archive(history_attrs, dataset_attrs, job_attrs, collection_attrs, out_file, gzip)


### PR DESCRIPTION
#4345 

Here are some first commits.

Collections are exported and their attributes and files are now present in the archive.

I have to deal now with import. I hope that I have exported enough stuff within the archive

Exports works within my install (I've add a column in one table of the database: job_export_history_archive). 
It's not heavily tested (two small histories, one with only one collection, another one with two collections)

Collections are type "list", I haven't tried type "pair" yet

I used pep8 in order to avoid common errors of style

I don't know what to do here: 

> lib/galaxy/model/migrate/versions/