### PR TITLE
[WIP] add an 'api' endpoint /api/docs/ to display all(?) available api urls…

### DIFF
--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -322,6 +322,9 @@ def populate_api_routes(webapp, app):
         conditions=dict(method=["PUT"])
     )
     webapp.mapper.resource('configuration', 'configuration', path_prefix='/api')
+    webapp.mapper.connect("api_docs",
+                          "/api/docs", controller="configuration",
+                          action="api_docs", conditions=dict(method=["GET"]))
     webapp.mapper.connect("configuration_version",
                           "/api/version", controller="configuration",
                           action="version", conditions=dict(method=["GET"]))


### PR DESCRIPTION
After the idea of the DRF browsable API, this would add an 'api' endpoint `/api/docs/` to display all(?) available api urls/methods and their docstring.

Currently this would look like below and obviously there is room for styling/cleanup - or rewrite.

<img width="572" alt="screen shot 2018-01-04 at 13 46 30" src="https://user-images.githubusercontent.com/102411/34564106-b3e179f2-f155-11e7-8b96-c867bd047700.png">

