### PR TITLE
Update all tools/converters using UCSC binaries to depend only on the binary they are using

### DIFF
--- a/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_bam_to_bigwig_0" name="Convert BAM to BigWig" version="1.0.0" hidden="true">
     <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
-        <requirement type="package">ucsc_tools</requirement>
+        <requirement type="package">ucsc-bedgraphtobigwig</requirement>
         <requirement type="package">bedtools</requirement>
     </requirements>
     <command><![CDATA[

--- a/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_bam_to_bigwig_0" name="Convert BAM to BigWig" version="1.0.0" hidden="true">
+<tool id="CONVERTER_bam_to_bigwig_0" name="Convert BAM to BigWig" version="1.0.1" hidden="true">
     <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
         <requirement type="package">ucsc-bedgraphtobigwig</requirement>

--- a/lib/galaxy/datatypes/converters/bed_gff_or_vcf_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bed_gff_or_vcf_to_bigwig_converter.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_bed_gff_or_vcf_to_bigwig_0" name="Convert BED, GFF, or VCF to BigWig" version="1.0.0" hidden="true">
     <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
-        <requirement type="package">ucsc_tools</requirement>
+        <requirement type="package">ucsc-bedgraphtobigwig</requirement>
         <requirement type="package">bedtools</requirement>
     </requirements>
     <command>

--- a/lib/galaxy/datatypes/converters/bed_gff_or_vcf_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bed_gff_or_vcf_to_bigwig_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_bed_gff_or_vcf_to_bigwig_0" name="Convert BED, GFF, or VCF to BigWig" version="1.0.0" hidden="true">
+<tool id="CONVERTER_bed_gff_or_vcf_to_bigwig_0" name="Convert BED, GFF, or VCF to BigWig" version="1.0.1" hidden="true">
     <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
         <requirement type="package">ucsc-bedgraphtobigwig</requirement>

--- a/lib/galaxy/datatypes/converters/bedgraph_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bedgraph_to_bigwig_converter.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_bedgraph_to_bigwig" name="Convert BedGraph to BigWig" version="1.0.0" hidden="true">
     <!-- Used internally to generate track indexes -->
     <requirements>
-        <requirement type="package">ucsc_tools</requirement>
+        <requirement type="package">ucsc-wigtobigwig</requirement>
     </requirements>
     <command>grep -v "^track" '$input' | wigToBigWig -clip stdin '$chromInfo' '$output'</command>
     <inputs>

--- a/lib/galaxy/datatypes/converters/bedgraph_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bedgraph_to_bigwig_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_bedgraph_to_bigwig" name="Convert BedGraph to BigWig" version="1.0.0" hidden="true">
+<tool id="CONVERTER_bedgraph_to_bigwig" name="Convert BedGraph to BigWig" version="1.0.1" hidden="true">
     <!-- Used internally to generate track indexes -->
     <requirements>
         <requirement type="package">ucsc-wigtobigwig</requirement>

--- a/lib/galaxy/datatypes/converters/fasta_to_2bit.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_2bit.xml
@@ -2,8 +2,7 @@
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <!-- Used on the metadata edit page. -->
     <requirements>
-        <requirement type="package" version="332">ucsc-fatotwobit</requirement>
-        <requirement type="package">ucsc_tools</requirement>
+        <requirement type="package">ucsc-fatotwobit</requirement>
     </requirements>
     <command>faToTwoBit '$input' '$output'</command>
     <inputs>

--- a/lib/galaxy/datatypes/converters/fasta_to_2bit.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_2bit.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_fasta_to_2bit" name="Convert FASTA to 2bit" version="1.0.0">
+<tool id="CONVERTER_fasta_to_2bit" name="Convert FASTA to 2bit" version="1.0.1">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <!-- Used on the metadata edit page. -->
     <requirements>

--- a/lib/galaxy/datatypes/converters/interval_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bigwig_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_interval_to_bigwig_0" name="Convert Genomic Intervals To Coverage" version="1.0.0">
+<tool id="CONVERTER_interval_to_bigwig_0" name="Convert Genomic Intervals To Coverage" version="1.0.1">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
         <requirement type="package">ucsc-bedgraphtobigwig</requirement>

--- a/lib/galaxy/datatypes/converters/interval_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bigwig_converter.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_interval_to_bigwig_0" name="Convert Genomic Intervals To Coverage" version="1.0.0">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
-        <requirement type="package">ucsc_tools</requirement>
+        <requirement type="package">ucsc-bedgraphtobigwig</requirement>
         <requirement type="package">bedtools</requirement>
     </requirements>
     <command>

--- a/lib/galaxy/datatypes/converters/sam_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/sam_to_bigwig_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_sam_to_bigwig_0" name="Convert SAM to BigWig" version="1.0.0" hidden="true">
+<tool id="CONVERTER_sam_to_bigwig_0" name="Convert SAM to BigWig" version="1.0.1" hidden="true">
     <requirements>
         <requirement type="package">ucsc-bedgraphtobigwig</requirement>
         <requirement type="package">samtools</requirement>

--- a/lib/galaxy/datatypes/converters/sam_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/sam_to_bigwig_converter.xml
@@ -1,6 +1,6 @@
 <tool id="CONVERTER_sam_to_bigwig_0" name="Convert SAM to BigWig" version="1.0.0" hidden="true">
     <requirements>
-        <requirement type="package">ucsc_tools</requirement>
+        <requirement type="package">ucsc-bedgraphtobigwig</requirement>
         <requirement type="package">samtools</requirement>
         <requirement type="package">bedtools</requirement>
     </requirements>

--- a/lib/galaxy/datatypes/converters/wig_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/wig_to_bigwig_converter.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_wig_to_bigwig" name="Convert Wiggle to BigWig" version="1.0.0" hidden="true">
     <!-- Used internally to generate track indexes -->
     <requirements>
-        <requirement type="package">ucsc_tools</requirement>
+        <requirement type="package">ucsc-wigtobigwig</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/lib/galaxy/datatypes/converters/wig_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/wig_to_bigwig_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_wig_to_bigwig" name="Convert Wiggle to BigWig" version="1.0.0" hidden="true">
+<tool id="CONVERTER_wig_to_bigwig" name="Convert Wiggle to BigWig" version="1.0.1" hidden="true">
     <!-- Used internally to generate track indexes -->
     <requirements>
         <requirement type="package">ucsc-wigtobigwig</requirement>

--- a/lib/galaxy/tools/deps/resolvers/default_conda_mapping.yml
+++ b/lib/galaxy/tools/deps/resolvers/default_conda_mapping.yml
@@ -13,7 +13,7 @@
     unversioned: true
   to:
     name: ucsc_tools
-    version: 332
+    version: 357
 - from:
     name: bedtools
     unversioned: true
@@ -44,4 +44,46 @@
   to:
     name: bowtie
     version: 1.2.0
-  
+- from:
+    name: ucsc-bedgraphtobigwig
+    unversioned: true
+  to:
+    name: ucsc-bedgraphtobigwig
+    version: 357
+- from:
+    name: ucsc-bedtobigbed
+    unversioned: true
+  to:
+    name: ucsc-bedtobigbed
+    version: 357
+- from:
+    name: ucsc-fatotwobit
+    unversioned: true
+  to:
+    name: ucsc-fatotwobit
+    version: 357
+- from:
+    name: ucsc-liftover
+    unversioned: true
+  to:
+    name: ucsc-liftover
+    version: 357
+- from:
+    name: ucsc-nibfrag
+    unversioned: true
+  to:
+    name: ucsc-nibfrag
+    version: 357
+- from:
+    name: ucsc-twobittofa
+    unversioned: true
+  to:
+    name: ucsc-twobittofa
+    version: 357
+- from:
+    name: ucsc-wigtobigwig
+    unversioned: true
+  to:
+    name: ucsc-wigtobigwig
+    version: 357
+

--- a/tools/evolution/codingSnps.xml
+++ b/tools/evolution/codingSnps.xml
@@ -47,7 +47,8 @@
 
   <requirements>
     <requirement type="package">gnu_coreutils</requirement>
-    <requirement type="package">ucsc_tools</requirement>
+    <requirement type="package">ucsc-twobittofa</requirement>
+    <requirement type="package">ucsc-nibfrag</requirement>
   </requirements>
 
   <tests>

--- a/tools/evolution/codingSnps.xml
+++ b/tools/evolution/codingSnps.xml
@@ -1,4 +1,4 @@
-<tool id="hgv_codingSnps" name="aaChanges" version="1.0.0">
+<tool id="hgv_codingSnps" name="aaChanges" version="1.0.1">
   <description>amino-acid changes caused by a set of SNPs</description>
 
   <command interpreter="perl">

--- a/tools/extract/extract_genomic_dna.xml
+++ b/tools/extract/extract_genomic_dna.xml
@@ -1,8 +1,7 @@
 <tool id="Extract genomic DNA 1" name="Extract Genomic DNA" version="2.2.3">
   <description>using coordinates from assembled/unassembled genomes</description>
   <requirements>
-      <requirement type="package">ucsc_tools</requirement>
-      <requirement type="binary">faToTwoBit</requirement>
+      <requirement type="package">ucsc-fatotwobit</requirement>
   </requirements>
   <command>
       python '$__tool_directory__/extract_genomic_dna.py' '${input}' '${out_file1}' -o ${out_format} -d '${dbkey}'

--- a/tools/extract/extract_genomic_dna.xml
+++ b/tools/extract/extract_genomic_dna.xml
@@ -1,4 +1,4 @@
-<tool id="Extract genomic DNA 1" name="Extract Genomic DNA" version="2.2.3">
+<tool id="Extract genomic DNA 1" name="Extract Genomic DNA" version="2.2.4">
   <description>using coordinates from assembled/unassembled genomes</description>
   <requirements>
       <requirement type="package">ucsc-fatotwobit</requirement>

--- a/tools/extract/liftOver_wrapper.xml
+++ b/tools/extract/liftOver_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="liftOver1" name="Convert genome coordinates" version="1.0.5">
+<tool id="liftOver1" name="Convert genome coordinates" version="1.0.6">
   <description> between assemblies and genomes</description>
   <requirements>
     <requirement type="package">ucsc-liftover</requirement>

--- a/tools/extract/liftOver_wrapper.xml
+++ b/tools/extract/liftOver_wrapper.xml
@@ -1,7 +1,7 @@
 <tool id="liftOver1" name="Convert genome coordinates" version="1.0.5">
   <description> between assemblies and genomes</description>
   <requirements>
-    <requirement type="package">ucsc_tools</requirement>
+    <requirement type="package">ucsc-liftover</requirement>
   </requirements>
   <command>
   python $__tool_directory__/liftOver_wrapper.py

--- a/tools/filters/bed_to_bigbed.xml
+++ b/tools/filters/bed_to_bigbed.xml
@@ -10,7 +10,7 @@
     2&gt;&amp;1 || echo "Error running bedToBigBed." >&amp;2
   </command>
   <requirements>
-    <requirement type="package">ucsc_tools</requirement>
+    <requirement type="package">ucsc-bedtobigbed</requirement>
   </requirements>
   <inputs>
     <param format="bed" name="input1" type="data" label="Convert">

--- a/tools/filters/bed_to_bigbed.xml
+++ b/tools/filters/bed_to_bigbed.xml
@@ -1,4 +1,4 @@
-<tool id="bed_to_bigBed" name="BED-to-bigBed" version="1.0.0">
+<tool id="bed_to_bigBed" name="BED-to-bigBed" version="1.0.1">
   <description>converter</description>
   <edam_operations>
     <edam_operation>operation_3434</edam_operation>

--- a/tools/filters/wig_to_bigwig.xml
+++ b/tools/filters/wig_to_bigwig.xml
@@ -1,7 +1,7 @@
 <tool id="wig_to_bigWig" name="Wig/BedGraph-to-bigWig" version="1.1.0">
   <description>converter</description>
   <requirements>
-    <requirement type="package">ucsc_tools</requirement>
+    <requirement type="package">ucsc-wigtobigwig</requirement>
   </requirements>
   <stdio>
       <!-- Anything other than zero is an error -->

--- a/tools/filters/wig_to_bigwig.xml
+++ b/tools/filters/wig_to_bigwig.xml
@@ -1,4 +1,4 @@
-<tool id="wig_to_bigWig" name="Wig/BedGraph-to-bigWig" version="1.1.0">
+<tool id="wig_to_bigWig" name="Wig/BedGraph-to-bigWig" version="1.1.1">
   <description>converter</description>
   <requirements>
     <requirement type="package">ucsc-wigtobigwig</requirement>


### PR DESCRIPTION
Currently, installing the `ucsc_tools` IUC package to resolve these dependencies will yield broken tools due to bioconda/bioconda-recipes#5430. A fix for stable Galaxy releases is in galaxyproject/conda-iuc#14. This removes the dependence on the IUC metapackage. We may still need to update versions for supported stable releases if the Bioconda packages break some time in the future due to dependency issues like the one in the linked issue.