### PR TITLE
remove .git and .hg from recursive file search

### DIFF
--- a/lib/galaxy/tools/loader_directory.py
+++ b/lib/galaxy/tools/loader_directory.py
@@ -22,7 +22,7 @@ TOOL_REGEX = re.compile(r"<tool\s")
 
 YAML_EXTENSIONS = [".yaml", ".yml", ".json"]
 CWL_EXTENSIONS = YAML_EXTENSIONS + [".cwl"]
-EXCLUDE_WALK_DIRS = ['.hg', '.git']
+EXCLUDE_WALK_DIRS = ['.hg', '.git', '.venv']
 
 
 def load_exception_handler(path, exc_info):

--- a/lib/galaxy/tools/loader_directory.py
+++ b/lib/galaxy/tools/loader_directory.py
@@ -22,6 +22,7 @@ TOOL_REGEX = re.compile(r"<tool\s")
 
 YAML_EXTENSIONS = [".yaml", ".yml", ".json"]
 CWL_EXTENSIONS = YAML_EXTENSIONS + [".cwl"]
+EXCLUDE_WALK_DIRS = ['.hg', '.git']
 
 
 def load_exception_handler(path, exc_info):
@@ -264,6 +265,8 @@ def _find_files(directory, pattern='*'):
 
     matches = []
     for root, dirnames, filenames in os.walk(directory):
+        # exclude some directories (like .hg) from traversing
+        dirnames[:] = [dir for dir in dirnames if dir not in EXCLUDE_WALK_DIRS]
         for filename in filenames:
             full_path = os.path.join(root, filename)
             if fnmatch.filter([full_path], pattern):


### PR DESCRIPTION
From @bgruening. We saw extraneous opens/reads for these directories during boot. E.g.

```
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapstatistics/e4c1d9a768db/openms_mapstatistics", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapstatistics/e4c1d9a768db/openms_mapstatistics/.hg", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapstatistics/e4c1d9a768db/openms_mapstatistics/.hg/store", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapstatistics/e4c1d9a768db/openms_mapstatistics/.hg/store/data", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapstatistics/e4c1d9a768db/openms_mapstatistics/.hg/store/data/test-data", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapstatistics/e4c1d9a768db/openms_mapstatistics/.hg/cache", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_mapstatistics/e4c1d9a768db/openms_mapstatistics/test-data", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("./config/tool_conf.xml", O_RDONLY) = 24
open("./config/shed_tool_conf.xml", O_RDONLY) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rtevaluation/d5b15b21844b", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rtevaluation/d5b15b21844b/openms_rtevaluation", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rtevaluation/d5b15b21844b/openms_rtevaluation/.hg", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rtevaluation/d5b15b21844b/openms_rtevaluation/.hg/store", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rtevaluation/d5b15b21844b/openms_rtevaluation/.hg/store/data", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rtevaluation/d5b15b21844b/openms_rtevaluation/.hg/store/data/test-data", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rtevaluation/d5b15b21844b/openms_rtevaluation/.hg/cache", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_rtevaluation/d5b15b21844b/openms_rtevaluation/test-data", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("./config/tool_conf.xml", O_RDONLY) = 24
open("./config/shed_tool_conf.xml", O_RDONLY) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_internalcalibration/975efdac387b", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_internalcalibration/975efdac387b/openms_internalcalibration", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_internalcalibration/975efdac387b/openms_internalcalibration/.hg", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_internalcalibration/975efdac387b/openms_internalcalibration/.hg/store", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_internalcalibration/975efdac387b/openms_internalcalibration/.hg/store/data", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_internalcalibration/975efdac387b/openms_internalcalibration/.hg/store/data/test-data", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_internalcalibration/975efdac387b/openms_internalcalibration/.hg/cache", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
open("../shed_tools/toolshed.g2.bx.psu.edu/repos/galaxyp/openms_internalcalibration/975efdac387b/openms_internalcalibration/test-data", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 24
```

(the duplicate re-reads of the shed tool conf were pre-#4495)