### PR TITLE
optimize the process of identifying public libraries

### DIFF
--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -112,7 +112,11 @@ class LibraryManager(object):
         """
         is_admin = trans.user_is_admin()
         query = trans.sa_session.query(trans.app.model.Library)
-
+        library_access_action = trans.app.security_agent.permitted_actions.LIBRARY_ACCESS.action
+        restricted_library_ids = [lp.library_id for lp in (
+            trans.sa_session.query(trans.model.LibraryPermissions).filter(
+                trans.model.LibraryPermissions.table.c.action == library_access_action
+            ).distinct())]
         if is_admin:
             if deleted is None:
                 #  Flag is not specified, do not filter on it.
@@ -124,11 +128,6 @@ class LibraryManager(object):
         else:
             #  Nonadmins can't see deleted libraries
             current_user_role_ids = [role.id for role in trans.get_current_user_roles()]
-            library_access_action = trans.app.security_agent.permitted_actions.LIBRARY_ACCESS.action
-            restricted_library_ids = [lp.library_id for lp in (
-                trans.sa_session.query(trans.model.LibraryPermissions).filter(
-                    trans.model.LibraryPermissions.table.c.action == library_access_action
-                ).distinct())]
             accessible_restricted_library_ids = [lp.library_id for lp in (
                 trans.sa_session.query(trans.model.LibraryPermissions).filter(
                     and_(
@@ -139,7 +138,7 @@ class LibraryManager(object):
                 not_(trans.model.Library.table.c.id.in_(restricted_library_ids)),
                 trans.model.Library.table.c.id.in_(accessible_restricted_library_ids)
             ))
-        return query
+        return query, restricted_library_ids
 
     def secure(self, trans, library, check_accessible=True):
         """
@@ -171,22 +170,27 @@ class LibraryManager(object):
         else:
             return library
 
-    def get_library_dict(self, trans, library):
+    def get_library_dict(self, trans, library, restricted_library_ids=[]):
         """
         Return library data in the form of a dictionary.
 
-        :param  library:       library
-        :type   library:       galaxy.model.Library
+        :param  library:                    library
+        :type   library:                    galaxy.model.Library
+        :param  restricted_library_ids:     ids of restricted libraries to speed up the
+                                            detection of public libraries
+        :type   restricted_library_ids:     list of ints
 
         :returns:   dict with data about the library
         :rtype:     dictionary
         """
         library_dict = library.to_dict(view='element', value_mapper={'id': trans.security.encode_id, 'root_folder_id': trans.security.encode_id})
-        if trans.app.security_agent.library_is_public(library, contents=False):
+        if library.id in restricted_library_ids:
+            library_dict['public'] = False
+        else:
             library_dict['public'] = True
         library_dict['create_time_pretty'] = pretty_print_time_interval(library.create_time, precise=True)
-        current_user_roles = trans.get_current_user_roles()
         if not trans.user_is_admin():
+            current_user_roles = trans.get_current_user_roles()
             library_dict['can_user_add'] = trans.app.security_agent.can_add_library_item(current_user_roles, library)
             library_dict['can_user_modify'] = trans.app.security_agent.can_modify_library_item(current_user_roles, library)
             library_dict['can_user_manage'] = trans.app.security_agent.can_manage_library_item(current_user_roles, library)

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -37,10 +37,10 @@ class LibrariesController(BaseAPIController):
 
         """
         deleted = util.string_as_bool_or_none(kwd.get('deleted', None))
-        query = self.library_manager.list(trans, deleted)
+        query, restricted_library_ids = self.library_manager.list(trans, deleted)
         libraries = []
         for library in query:
-            libraries.append(self.library_manager.get_library_dict(trans, library))
+            libraries.append(self.library_manager.get_library_dict(trans, library, restricted_library_ids))
         return libraries
 
     def __decode_id(self, trans, encoded_id, object_name=None):


### PR DESCRIPTION
By passing around the restricted libraries list instead of checking permissions individually in the loop.

This aims to speed up the library loading considerably.

```
before
galaxy.webapps.galaxy.api.libraries DEBUG 2017-09-18 14:44:09,115 0.381500959396
galaxy.webapps.galaxy.api.libraries DEBUG 2017-09-18 14:44:11,846 0.389669895172
galaxy.webapps.galaxy.api.libraries DEBUG 2017-09-18 14:44:13,964 0.562512874603
galaxy.webapps.galaxy.api.libraries DEBUG 2017-09-18 14:44:16,332 0.387053012848
galaxy.webapps.galaxy.api.libraries DEBUG 2017-09-18 14:44:18,643 0.411307096481

after
galaxy.webapps.galaxy.api.libraries DEBUG 2017-09-18 14:42:09,865 0.00899410247803
galaxy.webapps.galaxy.api.libraries DEBUG 2017-09-18 14:42:14,669 0.00431704521179
galaxy.webapps.galaxy.api.libraries DEBUG 2017-09-18 14:42:17,022 0.00520706176758
galaxy.webapps.galaxy.api.libraries DEBUG 2017-09-18 14:42:18,896 0.00606489181519
galaxy.webapps.galaxy.api.libraries DEBUG 2017-09-18 14:42:21,030 0.00485587120056
galaxy.webapps.galaxy.api.libraries DEBUG 2017-09-18 14:42:23,194 0.00697588920593
```