### PR TITLE
Add configuration for slow request timing to schema, regenerate

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1,21 +1,21 @@
 # Galaxy is configured by default to be usable in a single-user development
 # environment.  To tune the application for a multi-user production
 # environment, see the documentation at:
-#
+# 
 #  http://usegalaxy.org/production
-#
+# 
 # Throughout this sample configuration file, except where stated otherwise,
 # uncommented values override the default if left unset, whereas commented
 # values are set to the default value.  Relative paths are relative to the root
 # Galaxy directory.
-#
+# 
 # Examples of many of these options are explained in more detail in the Galaxy
 # Community Hub.
-#
+# 
 #   https://galaxyproject.org/admin/config
-#
+# 
 # Config hackers are encouraged to check there before asking for help.
-#
+# 
 uwsgi:
 
   # The address and port on which to listen.  By default, only listen to
@@ -618,12 +618,12 @@ galaxy:
   # standard).
   #pretty_datetime_format: $locale (UTC)
 
-  # Default localization for Galaxy UI.
-  # Allowed values are listed at the end of client/galaxy/scripts/nls/locale.js.
-  # With the default value (auto), the locale will be automatically adjusted to
-  # the user's navigator language.
-  # Users can override this settings in their user preferences if the localization
-  # settings are enabled in user_preferences_extra_conf.yml
+  # Default localization for Galaxy UI. Allowed values are listed at the
+  # end of client/galaxy/scripts/nls/locale.js. With the default value
+  # (auto), the locale will be automatically adjusted to the user's
+  # navigator language. Users can override this settings in their user
+  # preferences if the localization settings are enabled in
+  # user_preferences_extra_conf.yml
   #default_locale: auto
 
   # URL (with schema http/https) of the Galaxy instance as accessible
@@ -998,10 +998,11 @@ galaxy:
   # <project_name> -> Settings -> API Keys.
   #sentry_dsn: null
 
-  # Sentry slow request logging.  Requests slower than the threshold indicated
-  # below will be sent as events to the configured Sentry server (above).  A
-  # value of '0' is disabled.  For example, you would set this to .005 to log
-  # all queries taking longer than 5 milliseconds.
+  # Sentry slow request logging.  Requests slower than the threshold
+  # indicated below will be sent as events to the configured Sentry
+  # server (above, sentry_dsn).  A value of '0' is disabled.  For
+  # example, you would set this to .005 to log all queries taking longer
+  # than 5 milliseconds.
   #sentry_sloreq_threshold: 0
 
   # Log to statsd Statsd is an external statistics aggregator
@@ -1663,7 +1664,7 @@ galaxy:
   # Galaxy uses AMQP internally for communicating between processes.
   # For example, when reloading the toolbox or locking job execution,
   # the process that handled that particular request will tell all
-  # others to also reload, lock jobs, etc. For connection examples, see
+  # others to also reload, lock jobs, etc. For connection examples, see 
   # http://docs.celeryproject.org/projects/kombu/en/latest/userguide/con
   # nections.html  Without specifying anything here, galaxy will first
   # attempt to use your specified database_connection above.  If that's
@@ -1684,3 +1685,4 @@ galaxy:
   # persistent_communication_rooms is a comma-separated list of rooms
   # that should be always available.
   #persistent_communication_rooms: null
+

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1180,17 +1180,17 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 ``default_locale``
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Default localization for Galaxy UI.
-    Allowed values are listed at the end of client/galaxy/scripts/nls/locale.js.
-    With the default value (auto), the locale will be automatically adjusted to
-    the user's navigator language.
-    Users can override this settings in their user preferences if the localization
-    settings are enabled in user_preferences_extra_conf.yml
+    Default localization for Galaxy UI. Allowed values are listed at
+    the end of client/galaxy/scripts/nls/locale.js. With the default
+    value (auto), the locale will be automatically adjusted to the
+    user's navigator language. Users can override this settings in
+    their user preferences if the localization settings are enabled in
+    user_preferences_extra_conf.yml
 :Default: ``auto``
 :Type: str
 
@@ -2082,6 +2082,20 @@
     instance under <project_name> -> Settings -> API Keys.
 :Default: ``None``
 :Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``sentry_sloreq_threshold``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Sentry slow request logging.  Requests slower than the threshold
+    indicated below will be sent as events to the configured Sentry
+    server (above, sentry_dsn).  A value of '0' is disabled.  For
+    example, you would set this to .005 to log all queries taking
+    longer than 5 milliseconds.
+:Default: ``0``
+:Type: float
 
 
 ~~~~~~~~~~~~~~~
@@ -3526,3 +3540,6 @@
     that should be always available.
 :Default: ``None``
 :Type: str
+
+
+

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1553,6 +1553,17 @@ mapping:
           indicated sentry instance.  This connection string is available in your
           sentry instance under <project_name> -> Settings -> API Keys.
 
+      sentry_sloreq_threshold:
+        type: float
+        default: 0
+        required: false
+        desc: |
+          Sentry slow request logging.  Requests slower than the threshold
+          indicated below will be sent as events to the configured Sentry
+          server (above, sentry_dsn).  A value of '0' is disabled.  For
+          example, you would set this to .005 to log all queries taking longer
+          than 5 milliseconds.
+
       statsd_host:
         type: str
         required: false


### PR DESCRIPTION
xref #5479; this fixes the configuration options in the source yml and regenerates the sample correctly.