### PR TITLE
[18.01] Do not sniff BamInputSorted

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -499,6 +499,10 @@ class BamInputSorted(BamNative):
     This notaby keeps alignments produced by paired end sequencing adjacent.
     """
 
+    def sniff(self, file_name):
+        # We never want to sniff to this datatype
+        return False
+
     def dataset_content_needs_grooming(self, file_name):
         """
         Groom if the file is coordinate sorted


### PR DESCRIPTION
Only aligners should produce this datatype. If an alignment
is not explicitly coordinate or queryname sorted it should
be BamNative.
Also addresses https://github.com/galaxyproject/galaxy/pull/5628#issuecomment-370874329,
though I think the sniff order should be dependent on the order with which
datatypes are loaded.