### PR TITLE
Kubernetes resources requests/limits support

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -248,6 +248,39 @@
                  a requirement of the other.
 
                  -->
+            <!-- <param id="k8s_default_requests_cpu">"500m"</param> -->
+            <!-- <param id="k8s_default_requests_memory">"500Mi"</param> -->
+            <!-- <param id="k8s_default_limits_cpu">"2"</param> -->
+            <!-- <param id="k8s_default_limits_memory">"2Gi"</param> -->
+            <!-- Kubernetes resource Requests and Limits
+                 Parameters above (k8s_default_requests_* and k8s_default_limits_*) set default minimal (requests) and
+                 maximal (limits) CPU and memory resources to be allocated to all containers in Kubernetes jobs by
+                 default.
+
+                 Limits and requests for CPU resources are measured in cpu units. Fractional requests are allowed. A
+                 Container with requests_cpu of 0.5 is guaranteed half as much CPU as one that asks for 1 CPU. The
+                 expression 0.1 is equivalent to the expression 100m, which can be read as “one hundred millicpu”. Some
+                 people say “one hundred millicores”, and this is understood to mean the same thing. A request with a
+                 decimal point, like 0.1, is converted to 100m by the API, and precision finer than 1m is not allowed.
+                 For this reason, the form 100m might be preferred.
+
+                 You can express memory as a plain integer or as a fixed-point integer using one of these suffixes: E,
+                 P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.
+                 For instance, "1Gi" stands for 1 Gigabyte, and "500Mi" stands for 500 megabytes. Using other formats
+                 will make the jobs fail as Kubernetes won't recognize the assignment.
+
+                 For more details on the Kubernetes resources management, see:
+                 https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+
+                 It is the responsability of the tool developer or administrator to override these limits, either at the
+                 destination or the tool itself. If not set, current defaults set on the code are:
+
+                 requests_cpu     = "500m"
+                 limits_cpu       = "1"
+                 requests_memory  = "500Mi"
+                 limits_memory    = "1Gi"
+                 -->
+
         </plugin>
         <plugin id="godocker" type="runner" load="galaxy.jobs.runners.godocker:GodockerJobRunner">
             <!-- Go-Docker is a batch computing/cluster management tool using Docker

--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -248,14 +248,14 @@
                  a requirement of the other.
 
                  -->
-            <!-- <param id="k8s_default_requests_cpu">"500m"</param> -->
-            <!-- <param id="k8s_default_requests_memory">"500Mi"</param> -->
-            <!-- <param id="k8s_default_limits_cpu">"2"</param> -->
-            <!-- <param id="k8s_default_limits_memory">"2Gi"</param> -->
+            <!-- <param id="requests_cpu">500m</param> -->
+            <!-- <param id="requests_memory">500Mi</param> -->
+            <!-- <param id="limits_cpu">2</param> -->
+            <!-- <param id="limits_memory">2Gi</param> -->
             <!-- Kubernetes resource Requests and Limits
-                 Parameters above (k8s_default_requests_* and k8s_default_limits_*) set default minimal (requests) and
-                 maximal (limits) CPU and memory resources to be allocated to all containers in Kubernetes jobs by
-                 default.
+                 Parameters above (requests_* and limits_*) set default minimal (requests) and
+                 maximal (limits) CPU and memory resources to be allocated to all containers in
+                 Kubernetes jobs by default.
 
                  Limits and requests for CPU resources are measured in cpu units. Fractional requests are allowed. A
                  Container with requests_cpu of 0.5 is guaranteed half as much CPU as one that asks for 1 CPU. The
@@ -271,14 +271,6 @@
 
                  For more details on the Kubernetes resources management, see:
                  https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-
-                 It is the responsability of the tool developer or administrator to override these limits, either at the
-                 destination or the tool itself. If not set, current defaults set on the code are:
-
-                 requests_cpu     = "500m"
-                 limits_cpu       = "1"
-                 requests_memory  = "500Mi"
-                 limits_memory    = "1Gi"
                  -->
 
         </plugin>

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -357,10 +357,12 @@ class KubernetesJobRunner(AsynchronousJobRunner):
     def __get_k8s_container_name(self, job_wrapper):
         # These must follow a specific regex for Kubernetes.
         raw_id = job_wrapper.job_destination.id
-        cleaned_id = re.sub("[^-a-z0-9]", "-", raw_id)
-        if cleaned_id.startswith("-") or cleaned_id.endswith("-"):
-            cleaned_id = "x%sx" % cleaned_id
-        return cleaned_id
+        if isinstance(raw_id, str):
+            cleaned_id = re.sub("[^-a-z0-9]", "-", raw_id)
+            if cleaned_id.startswith("-") or cleaned_id.endswith("-"):
+                cleaned_id = "x%sx" % cleaned_id
+            return cleaned_id
+        return "job-container"
 
     def check_watched_item(self, job_state):
         """Checks the state of a job already submitted on k8s. Job state is a AsynchronousJobState"""

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -268,7 +268,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         return resources
 
-
     def __get_memory_request(self, job_wrapper):
         """Obtains memory requests for job, checking if available on the destination, otherwise using the default"""
         job_destinantion = job_wrapper.job_destination
@@ -312,7 +311,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         if not isinstance(cpu_value, str) and float(cpu_value) == 0:
             return None
         if isinstance(cpu_value, float):
-            return str(int(cpu_value*1000))+"m"
+            return str(int(cpu_value * 1000)) + "m"
         elif isinstance(cpu_value, int):
             return str(cpu_value)
         return cpu_value
@@ -328,11 +327,10 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         if not isinstance(mem_value, str) and float(mem_value) == 0:
             return None
         if isinstance(mem_value, float):
-            return str(int(mem_value*1000))+"M"
+            return str(int(mem_value * 1000)) + "M"
         elif isinstance(mem_value, int):
-            return str(mem_value)+"G"
+            return str(mem_value) + "G"
         return mem_value
-
 
     def __assemble_k8s_container_image_name(self, job_wrapper):
         """Assembles the container image name as repo/owner/image:tag, where repo, owner and tag are optional"""

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -275,7 +275,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         if 'requests_memory' in job_destinantion.params:
             return self.__transform_memory_value(job_destinantion.params['requests_memory'])
-        return self.runner_params['k8s_default_requests_memory']
+        return None
 
     def __get_memory_limit(self, job_wrapper):
         """Obtains memory limits for job, checking if available on the destination, otherwise using the default"""
@@ -283,7 +283,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         if 'limits_memory' in job_destinantion.params:
             return self.__transform_memory_value(job_destinantion.params['limits_memory'])
-        return self.runner_params['k8s_default_limits_memory']
+        return None
 
     def __get_cpu_request(self, job_wrapper):
         """Obtains cpu requests for job, checking if available on the destination, otherwise using the default"""
@@ -291,7 +291,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         if 'requests_cpu' in job_destinantion.params:
             return self.__transform_cpu_value(job_destinantion.params['requests_cpu'])
-        return self.runner_params['k8s_default_requests_cpu']
+        return None
 
     def __get_cpu_limit(self, job_wrapper):
         """Obtains cpu requests for job, checking if available on the destination, otherwise using the default"""
@@ -299,7 +299,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         if 'limits_cpu' in job_destinantion.params:
             return self.__transform_cpu_value(job_destinantion.params['limits_cpu'])
-        return self.runner_params['k8s_default_limits_cpu']
+        return None
 
     def __transform_cpu_value(self, cpu_value):
         """Transforms cpu value


### PR DESCRIPTION
This PR introduces support for setting memory/cpu requests and limits for Kubernetes based jobs, as explained in https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/.

This functionality permits that deployed containers for jobs can be throttled to use certain amount of resources, avoiding any potential cluster chokes on high loads. I have example `job_resource_params_conf.xml`, `job_conf.xml` and `rules/k8s_destinations.py` files that I could add to this PR for a more complete implementation, where we set different variable levels of resource usage through dynamic destinations, plus the ability for the user to override this with specific values for CPU and memory. It is just not clear to me where I should put these example files, please let me know.

Thanks to advice by @bgruening, this PR includes as well functionality which uses the resubmit capability if the job/pod failed due to reaching an imposed memory limit. This doesn't apply to CPU usage as k8s/docker manages to throttle CPU usage without actually needing to kill the job (as it happens to jobs that go beyond the memory allocated).