### PR TITLE
Python3: fix list.sort() and sorted() to use `key` parameter instead of `cmp`

### DIFF
--- a/lib/galaxy/tools/parameters/history_query.py
+++ b/lib/galaxy/tools/parameters/history_query.py
@@ -21,7 +21,7 @@ class HistoryQuery(object):
             # (until we expose it to the user) will default to providing tool as much
             # data as possible. So a list:list:paired mapped to a tool that takes
             # list,paired,list:paired - will map over list:paired and create a flat list.
-            collection_type_descriptions = sorted(collection_type_descriptions, lambda t: t.dimension, reverse=True)
+            collection_type_descriptions = sorted(collection_type_descriptions, key=lambda t: t.dimension, reverse=True)
         else:
             collection_type_descriptions = None
 

--- a/lib/galaxy/webapps/reports/controllers/history.py
+++ b/lib/galaxy/webapps/reports/controllers/history.py
@@ -54,6 +54,7 @@ class History(BaseUIController):
         sort_by = kwd.get('sorting', 'User')
         sorting = 0 if sort_by == 'User' else 1 if sort_by == "HSort" else 2 if sort_by == "DSort" else 3
         descending = 1 if kwd.get('descending', 'desc') == 'desc' else -1
+        reverse = descending == 1
 
         # select count (h.id) as history, u.email as email
         # from history h, galaxy_user u
@@ -94,18 +95,18 @@ class History(BaseUIController):
         datasets = dict([(_.email if _.email is not None else "Unknown", (int(_.dataset), int(_.size)))
                          for _ in datasets.execute()])
 
-        sorting_functions = [
-            lambda first, second: descending if first[0].lower() > second[0].lower() else -descending,
-            lambda first, second: descending if histories.get(first, 0) < histories.get(second, 0) else -descending,
-            lambda first, second: descending if datasets.get(first, [0])[0] < datasets.get(second, [0])[0] else -descending,
-            lambda first, second: descending if datasets.get(first, [0, 0])[1] < datasets.get(second, [0, 0])[1] else -descending
-        ]
+        sort_keys = (
+            lambda v: v[0].lower(),
+            lambda v: histories.get(v, 0),
+            lambda v: datasets.get(v, [0])[0],
+            lambda v: datasets.get(v, [0][0])[1]
+        )
 
         # fetch all users
         users = list(set(histories.keys()) | set(datasets.keys()))
 
         # sort users depending on sort function, defined by user choices
-        users.sort(sorting_functions[sorting])
+        users.sort(key=sort_keys[sorting], reverse=reverse)
         if user_cutoff > 0:
             users = users[:user_cutoff]
 
@@ -133,6 +134,7 @@ class History(BaseUIController):
         message = escape(util.restore_text(kwd.get('message', '')))
         user_cutoff = int(kwd.get('user_cutoff', 60))
         descending = 1 if kwd.get('descending', 'desc') == 'desc' else -1
+        reverse = descending == 1
         user_selection = kwd.get('user_selection', None)
 
         # select d.state, h.name
@@ -159,7 +161,7 @@ class History(BaseUIController):
                 for _ in histories.execute()]
 
         # sort by names descending or ascending
-        data.sort(lambda first, second: descending if first[0].lower() > second[0].lower() else -descending)
+        data.sort(key=lambda v: v[0].lower(), reverse=reverse)
 
         # fetch names in the first list and status in the second
         if data:

--- a/lib/galaxy/webapps/reports/controllers/users.py
+++ b/lib/galaxy/webapps/reports/controllers/users.py
@@ -195,9 +195,11 @@ class Users(BaseUIController, ReportQueryBuilder):
         user_cutoff = int(kwd.get('user_cutoff', 60))
         sorting = 0 if kwd.get('sorting', 'User') == 'User' else 1
         descending = 1 if kwd.get('descending', 'desc') == 'desc' else -1
-        sorting_functions = [
-            lambda first, second: descending if first[0].lower() > second[0].lower() else -descending,
-            lambda first, second: descending if first[1] < second[1] else -descending]
+        reverse = descending == 1
+        sort_keys = (
+            lambda v: v[0].lower(),
+            lambda v: v[1]
+        )
 
         req = sa.select(
             (sa.func.count(galaxy.model.History.table.c.id).label('history'),
@@ -208,7 +210,7 @@ class Users(BaseUIController, ReportQueryBuilder):
             order_by=[sa.desc('username'), 'history'])
 
         histories = [(_.username if _.username is not None else "Unknown", _.history) for _ in req.execute()]
-        histories.sort(sorting_functions[sorting])
+        histories.sort(key=sort_keys[sorting], reverse=reverse)
         if user_cutoff != 0:
             histories = histories[:user_cutoff]
 


### PR DESCRIPTION
xref. https://github.com/galaxyproject/galaxy/issues/1715
xref. https://github.com/galaxyproject/galaxy/issues/5216