### PR TITLE
Fix another issue with sorting by owner for published histories Selenium test.

### DIFF
--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -318,8 +318,7 @@ class NavigatesGalaxy(HasDriver):
 
         self.upload_start()
 
-        close_button = self.wait_for_selector_clickable("button#btn-close")
-        close_button.click()
+        self.wait_for_and_click_selector("button#btn-close")
 
     def upload_list(self, test_paths, name="test", ext=None, genome=None, hide_source_items=True):
         self._collection_upload_start(test_paths, ext, genome, "List")
@@ -368,16 +367,12 @@ class NavigatesGalaxy(HasDriver):
         self.upload_start(tab_id="collection")
         self.upload_build()
 
-    @retry_during_transitions
     def upload_tab_click(self, tab):
         tab_tag_id = "#tab-title-link-%s" % tab
-        tab_element = self.wait_for_selector_clickable(tab_tag_id)
-        tab_element.click()
+        self.wait_for_and_click_selector(tab_tag_id)
 
-    @retry_during_transitions
     def upload_start_click(self):
-        upload_button = self.wait_for_selector_clickable(".upload-button")
-        upload_button.click()
+        self.wait_for_and_click_selector(".upload-button")
 
     @retry_during_transitions
     def upload_set_footer_extension(self, ext, tab_id="regular"):
@@ -398,10 +393,8 @@ class NavigatesGalaxy(HasDriver):
         self.wait_for_selector_visible(".upload-footer-collection-type")
         self.select2_set_value(".upload-footer-collection-type", collection_type)
 
-    @retry_during_transitions
     def upload_start(self, tab_id="regular"):
-        start_button = self.wait_for_selector_clickable("div#%s button#btn-start" % tab_id)
-        start_button.click()
+        self.wait_for_and_click_selector("div#%s button#btn-start" % tab_id)
 
     @retry_during_transitions
     def upload_build(self):
@@ -414,8 +407,7 @@ class NavigatesGalaxy(HasDriver):
         build_button.click()
 
     def upload_queue_local_file(self, test_path, tab_id="regular"):
-        local_upload_button = self.wait_for_selector_clickable("div#%s button#btn-local" % tab_id)
-        local_upload_button.click()
+        self.wait_for_and_click_selector("div#%s button#btn-local" % tab_id)
 
         file_upload = self.wait_for_selector('div#%s input[type="file"]' % tab_id)
         file_upload.send_keys(test_path)
@@ -432,16 +424,11 @@ class NavigatesGalaxy(HasDriver):
     def workflow_index_table_row(self, workflow_index=0):
         return self.workflow_index_table_elements()[workflow_index]
 
-    @retry_during_transitions
     def workflow_index_click_search(self):
-        search_element = self.wait_for_selector_clickable("input.search-wf")
-        search_element.click()
-        return search_element
+        return self.wait_for_and_click_selector("input.search-wf")
 
-    @retry_during_transitions
     def workflow_index_click_import(self):
-        element = self.wait_for_selector_clickable(self.test_data["selectors"]["workflows"]["import_button"])
-        element.click()
+        self.wait_for_and_click_selector(self.test_data["selectors"]["workflows"]["import_button"])
 
     def workflow_index_rename(self, new_name, workflow_index=0):
         self.workflow_index_click_option("Rename", workflow_index=workflow_index)
@@ -486,8 +473,7 @@ class NavigatesGalaxy(HasDriver):
         self.click_submit(form_element)
 
     def workflow_sharing_click_publish(self):
-        button = self.wait_for_selector_clickable("input[name='make_accessible_and_publish']")
-        button.click()
+        self.wait_for_and_click_selector("input[name='make_accessible_and_publish']")
 
     def tagging_add(self, tags, auto_closes=True, parent_selector=""):
 
@@ -501,12 +487,10 @@ class NavigatesGalaxy(HasDriver):
             self.send_enter(tag_area)
 
     def workflow_run_submit(self):
-        button = self.wait_for_selector_clickable("button.btn-primary")
-        button.click()
+        self.wait_for_and_click_selector("button.btn-primary")
 
     def tool_open(self, tool_id):
-        link_element = self.wait_for_selector('a[href$="tool_runner?tool_id=%s"]' % tool_id)
-        link_element.click()
+        self.wait_for_and_click_selector('a[href$="tool_runner?tool_id=%s"]' % tool_id)
 
     def tool_parameter_div(self, expanded_parameter_id):
         return self.wait_for_selector("div.ui-form-element[tour_id$='%s']" % expanded_parameter_id)
@@ -524,8 +508,7 @@ class NavigatesGalaxy(HasDriver):
             input_element.send_keys(value)
 
     def tool_execute(self):
-        execute_button = self.wait_for_selector("button#execute")
-        execute_button.click()
+        self.wait_for_and_click_selector("button#execute")
 
     def click_masthead_user(self):
         self.click_xpath(self.navigation_data["selectors"]["masthead"]["user"])
@@ -533,10 +516,8 @@ class NavigatesGalaxy(HasDriver):
     def click_masthead_workflow(self):
         self.click_xpath(self.navigation_data["selectors"]["masthead"]["workflow"])
 
-    @retry_during_transitions
     def click_button_new_workflow(self):
-        element = self.wait_for_selector_clickable(self.navigation_data["selectors"]["workflows"]["new_button"])
-        element.click()
+        self.wait_for_and_click_selector(self.navigation_data["selectors"]["workflows"]["new_button"])
 
     def wait_for_sizzle_selector_clickable(self, selector):
         element = self._wait_on(
@@ -572,33 +553,27 @@ class NavigatesGalaxy(HasDriver):
         menu_selector = self.test_data["historyOptions"]["selectors"]["menu"]
         return menu_selector
 
-    @retry_during_transitions
     def history_panel_refresh_click(self):
-        refresh_item = self.wait_for_selector_clickable("#history-refresh-button")
-        refresh_item.click()
+        self.wait_for_and_click_selector("#history-refresh-button")
 
     def history_panel_multi_operations_selector(self):
         return self.test_data["historyPanel"]["selectors"]["history"]["multiOperationsIcon"]
 
     def history_panel_multi_operations_show(self):
         operations_selector = self.history_panel_multi_operations_selector()
-        operations_element = self.wait_for_selector_clickable(operations_selector)
-        operations_element.click()
+        self.wait_for_and_click_selector(operations_selector)
 
-    @retry_during_transitions
     def history_panel_muli_operation_select_hid(self, hid):
         item_selector = self.history_panel_item_selector(hid, wait=True)
         operation_radio_selector = "%s .selector" % item_selector
-        element = self.wait_for_selector_clickable(operation_radio_selector)
-        element.click()
+        self.wait_for_and_click_selector(operation_radio_selector)
 
     def history_panel_multi_operation_action_selector(self):
         return self.test_data["historyPanel"]["selectors"]["history"]["multiOperationsActionBtn"]
 
     def history_panel_multi_operation_action_click(self, action):
         time.sleep(5)
-        button_element = self.wait_for_selector_clickable(self.history_panel_multi_operation_action_selector())
-        button_element.click()
+        self.wait_for_and_click_selector(self.history_panel_multi_operation_action_selector())
         menu_element = self.wait_for_selector_visible(".list-action-menu.open")
         action_element = menu_element.find_element_by_link_text(action)
         action_element.click()
@@ -639,8 +614,7 @@ class NavigatesGalaxy(HasDriver):
 
         button_def = self.test_data["historyPanel"]["hdaPrimaryActionButtons"][button_key]
         button_selector = button_def["selector"]
-        button_item = self.wait_for_selector_visible("%s %s" % (buttons_selector, button_selector))
-        return button_item.click()
+        return self.wait_for_and_click_selector("%s %s" % (buttons_selector, button_selector))
 
     def history_panel_click_item_title(self, **kwds):
         if "hda_id" in kwds:
@@ -648,8 +622,7 @@ class NavigatesGalaxy(HasDriver):
         else:
             item_selector = self.history_panel_item_selector(kwds["hid"])
         title_selector = "%s .title" % item_selector
-        title_element = self.wait_for_selector(title_selector)
-        title_element.click()
+        self.wait_for_and_click_selector(title_selector)
         if kwds.get("wait", False):
             # Find a better way to wait for transition
             time.sleep(.5)
@@ -663,17 +636,13 @@ class NavigatesGalaxy(HasDriver):
         name_element.send_keys(name)
 
     def collection_builder_hide_originals(self):
-        hide_element = self.wait_for_selector_clickable("input.hide-originals")
-        hide_element.click()
+        self.wait_for_and_click_selector("input.hide-originals")
 
     def collection_builder_create(self):
-        create_element = self.wait_for_selector_clickable("button.create-collection")
-        create_element.click()
+        self.wait_for_and_click_selector("button.create-collection")
 
-    @retry_during_transitions
     def collection_builder_clear_filters(self):
-        clear_filter_link = self.wait_for_selector_visible("a.clear-filters-link")
-        clear_filter_link.click()
+        self.wait_for_and_click_selector("a.clear-filters-link")
 
     def collection_builder_click_paired_item(self, forward_or_reverse, item):
         assert forward_or_reverse in ["forward", "reverse"]
@@ -787,6 +756,12 @@ class NavigatesGalaxy(HasDriver):
             print("(Post)Clicking %s" % postclick_selector)
             element = self.tour_wait_for_clickable_element(postclick_selector)
             element.click()
+
+    @retry_during_transitions
+    def wait_for_and_click_selector(self, selector):
+        element = self.wait_for_selector_clickable(selector)
+        element.click()
+        return element
 
     def select2_set_value(self, container_selector, value, with_click=True):
         # There are two hacky was to select things from the select2 widget -

--- a/test/selenium_tests/test_history_panel.py
+++ b/test/selenium_tests/test_history_panel.py
@@ -59,8 +59,8 @@ class HistoryPanelTestCase(SeleniumTestCase):
         tag_area_selector = self.test_data["historyPanel"]["selectors"]["history"]["tagArea"]
         anno_area_selector = self.test_data["historyPanel"]["selectors"]["history"]["annoArea"]
 
-        tag_icon = self.wait_for_selector(tag_icon_selector)
-        annon_icon = self.wait_for_selector(anno_icon_selector)
+        tag_icon = self.wait_for_selector_clickable(tag_icon_selector)
+        annon_icon = self.wait_for_selector_clickable(anno_icon_selector)
 
         self.assert_selector_absent_or_hidden(tag_area_selector)
         self.assert_selector_absent_or_hidden(anno_area_selector)
@@ -83,6 +83,7 @@ class HistoryPanelTestCase(SeleniumTestCase):
         self.assert_selector_absent_or_hidden(tag_area_selector)
         self.assert_selector_absent_or_hidden(anno_area_selector)
 
+    @selenium_test
     def test_refresh_preserves_state(self):
         self.register()
         self.perform_upload(self.get_filename("1.txt"))
@@ -107,8 +108,7 @@ class HistoryPanelTestCase(SeleniumTestCase):
         self.assert_selector_absent_or_hidden(hda_body_selector)
 
     def click_history_refresh(self):
-        refresh_button_element = self.wait_for_selector('a#history-refresh-button')
-        refresh_button_element.click()
+        self.wait_for_and_click_selector('a#history-refresh-button')
 
     def click_to_rename_history(self):
         self.history_panel_name_element().click()

--- a/test/selenium_tests/test_published_histories_grid.py
+++ b/test/selenium_tests/test_published_histories_grid.py
@@ -82,16 +82,14 @@ class HistoryGridTestCase(SeleniumTestCase):
     @selenium_test
     def test_history_grid_sort_by_name(self):
         self.navigate_to_published_histories_page()
-        sort_link = self.wait_for_selector('th#name-header > a')
-        sort_link.click()
+        self.wait_for_and_click_selector('th#name-header > a')
         self.assert_grid_histories_are([HISTORY1_NAME, HISTORY2_NAME, HISTORY3_NAME])
 
     @selenium_test
     def test_history_grid_sort_by_owner(self):
         self.navigate_to_published_histories_page()
-        sort_link = self.wait_for_selector('th#username-header > a')
-        sort_link.click()
-        self.assert_grid_histories_are([HISTORY1_NAME, HISTORY3_NAME, HISTORY2_NAME])
+        self.wait_for_and_click_selector('th#username-header > a')
+        self.assert_grid_histories_sorted_by_owner()
 
     @selenium_test
     def test_history_grid_tag_click(self):
@@ -124,6 +122,15 @@ class HistoryGridTestCase(SeleniumTestCase):
             names.append(cell.text)
 
         return names
+
+    @retry_assertion_during_transitions
+    def assert_grid_histories_sorted_by_owner(self):
+        histories = self.get_histories()
+        index_1, index_2, index_3 = [histories.index(n) for n in [HISTORY1_NAME, HISTORY2_NAME, HISTORY3_NAME]]
+        # 1 and 3 are owned by a owner whose username lexicographically
+        # precedes 2. So verify 1 and 3 come before 2.
+        assert index_1 < index_2
+        assert index_3 < index_2
 
     @retry_assertion_during_transitions
     def assert_grid_histories_are(self, expected_histories, sort_matters=True):


### PR DESCRIPTION
![](https://jenkins.galaxyproject.org/job/selenium/lastCompletedBuild/artifact/243-test-errors/test_history_grid_sort_by_owner2017090817011504904471/last.png)

Locally this never happens, but remotely sometimes when sorting by owner the histories are sorted by owner but not in the same order as the test was asserting. I would assume this is likely a postgres vs. sqlite difference - perhaps the former doesn't sort the rows by the order they were created within equal sort classifications (i.e. same owner) but the latter does. I've fixed this - the test should not have been asserting such a strong condition I don't think.

This includes #4582 because it reused an abstraction introduced there so the diff is a bit messy. See b9cff7a for actual changes described here.

