### PR TITLE
Remove additional checkbox workarounds.

### DIFF
--- a/templates/admin/tool_shed_repository/deactivate_or_uninstall_repository.mako
+++ b/templates/admin/tool_shed_repository/deactivate_or_uninstall_repository.mako
@@ -121,7 +121,7 @@ else:
                     </div>
                     <div style="clear: both"></div>
                     <br/>
-                    <%                        
+                    <%
                         irm = trans.app.installed_repository_manager
                         repository_tup = irm.get_repository_tuple_for_installed_repository_manager( repository )
 
@@ -172,7 +172,7 @@ else:
                                         owner = containing_repository.owner
                                     %>
                                     <li>
-                                        Version <b>${version | h}</b> of ${type | h} <b>${name | h}</b> contained in revision 
+                                        Version <b>${version | h}</b> of ${type | h} <b>${name | h}</b> contained in revision
                                         <b>${changeset_revision | h}</b> of repository <b>${repository_name | h}</b> owned by <b>${owner | h}</b>
                                     </li>
                                 %endfor

--- a/templates/admin/tool_shed_repository/manage_repository_tool_dependencies.mako
+++ b/templates/admin/tool_shed_repository/manage_repository_tool_dependencies.mako
@@ -69,7 +69,7 @@ ${render_galaxy_repository_actions( repository )}
                 </div>
                 <div style="clear: both"></div>
                 <div class="form-row">
-                    <input type="checkbox" id="checkAllUninstalled" name="select_all_uninstalled_tool_dependencies_checkbox" value="true" onclick="checkAllUninstalledToolDependencyIdFields(1);"/><input type="hidden" name="select_all_uninstalled_tool_dependencies_checkbox" value="true"/><b>Select/unselect all tool dependencies</b>
+                    <input type="checkbox" id="checkAllUninstalled" name="select_all_uninstalled_tool_dependencies_checkbox" value="true" onclick="checkAllUninstalledToolDependencyIdFields(1);"/><b>Select/unselect all tool dependencies</b>
                 </div>
                 <div style="clear: both"></div>
                 <div class="form-row">
@@ -90,7 +90,7 @@ ${render_galaxy_repository_actions( repository )}
                 </div>
                 <div style="clear: both"></div>
                 <div class="form-row">
-                    <input type="checkbox" id="checkAllInstalled" name="select_all_installed_tool_dependencies_checkbox" value="true" onclick="checkAllInstalledToolDependencyIdFields(1);"/><input type="hidden" name="select_all_installed_tool_dependencies_checkbox" value="true"/><b>Select/unselect all tool dependencies</b>
+                    <input type="checkbox" id="checkAllInstalled" name="select_all_installed_tool_dependencies_checkbox" value="true" onclick="checkAllInstalledToolDependencyIdFields(1);"/><b>Select/unselect all tool dependencies</b>
                 </div>
                 <div style="clear: both"></div>
                 <div class="form-row">

--- a/templates/admin/tool_shed_repository/reset_metadata_on_selected_repositories.mako
+++ b/templates/admin/tool_shed_repository/reset_metadata_on_selected_repositories.mako
@@ -24,7 +24,7 @@
             </div>
             <div style="clear: both"></div>
             <div class="form-row">
-                <input type="checkbox" id="checkAll" name="select_all_repositories_checkbox" value="true" onclick="checkAllRepositoryIdFields(1);"/><input type="hidden" name="select_all_repositories_checkbox" value="true"/><b>Select/unselect all repositories</b>
+                <input type="checkbox" id="checkAll" name="select_all_repositories_checkbox" value="true" onclick="checkAllRepositoryIdFields(1);"/><b>Select/unselect all repositories</b>
             </div>
             <div style="clear: both"></div>
             <div class="form-row">

--- a/templates/webapps/tool_shed/common/reset_metadata_on_selected_repositories.mako
+++ b/templates/webapps/tool_shed/common/reset_metadata_on_selected_repositories.mako
@@ -47,7 +47,7 @@
             </div>
             <div style="clear: both"></div>
             <div class="form-row">
-                <input type="checkbox" id="checkAll" name="select_all_repositories_checkbox" value="true" onclick="checkAllRepositoryIdFields(1);"/><input type="hidden" name="select_all_repositories_checkbox" value="true"/><b>Select/unselect all repositories</b>
+                <input type="checkbox" id="checkAll" name="select_all_repositories_checkbox" value="true" onclick="checkAllRepositoryIdFields(1);"/><b>Select/unselect all repositories</b>
             </div>
             <div style="clear: both"></div>
             <div class="form-row">


### PR DESCRIPTION
As with #5363, the form value interpreter no longer uses ['true', 'true'] to determine whether a checkbox is checked, so a single form value of 'true' is sufficient.