### PR TITLE
Kill off processes when stopping the local job runner.

### DIFF
--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -7,6 +7,7 @@ import logging
 import os
 import subprocess
 import tempfile
+import threading
 from time import sleep
 
 from galaxy import model
@@ -42,6 +43,8 @@ class LocalJobRunner(BaseJobRunner):
 
         # create a local copy of os.environ to use as env for subprocess.Popen
         self._environ = os.environ.copy()
+        self._proc_lock = threading.Lock()
+        self._procs = []
 
         # Set TEMP if a valid temp value is not already set
         if not ('TMPDIR' in self._environ or 'TEMP' in self._environ or 'TMP' in self._environ):
@@ -98,20 +101,36 @@ class LocalJobRunner(BaseJobRunner):
                                     stderr=stderr_file,
                                     env=self._environ,
                                     preexec_fn=os.setpgrp)
-            job_wrapper.set_job_destination(job_wrapper.job_destination, proc.pid)
-            job_wrapper.change_state(model.Job.states.RUNNING)
 
-            terminated = self.__poll_if_needed(proc, job_wrapper, job_id)
-            if terminated:
-                return
+            proc.terminated_by_shutdown = False
+            with self._proc_lock:
+                self._procs.append(proc)
 
-            # Reap the process and get the exit code.
-            exit_code = proc.wait()
+            try:
+                job_wrapper.set_job_destination(job_wrapper.job_destination, proc.pid)
+                job_wrapper.change_state(model.Job.states.RUNNING)
+
+                terminated = self.__poll_if_needed(proc, job_wrapper, job_id)
+                if terminated:
+                    return
+
+                # Reap the process and get the exit code.
+                exit_code = proc.wait()
+
+            finally:
+                with self._proc_lock:
+                    self._procs.remove(proc)
+
             try:
                 exit_code = int(open(exit_code_path, 'r').read())
             except Exception:
                 log.warning("Failed to read exit code from path %s" % exit_code_path)
                 pass
+
+            if proc.terminated_by_shutdown:
+                self._fail_job_local(job_wrapper, "job terminated by Galaxy shutdown")
+                return
+
             stdout_file.seek(0)
             stderr_file.seek(0)
             stdout = shrink_stream_by_size(stdout_file, DATABASE_MAX_STRING_SIZE, join_by="\n..\n", left_larger=True, beginning_on_size_error=True)
@@ -164,6 +183,13 @@ class LocalJobRunner(BaseJobRunner):
     def recover(self, job, job_wrapper):
         # local jobs can't be recovered
         job_wrapper.change_state(model.Job.states.ERROR, info="This job was killed when Galaxy was restarted.  Please retry the job.")
+
+    def shutdown(self):
+        super(LocalJobRunner, self).shutdown()
+        with self._proc_lock:
+            for proc in self._procs:
+                proc.terminated_by_shutdown = True
+                self._terminate(proc)
 
     def _fail_job_local(self, job_wrapper, message):
         job_destination = job_wrapper.job_destination


### PR DESCRIPTION
Prevent Galaxy parent process space from hanging on to these processes at shutdown and non quiting properly.