### PR TITLE
Allow shell plugins with different parameters to co-exist

### DIFF
--- a/lib/galaxy/jobs/runners/util/cli/__init__.py
+++ b/lib/galaxy/jobs/runners/util/cli/__init__.py
@@ -1,5 +1,6 @@
 """
 """
+import json
 from glob import glob
 from os import getcwd
 from os.path import (
@@ -56,9 +57,10 @@ class CliInterface(object):
 
     def get_shell_plugin(self, shell_params):
         shell_plugin = shell_params.get('plugin', DEFAULT_SHELL_PLUGIN)
-        if shell_plugin not in self.active_cli_shells:
-            self.active_cli_shells[shell_plugin] = self.cli_shells[shell_plugin](**shell_params)
-        return self.active_cli_shells[shell_plugin]
+        requested_shell_settings = json.dumps(shell_params, sort_keys=True)
+        if requested_shell_settings not in self.active_cli_shells:
+            self.active_cli_shells[requested_shell_settings] = self.cli_shells[shell_plugin](**shell_params)
+        return self.active_cli_shells[requested_shell_settings]
 
     def get_job_interface(self, job_params):
         job_plugin = job_params.get('plugin', None)

--- a/lib/galaxy/jobs/runners/util/cli/shell/rsh.py
+++ b/lib/galaxy/jobs/runners/util/cli/shell/rsh.py
@@ -3,8 +3,8 @@ import time
 
 import paramiko
 
+from galaxy.util.bunch import Bunch
 from .local import LocalShell
-from ....util import Bunch
 
 log = logging.getLogger(__name__)
 logging.getLogger("paramiko").setLevel(logging.WARNING)  # paramiko logging is very verbose


### PR DESCRIPTION
I broke this in https://github.com/galaxyproject/galaxy/pull/4358 by re-using shell plugin instances. I'm not sure this warrants a backport, but let me know if you disagree.

Also addresses @jmchilton's [comment](https://github.com/galaxyproject/galaxy/pull/4358#discussion_r131740463) in the original PR.