### PR TITLE
Bump conditional Pygments version to 2.2.0 so it matches the dev

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -1,7 +1,7 @@
 # These dependencies are only required when certain config options are set
 psycopg2==2.6.1
 WebError==0.10.3
-Pygments==2.0.2
+Pygments==2.2.0
 python-openid
 MySQL-python
 fluent-logger


### PR DESCRIPTION
Otherwise you ping pong between versions:

```console
Collecting pygments==2.2.0 (from -r ./lib/galaxy/dependencies/dev-requirements.txt (line 5))
  Using cached Pygments-2.2.0-py2.py3-none-any.whl
Installing collected packages: pygments
  Found existing installation: Pygments 2.0.2
    Uninstalling Pygments-2.0.2:
      Successfully uninstalled Pygments-2.0.2
Successfully installed pygments-2.2.0

Collecting Pygments==2.0.2 (from -r /dev/stdin (line 3))
  Using cached Pygments-2.0.2-py2-none-any.whl
Installing collected packages: Pygments
  Found existing installation: Pygments 2.2.0
    Uninstalling Pygments-2.2.0:
      Successfully uninstalled Pygments-2.2.0
Successfully installed Pygments-2.0.2
```

If you came here from #5128 or #5347 wondering why this issue references those, it's because I accidentally did so in the original PR description and there's no way to remove the references. This PR is unrelated.