### PR TITLE
[18.01] Fix recursion bug in BamNative datatype

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -304,7 +304,7 @@ class BamNative(Binary):
         if offset is not None:
             return self.get_chunk(trans, dataset, offset, ck_size)
         elif to_ext or not preview:
-            return super(Bam, self).display_data(trans, dataset, preview, filename, to_ext, **kwd)
+            return super(BamNative, self).display_data(trans, dataset, preview, filename, to_ext, **kwd)
         else:
             column_names = dataset.metadata.column_names
             if not column_names:


### PR DESCRIPTION
We introduced this in
https://github.com/galaxyproject/galaxy/pull/5180/ where we moved a lot
of code form the Bam class into the BamNative class.

Reported by @natefoo on gitter.