### PR TITLE
Prevent in-place editing of uploaded files if files are imported from the FTP folder

### DIFF
--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -323,20 +323,26 @@ def create_paramfile(trans, uploaded_datasets):
         else:
             try:
                 is_binary = uploaded_dataset.datatype.is_binary
-            except:
+            except Exception:
                 is_binary = None
             try:
                 link_data_only = uploaded_dataset.link_data_only
-            except:
+            except Exception:
                 link_data_only = 'copy_files'
             try:
                 uuid_str = uploaded_dataset.uuid
-            except:
+            except Exception:
                 uuid_str = None
             try:
                 purge_source = uploaded_dataset.purge_source
-            except:
+            except Exception:
                 purge_source = True
+            try:
+                user_ftp_dir = os.path.abspath(trans.user_ftp_dir)
+            except Exception:
+                user_ftp_dir = None
+            if user_ftp_dir and uploaded_dataset.path.startswith(user_ftp_dir):
+                uploaded_dataset.type = 'ftp_import'
             json = dict(file_type=uploaded_dataset.file_type,
                         ext=uploaded_dataset.ext,
                         name=uploaded_dataset.name,

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -85,7 +85,7 @@ def add_file(dataset, registry, json_file, output_path):
     # however there are other instances where modifications should not occur in_place:
     # in-place unpacking or editing of line-ending when linking in data or when
     # importing data from the FTP folder while purge_source is set to false
-    if purge_source == False and dataset.get('type') == 'ftp_import':
+    if not purge_source and dataset.get('type') == 'ftp_import':
         # If we do not purge the source we should not modify it in place.
         in_place = False
     if dataset.type in ('server_dir', 'path_paste'):
@@ -288,8 +288,8 @@ def add_file(dataset, registry, json_file, output_path):
                 if check_content and check_html(dataset.path):
                     file_err('The uploaded file contains inappropriate HTML content', dataset, json_file)
                     return
-            if data_type not in ('gzip', 'bz2', 'zip', 'binary'):
-                if link_data_only == 'copy_files':
+            if data_type != 'binary':
+                if link_data_only == 'copy_files' and data_type not in ('gzip', 'bz2', 'zip'):
                     # Convert universal line endings to Posix line endings if to_posix_lines is True
                     # and the data is not binary or gzip-, bz2- or zip-compressed.
                     if dataset.to_posix_lines:


### PR DESCRIPTION
When importing files from the FTP folder files should not be
modified in-place by galaxy.

Also avoids removing uploaded files if the upload tool runs as a real user.

This also modifies relevant bare `except:` statements and modifies
the meaning of `in_place` in upload.py from no external chown script to
do not edit files in place if we keep the source file.

This fixes https://github.com/galaxyproject/galaxy/issues/4527 and https://github.com/galaxyproject/galaxy/issues/4300.