### PR TITLE
[17.09] Backport of #5043

### DIFF
--- a/tools/stats/gsummary.py
+++ b/tools/stats/gsummary.py
@@ -59,7 +59,7 @@ def main():
         except:
             pass
 
-    tmp_file = tempfile.NamedTemporaryFile('w+b')
+    tmp_file = tempfile.NamedTemporaryFile('w+')
     # Write the R header row to the temporary file
     hdr_str = "\t".join("c%s" % str(col + 1) for col in cols)
     tmp_file.write("%s\n" % hdr_str)


### PR DESCRIPTION
Backport of https://github.com/galaxyproject/galaxy/pull/5043, requested by @Petraea in https://github.com/galaxyproject/galaxy/pull/5606#issuecomment-369959945.

Under Python3, strings can not be written to byte mode file handlers.
writing resulted in:
TypeError: a bytes-like object is required, not 'str'