### PR TITLE
Mark transiently failing test_run_data as flakey.

### DIFF
--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -471,6 +471,9 @@ class NavigatesGalaxy(HasDriver):
 
         self.upload_queue_local_file(test_path)
 
+        # Having some problems with extension not being set properly.
+        self.sleep_for(WAIT_TYPES.UX_RENDER)
+
         if ext is not None:
             self.wait_for_selector_visible('.upload-extension')
             self.select2_set_value(".upload-extension", ext)

--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -471,9 +471,6 @@ class NavigatesGalaxy(HasDriver):
 
         self.upload_queue_local_file(test_path)
 
-        # Having some problems with extension not being set properly.
-        self.sleep_for(WAIT_TYPES.UX_RENDER)
-
         if ext is not None:
             self.wait_for_selector_visible('.upload-extension')
             self.select2_set_value(".upload-extension", ext)

--- a/test/selenium_tests/test_tool_form.py
+++ b/test/selenium_tests/test_tool_form.py
@@ -1,3 +1,4 @@
+from base.populators import flakey
 from galaxy_selenium.navigates_galaxy import retry_call_during_transitions
 
 from .framework import (
@@ -84,13 +85,16 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.history_panel_wait_for_hid_ok(2)
         self._check_dataset_details_for_inttest_value(2)
 
+    @flakey
     @selenium_test
     def test_run_data(self):
         test_path = self.get_filename("1.fasta")
         test_path_decoy = self.get_filename("1.txt")
+        # Upload form posts bad data if executed two times in a row like this, so
+        # wait between uploads. xref https://github.com/galaxyproject/galaxy/issues/5169
         self.perform_upload(test_path)
-        self.perform_upload(test_path_decoy)
         self.history_panel_wait_for_hid_ok(1)
+        self.perform_upload(test_path_decoy)
         self.history_panel_wait_for_hid_ok(2)
 
         self.home()


### PR DESCRIPTION
I do think it is a UI bug that the tool form is posting bad data in this case, but it shouldn't break everyone's PRs. I rearranged the uploads so they don't happen back-to-back hopefully that will help also.

xref https://github.com/galaxyproject/galaxy/issues/5169