### PR TITLE
[18.01] Remove href from grid sorting links

### DIFF
--- a/client/galaxy/scripts/mvc/grid/grid-template.js
+++ b/client/galaxy/scripts/mvc/grid/grid-template.js
@@ -92,8 +92,8 @@ export default {
         for (let column of options.columns) {
             if (column.visible) {
                 tmpl += `<th id="${column.key}-header">`;
-                if (column.href) {
-                    tmpl += `<a href="${column.href}" class="sort-link" sort_key="${column.key}">${column.label}</a>`;
+                if (column.sortable) {
+                    tmpl += `<a href="javascript:void(0)" class="sort-link" sort_key="${column.key}">${column.label}</a>`;
                 } else {
                     tmpl += column.label;
                 }

--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -286,8 +286,6 @@ class Grid(object):
                         extra = "&darr;"
                     else:
                         extra = "&uarr;"
-                else:
-                    href = url(sort=column.key)
             grid_config['columns'].append({
                 'key'               : column.key,
                 'visible'           : column.visible,

--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -279,15 +279,12 @@ class Grid(object):
         if current_item:
             grid_config['current_item_id'] = current_item.id
         for column in self.columns:
-            href = None
             extra = ''
             if column.sortable:
                 if sort_key.endswith(column.key):
                     if not sort_key.startswith("-"):
-                        href = url(sort=("-" + column.key))
                         extra = "&darr;"
                     else:
-                        href = url(sort=(column.key))
                         extra = "&uarr;"
                 else:
                     href = url(sort=column.key)
@@ -301,7 +298,6 @@ class Grid(object):
                 'label'             : column.label,
                 'filterable'        : column.filterable,
                 'is_text'           : isinstance(column, TextColumn),
-                'href'              : href,
                 'extra'             : extra
             })
         for operation in self.operations:


### PR DESCRIPTION
Users should not be able to left-click on the column sorting links in grid headers and then open them in a new tab. By now all sorting is done asynchronously. If opened in a new tab a json response dictionary is shown instead of the resorted grid. This is a fallout from the previous legacy handling.