### PR TITLE
[18.01] More intuitive options for collection deletion.

### DIFF
--- a/client/galaxy/scripts/mvc/collection/collection-model.js
+++ b/client/galaxy/scripts/mvc/collection/collection-model.js
@@ -1,5 +1,6 @@
 import DATASET_MODEL from "mvc/dataset/dataset-model";
 import BASE_MVC from "mvc/base-mvc";
+import Utils from "utils/utils";
 import _l from "utils/localization";
 
 //==============================================================================
@@ -280,16 +281,19 @@ var DatasetCollection = Backbone.Model.extend(BASE_MVC.LoggableMixin)
                 return parsed;
             },
 
-            /** save this dataset, _Mark_ing it as deleted (just a flag) */
-            delete: function(options) {
+            /** save this collection, _Mark_ing it as deleted (just a flag) */
+            delete: function(recursive, purge, options) {
+                recursive = recursive || false;
+                purge = purge || false;
                 if (this.get("deleted")) {
                     return jQuery.when();
                 }
-                return this.save({ deleted: true }, options);
+                options = Utils.merge(options, {"method": "delete"});
+                return this.save({ deleted: true, recursive: recursive, purge: purge }, options);
             },
-            /** save this dataset, _Mark_ing it as undeleted */
+            /** save this collection, _Mark_ing it as undeleted */
             undelete: function(options) {
-                if (!this.get("deleted") || this.get("purged")) {
+                if (!this.get("deleted")) {
                     return jQuery.when();
                 }
                 return this.save({ deleted: false }, options);

--- a/client/galaxy/scripts/mvc/dataset/dataset-li.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li.js
@@ -302,7 +302,7 @@ var DatasetListItemView = _super.extend(
             )}">
                         <span class="fa fa-floppy-o"></span>
                     </a>
-                    <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
+                    <ul class="dropdown-menu" role="menu">
                         <li>
                             <a href="${urls.download}">
                                 ${_l("Download dataset")}

--- a/client/galaxy/scripts/mvc/history/hdca-li-edit.js
+++ b/client/galaxy/scripts/mvc/history/hdca-li-edit.js
@@ -40,17 +40,17 @@ var HDCAListItemEdit = _super.extend(
                     </a>
                     <ul class="dropdown-menu pull-right" role="menu" aria-labelledby="dLabel">
                         <li>
-                            <a class="delete-collection">
+                            <a href="" class="delete-collection">
                                 ${_l("Collection Only")}
                             </a>
                         </li>
                         <li>
-                            <a class="delete-collection-and-datasets">
+                            <a href="" class="delete-collection-and-datasets">
                                 ${_l("Delete Datasets")}
                             </a>
                         </li>
                         <li style="display: ${this.purgeAllowed ? 'inherit' : 'none'}">
-                            <a class="delete-collection-and-purge-datasets">
+                            <a href="" class="delete-collection-and-purge-datasets">
                                 ${_l("Permenantly Delete Datasets")}
                             </a>
                         </li>

--- a/client/galaxy/scripts/mvc/history/hdca-li-edit.js
+++ b/client/galaxy/scripts/mvc/history/hdca-li-edit.js
@@ -34,11 +34,11 @@ var HDCAListItemEdit = _super.extend(
 
         _renderDeleteButton: function() {
             return $(`
-                <div class="delete-dropdown dropdown">
+                <div class="dropdown">
                     <a class="delete-btn icon-btn" title="${_l('Delete')}" data-toggle="dropdown">
                         <span class="fa fa-times"></span>
                     </a>
-                    <ul class="dropdown-menu pull-right" role="menu" aria-labelledby="dLabel">
+                    <ul class="dropdown-menu pull-right" role="menu">
                         <li>
                             <a href="" class="delete-collection">
                                 ${_l("Collection Only")}

--- a/client/galaxy/scripts/mvc/history/hdca-li-edit.js
+++ b/client/galaxy/scripts/mvc/history/hdca-li-edit.js
@@ -11,6 +11,13 @@ var HDCAListItemEdit = _super.extend(
     /** @lends HDCAListItemEdit.prototype */ {
         /** logger used to record this.log messages, commonly set to console */
         //logger              : console,
+        /** set up: options */
+        initialize: function(attributes) {
+            _super.prototype.initialize.call(this, attributes);
+
+            /** allow user purge of dataset files? */
+            this.purgeAllowed = attributes.purgeAllowed || false;
+        },
 
         /** Override to return editable versions of the collection panels */
         _getFoldoutPanelClass: function() {
@@ -25,21 +32,45 @@ var HDCAListItemEdit = _super.extend(
             return _super.prototype._renderPrimaryActions.call(this).concat([this._renderDeleteButton()]);
         },
 
-        /** Render icon-button to delete this collection. */
         _renderDeleteButton: function() {
-            var deleted = this.model.get("deleted");
-            return faIconButton({
-                title: deleted ? _l("Dataset collection is already deleted") : _l("Delete"),
-                classes: "delete-btn",
-                faIcon: "fa-times",
-                disabled: deleted,
-                onclick: () => {
-                    // ...bler... tooltips being left behind in DOM (hover out never called on deletion)
-                    this.$el.find(".icon-btn.delete-btn").trigger("mouseout");
-                    this.model["delete"]();
-                }
-            });
+            return $(`
+                <div class="delete-dropdown dropdown">
+                    <a class="delete-btn icon-btn" title="${_l('Delete')}" data-toggle="dropdown">
+                        <span class="fa fa-times"></span>
+                    </a>
+                    <ul class="dropdown-menu pull-right" role="menu" aria-labelledby="dLabel">
+                        <li>
+                            <a class="delete-collection">
+                                ${_l("Collection Only")}
+                            </a>
+                        </li>
+                        <li>
+                            <a class="delete-collection-and-datasets">
+                                ${_l("Delete Datasets")}
+                            </a>
+                        </li>
+                        <li style="display: ${this.purgeAllowed ? 'inherit' : 'none'}">
+                            <a class="delete-collection-and-purge-datasets">
+                                ${_l("Permenantly Delete Datasets")}
+                            </a>
+                        </li>
+                    </ul>
+                </div>`);
         },
+
+
+        // ......................................................................... misc
+        events: _.extend(_.clone(_super.prototype.events), {
+            "click .delete-collection": function(ev) {
+                this.model["delete"]();
+            },
+            "click .delete-collection-and-datasets": function(ev) {
+                this.model["delete"](true);
+            },
+            "click .delete-collection-and-purge-datasets": function(ev) {
+                this.model["delete"](true, true);
+            }
+        }),
 
         // ......................................................................... misc
         /** string rep */

--- a/client/galaxy/scripts/mvc/history/hdca-li-edit.js
+++ b/client/galaxy/scripts/mvc/history/hdca-li-edit.js
@@ -51,7 +51,7 @@ var HDCAListItemEdit = _super.extend(
                         </li>
                         <li style="display: ${this.purgeAllowed ? 'inherit' : 'none'}">
                             <a href="" class="delete-collection-and-purge-datasets">
-                                ${_l("Permenantly Delete Datasets")}
+                                ${_l("Permanently Delete Datasets")}
                             </a>
                         </li>
                     </ul>

--- a/client/galaxy/style/less/ui/icon-btn.less
+++ b/client/galaxy/style/less/ui/icon-btn.less
@@ -40,7 +40,7 @@
 
 .icon-btn-group {
     display: inline-block;
-    .icon-btn:not(:last-child) {
+    .icon-btn:not(:last-of-type) {
         margin: 0px;
         border-radius: 0px;
         border-right: none;


### PR DESCRIPTION
Delete button now a drop down menu (like dropdown for downloading metadata files).

- Top option just deletes the collection - like current behavior.
- Second option deletes the collection and attempts to delete the datasets contained within it.
- The third option deletes the collection and attempts to purge the datasets within it.

Related issues:

- Fixes https://github.com/galaxyproject/galaxy/issues/5310 for sure!
- Fixes https://github.com/galaxyproject/galaxy/issues/5435 maybe?
- Fixes pieces of https://github.com/galaxyproject/galaxy/issues/5402.
- xref https://github.com/galaxyproject/galaxy/issues/2319 (only because this makes that issue harder)
