### PR TITLE
Allow specification of resource requirements in tools.

### DIFF
--- a/lib/galaxy/tool_util/cwl/parser.py
+++ b/lib/galaxy/tool_util/cwl/parser.py
@@ -459,6 +459,24 @@ class CommandLineToolProxy(ToolProxy):
                     requirements.append((package["package"], first_version))
         return requirements
 
+    def resource_requirements(self) -> List[Dict[str, Union[int, float, str]]]:
+        cwl_to_galaxy = {
+            "coresMin": "cores_min",
+            "coresMax": "cores_max",
+            "ramMin": "ram_min",
+            "ramMax": "ram_max",
+            "tmpdirMin": "tmpdir_min",
+            "tmpdirMax": "tmpdir_max",
+        }
+        cwl_key_set = set(cwl_to_galaxy.keys())
+        rr = []
+        for r in self._tool.tool.get("requirements", []):
+            if r["class"] == "ResourceRequirement":
+                for key in cwl_key_set.intersection(set(r.keys())):
+                    galaxy_key = cwl_to_galaxy[key]
+                    rr.append({galaxy_key: r[key]})
+        return rr
+
     @property
     def requirements(self):
         return getattr(self._tool, "requirements", [])

--- a/lib/galaxy/tool_util/cwl/parser.py
+++ b/lib/galaxy/tool_util/cwl/parser.py
@@ -459,23 +459,8 @@ class CommandLineToolProxy(ToolProxy):
                     requirements.append((package["package"], first_version))
         return requirements
 
-    def resource_requirements(self) -> List[Dict[str, Union[int, float, str]]]:
-        cwl_to_galaxy = {
-            "coresMin": "cores_min",
-            "coresMax": "cores_max",
-            "ramMin": "ram_min",
-            "ramMax": "ram_max",
-            "tmpdirMin": "tmpdir_min",
-            "tmpdirMax": "tmpdir_max",
-        }
-        cwl_key_set = set(cwl_to_galaxy.keys())
-        rr = []
-        for r in self._tool.tool.get("requirements", []):
-            if r["class"] == "ResourceRequirement":
-                for key in cwl_key_set.intersection(set(r.keys())):
-                    galaxy_key = cwl_to_galaxy[key]
-                    rr.append({galaxy_key: r[key]})
-        return rr
+    def resource_requirements(self):
+        return [r for r in self.requirements if r["class"] == "ResourceRequirement"]
 
     @property
     def requirements(self):

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_tool.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_tool.py
@@ -29,7 +29,7 @@ def main(argv=None):
     parser.add_argument("tool", metavar="TOOL", default=None, help="Path to tool to build mulled image for.")
     args = parser.parse_args()
     tool_source = get_tool_source(args.tool)
-    requirements, _ = tool_source.parse_requirements_and_containers()
+    requirements, *_ = tool_source.parse_requirements_and_containers()
     targets = requirements_to_mulled_targets(requirements)
     kwds = args_to_mull_targets_kwds(args)
     mull_targets(targets, **kwds)

--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -236,17 +236,11 @@ class ResourceRequirement:
         if resource_type not in VALID_RESOURCE_TYPES:
             raise ValueError(f"Invalid resource requirement type '{resource_type}'")
         self.resource_type = resource_type
-        self._runtime_required: Optional[bool] = None
-
-    @property
-    def runtime_required(self):
-        if self._runtime_required is None:
-            try:
-                float(self.value_or_expression)
-                self._runtime_required = False
-            except ValueError:
-                self._runtime_required = True
-        return self._runtime_required
+        try:
+            float(self.value_or_expression)
+            self.runtime_required = False
+        except ValueError:
+            self.runtime_required = True
 
     @staticmethod
     def from_dict(resource_dict):

--- a/lib/galaxy/tool_util/linters/cwl.py
+++ b/lib/galaxy/tool_util/linters/cwl.py
@@ -32,7 +32,7 @@ def lint_new_draft(tool_source, lint_ctx):
 
 
 def lint_docker_image(tool_source, lint_ctx):
-    _, containers = tool_source.parse_requirements_and_containers()
+    _, containers, *_ = tool_source.parse_requirements_and_containers()
     if len(containers) == 0:
         lint_ctx.warn("Tool does not specify a DockerPull source.")
     else:

--- a/lib/galaxy/tool_util/linters/general.py
+++ b/lib/galaxy/tool_util/linters/general.py
@@ -69,7 +69,7 @@ def lint_general(tool_source, lint_ctx):
     else:
         lint_ctx.valid(PROFILE_INFO_SPECIFIED_MSG % profile, node=tool_node)
 
-    requirements, containers = tool_source.parse_requirements_and_containers()
+    requirements, containers, resource_requirements = tool_source.parse_requirements_and_containers()
     for r in requirements:
         if r.type == "package":
             if not r.name:
@@ -79,3 +79,6 @@ def lint_general(tool_source, lint_ctx):
             # Warn requirement attributes with leading/trailing whitespace:
             elif r.version != r.version.strip():
                 lint_ctx.warn(WARN_WHITESPACE_MSG % ("Requirement version", r.version))
+    for rr in resource_requirements:
+        if rr.runtime_required:
+            lint_ctx.warn("Expressions in resource requirement not supported yet")

--- a/lib/galaxy/tool_util/parser/cwl.py
+++ b/lib/galaxy/tool_util/parser/cwl.py
@@ -152,12 +152,14 @@ class CwlToolSource(ToolSource):
             containers.append({"type": "docker", "identifier": docker_identifier})
 
         software_requirements = self.tool_proxy.software_requirements()
+        resource_requirements = self.tool_proxy.resource_requirements()
         return requirements.parse_requirements_from_dict(
             dict(
                 requirements=list(
                     map(lambda r: {"name": r[0], "version": r[1], "type": "package"}, software_requirements)
                 ),
                 containers=containers,
+                resource_requirements=resource_requirements,
             )
         )
 

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -182,7 +182,7 @@ class ToolSource(metaclass=ABCMeta):
 
     @abstractmethod
     def parse_requirements_and_containers(self):
-        """Return pair of ToolRequirement and ContainerDescription lists."""
+        """Return triple of ToolRequirement, ContainerDescription and ResourceRequirements lists."""
 
     @abstractmethod
     def parse_input_pages(self):

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -182,7 +182,7 @@ class ToolSource(metaclass=ABCMeta):
 
     @abstractmethod
     def parse_requirements_and_containers(self):
-        """Return triple of ToolRequirement, ContainerDescription and ResourceRequirements lists."""
+        """Return triple of ToolRequirement, ContainerDescription and ResourceRequirement lists."""
 
     @abstractmethod
     def parse_input_pages(self):

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -284,7 +284,7 @@ class XmlToolSource(ToolSource):
         return RequiredFiles.from_dict(as_dict)
 
     def parse_requirements_and_containers(self):
-        return requirements.parse_requirements_from_xml(self.root)
+        return requirements.parse_requirements_from_xml(self.root, parse_resources=True)
 
     def parse_input_pages(self):
         return XmlPagesSource(self.root)

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -696,7 +696,7 @@ resolver.
       <xs:extension base="xs:string">
         <xs:attribute name="type" type="ResourceType" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">This value describes the resource available to the tool at runtime. Currently not implemented in Galaxy.</xs:documentation>
+            <xs:documentation xml:lang="en">This value describes the type of resource required by the tool at runtime. Not yet implemented in Galaxy.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -614,36 +614,37 @@ serve as complete descriptions of the runtime of a tool.
       <xs:element name="requirement" type="Requirement" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="container" type="Container" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
-    <xs:attribute name="cores_min" type="float" use="optional">
+    <xs:attribute name="cores_min" type="xs:float" use="optional">
       <xs:documentation xml:lang="en"><![CDATA[
 Maximum reserved number of CPU cores if runtime allows it (unimplemented in Galaxy currently).
 ]]></xs:documentation>
     </xs:attribute>
-    <xs:attribute name="cores_max" type="xs:long" use="optional">
+    <xs:attribute name="cores_max" type="xs:float" use="optional">
     </xs:attribute>
       <xs:documentation xml:lang="en"><![CDATA[
 Minimum reserved number of CPU cores if runtime allows it (unimplemented in Galaxy currently).
 ]]></xs:documentation>
-    <xs:attribute name="ram_min" type="xs:long" use="optional">
+    <xs:attribute name="ram_min" type="xs:float" use="optional">
       <xs:documentation xml:lang="en"><![CDATA[
 Minimum reserved RAM in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
 ]]></xs:documentation>
     </xs:attribute>
-    <xs:attribute name="ram_max" type="xs:long" use="optional">
+    <xs:attribute name="ram_max" type="xs:float" use="optional">
       <xs:documentation xml:lang="en"><![CDATA[
 Maximum reserved RAM in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
 ]]></xs:documentation>
     </xs:attribute>
-    <xs:attribute name="tmpdir_min" type="xs:long" use="optional">
+    <xs:attribute name="tmpdir_min" type="xs:float" use="optional">
       <xs:documentation xml:lang="en"><![CDATA[
 Minimum reserved filesystem based storage for the designated temporary directory, in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
 ]]></xs:documentation>
     </xs:attribute>
-    <xs:attribute name="tmpdir_max" type="xs:long" use="optional">
+    <xs:attribute name="tmpdir_max" type="xs:float" use="optional">
       <xs:documentation xml:lang="en"><![CDATA[
 Maximum reserved filesystem based storage for the designated temporary directory, in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
 ]]></xs:documentation>
     </xs:attribute>
+  </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="Requirement">

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -614,6 +614,36 @@ serve as complete descriptions of the runtime of a tool.
       <xs:element name="requirement" type="Requirement" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="container" type="Container" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
+    <xs:attribute name="cores_min" type="xs:long" use="optional">
+      <xs:documentation xml:lang="en"><![CDATA[
+Maximum reserved number of CPU cores if runtime allows it (unimplemented in Galaxy currently).
+]]></xs:documentation>
+    </xs:attribute>
+    <xs:attribute name="cores_max" type="xs:long" use="optional">
+    </xs:attribute>
+      <xs:documentation xml:lang="en"><![CDATA[
+Minimum reserved number of CPU cores if runtime allows it (unimplemented in Galaxy currently).
+]]></xs:documentation>
+    <xs:attribute name="ram_min" type="xs:long" use="optional">
+      <xs:documentation xml:lang="en"><![CDATA[
+Minimum reserved RAM in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
+]]></xs:documentation>
+    </xs:attribute>
+    <xs:attribute name="ram_max" type="xs:long" use="optional">
+      <xs:documentation xml:lang="en"><![CDATA[
+Maximum reserved RAM in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
+]]></xs:documentation>
+    </xs:attribute>
+    <xs:attribute name="tmpdir_min" type="xs:long" use="optional">
+      <xs:documentation xml:lang="en"><![CDATA[
+Minimum reserved filesystem based storage for the designated temporary directory, in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
+]]></xs:documentation>
+    </xs:attribute>
+    <xs:attribute name="tmpdir_max" type="xs:long" use="optional">
+      <xs:documentation xml:lang="en"><![CDATA[
+Maximum reserved filesystem based storage for the designated temporary directory, in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
+]]></xs:documentation>
+    </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="Requirement">

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -34,7 +34,7 @@ List of behavior changes associated with profile versions:
 - Use a separate home directory for each job.
 - Introduce `provided_metadata_style` with default `"default"` before `"legacy"`.
 
-#### 18.09 
+#### 18.09
 
 - References to other inputs need to be fully qualified by using `|`.
 - Do not allow provided but illegal default values.
@@ -46,7 +46,7 @@ List of behavior changes associated with profile versions:
 
 #### 20.05
 
-- json config files: 
+- json config files:
    - unselected optional `select` and `data_column` parameters get `None` instead of `"None"`
    - multiple `select` and `data_column` parameters are lists (before comma separated string)
 
@@ -2304,10 +2304,10 @@ is a regular expression that is matched against the full paths of the objects in
 the compressed file (remember that "matching" means it is checked if a prefix of
 the full path of an archive member is described by the regular expression).
 Valid archive formats include ``.zip``, ``.tar``, and ``.tar.gz``. Note that
-depending on the archive creation method: 
+depending on the archive creation method:
 
 - full paths of the members may be prefixed with ``./``
-- directories may be treated as empty files 
+- directories may be treated as empty files
 
 ```xml
 <has_archive_member path="./path/to/my-file.txt"/>
@@ -2325,7 +2325,7 @@ e.g., to assert an archive containing n&plusmn;1 elements out of which at least
 
 In addition the tag can contain additional assertions as child elements about
 the first member in the archive matching the regular expression ``path``. For
-instance 
+instance
 
 ```xml
 <has_archive_member path=".*/my-file.txt">
@@ -2364,7 +2364,7 @@ $attribute_list::5
       </xs:annotation>
     </xs:attribute>
     <xs:attributeGroup ref="AssertAttributeN"/>
-  </xs:complexType> 
+  </xs:complexType>
   <xs:complexType name="AssertIsValidXML">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
@@ -2432,7 +2432,7 @@ $attribute_list::5
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
 Asserts the XML output contains at least one element (or tag) with the specified
-XPath-like ``path``, e.g. 
+XPath-like ``path``, e.g.
 
 ```xml
 <has_element_with_path path="BlastOutput_param/Parameters/Parameters_matrix" />
@@ -2587,7 +2587,7 @@ XPath-like ``path``, e.g.
 ```
 
 The assertion implicitly also asserts that an element matching ``path`` exists.
-With ``negate`` the result of the implicit assertions can be inverted. 
+With ``negate`` the result of the implicit assertions can be inverted.
 The sub-assertions, which have their own ``negate`` attribute, are not affected
 by ``negate``.
 
@@ -2644,7 +2644,7 @@ $attribute_list::5
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
-  
+
   <xs:attributeGroup name="AssertAttributePath">
     <xs:attribute name="path" type="xs:string" use="required">
       <xs:annotation>
@@ -2660,7 +2660,7 @@ $attribute_list::5
       </xs:annotation>
     </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="AssertAttributeN">
     <xs:attribute name="n" type="Bytes" use="optional">
       <xs:annotation>
@@ -3067,7 +3067,7 @@ Note that references to other parameters in the `<inputs>` section are only poss
     </section>
 ```
 
-In the above example `bar` and `qux` will refer to the first foo outside of the section and `baz` to the `foo` inside the section. This illustrates why non-unique parameter names are strongly discouraged. 
+In the above example `bar` and `qux` will refer to the first foo outside of the section and `baz` to the `foo` inside the section. This illustrates why non-unique parameter names are strongly discouraged.
 
 The following will not work:
 
@@ -4303,7 +4303,7 @@ Check if a metadata value is contained in a specific column of a file in the ``t
 
 - ``regex``: Check if a regular expression **matches** the value, i.e. appears
 at the beginning of the value. To enforce a match of the complete value use
-``$`` at the end of the expression. The expression is given is the content 
+``$`` at the end of the expression. The expression is given is the content
 of the validator tag. Note that for ``selects`` each option is checked
 separately.
 - ``length``: Check if the length of the value is within a range.
@@ -4677,11 +4677,11 @@ a tool data table) or a dataset in the current history.
 
 Currently the following filters are defined:
 
-* ``static_value`` filter options for which the entry in a given ``column`` of the referenced file based on equality to the ``value`` attribute of the filter. 
+* ``static_value`` filter options for which the entry in a given ``column`` of the referenced file based on equality to the ``value`` attribute of the filter.
 * ``regexp`` similar to the ``static_value`` filter, but checks if the regular expression given by ``value`` matches the entry.
 * ``param_value`` filter options for which the entry in a given ``column`` of the referenced file based on properties of another input parameter specified by ``ref``. This property is by default the value of the parameter, but also the values of another attribute (``ref_attribute``) of the parameter can be used, e.g. the extension of a data input.
-* ``data_meta`` populate or filter options based on the metadata of another input parameter specified by ``ref``. If a ``column`` is given options are filtered for which the entry in this column ``column`` is equal to metadata of the input parameter specified by ``ref``. 
-If no ``column`` is given the metadata value of the referenced input is added to the options list (in this case the corresponding ``options`` tag must not have the ``from_data_table`` or ``from_dataset`` attributes). 
+* ``data_meta`` populate or filter options based on the metadata of another input parameter specified by ``ref``. If a ``column`` is given options are filtered for which the entry in this column ``column`` is equal to metadata of the input parameter specified by ``ref``.
+If no ``column`` is given the metadata value of the referenced input is added to the options list (in this case the corresponding ``options`` tag must not have the ``from_data_table`` or ``from_dataset`` attributes).
 In both cases the desired metadata is selected by ``key``.
 
 The ``static_value`` and ``regexp`` filters can be inverted by setting ``keep`` to true.
@@ -4690,7 +4690,7 @@ The ``static_value`` and ``regexp`` filters can be inverted by setting ``keep`` 
 * ``remove_value``: remove a value from the options. Either specified explicitly with ``value``, the value of another input specifified with ``ref``, or the metatdata ``key`` of another input ``meta_ref``.
 * ``unique_value``: remove options that have duplicate entries in the given ``column``.
 * ``sort_by``: sort options by the entries of a given ``column``.
-* ``multiple_splitter``: split the entries of the specified ``column``(s) in the referenced file using a ``separator``. Thereby the number of columns is increased. 
+* ``multiple_splitter``: split the entries of the specified ``column``(s) in the referenced file using a ``separator``. Thereby the number of columns is increased.
 
 ### Examples
 
@@ -4793,11 +4793,11 @@ demonstrates splitting up strings into multiple values.
       <xs:annotation>
         <xs:documentation xml:lang="en"><![CDATA[
 Currently the filters in the ``filter_types`` dictionary in the module
-[/lib/galaxy/tools/parameters/dynamic_options.py](https://github.com/galaxyproject/galaxy/blob/master/lib/galaxy/tools/parameters/dynamic_options.py) are defined. 
+[/lib/galaxy/tools/parameters/dynamic_options.py](https://github.com/galaxyproject/galaxy/blob/master/lib/galaxy/tools/parameters/dynamic_options.py) are defined.
 
 Deprecated filter types:
 
-* ``attribute_value_splitter`` 
+* ``attribute_value_splitter``
         ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
@@ -5251,7 +5251,7 @@ Note that also parameters in sections are accessed via a dictionary.
     </outputs>
 ```
 
-Note that variables that correspond to optional select parameters are `None` if nothing is selected. 
+Note that variables that correspond to optional select parameters are `None` if nothing is selected.
 Therefore a filter for such a variable looks like the following example.
 
 ### Example
@@ -5740,7 +5740,7 @@ against.</xs:documentation>
 
 - insert a column with a value in the options
   - if ``column`` is given then the column is inserted before this column, otherwise the column is appended
-  - the value can be given by ``ref`` or ``value`` 
+  - the value can be given by ``ref`` or ``value``
 
 ``column_strip``
 
@@ -7026,7 +7026,7 @@ A tool can have any number of EDAM operation references.
       <xs:documentation xml:lang="en"><![CDATA[
 Container tag set for the ``<xref>`` tags.
 A tool can refer multiple reference IDs.
-	
+
 ```xml
    <!-- Example: this tool is dada2 -->
    <xrefs>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -614,7 +614,7 @@ serve as complete descriptions of the runtime of a tool.
       <xs:element name="requirement" type="Requirement" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="container" type="Container" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
-    <xs:attribute name="cores_min" type="xs:long" use="optional">
+    <xs:attribute name="cores_min" type="float" use="optional">
       <xs:documentation xml:lang="en"><![CDATA[
 Maximum reserved number of CPU cores if runtime allows it (unimplemented in Galaxy currently).
 ]]></xs:documentation>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -598,17 +598,6 @@ practice.
     </xs:attribute>
   </xs:complexType>
 
-  <xs:complexType name="ResourceRequirement">
-    <xs:sequence>
-      <xs:element name="cores_min" type="Resource" minOccurs="0" maxOccurs="1" />
-      <xs:element name="cores_max" type="Resource" minOccurs="0" maxOccurs="1" />
-      <xs:element name="ram_min" type="Resource" minOccurs="0" maxOccurs="1" />
-      <xs:element name="ram_max" type="Resource" minOccurs="0" maxOccurs="1" />
-      <xs:element name="tmpdir_min" type="Resource" minOccurs="0" maxOccurs="1" />
-      <xs:element name="tmpdir_max" type="Resource" minOccurs="0" maxOccurs="1" />
-    </xs:sequence>
-  </xs:complexType>
-
   <xs:complexType name="Requirements">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -6753,27 +6753,27 @@ and ``bibtex`` are the only supported options.</xs:documentation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="cores_min">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Minimum reserved number of CPU cores, if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
+          <xs:documentation xml:lang="en">Minimum reserved number of CPU cores, if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
       <xs:enumeration value="cores_max">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Maximum reserved number of CPU cores, if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
+          <xs:documentation xml:lang="en">Maximum reserved number of CPU cores, if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
       <xs:enumeration value="ram_min">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Minimum reserved RAM in mebibytes (2**20 bytes), if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
+          <xs:documentation xml:lang="en">Minimum reserved RAM in mebibytes (2**20 bytes), if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
       <xs:enumeration value="ram_max">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Maximum reserved RAM in mebibytes (2**20 bytes), if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
+          <xs:documentation xml:lang="en">Maximum reserved RAM in mebibytes (2**20 bytes), if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
       <xs:enumeration value="tmpdir_min">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Minimum reserved filesystem-based storage for the designated temporary directory in mebibytes (2**20 bytes), if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
+          <xs:documentation xml:lang="en">Minimum reserved filesystem-based storage for the designated temporary directory in mebibytes (2**20 bytes), if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
       <xs:enumeration value="tmpdir_max">

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -6753,32 +6753,32 @@ and ``bibtex`` are the only supported options.</xs:documentation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="cores_min">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Minimum reserved number of CPU cores, if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
+          <xs:documentation xml:lang="en">Minimum reserved number of CPU cores, if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
       <xs:enumeration value="cores_max">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Maximum reserved number of CPU cores, if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
+          <xs:documentation xml:lang="en">Maximum reserved number of CPU cores, if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
       <xs:enumeration value="ram_min">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Minimum reserved RAM in mebibytes (2**20 bytes), if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
+          <xs:documentation xml:lang="en">Minimum reserved RAM in mebibytes (2**20 bytes), if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
       <xs:enumeration value="ram_max">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Maximum reserved RAM in mebibytes (2**20 bytes), if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
+          <xs:documentation xml:lang="en">Maximum reserved RAM in mebibytes (2**20 bytes), if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
       <xs:enumeration value="tmpdir_min">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Minimum reserved filesystem-based storage for the designated temporary directory in mebibytes (2**20 bytes), if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
+          <xs:documentation xml:lang="en">Minimum reserved filesystem-based storage for the designated temporary directory in mebibytes (2**20 bytes), if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
       <xs:enumeration value="tmpdir_max">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Maximum reserved filesystem based storage for the designated temporary directory in mebibytes (2**20 bytes), if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
+          <xs:documentation xml:lang="en">Maximum reserved filesystem based storage for the designated temporary directory, in mebibytes (2**20 bytes), if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
     </xs:restriction>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -598,11 +598,22 @@ practice.
     </xs:attribute>
   </xs:complexType>
 
+  <xs:complexType name="ResourceRequirement">
+    <xs:sequence>
+      <xs:element name="cores_min" type="Resource" minOccurs="0" maxOccurs="1" />
+      <xs:element name="cores_max" type="Resource" minOccurs="0" maxOccurs="1" />
+      <xs:element name="ram_min" type="Resource" minOccurs="0" maxOccurs="1" />
+      <xs:element name="ram_max" type="Resource" minOccurs="0" maxOccurs="1" />
+      <xs:element name="tmpdir_min" type="Resource" minOccurs="0" maxOccurs="1" />
+      <xs:element name="tmpdir_max" type="Resource" minOccurs="0" maxOccurs="1" />
+    </xs:sequence>
+  </xs:complexType>
+
   <xs:complexType name="Requirements">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
 
-This is a container tag set for the ``requirement`` and ``container`` tags
+This is a container tag set for the ``requirement``, ``resource`` and ``container`` tags
 described in greater detail below. ``requirement``s describe software packages
 and other individual computing requirements required to execute a tool, while
 ``container``s describe Docker or Singularity containers that should be able to
@@ -613,40 +624,9 @@ serve as complete descriptions of the runtime of a tool.
     <xs:sequence>
       <xs:element name="requirement" type="Requirement" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="container" type="Container" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="resource" type="Resource" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
-    <xs:attribute name="cores_min" type="xs:float" use="optional">
-      <xs:documentation xml:lang="en"><![CDATA[
-Maximum reserved number of CPU cores if runtime allows it (unimplemented in Galaxy currently).
-]]></xs:documentation>
-    </xs:attribute>
-    <xs:attribute name="cores_max" type="xs:float" use="optional">
-    </xs:attribute>
-      <xs:documentation xml:lang="en"><![CDATA[
-Minimum reserved number of CPU cores if runtime allows it (unimplemented in Galaxy currently).
-]]></xs:documentation>
-    <xs:attribute name="ram_min" type="xs:float" use="optional">
-      <xs:documentation xml:lang="en"><![CDATA[
-Minimum reserved RAM in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
-]]></xs:documentation>
-    </xs:attribute>
-    <xs:attribute name="ram_max" type="xs:float" use="optional">
-      <xs:documentation xml:lang="en"><![CDATA[
-Maximum reserved RAM in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
-]]></xs:documentation>
-    </xs:attribute>
-    <xs:attribute name="tmpdir_min" type="xs:float" use="optional">
-      <xs:documentation xml:lang="en"><![CDATA[
-Minimum reserved filesystem based storage for the designated temporary directory, in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
-]]></xs:documentation>
-    </xs:attribute>
-    <xs:attribute name="tmpdir_max" type="xs:float" use="optional">
-      <xs:documentation xml:lang="en"><![CDATA[
-Maximum reserved filesystem based storage for the designated temporary directory, in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).
-]]></xs:documentation>
-    </xs:attribute>
-  </xs:attribute>
   </xs:complexType>
-
   <xs:complexType name="Requirement">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
@@ -700,12 +680,23 @@ resolver.
       <xs:extension base="xs:string">
         <xs:attribute name="type" type="RequirementType" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en">This value defines the type of the 3rd party module required by this tool.</xs:documentation>
+            <xs:documentation xml:lang="en">Valid values are ``package``, ``set_environment``, ``python-module`` (deprecated), ``binary`` (deprecated)</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="version" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">For requirements of type ``package`` this value defines a specific version of the tool dependency.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Resource">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="type" type="ResourceType" use="required">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">This value describes the resource available to the tool at runtime. Currently not implemented in Galaxy.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -6753,6 +6744,43 @@ and ``bibtex`` are the only supported options.</xs:documentation>
       <xs:enumeration value="binary"/>
       <xs:enumeration value="package"/>
       <xs:enumeration value="set_environment"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ResourceType">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Type of resource specification.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="cores_min">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Minimum reserved number of CPU cores, if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="cores_max">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Maximum reserved number of CPU cores, if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ram_min">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Minimum reserved RAM in mebibytes (2**20 bytes), if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ram_max">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Maximum reserved RAM in mebibytes (2**20 bytes), if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tmpdir_min">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Minimum reserved filesystem-based storage for the designated temporary directory in mebibytes (2**20 bytes), if runtime allows it (not yet implemented in Galaxy).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tmpdir_max">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Maximum reserved filesystem based storage for the designated temporary directory, in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="ContainerType">

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -6778,7 +6778,7 @@ and ``bibtex`` are the only supported options.</xs:documentation>
       </xs:enumeration>
       <xs:enumeration value="tmpdir_max">
         <xs:annotation>
-          <xs:documentation xml:lang="en">Maximum reserved filesystem based storage for the designated temporary directory, in mebibytes (2**20) if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
+          <xs:documentation xml:lang="en">Maximum reserved filesystem based storage for the designated temporary directory in mebibytes (2**20 bytes), if runtime allows it (unimplemented in Galaxy currently).</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
     </xs:restriction>

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1038,9 +1038,10 @@ class Tool(Dictifiable):
         self.__parse_tests(tool_source)
 
         # Requirements (dependencies)
-        requirements, containers = tool_source.parse_requirements_and_containers()
+        requirements, containers, resource_requirements = tool_source.parse_requirements_and_containers()
         self.requirements = requirements
         self.containers = containers
+        self.resource_requirements = resource_requirements
 
         required_files = tool_source.parse_required_files()
         if required_files is None:

--- a/test/functional/tools/resource_requirements.xml
+++ b/test/functional/tools/resource_requirements.xml
@@ -1,0 +1,19 @@
+<tool id="resource_requirements" name="resource_requirements" version="1.0.0" profile="22.05">
+    <requirements>
+        <resource type="cores_min">1.1</resource>
+        <resource type="cores_max">2</resource>
+        <resource type="ram_min">1.1</resource>
+        <resource type="ram_max">2></resource>
+        <resource type="tmpdir_min"><![CDATA[$(inputs.input1.size)]]></resource>
+        <resource type="tmpdir_max"><![CDATA[$(inputs.input1.size * 2)]]></resource>
+    </requirements>
+    <command><![CDATA[
+echo "\$GALAXY_SLOTS" > $output
+    ]]></command>
+    <inputs>
+        <param type="data" name="input1" format="txt"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+</tool>

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -30,6 +30,7 @@ TOOL_XML_1 = """
     <requirements>
         <container type="docker">mycool/bwa</container>
         <requirement type="package" version="1.0">bwa</requirement>
+        <resource_requirement type="cores_min">1</resource_requirement>
     </requirements>
     <outputs>
         <data name="out1" format="bam" from_work_dir="out1.bam" />
@@ -118,6 +119,8 @@ command: "bowtie_wrapper.pl --map-the-stuff"
 interpreter: "perl"
 runtime_version:
   command: "bowtie --version"
+resource_requirements:
+  - cores_min: 1
 requirements:
   - type: package
     name: bwa
@@ -309,9 +312,11 @@ class XmlLoaderTestCase(BaseLoaderTestCase):
         assert self._tool_source.parse_action_module() is None
 
     def test_requirements(self):
-        requirements, containers = self._tool_source.parse_requirements_and_containers()
+        requirements, containers, resource_requirements = self._tool_source.parse_requirements_and_containers()
         assert requirements[0].type == "package"
         assert list(containers)[0].identifier == "mycool/bwa"
+        assert resource_requirements[0].resource_type == "cores_min"
+        assert not resource_requirements[0].runtime_required
 
     def test_outputs(self):
         outputs, output_collections = self._tool_source.parse_outputs(object())
@@ -477,10 +482,11 @@ class YamlLoaderTestCase(BaseLoaderTestCase):
         assert self._tool_source.parse_action_module() is None
 
     def test_requirements(self):
-        requirements, containers = self._tool_source.parse_requirements_and_containers()
+        requirements, containers, resource_requirements = self._tool_source.parse_requirements_and_containers()
         assert requirements[0].type == "package"
         assert requirements[0].name == "bwa"
         assert containers[0].identifier == "awesome/bowtie"
+        assert resource_requirements[0].resource_type == "cores_min"
 
     def test_outputs(self):
         outputs, output_collections = self._tool_source.parse_outputs(object())

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -30,7 +30,7 @@ TOOL_XML_1 = """
     <requirements>
         <container type="docker">mycool/bwa</container>
         <requirement type="package" version="1.0">bwa</requirement>
-        <resource_requirement type="cores_min">1</resource_requirement>
+        <resource type="cores_min">1</resource>
     </requirements>
     <outputs>
         <data name="out1" format="bam" from_work_dir="out1.bam" />
@@ -119,12 +119,12 @@ command: "bowtie_wrapper.pl --map-the-stuff"
 interpreter: "perl"
 runtime_version:
   command: "bowtie --version"
-resource_requirements:
-  - cores_min: 1
 requirements:
   - type: package
     name: bwa
     version: 1.0.1
+  - type: resource
+    cores_min: 1
 containers:
   - type: docker
     identifier: "awesome/bowtie"


### PR DESCRIPTION
Backend doesn't yet support them (except for providing a list of `ResourceRequirement` on the tool instance, so dynamic job rules could use them), but allow tool authors to specify what the runtime should support. Based on CWL resource requirements (http://www.commonwl.org/v1.2/CommandLineTool.html#ResourceRequirement).

xref https://github.com/galaxyproject/galaxy/issues/5369