### PR TITLE
Determine dynamically if an extension corresponds to an unsniffable binary datatype

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -33,7 +33,6 @@ log = logging.getLogger(__name__)
 class Binary(data.Data):
     """Binary data"""
     edam_format = "format_2333"
-    unsniffable_binary_formats = []
 
     @staticmethod
     def register_sniffable_binary_format(data_type, ext, type_class):
@@ -42,11 +41,8 @@ class Binary(data.Data):
 
     @staticmethod
     def register_unsniffable_binary_ext(ext):
-        Binary.unsniffable_binary_formats.append(ext.lower())
-
-    @staticmethod
-    def is_ext_unsniffable(ext):
-        return ext in Binary.unsniffable_binary_formats
+        """Deprecated method."""
+        pass
 
     def set_peek(self, dataset, is_multi_byte=False):
         """Set the peek and blurb text"""
@@ -91,9 +87,6 @@ class Ab1(Binary):
             return dataset.peek
         except Exception:
             return "Binary ab1 sequence file (%s)" % (nice_size(dataset.get_size()))
-
-
-Binary.register_unsniffable_binary_ext("ab1")
 
 
 class Idat(Binary):
@@ -164,9 +157,6 @@ class CompressedArchive(Binary):
             return "Compressed binary file (%s)" % (nice_size(dataset.get_size()))
 
 
-Binary.register_unsniffable_binary_ext("compressed_archive")
-
-
 class CompressedZipArchive(CompressedArchive):
     """
         Class describing an compressed binary file
@@ -189,17 +179,11 @@ class CompressedZipArchive(CompressedArchive):
             return "Compressed zip file (%s)" % (nice_size(dataset.get_size()))
 
 
-Binary.register_unsniffable_binary_ext("zip")
-
-
 class GenericAsn1Binary(Binary):
     """Class for generic ASN.1 binary format"""
     file_ext = "asn1-binary"
     edam_format = "format_1966"
     edam_data = "data_0849"
-
-
-Binary.register_unsniffable_binary_ext("asn1-binary")
 
 
 @dataproviders.decorators.has_dataproviders
@@ -927,9 +911,6 @@ class Scf(Binary):
             return dataset.peek
         except Exception:
             return "Binary scf sequence file (%s)" % (nice_size(dataset.get_size()))
-
-
-Binary.register_unsniffable_binary_ext("scf")
 
 
 class Sff(Binary):

--- a/lib/galaxy/datatypes/msa.py
+++ b/lib/galaxy/datatypes/msa.py
@@ -92,9 +92,6 @@ class HmmerPress(Binary):
         self.add_composite_file('model.hmm.h3p', is_binary=True)
 
 
-Binary.register_unsniffable_binary_ext("hmmpress")
-
-
 class Stockholm_1_0(Text):
     edam_data = "data_0863"
     edam_format = "format_1961"

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -465,6 +465,10 @@ class Registry(object):
                                         if sniffer_class not in sniffer_elem_classes:
                                             self.sniffer_elems.append(elem)
 
+    def is_extension_unsniffable_binary(self, ext):
+        datatype = self.get_datatype_by_extension(ext)
+        return datatype is not None and isinstance(datatype, binary.Binary) and not hasattr(datatype, 'sniff')
+
     def get_datatype_class_by_name(self, name):
         """
         Return the datatype class where the datatype's `type` attribute

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -16,7 +16,6 @@ import zipfile
 from six import text_type
 
 from galaxy import util
-from galaxy.datatypes.binary import Binary
 from galaxy.util import compression_utils
 from galaxy.util.checkers import (
     check_binary,
@@ -478,7 +477,7 @@ def handle_uploaded_dataset_file(filename, datatypes_registry, ext='auto'):
         ext = guess_ext(filename, sniff_order=datatypes_registry.sniff_order)
 
     if check_binary(filename):
-        if not Binary.is_ext_unsniffable(ext) and not datatypes_registry.get_datatype_by_extension(ext).sniff(filename):
+        if not datatypes_registry.is_extension_unsniffable_binary(ext) and not datatypes_registry.get_datatype_by_extension(ext).sniff(filename):
             raise InappropriateDatasetContentError('The binary uploaded file contains inappropriate content.')
     elif check_html(filename):
         raise InappropriateDatasetContentError('The uploaded file contains inappropriate HTML content.')


### PR DESCRIPTION
Remove the need to call `Binary.register_unsniffable_binary_ext()` for each unsniffable binary datatype.

Fix https://github.com/galaxyproject/galaxy/issues/3441 , where the upload of files of a datatype defined in `datatypes_conf.xml` as subclass of an unsniffable binary datatype ended up with "The uploaded binary file contains inappropriate content" because it was not possible to register the subclassed datatype as unsniffable.

Also remove unused `stop_err()` function in upload.py .