### PR TITLE
option to kill jobs if one of its outputs is removed

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -354,6 +354,7 @@ class Configuration(object):
         self.smtp_password = kwargs.get('smtp_password', None)
         self.smtp_ssl = kwargs.get('smtp_ssl', None)
         self.track_jobs_in_database = string_as_bool(kwargs.get('track_jobs_in_database', 'True'))
+        self.delete_output_dataset_kills_job  = string_as_bool(kwargs.get('delete_output_dataset_kills_job', 'False'))
         self.expose_dataset_path = string_as_bool(kwargs.get('expose_dataset_path', 'False'))
         self.expose_potentially_sensitive_job_metrics = string_as_bool(kwargs.get('expose_potentially_sensitive_job_metrics', 'False'))
         self.enable_communication_server = string_as_bool(kwargs.get('enable_communication_server', 'False'))

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -345,7 +345,7 @@ class DatasetAssociationManager(base.ModelManager,
             job = dataset_assoc.creating_job_associations[0].job
             if not job.finished:
                 # Are *all* of the job's other output datasets deleted?
-                if job.check_if_output_datasets_deleted():
+                if job.check_if_output_datasets_deleted() or self.app.config.delete_output_dataset_kills_job:
                     job.mark_deleted(self.app.config.track_jobs_in_database)
                     self.app.job_manager.job_stop_queue.put(job.id)
                     return True

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -338,13 +338,15 @@ class DatasetAssociationManager(base.ModelManager,
 
     def stop_creating_job(self, dataset_assoc):
         """
-        Stops an dataset_assoc's creating job if all the job's other outputs are deleted.
+        Stops an dataset_assoc's creating job if all the job's other outputs are deleted or
+        the config option "delete_output_dataset_kills_job" is set.
         """
         if dataset_assoc.parent_id is None and len(dataset_assoc.creating_job_associations) > 0:
             # Mark associated job for deletion
             job = dataset_assoc.creating_job_associations[0].job
             if not job.finished:
-                # Are *all* of the job's other output datasets deleted?
+                # check if *all* of the job's other output datasets are deleted or
+                # the config option delete_output_dataset_kills_job is set
                 if job.check_if_output_datasets_deleted() or self.app.config.delete_output_dataset_kills_job:
                     job.mark_deleted(self.app.config.track_jobs_in_database)
                     self.app.job_manager.job_stop_queue.put(job.id)

--- a/test/unit/config/1607_root_filters/config/galaxy.ini
+++ b/test/unit/config/1607_root_filters/config/galaxy.ini
@@ -1090,7 +1090,7 @@ use_interactive = True
 # Usually, a job is only killed if all output datasets are deleted in the history.
 # This option let's galaxy kill the job after only one of the jobs output datasets
 # is deleted
-#delete_output_dataset_kills_job = True
+#delete_output_dataset_kills_job = False
 
 # This enables splitting of jobs into tasks, if specified by the particular tool
 # config.

--- a/test/unit/config/1607_root_filters/config/galaxy.ini
+++ b/test/unit/config/1607_root_filters/config/galaxy.ini
@@ -1087,6 +1087,11 @@ use_interactive = True
 # done in memory, which is a bit quicker.
 #track_jobs_in_database = True
 
+# Usually, a job is only killed if all output datasets are deleted in the history.
+# This option let's galaxy kill the job after only one of the jobs output datasets
+# is deleted
+#delete_output_dataset_kills_job = True
+
 # This enables splitting of jobs into tasks, if specified by the particular tool
 # config.
 # This is a new feature and not recommended for production servers yet.


### PR DESCRIPTION
usually, all output datasets need to be removed from the history before a job is killed by Galaxy. With the new option "delete_output_dataset_kills_job" activated it is sufficient to just delete one output dataset to kill the job and deleted all other associated output datasets of the job.

Rationale:
The users in our lab have no straight forward possibility to kill a job, especially with hidden output datasets. Usually the steps to kill a job are to delete all (visible) outputs, make hidden outputs visible and also delete them. This "concept" is easily misunderstood, causing many "zombie" jobs on our (cluster) system that block resources.