### PR TITLE
Update to latest galaxy-lib.

### DIFF
--- a/lib/galaxy/tools/cwl/__init__.py
+++ b/lib/galaxy/tools/cwl/__init__.py
@@ -2,13 +2,14 @@ from .cwltool_deps import (
     needs_shell_quoting,
     shellescape,
 )
-from .parser import tool_proxy, workflow_proxy
+from .parser import tool_proxy, tool_proxy_from_persistent_representation, workflow_proxy
 from .representation import to_cwl_job, to_galaxy_parameters
 from .runtime_actions import handle_outputs
 
 
 __all__ = (
     'tool_proxy',
+    'tool_proxy_from_persistent_representation',
     'workflow_proxy',
     'handle_outputs',
     'to_cwl_job',

--- a/lib/galaxy/tools/cwl/parser.py
+++ b/lib/galaxy/tools/cwl/parser.py
@@ -5,33 +5,51 @@ of the framework.
 """
 from __future__ import absolute_import
 
+import base64
 import json
 import logging
 import os
+import pickle
 from abc import ABCMeta, abstractmethod
 
 import six
 
-from galaxy.util import safe_makedirs
+from galaxy.exceptions import MessageException
+from galaxy.util import listify, safe_makedirs
 from galaxy.util.bunch import Bunch
 from galaxy.util.odict import odict
 from .cwltool_deps import (
     ensure_cwltool_available,
+    pathmapper,
     process,
 )
+from .representation import (
+    field_to_field_type,
+    FIELD_TYPE_REPRESENTATION,
+    INPUT_TYPE,
+    type_descriptions_for_field_types,
+    USE_FIELD_TYPES,
+    USE_STEP_PARAMETERS,
+)
 from .schema import non_strict_schema_loader, schema_loader
+from .util import SECONDARY_FILES_EXTRA_PREFIX
 
 log = logging.getLogger(__name__)
 
 JOB_JSON_FILE = ".cwl_job.json"
-SECONDARY_FILES_EXTRA_PREFIX = "__secondary_files__"
 
-
+DOCKER_REQUIREMENT = "DockerRequirement"
 SUPPORTED_TOOL_REQUIREMENTS = [
     "CreateFileRequirement",
     "DockerRequirement",
     "EnvVarRequirement",
+    "InitialWorkDirRequirement",
     "InlineJavascriptRequirement",
+    "ShellCommandRequirement",
+    "ScatterFeatureRequirement",
+    "SubworkflowFeatureRequirement",
+    "StepInputExpressionRequirement",
+    "MultipleInputFeatureRequirement",
 ]
 
 
@@ -39,12 +57,22 @@ SUPPORTED_WORKFLOW_REQUIREMENTS = SUPPORTED_TOOL_REQUIREMENTS + [
 ]
 
 
-def tool_proxy(tool_path, strict_cwl_validation=True):
+def tool_proxy(tool_path=None, tool_object=None, strict_cwl_validation=True):
     """ Provide a proxy object to cwltool data structures to just
     grab relevant data.
     """
     ensure_cwltool_available()
-    tool = to_cwl_tool_object(tool_path, strict_cwl_validation=strict_cwl_validation)
+    tool = to_cwl_tool_object(
+        tool_path=tool_path,
+        tool_object=tool_object,
+        strict_cwl_validation=strict_cwl_validation
+    )
+    return tool
+
+
+def tool_proxy_from_persistent_representation(persisted_tool, strict_cwl_validation=True):
+    ensure_cwltool_available()
+    tool = to_cwl_tool_object(persisted_tool=persisted_tool, strict_cwl_validation=strict_cwl_validation)
     return tool
 
 
@@ -58,24 +86,62 @@ def load_job_proxy(job_directory, strict_cwl_validation=True):
     ensure_cwltool_available()
     job_objects_path = os.path.join(job_directory, JOB_JSON_FILE)
     job_objects = json.load(open(job_objects_path, "r"))
-    tool_path = job_objects["tool_path"]
     job_inputs = job_objects["job_inputs"]
     output_dict = job_objects["output_dict"]
-    cwl_tool = tool_proxy(tool_path, strict_cwl_validation=strict_cwl_validation)
+    # Any reason to retain older tool_path variant of this? Probably not?
+    if "tool_path" in job_objects:
+        tool_path = job_objects["tool_path"]
+        cwl_tool = tool_proxy(tool_path, strict_cwl_validation=strict_cwl_validation)
+    else:
+        persisted_tool = job_objects["tool_representation"]
+        cwl_tool = tool_proxy_from_persistent_representation(persisted_tool, strict_cwl_validation=strict_cwl_validation)
     cwl_job = cwl_tool.job_proxy(job_inputs, output_dict, job_directory=job_directory)
     return cwl_job
 
 
-def to_cwl_tool_object(tool_path, strict_cwl_validation=True):
-    proxy_class = None
-    cwl_tool = _schema_loader(strict_cwl_validation).tool(path=tool_path)
+def to_cwl_tool_object(tool_path=None, tool_object=None, persisted_tool=None, strict_cwl_validation=True):
+    schema_loader = _schema_loader(strict_cwl_validation)
+    if tool_path is not None:
+        cwl_tool = schema_loader.tool(
+            path=tool_path
+        )
+    elif tool_object is not None:
+        # Allow loading tools from YAML...
+        from ruamel import yaml as ryaml
+        import json
+        as_str = json.dumps(tool_object)
+        tool_object = ryaml.round_trip_load(as_str)
+        from schema_salad import sourceline
+        from schema_salad.ref_resolver import file_uri
+        uri = file_uri(os.getcwd()) + "/"
+        sourceline.add_lc_filename(tool_object, uri)
+        tool_object, _ = schema_loader.raw_document_loader.resolve_all(tool_object, uri)
+        raw_process_reference = schema_loader.raw_process_reference_for_object(
+            tool_object,
+            uri=uri
+        )
+        cwl_tool = schema_loader.tool(
+            raw_process_reference=raw_process_reference,
+        )
+    else:
+        cwl_tool = ToolProxy.from_persistent_representation(persisted_tool)
+
     if isinstance(cwl_tool, int):
         raise Exception("Failed to load tool.")
 
     raw_tool = cwl_tool.tool
+    # Apply Galaxy hacks to CWL tool representation to bridge semantic differences
+    # between Galaxy and cwltool.
+    _hack_cwl_requirements(cwl_tool)
     check_requirements(raw_tool)
+    return cwl_tool_object_to_proxy(cwl_tool, tool_path=tool_path)
+
+
+def cwl_tool_object_to_proxy(cwl_tool, tool_path=None):
+    raw_tool = cwl_tool.tool
     if "class" not in raw_tool:
         raise Exception("File does not declare a class, not a valid Draft 3+ CWL tool.")
+
     process_class = raw_tool["class"]
     if process_class == "CommandLineTool":
         proxy_class = CommandLineToolProxy
@@ -83,7 +149,8 @@ def to_cwl_tool_object(tool_path, strict_cwl_validation=True):
         proxy_class = ExpressionToolProxy
     else:
         raise Exception("File not a CWL CommandLineTool.")
-    if "cwlVersion" not in raw_tool:
+    top_level_object = tool_path is not None
+    if top_level_object and ("cwlVersion" not in raw_tool):
         raise Exception("File does not declare a CWL version, pre-draft 3 CWL tools are not supported.")
 
     proxy = proxy_class(cwl_tool, tool_path)
@@ -103,6 +170,17 @@ def to_cwl_workflow_object(workflow_path, strict_cwl_validation=None):
 def _schema_loader(strict_cwl_validation):
     target_schema_loader = schema_loader if strict_cwl_validation else non_strict_schema_loader
     return target_schema_loader
+
+
+def _hack_cwl_requirements(cwl_tool):
+    move_to_hints = []
+    for i, requirement in enumerate(cwl_tool.requirements):
+        if requirement["class"] == DOCKER_REQUIREMENT:
+            move_to_hints.insert(0, i)
+
+    for i in move_to_hints:
+        del cwl_tool.requirements[i]
+        cwl_tool.hints.append(requirement)
 
 
 def check_requirements(rec, tool=True):
@@ -125,7 +203,7 @@ def check_requirements(rec, tool=True):
 @six.add_metaclass(ABCMeta)
 class ToolProxy(object):
 
-    def __init__(self, tool, tool_path):
+    def __init__(self, tool, tool_path=None):
         self._tool = tool
         self._tool_path = tool_path
 
@@ -135,6 +213,23 @@ class ToolProxy(object):
         a cwltool compatible variant.
         """
         return JobProxy(self, input_dict, output_dict, job_directory=job_directory)
+
+    @property
+    def id(self):
+        raw_id = self._tool.tool.get("id", None)
+        return raw_id
+
+    def galaxy_id(self):
+        raw_id = self.id
+        tool_id = None
+        # don't reduce "search.cwl#index" to search
+        if raw_id and "#" not in raw_id:
+            tool_id = os.path.splitext(os.path.basename(raw_id))[0]
+        if not tool_id:
+            from galaxy.tools.hash import build_tool_hash
+            tool_id = build_tool_hash(self.to_persistent_representation())
+        assert tool_id
+        return tool_id
 
     @abstractmethod
     def input_instances(self):
@@ -156,8 +251,28 @@ class ToolProxy(object):
     def label(self):
         """ Return label for tool. """
 
+    def to_persistent_representation(self):
+        """Return a JSON representation of this tool. Not for serialization
+        over the wire, but serialization in a database."""
+        # TODO: Replace this with some more readable serialization,
+        # I really don't like using pickle here.
+        return {
+            "class": self._class,
+            "pickle": base64.b64encode(pickle.dumps(remove_pickle_problems(self._tool), -1)),
+        }
+
+    @staticmethod
+    def from_persistent_representation(as_object):
+        """Recover an object serialized with to_persistent_representation."""
+        if "class" not in as_object:
+            raise Exception("Failed to deserialize tool proxy from JSON object - no class found.")
+        if "pickle" not in as_object:
+            raise Exception("Failed to deserialize tool proxy from JSON object - no pickle representation found.")
+        return pickle.loads(base64.b64decode(as_object["pickle"]))
+
 
 class CommandLineToolProxy(ToolProxy):
+    _class = "CommandLineTool"
 
     def description(self):
         return self._tool.tool.get('doc')
@@ -165,35 +280,32 @@ class CommandLineToolProxy(ToolProxy):
     def label(self):
         return self._tool.tool.get('label')
 
+    def input_fields(self):
+        input_records_schema = self._tool.inputs_record_schema
+        schema_type = input_records_schema["type"]
+        if schema_type in self._tool.schemaDefs:
+            input_records_schema = self._tool.schemaDefs[schema_type]
+
+        if input_records_schema["type"] != "record":
+            raise Exception("Unhandled CWL tool input structure")
+
+        return input_records_schema["fields"]
+
     def input_instances(self):
-        return self._find_inputs(self._tool.inputs_record_schema)
-
-    def _find_inputs(self, schema):
-        schema_type = schema["type"]
-        if isinstance(schema_type, list):
-            raise Exception("Union types not yet implemented.")
-        elif isinstance(schema_type, dict):
-            return self._find_inputs(schema_type)
-        else:
-            if schema_type in self._tool.schemaDefs:
-                schema = self._tool.schemaDefs[schema_type]
-
-            if schema["type"] == "record":
-                return [_simple_field_to_input(_) for _ in schema["fields"]]
+        return [_outer_field_to_input_instance(_) for _ in self.input_fields()]
 
     def output_instances(self):
         outputs_schema = self._tool.outputs_record_schema
-        return self._find_outputs(outputs_schema)
+        schema_type = outputs_schema["type"]
+        if schema_type in self._tool.schemaDefs:
+            outputs_schema = self._tool.schemaDefs[schema_type]
 
-    def _find_outputs(self, schema):
+        if outputs_schema["type"] != "record":
+            raise Exception("Unhandled CWL tool output structure")
+
         rval = []
-        if not rval and schema["type"] == "record":
-            for output in schema["fields"]:
-                # output_type = output.get("type", None)
-                # if output_type != "File":
-                #     template = "Unhandled output type [%s] encountered."
-                #     raise Exception(template % output_type)
-                rval.append(_simple_field_to_output(output))
+        for output in outputs_schema["fields"]:
+            rval.append(_simple_field_to_output(output))
 
         return rval
 
@@ -208,9 +320,13 @@ class CommandLineToolProxy(ToolProxy):
                     return hint["dockerPull"]
         return None
 
+    @property
+    def requirements(self):
+        return getattr(self._tool, "requirements", [])
+
 
 class ExpressionToolProxy(CommandLineToolProxy):
-    pass
+    _class = "ExpressionTool"
 
 
 class JobProxy(object):
@@ -221,10 +337,12 @@ class JobProxy(object):
         self._output_dict = output_dict
         self._job_directory = job_directory
 
-        self._final_output = []
+        self._final_output = None
         self._ok = True
         self._cwl_job = None
         self._is_command_line_job = None
+
+        self._normalize_job()
 
     def cwl_job(self):
         self._ensure_cwl_job_initialized()
@@ -244,9 +362,65 @@ class JobProxy(object):
                 self._output_callback,
                 basedir=self._job_directory,
                 select_resources=self._select_resources,
-                use_container=False
+                outdir=os.path.join(self._job_directory, "working"),
+                tmpdir=os.path.join(self._job_directory, "cwltmp"),
+                stagedir=os.path.join(self._job_directory, "cwlstagedir"),
+                use_container=False,
             ))
             self._is_command_line_job = hasattr(self._cwl_job, "command_line")
+
+    def _normalize_job(self):
+        # Somehow reuse whatever causes validate in cwltool... maybe?
+        def pathToLoc(p):
+            if "location" not in p and "path" in p:
+                p["location"] = p["path"]
+                del p["path"]
+        process.fillInDefaults(self._tool_proxy._tool.tool["inputs"], self._input_dict)
+        process.visit_class(self._input_dict, ("File", "Directory"), pathToLoc)
+        # TODO: Why doesn't fillInDefault fill in locations instead of paths?
+        process.normalizeFilesDirs(self._input_dict)
+        # TODO: validate like cwltool process _init_job.
+        #    validate.validate_ex(self.names.get_name("input_record_schema", ""), builder.job,
+        #                         strict=False, logger=_logger_validation_warnings)
+
+    def rewrite_inputs_for_staging(self):
+        if hasattr(self._cwl_job, "pathmapper"):
+            pass
+            # DO SOMETHING LIKE THE FOLLOWING?
+            # path_rewrites = {}
+            # for f, p in self._cwl_job.pathmapper.items():
+            #     if not p.staged:
+            #         continue
+            #     if p.type in ("File", "Directory"):
+            #         path_rewrites[p.resolved] = p.target
+            # for key, value in self._input_dict.items():
+            #     if key in path_rewrites:
+            #         self._input_dict[key]["location"] = path_rewrites[value]
+        else:
+            stagedir = os.path.join(self._job_directory, "cwlstagedir")
+            safe_makedirs(stagedir)
+
+            def stage_recursive(value):
+                is_list = isinstance(value, list)
+                is_dict = isinstance(value, dict)
+                log.info("handling value %s, is_list %s, is_dict %s" % (value, is_list, is_dict))
+                if is_list:
+                    for val in value:
+                        stage_recursive(val)
+                elif is_dict:
+                    if "location" in value and "basename" in value:
+                        location = value["location"]
+                        basename = value["basename"]
+                        if not location.endswith(basename):  # TODO: sep()[-1]
+                            staged_loc = os.path.join(stagedir, basename)
+                            if not os.path.exists(staged_loc):
+                                os.symlink(location, staged_loc)
+                            value["location"] = staged_loc
+                    for key, dict_value in value.items():
+                        stage_recursive(dict_value)
+                else:
+                    log.info("skipping simple value...")
+            stage_recursive(self._input_dict)
 
     def _select_resources(self, request):
         new_request = request.copy()
@@ -289,6 +463,7 @@ class JobProxy(object):
             return {}
 
     def _output_callback(self, out, process_status):
+        self._process_status = process_status
         if process_status == "success":
             self._final_output = out
         else:
@@ -298,8 +473,11 @@ class JobProxy(object):
 
     def collect_outputs(self, tool_working_directory):
         if not self.is_command_line_job:
-            self.cwl_job().run(
+            cwl_job = self.cwl_job()
+            cwl_job.run(
             )
+            if not self._ok:
+                raise Exception("Final process state not ok, [%s]" % self._process_status)
             return self._final_output
         else:
             return self.cwl_job().collect_outputs(tool_working_directory)
@@ -307,7 +485,8 @@ class JobProxy(object):
     def save_job(self):
         job_file = JobProxy._job_file(self._job_directory)
         job_objects = {
-            "tool_path": os.path.abspath(self._tool_proxy._tool_path),
+            # "tool_path": os.path.abspath(self._tool_proxy._tool_path),
+            "tool_representation": self._tool_proxy.to_persistent_representation(),
             "job_inputs": self._input_dict,
             "output_dict": self._output_dict,
         }
@@ -325,6 +504,10 @@ class JobProxy(object):
         output_id = self._output_dict[output_name]["path"]
         return output_id
 
+    def output_directory_contents_dir(self, output_name, create=False):
+        extra_files_dir = self._output_extra_files_dir(output_name)
+        return extra_files_dir
+
     def output_secondary_files_dir(self, output_name, create=False):
         extra_files_dir = self._output_extra_files_dir(output_name)
         secondary_files_dir = os.path.join(extra_files_dir, SECONDARY_FILES_EXTRA_PREFIX)
@@ -334,8 +517,27 @@ class JobProxy(object):
 
     def stage_files(self):
         cwl_job = self.cwl_job()
+
+        def stageFunc(resolved_path, target_path):
+            log.info("resolving %s to %s" % (resolved_path, target_path))
+            try:
+                os.symlink(resolved_path, target_path)
+            except OSError:
+                pass
+
         if hasattr(cwl_job, "pathmapper"):
-            process.stageFiles(self.cwl_job().pathmapper, os.symlink, ignoreWritable=True)
+            process.stageFiles(cwl_job.pathmapper, stageFunc, ignoreWritable=True, symLink=False)
+
+        if hasattr(cwl_job, "generatefiles"):
+            outdir = os.path.join(self._job_directory, "working")
+            # TODO: Why doesn't cwl_job.generatemapper work?
+            generate_mapper = pathmapper.PathMapper(cwl_job.generatefiles["listing"],
+                                                    outdir, outdir, separateDirs=False)
+            # TODO: figure out what inplace_update should be.
+            inplace_update = getattr(cwl_job, "inplace_update")
+            process.stageFiles(generate_mapper, stageFunc, ignoreWritable=inplace_update, symLink=False)
+            from cwltool import job
+            job.relink_initialworkdir(generate_mapper, outdir, outdir, inplace_update=inplace_update)
         # else: expression tools do not have a path mapper.
 
     @staticmethod
@@ -345,14 +547,29 @@ class JobProxy(object):
 
 class WorkflowProxy(object):
 
-    def __init__(self, workflow, workflow_path):
+    def __init__(self, workflow, workflow_path=None):
         self._workflow = workflow
         self._workflow_path = workflow_path
 
+    @property
+    def cwl_id(self):
+        return self._workflow.tool["id"]
+
+    def tool_references(self):
+        """Fetch tool source definitions for all referenced tools."""
+        references = []
+        for step in self.step_proxies():
+            references.extend(step.tool_references())
+        return references
+
+    def tool_reference_proxies(self):
+        return map(lambda tool_object: cwl_tool_object_to_proxy(tool_object), self.tool_references())
+
     def step_proxies(self):
         proxies = []
-        for step in self._workflow.steps:
-            proxies.append(StepProxy(self, step))
+        num_input_steps = len(self._workflow.tool['inputs'])
+        for i, step in enumerate(self._workflow.steps):
+            proxies.append(build_step_proxy(self, step, i + num_input_steps))
         return proxies
 
     @property
@@ -363,47 +580,410 @@ class WorkflowProxy(object):
                 runnables.append(step.tool["run"])
         return runnables
 
+    def cwl_ids_to_index(self, step_proxies):
+        index = 0
+        cwl_ids_to_index = {}
+        for i, input_dict in enumerate(self._workflow.tool['inputs']):
+            cwl_ids_to_index[input_dict["id"]] = index
+            index += 1
+
+        for step_proxy in step_proxies:
+            cwl_ids_to_index[step_proxy.cwl_id] = index
+            index += 1
+
+        return cwl_ids_to_index
+
+    @property
+    def output_labels(self):
+        return [self.jsonld_id_to_label(o['id']) for o in self._workflow.tool['outputs']]
+
+    def input_connections_by_step(self, step_proxies):
+        cwl_ids_to_index = self.cwl_ids_to_index(step_proxies)
+        input_connections_by_step = []
+        for step_proxy in step_proxies:
+            input_connections_step = {}
+            for input_proxy in step_proxy.input_proxies:
+                cwl_source_id = input_proxy.cwl_source_id
+                input_name = input_proxy.input_name
+                # Consider only allow multiple if MultipleInputFeatureRequirement is enabled
+                for (output_step_name, output_name) in split_step_references(cwl_source_id, workflow_id=self.cwl_id):
+                    if "#" in self.cwl_id:
+                        sep_on = "/"
+                    else:
+                        sep_on = "#"
+                    output_step_id = self.cwl_id + sep_on + output_step_name
+
+                    if output_step_id not in cwl_ids_to_index:
+                        template = "Output [%s] does not appear in ID-to-index map [%s]."
+                        msg = template % (output_step_id, cwl_ids_to_index.keys())
+                        raise AssertionError(msg)
+
+                    if input_name not in input_connections_step:
+                        input_connections_step[input_name] = []
+
+                    input_connections_step[input_name].append({
+                        "id": cwl_ids_to_index[output_step_id],
+                        "output_name": output_name,
+                        "input_type": "dataset"
+                    })
+
+            input_connections_by_step.append(input_connections_step)
+
+        return input_connections_by_step
+
     def to_dict(self):
-        name = os.path.basename(self._workflow_path)
+        name = os.path.basename(self._workflow_path or 'TODO - derive a name from ID')
         steps = {}
 
+        step_proxies = self.step_proxies()
+        input_connections_by_step = self.input_connections_by_step(step_proxies)
         index = 0
-        for i, input_dict in self._workflow.tool['inputs']:
+        for i, input_dict in enumerate(self._workflow.tool['inputs']):
+            steps[index] = self.cwl_input_to_galaxy_step(input_dict, i)
             index += 1
-            steps[index] = input_dict
 
-        for i, step_proxy in enumerate(self.step_proxies()):
+        for i, step_proxy in enumerate(step_proxies):
+            input_connections = input_connections_by_step[i]
+            steps[index] = step_proxy.to_dict(input_connections)
             index += 1
-            steps[index] = step_proxy.to_dict()
 
         return {
             'name': name,
             'steps': steps,
+            'annotation': self.cwl_object_to_annotation(self._workflow.tool),
+        }
+
+    def find_inputs_step_index(self, label):
+        for i, input in enumerate(self._workflow.tool['inputs']):
+            if self.jsonld_id_to_label(input["id"]) == label:
+                return i
+
+        raise Exception("Failed to find index for label %s" % label)
+
+    def jsonld_id_to_label(self, id):
+        if "#" in self.cwl_id:
+            return id.rsplit("/", 1)[-1]
+        else:
+            return id.rsplit("#", 1)[-1]
+
+    def cwl_input_to_galaxy_step(self, input, i):
+        input_type = input["type"]
+        input_as_dict = {
+            "id": i,
+            "label": self.jsonld_id_to_label(input["id"]),
+            "position": {"left": 0, "top": 0},
+            "annotation": self.cwl_object_to_annotation(input),
+            "input_connections": {},  # Should the Galaxy API really require this? - Seems to.
+        }
+
+        if input_type == "File" and "default" not in input:
+            input_as_dict["type"] = "data_input"
+        elif isinstance(input_type, dict) and input_type.get("type") == "array":
+            input_as_dict["type"] = "data_collection_input"
+            input_as_dict["collection_type"] = "list"
+        elif isinstance(input_type, dict) and input_type.get("type") == "record":
+            input_as_dict["type"] = "data_collection_input"
+            input_as_dict["collection_type"] = "record"
+        else:
+            if USE_STEP_PARAMETERS:
+                input_as_dict["type"] = "parameter_input"
+                # TODO: dispatch on actual type so this doesn't always need
+                # to be field - simpler types could be simpler inputs.
+                tool_state = {}
+                tool_state["parameter_type"] = "field"
+                default_value = input.get("default")
+                optional = False
+                if isinstance(input_type, list) and "null" in input_type:
+                    optional = True
+                if not optional and isinstance(input_type, dict) and "type" in input_type:
+                    assert False
+                tool_state["default_value"] = {"src": "json", "value": default_value}
+                tool_state["optional"] = optional
+                input_as_dict["tool_state"] = tool_state
+            else:
+                input_as_dict["type"] = "data_input"
+                # TODO: format = expression.json
+
+        return input_as_dict
+
+    def cwl_object_to_annotation(self, cwl_obj):
+        return cwl_obj.get("doc", None)
+
+
+def split_step_references(step_references, workflow_id=None, multiple=True):
+    """Split a CWL step input or output reference into step id and name."""
+    # Trim off the workflow id part of the reference.
+    step_references = listify(step_references)
+    split_references = []
+
+    for step_reference in step_references:
+        if workflow_id is None:
+            # This path works fine for some simple workflows - but not so much
+            # for subworkflows (maybe same for $graph workflows?)
+            assert "#" in step_reference
+            _, step_reference = step_reference.split("#", 1)
+        else:
+            if "#" in workflow_id:
+                sep_on = "/"
+            else:
+                sep_on = "#"
+            assert step_reference.startswith(workflow_id + sep_on)
+            step_reference = step_reference[len(workflow_id + sep_on):]
+
+        # Now just grab the step name and input/output name.
+        assert "#" not in step_reference
+        if "/" in step_reference:
+            step_name, io_name = step_reference.split("/", 1)
+        else:
+            # Referencing an input, not a step.
+            # In Galaxy workflows input steps have an implicit output named
+            # "output" for consistency with tools - in cwl land
+            # just the input name is referenced.
+            step_name = step_reference
+            io_name = "output"
+        split_references.append((step_name, io_name))
+
+    if multiple:
+        return split_references
+    else:
+        assert len(split_references) == 1
+        return split_references[0]
+
+
+def build_step_proxy(workflow_proxy, step, index):
+    step_type = step.embedded_tool.tool["class"]
+    if step_type == "Workflow":
+        return SubworkflowStepProxy(workflow_proxy, step, index)
+    else:
+        return ToolStepProxy(workflow_proxy, step, index)
+
+
+class BaseStepProxy(object):
+
+    def __init__(self, workflow_proxy, step, index):
+        self._workflow_proxy = workflow_proxy
+        self._step = step
+        self._index = index
+
+    @property
+    def step_class(self):
+        return self.cwl_tool_object.tool["class"]
+
+    @property
+    def cwl_id(self):
+        return self._step.id
+
+    @property
+    def cwl_workflow_id(self):
+        return self._workflow_proxy.cwl_id
+
+    @property
+    def requirements(self):
+        return self._step.requirements
+
+    @property
+    def hints(self):
+        return self._step.hints
+
+    @property
+    def label(self):
+        label = self._workflow_proxy.jsonld_id_to_label(self._step.id)
+        return label
+
+    def galaxy_workflow_outputs_list(self):
+        outputs = []
+        for output in self._workflow_proxy._workflow.tool['outputs']:
+            step, output_name = split_step_references(
+                output["outputSource"],
+                multiple=False,
+                workflow_id=self._workflow_proxy.cwl_id,
+            )
+            if step == self.label:
+                output_id = output["id"]
+                if "#" not in self._workflow_proxy.cwl_id:
+                    _, output_label = output_id.rsplit("#", 1)
+                else:
+                    _, output_label = output_id.rsplit("/", 1)
+
+                outputs.append({
+                    "output_name": output_name,
+                    "label": output_label,
+                })
+        return outputs
+
+    @property
+    def cwl_tool_object(self):
+        return self._step.embedded_tool
+
+    @property
+    def input_proxies(self):
+        cwl_inputs = self._step.tool["inputs"]
+        for cwl_input in cwl_inputs:
+            yield InputProxy(self, cwl_input)
+
+    def inputs_to_dicts(self):
+        inputs_as_dicts = []
+        for input_proxy in self.input_proxies:
+            inputs_as_dicts.append(input_proxy.to_dict())
+        return inputs_as_dicts
+
+
+class InputProxy(object):
+
+    def __init__(self, step_proxy, cwl_input):
+        self._cwl_input = cwl_input
+        self.step_proxy = step_proxy
+        self.workflow_proxy = step_proxy._workflow_proxy
+
+        cwl_input_id = cwl_input["id"]
+        cwl_source_id = cwl_input.get("source", None)
+        if cwl_source_id is None:
+            if "valueFrom" not in cwl_input and "default" not in cwl_input:
+                msg = "Workflow step input must define a source, a valueFrom, or a default value. Obtained [%s]." % cwl_input
+                raise MessageException(msg)
+
+        assert cwl_input_id
+        step_name, input_name = split_step_references(
+            cwl_input_id,
+            multiple=False,
+            workflow_id=step_proxy.cwl_workflow_id
+        )
+        self.step_name = step_name
+        self.input_name = input_name
+
+        self.cwl_input_id = cwl_input_id
+        self.cwl_source_id = cwl_source_id
+
+        scatter_inputs = [split_step_references(
+            i, multiple=False, workflow_id=step_proxy.cwl_workflow_id
+        )[1] for i in listify(step_proxy._step.tool.get("scatter", []))]
+        scatter = self.input_name in scatter_inputs
+        self.scatter = scatter
+
+    def to_dict(self):
+        as_dict = {
+            "name": self.input_name,
+        }
+        if "linkMerge" in self._cwl_input:
+            as_dict["merge_type"] = self._cwl_input["linkMerge"]
+        if "scatterMethod" in self.step_proxy._step.tool:
+            as_dict["scatter_type"] = self.step_proxy._step.tool.get("scatterMethod", "dotproduct")
+        else:
+            as_dict["scatter_type"] = "dotproduct" if self.scatter else "disabled"
+        if "valueFrom" in self._cwl_input:
+            # TODO: Add a table for expressions - mark the type as CWL 1.0 JavaScript.
+            as_dict["value_from"] = self._cwl_input["valueFrom"]
+        if "default" in self._cwl_input:
+            as_dict["default"] = self._cwl_input["default"]
+        return as_dict
+
+
+class ToolStepProxy(BaseStepProxy):
+
+    @property
+    def tool_proxy(self):
+        return cwl_tool_object_to_proxy(self.cwl_tool_object)
+
+    def tool_references(self):
+        # Return a list so we can handle subworkflows recursively in the future.
+        return [self._step.embedded_tool]
+
+    def to_dict(self, input_connections):
+        # We are to the point where we need a content id for this. We got
+        # figure that out - short term we can load everything up as an
+        # in-memory tool and reference by the JSONLD ID I think. So workflow
+        # proxy should force the loading of a tool.
+        tool_proxy = cwl_tool_object_to_proxy(self.tool_references()[0])
+        from galaxy.tools.hash import build_tool_hash
+        tool_hash = build_tool_hash(tool_proxy.to_persistent_representation())
+
+        # We need to stub out null entries for things getting replaced by
+        # connections. This doesn't seem ideal - consider just making Galaxy
+        # handle this.
+        tool_state = {}
+        for input_name in input_connections.keys():
+            tool_state[input_name] = None
+
+        outputs = self.galaxy_workflow_outputs_list()
+        return {
+            "id": self._index,
+            "tool_hash": tool_hash,
+            "label": self.label,
+            "position": {"left": 0, "top": 0},
+            "type": "tool",
+            "annotation": self._workflow_proxy.cwl_object_to_annotation(self._step.tool),
+            "input_connections": input_connections,
+            "inputs": self.inputs_to_dicts(),
+            "workflow_outputs": outputs,
         }
 
 
-class StepProxy(object):
+class SubworkflowStepProxy(BaseStepProxy):
 
-    def __init__(self, workflow_proxy, step):
-        self._workflow_proxy = workflow_proxy
-        self._step = step
+    def to_dict(self, input_connections):
+        outputs = self.galaxy_workflow_outputs_list()
+        for key, input_connection_list in input_connections.items():
+            input_subworkflow_step_id = self.workflow_proxy.find_inputs_step_index(
+                key
+            )
+            for input_connection in input_connection_list:
+                input_connection["input_subworkflow_step_id"] = input_subworkflow_step_id
 
-    def to_dict(self):
-        return {}
+        return {
+            "id": self._index,
+            "label": self.label,
+            "position": {"left": 0, "top": 0},
+            "type": "subworkflow",
+            "subworkflow": self.workflow_proxy.to_dict(),
+            "annotation": self._workflow_proxy.cwl_object_to_annotation(self._step.tool),
+            "input_connections": input_connections,
+            "inputs": self.inputs_to_dicts(),
+            "workflow_outputs": outputs,
+        }
+
+    def tool_references(self):
+        return self.workflow_proxy.tool_references()
+
+    @property
+    def workflow_proxy(self):
+        return WorkflowProxy(self.cwl_tool_object)
 
 
-def _simple_field_union(field):
-    field_type = _field_to_field_type(field)  # Must be a list if in here?
+def remove_pickle_problems(obj):
+    """doc_loader does not pickle correctly"""
+    if hasattr(obj, "doc_loader"):
+        obj.doc_loader = None
+    if hasattr(obj, "embedded_tool"):
+        obj.embedded_tool = remove_pickle_problems(obj.embedded_tool)
+    if hasattr(obj, "steps"):
+        obj.steps = [remove_pickle_problems(s) for s in obj.steps]
+    return obj
 
-    def any_of_in_field_type(types):
-        return any([t in field_type for t in types])
+
+@six.add_metaclass(ABCMeta)
+class WorkflowToolReference(object):
+    pass
+
+
+class EmbeddedWorkflowToolReference(WorkflowToolReference):
+    pass
+
+
+class ExternalWorkflowToolReference(WorkflowToolReference):
+    pass
+
+
+def _outer_field_to_input_instance(field):
+    field_type = field_to_field_type(field)  # Must be a list if in here?
+    if not isinstance(field_type, list):
+        field_type = [field_type]
 
     name, label, description = _field_metadata(field)
 
     case_name = "_cwl__type_"
     case_label = "Specify Parameter %s As" % label
 
-    def value_input(**kwds):
+    def value_input(type_description):
         value_name = "_cwl__value_"
         value_label = label
         value_description = description
@@ -411,99 +991,57 @@ def _simple_field_union(field):
             value_name,
             value_label,
             value_description,
-            **kwds
+            input_type=type_description.galaxy_param_type,
+            collection_type=type_description.collection_type,
         )
 
     select_options = []
     case_options = []
-    if "null" in field_type:
-        select_options.append({"value": "null", "label": "None", "selected": True})
-        case_options.append(("null", []))
-    if any_of_in_field_type(["Any", "string"]):
-        select_options.append({"value": "string", "label": "Simple String"})
-        case_options.append(("string", [value_input(input_type=INPUT_TYPE.TEXT)]))
-    if any_of_in_field_type(["Any", "boolean"]):
-        select_options.append({"value": "boolean", "label": "Boolean"})
-        case_options.append(("boolean", [value_input(input_type=INPUT_TYPE.BOOLEAN)]))
-    if any_of_in_field_type(["Any", "int"]):
-        select_options.append({"value": "int", "label": "Integer"})
-        case_options.append(("int", [value_input(input_type=INPUT_TYPE.INTEGER)]))
-    if any_of_in_field_type(["Any", "float"]):
-        select_options.append({"value": "float", "label": "Floating Point Number"})
-        case_options.append(("float", [value_input(input_type=INPUT_TYPE.FLOAT)]))
-    if any_of_in_field_type(["Any", "File"]):
-        select_options.append({"value": "data", "label": "Dataset"})
-        case_options.append(("data", [value_input(input_type=INPUT_TYPE.DATA)]))
-    if "Any" in field_type:
-        select_options.append({"value": "json", "label": "JSON Data Structure"})
-        case_options.append(("json", [value_input(input_type=INPUT_TYPE.TEXT, area=True)]))
+    type_descriptions = type_descriptions_for_field_types(field_type)
+    for type_description in type_descriptions:
+        select_options.append({"value": type_description.name, "label": type_description.label})
+        input_instances = []
+        if type_description.uses_param():
+            input_instances.append(value_input(type_description))
+        case_options.append((type_description.name, input_instances))
 
-    case_input = SelectInputInstance(
-        name=case_name,
-        label=case_label,
-        description=False,
-        options=select_options,
-    )
+    # If there is more than one way to represent this parameter - produce a conditional
+    # requesting user to ask for what form they want to submit the data in, else just map
+    # a simple Galaxy parameter.
+    if len(case_options) > 1 and not USE_FIELD_TYPES:
+        case_input = SelectInputInstance(
+            name=case_name,
+            label=case_label,
+            description=False,
+            options=select_options,
+        )
 
-    return ConditionalInstance(name, case_input, case_options)
-
-
-def _simple_field_to_input(field):
-    field_type = _field_to_field_type(field)
-    if isinstance(field_type, list):
-        # Length must be greater than 1...
-        return _simple_field_union(field)
-
-    name, label, description = _field_metadata(field)
-
-    type_kwds = _simple_field_to_input_type_kwds(field)
-    return InputInstance(name, label, description, **type_kwds)
-
-
-def _simple_field_to_input_type_kwds(field, field_type=None):
-    simple_map_type_map = {
-        "File": INPUT_TYPE.DATA,
-        "int": INPUT_TYPE.INTEGER,
-        "long": INPUT_TYPE.INTEGER,
-        "float": INPUT_TYPE.INTEGER,
-        "double": INPUT_TYPE.INTEGER,
-        "string": INPUT_TYPE.TEXT,
-        "boolean": INPUT_TYPE.BOOLEAN,
-    }
-
-    if field_type is None:
-        field_type = _field_to_field_type(field)
-
-    if field_type in simple_map_type_map.keys():
-        input_type = simple_map_type_map[field_type]
-        return {"input_type": input_type, "array": False}
-    elif field_type == "array":
-        if isinstance(field["type"], dict):
-            array_type = field["type"]["items"]
-        else:
-            array_type = field["items"]
-        if array_type in simple_map_type_map.keys():
-            input_type = simple_map_type_map[array_type]
-        return {"input_type": input_type, "array": True}
+        return ConditionalInstance(name, case_input, case_options)
     else:
-        raise Exception("Unhandled simple field type encountered - [%s]." % field_type)
+        if len(case_options) > 1:
+            only_type_description = FIELD_TYPE_REPRESENTATION
+        else:
+            only_type_description = type_descriptions[0]
 
+        return InputInstance(
+            name, label, description, input_type=only_type_description.galaxy_param_type, collection_type=only_type_description.collection_type
+        )
 
-def _field_to_field_type(field):
-    field_type = field["type"]
-    if isinstance(field_type, dict):
-        field_type = field_type["type"]
-    if isinstance(field_type, list):
-        field_type_length = len(field_type)
-        if field_type_length == 0:
-            raise Exception("Zero-length type list encountered, invalid CWL?")
-        elif len(field_type) == 1:
-            field_type = field_type[0]
-
-    if field_type == "Any":
-        field_type = ["Any"]
-
-    return field_type
+    # Older array to repeat handling, now we are just representing arrays as
+    # dataset collections - we should offer a blended approach in the future.
+    # if field_type in simple_map_type_map.keys():
+    #     input_type = simple_map_type_map[field_type]
+    #     return {"input_type": input_type, "array": False}
+    # elif field_type == "array":
+    #     if isinstance(field["type"], dict):
+    #         array_type = field["type"]["items"]
+    #     else:
+    #         array_type = field["items"]
+    #     if array_type in simple_map_type_map.keys():
+    #         input_type = simple_map_type_map[array_type]
+    #     return {"input_type": input_type, "array": True}
+    # else:
+    #     raise Exception("Unhandled simple field type encountered - [%s]." % field_type)
 
 
 def _field_metadata(field):
@@ -522,17 +1060,6 @@ def _simple_field_to_output(field):
         output_type=OUTPUT_TYPE.GLOB
     )
     return output_instance
-
-
-INPUT_TYPE = Bunch(
-    DATA="data",
-    INTEGER="integer",
-    FLOAT="float",
-    TEXT="text",
-    BOOLEAN="boolean",
-    SELECT="select",
-    CONDITIONAL="conditional",
-)
 
 
 class ConditionalInstance(object):
@@ -580,8 +1107,9 @@ class SelectInputInstance(object):
 
 class InputInstance(object):
 
-    def __init__(self, name, label, description, input_type, array=False, area=False):
+    def __init__(self, name, label, description, input_type, array=False, area=False, collection_type=None):
         self.input_type = input_type
+        self.collection_type = collection_type
         self.name = name
         self.label = label
         self.description = description
@@ -614,6 +1142,9 @@ class InputInstance(object):
                 as_dict["value"] = "0"
             if self.input_type == INPUT_TYPE.FLOAT:
                 as_dict["value"] = "0.0"
+            elif self.input_type == INPUT_TYPE.DATA_COLLECTON:
+                as_dict["collection_type"] = self.collection_type
+
         return as_dict
 
 
@@ -623,13 +1154,15 @@ OUTPUT_TYPE = Bunch(
 )
 
 
+# TODO: Different subclasses - this is representing different types of things.
 class OutputInstance(object):
 
-    def __init__(self, name, output_data_type, output_type, path=None):
+    def __init__(self, name, output_data_type, output_type, path=None, fields=None):
         self.name = name
         self.output_data_type = output_data_type
         self.output_type = output_type
         self.path = path
+        self.fields = fields
 
 
 __all__ = (

--- a/lib/galaxy/tools/cwl/representation.py
+++ b/lib/galaxy/tools/cwl/representation.py
@@ -1,6 +1,7 @@
 """ This module is responsible for converting between Galaxy's tool
 input description and the CWL description for a job json. """
 
+import collections
 import json
 import logging
 import os
@@ -9,72 +10,243 @@ from six import string_types
 
 from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.util import safe_makedirs, string_as_bool
+from galaxy.util.bunch import Bunch
+from .util import set_basename_and_derived_properties
 
 log = logging.getLogger(__name__)
 
 NOT_PRESENT = object()
 
-GALAXY_TO_CWL_TYPES = {
-    'integer': 'integer',
-    'float': 'float',
-    'data': 'File',
-    'boolean': 'boolean',
-    'text': 'text'
-}
+NO_GALAXY_INPUT = object()
+
+INPUT_TYPE = Bunch(
+    DATA="data",
+    INTEGER="integer",
+    FLOAT="float",
+    TEXT="text",
+    BOOLEAN="boolean",
+    SELECT="select",
+    FIELD="field",
+    CONDITIONAL="conditional",
+    DATA_COLLECTON="data_collection",
+)
+
+# There are two approaches to mapping CWL tool state to Galaxy tool state
+# one is to map CWL types to compound Galaxy tool parameters combinations
+# with conditionals and the other is to use a new Galaxy parameter type that
+# allows unions, optional specifications, etc.... The problem with the former
+# is that it doesn't work with the workflow parameters for instance and is
+# very complex on the backend. The problem with the latter is that the GUI
+# for this parameter type is undefined curently.
+USE_FIELD_TYPES = True
+
+# There are two approaches to mapping CWL workflow inputs to Galaxy workflow
+# steps. The first is to simply map everything to expressions and stick them into
+# files and use data inputs - the second is to use parameter_input steps with
+# fields types. We are dispatching on USE_FIELD_TYPES for now - to choose but
+# may diverge later?
+# There are open issues with each approach:
+#  - Mapping everything to files makes the GUI harder to imagine but the backend
+#     easier to manage in someways.
+USE_STEP_PARAMETERS = USE_FIELD_TYPES
+
+TypeRepresentation = collections.namedtuple("TypeRepresentation", ["name", "galaxy_param_type", "label", "collection_type"])
+TYPE_REPRESENTATIONS = [
+    TypeRepresentation("null", NO_GALAXY_INPUT, "no input", None),
+    TypeRepresentation("integer", INPUT_TYPE.INTEGER, "an integer", None),
+    TypeRepresentation("float", INPUT_TYPE.FLOAT, "a decimal number", None),
+    TypeRepresentation("double", INPUT_TYPE.FLOAT, "a decimal number", None),
+    TypeRepresentation("file", INPUT_TYPE.DATA, "a dataset", None),
+    TypeRepresentation("directory", INPUT_TYPE.DATA, "a directory", None),
+    TypeRepresentation("boolean", INPUT_TYPE.BOOLEAN, "a boolean", None),
+    TypeRepresentation("text", INPUT_TYPE.TEXT, "a simple text field", None),
+    TypeRepresentation("record", INPUT_TYPE.DATA_COLLECTON, "record as a dataset collection", "record"),
+    TypeRepresentation("json", INPUT_TYPE.TEXT, "arbitrary JSON structure", None),
+    TypeRepresentation("array", INPUT_TYPE.DATA_COLLECTON, "as a dataset list", "list"),
+    TypeRepresentation("enum", INPUT_TYPE.TEXT, "enum value", None),  # TODO: make this a select...
+    TypeRepresentation("field", INPUT_TYPE.FIELD, "arbitrary JSON structure", None),
+]
+FIELD_TYPE_REPRESENTATION = TYPE_REPRESENTATIONS[-1]
+TypeRepresentation.uses_param = lambda self: self.galaxy_param_type is not NO_GALAXY_INPUT
+
+if not USE_FIELD_TYPES:
+    CWL_TYPE_TO_REPRESENTATIONS = {
+        "Any": ["integer", "float", "file", "boolean", "text", "record", "json"],
+        "array": ["array"],
+        "string": ["text"],
+        "boolean": ["boolean"],
+        "int": ["integer"],
+        "float": ["float"],
+        "File": ["file"],
+        "Directory": ["directory"],
+        "null": ["null"],
+        "record": ["record"],
+    }
+else:
+    CWL_TYPE_TO_REPRESENTATIONS = {
+        "Any": ["field"],
+        "array": ["array"],
+        "string": ["text"],
+        "boolean": ["boolean"],
+        "int": ["integer"],
+        "float": ["float"],
+        "File": ["file"],
+        "Directory": ["directory"],
+        "null": ["null"],
+        "record": ["record"],
+        "enum": ["enum"],
+        "double": ["double"],
+    }
+
+
+def type_representation_from_name(type_representation_name):
+    for type_representation in TYPE_REPRESENTATIONS:
+        if type_representation.name == type_representation_name:
+            return type_representation
+
+    assert False
+
+
+def type_descriptions_for_field_types(field_types):
+    type_representation_names = set([])
+    for field_type in field_types:
+        if isinstance(field_type, dict) and field_type.get("type"):
+            field_type = field_type.get("type")
+
+        try:
+            type_representation_names_for_field_type = CWL_TYPE_TO_REPRESENTATIONS.get(field_type)
+        except TypeError:
+            raise Exception("Failed to convert field_type %s" % field_type)
+        assert type_representation_names_for_field_type is not None, field_type
+        type_representation_names.update(type_representation_names_for_field_type)
+    type_representations = []
+    for type_representation in TYPE_REPRESENTATIONS:
+        if type_representation.name in type_representation_names:
+            type_representations.append(type_representation)
+    return type_representations
+
+
+def dataset_wrapper_to_file_json(inputs_dir, dataset_wrapper):
+    if dataset_wrapper.ext == "expression.json":
+        with open(dataset_wrapper.file_name, "r") as f:
+            return json.load(f)
+
+    if dataset_wrapper.ext == "directory":
+        return dataset_wrapper_to_directory_json(inputs_dir, dataset_wrapper)
+
+    extra_files_path = dataset_wrapper.extra_files_path
+    secondary_files_path = os.path.join(extra_files_path, "__secondary_files__")
+    path = str(dataset_wrapper)
+    raw_file_object = {"class": "File"}
+
+    if os.path.exists(secondary_files_path):
+        safe_makedirs(inputs_dir)
+        name = os.path.basename(path)
+        new_input_path = os.path.join(inputs_dir, name)
+        os.symlink(path, new_input_path)
+        secondary_files = []
+        for secondary_file_name in os.listdir(secondary_files_path):
+            secondary_file_path = os.path.join(secondary_files_path, secondary_file_name)
+            target = os.path.join(inputs_dir, secondary_file_name)
+            log.info("linking [%s] to [%s]" % (secondary_file_path, target))
+            os.symlink(secondary_file_path, target)
+            is_dir = os.path.isdir(os.path.realpath(secondary_file_path))
+            secondary_files.append({"class": "File" if not is_dir else "Directory", "location": target})
+
+        raw_file_object["secondaryFiles"] = secondary_files
+        path = new_input_path
+
+    raw_file_object["location"] = path
+    raw_file_object["size"] = int(dataset_wrapper.get_size())
+    set_basename_and_derived_properties(raw_file_object, str(dataset_wrapper.cwl_filename or dataset_wrapper.name))
+    return raw_file_object
+
+
+def dataset_wrapper_to_directory_json(inputs_dir, dataset_wrapper):
+    assert dataset_wrapper.ext == "directory"
+
+    return {"location": dataset_wrapper.extra_files_path,
+            "class": "Directory"}
+
+
+def collection_wrapper_to_array(inputs_dir, wrapped_value):
+    rval = []
+    for value in wrapped_value:
+        rval.append(dataset_wrapper_to_file_json(inputs_dir, value))
+    return rval
+
+
+def collection_wrapper_to_record(inputs_dir, wrapped_value):
+    rval = dict()  # TODO: THIS NEEDS TO BE ORDERED BUT odict not json serializable!
+    for key, value in wrapped_value.items():
+        rval[key] = dataset_wrapper_to_file_json(inputs_dir, value)
+    return rval
 
 
 def to_cwl_job(tool, param_dict, local_working_directory):
     """ tool is Galaxy's representation of the tool and param_dict is the
     parameter dictionary with wrapped values.
     """
+    tool_proxy = tool._cwl_tool_proxy
+    input_fields = tool_proxy.input_fields()
     inputs = tool.inputs
     input_json = {}
 
     inputs_dir = os.path.join(local_working_directory, "_inputs")
 
-    def simple_value(input, param_dict_value, cwl_type=None):
+    def simple_value(input, param_dict_value, type_representation_name=None):
+        type_representation = type_representation_from_name(type_representation_name)
         # Hmm... cwl_type isn't really the cwl type in every case,
         # like in the case of json for instance.
-        if cwl_type is None:
-            input_type = input.type
-            cwl_type = GALAXY_TO_CWL_TYPES[input_type]
 
-        if cwl_type == "null":
+        if type_representation.galaxy_param_type == NO_GALAXY_INPUT:
             assert param_dict_value is None
             return None
-        if cwl_type == "File":
-            dataset_wrapper = param_dict_value
-            extra_files_path = dataset_wrapper.extra_files_path
-            secondary_files_path = os.path.join(extra_files_path, "__secondary_files__")
-            path = str(dataset_wrapper)
-            if os.path.exists(secondary_files_path):
-                safe_makedirs(inputs_dir)
-                name = os.path.basename(path)
-                new_input_path = os.path.join(inputs_dir, name)
-                os.symlink(path, new_input_path)
-                for secondary_file_name in os.listdir(secondary_files_path):
-                    secondary_file_path = os.path.join(secondary_files_path, secondary_file_name)
-                    os.symlink(secondary_file_path, new_input_path + secondary_file_name)
-                path = new_input_path
 
-            return {"location": path,
-                    "class": "File"}
-        elif cwl_type == "integer":
+        if type_representation.name == "file":
+            dataset_wrapper = param_dict_value
+            return dataset_wrapper_to_file_json(inputs_dir, dataset_wrapper)
+        elif type_representation.name == "directory":
+            dataset_wrapper = param_dict_value
+            return dataset_wrapper_to_directory_json(inputs_dir, dataset_wrapper)
+        elif type_representation.name == "integer":
             return int(str(param_dict_value))
-        elif cwl_type == "long":
+        elif type_representation.name == "long":
             return int(str(param_dict_value))
-        elif cwl_type == "float":
+        elif type_representation.name in ["float", "double"]:
             return float(str(param_dict_value))
-        elif cwl_type == "double":
-            return float(str(param_dict_value))
-        elif cwl_type == "boolean":
+        elif type_representation.name == "boolean":
             return string_as_bool(param_dict_value)
-        elif cwl_type == "text":
+        elif type_representation.name == "text":
             return str(param_dict_value)
-        elif cwl_type == "json":
+        elif type_representation.name == "enum":
+            return str(param_dict_value)
+        elif type_representation.name == "json":
             raw_value = param_dict_value.value
-            log.info("raw_value is %s (%s)" % (raw_value, type(raw_value)))
             return json.loads(raw_value)
+        elif type_representation.name == "field":
+            if param_dict_value is None:
+                return None
+            if hasattr(param_dict_value, "value"):
+                # Is InputValueWrapper
+                return param_dict_value.value["value"]
+            elif not param_dict_value.is_collection:
+                # Is DatasetFilenameWrapper
+                return dataset_wrapper_to_file_json(inputs_dir, param_dict_value)
+            else:
+                # Is DatasetCollectionWrapper
+                hdca_wrapper = param_dict_value
+                if hdca_wrapper.collection_type == "list":
+                    # TODO: generalize to lists of lists and lists of non-files...
+                    return collection_wrapper_to_array(inputs_dir, hdca_wrapper)
+                elif hdca_wrapper.collection_type.collection_type == "record":
+                    return collection_wrapper_to_record(inputs_dir, hdca_wrapper)
+
+        elif type_representation.name == "array":
+            # TODO: generalize to lists of lists and lists of non-files...
+            return collection_wrapper_to_array(inputs_dir, param_dict_value)
+        elif type_representation.name == "record":
+            return collection_wrapper_to_record(inputs_dir, param_dict_value)
         else:
             return str(param_dict_value)
 
@@ -92,10 +264,23 @@ def to_cwl_job(tool, param_dict, local_working_directory):
                 case_index = input.get_current_case(current_case)
                 case_input = input.cases[case_index].inputs["_cwl__value_"]
                 case_value = param_dict[input_name]["_cwl__value_"]
-                input_json[input_name] = simple_value(case_input, case_value, cwl_type=current_case)
+                input_json[input_name] = simple_value(case_input, case_value, current_case)
         else:
-            input_json[input_name] = simple_value(input, param_dict[input_name])
+            matched_field = None
+            for field in input_fields:
+                if field["name"] == input_name:
+                    matched_field = field
+            field_type = field_to_field_type(matched_field)
+            if isinstance(field_type, list):
+                assert USE_FIELD_TYPES
+                type_descriptions = [FIELD_TYPE_REPRESENTATION]
+            else:
+                type_descriptions = type_descriptions_for_field_types([field_type])
+            assert len(type_descriptions) == 1
+            type_description_name = type_descriptions[0].name
+            input_json[input_name] = simple_value(input, param_dict[input_name], type_description_name)
 
+    log.debug("Galaxy Tool State is CWL State is %s" % input_json)
     return input_json
 
 
@@ -106,8 +291,8 @@ def to_galaxy_parameters(tool, as_dict):
     inputs = tool.inputs
     galaxy_request = {}
 
-    def from_simple_value(input, param_dict_value, cwl_type=None):
-        if cwl_type == "json":
+    def from_simple_value(input, param_dict_value, type_representation_name=None):
+        if type_representation_name == "json":
             return json.dumps(param_dict_value)
         else:
             return param_dict_value
@@ -129,7 +314,7 @@ def to_galaxy_parameters(tool, as_dict):
             case_strings = input.case_strings
             # TODO: less crazy handling of defaults...
             if (as_dict_value is NOT_PRESENT or as_dict_value is None) and "null" in case_strings:
-                cwl_type = "null"
+                type_representation_name = "null"
             elif (as_dict_value is NOT_PRESENT or as_dict_value is None):
                 raise RequestParameterInvalidException(
                     "Cannot translate CWL datatype - value [%s] of type [%s] with case_strings [%s]. Non-null property must be set." % (
@@ -137,34 +322,38 @@ def to_galaxy_parameters(tool, as_dict):
                     )
                 )
             elif isinstance(as_dict_value, bool) and "boolean" in case_strings:
-                cwl_type = "boolean"
+                type_representation_name = "boolean"
             elif isinstance(as_dict_value, int) and "integer" in case_strings:
-                cwl_type = "integer"
+                type_representation_name = "integer"
             elif isinstance(as_dict_value, int) and "long" in case_strings:
-                cwl_type = "long"
+                type_representation_name = "long"
             elif isinstance(as_dict_value, (int, float)) and "float" in case_strings:
-                cwl_type = "float"
+                type_representation_name = "float"
             elif isinstance(as_dict_value, (int, float)) and "double" in case_strings:
-                cwl_type = "double"
+                type_representation_name = "double"
             elif isinstance(as_dict_value, string_types) and "string" in case_strings:
-                cwl_type = "string"
-            elif isinstance(as_dict_value, dict) and "src" in as_dict_value and "id" in as_dict_value:
-                # Bit problematic...
-                cwl_type = "File"
+                type_representation_name = "string"
+            elif isinstance(as_dict_value, dict) and "src" in as_dict_value and "id" in as_dict_value and "file" in case_strings:
+                type_representation_name = "file"
+            elif isinstance(as_dict_value, dict) and "src" in as_dict_value and "id" in as_dict_value and "directory" in case_strings:
+                # TODO: can't disambiuate with above if both are available...
+                type_representation_name = "directory"
+            elif "field" in case_strings:
+                type_representation_name = "field"
             elif "json" in case_strings and as_dict_value is not None:
-                cwl_type = "json"
+                type_representation_name = "json"
             else:
                 raise RequestParameterInvalidException(
                     "Cannot translate CWL datatype - value [%s] of type [%s] with case_strings [%s]." % (
                         as_dict_value, type(as_dict_value), case_strings
                     )
                 )
-            galaxy_request["%s|_cwl__type_" % input_name] = cwl_type
-            if cwl_type != "null":
-                current_case_index = input.get_current_case(cwl_type)
+            galaxy_request["%s|_cwl__type_" % input_name] = type_representation_name
+            if type_representation_name != "null":
+                current_case_index = input.get_current_case(type_representation_name)
                 current_case_inputs = input.cases[current_case_index].inputs
                 current_case_input = current_case_inputs["_cwl__value_"]
-                galaxy_value = from_simple_value(current_case_input, as_dict_value, cwl_type)
+                galaxy_value = from_simple_value(current_case_input, as_dict_value, type_representation_name)
                 galaxy_request["%s|_cwl__value_" % input_name] = galaxy_value
         elif as_dict_value is NOT_PRESENT:
             continue
@@ -174,3 +363,17 @@ def to_galaxy_parameters(tool, as_dict):
 
     log.info("Converted galaxy_request is %s" % galaxy_request)
     return galaxy_request
+
+
+def field_to_field_type(field):
+    field_type = field["type"]
+    if isinstance(field_type, dict):
+        field_type = field_type["type"]
+    if isinstance(field_type, list):
+        field_type_length = len(field_type)
+        if field_type_length == 0:
+            raise Exception("Zero-length type list encountered, invalid CWL?")
+        elif len(field_type) == 1:
+            field_type = field_type[0]
+
+    return field_type

--- a/lib/galaxy/tools/cwl/runtime_actions.py
+++ b/lib/galaxy/tools/cwl/runtime_actions.py
@@ -2,11 +2,57 @@ import json
 import os
 import shutil
 
+from galaxy.util import safe_makedirs
 from .cwltool_deps import ref_resolver
 from .parser import (
     JOB_JSON_FILE,
     load_job_proxy,
 )
+from .util import (
+    SECONDARY_FILES_INDEX_PATH,
+    STORE_SECONDARY_FILES_WITH_BASENAME,
+)
+
+
+class FileDescription(object):
+    pass
+
+
+class PathFileDescription(object):
+
+    def __init__(self, path):
+        self.path = path
+
+    def write_to(self, destination):
+        # TODO: Move if we can be sure this is in the working directory for instance...
+        shutil.copy(self.path, destination)
+
+
+class LiteralFileDescription(object):
+
+    def __init__(self, content):
+        self.content = content
+
+    def write_to(self, destination):
+        with open(destination, "wb") as f:
+            f.write(self.content.encode("UTF-8"))
+
+
+def _possible_uri_to_path(location):
+    if location.startswith("file://"):
+        path = ref_resolver.uri_file_path(location)
+    else:
+        path = location
+    return path
+
+
+def file_dict_to_description(file_dict):
+    assert file_dict["class"] == "File", file_dict
+    location = file_dict["location"]
+    if location.startswith("_:"):
+        return LiteralFileDescription(file_dict["contents"])
+    else:
+        return PathFileDescription(_possible_uri_to_path(location))
 
 
 def handle_outputs(job_directory=None):
@@ -24,33 +70,123 @@ def handle_outputs(job_directory=None):
     job_proxy = load_job_proxy(job_directory, strict_cwl_validation=False)
     tool_working_directory = os.path.join(job_directory, "working")
     outputs = job_proxy.collect_outputs(tool_working_directory)
-    for output_name, output in outputs.items():
-        target_path = job_proxy.output_path(output_name)
-        if isinstance(output, dict) and "location" in output:
-            output_path = ref_resolver.uri_file_path(output["location"])
-            if output["class"] != "File":
-                open("galaxy.json", "w").write(json.dump({
-                    "dataset_id": job_proxy.output_id(output_name),
-                    "type": "dataset",
-                    "ext": "expression.json",
-                }))
+
+    # Build galaxy.json file.
+    provided_metadata = {}
+
+    def move_directory(output, target_path, output_name=None):
+        assert output["class"] == "Directory"
+        output_path = _possible_uri_to_path(output["location"])
+        if output_path.startswith("_:"):
+            # No a real path, just copy listing to target path.
+            safe_makedirs(target_path)
+            for listed_file in output["listing"]:
+                # TODO: handle directories
+                assert listed_file["class"] == "File"
+                file_description = file_dict_to_description(listed_file)
+                file_description.write_to(os.path.join(target_path, listed_file["basename"]))
+        else:
             shutil.move(output_path, target_path)
-            for secondary_file in output.get("secondaryFiles", []):
+        return {"cwl_filename": output["basename"]}
+
+    def move_output(output, target_path, output_name=None):
+        assert output["class"] == "File"
+        file_description = file_dict_to_description(output)
+        file_description.write_to(target_path)
+
+        secondary_files = output.get("secondaryFiles", [])
+        if secondary_files:
+
+            order = []
+            index_contents = {
+                "order": order
+            }
+
+            for secondary_file in secondary_files:
+                if output_name is None:
+                    raise NotImplementedError("secondaryFiles are unimplemented for dynamic list elements")
+
                 # TODO: handle nested files...
-                secondary_file_path = ref_resolver.uri_file_path(secondary_file["location"])
-                assert secondary_file_path.startswith(output_path)
-                secondary_file_name = secondary_file_path[len(output_path):]
+                secondary_file_description = file_dict_to_description(secondary_file)
+                # assert secondary_file_path.startswith(output_path), "[%s] does not start with [%s]" % (secondary_file_path, output_path)
+                secondary_file_basename = secondary_file["basename"]
+
+                if not STORE_SECONDARY_FILES_WITH_BASENAME:
+                    output_basename = output["basename"]
+                    prefix = ""
+                    while True:
+                        if secondary_file_basename.startswith(output_basename):
+                            secondary_file_name = prefix + secondary_file_basename[len(output_basename):]
+                            break
+                        prefix = "^%s" % prefix
+                        if "." not in output_basename:
+                            secondary_file_name = prefix + secondary_file_name
+                            break
+                        else:
+                            output_basename = output_basename.rsplit(".", 1)[0]
+                else:
+                    secondary_file_name = secondary_file_basename
+                # Convert to ^ format....
                 secondary_files_dir = job_proxy.output_secondary_files_dir(
                     output_name, create=True
                 )
                 extra_target = os.path.join(secondary_files_dir, secondary_file_name)
-                shutil.move(
-                    secondary_file_path,
-                    extra_target,
-                )
+                secondary_file_description.write_to(extra_target)
+                order.append(secondary_file_name)
+
+            with open(os.path.join(secondary_files_dir, "..", SECONDARY_FILES_INDEX_PATH), "w") as f:
+                json.dump(index_contents, f)
+
+        return {"cwl_filename": output["basename"]}
+
+    def handle_known_output(output, output_key, output_name):
+        # if output["class"] != "File":
+        #    # This case doesn't seem like it would be reached - why is this here?
+        #    provided_metadata[output_name] = {
+        #        "ext": "expression.json",
+        #    }
+        # else:
+        assert output_name
+        if output["class"] == "File":
+            target_path = job_proxy.output_path(output_name)
+            file_metadata = move_output(output, target_path, output_name=output_name)
+        elif output["class"] == "Directory":
+            target_path = job_proxy.output_directory_contents_dir(output_name)
+            file_metadata = move_directory(output, target_path, output_name=output_name)
         else:
+            raise Exception("Unknown output type [%s] encountered" % output)
+        provided_metadata[output_name] = file_metadata
+
+    for output_name, output in outputs.items():
+        if isinstance(output, dict) and "location" in output:
+            handle_known_output(output, output_name, output_name)
+        elif isinstance(output, dict):
+            prefix = "%s|__part__|" % output_name
+            for record_key, record_value in output.items():
+                record_value_output_key = "%s%s" % (prefix, record_key)
+                handle_known_output(record_value, record_value_output_key, output_name)
+        elif isinstance(output, list):
+            elements = []
+            for index, el in enumerate(output):
+                if isinstance(el, dict) and el["class"] == "File":
+                    output_path = _possible_uri_to_path(el["location"])
+                    elements.append({"name": str(index), "filename": output_path, "cwl_filename": el["basename"]})
+                else:
+                    target_path = "%s____%s" % (output_name, str(index))
+                    with open(target_path, "w") as f:
+                        f.write(json.dumps(el))
+                    elements.append({"name": str(index), "filename": target_path, "ext": "expression.json"})
+            provided_metadata[output_name] = {"elements": elements}
+        else:
+            target_path = job_proxy.output_path(output_name)
             with open(target_path, "w") as f:
                 f.write(json.dumps(output))
+            provided_metadata[output_name] = {
+                "ext": "expression.json",
+            }
+
+    with open("galaxy.json", "w") as f:
+        json.dump(provided_metadata, f)
 
 
 __all__ = (

--- a/lib/galaxy/tools/cwl/schema.py
+++ b/lib/galaxy/tools/cwl/schema.py
@@ -24,12 +24,18 @@ class SchemaLoader(object):
     @property
     def raw_document_loader(self):
         ensure_cwltool_available()
-        return schema_salad.ref_resolver.Loader({"cwl": "https://w3id.org/cwl/cwl#", "id": "@id"})
+        from cwltool.load_tool import jobloaderctx
+        return schema_salad.ref_resolver.Loader(jobloaderctx)
 
     def raw_process_reference(self, path):
         uri = "file://" + os.path.abspath(path)
         fileuri, _ = urldefrag(uri)
         return RawProcessReference(self.raw_document_loader.fetch(fileuri), uri)
+
+    def raw_process_reference_for_object(self, object, uri=None):
+        if uri is None:
+            uri = "galaxy://"
+        return RawProcessReference(object, uri)
 
     def process_definition(self, raw_reference):
         document_loader, avsc_names, process_object, metadata, uri = load_tool.validate_document(

--- a/lib/galaxy/tools/cwl/util.py
+++ b/lib/galaxy/tools/cwl/util.py
@@ -1,0 +1,383 @@
+"""Client-centric CWL-related utilities.
+
+Used to share code between the Galaxy test framework
+and other Galaxy CWL clients (e.g. Planemo)."""
+import hashlib
+import json
+import os
+import tarfile
+import tempfile
+from collections import namedtuple
+
+from six import iteritems, python_2_unicode_compatible, StringIO
+
+STORE_SECONDARY_FILES_WITH_BASENAME = True
+SECONDARY_FILES_EXTRA_PREFIX = "__secondary_files__"
+SECONDARY_FILES_INDEX_PATH = "__secondary_files_index.json"
+
+
+def set_basename_and_derived_properties(properties, basename):
+    properties["basename"] = basename
+    properties["nameroot"], properties["nameext"] = os.path.splitext(basename)
+    return properties
+
+
+def output_properties(path=None, content=None, basename=None, pseduo_location=False):
+    checksum = hashlib.sha1()
+    properties = {
+        "class": "File",
+    }
+    if path is not None:
+        properties["path"] = path
+        f = open(path, "rb")
+    else:
+        f = StringIO(content)
+
+    try:
+        contents = f.read(1024 * 1024)
+        filesize = 0
+        while contents != "":
+            checksum.update(contents)
+            filesize += len(contents)
+            contents = f.read(1024 * 1024)
+    finally:
+        f.close()
+    properties["checksum"] = "sha1$%s" % checksum.hexdigest()
+    properties["size"] = filesize
+    set_basename_and_derived_properties(properties, basename)
+    _handle_pseudo_location(properties, pseduo_location)
+    return properties
+
+
+def _handle_pseudo_location(properties, pseduo_location):
+    if pseduo_location:
+        properties["location"] = properties["basename"]
+
+
+def galactic_job_json(
+    job, test_data_directory, upload_func, collection_create_func, tool_or_workflow="workflow"
+):
+    """Adapt a CWL job object to the Galaxy API.
+
+    CWL derived tools in Galaxy can consume a job description sort of like
+    CWL job objects via the API but paths need to be replaced with datasets
+    and records and arrays with collection references. This function will
+    stage files and modify the job description to adapt to these changes
+    for Galaxy.
+    """
+
+    datasets = []
+    dataset_collections = []
+
+    def upload_file(file_path, secondary_files):
+        if not os.path.isabs(file_path):
+            file_path = os.path.join(test_data_directory, file_path)
+        _ensure_file_exists(file_path)
+        target = FileUploadTarget(file_path, secondary_files)
+        upload_response = upload_func(target)
+        dataset = upload_response["outputs"][0]
+        datasets.append((dataset, target))
+        dataset_id = dataset["id"]
+        return {"src": "hda", "id": dataset_id}
+
+    def upload_tar(file_path):
+        if not os.path.isabs(file_path):
+            file_path = os.path.join(test_data_directory, file_path)
+        _ensure_file_exists(file_path)
+        target = DirectoryUploadTarget(file_path)
+        upload_response = upload_func(target)
+        dataset = upload_response["outputs"][0]
+        datasets.append((dataset, target))
+        dataset_id = dataset["id"]
+        return {"src": "hda", "id": dataset_id}
+
+    def upload_object(the_object):
+        target = ObjectUploadTarget(the_object)
+        upload_response = upload_func(target)
+        dataset = upload_response["outputs"][0]
+        datasets.append((dataset, target))
+        dataset_id = dataset["id"]
+        return {"src": "hda", "id": dataset_id}
+
+    def replacement_item(value, force_to_file=False):
+        is_dict = isinstance(value, dict)
+        item_class = None if not is_dict else value.get("class", None)
+        is_file = item_class == "File"
+        is_directory = item_class == "Directory"
+
+        if force_to_file:
+            if is_file:
+                return replacement_file(value)
+            else:
+                return upload_object(value)
+
+        if isinstance(value, list):
+            return replacement_list(value)
+        elif not isinstance(value, dict):
+            if tool_or_workflow == "workflow":
+                # All inputs represented as dataset or collection parameters
+                return upload_object(value)
+            else:
+                return value
+
+        if is_file:
+            return replacement_file(value)
+        elif is_directory:
+            return replacement_directory(value)
+        else:
+            return replacement_record(value)
+
+    def replacement_file(value):
+        file_path = value.get("location", None) or value.get("path", None)
+        if file_path is None:
+            return value
+
+        secondary_files = value.get("secondaryFiles", [])
+        secondary_files_tar_path = None
+        if secondary_files:
+            tmp = tempfile.NamedTemporaryFile(delete=False)
+            tf = tarfile.open(fileobj=tmp, mode='w:')
+            order = []
+            index_contents = {
+                "order": order
+            }
+            for secondary_file in secondary_files:
+                secondary_file_path = secondary_file.get("location", None) or secondary_file.get("path", None)
+                assert secondary_file_path, "Invalid secondaryFile entry found [%s]" % secondary_file
+                full_secondary_file_path = os.path.join(test_data_directory, secondary_file_path)
+                basename = secondary_file.get("basename") or os.path.basename(secondary_file_path)
+                order.append(basename)
+                tf.add(full_secondary_file_path, os.path.join(SECONDARY_FILES_EXTRA_PREFIX, basename))
+            tmp_index = tempfile.NamedTemporaryFile(delete=False)
+            json.dump(index_contents, tmp_index)
+            tmp_index.close()
+            tf.add(tmp_index.name, SECONDARY_FILES_INDEX_PATH)
+            tf.close()
+            secondary_files_tar_path = tmp.name
+
+        return upload_file(file_path, secondary_files_tar_path)
+
+    def replacement_directory(value):
+        file_path = value.get("location", None) or value.get("path", None)
+        if file_path is None:
+            return value
+
+        if not os.path.isabs(file_path):
+            file_path = os.path.join(test_data_directory, file_path)
+
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tf = tarfile.open(fileobj=tmp, mode='w:')
+        tf.add(file_path, '.')
+        tf.close()
+
+        return upload_tar(tmp.name)
+
+    def replacement_list(value):
+        collection_element_identifiers = []
+        for i, item in enumerate(value):
+            dataset = replacement_item(item, force_to_file=True)
+            collection_element = dataset.copy()
+            collection_element["name"] = str(i)
+            collection_element_identifiers.append(collection_element)
+
+        collection = collection_create_func(collection_element_identifiers, "list")
+        dataset_collections.append(collection)
+        hdca_id = collection["id"]
+        return {"src": "hdca", "id": hdca_id}
+
+    def replacement_record(value):
+        collection_element_identifiers = []
+        for record_key, record_value in value.items():
+            if record_value.get("class") != "File":
+                dataset = replacement_item(record_value, force_to_file=True)
+                collection_element = dataset.copy()
+            else:
+                dataset = upload_file(record_value["location"])
+                collection_element = dataset.copy()
+
+            collection_element["name"] = record_key
+            collection_element_identifiers.append(collection_element)
+
+        collection = collection_create_func(collection_element_identifiers, "record")
+        dataset_collections.append(collection)
+        hdca_id = collection["id"]
+        return {"src": "hdca", "id": hdca_id}
+
+    replace_keys = {}
+    for key, value in iteritems(job):
+        replace_keys[key] = replacement_item(value)
+
+    job.update(replace_keys)
+    return job, datasets
+
+
+def _ensure_file_exists(file_path):
+    if not os.path.exists(file_path):
+        template = "File [%s] does not exist - parent directory [%s] does %sexist, cwd is [%s]"
+        parent_directory = os.path.dirname(file_path)
+        message = template % (
+            file_path,
+            parent_directory,
+            "" if os.path.exists(parent_directory) else "not ",
+            os.getcwd(),
+        )
+        raise Exception(message)
+
+
+@python_2_unicode_compatible
+class FileUploadTarget(object):
+
+    def __init__(self, path, secondary_files=None):
+        self.path = path
+        self.secondary_files = secondary_files
+
+    def __str__(self):
+        return "FileUploadTarget[path=%s]" % self.path
+
+
+@python_2_unicode_compatible
+class ObjectUploadTarget(object):
+
+    def __init__(self, the_object):
+        self.object = the_object
+
+    def __str__(self):
+        return "ObjectUploadTarget[object=%s]" % self.object
+
+
+@python_2_unicode_compatible
+class DirectoryUploadTarget(object):
+
+    def __init__(self, tar_path):
+        self.tar_path = tar_path
+
+    def __str__(self):
+        return "DirectoryUploadTarget[tar_path=%s]" % self.tar_path
+
+
+GalaxyOutput = namedtuple("GalaxyOutput", ["history_id", "history_content_type", "history_content_id"])
+
+
+def tool_response_to_output(tool_response, history_id, output_id):
+    for output in tool_response["outputs"]:
+        if output["output_name"] == output_id:
+            return GalaxyOutput(history_id, "dataset", output["id"])
+
+    for output_collection in tool_response["output_collections"]:
+        if output_collection["output_name"] == output_id:
+            return GalaxyOutput(history_id, "dataset_collection", output_collection["id"])
+
+    raise Exception("Failed to find output with label [%s]" % output_id)
+
+
+def invocation_to_output(invocation, history_id, output_id):
+    if output_id in invocation["outputs"]:
+        dataset = invocation["outputs"][output_id]
+        galaxy_output = GalaxyOutput(history_id, "dataset", dataset["id"])
+    elif output_id in invocation["output_collections"]:
+        collection = invocation["output_collections"][output_id]
+        galaxy_output = GalaxyOutput(history_id, "dataset_collection", collection["id"])
+    else:
+        raise Exception("Failed to find output with label [%s] in [%s]" % (output_id, invocation))
+
+    return galaxy_output
+
+
+def output_to_cwl_json(
+    galaxy_output, get_metadata, get_dataset, get_extra_files, pseduo_location=False,
+):
+    """Convert objects in a Galaxy history into a CWL object.
+
+    Useful in running conformance tests and implementing the cwl-runner
+    interface via Galaxy.
+    """
+    def element_to_cwl_json(element):
+        element_output = GalaxyOutput(
+            galaxy_output.history_id,
+            element["object"]["history_content_type"],
+            element["object"]["id"],
+        )
+        return output_to_cwl_json(element_output, get_metadata, get_dataset, get_extra_files)
+
+    output_metadata = get_metadata(galaxy_output.history_content_type, galaxy_output.history_content_id)
+
+    def dataset_dict_to_json_content(dataset_dict):
+        if "content" in dataset_dict:
+            return json.loads(dataset_dict["content"])
+        else:
+            with open(dataset_dict["path"]) as f:
+                return json.load(f)
+
+    if output_metadata["history_content_type"] == "dataset":
+        ext = output_metadata["file_ext"]
+        assert output_metadata["state"] == "ok"
+        if ext == "expression.json":
+            dataset_dict = get_dataset(output_metadata)
+            return dataset_dict_to_json_content(dataset_dict)
+        else:
+            file_or_directory = "Directory" if ext == "directory" else "File"
+            if file_or_directory == "File":
+                dataset_dict = get_dataset(output_metadata)
+                properties = output_properties(pseduo_location=pseduo_location, **dataset_dict)
+                basename = properties["basename"]
+                extra_files = get_extra_files(output_metadata)
+                found_index = False
+                for extra_file in extra_files:
+                    if extra_file["class"] == "File":
+                        path = extra_file["path"]
+                        if path == SECONDARY_FILES_INDEX_PATH:
+                            found_index = True
+
+                if found_index:
+                    ec = get_dataset(output_metadata, filename=SECONDARY_FILES_INDEX_PATH)
+                    index = dataset_dict_to_json_content(ec)
+                    for basename in index["order"]:
+                        for extra_file in extra_files:
+                            if extra_file["class"] == "File":
+                                path = extra_file["path"]
+                                if path == os.path.join(SECONDARY_FILES_EXTRA_PREFIX, basename):
+                                    ec = get_dataset(output_metadata, filename=path)
+                                    if not STORE_SECONDARY_FILES_WITH_BASENAME:
+                                        ec["basename"] = basename + os.path.basename(path)
+                                    else:
+                                        ec["basename"] = os.path.basename(path)
+                                    ec_properties = output_properties(pseduo_location=pseduo_location, **ec)
+                                    if "secondaryFiles" not in properties:
+                                        properties["secondaryFiles"] = []
+
+                                    properties["secondaryFiles"].append(ec_properties)
+            else:
+                basename = output_metadata.get("cwl_file_name")
+                if not basename:
+                    basename = output_metadata.get("name")
+
+                listing = []
+                properties = {
+                    "class": "Directory",
+                    "basename": basename,
+                    "listing": listing,
+                }
+
+                extra_files = get_extra_files(output_metadata)
+                for extra_file in extra_files:
+                    if extra_file["class"] == "File":
+                        path = extra_file["path"]
+                        ec = get_dataset(output_metadata, filename=path)
+                        ec["basename"] = os.path.basename(path)
+                        ec_properties = output_properties(pseduo_location=pseduo_location, **ec)
+                        listing.append(ec_properties)
+
+            return properties
+
+    elif output_metadata["history_content_type"] == "dataset_collection":
+        if output_metadata["collection_type"] == "list":
+            rval = []
+            for element in output_metadata["elements"]:
+                rval.append(element_to_cwl_json(element))
+        elif output_metadata["collection_type"] == "record":
+            rval = {}
+            for element in output_metadata["elements"]:
+                rval[element["element_identifier"]] = element_to_cwl_json(element)
+        return rval
+    else:
+        raise NotImplementedError("Unknown history content type encountered")

--- a/lib/galaxy/tools/deps/mulled/invfile.lua
+++ b/lib/galaxy/tools/deps/mulled/invfile.lua
@@ -42,7 +42,7 @@ end
 
 local conda_image = VAR.CONDA_IMAGE
 if conda_image == '' then
-    conda_image = 'continuumio/miniconda:latest'
+    conda_image = 'continuumio/miniconda3:latest'
 end
 
 
@@ -104,8 +104,8 @@ if VAR.SINGULARITY ~= '' then
         .withHostConfig({binds = {"build:/data",singularity_image_dir .. ":/import"}, privileged = true})
         .withConfig({entrypoint = {'/bin/sh', '-c'}})
         -- for small containers (less than 7MB), double the size otherwise, add a little bit more as half the conda size
-        .run("size=$(du -sc  /data/dist/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '7' ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi")
-        .run("singularity create --size `size=$(du -sc /data/dist/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '7' ]; then echo $(($size*2)); else  echo $(($size+$size*7/10)); fi` /import/" .. VAR.SINGULARITY_IMAGE_NAME)
+        .run("size=$(du -sc  /data/dist/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '10' ]; then echo 20; else  echo $(($size+$size*7/10)); fi")
+        .run("singularity create --size `size=$(du -sc /data/dist/ | tail -n 1 | cut -f 1 | awk '{print int($1/1024)}' ) && if [ $size -lt '10' ]; then echo 20; else  echo $(($size+$size*7/10)); fi` /import/" .. VAR.SINGULARITY_IMAGE_NAME)
         .run('mkdir -p /usr/local/var/singularity/mnt/container && singularity bootstrap /import/' .. VAR.SINGULARITY_IMAGE_NAME .. ' /import/Singularity')
         .run('chown ' .. VAR.USER_ID .. ' /import/' .. VAR.SINGULARITY_IMAGE_NAME)
 end

--- a/lib/galaxy/tools/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tools/deps/mulled/mulled_build.py
@@ -30,6 +30,7 @@ from .util import (
     build_target,
     conda_build_target_str,
     create_repository,
+    PrintProgress,
     quay_repository,
     v1_image_name,
     v2_image_name,
@@ -235,7 +236,8 @@ def mull_targets(
             with open(os.path.join(singularity_image_dir, 'Singularity'), 'w+') as sin_def:
                 fill_template = SINGULARITY_TEMPLATE % {'container_test': test}
                 sin_def.write(fill_template)
-        ret = involucro_context.exec_command(involucro_args)
+        with PrintProgress():
+            ret = involucro_context.exec_command(involucro_args)
         if singularity:
             # we can not remove this folder as it contains the image wich is owned by root
             pass

--- a/lib/galaxy/tools/deps/mulled/mulled_build_files.py
+++ b/lib/galaxy/tools/deps/mulled/mulled_build_files.py
@@ -15,6 +15,7 @@ Build all recipes discovered in tsv files in a single directory.
 import collections
 import glob
 import os
+import sys
 
 from ._cli import arg_parser
 from .mulled_build import (
@@ -36,7 +37,7 @@ def main(argv=None):
     args = parser.parse_args()
     for (targets, image_build, name_override) in generate_targets(args.files):
         try:
-            mull_targets(
+            ret = mull_targets(
                 targets,
                 image_build=image_build,
                 name_override=name_override,
@@ -44,6 +45,8 @@ def main(argv=None):
             )
         except BuildExistsException:
             continue
+        if ret > 0:
+            sys.exit(ret)
 
 
 def generate_targets(target_source):

--- a/lib/galaxy/tools/deps/mulled/util.py
+++ b/lib/galaxy/tools/deps/mulled/util.py
@@ -3,6 +3,9 @@ from __future__ import print_function
 
 import collections
 import hashlib
+import sys
+import threading
+import time
 
 import packaging.version
 try:
@@ -204,6 +207,27 @@ def v2_image_name(targets, image_build=None, name_override=None):
         if version_hash_str or build_suffix:
             suffix = ":%s%s" % (version_hash_str, build_suffix)
         return "mulled-v2-%s%s" % (package_hash.hexdigest(), suffix)
+
+
+class PrintProgress:
+    def __init__(self):
+        self.thread = threading.Thread(target=self.progress)
+        self.stop = False
+
+    def progress(self):
+        while not self.stop:
+            print(".", end="")
+            sys.stdout.flush()
+            time.sleep(60)
+        print("")
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop = True
+        self.thread.join()
 
 
 image_name = v1_image_name  # deprecated

--- a/lib/galaxy/tools/deps/requirements.py
+++ b/lib/galaxy/tools/deps/requirements.py
@@ -196,7 +196,7 @@ class ContainerDescription(object):
 def parse_requirements_from_dict(root_dict):
     requirements = root_dict.get("requirements", [])
     containers = root_dict.get("containers", [])
-    return ToolRequirements.from_list(requirements), map(ContainerDescription.from_dict, containers)
+    return ToolRequirements.from_list(requirements), [ContainerDescription.from_dict(c) for c in containers]
 
 
 def parse_requirements_from_xml(xml_root):

--- a/lib/galaxy/tools/linters/command.py
+++ b/lib/galaxy/tools/linters/command.py
@@ -30,8 +30,6 @@ def lint_command(tool_xml, lint_ctx):
             detect_errors = value
             if detect_errors not in ["default", "exit_code", "aggressive"]:
                 lint_ctx.warn("Unknown detect_errors attribute [%s]" % detect_errors)
-        else:
-            lint_ctx.warn("Unknown attribute [%s] encountered on command tag." % key)
 
     interpreter_info = ""
     if interpreter_type:

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -625,7 +625,7 @@ def in_directory(file, directory, local_path_module=os.path):
     >>> safe_dir = os.path.join(base_dir, "user")
     >>> os.mkdir(safe_dir)
     >>> good_file = os.path.join(safe_dir, "1")
-    >>> with open(good_file, "w") as f: f.write("hello")
+    >>> with open(good_file, "w") as f: _ = f.write("hello")
     >>> in_directory(good_file, safe_dir)
     True
     >>> in_directory("/other/file/is/here.txt", safe_dir)

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -9,7 +9,12 @@ from galaxy import util
 from galaxy.util.image_util import image_type
 
 if sys.version_info < (3, 3):
-    import bz2file as bz2
+    gzip.GzipFile.read1 = gzip.GzipFile.read  # workaround for https://bugs.python.org/issue12591
+    try:
+        import bz2file as bz2
+    except ImportError:
+        # If bz2file is unavailable, just fallback to not having pbzip2 support.
+        import bz2
 else:
     import bz2
 

--- a/lib/galaxy/util/compression_utils.py
+++ b/lib/galaxy/util/compression_utils.py
@@ -1,18 +1,12 @@
 import gzip
 import io
-import sys
 import zipfile
 
 from .checkers import (
+    bz2,
     is_bz2,
     is_gzip
 )
-
-if sys.version_info < (3, 3):
-    import bz2file as bz2
-    gzip.GzipFile.read1 = gzip.GzipFile.read  # workaround for https://bugs.python.org/issue12591
-else:
-    import bz2
 
 
 def get_fileobj(filename, mode="r", compressed_formats=None):

--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -319,7 +319,7 @@ def __copy_self(names=__name__, parent=None):
     if isinstance(names, string_types):
         names = iter(names.split('.'))
     try:
-        name = names.next()
+        name = next(names)
     except StopIteration:
         return parent
     path = parent and parent.__path__


### PR DESCRIPTION
Includes:

- Fixes for multi-requirement container building via mulled via https://github.com/galaxyproject/galaxy-lib/pull/84.
- Fixes for Conda search problems https://github.com/galaxyproject/galaxy-lib/pull/83.
- Updates to CWL library support https://github.com/galaxyproject/galaxy-lib/pull/78.
- Make bz2file dependency optional (xref https://github.com/galaxyproject/galaxy-lib/pull/79)
- Python 3 fixes for path stuff - runtime fixes caught because galaxy-lib runs tests using Python 3 https://github.com/galaxyproject/galaxy-lib/pull/85/commits/c056e39451ca8b4b9ab872b7ae12e74de5c98d48 and https://github.com/galaxyproject/galaxy-lib/pull/85/commits/c7cc9caba389770feb2913a7f0c789a4c8dec53d)
- Python 3 fix for linter (https://github.com/galaxyproject/galaxy-lib/pull/88/commits/17d167662cda2ae4a2cccfbe0f0e9d151cc57ced).

Redo of #5584 - I think the only things I changed were in galaxy.tools.deps.mulled. I double checked everything based on @nsoranzo's catch and undid a bunch changes in this commit that were undoing things (I'm used to people developing that package from the galaxy-lib side). I also noticed a problem where the last time I merged Galaxy into galaxy-lib I did that wrong and so this commit now includes https://github.com/galaxyproject/galaxy-lib/commit/0c69916e14f98fbd09bfb4e3312dc2517b8b1105 which restores a change that was in https://github.com/galaxyproject/galaxy-lib/pull/84 mentioned above. I also double checked that all the recent Python 3 work in still reflected in galaxy.tools.cwl and it seems to be.
