### PR TITLE
Add CRAM to BAM converter

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -16,7 +16,9 @@
       <display file="igb/bam.xml" />
       <display file="iobio/bam.xml" />
     </datatype>
-    <datatype extension="cram" type="galaxy.datatypes.binary:CRAM" mimetype="application/octet-stream" display_in_upload="true" description="CRAM is a file format for highly efficient and tunable reference-based compression of alignment data." description_url="http://www.ebi.ac.uk/ena/software/cram-usage"/>
+    <datatype extension="cram" type="galaxy.datatypes.binary:CRAM" mimetype="application/octet-stream" display_in_upload="true" description="CRAM is a file format for highly efficient and tunable reference-based compression of alignment data." description_url="http://www.ebi.ac.uk/ena/software/cram-usage">
+        <converter file="cram_to_bam_converter.xml" target_datatype="bam"/>
+    </datatype>
     <datatype extension="bed" type="galaxy.datatypes.interval:Bed" display_in_upload="true" description="BED format provides a flexible way to define the data lines that are displayed in an annotation track. BED lines have three required columns and nine additional optional columns. The three required columns are chrom, chromStart and chromEnd." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Bed">
       <converter file="bed_to_gff_converter.xml" target_datatype="gff"/>
       <converter file="bed_to_bgzip_converter.xml" target_datatype="bgzip"/>

--- a/lib/galaxy/datatypes/converters/cram_to_bam.py
+++ b/lib/galaxy/datatypes/converters/cram_to_bam.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+"""
+Uses pysam to convert a CRAM file to a sorted bam file.
+usage: %prog in_file out_file
+"""
+import optparse
+
+import pysam
+
+
+def main():
+    # Read options, args.
+    parser = optparse.OptionParser()
+    (options, args) = parser.parse_args()
+    input_fname, output_fname = args
+    pysam.sort('-o', output_fname, '-O', 'bam', '-T', '.', input_fname)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/galaxy/datatypes/converters/cram_to_bam_converter.xml
+++ b/lib/galaxy/datatypes/converters/cram_to_bam_converter.xml
@@ -1,0 +1,11 @@
+<tool id="CONVERTER_cram_to_bam_0" name="Convert CRAM to BAM" version="1.0.0" hidden="true">
+    <command><![CDATA[python $__tool_directory__/cram_to_bam.py '$input' '$output']]></command>
+    <inputs>
+        <param format="cram" name="input" type="data" label="Choose CRAM file"/>
+    </inputs>
+    <outputs>
+        <data format="bam" name="output"/>
+    </outputs>
+    <help>
+    </help>
+</tool>


### PR DESCRIPTION
This may become a more common task with long reads due to limitations in the BAM format. We should also have a converter for the opposite direction, but CRAM needs a reference fasta, so that is a little more complicated.