### PR TITLE
Demonstrate local components broken without template compiler.

### DIFF
--- a/client/galaxy/scripts/components/Citations.vue
+++ b/client/galaxy/scripts/components/Citations.vue
@@ -3,7 +3,7 @@
         <div class="toolFormTitle">
             Citations
             <button v-if="viewRender" v-on:click="toggleViewRender" type="button" class="btn btn-xs citations-to-bibtex" title="Show all in BibTeX format.">
-                <i class="fa fa-pencil-square-o"></i>
+                <times foo="bar"></times>
                 Show BibTeX
             </button>
             <button v-else type="button" v-on:click="toggleViewRender" class="btn btn-xs citations-to-formatted" title="Return to formatted citation list.">
@@ -31,6 +31,16 @@ import axios from "axios";
 import * as bibtexParse from "libs/bibtexParse";
 import { convertLaTeX } from "latex-to-unicode-converter";
 import { stringifyLaTeX } from "latex-parser";
+
+const Times = {
+    template: `<i class="fa fa-times">{{ foo }}</i>`,
+    props: {
+        foo: {
+            type: String,
+            required: true
+        },
+    }
+}
 
 export default {
     props: {
@@ -186,6 +196,9 @@ export default {
         toggleViewRender: function() {
             this.viewRender = !this.viewRender;
         }
+    },
+    components: {
+        Times,
     }
 };
 </script>


### PR DESCRIPTION
The second example of components from the Vue docs (https://vuejs.org/v2/guide/components.html#Local-Registration) seems to not work without the template compiler. I'm okay with us declaring we are not going to use the template compiler at runtime but I want to be clear about what we are loosing - I think it is being able to do this right - defining components in the same file?

PR not for merging.