### PR TITLE
Install numpy before bx-python in case you are installing from sdists

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -1,4 +1,6 @@
 # packages with C extensions
+# numpy must come before bx-python when doing source installs to so bx-python
+# is built properly (see #4982).
 numpy==1.9.2
 bx-python==0.7.3
 MarkupSafe==0.23

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -1,11 +1,11 @@
 # packages with C extensions
+numpy==1.9.2
 bx-python==0.7.3
 MarkupSafe==0.23
 PyYAML==3.11
 SQLAlchemy==1.0.15
 sqlalchemy-utils==0.32.19
 mercurial==3.7.3
-numpy==1.9.2
 pycrypto==2.6.1
 uWSGI==2.0.15
 


### PR DESCRIPTION
bx-python does not explicitly require numpy because it's only used to enable extra features, however, Galaxy depends on those extra features. This isn't usually a big deal because the bx-python wheel is built with numpy, but if you were to build the dependencies from source (explicitly with `pip install --no-binaries :all:` or `pip install` on a platform we don't build wheels for) using the requirements file, bx-python builds without numpy support and Galaxy fails to start:

```pytb
  File "/home/nate/work/galaxy/lib/galaxy/visualization/data_providers/genome.py", line 14, in <module>
    from bx.bbi.bigbed_file import BigBedFile
ImportError: No module named bigbed_file
```

Installing numpy before bx-python fixes this.