### PR TITLE
Rollback isolated, templated databases for integration tests.

### DIFF
--- a/test/base/integration_util.py
+++ b/test/base/integration_util.py
@@ -15,8 +15,6 @@ NO_APP_MESSAGE = "test_case._app called though no Galaxy has been configured."
 class IntegrationTestCase(TestCase, UsesApiTestCaseMixin):
     """Unit test case with utilities for spinning up Galaxy."""
 
-    prefer_template_database = True
-
     @classmethod
     def setUpClass(cls):
         """Configure and start Galaxy for a test."""


### PR DESCRIPTION
Integration tests are broken in dev - they can be fixed by merging #4914 and #4910 or by this commit. If those PRs are merged first (my preference) I'll just close this one. If not, I'll open a fourth PR to roll this back after those are merged.