### PR TITLE
[18.01] Fix setting job failure exception

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1762,9 +1762,13 @@ class JobWrapper(object, HasResourceParameters):
         method should be removed ASAP and replaced with some properly generic
         and stateful way of determining link-only datasets. -nate
         """
-        job = self.get_job()
-        param_dict = job.get_param_values(self.app)
-        return self.tool.id == 'upload1' and param_dict.get('link_data_only', None) == 'link_to_files'
+        if self.tool:
+            job = self.get_job()
+            param_dict = job.get_param_values(self.app)
+            return self.tool.id == 'upload1' and param_dict.get('link_data_only', None) == 'link_to_files'
+        else:
+            # The tool is unavailable, we try to move the outputs.
+            return False
 
     def _change_ownership(self, username, gid):
         job = self.get_job()


### PR DESCRIPTION
This can happen when the job's tool is unavailble and
outputs_to_working_directory is activated.
Fixes https://github.com/galaxyproject/galaxy/issues/5424.