### PR TITLE
[18.01] Fix rename post job actions to be more intuitive when mapping over collections.

### DIFF
--- a/lib/galaxy/jobs/actions/post.py
+++ b/lib/galaxy/jobs/actions/post.py
@@ -86,25 +86,27 @@ class RenameDatasetAction(DefaultJobAction):
     verbose_name = "Rename Dataset"
 
     @classmethod
-    def execute_on_mapped_over(cls, app, sa_session, action, step_outputs, replacement_dict):
+    def execute_on_mapped_over(cls, app, sa_session, action, step_inputs, step_outputs, replacement_dict):
         # Prevent renaming a dataset to the empty string.
-        if action.action_arguments and action.action_arguments.get('newname', ''):
-            new_name = action.action_arguments['newname']
+        input_names = {}
+        #  Lookp through inputs find one with "to_be_replaced" input
+        #  variable name, and get the replacement name
+        for input_key, step_input in step_inputs.items():
+            if step_input and hasattr(step_input, "name"):
+                input_names[input_key] = step_input.name
 
-            if replacement_dict:
-                for k, v in replacement_dict.items():
-                    new_name = new_name.replace("${%s}" % k, v)
-
+        new_name = cls._gen_new_name(action, input_names, replacement_dict)
+        if new_name:
             for name, step_output in step_outputs.items():
                 if action.output_name == '' or name == action.output_name:
                     step_output.name = new_name
 
     @classmethod
-    def execute(cls, app, sa_session, action, job, replacement_dict):
-        # Prevent renaming a dataset to the empty string.
+    def _gen_new_name(self, action, input_names, replacement_dict):
+        new_name = None
+
         if action.action_arguments and action.action_arguments.get('newname', ''):
             new_name = action.action_arguments['newname']
-
             #  TODO: Unify and simplify replacement options.
             #      Add interface through workflow editor UI
 
@@ -149,20 +151,7 @@ class RenameDatasetAction(DefaultJobAction):
                 # show correct valid inputs.
                 input_file_var = input_file_var.replace(".", "|")
 
-                replacement = ""
-                #  Lookp through inputs find one with "to_be_replaced" input
-                #  variable name, and get the replacement name
-                for input_assoc in job.input_datasets:
-                    if input_assoc.name == input_file_var:
-                        replacement = input_assoc.dataset.name
-
-                # Ditto for collections...
-                for input_assoc in job.input_dataset_collections:
-                    if input_assoc.name == input_file_var:
-                        # Either a HDCA or a DCE - only HDCA has a name.
-                        has_collection = input_assoc.dataset_collection
-                        if has_collection and hasattr(has_collection, "name"):
-                            replacement = has_collection.name
+                replacement = input_names.get(input_file_var, "")
 
                 # In case name was None.
                 replacement = replacement or ''
@@ -189,9 +178,33 @@ class RenameDatasetAction(DefaultJobAction):
             if replacement_dict:
                 for k, v in replacement_dict.items():
                     new_name = new_name.replace("${%s}" % k, v)
+
+        return new_name
+
+    @classmethod
+    def execute(cls, app, sa_session, action, job, replacement_dict):
+        input_names = {}
+        #  Lookp through inputs find one with "to_be_replaced" input
+        #  variable name, and get the replacement name
+        for input_assoc in job.input_datasets:
+            input_names[input_assoc.name] = input_assoc.dataset.name
+
+        # Ditto for collections...
+        for input_assoc in job.input_dataset_collections:
+            # Either a HDCA or a DCE - only HDCA has a name.
+            has_collection = input_assoc.dataset_collection
+            if has_collection and hasattr(has_collection, "name"):
+                input_names[input_assoc.name] = has_collection.name
+
+        new_name = cls._gen_new_name(action, input_names, replacement_dict)
+        if new_name:
             for dataset_assoc in job.output_datasets:
                 if action.output_name == '' or dataset_assoc.name == action.output_name:
                     dataset_assoc.dataset.name = new_name
+
+            for dataset_collection_assoc in job.output_dataset_collection_instances:
+                if action.output_name == '' or dataset_collection_assoc.name == action.output_name:
+                    dataset_collection_assoc.dataset_collection_instance.name = new_name
 
     @classmethod
     def get_short_str(cls, pja):
@@ -432,9 +445,9 @@ class ActionBox(object):
         return npd
 
     @classmethod
-    def execute_on_mapped_over(cls, app, sa_session, pja, step_outputs, replacement_dict=None):
+    def execute_on_mapped_over(cls, app, sa_session, pja, step_inputs, step_outputs, replacement_dict=None):
         if pja.action_type in ActionBox.actions:
-            ActionBox.actions[pja.action_type].execute_on_mapped_over(app, sa_session, pja, step_outputs, replacement_dict)
+            ActionBox.actions[pja.action_type].execute_on_mapped_over(app, sa_session, pja, step_inputs, step_outputs, replacement_dict)
 
     @classmethod
     def execute(cls, app, sa_session, pja, job, replacement_dict=None):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -985,7 +985,7 @@ class ToolModule(WorkflowModule):
     def _handle_mapped_over_post_job_actions(self, step, step_inputs, step_outputs, replacement_dict):
         effective_post_job_actions = self._effective_post_job_actions(step)
         for pja in effective_post_job_actions:
-            if pja.action_type in ActionBox.immediate_actions:
+            if pja.action_type in ActionBox.mapped_over_output_actions:
                 ActionBox.execute_on_mapped_over(self.trans.app, self.trans.sa_session, pja, step_inputs, step_outputs, replacement_dict)
 
     def _handle_post_job_actions(self, step, job, replacement_dict):

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -2029,6 +2029,11 @@ test_data:
         content = self.dataset_populator.get_history_dataset_details(history_id, hid=4, wait=True, assert_ok=True)
         name = content["name"]
         assert name == "my new name", name
+        assert content["history_content_type"] == "dataset"
+        content = self.dataset_populator.get_history_collection_details(history_id, hid=3, wait=True, assert_ok=True)
+        name = content["name"]
+        assert content["history_content_type"] == "dataset_collection", content
+        assert name == "my new name", name
 
     @skip_without_tool("create_2")
     def test_run_rename_multiple_outputs(self):


### PR DESCRIPTION
Actually rename to the mapped over collection output in addition to the individual datasets. RenameDatasetAction might better be terms RenameOutputAction now but that isn't done in this PR.

Applies https://github.com/galaxyproject/galaxy/pull/5414 targeting 17.09 to 18.01 also since this modifies that piece of code.