### PR TITLE
Re-organize edge case upload options for my own understanding.

### DIFF
--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -448,7 +448,7 @@ def create_paramfile(trans, uploaded_datasets):
                         auto_decompress=getattr(uploaded_dataset, "auto_decompress", True),
                         purge_source=purge_source,
                         space_to_tab=uploaded_dataset.space_to_tab,
-                        in_place=trans.app.config.external_chown_script is None,
+                        run_as_real_user=trans.app.config.external_chown_script is None,
                         check_content=trans.app.config.check_upload_content,
                         path=uploaded_dataset.path)
             # TODO: This will have to change when we start bundling inputs.


### PR DESCRIPTION
I think setting each of these variables once and simplifying the context they are used in (in the case of purge_upload) makes it more clear what each variable is and how it is set. I also think one, more detailed comment for each variable helps.

Note: ~This will break run-as-user uploads started prior to the upgrade to 18.XX and executed after the upgrade. It is a small switch to restore the old behavior but I'm not sure it is worth the complexity it adds to the file.~ Added the fix - this shouldn't be a problem for deployers.

Ping @mvdbeek - you are the one who understands these run-as-real-user options the best based on #4539. Does this new organization make sense to you - does it look functionally equivalent to the previous way things were working?
