### PR TITLE
[16.07] Fix modules resolver

### DIFF
--- a/lib/galaxy/tools/deps/resolvers/modules.py
+++ b/lib/galaxy/tools/deps/resolvers/modules.py
@@ -162,6 +162,14 @@ class ModuleDependency(Dependency):
         self._exact = exact
 
     @property
+    def name(self):
+        return self.module_name
+
+    @property
+    def version(self):
+        return self.module_version
+
+    @property
     def exact(self):
         return self._exact
 


### PR DESCRIPTION
The addition of the `resolver_msg` property on the base `Dependency` class references `name` and `version` attributes that were not defined in `ModuleDependecy`.

If this is merged I'll merge it forward through the stable releases to dev. I also need it in galaxy-lib so I can use it with Pulsar.

What milestone do I attach to this?