### PR TITLE
[17.09] Fix auth with ldaps://

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -12,7 +12,7 @@ statsd
 graphitesend
 azure-storage==0.32.0
 # PyRods not in PyPI
-python-ldap==2.4.27
+python-ldap==2.4.44
 
 # Chronos client
 chronos-python==0.38.0


### PR DESCRIPTION
Update the python-ldap requirement, the new version allows connecting to ldaps:// now
See galaxyproject/starforge#146 and #3178 