### PR TITLE
Add buffer-size to galaxy.yml.sample

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -23,6 +23,11 @@ uwsgi:
   # ':8080' to listen on all available network interfaces.
   http: 127.0.0.1:8080
 
+  # By default uWSGI allocates a very small buffer (4096 bytes) for the headers
+  # of each request. If you start receiving “invalid request block size” in
+  # your logs, it could mean you need a bigger buffer. Increase it up to 65535.
+  buffer-size: 4096
+
   # Number of web server (worker) processes to fork after the
   # application has loaded.
   processes: 1

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -23,9 +23,10 @@ uwsgi:
   # ':8080' to listen on all available network interfaces.
   http: 127.0.0.1:8080
 
-  # By default uWSGI allocates a very small buffer (4096 bytes) for the headers
-  # of each request. If you start receiving "invalid request block size" in
-  # your logs, it could mean you need a bigger buffer. Increase it up to 65535.
+  # By default uWSGI allocates a very small buffer (4096 bytes) for the
+  # headers of each request. If you start receiving "invalid request
+  # block size" in your logs, it could mean you need a bigger buffer.
+  # Increase it up to 65535. buffer-size: 4096
   buffer-size: 4096
 
   # Number of web server (worker) processes to fork after the

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -26,7 +26,7 @@ uwsgi:
   # By default uWSGI allocates a very small buffer (4096 bytes) for the
   # headers of each request. If you start receiving "invalid request
   # block size" in your logs, it could mean you need a bigger buffer.
-  # Increase it up to 65535. buffer-size: 4096
+  # Increase it up to 65535.
   buffer-size: 4096
 
   # Number of web server (worker) processes to fork after the

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -24,7 +24,7 @@ uwsgi:
   http: 127.0.0.1:8080
 
   # By default uWSGI allocates a very small buffer (4096 bytes) for the headers
-  # of each request. If you start receiving “invalid request block size” in
+  # of each request. If you start receiving "invalid request block size" in
   # your logs, it could mean you need a bigger buffer. Increase it up to 65535.
   buffer-size: 4096
 

--- a/config/reports.yml.sample
+++ b/config/reports.yml.sample
@@ -8,7 +8,7 @@ uwsgi:
   # By default uWSGI allocates a very small buffer (4096 bytes) for the
   # headers of each request. If you start receiving "invalid request
   # block size" in your logs, it could mean you need a bigger buffer.
-  # Increase it up to 65535. buffer-size: 4096
+  # Increase it up to 65535.
   buffer-size: 4096
 
   # Number of web server (worker) processes to fork after the

--- a/config/reports.yml.sample
+++ b/config/reports.yml.sample
@@ -5,6 +5,12 @@ uwsgi:
   # ':9001' to listen on all available network interfaces.
   http: 127.0.0.1:9001
 
+  # By default uWSGI allocates a very small buffer (4096 bytes) for the
+  # headers of each request. If you start receiving "invalid request
+  # block size" in your logs, it could mean you need a bigger buffer.
+  # Increase it up to 65535. buffer-size: 4096
+  buffer-size: 4096
+
   # Number of web server (worker) processes to fork after the
   # application has loaded.
   processes: 1

--- a/config/tool_shed.yml.sample
+++ b/config/tool_shed.yml.sample
@@ -8,7 +8,7 @@ uwsgi:
   # By default uWSGI allocates a very small buffer (4096 bytes) for the
   # headers of each request. If you start receiving "invalid request
   # block size" in your logs, it could mean you need a bigger buffer.
-  # Increase it up to 65535. buffer-size: 4096
+  # Increase it up to 65535.
   buffer-size: 4096
 
   # Number of web server (worker) processes to fork after the

--- a/config/tool_shed.yml.sample
+++ b/config/tool_shed.yml.sample
@@ -5,6 +5,12 @@ uwsgi:
   # ':9009' to listen on all available network interfaces.
   http: 127.0.0.1:9009
 
+  # By default uWSGI allocates a very small buffer (4096 bytes) for the
+  # headers of each request. If you start receiving "invalid request
+  # block size" in your logs, it could mean you need a bigger buffer.
+  # Increase it up to 65535. buffer-size: 4096
+  buffer-size: 4096
+
   # Number of web server (worker) processes to fork after the
   # application has loaded.
   processes: 1

--- a/lib/galaxy/webapps/config_manage.py
+++ b/lib/galaxy/webapps/config_manage.py
@@ -55,7 +55,7 @@ UWSGI_OPTIONS = OrderedDict([
         'type': 'str',
     }),
     ('buffer-size', {
-        'desc': """By default uWSGI allocates a very small buffer (4096 bytes) for the headers of each request. If you start receiving "invalid request block size" in your logs, it could mean you need a bigger buffer. Increase it up to 65535. buffer-size: 4096""",
+        'desc': """By default uWSGI allocates a very small buffer (4096 bytes) for the headers of each request. If you start receiving "invalid request block size" in your logs, it could mean you need a bigger buffer. Increase it up to 65535.""",
         'default': '4096',
         'type': 'int',
     }),

--- a/lib/galaxy/webapps/config_manage.py
+++ b/lib/galaxy/webapps/config_manage.py
@@ -54,6 +54,11 @@ UWSGI_OPTIONS = OrderedDict([
         'default': '127.0.0.1:$default_port',
         'type': 'str',
     }),
+    ('buffer-size', {
+        'desc': """By default uWSGI allocates a very small buffer (4096 bytes) for the headers of each request. If you start receiving "invalid request block size" in your logs, it could mean you need a bigger buffer. Increase it up to 65535. buffer-size: 4096""",
+        'default': '4096',
+        'type': 'int',
+    }),
     ('processes', {
         'desc': """Number of web server (worker) processes to fork after the application has loaded.""",
         'default': '1',


### PR DESCRIPTION
Bumped into "invalid request block size" message locally. Increasing buffer-size solved it for me.