### PR TITLE
[17.05][BUG] Fix listify import in show params

### DIFF
--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -1,6 +1,6 @@
 <%inherit file="/base.mako"/>
 <%namespace file="/message.mako" import="render_msg" />
-<% from galaxy.util import listify, nice_size, unicodify %>
+<% from galaxy.util import nice_size, unicodify %>
 
 <style>
     .inherit {
@@ -28,6 +28,7 @@
 
 <%def name="inputs_recursive( input_params, param_values, depth=1, upgrade_messages=None )">
     <%
+        from galaxy.util import listify
         if upgrade_messages is None:
             upgrade_messages = {}
     %>


### PR DESCRIPTION
This fixes a problem reported on the [mailing list](http://dev.list.galaxyproject.org/Show-history-structure-Error-Undefined-object-is-not-callable-td4671115.html).
To test this go to "Show structure" in the history menu.
I am not sure why importing at the top of the file is not enough though.