### PR TITLE
Retry job submissions in ShellJobRunner

### DIFF
--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -133,15 +133,14 @@ class ShellJobRunner(AsynchronousJobRunner):
             return cmd_out.returncode, cmd_out.stdout
         stdout = '(%s) submission failed (stdout): %s' % (galaxy_id_tag, cmd_out.stdout)
         stderr = '(%s) submission failed (stderr): %s' % (galaxy_id_tag, cmd_out.stderr)
-        log_func = log.warning if retry > 0 else log.error
         if retry > 0:
-            log_func("%s, retrying in %s seconds" % (stdout, timeout))
-            log_func("%s, retrying in %s seconds" % (stderr, timeout))
+            log.debug("%s, retrying in %s seconds", stdout, timeout)
+            log.debug("%s, retrying in %s seconds", stderr, timeout)
             time.sleep(timeout)
             return self.submit(shell, job_interface, job_file, galaxy_id_tag, retry=retry - 1, timeout=timeout)
         else:
-            log_func(stdout)
-            log_func(stderr)
+            log.error(stdout)
+            log.error(stderr)
             return cmd_out.returncode, cmd_out.stdout
 
     def check_watched_items(self):


### PR DESCRIPTION
If I submit a large amount of jobs in a very short time I sometimes see

```
galaxy.jobs.runners.cli ERROR 2017-09-11 05:03:02,404 (17633) submission
failed (stderr): qsub: submit error (Invalid credential)
```

in my logs for a minor subset of jobs (2 out of 120 in the last instance
that this happened).
In this case waiting a little while and trying again solves the problem.
By default we will try submitting the job 3 times, and sleep 10 seconds
before trying again.

Trying this today I was able to provoke the qsub error once while running filter1 on 250 small input files, and everything seems to have worked smoothly.