### PR TITLE
Restore WebHelpers functions used in visualization makos

### DIFF
--- a/lib/galaxy/web/framework/helpers/__init__.py
+++ b/lib/galaxy/web/framework/helpers/__init__.py
@@ -1,5 +1,9 @@
 """
 Galaxy web framework helpers
+
+The functions in this module should be considered part of the API used by
+visualizations in their mako files through the `$h` object, see
+GalaxyWebTransaction in galaxy/web/framework/webapp.py
 """
 from datetime import datetime, timedelta
 
@@ -11,7 +15,11 @@ from galaxy.util import (
     hash_util,
     unicodify
 )
-from galaxy.util.json import safe_dumps as dumps  # Used by mako templates # noqa: F401
+from galaxy.util.json import safe_dumps as dumps  # noqa: F401
+from .tags import (
+    javascript_link,
+    stylesheet_link
+)
 from ..base import server_starttime
 
 
@@ -49,9 +57,8 @@ def truncate(content, length=100, suffix='...'):
     else:
         return content[:length].rsplit(' ', 1)[0] + suffix
 
+
 # Quick helpers for static content
-
-
 def css(*args):
     """
     Take a list of stylesheet names (no extension) and return appropriate string
@@ -59,8 +66,8 @@ def css(*args):
 
     Cache-bust with time that server started running on
     """
-    stylesheet_link_template = u'<link href="%s" media="screen" rel="stylesheet" type="text/css" />'
-    return "\n".join([stylesheet_link_template % url_for("/static/style/%s.css?v=%s" % (name, server_starttime)) for name in args])
+    urls = (url_for("/static/style/%s.css?v=%s" % (name, server_starttime)) for name in args)
+    return stylesheet_link(*urls)
 
 
 def js_helper(prefix, *args):
@@ -70,8 +77,8 @@ def js_helper(prefix, *args):
 
     Cache-bust with time that server started running on
     """
-    javascript_link_template = u'<script src="%s" type="text/javascript"></script>'
-    return "\n".join([javascript_link_template % url_for("/%s%s.js?v=%s" % (prefix, name, server_starttime)) for name in args])
+    urls = (url_for("/%s%s.js?v=%s" % (prefix, name, server_starttime)) for name in args)
+    return javascript_link(*urls)
 
 
 def js(*args):

--- a/lib/galaxy/web/framework/helpers/tags.py
+++ b/lib/galaxy/web/framework/helpers/tags.py
@@ -1,0 +1,91 @@
+"""
+Code derived from WebHelpers: https://bitbucket.org/bbangert/webhelpers
+
+Licensed under the MIT license: https://bitbucket.org/bbangert/webhelpers/src/tip/LICENSE
+"""
+from __future__ import print_function
+
+from markupsafe import escape_silent
+
+
+def format_attrs(**attrs):
+    """Format HTML attributes into a string of ' key="value"' pairs which
+    can be inserted into an HTML tag.
+
+    The attributes are sorted alphabetically.  If any value is None, the entire
+    attribute is suppressed.
+
+    Usage:
+    >>> format_attrs(p=2, q=3) == u' p="2" q="3"'
+    True
+    >>> format_attrs(p=2, q=None) == u' p="2"'
+    True
+    >>> format_attrs(p=None) == u''
+    True
+    """
+    strings = [u' %s="%s"' % (attr, escape_silent(value))
+        for attr, value in sorted(attrs.items())
+        if value is not None]
+    return u''.join(strings)
+
+
+def javascript_link(*urls, **attrs):
+    """Return script include tags for the specified javascript URLs.
+
+    ``urls`` should be the exact URLs desired.  A previous version of this
+    helper added magic prefixes; this is no longer the case.
+
+    Specify the keyword argument ``defer=True`` to enable the script
+    defer attribute.
+
+    Examples::
+
+        >>> print(javascript_link('/javascripts/prototype.js', '/other-javascripts/util.js'))
+        <script src="/javascripts/prototype.js" type="text/javascript"></script>
+        <script src="/other-javascripts/util.js" type="text/javascript"></script>
+
+        >>> print(javascript_link('/app.js', '/test/test.1.js'))
+        <script src="/app.js" type="text/javascript"></script>
+        <script src="/test/test.1.js" type="text/javascript"></script>
+    """
+    if 'defer' in attrs:
+        if attrs['defer']:
+            attrs['defer'] = 'defer'
+        else:
+            del attrs['defer']
+    attrs['type'] = 'text/javascript'
+    tag_template = u'<script%s></script>'
+    tags = []
+    for url in urls:
+        attrs['src'] = url
+        tag = tag_template % format_attrs(**attrs)
+        tags.append(tag)
+    return u"\n".join(tags)
+
+
+def stylesheet_link(*urls, **attrs):
+    """Return CSS link tags for the specified stylesheet URLs.
+
+    ``urls`` should be the exact URLs desired.  A previous version of this
+    helper added magic prefixes; this is no longer the case.
+
+    Examples::
+
+        >>> print(stylesheet_link('/stylesheets/style.css'))
+        <link href="/stylesheets/style.css" media="screen" rel="stylesheet" type="text/css" />
+
+        >>> print(stylesheet_link('/stylesheets/dir/file.css', media='all'))
+        <link href="/stylesheets/dir/file.css" media="all" rel="stylesheet" type="text/css" />
+    """
+    if "href" in attrs:
+        raise TypeError("keyword arg 'href' not allowed")
+    attrs.setdefault("rel", "stylesheet")
+    attrs.setdefault("type", "text/css")
+    attrs.setdefault("media", "screen")
+    tag_template = u'<link%s />'
+    tags = []
+    for url in urls:
+        attrs['href'] = url
+        tag = tag_template % format_attrs(**attrs)
+        tags.append(tag)
+    return u"\n".join(tags)


### PR DESCRIPTION
Broken in commit fbd33a57e0033a1547c3bf6f9812dd574cdb36d2 .
Reported by @guerler.