### PR TITLE
[18.01] Use profile="18.01" for BamNative converters

### DIFF
--- a/lib/galaxy/datatypes/converters/bam_native_to_bam_converter.xml
+++ b/lib/galaxy/datatypes/converters/bam_native_to_bam_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_bam_native_to_bam" name="Convert BAM native to BAM" version="1.0.0" hidden="true">
+<tool id="CONVERTER_bam_native_to_bam" name="Convert BAM native to BAM" version="1.0.0" hidden="true" profile="18.01">
     <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
         <requirement type="package" version="1.6">samtools</requirement>

--- a/lib/galaxy/datatypes/converters/sam_to_bam_native.xml
+++ b/lib/galaxy/datatypes/converters/sam_to_bam_native.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_sam_to_bam_native" name="Convert SAM to BAM native - without sorting" version="1.0.0">
+<tool id="CONVERTER_sam_to_bam_native" name="Convert SAM to BAM native - without sorting" version="1.0.0" profile="18.01">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
         <requirement type="package" version="1.6">samtools</requirement>


### PR DESCRIPTION
This is because samtools writes to stderr when sorting/merging large files.
Part of https://github.com/galaxyproject/galaxy/issues/5496#issuecomment-365458089.