### PR TITLE
Add option to replace failed elements on job rerun

### DIFF
--- a/client/galaxy/scripts/mvc/tool/tool-form.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form.js
@@ -136,16 +136,22 @@ var View = Backbone.View.extend({
 
         // remap feature
         if (options.job_id && options.job_remap) {
+            if (options.job_remap === "job_produced_collection_elements") {
+                var label = "Replace elements in collection ?";
+                var help = "The previous run of this tool failed. Use this option to replace the failed element(s) in the dataset collectio that were produced during the previous tool run.";
+            } else {
+                var label = "Resume dependencies from this job ?";
+                var help = "The previous run of this tool failed and other tools were waiting for it to finish successfully. Use this option to resume those tools using the new output(s) of this tool run.";
+            }
             options.inputs.push({
-                label: "Resume dependencies from this job",
+                label: label,
                 name: "rerun_remap_job_id",
                 type: "select",
                 display: "radio",
                 ignore: "__ignore__",
                 value: "__ignore__",
                 options: [["Yes", options.job_id], ["No", "__ignore__"]],
-                help:
-                    "The previous run of this tool failed and other tools were waiting for it to finish successfully. Use this option to resume those tools using the new output(s) of this tool run."
+                help: help,
             });
         }
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1890,6 +1890,9 @@ class Tool(object, Dictifiable):
                 try:
                     if [hda.dependent_jobs for hda in [jtod.dataset for jtod in job.output_datasets] if hda.dependent_jobs]:
                         return True
+                    elif job.output_dataset_collection_instances:
+                        # We'll want to replace this item
+                        return 'job_produced_collection_elements'
                 except Exception as exception:
                     log.error(str(exception))
                     pass


### PR DESCRIPTION
Replacing failed collection elements was already possible when dependent jobs
were found (https://github.com/galaxyproject/galaxy/pull/5247).
This commit restructures the remapping so that remapping is possible when no
dependent jobs are available. This also simplifies the replacement of HDAs
between old and new jobs.