### PR TITLE
[17.05] Fix connecting non-input modules to subworkflow inputs.

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -282,7 +282,7 @@ class SubWorkflowModule( WorkflowModule ):
                     name=name,
                     label=name,
                     multiple=False,
-                    extensions="input",
+                    extensions=["data"],
                     input_type=step_to_input_type[step_type],
                 )
                 inputs.append(input)


### PR DESCRIPTION
Fix thanks to @erasche.

It has been broken since introduced in 16.01 - sorry all. I went to retest this again and it worked for me and then I realized what the problem is - it just happens that the test tools I normally use (cat, head, random lines, etc...) all have the same complete hack of an output type - the one random datatype that will happen to work with non-input modules.

Fixes #1739