### PR TITLE
[17.09] Allow get_history calls with create=False when evaluation workflows.

### DIFF
--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -28,8 +28,6 @@ class WorkRequestContext(ProvidesAppContext, ProvidesUserContext, ProvidesHistor
         self.workflow_building_mode = workflow_building_mode
 
     def get_history(self, create=False):
-        if create:
-            raise NotImplementedError("Cannot create histories from a work request context.")
         return self.__history
 
     def set_history(self):


### PR DESCRIPTION
No reasons to prevent this -  the ``create`` argument means "create if a history isn't available" not "force the creation of a history" as the author of this function must have thought when initially implemented. The work context always refers to a single history - so get_history has a very clear thing it should return and there should never be a reason to create a history.