### PR TITLE
parse_interpreter: log a warning only if interpreter is set

### DIFF
--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -127,12 +127,13 @@ class XmlToolSource(ToolSource):
         return environment_variables
 
     def parse_interpreter(self):
+        interpreter = None
         command_el = self._command_el
-        interpreter = (command_el is not None) and command_el.get("interpreter", None)
-        if not self.legacy_defaults:
-            log.warning("Deprecated interpeter attribute on command element is now ignored.")
+        if command_el is not None:
+            interpreter = command_el.get("interpreter", None)
+        if interpreter and not self.legacy_defaults:
+            log.warning("Deprecated interpreter attribute on command element is now ignored.")
             interpreter = None
-
         return interpreter
 
     def parse_version_command(self):


### PR DESCRIPTION
Also return `None` instead of `False` if there is no `<command>`.
Fix typo in warning.