### PR TITLE
Implement influxdb error reporter

### DIFF
--- a/config/error_report.yml.sample
+++ b/config/error_report.yml.sample
@@ -40,3 +40,14 @@
 # their behalf.
 # - type: biostars
 #   user_submission: true
+
+# InfluxDB error reporting backend. You will need to `pip install
+# influxdb` in the galaxy virtualenv yourself. This sends well tagged
+# errors InfluxDB allowing you to notice relationships between tool errors and
+# other infrastructure issues.
+# - type: influxdb
+#   # All arguments prefixed with `influxdb_` are per http://influxdb-python.readthedocs.io/en/latest/api-documentation.html#influxdbclient
+#   influxdb_host: 127.0.0.1
+#   influxdb_port: 8086
+#   influxdb_database: galaxy
+#   influxdb_timeout: 2

--- a/doc/source/admin/special_topics/bug_reports.rst
+++ b/doc/source/admin/special_topics/bug_reports.rst
@@ -70,3 +70,22 @@ When ``verbose="true" user_submission="true"``, the plugin will inform the user
 that ``Submitted bug report to Sentry. Your guru meditation number is
 dc907d44ce294f78b267a56f68e5cd1a``, using the same phrasing that is common to
 users from Galaxy internal server errors.
+
+InfluxDB
+--------
+
+This sends data directly to an InfluxDB server that you have available. If you wish to
+use this plugin you will first need to ``pip install influxdb`` in Galaxy's virtual environment.
+
+This plugin will send a value of ``1`` every time an error occurs, tagged with important information such as:
+
+- handler
+- tool_id
+- tool_version
+- exit_code
+
+This allows you to visualize the rate of bug reports (``group by time(30m)``,
+adjust as needed for how many error reports you see) in conjunction with any
+other data you're already tracking in InfluxDB/Grafana. This setup allows
+answering questions such as "did the change I make decrease the number of tool
+failures on average"

--- a/lib/galaxy/tools/error_reports/plugins/influxdb.py
+++ b/lib/galaxy/tools/error_reports/plugins/influxdb.py
@@ -54,6 +54,7 @@ class InfluxDBPlugin(ErrorPlugin):
                 'tool_id': unicodify(job.tool_id),
                 'tool_version': unicodify(job.tool_version),
                 'tool_xml': unicodify(tool.config_file) if tool else None,
+                'destination_id': unicodify(job.destination_id),
                 'handler': unicodify(job.handler),
             }
         }])

--- a/lib/galaxy/tools/error_reports/plugins/influxdb.py
+++ b/lib/galaxy/tools/error_reports/plugins/influxdb.py
@@ -1,0 +1,63 @@
+"""The module describes the ``influxdb`` error plugin plugin."""
+from __future__ import absolute_import
+
+import datetime
+import logging
+
+from galaxy.util import unicodify
+
+from ..plugins import ErrorPlugin
+
+try:
+    import influxdb
+except ImportError:
+    # This middleware will never be used without influxdb.
+    influxdb = None
+
+log = logging.getLogger(__name__)
+
+
+class InfluxDBPlugin(ErrorPlugin):
+    """Send error report to InfluxDB
+    """
+    plugin_type = "influxdb"
+
+    def __init__(self, **kwargs):
+        if not influxdb:
+            raise ImportError("Could not find InfluxDB Client, this error reporter will be disabled; please pip install influxdb")
+
+        self.app = kwargs['app']
+        # Neither of these matter
+        self.verbose = False
+        self.user_submission = False
+        # Anything with influxdb_ gets sent to the client initialization
+        influx_args = {
+            k[len('influxdb_'):]: v
+            for (k, v)
+            in kwargs.items()
+            if k.startswith('influxdb_')
+        }
+        print(influx_args)
+        self.client = influxdb.InfluxDBClient(**influx_args)
+
+    def submit_report(self, dataset, job, tool, **kwargs):
+        """Submit the error report to sentry
+        """
+        self.client.write_points([{
+            'measurement': 'galaxy_tool_error',
+            'time': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+            'fields': {
+                'value': 1
+            },
+            'tags': {
+                'exit_code': job.exit_code,
+                'tool_id': unicodify(job.tool_id),
+                'tool_version': unicodify(job.tool_version),
+                'tool_xml': unicodify(tool.config_file) if tool else None,
+                'handler': unicodify(job.handler),
+            }
+        }])
+        return ('Submitted to InfluxDB', 'success')
+
+
+__all__ = ('InfluxDBPlugin', )

--- a/lib/galaxy/tools/error_reports/plugins/json.py
+++ b/lib/galaxy/tools/error_reports/plugins/json.py
@@ -35,6 +35,7 @@ class JsonPlugin(ErrorPlugin):
                 'info' : job.info,
                 'id' : job.id,
                 'command_line' : job.command_line,
+                'destination_id': job.destination_id,
                 'stderr' : job.stderr,
                 'traceback': job.traceback,
                 'exit_code': job.exit_code,

--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -42,6 +42,7 @@ class SentryPlugin(ErrorPlugin):
                 'info': job.info,
                 'id': job.id,
                 'command_line': unicodify(job.command_line),
+                'destination_id': unicodify(job.destination_id),
                 'stderr': unicodify(job.stderr),
                 'traceback': unicodify(job.traceback),
                 'exit_code': job.exit_code,


### PR DESCRIPTION
ping @dannon @natefoo One can envision building dashboard like:

![auswahl_042](https://user-images.githubusercontent.com/458683/29927649-42a72dfa-8e67-11e7-986d-aef543b6107f.png)

This is created in response to an issue we had where I turned on uwsgi worker auto-killing and it caused a significant increase in number of set metadata tool failures, and they were regular errors too. With a dashboard like this we can get a better view (in conjunction with all of our existing influxdb data / dashboards) of if tool errors are suddenly increasing. Basically it was the easiest way to get this from sentry except in grafana.

![auswahl_043](https://user-images.githubusercontent.com/458683/29927730-7eef7da8-8e67-11e7-9984-f6dec861c848.png)

cc @bgruening 