### PR TITLE
Sync non-CWL galaxy-lib changes.

### DIFF
--- a/lib/galaxy/tools/deps/requirements.py
+++ b/lib/galaxy/tools/deps/requirements.py
@@ -77,7 +77,7 @@ class RequirementSpecification(object):
 
     @staticmethod
     def from_dict(dict):
-        uri = dict.get["uri"]
+        uri = dict.get("uri")
         version = dict.get("version", None)
         return RequirementSpecification(uri=uri, version=version)
 

--- a/lib/galaxy/tools/linters/help.py
+++ b/lib/galaxy/tools/linters/help.py
@@ -39,7 +39,7 @@ def rst_invalid(text):
     """
     invalid_rst = False
     try:
-        rst_to_html(text)
+        rst_to_html(text, error=True)
     except Exception as e:
         invalid_rst = str(e)
     return invalid_rst

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -760,7 +760,7 @@ class Params(object):
         self.__dict__.update(values)
 
 
-def rst_to_html(s):
+def rst_to_html(s, error=False):
     """Convert a blob of reStructuredText to HTML"""
     log = logging.getLogger("docutils")
 
@@ -770,6 +770,8 @@ def rst_to_html(s):
     class FakeStream(object):
         def write(self, str):
             if len(str) > 0 and not str.isspace():
+                if error:
+                    raise Exception(str)
                 log.warning(str)
 
     settings_overrides = {


### PR DESCRIPTION
Covers these two PRs:

- Improve error handling for RST problems when linting (thanks to @erasche) - galaxyproject/galaxy-lib#71
- Fix bug in parsing specifications for requirements - galaxyproject/galaxy-lib#69
