### PR TITLE
[17.09] Fix tool report submission with sentry

### DIFF
--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -64,6 +64,17 @@ class SentryPlugin(ErrorPlugin):
             error_message = ERROR_TEMPLATE.format(**extra)
 
             # Update context with user information in a sentry-specific manner
+
+            # Getting the url allows us to link to the dataset info page in case
+            # anything is missing from this report.
+            try:
+                url = web.url_for(controller="dataset",
+                                  action="show_params",
+                                  dataset_id=self.app.security.encode_id(dataset.id),
+                                  qualified=True)
+            except AttributeError:
+                # The above does not work when handlers are separate from the web handlers
+                url = None
             self.app.sentry_client.context.merge({
                 # User information here also places email links + allows seeing
                 # a list of affected users in the tags/filtering.
@@ -71,14 +82,8 @@ class SentryPlugin(ErrorPlugin):
                     'name': user.username,
                     'email': user.email,
                 },
-                # This allows us to link to the dataset info page in case
-                # anything is missing from this report.
                 'request': {
-                    'url': web.url_for(
-                        controller="dataset", action="show_params",
-                        dataset_id=self.app.security.encode_id(dataset.id),
-                        qualified=True
-                    )
+                    'url': url
                 }
             })
 


### PR DESCRIPTION
Otherwise tool error report submissions fail with:
```
AttributeError: 'thread._local' object has no attribute 'mapper'
  File "galaxy/tools/error_reports/__init__.py", line 58, in submit_report
    response = plugin.submit_report(dataset, job, tool, **kwargs)
  File "galaxy/tools/error_reports/plugins/sentry.py", line 80, in submit_report
    qualified=True
  File "routes/util.py", line 201, in url_for
    encoding = config.mapper.encoding
  File "routes/__init__.py", line 15, in __getattr__
    return getattr(self.__shared_state, name)
```