### PR TITLE
fix the doc for API creating DC in history

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -220,7 +220,7 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
     def create(self, trans, history_id, payload, **kwd):
         """
         create( self, trans, history_id, payload, **kwd )
-        * POST /api/histories/{history_id}/contents/{type}
+        * POST /api/histories/{history_id}/contents
             create a new HDA by copying an accessible LibraryDataset
 
         :type   history_id: str


### PR DESCRIPTION
This param is not parsed from the url, see https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/webapps/galaxy/buildapp.py#L203

discovered by @fabio-cumbo 