### PR TITLE
Fix invalid requests imports introduced in #4604.

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -2,6 +2,8 @@
 Upload class
 """
 
+from __future__ import absolute_import
+
 import logging
 import urllib
 

--- a/lib/galaxy/webapps/galaxy/controllers/library_common.py
+++ b/lib/galaxy/webapps/galaxy/controllers/library_common.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import glob
 import json
 import logging

--- a/lib/galaxy/webapps/galaxy/controllers/root.py
+++ b/lib/galaxy/webapps/galaxy/controllers/root.py
@@ -1,6 +1,8 @@
 """
 Contains the main interface in the Universe class
 """
+from __future__ import absolute_import
+
 import cgi
 import os
 

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import base64
 import httplib
 import json


### PR DESCRIPTION
Even when we remove the requests controller the pyc files will stick around - so probably best to keep these absolute imports for these controllers indefinitely. This broke workflow import from URL coming through the GUI and so it broke a bunch of Selenium tests.

xref #4604
xref https://jenkins.galaxyproject.org/job/selenium/614/testReport/junit/selenium_tests.test_workflow_management/WorkflowManagementTestCase/test_import_from_url/

![](https://jenkins.galaxyproject.org/job/selenium/614/artifact/614-test-errors/test_import_from_url2017092516451506372357/last.png)
