### PR TITLE
Fix to respect galaxy.json supplied metadata for empty outputs.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -43,6 +43,7 @@ log = logging.getLogger(__name__)
 # that import Galaxy internals - but it shouldn't be used in Galaxy's code
 # itself.
 TOOL_PROVIDED_JOB_METADATA_FILE = 'galaxy.json'
+TOOL_PROVIDED_JOB_METADATA_KEYS = ['name', 'info', 'dbkey']
 
 # Override with config.default_job_shell.
 DEFAULT_JOB_SHELL = '/bin/bash'
@@ -1320,14 +1321,17 @@ class JobWrapper(object, HasResourceParameters):
                             dataset.set_peek(is_multi_byte=True)
                         else:
                             dataset.set_peek()
-                    for context_key in ['name', 'info', 'dbkey']:
-                        if context_key in context:
-                            context_value = context[context_key]
-                            setattr(dataset, context_key, context_value)
                 else:
+                    # Handle an empty dataset.
                     dataset.blurb = "empty"
                     if dataset.ext == 'auto':
-                        dataset.extension = 'txt'
+                        dataset.extension = context.get('ext', 'txt')
+
+                for context_key in TOOL_PROVIDED_JOB_METADATA_KEYS:
+                    if context_key in context:
+                        context_value = context[context_key]
+                        setattr(dataset, context_key, context_value)
+
                 self.sa_session.add(dataset)
             if job.states.ERROR == final_job_state:
                 log.debug("(%s) setting dataset %s state to ERROR", job.id, dataset_assoc.dataset.dataset.id)

--- a/test/functional/tools/empty_datasets.xml
+++ b/test/functional/tools/empty_datasets.xml
@@ -1,0 +1,34 @@
+<tool id="empty_datasets" name="empty_datasets" version="1.0.0" profile="17.09">
+    <command>
+        touch $output;
+        touch out;
+        touch out_meta;
+        cp $c1 galaxy.json
+    </command>
+    <configfiles>
+      <configfile name="c1">{"output_tool_supplied_metadata": {
+  "name": "my dynamic name",
+  "ext": "fasta",
+  "info": "my dynamic info"
+}}
+</configfile>
+    </configfiles>
+    <inputs>
+        <param name="input" type="integer" value="0" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+        <data name="output_workdir" from_work_dir="out" format="txt" />
+        <data name="output_tool_supplied_metadata" from_work_dir="out_meta" format="auto" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="7" />
+            <output name="output" md5="d41d8cd98f00b204e9800998ecf8427e" />
+            <output name="output_workdir" md5="d41d8cd98f00b204e9800998ecf8427e" />
+            <output name="output_tool_supplied_metadata" md5="d41d8cd98f00b204e9800998ecf8427e" ftype="fasta">
+                <metadata name="name" value="my dynamic name" />
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -24,6 +24,7 @@
   <tool file="tool_provided_metadata_7.xml" />
   <tool file="tool_provided_metadata_8.xml" />
   <tool file="tool_provided_metadata_9.xml" />
+  <tool file="empty_datasets.xml" />
   <tool file="inputs_as_json.xml" />
   <tool file="dbkey_filter_input.xml" />
   <tool file="dbkey_filter_multi_input.xml" />


### PR DESCRIPTION
With a test case to verify this and a empty datasets in general (e.g. collecting empty datasets from work dir).

This is work from the CWL branch.