### PR TITLE
Workaround for extra metadata revision creation

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -440,7 +440,10 @@ class Tool(Dictifiable):
             raise e
         self.history_manager = histories.HistoryManager(app)
         self._view = views.DependencyResolversView(app)
-        self.job_search = JobSearch(app=self.app)
+        # The job search is only relevant in a galaxy context, and breaks
+        # loading tools into the toolshed for validation.
+        if self.app.name == 'galaxy':
+            self.job_search = JobSearch(app=self.app)
 
     @property
     def version_object(self):


### PR DESCRIPTION
Without this change, uploading non-metadata changes to a toolshed repository will display an error message and create a new metadata revision regardless of whether the code should determine that a new metadata revision is warranted.