### PR TITLE
Force window jquery access for charts

### DIFF
--- a/config/plugins/visualizations/charts/templates/charts.mako
+++ b/config/plugins/visualizations/charts/templates/charts.mako
@@ -38,6 +38,8 @@
                 error   : function(){},
                 assert  : function(){}
             };
+            window.jQuery = window.jquery = window.$;
+            define( 'jquery', [], function(){ return window.$; })
             require.config({
                 baseUrl: Galaxy.root + "static/scripts/",
                 paths: {


### PR DESCRIPTION
This isn't great, but charts *and* the rest of the viz framework are being refactored into bundles with correct imports, etc., that will avoid this hackery.

@gregvonkuster Let me know if this doesn't fix it for ya.