### PR TITLE
Make submitting logins for Selenium tests a bit more robust.

### DIFF
--- a/test/selenium_tests/test_login.py
+++ b/test/selenium_tests/test_login.py
@@ -10,7 +10,7 @@ class LoginTestCase(SeleniumTestCase):
         self.register(email)
         self.logout_if_needed()
         self.home()
-        self.submit_login(email)
+        self.submit_login(email, assert_valid=True)
         with self.main_panel():
             self.assert_no_error_message()
         assert self.is_logged_in()
@@ -20,7 +20,7 @@ class LoginTestCase(SeleniumTestCase):
         bad_emails = ['test2@test.org', 'test', '', "'; SELECT * FROM galaxy_user WHERE 'u' = 'u';"]
         for bad_email in bad_emails:
             self.home()
-            self.submit_login(bad_email)
+            self.submit_login(bad_email, assert_valid=False)
             with self.main_panel():
                 self.assert_error_message()
 
@@ -29,7 +29,7 @@ class LoginTestCase(SeleniumTestCase):
         bad_passwords = ['1234', '', '; SELECT * FROM galaxy_user']
         for bad_password in bad_passwords:
             self.home()
-            self.submit_login(self._get_random_email(), password=bad_password)
+            self.submit_login(self._get_random_email(), password=bad_password, assert_valid=False)
             with self.main_panel():
                 self.assert_error_message()
 
@@ -39,6 +39,6 @@ class LoginTestCase(SeleniumTestCase):
         self.register(email)
         self.logout_if_needed()
         self.home()
-        self.submit_login(email, password="12345678")
+        self.submit_login(email, password="12345678", assert_valid=False)
         with self.main_panel():
             self.assert_error_message()


### PR DESCRIPTION
There are a few different transiently failing tests on Jenkins that seem to fail because the test thinks Galaxy is logged in but it is not. So now after we click the login button in Selenium - we will wait for to see the "Register or Login" button turn into the "User" button.

This is a similar problem and fix to what was done in #4562 - which seemed to help.