### PR TITLE
Potential fix for transiently failing Selenium published histories test.

### DIFF
--- a/test/selenium_tests/test_published_histories_grid.py
+++ b/test/selenium_tests/test_published_histories_grid.py
@@ -221,6 +221,8 @@ class HistoryGridTestCase(SeleniumTestCase):
             publish_button = self.wait_for_selector_clickable(selector)
             publish_button.click()
 
+            self.wait_for_selector_clickable('input[name="disable_link_access_and_unpublish"]')
+
     def navigate_to_published_histories_page(self):
         self.home()
         self.click_masthead_user()  # Open masthead menu


### PR DESCRIPTION
The the [latest Selenium test execution](https://jenkins.galaxyproject.org/job/selenium/212/testReport/) most of the published histories tests failed. It looks like this is because of the three histories that were supposed to be published, only 2 were actually published. My best guess for what happend was that the click of the button to publish the history occurred but the next Selenium command happened so quickly that the page had not gotten a chance to respond to the click. This tweaked approach to publishing histories ensures we stay on the page until the "unpublish" link appears - this will either fix the problem or rule this theory out as the explanation.

The [build artifacts](https://jenkins.galaxyproject.org/job/selenium/212/artifact/212-test-errors/) for that Selenium run include this screenshot:

![Screenshot recorded from Jenkins](https://jenkins.galaxyproject.org/job/selenium/212/artifact/212-test-errors/test_history_grid_sort_by_name2017090513251504632344/last.png)

