### PR TITLE
[17.09] Backport #5233

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -531,7 +531,7 @@ def build_isolated_environment(
         # - https://github.com/galaxyproject/galaxy/issues/3635
         # - https://github.com/conda/conda/issues/2035
         offline_works = (conda_context.conda_version < LooseVersion("4.3")) or \
-                        (conda_context.conda_version >= LooseVersion("4.3.18"))
+                        (conda_context.conda_version >= LooseVersion("4.4"))
         if offline_works:
             create_args.extend(["--offline"])
         else:


### PR DESCRIPTION
In order to get rid of the conda error described in #5187 I raised the version number beginning from which conda is allowed to use the '--offline' parameter again to "4.4"