### PR TITLE
Fixes the --no-client-build startup option 

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -29,7 +29,7 @@ for arg in "$@"; do
     [ "$arg" = "--replace-pip" ] && REPLACE_PIP=1
     [ "$arg" = "--stop-daemon" ] && FETCH_WHEELS=0
     [ "$arg" = "--skip-samples" ] && COPY_SAMPLE_FILES=0
-    [ "$arg" = "--no-client-build" ] && SKIP_CLIENT_BUILD=1
+    [ "$arg" = "--skip-client-build" ] && SKIP_CLIENT_BUILD=1
 done
 
 SAMPLES="
@@ -83,7 +83,7 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
     fi
     if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
         echo "The Galaxy client build is out of date.  Please run 'make client' or your choice of client build target (client-*)."
-        echo "If you're sure you'd like to skip this check, you can run galaxy with the --no-client-build flag, though this is not recommended as the client and server code will potentially be out of sync."
+        echo "If you're sure you'd like to skip this check, you can run galaxy with the --skip-client-build flag, though this is not recommended as the client and server code will potentially be out of sync."
         echo "See ./client/README.md in the Galaxy repository for more information, including how to get help if you're having trouble."
         exit 1
     fi

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -6,7 +6,7 @@ parse_common_args() {
     while :
     do
         case "$1" in
-            --skip-eggs|--skip-wheels|--skip-samples|--dev-wheels|--no-create-venv|--no-replace-pip|--replace-pip)
+            --skip-eggs|--skip-wheels|--skip-samples|--dev-wheels|--no-create-venv|--no-replace-pip|--replace-pip|--skip-client-build)
                 common_startup_args="$common_startup_args $1"
                 shift
                 ;;


### PR DESCRIPTION
This wasn't being passed through the `parse_common_args` logic.
Also renames it `--skip-client-build`, which is a little more standard for us I think.