### PR TITLE
Python3: Update bx-python dependency to 0.8.1

### DIFF
--- a/lib/galaxy/datatypes/util/gff_util.py
+++ b/lib/galaxy/datatypes/util/gff_util.py
@@ -5,7 +5,6 @@ import copy
 
 from bx.intervals.io import GenomicInterval, GenomicIntervalReader, MissingFieldError, NiceReaderWrapper, ParseError
 from bx.tabular.io import Comment, Header
-from six import Iterator
 
 from galaxy.util.odict import odict
 
@@ -120,7 +119,7 @@ class GFFIntervalToBEDReaderWrapper(NiceReaderWrapper):
         return interval
 
 
-class GFFReaderWrapper(Iterator, NiceReaderWrapper):  # Iterator can be removed after bx-python library is ported to Python3
+class GFFReaderWrapper(NiceReaderWrapper):
     """
     Reader wrapper for GFF files.
 

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -1,8 +1,9 @@
-# packages with C extensions
-# numpy must come before bx-python when doing source installs to so bx-python
-# is built properly (see #4982).
+# bx-python and dependencies
 numpy==1.9.2
-bx-python==0.7.3
+python-lzo==1.11
+bx-python==0.8.1
+
+# packages with C extensions
 MarkupSafe==1.0
 PyYAML==3.12
 SQLAlchemy==1.0.15
@@ -12,10 +13,6 @@ pycrypto==2.6.1
 uWSGI==2.0.15
 # Flexible BAM index naming is new to core pysam
 pysam==0.14
-
-# Install python_lzo if you want to support indexed access to lzo-compressed
-# locally cached maf files via bx-python
-#python_lzo==1.8
 
 # pure Python packages
 bz2file==0.98; python_version < '3.3'

--- a/lib/galaxy/dependencies/requirements.txt
+++ b/lib/galaxy/dependencies/requirements.txt
@@ -1,7 +1,9 @@
-# packages with C extensions
-# numpy should be installed before bx to enable extra features in bx
+# bx-python and dependencies
 numpy
+python-lzo
 bx-python
+
+# packages with C extensions
 MarkupSafe
 PyYAML
 SQLAlchemy
@@ -9,10 +11,6 @@ mercurial; python_version < '3.0'
 pycrypto
 # Flexible BAM index naming is new to main pysam
 pysam>=0.13
-
-# Install python_lzo if you want to support indexed access to lzo-compressed
-# locally cached maf files via bx-python
-#python_lzo
 
 # pure Python packages
 bz2file; python_version < '3.3'


### PR DESCRIPTION
Thanks @jxtx for tagging a new bx-python release.

We need a bx-python wheel before merging this: https://github.com/galaxyproject/starforge/pull/195

xref. #1715 