### PR TITLE
Selenium - run tests with a proxy prefix.

### DIFF
--- a/.ci/jenkins/selenium/galaxy.ini
+++ b/.ci/jenkins/selenium/galaxy.ini
@@ -6,6 +6,12 @@ host = 0.0.0.0
 use_threadpool = True
 threadpool_kill_thread_limit = 10800
 
+[filter:proxy-prefix]
+use = egg:PasteDeploy#prefix
+prefix = /galaxypf
+
 [app:main]
 
 paste.app_factory = galaxy.web.buildapp:app_factory
+
+filter-with = proxy-prefix

--- a/.ci/jenkins/selenium/run_tests.sh
+++ b/.ci/jenkins/selenium/run_tests.sh
@@ -107,7 +107,8 @@ export GALAXY_TEST_SELENIUM_RETRIES=1
 export GALAXY_TEST_PORT="${GALAXY_PORT}"
 
 # Have Selenium access Galaxy at this URL
-export GALAXY_TEST_EXTERNAL_FROM_SELENIUM="http://galaxy:8080"
+export GALAXY_TEST_EXTERNAL_FROM_SELENIUM="http://galaxy:8080/galaxypf"
+export GALAXY_TEST_EXTERNAL="http://localhost:${GALAXY_TEST_PORT}/galaxypf"
 
 cd ../../..
 


### PR DESCRIPTION
Should allow catching this class of bugs in the future. 

Probably shouldn't be merged prior to #4705 being merged into dev.