### PR TITLE
[18.01] Fix collection mapping over for tools with `structured_like="<input>"` outputs

### DIFF
--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -216,7 +216,7 @@ class ExecutionTracker(object):
             return subcollection_mapping_type
             # return self.collection_info.structure.sliced_input_collection_type(self.implicit_inputs[input_name])
         else:
-            return self.mapping_params.param_template[input_name].collection.collection_type
+            return self.example_params[input_name].collection.collection_type
 
     def _structure_for_output(self, trans, tool_output):
         structure = self.collection_info.structure

--- a/lib/galaxy/tools/filter_from_file.xml
+++ b/lib/galaxy/tools/filter_from_file.xml
@@ -22,9 +22,9 @@
         </conditional>
     </inputs>
     <outputs>
-        <collection name="output_filtered" format_source="input" type_source="input" label="${on_string} (filtered)" >
+        <collection name="output_filtered" format_source="input" type_source="input" structured_like="input" label="${on_string} (filtered)" >
         </collection>
-        <collection name="output_discarded" format_source="input" type_source="input" label="${on_string} (discarded)" >
+        <collection name="output_discarded" format_source="input" type_source="input" structured_like="input" label="${on_string} (discarded)" >
         </collection>
     </outputs>
     <tests>

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -1264,7 +1264,7 @@ class ToolsTestCase(api.ApiTestCase):
         assert run_response.status_code >= 400
 
     @skip_without_tool("__FILTER_FROM_FILE__")
-    def test_map_over_collection_operation_tool(self):
+    def test_map_over_collection_structured_like(self):
         with self.dataset_populator.test_history() as history_id:
             hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("A", "A"), ("B", "B")]).json()['id']
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
@@ -1287,6 +1287,19 @@ class ToolsTestCase(api.ApiTestCase):
             second_collection_level = first_collection_level['object']
             assert second_collection_level['collection_type'] == 'list'
             assert second_collection_level['elements'][0]['element_type'] == 'hda'
+
+    @skip_without_tool("collection_type_source")
+    def test_map_over_collection_type_source(self):
+        with self.dataset_populator.test_history() as history_id:
+            hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("A", "A"), ("B", "B")]).json()['id']
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            inputs = {
+                "input_collect": {'values': [dict(src="hdca", id=hdca_id)]},
+                "header": {'batch': True, 'values': [dict(src="hdca", id=hdca_id)]}
+            }
+            self._run("collection_type_source", history_id, inputs, assert_ok=True, wait_for_job=True)
+            collection_details = self.dataset_populator.get_history_collection_details(history_id, hid=4)
+            assert collection_details['elements'][0]['object']['elements'][0]['element_type'] == 'hda'
 
     @skip_without_tool("multi_data_param")
     def test_reduce_collections_legacy(self):

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -1263,6 +1263,31 @@ class ToolsTestCase(api.ApiTestCase):
         # on server.
         assert run_response.status_code >= 400
 
+    @skip_without_tool("__FILTER_FROM_FILE__")
+    def test_map_over_collection_operation_tool(self):
+        with self.dataset_populator.test_history() as history_id:
+            hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("A", "A"), ("B", "B")]).json()['id']
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            inputs = {
+                "input": {'values': [dict(src="hdca", id=hdca_id)]},
+                "how|filter_source": {'batch': True, 'values': [dict(src="hdca", id=hdca_id)]}
+            }
+            self._run("__FILTER_FROM_FILE__", history_id, inputs, assert_ok=True)
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            history_contents = self.dataset_populator._get_contents_request(history_id).json()
+            # We should have a final collection count of 3 (2 nested collections, plus the input collection)
+            new_collections = len([c for c in history_contents if c['history_content_type'] == 'dataset_collection']) - 1
+            assert new_collections == 2, "Expected to generate 4 new, filtered collections, but got %d collections" % new_collections
+            filtered_collection = history_contents[7]
+            assert filtered_collection['collection_type'] == 'list:list'
+            collection_details = self.dataset_populator.get_history_collection_details(history_id, hid=filtered_collection['hid'])
+            assert collection_details['element_count'] == 2
+            first_collection_level = collection_details['elements'][0]
+            assert first_collection_level['element_type'] == 'dataset_collection'
+            second_collection_level = first_collection_level['object']
+            assert second_collection_level['collection_type'] == 'list'
+            assert second_collection_level['elements'][0]['element_type'] == 'hda'
+
     @skip_without_tool("multi_data_param")
     def test_reduce_collections_legacy(self):
         history_id = self.dataset_populator.new_history()


### PR DESCRIPTION
This fixes mapping over collection for tools that use `structured_like="<input>"` tag. This probably broke in https://github.com/galaxyproject/galaxy/commit/78babab6455f4cd1c51aed0b1ddf6b4b29ad6d03. Tools that don't use `structured_like`, but `type_source` are still broken, I think.