### PR TITLE
Additionally send all stats to a single bucket

### DIFF
--- a/lib/galaxy/web/framework/middleware/graphite.py
+++ b/lib/galaxy/web/framework/middleware/graphite.py
@@ -46,6 +46,7 @@ class GraphiteMiddleware(object):
         dt = int((time.time() - start_time) * 1000)
         try:
             self.graphite_client.send(environ.get('controller_action_key', None) or environ.get('PATH_INFO', "NOPATH").strip('/').replace('/', '.'), dt)
+            self.graphite_client.send('__global__', dt)
         except graphitesend.GraphiteSendException:
             log.exception("Graphite Error")
         return req

--- a/lib/galaxy/web/framework/middleware/statsd.py
+++ b/lib/galaxy/web/framework/middleware/statsd.py
@@ -35,4 +35,5 @@ class StatsdMiddleware(object):
         req = self.application(environ, start_response)
         dt = int((time.time() - start_time) * 1000)
         self.statsd_client.timing(environ.get('controller_action_key', None) or environ.get('PATH_INFO', "NOPATH").strip('/').replace('/', '.'), dt)
+        self.statsd_client.timing('__global__', dt)
         return req


### PR DESCRIPTION
Perhaps it is just my inability / missing skills with influxdb, but I can't find another way to aggregate over multiple series names without something like this. Feel free to reject if not interesting.

This allows us to calculate proper 90th percentile graphs for *all* responses rather than just a few.