### PR TITLE
[18.01] Fix exception if email is not specified or email is wrong

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -936,6 +936,9 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Create
         else:
             # Find the user
             user = trans.sa_session.query(trans.app.model.User).filter(trans.app.model.User.table.c.email == email).first()
+            if not user:
+                # Probably wrong email address
+                return trans.show_error_message("You are using an invalid activation link. Try to log in and we will send you a new activation email. <br><a href='%s'>Go to login page.</a>") % web.url_for(controller="root", action="index")
             # If the user is active already don't try to activate
             if user.active is True:
                 return trans.show_ok_message("Your account is already active. Nothing has changed. <br><a href='%s'>Go to login page.</a>") % web.url_for(controller='root', action='index')

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -925,7 +925,9 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Create
         Check whether token fits the user and then activate the user's account.
         """
         params = util.Params(kwd, sanitize=False)
-        email = unquote(params.get('email', None))
+        email = params.get('email', None)
+        if email is not None:
+            email = unquote(email)
         activation_token = params.get('activation_token', None)
 
         if email is None or activation_token is None:


### PR DESCRIPTION
We render a regular error a few lines lower.

The traceback is:
```
AttributeError: 'NoneType' object has no attribute 'split'
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python2.7/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 35, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python2.7/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 136, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 215, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/user.py", line 928, in activate
    email = unquote(params.get('email', None))
  File "python2.7/urllib.py", line 1238, in unquote
    bits = s.split('%')
```