### PR TITLE
[PROCEDURES] Reduce weight of security policies for now.

### DIFF
--- a/SECURITY_POLICY.md
+++ b/SECURITY_POLICY.md
@@ -13,8 +13,7 @@ Security issues which *only* affect a pre-release version of Galaxy (i.e. the `d
 The following branches or releases receive security support:
 
 - Development on the `dev` branch, hosted on GitHub, which will become the next release of Galaxy
-- Releases within the past 12 months.
-  - E.g. 16.04 will receive support until 2017-04. As the month changes to 2017-05 it will become unsupported.
+- The last two stable releases.
 - There are currently no plans for Long Term Support (LTS) releases.
 
 For unsupported branches:


### PR DESCRIPTION
I'd suggest we need more infrastructure in place to support this many releases - in particular we need more private testing of patches ahead of time (e.g. via Jenkins) and we need to ensure that all security patches (and indeed all features and bug fixes we wish to provide security support for) come in with regression tests.

The currently polices are not leading to more security testing, just more time patching old releases. I'm firmly of the belief that if it isn't tested it is broken so I don't see much value in security patches without tests.

On the off chance this is merged, once we have stronger policies regarding testings of components we wish to ensure security of and the means to run these tests on patches then I will be the first to open a PR to undo this change. I fully expect this policy change fails though - I just wanted to register my regret for +1'ing #4113 without policies and infrastructure for testing in place.