### PR TITLE
add API that allows admins to decode galaxy objects' ids

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -92,6 +92,18 @@ class ConfigurationController(BaseAPIController):
 
     @expose_api
     @require_admin
+    def decode_id(self, trans, encoded_id, **kwds):
+        """Decode a given id."""
+        decoded_id = None
+        # Handle the special case for library folders
+        if ((len(encoded_id) % 16 == 1) and encoded_id.startswith('F')):
+            decoded_id = trans.security.decode_id(encoded_id[1:])
+        else:
+            decoded_id = trans.security.decode_id(encoded_id)
+        return {"decoded_id": decoded_id}
+
+    @expose_api
+    @require_admin
     def tool_lineages(self, trans):
         rval = []
         for id, tool in self.app.toolbox.tools():

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -339,6 +339,10 @@ def populate_api_routes(webapp, app):
                           "/api/whoami", controller='configuration',
                           action='whoami',
                           conditions=dict(method=["GET"]))
+    webapp.mapper.connect("api_decode",
+                          "/api/configuration/decode/{encoded_id}", controller='configuration',
+                          action='decode_id',
+                          conditions=dict(method=["GET"]))
     webapp.mapper.resource('datatype',
                            'datatypes',
                            path_prefix='/api',

--- a/test/api/test_configuration.py
+++ b/test/api/test_configuration.py
@@ -3,6 +3,9 @@ from base.api_asserts import (
     assert_has_keys,
     assert_not_has_keys,
 )
+from base.populators import (
+    LibraryPopulator
+)
 
 TEST_KEYS_FOR_ALL_USERS = [
     'enable_unique_workflow_defaults',
@@ -24,6 +27,10 @@ TEST_KEYS_FOR_ADMIN_ONLY = [
 
 class ConfigurationApiTestCase(api.ApiTestCase):
 
+    def setUp(self):
+        super(ConfigurationApiTestCase, self).setUp()
+        self.library_populator = LibraryPopulator(self)
+
     def test_normal_user_configuration(self):
         config = self._get_configuration()
         assert_has_keys(config, *TEST_KEYS_FOR_ALL_USERS)
@@ -33,6 +40,22 @@ class ConfigurationApiTestCase(api.ApiTestCase):
         config = self._get_configuration(admin=True)
         assert_has_keys(config, *TEST_KEYS_FOR_ALL_USERS)
         assert_has_keys(config, *TEST_KEYS_FOR_ADMIN_ONLY)
+
+    def test_admin_decode_id(self):
+        new_lib = self.library_populator.new_library('DecodeTestLibrary')
+        decode_response = self._get("configuration/decode/" + new_lib["id"], admin=True)
+        response_id = decode_response.json()["decoded_id"]
+        decoded_library_id = self.security.decode_id(new_lib["id"])
+        assert decoded_library_id == response_id
+        # fake valid folder id by prepending F
+        valid_encoded_folder_id = 'F' + new_lib["id"]
+        folder_decode_response = self._get("configuration/decode/" + valid_encoded_folder_id, admin=True)
+        folder_response_id = folder_decode_response.json()["decoded_id"]
+        assert decoded_library_id == folder_response_id
+
+    def test_normal_user_decode_id(self):
+        decode_response = self._get("configuration/decode/badhombre", admin=False)
+        self._assert_status_code_is(decode_response, 403)
 
     def _get_configuration(self, data={}, admin=False):
         response = self._get("configuration", data=data, admin=admin)


### PR DESCRIPTION
ping @erasche I think you requested this in the past too?