### PR TITLE
Fix tox envlist to contain all envs that should pass

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,37 @@
 [tox]
-envlist = py27-lint, py27-lint-imports, py27-lint-imports-include-list, py27-unit, qunit, mako-count, web-controller-line-count, py33-lint, py34-lint, py35-lint, validate-test-tools, py27-lint-docstring-include-list, py27-lint-docstring
+# envlist is the list of envs that are tested when `tox` is run without any option
+envlist = first_startup, py27-lint, py27-lint-docstring-include-list, py27-lint-imports-include-list, py27-unit, py34-lint, qunit, validate-test-tools
 skipsdist = True
+
+[testenv:check-python-dependencies]
+commands = make list-dependency-updates # someday change exit code on this.
+whitelist_externals = make
+skip_install = True
+
+[testenv:first_startup]
+commands = bash .ci/first_startup.sh
+whitelist_externals = bash
+
+[testenv:mako-count]
+commands = bash .ci/check_mako.sh
+whitelist_externals = bash
 
 [testenv:py27-lint]
 commands = bash .ci/flake8_wrapper.sh
 whitelist_externals = bash
 deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
 
-[testenv:py33-lint]
-commands = bash .ci/flake8_wrapper.sh
+[testenv:py27-lint-docstring]
+commands = bash .ci/flake8_wrapper_docstrings.sh --exclude
 whitelist_externals = bash
+skip_install = True
 deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
 
-
-[testenv:py34-lint]
-commands = bash .ci/flake8_wrapper.sh
+[testenv:py27-lint-docstring-include-list]
+commands = bash .ci/flake8_wrapper_docstrings.sh --include
 whitelist_externals = bash
+skip_install = True
 deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
-
-[testenv:py35-lint]
-commands = bash .ci/flake8_wrapper.sh
-whitelist_externals = bash
-deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
-
-[testenv:py27-unit]
-commands = bash run_tests.sh --no-create-venv -u
-whitelist_externals = bash
-deps =
-    nose
-    NoseHTML
-    mock
-    mock-ssh-server
 
 # Setup tox environments for linting all of Galaxy for imports and
 # just a subset we expect to pass (the include import list). Once the
@@ -49,39 +50,33 @@ whitelist_externals = bash
 skip_install = True
 deps = -rlib/galaxy/dependencies/pipfiles/flake8_imports/pinned-hashed-requirements.txt
 
+[testenv:py27-unit]
+commands = bash run_tests.sh --no-create-venv -u
+whitelist_externals = bash
+deps =
+    nose
+    NoseHTML
+    mock
+    mock-ssh-server
+
+[testenv:py34-lint]
+commands = bash .ci/flake8_wrapper.sh
+whitelist_externals = bash
+deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
+
+[testenv:py35-lint]
+commands = bash .ci/flake8_wrapper.sh
+whitelist_externals = bash
+deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
+
 [testenv:qunit]
 commands = bash run_tests.sh -q
-whitelist_externals = bash
-
-[testenv:mako-count]
-commands = bash .ci/check_mako.sh
-whitelist_externals = bash
-
-[testenv:web-controller-line-count]
-commands = bash .ci/check_controller.sh
-whitelist_externals = bash
-
-[testenv:first_startup]
-commands = bash .ci/first_startup.sh
 whitelist_externals = bash
 
 [testenv:validate-test-tools]
 commands = bash .ci/validate_test_tools.sh
 whitelist_externals = bash
 
-[testenv:py27-lint-docstring]
-commands = bash .ci/flake8_wrapper_docstrings.sh --exclude
+[testenv:web-controller-line-count]
+commands = bash .ci/check_controller.sh
 whitelist_externals = bash
-skip_install = True
-deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
-
-[testenv:py27-lint-docstring-include-list]
-commands = bash .ci/flake8_wrapper_docstrings.sh --include
-whitelist_externals = bash
-skip_install = True
-deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
-
-[testenv:check-python-dependencies]
-commands = make list-dependency-updates # someday change exit code on this.
-whitelist_externals = make
-skip_install = True


### PR DESCRIPTION
Now simply running:
```
$ tox
```
is the equivalent of running all the Travis jobs that are not in the `allow_failures` list.

Also:
- remove `py33-lint` env
- sort envs alphabetically