### PR TITLE
Fix logic in deactivate or uninstall

### DIFF
--- a/templates/admin/tool_shed_repository/deactivate_or_uninstall_repository.mako
+++ b/templates/admin/tool_shed_repository/deactivate_or_uninstall_repository.mako
@@ -199,7 +199,7 @@ else:
                 %else:
                     <% deactivate_uninstall_button_text = "Uninstall" %>
                     ##hack to mimic check box
-                    <input type="hidden" name="remove_from_disk" value="true"/><input type="hidden" name="remove_from_disk" value="true"/>
+                    <input type="hidden" name="remove_from_disk" value="true"/>
                 %endif
                 <input type="submit" name="deactivate_or_uninstall_repository_button" value="${deactivate_uninstall_button_text|h}"/>
             </div>


### PR DESCRIPTION
The form value interpreter no longer uses `['true', 'true']` to determine whether a checkbox is checked, so a single form value of 'true' will now be sufficient.