### PR TITLE
Bugfix during error handling with linked files during upload

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -991,7 +991,7 @@ class JobWrapper(object, HasResourceParameters):
                 etype, evalue, tb = sys.exc_info()
 
             outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
-            if outputs_to_working_directory:
+            if outputs_to_working_directory and not self.__link_file_check():
                 for dataset_path in self.get_output_fnames():
                     try:
                         shutil.move(dataset_path.false_path, dataset_path.real_path)


### PR DESCRIPTION
Just add the same conditions to the if as it is in the finish method.
The problem is, if the upload runs ok but then the job wrapper finish method fails, the runner calls fail() method afterwards:  [https://github.com/galaxyproject/galaxy/blob/f4d45549cf9e59a6b3fe00b44744ef69683a149a/lib/galaxy/jobs/runners/__init__.py#L633]
If cases of upload by linking are not taken into account then the fail method overwrites the files that you are trying to link!

Not sure what are the odds of finish method failing, in my case it was because the data in peek was containing unicode character and that couldn't be inserted in the database with latin-1 coding format.This can happen, for example, when trying to link a pdf as fastqsanger.bz2.
Then your input pdf is overwritten !!!!!

