### PR TITLE
More HDCA copying tests, add option to copy HDAs into new history.

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -187,14 +187,17 @@ class DatasetCollectionManager(object):
         changed = self._set_from_dict(trans, dataset_collection_instance, payload)
         return changed
 
-    def copy(self, trans, parent, source, encoded_source_id):
+    def copy(self, trans, parent, source, encoded_source_id, copy_elements=False):
         """
         PRECONDITION: security checks on ability to add to parent occurred
         during load.
         """
         assert source == "hdca"  # for now
         source_hdca = self.__get_history_collection_instance(trans, encoded_source_id)
-        new_hdca = source_hdca.copy()
+        copy_kwds = {}
+        if copy_elements:
+            copy_kwds["element_destination"] = parent
+        new_hdca = source_hdca.copy(**copy_kwds)
         tags_str = self.tag_manager.get_tags_str(source_hdca.tags)
         self.tag_manager.apply_item_tags(trans.get_user(), new_hdca, tags_str)
         parent.add_dataset_collection(new_hdca)

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -247,6 +247,9 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
             copy from history dataset collection (for type 'dataset_collection')
             'source'    = 'hdca'
             'content'   = [the encoded id from the HDCA]
+            'copy_elements' = Copy child HDAs into the target history as well,
+                              defaults to False but this is less than ideal and may
+                              be changed in future releases.
 
             create new history dataset collection (for type 'dataset_collection')
             'source'              = 'new_collection' (default 'source' if type is
@@ -382,11 +385,13 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
             content = payload.get('content', None)
             if content is None:
                 raise exceptions.RequestParameterMissingException("'content' id of target to copy is missing")
+            copy_elements = payload.get('copy_elements', False)
             dataset_collection_instance = service.copy(
                 trans=trans,
                 parent=history,
                 source="hdca",
                 encoded_source_id=content,
+                copy_elements=copy_elements,
             )
         else:
             message = "Invalid 'source' parameter in request %s" % source

--- a/test/api/test_history_contents.py
+++ b/test/api/test_history_contents.py
@@ -220,7 +220,42 @@ class HistoryContentsApiTestCase(api.ApiTestCase, TestsDatasets):
         assert len(self._get("histories/%s/contents/dataset_collections" % second_history_id).json()) == 0
         create_response = self._post("histories/%s/contents/dataset_collections" % second_history_id, create_data)
         self.__check_create_collection_response(create_response)
-        assert len(self._get("histories/%s/contents/dataset_collections" % second_history_id).json()) == 1
+        contents = self._get("histories/%s/contents/dataset_collections" % second_history_id).json()
+        assert len(contents) == 1
+        new_forward, _ = self.__get_paired_response_elements(contents[0])
+        self._assert_has_keys(new_forward, "history_id")
+        assert new_forward["history_id"] == self.history_id
+
+    def test_hdca_copy_and_elements(self):
+        hdca = self.dataset_collection_populator.create_pair_in_history(self.history_id).json()
+        hdca_id = hdca["id"]
+        second_history_id = self._new_history()
+        create_data = dict(
+            source='hdca',
+            content=hdca_id,
+            copy_elements=True,
+        )
+        assert len(self._get("histories/%s/contents/dataset_collections" % second_history_id).json()) == 0
+        create_response = self._post("histories/%s/contents/dataset_collections" % second_history_id, create_data)
+        self.__check_create_collection_response(create_response)
+
+        contents = self._get("histories/%s/contents/dataset_collections" % second_history_id).json()
+        assert len(contents) == 1
+        new_forward, _ = self.__get_paired_response_elements(contents[0])
+        self._assert_has_keys(new_forward, "history_id")
+        assert new_forward["history_id"] == second_history_id
+
+    def __get_paired_response_elements(self, contents):
+        hdca = self.__show(contents).json()
+        self._assert_has_keys(hdca, "name", "deleted", "visible", "elements")
+        elements = hdca["elements"]
+        assert len(elements) == 2
+        element0 = elements[0]
+        element1 = elements[1]
+        self._assert_has_keys(element0, "object")
+        self._assert_has_keys(element1, "object")
+
+        return element0["object"], element1["object"]
 
     def __check_create_collection_response(self, response):
         self._assert_status_code_is(response, 200)


### PR DESCRIPTION
The GUI already operates this way but via web controller, this adds this option to the API and adds a test.
