### PR TITLE
[18.01] fix toolbox filters

### DIFF
--- a/lib/galaxy/tools/toolbox/filters/__init__.py
+++ b/lib/galaxy/tools/toolbox/filters/__init__.py
@@ -44,7 +44,7 @@ class FilterFactory(object):
                     elif name == 'toolbox_label_filters':
                         category = "label"
                     if category:
-                        validate = getattr(trans.app.config, 'user_%s_filters' % category, [])
+                        validate = getattr(trans.app.config, 'user_tools_%s_filters' % category, [])
                         self.__init_filters(category, user_filters, filters, validate=validate)
         else:
             if kwds.get("trackster", False):

--- a/lib/galaxy/tools/toolbox/filters/__init__.py
+++ b/lib/galaxy/tools/toolbox/filters/__init__.py
@@ -44,7 +44,7 @@ class FilterFactory(object):
                     elif name == 'toolbox_label_filters':
                         category = "label"
                     if category:
-                        validate = getattr(trans.app.config, 'user_tools_%s_filters' % category, [])
+                        validate = getattr(trans.app.config, 'user_tool_%s_filters' % category, [])
                         self.__init_filters(category, user_filters, filters, validate=validate)
         else:
             if kwds.get("trackster", False):

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -710,14 +710,14 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesUsersMixin, Cre
                 errors['%s|%s' % (filter_type, filter_name)] = 'Filter function not found.'
 
             short_description, description = None, None
-            doc_string = docstring_trim( function.__doc__ )
+            doc_string = docstring_trim(function.__doc__)
             split = doc_string.split('\n\n')
             if split:
                 short_description = split[0]
                 if len(split) > 1:
                     description = split[1]
             else:
-                log.warning( 'No description specified in the __doc__ string for %s.' % filter_name )
+                log.warning('No description specified in the __doc__ string for %s.' % filter_name)
 
             filter_inputs.append({
                 'type': 'boolean',

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -708,11 +708,22 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesUsersMixin, Cre
             function = factory.build_filter_function(filter_name)
             if function is None:
                 errors['%s|%s' % (filter_type, filter_name)] = 'Filter function not found.'
+
+            short_description, description = None, None
+            doc_string = docstring_trim( function.__doc__ )
+            split = doc_string.split('\n\n')
+            if split:
+                short_description = split[0]
+                if len(split) > 1:
+                    description = split[1]
+            else:
+                log.warning( 'No description specified in the __doc__ string for %s.' % filter_name )
+
             filter_inputs.append({
                 'type': 'boolean',
                 'name': filter_name,
-                'label': filter_name,
-                'help': docstring_trim(function.__doc__) or 'No description available.',
+                'label': short_description or filter_name,
+                'help': description or 'No description available.',
                 'value': 'true' if filter_name in filter_values else 'false'
             })
         if filter_inputs:


### PR DESCRIPTION
* the config variables are called `user_tool_*_filters`
* the user-preference labels where not fully populated 