### PR TITLE
Selenium fixes for publishing histories button.

### DIFF
--- a/test/selenium_tests/test_published_histories_grid.py
+++ b/test/selenium_tests/test_published_histories_grid.py
@@ -155,8 +155,7 @@ class HistoryGridTestCase(SharedStateSeleniumTestCase):
     def unset_filter(self, filter_key, filter_value):
         close_link_selector = 'a[filter_key="%s"][filter_val="%s"]' % \
             (filter_key, filter_value)
-        close_link = self.wait_for_selector_clickable(close_link_selector)
-        close_link.click()
+        self.wait_for_and_click_selector(close_link_selector)
         time.sleep(.5)
 
     def set_annotation(self, annotation):
@@ -219,10 +218,7 @@ class HistoryGridTestCase(SharedStateSeleniumTestCase):
     def publish_current_history(self):
         self.click_history_option('Share or Publish')
         with self.main_panel():
-            selector = 'input[name="make_accessible_and_publish"]'
-            publish_button = self.wait_for_selector_clickable(selector)
-            publish_button.click()
-
+            self.wait_for_and_click_selector('input[name="make_accessible_and_publish"]')
             self.wait_for_selector_clickable('input[name="disable_link_access_and_unpublish"]')
 
     def navigate_to_published_histories_page(self):


### PR DESCRIPTION
Fixes https://jenkins.galaxyproject.org/job/selenium/488/testReport/junit/selenium_tests.test_published_histories_grid/HistoryGridTestCase/test_history_grid_histories/.

It looks like a Toastr popup sometimes intercepts the click, this should solve that I believe.