### PR TITLE
[17.09] Explicitly include PyPI as an --extra-index-url to pip

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -139,9 +139,9 @@ if [ $REPLACE_PIP -eq 1 ]; then
 fi
 
 if [ $FETCH_WHEELS -eq 1 ]; then
-    pip install -r requirements.txt --index-url "${GALAXY_WHEELS_INDEX_URL}"
+    pip install -r requirements.txt --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url https://pypi.python.org/pypi
     GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))")
-    [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
+    [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url https://pypi.python.org/pypi
 fi
 
 if [ $FETCH_WHEELS -eq 1 -a $DEV_WHEELS -eq 1 ]; then


### PR DESCRIPTION
Previously, PyPI was only checked after wheels.galaxyproject.org because pypiserver (which provides the index on wheels.galaxyproject.org) performs an automatic redirect to PyPI for any packages that do not exist in its index. It does not to the redirect if you request a specific version of a package and that package exists in pypiserver but not the requested version.

Now that we are adding dependencies to Galaxy that had old versions on wheels.galaxyproject.org but that we will install new versions of from PyPI, we need to explicitly list PyPI as an extra index when calling pip.

Wheels and source that we include in Galaxy's requirements.txt that we don't place on wheels.galaxyproject.org should be added to cargo port for archival.

Cherry picked from the branch in #4497, which will not be included in 17.09.