### PR TITLE
Fix downloading of arbitrarily-nested collections

### DIFF
--- a/lib/galaxy/managers/collections_util.py
+++ b/lib/galaxy/managers/collections_util.py
@@ -67,12 +67,16 @@ def validate_input_element_identifiers(element_identifiers):
 
 def get_hda_and_element_identifiers(dataset_collection_instance):
     name = dataset_collection_instance.name
+    collection = dataset_collection_instance.collection
+    return get_collection(collection, name=name)
+
+
+def get_collection(collection, name=""):
     names = []
     hdas = []
-    collection = dataset_collection_instance.collection
     if collection.has_subcollections:
         for element in collection.elements:
-            subnames, subhdas = get_subcollections(element.child_collection, name="%s/%s" % (name, element.element_identifier))
+            subnames, subhdas = get_collection_elements(element.child_collection, name="%s/%s" % (name, element.element_identifier))
             names.extend(subnames)
             hdas.extend(subhdas)
     else:
@@ -82,12 +86,18 @@ def get_hda_and_element_identifiers(dataset_collection_instance):
     return names, hdas
 
 
-def get_subcollections(collection, name=""):
+def get_collection_elements(collection, name=""):
     names = []
     hdas = []
     for element in collection.elements:
-        names.append("%s/%s" % (name, element.element_identifier))
-        hdas.append(element.dataset_instance)
+        full_element_name = "%s/%s" % (name, element.element_identifier)
+        if element.is_collection:
+            subnames, subhdas = get_collection(element.child_collection, name=full_element_name)
+            names.extend(subnames)
+            hdas.extend(subhdas)
+        else:
+            names.append(full_element_name)
+            hdas.append(element.dataset_instance)
     return names, hdas
 
 

--- a/test/api/test_dataset_collections.py
+++ b/test/api/test_dataset_collections.py
@@ -140,6 +140,28 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
         for element, zip_path in zip(pair['object']['elements'], namelist):
             assert "%s/%s/%s.%s" % (list_collection_name, pair_collection_name, element['element_identifier'], element['object']['file_ext']) == zip_path
 
+    def test_list_list_download(self):
+        dataset_collection = self.dataset_collection_populator.create_list_of_list_in_history(self.history_id).json()
+        self.dataset_collection_populator.wait_for_dataset_collection(dataset_collection, assert_ok=True)
+        returned_dce = dataset_collection["elements"]
+        assert len(returned_dce) == 1, dataset_collection
+        create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
+        self._assert_status_code_is(create_response, 200)
+        tar_contents = tarfile.open(fileobj=StringIO(create_response.content))
+        namelist = tar_contents.getnames()
+        assert len(namelist) == 3, "Expected 3 elements in [%s]" % namelist
+
+    def test_list_list_list_download(self):
+        dataset_collection = self.dataset_collection_populator.create_list_of_list_in_history(self.history_id, collection_type='list:list:list').json()
+        self.dataset_collection_populator.wait_for_dataset_collection(dataset_collection, assert_ok=True)
+        returned_dce = dataset_collection["elements"]
+        assert len(returned_dce) == 1, dataset_collection
+        create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
+        self._assert_status_code_is(create_response, 200)
+        tar_contents = tarfile.open(fileobj=StringIO(create_response.content))
+        namelist = tar_contents.getnames()
+        assert len(namelist) == 3, "Expected 3 elements in [%s]" % namelist
+
     def test_hda_security(self):
         element_identifiers = self.dataset_collection_populator.pair_identifiers(self.history_id)
 

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -450,8 +450,14 @@ class LibraryPopulator(object):
 class BaseDatasetCollectionPopulator(object):
 
     def create_list_from_pairs(self, history_id, pairs, name="Dataset Collection from pairs"):
+        return self.create_nested_collection(history_id=history_id,
+                                             collection=pairs,
+                                             collection_type='list:paired',
+                                             name=name)
+
+    def create_nested_collection(self, history_id, collection, collection_type, name):
         element_identifiers = []
-        for i, pair in enumerate(pairs):
+        for i, pair in enumerate(collection):
             element_identifiers.append(dict(
                 name="test%d" % i,
                 src="hdca",
@@ -462,7 +468,7 @@ class BaseDatasetCollectionPopulator(object):
             instance_type="history",
             history_id=history_id,
             element_identifiers=json.dumps(element_identifiers),
-            collection_type="list:paired",
+            collection_type=collection_type,
             name=name,
         )
         return self.__create(payload)
@@ -470,6 +476,20 @@ class BaseDatasetCollectionPopulator(object):
     def create_list_of_pairs_in_history(self, history_id, **kwds):
         pair1 = self.create_pair_in_history(history_id, **kwds).json()["id"]
         return self.create_list_from_pairs(history_id, [pair1])
+
+    def create_list_of_list_in_history(self, history_id, **kwds):
+        collection_type = kwds.pop('collection_type', 'list:list')
+        collection_types = collection_type.split(':')
+        list = self.create_list_in_history(history_id, **kwds).json()['id']
+        current_collection_type = 'list'
+        for collection_type in collection_types[1:]:
+            current_collection_type = "%s:%s" % (current_collection_type, collection_type)
+            response = self.create_nested_collection(history_id=history_id,
+                                                     collection=[list],
+                                                     collection_type=current_collection_type,
+                                                     name=current_collection_type)
+            list = response.json()['id']
+        return response
 
     def create_pair_in_history(self, history_id, **kwds):
         payload = self.create_pair_payload(


### PR DESCRIPTION
This should work for any level of nesting and includes tests for the list:list
and list:list:list case. That's a first step towards https://github.com/galaxyproject/galaxy/issues/4415.