### PR TITLE
[16.10] Fix test fixtures dependency.

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -1,4 +1,5 @@
 nose
 NoseHTML
 twill==0.9.1
+testfixtures
 mock

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -29,7 +29,6 @@ nose==1.3.7
 Parsley==1.3
 six==1.9.0
 Whoosh==2.7.4
-testfixtures==4.10.0
 
 # Cheetah and dependencies
 Cheetah==2.4.4


### PR DESCRIPTION
It should have never been in the pinned requirements and has disappeared from PyPI.