### PR TITLE
Tag editor size constraint

### DIFF
--- a/client/galaxy/style/less/base.less
+++ b/client/galaxy/style/less/base.less
@@ -1889,10 +1889,10 @@ div.toolTitleNoSection
 
 /* Temporary tag editor display; will be moved to a scoped Vue SFC upon refactoring */
 .tags-display {
-    max-height: 80px;
-    overflow: auto;
     .list-item .vertical-spacing;
     .select2-container {
+        max-height: 80px;
+        overflow: auto;
         min-width: 0px;
         .select2-choices {
             border-radius: 3px;

--- a/client/galaxy/style/less/base.less
+++ b/client/galaxy/style/less/base.less
@@ -1887,6 +1887,19 @@ div.toolTitleNoSection
   opacity: 1;
 }
 
+/* Temporary tag editor display; will be moved to a scoped Vue SFC upon refactoring */
+.tags-display {
+    max-height: 80px;
+    overflow: auto;
+    .list-item .vertical-spacing;
+    .select2-container {
+        min-width: 0px;
+        .select2-choices {
+            border-radius: 3px;
+        }
+    }
+}
+
 /* For Vue */
 [v-cloak] {
     display:none;

--- a/client/galaxy/style/less/dataset.less
+++ b/client/galaxy/style/less/dataset.less
@@ -263,16 +263,9 @@
             }
         }
 
-        //TODO: move these out
         .tags-display {
+            // Hidden by default; the interface toggles this.
             display: none;
-            .list-item .vertical-spacing;
-            .select2-container {
-                min-width: 0px;
-                .select2-choices {
-                    border-radius: 3px;
-                }
-            }
         }
         .annotation-display {
             display: none;

--- a/client/galaxy/style/less/history.less
+++ b/client/galaxy/style/less/history.less
@@ -66,17 +66,6 @@
                 content: ':';
             }
         }
-        .tags-display {
-            .select2-container {
-                min-width: 0px;
-                .select2-choices {
-                    border-radius: 3px;
-                }
-            }
-            input {
-                border-radius: 3px;
-            }
-        }
         .annotation-display {
             .annotation {
                 background: white;


### PR DESCRIPTION
Constrain tag editor height, minor refactoring and standardization of style.  Will be removed with the planned conversion to a vue component that can pop out with a more flexible display, but this fixes https://github.com/galaxyproject/galaxy/issues/5280 in the short term.