### PR TITLE
Speedup toolform building

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -75,7 +75,7 @@ class Registry(object):
         self.xml_filename = None
         self._edam_formats_mapping = None
         self._edam_data_mapping = None
-        self._converters_by_datatype = None
+        self._converters_by_datatype = {}
         # Build sites
         self.build_sites = {}
         self.display_sites = {}
@@ -798,7 +798,7 @@ class Registry(object):
 
     def get_converters_by_datatype(self, ext):
         """Returns available converters by source type"""
-        if not self._converters_by_datatype:
+        if ext not in self._converters_by_datatype:
             converters = odict()
             source_datatype = type(self.get_datatype_by_extension(ext))
             for ext2, converters_dict in self.datatype_converters.items():
@@ -808,8 +808,8 @@ class Registry(object):
             # Ensure ext-level converters are present
             if ext in self.datatype_converters.keys():
                 converters.update(self.datatype_converters[ext])
-            self._converters_by_datatype = converters
-        return self._converters_by_datatype
+            self._converters_by_datatype[ext] = converters
+        return self._converters_by_datatype[ext]
 
     def get_converter_by_target_type(self, source_ext, target_ext):
         """Returns a converter based on source and target datatypes"""

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -75,6 +75,7 @@ class Registry(object):
         self.xml_filename = None
         self._edam_formats_mapping = None
         self._edam_data_mapping = None
+        self._converters_by_datatype = None
         # Build sites
         self.build_sites = {}
         self.display_sites = {}
@@ -797,16 +798,18 @@ class Registry(object):
 
     def get_converters_by_datatype(self, ext):
         """Returns available converters by source type"""
-        converters = odict()
-        source_datatype = type(self.get_datatype_by_extension(ext))
-        for ext2, converters_dict in self.datatype_converters.items():
-            converter_datatype = type(self.get_datatype_by_extension(ext2))
-            if issubclass(source_datatype, converter_datatype):
-                converters.update(converters_dict)
-        # Ensure ext-level converters are present
-        if ext in self.datatype_converters.keys():
-            converters.update(self.datatype_converters[ext])
-        return converters
+        if not self._converters_by_datatype:
+            converters = odict()
+            source_datatype = type(self.get_datatype_by_extension(ext))
+            for ext2, converters_dict in self.datatype_converters.items():
+                converter_datatype = type(self.get_datatype_by_extension(ext2))
+                if issubclass(source_datatype, converter_datatype):
+                    converters.update(converters_dict)
+            # Ensure ext-level converters are present
+            if ext in self.datatype_converters.keys():
+                converters.update(self.datatype_converters[ext])
+            self._converters_by_datatype = converters
+        return self._converters_by_datatype
 
     def get_converter_by_target_type(self, source_ext, target_ext):
         """Returns a converter based on source and target datatypes"""

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -22,6 +22,7 @@ class WorkRequestContext(ProvidesAppContext, ProvidesUserContext, ProvidesHistor
         self.app = app
         self.security = app.security
         self.__user = user
+        self.__user_current_roles = None
         self.__history = history
         self.api_inherit_admin = False
         self.workflow_building_mode = workflow_building_mode
@@ -39,6 +40,12 @@ class WorkRequestContext(ProvidesAppContext, ProvidesUserContext, ProvidesHistor
     def get_user(self):
         """Return the current user if logged in or None."""
         return self.__user
+
+    def get_current_user_roles(self):
+        if not self.__user_current_roles:
+            if self.__user:
+                self.__user_current_roles = self.__user.all_roles()
+        return self.__user_current_roles
 
     def set_user(self, user):
         """Set the current user."""


### PR DESCRIPTION
We now get the current user roles just once per WorkRequestContext (instead of for each data input parameter) and we cache the result of looking up the converter through the datatype extension.

The speedup will depend on the number of inputs a tool has. For building the tool form of hisat2 this is a total speedup of 3 fold on our production instance (from 2.4 seconds to ~ 800 ms), but this will also depend on how many items there are in a history (empty history is now at ~ 300 ms).