### PR TITLE
Fix Galaxy instance startup error

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -174,7 +174,7 @@ if [ $DEV_WHEELS -eq 1 ]; then
 fi
 
 if [ $FETCH_WHEELS -eq 1 ]; then
-    pip install "$requirement_args" --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
+    pip install $requirement_args --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
     GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))")
     [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
 fi


### PR DESCRIPTION
This PR fixes the Galaxy instance startup error by removing the "quotes" of a variable in 
`/scripts/scripts/common_startup.sh` at line `177`