### PR TITLE
[17.05] Follow IUC and drop r channel from default conda channels

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -209,7 +209,7 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # Pass debug flag to conda commands.
 #conda_debug = False
 # conda channels to enable by default (http://conda.pydata.org/docs/custom-channels.html)
-#conda_ensure_channels = iuc,bioconda,conda-forge,defaults,r
+#conda_ensure_channels = iuc,bioconda,conda-forge,defaults
 # Set to True to instruct Galaxy to look for and install missing tool
 # dependencies before each job runs.
 #conda_auto_install = False

--- a/doc/source/admin/dependency_resolvers.rst
+++ b/doc/source/admin/dependency_resolvers.rst
@@ -220,7 +220,7 @@ debug
 ensure_channels
     conda channels to enable by default. See
     http://conda.pydata.org/docs/custom-channels.html for more
-    information about channels. This defaults to ``iuc,bioconda,conda-forge,defaults,r``.
+    information about channels. This defaults to ``iuc,bioconda,conda-forge,defaults``.
     This order should be consistent with the `Bioconda prescribed order <https://github.com/bioconda/bioconda-recipes/blob/master/config.yml>`__
     if it includes ``bioconda``.
 

--- a/lib/galaxy/tools/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tools/deps/mulled/mulled_build.py
@@ -30,7 +30,7 @@ from ..conda_compat import MetaData
 
 DIRNAME = os.path.dirname(__file__)
 DEFAULT_CHANNEL = "bioconda"
-DEFAULT_EXTRA_CHANNELS = ["conda-forge", "r"]
+DEFAULT_EXTRA_CHANNELS = ["conda-forge"]
 DEFAULT_CHANNELS = [DEFAULT_CHANNEL] + DEFAULT_EXTRA_CHANNELS
 DEFAULT_REPOSITORY_TEMPLATE = "quay.io/${namespace}/${image}"
 DEFAULT_BINDS = ["build/dist:/usr/local/"]

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -43,7 +43,7 @@ DEFAULT_CONDARC_OVERRIDE = "_condarc"
 # https://github.com/bioconda/bioconda-recipes/blob/master/config.yml , but
 # adding `iuc` as first channel (for Galaxy-specific packages) and `r` as last
 # (for old R packages)
-DEFAULT_ENSURE_CHANNELS = "iuc,bioconda,conda-forge,defaults,r"
+DEFAULT_ENSURE_CHANNELS = "iuc,bioconda,conda-forge,defaults"
 CONDA_SOURCE_CMD = """[ "$CONDA_DEFAULT_ENV" = "%s" ] ||
 MAX_TRIES=3
 COUNT=0


### PR DESCRIPTION
We [switched the defaults for IUC tests](https://github.com/galaxyproject/tools-iuc/commit/370757a5aa7623fef5311f9484dcb4ffe0aba67b#diff-354f30a63fb0907d4ad57269548329e3) , so we should backport the new order to the supported galaxy releases.

xref #5405 