### PR TITLE
#5187: altered conda version number for using '--offline' option again

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -530,7 +530,7 @@ def build_isolated_environment(
         # - https://github.com/galaxyproject/galaxy/issues/3635
         # - https://github.com/conda/conda/issues/2035
         offline_works = (conda_context.conda_version < LooseVersion("4.3")) or \
-                        (conda_context.conda_version >= LooseVersion("4.3.18"))
+                        (conda_context.conda_version >= LooseVersion("4.4"))
         if offline_works:
             create_args.extend(["--offline"])
         else:


### PR DESCRIPTION
In order to get rid of the conda error described in #5187 I raised the version number, from which conda is allowed to use the '--offline' parameter again, to "4.4" (according to the post of @nsoranzo in #5187).

Annotation:
It seems that a galaxy instance in which the mentioned conda error was raised once may be damaged. After altering the file 'conda_util.py' in an old galaxy instance we still got problems e.g. in starting workflows (first job in workflow started, all the following jobs in the chain immediately went to red color and were aborted).

So I suggest to test this workaround (changed from @natefoo's version in #4701) in newly installed galaxy instances right after cloning fom git and BEFORE first startup. For us this seems to work fine so far. 
