### PR TITLE
More structured app shutdown.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -853,6 +853,11 @@ nglims_config_file = tool-data/nglims.yaml
 # public site.  Enabled in the sample config for development.
 use_interactive = True
 
+# When stopping Galaxy cleanly, how much time to give various monitoring/polling
+# threads to finish before giving up on joining them. Set to 0 to disable this and
+# restore the pre-18.01 default behavior.
+#monitor_thread_join_timeout = 5
+
 # Write thread status periodically to 'heartbeat.log',  (careful, uses disk
 # space rapidly!).  Useful to determine why your processes may be consuming a
 # lot of CPU.

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -212,18 +212,57 @@ class UniverseApplication(object, config.ConfiguresGalaxyMixin):
         log.info("Galaxy app startup finished %s" % self.startup_timer)
 
     def shutdown(self):
-        self.watchers.shutdown()
-        self.workflow_scheduling_manager.shutdown()
-        self.job_manager.shutdown()
-        self.object_store.shutdown()
-        if self.heartbeat:
-            self.heartbeat.shutdown()
-        self.update_repository_manager.shutdown()
+        exception = None
         try:
-            self.control_worker.shutdown()
+            self.watchers.shutdown()
+        except Exception as e:
+            exception = exception or e
+            log.exception("Failed to shutdown configuration watchers cleanly")
+        try:
+            self.workflow_scheduling_manager.shutdown()
+        except Exception as e:
+            exception = exception or e
+            log.exception("Failed to shutdown workflow scheduling manager cleanly")
+        try:
+            self.job_manager.shutdown()
+        except Exception as e:
+            exception = exception or e
+            log.exception("Failed to shutdown job manager cleanly")
+        try:
+            self.object_store.shutdown()
+        except Exception as e:
+            exception = exception or e
+            log.exception("Failed to shutdown object store cleanly")
+        try:
+            if self.heartbeat:
+                self.heartbeat.shutdown()
+        except Exception as e:
+            exception = exception or e
+            log.exception("Failed to shutdown heartbeat cleanly")
+        try:
+            self.update_repository_manager.shutdown()
+        except Exception as e:
+            exception = exception or e
+            log.exception("Failed to shutdown update repository manager cleanly")
+
+        try:
+            try:
+                self.control_worker.shutdown()
+            except Exception as e:
+                exception = exception or e
+                log.exception("Failed to shutdown control worker cleanly")
         except AttributeError:
             # There is no control_worker
             pass
+
+        try:
+            self.model.engine.dispose()
+        except Exception as e:
+            exception = exception or e
+            log.exception("Failed to shutdown SA database engine cleanly")
+
+        if exception:
+            raise exception
 
     def configure_fluent_log(self):
         if self.config.fluent_log:

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -371,6 +371,7 @@ class Configuration(object):
         self.use_heartbeat = string_as_bool(kwargs.get('use_heartbeat', 'False'))
         self.heartbeat_interval = int(kwargs.get('heartbeat_interval', 20))
         self.heartbeat_log = kwargs.get('heartbeat_log', None)
+        self.monitor_thread_join_timeout = int(kwargs.get("monitor_thread_join_timeout", 5))
         self.log_actions = string_as_bool(kwargs.get('log_actions', 'False'))
         self.log_events = string_as_bool(kwargs.get('log_events', 'False'))
         self.sanitize_all_html = string_as_bool(kwargs.get('sanitize_all_html', True))

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -4,7 +4,6 @@ Galaxy job handler, prepares, runs, tracks, and finishes Galaxy jobs
 import datetime
 import logging
 import os
-import threading
 import time
 from Queue import (
     Empty,
@@ -27,7 +26,7 @@ from galaxy.jobs import (
     TaskWrapper
 )
 from galaxy.jobs.mapper import JobNotReadyException
-from galaxy.util.sleeper import Sleeper
+from galaxy.util.monitors import Monitors
 
 log = logging.getLogger(__name__)
 
@@ -57,7 +56,7 @@ class JobHandler(object):
         self.job_stop_queue.shutdown()
 
 
-class JobHandlerQueue(object):
+class JobHandlerQueue(Monitors, object):
     """
     Job Handler's Internal Queue, this is what actually implements waiting for
     jobs to be runnable and dispatching to a JobRunner.
@@ -84,11 +83,8 @@ class JobHandlerQueue(object):
         self.waiting_jobs = []
         # Contains wrappers of jobs that are limited or ready (so they aren't created unnecessarily/multiple times)
         self.job_wrappers = {}
-        # Helper for interruptable sleep
-        self.sleeper = Sleeper()
-        self.running = True
-        self.monitor_thread = threading.Thread(name="JobHandlerQueue.monitor_thread", target=self.__monitor)
-        self.monitor_thread.setDaemon(True)
+        name = "JobHandlerQueue.monitor_thread"
+        self._init_monitor_thread(name, target=self.__monitor, config=app.config)
 
     def start(self):
         """
@@ -203,7 +199,7 @@ class JobHandlerQueue(object):
         Continually iterate the waiting jobs, checking is each is ready to
         run and dispatching if so.
         """
-        while self.running:
+        while self.monitor_running:
             try:
                 # If jobs are locked, there's nothing to monitor and we skip
                 # to the sleep.
@@ -211,8 +207,7 @@ class JobHandlerQueue(object):
                     self.__monitor_step()
             except Exception:
                 log.exception("Exception in monitor_step")
-            # Sleep
-            self.sleeper.sleep(1)
+            self._monitor_sleep(1)
 
     def __monitor_step(self):
         """
@@ -670,15 +665,15 @@ class JobHandlerQueue(object):
             return
         else:
             log.info("sending stop signal to worker thread")
-            self.running = False
+            self.stop_monitoring()
             if not self.app.config.track_jobs_in_database:
                 self.queue.put(self.STOP_SIGNAL)
-            self.sleeper.wake()
+            self.shutdown_monitor()
             log.info("job handler queue stopped")
             self.dispatcher.shutdown()
 
 
-class JobHandlerStopQueue(object):
+class JobHandlerStopQueue(Monitors):
     """
     A queue for jobs which need to be terminated prematurely.
     """
@@ -699,12 +694,8 @@ class JobHandlerStopQueue(object):
         # Contains jobs that are waiting (only use from monitor thread)
         self.waiting = []
 
-        # Helper for interruptable sleep
-        self.sleeper = Sleeper()
-        self.running = True
-        self.monitor_thread = threading.Thread(name="JobHandlerStopQueue.monitor_thread", target=self.monitor)
-        self.monitor_thread.setDaemon(True)
-        self.monitor_thread.start()
+        name = "JobHandlerStopQueue.monitor_thread"
+        self._init_monitor_thread(name, start=True, config=app.config)
         log.info("job handler stop queue started")
 
     def monitor(self):
@@ -713,13 +704,13 @@ class JobHandlerStopQueue(object):
         """
         # HACK: Delay until after forking, we need a way to do post fork notification!!!
         time.sleep(10)
-        while self.running:
+        while self.monitor_running:
             try:
                 self.monitor_step()
             except Exception:
                 log.exception("Exception in monitor_step")
             # Sleep
-            self.sleeper.sleep(1)
+            self._monitor_sleep(1)
 
     def monitor_step(self):
         """
@@ -778,10 +769,10 @@ class JobHandlerStopQueue(object):
             return
         else:
             log.info("sending stop signal to worker thread")
-            self.running = False
+            self.stop_monitoring()
             if not self.app.config.track_jobs_in_database:
                 self.queue.put(self.STOP_SIGNAL)
-            self.sleeper.wake()
+            self.shutdown_monitor()
             log.info("job handler stop queue stopped")
 
 
@@ -873,4 +864,7 @@ class DefaultJobDispatcher(object):
 
     def shutdown(self):
         for runner in self.job_runners.itervalues():
-            runner.shutdown()
+            try:
+                runner.shutdown()
+            except Exception:
+                raise Exception("Failed to shutdown runner %s" % runner)

--- a/lib/galaxy/util/monitors.py
+++ b/lib/galaxy/util/monitors.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+import logging
+import threading
+
+from .sleeper import Sleeper
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MONITOR_THREAD_JOIN_TIMEOUT = 5
+
+
+class Monitors:
+
+    def _init_monitor_thread(self, name, target_name=None, target=None, start=False, config=None):
+        self.monitor_join_sleep = getattr(config, "monitor_thread_join_timeout", DEFAULT_MONITOR_THREAD_JOIN_TIMEOUT)
+        self.monitor_join = self.monitor_join_sleep > 0
+        self.monitor_sleeper = Sleeper()
+        self.monitor_running = True
+
+        if target is not None:
+            assert target_name is None
+            monitor_func = target
+        else:
+            target_name = target_name or "monitor"
+            monitor_func = getattr(self, target_name)
+        self.sleeper = Sleeper()
+        self.monitor_thread = threading.Thread(name=name, target=monitor_func)
+        self.monitor_thread.setDaemon(True)
+        if start:
+            self.monitor_thread.start()
+
+    def stop_monitoring(self):
+        self.monitor_running = False
+
+    def _monitor_sleep(self, sleep_amount):
+        self.sleeper.sleep(sleep_amount)
+
+    def shutdown_monitor(self):
+        self.stop_monitoring()
+        self.sleeper.wake()
+        if self.monitor_join:
+            log.debug("Joining monitor thread")
+            self.monitor_thread.join(self.monitor_join_sleep)


### PR DESCRIPTION
- Cleanup database engine when shutting down Galaxy app (this wasn't done previously and I think it can cause connection issues when testing across different databases).
- Join monitor threads when shutting down (old behavior can be restored by setting wait time for monitor threads back to "0"). See note in galaxy.ini.sample.
- Better error handling during shutdown, don't let a failure to cleanup one thing cause other things not to be cleaned up.
- New monitor thread mixin based on jobs stuff - reuse for workflows so it properly wakes up workflow scheduling on shutdown.