### PR TITLE
Fix TDT's dependency

### DIFF
--- a/config/plugins/webhooks/demo/tour_generator/static/script.js
+++ b/config/plugins/webhooks/demo/tour_generator/static/script.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-    require(['libs/toastr'], function(Toastr){
+    require(['libs/toastr', 'mvc/tours'], function(Toastr, Tours) {
         window.TourGenerator = Backbone.View.extend({
             initialize: function(options) {
                 var me = this;


### PR DESCRIPTION
It seems some of the latest changes made the `Tours` module not global anymore. This PR fixes the error `Uncaught ReferenceError: Tours is not defined`.