### PR TITLE
[17.09] Fix tool-shed-config-validate

### DIFF
--- a/lib/galaxy/webapps/config_manage.py
+++ b/lib/galaxy/webapps/config_manage.py
@@ -397,15 +397,14 @@ def _lint(args, app_desc):
 
 def _validate(args, app_desc):
     path = _find_config(args, app_desc)
-    with open(path, "r") as f:
-        # Allow empty mapping (not allowed by pykawlify)
-        raw_config = _order_load_path(f)
-        if raw_config.get(app_desc.app_name, None) is None:
-            raw_config[app_desc.app_name] = {}
-            config_p = tempfile.NamedTemporaryFile(delete=False, suffix=".yml")
-            _ordered_dump(raw_config, config_p)
-            config_p.flush()
-            path = config_p.name
+    # Allow empty mapping (not allowed by pykawlify)
+    raw_config = _order_load_path(path)
+    if raw_config.get(app_desc.app_name, None) is None:
+        raw_config[app_desc.app_name] = {}
+        config_p = tempfile.NamedTemporaryFile(delete=False, suffix=".yml")
+        _ordered_dump(raw_config, config_p)
+        config_p.flush()
+        path = config_p.name
 
     fp = tempfile.NamedTemporaryFile(delete=False, suffix=".yml")
     _ordered_dump(app_desc.schema.raw_schema, fp)


### PR DESCRIPTION
I test the  command `make tool-shed-config-validate` with @erasche , and it returns
```
root@v-VirtualBox:~/galaxy# make tool-shed-config-validate
if [ -f .venv/bin/activate ]; then . .venv/bin/activate; fi; python lib/galaxy/webapps/config_manage.py validate tool_shed
Traceback (most recent call last):
  File "lib/galaxy/webapps/config_manage.py", line 709, in <module>
    main()
  File "lib/galaxy/webapps/config_manage.py", line 264, in main
    action_func(args, app_desc)
  File "lib/galaxy/webapps/config_manage.py", line 402, in _validate
    raw_config = _order_load_path(f)
  File "lib/galaxy/webapps/config_manage.py", line 576, in _order_load_path
    with open(path, "r") as f:
TypeError: coercing to Unicode: need string or buffer, file found
Makefile:60: recipe for target 'tool-shed-config-validate' failed
make: *** [tool-shed-config-validate] Error 1
```
The problem seems to come from the function `def _validate(args, app_desc):`
In the function`_validate` a path is found and the config file open, and the file object is given to the function  `def _order_load_path(path):` [line 398](
https://github.com/galaxyproject/galaxy/blob/release_17.09/lib/galaxy/webapps/config_manage.py#L398)
The problem is, in the function  `_order_load_path`  try to open again the config file and failed, [line574](
https://github.com/galaxyproject/galaxy/blob/release_17.09/lib/galaxy/webapps/config_manage.py#L574)

I propose to remove the [line 400](https://github.com/galaxyproject/galaxy/blob/release_17.09/lib/galaxy/webapps/config_manage.py#L400) `with open(path, "r") as f:` because the file object named `f` isn't used somewhere else and to replace it by the `path` variable when the function `_order_load_path(path)` is called, like it's used [line 372](https://github.com/galaxyproject/galaxy/blob/release_17.09/lib/galaxy/webapps/config_manage.py#L372)
