### PR TITLE
Always skip install Galaxy during tox tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ skipsdist = True
 [testenv:check-python-dependencies]
 commands = make list-dependency-updates # someday change exit code on this.
 whitelist_externals = make
-skip_install = True
 
 [testenv:first_startup]
 commands = bash .ci/first_startup.sh
@@ -24,13 +23,11 @@ deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
 [testenv:py27-lint-docstring]
 commands = bash .ci/flake8_wrapper_docstrings.sh --exclude
 whitelist_externals = bash
-skip_install = True
 deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
 
 [testenv:py27-lint-docstring-include-list]
 commands = bash .ci/flake8_wrapper_docstrings.sh --include
 whitelist_externals = bash
-skip_install = True
 deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
 
 # Setup tox environments for linting all of Galaxy for imports and
@@ -41,13 +38,11 @@ deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-hashed-requirements.txt
 [testenv:py27-lint-imports]
 commands = bash .ci/flake8_wrapper.sh
 whitelist_externals = bash
-skip_install = True
 deps = -rlib/galaxy/dependencies/pipfiles/flake8_imports/pinned-hashed-requirements.txt
 
 [testenv:py27-lint-imports-include-list]
 commands = bash .ci/flake8_wrapper_imports.sh
 whitelist_externals = bash
-skip_install = True
 deps = -rlib/galaxy/dependencies/pipfiles/flake8_imports/pinned-hashed-requirements.txt
 
 [testenv:py27-unit]


### PR DESCRIPTION
We don't use Galaxy from the virtualenv, we use it from lib in our testing so far. We may re-evaluate that once we have a proper setup.py file.

Based on comment from @nsoranzo.