### PR TITLE
[17.09] Shutdown watchers during app shutdown.

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -212,6 +212,7 @@ class UniverseApplication(object, config.ConfiguresGalaxyMixin):
         log.info("Galaxy app startup finished %s" % self.startup_timer)
 
     def shutdown(self):
+        self.watchers.shutdown()
         self.workflow_scheduling_manager.shutdown()
         self.job_manager.shutdown()
         self.object_store.shutdown()

--- a/lib/galaxy/webapps/galaxy/config_watchers.py
+++ b/lib/galaxy/webapps/galaxy/config_watchers.py
@@ -32,6 +32,12 @@ class ConfigWatchers(object):
         [self.data_manager_config_watcher.watch_file(config) for config in self.data_manager_configs]
         [self.tool_data_watcher.watch_directory(tool_data_path) for tool_data_path in self.tool_data_paths]
 
+    def shutdown(self):
+        self.tool_config_watcher.shutdown()
+        self.data_manager_config_watcher.shutdown()
+        self.tool_data_watcher.shutdown()
+        self.tool_watcher.shutdown()
+
     def update_watch_data_table_paths(self):
         if hasattr(self.tool_data_watcher, 'monitored_dirs'):
             for tool_data_table_path in self.tool_data_paths:


### PR DESCRIPTION
Might fix https://github.com/galaxyproject/galaxy/issues/4738 - probably the right thing to do even if it doesn't.