### PR TITLE
Resolve broken link for "all workflows"

### DIFF
--- a/client/galaxy/scripts/apps/panels/tool-panel.js
+++ b/client/galaxy/scripts/apps/panels/tool-panel.js
@@ -59,7 +59,7 @@ var ToolPanel = Backbone.View.extend({
         self.$("#internal-workflows").append(
             self._templateAllWorkflow({
                 title: _l("All workflows"),
-                href: "workflow"
+                href: "workflows/list"
             })
         );
         _.each(this.stored_workflow_menu_entries, menu_entry => {


### PR DESCRIPTION
The galaxy flavors which are built on dev branch, have a broken link to workflows within the tool panel, under "All workflows" section. This PR should fix it.