### PR TITLE
[18.01] Replace distutils.version with packaging.version

### DIFF
--- a/lib/galaxy/datatypes/converters/sam_to_bam.py
+++ b/lib/galaxy/datatypes/converters/sam_to_bam.py
@@ -11,7 +11,8 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from distutils.version import LooseVersion
+
+import packaging.version
 
 CHUNK_SIZE = 2 ** 20  # 1mb
 
@@ -87,8 +88,8 @@ def __main__():
     sorted_stderr_filename = os.path.join(tmp_dir, 'sorted.stderr')
     sorting_prefix = os.path.join(tmp_dir, 'sorted_bam')
     # samtools changed sort command arguments (starting from version 1.3)
-    samtools_version = LooseVersion(_get_samtools_version())
-    if samtools_version < LooseVersion('1.0'):
+    samtools_version = packaging.version.parse(_get_samtools_version())
+    if samtools_version < packaging.version.parse('1.0'):
         sort_args = ['-o', unsorted_bam_filename, sorting_prefix]
     else:
         sort_args = ['-T', sorting_prefix, unsorted_bam_filename]

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -39,6 +39,7 @@ six==1.11.0
 Whoosh==2.7.4
 galaxy_sequence_utils==1.0.2
 h5py==2.7.1
+packaging==16.8
 
 # pykwalify and dependencies
 pykwalify==1.6.0

--- a/lib/galaxy/dependencies/requirements.txt
+++ b/lib/galaxy/dependencies/requirements.txt
@@ -35,6 +35,8 @@ Parsley
 six
 Whoosh
 galaxy_sequence_utils
+h5py
+packaging
 
 # Cheetah and dependencies
 Cheetah

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -8,9 +8,9 @@ import errno
 import logging
 import os
 import subprocess
-from distutils.version import LooseVersion
 from time import sleep
 
+import packaging.version
 import pulsar.core
 import yaml
 from pulsar.client import (
@@ -53,8 +53,8 @@ __all__ = (
 )
 
 MINIMUM_PULSAR_VERSIONS = {
-    '_default_': LooseVersion("0.7.0.dev3"),
-    'remote_metadata': LooseVersion("0.8.0"),
+    '_default_': packaging.version.parse("0.7.0.dev3"),
+    'remote_metadata': packaging.version.parse("0.8.0"),
 }
 
 NO_REMOTE_GALAXY_FOR_METADATA_MESSAGE = "Pulsar misconfiguration - Pulsar client configured to set metadata remotely, but remote Pulsar isn't properly configured with a galaxy_home directory."
@@ -613,8 +613,8 @@ class PulsarJobRunner(AsynchronousJobRunner):
     def check_job_config(remote_job_config, check_features=None):
         check_features = check_features or {}
         # 0.6.0 was newest Pulsar version that did not report it's version.
-        pulsar_version = LooseVersion(remote_job_config.get('pulsar_version', "0.6.0"))
-        needed_version = LooseVersion("0.0.0")
+        pulsar_version = packaging.version.parse(remote_job_config.get('pulsar_version', "0.6.0"))
+        needed_version = packaging.version.parse("0.0.0")
         log.info("pulsar_version is %s" % pulsar_version)
         for feature in list(check_features.keys()) + ['_default_']:
             if pulsar_version < MINIMUM_PULSAR_VERSIONS[feature]:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -11,9 +11,9 @@ import threading
 from cgi import FieldStorage
 from collections import OrderedDict
 from datetime import datetime
-from distutils.version import LooseVersion
 from xml.etree import ElementTree
 
+import packaging.version
 from mako.template import Template
 from paste import httpexceptions
 from six import string_types
@@ -163,9 +163,9 @@ GALAXY_LIB_TOOLS_UNVERSIONED = [
 # Tools that needed galaxy on the PATH in the past but no longer do along
 # with the version at which they were fixed.
 GALAXY_LIB_TOOLS_VERSIONED = {
-    "sam_to_bam": LooseVersion("1.1.3"),
-    "PEsortedSAM2readprofile": LooseVersion("1.1.1"),
-    "fetchflank": LooseVersion("1.0.1"),
+    "sam_to_bam": packaging.version.parse("1.1.3"),
+    "PEsortedSAM2readprofile": packaging.version.parse("1.1.1"),
+    "fetchflank": packaging.version.parse("1.0.1"),
 }
 
 
@@ -447,7 +447,7 @@ class Tool(object, Dictifiable):
 
     @property
     def version_object(self):
-        return LooseVersion(self.version)
+        return packaging.version.parse(self.version)
 
     @property
     def sa_session(self):
@@ -586,8 +586,8 @@ class Tool(object, Dictifiable):
         if not self.id:
             raise Exception("Missing tool 'id' for tool at '%s'" % tool_source)
 
-        profile = LooseVersion(str(self.profile))
-        if profile >= LooseVersion("16.04") and LooseVersion(VERSION_MAJOR) < profile:
+        profile = packaging.version.parse(str(self.profile))
+        if profile >= packaging.version.parse("16.04") and packaging.version.parse(VERSION_MAJOR) < profile:
             template = "The tool %s targets version %s of Galaxy, you should upgrade Galaxy to ensure proper functioning of this tool."
             message = template % (self.id, self.profile)
             raise Exception(message)

--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -7,8 +7,8 @@ import re
 import shutil
 import sys
 import tempfile
-from distutils.version import LooseVersion
 
+import packaging.version
 import six
 from six.moves import shlex_quote
 
@@ -118,7 +118,7 @@ class CondaContext(installable.InstallableContext):
         conda_meta_path = self._conda_meta_path
         # Perhaps we should call "conda info --json" and parse it but for now we are going
         # to assume the default.
-        conda_version = LooseVersion(CONDA_VERSION)
+        conda_version = packaging.version.parse(CONDA_VERSION)
         conda_build_available = False
         miniconda_version = "3"
 
@@ -131,7 +131,7 @@ class CondaContext(installable.InstallableContext):
                 version = package_parts[-2]
                 # build = package_parts[-1]
                 if package == "conda":
-                    conda_version = LooseVersion(version)
+                    conda_version = packaging.version.parse(version)
                 if package == "python" and version.startswith("2"):
                     miniconda_version = "2"
                 if package == "conda-build":
@@ -495,7 +495,7 @@ def best_search_result(conda_target, conda_context, channels_override=None, offl
     search_cmd.append(conda_target.package)
     res = commands.execute(search_cmd)
     hits = json.loads(res).get(conda_target.package, [])
-    hits = sorted(hits, key=lambda hit: LooseVersion(hit['version']), reverse=True)
+    hits = sorted(hits, key=lambda hit: packaging.version.parse(hit['version']), reverse=True)
 
     if len(hits) == 0:
         return (None, None)
@@ -564,8 +564,8 @@ def build_isolated_environment(
         # Adjust fix if they fix Conda - xref
         # - https://github.com/galaxyproject/galaxy/issues/3635
         # - https://github.com/conda/conda/issues/2035
-        offline_works = (conda_context.conda_version < LooseVersion("4.3")) or \
-                        (conda_context.conda_version >= LooseVersion("4.4"))
+        offline_works = (conda_context.conda_version < packaging.version.parse("4.3")) or \
+                        (conda_context.conda_version >= packaging.version.parse("4.4"))
         if offline_works:
             create_args.extend(["--offline"])
         else:

--- a/lib/galaxy/tools/deps/mulled/util.py
+++ b/lib/galaxy/tools/deps/mulled/util.py
@@ -3,8 +3,8 @@ from __future__ import print_function
 
 import collections
 import hashlib
-from distutils.version import LooseVersion
 
+import packaging.version
 try:
     import requests
 except ImportError:
@@ -69,7 +69,7 @@ def split_tag(tag):
 
 def version_sorted(elements):
     """Sort iterable based on loose description of "version" from newest to oldest."""
-    return sorted(elements, key=LooseVersion, reverse=True)
+    return sorted(elements, key=packaging.version.parse, reverse=True)
 
 
 Target = collections.namedtuple("Target", ["package_name", "version", "build"])

--- a/lib/galaxy/tools/toolbox/lineages/interface.py
+++ b/lib/galaxy/tools/toolbox/lineages/interface.py
@@ -1,5 +1,6 @@
 import threading
-from distutils.version import LooseVersion
+
+import packaging.version
 
 from galaxy.util.tool_version import remove_version_from_guid
 
@@ -31,7 +32,7 @@ class ToolLineageVersion(object):
 
 class ToolLineage:
     """ Simple tool's loaded directly from file system with lineage
-    determined solely by distutil's LooseVersion naming scheme.
+    determined solely by PEP 440 versioning scheme.
     """
     lineages_by_id = {}
     lock = threading.Lock()
@@ -42,7 +43,7 @@ class ToolLineage:
 
     @property
     def tool_versions(self):
-        return sorted(self._tool_versions, key=LooseVersion)
+        return sorted(self._tool_versions, key=packaging.version.parse)
 
     @property
     def tool_ids(self):

--- a/lib/galaxy/visualization/data_providers/genome.py
+++ b/lib/galaxy/visualization/data_providers/genome.py
@@ -10,9 +10,9 @@ import re
 import sys
 import tempfile
 from contextlib import contextmanager
-from distutils.version import LooseVersion
 from json import loads
 
+import packaging.version
 import pysam
 from bx.bbi.bigbed_file import BigBedFile
 from bx.bbi.bigwig_file import BigWigFile
@@ -27,7 +27,7 @@ from galaxy.visualization.data_providers.cigar import get_ref_based_read_seq_and
 # Utility functions.
 #
 
-PYSAM_INDEX_SYMLINK_NECESSARY = LooseVersion(pysam.__version__) <= LooseVersion('0.13.0')
+PYSAM_INDEX_SYMLINK_NECESSARY = packaging.version.parse(pysam.__version__) <= packaging.version.parse('0.13.0')
 
 
 def float_nan(n):


### PR DESCRIPTION
This is a backport from dev because this seems to fix the tool lineage for deployed freebayes versions.

distutils under Python3 has this bug:

https://bugs.python.org/issue14894

which causes this traceback:

```
Traceback (most recent call last):
  File "lib/galaxy/webapps/galaxy/buildapp.py", line 49, in app_factory
    app = galaxy.app.UniverseApplication(global_conf=global_conf, **kwargs)
  File "lib/galaxy/app.py", line 125, in __init__
    self._configure_toolbox()
  File "lib/galaxy/config.py", line 930, in _configure_toolbox
    self.toolbox = tools.ToolBox(tool_configs, self.config.tool_path, self)
  File "lib/galaxy/tools/__init__.py", line 232, in __init__
    app=app,
  File "lib/galaxy/tools/toolbox/base.py", line 1056, in __init__
    super(BaseGalaxyToolBox, self).__init__(config_filenames, tool_root_dir, app)
  File "lib/galaxy/tools/toolbox/base.py", line 84, in __init__
    self._load_tool_panel()
  File "lib/galaxy/tools/toolbox/base.py", line 358, in _load_tool_panel
    self.__add_tool_to_tool_panel(section_val, section, section=True)
  File "lib/galaxy/tools/toolbox/base.py", line 278, in __add_tool_to_tool_panel
    related_tool = self._lineage_in_panel(panel_dict, tool=tool)
  File "lib/galaxy/tools/toolbox/base.py", line 961, in _lineage_in_panel
    lineage_tool_versions = reversed(tool_lineage.get_versions())
  File "lib/galaxy/tools/toolbox/lineages/interface.py", line 77, in get_versions
    return [ToolLineageVersion(tool_id, tool_version) for tool_id, tool_version in zip(self.tool_ids, self.tool_versions)]
  File "lib/galaxy/tools/toolbox/lineages/interface.py", line 55, in tool_ids
    return ["%s/%s" % (tool_id, version) for version in self.tool_versions]
  File "lib/galaxy/tools/toolbox/lineages/interface.py", line 49, in tool_versions
    return sorted(self._tool_versions, key=LooseVersion)
  File "/usr/lib/python3.4/distutils/version.py", line 58, in __lt__
    c = self._cmp(other)
  File "/usr/lib/python3.4/distutils/version.py", line 343, in _cmp
    if self.version < other.version:
TypeError: unorderable types: str() < int()
```

when a tool version contains a letter in the "wrong" place (e.g. in the first position).

Fix https://github.com/galaxyproject/galaxy/issues/5408 .