### PR TITLE
[17.09] Fix joiner tool to inherit datatype from the input format

### DIFF
--- a/tools/filters/joiner.xml
+++ b/tools/filters/joiner.xml
@@ -1,4 +1,4 @@
-<tool id="join1" name="Join two Datasets" version="2.1.0">
+<tool id="join1" name="Join two Datasets" version="2.1.1">
   <description>side by side on a specified field</description>
   <requirements>
     <requirement type="package" version="2.7.13">python</requirement>
@@ -85,7 +85,7 @@ ${json.dumps( __fill_options )}
    </param>
   </inputs>
   <outputs>
-     <data format_source="input" name="out_file1" metadata_source="input1" />
+     <data format_source="input1" name="out_file1" metadata_source="input1" />
   </outputs>
   <tests>
     <test>


### PR DESCRIPTION
This should be output-format-identification as was the behavior prior to #4229 (yet using `format_source` instead of `format`, as was the intent in that change in the PR I think), but I'm not a tool author.  Anything I'm missing here?

Without this, the outputs are just 'data' format, reported by @jennaj 