### PR TITLE
[17.09] Remove chatty debug statement

### DIFF
--- a/lib/galaxy/jobs/actions/post.py
+++ b/lib/galaxy/jobs/actions/post.py
@@ -308,7 +308,6 @@ class DeleteIntermediatesAction(DefaultJobAction):
                     safe_to_delete = True
                     for job_to_check in [d_j.job for d_j in input_dataset.dependent_jobs]:
                         if job_to_check != job and job_to_check.state not in [job.states.OK, job.states.DELETED]:
-                            log.debug("Workflow Intermediates cleanup attempted, but non-terminal state '%s' detected for job %s" % (job_to_check.state, job_to_check.id))
                             safe_to_delete = False
                     if safe_to_delete:
                         # Support purging here too.


### PR DESCRIPTION
This happens pretty often and much of the time is not a problem at all.  If we have to track down any new issues with workflow output cleanup, it's easy enough to temporarily reintroduce this logging.

It's not *reeealy* a bugfix, but it does make logs easier to filter and read.  And it's definitely not the kind of 'enhancement' the freeze is designed to prevent merging/work on.  I feel like this follows the spirit of the rules, if not exactly.