### PR TITLE
[18.01] Rename datatype extension 'bam_native' to 'unsorted.bam'.

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -21,7 +21,7 @@
     </datatype>
     <datatype extension="qname_sorted.bam" type="galaxy.datatypes.binary:BamQuerynameSorted" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension and sorted by queryname." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM">
     </datatype>
-    <datatype extension="bam_native" type="galaxy.datatypes.binary:BamNative" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM">
+    <datatype extension="unsorted.bam" type="galaxy.datatypes.binary:BamNative" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM">
       <converter file="bam_to_bigwig_converter.xml" target_datatype="bigwig"/>
       <converter file="to_coordinate_sorted_bam.xml" target_datatype="bam"/>
       <converter file="to_qname_sorted_bam.xml" target_datatype="qname_sorted.bam"/>
@@ -297,7 +297,7 @@
     <datatype extension="qual454" type="galaxy.datatypes.qualityscore:QualityScore454" display_in_upload="true"/>
     <datatype extension="roadmaps" type="galaxy.datatypes.assembly:Roadmaps" display_in_upload="false"/>
     <datatype extension="sam" type="galaxy.datatypes.tabular:Sam" display_in_upload="true">
-        <converter file="sam_to_bam_native.xml" target_datatype="bam_native"/>
+        <converter file="sam_to_unsorted_bam.xml" target_datatype="unsorted.bam"/>
         <converter file="to_coordinate_sorted_bam.xml" target_datatype="bam"/>
         <converter file="to_qname_sorted_bam.xml" target_datatype="qname_sorted.bam"/>
         <converter file="sam_to_bigwig_converter.xml" target_datatype="bigwig"/>

--- a/doc/source/releases/18.01.rst
+++ b/doc/source/releases/18.01.rst
@@ -1181,4 +1181,4 @@ Fixes
 .. _Pull Request 5663: https://github.com/galaxyproject/galaxy/pull/5663
 .. _Pull Request 5664: https://github.com/galaxyproject/galaxy/pull/5664
 .. _Pull Request 5665: https://github.com/galaxyproject/galaxy/pull/5665
-
+.. _Pull Request 5674: https://github.com/galaxyproject/galaxy/pull/5674

--- a/doc/source/releases/18.01_announce.rst
+++ b/doc/source/releases/18.01_announce.rst
@@ -55,7 +55,7 @@ Highlights
   A huge thanks goes out to `@bgruening <https://github.com/bgruening>`__ and `@mvdbeek <https://github.com/mvdbeek>`__ who
   implemented these datatypes.
 
-  `Pull Request 5180`_, `Pull Request 5589`_, `Pull Request 5532`_, `Pull Request 5644`_
+  `Pull Request 5180`_, `Pull Request 5589`_, `Pull Request 5532`_, `Pull Request 5644`_, `Pull Request 5674`_
 
 **Experimental Job Caching**
   Galaxy can now be configured to allow users the option of skipping duplicated jobs if one with

--- a/doc/source/releases/18.01_announce.rst
+++ b/doc/source/releases/18.01_announce.rst
@@ -50,7 +50,7 @@ Highlights
 
   - ``qname_sorted.bam``, that ensures that the file is queryname sorted (e.g. ``SO:queryname``);
   - ``qname_input_sorted.bam``, that can be used to describe the output of aligners which generally keep mate pairs adjacent
-  - ``native_bam``, that makes no assumptions about the sort order of the file.
+  - ``unsorted.bam``, that makes no assumptions about the sort order of the file.
 
   A huge thanks goes out to `@bgruening <https://github.com/bgruening>`__ and `@mvdbeek <https://github.com/mvdbeek>`__ who
   implemented these datatypes.

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -192,7 +192,7 @@ class BamNative(Binary):
     """Class describing a BAM binary file that is not necessarily sorted"""
     edam_format = "format_2572"
     edam_data = "data_0863"
-    file_ext = "bam_native"
+    file_ext = "unsorted.bam"
     sort_flag = None
 
     MetadataElement(name="bam_index", desc="BAM Index File", param=metadata.FileParameter, file_ext="bai", readonly=True, no_value=None, visible=False, optional=True)

--- a/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
@@ -17,7 +17,7 @@
         > temp.bg && bedGraphToBigWig temp.bg '$chromInfo' '$output']]>
     </command>
     <inputs>
-        <param format="bam,bam_native" name="input" type="data" label="Choose BAM file"/>
+        <param format="bam,unsorted.bam" name="input" type="data" label="Choose BAM file"/>
     </inputs>
     <outputs>
         <data format="bigwig" name="output"/>

--- a/lib/galaxy/datatypes/converters/sam_to_unsorted_bam.xml
+++ b/lib/galaxy/datatypes/converters/sam_to_unsorted_bam.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_sam_to_bam_native" name="Convert SAM to BAM native - without sorting" version="1.0.0" profile="18.01">
+<tool id="CONVERTER_sam_to_unsorted_bam" name="Convert SAM to BAM without sorting" version="1.0.0" profile="18.01">
     <requirements>
         <requirement type="package" version="1.6">samtools</requirement>
     </requirements>
@@ -15,7 +15,7 @@
         <param name="input" type="data" format="sam" label="SAM file"/>
     </inputs>
     <outputs>
-        <data name="output" format="bam_native"/>
+        <data name="output" format="unsorted.bam"/>
     </outputs>
     <help>
     </help>

--- a/lib/galaxy/datatypes/converters/to_coordinate_sorted_bam.xml
+++ b/lib/galaxy/datatypes/converters/to_coordinate_sorted_bam.xml
@@ -12,7 +12,7 @@
     ]]>
     </command>
     <inputs>
-        <param format="sam,bam_native,qname_sorted.bam" name="input" type="data" label="Choose a BAM native or queryname sortedfile"/>
+        <param format="sam,unsorted.bam,qname_sorted.bam" name="input" type="data" label="Choose a BAM native or queryname sortedfile"/>
     </inputs>
     <outputs>
         <data format="bam" name="output"/>

--- a/lib/galaxy/datatypes/converters/to_qname_sorted_bam.xml
+++ b/lib/galaxy/datatypes/converters/to_qname_sorted_bam.xml
@@ -13,7 +13,7 @@
     ]]>
     </command>
     <inputs>
-        <param format="sam,bam_native" name="input" type="data" label="Choose a BAM native or queryname sortedfile"/>
+        <param format="sam,unsorted.bam" name="input" type="data" label="Choose a BAM native or queryname sortedfile"/>
     </inputs>
     <outputs>
         <data format="qname_sorted.bam" name="output"/>

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -337,7 +337,7 @@ def guess_ext(fname, sniff_order):
     'bam'
     >>> fname = get_test_fname('3unsorted.bam')
     >>> guess_ext(fname, sniff_order)
-    'bam_native'
+    'unsorted.bam'
     >>> fname = get_test_fname('test.idpDB')
     >>> guess_ext(fname, sniff_order)
     'idpdb'

--- a/test/functional/tools/sam_to_unsorted_bam.xml
+++ b/test/functional/tools/sam_to_unsorted_bam.xml
@@ -23,13 +23,13 @@
     </command>
     <inputs>
         <param name="input1" type="data" format="sam" label="SAM file" optional="true"/>
-        <param name="input2" type="data" format="bam_native" label="Unsorted BAM file" optional="true"/>
+        <param name="input2" type="data" format="unsorted.bam" label="Unsorted BAM file" optional="true"/>
         <param name="input3" type="data" format="bam" label="BAM file sorted by coordinate" optional="true"/>
         <param name="input4" type="data" format="qname_sorted.bam" label="BAM file sorted by queryname" optional="true"/>
         <param name="input5" type="data" format="qname_input_sorted.bam" label="BAM file with sort order determined by the aligner" optional="true"/>
     </inputs>
     <outputs>
-        <data name="bam_native_output" format="bam_native">
+        <data name="bam_native_output" format="unsorted.bam">
             <filter>input1 or input2</filter>
         </data>
         <data name="bam_output" format="bam">
@@ -46,12 +46,12 @@
         <!-- Test that bam native output won't be sorted-->
         <test>
             <param name="input1" value="sam_with_header.sam" ftype="sam"/>
-            <output name="bam_native_output" file="bam_native_from_sam.bam" ftype="bam_native"/>
+            <output name="bam_native_output" file="bam_native_from_sam.bam" ftype="unsorted.bam"/>
         </test>
         <!-- Test that sam input is properly converted to bam native -->
         <test>
             <param name="input2" value="sam_with_header.sam" ftype="sam"/>
-            <output name="bam_native_output" file="bam_native_from_sam.bam" ftype="bam_native"/>
+            <output name="bam_native_output" file="bam_native_from_sam.bam" ftype="unsorted.bam"/>
         </test>
         <!-- Test that sam input is properly converted to bam -->
         <test>

--- a/test/functional/tools/sample_datatypes_conf.xml
+++ b/test/functional/tools/sample_datatypes_conf.xml
@@ -15,7 +15,7 @@
     <datatype extension="fastqcssanger" type="galaxy.datatypes.sequence:FastqCSSanger" display_in_upload="true" />
     <datatype extension="fastqillumina" type="galaxy.datatypes.sequence:FastqIllumina" display_in_upload="true" />
     <datatype extension="sam" type="galaxy.datatypes.tabular:Sam" display_in_upload="true">
-        <converter file="sam_to_bam_native.xml" target_datatype="bam_native"/>
+        <converter file="sam_to_unsorted_bam.xml" target_datatype="unsorted.bam"/>
         <converter file="to_qname_sorted_bam.xml" target_datatype="qname_sorted.bam"/>
         <converter file="to_coordinate_sorted_bam.xml" target_datatype="bam"/>
         <converter file="sam_to_bigwig_converter.xml" target_datatype="bigwig"/>
@@ -23,7 +23,7 @@
     <datatype extension="bam" type="galaxy.datatypes.binary:Bam" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension." description_url="https://galaxyproject.org/learn/datatypes/#bam" />
     <datatype extension="qname_input_sorted.bam" type="galaxy.datatypes.binary:BamInputSorted" mimetype="application/octet-stream" display_in_upload="false" description="A binary file compressed in the BGZF format with a '.bam' file extension and sorted based on the aligner output." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM"/>
     <datatype extension="qname_sorted.bam" type="galaxy.datatypes.binary:BamQuerynameSorted" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension and sorted by queryname." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM"/>
-    <datatype extension="bam_native" type="galaxy.datatypes.binary:BamNative" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM">
+    <datatype extension="unsorted.bam" type="galaxy.datatypes.binary:BamNative" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM">
         <converter file="bam_to_bigwig_converter.xml" target_datatype="bigwig"/>
         <converter file="to_coordinate_sorted_bam.xml" target_datatype="bam"/>
         <converter file="to_qname_sorted_bam.xml" target_datatype="qname_sorted.bam"/>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -86,7 +86,7 @@
   <tool file="column_multi_param.xml" />
   <tool file="special_params.xml" />
   <tool file="section.xml" />
-  <tool file="sam_to_bam_native.xml" />
+  <tool file="sam_to_unsorted_bam.xml" />
   <tool file="top_level_data.xml" />
   <tool file="validation_default.xml" />
   <tool file="validation_sanitizer.xml" />


### PR DESCRIPTION
We handle other bam types this way and other more specific variants of an extension (e.g. thermo.raw) so this feels like the more consistent thing to do.

Sorry for the last minute change to 18.01, I think it is important though.
