### PR TITLE
[17.09] Fix t, a, g, s returned in to_dict() method

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -87,8 +87,8 @@ def set_datatypes_registry(d_registry):
 
 
 class HasTags(object):
-    dict_collection_visible_keys = ('tags')
-    dict_element_visible_keys = ('tags')
+    dict_collection_visible_keys = ('tags',)
+    dict_element_visible_keys = ('tags',)
 
     def to_dict(self, *args, **kwargs):
         rval = super(HasTags, self).to_dict(*args, **kwargs)


### PR DESCRIPTION
This doesn't have much of an impact, but some API calls would just return `'t': None, 'a': None, g: None, 's': None` and so on.