### PR TITLE
[17.09] Only subqueryload latest_workflow instead of all workflows

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -56,7 +56,7 @@ class WorkflowsManager(object):
                 filter(trans.app.model.StoredWorkflow.id == workflow_id)
         stored_workflow = workflow_query.options(joinedload('annotations'),
                                                  joinedload('tags'),
-                                                 subqueryload('workflows').joinedload('steps').joinedload('*')).first()
+                                                 subqueryload('latest_workflow').joinedload('steps').joinedload('*')).first()
         if stored_workflow is None:
             raise exceptions.ObjectNotFound("No such workflow found.")
         return stored_workflow


### PR DESCRIPTION
This was initially part of https://github.com/galaxyproject/galaxy/pull/4500, and I suspect this could be the cause of slowness/crashes that @natefoo has observed on main. I think this should have been `latest_workflow` from the start. I will dig a bit deeper and see which calls will access annotation/tags/latest workflow and only load them if needed.