### PR TITLE
Fix logic error in new published histories sort by owner test.

### DIFF
--- a/test/selenium_tests/test_published_histories_grid.py
+++ b/test/selenium_tests/test_published_histories_grid.py
@@ -188,8 +188,8 @@ class HistoryGridTestCase(SeleniumTestCase):
         if getattr(HistoryGridTestCase, "user1_email", None):
             return
 
-        HistoryGridTestCase.user1_email = self._get_random_email()
-        HistoryGridTestCase.user2_email = self._get_random_email()
+        HistoryGridTestCase.user1_email = self._get_random_email("test1")
+        HistoryGridTestCase.user2_email = self._get_random_email("test2")
         self.register(self.user1_email)
         self.create_history(HISTORY1_NAME)
         self.set_tags(HISTORY1_TAGS)


### PR DESCRIPTION
I switched to randomly generated usernames without actually ensure the random usernames would be generated in the same lexiographic order - that wasn't super bright of me. That sort by owner test should pass as frequently as the other tests in that test case class now.