### PR TITLE
Fail job if job output collection fails

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -623,13 +623,14 @@ class AsynchronousJobRunner(Monitors, BaseJobRunner):
                     stdout = ''
                     stderr = 'Job output not returned from cluster'
                     log.error('(%s/%s) %s: %s' % (galaxy_id_tag, external_job_id, stderr, str(e)))
+                    exit_code_str = "123"  # Indicate that job probaly failed, given that we couldn't collect the Job output
                 else:
                     time.sleep(1)
                 which_try += 1
 
         try:
             # This should be an 8-bit exit code, but read ahead anyway:
-            exit_code_str = open(job_state.exit_code_file, "r").read(32)
+            exit_code_str = open(job_state.exit_code_file, "r").read(32) if not exit_code_str else exit_code_str
         except Exception:
             # By default, the exit code is 0, which typically indicates success.
             exit_code_str = "0"

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -414,6 +414,7 @@ class JobState(object):
     runner_states = Bunch(
         WALLTIME_REACHED='walltime_reached',
         MEMORY_LIMIT_REACHED='memory_limit_reached',
+        JOB_OUTPUT_NOT_RETURNED_FROM_CLUSTER='Job output not returned from cluster',
         UNKNOWN_ERROR='unknown_error',
         GLOBAL_WALLTIME_REACHED='global_walltime_reached',
         OUTPUT_SIZE_LIMIT='output_size_limit'
@@ -622,7 +623,7 @@ class AsynchronousJobRunner(Monitors, BaseJobRunner):
             except Exception as e:
                 if which_try == self.app.config.retry_job_output_collection:
                     stdout = ''
-                    stderr = 'Job output not returned from cluster'
+                    stderr = job_state.runner_states.JOB_OUTPUT_NOT_RETURNED_FROM_CLUSTER
                     log.error('(%s/%s) %s: %s' % (galaxy_id_tag, external_job_id, stderr, str(e)))
                     collect_output_success = False
                 else:
@@ -631,6 +632,7 @@ class AsynchronousJobRunner(Monitors, BaseJobRunner):
 
         if not collect_output_success:
             job_state.fail_message = stderr
+            job_state.runner_state = job_state.runner_states.JOB_OUTPUT_NOT_RETURNED_FROM_CLUSTER
             self.mark_as_failed(job_state)
             return
 

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -68,6 +68,7 @@ def failure(app, job_runner, job_state):
     runner_state = getattr(job_state, 'runner_state', None) or JobState.runner_states.UNKNOWN_ERROR
     if (runner_state not in (JobState.runner_states.WALLTIME_REACHED,
                              JobState.runner_states.MEMORY_LIMIT_REACHED,
+                             JobState.runner_states.JOB_OUTPUT_NOT_RETURNED_FROM_CLUSTER,
                              JobState.runner_states.UNKNOWN_ERROR)):
         # not set or not a handleable runner state
         return


### PR DESCRIPTION
We now set a non-zero exit code to actually set a job to failed.
I believe this is a reasonable action, and it avoids green, empty datasets
with log messages like:
```
galaxy.jobs.runners ERROR 2017-11-14 13:32:06,469 (19020/860246.torque6.curie.fr) Job output not returned from cluster: [Errno 2] No such file or directory: '/data/users/mvandenb/gx
124/tmp_nfs/jwd/019/19020/galaxy_19020.o'
galaxy.jobs.runners DEBUG 2017-11-14 13:32:06,491 (19020/860246.torque6.curie.fr) Unable to cleanup /data/users/mvandenb/gx124/tmp_nfs/jwd/019/19020/galaxy_19020.o: [Errno 2] No suc
h file or directory: '/data/users/mvandenb/gx124/tmp_nfs/jwd/019/19020/galaxy_19020.o'
galaxy.jobs.runners DEBUG 2017-11-14 13:32:06,503 (19020/860246.torque6.curie.fr) Unable to cleanup /data/users/mvandenb/gx124/tmp_nfs/jwd/019/19020/galaxy_19020.e: [Errno 2] No suc
h file or directory: '/data/users/mvandenb/gx124/tmp_nfs/jwd/019/19020/galaxy_19020.e'
galaxy.jobs.runners DEBUG 2017-11-14 13:32:06,513 (19020/860246.torque6.curie.fr) Unable to cleanup /data/users/mvandenb/gx124/tmp_nfs/jwd/019/19020/galaxy_19020.ec: [Errno 2] No su
ch file or directory: '/data/users/mvandenb/gx124/tmp_nfs/jwd/019/19020/galaxy_19020.ec'
```