### PR TITLE
Better logging for a large number of workflow API tests.

### DIFF
--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -591,8 +591,8 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase):
 
     @skip_without_tool("multiple_versions")
     def test_run_versioned_tools(self):
-        history_01_id = self.dataset_populator.new_history()
-        workflow_version_01 = self._upload_yaml_workflow("""
+        with self.dataset_populator.test_history() as history_01_id:
+            workflow_version_01 = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
   - tool_id: multiple_versions
@@ -600,11 +600,11 @@ steps:
     state:
       inttest: 0
 """)
-        self.__invoke_workflow(history_01_id, workflow_version_01)
-        self.dataset_populator.wait_for_history(history_01_id, assert_ok=True)
+            self.__invoke_workflow(history_01_id, workflow_version_01)
+            self.dataset_populator.wait_for_history(history_01_id, assert_ok=True)
 
-        history_02_id = self.dataset_populator.new_history()
-        workflow_version_02 = self._upload_yaml_workflow("""
+        with self.dataset_populator.test_history() as history_02_id:
+            workflow_version_02 = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
   - tool_id: multiple_versions
@@ -612,8 +612,8 @@ steps:
     state:
       inttest: 1
 """)
-        self.__invoke_workflow(history_02_id, workflow_version_02)
-        self.dataset_populator.wait_for_history(history_02_id, assert_ok=True)
+            self.__invoke_workflow(history_02_id, workflow_version_02)
+            self.dataset_populator.wait_for_history(history_02_id, assert_ok=True)
 
     def __run_cat_workflow(self, inputs_by):
         workflow = self.workflow_populator.load_workflow(name="test_for_run")
@@ -648,15 +648,15 @@ steps:
       f1:
         $link: split_up#paired_output
 """)
-        history_id = self.dataset_populator.new_history()
-        hda1 = self.dataset_populator.new_dataset(history_id, content="a\nb\nc\nd\n")
-        inputs = {
-            '0': self._ds_entry(hda1),
-        }
-        invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
-        self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        self.assertEqual("a\nc\nb\nd\n", self.dataset_populator.get_history_dataset_content(history_id, hid=0))
+        with self.dataset_populator.test_history() as history_id:
+            hda1 = self.dataset_populator.new_dataset(history_id, content="a\nb\nc\nd\n")
+            inputs = {
+                '0': self._ds_entry(hda1),
+            }
+            invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
+            self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            self.assertEqual("a\nc\nb\nd\n", self.dataset_populator.get_history_dataset_content(history_id, hid=0))
 
     @skip_without_tool("job_properties")
     @skip_without_tool("identifier_multiple_in_conditional")
@@ -677,22 +677,22 @@ steps:
           input1:
             $link: 0#out_file1
 """)
-        history_id = self.dataset_populator.new_history()
-        invocation_id = self.__invoke_workflow(history_id, workflow_id)
-        self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id, assert_ok=False)
-        failed_dataset_one = self.dataset_populator.get_history_dataset_details(history_id, hid=1, wait=True, assert_ok=False)
-        assert failed_dataset_one['state'] == 'error', failed_dataset_one
-        paused_dataset = self.dataset_populator.get_history_dataset_details(history_id, hid=5, wait=True, assert_ok=False)
-        assert paused_dataset['state'] == 'paused', paused_dataset
-        inputs = {"thebool": "false",
-                  "failbool": "false",
-                  "rerun_remap_job_id": failed_dataset_one['creating_job']}
-        self.dataset_populator.run_tool(tool_id='job_properties',
-                                        inputs=inputs,
-                                        history_id=history_id,
-                                        assert_ok=True)
-        unpaused_dataset = self.dataset_populator.get_history_dataset_details(history_id, hid=5, wait=True, assert_ok=False)
-        assert unpaused_dataset['state'] == 'ok'
+        with self.dataset_populator.test_history() as history_id:
+            invocation_id = self.__invoke_workflow(history_id, workflow_id)
+            self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id, assert_ok=False)
+            failed_dataset_one = self.dataset_populator.get_history_dataset_details(history_id, hid=1, wait=True, assert_ok=False)
+            assert failed_dataset_one['state'] == 'error', failed_dataset_one
+            paused_dataset = self.dataset_populator.get_history_dataset_details(history_id, hid=5, wait=True, assert_ok=False)
+            assert paused_dataset['state'] == 'paused', paused_dataset
+            inputs = {"thebool": "false",
+                      "failbool": "false",
+                      "rerun_remap_job_id": failed_dataset_one['creating_job']}
+            self.dataset_populator.run_tool(tool_id='job_properties',
+                                            inputs=inputs,
+                                            history_id=history_id,
+                                            assert_ok=True)
+            unpaused_dataset = self.dataset_populator.get_history_dataset_details(history_id, hid=5, wait=True, assert_ok=False)
+            assert unpaused_dataset['state'] == 'ok'
 
     @skip_without_tool("job_properties")
     @skip_without_tool("identifier_multiple_in_conditional")
@@ -796,21 +796,21 @@ steps:
       input1:
         $link: 2#out1
 """)
-        history_id = self.dataset_populator.new_history()
-        hdca1 = self.dataset_collection_populator.create_list_in_history(history_id, contents=["a\nb\nc\nd\n", "e\nf\ng\nh\n"]).json()
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        inputs = {
-            '0': self._ds_entry(hdca1),
-        }
-        invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
-        self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        self.assertEqual("a\nc\nb\nd\ne\ng\nf\nh\n", self.dataset_populator.get_history_dataset_content(history_id, hid=0))
+        with self.dataset_populator.test_history() as history_id:
+            hdca1 = self.dataset_collection_populator.create_list_in_history(history_id, contents=["a\nb\nc\nd\n", "e\nf\ng\nh\n"]).json()
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            inputs = {
+                '0': self._ds_entry(hdca1),
+            }
+            invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
+            self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            self.assertEqual("a\nc\nb\nd\ne\ng\nf\nh\n", self.dataset_populator.get_history_dataset_content(history_id, hid=0))
 
     @skip_without_tool("collection_split_on_column")
     def test_workflow_run_dynamic_output_collections(self):
-        history_id = self.dataset_populator.new_history()
-        workflow_id = self._upload_yaml_workflow("""
+        with self.dataset_populator.test_history() as history_id:
+            workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
   - label: text_input1
@@ -835,20 +835,20 @@ steps:
       input1:
         $link: split_up#split_output
 """)
-        hda1 = self.dataset_populator.new_dataset(history_id, content="samp1\t10.0\nsamp2\t20.0\n")
-        hda2 = self.dataset_populator.new_dataset(history_id, content="samp1\t30.0\nsamp2\t40.0\n")
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        inputs = {
-            '0': self._ds_entry(hda1),
-            '1': self._ds_entry(hda2),
-        }
-        invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
-        self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
-        details = self.dataset_populator.get_history_dataset_details(history_id, hid=0)
-        last_item_hid = details["hid"]
-        assert last_item_hid == 7, "Expected 7 history items, got %s" % last_item_hid
-        content = self.dataset_populator.get_history_dataset_content(history_id, hid=0)
-        self.assertEqual("10.0\n30.0\n20.0\n40.0\n", content)
+            hda1 = self.dataset_populator.new_dataset(history_id, content="samp1\t10.0\nsamp2\t20.0\n")
+            hda2 = self.dataset_populator.new_dataset(history_id, content="samp1\t30.0\nsamp2\t40.0\n")
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            inputs = {
+                '0': self._ds_entry(hda1),
+                '1': self._ds_entry(hda2),
+            }
+            invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
+            self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
+            details = self.dataset_populator.get_history_dataset_details(history_id, hid=0)
+            last_item_hid = details["hid"]
+            assert last_item_hid == 7, "Expected 7 history items, got %s" % last_item_hid
+            content = self.dataset_populator.get_history_dataset_content(history_id, hid=0)
+            self.assertEqual("10.0\n30.0\n20.0\n40.0\n", content)
 
     @skip_without_tool("collection_split_on_column")
     @skip_without_tool("min_repeat")
@@ -899,8 +899,8 @@ steps:
     @skip_without_tool("collection_split_on_column")
     def test_workflow_run_dynamic_output_collections_3(self):
         # Test a workflow that create a list:list:list followed by a mapping step.
-        history_id = self.dataset_populator.new_history()
-        workflow_id = self._upload_yaml_workflow("""
+        with self.dataset_populator.test_history() as history_id:
+            workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
   - label: text_input1
@@ -930,23 +930,23 @@ steps:
       input1:
         $link: split_up_2#split_output
 """)
-        hda1 = self.dataset_populator.new_dataset(history_id, content="samp1\t10.0\nsamp2\t20.0\n")
-        hda2 = self.dataset_populator.new_dataset(history_id, content="samp1\t30.0\nsamp2\t40.0\n")
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        inputs = {
-            '0': self._ds_entry(hda1),
-            '1': self._ds_entry(hda2),
-        }
-        invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
-        self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
+            hda1 = self.dataset_populator.new_dataset(history_id, content="samp1\t10.0\nsamp2\t20.0\n")
+            hda2 = self.dataset_populator.new_dataset(history_id, content="samp1\t30.0\nsamp2\t40.0\n")
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            inputs = {
+                '0': self._ds_entry(hda1),
+                '1': self._ds_entry(hda2),
+            }
+            invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
+            self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
 
     @skip_without_tool("mapper")
     @skip_without_tool("pileup")
     def test_workflow_metadata_validation_0(self):
         # Testing regression of
         # https://github.com/galaxyproject/galaxy/issues/1514
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 steps:
   - label: input_fastqs
@@ -983,24 +983,24 @@ test_data:
 """, history_id=history_id)
 
     def test_run_subworkflow_simple(self):
-        history_id = self.dataset_populator.new_history()
-        workflow_run_description = """%s
+        with self.dataset_populator.test_history() as history_id:
+            workflow_run_description = """%s
 
 test_data:
   outer_input:
     value: 1.bed
     type: File
 """ % SIMPLE_NESTED_WORKFLOW_YAML
-        self._run_jobs(workflow_run_description, history_id=history_id)
+            self._run_jobs(workflow_run_description, history_id=history_id)
 
-        content = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual("chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\nchr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n", content)
+            content = self.dataset_populator.get_history_dataset_content(history_id)
+            self.assertEqual("chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\nchr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n", content)
 
     @skip_without_tool("cat1")
     @skip_without_tool("collection_paired_test")
     def test_workflow_run_zip_collections(self):
-        history_id = self.dataset_populator.new_history()
-        workflow_id = self._upload_yaml_workflow("""
+        with self.dataset_populator.test_history() as history_id:
+            workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
   - label: test_input_1
@@ -1025,21 +1025,21 @@ steps:
       f1:
         $link: zip_it#output
 """)
-        hda1 = self.dataset_populator.new_dataset(history_id, content="samp1\t10.0\nsamp2\t20.0\n")
-        hda2 = self.dataset_populator.new_dataset(history_id, content="samp1\t20.0\nsamp2\t40.0\n")
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        inputs = {
-            '0': self._ds_entry(hda1),
-            '1': self._ds_entry(hda2),
-        }
-        invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
-        self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
-        content = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual(content.strip(), "samp1\t10.0\nsamp2\t20.0\nsamp1\t20.0\nsamp2\t40.0")
+            hda1 = self.dataset_populator.new_dataset(history_id, content="samp1\t10.0\nsamp2\t20.0\n")
+            hda2 = self.dataset_populator.new_dataset(history_id, content="samp1\t20.0\nsamp2\t40.0\n")
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            inputs = {
+                '0': self._ds_entry(hda1),
+                '1': self._ds_entry(hda2),
+            }
+            invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
+            self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
+            content = self.dataset_populator.get_history_dataset_content(history_id)
+            self.assertEqual(content.strip(), "samp1\t10.0\nsamp2\t20.0\nsamp1\t20.0\nsamp2\t40.0")
 
     def test_filter_failed_mapping(self):
-        history_id = self.dataset_populator.new_history()
-        summary = self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - type: collection
@@ -1070,16 +1070,16 @@ test_data:
       - identifier: i2
         content: "1"
 """, history_id=history_id, wait=True, assert_ok=False)
-        jobs = summary.jobs
+            jobs = summary.jobs
 
-        def filter_jobs_by_tool(tool_id):
-            return [j for j in summary.jobs if j["tool_id"] == tool_id]
+            def filter_jobs_by_tool(tool_id):
+                return [j for j in summary.jobs if j["tool_id"] == tool_id]
 
-        assert len(filter_jobs_by_tool("upload1")) == 2, jobs
-        assert len(filter_jobs_by_tool("exit_code_from_file")) == 2, jobs
-        assert len(filter_jobs_by_tool("__FILTER_FAILED_DATASETS__")) == 1, jobs
-        # Follow proves one job was filtered out of the result of cat1
-        assert len(filter_jobs_by_tool("cat1")) == 1, jobs
+            assert len(filter_jobs_by_tool("upload1")) == 2, jobs
+            assert len(filter_jobs_by_tool("exit_code_from_file")) == 2, jobs
+            assert len(filter_jobs_by_tool("__FILTER_FAILED_DATASETS__")) == 1, jobs
+            # Follow proves one job was filtered out of the result of cat1
+            assert len(filter_jobs_by_tool("cat1")) == 1, jobs
 
     def test_workflow_request(self):
         workflow = self.workflow_populator.load_workflow(name="test_for_queue")
@@ -1094,8 +1094,8 @@ test_data:
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
 
     def test_workflow_output_dataset(self):
-        history_id = self.dataset_populator.new_history()
-        summary = self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: input1
@@ -1112,20 +1112,20 @@ steps:
 test_data:
   input1: "hello world"
 """, history_id=history_id)
-        workflow_id = summary.workflow_id
-        invocation_id = summary.invocation_id
-        invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
-        self._assert_status_code_is(invocation_response, 200)
-        invocation = invocation_response.json()
-        self._assert_has_keys(invocation , "id", "outputs", "output_collections")
-        assert len(invocation["output_collections"]) == 0
-        assert len(invocation["outputs"]) == 1
-        output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=invocation["outputs"]["wf_output_1"]["id"])
-        assert "hello world" == output_content.strip()
+            workflow_id = summary.workflow_id
+            invocation_id = summary.invocation_id
+            invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
+            self._assert_status_code_is(invocation_response, 200)
+            invocation = invocation_response.json()
+            self._assert_has_keys(invocation , "id", "outputs", "output_collections")
+            assert len(invocation["output_collections"]) == 0
+            assert len(invocation["outputs"]) == 1
+            output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=invocation["outputs"]["wf_output_1"]["id"])
+            assert "hello world" == output_content.strip()
 
     def test_workflow_output_dataset_collection(self):
-        history_id = self.dataset_populator.new_history()
-        summary = self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: input1
@@ -1149,25 +1149,25 @@ test_data:
         value: 1.fastq
         type: File
 """, history_id=history_id)
-        workflow_id = summary.workflow_id
-        invocation_id = summary.invocation_id
-        invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
-        self._assert_status_code_is(invocation_response, 200)
-        invocation = invocation_response.json()
-        self._assert_has_keys(invocation , "id", "outputs", "output_collections")
-        assert len(invocation["output_collections"]) == 1
-        assert len(invocation["outputs"]) == 0
-        output_content = self.dataset_populator.get_history_collection_details(history_id, content_id=invocation["output_collections"]["wf_output_1"]["id"])
-        self._assert_has_keys(output_content , "id", "elements")
-        assert output_content["collection_type"] == "list"
-        elements = output_content["elements"]
-        assert len(elements) == 1
-        elements0 = elements[0]
-        assert elements0["element_identifier"] == "el1"
+            workflow_id = summary.workflow_id
+            invocation_id = summary.invocation_id
+            invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
+            self._assert_status_code_is(invocation_response, 200)
+            invocation = invocation_response.json()
+            self._assert_has_keys(invocation , "id", "outputs", "output_collections")
+            assert len(invocation["output_collections"]) == 1
+            assert len(invocation["outputs"]) == 0
+            output_content = self.dataset_populator.get_history_collection_details(history_id, content_id=invocation["output_collections"]["wf_output_1"]["id"])
+            self._assert_has_keys(output_content , "id", "elements")
+            assert output_content["collection_type"] == "list"
+            elements = output_content["elements"]
+            assert len(elements) == 1
+            elements0 = elements[0]
+            assert elements0["element_identifier"] == "el1"
 
     def test_worklfow_input_mapping(self):
-        history_id = self.dataset_populator.new_history()
-        summary = self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: input1
@@ -1192,25 +1192,25 @@ test_data:
         value: 1.fastq
         type: File
 """, history_id=history_id)
-        workflow_id = summary.workflow_id
-        invocation_id = summary.invocation_id
-        invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
-        self._assert_status_code_is(invocation_response, 200)
-        invocation = invocation_response.json()
-        self._assert_has_keys(invocation , "id", "outputs", "output_collections")
-        assert len(invocation["output_collections"]) == 1
-        assert len(invocation["outputs"]) == 0
-        output_content = self.dataset_populator.get_history_collection_details(history_id, content_id=invocation["output_collections"]["wf_output_1"]["id"])
-        self._assert_has_keys(output_content , "id", "elements")
-        elements = output_content["elements"]
-        assert len(elements) == 2
-        elements0 = elements[0]
-        assert elements0["element_identifier"] == "el1"
+            workflow_id = summary.workflow_id
+            invocation_id = summary.invocation_id
+            invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
+            self._assert_status_code_is(invocation_response, 200)
+            invocation = invocation_response.json()
+            self._assert_has_keys(invocation , "id", "outputs", "output_collections")
+            assert len(invocation["output_collections"]) == 1
+            assert len(invocation["outputs"]) == 0
+            output_content = self.dataset_populator.get_history_collection_details(history_id, content_id=invocation["output_collections"]["wf_output_1"]["id"])
+            self._assert_has_keys(output_content , "id", "elements")
+            elements = output_content["elements"]
+            assert len(elements) == 2
+            elements0 = elements[0]
+            assert elements0["element_identifier"] == "el1"
 
     @skip_without_tool("collection_creates_pair")
     def test_workflow_run_input_mapping_with_output_collections(self):
-        history_id = self.dataset_populator.new_history()
-        summary = self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_jobs("""
 class: GalaxyWorkflow
 outputs:
   - id: wf_output_1
@@ -1235,21 +1235,21 @@ test_data:
         value: 1.fastq
         type: File
 """, history_id=history_id)
-        workflow_id = summary.workflow_id
-        invocation_id = summary.invocation_id
-        invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
-        self._assert_status_code_is(invocation_response, 200)
-        invocation = invocation_response.json()
-        self._assert_has_keys(invocation , "id", "outputs", "output_collections")
-        assert len(invocation["output_collections"]) == 1
-        assert len(invocation["outputs"]) == 0
-        output_content = self.dataset_populator.get_history_collection_details(history_id, content_id=invocation["output_collections"]["wf_output_1"]["id"])
-        self._assert_has_keys(output_content , "id", "elements")
-        assert output_content["collection_type"] == "list:paired", output_content
-        elements = output_content["elements"]
-        assert len(elements) == 2
-        elements0 = elements[0]
-        assert elements0["element_identifier"] == "el1"
+            workflow_id = summary.workflow_id
+            invocation_id = summary.invocation_id
+            invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
+            self._assert_status_code_is(invocation_response, 200)
+            invocation = invocation_response.json()
+            self._assert_has_keys(invocation , "id", "outputs", "output_collections")
+            assert len(invocation["output_collections"]) == 1
+            assert len(invocation["outputs"]) == 0
+            output_content = self.dataset_populator.get_history_collection_details(history_id, content_id=invocation["output_collections"]["wf_output_1"]["id"])
+            self._assert_has_keys(output_content , "id", "elements")
+            assert output_content["collection_type"] == "list:paired", output_content
+            elements = output_content["elements"]
+            assert len(elements) == 2
+            elements0 = elements[0]
+            assert elements0["element_identifier"] == "el1"
 
     def test_workflow_run_input_mapping_with_subworkflows(self):
         with self.dataset_populator.test_history() as history_id:
@@ -1687,8 +1687,8 @@ test_data:
             assert invocation['state'] == 'cancelled'
 
     def test_run_with_implicit_connection(self):
-        history_id = self.dataset_populator.new_history()
-        run_summary = self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            run_summary = self._run_jobs("""
 class: GalaxyWorkflow
 steps:
 - label: test_input
@@ -1722,25 +1722,25 @@ steps:
 test_data:
   test_input: "hello world"
 """, history_id=history_id, wait=False)
-        history_id = run_summary.history_id
-        workflow_id = run_summary.workflow_id
-        invocation_id = run_summary.invocation_id
-        # Wait for first two jobs to be scheduled - upload and first cat.
-        wait_on(lambda: len(self._history_jobs(history_id)) >= 2 or None, "history jobs")
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        invocation = self._invocation_details(workflow_id, invocation_id)
-        assert invocation['state'] != 'scheduled', invocation
-        # Expect two jobs - the upload and first cat. randomlines shouldn't run
-        # it is implicitly dependent on second cat.
-        self._assert_history_job_count(history_id, 2)
+            history_id = run_summary.history_id
+            workflow_id = run_summary.workflow_id
+            invocation_id = run_summary.invocation_id
+            # Wait for first two jobs to be scheduled - upload and first cat.
+            wait_on(lambda: len(self._history_jobs(history_id)) >= 2 or None, "history jobs")
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            invocation = self._invocation_details(workflow_id, invocation_id)
+            assert invocation['state'] != 'scheduled', invocation
+            # Expect two jobs - the upload and first cat. randomlines shouldn't run
+            # it is implicitly dependent on second cat.
+            self._assert_history_job_count(history_id, 2)
 
-        self.__review_paused_steps(workflow_id, invocation_id, order_index=2, action=True)
-        self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
-        self._assert_history_job_count(history_id, 4)
+            self.__review_paused_steps(workflow_id, invocation_id, order_index=2, action=True)
+            self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
+            self._assert_history_job_count(history_id, 4)
 
     def test_run_with_validated_parameter_connection_valid(self):
-        history_id = self.dataset_populator.new_history()
-        run_summary = self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            run_summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - label: text_input
@@ -1756,14 +1756,14 @@ test_data:
     value: "abd"
     type: raw
 """, history_id=history_id, wait=True)
-        time.sleep(10)
-        self.workflow_populator.wait_for_invocation(run_summary.workflow_id, run_summary.invocation_id)
-        jobs = self._history_jobs(history_id)
-        assert len(jobs) == 1
+            time.sleep(10)
+            self.workflow_populator.wait_for_invocation(run_summary.workflow_id, run_summary.invocation_id)
+            jobs = self._history_jobs(history_id)
+            assert len(jobs) == 1
 
     def test_run_with_validated_parameter_connection_invalid(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - label: text_input
@@ -1781,8 +1781,8 @@ test_data:
 """, history_id=history_id, wait=True, assert_ok=False)
 
     def test_run_with_text_connection(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - label: data_input
@@ -1809,9 +1809,9 @@ test_data:
     type: raw
 """, history_id=history_id)
 
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        content = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual("chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n", content)
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            content = self.dataset_populator.get_history_dataset_content(history_id)
+            self.assertEqual("chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n", content)
 
     def wait_for_invocation_and_jobs(self, history_id, workflow_id, invocation_id, assert_ok=True):
         state = self.workflow_populator.wait_for_invocation(workflow_id, invocation_id)
@@ -1915,20 +1915,20 @@ test_data:
     def test_workflow_run_with_matching_lists(self):
         workflow = self.workflow_populator.load_workflow_from_resource("test_workflow_matching_lists")
         workflow_id = self.workflow_populator.create_workflow(workflow)
-        history_id = self.dataset_populator.new_history()
-        hdca1 = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("sample1-1", "1 2 3"), ("sample2-1", "7 8 9")]).json()
-        hdca2 = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("sample1-2", "4 5 6"), ("sample2-2", "0 a b")]).json()
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        label_map = {"list1": self._ds_entry(hdca1), "list2": self._ds_entry(hdca2)}
-        workflow_request = dict(
-            history="hist_id=%s" % history_id,
-            workflow_id=workflow_id,
-            ds_map=self._build_ds_map(workflow_id, label_map),
-        )
-        run_workflow_response = self._post("workflows", data=workflow_request)
-        self._assert_status_code_is(run_workflow_response, 200)
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        self.assertEqual("1 2 3\n4 5 6\n7 8 9\n0 a b\n", self.dataset_populator.get_history_dataset_content(history_id))
+        with self.dataset_populator.test_history() as history_id:
+            hdca1 = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("sample1-1", "1 2 3"), ("sample2-1", "7 8 9")]).json()
+            hdca2 = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("sample1-2", "4 5 6"), ("sample2-2", "0 a b")]).json()
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            label_map = {"list1": self._ds_entry(hdca1), "list2": self._ds_entry(hdca2)}
+            workflow_request = dict(
+                history="hist_id=%s" % history_id,
+                workflow_id=workflow_id,
+                ds_map=self._build_ds_map(workflow_id, label_map),
+            )
+            run_workflow_response = self._post("workflows", data=workflow_request)
+            self._assert_status_code_is(run_workflow_response, 200)
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            self.assertEqual("1 2 3\n4 5 6\n7 8 9\n0 a b\n", self.dataset_populator.get_history_dataset_content(history_id))
 
     def test_workflow_stability(self):
         # Run this index stability test with following command:
@@ -2001,8 +2001,8 @@ test_data: {}
 
     @skip_without_tool("cat")
     def test_run_rename_on_mapped_over_collection(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: input1
@@ -2026,19 +2026,19 @@ test_data:
         value: 1.fastq
         type: File
 """, history_id=history_id)
-        content = self.dataset_populator.get_history_dataset_details(history_id, hid=4, wait=True, assert_ok=True)
-        name = content["name"]
-        assert name == "my new name", name
-        assert content["history_content_type"] == "dataset"
-        content = self.dataset_populator.get_history_collection_details(history_id, hid=3, wait=True, assert_ok=True)
-        name = content["name"]
-        assert content["history_content_type"] == "dataset_collection", content
-        assert name == "my new name", name
+            content = self.dataset_populator.get_history_dataset_details(history_id, hid=4, wait=True, assert_ok=True)
+            name = content["name"]
+            assert name == "my new name", name
+            assert content["history_content_type"] == "dataset"
+            content = self.dataset_populator.get_history_collection_details(history_id, hid=3, wait=True, assert_ok=True)
+            name = content["name"]
+            assert content["history_content_type"] == "dataset_collection", content
+            assert name == "my new name", name
 
     @skip_without_tool("cat")
     def test_run_rename_based_on_inputs_on_mapped_over_collection(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: input1
@@ -2062,10 +2062,10 @@ test_data:
         value: 1.fastq
         type: File
 """, history_id=history_id)
-        content = self.dataset_populator.get_history_collection_details(history_id, hid=3, wait=True, assert_ok=True)
-        name = content["name"]
-        assert content["history_content_type"] == "dataset_collection", content
-        assert name == "the_dataset_list suffix", name
+            content = self.dataset_populator.get_history_collection_details(history_id, hid=3, wait=True, assert_ok=True)
+            name = content["name"]
+            assert content["history_content_type"] == "dataset_collection", content
+            assert name == "the_dataset_list suffix", name
 
     @skip_without_tool("collection_creates_pair")
     def test_run_rename_collection_output(self):
@@ -2118,8 +2118,8 @@ test_data: {}
 
     @skip_without_tool("cat")
     def test_run_rename_based_on_input(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: input1
@@ -2138,9 +2138,9 @@ test_data:
     type: File
     name: fasta1
 """, history_id=history_id)
-        content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
-        name = content["name"]
-        assert name == "fasta1 suffix", name
+            content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
+            name = content["name"]
+            assert name == "fasta1 suffix", name
 
     @skip_without_tool("fail_identifier")
     @skip_without_tool("cat")
@@ -2193,8 +2193,8 @@ test_data:
 
     @skip_without_tool("cat")
     def test_run_rename_based_on_input_recursive(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: input1
@@ -2213,14 +2213,14 @@ test_data:
     type: File
     name: '#{input1}'
 """, history_id=history_id)
-        content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
-        name = content["name"]
-        assert name == "#{input1} #{INPUT1} suffix", name
+            content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
+            name = content["name"]
+            assert name == "#{input1} #{INPUT1} suffix", name
 
     @skip_without_tool("cat")
     def test_run_rename_based_on_input_repeat(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: input1
@@ -2247,14 +2247,14 @@ test_data:
     type: File
     name: fasta2
 """, history_id=history_id)
-        content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
-        name = content["name"]
-        assert name == "fasta2 suffix", name
+            content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
+            name = content["name"]
+            assert name == "fasta2 suffix", name
 
     @skip_without_tool("mapper2")
     def test_run_rename_based_on_input_conditional(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: fasta_input
@@ -2285,14 +2285,14 @@ test_data:
     name: fastq1
     file_type: fastqsanger
 """, history_id=history_id)
-        content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
-        name = content["name"]
-        assert name == "fastq1 suffix", name
+            content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
+            name = content["name"]
+            assert name == "fastq1 suffix", name
 
     @skip_without_tool("mapper2")
     def test_run_rename_based_on_input_collection(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: fasta_input
@@ -2328,9 +2328,9 @@ test_data:
         value: 1.fastq
         type: File
 """, history_id=history_id)
-        content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
-        name = content["name"]
-        assert name == "the_dataset_pair suffix", name
+            content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
+            name = content["name"]
+            assert name == "the_dataset_pair suffix", name
 
     @skip_without_tool("collection_creates_pair")
     def test_run_hide_on_collection_output(self):
@@ -2360,8 +2360,8 @@ test_data:
 
     @skip_without_tool("cat")
     def test_run_hide_on_mapped_over_collection(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: input1
@@ -2386,13 +2386,13 @@ test_data:
         type: File
 """, history_id=history_id)
 
-        content = self.dataset_populator.get_history_dataset_details(history_id, hid=4, wait=True, assert_ok=True)
-        assert content["history_content_type"] == "dataset"
-        assert content["visible"] is False
+            content = self.dataset_populator.get_history_dataset_details(history_id, hid=4, wait=True, assert_ok=True)
+            assert content["history_content_type"] == "dataset"
+            assert content["visible"] is False
 
-        content = self.dataset_populator.get_history_collection_details(history_id, hid=3, wait=True, assert_ok=True)
-        assert content["history_content_type"] == "dataset_collection", content
-        assert content["visible"] is False
+            content = self.dataset_populator.get_history_collection_details(history_id, hid=3, wait=True, assert_ok=True)
+            assert content["history_content_type"] == "dataset_collection", content
+            assert content["visible"] is False
 
     @skip_without_tool("collection_creates_pair")
     def test_run_add_tag_on_collection_output(self):
@@ -2552,43 +2552,42 @@ steps:
         $link: the_pause
 """)
         downloaded_workflow = self._download_workflow(workflow_id)
-        print(downloaded_workflow)
         uuid_dict = dict((int(index), step["uuid"]) for index, step in downloaded_workflow["steps"].items())
-        history_id = self.dataset_populator.new_history()
-        hda = self.dataset_populator.new_dataset(history_id, content="1 2 3")
-        self.dataset_populator.wait_for_history(history_id)
-        inputs = {
-            '0': self._ds_entry(hda),
-        }
-        print(inputs)
-        uuid2 = uuid_dict[3]
-        workflow_request = {}
-        workflow_request["replacement_params"] = dumps(dict(replaceme="was replaced"))
-        pja_map = {
-            "RenameDatasetActionout_file1": dict(
-                action_type="RenameDatasetAction",
-                output_name="out_file1",
-                action_arguments=dict(newname="foo ${replaceme}"),
-            )
-        }
-        workflow_request["parameters"] = dumps({
-            uuid2: {"__POST_JOB_ACTIONS__": pja_map}
-        })
-        invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs=inputs, request=workflow_request)
+        with self.dataset_populator.test_history() as history_id:
+            hda = self.dataset_populator.new_dataset(history_id, content="1 2 3")
+            self.dataset_populator.wait_for_history(history_id)
+            inputs = {
+                '0': self._ds_entry(hda),
+            }
+            print(inputs)
+            uuid2 = uuid_dict[3]
+            workflow_request = {}
+            workflow_request["replacement_params"] = dumps(dict(replaceme="was replaced"))
+            pja_map = {
+                "RenameDatasetActionout_file1": dict(
+                    action_type="RenameDatasetAction",
+                    output_name="out_file1",
+                    action_arguments=dict(newname="foo ${replaceme}"),
+                )
+            }
+            workflow_request["parameters"] = dumps({
+                uuid2: {"__POST_JOB_ACTIONS__": pja_map}
+            })
+            invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs=inputs, request=workflow_request)
 
-        time.sleep(2)
-        self.dataset_populator.wait_for_history(history_id)
-        self.__review_paused_steps(workflow_id, invocation_id, order_index=2, action=True)
+            time.sleep(2)
+            self.dataset_populator.wait_for_history(history_id)
+            self.__review_paused_steps(workflow_id, invocation_id, order_index=2, action=True)
 
-        self.workflow_populator.wait_for_workflow(workflow_id, invocation_id, history_id)
-        time.sleep(1)
-        content = self.dataset_populator.get_history_dataset_details(history_id)
-        assert content["name"] == "foo was replaced", content["name"]
+            self.workflow_populator.wait_for_workflow(workflow_id, invocation_id, history_id)
+            time.sleep(1)
+            content = self.dataset_populator.get_history_dataset_details(history_id)
+            assert content["name"] == "foo was replaced", content["name"]
 
     @skip_without_tool("cat1")
     def test_delete_intermediate_datasets_pja_1(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
   - id: input1
@@ -2617,17 +2616,17 @@ steps:
 test_data:
   input1: "hello world"
 """, history_id=history_id)
-        hda1 = self.dataset_populator.get_history_dataset_details(history_id, hid=1)
-        hda2 = self.dataset_populator.get_history_dataset_details(history_id, hid=2)
-        hda3 = self.dataset_populator.get_history_dataset_details(history_id, hid=3)
-        hda4 = self.dataset_populator.get_history_dataset_details(history_id, hid=4)
-        assert not hda1["deleted"]
-        assert hda2["deleted"]
-        # I think hda3 should be deleted, but the inputs to
-        # steps with workflow outputs are not deleted.
-        # assert hda3["deleted"]
-        print(hda3["deleted"])
-        assert not hda4["deleted"]
+            hda1 = self.dataset_populator.get_history_dataset_details(history_id, hid=1)
+            hda2 = self.dataset_populator.get_history_dataset_details(history_id, hid=2)
+            hda3 = self.dataset_populator.get_history_dataset_details(history_id, hid=3)
+            hda4 = self.dataset_populator.get_history_dataset_details(history_id, hid=4)
+            assert not hda1["deleted"]
+            assert hda2["deleted"]
+            # I think hda3 should be deleted, but the inputs to
+            # steps with workflow outputs are not deleted.
+            # assert hda3["deleted"]
+            print(hda3["deleted"])
+            assert not hda4["deleted"]
 
     @skip_without_tool("random_lines1")
     def test_run_replace_params_by_tool(self):
@@ -2659,39 +2658,39 @@ test_data:
     def test_run_batch(self):
         workflow = self.workflow_populator.load_workflow_from_resource("test_workflow_batch")
         workflow_id = self.workflow_populator.create_workflow(workflow)
-        history_id = self.dataset_populator.new_history()
-        hda1 = self.dataset_populator.new_dataset(history_id, content="1 2 3")
-        hda2 = self.dataset_populator.new_dataset(history_id, content="4 5 6")
-        hda3 = self.dataset_populator.new_dataset(history_id, content="7 8 9")
-        hda4 = self.dataset_populator.new_dataset(history_id, content="10 11 12")
-        parameters = {
-            "0": {"input": {"batch": True, "values": [{"id" : hda1.get("id"), "hid": hda1.get("hid"), "src": "hda"},
-                                                      {"id" : hda2.get("id"), "hid": hda2.get("hid"), "src": "hda"},
-                                                      {"id" : hda3.get("id"), "hid": hda2.get("hid"), "src": "hda"},
-                                                      {"id" : hda4.get("id"), "hid": hda2.get("hid"), "src": "hda"}]}},
-            "1": {"input": {"batch": False, "values": [{"id" : hda1.get("id"), "hid": hda1.get("hid"), "src": "hda"}]}, "exp": "2"}}
-        workflow_request = {
-            "history_id" : history_id,
-            "batch"      : True,
-            "parameters_normalized": True,
-            "parameters" : dumps(parameters),
-        }
-        invocation_response = self._post("workflows/%s/usage" % workflow_id, data=workflow_request)
-        self._assert_status_code_is(invocation_response, 200)
-        time.sleep(5)
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        r1 = "1 2 3\t1\n1 2 3\t2\n"
-        r2 = "4 5 6\t1\n1 2 3\t2\n"
-        r3 = "7 8 9\t1\n1 2 3\t2\n"
-        r4 = "10 11 12\t1\n1 2 3\t2\n"
-        t1 = self.dataset_populator.get_history_dataset_content(history_id, hid=7)
-        t2 = self.dataset_populator.get_history_dataset_content(history_id, hid=10)
-        t3 = self.dataset_populator.get_history_dataset_content(history_id, hid=13)
-        t4 = self.dataset_populator.get_history_dataset_content(history_id, hid=16)
-        self.assertEqual(r1, t1)
-        self.assertEqual(r2, t2)
-        self.assertEqual(r3, t3)
-        self.assertEqual(r4, t4)
+        with self.dataset_populator.test_history() as history_id:
+            hda1 = self.dataset_populator.new_dataset(history_id, content="1 2 3")
+            hda2 = self.dataset_populator.new_dataset(history_id, content="4 5 6")
+            hda3 = self.dataset_populator.new_dataset(history_id, content="7 8 9")
+            hda4 = self.dataset_populator.new_dataset(history_id, content="10 11 12")
+            parameters = {
+                "0": {"input": {"batch": True, "values": [{"id" : hda1.get("id"), "hid": hda1.get("hid"), "src": "hda"},
+                                                          {"id" : hda2.get("id"), "hid": hda2.get("hid"), "src": "hda"},
+                                                          {"id" : hda3.get("id"), "hid": hda2.get("hid"), "src": "hda"},
+                                                          {"id" : hda4.get("id"), "hid": hda2.get("hid"), "src": "hda"}]}},
+                "1": {"input": {"batch": False, "values": [{"id" : hda1.get("id"), "hid": hda1.get("hid"), "src": "hda"}]}, "exp": "2"}}
+            workflow_request = {
+                "history_id" : history_id,
+                "batch"      : True,
+                "parameters_normalized": True,
+                "parameters" : dumps(parameters),
+            }
+            invocation_response = self._post("workflows/%s/usage" % workflow_id, data=workflow_request)
+            self._assert_status_code_is(invocation_response, 200)
+            time.sleep(5)
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            r1 = "1 2 3\t1\n1 2 3\t2\n"
+            r2 = "4 5 6\t1\n1 2 3\t2\n"
+            r3 = "7 8 9\t1\n1 2 3\t2\n"
+            r4 = "10 11 12\t1\n1 2 3\t2\n"
+            t1 = self.dataset_populator.get_history_dataset_content(history_id, hid=7)
+            t2 = self.dataset_populator.get_history_dataset_content(history_id, hid=10)
+            t3 = self.dataset_populator.get_history_dataset_content(history_id, hid=13)
+            t4 = self.dataset_populator.get_history_dataset_content(history_id, hid=16)
+            self.assertEqual(r1, t1)
+            self.assertEqual(r2, t2)
+            self.assertEqual(r3, t3)
+            self.assertEqual(r4, t4)
 
     @skip_without_tool("validation_default")
     def test_parameter_substitution_sanitization(self):
@@ -2703,8 +2702,8 @@ test_data:
 
     @skip_without_tool("validation_repeat")
     def test_parameter_substitution_validation_value_errors_0(self):
-        history_id = self.dataset_populator.new_history()
-        workflow_id = self._upload_yaml_workflow("""
+        with self.dataset_populator.test_history() as history_id:
+            workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
  - tool_id: validation_repeat
@@ -2712,14 +2711,14 @@ steps:
      r2:
       - text: "abd"
 """)
-        workflow_request = dict(
-            history="hist_id=%s" % history_id,
-            parameters=dumps(dict(validation_repeat={"r2_0|text": ""}))
-        )
-        url = "workflows/%s/invocations" % workflow_id
-        invocation_response = self._post(url, data=workflow_request)
-        # Take a valid stat and make it invalid, assert workflow won't run.
-        self._assert_status_code_is(invocation_response, 400)
+            workflow_request = dict(
+                history="hist_id=%s" % history_id,
+                parameters=dumps(dict(validation_repeat={"r2_0|text": ""}))
+            )
+            url = "workflows/%s/invocations" % workflow_id
+            invocation_response = self._post(url, data=workflow_request)
+            # Take a valid stat and make it invalid, assert workflow won't run.
+            self._assert_status_code_is(invocation_response, 400)
 
     @skip_without_tool("validation_default")
     def test_parameter_substitution_validation_value_errors_1(self):
@@ -2730,8 +2729,8 @@ steps:
 
     @skip_without_tool("validation_repeat")
     def test_workflow_import_state_validation_1(self):
-        history_id = self.dataset_populator.new_history()
-        self._run_jobs("""
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
 class: GalaxyWorkflow
 steps:
  - tool_id: validation_repeat


### PR DESCRIPTION
I did a few of these test conversions with 0ff639a29c6179e530c977b358cebf229c76139d but this covers many more the workflow API tests. The idea is to switch to this with statement and context manager that does a better job managing test histories including summarizing the history when problems occur (this summary will include job information after #5697).