### PR TITLE
Improve error logging for API-based testing.

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -401,7 +401,7 @@ class GalaxyInteractorApi(object):
     def _summarize_history(self, history_id):
         if history_id is None:
             raise ValueError("_summarize_history passed empty history_id")
-        print("Problem in history with id %s - summary of datasets below." % history_id)
+        print("Problem in history with id %s - summary of history's datasets and jobs below." % history_id)
         try:
             history_contents = self.__contents(history_id)
         except Exception:
@@ -417,6 +417,7 @@ class GalaxyInteractorApi(object):
             if history_content['history_content_type'] == 'dataset_collection':
                 history_contents_json = self._get("histories/%s/contents/dataset_collections/%s" % (history_id, history_content["id"])).json()
                 print("| Dataset Collection: %s" % history_contents_json)
+                print("|")
                 continue
 
             try:
@@ -440,7 +441,23 @@ class GalaxyInteractorApi(object):
             except Exception:
                 print("| *TEST FRAMEWORK ERROR FETCHING JOB DETAILS*")
             print("|")
-        print(ERROR_MESSAGE_DATASET_SEP)
+        try:
+            jobs_json = self._get("jobs?history_id=%s" % history_id).json()
+            for job_json in jobs_json:
+                print(ERROR_MESSAGE_DATASET_SEP)
+                print("| Job %s" % job_json["id"])
+                print("| State: ")
+                print(self.format_for_summary(job_json.get("state", ""), "Job state is unknown."))
+                print("| Update Time:")
+                print(self.format_for_summary(job_json.get("update_time", ""), "Job update time is unknown."))
+                print("| Create Time:")
+                print(self.format_for_summary(job_json.get("create_time", ""), "Job create time is unknown."))
+                print("|")
+            print(ERROR_MESSAGE_DATASET_SEP)
+        except Exception:
+            print(ERROR_MESSAGE_DATASET_SEP)
+            print("*TEST FRAMEWORK FAILED TO FETCH HISTORY JOBS*")
+            print(ERROR_MESSAGE_DATASET_SEP)
 
     def format_for_summary(self, blob, empty_message, prefix="|  "):
         contents = "\n".join(["%s%s" % (prefix, line.strip()) for line in StringIO(blob).readlines() if line.rstrip("\n\r")])

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -174,7 +174,7 @@ class BaseDatasetPopulator(object):
 
     def wait_for_history(self, history_id, assert_ok=False, timeout=DEFAULT_TIMEOUT):
         try:
-            return wait_on_state(lambda: self._get("histories/%s" % history_id), assert_ok=assert_ok, timeout=timeout)
+            return wait_on_state(lambda: self._get("histories/%s" % history_id), desc="history state", assert_ok=assert_ok, timeout=timeout)
         except AssertionError:
             self._summarize_history(history_id)
             raise
@@ -182,22 +182,32 @@ class BaseDatasetPopulator(object):
     def wait_for_history_jobs(self, history_id, assert_ok=False, timeout=DEFAULT_TIMEOUT):
         query_params = {"history_id": history_id}
 
-        def has_active_jobs():
+        def get_jobs():
             jobs_response = self._get("jobs", query_params)
             assert jobs_response.status_code == 200
-            active_jobs = [j for j in jobs_response.json() if j["state"] in ["new", "upload", "waiting", "queued", "running"]]
+            return jobs_response.json()
+
+        def has_active_jobs():
+            jobs = get_jobs()
+            active_jobs = [j for j in jobs if j["state"] in ["new", "upload", "waiting", "queued", "running"]]
 
             if len(active_jobs) == 0:
                 return True
             else:
                 return None
 
-        wait_on(has_active_jobs, "active jobs", timeout=timeout)
+        try:
+            wait_on(has_active_jobs, "active jobs", timeout=timeout)
+        except TimeoutAssertionError as e:
+            jobs = get_jobs()
+            message = "Failed waiting on active jobs to complete, current jobs are [%s]. %s" % (jobs, e.message)
+            raise TimeoutAssertionError(message)
+
         if assert_ok:
             return self.wait_for_history(history_id, assert_ok=True, timeout=timeout)
 
     def wait_for_job(self, job_id, assert_ok=False, timeout=DEFAULT_TIMEOUT):
-        return wait_on_state(lambda: self.get_job_details(job_id), assert_ok=assert_ok, timeout=timeout)
+        return wait_on_state(lambda: self.get_job_details(job_id), desc="job state", assert_ok=assert_ok, timeout=timeout)
 
     def get_job_details(self, job_id, full=False):
         return self._get("jobs/%s?full=%s" % (job_id, full))
@@ -378,7 +388,7 @@ class DatasetPopulator(BaseDatasetPopulator):
         self.galaxy_interactor._summarize_history(history_id)
 
     def wait_for_dataset(self, history_id, dataset_id, assert_ok=False, timeout=DEFAULT_TIMEOUT):
-        return wait_on_state(lambda: self._get("histories/%s/contents/%s" % (history_id, dataset_id)), assert_ok=assert_ok, timeout=timeout)
+        return wait_on_state(lambda: self._get("histories/%s/contents/%s" % (history_id, dataset_id)), desc="dataset state", assert_ok=assert_ok, timeout=timeout)
 
 
 class BaseWorkflowPopulator(object):
@@ -427,7 +437,7 @@ class BaseWorkflowPopulator(object):
 
     def wait_for_invocation(self, workflow_id, invocation_id, timeout=DEFAULT_TIMEOUT):
         url = "workflows/%s/usage/%s" % (workflow_id, invocation_id)
-        return wait_on_state(lambda: self._get(url), timeout=timeout)
+        return wait_on_state(lambda: self._get(url), desc="workflow invocation state", timeout=timeout)
 
     def wait_for_workflow(self, workflow_id, invocation_id, history_id, assert_ok=True, timeout=DEFAULT_TIMEOUT):
         """ Wait for a workflow invocation to completely schedule and then history
@@ -782,7 +792,7 @@ class DatasetCollectionPopulator(BaseDatasetCollectionPopulator):
         return create_response
 
 
-def wait_on_state(state_func, skip_states=["running", "queued", "new", "ready"], assert_ok=False, timeout=DEFAULT_TIMEOUT):
+def wait_on_state(state_func, desc="state", skip_states=["running", "queued", "new", "ready"], assert_ok=False, timeout=DEFAULT_TIMEOUT):
     def get_state():
         response = state_func()
         assert response.status_code == 200, "Failed to fetch state update while waiting."
@@ -793,7 +803,11 @@ def wait_on_state(state_func, skip_states=["running", "queued", "new", "ready"],
             if assert_ok:
                 assert state == "ok", "Final state - %s - not okay." % state
             return state
-    return wait_on(get_state, desc="state", timeout=timeout)
+    try:
+        return wait_on(get_state, desc=desc, timeout=timeout)
+    except TimeoutAssertionError as e:
+        response = state_func()
+        raise TimeoutAssertionError("%s Current response containing state [%s]." % (e.message, response.json()))
 
 
 class GiPostGetMixin:
@@ -858,9 +872,15 @@ def wait_on(function, desc, timeout=DEFAULT_TIMEOUT):
             timeout_message = "Timed out after %s seconds waiting on %s." % (
                 total_wait, desc
             )
-            assert False, timeout_message
+            raise TimeoutAssertionError(timeout_message)
         iteration += 1
         value = function()
         if value is not None:
             return value
         time.sleep(delta)
+
+
+class TimeoutAssertionError(AssertionError):
+
+    def __init__(self, message):
+        super(TimeoutAssertionError, self).__init__(message)


### PR DESCRIPTION
Example below.

Should help debugging #5694. There are various niceties such as specifying what kind of state is being waited on, but for debugging referenced issue in particular this will now show job summaries in addition to dataset summaries on failed tests - and will show the final workflow invocation state when waiting on workflows (or anything - jobs, etc...) and it will show the final state of all jobs in a history when waiting on a history's jobs. I hope these gives some indication as to why timeouts are occurring.

```
======================================================================
FAIL: test_recover_mapping_in_subworkflow (api.test_workflows.WorkflowsApiTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/john/workspace/galaxy/test/base/populators.py", line 64, in wrapped_method
    return method(api_test_case, *args, **kwargs)
  File "/Users/john/workspace/galaxy/test/base/populators.py", line 64, in wrapped_method
    return method(api_test_case, *args, **kwargs)
  File "/Users/john/workspace/galaxy/test/base/populators.py", line 64, in wrapped_method
    return method(api_test_case, *args, **kwargs)
  File "/Users/john/workspace/galaxy/test/api/test_workflows.py", line 1467, in test_recover_mapping_in_subworkflow
    """, history_id=history_id, wait=True)
  File "/Users/john/workspace/galaxy/test/api/test_workflows.py", line 251, in _run_jobs
    self.workflow_populator.wait_for_workflow(workflow_id, invocation_id, history_id, assert_ok=assert_ok)
  File "/Users/john/workspace/galaxy/test/base/populators.py", line 445, in wait_for_workflow
    self.wait_for_invocation(workflow_id, invocation_id, timeout=timeout)
  File "/Users/john/workspace/galaxy/test/base/populators.py", line 440, in wait_for_invocation
    return wait_on_state(lambda: self._get(url), desc="workflow invocation state", timeout=timeout)
  File "/Users/john/workspace/galaxy/test/base/populators.py", line 810, in wait_on_state
    raise TimeoutAssertionError("%s Current response containing state [%s]." % (e.message, response.json()))
TimeoutAssertionError: Timed out after 60.25 seconds waiting on workflow invocation state. Current response containing state [{u'inputs': {u'0': {u'src': u'hda', u'id': u'adb5f5c93f827949', u'uuid': u'de3d999f-d993-447f-a7c4-0389a358034f'}}, u'update_time': u'2018-03-14T15:58:08.615444', u'uuid': u'7b0fc935-27a0-11e8-b255-784f435ea615', u'outputs': {}, u'history_id': u'adb5f5c93f827949', u'workflow_id': u'529fd61ab1c6cc36', u'output_collections': {}, u'state': u'ready', u'steps': [{u'workflow_step_label': u'outer_input', u'update_time': u'2018-03-14T15:58:05.629190', u'job_id': None, u'state': u'scheduled', u'workflow_step_uuid': u'afafbeb3-c3d8-49c8-ae21-5add12558c90', u'order_index': 0, u'action': None, u'model_class': u'WorkflowInvocationStep', u'workflow_step_id': u'cb6e11b662890a90', u'id': u'adb5f5c93f827949'}, {u'workflow_step_label': u'first_cat', u'update_time': u'2018-03-14T15:58:06.015192', u'job_id': u'529fd61ab1c6cc36', u'state': u'scheduled', u'workflow_step_uuid': u'6a5b3ac3-bacf-4e97-bcca-57ea8d8161dd', u'order_index': 1, u'action': None, u'model_class': u'WorkflowInvocationStep', u'workflow_step_id': u'cb227cec8ca83994', u'id': u'529fd61ab1c6cc36'}, {u'workflow_step_label': u'nested_workflow', u'update_time': u'2018-03-14T15:58:06.770332', u'job_id': None, u'state': u'scheduled', u'workflow_step_uuid': u'55640d5d-5e8d-490f-9d68-736f66b1b65a', u'order_index': 2, u'action': None, u'model_class': u'WorkflowInvocationStep', u'workflow_step_id': u'f3f73e481f432006', u'id': u'd9abeb98649a6a7e'}, {u'workflow_step_label': u'second_cat', u'update_time': u'2018-03-14T15:58:06.770643', u'job_id': None, u'state': u'new', u'workflow_step_uuid': u'67beb950-271c-46f4-aca0-42dbe59c6d57', u'order_index': 3, u'action': None, u'model_class': u'WorkflowInvocationStep', u'workflow_step_id': u'2234cb1fd1df4331', u'id': u'cb6e11b662890a90'}], u'model_class': u'WorkflowInvocation', u'id': u'adb5f5c93f827949'}].
-------------------- >> begin captured stdout << ---------------------
Executing git --work-tree test-data-cache/ad1daf4e1504da1acd42c088c6f49be6 --git-dir test-data-cache/ad1daf4e1504da1acd42c088c6f49be6/.git fetch && git --work-tree test-data-cache/ad1daf4e1504da1acd42c088c6f49be6 --git-dir test-data-cache/ad1daf4e1504da1acd42c088c6f49be6/.git merge origin/master
Problem in history with id adb5f5c93f827949 - summary of history's datasets and jobs below.
--------------------------------------
| 1 - Test Dataset (HID - NAME)
| Dataset State:
|  ok
| Dataset Blurb:
|  65 lines
| Dataset Info:
|  uploaded txt file
| Peek:
|  <table cellspacing="0" cellpadding="3"><tr><td>chr1  147962192       147962580       CCDS989.1_cds_0_0_chr1_147962193_r 0 -</td></tr><tr><td>chr1 147984545 147984630 CCDS990.1_cds_0_0_chr1_147984546_f 0 +</td></tr><tr><td>chr1 148078400 148078582 CCDS993.1_cds_0_0_chr1_148078401_r 0 -</td></tr><tr><td>chr1 148185136 148185276 CCDS996.1_cds_0_0_chr1_148185137_f 0 +</td></tr><tr><td>chr10 55251623 55253124 CCDS7248.1_cds_0_0_chr10_55251624_r 0 -</td></tr></table>
| Dataset Job Standard Output:
|  *Standard output was empty.*
| Dataset Job Standard Error:
|  *Standard error was empty.*
|
--------------------------------------
| 2 - Concatenate datasets on data 1 (HID - NAME)
| Dataset State:
|  ok
| Dataset Blurb:
|  65 lines
| Dataset Info:
|  *Dataset info is empty.*
| Peek:
|  <table cellspacing="0" cellpadding="3"><tr><td>chr1  147962192       147962580       CCDS989.1_cds_0_0_chr1_147962193_r 0 -</td></tr><tr><td>chr1 147984545 147984630 CCDS990.1_cds_0_0_chr1_147984546_f 0 +</td></tr><tr><td>chr1 148078400 148078582 CCDS993.1_cds_0_0_chr1_148078401_r 0 -</td></tr><tr><td>chr1 148185136 148185276 CCDS996.1_cds_0_0_chr1_148185137_f 0 +</td></tr><tr><td>chr10 55251623 55253124 CCDS7248.1_cds_0_0_chr10_55251624_r 0 -</td></tr></table>
| Dataset Job Standard Output:
|  *Standard output was empty.*
| Dataset Job Standard Error:
|  *Standard error was empty.*
|
--------------------------------------
| 3 - Select random lines on data 2 (HID - NAME)
| Dataset State:
|  running
| Dataset Blurb:
|  queued
| Dataset Info:
|  None
| Peek:
|  None
| Dataset Job Standard Output:
|  None
| Dataset Job Standard Error:
|  None
|
--------------------------------------
| 4 - lines (HID - NAME)
| Dataset Collection: {u'hid': 4, u'history_content_type': u'dataset_collection', u'populated_state_message': None, u'name': u'lines', u'populated': False, u'deleted': False, u'job_source_type': u'Job', u'history_id': u'adb5f5c93f827949', u'tags': [], u'element_count': None, u'job_source_id': u'f3f73e481f432006', u'visible': True, u'elements': [], u'collection_type': u'list', u'url': u'/api/histories/adb5f5c93f827949/contents/dataset_collections/adb5f5c93f827949', u'model_class': u'HistoryDatasetCollectionAssociation', u'type': u'collection', u'id': u'adb5f5c93f827949', u'populated_state': u'new'}
|
--------------------------------------
| Job d9abeb98649a6a7e
| State:
|  running
| Update Time:
|  2018-03-14T15:58:09.483449
| Create Time:
|  2018-03-14T15:58:06.139665
|
--------------------------------------
| Job 529fd61ab1c6cc36
| State:
|  ok
| Update Time:
|  2018-03-14T15:58:08.633359
| Create Time:
|  2018-03-14T15:58:05.706745
|
--------------------------------------
| Job f3f73e481f432006
| State:
|  new
| Update Time:
|  2018-03-14T15:58:06.559809
| Create Time:
|  2018-03-14T15:58:06.559799
|
--------------------------------------
| Job adb5f5c93f827949
| State:
|  ok
| Update Time:
|  2018-03-14T15:58:04.602106
| Create Time:
|  2018-03-14T15:58:00.368911
|
--------------------------------------
```