### PR TITLE
[18.01] fix for cases where panel elements have to_dict with different signature

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -927,7 +927,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin, object):
             if elt:
                 yield elt
 
-    def _get_tool_to_dict(self, trans, tool):
+    def get_tool_to_dict(self, trans, tool):
         """Return tool's to_dict.
         Use cache if present, store to cache otherwise.
         Note: The cached tool's to_dict is specific to the calls from toolbox.
@@ -953,14 +953,19 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin, object):
         if in_panel:
             panel_elts = list(self.tool_panel_contents(trans, **kwds))
             for elt in panel_elts:
-                rval.append(self._get_tool_to_dict(trans, elt))
+                # Only use cache for galaxy.tools.Tool objects.
+                if elt.__class__.__name__ == 'Tool':
+                    rval.append(self.get_tool_to_dict(trans, elt))
+                else:
+                    kwargs = dict(trans=trans, link_details=True)
+                    rval.append(elt.to_dict(**kwargs))
         else:
             filter_method = self._build_filter_method(trans)
             for id, tool in self._tools_by_id.items():
                 tool = filter_method(tool, panel_item_types.TOOL)
                 if not tool:
                     continue
-                rval.append(self._get_tool_to_dict(trans, tool))
+                rval.append(self.get_tool_to_dict(trans, tool))
         return rval
 
     def _lineage_in_panel(self, panel_dict, tool=None, tool_lineage=None):

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -957,7 +957,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin, object):
                 if elt.__class__.__name__ == 'Tool':
                     rval.append(self.get_tool_to_dict(trans, elt))
                 else:
-                    kwargs = dict(trans=trans, link_details=True)
+                    kwargs = dict(trans=trans, link_details=True, toolbox=self)
                     rval.append(elt.to_dict(**kwargs))
         else:
             filter_method = self._build_filter_method(trans)

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -953,8 +953,8 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin, object):
         if in_panel:
             panel_elts = list(self.tool_panel_contents(trans, **kwds))
             for elt in panel_elts:
-                # Only use cache for galaxy.tools.Tool objects.
-                if elt.__class__.__name__ == 'Tool':
+                # Only use cache for objects that are Tools.
+                if hasattr(elt, "tool_type"):
                     rval.append(self.get_tool_to_dict(trans, elt))
                 else:
                     kwargs = dict(trans=trans, link_details=True, toolbox=self)

--- a/lib/galaxy/tools/toolbox/panel.py
+++ b/lib/galaxy/tools/toolbox/panel.py
@@ -79,7 +79,7 @@ class ToolSection(Dictifiable, HasPanelItems, object):
             link_details=link_details
         )
         for elt in self.elems.values():
-            if elt.__class__.__name__ == 'Tool' and toolbox:
+            if hasattr(elt, "tool_type") and toolbox:
                 section_elts.append(toolbox.get_tool_to_dict(trans, elt))
             else:
                 section_elts.append(elt.to_dict(**kwargs))

--- a/lib/galaxy/tools/toolbox/panel.py
+++ b/lib/galaxy/tools/toolbox/panel.py
@@ -69,7 +69,7 @@ class ToolSection(Dictifiable, HasPanelItems, object):
         copy.elems = self.elems.copy()
         return copy
 
-    def to_dict(self, trans, link_details=False):
+    def to_dict(self, trans, link_details=False, toolbox=None):
         """ Return a dict that includes section's attributes. """
 
         section_dict = super(ToolSection, self).to_dict()
@@ -79,8 +79,8 @@ class ToolSection(Dictifiable, HasPanelItems, object):
             link_details=link_details
         )
         for elt in self.elems.values():
-            if elt.__class__.__name__ == 'Tool':
-                section_elts.append(trans.app.toolbox.get_tool_to_dict(trans, elt))
+            if elt.__class__.__name__ == 'Tool' and toolbox:
+                section_elts.append(toolbox.get_tool_to_dict(trans, elt))
             else:
                 section_elts.append(elt.to_dict(**kwargs))
         section_dict['elems'] = section_elts

--- a/lib/galaxy/tools/toolbox/panel.py
+++ b/lib/galaxy/tools/toolbox/panel.py
@@ -79,7 +79,10 @@ class ToolSection(Dictifiable, HasPanelItems, object):
             link_details=link_details
         )
         for elt in self.elems.values():
-            section_elts.append(elt.to_dict(**kwargs))
+            if elt.__class__.__name__ == 'Tool':
+                section_elts.append(trans.app.toolbox.get_tool_to_dict(trans, elt))
+            else:
+                section_elts.append(elt.to_dict(**kwargs))
         section_dict['elems'] = section_elts
 
         return section_dict


### PR DESCRIPTION
we want to only cache Tools anyways, so this fixes other possible bug
where section/label etc would have same id as a Tool

The to_dict bug caused the following exception on Main, because it has a ToolSectionLabel element. No other env this was tested on had it.

```
TypeError: to_dict() takes exactly 1 argument (3 given)
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python2.7/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 35, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python2.7/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 136, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 215, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/root.py", line 110, in index
    config.update(self._get_extended_config(trans))
  File "galaxy/webapps/galaxy/controllers/root.py", line 58, in _get_extended_config
    'toolbox_in_panel'              : app.toolbox.to_dict(trans),
  File "galaxy/tools/toolbox/base.py", line 956, in to_dict
    rval.append(self._get_tool_to_dict(trans, elt))
  File "galaxy/tools/toolbox/base.py", line 938, in _get_tool_to_dict
    to_dict = tool.to_dict(trans, link_details=True)
```