### PR TITLE
Use github instead of NCBI for problematic data manager test FASTA.

### DIFF
--- a/test/integration/test_data_manager_table_reload.py
+++ b/test/integration/test_data_manager_table_reload.py
@@ -37,8 +37,8 @@ FETCH_GENOME_DBKEYS_ALL_FASTA_INPUT = {"dbkey_source|dbkey_source_selector": "ne
                                        "dbkey_source|dbkey_name": "NC_001617.1",
                                        "sequence_name": "NC_001617.1",
                                        "sequence_id": "NC_001617.1",
-                                       "reference_source|reference_source_selector": "ncbi",
-                                       "reference_source|requested_identifier": "NC_001617.1",
+                                       "reference_source|reference_source_selector": "url",
+                                       "reference_source|user_url": "https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/master/NC_001617.1.fasta",
                                        "sorting|sort_selector": "as_is"}
 SAM_FASTA_ID = "toolshed.g2.bx.psu.edu/repos/devteam/data_manager_sam_fasta_index_builder/sam_fasta_index_builder/0.0.2"
 SAM_FASTA_INPUT = {"all_fasta_source": "NC_001617.1", "sequence_name": "", "sequence_id": ""}


### PR DESCRIPTION
Seems to be failing many of the integration tool runs I've seen today. I've seen a couple different errors:

```
|  File "/tmp/tmpVp6xM0/toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/b1bc53e9bbc5/data_manager_fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.py", line 312, in download_from_ncbi
|  return get_stream_reader(urlopen(url), tmp_dir)
|  File "/usr/lib/python2.7/urllib2.py", line 154, in urlopen
|  return opener.open(url, data, timeout)
|  File "/usr/lib/python2.7/urllib2.py", line 435, in open
|  response = meth(req, response)
|  File "/usr/lib/python2.7/urllib2.py", line 548, in http_response
|  'http', request, response, code, msg, hdrs)
|  File "/usr/lib/python2.7/urllib2.py", line 473, in error
|  return self._call_chain(*args)
|  File "/usr/lib/python2.7/urllib2.py", line 407, in _call_chain
|  result = func(*args)
|  File "/usr/lib/python2.7/urllib2.py", line 556, in http_error_default
|  raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
```

and

```
Timed out after 60.25 seconds waiting on state.
-------------------- >> begin captured stdout << ---------------------
Problem in history with id adb5f5c93f827949 - summary of datasets below.
--------------------------------------
| 1 - Create DBKey and Reference Genome (HID - NAME)
| Dataset State:
|  queued
| Dataset Blurb:
|  queued
| Dataset Info:
|  None
| Peek:
|  None
| Dataset Job Standard Output:
|  None
| Dataset Job Standard Error:
|  None
|
--------------------------------------
```