### PR TITLE
Log errors from external chown script.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1757,9 +1757,9 @@ class JobWrapper(object, HasResourceParameters):
             p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
             if p.returncode != 0:
-                logging.error('external script failed.')
-                logging.error('stdout was: %s' %stdout)
-                logging.error('stderr was: %s' %stderr)
+                log.error('external script failed.')
+                log.error('stdout was: %s' % stdout)
+                log.error('stderr was: %s' % stderr)
             assert p.returncode == 0
 
     def change_ownership_for_run(self):

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1755,8 +1755,11 @@ class JobWrapper(object, HasResourceParameters):
             cmd.extend([self.working_directory, username, str(gid)])
             log.debug('(%s) Changing ownership of working directory with: %s' % (job.id, ' '.join(cmd)))
             p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            # TODO: log stdout/stderr
             stdout, stderr = p.communicate()
+            if p.returncode != 0:
+                logging.error('external script failed.')
+                logging.error('stdout was: %s' %stdout)
+                logging.error('stderr was: %s' %stderr)
             assert p.returncode == 0
 
     def change_ownership_for_run(self):


### PR DESCRIPTION
Hi there,
I noticed this TODO here related to helping debug external chown scripts. I've just been debugging this, so this patch helped me to figure out what is going on.

Does this need tests attached?