### PR TITLE
Aggressively retry buggy submit_login() function in Selenium tests.

### DIFF
--- a/test/selenium_tests/test_custom_builds.py
+++ b/test/selenium_tests/test_custom_builds.py
@@ -12,7 +12,7 @@ class CustomBuildsTestcase(SharedStateSeleniumTestCase):
     def setUp(self):
         super(CustomBuildsTestcase, self).setUp()
         self.home()  # ensure Galaxy is loaded
-        self.submit_login(self.user_email)
+        self.submit_login(self.user_email, retries=2)
 
     @selenium_test
     def test_build_add(self):

--- a/test/selenium_tests/test_history_sharing.py
+++ b/test/selenium_tests/test_history_sharing.py
@@ -1,27 +1,30 @@
 from .framework import SeleniumTestCase
 from .framework import selenium_test
 
+# Remove hack when submit_login works more consistently.
+VALID_LOGIN_RETRIES = 3
+
 
 class HistorySharingTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_sharing_valid(self):
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history()
-        self.submit_login(user2_email)
+        self.submit_login(user2_email, retries=VALID_LOGIN_RETRIES)
         response = self.api_get("histories/%s" % history_id, raw=True)
         assert response.status_code == 200, response.json()
 
     @selenium_test
     def test_sharing_valid_by_id(self):
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history(share_by_id=True)
-        self.submit_login(user2_email)
+        self.submit_login(user2_email, retries=VALID_LOGIN_RETRIES)
         response = self.api_get("histories/%s" % history_id, raw=True)
         assert response.status_code == 200, response.json()
 
     @selenium_test
     def test_unsharing(self):
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history()
-        self.submit_login(user1_email)
+        self.submit_login(user1_email, retries=VALID_LOGIN_RETRIES)
         self.navigate_to_history_share_page()
 
         with self.main_panel():
@@ -36,7 +39,7 @@ class HistorySharingTestCase(SeleniumTestCase):
             self.assert_selector_absent("#user-0-popup")
 
         self.logout_if_needed()
-        self.submit_login(user2_email)
+        self.submit_login(user2_email, retries=VALID_LOGIN_RETRIES)
         response = self.api_get("histories/%s" % history_id, raw=True)
         assert response.status_code == 403
 
@@ -80,7 +83,7 @@ class HistorySharingTestCase(SeleniumTestCase):
         user2_id = self.api_get("users")[0]["id"]
         self.logout_if_needed()
 
-        self.submit_login(user1_email)
+        self.submit_login(user1_email, retries=VALID_LOGIN_RETRIES)
         # Can't share an empty history...
         self.perform_upload(self.get_filename("1.txt"))
         self.wait_for_history()

--- a/test/selenium_tests/test_saved_histories.py
+++ b/test/selenium_tests/test_saved_histories.py
@@ -12,7 +12,7 @@ class SavedHistoriesTestCase(SharedStateSeleniumTestCase):
     def setUp(self):
         super(SavedHistoriesTestCase, self).setUp()
         self.home()
-        self.submit_login(self.user_email)
+        self.submit_login(self.user_email, retries=3)
 
     @selenium_test
     def test_saved_histories_list(self):


### PR DESCRIPTION
I don't get why when we click submit the user does not actually get logged in, but based on the last round of improved error messages this seems to be the case. You might think there is some callback in the login form that doesn't get registered by the time Selenium clicks the submit button - but this doesn't seem to be the case - I don't see any jquery magic happening in login.mako.

Should fix failures like this:

https://jenkins.galaxyproject.org/job/selenium/482/testReport/junit/selenium_tests.test_saved_histories/SavedHistoriesTestCase/test_history_publish/

I'd say at this point this is the most common problem in the Selenium tests.

This also introduces a framework for taking state snapshots of the Galaxy interface during tests that will only get written out if the tests fail. We now take screenshots before and after submitting the login form but this is a general purpose debugging mechanism that could be used other places.