### PR TITLE
Fix exception handling for app shutdown.

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -246,14 +246,10 @@ class UniverseApplication(object, config.ConfiguresGalaxyMixin):
             log.exception("Failed to shutdown update repository manager cleanly")
 
         try:
-            try:
-                self.control_worker.shutdown()
-            except Exception as e:
-                exception = exception or e
-                log.exception("Failed to shutdown control worker cleanly")
-        except AttributeError:
-            # There is no control_worker
-            pass
+            self.control_worker.shutdown()
+        except Exception as e:
+            exception = exception or e
+            log.exception("Failed to shutdown control worker cleanly")
 
         try:
             self.model.engine.dispose()


### PR DESCRIPTION
This was broken by @jmchilton in #4910 (09c9f27f69ae72cac34b1286dfefce125ac404a6) and spotted by @nsoranzo.