### PR TITLE
Fix bam conversion test tool

### DIFF
--- a/test/functional/tools/sam_to_bam_native.xml
+++ b/test/functional/tools/sam_to_bam_native.xml
@@ -23,8 +23,12 @@
         <param name="input3" type="data" format="bam" label="Sorted BAM file" optional="true"/>
     </inputs>
     <outputs>
-        <data name="bam_native_output" format="bam_native"/>
-        <data name="bam_output" format="bam"/>
+        <data name="bam_native_output" format="bam_native">
+            <filter>input1 or input2</filter>
+        </data>
+        <data name="bam_output" format="bam">
+            <filter>input3</filter>
+        </data>
     </outputs>
     <tests>
         <!-- Test that bam native output won't be sorted-->


### PR DESCRIPTION
Starting with 16344a6 we attempt to set metadata also for files that have no
content. BAM files need to contain at least a header. To avoid failing tests we
only create the appropriate output based on the input.