### PR TITLE
Fix virtualenv activation for some scripts

### DIFF
--- a/create_db.sh
+++ b/create_db.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+cd `dirname $0`
 : ${GALAXY_VIRTUAL_ENV:=.venv}
 
 if [ -d "$GALAXY_VIRTUAL_ENV" ];
@@ -8,5 +9,4 @@ then
     . "$GALAXY_VIRTUAL_ENV/bin/activate"
 fi
 
-cd `dirname $0`
 python ./scripts/create_db.py $@

--- a/extract_dataset_parts.sh
+++ b/extract_dataset_parts.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 
 cd `dirname $0`
+: ${GALAXY_VIRTUAL_ENV:=.venv}
+
+if [ -d "$GALAXY_VIRTUAL_ENV" ];
+then
+    printf "Activating virtualenv at $GALAXY_VIRTUAL_ENV\n"
+    . "$GALAXY_VIRTUAL_ENV/bin/activate"
+fi
+
 for file in $1/split_info*.json
 do
     # echo processing $file

--- a/manage_db.sh
+++ b/manage_db.sh
@@ -5,6 +5,7 @@
 # sh manage_db.sh downgrade --version=3 <tool_shed if using that webapp - galaxy is the default>
 #######
 
+cd `dirname $0`
 : ${GALAXY_VIRTUAL_ENV:=.venv}
 
 if [ -d "$GALAXY_VIRTUAL_ENV" ];
@@ -13,5 +14,4 @@ then
     . "$GALAXY_VIRTUAL_ENV/bin/activate"
 fi
 
-cd `dirname $0`
 python ./scripts/manage_db.py $@

--- a/manage_tools.sh
+++ b/manage_tools.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+cd `dirname $0`
 : ${GALAXY_VIRTUAL_ENV:=.venv}
 
 if [ -d "$GALAXY_VIRTUAL_ENV" ];
@@ -8,5 +9,4 @@ then
     . "$GALAXY_VIRTUAL_ENV/bin/activate"
 fi
 
-cd `dirname $0`
 python ./scripts/manage_tools.py $@


### PR DESCRIPTION
In particular add virtualenv activation to `extract_dataset_parts.sh` to fix the following error when running tools which use `<parallelism>`:
```
Fatal error:
/tmp/tmpOoQ01k/job_working_directory/000/12/task_0:
Traceback (most recent call last):
File "./scripts/extract_dataset_part.py", line 17, in <module>
import galaxy.model.mapping  # need to load this before we unpickle, in order to setup properties assigned by the mappers
File "/opt/galaxyproject_galaxy_release_17.05/lib/galaxy/model/__init__.py", line 20, in <module>
from six import string_types
ModuleNotFoundError: No module named 'six'
```