### PR TITLE
[18.01] Fix exception if user preference value undefined

### DIFF
--- a/lib/galaxy/tools/toolbox/filters/__init__.py
+++ b/lib/galaxy/tools/toolbox/filters/__init__.py
@@ -34,7 +34,7 @@ class FilterFactory(object):
         filters = deepcopy(self.default_filters)
         if trans.user:
             for name, value in trans.user.preferences.items():
-                if value.strip():
+                if value and value.strip():
                     user_filters = listify(value, do_strip=True)
                     category = ''
                     if name == 'toolbox_tool_filters':


### PR DESCRIPTION
Fixes the following traceback on main:
```
AttributeError: 'NoneType' object has no attribute 'strip'
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python2.7/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 35, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python2.7/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 136, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 215, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/root.py", line 110, in index
    config.update(self._get_extended_config(trans))
  File "galaxy/webapps/galaxy/controllers/root.py", line 57, in _get_extended_config
    'toolbox'                       : app.toolbox.to_dict(trans, in_panel=False),
  File "galaxy/tools/toolbox/base.py", line 963, in to_dict
    filter_method = self._build_filter_method(trans)
  File "galaxy/tools/toolbox/base.py", line 1004, in _build_filter_method
    filters = self._filter_factory.build_filters(trans)
  File "galaxy/tools/toolbox/filters/__init__.py", line 37, in build_filters
    if value.strip():
```