### PR TITLE
[17.09] History import fixes

### DIFF
--- a/lib/galaxy/tools/imp_exp/imp_history_from_archive.xml
+++ b/lib/galaxy/tools/imp_exp/imp_history_from_archive.xml
@@ -1,7 +1,7 @@
 <tool id="__IMPORT_HISTORY__" name="Import History" version="0.1" tool_type="import_history">
   <type class="ImportHistoryTool" module="galaxy.tools"/>
   <action module="galaxy.tools.actions.history_imp_exp" class="ImportHistoryToolAction"/>
-  <command interpreter="python">unpack_tar_gz_archive.py "${ str( $__ARCHIVE_SOURCE__ ).encode( 'base64' ) }" "${ str( $__DEST_DIR__ ).encode( 'base64' ) }" --$__ARCHIVE_TYPE__ --encoded</command>
+  <command>python $__tool_directory__/unpack_tar_gz_archive.py '${ str( $__ARCHIVE_SOURCE__ ).encode( 'base64' ) }' '${ str( $__DEST_DIR__ ).encode( 'base64' ) }' --$__ARCHIVE_TYPE__ --encoded</command>
   <inputs>
     <param name="__ARCHIVE_SOURCE__" type="text">
       <sanitizer sanitize="False"/>

--- a/lib/galaxy/tools/imp_exp/imp_history_from_archive.xml
+++ b/lib/galaxy/tools/imp_exp/imp_history_from_archive.xml
@@ -1,7 +1,7 @@
 <tool id="__IMPORT_HISTORY__" name="Import History" version="0.1" tool_type="import_history">
   <type class="ImportHistoryTool" module="galaxy.tools"/>
   <action module="galaxy.tools.actions.history_imp_exp" class="ImportHistoryToolAction"/>
-  <command>python $__tool_directory__/unpack_tar_gz_archive.py '${ str( $__ARCHIVE_SOURCE__ ).encode( 'base64' ) }' '${ str( $__DEST_DIR__ ).encode( 'base64' ) }' --$__ARCHIVE_TYPE__ --encoded</command>
+  <command>python '$__tool_directory__/unpack_tar_gz_archive.py' '${ str( $__ARCHIVE_SOURCE__ ).encode( 'base64' ) }' '${ str( $__DEST_DIR__ ).encode( 'base64' ) }' --$__ARCHIVE_TYPE__ --encoded</command>
   <inputs>
     <param name="__ARCHIVE_SOURCE__" type="text">
       <sanitizer sanitize="False"/>

--- a/lib/galaxy/tools/imp_exp/unpack_tar_gz_archive.py
+++ b/lib/galaxy/tools/imp_exp/unpack_tar_gz_archive.py
@@ -49,7 +49,7 @@ def check_archive(archive_file, dest_dir):
     Ensure that a tar archive has no absolute paths or relative paths outside
     the archive.
     """
-    with tarfile.open(archive_file, mode='r:gz') as archive_fp:
+    with tarfile.open(archive_file, mode='r') as archive_fp:
         for arc_path in archive_fp.getnames():
             assert os.path.normpath(
                 os.path.join(
@@ -64,7 +64,7 @@ def unpack_archive(archive_file, dest_dir):
     """
     Unpack a tar and/or gzipped archive into a destination directory.
     """
-    archive_fp = tarfile.open(archive_file, mode='r:gz')
+    archive_fp = tarfile.open(archive_file, mode='r')
     archive_fp.extractall(path=dest_dir)
     archive_fp.close()
 

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1155,6 +1155,9 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         archive_url = kwargs.get('archive_url', None)
         archive_source = None
         if hasattr(archive_file, 'file'):
+            # archive_file.file is a TemporaryFile and will be deleted once it is closed.
+            # We prevent this by setting `delete` to `False`.
+            archive_file.file.delete = False
             archive_source = archive_file.file.name
             archive_type = 'file'
         elif archive_url:


### PR DESCRIPTION
This fixes the history import on production setups. The first two commits are backported from dev, the third commit needs to be applied to dev (this has moved to the API and won't apply cleanly).

Addresses most of https://github.com/galaxyproject/galaxy/issues/3235#issuecomment-358805440