### PR TITLE
Install dev and regular dependencies at the same time.

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -1,7 +1,7 @@
 # packages with C extensions
 bx-python==0.7.3
-MarkupSafe==0.23
-PyYAML==3.11
+MarkupSafe==1.0
+PyYAML==3.12
 SQLAlchemy==1.0.15
 sqlalchemy-utils==0.32.19
 mercurial==3.7.3
@@ -18,20 +18,20 @@ bz2file==0.98; python_version < '3.3'
 boltons==17.1.0
 Paste==2.0.2
 PasteDeploy==1.5.2
-docutils==0.12
+docutils==0.14
 wchartype==0.1
 repoze.lru==0.6
 Routes==2.4.1
 WebOb==1.4.1
 WebHelpers==1.3
 Mako==1.0.2
-pytz==2015.4
+pytz==2017.3
 Babel==2.5.1
 Beaker==1.7.0
 dictobj==0.3.1
 nose==1.3.7
 Parsley==1.3
-six==1.10.0
+six==1.11.0
 Whoosh==2.7.4
 galaxy_sequence_utils==1.0.2
 h5py==2.7.1
@@ -72,7 +72,7 @@ sqlalchemy-migrate==0.10.0
 decorator==4.0.2
 Tempita==0.5.3dev
 sqlparse==0.1.16
-pbr==1.8.0
+pbr==3.1.1
 
 # svgwrite and dependencies
 svgwrite==1.1.6

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -135,17 +135,18 @@ fi
 
 : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
 : ${PYPI_INDEX_URL:="https://pypi.python.org/simple"}
+: ${GALAXY_DEV_REQUIREMENTS:="./lib/galaxy/dependencies/dev-requirements.txt"}
 if [ $REPLACE_PIP -eq 1 ]; then
     pip install 'pip>=8.1'
 fi
 
-if [ $FETCH_WHEELS -eq 1 ]; then
-    pip install -r requirements.txt --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
-    GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))")
-    [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
+requirement_args="-r requirements.txt"
+if [ $DEV_WHEELS -eq 1 ]; then
+    requirement_args="$requirement_args -r ${GALAXY_DEV_REQUIREMENTS}"
 fi
 
-if [ $FETCH_WHEELS -eq 1 -a $DEV_WHEELS -eq 1 ]; then
-    dev_requirements='./lib/galaxy/dependencies/dev-requirements.txt'
-    [ -f $dev_requirements ] && pip install -r $dev_requirements --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
+if [ $FETCH_WHEELS -eq 1 ]; then
+    pip install $requirement_args --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
+    GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))")
+    [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
 fi


### PR DESCRIPTION
Builds on #4891. If installing dev dependencies, do so along side regular dependencies. This allows catching conflicts automatically and works faster.