### PR TITLE
Small improvements to workflow editor Selenium tests.

### DIFF
--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -425,6 +425,31 @@ class NavigatesGalaxy(HasDriver):
         file_upload = self.wait_for_selector('div#%s input[type="file"]' % tab_id)
         file_upload.send_keys(test_path)
 
+    def workflow_editor_click_option(self, option_label):
+        self.workflow_editor_click_options()
+        menu_element = self.workflow_editor_options_menu_element()
+        option_elements = menu_element.find_elements_by_css_selector("a")
+        assert len(option_elements) > 0, "Failed to find workflow editor options"
+        time.sleep(1)
+        found_option = False
+        for option_element in option_elements:
+            if option_label in option_element.text:
+                action_chains = self.action_chains()
+                action_chains.move_to_element(option_element)
+                action_chains.click()
+                action_chains.perform()
+                found_option = True
+                break
+
+        if not found_option:
+            raise Exception("Failed to find workflow editor option with label [%s]" % option_label)
+
+    def workflow_editor_click_options(self):
+        return self.wait_for_and_click_selector("#workflow-options-button")
+
+    def workflow_editor_options_menu_element(self):
+        return self.wait_for_selector_visible("#workflow-options-button-menu")
+
     def workflow_index_open(self):
         self.home()
         self.click_masthead_workflow()

--- a/test/selenium_tests/test_workflow_editor.py
+++ b/test/selenium_tests/test_workflow_editor.py
@@ -104,29 +104,3 @@ steps:
             'workflow_annotation': annotation,
         })
         self.click_submit(form_element)
-
-    def workflow_editor_click_option(self, option_label):
-        self.workflow_editor_click_options()
-        menu_element = self.workflow_editor_options_menu_element()
-        option_elements = menu_element.find_elements_by_css_selector("a")
-        assert len(option_elements) > 0, "Failed to find workflow editor options"
-        time.sleep(1)
-        found_option = False
-        for option_element in option_elements:
-            if option_label in option_element.text:
-                action_chains = self.action_chains()
-                action_chains.move_to_element(option_element)
-                action_chains.click()
-                action_chains.perform()
-                found_option = True
-                break
-
-        if not found_option:
-            raise Exception("Failed to find workflow editor option with label [%s]" % option_label)
-
-    def workflow_editor_click_options(self):
-        button = self.wait_for_selector("#workflow-options-button")
-        button.click()
-
-    def workflow_editor_options_menu_element(self):
-        return self.wait_for_selector_visible("#workflow-options-button-menu")


### PR DESCRIPTION
I saw a failed test earlier that would have been fixed by a switch to wait_for_and_click in workflow_editor_click_options. This makes that switch and moves some of these workflow editor helper functions into navigates_galaxy.py for reuse by other test cases and by library users.