### PR TITLE
[17.09] Append fewer characters to id_secret by default for encrypting csrf tokens.

### DIFF
--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -888,7 +888,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
         token = ''
         if self.galaxy_session:
             token = self.security.encode_id(
-                self.galaxy_session.id, kind="session_csrf_token"
+                self.galaxy_session.id, kind="csrf"
             )
         return token
 


### PR DESCRIPTION
Seems there is a maximum length and main hit it. It never did for job files - so this should be fine. If you have a secret that is near the maximum lenght one just needs to set ``per_kind_id_secret_base`` to something shorter than ``id_secret``.