### PR TITLE
[18.01] Fix server_name when config is a dict

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -551,8 +551,9 @@ class Configuration(object):
         # Allow explicit override of server name in config params
         if "server_name" in kwargs:
             self.server_name = kwargs.get("server_name")
-        # The application stack code may manipulate the server name
-        self.base_server_name = self.server_name
+        # The application stack code may manipulate the server name. It also needs to be accessible via the get() method
+        # for galaxy.util.facts()
+        self.config_dict['base_server_name'] = self.base_server_name = self.server_name
         # Store all configured server names for the message queue routing
         self.server_names = []
         for section in global_conf_parser.sections():

--- a/lib/galaxy/util/facts.py
+++ b/lib/galaxy/util/facts.py
@@ -18,7 +18,7 @@ class Facts(MutableMapping):
     def __set_defaults(self, config):
         # config here may be a Galaxy config object, or it may just be a dict
         defaults = {
-            'server_name': config.base_server_name,
+            'server_name': lambda: config.get('base_server_name', 'main'),
             'server_id': None,
             'instance_id': None,
             'pool_name': None,


### PR DESCRIPTION
Scripts do this, so you can't assume the config is an actual Configuration object. Fixes #5420.

Also, an (unintended)? consequence of my server name hacking is that you can only set the server name by setting `server_name` in the config file (any), `galaxy-main --server-name` (webless), or `[server:name]` (paste). The default *base* server name is `main`, I think maybe @jmchilton had intended for it to be the webapp name (e.g. `galaxy`)?