### PR TITLE
Make history sharing Selenium tests more robust and informative.

### DIFF
--- a/test/selenium_tests/test_history_sharing.py
+++ b/test/selenium_tests/test_history_sharing.py
@@ -9,14 +9,14 @@ class HistorySharingTestCase(SeleniumTestCase):
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history()
         self.submit_login(user2_email)
         response = self.api_get("histories/%s" % history_id, raw=True)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json()
 
     @selenium_test
     def test_sharing_valid_by_id(self):
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history(share_by_id=True)
         self.submit_login(user2_email)
         response = self.api_get("histories/%s" % history_id, raw=True)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json()
 
     @selenium_test
     def test_unsharing(self):
@@ -58,7 +58,7 @@ class HistorySharingTestCase(SeleniumTestCase):
     def test_sharing_with_invalid_user(self):
         user1_email = self._get_random_email()
         self.register(user1_email)
-        self.share_history_with_user("invalid_user@test.com")
+        self.share_history_with_user(user_email="invalid_user@test.com")
         with self.main_panel():
             self.assert_error_message(contains='is not a valid Galaxy user')
 
@@ -66,7 +66,7 @@ class HistorySharingTestCase(SeleniumTestCase):
     def test_sharing_with_self(self):
         user1_email = self._get_random_email()
         self.register(user1_email)
-        self.share_history_with_user(user1_email)
+        self.share_history_with_user(user_email=user1_email)
         with self.main_panel():
             self.assert_error_message(contains='You cannot send histories to yourself')
 
@@ -87,11 +87,9 @@ class HistorySharingTestCase(SeleniumTestCase):
 
         history_id = self.current_history_id()
         if share_by_id:
-            self.share_history_with_user(user2_email)
+            self.share_history_with_user(user_email=user2_email, assert_valid=True)
         else:
-            self.share_history_with_user(user2_id)
-        with self.main_panel():
-            self.assert_no_error_message()
+            self.share_history_with_user(user_id=user2_id, user_email=user2_email, assert_valid=True)
         self.logout_if_needed()
 
         return user1_email, user2_email, history_id
@@ -104,10 +102,15 @@ class HistorySharingTestCase(SeleniumTestCase):
         self.navigate_to_history_share_page()
         with self.main_panel():
             user_share_link_selector = 'a[href^="/history/share?"]'
-            user_share_element = self.wait_for_selector(user_share_link_selector)
-            user_share_element.click()
+            self.wait_for_and_click_selector(user_share_link_selector)
 
-    def share_history_with_user(self, email):
+    def share_history_with_user(self, user_id=None, user_email=None, assert_valid=False):
+        """Share the current history with a target user by ID or email.
+
+        ``user_email`` will be used to enter in the share form unless ``user_id``
+        is also specified. The ``user_email`` however is always used to check
+        the result if ``assert_valid`` is True.
+        """
         self.navigate_to_history_user_share_page()
         with self.main_panel():
             form_selector = "form#share"
@@ -115,5 +118,11 @@ class HistorySharingTestCase(SeleniumTestCase):
             # If expose_user_info is on would fill form out with this
             # line, in future dispatch on actual select2 div present or not.
             # self.select2_set_value(form_selector, email)
-            self.fill(form, {"email": email})
+            self.fill(form, {"email": user_id or user_email})
             self.click_submit(form)
+        if assert_valid:
+            with self.main_panel():
+                self.assert_no_error_message()
+
+                xpath = '//div[contains(text(), "%s")]' % user_email
+                self.wait_for_xpath_visible(xpath)


### PR DESCRIPTION
- Be sure when sharing a history with a user we wait to actually see that user's e-mail address appear in the history's sharing list after submission.
- Print something for the failed history sharing assertions (I'm pretty sure they are 403 errors because some aspect of the sharing or login didn't work - but might as well verify).