### PR TITLE
Library Upload Refactoring, Testing, and Fixes

### DIFF
--- a/test/api/test_configuration.py
+++ b/test/api/test_configuration.py
@@ -29,7 +29,7 @@ class ConfigurationApiTestCase(api.ApiTestCase):
 
     def setUp(self):
         super(ConfigurationApiTestCase, self).setUp()
-        self.library_populator = LibraryPopulator(self)
+        self.library_populator = LibraryPopulator(self.galaxy_interactor)
 
     def test_normal_user_configuration(self):
         config = self._get_configuration()

--- a/test/api/test_history_contents.py
+++ b/test/api/test_history_contents.py
@@ -22,7 +22,7 @@ class HistoryContentsApiTestCase(api.ApiTestCase, TestsDatasets):
         self.history_id = self._new_history()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
-        self.library_populator = LibraryPopulator(self)
+        self.library_populator = LibraryPopulator(self.galaxy_interactor)
 
     def test_index_hda_summary(self):
         hda1 = self._new_dataset(self.history_id)

--- a/test/api/test_libraries.py
+++ b/test/api/test_libraries.py
@@ -13,7 +13,7 @@ class LibrariesApiTestCase(api.ApiTestCase, TestsDatasets):
         super(LibrariesApiTestCase, self).setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
-        self.library_populator = LibraryPopulator(self)
+        self.library_populator = LibraryPopulator(self.galaxy_interactor)
 
     def test_create(self):
         data = dict(name="CreateTestLibrary")

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -259,7 +259,7 @@ class ToolsTestCase(api.ApiTestCase):
     @skip_without_tool("library_data")
     def test_library_data_param(self):
         with self.dataset_populator.test_history() as history_id:
-            ld = LibraryPopulator(self).new_library_dataset("lda_test_library")
+            ld = LibraryPopulator(self.galaxy_interactor).new_library_dataset("lda_test_library")
             inputs = {
                 "library_dataset": ld["ldda_id"],
                 "library_dataset_multiple": [ld["ldda_id"], ld["ldda_id"]]

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -34,6 +34,7 @@ from base.constants import (
 )
 from base.populators import (
     DatasetPopulator,
+    LibraryPopulator,
     skip_without_datatype,
 )
 
@@ -49,6 +50,7 @@ class BaseUploadContentConfigurationTestCase(integration_util.IntegrationTestCas
     def setUp(self):
         super(BaseUploadContentConfigurationTestCase, self).setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.library_populator = LibraryPopulator(self.galaxy_interactor)
         self.history_id = self.dataset_populator.new_history()
 
 
@@ -85,6 +87,12 @@ class NonAdminsCannotPasteFilePathTestCase(BaseUploadContentConfigurationTestCas
         # the newer API decorator that handles those details.
         assert create_response.status_code >= 400
 
+    def test_disallowed_for_libraries(self):
+        library = self.library_populator.new_private_library("pathpastedisallowedlibraries")
+        payload, files = self.library_populator.create_dataset_request(library, upload_option="upload_paths", paths="%s/1.txt" % TEST_DATA_DIRECTORY)
+        response = self.library_populator.raw_library_contents_create(library["id"], payload, files=files)
+        assert response.status_code == 403, response.json()
+
 
 class AdminsCanPasteFilePathsTestCase(BaseUploadContentConfigurationTestCase):
 
@@ -99,9 +107,15 @@ class AdminsCanPasteFilePathsTestCase(BaseUploadContentConfigurationTestCase):
             self.history_id, 'file://%s/random-file' % TEST_DATA_DIRECTORY,
         )
         create_response = self._post("tools", data=payload)
-        # Ideally this would be 403 but the tool API endpoint isn't using
-        # the newer API decorator that handles those details.
+        # Is admin - so this should work fine!
         assert create_response.status_code == 200
+
+    def test_admin_path_paste_libraries(self):
+        library = self.library_populator.new_private_library("pathpasteallowedlibraries")
+        payload, files = self.library_populator.create_dataset_request(library, upload_option="upload_paths", paths="%s/1.txt" % TEST_DATA_DIRECTORY)
+        response = self.library_populator.raw_library_contents_create(library["id"], payload, files=files)
+        # Was 403 for non-admin above.
+        assert response.status_code == 200
 
 
 class DefaultBinaryContentFiltersTestCase(BaseUploadContentConfigurationTestCase):
@@ -414,3 +428,45 @@ class UploadOptionsFtpUploadConfigurationTestCase(BaseFtpUploadConfigurationTest
 
     def _write_user_ftp_file(self, path, content):
         return self._write_ftp_file(os.path.join(self.ftp_dir(), TEST_USER), content, filename=path)
+
+
+class ServerDirectoryOffByDefaultTestCase(BaseUploadContentConfigurationTestCase):
+
+    require_admin_user = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["library_import_dir"] = None
+
+    def test_server_dir_uploads_403_if_dir_not_set(self):
+        library = self.library_populator.new_private_library("serverdiroffbydefault")
+        payload, files = self.library_populator.create_dataset_request(library, upload_option="upload_directory", server_dir="foobar")
+        response = self.library_populator.raw_library_contents_create(library["id"], payload, files=files)
+        assert response.status_code == 403, response.json()
+        assert '"library_import_dir" is not set' in response.json()["err_msg"]
+
+
+class ServerDirectoryValidUsageTestCase(BaseUploadContentConfigurationTestCase):
+
+    require_admin_user = True
+
+    def test_valid_server_dir_uploads_okay(self):
+        library = self.library_populator.new_private_library("serverdirupload")
+        # upload $GALAXY_ROOT/test-data/library
+        payload, files = self.library_populator.create_dataset_request(library, upload_option="upload_directory", server_dir="library")
+        response = self.library_populator.raw_library_contents_create(library["id"], payload, files=files)
+        assert response.status_code == 200, response.json()
+
+
+class ServerDirectoryRestrictedToAdminsUsageTestCase(BaseUploadContentConfigurationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["user_library_import_dir"] = None
+
+    def test_library_import_dir_not_available_to_non_admins(self):
+        # same test case above works for admins
+        library = self.library_populator.new_private_library("serverdirupload")
+        payload, files = self.library_populator.create_dataset_request(library, upload_option="upload_directory", server_dir="library")
+        response = self.library_populator.raw_library_contents_create(library["id"], payload, files=files)
+        assert response.status_code == 403, response.json()


### PR DESCRIPTION
- #4908 broke server directory uploading, this adds back in the method that was dropped and is now needed in the library actions code (``_get_server_dir_files``).
- Fix some handling of some error cases so ConfigNotAllowedExceptions are raised and handled by the framework instead of NoneType errors.
- New test cases that cover essentially permission handling for library uploads for admins vs. non-admins with different Galaxy configurations.
- Modify the library contents API to use the newer API decorator - this allows refactoring some option validation code out into methods that can throw exceptions (as opposed to passing ``message`` around) and results in superior JSON exceptions (at least from the API standpoint - does the UI need to be tweaked for this?). I'm reusing these validation methods in my new library folder / collection upload API.
