### PR TITLE
[17.09] Fix for single select list initial value when multiple options are selected by default.

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -910,7 +910,7 @@ class SelectToolParameter(ToolParameter):
                 value = options[0][1]
             else:
                 value = None
-        elif len(value) == 1:
+        elif len(value) == 1 or not self.multiple:
             value = value[0]
         return value
 


### PR DESCRIPTION
This happens, for example, in the genomebuild parameter type where there are two entries with the value of `?`.