### PR TITLE
Reuse existing dependency manager if possible

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -1056,7 +1056,11 @@ class BaseGalaxyToolBox(AbstractToolBox):
 
     def __init__(self, config_filenames, tool_root_dir, app):
         super(BaseGalaxyToolBox, self).__init__(config_filenames, tool_root_dir, app)
-        self._init_dependency_manager()
+        old_toolbox = getattr(app, 'toolbox', None)
+        if old_toolbox:
+            self.dependency_manager = old_toolbox.dependency_manager
+        else:
+            self._init_dependency_manager()
 
     @property
     def sa_session(self):


### PR DESCRIPTION
This does slightly speedup toolbox reloads (and this is what is happening during the last traceback in https://github.com/galaxyproject/galaxy/issues/4738#issue-262429620). Initialising conda for instance checks if conda is installed, and if not may attempt to lock the directory and try to install conda.