### PR TITLE
Removed Yahoo OpenID support

### DIFF
--- a/config/openid_conf.xml.sample
+++ b/config/openid_conf.xml.sample
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <openid>
     <provider file="genomespace.xml" />
-    <provider file="yahoo.xml" />
     <provider file="aol.xml" />
     <provider file="launchpad.xml" />
 </openid>

--- a/openid/yahoo.xml
+++ b/openid/yahoo.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0"?>
-<provider id="yahoo" name="Yahoo!">
-    <op_endpoint_url>http://openid.yahoo.com</op_endpoint_url>
-</provider>


### PR DESCRIPTION
Yahoo has deprecated its OpenID support (https://openid.yahoo.com & https://me.yahoo.com). Therefore, I removed Yahoo OpenID urls and provider from config. 

We're working on the newer technologies, OpenID Connect and OAuth2.0 (see PR #4474 and [this branch](https://github.com/VJalili/galaxy/tree/psaAlpha)), which will largely replace OpenID support.