### PR TITLE
Disable tool input datatype validation for dropped history items

### DIFF
--- a/client/galaxy/scripts/mvc/collection/collection-view.js
+++ b/client/galaxy/scripts/mvc/collection/collection-view.js
@@ -32,7 +32,7 @@ var CollectionView = _super.extend(
         initialize: function(attributes) {
             _super.prototype.initialize.call(this, attributes);
             this.linkTarget = attributes.linkTarget || "_blank";
-
+            this.dragItems = true;
             this.hasUser = attributes.hasUser;
             /** A stack of panels that currently cover or hide this panel */
             this.panelStack = [];

--- a/client/galaxy/scripts/mvc/ui/ui-select-content.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-content.js
@@ -414,9 +414,25 @@ var View = Backbone.View.extend({
             var field = this.fields[current];
             var drop_data = JSON.parse(ev.originalEvent.dataTransfer.getData("text"))[0];
             var new_id = drop_data.id;
+            var new_hid = drop_data.hid;
+            var new_name = drop_data.name;
             var new_src = drop_data.history_content_type == "dataset" ? "hda" : "hdca";
             var new_value = { id: new_id, src: new_src };
-            if (data && _.findWhere(data[new_src], new_value)) {
+            if (data) {
+
+                if (!_.findWhere(data[new_src], new_value)) {
+                    window.console.log(drop_data);
+                    data[new_src].push({
+                        id: new_id,
+                        hid: new_hid || "Dropped",
+                        name: new_hid ? new_name : new_id,
+                        keep: true,
+                        tags: []
+                    });
+                    this._changeData();
+                }
+
+
                 if (config.src == new_src) {
                     var current_value = field.value();
                     if (current_value && config.multiple) {

--- a/client/galaxy/scripts/mvc/ui/ui-select-content.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-content.js
@@ -416,7 +416,7 @@ var View = Backbone.View.extend({
             var new_id = drop_data.id;
             var new_src = drop_data.history_content_type == "dataset_collection" ? "hdca" : "hda";
             var new_value = { id: new_id, src: new_src };
-            if (data) {
+            if (data && drop_data.history_id) {
                 if (!_.findWhere(data[new_src], new_value)) {
                     data[new_src].push({
                         id: new_id,

--- a/client/galaxy/scripts/mvc/ui/ui-select-content.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-content.js
@@ -414,25 +414,19 @@ var View = Backbone.View.extend({
             var field = this.fields[current];
             var drop_data = JSON.parse(ev.originalEvent.dataTransfer.getData("text"))[0];
             var new_id = drop_data.id;
-            var new_hid = drop_data.hid;
-            var new_name = drop_data.name;
             var new_src = drop_data.history_content_type == "dataset" ? "hda" : "hdca";
             var new_value = { id: new_id, src: new_src };
             if (data) {
-
                 if (!_.findWhere(data[new_src], new_value)) {
-                    window.console.log(drop_data);
                     data[new_src].push({
                         id: new_id,
-                        hid: new_hid || "Dropped",
-                        name: new_hid ? new_name : new_id,
+                        hid: drop_data.hid || "Dropped",
+                        name: drop_data.hid ? drop_data.name : new_id,
                         keep: true,
                         tags: []
                     });
                     this._changeData();
                 }
-
-
                 if (config.src == new_src) {
                     var current_value = field.value();
                     if (current_value && config.multiple) {

--- a/client/galaxy/scripts/mvc/ui/ui-select-content.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-content.js
@@ -414,7 +414,7 @@ var View = Backbone.View.extend({
             var field = this.fields[current];
             var drop_data = JSON.parse(ev.originalEvent.dataTransfer.getData("text"))[0];
             var new_id = drop_data.id;
-            var new_src = drop_data.history_content_type == "dataset" ? "hda" : "hdca";
+            var new_src = drop_data.history_content_type == "dataset_collection" ? "hdca" : "hda";
             var new_value = { id: new_id, src: new_src };
             if (data) {
                 if (!_.findWhere(data[new_src], new_value)) {

--- a/client/galaxy/scripts/mvc/ui/ui-select-content.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-content.js
@@ -420,6 +420,7 @@ var View = Backbone.View.extend({
                 if (!_.findWhere(data[new_src], new_value)) {
                     data[new_src].push({
                         id: new_id,
+                        src: new_src,
                         hid: drop_data.hid || "Dropped",
                         name: drop_data.hid ? drop_data.name : new_id,
                         keep: true,


### PR DESCRIPTION
This is equivalent to #5384. It disables the client-sided datatype input validation for items dropped from the history. Side effects include that dropped items may show the info label "unavailable" which previously indicated that a dataset is not available anymore. Additionally dropped items will be shown with preliminary attributes first before attributes can be updated through the backend. The consensus is that the benefit of dropping datasets contained in collections outweighs the disadvantages. ping @jmchilton. Can you help test this to make sure it behaves the same as #5384? Thanks in advance.