### PR TITLE
Create object store extra_dirs if not existing

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -566,6 +566,10 @@ class DistributedObjectStore(NestedObjectStore):
             self.filesystem_monitor_thread.start()
             log.info("Filesystem space monitor started")
 
+        for directory in self.extra_dirs.items():
+            if not os.path.exists(directory):
+                os.makedirs(directory)
+
     def __parse_distributed_config(self, config, config_xml=None):
         if config_xml is None:
             root = ElementTree.parse(self.distributed_config).getroot()


### PR DESCRIPTION
We saw an increase in job failures and I believe it was due to directories specified here which did not exist and were not created when missing. I've applied this to distributed because that's what we use, but maybe it needs to be done at a higher level? Not sure if that would negatively impact other objectstores.