### PR TITLE
Another round of Docker enhancements and fixes for 18.01.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -263,7 +263,7 @@ ensure_grunt_for_qunit() {
 }
 
 
-DOCKER_DEFAULT_IMAGE='galaxy/testing-base:18.01.3'
+DOCKER_DEFAULT_IMAGE='galaxy/testing-base:18.01.4'
 
 test_script="./scripts/functional_tests.py"
 report_file="run_functional_tests.html"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -263,7 +263,7 @@ ensure_grunt_for_qunit() {
 }
 
 
-DOCKER_DEFAULT_IMAGE='galaxy/testing-base:18.01.1'
+DOCKER_DEFAULT_IMAGE='galaxy/testing-base:18.01.3'
 
 test_script="./scripts/functional_tests.py"
 report_file="run_functional_tests.html"
@@ -284,6 +284,10 @@ then
        shift 2
     else
        db_type="sqlite"
+    fi
+    if [ "$1" = "--selenium" ]; then
+        DOCKER_RUN_EXTRA_ARGS="-e USE_SELENIUM=1 ${DOCKER_RUN_EXTRA_ARGS}"
+        shift
     fi
     if [ "$1" = "--external_tmp" ]; then
        # If /tmp is a tmpfs there may be better performance by reusing

--- a/test/docker/base/Dockerfile
+++ b/test/docker/base/Dockerfile
@@ -60,7 +60,6 @@ ADD start_mysql.sh /opt/galaxy/start_mysql.sh
 ADD ansible_vars.yml /tmp/ansible/ansible_vars.yml
 ADD provision.yml /tmp/ansible/provision.yml
 
-
 RUN mkdir /etc/galaxy && cd /tmp/ansible && mkdir roles && \
     mkdir roles/galaxyprojectdotorg.galaxy-os && \
     wget --quiet -O- https://github.com/galaxyproject/ansible-galaxy-os/archive/master.tar.gz | tar -xzf- --strip-components=1 -C roles/galaxyprojectdotorg.galaxy-os && \

--- a/test/docker/base/Dockerfile
+++ b/test/docker/base/Dockerfile
@@ -1,7 +1,13 @@
 FROM ubuntu:16.04
 MAINTAINER John Chilton <jmchilton@gmail.com>
 
-ENV MYSQL_MAJOR=5.7 \
+ARG CHROME_VERSION="google-chrome-stable"
+ARG CHROME_DRIVER_VERSION="latest"
+
+# TODO: merge with first ENV statement.
+ENV DEBIAN_FRONTEND=noninteractive \
+    DEBCONF_NONINTERACTIVE_SEEN=true \
+    MYSQL_MAJOR=5.7 \
     POSTGRES_MAJOR=9.5 \
     GALAXY_ROOT=/galaxy \
     GALAXY_VIRTUAL_ENV=/galaxy_venv
@@ -9,10 +15,12 @@ ENV MYSQL_MAJOR=5.7 \
 # Pre-install a bunch of packages to speed up ansible steps.
 RUN apt-get update -y && apt-get install -y software-properties-common apt-transport-https curl && \
     apt-add-repository -y ppa:ansible/ansible && \
+    curl -s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
     curl -sL https://deb.nodesource.com/setup_8.x | bash -  && \
     apt-key adv --keyserver pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5 && \
     echo "deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list && \
+    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
     { \
 		echo mysql-community-server mysql-community-server/data-dir select ''; \
 		echo mysql-community-server mysql-community-server/root-pass password ''; \
@@ -35,6 +43,9 @@ RUN apt-get update -y && apt-get install -y software-properties-common apt-trans
             openjdk-8-jre-headless \
             tzdata \
             sudo \
+            locales \
+            xvfb \
+            ${CHROME_VERSION:-google-chrome-stable} \
             wget zlib1g-dev nodejs && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -101,6 +112,68 @@ RUN mkdir -p /tmp/install && \
     make && \
     make install && \
     cd && rm -rf /tmp/install
+
+#========================================
+# Add Selenium user with passwordless sudo
+#========================================
+RUN useradd seluser \
+         --shell /bin/bash  \
+         --create-home \
+  && usermod -a -G sudo seluser \
+  && echo 'ALL ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers \
+  && echo 'seluser:secret' | chpasswd
+
+USER seluser
+
+#==========
+# Selenium
+#==========
+RUN  sudo mkdir -p /opt/selenium \
+  && sudo chown seluser:seluser /opt/selenium \
+  && wget --no-verbose https://selenium-release.storage.googleapis.com/3.6/selenium-server-standalone-3.6.0.jar \
+    -O /opt/selenium/selenium-server-standalone.jar
+
+USER root
+
+#==============================
+# Scripts to run Selenium Node
+#==============================
+COPY selenium/entry_point.sh selenium/functions.sh selenium/wrap_chrome_binary selenium/generate_config /opt/bin/
+
+RUN /opt/bin/wrap_chrome_binary
+
+USER seluser
+
+RUN CD_VERSION=$(if [ ${CHROME_DRIVER_VERSION:-latest} = "latest" ]; then echo $(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE); else echo $CHROME_DRIVER_VERSION; fi) \
+  && echo "Using chromedriver version: "$CD_VERSION \
+  && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
+  && rm -rf /opt/selenium/chromedriver \
+  && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \
+  && rm /tmp/chromedriver_linux64.zip \
+  && mv /opt/selenium/chromedriver /opt/selenium/chromedriver-$CD_VERSION \
+  && chmod 755 /opt/selenium/chromedriver-$CD_VERSION \
+  && sudo ln -fs /opt/selenium/chromedriver-$CD_VERSION /usr/bin/chromedriver
+
+RUN /opt/bin/generate_config > /opt/selenium/config.json
+
+#============================
+# Some configuration options
+#============================
+ENV SCREEN_WIDTH=1360 \
+    SCREEN_HEIGHT=1020 \
+    SCREEN_DEPTH=24 \
+    DISPLAY=:99.0 \
+    NODE_MAX_INSTANCES=1 \
+    NODE_MAX_SESSION=1 \
+    NODE_PORT=5555 \
+    NODE_REGISTER_CYCLE=5000 \
+    NODE_POLLING=5000 \
+    NODE_UNREGISTER_IF_STILL_DOWN_AFTER=60000 \
+    NODE_DOWN_POLLING_LIMIT=2 \
+    NODE_APPLICATION_NAME="" \
+    DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+USER root
 
 ADD run_test_wrapper.sh /usr/local/bin/run_test_wrapper.sh
 

--- a/test/docker/base/run_test_wrapper.sh
+++ b/test/docker/base/run_test_wrapper.sh
@@ -41,6 +41,7 @@ then
     GALAXY_TEST_INSTALL_DB_MERGED="true"
     GALAXY_TEST_DBURI="postgres://root@localhost:5930/galaxy?client_encoding=utf8"
     TOOL_SHED_TEST_DBURI="postgres://root@localhost:5930/toolshed?client_encoding=utf8"
+    export GALAXY_CONFIG_OVERRIDE_DATABASE_ENCODING="SQL_ASCII"
 elif [ "$GALAXY_TEST_DATABASE_TYPE" = "mysql" ];
 then
     sh /opt/galaxy/start_mysql.sh

--- a/test/docker/base/run_test_wrapper.sh
+++ b/test/docker/base/run_test_wrapper.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 set -e
 
+if [ ! -z "$USE_SELENIUM" ];
+then
+    sudo -E -u seluser /opt/bin/entry_point.sh &
+    # TODO:...
+    while ! curl -s "http://localhost:4444";
+    do
+        printf "."
+        sleep 4;
+    done;
+    GALAXY_TEST_SELENIUM_REMOTE=1
+    GALAXY_TEST_SELENIUM_REMOTE_HOST=localhost
+    GALAXY_TEST_SELENIUM_REMOTE_PORT=4444
+
+    export GALAXY_TEST_SELENIUM_REMOTE
+    export GALAXY_TEST_SELENIUM_REMOTE_HOST
+    export GALAXY_TEST_SELENIUM_REMOTE_PORT
+fi
+
 echo "Deleting galaxy user - it may not exist and this is fine."
 deluser galaxy | true
 
@@ -17,6 +35,7 @@ chown -R "$GALAXY_TEST_UID:$GALAXY_TEST_UID" /galaxy_venv
 : ${GALAXY_TEST_DATABASE_TYPE:-"postgres"}
 if [ "$GALAXY_TEST_DATABASE_TYPE" = "postgres" ];
 then
+    echo "Starting postgres and then sleeping for 3 seconds"
     su -c '/usr/lib/postgresql/9.5/bin/pg_ctl -o "-F" start -D /opt/galaxy/db' postgres
     sleep 3
     GALAXY_TEST_INSTALL_DB_MERGED="true"
@@ -35,36 +54,33 @@ then
     TOOL_SHED_TEST_DBURI="sqlite:////opt/galaxy/toolshed.sqlite"
     chown -R "$GALAXY_TEST_UID:$GALAXY_TEST_UID" /opt/galaxy
 else
-	echo "Unknown database type"
-	exit 1
+    echo "Unknown database type"
+    exit 1
 fi
 export GALAXY_TEST_DBURI
 export TOOL_SHED_TEST_DBURI
 export GALAXY_TEST_INSTALL_DB_MERGED
 
 cd /galaxy
-GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION="$GALAXY_TEST_DBURI";
-export GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
-TOOL_SHED_CONFIG_OVERRIDE_DATABASE_CONNECTION="$TOOL_SHED_TEST_DBURI";
-export TOOL_SHED_CONFIG_OVERRIDE_DATABASE_CONNECTION
 
 : ${GALAXY_VIRTUAL_ENV:=.venv}
 
 HOME=/galaxy
-sudo -E -u "#${GALAXY_TEST_UID}" ./scripts/common_startup.sh || { echo "common_startup.sh failed"; exit 1; }
-
-dev_requirements=./lib/galaxy/dependencies/dev-requirements.txt
-[ -f $dev_requirements ] && sudo -E -u "#${GALAXY_TEST_UID}" $GALAXY_VIRTUAL_ENV/bin/pip install -r $dev_requirements
+echo "Running common startup for updated dependencies (if any)"
+sudo -E -u "#${GALAXY_TEST_UID}" ./scripts/common_startup.sh --dev-wheels || { echo "common_startup.sh failed"; exit 1; }
 
 echo "Upgrading test database..."
-sudo -E -u "#${GALAXY_TEST_UID}" sh manage_db.sh upgrade
+sudo -E -u "#${GALAXY_TEST_UID}" GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION="$GALAXY_TEST_DBURI" sh manage_db.sh upgrade
 echo "Upgrading tool shed database... $TOOL_SHED_CONFIG_OVERRIDE_DATABASE_CONNECTION"
-sudo -E -u "#${GALAXY_TEST_UID}" sh manage_db.sh upgrade tool_shed
+sudo -E -u "#${GALAXY_TEST_UID}" TOOL_SHED_CONFIG_OVERRIDE_DATABASE_CONNECTION="$TOOL_SHED_TEST_DBURI" sh manage_db.sh upgrade tool_shed
+
 
 if [ -z "$GALAXY_NO_TESTS" ];
 then
     sudo -E -u "#${GALAXY_TEST_UID}" sh run_tests.sh --skip-common-startup $@
 else
+    GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION="$GALAXY_TEST_DBURI"
+    TOOL_SHED_CONFIG_OVERRIDE_DATABASE_CONNECTION="$TOOL_SHED_TEST_DBURI"
     GALAXY_CONFIG_MASTER_API_KEY=${GALAXY_CONFIG_MASTER_API_KEY:-"testmasterapikey"}
     GALAXY_CONFIG_FILE=${GALAXY_CONFIG_FILE:-config/galaxy.ini.sample}
     TOOL_SHED_CONFIG_FILE=${GALAXY_CONFIG_FILE:-config/tool_shed.ini.sample}
@@ -73,6 +89,8 @@ else
     GALAXY_CONFIG_FILE_PATH=${GALAXY_CONFIG_FILE_PATH:-/tmp/gx1}
     GALAXY_CONFIG_NEW_FILE_PATH=${GALAXY_CONFIG_NEW_FILE_PATH:-/tmp/gxtmp}
 
+    export GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
+    export TOOL_SHED_CONFIG_OVERRIDE_DATABASE_CONNECTION
     export GALAXY_CONFIG_MASTER_API_KEY
     export GALAXY_CONFIG_FILE
     export TOOL_SHED_CONFIG_FILE

--- a/test/docker/base/selenium/LICENSE
+++ b/test/docker/base/selenium/LICENSE
@@ -1,0 +1,2 @@
+The files in this directory are from https://github.com/SeleniumHQ/docker-selenium and as such
+fall under the Apache Version 2.0 license as described here https://github.com/SeleniumHQ/docker-selenium/blob/master/LICENSE.md.

--- a/test/docker/base/selenium/README
+++ b/test/docker/base/selenium/README
@@ -1,0 +1,1 @@
+LICENSE

--- a/test/docker/base/selenium/entry_point.sh
+++ b/test/docker/base/selenium/entry_point.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# IMPORTANT: Change this file only in directory Standalone!
+
+source /opt/bin/functions.sh
+
+export GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT""x""$SCREEN_DEPTH"
+
+function shutdown {
+  kill -s SIGTERM $NODE_PID
+  wait $NODE_PID
+}
+
+if [ ! -z "$SE_OPTS" ]; then
+  echo "appending selenium options: ${SE_OPTS}"
+fi
+
+SERVERNUM=$(get_server_num)
+
+rm -f /tmp/.X*lock
+
+xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
+  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+  ${SE_OPTS} &
+NODE_PID=$!
+
+trap shutdown SIGTERM SIGINT
+wait $NODE_PID

--- a/test/docker/base/selenium/functions.sh
+++ b/test/docker/base/selenium/functions.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# https://github.com/SeleniumHQ/docker-selenium/issues/184
+function get_server_num() {
+  echo $(echo $DISPLAY | sed -r -e 's/([^:]+)?:([0-9]+)(\.[0-9]+)?/\2/')
+}

--- a/test/docker/base/selenium/generate_config
+++ b/test/docker/base/selenium/generate_config
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+CHROME_VERSION=$(/usr/bin/google-chrome -version | awk '{ print $3 }')
+
+cat <<_EOF
+{
+  "capabilities": [
+    {
+      "version": "$CHROME_VERSION",
+      "browserName": "chrome",
+      "maxInstances": $NODE_MAX_INSTANCES,
+      "seleniumProtocol": "WebDriver",
+      "applicationName": "$NODE_APPLICATION_NAME"
+    }
+  ],
+  "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
+  "maxSession": $NODE_MAX_SESSION,
+  "port": $NODE_PORT,
+  "register": true,
+  "registerCycle": $NODE_REGISTER_CYCLE,
+  "nodePolling": $NODE_POLLING,
+  "unregisterIfStillDownAfter": $NODE_UNREGISTER_IF_STILL_DOWN_AFTER,
+  "downPollingLimit": $NODE_DOWN_POLLING_LIMIT
+}
+_EOF

--- a/test/docker/base/selenium/wrap_chrome_binary
+++ b/test/docker/base/selenium/wrap_chrome_binary
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+WRAPPER_PATH=$(readlink -f /usr/bin/google-chrome)
+BASE_PATH="$WRAPPER_PATH-base"
+mv "$WRAPPER_PATH" "$BASE_PATH"
+
+cat > "$WRAPPER_PATH" <<_EOF
+#!/bin/bash
+
+# Note: exec -a below is a bashism.
+exec -a "\$0" "$BASE_PATH" --no-sandbox "\$@"
+_EOF
+chmod +x "$WRAPPER_PATH"


### PR DESCRIPTION
- Bake Selenium (chrome, chrome-wrapper, xvfb, and Selenium server) into Docker test image. (1)
- Correct usage of common_startup.sh to fetch dev wheels (don't use pip directly).
- Fix/enhance the test wrapper file to not set GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECATION - this prevents integration database templating (#4887) from working with the Docker image.
- Update target Dockerfile.

1) The Docker compose setup for Selenium tests currently used by Jenkins is nice in that it uses official Selenium and Postgres Docker images - but it is problematic in that it takes more resources than the other single container Docker jobs, it doesn't cleanup as nicely, it doesn't have a pre-migrated database or pre-installed dependencies so it takes longer to run, and isn't easily exposed to developers via run_tests.sh. A more pragmatic Jenkins job based on this work should be runnable for every PR - the current variant simply takes too long and requires too many resources.