### PR TITLE
Support separate DSN for job sentry error reports

### DIFF
--- a/config/error_report.yml.sample
+++ b/config/error_report.yml.sample
@@ -29,7 +29,8 @@
 #   directory: /tmp/reports/
 
 # Submit error reports to sentry. If a sentry_dsn is configured in your
-# galaxy.ini, then Galaxy will submit the job error to Sentry.
+# galaxy.ini, then Galaxy will submit the job error to Sentry. You may supply a
+# separate DSN for tool reports by supplying a ``custom_dsn`` parameter.
 - type: sentry
   user_submission: false
 

--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -34,7 +34,7 @@ class SentryPlugin(ErrorPlugin):
         self.custom_dsn = kwargs.get('custom_dsn', None)
         self.sentry = None
         # Use the built in one by default
-        if self.app.sentry_client:
+        if hasattr(self.app, 'sentry_client'):
             self.sentry = self.app.sentry_client
 
         # if they've set a custom one, override.

--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -31,11 +31,21 @@ class SentryPlugin(ErrorPlugin):
         self.app = kwargs['app']
         self.verbose = string_as_bool(kwargs.get('verbose', False))
         self.user_submission = string_as_bool(kwargs.get('user_submission', False))
+        self.custom_dsn = kwargs.get('custom_dsn', None)
+        self.sentry = None
+        # Use the built in one by default
+        if self.app.sentry_client:
+            self.sentry = self.app.sentry_client
+
+        # if they've set a custom one, override.
+        if self.custom_dsn:
+            import raven
+            self.sentry = raven.Client(self.custom_dsn)
 
     def submit_report(self, dataset, job, tool, **kwargs):
         """Submit the error report to sentry
         """
-        if self.app.sentry_client:
+        if self.sentry_client:
             user = job.get_user()
             extra = {
                 'info': job.info,
@@ -64,7 +74,7 @@ class SentryPlugin(ErrorPlugin):
             error_message = ERROR_TEMPLATE.format(**extra)
 
             # Update context with user information in a sentry-specific manner
-            self.app.sentry_client.context.merge({
+            self.sentry_client.context.merge({
                 # User information here also places email links + allows seeing
                 # a list of affected users in the tags/filtering.
                 'user': {
@@ -83,7 +93,7 @@ class SentryPlugin(ErrorPlugin):
             })
 
             # Send the message, using message because
-            response = self.app.sentry_client.capture(
+            response = self.sentry_client.capture(
                 'raven.events.Message',
                 tags={
                     'tool_id': job.tool_id,


### PR DESCRIPTION
It isn't otherwise easy to pull out the tool errors from the other error reports, and impossible to grant community-relations type people access to just the tool errors without granting them access to all error reports.