### PR TITLE
Add a FilterEmptyDatasetsTool and allow filtering tools to apply to arbitrary collection structures

### DIFF
--- a/config/tool_conf.xml.sample
+++ b/config/tool_conf.xml.sample
@@ -29,6 +29,7 @@
     <tool file="${model_tools_path}/unzip_collection.xml" />
     <tool file="${model_tools_path}/zip_collection.xml" />
     <tool file="${model_tools_path}/filter_failed_collection.xml" />
+    <tool file="${model_tools_path}/filter_empty_collection.xml" />
     <tool file="${model_tools_path}/flatten_collection.xml" />
     <tool file="${model_tools_path}/merge_collection.xml" />
     <tool file="${model_tools_path}/relabel_from_file.xml" />

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2528,7 +2528,7 @@ class FilterFailedDatasetsTool(DatabaseOperationTool):
 
             # dealing with a single element
             if hasattr(element, "is_ok"):
-                if element.is_ok:
+                if element.is_ok and element.has_data():
                     valid = True
             elif hasattr(element, "dataset_instances"):
                 # we are probably a list:paired dataset, both need to be in non error state

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2510,12 +2510,7 @@ class MergeCollectionTool(DatabaseOperationTool):
         )
 
 
-class FilterFailedDatasetsTool(DatabaseOperationTool):
-    tool_type = 'filter_failed_datasets_collection'
-    require_dataset_ok = False
-
-    def element_is_valid(self, element):
-        return element.element_object.is_ok
+class FilterDatasetsTool(DatabaseOperationTool):
 
     def get_new_elements(self, history, elements_to_copy):
         new_elements = odict()
@@ -2559,8 +2554,17 @@ class FilterFailedDatasetsTool(DatabaseOperationTool):
         )
 
 
-class FilterEmptyDatasetsTool(DatabaseOperationTool):
+class FilterFailedDatasetsTool(FilterDatasetsTool):
+    tool_type = 'filter_failed_datasets_collection'
+    require_dataset_ok = False
+
+    def element_is_valid(self, element):
+        return element.element_object.is_ok
+
+
+class FilterEmptyDatasetsTool(FilterDatasetsTool):
     tool_type = 'filter_empty_datasets_collection'
+    require_dataset_ok = False
 
     def element_is_valid(self, element):
         return element.element_object.has_data()

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2530,10 +2530,10 @@ class FilterDatasetsTool(DatabaseOperationTool):
             elements = collection.element_object.elements
             collection_type = collection.element_object.collection_type
         else:
-            # A pair
+            # A list of pairs
             elements = collection.collection.elements
             collection_type = collection.collection.collection_type
-        # We only process list or paired collections. Higher order collection will be mapped over
+        # We only process list or list of pair collections. Higher order collection will be mapped over
         assert collection_type in ("list", "list:paired")
 
         elements_to_copy = []

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2512,7 +2512,7 @@ class MergeCollectionTool(DatabaseOperationTool):
 
 class FilterDatasetsTool(DatabaseOperationTool):
 
-    def get_new_elements(self, history, elements_to_copy):
+    def _get_new_elements(self, history, elements_to_copy):
         new_elements = odict()
         for dce in elements_to_copy:
             element_identifier = dce.element_identifier
@@ -2544,7 +2544,7 @@ class FilterDatasetsTool(DatabaseOperationTool):
                 # One of the pairs is not OK, skip creating output for this pair
                 return
 
-        new_elements = self.get_new_elements(elements_to_copy=elements_to_copy, history=history)
+        new_elements = self._get_new_elements(history=history, elements_to_copy=elements_to_copy)
 
         output_collections.create_collection(
             next(iter(self.outputs.values())),

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2516,6 +2516,7 @@ class FilterFailedDatasetsTool(DatabaseOperationTool):
 
     def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
         hdca = incoming["input"]
+        remove_empty = incoming["remove_empty"]
 
         assert hdca.collection.collection_type == "list" or hdca.collection.collection_type == 'list:paired'
 
@@ -2528,13 +2529,21 @@ class FilterFailedDatasetsTool(DatabaseOperationTool):
 
             # dealing with a single element
             if hasattr(element, "is_ok"):
-                if element.is_ok and element.has_data():
-                    valid = True
+                if remove_empty == "Yes":
+                    if element.is_ok and element.has_data():
+                        valid = True
+                elif remove_empty == "No":
+                    if element.is_ok :
+                        valid = True
             elif hasattr(element, "dataset_instances"):
                 # we are probably a list:paired dataset, both need to be in non error state
                 forward_o, reverse_o = element.dataset_instances
-                if forward_o.is_ok and reverse_o.is_ok:
-                    valid = True
+                if remove_empty == "Yes":
+                    if forward_o.is_ok and reverse_o.is_ok and forward_o.has_data() and reverse_o.has_data():
+                        valid = True
+                elif remove_empty == "No":
+                    if forward_o.is_ok and reverse_o.is_ok:
+                        valid = True
 
             if valid:
                 element_identifier = dce.element_identifier

--- a/lib/galaxy/tools/filter_empty_collection.xml
+++ b/lib/galaxy/tools/filter_empty_collection.xml
@@ -1,0 +1,41 @@
+<tool id="__FILTER_EMPTY_DATASETS__"
+      name="Filter empty"
+      version="1.0.0"
+      tool_type="filter_empty_datasets_collection">
+    <description>datasets from a collection</description>
+    <type class="FilterEmptyDatasetsTool" module="galaxy.tools" />
+    <action module="galaxy.tools.actions.model_operations"
+            class="ModelOperationToolAction"/>
+    <inputs>
+        <param type="data_collection" collection_type="list,paired" name="input" label="Input Collection" />
+    </inputs>
+    <outputs>
+        <collection name="output" format_source="input" type_source="input" label="${on_string} (filtered empty datasets)" >
+        </collection>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input">
+                <collection type="list">
+                    <element name="e1" value="simple_line.txt" />
+                </collection>
+            </param>
+            <output_collection name="output" type="list" count="1">
+                <element name="e1">
+                  <assert_contents>
+                      <has_text_matching expression="^This is a line of text.\n$" />
+                  </assert_contents>
+                </element>
+            </output_collection>
+        </test>
+    </tests>
+    <help><![CDATA[
+
+This tool takes a list dataset collection and filters out empty datasets. This is useful for continuing a multi-sample analysis when downstream tools require datasets to have content.
+
+.. class:: infomark
+
+This tool will create new history datasets from your collection but your quota usage will not increase.
+
+      ]]></help>
+</tool>

--- a/lib/galaxy/tools/filter_empty_collection.xml
+++ b/lib/galaxy/tools/filter_empty_collection.xml
@@ -7,7 +7,7 @@
     <action module="galaxy.tools.actions.model_operations"
             class="ModelOperationToolAction"/>
     <inputs>
-        <param type="data_collection" collection_type="list,paired" name="input" label="Input Collection" />
+        <param type="data_collection" collection_type="list,list:paired" name="input" label="Input Collection" />
     </inputs>
     <outputs>
         <collection name="output" format_source="input" type_source="input" label="${on_string} (filtered empty datasets)" >

--- a/lib/galaxy/tools/filter_empty_collection.xml
+++ b/lib/galaxy/tools/filter_empty_collection.xml
@@ -31,7 +31,7 @@
     </tests>
     <help><![CDATA[
 
-This tool takes a list dataset collection and filters out empty datasets. This is useful for continuing a multi-sample analysis when downstream tools require datasets to have content.
+This tool takes a dataset collection and filters out empty datasets. This is useful for continuing a multi-sample analysis when downstream tools require datasets to have content.
 
 .. class:: infomark
 

--- a/lib/galaxy/tools/filter_failed_collection.xml
+++ b/lib/galaxy/tools/filter_failed_collection.xml
@@ -7,7 +7,7 @@
     <action module="galaxy.tools.actions.model_operations"
             class="ModelOperationToolAction"/>
     <inputs>
-        <param type="data_collection" collection_type="list,paired" name="input" label="Input Collection" />
+        <param type="data_collection" collection_type="list,list:paired" name="input" label="Input Collection" />
     </inputs>
     <outputs>
         <collection name="output" format_source="input" type_source="input" label="${on_string} (filtered failed datasets)" >

--- a/lib/galaxy/tools/filter_failed_collection.xml
+++ b/lib/galaxy/tools/filter_failed_collection.xml
@@ -8,6 +8,10 @@
             class="ModelOperationToolAction"/>
     <inputs>
         <param type="data_collection" name="input" label="Input Collection" />
+        <param type="select" name="remove_empty" label="Remove also empty files" help="Selecting yes will also remove empty files from the collection">
+            <option value="Yes">Yes</option>
+            <option value="No" selected="true">No</option>
+        </param>
     </inputs>
     <outputs>
         <collection name="output" format_source="input" type_source="input" label="${on_string} (filtered failed datasets)" >

--- a/lib/galaxy/tools/filter_failed_collection.xml
+++ b/lib/galaxy/tools/filter_failed_collection.xml
@@ -2,7 +2,7 @@
       name="Filter failed"
       version="1.0.0"
       tool_type="filter_failed_datasets_collection">
-    <description>datasets from a list</description>
+    <description>datasets from a collection</description>
     <type class="FilterFailedDatasetsTool" module="galaxy.tools" />
     <action module="galaxy.tools.actions.model_operations"
             class="ModelOperationToolAction"/>
@@ -36,7 +36,7 @@
     </tests>
     <help><![CDATA[
 
-This tool takes a list dataset collection and filters out datasets in the failed state. This is useful for continuing a multi-sample analysis when one of more of the samples fails at some point.
+This tool takes a dataset collection and filters out datasets in the failed state. This is useful for continuing a multi-sample analysis when one of more of the samples fails at some point.
 
 .. class:: infomark
 

--- a/lib/galaxy/tools/filter_failed_collection.xml
+++ b/lib/galaxy/tools/filter_failed_collection.xml
@@ -7,11 +7,7 @@
     <action module="galaxy.tools.actions.model_operations"
             class="ModelOperationToolAction"/>
     <inputs>
-        <param type="data_collection" name="input" label="Input Collection" />
-        <param type="select" name="remove_empty" label="Remove also empty files" help="Selecting yes will also remove empty files from the collection">
-            <option value="Yes">Yes</option>
-            <option value="No" selected="true">No</option>
-        </param>
+        <param type="data_collection" collection_type="list,paired" name="input" label="Input Collection" />
     </inputs>
     <outputs>
         <collection name="output" format_source="input" type_source="input" label="${on_string} (filtered failed datasets)" >

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -183,6 +183,7 @@
   <tool file="${model_tools_path}/unzip_collection.xml" />
   <tool file="${model_tools_path}/zip_collection.xml" />
   <tool file="${model_tools_path}/filter_failed_collection.xml" />
+  <tool file="${model_tools_path}/filter_empty_collection.xml" />
   <tool file="${model_tools_path}/flatten_collection.xml" />
   <tool file="${model_tools_path}/sort_collection_list.xml" />
   <tool file="${model_tools_path}/merge_collection.xml" />


### PR DESCRIPTION
Hello,

Here is an extra-condition for the tool ``FilterFailedDatasetsTool`` to allow it to remove empty datasets as well as failed datasets in a collection. I tested it on my data and it seems to work fine. Since it's my first time looking at galaxy's source code, I don't know if there is a proper way to do that ... And I didn't make the improvement for paired datasets because I don't have proper data to test it. But I assume it would be something like ``if forward_o.is_ok and reverse_o.is_ok and forward_o.has_data() and reverse_o.has_data():`` ?