### PR TITLE
[18.01] disable loading of webhooks in TS and reports apps

### DIFF
--- a/client/galaxy/scripts/onload.js
+++ b/client/galaxy/scripts/onload.js
@@ -179,18 +179,20 @@ $(document).ready(() => {
 
     function onloadWebhooks() {
         if (Galaxy.root !== undefined) {
-            // Load all webhooks with the type 'onload'
-            Webhooks.load({
-                type: "onload",
-                callback: function(webhooks) {
-                    webhooks.each(model => {
-                        var webhook = model.toJSON();
-                        if (webhook.activate && webhook.script) {
-                            Utils.appendScriptStyle(webhook);
-                        }
-                    });
-                }
-            });
+            if (Galaxy.config.enable_webhooks) {
+                // Load all webhooks with the type 'onload'
+                Webhooks.load({
+                    type: "onload",
+                    callback: function(webhooks) {
+                        webhooks.each(model => {
+                            var webhook = model.toJSON();
+                            if (webhook.activate && webhook.script) {
+                                Utils.appendScriptStyle(webhook);
+                            }
+                        });
+                    }
+                });
+            }
         } else {
             setTimeout(onloadWebhooks, 100);
         }


### PR DESCRIPTION
This has already been disabled in https://github.com/galaxyproject/galaxy/pull/5116/commits/3dfbbc7e081cae0c8b95b727e3791915afcc47ec but then again broken in https://github.com/galaxyproject/galaxy/commit/6070bf07e18b0d3ebc210f3c4c44a1ed14b1dd27#diff-7b920e09d422900f9f73c2cace0fae96R183