### PR TITLE
Attempt to make data manager integration test more robust.

### DIFF
--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -136,12 +136,12 @@ class BaseDatasetPopulator(object):
             self.wait_for_tool_run(history_id, run_response)
         return run_response
 
-    def wait_for_tool_run(self, history_id, run_response):
+    def wait_for_tool_run(self, history_id, run_response, timeout=DEFAULT_TIMEOUT):
         run = run_response.json()
         assert run_response.status_code == 200, run
         job = run["jobs"][0]
-        self.wait_for_job(job["id"])
-        self.wait_for_history(history_id, assert_ok=True)
+        self.wait_for_job(job["id"], timeout=timeout)
+        self.wait_for_history(history_id, assert_ok=True, timeout=timeout)
         return run_response
 
     def wait_for_history(self, history_id, assert_ok=False, timeout=DEFAULT_TIMEOUT):

--- a/test/functional/tools/sample_datatypes_conf.xml
+++ b/test/functional/tools/sample_datatypes_conf.xml
@@ -25,5 +25,6 @@
     <datatype extension="bgzip" type="galaxy.datatypes.binary:Binary" subclass="true" />
     <datatype extension="vcf_bgzip" type="galaxy.datatypes.tabular:VcfGz" display_in_upload="true"/>
     <datatype extension="html" type="galaxy.datatypes.text:Html" mimetype="text/html"/>
+    <datatype extension="data_manager_json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="false"/>
   </registration>
 </datatypes>

--- a/test/integration/test_data_manager_table_reload.py
+++ b/test/integration/test_data_manager_table_reload.py
@@ -4,9 +4,11 @@ import string
 import tempfile
 
 from base import integration_util
-from base.populators import DatasetPopulator
+from base.populators import DatasetPopulator, DEFAULT_TIMEOUT
 from nose.plugins.skip import SkipTest
 
+# Needs a longer timeout because of the conda_auto_install.
+DATA_MANAGER_JOB_TIMEOUT = DEFAULT_TIMEOUT * 3
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 TOOL_SHEDS_CONF = os.path.join(SCRIPT_DIRECTORY, "tool_sheds_conf.xml")
@@ -98,12 +100,12 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase):
                                                                inputs=FETCH_GENOME_DBKEYS_ALL_FASTA_INPUT,
                                                                history_id=history_id,
                                                                assert_ok=False)
-                self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response)
+                self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=DATA_MANAGER_JOB_TIMEOUT)
                 run_response = self.dataset_populator.run_tool(tool_id=SAM_FASTA_ID,
                                                                inputs=SAM_FASTA_INPUT,
                                                                history_id=history_id,
                                                                assert_ok=False)
-                self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response)
+                self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=DATA_MANAGER_JOB_TIMEOUT)
 
     def create_local_user(self):
         """Creates a local user and returns the user id."""


### PR DESCRIPTION
Increase the job timeout - this test fails on Jenkins every now and then and reports the DM job is still queued. I assume this is because of conda_auto_install setting up the requirements for this data manager and the logs seem consistent with that assumption.

I also added data manager json type to the sample so this warning goes away:

```
galaxy.model WARNING 2017-11-30 06:39:59,335 Datatype class not found for extension 'data_manager_json'
```