### PR TITLE
[18.01] Ensure jobStateSummariesCollection exists; 

### DIFF
--- a/client/galaxy/scripts/mvc/history/history-contents.js
+++ b/client/galaxy/scripts/mvc/history/history-contents.js
@@ -72,7 +72,7 @@ var HistoryContents = _super.extend(BASE_MVC.LoggableMixin).extend({
             if (historyContent.attributes.history_content_type === "dataset_collection") {
                 var jobSourceType = historyContent.attributes.job_source_type;
                 var jobSourceId = historyContent.attributes.job_source_id;
-                if (jobSourceType) {
+                if (jobSourceType && this.jobStateSummariesCollection) {
                     this.jobStateSummariesCollection.add({
                         id: jobSourceId,
                         model: jobSourceType,


### PR DESCRIPTION
events can fire during deletion actions causing this action to fail and halt execution; this just skips it and the objects should get cleaned up during the normal course of things.

fixes #5354

(I did some cleanup in the file while looking for this, but will open a separate PR against dev including that)