### PR TITLE
[17.09] If the newest version of a tool is hidden, load the newest older version, if any, into the tool panel

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -264,6 +264,9 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin, object):
         # See if a version of this tool is already loaded into the tool panel.
         # The value of panel_component will be a ToolSection (if the value of
         # section=True) or self._tool_panel (if section=False).
+        if tool.hidden:
+            log.debug("Skipping tool panel addition of hidden tool: %s, version: %s", tool.id, tool.version)
+            return
         tool_id = str(tool.id)
         tool = self._tools_by_id[tool_id]
         log_msg = ""


### PR DESCRIPTION
With recent tool lineage handling that always uses tool version comparisons instead of installation order from the database (I think this is how it worked before?), we have some "broken" tool versions that show up as newer versions of tools that should in fact be older.

For example, at one point we had installed `freebayes` version `freebayes-0.9.14`. Later we installed version `1.0.2.29-3`, and hid the older version by setting `hidden="true"` on its `<tool>` tag in `shed_tool_conf.xml`. This worked fine with Galaxy < 17.09 since lineage came from the database, but unfortunately:

```python
>>> from distutils.version import LooseVersion
>>> LooseVersion('1.0.2.29-3') > LooseVersion('freebayes-0.9.14')
False
>>> 
```

Because tools are loaded into the panel regardless of whether they're hidden and, and newer versions replace older versions, and only at runtime are hidden tools filtered out, if the "newest" version is hidden, no version will show up in the panel. This change allows the "newest" unhidden version to appear.

Here are two things probably worth being aware of:

- With this change, we don't load hidden tools in to the panel at all. It does result in the old version not being in `config.toolbox` in the client's app dict, I don't know if that is a problem, because I'm still able to switch to the old version and run it. I am not sure of the overall ramifications of this change as I don't really know the client at all and not much about the toolbox, so feel free to tell me this is the wrong way to do it.
- The hidden version will forever appear as the "newest" (last) version in the Versions dropdown on the tool form.

On gitter we considered adding a forever-hack to the lineage module to fix this for this specific tool (and any others that we might encounter), but this newest-version-hiding fix was deemed more palatable.