### PR TITLE
Many more upload tests.

### DIFF
--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -6,10 +6,8 @@ from base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
     LibraryPopulator,
-    skip_without_datatype,
     skip_without_tool,
 )
-from galaxy.tools.verify.test_data import TestDataResolver
 
 
 class ToolsTestCase(api.ApiTestCase):
@@ -86,197 +84,6 @@ class ToolsTestCase(api.ApiTestCase):
         tool_info = tool_show_response.json()
         self._assert_has_keys(tool_info, "inputs", "outputs", "panel_section_id")
         return tool_info
-
-    def test_upload1_paste(self):
-        with self.dataset_populator.test_history() as history_id:
-            payload = self.dataset_populator.upload_payload(history_id, 'Hello World')
-            create_response = self._post("tools", data=payload)
-            self._assert_has_keys(create_response.json(), 'outputs')
-
-    def test_upload_posix_newline_fixes(self):
-        windows_content = "1\t2\t3\r4\t5\t6\r"
-        posix_content = windows_content.replace("\r", "\n")
-        result_content = self._upload_and_get_content(windows_content)
-        self.assertEquals(result_content, posix_content)
-
-    def test_upload_disable_posix_fix(self):
-        windows_content = "1\t2\t3\r4\t5\t6\r"
-        result_content = self._upload_and_get_content(windows_content, to_posix_lines=None)
-        self.assertEquals(result_content, windows_content)
-
-    def test_upload_tab_to_space(self):
-        table = "1 2 3\n4 5 6\n"
-        result_content = self._upload_and_get_content(table, space_to_tab="Yes")
-        self.assertEquals(result_content, "1\t2\t3\n4\t5\t6\n")
-
-    def test_upload_tab_to_space_off_by_default(self):
-        table = "1 2 3\n4 5 6\n"
-        result_content = self._upload_and_get_content(table)
-        self.assertEquals(result_content, table)
-
-    def test_rdata_not_decompressed(self):
-        # Prevent regression of https://github.com/galaxyproject/galaxy/issues/753
-        rdata_path = TestDataResolver().get_filename("1.RData")
-        rdata_metadata = self._upload_and_get_details(open(rdata_path, "rb"), file_type="auto")
-        self.assertEquals(rdata_metadata["file_ext"], "rdata")
-
-    @skip_without_datatype("velvet")
-    def test_composite_datatype(self):
-        with self.dataset_populator.test_history() as history_id:
-            dataset = self._velvet_upload(history_id, extra_inputs={
-                "files_1|url_paste": "roadmaps content",
-                "files_1|type": "upload_dataset",
-                "files_2|url_paste": "log content",
-                "files_2|type": "upload_dataset",
-            })
-
-            roadmaps_content = self._get_roadmaps_content(history_id, dataset)
-            assert roadmaps_content.strip() == "roadmaps content", roadmaps_content
-
-    @skip_without_datatype("velvet")
-    def test_composite_datatype_space_to_tab(self):
-        # Like previous test but set one upload with space_to_tab to True to
-        # verify that works.
-        with self.dataset_populator.test_history() as history_id:
-            dataset = self._velvet_upload(history_id, extra_inputs={
-                "files_1|url_paste": "roadmaps content",
-                "files_1|type": "upload_dataset",
-                "files_1|space_to_tab": "Yes",
-                "files_2|url_paste": "log content",
-                "files_2|type": "upload_dataset",
-            })
-
-            roadmaps_content = self._get_roadmaps_content(history_id, dataset)
-            assert roadmaps_content.strip() == "roadmaps\tcontent", roadmaps_content
-
-    @skip_without_datatype("velvet")
-    def test_composite_datatype_posix_lines(self):
-        # Like previous test but set one upload with space_to_tab to True to
-        # verify that works.
-        with self.dataset_populator.test_history() as history_id:
-            dataset = self._velvet_upload(history_id, extra_inputs={
-                "files_1|url_paste": "roadmaps\rcontent",
-                "files_1|type": "upload_dataset",
-                "files_1|space_to_tab": "Yes",
-                "files_2|url_paste": "log\rcontent",
-                "files_2|type": "upload_dataset",
-            })
-
-            roadmaps_content = self._get_roadmaps_content(history_id, dataset)
-            assert roadmaps_content.strip() == "roadmaps\ncontent", roadmaps_content
-
-    def _velvet_upload(self, history_id, extra_inputs):
-        payload = self.dataset_populator.upload_payload(
-            history_id,
-            "sequences content",
-            file_type="velvet",
-            extra_inputs=extra_inputs,
-        )
-        run_response = self.dataset_populator.tools_post(payload)
-        self.dataset_populator.wait_for_tool_run(history_id, run_response)
-        datasets = run_response.json()["outputs"]
-
-        assert len(datasets) == 1
-        dataset = datasets[0]
-
-        return dataset
-
-    def _get_roadmaps_content(self, history_id, dataset):
-        roadmaps_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=dataset, filename="Roadmaps")
-        return roadmaps_content
-
-    def test_upload_dbkey(self):
-        with self.dataset_populator.test_history() as history_id:
-            payload = self.dataset_populator.upload_payload(history_id, "Test123", dbkey="hg19")
-            run_response = self.dataset_populator.tools_post(payload)
-            self.dataset_populator.wait_for_tool_run(history_id, run_response)
-            datasets = run_response.json()["outputs"]
-            assert datasets[0].get("genome_build") == "hg19", datasets[0]
-
-    def test_upload_multiple_files_1(self):
-        with self.dataset_populator.test_history() as history_id:
-            payload = self.dataset_populator.upload_payload(history_id, "Test123",
-                dbkey="hg19",
-                extra_inputs={
-                    "files_1|url_paste": "SecondOutputContent",
-                    "files_1|NAME": "SecondOutputName",
-                    "files_1|file_type": "tabular",
-                    "files_1|dbkey": "hg18",
-                    "file_count": "2",
-                }
-            )
-            run_response = self.dataset_populator.tools_post(payload)
-            self.dataset_populator.wait_for_tool_run(history_id, run_response)
-            datasets = run_response.json()["outputs"]
-
-            assert len(datasets) == 2, datasets
-            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[0])
-            assert content.strip() == "Test123"
-            assert datasets[0]["file_ext"] == "txt"
-            assert datasets[0]["genome_build"] == "hg19", datasets
-
-            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[1])
-            assert content.strip() == "SecondOutputContent"
-            assert datasets[1]["file_ext"] == "tabular"
-            assert datasets[1]["genome_build"] == "hg18", datasets
-
-    def test_upload_multiple_files_2(self):
-        with self.dataset_populator.test_history() as history_id:
-            payload = self.dataset_populator.upload_payload(history_id, "Test123",
-                file_type="tabular",
-                dbkey="hg19",
-                extra_inputs={
-                    "files_1|url_paste": "SecondOutputContent",
-                    "files_1|NAME": "SecondOutputName",
-                    "files_1|file_type": "txt",
-                    "files_1|dbkey": "hg18",
-                    "file_count": "2",
-                }
-            )
-            run_response = self.dataset_populator.tools_post(payload)
-            self.dataset_populator.wait_for_tool_run(history_id, run_response)
-            datasets = run_response.json()["outputs"]
-
-            assert len(datasets) == 2, datasets
-            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[0])
-            assert content.strip() == "Test123"
-            assert datasets[0]["file_ext"] == "tabular", datasets
-            assert datasets[0]["genome_build"] == "hg19", datasets
-
-            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[1])
-            assert content.strip() == "SecondOutputContent"
-            assert datasets[1]["file_ext"] == "txt"
-            assert datasets[1]["genome_build"] == "hg18", datasets
-
-    def test_upload_multiple_files_3(self):
-        with self.dataset_populator.test_history() as history_id:
-            payload = self.dataset_populator.upload_payload(history_id, "Test123",
-                file_type="tabular",
-                dbkey="hg19",
-                extra_inputs={
-                    "files_0|file_type": "txt",
-                    "files_0|dbkey": "hg18",
-                    "files_1|url_paste": "SecondOutputContent",
-                    "files_1|NAME": "SecondOutputName",
-                    "files_1|file_type": "txt",
-                    "files_1|dbkey": "hg18",
-                    "file_count": "2",
-                }
-            )
-            run_response = self.dataset_populator.tools_post(payload)
-            self.dataset_populator.wait_for_tool_run(history_id, run_response)
-            datasets = run_response.json()["outputs"]
-
-            assert len(datasets) == 2, datasets
-            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[0])
-            assert content.strip() == "Test123"
-            assert datasets[0]["file_ext"] == "txt", datasets
-            assert datasets[0]["genome_build"] == "hg18", datasets
-
-            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[1])
-            assert content.strip() == "SecondOutputContent"
-            assert datasets[1]["file_ext"] == "txt"
-            assert datasets[1]["genome_build"] == "hg18", datasets
 
     def test_unzip_collection(self):
         with self.dataset_populator.test_history() as history_id:
@@ -1469,20 +1276,6 @@ class ToolsTestCase(api.ApiTestCase):
             return create
         else:
             return create_response
-
-    def _upload(self, content, **upload_kwds):
-        history_id = self.dataset_populator.new_history()
-        new_dataset = self.dataset_populator.new_dataset(history_id, content=content, **upload_kwds)
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        return history_id, new_dataset
-
-    def _upload_and_get_content(self, content, **upload_kwds):
-        history_id, new_dataset = self._upload(content, **upload_kwds)
-        return self.dataset_populator.get_history_dataset_content(history_id, dataset=new_dataset)
-
-    def _upload_and_get_details(self, content, **upload_kwds):
-        history_id, new_dataset = self._upload(content, **upload_kwds)
-        return self.dataset_populator.get_history_dataset_details(history_id, dataset=new_dataset)
 
     def __tool_ids(self):
         index = self._get("tools")

--- a/test/api/test_tools_upload.py
+++ b/test/api/test_tools_upload.py
@@ -1,0 +1,220 @@
+from base import api
+
+from base.populators import (
+    DatasetPopulator,
+    skip_without_datatype,
+)
+
+from galaxy.tools.verify.test_data import TestDataResolver
+
+
+class ToolsUploadTestCase(api.ApiTestCase):
+
+    def setUp(self):
+        super(ToolsUploadTestCase, self).setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    def test_upload1_paste(self):
+        with self.dataset_populator.test_history() as history_id:
+            payload = self.dataset_populator.upload_payload(history_id, 'Hello World')
+            create_response = self._post("tools", data=payload)
+            self._assert_has_keys(create_response.json(), 'outputs')
+
+    def test_upload_posix_newline_fixes(self):
+        windows_content = "1\t2\t3\r4\t5\t6\r"
+        posix_content = windows_content.replace("\r", "\n")
+        result_content = self._upload_and_get_content(windows_content)
+        self.assertEquals(result_content, posix_content)
+
+    def test_upload_disable_posix_fix(self):
+        windows_content = "1\t2\t3\r4\t5\t6\r"
+        result_content = self._upload_and_get_content(windows_content, to_posix_lines=None)
+        self.assertEquals(result_content, windows_content)
+
+    def test_upload_tab_to_space(self):
+        table = "1 2 3\n4 5 6\n"
+        result_content = self._upload_and_get_content(table, space_to_tab="Yes")
+        self.assertEquals(result_content, "1\t2\t3\n4\t5\t6\n")
+
+    def test_upload_tab_to_space_off_by_default(self):
+        table = "1 2 3\n4 5 6\n"
+        result_content = self._upload_and_get_content(table)
+        self.assertEquals(result_content, table)
+
+    def test_rdata_not_decompressed(self):
+        # Prevent regression of https://github.com/galaxyproject/galaxy/issues/753
+        rdata_path = TestDataResolver().get_filename("1.RData")
+        rdata_metadata = self._upload_and_get_details(open(rdata_path, "rb"), file_type="auto")
+        self.assertEquals(rdata_metadata["file_ext"], "rdata")
+
+    @skip_without_datatype("velvet")
+    def test_composite_datatype(self):
+        with self.dataset_populator.test_history() as history_id:
+            dataset = self._velvet_upload(history_id, extra_inputs={
+                "files_1|url_paste": "roadmaps content",
+                "files_1|type": "upload_dataset",
+                "files_2|url_paste": "log content",
+                "files_2|type": "upload_dataset",
+            })
+
+            roadmaps_content = self._get_roadmaps_content(history_id, dataset)
+            assert roadmaps_content.strip() == "roadmaps content", roadmaps_content
+
+    @skip_without_datatype("velvet")
+    def test_composite_datatype_space_to_tab(self):
+        # Like previous test but set one upload with space_to_tab to True to
+        # verify that works.
+        with self.dataset_populator.test_history() as history_id:
+            dataset = self._velvet_upload(history_id, extra_inputs={
+                "files_1|url_paste": "roadmaps content",
+                "files_1|type": "upload_dataset",
+                "files_1|space_to_tab": "Yes",
+                "files_2|url_paste": "log content",
+                "files_2|type": "upload_dataset",
+            })
+
+            roadmaps_content = self._get_roadmaps_content(history_id, dataset)
+            assert roadmaps_content.strip() == "roadmaps\tcontent", roadmaps_content
+
+    @skip_without_datatype("velvet")
+    def test_composite_datatype_posix_lines(self):
+        # Like previous test but set one upload with space_to_tab to True to
+        # verify that works.
+        with self.dataset_populator.test_history() as history_id:
+            dataset = self._velvet_upload(history_id, extra_inputs={
+                "files_1|url_paste": "roadmaps\rcontent",
+                "files_1|type": "upload_dataset",
+                "files_1|space_to_tab": "Yes",
+                "files_2|url_paste": "log\rcontent",
+                "files_2|type": "upload_dataset",
+            })
+
+            roadmaps_content = self._get_roadmaps_content(history_id, dataset)
+            assert roadmaps_content.strip() == "roadmaps\ncontent", roadmaps_content
+
+    def test_upload_dbkey(self):
+        with self.dataset_populator.test_history() as history_id:
+            payload = self.dataset_populator.upload_payload(history_id, "Test123", dbkey="hg19")
+            run_response = self.dataset_populator.tools_post(payload)
+            self.dataset_populator.wait_for_tool_run(history_id, run_response)
+            datasets = run_response.json()["outputs"]
+            assert datasets[0].get("genome_build") == "hg19", datasets[0]
+
+    def test_upload_multiple_files_1(self):
+        with self.dataset_populator.test_history() as history_id:
+            payload = self.dataset_populator.upload_payload(history_id, "Test123",
+                dbkey="hg19",
+                extra_inputs={
+                    "files_1|url_paste": "SecondOutputContent",
+                    "files_1|NAME": "SecondOutputName",
+                    "files_1|file_type": "tabular",
+                    "files_1|dbkey": "hg18",
+                    "file_count": "2",
+                }
+            )
+            run_response = self.dataset_populator.tools_post(payload)
+            self.dataset_populator.wait_for_tool_run(history_id, run_response)
+            datasets = run_response.json()["outputs"]
+
+            assert len(datasets) == 2, datasets
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[0])
+            assert content.strip() == "Test123"
+            assert datasets[0]["file_ext"] == "txt"
+            assert datasets[0]["genome_build"] == "hg19", datasets
+
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[1])
+            assert content.strip() == "SecondOutputContent"
+            assert datasets[1]["file_ext"] == "tabular"
+            assert datasets[1]["genome_build"] == "hg18", datasets
+
+    def test_upload_multiple_files_2(self):
+        with self.dataset_populator.test_history() as history_id:
+            payload = self.dataset_populator.upload_payload(history_id, "Test123",
+                file_type="tabular",
+                dbkey="hg19",
+                extra_inputs={
+                    "files_1|url_paste": "SecondOutputContent",
+                    "files_1|NAME": "SecondOutputName",
+                    "files_1|file_type": "txt",
+                    "files_1|dbkey": "hg18",
+                    "file_count": "2",
+                }
+            )
+            run_response = self.dataset_populator.tools_post(payload)
+            self.dataset_populator.wait_for_tool_run(history_id, run_response)
+            datasets = run_response.json()["outputs"]
+
+            assert len(datasets) == 2, datasets
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[0])
+            assert content.strip() == "Test123"
+            assert datasets[0]["file_ext"] == "tabular", datasets
+            assert datasets[0]["genome_build"] == "hg19", datasets
+
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[1])
+            assert content.strip() == "SecondOutputContent"
+            assert datasets[1]["file_ext"] == "txt"
+            assert datasets[1]["genome_build"] == "hg18", datasets
+
+    def test_upload_multiple_files_3(self):
+        with self.dataset_populator.test_history() as history_id:
+            payload = self.dataset_populator.upload_payload(history_id, "Test123",
+                file_type="tabular",
+                dbkey="hg19",
+                extra_inputs={
+                    "files_0|file_type": "txt",
+                    "files_0|dbkey": "hg18",
+                    "files_1|url_paste": "SecondOutputContent",
+                    "files_1|NAME": "SecondOutputName",
+                    "files_1|file_type": "txt",
+                    "files_1|dbkey": "hg18",
+                    "file_count": "2",
+                }
+            )
+            run_response = self.dataset_populator.tools_post(payload)
+            self.dataset_populator.wait_for_tool_run(history_id, run_response)
+            datasets = run_response.json()["outputs"]
+
+            assert len(datasets) == 2, datasets
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[0])
+            assert content.strip() == "Test123"
+            assert datasets[0]["file_ext"] == "txt", datasets
+            assert datasets[0]["genome_build"] == "hg18", datasets
+
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[1])
+            assert content.strip() == "SecondOutputContent"
+            assert datasets[1]["file_ext"] == "txt"
+            assert datasets[1]["genome_build"] == "hg18", datasets
+
+    def _velvet_upload(self, history_id, extra_inputs):
+        payload = self.dataset_populator.upload_payload(
+            history_id,
+            "sequences content",
+            file_type="velvet",
+            extra_inputs=extra_inputs,
+        )
+        run_response = self.dataset_populator.tools_post(payload)
+        self.dataset_populator.wait_for_tool_run(history_id, run_response)
+        datasets = run_response.json()["outputs"]
+
+        assert len(datasets) == 1
+        dataset = datasets[0]
+
+        return dataset
+
+    def _get_roadmaps_content(self, history_id, dataset):
+        roadmaps_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=dataset, filename="Roadmaps")
+        return roadmaps_content
+
+    def _upload_and_get_content(self, content, **upload_kwds):
+        history_id, new_dataset = self._upload(content, **upload_kwds)
+        return self.dataset_populator.get_history_dataset_content(history_id, dataset=new_dataset)
+
+    def _upload_and_get_details(self, content, **upload_kwds):
+        history_id, new_dataset = self._upload(content, **upload_kwds)
+        return self.dataset_populator.get_history_dataset_details(history_id, dataset=new_dataset)
+
+    def _upload(self, content, **upload_kwds):
+        history_id = self.dataset_populator.new_history()
+        new_dataset = self.dataset_populator.new_dataset(history_id, content=content, **upload_kwds)
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        return history_id, new_dataset

--- a/test/api/test_tools_upload.py
+++ b/test/api/test_tools_upload.py
@@ -7,6 +7,10 @@ from base.populators import (
 
 from galaxy.tools.verify.test_data import TestDataResolver
 
+ONE_TO_SIX_WITH_SPACES = "1 2 3\n4 5 6\n"
+ONE_TO_SIX_WITH_TABS = "1\t2\t3\n4\t5\t6\n"
+ONE_TO_SIX_ON_WINDOWS = "1\t2\t3\r4\t5\t6\r"
+
 
 class ToolsUploadTestCase(api.ApiTestCase):
 
@@ -21,26 +25,26 @@ class ToolsUploadTestCase(api.ApiTestCase):
             self._assert_has_keys(create_response.json(), 'outputs')
 
     def test_upload_posix_newline_fixes(self):
-        windows_content = "1\t2\t3\r4\t5\t6\r"
-        posix_content = windows_content.replace("\r", "\n")
+        windows_content = ONE_TO_SIX_ON_WINDOWS
         result_content = self._upload_and_get_content(windows_content)
-        self.assertEquals(result_content, posix_content)
+        self.assertEquals(result_content, ONE_TO_SIX_WITH_TABS)
 
     def test_upload_disable_posix_fix(self):
-        windows_content = "1\t2\t3\r4\t5\t6\r"
+        windows_content = ONE_TO_SIX_ON_WINDOWS
         result_content = self._upload_and_get_content(windows_content, to_posix_lines=None)
         self.assertEquals(result_content, windows_content)
 
     def test_upload_tab_to_space(self):
-        table = "1 2 3\n4 5 6\n"
+        table = ONE_TO_SIX_WITH_SPACES
         result_content = self._upload_and_get_content(table, space_to_tab="Yes")
-        self.assertEquals(result_content, "1\t2\t3\n4\t5\t6\n")
+        self.assertEquals(result_content, ONE_TO_SIX_WITH_TABS)
 
     def test_upload_tab_to_space_off_by_default(self):
-        table = "1 2 3\n4 5 6\n"
+        table = ONE_TO_SIX_WITH_SPACES
         result_content = self._upload_and_get_content(table)
         self.assertEquals(result_content, table)
 
+    @skip_without_datatype("rdata")
     def test_rdata_not_decompressed(self):
         # Prevent regression of https://github.com/galaxyproject/galaxy/issues/753
         rdata_path = TestDataResolver().get_filename("1.RData")
@@ -184,6 +188,72 @@ class ToolsUploadTestCase(api.ApiTestCase):
             assert content.strip() == "SecondOutputContent"
             assert datasets[1]["file_ext"] == "txt"
             assert datasets[1]["genome_build"] == "hg18", datasets
+
+    def test_upload_multiple_files_space_to_tab(self):
+        with self.dataset_populator.test_history() as history_id:
+            payload = self.dataset_populator.upload_payload(history_id,
+                content=ONE_TO_SIX_WITH_SPACES,
+                file_type="tabular",
+                dbkey="hg19",
+                extra_inputs={
+                    "files_0|file_type": "txt",
+                    "files_0|space_to_tab": "Yes",
+                    "files_1|url_paste": ONE_TO_SIX_WITH_SPACES,
+                    "files_1|NAME": "SecondOutputName",
+                    "files_1|file_type": "txt",
+                    "files_2|url_paste": ONE_TO_SIX_WITH_SPACES,
+                    "files_2|NAME": "ThirdOutputName",
+                    "files_2|file_type": "txt",
+                    "files_2|space_to_tab": "Yes",
+                    "file_count": "3",
+                }
+            )
+            run_response = self.dataset_populator.tools_post(payload)
+            self.dataset_populator.wait_for_tool_run(history_id, run_response)
+            datasets = run_response.json()["outputs"]
+
+            assert len(datasets) == 3, datasets
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[0])
+            assert content == ONE_TO_SIX_WITH_TABS
+
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[1])
+            assert content == ONE_TO_SIX_WITH_SPACES
+
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[2])
+            assert content == ONE_TO_SIX_WITH_TABS
+
+    def test_multiple_files_posix_lines(self):
+        with self.dataset_populator.test_history() as history_id:
+            payload = self.dataset_populator.upload_payload(history_id,
+                content=ONE_TO_SIX_ON_WINDOWS,
+                file_type="tabular",
+                dbkey="hg19",
+                extra_inputs={
+                    "files_0|file_type": "txt",
+                    "files_0|to_posix_lines": "Yes",
+                    "files_1|url_paste": ONE_TO_SIX_ON_WINDOWS,
+                    "files_1|NAME": "SecondOutputName",
+                    "files_1|file_type": "txt",
+                    "files_1|to_posix_lines": None,
+                    "files_2|url_paste": ONE_TO_SIX_ON_WINDOWS,
+                    "files_2|NAME": "ThirdOutputName",
+                    "files_2|file_type": "txt",
+                    "file_count": "3",
+                }
+            )
+            run_response = self.dataset_populator.tools_post(payload)
+            self.dataset_populator.wait_for_tool_run(history_id, run_response)
+            datasets = run_response.json()["outputs"]
+
+            assert len(datasets) == 3, datasets
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[0])
+            assert content == ONE_TO_SIX_WITH_TABS
+
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[1])
+            assert content == ONE_TO_SIX_ON_WINDOWS
+
+            content = self.dataset_populator.get_history_dataset_content(history_id, dataset=datasets[2])
+            assert content == ONE_TO_SIX_WITH_TABS
 
     def _velvet_upload(self, history_id, extra_inputs):
         payload = self.dataset_populator.upload_payload(

--- a/test/api/test_tools_upload.py
+++ b/test/api/test_tools_upload.py
@@ -1,15 +1,15 @@
 from base import api
-
+from base.constants import (
+    ONE_TO_SIX_ON_WINDOWS,
+    ONE_TO_SIX_WITH_SPACES,
+    ONE_TO_SIX_WITH_TABS,
+)
 from base.populators import (
     DatasetPopulator,
     skip_without_datatype,
 )
 
 from galaxy.tools.verify.test_data import TestDataResolver
-
-ONE_TO_SIX_WITH_SPACES = "1 2 3\n4 5 6\n"
-ONE_TO_SIX_WITH_TABS = "1\t2\t3\n4\t5\t6\n"
-ONE_TO_SIX_ON_WINDOWS = "1\t2\t3\r4\t5\t6\r"
 
 
 class ToolsUploadTestCase(api.ApiTestCase):

--- a/test/base/api.py
+++ b/test/base/api.py
@@ -8,13 +8,15 @@ from .api_asserts import (
     assert_not_has_keys,
     assert_status_code_is,
 )
-from .api_util import get_master_api_key, get_user_api_key
+from .api_util import (
+    ADMIN_TEST_USER,
+    get_master_api_key,
+    get_user_api_key,
+    OTHER_USER,
+    TEST_USER,
+)
 from .interactor import GalaxyInteractorApi as BaseInteractor
 from .testcase import FunctionalTestCase
-
-TEST_USER = "user@bx.psu.edu"
-ADMIN_TEST_USER = "test@bx.psu.edu"
-DEFAULT_OTHER_USER = "otheruser@bx.psu.edu"  # A second user for API testing.
 
 
 class UsesApiTestCaseMixin:
@@ -48,7 +50,7 @@ class UsesApiTestCaseMixin:
         return self._post("users/%s/api_key" % user["id"], admin=True).json()
 
     @contextmanager
-    def _different_user(self, email=DEFAULT_OTHER_USER):
+    def _different_user(self, email=OTHER_USER):
         """ Use in test cases to switch get/post operations to act as new user,
 
             with self._different_user( "other_user@bx.psu.edu" ):

--- a/test/base/api_util.py
+++ b/test/base/api_util.py
@@ -3,6 +3,14 @@ import os
 DEFAULT_GALAXY_MASTER_API_KEY = "TEST123"
 DEFAULT_GALAXY_USER_API_KEY = None
 
+DEFAULT_TEST_USER = "user@bx.psu.edu"
+DEFAULT_ADMIN_TEST_USER = "test@bx.psu.edu"
+DEFAULT_OTHER_USER = "otheruser@bx.psu.edu"  # A second user for API testing.
+
+TEST_USER = os.environ.get("GALAXY_TEST_USER_EMAIL", DEFAULT_TEST_USER)
+ADMIN_TEST_USER = os.environ.get("GALAXY_TEST_ADMIN_USER_EMAIL", DEFAULT_ADMIN_TEST_USER)
+OTHER_USER = os.environ.get("GALAXY_TEST_OTHER_USER_EMAIL", DEFAULT_OTHER_USER)
+
 
 def get_master_api_key():
     """ Test master API key to use for functional test. This key should be

--- a/test/base/constants.py
+++ b/test/base/constants.py
@@ -1,0 +1,6 @@
+"""Just constants useful for testing across test types."""
+
+# Following constants used by upload tests.
+ONE_TO_SIX_WITH_SPACES = "1 2 3\n4 5 6\n"
+ONE_TO_SIX_WITH_TABS = "1\t2\t3\n4\t5\t6\n"
+ONE_TO_SIX_ON_WINDOWS = "1\t2\t3\r4\t5\t6\r"

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -5,33 +5,51 @@ configuration options. More vanilla upload options and behaviors are tested
 with the API test framework (located in test_tools.py).
 
 These options include:
- - The config optiond check_upload_content and allow_path_paste.
- - The upload API parameter auto_decompress.
+ - The config options ``check_upload_content`` and ``allow_path_paste``.
+ - The upload API parameter ``auto_decompress``.
  - Checking for malicious content in uploads of compressed files.
- - Restricting file:// uploads to admins and allowing them only when
-   allow_path_paste is set to True.
+ - Restricting ``file://`` uploads to admins and allowing them only when
+   ``allow_path_paste`` is set to ``True``.
+ - Various FTP upload configuration options including:
+    - ftp_upload_dir
+    - ftp_upload_identifier
+    - ftp_upload_dir_template
+    - ftp_upload_purge (sort of - seems broken...)
+ - Various upload API options tested for url_paste uploads in the API test
+   framework but tested here for FTP uploads.
 """
 
 import os
+import re
+import shutil
 
 from base import integration_util
+from base.api_util import (
+    TEST_USER,
+)
+from base.constants import (
+    ONE_TO_SIX_ON_WINDOWS,
+    ONE_TO_SIX_WITH_SPACES,
+    ONE_TO_SIX_WITH_TABS,
+)
 from base.populators import DatasetPopulator
+
 
 SCRIPT_DIR = os.path.normpath(os.path.dirname(__file__))
 TEST_DATA_DIRECTORY = os.path.join(SCRIPT_DIR, os.pardir, os.pardir, "test-data")
 
 
-class BaseCheckUploadContentConfigurationTestCase(integration_util.IntegrationTestCase):
+class BaseUploadContentConfigurationTestCase(integration_util.IntegrationTestCase):
 
     framework_tool_and_types = True
 
     def setUp(self):
-        super(BaseCheckUploadContentConfigurationTestCase, self).setUp()
+        super(BaseUploadContentConfigurationTestCase, self).setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.history_id = self.dataset_populator.new_history()
 
 
-class NonAdminsCannotPasteFilePathTestCase(BaseCheckUploadContentConfigurationTestCase):
+class NonAdminsCannotPasteFilePathTestCase(BaseUploadContentConfigurationTestCase):
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
@@ -47,7 +65,7 @@ class NonAdminsCannotPasteFilePathTestCase(BaseCheckUploadContentConfigurationTe
         assert create_response.status_code >= 400
 
 
-class AdminsCanPasteFilePathsTestCase(BaseCheckUploadContentConfigurationTestCase):
+class AdminsCanPasteFilePathsTestCase(BaseUploadContentConfigurationTestCase):
 
     require_admin_user = True
 
@@ -65,7 +83,7 @@ class AdminsCanPasteFilePathsTestCase(BaseCheckUploadContentConfigurationTestCas
         assert create_response.status_code == 200
 
 
-class DefaultBinaryContentFiltersTestCase(BaseCheckUploadContentConfigurationTestCase):
+class DefaultBinaryContentFiltersTestCase(BaseUploadContentConfigurationTestCase):
 
     require_admin_user = True
 
@@ -88,7 +106,7 @@ class DefaultBinaryContentFiltersTestCase(BaseCheckUploadContentConfigurationTes
         assert dataset["file_size"] == 0
 
 
-class DisableContentCheckingTestCase(BaseCheckUploadContentConfigurationTestCase):
+class DisableContentCheckingTestCase(BaseUploadContentConfigurationTestCase):
 
     require_admin_user = True
 
@@ -106,7 +124,7 @@ class DisableContentCheckingTestCase(BaseCheckUploadContentConfigurationTestCase
         assert dataset["file_size"] != 0
 
 
-class AutoDecompressTestCase(BaseCheckUploadContentConfigurationTestCase):
+class AutoDecompressTestCase(BaseUploadContentConfigurationTestCase):
 
     require_admin_user = True
 
@@ -129,7 +147,7 @@ class AutoDecompressTestCase(BaseCheckUploadContentConfigurationTestCase):
         assert dataset["file_ext"] == "sam", dataset
 
 
-class LocalAddressWhitelisting(BaseCheckUploadContentConfigurationTestCase):
+class LocalAddressWhitelisting(BaseUploadContentConfigurationTestCase):
 
     def test_external_url(self):
         payload = self.dataset_populator.upload_payload(
@@ -139,3 +157,221 @@ class LocalAddressWhitelisting(BaseCheckUploadContentConfigurationTestCase):
         # Ideally this would be 403 but the tool API endpoint isn't using
         # the newer API decorator that handles those details.
         assert create_response.status_code >= 400
+
+
+class BaseFtpUploadConfigurationTestCase(BaseUploadContentConfigurationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        ftp_dir = cls.ftp_dir()
+        os.makedirs(ftp_dir)
+        config["ftp_upload_dir"] = ftp_dir
+        cls.handle_extra_ftp_config(config)
+
+    @classmethod
+    def handle_extra_ftp_config(cls, config):
+        """Overrride to specify additional FTP configuration options."""
+
+    @classmethod
+    def ftp_dir(cls):
+        return os.path.join(cls._test_driver.galaxy_test_tmp_dir, "ftp")
+
+    def check_content(self, dataset, content, ext="txt"):
+        dataset = self.dataset_populator.get_history_dataset_details(self.history_id, dataset=dataset)
+        assert dataset["file_ext"] == ext, dataset
+        content = self.dataset_populator.get_history_dataset_content(self.history_id, dataset=dataset)
+        assert content == content, content
+
+    def write_ftp_file(self, dir_path, content, filename="test"):
+        self._ensure_directory(dir_path)
+        path = os.path.join(dir_path, filename)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def _ensure_directory(self, path):
+        if not os.path.exists(path):
+            os.makedirs(path)
+
+
+class SimpleFtpUploadConfigurationTestCase(BaseFtpUploadConfigurationTestCase):
+
+    def test_ftp_uploads(self):
+        content = "hello world\n"
+        dir_path = self.get_user_ftp_path()
+        ftp_path = self.write_ftp_file(dir_path, content)
+        ftp_files = self.dataset_populator.get_remote_files()
+        assert len(ftp_files) == 1, ftp_files
+        assert ftp_files[0]["path"] == "test"
+        assert os.path.exists(ftp_path)
+        dataset = self.dataset_populator.new_dataset(
+            self.history_id, ftp_files="test", file_type="txt", wait=True
+        )
+        self.check_content(dataset, content)
+        # Purge is set by default so this should be gone.
+        # ... but it isn't - is this a bug? Are only certain kinds of uploads purged?
+        # assert not os.path.exists(ftp_path)
+
+    def get_user_ftp_path(self):
+        return os.path.join(self.ftp_dir(), TEST_USER)
+
+
+class ExplicitEmailAsIdentifierFtpUploadConfigurationTestCase(SimpleFtpUploadConfigurationTestCase):
+
+    @classmethod
+    def handle_extra_ftp_config(cls, config):
+        config["ftp_upload_dir_identifier"] = "email"
+
+
+class PerUsernameFtpUploadConfigurationTestCase(SimpleFtpUploadConfigurationTestCase):
+
+    @classmethod
+    def handle_extra_ftp_config(cls, config):
+        config["ftp_upload_dir_identifier"] = "username"
+
+    def get_user_ftp_path(self):
+        username = re.sub('[^a-z-]', '--', TEST_USER.lower())
+        return os.path.join(self.ftp_dir(), username)
+
+
+class TemplatedFtpDirectoryUploadConfigurationTestCase(SimpleFtpUploadConfigurationTestCase):
+
+    @classmethod
+    def handle_extra_ftp_config(cls, config):
+        config["ftp_upload_dir_template"] = "${ftp_upload_dir}/moo_${ftp_upload_dir_identifier}_cow"
+
+    def get_user_ftp_path(self):
+        return os.path.join(self.ftp_dir(), "moo_%s_cow" % TEST_USER)
+
+
+class DisableFtpPurgeUploadConfigurationTestCase(BaseFtpUploadConfigurationTestCase):
+
+    @classmethod
+    def handle_extra_ftp_config(cls, config):
+        config["ftp_upload_purge"] = "False"
+
+    def test_ftp_uploads(self):
+        content = "hello world\n"
+        dir_path = os.path.join(self.ftp_dir(), TEST_USER)
+        ftp_path = self.write_ftp_file(dir_path, content)
+        ftp_files = self.dataset_populator.get_remote_files()
+        assert len(ftp_files) == 1
+        assert ftp_files[0]["path"] == "test"
+        assert os.path.exists(ftp_path)
+        dataset = self.dataset_populator.new_dataset(
+            self.history_id, ftp_files="test", file_type="txt", wait=True
+        )
+        self.check_content(dataset, content)
+        # Purge is disabled, this better still be here.
+        assert os.path.exists(ftp_path)
+
+
+class UploadOptionsFtpUploadConfigurationTestCase(BaseFtpUploadConfigurationTestCase):
+
+    def test_upload_api_options_space_to_tab(self):
+        self.write_user_ftp_file("0.txt", ONE_TO_SIX_WITH_SPACES)
+        self.write_user_ftp_file("1.txt", ONE_TO_SIX_WITH_SPACES)
+        self.write_user_ftp_file("2.txt", ONE_TO_SIX_WITH_SPACES)
+
+        payload = self.dataset_populator.upload_payload(self.history_id,
+            ftp_files="0.txt",
+            file_type="tabular",
+            dbkey="hg19",
+            extra_inputs={
+                "files_0|file_type": "txt",
+                "files_0|space_to_tab": "Yes",
+                "files_1|ftp_files": "1.txt",
+                "files_1|NAME": "SecondOutputName",
+                "files_1|file_type": "txt",
+                "files_2|ftp_files": "2.txt",
+                "files_2|NAME": "ThirdOutputName",
+                "files_2|file_type": "txt",
+                "files_2|space_to_tab": "Yes",
+                "file_count": "3",
+            }
+        )
+        run_response = self.dataset_populator.tools_post(payload)
+        self.dataset_populator.wait_for_tool_run(self.history_id, run_response)
+        datasets = run_response.json()["outputs"]
+
+        assert len(datasets) == 3, datasets
+        content = self.dataset_populator.get_history_dataset_content(self.history_id, dataset=datasets[0])
+        assert content == ONE_TO_SIX_WITH_TABS
+
+        content = self.dataset_populator.get_history_dataset_content(self.history_id, dataset=datasets[1])
+        assert content == ONE_TO_SIX_WITH_SPACES
+
+        content = self.dataset_populator.get_history_dataset_content(self.history_id, dataset=datasets[2])
+        assert content == ONE_TO_SIX_WITH_TABS
+
+    def test_upload_api_options_posix_lines(self):
+        self.write_user_ftp_file("0.txt", ONE_TO_SIX_ON_WINDOWS)
+        self.write_user_ftp_file("1.txt", ONE_TO_SIX_ON_WINDOWS)
+        self.write_user_ftp_file("2.txt", ONE_TO_SIX_ON_WINDOWS)
+
+        payload = self.dataset_populator.upload_payload(self.history_id,
+            ftp_files="0.txt",
+            file_type="tabular",
+            dbkey="hg19",
+            extra_inputs={
+                "files_0|file_type": "txt",
+                "files_0|to_posix_lines": "Yes",
+                "files_1|ftp_files": "1.txt",
+                "files_1|NAME": "SecondOutputName",
+                "files_1|file_type": "txt",
+                "files_1|to_posix_lines": None,
+                "files_2|ftp_files": "2.txt",
+                "files_2|NAME": "ThirdOutputName",
+                "files_2|file_type": "txt",
+                "file_count": "3",
+            }
+        )
+        run_response = self.dataset_populator.tools_post(payload)
+        self.dataset_populator.wait_for_tool_run(self.history_id, run_response)
+        datasets = run_response.json()["outputs"]
+
+        assert len(datasets) == 3, datasets
+        content = self.dataset_populator.get_history_dataset_content(self.history_id, dataset=datasets[0])
+        assert content == ONE_TO_SIX_WITH_TABS
+
+        content = self.dataset_populator.get_history_dataset_content(self.history_id, dataset=datasets[1])
+        assert content == ONE_TO_SIX_ON_WINDOWS
+
+        content = self.dataset_populator.get_history_dataset_content(self.history_id, dataset=datasets[2])
+        assert content == ONE_TO_SIX_WITH_TABS
+
+    def test_auto_decompress_default(self):
+        self.copy_to_user_ftp_file("1.sam.gz")
+        payload = self.dataset_populator.upload_payload(
+            self.history_id,
+            ftp_files="1.sam.gz",
+            file_type="auto",
+        )
+        run_response = self.dataset_populator.tools_post(payload)
+        self.dataset_populator.wait_for_tool_run(self.history_id, run_response)
+        datasets = run_response.json()["outputs"]
+        dataset = self.dataset_populator.get_history_dataset_details(self.history_id, dataset=datasets[0])
+        assert dataset["file_ext"] == "sam", dataset
+
+    def test_auto_decompress_off(self):
+        self.copy_to_user_ftp_file("1.sam.gz")
+        payload = self.dataset_populator.upload_payload(
+            self.history_id,
+            ftp_files="1.sam.gz",
+            file_type="auto",
+            auto_decompress=False,
+        )
+        run_response = self.dataset_populator.tools_post(payload)
+        self.dataset_populator.wait_for_tool_run(self.history_id, run_response)
+        datasets = run_response.json()["outputs"]
+        dataset = self.dataset_populator.get_history_dataset_details(self.history_id, dataset=datasets[0])
+        assert dataset["file_ext"] != "sam", dataset
+
+    def copy_to_user_ftp_file(self, test_data_path):
+        input_path = os.path.join(TEST_DATA_DIRECTORY, test_data_path)
+        target_dir = os.path.join(self.ftp_dir(), TEST_USER)
+        self._ensure_directory(target_dir)
+        shutil.copyfile(input_path, os.path.join(target_dir, test_data_path))
+
+    def write_user_ftp_file(self, path, content):
+        return self.write_ftp_file(os.path.join(self.ftp_dir(), TEST_USER), content, filename=path)


### PR DESCRIPTION
This extends #4563 and adds a bunch of new tests around upload - including deeper test coverage for the new feature in #4563 (trying different combinations, etc...) and new FTP upload integration tests with tests both for FTP upload configuration options (from galaxy.ini) and API options during FTP upload (space-to-tab, etc...).