### PR TITLE
[17.09] Always fill `message` to avoid KeyError for sentry ERROR_TEMPLATE

### DIFF
--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -56,8 +56,7 @@ class SentryPlugin(ErrorPlugin):
                 extra['email'] = unicodify(kwargs['email'])
 
             # User submitted message
-            if 'message' in kwargs:
-                extra['message'] = unicodify(kwargs['message'])
+            extra['message'] = unicodify(kwargs.get('message', ''))
 
             # Construct the error message to send to sentry. The first line
             # will be the issue title, everything after that becomes the


### PR DESCRIPTION
Otherwise I'm seeing 
```
KeyError: u'message'
  File "galaxy/tools/error_reports/__init__.py", line 58, in submit_report
    response = plugin.submit_report(dataset, job, tool, **kwargs)
  File "galaxy/tools/error_reports/plugins/sentry.py", line 65, in submit_report
    error_message = ERROR_TEMPLATE.format(**extra)
```