### PR TITLE
Fixes genome decode handling.  

### DIFF
--- a/lib/galaxy/visualization/genomes.py
+++ b/lib/galaxy/visualization/genomes.py
@@ -4,6 +4,7 @@ import re
 import sys
 from json import loads
 
+import six
 from bx.seq.twobit import TwoBitFile
 
 from galaxy.util.bunch import Bunch
@@ -26,7 +27,7 @@ messages = Bunch(
 
 def decode_dbkey(dbkey):
     """ Decodes dbkey and returns tuple ( username, dbkey )"""
-    if isinstance(dbkey, basestring) and ':' in dbkey:
+    if isinstance(dbkey, six.string_types) and ':' in dbkey:
         return dbkey.split(':')
     else:
         return None, dbkey

--- a/lib/galaxy/visualization/genomes.py
+++ b/lib/galaxy/visualization/genomes.py
@@ -26,7 +26,7 @@ messages = Bunch(
 
 def decode_dbkey(dbkey):
     """ Decodes dbkey and returns tuple ( username, dbkey )"""
-    if isinstance(dbkey, str) and ':' in dbkey:
+    if isinstance(dbkey, basestring) and ':' in dbkey:
         return dbkey.split(':')
     else:
         return None, dbkey


### PR DESCRIPTION
`dbkey` is either unicode or str here variously, and the previous change in https://github.com/galaxyproject/galaxy/commit/daa973a5d9e47cb9cc92dd8b83823fe8be7f7f52 broke the case where it was unicode.