### PR TITLE
Close tempfile handles.

### DIFF
--- a/lib/galaxy/tools/repositories.py
+++ b/lib/galaxy/tools/repositories.py
@@ -44,10 +44,7 @@ class ValidationContext(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        try:
-            shutil.rmtree(self.temporary_path)
-        except Exception:
-            pass
+        shutil.rmtree(self.temporary_path)
 
     @staticmethod
     @contextmanager

--- a/lib/galaxy/tools/repositories.py
+++ b/lib/galaxy/tools/repositories.py
@@ -27,13 +27,15 @@ class ValidationContext(object):
         self.config = Bunch()
         self.config.tool_data_path = tool_data_path
         self.config.shed_tool_data_path = shed_tool_data_path
-        _, self.config.tool_data_table_config = tempfile.mkstemp()
-        _, self.config.shed_tool_data_table_config = tempfile.mkstemp()
+        tool_data_table_handle, self.config.tool_data_table_config = tempfile.mkstemp()
+        shed_tool_data_table_handle, self.config.shed_tool_data_table_config = tempfile.mkstemp()
         self.tool_data_tables = tool_data_tables
         self.datatypes_registry = registry or Registry()
         self.hgweb_config_manager = hgweb_config_manager
-        _, self.config.len_file_path = tempfile.mkstemp()
-        _, self.config.builds_file_path = tempfile.mkstemp()
+        len_file_handle, self.config.len_file_path = tempfile.mkstemp()
+        builds_file_handle, self.config.builds_file_path = tempfile.mkstemp()
+        for fh in [tool_data_table_handle, shed_tool_data_table_handle, len_file_handle, builds_file_handle]:
+            os.close(fh)
         self.genome_builds = GenomeBuilds(self)
 
     def __enter__(self):


### PR DESCRIPTION
The old code would create four temporary files whenever adding or removing repository files, and these file handles would remain open after the files were deleted in the subsequent cleanup methods, leading to TTS reporting too many open files after a certain time running.