### PR TITLE
Extend job search for hdcas

### DIFF
--- a/.ci/flake8_lint_include_list.txt
+++ b/.ci/flake8_lint_include_list.txt
@@ -52,6 +52,7 @@ lib/galaxy/managers/collections_util.py
 lib/galaxy/managers/context.py
 lib/galaxy/managers/deletable.py
 lib/galaxy/managers/__init__.py
+lib/galaxy/managers/jobs.py
 lib/galaxy/managers/lddas.py
 lib/galaxy/managers/libraries.py
 lib/galaxy/managers/secured.py

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -14,6 +14,7 @@ uWSGI==2.0.15
 
 # pure Python packages
 bz2file==0.98; python_version < '3.3'
+boltons==17.1.0
 Paste==2.0.2
 PasteDeploy==1.5.2
 docutils==0.12

--- a/lib/galaxy/dependencies/requirements.txt
+++ b/lib/galaxy/dependencies/requirements.txt
@@ -14,6 +14,7 @@ pycrypto
 
 # pure Python packages
 bz2file; python_version < '3.3'
+boltons
 Paste
 PasteDeploy
 docutils

--- a/lib/galaxy/jobs/search.py
+++ b/lib/galaxy/jobs/search.py
@@ -45,9 +45,7 @@ class JobSearch(object):
                             return []
                     parameter_values = []
                     for item in all_items:
-                        parameter_value = v.copy()
-                        parameter_value['id'] = item.id
-                        parameter_values.append(json.dumps({'values': [parameter_value]}))
+                        parameter_values.append(json.dumps({'values': [{'src': src, 'id': item.id}]}))
                     input_param[k] = parameter_values
             else:
                 input_param[k] = json.dumps(str(v))

--- a/lib/galaxy/jobs/search.py
+++ b/lib/galaxy/jobs/search.py
@@ -1,0 +1,143 @@
+import json
+from six import string_types
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import aliased
+
+from galaxy import model
+from galaxy.managers.hdas import HDAManager
+from galaxy.managers.collections import DatasetCollectionManager
+from galaxy.managers.lddas import LDDAManager
+
+
+class JobSearch(object):
+    """Search for jobs using tool inputs or other jobs"""
+    def __init__(self, app):
+        self.app = app
+        self.sa_session = app.model.context
+        self.hda_manager = HDAManager(app)
+        self.dataset_collection_manager = DatasetCollectionManager(app)
+        self.ldda_manager = LDDAManager(app)
+        self.decode_id = self.app.security.decode_id
+
+    def by_tool_input(self, trans, tool_id, inputs, job_state='ok'):
+        """Search for jobs producing same results using the 'inputs' part of a tool POST."""
+        user = trans.user
+        input_param = {}
+        for k, v in inputs.items():
+            if isinstance(v, dict):
+                if 'id' in v:
+                    decoded_id = self.decode_id(v['id'])
+                    src = v.get('src', 'hda')
+                    if src == 'hda':
+                        all_items = self._get_all_hdas(trans=trans, hda_id=decoded_id)
+                        if not self.one_not_deleted(all_items):
+                            return []
+                    elif src == 'ldda':
+                        all_items = self._get_all_lddas(trans=trans, ldda_id=v['id'])
+                        if not self.one_not_deleted(all_items):
+                            return []
+                    elif src == 'hdca':
+                        all_items = self._get_all_hdcas(trans=trans, hdca_id=v['id'])
+                        if self.one_not_deleted(all_items):
+                            if any((True for hda in all_items[0].dataset_instances if hda.deleted)):
+                                return []
+                        else:
+                            return []
+                    parameter_values = []
+                    for item in all_items:
+                        parameter_value = v.copy()
+                        parameter_value['id'] = item.id
+                        parameter_values.append(json.dumps({'values': [parameter_value]}))
+                    input_param[k] = parameter_values
+            else:
+                input_param[k] = json.dumps(str(v))
+        return self.__search(tool_id=tool_id, user=user, input_param=input_param, job_state=job_state)
+
+    def one_not_deleted(self, items):
+        return any((True for item in items if not item.deleted))
+
+    def _get_all_hdas(self, trans, hda_id):
+        """Given a decoded `hda_id`, find other instances that refer to the same dataset."""
+        hda = self.hda_manager.get_accessible(hda_id, trans.user)
+        return self.sa_session.query(model.HistoryDatasetAssociation).filter(
+            model.HistoryDatasetAssociation.dataset_id == hda.dataset_id).all()
+
+    def _get_all_lddas(self, trans, ldda_id):
+        """Given a decoded `ldda_id`, find other instances that refer to the same dataset."""
+        ldda = self.ldda_manager.get(trans=trans, id=ldda_id)
+        hdas = self.sa_session.query(model.HistoryDatasetAssociation).filter(
+            model.HistoryDatasetAssociation.dataset_id == ldda.dataset_id).all()
+        hdas.append(ldda)
+        return hdas
+
+    def _get_all_hdcas(self, trans, hdca_id):
+        """Given an hdca, returns a list of other hdcas that were copied from this hdca."""
+        # TODO: would be great if we can find all identical hdcas
+        hdca = self.dataset_collection_manager.get_dataset_collection_instance(trans=trans,
+                                                                               instance_type='history',
+                                                                               id=hdca_id)
+        copied_from = getattr(hdca, 'copied_from_history_dataset_collection_association', None)
+        hdcas = [hdca]
+        if copied_from:
+            hdcas.append(copied_from)
+        return hdcas
+
+    def __search(self, tool_id, user, input_param, job_state=None):
+
+        query = self.sa_session.query(model.Job).filter(
+            model.Job.tool_id == tool_id,
+            model.Job.user == user
+        )
+
+        if job_state is None:
+            query = query.filter(
+                or_(
+                    model.Job.state == 'running',
+                    model.Job.state == 'queued',
+                    model.Job.state == 'waiting',
+                    model.Job.state == 'running',
+                    model.Job.state == 'ok',
+                )
+            )
+        else:
+            if isinstance(job_state, string_types):
+                query = query.filter(model.Job.state == job_state)
+            elif isinstance(job_state, list):
+                o = []
+                for s in job_state:
+                    o.append(model.Job.state == s)
+                query = query.filter(
+                    or_(*o)
+                )
+
+        for k, v in input_param.items():
+            a = aliased(model.JobParameter)
+            if isinstance(v, string_types):
+                query = query.filter(and_(
+                    model.Job.id == a.job_id,
+                    a.name == k,
+                    a.value == v
+                ))
+            elif isinstance(v, list):
+                query = query.filter(and_(
+                    model.Job.id == a.job_id,
+                    a.name == k,
+                    a.value.in_(v)
+                ))
+
+        jobs = []
+        for job in query.all():
+            # check to make sure none of the output datasets or collections have been deleted
+            outputs_deleted = False
+            for hda in job.output_datasets:
+                if hda.dataset.deleted:
+                    outputs_deleted = True
+                    break
+            if not outputs_deleted:
+                for collection_instance in job.output_dataset_collection_instances:
+                    if collection_instance.dataset_collection_instance.deleted:
+                        outputs_deleted = True
+                        break
+            if not outputs_deleted:
+                jobs.append(job)
+        return jobs

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -1,11 +1,12 @@
 import json
+
 from six import string_types
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import aliased
 
 from galaxy import model
-from galaxy.managers.hdas import HDAManager
 from galaxy.managers.collections import DatasetCollectionManager
+from galaxy.managers.hdas import HDAManager
 from galaxy.managers.lddas import LDDAManager
 
 
@@ -40,7 +41,7 @@ class JobSearch(object):
                     elif src == 'hdca':
                         all_items = self._get_all_hdcas(trans=trans, hdca_id=v['id'])
                         if self.one_not_deleted(all_items):
-                            if any((True for hda in all_items[0].dataset_instances if hda.deleted)):
+                            if any(True for hda in all_items[0].dataset_instances if hda.deleted):
                                 return []
                         else:
                             return []
@@ -50,11 +51,11 @@ class JobSearch(object):
                         return []
                     input_data[k] = {src: {item.id for item in all_items}}
             else:
-                input_param[k] = json.dumps(str(v))
+                input_param[k] = json.dumps(v) if not isinstance(v, int) else json.dumps(str(v))
         return self.__search(tool_id=tool_id, user=user, input_param=input_param, input_data=input_data, job_state=job_state)
 
     def one_not_deleted(self, items):
-        return any((True for item in items if not item.deleted))
+        return any(True for item in items if not item.deleted)
 
     def _get_all_hdas(self, trans, hda_id):
         """Given a decoded `hda_id`, find other instances that refer to the same dataset."""

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -44,6 +44,10 @@ class JobSearch(object):
                                 return []
                         else:
                             return []
+                    else:
+                        # We don't know how to deal with inputs that are not HDCA/HDA/LDDA
+                        # and possibly LDCA in the future.
+                        return []
                     input_data[k] = {src: {item.id for item in all_items}}
             else:
                 input_param[k] = json.dumps(str(v))

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -1,13 +1,40 @@
 import json
+import logging
 
+from boltons.iterutils import remap
 from six import string_types
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, false, or_
 from sqlalchemy.orm import aliased
 
 from galaxy import model
 from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.lddas import LDDAManager
+from galaxy.util import (
+    defaultdict,
+    ExecutionTimer
+)
+
+log = logging.getLogger(__name__)
+
+
+def get_path_key(path_tuple):
+    path_key = ""
+    tuple_elements = len(path_tuple)
+    for i, p in enumerate(path_tuple):
+        if isinstance(p, int):
+            sep = '_'
+        else:
+            sep = '|'
+        if i == (tuple_elements - 2) and p == 'values':
+            # dataset inputs are always wrapped in lists. To avoid 'rep_factorName_0|rep_factorLevel_2|countsFile|values_0',
+            # we remove the last 2 items of the path tuple (values and list index)
+            return path_key
+        if path_key:
+            path_key = "%s%s%s" % (path_key, sep, p)
+        else:
+            path_key = p
+    return path_key
 
 
 class JobSearch(object):
@@ -20,69 +47,36 @@ class JobSearch(object):
         self.ldda_manager = LDDAManager(app)
         self.decode_id = self.app.security.decode_id
 
-    def by_tool_input(self, trans, tool_id, inputs, job_state='ok'):
+    def by_tool_input(self, trans, tool_id, param_dump=None, job_state='ok', is_workflow_step=False):
         """Search for jobs producing same results using the 'inputs' part of a tool POST."""
         user = trans.user
-        input_param = {}
-        input_data = {}
-        for k, v in inputs.items():
-            if isinstance(v, dict):
-                if 'id' in v:
-                    decoded_id = self.decode_id(v['id'])
-                    src = v.get('src', 'hda')
-                    if src == 'hda':
-                        all_items = self._get_all_hdas(trans=trans, hda_id=decoded_id)
-                        if not self.one_not_deleted(all_items):
-                            return []
-                    elif src == 'ldda':
-                        all_items = self._get_all_lddas(trans=trans, ldda_id=v['id'])
-                        if not self.one_not_deleted(all_items):
-                            return []
-                    elif src == 'hdca':
-                        all_items = self._get_all_hdcas(trans=trans, hdca_id=v['id'])
-                        if self.one_not_deleted(all_items):
-                            if any(True for hda in all_items[0].dataset_instances if hda.deleted):
-                                return []
-                        else:
-                            return []
-                    else:
-                        # We don't know how to deal with inputs that are not HDCA/HDA/LDDA
-                        # and possibly LDCA in the future.
-                        return []
-                    input_data[k] = {src: {item.id for item in all_items}}
-            else:
-                input_param[k] = json.dumps(v) if not isinstance(v, int) else json.dumps(str(v))
-        return self.__search(tool_id=tool_id, user=user, input_param=input_param, input_data=input_data, job_state=job_state)
+        input_data = defaultdict(list)
+        input_ids = defaultdict(dict)
 
-    def one_not_deleted(self, items):
-        return any(True for item in items if not item.deleted)
+        def populate_input_data_input_id(path, key, value):
+            """Traverses expanded incoming using remap and collects input_ids and input_data."""
+            if key == 'id':
+                path_key = get_path_key(path[:-2])
+                current_case = param_dump
+                for p in path:
+                    current_case = current_case[p]
+                src = current_case['src']
+                input_data[path_key].append({'src': src, 'id': value})
+                input_ids[src][value] = True
+                return key, value
+            return key, value
 
-    def _get_all_hdas(self, trans, hda_id):
-        """Given a decoded `hda_id`, find other instances that refer to the same dataset."""
-        hda = self.hda_manager.get_accessible(hda_id, trans.user)
-        return self.sa_session.query(model.HistoryDatasetAssociation).filter(
-            model.HistoryDatasetAssociation.dataset_id == hda.dataset_id).all()
+        remap(param_dump, visit=populate_input_data_input_id)
+        return self.__search(tool_id=tool_id,
+                             user=user,
+                             input_data=input_data,
+                             job_state=job_state,
+                             param_dump=param_dump,
+                             input_ids=input_ids,
+                             is_workflow_step=is_workflow_step)
 
-    def _get_all_lddas(self, trans, ldda_id):
-        """Given a decoded `ldda_id` return the corresponding ldda"""
-        # TODO: implement looking up HDAs that point to the same dataset
-        ldda = self.ldda_manager.get(trans=trans, id=ldda_id)
-        return [ldda]
-
-    def _get_all_hdcas(self, trans, hdca_id):
-        """Given an hdca, returns a list of other hdcas that were copied from this hdca."""
-        # TODO: would be great if we can find all identical hdcas
-        hdca = self.dataset_collection_manager.get_dataset_collection_instance(trans=trans,
-                                                                               instance_type='history',
-                                                                               id=hdca_id)
-        copied_from = getattr(hdca, 'copied_from_history_dataset_collection_association', None)
-        hdcas = [hdca]
-        if copied_from:
-            hdcas.append(copied_from)
-        return hdcas
-
-    def __search(self, tool_id, user, input_param, input_data, job_state=None):
-
+    def __search(self, tool_id, user, input_data, input_ids=None, job_state=None, param_dump=None, is_workflow_step=False):
+        search_timer = ExecutionTimer()
         query = self.sa_session.query(model.Job).filter(
             model.Job.tool_id == tool_id,
             model.Job.user == user
@@ -109,44 +103,132 @@ class JobSearch(object):
                     or_(*o)
                 )
 
-        for k, v in input_param.items():
-            a = aliased(model.JobParameter)
-            if isinstance(v, string_types):
-                query = query.filter(and_(
-                    model.Job.id == a.job_id,
-                    a.name == k,
-                    a.value == v
-                ))
-        for k, type_values in input_data.items():
-            for t, v in type_values.items():
+        for k, input_list in input_data.items():
+            for type_values in input_list:
+                t = type_values['src']
+                v = type_values['id']
                 if t == 'hda':
                     a = aliased(model.JobToInputDatasetAssociation)
+                    b = aliased(model.HistoryDatasetAssociation)
+                    c = aliased(model.HistoryDatasetAssociation)
                     query = query.filter(and_(
                         model.Job.id == a.job_id,
                         a.name == k,
-                        a.dataset_id.in_(v)
+                        a.dataset_id == b.id,
+                        c.dataset_id == b.dataset_id,
+                        c.id == v,
+                        or_(b.deleted == false(), c.deleted == false())
                     ))
                 elif t == 'ldda':
                         a = aliased(model.JobToInputLibraryDatasetAssociation)
                         query = query.filter(and_(
                             model.Job.id == a.job_id,
                             a.name == k,
-                            a.ldda_id.in_(v)
+                            a.ldda_id == v
                         ))
                 elif t == 'hdca':
                     a = aliased(model.JobToInputDatasetCollectionAssociation)
+                    b = aliased(model.HistoryDatasetCollectionAssociation)
+                    c = aliased(model.HistoryDatasetCollectionAssociation)
                     query = query.filter(and_(
                         model.Job.id == a.job_id,
                         a.name == k,
-                        a.dataset_collection_id.in_(v)
+                        b.id == a.dataset_collection_id,
+                        c.id == v,
+                        or_(and_(b.deleted == false(), b.id == v),
+                            and_(or_(c.copied_from_history_dataset_collection_association_id == b.id,
+                                     b.copied_from_history_dataset_collection_association_id == c.id),
+                                 c.deleted == false()
+                                 )
+                            )
                     ))
                 else:
                     return []
 
-        jobs = []
         for job in query.all():
+            # We found a job that is equal in terms of tool_id, user, state and input datasets,
+            # but to be able to verify that the parameters match we need to modify all instances of
+            # dataset_ids (HDA, LDDA, HDCA) in the incoming param_dump to point to those used by the
+            # possibly equivalent job, which may have been run on copies of the original input data.
+            replacement_timer = ExecutionTimer()
+            job_input_ids = {}
+            for src, items in input_ids.items():
+                for dataset_id in items:
+                    if src in job_input_ids and dataset_id in job_input_ids[src]:
+                        continue
+                    if src == 'hda':
+                        a = aliased(model.JobToInputDatasetAssociation)
+                        b = aliased(model.HistoryDatasetAssociation)
+                        c = aliased(model.HistoryDatasetAssociation)
+
+                        (job_dataset_id,) = self.sa_session.query(b.id).filter(
+                            and_(
+                                a.job_id == job.id,
+                                b.id == a.dataset_id,
+                                c.dataset_id == b.dataset_id,
+                                c.id == dataset_id
+                            )
+                        ).first()
+                    elif src == 'hdca':
+                        a = aliased(model.JobToInputDatasetCollectionAssociation)
+                        b = aliased(model.HistoryDatasetCollectionAssociation)
+                        c = aliased(model.HistoryDatasetCollectionAssociation)
+
+                        (job_dataset_id,) = self.sa_session.query(b.id).filter(
+                            and_(
+                                a.job_id == job.id,
+                                b.id == a.dataset_collection_id,
+                                c.id == dataset_id,
+                                or_(b.id == c.id, or_(c.copied_from_history_dataset_collection_association_id == b.id,
+                                                      b.copied_from_history_dataset_collection_association_id == c.id)
+                                    )
+                            )
+                        ).first()
+                    elif src == 'ldda':
+                        job_dataset_id = dataset_id
+                    else:
+                        return []
+                    if src not in job_input_ids:
+                        job_input_ids[src] = {dataset_id: job_dataset_id}
+                    else:
+                        job_input_ids[src][dataset_id] = job_dataset_id
+
+            def replace_dataset_ids(path, key, value):
+                """Exchanges dataset_ids (HDA, LDA, HDCA, not Dataset) in param_dump with dataset ids used in job."""
+                if key == 'id':
+                    current_case = param_dump
+                    for p in path:
+                        current_case = current_case[p]
+                    src = current_case['src']
+                    value = job_input_ids[src][value]
+                    return key, value
+                return key, value
+
+            new_param_dump = remap(param_dump, visit=replace_dataset_ids)
+            log.info("Parameter replacement finished %s", replacement_timer)
+            # new_param_dump has its dataset ids remapped to those used by the job.
+            # We now ask if the remapped job parameters match the current job.
+            query = self.sa_session.query(model.Job).filter(model.Job.id == job.id)
+            for k, v in new_param_dump.items():
+                a = aliased(model.JobParameter)
+                query = query.filter(and_(
+                    a.job_id == job.id,
+                    a.name == k,
+                    a.value == json.dumps(v)
+                ))
+            if query.first() is None:
+                continue
+            if is_workflow_step:
+                add_n_parameters = 3
+            else:
+                add_n_parameters = 2
+            if not len(job.parameters) == (len(new_param_dump) + add_n_parameters):
+                # Verify that equivalent jobs had the same number of job parameters
+                # We add 2 or 3 to new_param_dump because chrominfo and dbkey (and __workflow_invocation_uuid__) are not passed
+                # as input parameters
+                continue
             # check to make sure none of the output datasets or collections have been deleted
-            # TODO: find copies if output is deleted
+            # TODO: refactors this into the initial job query
             outputs_deleted = False
             for hda in job.output_datasets:
                 if hda.dataset.deleted:
@@ -158,5 +240,6 @@ class JobSearch(object):
                         outputs_deleted = True
                         break
             if not outputs_deleted:
-                jobs.append(job)
-        return jobs
+                log.info("Searching jobs finished %s", search_timer)
+                return job
+        return None

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -122,14 +122,14 @@ class JobSearch(object):
                         a.dataset_id.in_(v)
                     ))
                 elif t == 'ldda':
-                        a = aliased(model.JobToInputDatasetCollectionAssociation)
+                        a = aliased(model.JobToInputLibraryDatasetAssociation)
                         query = query.filter(and_(
                             model.Job.id == a.job_id,
                             a.name == k,
                             a.ldda_id.in_(v)
                         ))
                 elif t == 'hdca':
-                    a = aliased(model.JobToInputLibraryDatasetAssociation)
+                    a = aliased(model.JobToInputDatasetCollectionAssociation)
                     query = query.filter(and_(
                         model.Job.id == a.job_id,
                         a.name == k,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2137,6 +2137,7 @@ mapper(model.Job, model.Job.table, properties=dict(
     library_folder=relation(model.LibraryFolder, lazy=True),
     parameters=relation(model.JobParameter, lazy=True),
     input_datasets=relation(model.JobToInputDatasetAssociation),
+    input_dataset_collections=relation(model.JobToInputDatasetCollectionAssociation, lazy=True),
     output_datasets=relation(model.JobToOutputDatasetAssociation, lazy=True),
     output_dataset_collection_instances=relation(model.JobToOutputDatasetCollectionAssociation, lazy=True),
     output_dataset_collections=relation(model.JobToImplicitOutputDatasetCollectionAssociation, lazy=True),

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -559,7 +559,11 @@ class DefaultToolAction(object):
                     reductions[name].append(dataset_collection)
 
                 # TODO: verify can have multiple with same name, don't want to lose traceability
-                job.add_input_dataset_collection(name, dataset_collection)
+                if isinstance(dataset_collection, model.HistoryDatasetCollectionAssociation):
+                    # FIXME: when recording inputs for special tools (e.g. ModelOperationToolAction),
+                    # dataset_collection is actually a DatasetCollectionElement, which can't be added
+                    # to a jobs' input_dataset_collection relation, which expects HDCA instances
+                    job.add_input_dataset_collection(name, dataset_collection)
 
         # If this an input collection is a reduction, we expanded it for dataset security, type
         # checking, and such, but the persisted input must be the original collection

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -68,6 +68,9 @@ BINARY_CHARS = [NULL_CHAR]
 FILENAME_VALID_CHARS = '.,^_-()[]0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 
+defaultdict = collections.defaultdict
+
+
 def remove_protocol_from_url(url):
     """ Supplied URL may be null, if not ensure http:// or https://
     etc... is stripped off.

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -12,7 +12,7 @@ from sqlalchemy import or_
 from galaxy import exceptions
 from galaxy import model
 from galaxy import util
-from galaxy.jobs.search import JobSearch
+from galaxy.managers.jobs import JobSearch
 from galaxy.web import _future_expose_api as expose_api
 from galaxy.web import _future_expose_api_anonymous as expose_api_anonymous
 from galaxy.web.base.controller import BaseAPIController

--- a/test/api/test_jobs.py
+++ b/test/api/test_jobs.py
@@ -291,7 +291,14 @@ class JobsApiTestCase(api.ApiTestCase):
         search_payload = self._search_payload(history_id=history_id, tool_id='cat1', inputs=copied_inputs)
         search_count = self._search(search_payload)
         self.assertEquals(search_count, 1)
-
+        delete_respone = self._delete("histories/%s/contents/%s" % (history_id, dataset_id))
+        self._assert_status_code_is(delete_respone, 200)
+        search_count = self._search(search_payload)
+        self.assertEquals(search_count, 1)
+        delete_respone = self._delete("histories/%s/contents/%s" % (history_id, new_dataset_id))
+        self._assert_status_code_is(delete_respone, 200)
+        search_count = self._search(search_payload)
+        self.assertEquals(search_count, 0)
 
     def test_search_with_hdca_list_input(self):
         history_id, list_id_a = self.__history_with_ok_collection(collection_type='list')

--- a/test/api/test_jobs.py
+++ b/test/api/test_jobs.py
@@ -291,10 +291,12 @@ class JobsApiTestCase(api.ApiTestCase):
         search_payload = self._search_payload(history_id=history_id, tool_id='cat1', inputs=copied_inputs)
         search_count = self._search(search_payload)
         self.assertEquals(search_count, 1)
+        # Now we delete the original HDA that was used -- we should still be able to find the job
         delete_respone = self._delete("histories/%s/contents/%s" % (history_id, dataset_id))
         self._assert_status_code_is(delete_respone, 200)
         search_count = self._search(search_payload)
         self.assertEquals(search_count, 1)
+        # Now we also delete the copy -- we shouldn't find a job
         delete_respone = self._delete("histories/%s/contents/%s" % (history_id, new_dataset_id))
         self._assert_status_code_is(delete_respone, 200)
         search_count = self._search(search_payload)
@@ -324,6 +326,7 @@ class JobsApiTestCase(api.ApiTestCase):
             'f2': {'src': 'hdca', 'id': list_id_a},
         })
         self._job_search(tool_id='multi_data_param', history_id=history_id, inputs=inputs)
+        # We test that a job can be found even if the collection has been copied to another history
         new_history_id = self.dataset_populator.new_history()
         copy_payload = {"content": list_id_a, "source": "hdca", "type": "dataset_collection"}
         copy_response = self._post("histories/%s/contents" % new_history_id, data=copy_payload)
@@ -336,6 +339,16 @@ class JobsApiTestCase(api.ApiTestCase):
         search_payload = self._search_payload(history_id=new_history_id, tool_id='multi_data_param', inputs=copied_inputs)
         search_count = self._search(search_payload)
         self.assertEquals(search_count, 1)
+        # Now we delete the original HDCA that was used -- we should still be able to find the job
+        delete_respone = self._delete("histories/%s/contents/%s" % (history_id, list_id_a))
+        self._assert_status_code_is(delete_respone, 200)
+        search_count = self._search(search_payload)
+        self.assertEquals(search_count, 1)
+        # Now we also delete the copy -- we shouldn't find a job
+        delete_respone = self._delete("histories/%s/contents/%s" % (history_id, new_list_a))
+        self._assert_status_code_is(delete_respone, 200)
+        search_count = self._search(search_payload)
+        self.assertEquals(search_count, 0)
 
     def test_search_with_hdca_list_pair_input(self):
         history_id, list_id_a = self.__history_with_ok_collection(collection_type='list:pair')


### PR DESCRIPTION
This PR extends the job search:
  - Jobs that used dataset collections can now be found correctly (jobs have to be newer than this PR, see 19818cb380889e584741caf4a78462e0502f30c1)
  - We check that a input dataset is supplied at the correct input parameter (previously jobs with same inputs for different parameters would be returned as well)
  - The core of the functionality is now in galaxy.manager.jobs so that it can be re-used for https://github.com/galaxyproject/galaxy/issues/4468
  - Some new API tests that exercise this functionality.