### PR TITLE
Bump psycopg2 to 2.7.4;

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -66,7 +66,7 @@ class ConditionalDependencies(object):
         except Exception:
             return False
 
-    def check_psycopg2(self):
+    def check_psycopg2_binary(self):
         return self.config["database_connection"].startswith("postgres")
 
     def check_mysql_python(self):

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -1,5 +1,5 @@
 # These dependencies are only required when certain config options are set
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
 WebError==0.10.3
 Pygments==2.2.0
 python-openid

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -1,5 +1,5 @@
 # These dependencies are only required when certain config options are set
-psycopg2==2.7.3
+psycopg2==2.7.4
 WebError==0.10.3
 Pygments==2.2.0
 python-openid

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -187,7 +187,7 @@ if [ $FETCH_WHEELS -eq 1 ]; then
     pip install $requirement_args --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
     GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "from __future__ import print_function; import galaxy.dependencies; print('\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE')))")
     if [ -n "$GALAXY_CONDITIONAL_DEPENDENCIES" ]; then
-        if pip list --format=columns | grep -q "psycopg2[\(\ ]*2.7.3"; then
+        if pip list --format=columns | grep "psycopg2[\(\ ]*2.7.3" > /dev/null; then
             echo "An older version of psycopg2 (non-binary, version 2.7.3) has been detected.  Galaxy now uses psycopg2-binary, which will be installed after removing psycopg2."
             pip uninstall -y psycopg2==2.7.3
         fi

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -187,7 +187,7 @@ if [ $FETCH_WHEELS -eq 1 ]; then
     pip install $requirement_args --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
     GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "from __future__ import print_function; import galaxy.dependencies; print('\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE')))")
     if [ -n "$GALAXY_CONDITIONAL_DEPENDENCIES" ]; then
-        if pip list | grep "psycopg2[\(\ ]*2.7.3"; then
+        if pip list --format=columns | grep "psycopg2[\(\ ]*2.7.3"; then
             echo "An older version of psycopg2 (non-binary, version 2.7.3) has been detected.  Galaxy now uses psycopg2-binary, which will be installed after removing psycopg2."
             pip uninstall -y psycopg2==2.7.3
         fi

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -187,7 +187,7 @@ if [ $FETCH_WHEELS -eq 1 ]; then
     pip install $requirement_args --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
     GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "from __future__ import print_function; import galaxy.dependencies; print('\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE')))")
     if [ -n "$GALAXY_CONDITIONAL_DEPENDENCIES" ]; then
-        if pip list | grep "psycopg2 (2.7.3)"; then
+        if pip list | grep "psycopg2[\(\ ]*2.7.3"; then
             echo "An older version of psycopg2 (non-binary, version 2.7.3) has been detected.  Galaxy now uses psycopg2-binary, which will be installed after removing psycopg2."
             pip uninstall -y psycopg2==2.7.3
         fi

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -187,7 +187,7 @@ if [ $FETCH_WHEELS -eq 1 ]; then
     pip install $requirement_args --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
     GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "from __future__ import print_function; import galaxy.dependencies; print('\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE')))")
     if [ -n "$GALAXY_CONDITIONAL_DEPENDENCIES" ]; then
-        if pip list --format=columns | grep "psycopg2[\(\ ]*2.7.3"; then
+        if pip list --format=columns | grep -q "psycopg2[\(\ ]*2.7.3"; then
             echo "An older version of psycopg2 (non-binary, version 2.7.3) has been detected.  Galaxy now uses psycopg2-binary, which will be installed after removing psycopg2."
             pip uninstall -y psycopg2==2.7.3
         fi

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -186,7 +186,13 @@ fi
 if [ $FETCH_WHEELS -eq 1 ]; then
     pip install $requirement_args --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
     GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "from __future__ import print_function; import galaxy.dependencies; print('\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE')))")
-    [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
+    if [ -n "$GALAXY_CONDITIONAL_DEPENDENCIES" ]; then
+        if pip list | grep "psycopg2 (2.7.3)"; then
+            echo "An older version of psycopg2 (non-binary, version 2.7.3) has been detected.  Galaxy now uses psycopg2-binary, which will be installed after removing psycopg2."
+            pip uninstall -y psycopg2==2.7.3
+        fi
+        echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
+    fi
 fi
 
 # Check client build state.


### PR DESCRIPTION
Fixes #5696 

Pypi has wheels ready to go, so we can swap to tracking those instead of building our own.

@natefoo Just adding them to cargo-port and leaving starforge as-is should be all I need to do after this, right?