### PR TITLE
[17.09] Map static content by default for Reports and Tool Shed webapps

### DIFF
--- a/config/reports.yml.sample
+++ b/config/reports.yml.sample
@@ -11,6 +11,9 @@ uwsgi:
 
   offload-threads: 8
 
+  static-map: /static/style=static/style/blue
+  static-map: /static=static
+
   module: galaxy.webapps.reports.buildapp:uwsgi_app()
 
 reports:

--- a/config/tool_shed.yml.sample
+++ b/config/tool_shed.yml.sample
@@ -11,6 +11,9 @@ uwsgi:
 
   offload-threads: 8
 
+  static-map: /static/style=static/style/blue
+  static-map: /static=static
+
   module: galaxy.webapps.tool_shed.buildapp:uwsgi_app()
 
 tool_shed:


### PR DESCRIPTION
I'm not sure how these worked in 17.09 without the mappings, unless it was expected they'd always be run behind a proxy which served the static content.

All of the config stuff is reworked in 18.01 and the samples are no longer used directly, so this is only relevant to 17.09.