### PR TITLE
[18.01] Trackster fixes.

### DIFF
--- a/client/galaxy/scripts/utils/config.js
+++ b/client/galaxy/scripts/utils/config.js
@@ -1,6 +1,10 @@
 import * as _ from "libs/underscore";
+import * as Backbone from "libs/backbone";
 import util_mod from "viz/trackster/util";
-import config_mod from "utils/config";
+
+/* global $ */
+/* global Galaxy */
+
 /**
  * A configuration setting. Currently key is used as id.
  */
@@ -307,23 +311,22 @@ var ConfigSettingCollectionView = Backbone.View.extend({
                         // No propagation to avoid triggering document click (and tip hiding) above.
                         e.stopPropagation();
                     });
-
-                var // Icon for setting a new random color; behavior set below.
-                new_color_icon = $("<a href='javascript:void(0)'/>")
+                // Icon for setting a new random color; behavior set below.
+                var new_color_icon = $("<a href='javascript:void(0)'/>")
                     .addClass("icon-button arrow-circle")
                     .appendTo(container_div)
                     .attr("title", "Set new random color")
                     .tooltip();
 
-                var // Color picker in tool tip style.
-                tip = $("<div class='tooltip right' style='position: absolute;' />")
+                // Color picker in tool tip style.
+                var tip = $("<div class='tooltip right' style='position: absolute;' />")
                     .appendTo(container_div)
                     .hide();
 
-                var // Inner div for padding purposes
-                tip_inner = $("<div class='tooltip-inner' style='text-align: inherit'></div>").appendTo(tip);
+                // Inner div for padding purposes
+                var tip_inner = $("<div class='tooltip-inner' style='text-align: inherit'></div>").appendTo(tip);
 
-                var tip_arrow = $("<div class='tooltip-arrow'></div>").appendTo(tip);
+                $("<div class='tooltip-arrow'></div>").appendTo(tip);
 
                 var farb_obj = $.farbtastic(tip_inner, {
                     width: 100,

--- a/client/galaxy/scripts/viz/trackster.js
+++ b/client/galaxy/scripts/viz/trackster.js
@@ -26,32 +26,26 @@ var view = null;
 var browser_router = null;
 
 /**
- * Base Object/Model for inheritance.
- */
-var Base = function() {
-    if (this.initialize) {
-        this.initialize.apply(this, arguments);
-    }
-};
-Base.extend = Backbone.Model.extend;
-
-/**
  * User interface controls for trackster
  */
-var TracksterUI = Base.extend({
-    initialize: function(baseURL) {
+class TracksterUI extends Backbone.Model {
+    constructor(options) {
+        super(options);
+    }
+
+    initialize(baseURL) {
+        this.baseURL = baseURL;
         mod_utils.cssLoadFile("static/style/jquery.rating.css");
         mod_utils.cssLoadFile("static/style/autocomplete_tagging.css");
         mod_utils.cssLoadFile("static/style/jquery-ui/smoothness/jquery-ui.css");
         mod_utils.cssLoadFile("static/style/library.css");
         mod_utils.cssLoadFile("static/style/trackster.css");
-        this.baseURL = baseURL;
-    },
+    }
 
     /**
      * Save visualization, returning a Deferred object for the remote call to save.
      */
-    save_viz: function() {
+    save_viz() {
         // show dialog
         Galaxy.modal.show({ title: "Saving...", body: "progress" });
 
@@ -115,12 +109,12 @@ var TracksterUI = Base.extend({
                     }
                 });
             });
-    },
+    }
 
     /**
      * Create button menu
      */
-    createButtonMenu: function() {
+    createButtonMenu() {
         var self = this;
 
         var menu = mod_icon_btn.create_icon_buttons_menu(
@@ -184,12 +178,12 @@ var TracksterUI = Base.extend({
 
         this.buttonMenu = menu;
         return menu;
-    },
+    }
 
     /**
      * Add bookmark.
      */
-    add_bookmark: function(position, annotation, editable) {
+    add_bookmark(position, annotation, editable) {
         // Create HTML.
         var bookmarks_container = $("#right .unified-panel-body");
 
@@ -241,12 +235,12 @@ var TracksterUI = Base.extend({
 
         view.has_changes = true;
         return new_bookmark;
-    },
+    }
 
     /**
      * Create a complete Trackster visualization. Returns view.
      */
-    create_visualization: function(view_config, viewport_config, drawables_config, bookmarks_config, editable) {
+    create_visualization(view_config, viewport_config, drawables_config, bookmarks_config, editable) {
         // Create view.
         var self = this;
 
@@ -310,20 +304,20 @@ var TracksterUI = Base.extend({
         this.set_up_router({ view: view });
 
         return view;
-    },
+    }
 
     /**
      * Set up location router to use hashes as track browser locations.
      */
-    set_up_router: function(options) {
+    set_up_router(options) {
         new visualization.TrackBrowserRouter(options);
         Backbone.history.start();
-    },
+    }
 
     /**
      * Set up keyboard navigation for a visualization.
      */
-    init_keyboard_nav: function(view) {
+    init_keyboard_nav(view) {
         // Keyboard navigation. Scroll ~7% of height when scrolling up/down.
         $(document).keyup(e => {
             // Do not navigate if arrow keys used in input element.
@@ -349,12 +343,12 @@ var TracksterUI = Base.extend({
                     break;
             }
         });
-    },
+    }
 
     /**
      * Handle unsaved changes in visualization.
      */
-    handle_unsaved_changes: function(view) {
+    handle_unsaved_changes(view) {
         if (view.has_changes) {
             var self = this;
             Galaxy.modal.show({
@@ -379,11 +373,14 @@ var TracksterUI = Base.extend({
             window.location = `${Galaxy.root}visualization`;
         }
     }
-});
+}
 
-var TracksterView = Backbone.View.extend({
+class TracksterView extends Backbone.View {
+    constructor(options) {
+        super(options);
+    }
     // initalize trackster
-    initialize: function() {
+    initialize() {
         // load ui
         ui = new TracksterUI(Galaxy.root);
 
@@ -418,10 +415,9 @@ var TracksterView = Backbone.View.extend({
         } else {
             this.view_new();
         }
-    },
+    }
 
-    choose_existing_or_new: function() {
-        var self = this;
+    choose_existing_or_new() {
         var dbkey = query_string.get("dbkey");
         var listTracksParams = {};
 
@@ -442,21 +438,21 @@ var TracksterView = Backbone.View.extend({
             body: `<p><ul style='list-style: disc inside none'>You can add this dataset as:<li>a new track to one of your existing, saved Trackster sessions if they share the genome build: <b>${dbkey ||
                 "Not available."}</b></li><li>or create a new session with this dataset as the only track</li></ul></p>`,
             buttons: {
-                Cancel: function() {
+                Cancel: () => {
                     window.location = `${Galaxy.root}visualizations/list`;
                 },
-                "View in saved visualization": function() {
-                    self.view_in_saved(dataset_params);
+                "View in saved visualization": () => {
+                    this.view_in_saved(dataset_params);
                 },
-                "View in new visualization": function() {
-                    self.view_new();
+                "View in new visualization": () => {
+                    this.view_new();
                 }
             }
         });
-    },
+    }
 
     // view
-    view_in_saved: function(dataset_params) {
+    view_in_saved(dataset_params) {
         var tracks_grid = new GridView({
             url_base: `${Galaxy.root}visualization/list_tracks`,
             embedded: true
@@ -478,10 +474,10 @@ var TracksterView = Backbone.View.extend({
                 }
             }
         });
-    },
+    }
 
     // view
-    view_existing: function() {
+    view_existing() {
         // get config
         var viz_config = window.galaxy_config.app.viz_config;
 
@@ -501,31 +497,28 @@ var TracksterView = Backbone.View.extend({
 
         // initialize editor
         this.init_editor();
-    },
+    }
 
     // view
-    view_new: function() {
-        // reference this
-        var self = this;
-
+    view_new() {
         // ajax
         $.ajax({
             url: `${Galaxy.root}api/genomes?chrom_info=True`,
             data: {},
-            error: function() {
+            error: () => {
                 alert("Couldn't create new browser.");
             },
-            success: function(response) {
+            success: response => {
                 // show dialog
                 Galaxy.modal.show({
                     title: _l("New Visualization"),
-                    body: self.template_view_new(response),
+                    body: this.template_view_new(response),
                     buttons: {
-                        Cancel: function() {
+                        Cancel: () => {
                             window.location = `${Galaxy.root}visualizations/list`;
                         },
-                        Create: function() {
-                            self.create_browser($("#new-title").val(), $("#new-dbkey").val());
+                        Create: () => {
+                            this.create_browser($("#new-title").val(), $("#new-dbkey").val());
                             Galaxy.modal.hide();
                         }
                     }
@@ -548,10 +541,10 @@ var TracksterView = Backbone.View.extend({
                 $("#overlay").css("overflow", "auto");
             }
         });
-    },
+    }
 
     // new browser form
-    template_view_new: function(response) {
+    template_view_new(response) {
         // start template
         var html =
             '<form id="new-browser-form" action="javascript:void(0);" method="post" onsubmit="return false;">' +
@@ -579,10 +572,10 @@ var TracksterView = Backbone.View.extend({
 
         // return
         return html;
-    },
+    }
 
     // create
-    create_browser: function(name, dbkey) {
+    create_browser(name, dbkey) {
         $(document).trigger("convert_to_values");
 
         view = ui.create_visualization(
@@ -599,10 +592,10 @@ var TracksterView = Backbone.View.extend({
 
         // modify view setting
         view.editor = true;
-    },
+    }
 
     // initialization for editor-specific functions.
-    init_editor: function() {
+    init_editor() {
         // set title
         $("#center .unified-panel-title").text(`${view.config.get_value("name")} (${view.dbkey})`);
 
@@ -635,7 +628,7 @@ var TracksterView = Backbone.View.extend({
             }
         });
     }
-});
+}
 
 export default {
     TracksterUI: TracksterUI,

--- a/client/galaxy/scripts/viz/trackster.js
+++ b/client/galaxy/scripts/viz/trackster.js
@@ -20,10 +20,7 @@ import "libs/jquery/jquery.form";
 import "libs/jquery/jquery.rating";
 import "ui/editable-text";
 
-// trackster global variables
-var ui = null;
 var view = null;
-var browser_router = null;
 
 /**
  * User interface controls for trackster
@@ -51,7 +48,7 @@ class TracksterUI extends Backbone.Model {
 
         // Save bookmarks.
         var bookmarks = [];
-        $(".bookmark").each(function() {
+        $(".bookmark").each(() => {
             bookmarks.push({
                 position: $(this)
                     .children(".position")
@@ -103,7 +100,7 @@ class TracksterUI extends Backbone.Model {
                     title: _l("Could Not Save"),
                     body: "Could not save visualization. Please try again later.",
                     buttons: {
-                        Cancel: function() {
+                        Cancel: () => {
                             Galaxy.modal.hide();
                         }
                     }
@@ -115,14 +112,12 @@ class TracksterUI extends Backbone.Model {
      * Create button menu
      */
     createButtonMenu() {
-        var self = this;
-
         var menu = mod_icon_btn.create_icon_buttons_menu(
             [
                 {
                     icon_class: "plus-button",
                     title: _l("Add tracks"),
-                    on_click: function() {
+                    on_click: () => {
                         visualization.select_datasets({ dbkey: view.dbkey }, new_tracks => {
                             _.each(new_tracks, track => {
                                 view.add_drawable(tracks.object_from_template(track, view, view));
@@ -133,7 +128,7 @@ class TracksterUI extends Backbone.Model {
                 {
                     icon_class: "block--plus",
                     title: _l("Add group"),
-                    on_click: function() {
+                    on_click: () => {
                         view.add_drawable(
                             new tracks.DrawableGroup(view, view, {
                                 name: "New Group"
@@ -144,7 +139,7 @@ class TracksterUI extends Backbone.Model {
                 {
                     icon_class: "bookmarks",
                     title: _l("Bookmarks"),
-                    on_click: function() {
+                    on_click: () => {
                         // HACK -- use style to determine if panel is hidden and hide/show accordingly.
                         window.force_right_panel($("div#right").css("right") == "0px" ? "hide" : "show");
                     }
@@ -152,22 +147,22 @@ class TracksterUI extends Backbone.Model {
                 {
                     icon_class: "globe",
                     title: _l("Circster"),
-                    on_click: function() {
-                        window.location = `${self.baseURL}visualization/circster?id=${view.vis_id}`;
+                    on_click: () => {
+                        window.location = `${this.baseURL}visualization/circster?id=${view.vis_id}`;
                     }
                 },
                 {
                     icon_class: "disk--arrow",
                     title: _l("Save"),
-                    on_click: function() {
-                        self.save_viz();
+                    on_click: () => {
+                        this.save_viz();
                     }
                 },
                 {
                     icon_class: "cross-circle",
                     title: _l("Close"),
-                    on_click: function() {
-                        self.handle_unsaved_changes(view);
+                    on_click: () => {
+                        this.handle_unsaved_changes(view);
                     }
                 }
             ],
@@ -242,8 +237,6 @@ class TracksterUI extends Backbone.Model {
      */
     create_visualization(view_config, viewport_config, drawables_config, bookmarks_config, editable) {
         // Create view.
-        var self = this;
-
         view = new tracks.TracksterView(_.extend(view_config, { header: false }));
 
         view.editor = true;
@@ -292,7 +285,7 @@ class TracksterUI extends Backbone.Model {
                 var bookmark;
                 for (let i = 0; i < bookmarks_config.length; i++) {
                     bookmark = bookmarks_config[i];
-                    self.add_bookmark(bookmark["position"], bookmark["annotation"], editable);
+                    this.add_bookmark(bookmark["position"], bookmark["annotation"], editable);
                 }
             }
 
@@ -350,20 +343,19 @@ class TracksterUI extends Backbone.Model {
      */
     handle_unsaved_changes(view) {
         if (view.has_changes) {
-            var self = this;
             Galaxy.modal.show({
                 title: _l("Close visualization"),
                 body: "There are unsaved changes to your visualization which will be lost if you do not save them.",
                 buttons: {
-                    Cancel: function() {
+                    Cancel: () => {
                         Galaxy.modal.hide();
                     },
-                    "Leave without Saving": function() {
+                    "Leave without Saving": () => {
                         $(window).off("beforeunload");
                         window.location = `${Galaxy.root}visualization`;
                     },
-                    Save: function() {
-                        $.when(self.save_viz()).then(() => {
+                    Save: () => {
+                        $.when(this.save_viz()).then(() => {
                             window.location = `${Galaxy.root}visualization`;
                         });
                     }
@@ -382,16 +374,16 @@ class TracksterView extends Backbone.View {
     // initalize trackster
     initialize() {
         // load ui
-        ui = new TracksterUI(Galaxy.root);
+        this.ui = new TracksterUI(Galaxy.root);
 
         // create button menu
-        ui.createButtonMenu();
+        this.ui.createButtonMenu();
 
         // attach the button menu to the panel header and float it left
-        ui.buttonMenu.$el.attr("style", "float: right");
+        this.ui.buttonMenu.$el.attr("style", "float: right");
 
         // add to center panel
-        $("#center .unified-panel-header-inner").append(ui.buttonMenu.$el);
+        $("#center .unified-panel-header-inner").append(this.ui.buttonMenu.$el);
 
         // configure right panel
         $("#right .unified-panel-title").append("Bookmarks");
@@ -461,13 +453,13 @@ class TracksterView extends Backbone.View {
             title: _l("Add Data to Saved Visualization"),
             body: tracks_grid.$el,
             buttons: {
-                Cancel: function() {
+                Cancel: () => {
                     window.location = `${Galaxy.root}visualizations/list`;
                 },
-                "Add to visualization": function() {
+                "Add to visualization": () => {
                     $(parent.document)
                         .find("input[name=id]:checked")
-                        .each(function() {
+                        .each(() => {
                             dataset_params.id = $(this).val();
                             window.location = `${Galaxy.root}visualization/trackster?${$.param(dataset_params)}`;
                         });
@@ -482,7 +474,7 @@ class TracksterView extends Backbone.View {
         var viz_config = window.galaxy_config.app.viz_config;
 
         // view
-        view = ui.create_visualization(
+        view = this.ui.create_visualization(
             {
                 container: $("#center .unified-panel-body"),
                 name: viz_config.title,
@@ -578,7 +570,7 @@ class TracksterView extends Backbone.View {
     create_browser(name, dbkey) {
         $(document).trigger("convert_to_values");
 
-        view = ui.create_visualization(
+        view = this.ui.create_visualization(
             {
                 container: $("#center .unified-panel-body"),
                 name: name,
@@ -605,7 +597,7 @@ class TracksterView extends Backbone.View {
                 url: `${Galaxy.root}api/datasets/${window.galaxy_config.app.add_dataset}`,
                 data: { hda_ldda: "hda", data_type: "track_config" },
                 dataType: "json",
-                success: function(track_data) {
+                success: track_data => {
                     view.add_drawable(tracks.object_from_template(track_data, view, view));
                 }
             });
@@ -616,11 +608,11 @@ class TracksterView extends Backbone.View {
             var position = `${view.chrom}:${view.low}-${view.high}`;
 
             var annotation = "Bookmark description";
-            return ui.add_bookmark(position, annotation, true);
+            return this.ui.add_bookmark(position, annotation, true);
         });
 
         // initialize keyboard
-        ui.init_keyboard_nav(view);
+        this.ui.init_keyboard_nav(view);
 
         $(window).on("beforeunload", () => {
             if (view.has_changes) {

--- a/client/galaxy/scripts/viz/trackster.js
+++ b/client/galaxy/scripts/viz/trackster.js
@@ -1,9 +1,9 @@
-import _l from "utils/localization";
 /**
  * Top-level trackster code, used for creating/loading visualizations and user interface elements.
  */
-//import * as $ from "jquery";  TODO: fix local import here
+import _l from "utils/localization";
 import * as _ from "libs/underscore";
+import * as Backbone from "libs/backbone";
 import tracks from "viz/trackster/tracks";
 import visualization from "viz/visualization";
 import IconButton from "mvc/ui/icon-button";
@@ -19,6 +19,9 @@ import "libs/farbtastic";
 import "libs/jquery/jquery.form";
 import "libs/jquery/jquery.rating";
 import "ui/editable-text";
+
+/* global Galaxy */
+/* global $ */
 
 /**
  * User interface controls for trackster

--- a/client/galaxy/scripts/viz/trackster.js
+++ b/client/galaxy/scripts/viz/trackster.js
@@ -2,14 +2,14 @@ import _l from "utils/localization";
 /**
  * Top-level trackster code, used for creating/loading visualizations and user interface elements.
  */
-//import * as $ from 'jquery';
+//import * as $ from "jquery";  TODO: fix local import here
 import * as _ from "libs/underscore";
 import tracks from "viz/trackster/tracks";
 import visualization from "viz/visualization";
-import mod_icon_btn from "mvc/ui/icon-button";
+import IconButton from "mvc/ui/icon-button";
 import query_string from "utils/query-string-parsing";
 import GridView from "mvc/grid/grid-view";
-import mod_utils from "utils/utils";
+import Utils from "utils/utils";
 import "libs/jquery/jquery.event.drag";
 import "libs/jquery/jquery.event.hover";
 import "libs/jquery/jquery.mousewheel";
@@ -19,8 +19,6 @@ import "libs/farbtastic";
 import "libs/jquery/jquery.form";
 import "libs/jquery/jquery.rating";
 import "ui/editable-text";
-
-var view = null;
 
 /**
  * User interface controls for trackster
@@ -32,11 +30,11 @@ class TracksterUI extends Backbone.Model {
 
     initialize(baseURL) {
         this.baseURL = baseURL;
-        mod_utils.cssLoadFile("static/style/jquery.rating.css");
-        mod_utils.cssLoadFile("static/style/autocomplete_tagging.css");
-        mod_utils.cssLoadFile("static/style/jquery-ui/smoothness/jquery-ui.css");
-        mod_utils.cssLoadFile("static/style/library.css");
-        mod_utils.cssLoadFile("static/style/trackster.css");
+        Utils.cssLoadFile("static/style/jquery.rating.css");
+        Utils.cssLoadFile("static/style/autocomplete_tagging.css");
+        Utils.cssLoadFile("static/style/jquery-ui/smoothness/jquery-ui.css");
+        Utils.cssLoadFile("static/style/library.css");
+        Utils.cssLoadFile("static/style/trackster.css");
     }
 
     /**
@@ -60,14 +58,16 @@ class TracksterUI extends Backbone.Model {
         });
 
         // FIXME: give unique IDs to Drawables and save overview as ID.
-        var overview_track_name = view.overview_drawable ? view.overview_drawable.config.get_value("name") : null;
+        var overview_track_name = this.view.overview_drawable
+            ? this.view.overview_drawable.config.get_value("name")
+            : null;
 
         var viz_config = {
-            view: view.to_dict(),
+            view: this.view.to_dict(),
             viewport: {
-                chrom: view.chrom,
-                start: view.low,
-                end: view.high,
+                chrom: this.view.chrom,
+                start: this.view.low,
+                end: this.view.high,
                 overview: overview_track_name
             },
             bookmarks: bookmarks
@@ -79,17 +79,17 @@ class TracksterUI extends Backbone.Model {
             type: "POST",
             dataType: "json",
             data: {
-                id: view.vis_id,
-                title: view.config.get_value("name"),
-                dbkey: view.dbkey,
+                id: this.view.vis_id,
+                title: this.view.config.get_value("name"),
+                dbkey: this.view.dbkey,
                 type: "trackster",
                 vis_json: JSON.stringify(viz_config)
             }
         })
             .success(vis_info => {
                 Galaxy.modal.hide();
-                view.vis_id = vis_info.vis_id;
-                view.has_changes = false;
+                this.view.vis_id = vis_info.vis_id;
+                this.view.has_changes = false;
 
                 // Needed to set URL when first saving a visualization.
                 window.history.pushState({}, "", vis_info.url + window.location.hash);
@@ -112,15 +112,15 @@ class TracksterUI extends Backbone.Model {
      * Create button menu
      */
     createButtonMenu() {
-        var menu = mod_icon_btn.create_icon_buttons_menu(
+        var menu = IconButton.create_icon_buttons_menu(
             [
                 {
                     icon_class: "plus-button",
                     title: _l("Add tracks"),
                     on_click: () => {
-                        visualization.select_datasets({ dbkey: view.dbkey }, new_tracks => {
+                        visualization.select_datasets({ dbkey: this.view.dbkey }, new_tracks => {
                             _.each(new_tracks, track => {
-                                view.add_drawable(tracks.object_from_template(track, view, view));
+                                this.view.add_drawable(tracks.object_from_template(track, this.view, this.view));
                             });
                         });
                     }
@@ -129,8 +129,8 @@ class TracksterUI extends Backbone.Model {
                     icon_class: "block--plus",
                     title: _l("Add group"),
                     on_click: () => {
-                        view.add_drawable(
-                            new tracks.DrawableGroup(view, view, {
+                        this.view.add_drawable(
+                            new tracks.DrawableGroup(this.view, this.view, {
                                 name: "New Group"
                             })
                         );
@@ -148,7 +148,7 @@ class TracksterUI extends Backbone.Model {
                     icon_class: "globe",
                     title: _l("Circster"),
                     on_click: () => {
-                        window.location = `${this.baseURL}visualization/circster?id=${view.vis_id}`;
+                        window.location = `${this.baseURL}visualization/circster?id=${this.view.vis_id}`;
                     }
                 },
                 {
@@ -162,7 +162,7 @@ class TracksterUI extends Backbone.Model {
                     icon_class: "cross-circle",
                     title: _l("Close"),
                     on_click: () => {
-                        this.handle_unsaved_changes(view);
+                        this.handle_unsaved_changes(this.view);
                     }
                 }
             ],
@@ -190,11 +190,12 @@ class TracksterUI extends Backbone.Model {
             .addClass("position")
             .appendTo(new_bookmark);
 
-        var position_link = $("<a href=''/>")
+        //position_link
+        $("<a href=''/>")
             .text(position)
             .appendTo(position_div)
             .click(() => {
-                view.go_to(position);
+                this.view.go_to(position);
                 return false;
             });
 
@@ -211,11 +212,12 @@ class TracksterUI extends Backbone.Model {
                     // Remove bookmark.
                     new_bookmark.slideUp("fast");
                     new_bookmark.remove();
-                    view.has_changes = true;
+                    this.view.has_changes = true;
                     return false;
                 });
 
-            var delete_icon = $("<a href=''/>")
+            // delete_icon
+            $("<a href=''/>")
                 .addClass("icon-button delete")
                 .appendTo(delete_icon_container);
 
@@ -228,7 +230,7 @@ class TracksterUI extends Backbone.Model {
                 .addClass("annotation");
         }
 
-        view.has_changes = true;
+        this.view.has_changes = true;
         return new_bookmark;
     }
 
@@ -237,45 +239,41 @@ class TracksterUI extends Backbone.Model {
      */
     create_visualization(view_config, viewport_config, drawables_config, bookmarks_config, editable) {
         // Create view.
-        view = new tracks.TracksterView(_.extend(view_config, { header: false }));
+        this.view = new tracks.TracksterView(_.extend(view_config, { header: false }));
+        this.view.editor = true;
 
-        view.editor = true;
-        $.when(view.load_chroms_deferred).then(chrom_info => {
+        $.when(this.view.load_chroms_deferred).then(chrom_info => {
+            var overview_drawable_name = null;
             // Viewport config.
             if (viewport_config) {
                 var chrom = viewport_config.chrom;
                 var start = viewport_config.start;
                 var end = viewport_config.end;
-                var overview_drawable_name = viewport_config.overview;
+                overview_drawable_name = viewport_config.overview;
 
                 if (chrom && start !== undefined && end) {
-                    view.change_chrom(chrom, start, end);
+                    this.view.change_chrom(chrom, start, end);
                 } else {
                     // No valid viewport, so use first chromosome.
-                    view.change_chrom(chrom_info[0].chrom);
+                    this.view.change_chrom(chrom_info[0].chrom);
                 }
             } else {
                 // No viewport, so use first chromosome.
-                view.change_chrom(chrom_info[0].chrom);
+                this.view.change_chrom(chrom_info[0].chrom);
             }
 
             // Add drawables to view.
             if (drawables_config) {
                 // FIXME: can from_dict() be used to create view and add drawables?
-                var drawable_config;
-
-                var drawable_type;
-                var drawable;
                 for (let i = 0; i < drawables_config.length; i++) {
-                    view.add_drawable(tracks.object_from_template(drawables_config[i], view, view));
+                    this.view.add_drawable(tracks.object_from_template(drawables_config[i], this.view, this.view));
                 }
             }
 
             // Set overview.
-            var overview_drawable;
-            for (let i = 0; i < view.drawables.length; i++) {
-                if (view.drawables[i].config.get_value("name") === overview_drawable_name) {
-                    view.set_overview(view.drawables[i]);
+            for (let i = 0; i < this.view.drawables.length; i++) {
+                if (this.view.drawables[i].config.get_value("name") === overview_drawable_name) {
+                    this.view.set_overview(this.view.drawables[i]);
                     break;
                 }
             }
@@ -285,18 +283,19 @@ class TracksterUI extends Backbone.Model {
                 var bookmark;
                 for (let i = 0; i < bookmarks_config.length; i++) {
                     bookmark = bookmarks_config[i];
-                    this.add_bookmark(bookmark["position"], bookmark["annotation"], editable);
+                    this.add_bookmark(bookmark.position, bookmark.annotation, editable);
                 }
             }
 
             // View has no changes as of yet.
-            view.has_changes = false;
+            this.view.has_changes = false;
         });
 
         // Final initialization.
-        this.set_up_router({ view: view });
+        this.set_up_router({ view: this.view });
 
-        return view;
+        // TODO: This is hopefully not necessary anymore, since we're using the instance view.  Do it for compatibility for now.
+        return this.view;
     }
 
     /**
@@ -393,7 +392,7 @@ class TracksterView extends Backbone.View {
 
         // resize view when showing/hiding right panel (bookmarks for now).
         $("#right-border").click(() => {
-            view.resize_window();
+            this.ui.view.resize_window();
         });
 
         // hide right panel
@@ -457,7 +456,7 @@ class TracksterView extends Backbone.View {
                     window.location = `${Galaxy.root}visualizations/list`;
                 },
                 "Add to visualization": () => {
-                    $(parent.document)
+                    $(window.parent.document)
                         .find("input[name=id]:checked")
                         .each(() => {
                             dataset_params.id = $(this).val();
@@ -474,7 +473,7 @@ class TracksterView extends Backbone.View {
         var viz_config = window.galaxy_config.app.viz_config;
 
         // view
-        view = this.ui.create_visualization(
+        this.ui.create_visualization(
             {
                 container: $("#center .unified-panel-body"),
                 name: viz_config.title,
@@ -566,11 +565,46 @@ class TracksterView extends Backbone.View {
         return html;
     }
 
+    // initialization for editor-specific functions.
+    init_editor() {
+        // set title
+        $("#center .unified-panel-title").text(`${this.ui.view.config.get_value("name")} (${this.ui.view.dbkey})`);
+
+        // add dataset
+        if (window.galaxy_config.app.add_dataset)
+            $.ajax({
+                url: `${Galaxy.root}api/datasets/${window.galaxy_config.app.add_dataset}`,
+                data: { hda_ldda: "hda", data_type: "track_config" },
+                dataType: "json",
+                success: track_data => {
+                    this.ui.view.add_drawable(tracks.object_from_template(track_data, this.ui.view, this.ui.view));
+                }
+            });
+
+        // initialize icons
+        $("#add-bookmark-button").click(() => {
+            // add new bookmark.
+            var position = `${this.ui.view.chrom}:${this.ui.view.low}-${this.ui.view.high}`;
+
+            var annotation = "Bookmark description";
+            return this.ui.add_bookmark(position, annotation, true);
+        });
+
+        // initialize keyboard
+        this.ui.init_keyboard_nav(this.ui.view);
+
+        $(window).on("beforeunload", () => {
+            if (this.ui.view.has_changes) {
+                return "There are unsaved changes to your visualization that will be lost if you leave this page.";
+            }
+        });
+    }
+
     // create
     create_browser(name, dbkey) {
         $(document).trigger("convert_to_values");
 
-        view = this.ui.create_visualization(
+        this.ui.create_visualization(
             {
                 container: $("#center .unified-panel-body"),
                 name: name,
@@ -583,42 +617,7 @@ class TracksterView extends Backbone.View {
         this.init_editor();
 
         // modify view setting
-        view.editor = true;
-    }
-
-    // initialization for editor-specific functions.
-    init_editor() {
-        // set title
-        $("#center .unified-panel-title").text(`${view.config.get_value("name")} (${view.dbkey})`);
-
-        // add dataset
-        if (window.galaxy_config.app.add_dataset)
-            $.ajax({
-                url: `${Galaxy.root}api/datasets/${window.galaxy_config.app.add_dataset}`,
-                data: { hda_ldda: "hda", data_type: "track_config" },
-                dataType: "json",
-                success: track_data => {
-                    view.add_drawable(tracks.object_from_template(track_data, view, view));
-                }
-            });
-
-        // initialize icons
-        $("#add-bookmark-button").click(() => {
-            // add new bookmark.
-            var position = `${view.chrom}:${view.low}-${view.high}`;
-
-            var annotation = "Bookmark description";
-            return this.ui.add_bookmark(position, annotation, true);
-        });
-
-        // initialize keyboard
-        this.ui.init_keyboard_nav(view);
-
-        $(window).on("beforeunload", () => {
-            if (view.has_changes) {
-                return "There are unsaved changes to your visualization that will be lost if you leave this page.";
-            }
-        });
+        this.ui.view.editor = true;
     }
 }
 

--- a/client/galaxy/scripts/viz/trackster.js
+++ b/client/galaxy/scripts/viz/trackster.js
@@ -26,7 +26,7 @@ var view = null;
 var browser_router = null;
 
 /**
- * Base Object/Model for inhertiance.
+ * Base Object/Model for inheritance.
  */
 var Base = function() {
     if (this.initialize) {

--- a/client/galaxy/scripts/viz/trackster.js
+++ b/client/galaxy/scripts/viz/trackster.js
@@ -369,7 +369,7 @@ class TracksterUI extends Backbone.Model {
     }
 }
 
-class TracksterView extends Backbone.View {
+class TracksterUIView extends Backbone.View {
     constructor(options) {
         super(options);
     }
@@ -626,5 +626,5 @@ class TracksterView extends Backbone.View {
 
 export default {
     TracksterUI: TracksterUI,
-    GalaxyApp: TracksterView
+    GalaxyApp: TracksterUIView
 };

--- a/client/galaxy/scripts/viz/trackster.js
+++ b/client/galaxy/scripts/viz/trackster.js
@@ -279,14 +279,14 @@ var TracksterUI = Base.extend({
 
                 var drawable_type;
                 var drawable;
-                for (var i = 0; i < drawables_config.length; i++) {
+                for (let i = 0; i < drawables_config.length; i++) {
                     view.add_drawable(tracks.object_from_template(drawables_config[i], view, view));
                 }
             }
 
             // Set overview.
             var overview_drawable;
-            for (var i = 0; i < view.drawables.length; i++) {
+            for (let i = 0; i < view.drawables.length; i++) {
                 if (view.drawables[i].config.get_value("name") === overview_drawable_name) {
                     view.set_overview(view.drawables[i]);
                     break;
@@ -296,7 +296,7 @@ var TracksterUI = Base.extend({
             // Load bookmarks.
             if (bookmarks_config) {
                 var bookmark;
-                for (var i = 0; i < bookmarks_config.length; i++) {
+                for (let i = 0; i < bookmarks_config.length; i++) {
                     bookmark = bookmarks_config[i];
                     self.add_bookmark(bookmark["position"], bookmark["annotation"], editable);
                 }
@@ -337,14 +337,14 @@ var TracksterUI = Base.extend({
                     view.move_fraction(0.25);
                     break;
                 case 38:
-                    var change = Math.round(view.viewport_container.height() / 15.0);
+                    // var change = Math.round(view.viewport_container.height() / 15.0);
                     view.viewport_container.scrollTop(view.viewport_container.scrollTop() - 20);
                     break;
                 case 39:
                     view.move_fraction(-0.25);
                     break;
                 case 40:
-                    var change = Math.round(view.viewport_container.height() / 15.0);
+                    // var change = Math.round(view.viewport_container.height() / 15.0);
                     view.viewport_container.scrollTop(view.viewport_container.scrollTop() + 20);
                     break;
             }
@@ -568,7 +568,7 @@ var TracksterView = Backbone.View.extend({
             '<select name="dbkey" id="new-dbkey">';
 
         // add dbkeys
-        for (var i = 0; i < response.length; i++) {
+        for (let i = 0; i < response.length; i++) {
             html += `<option value="${response[i][1]}">${response[i][0]}</option>`;
         }
 

--- a/client/galaxy/scripts/viz/trackster/filters.js
+++ b/client/galaxy/scripts/viz/trackster/filters.js
@@ -151,7 +151,7 @@ var NumberFilter = function(obj_dict) {
         .addClass("elt-label")
         .appendTo(filter.parent_div);
 
-    var name_span = $("<span/>")
+    $("<span/>")
         .addClass("slider-name")
         .text(`${filter.name}  `)
         .appendTo(filter_label);
@@ -341,9 +341,6 @@ extend(NumberFilter.prototype, {
             return true;
         }
 
-        // Keep value function.
-        var filter = this;
-
         // Do filtering.
         var to_filter = element[this.index];
         if (to_filter instanceof Array) {
@@ -482,7 +479,7 @@ var FiltersManager = function(track, obj_dict) {
                     filter.height_icon.addClass("active").show();
                 }
             } else {
-                console.log("ERROR: unsupported filter: ", name, type);
+                console.log("ERROR: unsupported filter: ", filters_dict[i]);
             }
         }
 
@@ -656,6 +653,7 @@ extend(FiltersManager.prototype, {
             // Remove current filter.
             filters = filters.slice(1);
 
+            // DBTODO: This will never work, run_tool_url doesn't exist?
             $.getJSON(run_tool_url, url_params, response => {
                 if (response.error) {
                     // General error.

--- a/client/galaxy/scripts/viz/trackster/painters.js
+++ b/client/galaxy/scripts/viz/trackster/painters.js
@@ -1,5 +1,4 @@
 import * as _ from "libs/underscore";
-
 /**
  * Compute the type of overlap between two regions. They are assumed to be on the same chrom/contig.
  * The overlap is computed relative to the second region; hence, OVERLAP_START indicates that the first
@@ -219,7 +218,6 @@ LinePainter.prototype.draw = function(ctx, width, height, w_scale) {
 
     var // Extract RGB from preference color.
     pref_color = parseInt(painter_color.slice(1), 16);
-
     var pref_r = (pref_color & 0xff0000) >> 16;
     var pref_g = (pref_color & 0x00ff00) >> 8;
     var pref_b = pref_color & 0x0000ff;
@@ -524,7 +522,8 @@ _.extend(LinkedFeaturePainter.prototype, FeaturePainter.prototype, {
      * Draw a feature. Returns an array with feature's start and end X coordinates.
      */
     draw_element: function(ctx, mode, feature, slot, tile_low, tile_high, w_scale, y_scale, width) {
-        var feature_uid = feature[0];
+        console.debug("draw_element", feature);
+        // var feature_uid = feature[0];
         var feature_start = feature[1];
         var feature_end = feature[2];
         var feature_name = feature[3];
@@ -540,14 +539,12 @@ _.extend(LinkedFeaturePainter.prototype, FeaturePainter.prototype, {
 
         var y_start = (mode === "Dense" ? 0 : 0 + slot) * y_scale + this.get_top_padding(width);
 
-        var thickness;
-        var y_start;
         var thick_start = null;
         var thick_end = null;
 
-        var // TODO: is there any reason why block, label color cannot be set at the Painter level?
+        // TODO: is there any reason why block, label color cannot be set at the Painter level?
         // For now, assume '.' === '+'
-        block_color =
+        var block_color =
             !feature_strand || feature_strand === "+" || feature_strand === "."
                 ? this.prefs.block_color
                 : this.prefs.reverse_strand_color;
@@ -660,7 +657,6 @@ _.extend(LinkedFeaturePainter.prototype, FeaturePainter.prototype, {
                 }
 
                 // Draw blocks.
-                var start_and_height;
                 for (var k = 0, k_len = feature_blocks.length; k < k_len; k++) {
                     var block = feature_blocks[k];
 
@@ -988,11 +984,11 @@ _.extend(ReadPainter.prototype, FeaturePainter.prototype, {
 
                     // Draw sequence. Because cur_seq starts and read/tile start, go to there to start writing.
                     var start_pos = Math.max(seq_start, tile_low);
-                    for (var c = 0; c < cur_seq.length; c++) {
+                    for (let c = 0; c < cur_seq.length; c++) {
                         // Draw base if showing all (i.e. not showing differences) or there is a mismatch.
                         if ((cur_seq && !this.prefs.show_differences) || cig_op === "X") {
                             // Draw base.
-                            var c_start = Math.floor(Math.max(0, (start_pos + c - tile_low) * w_scale));
+                            let c_start = Math.floor(Math.max(0, (start_pos + c - tile_low) * w_scale));
                             ctx.fillStyle = this.base_color_fn(cur_seq[c]);
                             if (pack_mode && w_scale > char_width_px) {
                                 ctx.fillText(cur_seq[c], c_start, y_start + 9);
@@ -1066,8 +1062,8 @@ _.extend(ReadPainter.prototype, FeaturePainter.prototype, {
                                         break;
                                 }
                                 // Draw sequence.
-                                for (var c = 0, str_len = seq.length; c < str_len; c++) {
-                                    var c_start = Math.floor(Math.max(0, (seq_start + c - tile_low) * w_scale));
+                                for (let c = 0, str_len = seq.length; c < str_len; c++) {
+                                    let c_start = Math.floor(Math.max(0, (seq_start + c - tile_low) * w_scale));
                                     ctx.fillText(seq[c], c_start - (s_end - s_start) / 2, y_start);
                                 }
                             } else {
@@ -1110,7 +1106,7 @@ _.extend(ReadPainter.prototype, FeaturePainter.prototype, {
         var item;
         var type;
         var data;
-        for (var i = 0; i < draw_last.length; i++) {
+        for (let i = 0; i < draw_last.length; i++) {
             item = draw_last[i];
             type = item.type;
             data = item.data;
@@ -1130,8 +1126,7 @@ _.extend(ReadPainter.prototype, FeaturePainter.prototype, {
      */
     draw_element: function(ctx, mode, feature, slot, tile_low, tile_high, w_scale, y_scale, width) {
         // All features need a start, end, and vertical center.
-        var feature_uid = feature[0];
-
+        // var feature_uid = feature[0];
         var feature_start = feature[1];
         var feature_end = feature[2];
         var feature_name = feature[3];
@@ -1144,8 +1139,6 @@ _.extend(ReadPainter.prototype, FeaturePainter.prototype, {
         var y_start = (mode === "Dense" ? 0 : 0 + slot) * y_scale;
 
         var draw_height = mode === "Pack" ? PACK_FEATURE_HEIGHT : SQUISH_FEATURE_HEIGHT;
-
-        var label_color = this.prefs.label_color;
 
         // Draw read.
         if (feature[5] instanceof Array) {
@@ -1247,7 +1240,7 @@ var ArcLinkedFeaturePainter = function(data, view_start, view_end, prefs, mode, 
 _.extend(ArcLinkedFeaturePainter.prototype, FeaturePainter.prototype, LinkedFeaturePainter.prototype, {
     calculate_longest_feature_length: function() {
         var longest_feature_length = 0;
-        for (var i = 0, len = this.data.length; i < len; i++) {
+        for (let i = 0, len = this.data.length; i < len; i++) {
             var feature = this.data[i];
             var feature_start = feature[1];
             var feature_end = feature[2];
@@ -1265,13 +1258,7 @@ _.extend(ArcLinkedFeaturePainter.prototype, FeaturePainter.prototype, LinkedFeat
     draw_connector: function(ctx, block1_start, block1_end, block2_start, block2_end, y_start) {
         // Arc drawing -- from closest endpoints
         var x_center = (block1_end + block2_start) / 2;
-
         var radius = block2_start - x_center;
-
-        // For full half circles
-        var angle1 = Math.PI;
-
-        var angle2 = 0;
         if (radius > 0) {
             ctx.beginPath();
             ctx.arc(x_center, y_start, block2_start - x_center, Math.PI, 0);
@@ -1471,11 +1458,7 @@ DiagonalHeatmapPainter.prototype.default_prefs = {
 DiagonalHeatmapPainter.prototype.draw = function(ctx, width, height, w_scale) {
     var min_value = this.prefs.min_value;
     var max_value = this.prefs.max_value;
-    var value_range = max_value - min_value;
-    var height_px = height;
     var view_start = this.view_start;
-    var mode = this.mode;
-    var data = this.data;
     var invsqrt2 = 1 / Math.sqrt(2);
 
     var ramp = new SplitRamp(this.prefs.neg_color, "#FFFFFF", this.prefs.pos_color, min_value, max_value);
@@ -1496,8 +1479,8 @@ DiagonalHeatmapPainter.prototype.draw = function(ctx, width, height, w_scale) {
     ctx.scale(invsqrt2, invsqrt2);
 
     // Paint track.
-    for (var i = 0, len = data.length; i < len; i++) {
-        d = data[i];
+    for (var i = 0, len = this.data.length; i < len; i++) {
+        d = this.data[i];
 
         s1 = scale(d[1]);
         e1 = scale(d[2]);
@@ -1618,11 +1601,8 @@ _.extend(VariantPainter.prototype, Painter.prototype, {
         var locus_data;
 
         var pos;
-        var id;
         var ref;
         var alt;
-        var qual;
-        var filter;
         var sample_gts;
         var allele_counts;
         var variant;

--- a/client/galaxy/scripts/viz/trackster/painters.js
+++ b/client/galaxy/scripts/viz/trackster/painters.js
@@ -144,6 +144,7 @@ class Painter {
     constructor(data, view_start, view_end, prefs, mode) {
         // Data and data properties
         this.data = data;
+        this.default_prefs = {};
         // View
         this.view_start = view_start;
         this.view_end = view_end;
@@ -416,7 +417,6 @@ class FeaturePainter extends Painter {
             connector_color: "#FFF"
         };
     }
-
     get_required_height(rows_required, width) {
         // y_scale is the height per row
         var required_height = this.get_row_height();

--- a/client/galaxy/scripts/viz/trackster/painters.js
+++ b/client/galaxy/scripts/viz/trackster/painters.js
@@ -13,6 +13,19 @@ const OVERLAP_END = 1004;
 const CONTAINED_BY = 1005;
 const AFTER = 1006;
 
+// Constants specific to feature tracks moved here (HACKING, these should
+// basically all be configuration options)
+const DENSE_TRACK_HEIGHT = 10;
+const NO_DETAIL_TRACK_HEIGHT = 3;
+const SQUISH_TRACK_HEIGHT = 5;
+const PACK_TRACK_HEIGHT = 10;
+const NO_DETAIL_FEATURE_HEIGHT = 1;
+const DENSE_FEATURE_HEIGHT = 9;
+const SQUISH_FEATURE_HEIGHT = 3;
+const PACK_FEATURE_HEIGHT = 9;
+const LABEL_SPACING = 2;
+const CONNECTOR_COLOR = "#ccc";
+
 function compute_overlap(first_region, second_region) {
     var first_start = first_region[0];
     var first_end = first_region[1];
@@ -100,296 +113,309 @@ function drawDownwardEquilateralTriangle(ctx, down_vertex_x, down_vertex_y, side
 /**
  * Base class for all scalers. Scalers produce values that are used to change (scale) drawing attributes.
  */
-var Scaler = function(default_val) {
-    this.default_val = default_val ? default_val : 1;
-};
+class Scaler {
+    constructor(default_val) {
+        this.default_val = default_val ? default_val : 1;
+    }
 
-/**
- * Produce a scaling value.
- */
-Scaler.prototype.gen_val = function(input) {
-    return this.default_val;
-};
+    /**
+     * Produce a scaling value.
+     */
+    gen_val(input) {
+        return this.default_val;
+    }
+}
 
 /**
  * Results from painter.draw()
  */
-var DrawResults = function(options) {
-    this.incomplete_features = options.incomplete_features;
-    this.feature_mapper = options.feature_mapper;
-};
+class DrawResults {
+    constructor(options) {
+        this.incomplete_features = options.incomplete_features;
+        this.feature_mapper = options.feature_mapper;
+    }
+}
 
 /**
  * Base class for painters
  *
  * -- Mode and prefs are both optional
  */
-var Painter = function(data, view_start, view_end, prefs, mode) {
-    // Data and data properties
-    this.data = data;
-    // View
-    this.view_start = view_start;
-    this.view_end = view_end;
-    // Drawing prefs
-    this.prefs = _.extend({}, this.default_prefs, prefs);
-    this.mode = mode;
-};
-
-Painter.prototype.default_prefs = {};
-
-/**
- * Draw on the context using a rectangle of width x height using scale w_scale.
- */
-Painter.prototype.draw = (ctx, width, height, w_scale) => {};
-
-/**
- * Get starting drawing position, which is offset a half-base left of coordinate.
- */
-Painter.prototype.get_start_draw_pos = function(chrom_pos, w_scale) {
-    return this._chrom_pos_to_draw_pos(chrom_pos, w_scale, -0.5);
-};
-
-/**
- * Get end drawing position, which is offset a half-base right of coordinate.
- */
-Painter.prototype.get_end_draw_pos = function(chrom_pos, w_scale) {
-    return this._chrom_pos_to_draw_pos(chrom_pos, w_scale, 0.5);
-};
-
-/**
- * Get drawing position.
- */
-Painter.prototype.get_draw_pos = function(chrom_pos, w_scale) {
-    return this._chrom_pos_to_draw_pos(chrom_pos, w_scale, 0);
-};
-
-/**
- * Convert chromosome position to drawing position.
- */
-Painter.prototype._chrom_pos_to_draw_pos = function(chrom_pos, w_scale, offset) {
-    return Math.floor(w_scale * (Math.max(0, chrom_pos - this.view_start) + offset));
-};
-
-var LinePainter = function(data, view_start, view_end, prefs, mode) {
-    Painter.call(this, data, view_start, view_end, prefs, mode);
-};
-
-LinePainter.prototype.default_prefs = {
-    min_value: undefined,
-    max_value: undefined,
-    mode: "Histogram",
-    color: "#000",
-    overflow_color: "#F66"
-};
-
-LinePainter.prototype.draw = function(ctx, width, height, w_scale) {
-    var in_path = false;
-    var min_value = this.prefs.min_value;
-    var max_value = this.prefs.max_value;
-    var vertical_range = max_value - min_value;
-    var height_px = height;
-    var view_start = this.view_start;
-    var mode = this.mode;
-    var data = this.data;
-
-    ctx.save();
-
-    // Pixel position of 0 on the y axis
-    var y_zero = Math.round(height + min_value / vertical_range * height);
-
-    // Horizontal line to denote x-axis
-    if (mode !== "Intensity") {
-        ctx.fillStyle = "#aaa";
-        ctx.fillRect(0, y_zero, width, 1);
+class Painter {
+    constructor(data, view_start, view_end, prefs, mode) {
+        // Data and data properties
+        this.data = data;
+        // View
+        this.view_start = view_start;
+        this.view_end = view_end;
+        // Drawing prefs
+        this.prefs = _.extend({}, this.getDefaultPrefs(), prefs);
+        this.mode = mode;
     }
 
-    ctx.beginPath();
-    var x_scaled;
-    var y;
-    var delta_x_pxs;
-    if (data.length > 1) {
-        delta_x_pxs = _.map(data.slice(0, -1), (d, i) => Math.ceil((data[i + 1][0] - data[i][0]) * w_scale));
-    } else {
-        delta_x_pxs = [10];
+    getDefaultPrefs() {
+        return {};
     }
 
-    // Painter color can be in either block_color (FeatureTrack) or color pref (LineTrack).
-    var painter_color = this.prefs.block_color || this.prefs.color;
+    /**
+     * Draw on the context using a rectangle of width x height using scale w_scale.
+     */
+    draw(ctx, width, height, w_scale) {}
 
-    var // Extract RGB from preference color.
-    pref_color = parseInt(painter_color.slice(1), 16);
-    var pref_r = (pref_color & 0xff0000) >> 16;
-    var pref_g = (pref_color & 0x00ff00) >> 8;
-    var pref_b = pref_color & 0x0000ff;
-    var top_overflow = false;
-    var bot_overflow = false;
+    /**
+     * Get starting drawing position, which is offset a half-base left of coordinate.
+     */
+    get_start_draw_pos(chrom_pos, w_scale) {
+        return this._chrom_pos_to_draw_pos(chrom_pos, w_scale, -0.5);
+    }
 
-    // Paint track.
-    var delta_x_px;
-    for (var i = 0, len = data.length; i < len; i++) {
-        // Reset attributes for next point.
-        ctx.fillStyle = ctx.strokeStyle = painter_color;
-        top_overflow = bot_overflow = false;
-        delta_x_px = delta_x_pxs[i];
+    /**
+     * Get end drawing position, which is offset a half-base right of coordinate.
+     */
+    get_end_draw_pos(chrom_pos, w_scale) {
+        return this._chrom_pos_to_draw_pos(chrom_pos, w_scale, 0.5);
+    }
 
-        x_scaled = Math.floor((data[i][0] - view_start - 0.5) * w_scale);
-        y = data[i][1];
+    /**
+     * Get drawing position.
+     */
+    get_draw_pos(chrom_pos, w_scale) {
+        return this._chrom_pos_to_draw_pos(chrom_pos, w_scale, 0);
+    }
 
-        // Process Y (scaler) value.
-        if (y === null) {
-            if (in_path && mode === "Filled") {
-                ctx.lineTo(x_scaled, height_px);
-            }
-            in_path = false;
-            continue;
+    /**
+     * Convert chromosome position to drawing position.
+     */
+    _chrom_pos_to_draw_pos(chrom_pos, w_scale, offset) {
+        return Math.floor(w_scale * (Math.max(0, chrom_pos - this.view_start) + offset));
+    }
+}
+
+class LinePainter extends Painter {
+    constructor(data, view_start, view_end, prefs, mode) {
+        super(data, view_start, view_end, prefs, mode);
+    }
+
+    getDefaultPrefs() {
+        return {
+            min_value: undefined,
+            max_value: undefined,
+            mode: "Histogram",
+            color: "#000",
+            overflow_color: "#F66"
+        };
+    }
+
+    draw(ctx, width, height, w_scale) {
+        var in_path = false;
+        var min_value = this.prefs.min_value;
+        var max_value = this.prefs.max_value;
+        var vertical_range = max_value - min_value;
+        var height_px = height;
+        var view_start = this.view_start;
+        var mode = this.mode;
+        var data = this.data;
+
+        ctx.save();
+
+        // Pixel position of 0 on the y axis
+        var y_zero = Math.round(height + min_value / vertical_range * height);
+
+        // Horizontal line to denote x-axis
+        if (mode !== "Intensity") {
+            ctx.fillStyle = "#aaa";
+            ctx.fillRect(0, y_zero, width, 1);
         }
 
-        // Bound Y value by min, max.
-        if (y < min_value) {
-            bot_overflow = true;
-            y = min_value;
-        } else if (y > max_value) {
-            top_overflow = true;
-            y = max_value;
-        }
-
-        // Draw point.
-        if (mode === "Histogram") {
-            // y becomes the bar height in pixels, which is the negated for canvas coords
-            y = Math.round(y / vertical_range * height_px);
-            ctx.fillRect(x_scaled, y_zero, delta_x_px, -y);
-        } else if (mode === "Intensity") {
-            var saturation = (y - min_value) / vertical_range;
-
-            var // Range is [pref_color, 255] where saturation = 0 --> 255 and saturation = 1 --> pref color
-            new_r = Math.round(pref_r + (255 - pref_r) * (1 - saturation));
-
-            var new_g = Math.round(pref_g + (255 - pref_g) * (1 - saturation));
-            var new_b = Math.round(pref_b + (255 - pref_b) * (1 - saturation));
-            ctx.fillStyle = `rgb(${new_r},${new_g},${new_b})`;
-            ctx.fillRect(x_scaled, 0, delta_x_px, height_px);
+        ctx.beginPath();
+        var x_scaled;
+        var y;
+        var delta_x_pxs;
+        if (data.length > 1) {
+            delta_x_pxs = _.map(data.slice(0, -1), (d, i) => Math.ceil((data[i + 1][0] - data[i][0]) * w_scale));
         } else {
-            // mode is Coverage/Line or Filled.
+            delta_x_pxs = [10];
+        }
 
-            // Scale Y value.
-            y = Math.round(height_px - (y - min_value) / vertical_range * height_px);
-            if (in_path) {
-                ctx.lineTo(x_scaled, y);
+        // Painter color can be in either block_color (FeatureTrack) or color pref (LineTrack).
+        var painter_color = this.prefs.block_color || this.prefs.color;
+
+        var // Extract RGB from preference color.
+        pref_color = parseInt(painter_color.slice(1), 16);
+        var pref_r = (pref_color & 0xff0000) >> 16;
+        var pref_g = (pref_color & 0x00ff00) >> 8;
+        var pref_b = pref_color & 0x0000ff;
+        var top_overflow = false;
+        var bot_overflow = false;
+
+        // Paint track.
+        var delta_x_px;
+        for (var i = 0, len = data.length; i < len; i++) {
+            // Reset attributes for next point.
+            ctx.fillStyle = ctx.strokeStyle = painter_color;
+            top_overflow = bot_overflow = false;
+            delta_x_px = delta_x_pxs[i];
+
+            x_scaled = Math.floor((data[i][0] - view_start - 0.5) * w_scale);
+            y = data[i][1];
+
+            // Process Y (scaler) value.
+            if (y === null) {
+                if (in_path && mode === "Filled") {
+                    ctx.lineTo(x_scaled, height_px);
+                }
+                in_path = false;
+                continue;
+            }
+
+            // Bound Y value by min, max.
+            if (y < min_value) {
+                bot_overflow = true;
+                y = min_value;
+            } else if (y > max_value) {
+                top_overflow = true;
+                y = max_value;
+            }
+
+            // Draw point.
+            if (mode === "Histogram") {
+                // y becomes the bar height in pixels, which is the negated for canvas coords
+                y = Math.round(y / vertical_range * height_px);
+                ctx.fillRect(x_scaled, y_zero, delta_x_px, -y);
+            } else if (mode === "Intensity") {
+                var saturation = (y - min_value) / vertical_range;
+
+                var // Range is [pref_color, 255] where saturation = 0 --> 255 and saturation = 1 --> pref color
+                new_r = Math.round(pref_r + (255 - pref_r) * (1 - saturation));
+
+                var new_g = Math.round(pref_g + (255 - pref_g) * (1 - saturation));
+                var new_b = Math.round(pref_b + (255 - pref_b) * (1 - saturation));
+                ctx.fillStyle = `rgb(${new_r},${new_g},${new_b})`;
+                ctx.fillRect(x_scaled, 0, delta_x_px, height_px);
             } else {
-                in_path = true;
-                if (mode === "Filled") {
-                    ctx.moveTo(x_scaled, height_px);
+                // mode is Coverage/Line or Filled.
+
+                // Scale Y value.
+                y = Math.round(height_px - (y - min_value) / vertical_range * height_px);
+                if (in_path) {
                     ctx.lineTo(x_scaled, y);
                 } else {
-                    ctx.moveTo(x_scaled, y);
-                    // Use this approach (note: same as for filled) to draw line from 0 to
-                    // first data point.
-                    //ctx.moveTo(x_scaled, height_px);
-                    //ctx.lineTo(x_scaled, y);
+                    in_path = true;
+                    if (mode === "Filled") {
+                        ctx.moveTo(x_scaled, height_px);
+                        ctx.lineTo(x_scaled, y);
+                    } else {
+                        ctx.moveTo(x_scaled, y);
+                        // Use this approach (note: same as for filled) to draw line from 0 to
+                        // first data point.
+                        //ctx.moveTo(x_scaled, height_px);
+                        //ctx.lineTo(x_scaled, y);
+                    }
                 }
             }
+
+            // Draw lines at boundaries if overflowing min or max
+            ctx.fillStyle = this.prefs.overflow_color;
+            if (top_overflow || bot_overflow) {
+                var overflow_x;
+                if (mode === "Histogram" || mode === "Intensity") {
+                    overflow_x = delta_x_px;
+                } else {
+                    // Line and Filled, which are points
+                    x_scaled -= 2; // Move it over to the left so it's centered on the point
+                    overflow_x = 4;
+                }
+                if (top_overflow) {
+                    ctx.fillRect(x_scaled, 0, overflow_x, 3);
+                }
+                if (bot_overflow) {
+                    ctx.fillRect(x_scaled, height_px - 3, overflow_x, 3);
+                }
+            }
+            ctx.fillStyle = painter_color;
+        }
+        if (mode === "Filled") {
+            if (in_path) {
+                ctx.lineTo(x_scaled, y_zero);
+                ctx.lineTo(0, y_zero);
+            }
+            ctx.fill();
+        } else {
+            ctx.stroke();
         }
 
-        // Draw lines at boundaries if overflowing min or max
-        ctx.fillStyle = this.prefs.overflow_color;
-        if (top_overflow || bot_overflow) {
-            var overflow_x;
-            if (mode === "Histogram" || mode === "Intensity") {
-                overflow_x = delta_x_px;
-            } else {
-                // Line and Filled, which are points
-                x_scaled -= 2; // Move it over to the left so it's centered on the point
-                overflow_x = 4;
-            }
-            if (top_overflow) {
-                ctx.fillRect(x_scaled, 0, overflow_x, 3);
-            }
-            if (bot_overflow) {
-                ctx.fillRect(x_scaled, height_px - 3, overflow_x, 3);
-            }
-        }
-        ctx.fillStyle = painter_color;
+        ctx.restore();
     }
-    if (mode === "Filled") {
-        if (in_path) {
-            ctx.lineTo(x_scaled, y_zero);
-            ctx.lineTo(0, y_zero);
-        }
-        ctx.fill();
-    } else {
-        ctx.stroke();
-    }
-
-    ctx.restore();
-};
+}
 
 /**
  * Mapper that contains information about feature locations and data.
  */
-var FeaturePositionMapper = function(slot_height) {
-    this.feature_positions = {};
-    this.slot_height = slot_height;
-    this.translation = 0;
-    this.y_translation = 0;
-};
-
-/**
- * Map feature data to a position defined by <slot, x_start, x_end>.
- */
-FeaturePositionMapper.prototype.map_feature_data = function(feature_data, slot, x_start, x_end) {
-    if (!this.feature_positions[slot]) {
-        this.feature_positions[slot] = [];
-    }
-    this.feature_positions[slot].push({
-        data: feature_data,
-        x_start: x_start,
-        x_end: x_end
-    });
-};
-
-/**
- * Get feature data for position <x, y>
- */
-FeaturePositionMapper.prototype.get_feature_data = function(x, y) {
-    // Find slot using Y.
-    var slot = Math.floor((y - this.y_translation) / this.slot_height);
-
-    var feature_dict;
-
-    // May not be over a slot due to padding, margin, etc.
-    if (!this.feature_positions[slot]) {
-        return null;
+class FeaturePositionMapper {
+    constructor(slot_height) {
+        this.feature_positions = {};
+        this.slot_height = slot_height;
+        this.translation = 0;
+        this.y_translation = 0;
     }
 
-    // Find feature using X.
-    x += this.translation;
-    for (var i = 0; i < this.feature_positions[slot].length; i++) {
-        feature_dict = this.feature_positions[slot][i];
-        if (x >= feature_dict.x_start && x <= feature_dict.x_end) {
-            return feature_dict.data;
+    /**
+     * Map feature data to a position defined by <slot, x_start, x_end>.
+     */
+    map_feature_data(feature_data, slot, x_start, x_end) {
+        if (!this.feature_positions[slot]) {
+            this.feature_positions[slot] = [];
+        }
+        this.feature_positions[slot].push({
+            data: feature_data,
+            x_start: x_start,
+            x_end: x_end
+        });
+    }
+
+    /**
+     * Get feature data for position <x, y>
+     */
+    get_feature_data(x, y) {
+        // Find slot using Y.
+        var slot = Math.floor((y - this.y_translation) / this.slot_height);
+
+        var feature_dict;
+
+        // May not be over a slot due to padding, margin, etc.
+        if (!this.feature_positions[slot]) {
+            return null;
+        }
+
+        // Find feature using X.
+        x += this.translation;
+        for (var i = 0; i < this.feature_positions[slot].length; i++) {
+            feature_dict = this.feature_positions[slot][i];
+            if (x >= feature_dict.x_start && x <= feature_dict.x_end) {
+                return feature_dict.data;
+            }
         }
     }
-};
+}
 
 /**
  * Abstract object for painting feature tracks. Subclasses must implement draw_element() for painting to work.
  * Painter uses a 0-based, half-open coordinate system; start coordinate is closed--included--and the end is open.
  * This coordinate system matches the BED format.
  */
-var FeaturePainter = function(data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler) {
-    Painter.call(this, data, view_start, view_end, prefs, mode);
-    this.alpha_scaler = alpha_scaler ? alpha_scaler : new Scaler();
-    this.height_scaler = height_scaler ? height_scaler : new Scaler();
-    this.max_label_length = 200;
-};
+class FeaturePainter extends Painter {
+    constructor(data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler) {
+        super(data, view_start, view_end, prefs, mode);
+        this.alpha_scaler = alpha_scaler ? alpha_scaler : new Scaler();
+        this.height_scaler = height_scaler ? height_scaler : new Scaler();
+        this.max_label_length = 200;
+        this.default_prefs = {
+            block_color: "#FFF",
+            connector_color: "#FFF"
+        };
+    }
 
-FeaturePainter.prototype.default_prefs = {
-    block_color: "#FFF",
-    connector_color: "#FFF"
-};
-
-_.extend(FeaturePainter.prototype, {
-    get_required_height: function(rows_required, width) {
+    get_required_height(rows_required, width) {
         // y_scale is the height per row
         var required_height = this.get_row_height();
 
@@ -400,18 +426,18 @@ _.extend(FeaturePainter.prototype, {
             required_height = rows_required * y_scale;
         }
         return required_height + this.get_top_padding(width);
-    },
+    }
 
     /** Extra padding before first row of features */
-    get_top_padding: function(width) {
+    get_top_padding(width) {
         return 0;
-    },
+    }
 
     /**
      * Draw data on ctx using slots and within the rectangle defined by width and height. Returns
      * a FeaturePositionMapper object with information about where features were drawn.
      */
-    draw: function(ctx, width, height, w_scale, slots) {
+    draw(ctx, width, height, w_scale, slots) {
         var data = this.data;
         var view_start = this.view_start;
         var view_end = this.view_end;
@@ -466,43 +492,29 @@ _.extend(FeaturePainter.prototype, {
             incomplete_features: incomplete_features,
             feature_mapper: feature_mapper
         });
-    },
+    }
 
     /**
      * Abstract function for drawing an individual feature.
      */
-    draw_element: function(ctx, mode, feature, slot, tile_low, tile_high, w_scale, y_scale, width) {
+    draw_element(ctx, mode, feature, slot, tile_low, tile_high, w_scale, y_scale, width) {
         return [0, 0];
     }
-});
+}
 
-// Constants specific to feature tracks moved here (HACKING, these should
-// basically all be configuration options)
-var DENSE_TRACK_HEIGHT = 10;
+class LinkedFeaturePainter extends FeaturePainter {
+    constructor(data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler) {
+        super(data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler);
+        // Whether to draw a single connector in the background that spans the entire feature (the intron fishbone)
+        this.draw_background_connector = true;
+        // Whether to call draw_connector for every pair of blocks
+        this.draw_individual_connectors = false;
+    }
 
-var NO_DETAIL_TRACK_HEIGHT = 3;
-var SQUISH_TRACK_HEIGHT = 5;
-var PACK_TRACK_HEIGHT = 10;
-var NO_DETAIL_FEATURE_HEIGHT = 1;
-var DENSE_FEATURE_HEIGHT = 9;
-var SQUISH_FEATURE_HEIGHT = 3;
-var PACK_FEATURE_HEIGHT = 9;
-var LABEL_SPACING = 2;
-var CONNECTOR_COLOR = "#ccc";
-
-var LinkedFeaturePainter = function(data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler) {
-    FeaturePainter.call(this, data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler);
-    // Whether to draw a single connector in the background that spans the entire feature (the intron fishbone)
-    this.draw_background_connector = true;
-    // Whether to call draw_connector for every pair of blocks
-    this.draw_individual_connectors = false;
-};
-
-_.extend(LinkedFeaturePainter.prototype, FeaturePainter.prototype, {
     /**
      * Height of a single row, depends on mode
      */
-    get_row_height: function() {
+    get_row_height() {
         var mode = this.mode;
         var height;
         if (mode === "Dense") {
@@ -516,12 +528,12 @@ _.extend(LinkedFeaturePainter.prototype, FeaturePainter.prototype, {
             height = PACK_TRACK_HEIGHT;
         }
         return height;
-    },
+    }
 
     /**
      * Draw a feature. Returns an array with feature's start and end X coordinates.
      */
-    draw_element: function(ctx, mode, feature, slot, tile_low, tile_high, w_scale, y_scale, width) {
+    draw_element(ctx, mode, feature, slot, tile_low, tile_high, w_scale, y_scale, width) {
         // var feature_uid = feature[0];
         var feature_start = feature[1];
         var feature_end = feature[2];
@@ -760,29 +772,18 @@ _.extend(LinkedFeaturePainter.prototype, FeaturePainter.prototype, {
 
         return [draw_start, draw_end];
     }
-});
+}
 
-var ReadPainter = function(
-    data,
-    view_start,
-    view_end,
-    prefs,
-    mode,
-    alpha_scaler,
-    height_scaler,
-    ref_seq,
-    base_color_fn
-) {
-    FeaturePainter.call(this, data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler);
-    this.ref_seq = ref_seq ? ref_seq.data : null;
-    this.base_color_fn = base_color_fn;
-};
-
-_.extend(ReadPainter.prototype, FeaturePainter.prototype, {
+class ReadPainter extends FeaturePainter {
+    constructor(data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler, ref_seq, base_color_fn) {
+        super(data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler);
+        this.ref_seq = ref_seq ? ref_seq.data : null;
+        this.base_color_fn = base_color_fn;
+    }
     /**
      * Returns height based on mode.
      */
-    get_row_height: function() {
+    get_row_height() {
         var height;
         var mode = this.mode;
         if (mode === "Dense") {
@@ -797,14 +798,14 @@ _.extend(ReadPainter.prototype, FeaturePainter.prototype, {
             }
         }
         return height;
-    },
+    }
 
     /**
      * Parse CIGAR string to get (a) a list of contiguous drawing blocks (MD=X) and
      * (b) an array of [ op_index, op_len ] pairs where op_index is an index into the
      * string 'MIDNSHP=X' Return value is a dictionary with two entries, blocks and cigar
      */
-    _parse_cigar: function(cigar_str) {
+    _parse_cigar(cigar_str) {
         var cigar_ops = "MIDNSHP=X";
 
         // Parse cigar.
@@ -841,12 +842,12 @@ _.extend(ReadPainter.prototype, FeaturePainter.prototype, {
             blocks: blocks,
             cigar: parsed_cigar
         };
-    },
+    }
 
     /**
      * Draw a single read from reference-based read sequence and cigar.
      */
-    draw_read: function(ctx, mode, w_scale, y_start, tile_low, tile_high, feature_start, cigar, strand, read_seq) {
+    draw_read(ctx, mode, w_scale, y_start, tile_low, tile_high, feature_start, cigar, strand, read_seq) {
         // Helper function to update base and sequnence offsets.
         var update_base_offset = (offset, cig_op, cig_len) => {
             if ("M=NXD".indexOf(cig_op) !== -1) {
@@ -1112,12 +1113,12 @@ _.extend(ReadPainter.prototype, FeaturePainter.prototype, {
                 drawDownwardEquilateralTriangle(ctx, data[0], data[1], data[2]);
             }
         }
-    },
+    }
 
     /**
      * Draw a complete read pair
      */
-    draw_element: function(ctx, mode, feature, slot, tile_low, tile_high, w_scale, y_scale, width) {
+    draw_element(ctx, mode, feature, slot, tile_low, tile_high, w_scale, y_scale, width) {
         // All features need a start, end, and vertical center.
         // var feature_uid = feature[0];
         var feature_start = feature[1];
@@ -1220,18 +1221,18 @@ _.extend(ReadPainter.prototype, FeaturePainter.prototype, {
         // FIXME: provide actual coordinates for drawn read.
         return [0, 0];
     }
-});
+}
 
-var ArcLinkedFeaturePainter = function(data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler) {
-    LinkedFeaturePainter.call(this, data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler);
-    // Need to know the longest feature length for adding spacing
-    this.longest_feature_length = this.calculate_longest_feature_length();
-    this.draw_background_connector = false;
-    this.draw_individual_connectors = true;
-};
+class ArcLinkedFeaturePainter extends LinkedFeaturePainter {
+    constructor(data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler) {
+        super(data, view_start, view_end, prefs, mode, alpha_scaler, height_scaler);
+        // Need to know the longest feature length for adding spacing
+        this.longest_feature_length = this.calculate_longest_feature_length();
+        this.draw_background_connector = false;
+        this.draw_individual_connectors = true;
+    }
 
-_.extend(ArcLinkedFeaturePainter.prototype, FeaturePainter.prototype, LinkedFeaturePainter.prototype, {
-    calculate_longest_feature_length: function() {
+    calculate_longest_feature_length() {
         var longest_feature_length = 0;
         for (let i = 0, len = this.data.length; i < len; i++) {
             var feature = this.data[i];
@@ -1240,15 +1241,15 @@ _.extend(ArcLinkedFeaturePainter.prototype, FeaturePainter.prototype, LinkedFeat
             longest_feature_length = Math.max(longest_feature_length, feature_end - feature_start);
         }
         return longest_feature_length;
-    },
+    }
 
-    get_top_padding: function(width) {
+    get_top_padding(width) {
         var view_range = this.view_end - this.view_start;
         var w_scale = width / view_range;
         return Math.min(128, Math.ceil(this.longest_feature_length / 2 * w_scale));
-    },
+    }
 
-    draw_connector: function(ctx, block1_start, block1_end, block2_start, block2_end, y_start) {
+    draw_connector(ctx, block1_start, block1_end, block2_start, block2_end, y_start) {
         // Arc drawing -- from closest endpoints
         var x_center = (block1_end + block2_start) / 2;
         var radius = block2_start - x_center;
@@ -1258,35 +1259,36 @@ _.extend(ArcLinkedFeaturePainter.prototype, FeaturePainter.prototype, LinkedFeat
             ctx.stroke();
         }
     }
-});
+}
 
 // Color stuff from less.js
 
-var Color = function(rgb, a) {
-    /**
-     * The end goal here, is to parse the arguments
-     * into an integer triplet, such as `128, 255, 0`
-     *
-     * This facilitates operations and conversions.
-     */
-    if (Array.isArray(rgb)) {
-        this.rgb = rgb;
-    } else if (rgb.length == 6) {
-        this.rgb = rgb.match(/.{2}/g).map(c => parseInt(c, 16));
-    } else if (rgb.length == 7) {
-        this.rgb = rgb
-            .substring(1, 7)
-            .match(/.{2}/g)
-            .map(c => parseInt(c, 16));
-    } else {
-        this.rgb = rgb.split("").map(c => parseInt(c + c, 16));
+class Color {
+    constructor(rgb, a) {
+        /**
+         * The end goal here, is to parse the arguments
+         * into an integer triplet, such as `128, 255, 0`
+         *
+         * This facilitates operations and conversions.
+         */
+        if (Array.isArray(rgb)) {
+            this.rgb = rgb;
+        } else if (rgb.length == 6) {
+            this.rgb = rgb.match(/.{2}/g).map(c => parseInt(c, 16));
+        } else if (rgb.length == 7) {
+            this.rgb = rgb
+                .substring(1, 7)
+                .match(/.{2}/g)
+                .map(c => parseInt(c, 16));
+        } else {
+            this.rgb = rgb.split("").map(c => parseInt(c + c, 16));
+        }
+        this.alpha = typeof a === "number" ? a : 1;
     }
-    this.alpha = typeof a === "number" ? a : 1;
-};
-Color.prototype = {
-    eval: function() {
+
+    eval() {
         return this;
-    },
+    }
 
     //
     // If we have some transparency, the only way to represent it
@@ -1294,7 +1296,7 @@ Color.prototype = {
     // which has better compatibility with older browsers.
     // Values are capped between `0` and `255`, rounded and zero-padded.
     //
-    toCSS: function() {
+    toCSS() {
         if (this.alpha < 1.0) {
             return `rgba(${this.rgb
                 .map(c => Math.round(c))
@@ -1309,9 +1311,9 @@ Color.prototype = {
                 })
                 .join("")}`;
         }
-    },
+    }
 
-    toHSL: function() {
+    toHSL() {
         var r = this.rgb[0] / 255;
         var g = this.rgb[1] / 255;
         var b = this.rgb[2] / 255;
@@ -1342,9 +1344,9 @@ Color.prototype = {
             h /= 6;
         }
         return { h: h * 360, s: s, l: l, a: a };
-    },
+    }
 
-    toARGB: function() {
+    toARGB() {
         var argb = [Math.round(this.alpha * 255)].concat(this.rgb);
         return `#${argb
             .map(i => {
@@ -1353,9 +1355,9 @@ Color.prototype = {
                 return i.length === 1 ? `0${i}` : i;
             })
             .join("")}`;
-    },
+    }
 
-    mix: function(color2, weight) {
+    mix(color2, weight) {
         var color1 = this;
 
         var p = weight; // .value / 100.0;
@@ -1375,157 +1377,165 @@ Color.prototype = {
 
         return new Color(rgb, alpha);
     }
-};
+}
 
 // End colors from less.js
 
-var LinearRamp = function(start_color, end_color, start_value, end_value) {
-    /**
-     * Simple linear gradient
-     */
-    this.start_color = new Color(start_color);
-    this.end_color = new Color(end_color);
-    this.start_value = start_value;
-    this.end_value = end_value;
-    this.value_range = end_value - start_value;
-};
-
-LinearRamp.prototype.map_value = function(value) {
-    value = Math.max(value, this.start_value);
-    value = Math.min(value, this.end_value);
-    value = (value - this.start_value) / this.value_range;
-    // HACK: just red for now
-    // return "hsl(0,100%," + (value * 100) + "%)"
-    return this.start_color.mix(this.end_color, 1 - value).toCSS();
-};
-
-var SplitRamp = function(start_color, middle_color, end_color, start_value, end_value) {
-    /**
-     * Two gradients split away from 0
-     */
-    this.positive_ramp = new LinearRamp(middle_color, end_color, 0, end_value);
-    this.negative_ramp = new LinearRamp(middle_color, start_color, 0, -start_value);
-    this.start_value = start_value;
-    this.end_value = end_value;
-};
-
-SplitRamp.prototype.map_value = function(value) {
-    value = Math.max(value, this.start_value);
-    value = Math.min(value, this.end_value);
-    if (value >= 0) {
-        return this.positive_ramp.map_value(value);
-    } else {
-        return this.negative_ramp.map_value(-value);
+class LinearRamp {
+    constructor(start_color, end_color, start_value, end_value) {
+        /**
+         * Simple linear gradient
+         */
+        this.start_color = new Color(start_color);
+        this.end_color = new Color(end_color);
+        this.start_value = start_value;
+        this.end_value = end_value;
+        this.value_range = end_value - start_value;
     }
-};
 
-var DiagonalHeatmapPainter = function(data, view_start, view_end, prefs, mode) {
-    Painter.call(this, data, view_start, view_end, prefs, mode);
-    var i;
-    var len;
+    map_value(value) {
+        value = Math.max(value, this.start_value);
+        value = Math.min(value, this.end_value);
+        value = (value - this.start_value) / this.value_range;
+        // HACK: just red for now
+        // return "hsl(0,100%," + (value * 100) + "%)"
+        return this.start_color.mix(this.end_color, 1 - value).toCSS();
+    }
+}
 
-    if (this.prefs.min_value === undefined) {
-        var min_value = Infinity;
-        for (i = 0, len = this.data.length; i < len; i++) {
-            min_value = Math.min(min_value, this.data[i][6]);
+class SplitRamp {
+    constructor(start_color, middle_color, end_color, start_value, end_value) {
+        /**
+         * Two gradients split away from 0
+         */
+        this.positive_ramp = new LinearRamp(middle_color, end_color, 0, end_value);
+        this.negative_ramp = new LinearRamp(middle_color, start_color, 0, -start_value);
+        this.start_value = start_value;
+        this.end_value = end_value;
+    }
+
+    map_value(value) {
+        value = Math.max(value, this.start_value);
+        value = Math.min(value, this.end_value);
+        if (value >= 0) {
+            return this.positive_ramp.map_value(value);
+        } else {
+            return this.negative_ramp.map_value(-value);
         }
-        this.prefs.min_value = min_value;
     }
-    if (this.prefs.max_value === undefined) {
-        var max_value = -Infinity;
-        for (i = 0, len = this.data.length; i < len; i++) {
-            max_value = Math.max(max_value, this.data[i][6]);
+}
+
+class DiagonalHeatmapPainter extends Painter {
+    constructor(data, view_start, view_end, prefs, mode) {
+        super(data, view_start, view_end, prefs, mode);
+        var i;
+        var len;
+
+        if (this.prefs.min_value === undefined) {
+            var min_value = Infinity;
+            for (i = 0, len = this.data.length; i < len; i++) {
+                min_value = Math.min(min_value, this.data[i][6]);
+            }
+            this.prefs.min_value = min_value;
         }
-        this.prefs.max_value = max_value;
-    }
-};
-
-DiagonalHeatmapPainter.prototype.default_prefs = {
-    min_value: undefined,
-    max_value: undefined,
-    mode: "Heatmap",
-    pos_color: "#FF8C00",
-    neg_color: "#4169E1"
-};
-
-DiagonalHeatmapPainter.prototype.draw = function(ctx, width, height, w_scale) {
-    var min_value = this.prefs.min_value;
-    var max_value = this.prefs.max_value;
-    var view_start = this.view_start;
-    var invsqrt2 = 1 / Math.sqrt(2);
-
-    var ramp = new SplitRamp(this.prefs.neg_color, "#FFFFFF", this.prefs.pos_color, min_value, max_value);
-
-    var d;
-    var s1;
-    var e1;
-    var s2;
-    var e2;
-    var value;
-
-    var scale = p => (p - view_start) * w_scale;
-
-    ctx.save();
-
-    // Draw into triangle, then rotate and scale
-    ctx.rotate(-45 * Math.PI / 180);
-    ctx.scale(invsqrt2, invsqrt2);
-
-    // Paint track.
-    for (var i = 0, len = this.data.length; i < len; i++) {
-        d = this.data[i];
-
-        s1 = scale(d[1]);
-        e1 = scale(d[2]);
-        s2 = scale(d[4]);
-        e2 = scale(d[5]);
-        value = d[6];
-
-        ctx.fillStyle = ramp.map_value(value);
-        ctx.fillRect(s1, s2, e1 - s1, e2 - s2);
+        if (this.prefs.max_value === undefined) {
+            var max_value = -Infinity;
+            for (i = 0, len = this.data.length; i < len; i++) {
+                max_value = Math.max(max_value, this.data[i][6]);
+            }
+            this.prefs.max_value = max_value;
+        }
     }
 
-    ctx.restore();
-};
+    getDefailtPrefs() {
+        return {
+            min_value: undefined,
+            max_value: undefined,
+            mode: "Heatmap",
+            pos_color: "#FF8C00",
+            neg_color: "#4169E1"
+        };
+    }
+
+    draw(ctx, width, height, w_scale) {
+        var min_value = this.prefs.min_value;
+        var max_value = this.prefs.max_value;
+        var view_start = this.view_start;
+        var invsqrt2 = 1 / Math.sqrt(2);
+
+        var ramp = new SplitRamp(this.prefs.neg_color, "#FFFFFF", this.prefs.pos_color, min_value, max_value);
+
+        var d;
+        var s1;
+        var e1;
+        var s2;
+        var e2;
+        var value;
+
+        var scale = p => (p - view_start) * w_scale;
+
+        ctx.save();
+
+        // Draw into triangle, then rotate and scale
+        ctx.rotate(-45 * Math.PI / 180);
+        ctx.scale(invsqrt2, invsqrt2);
+
+        // Paint track.
+        for (var i = 0, len = this.data.length; i < len; i++) {
+            d = this.data[i];
+
+            s1 = scale(d[1]);
+            e1 = scale(d[2]);
+            s2 = scale(d[4]);
+            e2 = scale(d[5]);
+            value = d[6];
+
+            ctx.fillStyle = ramp.map_value(value);
+            ctx.fillRect(s1, s2, e1 - s1, e2 - s2);
+        }
+
+        ctx.restore();
+    }
+}
 
 /**
  * Utilities for painting reads.
  */
-var ReadPainterUtils = function(ctx, row_height, px_per_base, mode) {
-    this.ctx = ctx;
-    this.row_height = row_height;
-    this.px_per_base = px_per_base;
-    this.draw_details = (mode === "Pack" || mode === "Auto") && px_per_base >= ctx.canvas.manager.char_width_px;
-    this.delete_details_thickness = 0.2;
-};
+class ReadPainterUtils {
+    constructor(ctx, row_height, px_per_base, mode) {
+        this.ctx = ctx;
+        this.row_height = row_height;
+        this.px_per_base = px_per_base;
+        this.draw_details = (mode === "Pack" || mode === "Auto") && px_per_base >= ctx.canvas.manager.char_width_px;
+        this.delete_details_thickness = 0.2;
+    }
 
-_.extend(ReadPainterUtils.prototype, {
     /**
      * Draw deletion of base(s).
      * @param draw_detail if true, drawing in detail and deletion is drawn more subtly
      */
-    draw_deletion: function(x, y, len) {
+    draw_deletion(x, y, len) {
         this.ctx.fillStyle = "black";
         var thickness = (this.draw_details ? this.delete_details_thickness : 1) * this.row_height;
         y += 0.5 * (this.row_height - thickness);
         this.ctx.fillRect(x, y, len * this.px_per_base, thickness);
     }
-});
+}
 
 /**
  * Paints variant data onto canvas.
  */
-var VariantPainter = function(data, view_start, view_end, prefs, mode, base_color_fn) {
-    Painter.call(this, data, view_start, view_end, prefs, mode);
-    this.base_color_fn = base_color_fn;
-    this.divider_height = 1;
-};
+class VariantPainter extends Painter {
+    constructor(data, view_start, view_end, prefs, mode, base_color_fn) {
+        super(data, view_start, view_end, prefs, mode);
+        this.base_color_fn = base_color_fn;
+        this.divider_height = 1;
+    }
 
-_.extend(VariantPainter.prototype, Painter.prototype, {
     /**
      * Height of a single row, depends on mode
      */
-    get_row_height: function() {
+    get_row_height() {
         var mode = this.mode;
         var height;
         if (mode === "Dense") {
@@ -1537,12 +1547,12 @@ _.extend(VariantPainter.prototype, Painter.prototype, {
             height = PACK_TRACK_HEIGHT;
         }
         return height;
-    },
+    }
 
     /**
      * Returns required height to draw a particular number of samples in a given mode.
      */
-    get_required_height: function(num_samples) {
+    get_required_height(num_samples) {
         // FIXME: for single-sample data, height should be summary_height when zoomed out and
         // row_height when zoomed in.
         var height = this.prefs.summary_height;
@@ -1552,12 +1562,12 @@ _.extend(VariantPainter.prototype, Painter.prototype, {
             height += this.divider_height + num_samples * this.get_row_height();
         }
         return height;
-    },
+    }
 
     /**
      * Draw on the context using a rectangle of width x height with scale w_scale.
      */
-    draw: function(ctx, width, height, w_scale) {
+    draw(ctx, width, height, w_scale) {
         ctx.save();
 
         var /**
@@ -1737,7 +1747,7 @@ _.extend(VariantPainter.prototype, Painter.prototype, {
 
         ctx.restore();
     }
-});
+}
 
 export default {
     Scaler: Scaler,

--- a/client/galaxy/scripts/viz/trackster/painters.js
+++ b/client/galaxy/scripts/viz/trackster/painters.js
@@ -522,7 +522,6 @@ _.extend(LinkedFeaturePainter.prototype, FeaturePainter.prototype, {
      * Draw a feature. Returns an array with feature's start and end X coordinates.
      */
     draw_element: function(ctx, mode, feature, slot, tile_low, tile_high, w_scale, y_scale, width) {
-        console.debug("draw_element", feature);
         // var feature_uid = feature[0];
         var feature_start = feature[1];
         var feature_end = feature[2];

--- a/client/galaxy/scripts/viz/trackster/painters.js
+++ b/client/galaxy/scripts/viz/trackster/painters.js
@@ -148,11 +148,11 @@ class Painter {
         this.view_start = view_start;
         this.view_end = view_end;
         // Drawing prefs
-        this.prefs = _.extend({}, this.getDefaultPrefs(), prefs);
+        this.prefs = _.extend({}, this.default_prefs, prefs);
         this.mode = mode;
     }
 
-    getDefaultPrefs() {
+    static get default_prefs() {
         return {};
     }
 
@@ -195,7 +195,7 @@ class LinePainter extends Painter {
         super(data, view_start, view_end, prefs, mode);
     }
 
-    getDefaultPrefs() {
+    static get default_prefs() {
         return {
             min_value: undefined,
             max_value: undefined,
@@ -408,7 +408,10 @@ class FeaturePainter extends Painter {
         this.alpha_scaler = alpha_scaler ? alpha_scaler : new Scaler();
         this.height_scaler = height_scaler ? height_scaler : new Scaler();
         this.max_label_length = 200;
-        this.default_prefs = {
+    }
+
+    static get default_prefs() {
+        return {
             block_color: "#FFF",
             connector_color: "#FFF"
         };
@@ -1444,7 +1447,7 @@ class DiagonalHeatmapPainter extends Painter {
         }
     }
 
-    getDefailtPrefs() {
+    static get default_prefs() {
         return {
             min_value: undefined,
             max_value: undefined,

--- a/client/galaxy/scripts/viz/trackster/painters.js
+++ b/client/galaxy/scripts/viz/trackster/painters.js
@@ -437,12 +437,7 @@ class FeaturePainter extends Painter {
      * a FeaturePositionMapper object with information about where features were drawn.
      */
     draw(ctx, width, height, w_scale, slots) {
-        var data = this.data;
-        var view_start = this.view_start;
-        var view_end = this.view_end;
-
         ctx.save();
-
         ctx.fillStyle = this.prefs.block_color;
         ctx.textAlign = "right";
 
@@ -451,26 +446,29 @@ class FeaturePainter extends Painter {
         var x_draw_coords;
         var incomplete_features = [];
 
-        for (var i = 0, len = data.length; i < len; i++) {
-            var feature = data[i];
+        for (var i = 0, len = this.data.length; i < len; i++) {
+            var feature = this.data[i];
             var feature_uid = feature[0];
             var feature_start = feature[1];
             var feature_end = feature[2];
 
-            var // Slot valid only if features are slotted and this feature is slotted;
+            // Slot valid only if features are slotted and this feature is slotted;
             // feature may not be due to lack of space.
-            slot = slots && slots[feature_uid] !== undefined ? slots[feature_uid].slot : null;
+            var slot = slots && slots[feature_uid] !== undefined ? slots[feature_uid].slot : null;
 
             // Draw feature if (a) mode is dense or feature is slotted (as it must be for all non-dense modes) and
             // (b) there's overlap between the feature and drawing region.
-            if ((this.mode === "Dense" || slot !== null) && (feature_start < view_end && feature_end > view_start)) {
+            if (
+                (this.mode === "Dense" || slot !== null) &&
+                (feature_start < this.view_end && feature_end > this.view_start)
+            ) {
                 x_draw_coords = this.draw_element(
                     ctx,
                     this.mode,
                     feature,
                     slot,
-                    view_start,
-                    view_end,
+                    this.view_start,
+                    this.view_end,
                     w_scale,
                     y_scale,
                     width
@@ -478,7 +476,7 @@ class FeaturePainter extends Painter {
                 feature_mapper.map_feature_data(feature, slot, x_draw_coords[0], x_draw_coords[1]);
 
                 // Add to incomplete features if it's not drawn completely in region.
-                if (feature_start < view_start || feature_end > view_end) {
+                if (feature_start < this.view_start || feature_end > this.view_end) {
                     incomplete_features.push(feature);
                 }
             }

--- a/client/galaxy/scripts/viz/trackster/painters.js
+++ b/client/galaxy/scripts/viz/trackster/painters.js
@@ -1,20 +1,13 @@
 import * as _ from "libs/underscore";
-/**
- * Compute the type of overlap between two regions. They are assumed to be on the same chrom/contig.
- * The overlap is computed relative to the second region; hence, OVERLAP_START indicates that the first
- * region overlaps the start (but not the end) of the second region.
- * NOTE: Coordinates are assumed to be in BED format: half open (start is closed, end is open).
- */
+// Constants specific to feature tracks moved here (HACKING, these should
+// basically all be configuration options)
 const BEFORE = 1001;
-
 const CONTAINS = 1002;
 const OVERLAP_START = 1003;
 const OVERLAP_END = 1004;
 const CONTAINED_BY = 1005;
 const AFTER = 1006;
 
-// Constants specific to feature tracks moved here (HACKING, these should
-// basically all be configuration options)
 const DENSE_TRACK_HEIGHT = 10;
 const NO_DETAIL_TRACK_HEIGHT = 3;
 const SQUISH_TRACK_HEIGHT = 5;
@@ -26,6 +19,12 @@ const PACK_FEATURE_HEIGHT = 9;
 const LABEL_SPACING = 2;
 const CONNECTOR_COLOR = "#ccc";
 
+/**
+ * Compute the type of overlap between two regions. They are assumed to be on the same chrom/contig.
+ * The overlap is computed relative to the second region; hence, OVERLAP_START indicates that the first
+ * region overlaps the start (but not the end) of the second region.
+ * NOTE: Coordinates are assumed to be in BED format: half open (start is closed, end is open).
+ */
 function compute_overlap(first_region, second_region) {
     var first_start = first_region[0];
     var first_end = first_region[1];

--- a/client/galaxy/scripts/viz/trackster/painters.js
+++ b/client/galaxy/scripts/viz/trackster/painters.js
@@ -5,14 +5,15 @@ import * as _ from "libs/underscore";
  * region overlaps the start (but not the end) of the second region.
  * NOTE: Coordinates are assumed to be in BED format: half open (start is closed, end is open).
  */
-var BEFORE = 1001;
+const BEFORE = 1001;
 
-var CONTAINS = 1002;
-var OVERLAP_START = 1003;
-var OVERLAP_END = 1004;
-var CONTAINED_BY = 1005;
-var AFTER = 1006;
-var compute_overlap = (first_region, second_region) => {
+const CONTAINS = 1002;
+const OVERLAP_START = 1003;
+const OVERLAP_END = 1004;
+const CONTAINED_BY = 1005;
+const AFTER = 1006;
+
+function compute_overlap(first_region, second_region) {
     var first_start = first_region[0];
     var first_end = first_region[1];
     var second_start = second_region[0];
@@ -37,17 +38,16 @@ var compute_overlap = (first_region, second_region) => {
             overlap = OVERLAP_END;
         }
     }
-
     return overlap;
-};
+}
 
 /**
  * Returns true if regions overlap.
  */
-var is_overlap = (first_region, second_region) => {
+function is_overlap(first_region, second_region) {
     var overlap = compute_overlap(first_region, second_region);
     return overlap !== BEFORE && overlap !== AFTER;
-};
+}
 
 /**
  * Draw a dashed line on a canvas using filled rectangles. This function is based on:
@@ -55,7 +55,7 @@ var is_overlap = (first_region, second_region) => {
  * However, that approach uses lines, which don't seem to render as well, so use
  * rectangles instead.
  */
-var dashedLine = (ctx, x1, y1, x2, y2, dashLen) => {
+function dashedLine(ctx, x1, y1, x2, y2, dashLen) {
     if (dashLen === undefined) {
         dashLen = 4;
     }
@@ -72,12 +72,12 @@ var dashedLine = (ctx, x1, y1, x2, y2, dashLen) => {
         }
         ctx.fillRect(x1, y1, dashLen, 1);
     }
-};
+}
 
 /**
  * Draw an isosceles triangle that points down.
  */
-var drawDownwardEquilateralTriangle = function(ctx, down_vertex_x, down_vertex_y, side_len) {
+function drawDownwardEquilateralTriangle(ctx, down_vertex_x, down_vertex_y, side_len) {
     // Compute other two points of triangle.
     var x1 = down_vertex_x - side_len / 2;
 
@@ -95,7 +95,7 @@ var drawDownwardEquilateralTriangle = function(ctx, down_vertex_x, down_vertex_y
     ctx.fill();
     ctx.stroke();
     ctx.closePath();
-};
+}
 
 /**
  * Base class for all scalers. Scalers produce values that are used to change (scale) drawing attributes.
@@ -527,17 +527,12 @@ _.extend(LinkedFeaturePainter.prototype, FeaturePainter.prototype, {
         var feature_end = feature[2];
         var feature_name = feature[3];
         var feature_strand = feature[4];
-
-        var // -0.5 to offset region between bases.
-        f_start = Math.floor(Math.max(0, (feature_start - tile_low - 0.5) * w_scale));
-
+        // -0.5 to offset region between bases.
+        var f_start = Math.floor(Math.max(0, (feature_start - tile_low - 0.5) * w_scale));
         var f_end = Math.ceil(Math.min(width, Math.max(0, (feature_end - tile_low - 0.5) * w_scale)));
-
         var draw_start = f_start;
         var draw_end = f_end;
-
         var y_start = (mode === "Dense" ? 0 : 0 + slot) * y_scale + this.get_top_padding(width);
-
         var thick_start = null;
         var thick_end = null;
 
@@ -547,7 +542,6 @@ _.extend(LinkedFeaturePainter.prototype, FeaturePainter.prototype, {
             !feature_strand || feature_strand === "+" || feature_strand === "."
                 ? this.prefs.block_color
                 : this.prefs.reverse_strand_color;
-
         var label_color = this.prefs.label_color;
 
         // Set global alpha.

--- a/client/galaxy/scripts/viz/trackster/slotting.js
+++ b/client/galaxy/scripts/viz/trackster/slotting.js
@@ -45,7 +45,7 @@ extend(FeatureSlotter.prototype, {
 
         var draw_end = Math.ceil(feature[2] * this.w_scale);
         var f_name = feature[3];
-        var text_align;
+        //var text_align;
 
         // Update start, end drawing locations to include feature name.
         // Try to put the name on the left, if not, put on right.
@@ -55,10 +55,10 @@ extend(FeatureSlotter.prototype, {
             var text_len = this.measureText(f_name).width + (LABEL_SPACING + PACK_SPACING);
             if (draw_start - text_len >= 0) {
                 draw_start -= text_len;
-                text_align = "left";
+                //text_align = "left";
             } else {
                 draw_end += text_len;
-                text_align = "right";
+                //text_align = "right";
             }
         }
 
@@ -130,7 +130,7 @@ extend(FeatureSlotter.prototype, {
         // Loop through features to (a) find those that are not yet slotted and (b) update
         // those that are slotted if new information is availabe. For (a), features already
         // slotted (based on slotting from other tiles) will retain their current slot.
-        for (var i = 0, len = features.length; i < len; i++) {
+        for (let i = 0, len = features.length; i < len; i++) {
             feature = features[i];
             feature_uid = feature[0];
             var slotted_info = this.slots[feature_uid];
@@ -163,7 +163,7 @@ extend(FeatureSlotter.prototype, {
         // Slot unslotted features.
 
         // Do slotting.
-        for (var i = 0, len = undone.length; i < len; i++) {
+        for (let i = 0, len = undone.length; i < len; i++) {
             feature = features[undone[i]];
             feature_uid = feature[0];
             var draw_coords = this._get_draw_coords(feature);

--- a/client/galaxy/scripts/viz/trackster/tracks.js
+++ b/client/galaxy/scripts/viz/trackster/tracks.js
@@ -1484,7 +1484,7 @@ extend(TracksterView.prototype, DrawableCollection.prototype, {
         str = str.replace(/,/g, "");
 
         // Replace colons and hyphens with space for easy parsing.
-        str = str.replace(/:|\-/g, " ");
+        str = str.replace(/:|-/g, " ");
 
         // Parse new location.
         var chrom_pos = str.split(/\s+/);

--- a/client/galaxy/scripts/viz/trackster/tracks.js
+++ b/client/galaxy/scripts/viz/trackster/tracks.js
@@ -4150,10 +4150,9 @@ var FeatureTrack = function(view, container, obj_dict) {
     this.slotters = {};
     this.start_end_dct = {};
     this.left_offset = 200;
-
-    // this.painter = painters.LinkedFeaturePainter;
     this.set_painter_from_config();
 };
+
 extend(FeatureTrack.prototype, Drawable.prototype, TiledTrack.prototype, {
     display_modes: ["Auto", "Coverage", "Dense", "Squish", "Pack"],
 

--- a/client/galaxy/scripts/viz/trackster/tracks.js
+++ b/client/galaxy/scripts/viz/trackster/tracks.js
@@ -147,22 +147,23 @@ var moveable = (element, handle_class, container_selector, element_js_obj) => {
 /**
  * Init constants & functions used throughout trackster.
  */
-var // Padding at the top of tracks for error messages
-ERROR_PADDING = 20;
 
-var // Maximum number of rows un a slotted track
-MAX_FEATURE_DEPTH = 100;
+// Padding at the top of tracks for error messages
+var ERROR_PADDING = 20;
 
-var // Minimum width for window for squish to be used.
-MIN_SQUISH_VIEW_WIDTH = 12000;
+// Maximum number of rows un a slotted track
+var MAX_FEATURE_DEPTH = 100;
 
-var // Number of pixels per tile, not including left offset.
-TILE_SIZE = 400;
+// Minimum width for window for squish to be used.
+var MIN_SQUISH_VIEW_WIDTH = 12000;
+
+// Number of pixels per tile, not including left offset.
+var TILE_SIZE = 400;
 
 var DEFAULT_DATA_QUERY_WAIT = 5000;
 
-var // Maximum number of chromosomes that are selectable at any one time.
-MAX_CHROMS_SELECTABLE = 100;
+// Maximum number of chromosomes that are selectable at any one time.
+var MAX_CHROMS_SELECTABLE = 100;
 
 var DATA_ERROR = "Cannot display dataset due to an error. ";
 
@@ -175,13 +176,13 @@ var DATA_PENDING =
     "If the visualization is saved and closed, preparation will continue in the background.";
 
 var DATA_CANNOT_RUN_TOOL = "Tool cannot be rerun: ";
-var DATA_LOADING = "Loading data...";
+//var DATA_LOADING = "Loading data...";
 var DATA_OK = "Ready for display";
 var TILE_CACHE_SIZE = 10;
-var DATA_CACHE_SIZE = 20;
-
-var // Numerical/continuous data display modes.
-CONTINUOUS_DATA_MODES = ["Histogram", "Line", "Filled", "Intensity"];
+//var DATA_CACHE_SIZE = 20;
+//
+// Numerical/continuous data display modes.
+var CONTINUOUS_DATA_MODES = ["Histogram", "Line", "Filled", "Intensity"];
 
 /**
  * Round a number to a given number of decimal places.
@@ -769,16 +770,12 @@ extend(DrawableGroup.prototype, Drawable.prototype, DrawableCollection.prototype
                 // manager.
                 //
                 this.filters_manager.remove_all();
-                var filters;
-                var new_filter;
-                var min;
-                var max;
                 for (var filter_name in shared_filters) {
-                    filters = shared_filters[filter_name];
+                    let filters = shared_filters[filter_name];
                     if (filters.length === num_feature_tracks) {
                         // Add new filter.
                         // FIXME: can filter.copy() be used?
-                        new_filter = new filters_mod.NumberFilter({
+                        let new_filter = new filters_mod.NumberFilter({
                             name: filters[0].name,
                             index: filters[0].index
                         });
@@ -831,7 +828,7 @@ extend(DrawableGroup.prototype, Drawable.prototype, DrawableCollection.prototype
             name: this.config.get_value("name"),
             drawables: this.drawables
         });
-        var index = this.container.replace_drawable(this, composite_track, true);
+        this.container.replace_drawable(this, composite_track, true);
         composite_track.request_draw();
     },
 
@@ -1984,44 +1981,42 @@ var TracksterToolView = Backbone.View.extend({
             regions: [region.toJSON()]
         };
 
-        var current_track = track;
-
-        var // Set name of track to include tool name, parameters, and region used.
-        track_name = tool.get("name") + current_track.tool_region_and_parameters_str(region);
+        // Set name of track to include tool name, parameters, and region used.
+        var track_name = tool.get("name") + track.tool_region_and_parameters_str(region);
 
         var container;
 
         // If track not in a group, create a group for it and add new track to group. If track
         // already in group, add track to group.
-        if (current_track.container === view) {
+        if (track.container === track.view) {
             // Create new group.
-            var group = new DrawableGroup(view, view, {
+            var group = new DrawableGroup(track.view, track.view, {
                 name: track.config.get_value("name")
             });
 
             // Replace track with group.
-            var index = current_track.container.replace_drawable(current_track, group, false);
+            var index = track.container.replace_drawable(track, group, false);
 
             // Update HTML.
             // FIXME: this is ugly way to replace a track with a group -- make this easier via
             // a Drawable or DrawableCollection function.
-            group.container_div.insertBefore(current_track.view.content_div.children()[index]);
-            group.add_drawable(current_track);
-            current_track.container_div.appendTo(group.content_div);
+            group.container_div.insertBefore(track.view.content_div.children()[index]);
+            group.add_drawable(track);
+            track.container_div.appendTo(group.content_div);
             container = group;
         } else {
             // Use current group.
-            container = current_track.container;
+            container = track.container;
         }
 
         // Create and init new track.
-        var new_track = new current_track.constructor(view, container, {
+        var new_track = new track.constructor(track.view, container, {
             name: track_name,
             hda_ldda: "hda"
         });
         new_track.init_for_tool_data();
-        new_track.change_mode(current_track.mode);
-        new_track.set_filters_manager(current_track.filters_manager.copy(new_track));
+        new_track.change_mode(track.mode);
+        new_track.set_filters_manager(track.filters_manager.copy(new_track));
         new_track.update_icons();
         container.add_drawable(new_track);
         new_track.tiles_div.text("Starting job.");
@@ -3035,7 +3030,7 @@ extend(TiledTrack.prototype, Drawable.prototype, Track.prototype, {
         var clear_after = options && options.clear_after;
         var low = this.view.low;
         var high = this.view.high;
-        var range = high - low;
+        //var range = high - low;
         var width = this.view.container.width();
         var w_scale = this.view.resolution_px_b;
         var resolution = 1 / w_scale;
@@ -3423,7 +3418,6 @@ extend(TiledTrack.prototype, Drawable.prototype, Track.prototype, {
      * an existing tile rather than reshowing it.
      */
     show_tile: function(tile, w_scale) {
-        var track = this;
         var tile_element = tile.html_elt;
 
         // -- Show/move tile element. --
@@ -4131,6 +4125,7 @@ extend(DiagonalHeatmapTrack.prototype, Drawable.prototype, TiledTrack.prototype,
      * Draw tile.
      */
     draw_tile: function(result, ctx, mode, region, w_scale) {
+        console.debug("DRaw tile!", result, ctx, mode, region, w_scale);
         // Paint onto canvas.
         var canvas = ctx.canvas;
 
@@ -4253,9 +4248,6 @@ extend(FeatureTrack.prototype, Drawable.prototype, TiledTrack.prototype, {
     postdraw_actions: function(tiles, width, w_scale, clear_after) {
         TiledTrack.prototype.postdraw_actions.call(this, tiles, width, w_scale, clear_after);
 
-        var track = this;
-        var i;
-
         var line_track_tiles = _.filter(tiles, t => t instanceof LineTrackTile);
 
         //
@@ -4272,7 +4264,6 @@ extend(FeatureTrack.prototype, Drawable.prototype, TiledTrack.prototype, {
             });
 
             // Draw incomplete features on each tile.
-            var self = this;
             _.each(tiles, tile => {
                 // Remove features already drawn on tile originally.
                 var tile_incomplete_features = _.omit(
@@ -4291,16 +4282,16 @@ extend(FeatureTrack.prototype, Drawable.prototype, TiledTrack.prototype, {
                         data: _.values(tile_incomplete_features)
                     };
 
-                    var new_canvas = self.view.canvas_manager.new_canvas();
+                    var new_canvas = this.view.canvas_manager.new_canvas();
                     var new_canvas_ctx = new_canvas.getContext("2d");
                     new_canvas.height = Math.max(
                         tile.canvas.height,
-                        self.get_canvas_height(features, tile.mode, tile.w_scale, 100)
+                        this.get_canvas_height(features, tile.mode, tile.w_scale, 100)
                     );
                     new_canvas.width = tile.canvas.width;
                     new_canvas_ctx.drawImage(tile.canvas, 0, 0);
-                    new_canvas_ctx.translate(track.left_offset, 0);
-                    var new_tile = self.draw_tile(
+                    new_canvas_ctx.translate(this.left_offset, 0);
+                    var new_tile = this.draw_tile(
                         features,
                         new_canvas_ctx,
                         tile.mode,
@@ -4343,8 +4334,8 @@ extend(FeatureTrack.prototype, Drawable.prototype, TiledTrack.prototype, {
         //
 
         // Update filtering UI.
-        if (track.filters_manager) {
-            var filters = track.filters_manager.filters;
+        if (this.filters_manager) {
+            var filters = this.filters_manager.filters;
             var f;
             for (f = 0; f < filters.length; f++) {
                 filters[f].update_ui_elt();
@@ -4356,7 +4347,7 @@ extend(FeatureTrack.prototype, Drawable.prototype, TiledTrack.prototype, {
 
             var example_feature;
             var filter;
-            for (i = 0; i < tiles.length; i++) {
+            for (let i = 0; i < tiles.length; i++) {
                 if (tiles[i].data.length) {
                     example_feature = tiles[i].data[0];
                     for (f = 0; f < filters.length; f++) {
@@ -4370,12 +4361,12 @@ extend(FeatureTrack.prototype, Drawable.prototype, TiledTrack.prototype, {
             }
 
             // If filter availability changed, hide filter div if necessary and update menu.
-            if (track.filters_available !== filters_available) {
-                track.filters_available = filters_available;
-                if (!track.filters_available) {
-                    track.filters_manager.hide();
+            if (this.filters_available !== filters_available) {
+                this.filters_available = filters_available;
+                if (!this.filters_available) {
+                    this.filters_manager.hide();
                 }
-                track.update_icons();
+                this.update_icons();
             }
         }
 
@@ -4384,7 +4375,7 @@ extend(FeatureTrack.prototype, Drawable.prototype, TiledTrack.prototype, {
         //
         if (tiles[0] instanceof FeatureTrackTile) {
             var all_slotted = true;
-            for (i = 0; i < tiles.length; i++) {
+            for (let i = 0; i < tiles.length; i++) {
                 if (!tiles[i].all_slotted) {
                     all_slotted = false;
                     break;

--- a/client/galaxy/scripts/viz/trackster/tracks.js
+++ b/client/galaxy/scripts/viz/trackster/tracks.js
@@ -251,7 +251,10 @@ var Drawable = function(view, container, obj_dict) {
     this.action_icons = {};
 
     // -- Set up drawable configuration. --
-    this.config = config_mod.ConfigSettingCollection.from_models_and_saved_values(this.config_params, obj_dict.prefs);
+    this.config = config_mod.ConfigSettingCollection.from_models_and_saved_values(
+        this.build_config_params(),
+        obj_dict.prefs
+    );
 
     // If there's no saved name, use object name.
     if (!this.config.get_value("name")) {
@@ -344,6 +347,10 @@ extend(Drawable.prototype, {
             hidden: true
         }
     ],
+
+    build_config_params: function() {
+        return this.config_params;
+    },
 
     config_onchange: function() {},
 

--- a/client/galaxy/scripts/viz/trackster/tracks.js
+++ b/client/galaxy/scripts/viz/trackster/tracks.js
@@ -24,9 +24,9 @@ var html_elt_js_obj_dict = {};
 /**
  * Designates an HTML as a container.
  */
-var is_container = (element, obj) => {
+function is_container(element, obj) {
     html_elt_js_obj_dict[element.attr("id")] = obj;
-};
+}
 
 /**
  * Make `element` moveable within parent and sibling elements by dragging `handle` (a selector).
@@ -37,7 +37,7 @@ var is_container = (element, obj) => {
  * @param container_selector selector used to identify possible containers for this element
  * @param element_js_obj JavaScript object associated with element; used
  */
-var moveable = (element, handle_class, container_selector, element_js_obj) => {
+function moveable(element, handle_class, container_selector, element_js_obj) {
     // HACK: set default value for container selector.
     container_selector = ".group";
 
@@ -142,47 +142,47 @@ var moveable = (element, handle_class, container_selector, element_js_obj) => {
         .bind("dragend", function() {
             $(this).removeClass("dragging");
         });
-};
+}
 
 /**
  * Init constants & functions used throughout trackster.
  */
 
 // Padding at the top of tracks for error messages
-var ERROR_PADDING = 20;
+const ERROR_PADDING = 20;
 
 // Maximum number of rows un a slotted track
-var MAX_FEATURE_DEPTH = 100;
+const MAX_FEATURE_DEPTH = 100;
 
 // Minimum width for window for squish to be used.
-var MIN_SQUISH_VIEW_WIDTH = 12000;
+const MIN_SQUISH_VIEW_WIDTH = 12000;
 
 // Number of pixels per tile, not including left offset.
-var TILE_SIZE = 400;
+const TILE_SIZE = 400;
 
-var DEFAULT_DATA_QUERY_WAIT = 5000;
+const DEFAULT_DATA_QUERY_WAIT = 5000;
 
 // Maximum number of chromosomes that are selectable at any one time.
-var MAX_CHROMS_SELECTABLE = 100;
+const MAX_CHROMS_SELECTABLE = 100;
 
-var DATA_ERROR = "Cannot display dataset due to an error. ";
+const DATA_ERROR = "Cannot display dataset due to an error. ";
 
-var DATA_NOCONVERTER = "A converter for this dataset is not installed. Please check your datatypes_conf.xml file.";
+const DATA_NOCONVERTER = "A converter for this dataset is not installed. Please check your datatypes_conf.xml file.";
 
-var DATA_NONE = "No data for this chrom/contig.";
+const DATA_NONE = "No data for this chrom/contig.";
 
-var DATA_PENDING =
+const DATA_PENDING =
     "Preparing data. This can take a while for a large dataset. " +
     "If the visualization is saved and closed, preparation will continue in the background.";
 
-var DATA_CANNOT_RUN_TOOL = "Tool cannot be rerun: ";
+const DATA_CANNOT_RUN_TOOL = "Tool cannot be rerun: ";
 //var DATA_LOADING = "Loading data...";
-var DATA_OK = "Ready for display";
-var TILE_CACHE_SIZE = 10;
+const DATA_OK = "Ready for display";
+const TILE_CACHE_SIZE = 10;
 //var DATA_CACHE_SIZE = 20;
 //
 // Numerical/continuous data display modes.
-var CONTINUOUS_DATA_MODES = ["Histogram", "Line", "Filled", "Intensity"];
+const CONTINUOUS_DATA_MODES = ["Histogram", "Line", "Filled", "Intensity"];
 
 /**
  * Round a number to a given number of decimal places.
@@ -975,7 +975,8 @@ var TracksterView = Backbone.View.extend({
         this.intro_div = $("<div/>")
             .addClass("intro")
             .appendTo(this.viewport_container);
-        var add_tracks_button = $("<div/>")
+        // Add tracks button
+        $("<div/>")
             .text("Add Datasets to Visualization")
             .addClass("action-button")
             .appendTo(this.intro_div)
@@ -1820,7 +1821,7 @@ var ToolParameterView = Backbone.View.extend({
         var param = this.model;
 
         // Param label.
-        var label_div = $("<div>")
+        $("<div>")
             .addClass("param-label")
             .text(param.get("label"))
             .appendTo(param_div);
@@ -1873,7 +1874,7 @@ var TracksterToolView = Backbone.View.extend({
             });
 
         // Add name, inputs.
-        var name_div = $("<div class='tool-name'>")
+        $("<div class='tool-name'>")
             .appendTo(parent_div)
             .text(tool.get("name"));
         tool.get("inputs").each(param => {
@@ -2431,12 +2432,17 @@ extend(Track.prototype, Drawable.prototype, {
             name: "param_space_viz_icon",
             title: _l("Tool parameter space visualization"),
             css_class: "arrow-split",
-            on_click_fn: function(track) {
-                var html = `<strong>Tool</strong>:${track.tool.get(
-                    "name"
-                )}<br/><strong>Dataset</strong>:${track.config.get_value(
-                    "name"
-                )}<br/><strong>Region(s)</strong>: <select name="regions"><option value="cur">current viewing area</option><option value="bookmarks">bookmarks</option><option value="both">current viewing area and bookmarks</option></select>`;
+            on_click_fn: track => {
+                var html = `
+                    <strong>Tool</strong>:${track.tool.get("name")}<br/>
+                    <strong>Dataset</strong>:${track.config.get_value("name")}<br/>
+                    <strong>Region(s)</strong>:
+                        <select name="regions">
+                            <option value="cur">current viewing area</option>
+                            <option value="bookmarks">bookmarks</option>
+                            <option value="both">current viewing area and bookmarks</option>
+                        </select>
+                    `;
 
                 var cancel_fn = () => {
                     Galaxy.modal.hide();
@@ -2444,22 +2450,22 @@ extend(Track.prototype, Drawable.prototype, {
                 };
 
                 var ok_fn = () => {
-                    var regions_to_use = $('select[name="regions"] option:selected').val(),
-                        regions,
-                        view_region = new visualization.GenomeRegion({
-                            chrom: view.chrom,
-                            start: view.low,
-                            end: view.high
-                        }),
-                        bookmarked_regions = _.map(
-                            $(".bookmark"),
-                            elt =>
-                                new visualization.GenomeRegion({
-                                    from_str: $(elt)
-                                        .children(".position")
-                                        .text()
-                                })
-                        );
+                    var regions_to_use = $('select[name="regions"] option:selected').val();
+                    var regions;
+                    var view_region = new visualization.GenomeRegion({
+                        chrom: this.view.chrom,
+                        start: this.view.low,
+                        end: this.view.high
+                    });
+                    var bookmarked_regions = _.map(
+                        $(".bookmark"),
+                        elt =>
+                            new visualization.GenomeRegion({
+                                from_str: $(elt)
+                                    .children(".position")
+                                    .text()
+                            })
+                    );
 
                     // Get regions for visualization.
                     if (regions_to_use === "cur") {
@@ -2483,6 +2489,8 @@ extend(Track.prototype, Drawable.prototype, {
                     })}`;
                 };
 
+                /*
+                 * TODO: Re-enable this when functional.
                 var check_enter_esc = e => {
                     if ((e.keyCode || e.which) === 27) {
                         // Escape key
@@ -2492,6 +2500,7 @@ extend(Track.prototype, Drawable.prototype, {
                         ok_fn();
                     }
                 };
+                */
 
                 // show dialog
                 Galaxy.modal.show({
@@ -3330,10 +3339,7 @@ extend(TiledTrack.prototype, Drawable.prototype, Track.prototype, {
             var canvas = track.view.canvas_manager.new_canvas();
             var tile_low = region.get("start");
             var tile_high = region.get("end");
-            var all_data_index = 0;
-
             var width = Math.ceil((tile_high - tile_low) * w_scale) + track.left_offset;
-
             var height = _.max(drawing_heights);
             var tile;
 
@@ -3774,7 +3780,7 @@ extend(CompositeTrack.prototype, TiledTrack.prototype, {
         }
 
         // Replace track with group.
-        var index = this.container.replace_drawable(this, group, true);
+        this.container.replace_drawable(this, group, true);
         group.request_draw({ clear_tile_cache: true });
     },
 
@@ -3808,7 +3814,6 @@ extend(CompositeTrack.prototype, TiledTrack.prototype, {
      * Update minimum, maximum for component tracks.
      */
     update_all_min_max: function() {
-        var track = this;
         var min_value = this.config.get_value("min_value");
         var max_value = this.config.get_value("max_value");
         _.each(this.drawables, d => {
@@ -4116,6 +4121,7 @@ extend(DiagonalHeatmapTrack.prototype, Drawable.prototype, TiledTrack.prototype,
                 hda_ldda: track.dataset.get("hda_ldda")
             },
             result => {
+                // What does this do?  Is it meant to be attached to some higher scope state object?
                 var data = result.data;
             }
         );
@@ -4125,7 +4131,6 @@ extend(DiagonalHeatmapTrack.prototype, Drawable.prototype, TiledTrack.prototype,
      * Draw tile.
      */
     draw_tile: function(result, ctx, mode, region, w_scale) {
-        console.debug("DRaw tile!", result, ctx, mode, region, w_scale);
         // Paint onto canvas.
         var canvas = ctx.canvas;
 

--- a/client/galaxy/scripts/viz/trackster/tracks.js
+++ b/client/galaxy/scripts/viz/trackster/tracks.js
@@ -48,11 +48,9 @@ var moveable = (element, handle_class, container_selector, element_js_obj) => {
     element
         .bind("drag", { handle: `.${handle_class}`, relative: true }, function(e, d) {
             var element = $(this);
-            var parent = $(this).parent();
-
-            var // Only sorting amongst tracks and groups.
-            children = parent.children(".track,.group");
-
+            var parent = element.parent();
+            // Only sorting amongst tracks and groups.
+            var children = parent.children(".track,.group");
             var this_obj = html_elt_js_obj_dict[$(this).attr("id")];
             var child;
             var container;
@@ -723,7 +721,6 @@ extend(DrawableGroup.prototype, Drawable.prototype, DrawableCollection.prototype
             for (i = 0; i < num_drawables; i++) {
                 drawable = this.drawables[i];
                 if (drawable.get_type() !== a_type) {
-                    can_composite = false;
                     break;
                 }
                 if (drawable instanceof FeatureTrack) {
@@ -1315,12 +1312,11 @@ extend(TracksterView.prototype, DrawableCollection.prototype, {
         if (delay) {
             // To aggregate calls, use timer and only navigate once
             // location has stabilized.
-            var self = this;
             this.timer = setTimeout(() => {
-                self.trigger("navigate", `${new_chrom}:${new_low}-${new_high}`);
+                this.trigger("navigate", `${new_chrom}:${new_low}-${new_high}`);
             }, 500);
         } else {
-            view.trigger("navigate", `${new_chrom}:${new_low}-${new_high}`);
+            this.trigger("navigate", `${new_chrom}:${new_low}-${new_high}`);
         }
     },
 
@@ -1343,13 +1339,12 @@ extend(TracksterView.prototype, DrawableCollection.prototype, {
     load_chroms: function(url_parms) {
         url_parms.num = MAX_CHROMS_SELECTABLE;
 
-        var view = this;
         var chrom_data = $.Deferred();
         $.ajax({
             url: `${Galaxy.root}api/genomes/${this.dbkey}`,
             data: url_parms,
             dataType: "json",
-            success: function(result) {
+            success: result => {
                 // Do nothing if could not load chroms.
                 if (result.chrom_info.length === 0) {
                     return;
@@ -1357,34 +1352,34 @@ extend(TracksterView.prototype, DrawableCollection.prototype, {
 
                 // Load chroms.
                 if (result.reference) {
-                    var ref_track = new ReferenceTrack(view);
-                    view.add_label_track(ref_track);
-                    view.reference_track = ref_track;
+                    var ref_track = new ReferenceTrack(this);
+                    this.add_label_track(ref_track);
+                    this.reference_track = ref_track;
                 }
-                view.chrom_data = result.chrom_info;
+                this.chrom_data = result.chrom_info;
 
-                view.chrom_select.html("");
-                view.chrom_select.append($('<option value="">Select Chrom/Contig</option>'));
+                this.chrom_select.html("");
+                this.chrom_select.append($('<option value="">Select Chrom/Contig</option>'));
 
-                for (var i = 0, len = view.chrom_data.length; i < len; i++) {
-                    var chrom = view.chrom_data[i].chrom;
+                for (var i = 0, len = this.chrom_data.length; i < len; i++) {
+                    var chrom = this.chrom_data[i].chrom;
                     var chrom_option = $("<option>");
                     chrom_option.text(chrom);
                     chrom_option.val(chrom);
-                    view.chrom_select.append(chrom_option);
+                    this.chrom_select.append(chrom_option);
                 }
                 if (result.prev_chroms) {
-                    view.chrom_select.append($(`<option value="previous">Previous ${MAX_CHROMS_SELECTABLE}</option>`));
+                    this.chrom_select.append($(`<option value="previous">Previous ${MAX_CHROMS_SELECTABLE}</option>`));
                 }
                 if (result.next_chroms) {
-                    view.chrom_select.append($(`<option value="next">Next ${MAX_CHROMS_SELECTABLE}</option>`));
+                    this.chrom_select.append($(`<option value="next">Next ${MAX_CHROMS_SELECTABLE}</option>`));
                 }
-                view.chrom_start_index = result.start_index;
+                this.chrom_start_index = result.start_index;
 
                 chrom_data.resolve(result.chrom_info);
             },
             error: function() {
-                alert(`Could not load chroms for this dbkey: ${view.dbkey}`);
+                alert(`Could not load chroms for this dbkey: ${this.dbkey}`);
             }
         });
         return chrom_data;
@@ -1779,8 +1774,8 @@ extend(TracksterView.prototype, DrawableCollection.prototype, {
         this.overview_box.height(this.default_overview_height);
         this.overview_close.hide();
         this.overview_highlight.hide();
-        view.resize_window();
-        view.overview_drawable = null;
+        this.resize_window();
+        this.overview_drawable = null;
     }
 });
 

--- a/client/galaxy/scripts/viz/trackster/tracks.js
+++ b/client/galaxy/scripts/viz/trackster/tracks.js
@@ -1,5 +1,6 @@
 import _l from "utils/localization";
 import * as _ from "libs/underscore";
+import * as Backbone from "libs/backbone";
 import visualization from "viz/visualization";
 import viz_views from "viz/viz_views";
 import util from "viz/trackster/util";
@@ -12,6 +13,9 @@ import config_mod from "utils/config";
 import bbi from "viz/bbi-data-manager";
 import "ui/editable-text";
 var extend = _.extend;
+
+/* global $ */
+/* global Galaxy */
 
 // ---- Web UI specific utilities ----
 
@@ -1265,11 +1269,11 @@ var TracksterView = Backbone.View.extend({
         $(window).bind("resize", function() {
             // Stop previous timer.
             if (this.resize_timer) {
-                clearTimeout(this.resize_timer);
+                window.clearTimeout(this.resize_timer);
             }
 
             // When function activated, resize window and redraw.
-            this.resize_timer = setTimeout(() => {
+            this.resize_timer = window.setTimeout(() => {
                 view.resize_window();
             }, 500);
         });
@@ -1304,13 +1308,13 @@ extend(TracksterView.prototype, DrawableCollection.prototype, {
     trigger_navigate: function(new_chrom, new_low, new_high, delay) {
         // Stop previous timer.
         if (this.timer) {
-            clearTimeout(this.timer);
+            window.clearTimeout(this.timer);
         }
 
         if (delay) {
             // To aggregate calls, use timer and only navigate once
             // location has stabilized.
-            this.timer = setTimeout(() => {
+            this.timer = window.setTimeout(() => {
                 this.trigger("navigate", `${new_chrom}:${new_low}-${new_high}`);
             }, 500);
         } else {
@@ -1530,10 +1534,10 @@ extend(TracksterView.prototype, DrawableCollection.prototype, {
 
         // Set up timeout to redraw with more data when moving stops.
         if (this.redraw_on_move_fn) {
-            clearTimeout(this.redraw_on_move_fn);
+            window.clearTimeout(this.redraw_on_move_fn);
         }
 
-        this.redraw_on_move_fn = setTimeout(() => {
+        this.redraw_on_move_fn = window.setTimeout(() => {
             view.request_redraw();
         }, 200);
 
@@ -2731,7 +2735,7 @@ extend(Track.prototype, Drawable.prototype, {
                 track.container_div.addClass("pending");
                 track.show_message(DATA_PENDING);
                 //$("<img/>").attr("src", image_path + "/yui/rel_interstitial_loading.gif").appendTo(track.tiles_div);
-                setTimeout(() => {
+                window.setTimeout(() => {
                     track.init();
                 }, track.data_query_wait);
             } else if (result === "data" || result.status === "data") {
@@ -4114,7 +4118,7 @@ extend(DiagonalHeatmapTrack.prototype, Drawable.prototype, TiledTrack.prototype,
             },
             result => {
                 // What does this do?  Is it meant to be attached to some higher scope state object?
-                var data = result.data;
+                // var data = result.data;
             }
         );
     },

--- a/client/galaxy/scripts/viz/trackster/tracks.js
+++ b/client/galaxy/scripts/viz/trackster/tracks.js
@@ -3044,7 +3044,7 @@ extend(TiledTrack.prototype, Drawable.prototype, Track.prototype, {
         if (this.is_overview) {
             low = this.view.max_low;
             high = this.view.max_high;
-            w_scale = width / (view.max_high - view.max_low);
+            w_scale = width / (this.view.max_high - this.view.max_low);
             resolution = 1 / w_scale;
         }
 
@@ -3275,13 +3275,13 @@ extend(TiledTrack.prototype, Drawable.prototype, Track.prototype, {
             ) => d.data_manager.get_data(region, data_mode, resolution, track.data_url_extra_params));
 
             // Get reference data/promise.
-            if (view.reference_track) {
+            if (this.view.reference_track) {
                 tile_data.push(
-                    view.reference_track.data_manager.get_data(
+                    this.view.reference_track.data_manager.get_data(
                         region,
                         mode,
                         resolution,
-                        view.reference_track.data_url_extra_params
+                        this.view.reference_track.data_url_extra_params
                     )
                 );
             }
@@ -3312,8 +3312,8 @@ extend(TiledTrack.prototype, Drawable.prototype, Track.prototype, {
             }
 
             // If sequence data is available, subset to get only data in region.
-            if (view.reference_track) {
-                seq_data = view.reference_track.data_manager.subset_entry(tile_data.pop(), region);
+            if (this.view.reference_track) {
+                seq_data = this.view.reference_track.data_manager.subset_entry(tile_data.pop(), region);
             }
 
             // Get drawing modes, heights for all tracks.
@@ -4552,6 +4552,7 @@ extend(FeatureTrack.prototype, Drawable.prototype, TiledTrack.prototype, {
         );
 
         var feature_mapper = null;
+        var incomplete_features = null;
 
         ctx.fillStyle = this.config.get_value("block_color");
         ctx.font = ctx.canvas.manager.default_font;

--- a/client/galaxy/scripts/viz/visualization.js
+++ b/client/galaxy/scripts/viz/visualization.js
@@ -5,7 +5,6 @@ import util_mod from "viz/trackster/util";
 import config_mod from "utils/config";
 import GridView from "mvc/grid/grid-view";
 import Tabs from "mvc/ui/ui-tabs";
-import Ui from "mvc/ui/ui-misc";
 /**
  * Mixin for returning custom JSON representation from toJSON. Class attribute to_json_keys defines a set of attributes
  * to include in the representation; to_json_mappers defines mappers for returned objects.
@@ -1112,9 +1111,8 @@ var TrackBrowserRouter = Backbone.Router.extend({
         this.route(/([\w\+]+\:[\d,]+-[\d,]+)$/, "change_location");
 
         // Handle navigate events from view.
-        var self = this;
-        self.view.on("navigate", new_loc => {
-            self.navigate(new_loc);
+        this.view.on("navigate", new_loc => {
+            this.navigate(new_loc);
         });
     },
 

--- a/client/galaxy/scripts/viz/visualization.js
+++ b/client/galaxy/scripts/viz/visualization.js
@@ -1108,7 +1108,7 @@ var TrackBrowserRouter = Backbone.Router.extend({
         // Can't put regular expression in routes dictionary.
         // NOTE: parentheses are used to denote parameters returned to callback.
         this.route(/([\w]+)$/, "change_location");
-        this.route(/([\w\+]+\:[\d,]+-[\d,]+)$/, "change_location");
+        this.route(/([\w+]+:[\d,]+-[\d,]+)$/, "change_location");
 
         // Handle navigate events from view.
         this.view.on("navigate", new_loc => {


### PR DESCRIPTION
This makes the Trackster work again.

The gist here is a reasonably large viz overhaul with the goals of 1) making it work again, and 2) converting the whole thing to classes and modern javascript inheritance.

Implementing ES6 multiple inheritance w/ backbone objects/etc. turned out to be more of a pain than I expected, so I pulled those changes into another branch to keep working on in order to get the core fixes into 18.01.