### PR TITLE
[17.09] Better handling of long id secrets when generating per-kind encryption keys.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -978,7 +978,7 @@ use_interactive = True
 # Galaxy encodes various internal values when these values will be output in
 # some format (for example, in a URL or cookie).  You should set a key to be
 # used by the algorithm that encodes and decodes these values.  It can be any
-# string.
+# string up to 448 bits long.
 # One simple way to generate a value for this is with the shell command:
 #   python -c 'import time; print time.time()' | md5sum | cut -f 1 -d ' '
 #id_secret = USING THE DEFAULT IS NOT SECURE!

--- a/test/unit/test_security_helper.py
+++ b/test/unit/test_security_helper.py
@@ -1,8 +1,68 @@
+# -*- coding: utf-8 -*-
+
 from galaxy.web import security
 
 
 test_helper_1 = security.SecurityHelper(id_secret="sec1")
 test_helper_2 = security.SecurityHelper(id_secret="sec2")
+
+
+def test_maximum_length_handling_ascii():
+    # Test that id secrets can be up to 56 characters long.
+    longest_id_secret = "m" * security.MAXIMUM_ID_SECRET_LENGTH
+    helper = security.SecurityHelper(id_secret=longest_id_secret)
+    helper.encode_id(1)
+
+    # Test that security helper will catch if the id secret is too long.
+    threw_exception = False
+    longer_id_secret = "m" * (security.MAXIMUM_ID_SECRET_LENGTH + 1)
+    try:
+        security.SecurityHelper(id_secret=longer_id_secret)
+    except Exception:
+        threw_exception = True
+
+    assert threw_exception
+
+    # Test that different kinds produce different keys even when id secret
+    # is very long.
+    e11 = helper.encode_id(1, kind="moo")
+    e12 = helper.encode_id(1, kind="moo2")
+
+    assert e11 != e12
+
+    # Test that long kinds are rejected because it uses up "too much" randomness
+    # from id_secret values. This isn't a strict requirement up but lets just enforce
+    # the best practice.
+    assertion_error_raised = False
+    try:
+        helper.encode_id(1, kind="this is a really long kind")
+    except AssertionError:
+        assertion_error_raised = True
+
+    assert assertion_error_raised
+
+
+def test_maximum_length_handling_nonascii():
+    longest_id_secret = "◎◎◎◎◎◎◎◎◎◎◎◎◎◎◎◎◎◎"
+    helper = security.SecurityHelper(id_secret=longest_id_secret)
+    helper.encode_id(1)
+
+    # Test that security helper will catch if the id secret is too long.
+    threw_exception = False
+    longer_id_secret = "◎◎◎◎◎◎◎◎◎◎◎◎◎◎◎◎◎◎◎"
+    try:
+        security.SecurityHelper(id_secret=longer_id_secret)
+    except Exception:
+        threw_exception = True
+
+    assert threw_exception
+
+    # Test that different kinds produce different keys even when id secret
+    # is very long.
+    e11 = helper.encode_id(1, kind="moo")
+    e12 = helper.encode_id(1, kind="moo2")
+
+    assert e11 != e12
 
 
 def test_encode_decode():


### PR DESCRIPTION
Generally more validation and more testing as well. Test cases layout the reasons for some of these changes.

Prevents bugs like https://github.com/galaxyproject/galaxy/pull/4710. Ensure CSRF tokens won't break existing Galaxies regardless of how long id_secret people have chosen (unless they chose one that would have broken normal generation of keys).