### PR TITLE
Test both endpoints for collection creation in history contents API.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -220,14 +220,16 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
     def create(self, trans, history_id, payload, **kwd):
         """
         create( self, trans, history_id, payload, **kwd )
-        * POST /api/histories/{history_id}/contents/{type}
-            create a new HDA by copying an accessible LibraryDataset
+        * POST /api/histories/{history_id}/contents/{type}s
+        * POST /api/histories/{history_id}/contents
+            create a new HDA or HDCA
 
         :type   history_id: str
         :param  history_id: encoded id string of the new HDA's History
         :type   type: str
         :param  type: Type of history content - 'dataset' (default) or
-                      'dataset_collection'.
+                      'dataset_collection'. This can be passed in via payload
+                      or parsed from the route.
         :type   payload:    dict
         :param  payload:    dictionary structure containing::
             copy from library (for type 'dataset'):

--- a/test/api/test_history_contents.py
+++ b/test/api/test_history_contents.py
@@ -125,16 +125,27 @@ class HistoryContentsApiTestCase(api.ApiTestCase, TestsDatasets):
         assert str(self.__show(hda1).json()["deleted"]).lower() == "true"
         assert str(self.__show(hda1).json()["purged"]).lower() == "true"
 
-    def test_dataset_collections(self):
+    def test_dataset_collection_creation_on_contents(self):
         payload = self.dataset_collection_populator.create_pair_payload(
             self.history_id,
             type="dataset_collection"
         )
+        endpoint = "histories/%s/contents" % self.history_id
+        self._check_pair_creation(endpoint, payload)
+
+    def test_dataset_collection_creation_on_typed_contents(self):
+        payload = self.dataset_collection_populator.create_pair_payload(
+            self.history_id,
+        )
+        endpoint = "histories/%s/contents/dataset_collections" % self.history_id
+        self._check_pair_creation(endpoint, payload)
+
+    def _check_pair_creation(self, endpoint, payload):
         pre_collection_count = self.__count_contents(type="dataset_collection")
         pre_dataset_count = self.__count_contents(type="dataset")
         pre_combined_count = self.__count_contents(type="dataset,dataset_collection")
 
-        dataset_collection_response = self._post("histories/%s/contents" % self.history_id, payload)
+        dataset_collection_response = self._post(endpoint, payload)
 
         dataset_collection = self.__check_create_collection_response(dataset_collection_response)
 


### PR DESCRIPTION
Update API docs to reflect two different valid routes.