### PR TITLE
[18.01] Consistent sniffing regardless of in_place.

### DIFF
--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -290,7 +290,7 @@ def add_file(dataset, registry, json_file, output_path):
                         else:
                             line_count, converted_path = sniff.convert_newlines(dataset.path, in_place=in_place, tmp_dir=tmpdir, tmp_prefix=tmp_prefix)
                 if dataset.file_type == 'auto':
-                    ext = sniff.guess_ext(dataset.path, registry.sniff_order)
+                    ext = sniff.guess_ext(converted_path or dataset.path, registry.sniff_order)
                 else:
                     ext = dataset.file_type
                 data_type = ext


### PR DESCRIPTION
Previously sniffing would happen on the original file (before carriage returns and tabular spaces were converted) if `in_place` was false and on the converted file if it was true. This fixes it to always sniff the converted file - which I think is the right call (at least in the case of Mac OS CSV files that I am chasing down as part of #5220).