### PR TITLE
Tool-based annotation of out of memory errors.

### DIFF
--- a/lib/galaxy/jobs/error_level.py
+++ b/lib/galaxy/jobs/error_level.py
@@ -8,12 +8,14 @@ class StdioErrorLevel(object):
     LOG = 1
     WARNING = 2
     FATAL = 3
-    MAX = 3
+    FATAL_OOM = 4
+    MAX = 4
     descs = {
         NO_ERROR: 'No error',
         LOG: 'Log',
         WARNING: 'Warning',
         FATAL: 'Fatal error',
+        FATAL_OOM: 'Out of memory error',
     }
 
     @staticmethod

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -143,9 +143,13 @@ class LocalJobRunner(BaseJobRunner):
             return
 
         self._handle_metadata_if_needed(job_wrapper)
+
+        job_destination = job_wrapper.job_destination
+        job_state = JobState(job_wrapper, job_destination)
+        job_state.stop_job = False
         # Finish the job!
         try:
-            job_wrapper.finish(stdout, stderr, exit_code)
+            self._finish_or_resubmit_job(job_state, stdout, stderr, exit_code)
         except Exception:
             log.exception("Job wrapper finish method failed")
             self._fail_job_local(job_wrapper, "Unable to finish job")

--- a/lib/galaxy/tools/parser/util.py
+++ b/lib/galaxy/tools/parser/util.py
@@ -2,26 +2,50 @@ from .interface import ToolStdioExitCode
 from .interface import ToolStdioRegex
 
 
-def error_on_exit_code():
+def error_on_exit_code(out_of_memory_exit_code=None):
+    exit_codes = []
+
+    if out_of_memory_exit_code:
+        exit_code_oom = ToolStdioExitCode()
+        exit_code_oom.range_start = int(out_of_memory_exit_code)
+        exit_code_oom.range_end = int(out_of_memory_exit_code)
+        _set_oom(exit_code_oom)
+        exit_codes.append(exit_code_oom)
+
     exit_code_lower = ToolStdioExitCode()
     exit_code_lower.range_start = float("-inf")
     exit_code_lower.range_end = -1
     _set_fatal(exit_code_lower)
+    exit_codes.append(exit_code_lower)
     exit_code_high = ToolStdioExitCode()
     exit_code_high.range_start = 1
     exit_code_high.range_end = float("inf")
     _set_fatal(exit_code_high)
-    return [exit_code_lower, exit_code_high], []
+    exit_codes.append(exit_code_high)
+    return exit_codes, []
 
 
 def aggressive_error_checks():
     exit_codes, _ = error_on_exit_code()
     # these regexes are processed as case insensitive by default
     regexes = [
+        _oom_regex("MemoryError"),
+        _oom_regex("std::bad_alloc"),
+        _oom_regex("java.lang.OutOfMemoryError"),
+        _oom_regex("Out of memory"),
         _error_regex("exception:"),
         _error_regex("error:")
     ]
     return exit_codes, regexes
+
+
+def _oom_regex(match):
+    regex = ToolStdioRegex()
+    _set_oom(regex)
+    regex.match = match
+    regex.stdout_match = True
+    regex.stderr_match = True
+    return regex
 
 
 def _error_regex(match):
@@ -31,6 +55,11 @@ def _error_regex(match):
     regex.stdout_match = True
     regex.stderr_match = True
     return regex
+
+
+def _set_oom(obj):
+    from galaxy.jobs.error_level import StdioErrorLevel
+    obj.error_level = StdioErrorLevel.FATAL_OOM
 
 
 def _set_fatal(obj):

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -327,9 +327,15 @@ class XmlToolSource(ToolSource):
         detect_errors = None
         if command_el is not None:
             detect_errors = command_el.get("detect_errors")
+
         if detect_errors and detect_errors != "default":
             if detect_errors == "exit_code":
-                return error_on_exit_code()
+                oom_exit_code = None
+                if command_el is not None:
+                    oom_exit_code = command_el.get("oom_exit_code", None)
+                if oom_exit_code is not None:
+                    int(oom_exit_code)
+                return error_on_exit_code(out_of_memory_exit_code=oom_exit_code)
             elif detect_errors == "aggressive":
                 return aggressive_error_checks()
             else:

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -2669,8 +2669,9 @@ If present on the ``command`` tag, this attribute can be one of:
 
 * ``default`` no-op fallback to ``stdio`` tags and erroring on standard error output (for legacy tools).
 * ``exit_code`` error if tool exit code is not 0. (The @jmchilton recommendation).
-* ``aggressive`` error if tool exit code is not 0 or either ``Exception:`` or ``Error:``
-  appears in standard error/output. (The @bgruening recommendation).
+* ``aggressive`` error if tool exit code is not 0 or ``Exception:``, ``Error:``, or
+  various messages related to being out of memory appear in the standard error or output.
+  (The @bgruening recommendation).
 
 For newer tools with ``profile>=16.04``, the default behavior is ``exit_code``.
 Legacy tools default to ``default`` behavior described above (erroring if the tool
@@ -2698,6 +2699,11 @@ deprecated and using the ``$__tool_directory__`` variable is superior.
         <xs:attribute name="detect_errors" type="xs:string">
           <xs:annotation>
             <xs:documentation></xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="oom_exit_code" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Only used if ``detect_errors="exit_code", tells Galaxy the specified exit code indicates an out of memory error. Galaxy instances may be configured to retry such jobs on resources with more memory.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="interpreter" type="xs:string" gxdocs:deprecated="true">
@@ -4838,9 +4844,11 @@ The following is an example of the <exit_code> tag:
 
 ```xml
 <stdio>
-    <exit_code range="2"   level="fatal"   description="Out of Memory" />
     <exit_code range="3:5" level="warning" description="Low disk space" />
     <exit_code range="6:"  level="fatal"   description="Bad input dataset" />
+    <!-- Catching fatal_oom allows the job runner to potentially resubmit to a resource with more
+         memory if Galaxy is configured to do this. -->
+    <exit_code range="2"   level="fatal_oom"   description="Out of Memory" />
 </stdio>
 ```
 
@@ -4912,6 +4920,12 @@ The following is an example of regular expressions that may be used:
            source="stdout"
            level="fatal"
            description="Unknown error encountered" />
+    <!-- Catching fatal_oom allows the job runner to potentially resubmit to a resource with more
+         memory if Galaxy is configured to do this. -->
+    <regex match="out of memory"
+           source="stdout"
+           level="fatal_oom"
+           description="Out of memory error occurred" />
     <regex match="[CG]{12}"
            description="Fatal error - CG island 12 nts long found" />
     <regex match="^Branch A"

--- a/test/functional/tools/exit_code_oom.xml
+++ b/test/functional/tools/exit_code_oom.xml
@@ -1,0 +1,33 @@
+<tool id="exit_code_oom" name="exit_code_oom">
+    <!-- tool errors out with identified OOM error if less than 10MB are allocated. -->
+    <command detect_errors="exit_code" oom_exit_code="42"><![CDATA[
+        echo 'Hello' > '$out_file1';
+        echo "\$GALAXY_MEMORY_MB";
+        : \${GALAXY_MEMORY_MB:=20};
+        echo "\$GALAXY_MEMORY_MB";
+        if [ "\$GALAXY_MEMORY_MB" -lt 10 ];
+        then
+            exit 42;
+        else
+            exit 0;
+        fi
+    ]]></command>
+    <inputs>
+        <param name="input" type="integer" label="Dummy" value="6" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" />
+    </outputs>
+    <help>
+    </help>
+    <tests>
+        <test>
+            <param name="input" value="5" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="Hello" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -54,6 +54,7 @@
   <tool file="version_command_plain.xml" />
   <tool file="version_command_interpreter.xml" />
   <tool file="version_command_tool_dir.xml" />
+  <tool file="exit_code_oom.xml" />
   <tool file="exit_code_from_file.xml" />
   <tool file="gzipped_inputs.xml" />
   <tool file="output_order.xml" />

--- a/test/integration/resubmission_small_memory_job_conf.xml
+++ b/test/integration/resubmission_small_memory_job_conf.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<job_conf>
+    <plugins>
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="2"/>
+    </plugins>
+
+    <handlers>
+        <handler id="main"/>
+    </handlers>
+
+    <destinations default="local_too_small">
+        <destination id="local_too_small" runner="local">
+            <env id="GALAXY_MEMORY_MB">4</env>
+        </destination>
+    </destinations>
+
+</job_conf>

--- a/test/integration/resubmission_small_memory_resubmission_to_large_job_conf.xml
+++ b/test/integration/resubmission_small_memory_resubmission_to_large_job_conf.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<job_conf>
+    <plugins>
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="2"/>
+    </plugins>
+
+    <handlers>
+        <handler id="main"/>
+    </handlers>
+
+    <destinations default="local_too_small">
+        <destination id="local_too_small" runner="local">
+            <env id="GALAXY_MEMORY_MB">4</env>
+            <resubmit condition="memory_limit_reached" destination="local_more_memory" />
+        </destination>
+
+        <destination id="local_more_memory" runner="local">
+            <env id="GALAXY_MEMORY_MB">40</env>
+        </destination>
+    </destinations>
+
+</job_conf>

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -8,6 +8,8 @@ SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 JOB_RESUBMISSION_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_job_conf.xml")
 JOB_RESUBMISSION_DEFAULT_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_default_job_conf.xml")
 JOB_RESUBMISSION_DYNAMIC_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_dynamic_job_conf.xml")
+JOB_RESUBMISSION_SMALL_MEMORY_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_small_memory_job_conf.xml")
+JOB_RESUBMISSION_SMALL_MEMORY_RESUBMISSION_TO_LARGE_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_small_memory_resubmission_to_large_job_conf.xml")
 JOB_RESUBMISSION_JOB_RESOURCES_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_job_resource_parameters_conf.xml")
 
 
@@ -15,12 +17,12 @@ class _BaseResubmissionIntegerationTestCase(integration_util.IntegrationTestCase
     framework_tool_and_types = True
 
     def _assert_job_passes(self, resource_parameters={}):
-        self._run_tool_test("simple_constructs", resource_parameters=resource_parameters)
+        self._run_tool_test("exit_code_oom", resource_parameters=resource_parameters)
 
     def _assert_job_fails(self, resource_parameters={}):
         exception_thrown = False
         try:
-            self._run_tool_test("simple_constructs", resource_parameters=resource_parameters)
+            self._run_tool_test("exit_code_oom", resource_parameters=resource_parameters)
         except Exception:
             exception_thrown = True
 
@@ -125,6 +127,28 @@ class JobResubmissionDynamicIntegrationTestCase(_BaseResubmissionIntegerationTes
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         config["job_config_file"] = JOB_RESUBMISSION_DYNAMIC_JOB_CONFIG_FILE
+
+    def test_dynamic_resubmission(self):
+        self._assert_job_passes()
+
+
+# Verify the test tool fails if only a small amount of memory is allocated.
+class JobResubmissionSmallMemoryIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["job_config_file"] = JOB_RESUBMISSION_SMALL_MEMORY_JOB_CONFIG_FILE
+
+    def test_dynamic_resubmission(self):
+        self._assert_job_fails()
+
+
+# Verify the test tool fails if only a small amount of memory is allocated.
+class JobResubmissionSmallMemoryResubmitsToLargeIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["job_config_file"] = JOB_RESUBMISSION_SMALL_MEMORY_RESUBMISSION_TO_LARGE_JOB_CONFIG_FILE
 
     def test_dynamic_resubmission(self):
         self._assert_job_passes()

--- a/test/unit/jobs/test_job_output_checker.py
+++ b/test/unit/jobs/test_job_output_checker.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from galaxy.jobs.error_level import StdioErrorLevel
-from galaxy.jobs.output_checker import check_output
+from galaxy.jobs.output_checker import check_output, DETECTED_JOB_STATE
 from galaxy.model import Job
 from galaxy.tools.parser.interface import ToolStdioRegex
 from galaxy.util.bunch import Bunch
@@ -87,10 +87,10 @@ class OutputCheckerTestCase(TestCase):
         self.tool.stdio_regexes.append(regex)
 
     def __assertSuccessful(self):
-        self.assertTrue(self.__check_output())
+        assert self.__check_output() == DETECTED_JOB_STATE.OK
 
     def __assertNotSuccessful(self):
-        self.assertFalse(self.__check_output())
+        assert self.__check_output() != DETECTED_JOB_STATE.OK
 
     def __check_output(self):
         return check_output(self.tool, self.stdout, self.stderr, self.tool_exit_code, self.job)

--- a/test/unit/jobs/test_runner_local.py
+++ b/test/unit/jobs/test_runner_local.py
@@ -156,6 +156,9 @@ class MockJobWrapper(object):
             build_dependency_shell_commands=lambda: []
         )
 
+    def check_tool_output(*args, **kwds):
+        return "ok"
+
     def wait_for_external_id(self):
         """Test method for waiting til an external id has been registered."""
         external_id = None
@@ -203,7 +206,7 @@ class MockJobWrapper(object):
         self.fail_message = message
         self.fail_exception = exception
 
-    def finish(self, stdout, stderr, exit_code):
+    def finish(self, stdout, stderr, exit_code, **kwds):
         self.stdout = stdout
         self.stderr = stderr
         self.exit_code = exit_code

--- a/test/unit/tools/test_parsing.py
+++ b/test/unit/tools/test_parsing.py
@@ -244,7 +244,8 @@ class XmlLoaderTestCase(BaseLoaderTestCase):
         """)
         exit, regexes = tool_source.parse_stdio()
         assert len(exit) == 2, exit
-        assert len(regexes) == 2, regexes
+        # error:, exception: various memory exception...
+        assert len(regexes) > 2, regexes
 
     def test_sanitize_option(self):
         assert self._tool_source.parse_sanitize() is True


### PR DESCRIPTION
- Update explicit ``stdio`` definitions as well as detect_errors-based definitions to allow this.
  - If ``detect_errors="exit_code"`` is set, an extra attribute ``oom_exit_code`` can be defined on the same command block.
  - If ``detect_errors='aggressive"`` is set, Galaxy will now look for newer strings indicating common memory problems. (Do we need to restrict this to just newer profile version tools for greater reproducibility or do we want to catch more errors on older tools?).
- Update runner code to allow resubmission in such cases (and other tool errors).

Fixes #3320
Implements #3107
