### PR TITLE
[WIP] Allow mapping over empty collections.

### DIFF
--- a/lib/galaxy/dataset_collections/matching.py
+++ b/lib/galaxy/dataset_collections/matching.py
@@ -65,7 +65,9 @@ class MatchingCollections(object):
         effective_structure = leaf
         for unlinked_structure in self.unlinked_structures:
             effective_structure = effective_structure.multiply(unlinked_structure)
-        linked_structure = self.linked_structure or leaf
+        linked_structure = self.linked_structure
+        if linked_structure is None:
+            linked_structure = leaf
         effective_structure = effective_structure.multiply(linked_structure)
         return None if effective_structure.is_leaf else effective_structure
 

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -18,12 +18,16 @@ log = logging.getLogger(__name__)
 EXECUTION_SUCCESS_MESSAGE = "Tool [%s] created job [%s] %s"
 
 
-def execute(trans, tool, param_combinations, history, rerun_remap_job_id=None, collection_info=None, workflow_invocation_uuid=None):
+MappingParameters = collections.namedtuple("MappingParameters", ["param_template", "param_combinations"])
+
+
+def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, collection_info=None, workflow_invocation_uuid=None):
     """
     Execute a tool and return object containing summary (output data, number of
     failures, etc...).
     """
     all_jobs_timer = ExecutionTimer()
+    param_combinations = mapping_params.param_combinations
     execution_tracker = ToolExecutionTracker(tool, param_combinations, collection_info)
     app = trans.app
     execution_cache = ToolExecutionCache(trans)
@@ -85,12 +89,8 @@ def execute(trans, tool, param_combinations, history, rerun_remap_job_id=None, c
     log.debug("Executed %d job(s) for tool %s request: %s" % (job_count, tool.id, all_jobs_timer))
     if collection_info:
         history = history or tool.get_default_history_by_trans(trans)
-        if len(param_combinations) == 0:
-            template = "Attempting to map over an empty collection, this is not yet implemented. collection_info is [%s]"
-            message = template % collection_info
-            log.warning(message)
-            raise Exception(message)
-        params = param_combinations[0]
+        # TODO: this perhaps should always just be the param_template. Going to try to be safe first. -John
+        params = param_combinations[0] if param_combinations else mapping_params.param_template
         execution_tracker.create_output_collections(trans, history, params)
 
     return execution_tracker
@@ -150,13 +150,13 @@ class ToolExecutionTracker(object):
         collections = {}
 
         implicit_inputs = list(self.collection_info.collections.items())
-        for output_name, outputs in self.outputs_by_output_name.items():
+        for output_name, output in self.tool.outputs.items():
+            outputs = self.outputs_by_output_name[output_name]
             if not len(structure) == len(outputs):
                 # Output does not have the same structure, if all jobs were
                 # successfully submitted this shouldn't have happened.
                 log.warning("Problem matching up datasets while attempting to create implicit dataset collections")
                 continue
-            output = self.tool.outputs[output_name]
 
             element_identifiers = None
             if hasattr(output, "default_identifier_source"):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -21,7 +21,7 @@ from galaxy.tools import (
     DefaultToolState,
     ToolInputsNotReadyException
 )
-from galaxy.tools.execute import execute
+from galaxy.tools.execute import execute, MappingParameters
 from galaxy.tools.parameters import (
     check_param,
     params_to_incoming,
@@ -856,10 +856,11 @@ class ToolModule(WorkflowModule):
             param_combinations.append(execution_state.inputs)
 
         try:
+            mapping_params = MappingParameters(tool_state.inputs, param_combinations)
             execution_tracker = execute(
                 trans=self.trans,
                 tool=tool,
-                param_combinations=param_combinations,
+                mapping_params=mapping_params,
                 history=invocation.history,
                 collection_info=collection_info,
                 workflow_invocation_uuid=invocation.uuid.hex

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -731,6 +731,24 @@ class ToolsTestCase(api.ApiTestCase):
         }
         self._run_and_check_simple_collection_mapping(history_id, inputs)
 
+    @skip_without_tool("cat1")
+    def test_map_over_empty_collection(self):
+        with self.dataset_populator.test_history() as history_id:
+            hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[]).json()['id']
+            inputs = {
+                "input1": {'batch': True, 'values': [{'src': 'hdca', 'id': hdca_id}]},
+            }
+            create = self._run_cat1(history_id, inputs=inputs, assert_ok=True)
+            outputs = create['outputs']
+            jobs = create['jobs']
+            implicit_collections = create['implicit_collections']
+            self.assertEquals(len(jobs), 0)
+            self.assertEquals(len(outputs), 0)
+            self.assertEquals(len(implicit_collections), 1)
+
+            empty_output = implicit_collections[0]
+            assert empty_output["name"] == "Concatenate datasets on collection 1", empty_output
+
     @skip_without_tool("output_action_change_format")
     def test_map_over_with_output_format_actions(self):
         for use_action in ["do", "dont"]:

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -515,7 +515,7 @@ class BaseDatasetCollectionPopulator(object):
         return element_identifiers
 
     def list_identifiers(self, history_id, contents=None):
-        count = 3 if not contents else len(contents)
+        count = 3 if contents is None else len(contents)
         # Contents can be a list of strings (with name auto-assigned here) or a list of
         # 2-tuples of form (name, dataset_content).
         if contents and isinstance(contents[0], tuple):


### PR DESCRIPTION
If one maps a tool over an empty collection, one should get an empty output collection for each of the tool's outputs.

This should have always been a valid operation I think, the code just wasn't quite structured right when the collection work was merged - there were too many places I was assuming the existence of at least one actual output or input that was mapped over to continue going. This reworks all of that and seems to handle empty collections appropriately.

Fixes #4025 (not being informing the user of the operation, but actually by allowing the operation - which it should be allowed I think).