### PR TITLE
[17.09] Fix links on workflow, history items.

### DIFF
--- a/templates/display_base.mako
+++ b/templates/display_base.mako
@@ -117,10 +117,10 @@
     ## Get URL to other published items owned by user that owns this item.
     <%
         ##TODO: is there a better way to create this URL? Can't use 'f-username' as a key b/c it's not a valid identifier.
-        controller_name = get_controller_name( item )
+        modern_route = modern_route_for_controller(get_controller_name(item))
         item_plural = get_item_plural( item )
-        href_to_all_items = h.url_for( controller='/' + controller_name, action='list_published')
-        href_to_user_items = h.url_for( controller='/' + controller_name, action='list_published', xxx=item.user.username)
+        href_to_all_items = h.url_for( controller='/' + modern_route, action='list_published')
+        href_to_user_items = h.url_for( controller='/' + modern_route, action='list_published', xxx=item.user.username)
         href_to_user_items = href_to_user_items.replace( 'xxx', 'f-username')
     %>
 
@@ -162,10 +162,10 @@
 
     <%
         ## FIXME: duplicated from above for now
-        controller_name = get_controller_name( item )
+        modern_route = modern_route_for_controller(get_controller_name(item))
         item_plural = get_item_plural( item )
-        href_to_all_items = h.url_for( controller='/' + controller_name, action='list_published')
-        href_to_user_items = h.url_for( controller='/' + controller_name, action='list_published', xxx=item.user.username)
+        href_to_all_items = h.url_for( controller='/' + modern_route , action='list_published')
+        href_to_user_items = h.url_for( controller='/' + modern_route, action='list_published', xxx=item.user.username)
         href_to_user_items = href_to_user_items.replace( 'xxx', 'f-username')
     %>
 

--- a/templates/display_common.mako
+++ b/templates/display_common.mako
@@ -111,6 +111,21 @@
     %>
 </%def>
 
+<%def name="modern_route_for_controller( controller )">
+    <%
+        if controller == "history":
+            return "histories"
+        elif controller == "workflow":
+            return "workflows"
+        elif controller == "dataset":
+            return "datasets"
+        elif controller == "page":
+            return "pages"
+        else:
+            return controller
+    %>
+</%def>
+
 ## Returns item user/owner.
 <%def name="get_item_user( item )">
     <%


### PR DESCRIPTION
Added a small layer to support modern routes in old display_base pages (workflow, history, etc).

Without this bugfix, the following links go to the big blob of json that replaced these endpoints.

![image](https://user-images.githubusercontent.com/155398/30652567-b3120da0-9df6-11e7-833c-87b972cf6eb5.png)

