### PR TITLE
[17.09] Bug fix for XML warning during tool loads.

### DIFF
--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -200,7 +200,7 @@ class XmlToolSource(ToolSource):
     def parse_provided_metadata_style(self):
         style = None
         out_elem = self.root.find("outputs")
-        if out_elem and "provided_metadata_style" in out_elem.attrib:
+        if out_elem is not None and "provided_metadata_style" in out_elem.attrib:
             style = out_elem.attrib["provided_metadata_style"]
 
         if style is None:
@@ -212,7 +212,7 @@ class XmlToolSource(ToolSource):
     def parse_provided_metadata_file(self):
         provided_metadata_file = "galaxy.json"
         out_elem = self.root.find("outputs")
-        if out_elem and "provided_metadata_file" in out_elem.attrib:
+        if out_elem is not None and "provided_metadata_file" in out_elem.attrib:
             provided_metadata_file = out_elem.attrib["provided_metadata_file"]
 
         return provided_metadata_file


### PR DESCRIPTION
```
galaxy.tools.toolbox.base INFO 2017-10-10 12:31:43,026 Parsing the tool configuration ./config/tool_conf.xml.sample
/Users/john/workspace/galaxy/lib/galaxy/tools/parser/xml.py:216: FutureWarning: The behavior of this method will change in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  if out_elem and "provided_metadata_file" in out_elem.attrib:
/Users/john/workspace/galaxy/lib/galaxy/tools/parser/xml.py:204: FutureWarning: The behavior of this method will change in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  if out_elem and "provided_metadata_style" in out_elem.attrib:
```