### PR TITLE
Touch up issue labels.

### DIFF
--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -76,7 +76,6 @@ request/report to separate enhancements and new features from bugs, etc.
 -  ``kind/feature`` - something brand new
 -  ``kind/refactoring`` - refactoring of existing code, no functional
    changes
--  ``kind/testing`` - issues related to tests and the testing framework
 
 Status Labels
 -------------
@@ -121,11 +120,13 @@ particular domain, as well as more organized release notes.
 -  ``area/dataset-collections``
 -  ``area/datatypes`` - Changes to Galaxy's datatypes
 -  ``area/datatype-framework`` - Changes to Galaxy's datatype and metadata framework
+-  ``area/dependencies`` - Changes related to Python or JavaScript dependencies of Galaxy itself
 -  ``area/documentation``
 -  ``area/framework``
 -  ``area/GIEs``
 -  ``area/histories``
 -  ``area/i18n``
+-  ``area/libraries`` - Change related to data libraries.
 -  ``area/jobs``
 -  ``area/objectstore``
 -  ``area/performance``

--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -116,6 +116,7 @@ particular domain, as well as more organized release notes.
 -  ``area/admin`` - Changes to admin functionality of the Galaxy webapp.
 -  ``area/API``
 -  ``area/cleanup`` - General code cleanup.
+-  ``area/cwl`` - changes related to supporting the common workflow language in Galaxy
 -  ``area/database`` - Change requires a modification to Galaxy's database.
 -  ``area/dataset-collections``
 -  ``area/datatypes`` - Changes to Galaxy's datatypes
@@ -124,17 +125,28 @@ particular domain, as well as more organized release notes.
 -  ``area/framework``
 -  ``area/GIEs``
 -  ``area/histories``
+-  ``area/i18n``
 -  ``area/jobs``
+-  ``area/objectstore``
 -  ``area/performance``
 -  ``area/reports``
+-  ``area/security``
 -  ``area/system`` - Changes to scripts used to run or manage Galaxy.
--  ``area/tools`` - Changes to specific tools in Galaxy.
+-  ``area/testing``
+-  ``area/testing/api``
+-  ``area/testing/integration``
+-  ``area/testing/selenium``
 -  ``area/tool-framework``
+-  ``area/tool-dependencies`` - Changes to dependency resolution (including Conda).
+-  ``area/tools`` - Changes to specific tools in Galaxy.
 -  ``area/toolshed``- Changes to the tool shed client or server.
 -  ``area/UI-UX``
+-  ``area/upload``
 -  ``area/util``
 -  ``area/visualizations``
+-  ``area/webhooks``
 -  ``area/workflows``
+-  ``area/workflows/subworkflows``
 
 New labels should be proposed by opening a pull request against this document
 in the dev branch of Galaxy.


### PR DESCRIPTION
- Add some labels that have been added to Github but not this list (``area/tool-dependencies``, ``area/i18n``, ``area/security``).
- Add subworkflows which was added to Github as ``area/subworkflows`` but which I think should be ``area/workflows/subworkflows``. Objections?
- Add various specific testing areas (integration, selenium, and api) and a general testing area for bugs and enhancements for other parts of testing.*
- Add labels I think should be there but aren't (``area/cwl``, ``area/objectstore``, ``area/upload``, ``area/webhooks``).

\* I know there is a ``kind/testing``, but I really dislike using it. I initially thought it should be an area and I still do. I'm either making enhancements or bug fixes to testing - I think ``kind/bug``, ``kind/enhancement``, and ``kind/refactoring`` apply to the ``area`` of testing. Maybe the new more specific areas for testing make that clear? I wanted to see all the recent Selenium changes but I didn't have a real clear way to do that without this. Maybe a compromise if others haven't come around to my way of seeing things is to keep the area sub-types of testing (e.g. ``area/testing/selenium``) but drop ``area/testing`` from this list?