### PR TITLE
Fix docstring linting.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@
 # 501 is line length
 # W503 is line breaks before binary operators, which has been reversed in PEP 8.
 # D** are docstring linting - which we mostly ignore except D302. (Hopefully we will solve more over time).
-ignore = E128,E203,E501,E402,W503,D100,D101,D102,D103,D104,D105,D200,D201,D202,D204,D205,D206,D207,D208,D209,D210,D211,D300,D301,D400,D401,D402,D403,D412,D413
+ignore = E128,E203,E501,E402,W503,D100,D101,D102,D103,D104,D105,D106,D107,D200,D201,D202,D204,D205,D206,D207,D208,D209,D210,D211,D300,D301,D400,D401,D402,D403,D412,D413
 exclude = lib/galaxy/util/jstree.py
 # For flake8-import-order
 # https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_smarkets.py


### PR DESCRIPTION
The module we used added a new issue D107 (lack of docstring in `__init__` methods) which we fail extensively - so add it to the ignore list.