### PR TITLE
Bring in the latest galaxy-lib updates.

### DIFF
--- a/lib/galaxy/tools/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tools/deps/mulled/mulled_build.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 from sys import platform as _platform
 
+from six.moves import shlex_quote
 try:
     import yaml
 except ImportError:
@@ -47,6 +48,7 @@ DEFAULT_WORKING_DIR = '/source/'
 IS_OS_X = _platform == "darwin"
 INVOLUCRO_VERSION = "1.1.2"
 DEST_BASE_IMAGE = os.environ.get('DEST_BASE_IMAGE', None)
+CONDA_IMAGE = os.environ.get('CONDA_IMAGE', None)
 
 SINGULARITY_TEMPLATE = """Bootstrap: docker
 From: bgruening/busybox-bash:0.1
@@ -195,7 +197,7 @@ def mull_targets(
     involucro_args = [
         '-f', '%s/invfile.lua' % DIRNAME,
         '-set', "CHANNELS='%s'" % channels,
-        '-set', "TEST='%s'" % test,
+        '-set', "TEST=%s" % shlex_quote(test),
         '-set', "TARGETS='%s'" % target_str,
         '-set', "REPO='%s'" % repo,
         '-set', "BINDS='%s'" % bind_str,
@@ -203,6 +205,8 @@ def mull_targets(
 
     if DEST_BASE_IMAGE:
         involucro_args.extend(["-set", "DEST_BASE_IMAGE='%s'" % DEST_BASE_IMAGE])
+    if CONDA_IMAGE:
+        involucro_args.extend(["-set", "CONDA_IMAGE='%s'" % CONDA_IMAGE])
     if verbose:
         involucro_args.extend(["-set", "VERBOSE='1'"])
     if singularity:

--- a/lib/galaxy/tools/verify/asserts/__init__.py
+++ b/lib/galaxy/tools/verify/asserts/__init__.py
@@ -2,6 +2,8 @@ import inspect
 import logging
 import sys
 
+from galaxy.util import unicodify
+
 log = logging.getLogger(__name__)
 
 assertion_module_names = ['text', 'tabular', 'xml']
@@ -66,7 +68,11 @@ def verify_assertion(data, assertion_description):
     # - <has_column_titles><with_name name="sequence"><with_name
     # name="probability"></has_column_titles>.)
     if "output" in assert_function_args:
-        args["output"] = data
+        # This was read in as bytes for checksum and such, but all current
+        # assertions expect text data. If binary assertions are added at
+        # some point, just checkout for "output_bytes" for instance and pass
+        # data in unchanged.
+        args["output"] = unicodify(data)
 
     if "verify_assertions_function" in assert_function_args:
         args["verify_assertions_function"] = verify_assertions

--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -6,7 +6,10 @@ import errno
 import imp
 import logging
 from functools import partial
-from grp import getgrgid
+try:
+    from grp import getgrgid
+except ImportError:
+    getgrgid = None
 from itertools import starmap
 from operator import getitem
 from os import (
@@ -28,7 +31,10 @@ from os.path import (
     relpath,
     sep as separator,
 )
-from pwd import getpwuid
+try:
+    from pwd import getpwuid
+except ImportError:
+    getpwuid = None
 
 from six import iteritems, string_types
 from six.moves import filter, map, zip
@@ -165,6 +171,9 @@ def __path_permission_for_user(path, username):
     :type username:     string
     :param username:    a username matching the systems username
     """
+    if getpwuid is None:
+        raise NotImplementedError("This functionality is not implemented for Windows.")
+
     group_id_of_file = stat(path).st_gid
     file_owner = getpwuid(stat(path).st_uid)
     group_members = getgrgid(group_id_of_file).gr_mem


### PR DESCRIPTION
These fixes include:

- Python 3 fix for assertion testing code (https://github.com/galaxyproject/galaxy-lib/pull/101). xref #1715
- Mulled enhancement to escape quotes in test code for mulled images - https://github.com/galaxyproject/galaxy-lib/pull/100.
- Mulled enhancement to make ``CONDA_IMAGE`` configurable - https://github.com/galaxyproject/galaxy-lib/pull/99.
- Fix galaxy.util.path for import on Windows (https://github.com/galaxyproject/galaxy-lib/pull/98).