### PR TITLE
[17.09] Pass job output file unqualified names to Pulsar so that it can create them before running the job

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -57,7 +57,7 @@ anyjson==0.3.3
 
 # Pulsar requirements
 psutil==4.1.0
-pulsar-galaxy-lib==0.7.0.dev5
+pulsar-galaxy-lib==0.8.0
 
 # sqlalchemy-migrate and dependencies
 sqlalchemy-migrate==0.10.0

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1571,6 +1571,9 @@ class JobWrapper(object, HasResourceParameters):
                     paths.append(DatasetPath(da.id, real_path=real_path, false_path=false_path, mutable=False))
         return paths
 
+    def get_output_basenames(self):
+        return map(os.path.basename, map(str, self.get_output_fnames()))
+
     def get_output_fnames(self):
         if self.output_paths is None:
             self.compute_outputs()
@@ -1998,6 +2001,10 @@ class ComputeEnvironment(object):
     """
 
     @abstractmethod
+    def output_names(self):
+        """ Output unqualified filenames defined by job. """
+
+    @abstractmethod
     def output_paths(self):
         """ Output DatasetPaths defined by job. """
 
@@ -2061,6 +2068,9 @@ class SharedComputeEnvironment(SimpleComputeEnvironment):
         self.app = job_wrapper.app
         self.job_wrapper = job_wrapper
         self.job = job
+
+    def output_names(self):
+        return self.job_wrapper.get_output_basenames()
 
     def output_paths(self):
         return self.job_wrapper.get_output_fnames()

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -277,8 +277,10 @@ class PulsarJobRunner(AsynchronousJobRunner):
             dependencies_description = PulsarJobRunner.__dependencies_description(client, job_wrapper)
             rewrite_paths = not PulsarJobRunner.__rewrite_parameters(client)
             unstructured_path_rewrites = {}
+            output_names = []
             if compute_environment:
                 unstructured_path_rewrites = compute_environment.unstructured_path_rewrites
+                output_names = compute_environment.output_names()
 
             client_job_description = ClientJobDescription(
                 command_line=command_line,
@@ -292,6 +294,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
                 env=client.env,
                 rewrite_paths=rewrite_paths,
                 arbitrary_files=unstructured_path_rewrites,
+                touch_outputs=output_names,
             )
             job_id = pulsar_submit_job(client, client_job_description, remote_job_config)
             log.info("Pulsar job submitted with job_id %s" % job_id)
@@ -782,6 +785,10 @@ class PulsarComputeEnvironment(ComputeEnvironment):
         if new_version_path:
             version_path = new_version_path
         self._version_path = version_path
+
+    def output_names(self):
+        # Maybe this should use the path mapper, but the path mapper just uses basenames
+        return self.job_wrapper.get_output_basenames()
 
     def output_paths(self):
         local_output_paths = self._wrapper_output_paths


### PR DESCRIPTION
Fixes a bug whereby detailed error reporting is not possible when using Pulsar and the job doesn't create its outputs. In this case, Pulsar attempts to stage the outputs back to Galaxy, fails, and the output dataset message is set to the generic `Remote job server indicated a problem running or monitoring this job.` message.

Cannot be merged or run tests until Pulsar 0.7.5 is released (which will be soon).

xref galaxyproject/pulsar#141