### PR TITLE
Fix for running Yarn in Docker for tests that do not need it.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -289,7 +289,9 @@ then
        shift
     fi
     MY_UID=$(id -u)
-    DOCKER_RUN_EXTRA_ARGS="-e GALAXY_TEST_UID=${MY_UID} ${DOCKER_RUN_EXTRA_ARGS}"
+    # Skip client build process in the Docker container for all tests, the Jenkins task builds the client
+    # locally before testing - you will need to do this also if using this script for Selenium testing.
+    DOCKER_RUN_EXTRA_ARGS="-e GALAXY_TEST_UID=${MY_UID} -e GALAXY_SKIP_CLIENT_BUILD=1 ${DOCKER_RUN_EXTRA_ARGS}"
     echo "Launching docker container for testing with extra args ${DOCKER_RUN_EXTRA_ARGS}..."
     docker $DOCKER_EXTRA_ARGS run $DOCKER_RUN_EXTRA_ARGS -e "BUILD_NUMBER=$BUILD_NUMBER" -e "GALAXY_TEST_DATABASE_TYPE=$db_type" --rm -v `pwd`:/galaxy $DOCKER_IMAGE "$@"
     exit $?


### PR DESCRIPTION
Alternative approach to https://github.com/galaxyproject/galaxy/pull/5684.