### PR TITLE
[17.09] Fix copying of loc.sample files

### DIFF
--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -143,7 +143,7 @@ class ToolShedRepository(object):
                             if tool_id in tool_ids:
                                 self.shed_config_filename = name
                                 return shed_tool_conf_dict
-        if self.includes_datatypes:
+        if self.includes_datatypes or self.includes_data_managers:
             # We need to search by file paths here, which is less desirable.
             tool_shed = common_util.remove_protocol_and_port_from_tool_shed_url(self.tool_shed)
             for shed_tool_conf_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -21,6 +21,7 @@ import requests
 from galaxy import util
 from galaxy.util.dictifiable import Dictifiable
 from galaxy.util.odict import odict
+from galaxy.util.renamed_temporary_file import RenamedTemporaryFile
 
 log = logging.getLogger(__name__)
 
@@ -186,7 +187,7 @@ class ToolDataTableManager(object):
         # add new elems
         out_elems.extend(new_elems)
         out_path_is_new = not os.path.exists(full_path)
-        with open(full_path, 'wb') as out:
+        with RenamedTemporaryFile(full_path) as out:
             out.write('<?xml version="1.0"?>\n<tables>\n')
             for elem in out_elems:
                 out.write(util.xml_to_string(elem, pretty=True))

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -95,7 +95,7 @@ class ToolDataTableManager(object):
     def get_tables(self):
         return self.data_tables
 
-    def load_from_config_file(self, config_filename, tool_data_path, from_shed_config=False):
+    def load_from_config_file(self, config_filename, tool_data_path, from_shed_config=False, dry_run=False):
         """
         This method is called under 3 conditions:
 
@@ -103,7 +103,10 @@ class ToolDataTableManager(object):
         2. Just after the ToolDataTableManager is initialized and the additional entries defined by shed_tool_data_table_conf.xml
            are being loaded into the ToolDataTableManager.data_tables.
         3. When a tool shed repository that includes a tool_data_table_conf.xml.sample file is being installed into a local
-           Galaxy instance.  In this case, we have 2 entry types to handle, files whose root tag is <tables>, for example:
+           Galaxy instance.
+
+        When installing a new repository dry_run is set to True and we skip registering the new data table,
+        as it points to temporary files.
         """
         table_elems = []
         if not isinstance(config_filename, list):
@@ -114,16 +117,17 @@ class ToolDataTableManager(object):
             for table_elem in root.findall('table'):
                 table = ToolDataTable.from_elem(table_elem, tool_data_path, from_shed_config, filename=filename, tool_data_path_files=self.tool_data_path_files)
                 table_elems.append(table_elem)
-                if table.name not in self.data_tables:
-                    self.data_tables[table.name] = table
-                    log.debug("Loaded tool data table '%s' from file '%s'", table.name, filename)
-                else:
-                    log.debug("Loading another instance of data table '%s' from file '%s', attempting to merge content.", table.name, filename)
-                    self.data_tables[table.name].merge_tool_data_table(table, allow_duplicates=False)  # only merge content, do not persist to disk, do not allow duplicate rows when merging
-                    # FIXME: This does not account for an entry with the same unique build ID, but a different path.
+                if not dry_run:
+                    if table.name not in self.data_tables:
+                        self.data_tables[table.name] = table
+                        log.debug("Loaded tool data table '%s' from file '%s'", table.name, filename)
+                    else:
+                        log.debug("Loading another instance of data table '%s' from file '%s', attempting to merge content.", table.name, filename)
+                        self.data_tables[table.name].merge_tool_data_table(table, allow_duplicates=False)  # only merge content, do not persist to disk, do not allow duplicate rows when merging
+                        # FIXME: This does not account for an entry with the same unique build ID, but a different path.
         return table_elems
 
-    def add_new_entries_from_config_file(self, config_filename, tool_data_path, shed_tool_data_table_config, persist=False):
+    def add_new_entries_from_config_file(self, config_filename, tool_data_path, shed_tool_data_table_config, persist=False, dry_run=False):
         """
         This method is called when a tool shed repository that includes a tool_data_table_conf.xml.sample file is being
         installed into a local galaxy instance.  We have 2 cases to handle, files whose root tag is <tables>, for example::
@@ -149,7 +153,8 @@ class ToolDataTableManager(object):
         try:
             table_elems = self.load_from_config_file(config_filename=config_filename,
                                                      tool_data_path=tool_data_path,
-                                                     from_shed_config=True)
+                                                     from_shed_config=True,
+                                                     dry_run=dry_run)
         except Exception as e:
             error_message = 'Error attempting to parse file %s: %s' % (str(os.path.split(config_filename)[1]), str(e))
             log.debug(error_message)

--- a/lib/galaxy/util/renamed_temporary_file.py
+++ b/lib/galaxy/util/renamed_temporary_file.py
@@ -1,0 +1,41 @@
+"""Safely write file to temporary file and then move file into place Copied from https://stackoverflow.com/a/12007885."""
+import os
+import tempfile
+
+
+class RenamedTemporaryFile(object):
+    """
+    A temporary file object which will be renamed to the specified
+    path on exit.
+    """
+    def __init__(self, final_path, **kwargs):
+        tmpfile_dir = kwargs.pop('dir', None)
+
+        # Put temporary file in the same directory as the location for the
+        # final file so that an atomic move into place can occur.
+
+        if tmpfile_dir is None:
+            tmpfile_dir = os.path.dirname(final_path)
+
+        self.tmpfile = tempfile.NamedTemporaryFile(dir=tmpfile_dir, **kwargs)
+        self.final_path = final_path
+
+    def __getattr__(self, attr):
+        """
+        Delegate attribute access to the underlying temporary file object.
+        """
+        return getattr(self.tmpfile, attr)
+
+    def __enter__(self):
+        self.tmpfile.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self.tmpfile.delete = False
+            result = self.tmpfile.__exit__(exc_type, exc_val, exc_tb)
+            os.rename(self.tmpfile.name, self.final_path)
+        else:
+            result = self.tmpfile.__exit__(exc_type, exc_val, exc_tb)
+
+        return result

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -532,7 +532,7 @@ class InstallRepositoryManager(object):
                 tdtm.install_tool_data_tables(tool_shed_repository, tool_index_sample_files)
             if tool_data_table_elems:
                 self.app.tool_data_tables.add_new_entries_from_config_file(tool_data_table_conf_filename,
-                                                                           None,
+                                                                           self.app.config.shed_tool_data_path,
                                                                            self.app.config.shed_tool_data_table_config,
                                                                            persist=True)
         if 'tools' in irmm_metadata_dict:

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -511,7 +511,7 @@ class InstallRepositoryManager(object):
                                                   resetting_all_metadata_on_repository=False,
                                                   updating_installed_repository=False,
                                                   persist=True)
-        irmm.generate_metadata_for_changeset_revision()
+        irmm.generate_metadata_for_changeset_revision(dry_run=True)
         irmm_metadata_dict = irmm.get_metadata_dict()
         tool_shed_repository.metadata = irmm_metadata_dict
         # Update the tool_shed_repository.tool_shed_status column in the database.
@@ -534,7 +534,7 @@ class InstallRepositoryManager(object):
                 self.app.tool_data_tables.add_new_entries_from_config_file(tool_data_table_conf_filename,
                                                                            self.app.config.shed_tool_data_path,
                                                                            self.app.config.shed_tool_data_table_config,
-                                                                           persist=True)
+                                                                           persist=True,)
         if 'tools' in irmm_metadata_dict:
             # Get the tool_versions from the Tool Shed for each tool in the installed change set.
             self.update_tool_shed_repository_status(tool_shed_repository,

--- a/lib/tool_shed/metadata/metadata_generator.py
+++ b/lib/tool_shed/metadata/metadata_generator.py
@@ -361,7 +361,8 @@ class MetadataGenerator(object):
             # If the list of sample files includes a tool_data_table_conf.xml.sample file, load
             # its table elements into memory.
             relative_path, filename = os.path.split(sample_file)
-            if filename == 'tool_data_table_conf.xml.sample':
+            if filename == 'tool_data_table_conf.xml.sample' and self.resetting_all_metadata_on_repository:
+                # Don't load table from temporary locations into memory
                 new_table_elems, error_message = \
                     self.app.tool_data_tables.add_new_entries_from_config_file(config_filename=sample_file,
                                                                                tool_data_path=work_dir,

--- a/lib/tool_shed/metadata/metadata_generator.py
+++ b/lib/tool_shed/metadata/metadata_generator.py
@@ -290,7 +290,7 @@ class MetadataGenerator(object):
         tmp_url = common_util.remove_protocol_and_user_from_clone_url(self.repository_clone_url)
         return '%s/%s/%s/%s' % (tmp_url, guid_type, obj_id, version)
 
-    def generate_metadata_for_changeset_revision(self):
+    def generate_metadata_for_changeset_revision(self, dry_run=False):
         """
         Generate metadata for a repository using its files on disk.  To generate metadata
         for changeset revisions older than the repository tip, the repository will have been
@@ -303,6 +303,7 @@ class MetadataGenerator(object):
         The value of self.persist will be True when the installed repository contains a valid
         tool_data_table_conf.xml.sample file, in which case the entries should ultimately be
         persisted to the file referred to by self.app.config.shed_tool_data_table_config.
+        When dry_run is set to 'True' tool data tables will not be loaded into memory.
         """
         tv = tool_validator.ToolValidator(self.app)
         if self.shed_config_dict is None:
@@ -361,13 +362,14 @@ class MetadataGenerator(object):
             # If the list of sample files includes a tool_data_table_conf.xml.sample file, load
             # its table elements into memory.
             relative_path, filename = os.path.split(sample_file)
-            if filename == 'tool_data_table_conf.xml.sample' and self.resetting_all_metadata_on_repository:
+            if filename == 'tool_data_table_conf.xml.sample':
                 # Don't load table from temporary locations into memory
                 new_table_elems, error_message = \
                     self.app.tool_data_tables.add_new_entries_from_config_file(config_filename=sample_file,
                                                                                tool_data_path=work_dir,
                                                                                shed_tool_data_table_config=work_dir,
-                                                                               persist=False)
+                                                                               persist=False,
+                                                                               dry_run=dry_run)
                 if error_message:
                     self.invalid_file_tups.append((filename, error_message))
         for root, dirs, files in os.walk(files_dir):

--- a/lib/tool_shed/util/tool_util.py
+++ b/lib/tool_shed/util/tool_util.py
@@ -42,13 +42,13 @@ def build_tool_panel_section_select_field(app):
 
 def copy_sample_file(app, filename, dest_path=None):
     """
-    Copy xxx.sample to dest_path/xxx.sample and dest_path/xxx.  The default value for dest_path
-    is ~/tool-data.
+    Copies a sample file at `filename` to `the dest_path`
+    directory and strips the '.sample' extensions from `filename`.
     """
     if dest_path is None:
         dest_path = os.path.abspath(app.config.tool_data_path)
     sample_file_name = basic_util.strip_path(filename)
-    copied_file = sample_file_name.replace('.sample', '')
+    copied_file = sample_file_name.rsplit('.sample', 1)[0]
     full_source_path = os.path.abspath(filename)
     full_destination_path = os.path.join(dest_path, sample_file_name)
     # Don't copy a file to itself - not sure how this happens, but sometimes it does...
@@ -174,7 +174,7 @@ def handle_missing_index_file(app, tool_path, sample_files, repository_tools_tup
                 for sample_file in sample_files:
                     sample_file_name = basic_util.strip_path(sample_file)
                     if sample_file_name == '%s.sample' % missing_file_name:
-                        copy_sample_file(app, sample_file)
+                        copy_sample_file(app, os.path.join(tool_path, sample_file))
                         if options.tool_data_table and options.tool_data_table.missing_index_file:
                             options.tool_data_table.handle_found_index_file(options.missing_index_file)
                         sample_files_copied.append(options.missing_index_file)


### PR DESCRIPTION
`filename` should be joined with the tool_path, as evidenced by other uses of
copy_sample_file.

Prior to this change I would sometimes see this during installation of tool that should be copying `.loc.sample` files:
```
IOError: [Errno 2] No such file or directory: u'/bioinfo/guests/mvandenb/galaxy/toolshed.g2.bx.psu.edu/repos/bgruening/sailfish/a8f343909c17/sailfish/tool-data/sailfish_indexes.loc.sample'
  File "galaxy/web/framework/decorators.py", line 281, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/tool_shed_repositories.py", line 528, in install_repository_revision
    payload)
  File "tool_shed/galaxy_install/install_manager.py", line 706, in install
    install_options
  File "tool_shed/galaxy_install/install_manager.py", line 805, in __initiate_and_install_repositories
    return self.install_repositories(tsr_ids, decoded_kwd, reinstalling=False)
  File "tool_shed/galaxy_install/install_manager.py", line 852, in install_repositories
    tool_panel_section_mapping=tool_panel_section_mapping)
  File "tool_shed/galaxy_install/install_manager.py", line 902, in install_tool_shed_repository
    tool_panel_section_mapping=tool_panel_section_mapping)
  File "tool_shed/galaxy_install/install_manager.py", line 561, in __handle_repository_contents
    sample_files_copied)
  File "tool_shed/util/tool_util.py", line 177, in handle_missing_index_file
    copy_sample_file(app, sample_file)
  File "tool_shed/util/tool_util.py", line 57, in copy_sample_file
    shutil.copy(full_source_path, full_destination_path)
  File "python2.7/shutil.py", line 119, in copy
    copyfile(src, dst)
  File "python2.7/shutil.py", line 82, in copyfile
    with open(src, 'rb') as fsrc:
```