### PR TITLE
[17.01] Pin linting functions in tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ whitelist_externals = bash
 deps =
     flake8==3.2.1
     flake8-docstrings==1.1.0
+    pydocstyle==2.0.0
 
 [testenv:py33-lint]
 commands = bash .ci/flake8_py3_wrapper.sh
@@ -78,8 +79,10 @@ commands = bash .ci/flake8_wrapper_docstrings.sh --exclude
 whitelist_externals = bash
 skip_install = True
 deps =
-    flake8
-    flake8-docstrings
+    flake8==3.2.1
+    flake8-docstrings==1.1.0
+    pydocstyle==2.0.0
+
 
 [testenv:py27-lint-docstring-include-list]
 commands = bash .ci/flake8_wrapper_docstrings.sh --include
@@ -88,3 +91,4 @@ skip_install = True
 deps =
     flake8==3.2.1
     flake8-docstrings==1.1.0
+    pydocstyle==2.0.0


### PR DESCRIPTION
16.10 maybe should be patched but it targets an older flake8-docstrings so this wouldn't apply.