### PR TITLE
Python3: make encoded id JSON-serializable

### DIFF
--- a/lib/galaxy/web/security/__init__.py
+++ b/lib/galaxy/web/security/__init__.py
@@ -37,7 +37,7 @@ class SecurityHelper(object):
         # Pad to a multiple of 8 with leading "!"
         s = (b"!" * (8 - len(s) % 8)) + s
         # Encrypt
-        return codecs.encode(id_cipher.encrypt(s), 'hex')
+        return unicodify(codecs.encode(id_cipher.encrypt(s), 'hex'))
 
     def encode_dict_ids(self, a_dict, kind=None, skip_startswith=None):
         """

--- a/test/functional/twilltestcase.py
+++ b/test/functional/twilltestcase.py
@@ -16,6 +16,7 @@ from six.moves.urllib.parse import urlencode, urlparse
 from twill.other_packages._mechanize_dist import ClientForm
 
 from base.testcase import FunctionalTestCase  # noqa: I100,I202
+from galaxy.util import unicodify  # noqa: I201
 
 # Force twill to log to a buffer -- FIXME: Should this go to stdout and be captured by nose?
 buffer = StringIO()
@@ -65,7 +66,7 @@ class TwillTestCase(FunctionalTestCase):
 
     def check_page_for_string(self, patt):
         """Looks for 'patt' in the current browser page"""
-        page = self.last_page()
+        page = unicodify(self.last_page())
         if page.find(patt) == -1:
             fname = self.write_temp_file(page)
             errmsg = "no match to '%s'\npage content written to '%s'\npage: [[%s]]" % (patt, fname, page)
@@ -205,6 +206,10 @@ class TwillTestCase(FunctionalTestCase):
         return loads(self.last_page())
 
     def last_page(self):
+        """
+        Return the last visited page (usually HTML, but can binary data as
+        well).
+        """
         return tc.browser.get_html()
 
     def last_url(self):


### PR DESCRIPTION
Fix the following traceback when visiting the Galaxy homepage:
```
Error - <class 'TypeError'>: b'f5cd946f78fsbc0d' is not JSON serializable
URL: http://127.0.0.1:8080/
File 'lib/galaxy/web/framework/middleware/error.py', line 157 in __call__
  app_iter = self.application(environ, sr_checker)
File '/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv3/lib/python3.4/site-packages/paste/recursive.py', line 85 in __call__
  return self.application(environ, start_response)
File '/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv3/lib/python3.4/site-packages/paste/httpexceptions.py', line 640 in __call__
  return self.application(environ, start_response)
File 'lib/galaxy/web/framework/base.py', line 137 in __call__
  return self.handle_request(environ, start_response)
File 'lib/galaxy/web/framework/base.py', line 216 in handle_request
  body = method(trans, **kwargs)
File 'lib/galaxy/webapps/galaxy/controllers/root.py', line 112 in index
  return self.template(trans, 'analysis', options=js_options)
File 'lib/galaxy/web/base/controller.py', line 325 in template
  masthead=masthead
File 'lib/galaxy/web/framework/webapp.py', line 920 in fill_template
  return self.fill_template_mako(filename, **kwargs)
File 'lib/galaxy/web/framework/webapp.py', line 934 in fill_template_mako
  return template.render(**data)
File '/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv3/lib/python3.4/site-packages/mako/template.py', line 445 in render
  return runtime._render(self, self.callable_, args, data)
File '/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv3/lib/python3.4/site-packages/mako/runtime.py', line 829 in _render
  **_kwargs_for_callable(callable_, data))
File '/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv3/lib/python3.4/site-packages/mako/runtime.py', line 864 in _render_context
  _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
File '/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv3/lib/python3.4/site-packages/mako/runtime.py', line 890 in _exec_template
  callable_(context, *args, **kwargs)
File '/usr/users/ga002/soranzon/software/nsoranzo_galaxy/database/compiled_templates/js-app.mako.py', line 75 in render_body
  __M_writer(str( h.dumps( options ) ))
File 'lib/galaxy/util/json.py', line 79 in safe_dumps
  dumped = json.dumps(*args, allow_nan=False, **kwargs)
File '/usr/lib/python3.4/json/__init__.py', line 237 in dumps
  **kw).encode(obj)
File '/usr/lib/python3.4/json/encoder.py', line 192 in encode
  chunks = self.iterencode(o, _one_shot=True)
File '/usr/lib/python3.4/json/encoder.py', line 250 in iterencode
  return _iterencode(o, 0)
File '/usr/lib/python3.4/json/encoder.py', line 173 in default
  raise TypeError(repr(o) + " is not JSON serializable")
TypeError: b'f5cd946f78fsbc0d' is not JSON serializable
```

xref. #1715 