### PR TITLE
[17.05][BUG] Specify TagAssociation class when copying a tag

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -104,7 +104,7 @@ class DatasetCollectionManager( object ):
                 for tag in [t for t in v.tags if t.user_tname == 'name']:
                     tags[tag.value] = tag
         for _, tag in tags.items():
-            dataset_collection_instance.tags.append(tag.copy())
+            dataset_collection_instance.tags.append(tag.copy(cls=model.HistoryDatasetCollectionTagAssociation))
 
         return self.__persist( dataset_collection_instance )
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5088,8 +5088,11 @@ class ItemTagAssociation ( object, Dictifiable ):
         self.value = None
         self.user_value = None
 
-    def copy(self):
-        new_ta = type(self)()
+    def copy(self, cls=None):
+        if cls:
+            new_ta = cls()
+        else:
+            new_ta = type(self)()
         new_ta.tag_id = self.tag_id
         new_ta.user_tname = self.user_tname
         new_ta.value = self.value


### PR DESCRIPTION
This probably fixes https://github.com/galaxyproject/galaxy/issues/4975.
Otherwise if a collection is created from a HDA with a tag (i.e by splitting the dataset)
a HistoryDatasetAssociationTag would be added to a collection of
HistoryDatasetCollectionAssociationTags.