### PR TITLE
[17.09] remove charlimit for fetching urls

### DIFF
--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -310,7 +310,7 @@ class UploadDataset(Group):
         def get_url_paste_urls_or_filename(group_incoming, override_name=None, override_info=None):
             url_paste_file = group_incoming.get('url_paste', None)
             if url_paste_file is not None:
-                url_paste = open(url_paste_file, 'r').read(1024)
+                url_paste = open(url_paste_file, 'r').read()
 
                 def start_of_url(content):
                     start_of_url_paste = content.lstrip()[0:8].lower()


### PR DESCRIPTION
fixes #5349
this would only allow a number of urls that fit 1024 chars together
moreover it would (unless you are in luck) truncate (and break) the last one

>[jxtx] So much of Galaxy was built in a world where two datasets was a lot.