### PR TITLE
[17.09] Move `Extract genomic DNA 1` to list of versioned galaxy tools requiring galaxy to be importable

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -109,7 +109,6 @@ GALAXY_LIB_TOOLS_UNVERSIONED = [
     "join1",
     "gff2bed1",
     "gff_filter_by_feature_count",
-    "Extract genomic DNA 1",
     "aggregate_scores_in_intervals2",
     "Interval_Maf_Merged_Fasta2",
     "GeneBed_Maf_Fasta2",
@@ -164,6 +163,7 @@ GALAXY_LIB_TOOLS_VERSIONED = {
     "sam_to_bam": LooseVersion("1.1.3"),
     "PEsortedSAM2readprofile": LooseVersion("1.1.1"),
     "fetchflank": LooseVersion("1.0.1"),
+    "Extract genomic DNA 1": LooseVersion("3.0.0"),
 }
 
 


### PR DESCRIPTION
This tool also exists on the TS, and that version works without requiring galaxy to be importable.
xref https://github.com/galaxyproject/tools-iuc/pull/1750