### PR TITLE
[17.09] Pulsar remote metadata fixes

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -57,7 +57,7 @@ anyjson==0.3.3
 
 # Pulsar requirements
 psutil==4.1.0
-pulsar-galaxy-lib==0.7.0.dev5
+pulsar-galaxy-lib==0.7.5
 
 # sqlalchemy-migrate and dependencies
 sqlalchemy-migrate==0.10.0

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -57,7 +57,7 @@ anyjson==0.3.3
 
 # Pulsar requirements
 psutil==4.1.0
-pulsar-galaxy-lib==0.7.5
+pulsar-galaxy-lib==0.8.0
 
 # sqlalchemy-migrate and dependencies
 sqlalchemy-migrate==0.10.0

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1648,7 +1648,8 @@ class JobWrapper(object, HasResourceParameters):
 
     def setup_external_metadata(self, exec_dir=None, tmp_dir=None,
                                 dataset_files_path=None, config_root=None,
-                                config_file=None, resolve_metadata_dependencies=False,
+                                config_file=None, datatypes_config=None,
+                                resolve_metadata_dependencies=False,
                                 set_extension=True, **kwds):
         # extension could still be 'auto' if this is the upload tool.
         job = self.get_job()
@@ -1667,8 +1668,9 @@ class JobWrapper(object, HasResourceParameters):
             config_root = self.app.config.root
         if config_file is None:
             config_file = self.app.config.config_file
-        datatypes_config = os.path.join(self.working_directory, 'registry.xml')
-        self.app.datatypes_registry.to_xml_file(path=datatypes_config)
+        if datatypes_config is None:
+            datatypes_config = os.path.join(self.working_directory, 'registry.xml')
+            self.app.datatypes_registry.to_xml_file(path=datatypes_config)
         command = self.external_output_metadata.setup_external_metadata([output_dataset_assoc.dataset for
                                                                          output_dataset_assoc in
                                                                          job.output_datasets + job.output_library_datasets],
@@ -1977,7 +1979,7 @@ class TaskWrapper(JobWrapper):
         pass
 
     def setup_external_metadata(self, exec_dir=None, tmp_dir=None, dataset_files_path=None,
-                                config_root=None, config_file=None,
+                                config_root=None, config_file=None, datatypes_config=None,
                                 set_extension=True, **kwds):
         # There is no metadata setting for tasks.  This is handled after the merge, at the job level.
         return ""

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -17,19 +17,7 @@ log = getLogger(__name__)
 CAPTURE_RETURN_CODE = "return_code=$?"
 YIELD_CAPTURED_CODE = 'sh -c "exit $return_code"'
 SETUP_GALAXY_FOR_METADATA = """
-if [ "$GALAXY_LIB" != "None" ]; then
-    if [ -n "$PYTHONPATH" ]; then
-        PYTHONPATH="$GALAXY_LIB:$PYTHONPATH"
-    else
-        PYTHONPATH="$GALAXY_LIB"
-    fi
-    export PYTHONPATH
-fi
-if [ "$GALAXY_VIRTUAL_ENV" != "None" -a -z "$VIRTUAL_ENV" \
-     -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" ]; then
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
-fi
-GALAXY_PYTHON=`command -v python`
+_galaxy_setup_environment True
 """
 
 

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -186,6 +186,7 @@ def __handle_metadata(commands_builder, job_wrapper, runner, remote_command_para
     output_fnames = metadata_kwds.get('output_fnames', job_wrapper.get_output_fnames())
     config_root = metadata_kwds.get('config_root', None)
     config_file = metadata_kwds.get('config_file', None)
+    datatypes_config = metadata_kwds.get('datatypes_config', None)
     compute_tmp_dir = metadata_kwds.get('compute_tmp_dir', None)
     resolve_metadata_dependencies = job_wrapper.commands_in_new_shell
     metadata_command = job_wrapper.setup_external_metadata(
@@ -196,6 +197,7 @@ def __handle_metadata(commands_builder, job_wrapper, runner, remote_command_para
         set_extension=False,
         config_root=config_root,
         config_file=config_file,
+        datatypes_config=datatypes_config,
         compute_tmp_dir=compute_tmp_dir,
         resolve_metadata_dependencies=resolve_metadata_dependencies,
         kwds={'overwrite': False}

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -17,7 +17,7 @@ log = getLogger(__name__)
 CAPTURE_RETURN_CODE = "return_code=$?"
 YIELD_CAPTURED_CODE = 'sh -c "exit $return_code"'
 SETUP_GALAXY_FOR_METADATA = """
-_galaxy_setup_environment True
+[ "$GALAXY_VIRTUAL_ENV" = "None" ] && GALAXY_VIRTUAL_ENV="$_GALAXY_VIRTUAL_ENV"; _galaxy_setup_environment True
 """
 
 

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -701,7 +701,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
                     remote_datatypes_config = os.path.join(remote_galaxy_home, 'datatypes_conf.xml')
                 metadata_kwds['datatypes_config'] = remote_datatypes_config
             else:
-                datatypes_config = os.path.join(configs_directory, 'registry.xml')
+                datatypes_config = os.path.join(job_wrapper.working_directory, 'registry.xml')
                 self.app.datatypes_registry.to_xml_file(path=datatypes_config)
                 # Ensure this file gets pushed out to the remote config dir.
                 job_wrapper.extra_filenames.append(datatypes_config)

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -670,7 +670,6 @@ class PulsarJobRunner(AsynchronousJobRunner):
                 raise Exception(NO_REMOTE_GALAXY_FOR_METADATA_MESSAGE)
             metadata_kwds['exec_dir'] = remote_galaxy_home
             outputs_directory = remote_job_config['outputs_directory']
-            configs_directory = remote_job_config['configs_directory']
             working_directory = remote_job_config['working_directory']
             metadata_directory = remote_job_config['metadata_directory']
             # For metadata calculation, we need to build a list of of output

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -53,7 +53,7 @@ __all__ = (
 
 MINIMUM_PULSAR_VERSIONS = {
     '_default_': LooseVersion("0.7.0.dev3"),
-    'remote_metadata': LooseVersion("0.7.5"),
+    'remote_metadata': LooseVersion("0.8.0"),
 }
 
 NO_REMOTE_GALAXY_FOR_METADATA_MESSAGE = "Pulsar misconfiguration - Pulsar client configured to set metadata remotely, but remote Pulsar isn't properly configured with a galaxy_home directory."

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -1,25 +1,32 @@
 #!$shell
 
+_galaxy_setup_environment() {
+    local _use_framework_galaxy="$1"
+    if [ "$GALAXY_LIB" != "None" -a "$_use_framework_galaxy" = "True" ]; then
+        if [ -n "$PYTHONPATH" ]; then
+            PYTHONPATH="$GALAXY_LIB:$PYTHONPATH"
+        else
+            PYTHONPATH="$GALAXY_LIB"
+        fi
+        export PYTHONPATH
+    fi
+    $env_setup_commands
+    if [ "$GALAXY_VIRTUAL_ENV" != "None" -a  "$_use_framework_galaxy" = "True" \
+         -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" \
+         -a "`command -v python`" != "$GALAXY_VIRTUAL_ENV/bin/python" ]; then
+        . "$GALAXY_VIRTUAL_ENV/bin/activate"
+    fi
+}
+
 $headers
 $integrity_injection
 $slots_statement
 export GALAXY_SLOTS
+GALAXY_VIRTUAL_ENV="$galaxy_virtual_env"
 PRESERVE_GALAXY_ENVIRONMENT="$preserve_python_environment"
 GALAXY_LIB="$galaxy_lib"
-if [ "$GALAXY_LIB" != "None" -a "$PRESERVE_GALAXY_ENVIRONMENT" = "True" ]; then
-    if [ -n "$PYTHONPATH" ]; then
-        PYTHONPATH="$GALAXY_LIB:$PYTHONPATH"
-    else
-        PYTHONPATH="$GALAXY_LIB"
-    fi
-    export PYTHONPATH
-fi
-$env_setup_commands
-GALAXY_VIRTUAL_ENV="$galaxy_virtual_env"
-if [ "$GALAXY_VIRTUAL_ENV" != "None" -a -z "$VIRTUAL_ENV" \
-     -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" -a "$PRESERVE_GALAXY_ENVIRONMENT" = "True" ]; then
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
-fi
+_galaxy_setup_environment "$PRESERVE_GALAXY_ENVIRONMENT"
+GALAXY_PYTHON=`command -v python`
 $instrument_pre_commands
 cd $working_directory
 $command

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -1,5 +1,7 @@
 #!$shell
 
+$headers
+
 _galaxy_setup_environment() {
     local _use_framework_galaxy="$1"
     if [ "$GALAXY_LIB" != "None" -a "$_use_framework_galaxy" = "True" ]; then
@@ -11,18 +13,17 @@ _galaxy_setup_environment() {
         export PYTHONPATH
     fi
     $env_setup_commands
-    if [ "$GALAXY_VIRTUAL_ENV" != "None" -a  "$_use_framework_galaxy" = "True" \
-         -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" \
+    if [ "$GALAXY_VIRTUAL_ENV" != "None" -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" \
          -a "`command -v python`" != "$GALAXY_VIRTUAL_ENV/bin/python" ]; then
         . "$GALAXY_VIRTUAL_ENV/bin/activate"
     fi
 }
 
-$headers
 $integrity_injection
 $slots_statement
 export GALAXY_SLOTS
 GALAXY_VIRTUAL_ENV="$galaxy_virtual_env"
+_GALAXY_VIRTUAL_ENV="$galaxy_virtual_env"
 PRESERVE_GALAXY_ENVIRONMENT="$preserve_python_environment"
 GALAXY_LIB="$galaxy_lib"
 _galaxy_setup_environment "$PRESERVE_GALAXY_ENVIRONMENT"

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -836,7 +836,7 @@ class JobExternalOutputMetadataWrapper(object):
                 sa_session.add(metadata_files)
                 sa_session.flush()
             metadata_files_list.append(metadata_files)
-        args = '"%s" "%s" %s %s' % (datatypes_config,
+        args = '"%s" "%s" %s %s' % (metadata_path_on_compute(datatypes_config),
                                     job_metadata,
                                     " ".join(map(__metadata_files_list_to_cmd_line, metadata_files_list)),
                                     max_metadata_value_size)


### PR DESCRIPTION
Because Pulsar cannot use a subshell for the tool command (see galaxyproject/pulsar#137 for details), we must provide a way to properly set up the Galaxy virtutalenv and lib after the tool command is run and before `set_metadata.py` in order to use remote metadata. To do this, I've slightly overhauled and removed some duplication in the job script.

Note: `$VIRTUAL_ENV` being set will no longer prevent `$GALAXY_VIRTUAL_ENV` from being used. This is because I can't think of a way that, under Galaxy, `$GALAXY_VIRTUAL_ENV` and `$VIRTUAL_ENV` would not be the same thing, if `$VIRTUAL_ENV` was set at all (it is technically possible to run from outside a virtualenv, and in this case, `$GALAXY_VIRTUAL_ENV` will be `None`). Further, the `$VIRTUAL_ENV` handling wouldn't have worked for Pulsar because under Pulsar it was set to Pulsar's virtualenv, which prevented Galaxy's virtualenv from being activated.

I am not sure if this was the intent, but while `$PRESERVE_GALAXY_ENVIRONMENT` prevents `$PYTHONPATH` from including Galaxy's `lib` directory, the first `python` on `$PATH` will still be the one Galaxy started with (and honestly, what else would it be?). The conditional of `$PRESERVE_GALAXY_ENVIRONMENT` for the virtualenv doesn't really add anything there other than not reactivating the already activated virtualenv.

If I am missing something about the two paragraphs above, please let me know.

This also adds `$PRESERVE_GALAXY_ENVIRONMENT` support for Pulsar.

Because these changes are really only for remote metadata and I'm probably the only person using it, I added some conditional feature checking to the remote Pulsar version check so that people wouldn't be forced to upgrade their Pulsar servers just because of this change.

Tests will not pass until we release a new version of pulsar-galaxy-lib.