### PR TITLE
[18.01] Additional error handling for GIE container launching

### DIFF
--- a/lib/galaxy/containers/docker_model.py
+++ b/lib/galaxy/containers/docker_model.py
@@ -85,7 +85,12 @@ class DockerContainer(Container):
         #                 }
         #             ]
         rval = []
-        port_mappings = self.inspect[0]['NetworkSettings']['Ports']
+        try:
+            port_mappings = self.inspect[0]['NetworkSettings']['Ports']
+        except (IndexError, KeyError) as exc:
+            log.warning("Failed to get ports for container %s from `docker inspect` output at "
+                        "[0]['NetworkSettings']['Ports']: %s: %s", self.id, exc.__class__.__name__, str(exc))
+            return None
         for port_name in port_mappings:
             for binding in port_mappings[port_name]:
                 rval.append(ContainerPort(
@@ -165,7 +170,12 @@ class DockerService(Container):
         #             }
         #         ]
         rval = []
-        port_mappings = self.inspect[0]['Endpoint']['Ports']
+        try:
+            port_mappings = self.inspect[0]['Endpoint']['Ports']
+        except (IndexError, KeyError) as exc:
+            log.warning("Failed to get ports for container %s from `docker service inspect` output at "
+                        "[0]['Endpoint']['Ports']: %s: %s", self.id, exc.__class__.__name__, str(exc))
+            return None
         for binding in port_mappings:
             rval.append(ContainerPort(
                 binding['TargetPort'],

--- a/lib/galaxy/visualization/plugins/plugin.py
+++ b/lib/galaxy/visualization/plugins/plugin.py
@@ -245,6 +245,14 @@ class InteractiveEnvironmentPlugin(VisualizationPlugin):
         context['base_url'] = 'interactive_environments'
         super(InteractiveEnvironmentPlugin, self).__init__(app, path, name, config, context=context, **kwargs)
 
+    def _error_template(self, trans):
+        return trans.fill_template('message.mako',
+            message='Loading the interactive environment failed, please contact the {admin_tag} for assistance'.format(
+                admin_tag='<a href="mailto:{admin_mail}">Galaxy administrator</a>'.format(
+                    admin_mail=trans.app.config.error_email_to)
+                if trans.app.config.error_email_to else 'Galaxy administrator'),
+            status='error')
+
     def _render(self, render_vars, trans=None, embedded=None, **kwargs):
         """
         Override to add interactive environment specific template vars.
@@ -270,16 +278,15 @@ class InteractiveEnvironmentPlugin(VisualizationPlugin):
                 request = self.INTENV_REQUEST_FACTORY(trans, self)
             except Exception:
                 log.exception("IE plugin request handling failed")
-                return trans.fill_template('message.mako',
-                    message='Loading the interactive environment failed, please contact the {admin_tag} for assistance'.format(
-                        admin_tag='<a href="mailto:{admin_mail}">Galaxy administrator</a>'.format(
-                            admin_mail=trans.app.config.error_email_to)
-                        if trans.app.config.error_email_to else 'Galaxy administrator'),
-                    status='error')
+                return self._error_template(trans)
             render_vars["ie_request"] = request
 
         template_filename = self.config['entry_point']['file']
-        return trans.fill_template(template_filename, template_lookup=self.template_lookup, **render_vars)
+        try:
+            return trans.fill_template(template_filename, template_lookup=self.template_lookup, **render_vars)
+        except Exception:
+            log.exception("IE plugin template fill failed")
+            return self._error_template(trans)
 
 
 class ScriptVisualizationPlugin(VisualizationPlugin):


### PR DESCRIPTION
Catch any failures that occur in filling the launch template. Additionally, handle cases where `docker inspect` or `docker service inspect` may not (yet) contain the expected data structures for determining published ports.

EDIT: This is non-release blocking  
EDIT2: But I do need this on Main