### PR TITLE
[18.01] Paginate published workflows grid.

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -136,6 +136,8 @@ class StoredWorkflowAllPublishedGrid(grids.Grid):
             url_args=dict(action="export_to_file")
         ),
     ]
+    num_rows_per_page = 50
+    use_paging = True
 
     def build_initial_query(self, trans, **kwargs):
         # See optimization description comments and TODO for tags in matching public histories query.


### PR DESCRIPTION
@martenson mentioned he prefers the look and feel of the published history grid so this replicates that and very likely will result in quicker rendering on usegalaxy.org - though we should verify this after it is deployed since the paginated grid do result in two big join queries instead of one big query - but I suspect rendering details on fewer objects (which includes fetching tag information from the db) will saved more than enough to make up for that.

Labelling this as a performance bug in order to target 18.01 - but I can target usegalaxy branch if people would be more comfortable with that.
