### PR TITLE
Eliminate precreated datasets concept in upload API.

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -103,15 +103,13 @@ class LibraryActions(object):
             message = "Unable to parse upload parameters, please report this error."
         # Proceed with (mostly) regular upload processing if we're still errorless
         if response_code == 200:
-            precreated_datasets = upload_common.get_precreated_datasets(trans, tool_params, trans.app.model.LibraryDatasetDatasetAssociation, controller=cntrller)
             if upload_option == 'upload_file':
                 tool_params = upload_common.persist_uploads(tool_params, trans)
-                uploaded_datasets = upload_common.get_uploaded_datasets(trans, cntrller, tool_params, precreated_datasets, dataset_upload_inputs, library_bunch=library_bunch)
+                uploaded_datasets = upload_common.get_uploaded_datasets(trans, cntrller, tool_params, dataset_upload_inputs, library_bunch=library_bunch)
             elif upload_option == 'upload_directory':
                 uploaded_datasets, response_code, message = self._get_server_dir_uploaded_datasets(trans, kwd, full_dir, import_dir_desc, library_bunch, response_code, message)
             elif upload_option == 'upload_paths':
                 uploaded_datasets, response_code, message = self._get_path_paste_uploaded_datasets(trans, kwd, library_bunch, response_code, message)
-            upload_common.cleanup_unused_precreated_datasets(precreated_datasets)
             if upload_option == 'upload_file' and not uploaded_datasets:
                 response_code = 400
                 message = 'Select a file, enter a URL or enter text'

--- a/lib/galaxy/tools/actions/upload.py
+++ b/lib/galaxy/tools/actions/upload.py
@@ -17,19 +17,17 @@ class UploadToolAction(ToolAction):
         assert dataset_upload_inputs, Exception("No dataset upload groups were found.")
 
         persisting_uploads_timer = ExecutionTimer()
-        precreated_datasets = upload_common.get_precreated_datasets(trans, incoming, trans.app.model.HistoryDatasetAssociation)
         incoming = upload_common.persist_uploads(incoming, trans)
         log.debug("Persisted uploads %s" % persisting_uploads_timer)
+        check_timer = ExecutionTimer()
         # We can pass an empty string as the cntrller here since it is used to check whether we
         # are in an admin view, and this tool is currently not used there.
-        check_and_cleanup_timer = ExecutionTimer()
-        uploaded_datasets = upload_common.get_uploaded_datasets(trans, '', incoming, precreated_datasets, dataset_upload_inputs, history=history)
-        upload_common.cleanup_unused_precreated_datasets(precreated_datasets)
+        uploaded_datasets = upload_common.get_uploaded_datasets(trans, '', incoming, dataset_upload_inputs, history=history)
 
         if not uploaded_datasets:
             return None, 'No data was entered in the upload form, please go back and choose data to upload.'
 
-        log.debug("Checked and cleaned uploads %s" % check_and_cleanup_timer)
+        log.debug("Checked uploads %s" % check_timer)
         create_job_timer = ExecutionTimer()
         json_file_path = upload_common.create_paramfile(trans, uploaded_datasets)
         data_list = [ud.data for ud in uploaded_datasets]

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -562,7 +562,7 @@ class UploadDataset(Group):
                         if meta_name in metadata_name_substition_default_dict:
                             meta_value = sanitize_for_filename(meta_value, default=metadata_name_substition_default_dict[meta_name])
                         dataset.metadata[meta_name] = meta_value
-            dataset.precreated_name = dataset.name = self.get_composite_dataset_name(context)
+            dataset.name = self.get_composite_dataset_name(context)
             if dataset.datatype.composite_type == 'auto_primary_file':
                 # replace sniff here with just creating an empty file
                 temp_name = sniff.stream_to_file(StringIO(d_type.generate_primary_file(dataset)), prefix='upload_auto_primary_file')

--- a/tools/data_source/upload.xml
+++ b/tools/data_source/upload.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<tool name="Upload File" id="upload1" version="1.1.4" workflow_compatible="false">
+<tool name="Upload File" id="upload1" version="1.1.5" workflow_compatible="false">
   <description>
     from your computer  
   </description>
@@ -28,7 +28,6 @@
         <filter type="add_value" name="Auto-detect" value="auto" index="0"/>
       </options>
     </param>
-    <param name="async_datasets" type="hidden" value="None"/>
     <param name="file_count" type="hidden" value="auto" />
     <upload_dataset name="files" title="Specify Files for Dataset" file_type_name="file_type" metadata_ref="files_metadata">
         <param name="file_data" type="file" size="30" label="File" ajax-upload="true" help="TIP: Due to browser limitations, uploading files larger than 2GB is guaranteed to fail.  To upload large files, use the URL method (below) or FTP (if enabled by the site administrator).">


### PR DESCRIPTION
Was used by the async controller in the past I think (https://github.com/galaxyproject/galaxy/blob/v13.01/lib/galaxy/webapps/galaxy/controllers/tool_runner.py#L256), but doesn't seem to be used now as far as I can tell.