### PR TITLE
Work around (temporarily) wrong getsize() output

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1251,7 +1251,7 @@ class JobWrapper(object, HasResourceParameters):
                 if job.states.ERROR == final_job_state:
                     dataset.blurb = "error"
                     dataset.mark_unhidden()
-                elif not purged and dataset.has_data():
+                elif not purged:
                     # If the tool was expected to set the extension, attempt to retrieve it
                     if dataset.ext == 'auto':
                         dataset.extension = context.get('ext', 'data')
@@ -1299,7 +1299,7 @@ class JobWrapper(object, HasResourceParameters):
                     except Exception:
                         dataset.set_peek()
                 else:
-                    # Handle an empty dataset.
+                    # Handle purged datasets.
                     dataset.blurb = "empty"
                     if dataset.ext == 'auto':
                         dataset.extension = context.get('ext', 'txt')

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -10,6 +10,7 @@ import os
 import random
 import shutil
 import threading
+import time
 from xml.etree import ElementTree
 
 try:
@@ -367,7 +368,12 @@ class DiskObjectStore(ObjectStore):
         """
         if self.exists(obj, **kwargs):
             try:
-                return os.path.getsize(self.get_filename(obj, **kwargs))
+                size = os.path.getsize(self.get_filename(obj, **kwargs))
+                if size == 0:
+                    # May be legitimately 0, or there may be an issue with the FS / kernel, so we try again
+                    time.sleep(0.01)
+                    size = os.path.getsize(self.get_filename(obj, **kwargs))
+                return size
             except OSError:
                 return 0
         else:

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -359,7 +359,7 @@ class DiskObjectStore(ObjectStore):
 
     def empty(self, obj, **kwargs):
         """Override `ObjectStore`'s stub by checking file size on disk."""
-        return os.path.getsize(self.get_filename(obj, **kwargs)) == 0
+        return self.size(obj, **kwargs) == 0
 
     def size(self, obj, **kwargs):
         """Override `ObjectStore`'s stub by return file size on disk.
@@ -368,11 +368,13 @@ class DiskObjectStore(ObjectStore):
         """
         if self.exists(obj, **kwargs):
             try:
-                size = os.path.getsize(self.get_filename(obj, **kwargs))
-                if size == 0:
+                filepath = self.get_filename(obj, **kwargs)
+                for _ in range(0, 2):
+                    size = os.path.getsize(filepath)
+                    if size != 0:
+                        break
                     # May be legitimately 0, or there may be an issue with the FS / kernel, so we try again
                     time.sleep(0.01)
-                    size = os.path.getsize(self.get_filename(obj, **kwargs))
                 return size
             except OSError:
                 return 0


### PR DESCRIPTION
This is an alternative to https://github.com/galaxyproject/galaxy/pull/5316.

This consists of 2 things: In the object store code we check the file size twice if it is 0, this seems to be sufficient to work around the behaviour I described in the commit message of b7fb583.

The other thing is that we can set metadata for empty files, we don't need to special-case this IMO. It is possible though that some datatypes won't be able to set metadata, but that's not worse than not loading metadata at all.