### PR TITLE
[16.01] Backport uwsgi fix from #2836.

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -29,8 +29,10 @@ log = logging.getLogger( __name__ )
 # uwsgi-managed process.
 try:
     import uwsgi
-    if uwsgi.numproc:
+    if hasattr(uwsgi, "numproc"):
         process_is_uwsgi = True
+    else:
+        process_is_uwsgi = False
 except ImportError:
     # This is not a uwsgi process, or something went horribly wrong.
     process_is_uwsgi = False


### PR DESCRIPTION
Now that newer releases require a library that the mere presence of breaks an older version of Galaxy, I think this will be encountered more during development. It is breaking Planemo's ability to switch between different versions of Galaxy.

https://github.com/galaxyproject/galaxy/pull/2836