### PR TITLE
[17.05][BUG] Tolerate IOError in tool and data table watcher

### DIFF
--- a/lib/galaxy/tools/toolbox/cache.py
+++ b/lib/galaxy/tools/toolbox/cache.py
@@ -76,6 +76,8 @@ class ToolCache(object):
 
     def cache_tool(self, config_filename, tool):
         tool_hash = md5_hash_file(config_filename)
+        if tool_hash is None:
+            return
         tool_id = str( tool.id )
         self._hash_by_tool_paths[config_filename] = tool_hash
         self._mod_time_by_path[config_filename] = os.path.getmtime(config_filename)

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -100,21 +100,36 @@ class ToolConfWatcher(object):
             with self._lock:
                 paths = list(self.paths.keys())
             for path in paths:
-                if not os.path.exists(path):
-                    continue
-                mod_time = self.paths[path]
-                if not hashes.get(path, None):
-                    hashes[path] = md5_hash_file(path)
-                new_mod_time = None
-                if os.path.exists(path):
+                try:
+                    if not os.path.exists(path):
+                        continue
+                    mod_time = self.paths[path]
+                    if not hashes.get(path, None):
+                        hash = md5_hash_file(path)
+                        if hash:
+                            hashes[path] = md5_hash_file(path)
+                        else:
+                            continue
                     new_mod_time = os.path.getmtime(path)
-                if new_mod_time > mod_time:
-                    new_hash = md5_hash_file(path)
-                    if hashes[path] != new_hash:
-                        self.paths[path] = new_mod_time
-                        hashes[path] = new_hash
-                        log.debug("The file '%s' has changes.", path)
-                        do_reload = True
+                    if new_mod_time > mod_time:
+                        new_hash = md5_hash_file(path)
+                        if hashes[path] != new_hash:
+                            self.paths[path] = new_mod_time
+                            hashes[path] = new_hash
+                            log.debug("The file '%s' has changes.", path)
+                            do_reload = True
+                except IOError:
+                    # in rare cases `path` may be deleted between `os.path.exists` calls
+                    # and reading the file from the filesystem. We do not want the watcher
+                    # thread to die in these cases.
+                    try:
+                        del hashes[path]
+                        del paths[path]
+                    except KeyError:
+                        pass
+                    if self.cache:
+                        self.cache.cleanup()
+                    do_reload = True
             if not do_reload and self.cache:
                 removed_ids = self.cache.cleanup()
                 if removed_ids:
@@ -233,11 +248,12 @@ class LocFileEventHandler(FileSystemEventHandler):
         path = os.path.abspath( path )
         if path.endswith(".loc"):
             cur_hash = md5_hash_file(path)
-            if self.loc_watcher.path_hash.get(path) == cur_hash:
-                return
-            else:
-                self.loc_watcher.path_hash[path] = cur_hash
-                self.loc_watcher.tool_data_tables.reload_tables(path=path)
+            if cur_hash:
+                if self.loc_watcher.path_hash.get(path) == cur_hash:
+                    return
+                else:
+                    self.loc_watcher.path_hash[path] = cur_hash
+                    self.loc_watcher.tool_data_tables.reload_tables(path=path)
 
 
 class ToolFileEventHandler(FileSystemEventHandler):

--- a/lib/galaxy/util/hash_util.py
+++ b/lib/galaxy/util/hash_util.py
@@ -15,13 +15,17 @@ md5 = hashlib.md5
 
 def md5_hash_file(path):
     """
-    Return a md5 hashdigest for a file.
+    Return a md5 hashdigest for a file or None if path could not be read.
     """
     hasher = hashlib.md5()
-    with open(path, 'rb') as afile:
-        buf = afile.read()
-        hasher.update(buf)
-        return hasher.hexdigest()
+    try:
+        with open(path, 'rb') as afile:
+            buf = afile.read()
+            hasher.update(buf)
+            return hasher.hexdigest()
+    except IOError:
+        # This may happen if path has been deleted
+        return None
 
 
 def new_secure_hash( text_type=None ):


### PR DESCRIPTION
Without these changes the watcher thread may die when manually deleting loc files:
```
Exception in thread Thread-7:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.13_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/Users/mvandenb/src/galaxy/.venv/lib/python2.7/site-packages/watchdog/observers/api.py", line 199, in run
    self.dispatch_events(self.event_queue, self.timeout)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python2.7/site-packages/watchdog/observers/api.py", line 368, in dispatch_events
    handler.dispatch(event)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python2.7/site-packages/watchdog/events.py", line 322, in dispatch
    self.on_any_event(event)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/toolbox/watcher.py", line 226, in on_any_event
    self._handle(event)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/toolbox/watcher.py", line 235, in _handle
    cur_hash = md5_hash_file(path)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/hash_util.py", line 23, in md5_hash_file
    with open(path, 'rb') as afile:
IOError: [Errno 2] No such file or directory: '/Users/mvandenb/src/galaxy/tool-data/toolshed.g2.bx.psu.edu/repos/lparsons/htseq_count/620d5603d1a8/sam_fa_indices.loc'
```
Similar problems could occur when deleting tool xml files.