### PR TITLE
Hack to fix bug in uploader where it sometimes posts with empty "file_type".

### DIFF
--- a/client/galaxy/scripts/mvc/upload/upload-view.js
+++ b/client/galaxy/scripts/mvc/upload/upload-view.js
@@ -169,7 +169,9 @@ export default Backbone.View.extend({
             var inputs = {
                 file_count: items.length,
                 dbkey: items[0].get("genome", "?"),
-                file_type: items[0].get("extension", "auto")
+                // sometimes extension set to "" in automated testing after first upload of
+                // a session. https://github.com/galaxyproject/galaxy/issues/5169
+                file_type: items[0].get("extension") || "auto"
             };
             for (var index in items) {
                 var it = items[index];


### PR DESCRIPTION
Galaxy really needs this to be "auto" and not empty on the backend. Seems to happen in automated testing, maybe because things move faster and something hasn't had time to reset?

xref https://github.com/galaxyproject/galaxy/issues/5169