### PR TITLE
Add middleware and instrumentation to allow per-request SQL debugging.

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -133,6 +133,12 @@ galaxy:
   # than 5 milliseconds.
   #slow_query_log_threshold: 0
 
+  # Enable's a per request sql debugging option. If this is set to true,
+  # append ?sql_debug=1 to web request URLs to enable detailed logging
+  # on the backend of SQL queries generated during that request. This is
+  # useful for debugging slow endpoints during development.
+  #enable_per_request_sql_debugging: false
+
   # By default, Galaxy will use the same database to track user data and
   # tool shed install data.  There are many situations in which it is
   # valuable to separate these - for instance bootstrapping fresh Galaxy

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -126,6 +126,20 @@
 :Type: int
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enable_per_request_sql_debugging``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Enable's a per request sql debugging option. If this is set to
+    true, append ?sql_debug=1 to web request URLs to enable detailed
+    logging on the backend of SQL queries generated during that
+    request. This is useful for debugging slow endpoints during
+    development.
+:Default: ``false``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``install_database_connection``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -177,6 +177,9 @@ class Configuration(object):
         self.database_template = kwargs.get("database_template", None)
         self.database_encoding = kwargs.get("database_encoding", None)  # Create new databases with this encoding.
         self.slow_query_log_threshold = float(kwargs.get("slow_query_log_threshold", 0))
+        self.thread_local_log = None
+        if string_as_bool(kwargs.get("enable_per_request_sql_debugging", "False")):
+            self.thread_local_log = threading.local()
 
         # Don't set this to true for production databases, but probably should
         # default to True for sqlite databases.
@@ -1046,7 +1049,8 @@ class ConfiguresGalaxyMixin(object):
                                   object_store=self.object_store,
                                   trace_logger=getattr(self, "trace_logger", None),
                                   use_pbkdf2=self.config.get_bool('use_pbkdf2', True),
-                                  slow_query_log_threshold=self.config.slow_query_log_threshold)
+                                  slow_query_log_threshold=self.config.slow_query_log_threshold,
+                                  thread_local_log=self.config.thread_local_log)
 
         if combined_install_database:
             log.info("Install database targetting Galaxy's database configuration.")

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2509,7 +2509,7 @@ model.WorkflowInvocation.update = _workflow_invocation_update
 
 def init(file_path, url, engine_options=None, create_tables=False, map_install_models=False,
         database_query_profiling_proxy=False, object_store=None, trace_logger=None, use_pbkdf2=True,
-        slow_query_log_threshold=0):
+        slow_query_log_threshold=0, thread_local_log=None):
     """Connect mappings to the database"""
     if engine_options is None:
         engine_options = {}
@@ -2520,7 +2520,7 @@ def init(file_path, url, engine_options=None, create_tables=False, map_install_m
     # Use PBKDF2 password hashing?
     model.User.use_pbkdf2 = use_pbkdf2
     # Load the appropriate db module
-    engine = build_engine(url, engine_options, database_query_profiling_proxy, trace_logger, slow_query_log_threshold)
+    engine = build_engine(url, engine_options, database_query_profiling_proxy, trace_logger, slow_query_log_threshold, thread_local_log=thread_local_log)
 
     # Connect the metadata to the database.
     metadata.bind = engine
@@ -2541,4 +2541,5 @@ def init(file_path, url, engine_options=None, create_tables=False, map_install_m
     result.create_tables = create_tables
     # load local galaxy security policy
     result.security_agent = GalaxyRBACAgent(result)
+    result.thread_local_log = thread_local_log
     return result

--- a/lib/galaxy/model/orm/engine_factory.py
+++ b/lib/galaxy/model/orm/engine_factory.py
@@ -7,7 +7,7 @@ from sqlalchemy.engine import Engine
 log = logging.getLogger(__name__)
 
 
-def build_engine(url, engine_options, database_query_profiling_proxy=False, trace_logger=None, slow_query_log_threshold=0):
+def build_engine(url, engine_options, database_query_profiling_proxy=False, trace_logger=None, slow_query_log_threshold=0, thread_local_log=None):
     # Should we use the logging proxy?
     if database_query_profiling_proxy:
         import galaxy.model.orm.logging_connection_proxy as logging_connection_proxy
@@ -18,7 +18,7 @@ def build_engine(url, engine_options, database_query_profiling_proxy=False, trac
         proxy = logging_connection_proxy.TraceLoggerProxy(trace_logger)
     else:
         proxy = None
-    if slow_query_log_threshold:
+    if slow_query_log_threshold or thread_local_log:
         @event.listens_for(Engine, "before_cursor_execute")
         def before_cursor_execute(conn, cursor, statement,
                                   parameters, context, executemany):
@@ -30,6 +30,12 @@ def build_engine(url, engine_options, database_query_profiling_proxy=False, trac
             total = time.time() - conn.info['query_start_time'].pop(-1)
             if total > slow_query_log_threshold:
                 log.debug("Slow query: %f(s)\n%s\nParameters: %s" % (total, statement, parameters))
+            if thread_local_log is not None:
+                try:
+                    if thread_local_log.log:
+                        log.debug("Request query: %f(s)\n%s\nParameters: %s" % (total, statement, parameters))
+                except AttributeError:
+                    pass
 
     # Create the database engine
     engine = create_engine(url, proxy=proxy, **engine_options)

--- a/lib/galaxy/web/framework/middleware/sqldebug.py
+++ b/lib/galaxy/web/framework/middleware/sqldebug.py
@@ -1,0 +1,22 @@
+"""
+Per-request SQL debugging middleware.
+"""
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class SQLDebugMiddleware(object):
+
+    def __init__(self, application, galaxy, config=None):
+        #: the wrapped webapp
+        self.application = application
+
+    def __call__(self, environ, start_response):
+        query_string = environ.get('QUERY_STRING')
+        if "sql_debug=1" in query_string:
+            import galaxy.app
+            if galaxy.app.app.model.thread_local_log:
+                galaxy.app.app.model.thread_local_log.log = True
+
+        return self.application(environ, start_response)

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1042,6 +1042,9 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
     # api batch call processing middleware
     from galaxy.web.framework.middleware.batch import BatchMiddleware
     app = wrap_if_allowed(app, stack, BatchMiddleware, args=(webapp, {}))
+    if asbool(conf.get('enable_per_request_sql_debugging', False)):
+        from galaxy.web.framework.middleware.sqldebug import SQLDebugMiddleware
+        app = wrap_if_allowed(app, stack, SQLDebugMiddleware, args=(webapp, {}))
     return app
 
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -125,6 +125,16 @@ mapping:
           be logged to debug.  A value of '0' is disabled.  For example, you would set
           this to .005 to log all queries taking longer than 5 milliseconds.
 
+      enable_per_request_sql_debugging:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Enable's a per request sql debugging option. If this is set to true, append
+          ?sql_debug=1 to web request URLs to enable detailed logging on the backend of SQL
+          queries generated during that request. This is useful for debugging slow endpoints
+          during development.
+
       install_database_connection:
         type: str
         default: sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE


### PR DESCRIPTION
This has been super helpful in debugging the SQL generated by Galaxy for recent PRs (#5533, #5515 , #5514).

To use this simply enable the middleware, use your browser's network logger to find the URL of interest, copy the URL into the browser address bar and add ``?sql_debug=1`` to it. You will then see the sql in the logs only for that request and for every statement in that request.

Simply turning all logging on results in a deluge of logging that I've never been able to grok and that is very hard to pin to particular request. Slow request logging is great but it doesn't make this kind of per-request full profile of the SQL generated as easy as this approach and isn't great at debugging performance problems when they result from a large number of small requests (you'd have to set a very low threshold to make sure you are logging every query and then it is no different from the full log).