### PR TITLE
[18.01] Bump sqlite3 dependency for web proxy

### DIFF
--- a/lib/galaxy/web/proxy/js/package.json
+++ b/lib/galaxy/web/proxy/js/package.json
@@ -11,9 +11,9 @@
     "url": "https://bitbucket.org/galaxy/galaxy-central"
   },
   "dependencies": {
+    "commander": "~2.2",
     "eventemitter3": "0.1.6",
     "http-proxy": "1.6.0",
-    "commander": "~2.2",
-    "sqlite3": "3.1.8"
+    "sqlite3": "3.1.13"
   }
 }

--- a/lib/galaxy/web/proxy/js/package.json
+++ b/lib/galaxy/web/proxy/js/package.json
@@ -11,9 +11,9 @@
     "url": "https://bitbucket.org/galaxy/galaxy-central"
   },
   "dependencies": {
-    "commander": "~2.2",
+    "commander": "~2.14.1",
     "eventemitter3": "0.1.6",
-    "http-proxy": "1.6.0",
+    "http-proxy": "1.16.2",
     "sqlite3": "3.1.13"
   }
 }


### PR DESCRIPTION
The old version of sqlite3 was failing due to a missing archive download from aws.  May be something we need to look into caching?

Noticed by @bgruening 

`# TODO:`  We could also autobuild all this now?