### PR TITLE
Improve error reporting in Selenium tests when ``wait_for_logged_in`` fails.

### DIFF
--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -292,7 +292,17 @@ class NavigatesGalaxy(HasDriver):
             self.click_center()
 
     def wait_for_logged_in(self):
-        self.wait_for_selector_visible("a.loggedin-only")
+        try:
+            self.wait_for_selector_visible("a.loggedin-only")
+        except self.TimeoutException as e:
+            user_info = self.api_get("users/current")
+            if "username" in user_info:
+                template = "Failed waiting for masthead to update for login, but user API response indicates [%s] is logged in. This seems to be a bug in Galaxy. API response was [%s]. "
+                message = template % (user_info["username"], user_info)
+            else:
+                template = "Failed waiting for masthead to update for login, API indicates no user is logged in - there is a problem with this test. API response was [%s]. "
+                message = template % user_info
+            raise self.prepend_timeout_message(e, message)
 
     def click_center(self):
         action_chains = self.action_chains()


### PR DESCRIPTION
Previously just a notification about waiting for ``a.loggedin-only`` failed would show up. This doesn't indicate if the login failed completely or the masthead just failed to update. I suspect the login failed completely, but just in case I've updated the error handling to actually ping the API and check and print a better error message with this information.

New messages look like:

TimeoutException: Message: Failed waiting for masthead to update for login, but user API response indicates [test0ol61vs8fo] is logged in. This seems to be a bug in Galaxy. API response was [{u'username': u'test0ol61vs8fo', u'quota_percent': None, u'preferences': {}, u'total_disk_usage': 0.0, u'deleted': False, u'id': u'adb5f5c93f827949', u'nice_total_disk_usage': u'0 bytes', u'quota': None, u'email': u'test0ol61vs8fo@test.test', u'is_admin': False, u'tags_used': [], u'purged': False}].Timeout waiting on CSS selector [a.loggedin-only] to become visible.

and

TimeoutException: Message: Failed waiting for masthead to update for login, API indicates no user is logged in - there is a problem with this test. API response was [{u'quota_percent': None, u'nice_total_disk_usage': u'0 bytes', u'total_disk_usage': 0}]. Timeout waiting on CSS selector [a.loggedin-only] to become visible.

This will help diagnose problems with some of the Selenium tests on Jenkins and could lead to a next step of dispatching on this information and retrying the login if it is the second problem and reloading the page if it is the first.