### PR TITLE
Test resubmit for dynamic JobDestination structures.

### DIFF
--- a/test/integration/resubmission_dynamic_job_conf.xml
+++ b/test/integration/resubmission_dynamic_job_conf.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<!-- 
+    Slimmed down resubmission_job_conf.xml for testing dynamic resubmission rules.
+-->
+<job_conf>
+    <plugins>
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="2"/>
+        <plugin id="failure_runner" type="runner" load="integration.resubmission_runners:FailsJobRunner" workers="2">
+        </plugin>
+        <plugin id="dynamic" type="runner">
+            <param id="rules_module">integration.resubmission_rules</param>
+        </plugin>
+    </plugins>
+
+    <handlers>
+        <handler id="main"/>
+    </handlers>
+
+    <destinations default="initial_destination">
+        <destination id="initial_destination" runner="dynamic">
+            <param id="type">python</param>
+            <param id="function">dynamic_resubmit_once</param>
+        </destination>
+
+        <!-- Upload destination. -->
+        <destination id="local" runner="local">
+        </destination>
+
+    </destinations>
+
+    <tools>
+        <tool id="upload1" destination="local" resources="upload" />
+    </tools>
+
+</job_conf>

--- a/test/integration/resubmission_rules/rules.py
+++ b/test/integration/resubmission_rules/rules.py
@@ -1,6 +1,20 @@
+from galaxy.jobs import JobDestination
 
 DEFAULT_INITIAL_DESTINATION = "fail_first_try"
 
 
 def initial_destination(resource_params):
     return resource_params.get("initial_destination", None) or DEFAULT_INITIAL_DESTINATION
+
+
+def dynamic_resubmit_once(resource_params):
+    """Build destination that always fails first time and always re-routes to passing destination."""
+    job_destination = JobDestination()
+    # Always fail on the first attempt.
+    job_destination['runner'] = "failure_runner"
+    # Resubmit to a valid destination.
+    job_destination['resubmit'] = [dict(
+        condition="any_failure",
+        destination="local",
+    )]
+    return job_destination

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -7,16 +7,17 @@ from base import integration_util
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 JOB_RESUBMISSION_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_job_conf.xml")
 JOB_RESUBMISSION_DEFAULT_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_default_job_conf.xml")
+JOB_RESUBMISSION_DYNAMIC_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_dynamic_job_conf.xml")
 JOB_RESUBMISSION_JOB_RESOURCES_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_job_resource_parameters_conf.xml")
 
 
 class _BaseResubmissionIntegerationTestCase(integration_util.IntegrationTestCase):
     framework_tool_and_types = True
 
-    def _assert_job_passes(self, resource_parameters):
+    def _assert_job_passes(self, resource_parameters={}):
         self._run_tool_test("simple_constructs", resource_parameters=resource_parameters)
 
-    def _assert_job_fails(self, resource_parameters):
+    def _assert_job_fails(self, resource_parameters={}):
         exception_thrown = False
         try:
             self._run_tool_test("simple_constructs", resource_parameters=resource_parameters)
@@ -115,3 +116,15 @@ class JobResubmissionDefaultIntegrationTestCase(_BaseResubmissionIntegerationTes
 
     def test_default_resubmission(self):
         self._assert_job_passes(resource_parameters={"test_name": "test_default_resubmission"})
+
+
+class JobResubmissionDynamicIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["job_config_file"] = JOB_RESUBMISSION_DYNAMIC_JOB_CONFIG_FILE
+
+    def test_dynamic_resubmission(self):
+        self._assert_job_passes()


### PR DESCRIPTION
Inspired by a question from @erasche.

> also how does resubmit work in the dynamic destination world? I can understand that working in non-dynamic world because you could loop over the existing destinations. But when the destination is generated completely dynamically in response to tool_id + other info?


It seems to just work - though I'm a bit shocked it works with somehow persisting the job destination resubmission criteria (perhaps this is re-generated after failure or perhaps it works only in this test case because it is cached).

If this test is missing something and we do need to work a bit harder to persist the resubmission criteria - I think something like https://github.com/galaxyproject/galaxy/commit/56d93c08e04fe2847a4c5519b54ca8dd8a0c77cc would work - though we should rework that commit a bit a give it a real DB field instead of persisting it with the job destination parameters.