### PR TITLE
Fixes for testing Dockerfile recipe.

### DIFF
--- a/test/docker/base/Dockerfile
+++ b/test/docker/base/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER John Chilton <jmchilton@gmail.com>
 
 ARG CHROME_VERSION="google-chrome-stable"
-ARG CHROME_DRIVER_VERSION="latest"
+ARG CHROME_DRIVER_VERSION="2.35"
 
 # TODO: merge with first ENV statement.
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -46,7 +46,8 @@ RUN apt-get update -y && apt-get install -y software-properties-common apt-trans
             locales \
             xvfb \
             ${CHROME_VERSION:-google-chrome-stable} \
-            wget zlib1g-dev nodejs && \
+            wget zlib1g-dev nodejs \
+            libnss3 libgconf-2-4 && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN npm install -g grunt grunt-cli


### PR DESCRIPTION
The current Dockerfile build is broken because Selenium is not compatible with the latest chromedriver it seems (and the version in galaxy/testing-base:18.01.4 isn't compatible with the latest stable Chrome - version 65). I can't get older versions of Chrome to install with the current apt source but this does at least pin the version of chromedriver.

Longer term it would be good to have the version of chrome we target to be pinned also, I hate that this Dockerfile isn't reproducible.