### PR TITLE
Stop running common_startup.sh twice when starting from run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,8 +16,6 @@ then
     . $GALAXY_LOCAL_ENV_FILE
 fi
 
-./scripts/common_startup.sh $common_startup_args || exit 1
-
 parse_common_args $@
 
 run_common_start_up


### PR DESCRIPTION
Running twice doesn't break anything but it's unnecessary and presumably a mistake.

@jmchilton I assume this was just an oversight when the common startup functions were added?