### PR TITLE
Fix integration database encoding issue with templated database stuff.

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -133,6 +133,7 @@ class Configuration(object):
         self.database_create_tables = string_as_bool(kwargs.get("database_create_tables", "True"))
         self.database_query_profiling_proxy = string_as_bool(kwargs.get("database_query_profiling_proxy", "False"))
         self.database_template = kwargs.get("database_template", None)
+        self.database_encoding = kwargs.get("database_encoding", None)  # Create new databases with this encoding.
         self.slow_query_log_threshold = float(kwargs.get("slow_query_log_threshold", 0))
 
         # Don't set this to true for production databases, but probably should

--- a/lib/galaxy/model/migrate/check.py
+++ b/lib/galaxy/model/migrate/check.py
@@ -34,7 +34,18 @@ def create_or_verify_database(url, galaxy_config_file, engine_options={}, app=No
     new_database = not database_exists(url)
     if new_database:
         template = app and getattr(app.config, "database_template", None)
-        create_database(url, template=template)
+        encoding = app and getattr(app.config, "database_encoding", None)
+        create_kwds = {}
+
+        message = "Creating database for URI [%s]" % url
+        if template:
+            message += " from template [%s]" % template
+            create_kwds["template"] = template
+        if encoding:
+            message += " with encoding [%s]" % encoding
+            create_kwds["encoding"] = encoding
+        log.info(message)
+        create_database(url, **create_kwds)
 
     # Create engine and metadata
     engine = create_engine(url, **engine_options)


### PR DESCRIPTION
This is causing all integration tests to fail against dev currently (sorry everyone).

So #4900 and #4887 were both fine on their own - but there is a bad interaction together as #4900 fixed a bug in #4887 that actually allowed the database templating stuff to start working without actually fixing that process. This fix is from my working branch in #4763 (which contained both #4900 and #4887) and the integration tests worked. You can actually see in #4900 the new Docker image enables this [new option](https://github.com/galaxyproject/galaxy/pull/4900/files#diff-e52ff6c96499a546e5d5d49e700ccd97R44).