### PR TITLE
[17.09] Do not visit child inputs of invalid conditionals

### DIFF
--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -41,18 +41,12 @@ def visit_input_values(inputs, input_values, callback, name_prefix='', label_pre
     >>> h = TextToolParameter( None, XML( '<param name="h"/>' ) )
     >>> i = TextToolParameter( None, XML( '<param name="i"/>' ) )
     >>> j = TextToolParameter( None, XML( '<param name="j"/>' ) )
-    >>> a.name = 'a'
     >>> b.name = b.title = 'b'
-    >>> c.name = 'c'
-    >>> d.name = d.title = 'd'
-    >>> e.name = 'e'
-    >>> f.name = 'f'
-    >>> g.name = 'g'
-    >>> h.name = 'h'
-    >>> j.name = 'j'
     >>> b.inputs = odict([ ('c', c), ('d', d) ])
+    >>> d.name = d.title = 'd'
     >>> d.inputs = odict([ ('e', e), ('f', f) ])
     >>> f.test_param = g
+    >>> f.name = 'f'
     >>> f.cases = [ Bunch( value='true', inputs= { 'h': h } ), Bunch( value='false', inputs= { 'i': i } ) ]
     >>>
     >>> def visitor( input, value, prefix, prefixed_name, prefixed_label, error, **kwargs ):

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -74,7 +74,7 @@ def visit_input_values(inputs, input_values, callback, name_prefix='', label_pre
     name=j, prefix=b_0|d_0|, prefixed_name=b_0|d_0|f|j, prefixed_label=b 1 > d 1 > j,value=j
     The selected case is unavailable/invalid.
 
-    >>> # Conditional test parameter missing from state, value error
+    >>> # Test parameter missing in state, value error
     >>> del nested['b'][0]['d'][0]['f']['j']
     >>> visit_input_values( inputs, nested, visitor )
     name=a, prefix=, prefixed_name=a, prefixed_label=a,value=1
@@ -83,7 +83,7 @@ def visit_input_values(inputs, input_values, callback, name_prefix='', label_pre
     name=j, prefix=b_0|d_0|, prefixed_name=b_0|d_0|f|j, prefixed_label=b 1 > d 1 > j,value=None
     No value found for 'b 1 > d 1 > j'.
 
-    >>> # Conditional parameter missing from state, value error
+    >>> # Conditional parameter missing in state, value error
     >>> del nested['b'][0]['d'][0]['f']
     >>> visit_input_values( inputs, nested, visitor )
     name=a, prefix=, prefixed_name=a, prefixed_label=a,value=1
@@ -92,7 +92,7 @@ def visit_input_values(inputs, input_values, callback, name_prefix='', label_pre
     name=j, prefix=b_0|d_0|, prefixed_name=b_0|d_0|f|j, prefixed_label=b 1 > d 1 > j,value=None
     No value found for 'b 1 > d 1 > j'.
 
-    >>> # Conditional input name has changed due to version change, key error
+    >>> # Conditional input name has changed e.g. due to tool changes, key error
     >>> f.name = 'f_1'
     >>> visit_input_values( inputs, nested, visitor )
     name=a, prefix=, prefixed_name=a, prefixed_label=a,value=1
@@ -101,7 +101,7 @@ def visit_input_values(inputs, input_values, callback, name_prefix='', label_pre
     name=j, prefix=b_0|d_0|, prefixed_name=b_0|d_0|f_1|j, prefixed_label=b 1 > d 1 > j,value=None
     No value found for 'b 1 > d 1 > j'.
 
-    >>> # Other parameters are missing from state
+    >>> # Other parameters are missing in state
     >>> nested = odict([ ('b', [ odict([ ( 'd', [odict([ ('f', odict([ ('g', True), ('h', 7) ])) ]) ])]) ]) ])
     >>> visit_input_values( inputs, nested, visitor )
     name=a, prefix=, prefixed_name=a, prefixed_label=a,value=None

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -102,8 +102,9 @@ def visit_input_values(inputs, input_values, callback, name_prefix='', label_pre
                 case_error = 'The selected case is unavailable/invalid.'
                 pass
             callback_helper(input.test_param, values, new_name_prefix, label_prefix, parent_prefix=name_prefix, context=context, error=case_error)
-            values['__current_case__'] = input.get_current_case(values[input.test_param.name])
-            visit_input_values(input.cases[values['__current_case__']].inputs, values, callback, new_name_prefix, label_prefix, parent_prefix=name_prefix, **payload)
+            if input.test_param.name in values:
+                values['__current_case__'] = input.get_current_case(values[input.test_param.name])
+                visit_input_values(input.cases[values['__current_case__']].inputs, values, callback, new_name_prefix, label_prefix, parent_prefix=name_prefix, **payload)
         elif isinstance(input, Section):
             values = input_values[input.name] = input_values.get(input.name, {})
             new_name_prefix = name_prefix + input.name + '|'


### PR DESCRIPTION
Fixes #4889. Invalid conditionals states are usually the result of tool version changes. Child inputs of invalid conditionals should not be visited if the underlying visitor is unable to fix them. The only input visitor which is able to resolve them and warn the user is `check_and_update_param_values` in `tools.py`.