### PR TITLE
Force a fixed node image version when building client for Jenkins.

### DIFF
--- a/.ci/jenkins/selenium/run_tests.sh
+++ b/.ci/jenkins/selenium/run_tests.sh
@@ -2,6 +2,7 @@
 
 # Enable retries on tests to reduce chances of transient failures.
 : ${GALAXY_TEST_SELENIUM_RETRIES:=1}
+: ${GALAXY_TEST_CLIENT_BUILD_IMAGE:='node:9.4.0'}
 
 # If in Jenkins environment, use it for artifacts.
 if [ -n "$BUILD_NUMBER" ];
@@ -16,7 +17,7 @@ fi
 mkdir -p "$GALAXY_TEST_ERRORS_DIRECTORY"
 mkdir -p "$GALAXY_TEST_SCREENSHOTS_DIRECTORY"
 
-docker run -v `pwd`:`pwd`:rw -w `pwd` -u $UID node /bin/bash -c 'make client-production-maps'
+docker run -v `pwd`:`pwd`:rw -w `pwd` -u $UID $GALAXY_TEST_CLIENT_BUILD_IMAGE /bin/bash -c 'make client-production-maps'
 
 # Start Selenium server in the test Docker container.
 DOCKER_RUN_EXTRA_ARGS="-e USE_SELENIUM=1 -e GALAXY_TEST_SELENIUM_RETRIES=${GALAXY_TEST_SELENIUM_RETRIES} -e GALAXY_TEST_ERRORS_DIRECTORY=${GALAXY_TEST_ERRORS_DIRECTORY} -e GALAXY_TEST_SCREENSHOTS_DIRECTORY=${GALAXY_TEST_SCREENSHOTS_DIRECTORY} ${DOCKER_RUN_EXTRA_ARGS}"


### PR DESCRIPTION
At least one of our Jenkins nodes - possibly more - is failing to build the client without failing the test outright. Can see this toward the top of the logs - this is why the Selenium tests in #5365 are failing.