### PR TITLE
Show parameter name in DataToolParameter exception

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1621,7 +1621,7 @@ class DataToolParameter(BaseDataToolParameter):
         if trans.workflow_building_mode is workflow_building_modes.ENABLED:
             return None
         if not value and not self.optional:
-            raise ValueError("Specify a dataset of the required format / build.")
+            raise ValueError("Specify a dataset of the required format / build for parameter %s." % self.name)
         if value in [None, "None", '']:
             return None
         if isinstance(value, dict) and 'values' in value:


### PR DESCRIPTION
Goal is to replace this kind of output in a failed test run:

``RunToolException: Error creating a job for these tool inputs - Specify a dataset of the required format / build.``

with:

``RunToolException: Error creating a job for these tool inputs - Specify a dataset of the required format / build in parameter 'XXX'.``