### PR TITLE
Wait for dataset to be present when getting size

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1239,7 +1239,7 @@ class JobWrapper(object, HasResourceParameters):
                 if not purged:
                     self._collect_extra_files(dataset.dataset, self.working_directory)
                 # Handle composite datatypes of auto_primary_file type
-                if dataset.datatype.composite_type == 'auto_primary_file' and not dataset.has_data():
+                if dataset.datatype.composite_type == 'auto_primary_file' and not dataset.has_data(wait_seconds=self.app.config.retry_job_output_collection):
                     try:
                         with NamedTemporaryFile() as temp_fh:
                             temp_fh.write(dataset.datatype.generate_primary_file(dataset))
@@ -1251,7 +1251,7 @@ class JobWrapper(object, HasResourceParameters):
                 if job.states.ERROR == final_job_state:
                     dataset.blurb = "error"
                     dataset.mark_unhidden()
-                elif not purged and dataset.has_data():
+                elif not purged and dataset.has_data(wait_seconds=self.app.config.retry_job_output_collection):
                     # If the tool was expected to set the extension, attempt to retrieve it
                     if dataset.ext == 'auto':
                         dataset.extension = context.get('ext', 'data')

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1916,9 +1916,14 @@ class Dataset(StorableObject):
             for root, dirs, files in os.walk(self.extra_files_path):
                 self.total_size += sum([os.path.getsize(os.path.join(root, file)) for file in files if os.path.exists(os.path.join(root, file))])
 
-    def has_data(self):
+    def has_data(self, wait_seconds=0):
         """Detects whether there is any data"""
-        return self.get_size() > 0
+        size = self.get_size()
+        while size == 0 and wait_seconds > 0:
+            time.sleep(0.25)
+            wait_seconds -= 0.25
+            size = self.get_size()
+        return size > 0
 
     def mark_deleted(self):
         self.deleted = True
@@ -2098,9 +2103,9 @@ class DatasetInstance(object):
     def set_total_size(self):
         return self.dataset.set_total_size()
 
-    def has_data(self):
+    def has_data(self, wait_seconds=0):
         """Detects whether there is any data"""
-        return self.dataset.has_data()
+        return self.dataset.has_data(wait_seconds=wait_seconds)
 
     def get_raw_data(self):
         """Returns the full data. To stream it open the file_name and read/write as needed"""

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1874,16 +1874,19 @@ class Dataset(StorableObject):
 
     def _calculate_size(self, wait_seconds=0):
         if self.external_filename:
-            exists = False
-            while exists is False and wait_seconds > 0:
-                exists = os.path.exists(self.external_filename)
-                if exists is False:
+            try:
+                size = os.path.getsize(self.external_filename)
+            except OSError:
+                size = 0
+            while size == 0 and wait_seconds > 0:
+                try:
+                    size = os.path.getsize(self.external_filename)
+                except OSError:
+                    pass
+                if size == 0:
                     time.sleep(0.25)
                     wait_seconds -= 0.25
-            try:
-                return os.path.getsize(self.external_filename)
-            except OSError:
-                return 0
+            return size
         else:
             return self.object_store.size(self)
 

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -366,19 +366,22 @@ class DiskObjectStore(ObjectStore):
 
         Returns 0 if the object doesn't exist yet or other error.
         """
-        exists = self.exists(obj, **kwargs)
-        wait_seconds = getattr(self.config, 'retry_job_output_collection', 0)
-        while exists is False and wait_seconds > 0:
-            wait_seconds -= 0.25
-            time.sleep(0.25)
-            exists = self.exists(obj, **kwargs)
-        if exists:
+        size = 0
+        if self.exists(obj, **kwargs):
+            filename = self.get_filename(obj, **kwargs)
             try:
-                return os.path.getsize(self.get_filename(obj, **kwargs))
+                size = os.path.getsize(filename)
             except OSError:
-                return 0
-        else:
-            return 0
+                pass
+            wait_seconds = getattr(self.config, 'retry_job_output_collection', 0)
+            while size == 0 and wait_seconds > 0:
+                wait_seconds -= 0.25
+                time.sleep(0.25)
+                try:
+                    size = os.path.getsize(filename)
+                except OSError:
+                    pass
+        return size
 
     def delete(self, obj, entire_dir=False, **kwargs):
         """Override `ObjectStore`'s stub; delete the file or folder on disk."""


### PR DESCRIPTION
I noticed that for very short but numerous grep jobs or very small alignments
I would get datasets that had `empty` written where I would expect the dataset peak,
and alignments would be missing the index file.

I traced this down to the file size being 0, which leads to external metadata
not being read in. The time during which we wait for the dataset is controlled
by the `retry_job_output_collection` setting.