### PR TITLE
Fix dev sourcemap firefox compatibility

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -78,10 +78,10 @@ let buildconfig = {
                     }
                 ]
             },
-              {
+            {
                 test: /\.vue$/,
-                loader: 'vue-loader',
-              }
+                loader: "vue-loader"
+            }
         ]
     },
     node: {
@@ -112,8 +112,8 @@ let buildconfig = {
     ]
 };
 
-if (process.env.GXY_BUILD_SOURCEMAPS || process.env.NODE_ENV == "development"){
-    buildconfig.devtool = 'source-map';
+if (process.env.GXY_BUILD_SOURCEMAPS || process.env.NODE_ENV == "development") {
+    buildconfig.devtool = "source-map";
 }
 
 module.exports = buildconfig;

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -99,9 +99,6 @@ let buildconfig = {
             name: "libs",
             filename: "libs.bundled.js"
         }),
-        new webpack.SourceMapDevToolPlugin({
-            filename: '[name].js.map',
-        }),
         // this plugin allows using the following keys/globals in scripts (w/o req'ing them first)
         // and webpack will automagically require them in the bundle for you
         new webpack.ProvidePlugin({
@@ -115,7 +112,7 @@ let buildconfig = {
     ]
 };
 
-if (process.env.GXY_BUILD_SOURCEMAPS){
+if (process.env.GXY_BUILD_SOURCEMAPS || process.env.NODE_ENV == "development"){
     buildconfig.devtool = 'source-map';
 }
 


### PR DESCRIPTION
The plugin version sourcemap devtool generates sourcemaps that don't play nicely in firefox (link to bundles instead of original source);  this swaps to the single devtool version that is less configurable but it works everywhere.  Shouldn't be a problem since we're not using any of the advanced configuration options (yet).