### PR TITLE
[18.01] Fix framework tests.

### DIFF
--- a/test/functional/tools/collection_creates_dynamic_list_of_pairs.xml
+++ b/test/functional/tools/collection_creates_dynamic_list_of_pairs.xml
@@ -28,6 +28,7 @@
   </outputs>
   <tests>
     <test>
+      <param name="file" value="simple_line.txt" />
       <param name="foo" value="bar" />
       <output_collection name="list_output" type="list:paired">
         <element name="samp1">


### PR DESCRIPTION
Broken by https://github.com/galaxyproject/galaxy/commit/eb506b25b9cc02e828442ecb9772cc0d4bcc029b#diff-e713c9609c6e478b95d49769feeb8beaR17 while framework tests were misconfigured. Thanks for @nsoranzo for tracking down the problem.