### PR TITLE
Fix the case where 'Labels' in a docker node inspect exists but is null.

### DIFF
--- a/lib/galaxy/containers/docker_model.py
+++ b/lib/galaxy/containers/docker_model.py
@@ -374,7 +374,7 @@ class DockerNode(object):
 
     @property
     def labels(self):
-        labels = self.inspect[0]['Spec'].get('Labels', {})
+        labels = self.inspect[0]['Spec'].get('Labels', {}) or {}
         return DockerNodeLabels.from_label_dictionary(labels)
 
     def label_add(self, label, value):


### PR DESCRIPTION
It used to be the case that the key didn't exist if no labels were set, apparently at some point it changed to be set to `null`.