### PR TITLE
Fix and enhance job resume functionality

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1030,6 +1030,7 @@ class JobWrapper(object, HasResourceParameters):
                 dataset_assoc.dataset.dataset.state = dataset_assoc.dataset.dataset.states.PAUSED
                 dataset_assoc.dataset.info = message
                 self.sa_session.add(dataset_assoc.dataset)
+            log.debug("Pausing Job '%d', %s", job.id, message)
             job.set_state(job.states.PAUSED)
             self.sa_session.add(job)
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3139,6 +3139,13 @@ class DatasetCollection(object, Dictifiable, UsesAnnotations):
         object_session(self).flush()
         return new_collection
 
+    def replace_failed_elements(self, replacements):
+        for element in self.elements:
+            if element.element_object in replacements:
+                if element.element_type == 'hda':
+                    element.hda = replacements[element.element_object]
+                # TODO: handle the case where elements are collections
+
     def set_from_dict(self, new_data):
         # Nothing currently editable in this class.
         return {}

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -8,7 +8,7 @@ from six import string_types
 from galaxy import model
 from galaxy.exceptions import ObjectInvalid
 from galaxy.model import LibraryDatasetDatasetAssociation
-from galaxy.tools.parameters import update_param
+from galaxy.tools.parameters import update_dataset_ids
 from galaxy.tools.parameters.basic import DataCollectionToolParameter, DataToolParameter, RuntimeValue
 from galaxy.tools.parameters.wrapped import WrappedParameters
 from galaxy.util import ExecutionTimer
@@ -474,7 +474,9 @@ class DefaultToolAction(object):
                                     hda.state = hda.states.NEW
                                     hda.info = None
                             input_values = dict([(p.name, json.loads(p.value)) for p in job_to_remap.parameters])
-                            update_param(jtid.name, input_values, str(out_data[jtod.name].id))
+                            old_dataset_id = jtod.dataset_id
+                            new_dataset_id = out_data[jtod.name].id
+                            input_values = update_dataset_ids(input_values, {old_dataset_id: new_dataset_id}, src='hda')
                             for p in job_to_remap.parameters:
                                 p.value = json.dumps(input_values[p.name])
                             jtid.dataset = out_data[jtod.name]

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -275,19 +275,19 @@ class BaseDatasetPopulator(object):
         data = {}
         if filename:
             data["filename"] = filename
-        display_response = self.__get_contents_request(history_id, "/%s/display" % dataset_id, data=data)
+        display_response = self._get_contents_request(history_id, "/%s/display" % dataset_id, data=data)
         assert display_response.status_code == 200, display_response.content
         return display_response.content
 
     def get_history_dataset_details(self, history_id, **kwds):
         dataset_id = self.__history_content_id(history_id, **kwds)
-        details_response = self.__get_contents_request(history_id, "/datasets/%s" % dataset_id)
+        details_response = self._get_contents_request(history_id, "/datasets/%s" % dataset_id)
         assert details_response.status_code == 200
         return details_response.json()
 
     def get_history_collection_details(self, history_id, **kwds):
         hdca_id = self.__history_content_id(history_id, **kwds)
-        details_response = self.__get_contents_request(history_id, "/dataset_collections/%s" % hdca_id)
+        details_response = self._get_contents_request(history_id, "/dataset_collections/%s" % hdca_id)
         assert details_response.status_code == 200, details_response.content
         return details_response.json()
 
@@ -320,7 +320,7 @@ class BaseDatasetPopulator(object):
             history_content_id = kwds["dataset"]["id"]
         else:
             hid = kwds.get("hid", None)  # If not hid, just grab last dataset
-            history_contents = self.__get_contents_request(history_id).json()
+            history_contents = self._get_contents_request(history_id).json()
             if hid:
                 history_content_id = None
                 for history_item in history_contents:
@@ -333,7 +333,7 @@ class BaseDatasetPopulator(object):
                 history_content_id = history_contents[-1]["id"]
         return history_content_id
 
-    def __get_contents_request(self, history_id, suffix="", data={}):
+    def _get_contents_request(self, history_id, suffix="", data={}):
         url = "histories/%s/contents" % history_id
         if suffix:
             url = "%s%s" % (url, suffix)

--- a/test/functional/tools/fail_identifier.xml
+++ b/test/functional/tools/fail_identifier.xml
@@ -1,0 +1,21 @@
+<tool id="fail_identifier" name="Fail input with identifier that contains fail">
+    <command><![CDATA[
+        #if $failbool and 'fail' in $input1.element_identifier
+            sh -c "exit 127"
+        #else
+            cp '$input1' '$out_file1'
+        #end if
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" label="An input file" />
+        <param name="failbool" type="boolean" label="The failure property" checked="false" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="data"/>
+    </outputs>
+    <stdio>
+        <exit_code range="127"   level="fatal"   description="Failing exit code." />
+    </stdio>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/job_properties.xml
+++ b/test/functional/tools/job_properties.xml
@@ -1,26 +1,32 @@
 <tool id="job_properties" name="Test Job Properties">
-    <command>
+    <command><![CDATA[
         #if $thebool
-            echo "The bool is true";
-            echo "The bool is really true" 1>&amp;2;
-            echo "This is a line of text." > $out_file1
+            echo "The bool is true" &&
+            echo "The bool is really true" 1>&2 &&
+            echo "This is a line of text." > '$out_file1' &&
+            cp '$out_file1' $one &&
+            cp '$out_file1' $two
         #else
-            echo "The bool is not true";
-            echo "The bool is very not true" 1>&amp;2;
-            echo "This is a different line of text." > $out_file1;
+            echo "The bool is not true" &&
+            echo "The bool is very not true" 1>&2 &&
+            echo "This is a different line of text." > '$out_file1' &&
             sh -c "exit 2"
         #end if
         #if $failbool
             ; sh -c "exit 127"
         #end if
 
-    </command>
+    ]]></command>
     <inputs>
         <param name="thebool" type="boolean" label="The boolean property" />
         <param name="failbool" type="boolean" label="The failure property" checked="false" />
     </inputs>
     <outputs>
         <data name="out_file1" />
+        <collection name="list_output" type="list" label="A list output">
+            <data name="one" format="txt" />
+            <data name="two" format="txt" />
+        </collection>
     </outputs>
     <stdio>
         <exit_code range="127"   level="fatal"   description="Failing exit code." />

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -96,6 +96,7 @@
   <tool file="identifier_multiple_in_repeat.xml" />
   <tool file="identifier_collection.xml" />
   <tool file="identifier_in_actions.xml" />
+  <tool file="fail_identifier.xml" />
   <tool file="tool_directory.xml" />
   <tool file="output_action_change_format.xml" />
   <tool file="collection_paired_test.xml" />


### PR DESCRIPTION
This should fix https://github.com/galaxyproject/galaxy/issues/5222.

The problem was that HDA ids in nested parameters were not always being updated
properly. In the case of bowtie2 the input dataset is provided via a
conditional, but the conditional prefix is not being stored in the
JobToInputDatasetAssociation, and so the `update_param` function was not able
to update the dataset id in these instances.  The approach now is to simply
replace all occurences of the old dataset id with the new dataset id.

The PR includes 2 testcases for this functionality, one for hda input and one for hdca input.

With this PR we also replace failed element of a collection with a job rerun (including a testcase), which fixes #2235.