### PR TITLE
Mark rerun_with_use_cached_job as flakey

### DIFF
--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -13,6 +13,7 @@ from base import api  # noqa: I100,I202
 from base.populators import (  # noqa: I100
     DatasetCollectionPopulator,
     DatasetPopulator,
+    flakey,
     skip_without_tool,
     wait_on,
     WorkflowPopulator
@@ -1822,6 +1823,7 @@ test_data:
         self.dataset_populator.wait_for_history_jobs(history_id, assert_ok=assert_ok)
         time.sleep(.5)
 
+    @flakey
     @skip_without_tool('cat1')
     def test_workflow_rerun_with_use_cached_job(self):
         workflow = self.workflow_populator.load_workflow(name="test_for_run")


### PR DESCRIPTION
Sometimes it does not pick up the equivalent job that should exist. Will need
to dig into this, but in the meantime we can allow the test to fail.