### PR TITLE
[17.09] Fix exception in admin panel

### DIFF
--- a/lib/tool_shed/galaxy_install/grids/admin_toolshed_grids.py
+++ b/lib/tool_shed/galaxy_install/grids/admin_toolshed_grids.py
@@ -1,5 +1,7 @@
+import json
 import logging
 
+from six import string_types
 from sqlalchemy import false, or_
 
 from galaxy import util
@@ -328,8 +330,15 @@ class RepositoryInstallationGrid(grids.Grid):
 
     def build_initial_query(self, trans, **kwd):
         clause_list = []
-        tool_shed_repository_ids = util.listify(kwd.get('tool_shed_repository_ids', None))
+        tool_shed_repository_ids = kwd.get('tool_shed_repository_ids', None)
         if tool_shed_repository_ids:
+            if isinstance(tool_shed_repository_ids, string_types):
+                try:
+                    # kwd['tool_shed_repository_ids'] may be a json dump of repo ids like u'['aebaa141e7243ebf']'
+                    tool_shed_repository_ids = json.loads(tool_shed_repository_ids)
+                except ValueError:
+                    pass
+            tool_shed_repository_ids = util.listify(tool_shed_repository_ids)
             for tool_shed_repository_id in tool_shed_repository_ids:
                 clause_list.append(self.model_class.table.c.id == trans.security.decode_id(tool_shed_repository_id))
             if clause_list:


### PR DESCRIPTION
```
TypeError: Non-hexadecimal digit found
  File "galaxy/web/framework/middleware/sentry.py", line 40, in __call__
    iterable = self.application(environ, start_response)
  File "/bioinfo/guests/mvandenb/galaxy/.venv/local/lib/python2.7/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "/bioinfo/guests/mvandenb/galaxy/.venv/local/lib/python2.7/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 136, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 215, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/web/framework/decorators.py", line 98, in decorator
    return func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/controllers/admin_toolshed.py", line 660, in manage_repositories
    return self.repository_installation_grid(trans, **kwd)
  File "galaxy/web/framework/helpers/grids.py", line 85, in __call__
    query = self.build_initial_query(trans, **kwargs)
  File "tool_shed/galaxy_install/grids/admin_toolshed_grids.py", line 334, in build_initial_query
    clause_list.append(self.model_class.table.c.id == trans.security.decode_id(tool_shed_repository_id))
  File "galaxy/web/security/__init__.py", line 107, in decode_id
    return int(id_cipher.decrypt(obj_id.decode('hex')).lstrip("!"))
  File "encodings/hex_codec.py", line 42, in hex_decode
    output = binascii.a2b_hex(input)
```

This is due to `tool_shed_repository_ids` being a json dump of a list
in certain conditions (noticed this after installing a new repository).