### PR TITLE
Fix string substitution syntax in sort tool action

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2517,7 +2517,7 @@ class SortTool(DatabaseOperationTool):
                 try:
                     sorted_elements = [old_elements_dict[line.strip()] for line in open(hda.file_name)]
                 except KeyError:
-                    hdca_history_name = "%s: %s" (hdca.hid, hdca.name)
+                    hdca_history_name = "%s: %s" % (hdca.hid, hdca.name)
                     message = "List of element identifiers does not match element identifiers in collection '%s'" % hdca_history_name
                     raise Exception(message)
 


### PR DESCRIPTION
Introduced together with the sort from file feature in https://github.com/galaxyproject/galaxy/pull/5273