### PR TITLE
[BUG][17.09] Ignore OSError when chmod'ing integrated_tool_panel_conf.xml

### DIFF
--- a/lib/galaxy/tools/toolbox/integrated_panel.py
+++ b/lib/galaxy/tools/toolbox/integrated_panel.py
@@ -103,4 +103,9 @@ class ManagesIntegratedToolPanelMixin:
             shutil.copy(filename, filename + ".copy")
             filename = filename + ".copy"
         shutil.move(filename, destination)
-        os.chmod(self._integrated_tool_panel_config, 0o644)
+        try:
+            os.chmod(destination, 0o644)
+        except OSError:
+            # That can happen if multiple threads are simultaneously moving/chmod'ing this file
+            # Should be harmless, though this race condition should be avoided.
+            pass


### PR DESCRIPTION
This fixes the first error in https://github.com/galaxyproject/galaxy/issues/5031:
```
Exception in thread ToolConfWatcher.thread:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "lib/galaxy/tools/toolbox/watcher.py", line 138, in check
    self.reload_callback()
  File "lib/galaxy/webapps/galaxy/config_watchers.py", line 24, in <lambda>
    self.tool_config_watcher = get_tool_conf_watcher(reload_callback=lambda: reload_toolbox(self.app), tool_cache=self.app.tool_cache)
  File "lib/galaxy/queue_worker.py", line 92, in reload_toolbox
    _get_new_toolbox(app)
  File "lib/galaxy/queue_worker.py", line 111, in _get_new_toolbox
    new_toolbox = tools.ToolBox(tool_configs, app.config.tool_path, app)
  File "lib/galaxy/tools/__init__.py", line 226, in __init__
    app=app,
  File "lib/galaxy/tools/toolbox/base.py", line 1061, in __init__
    super(BaseGalaxyToolBox, self).__init__(config_filenames, tool_root_dir, app)
  File "lib/galaxy/tools/toolbox/base.py", line 87, in __init__
    self._save_integrated_tool_panel()
  File "lib/galaxy/tools/toolbox/integrated_panel.py", line 46, in _save_integrated_tool_panel
    self._write_integrated_tool_panel_config_file()
  File "lib/galaxy/tools/toolbox/integrated_panel.py", line 106, in _write_integrated_tool_panel_config_file
    os.chmod(self._integrated_tool_panel_config, 0o644)
OSError: [Errno 2] No such file or directory: '/data/users/mvandenb/gx/config/integrated_tool_panel.xml'
```

That actually also happens sometime when starting up many handlers at the same time. 