### PR TITLE
[18.01] Allow map-over when discovering dataset collections

### DIFF
--- a/lib/galaxy/dataset_collections/structure.py
+++ b/lib/galaxy/dataset_collections/structure.py
@@ -177,19 +177,14 @@ def tool_output_to_structure(get_sliced_input_collection_type, tool_output, coll
     if not tool_output.collection:
         tree = leaf
     else:
-        collection_type_descriptions = collections_manager.collection_type_descriptions
         # Okay this is ToolCollectionOutputStructure not a Structure - different
         # concepts of structure.
-        if tool_output.dynamic_structure:
-            # Two cases collection_type_source and collection_type right?
-            tree = UnitializedTree(collection_type_descriptions.for_type_description("list"))  # list is obviously wrong...
+        structured_like = tool_output.structure.structured_like
+        if structured_like:
+            collection_type = get_sliced_input_collection_type(structured_like)
         else:
-            structured_like = tool_output.structure.structured_like
-            if structured_like:
-                collection_type = get_sliced_input_collection_type(structured_like)
-            else:
-                collection_type = tool_output.structure.collection_type
-            tree = UnitializedTree(collection_type)
+            collection_type = tool_output.structure.collection_type
+        tree = UnitializedTree(collection_type)
 
     return tree
 

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -164,6 +164,9 @@ def collect_dynamic_collections(
         else:
             collection = has_collection
 
+        # We are adding dynamic collections, which may be precreated, but their actually state is still new!
+        collection.populated_state = collection.populated_states.NEW
+
         try:
             collection_builder = collections_service.collection_builder_for(
                 collection

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -1814,11 +1814,9 @@ test_data:
         self.assertEqual("chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n", content)
 
     def wait_for_invocation_and_jobs(self, history_id, workflow_id, invocation_id, assert_ok=True):
-        # Revert after https://github.com/galaxyproject/galaxy/issues/5146 is fixed.
-        # state = self.workflow_populator.wait_for_invocation(workflow_id, invocation_id)
-        # if assert_ok:
-        #    assert state == "scheduled", state
-        self.workflow_populator.wait_for_invocation(workflow_id, invocation_id)
+        state = self.workflow_populator.wait_for_invocation(workflow_id, invocation_id)
+        if assert_ok:
+            assert state == "scheduled", state
         time.sleep(.5)
         self.dataset_populator.wait_for_history_jobs(history_id, assert_ok=assert_ok)
         time.sleep(.5)

--- a/test/functional/tools/collection_creates_dynamic_list_of_pairs.xml
+++ b/test/functional/tools/collection_creates_dynamic_list_of_pairs.xml
@@ -14,6 +14,7 @@
   ]]></command>
   <inputs>
     <param name="foo" type="text" label="Dummy Parameter" />
+    <param name="file" type="data" label="Dummy File Parameter" />
   </inputs>
   <outputs>
     <collection name="list_output" type="list:paired" label="Duplicate List">


### PR DESCRIPTION
This would affect for example the mapping over of fastq-dump (and all other
tools in the sra-toolkit).

If one had attempted this previously the discovery phase would fail with:
```
galaxy.tools.parameters.output_collect ERROR 2018-01-30 08:56:46,369 Problem gathering output collection.
Traceback (most recent call last):
  File "/bioinfo/guests/mvandenb/galaxy/lib/galaxy/tools/parameters/output_collect.py", line 169, in collect_dynamic_collections
    collection
  File "/bioinfo/guests/mvandenb/galaxy/lib/galaxy/managers/collections.py", line 216, in collection_builder_for
    return builder.BoundCollectionBuilder(dataset_collection, collection_type_description)
  File "/bioinfo/guests/mvandenb/galaxy/lib/galaxy/dataset_collections/builder.py", line 84, in __init__
    raise Exception("Cannot reset elements of an already populated dataset collection.")
Exception: Cannot reset elements of an already populated dataset collection.
```

Instead we force the collection state to be new when we are discovering output collection datasets,
which seems reasonable to me. This includes an API testcase that would have failed previously.