### PR TITLE
Don't let failure to save Selenium screenshot for debugging mask underlying errors.

### DIFF
--- a/test/selenium_tests/framework.py
+++ b/test/selenium_tests/framework.py
@@ -110,29 +110,28 @@ def dump_test_information(self, name_prefix):
                 buf.write(content.encode("utf-8") if not raw else content)
 
         os.makedirs(target_directory)
-        self.driver.save_screenshot(os.path.join(target_directory, "last.png"))
-        write_file("page_source.txt", self.driver.page_source)
-        write_file("DOM.txt", self.driver.execute_script("return document.documentElement.outerHTML"))
         write_file("stacktrace.txt", traceback.format_exc())
-
         for snapshot in getattr(self, "snapshots", []):
             snapshot.write_to_error_directory(write_file)
 
+        # Try to use the Selenium driver to recover more debug information, but don't
+        # throw an exception if the connection is broken in some way.
+        try:
+            self.driver.save_screenshot(os.path.join(target_directory, "last.png"))
+            write_file("page_source.txt", self.driver.page_source)
+            write_file("DOM.txt", self.driver.execute_script("return document.documentElement.outerHTML"))
+        except Exception:
+            print("Failed to use test driver to recover debug information from Selenium.")
+            write_file("selenium_exception.txt", traceback.format_exc())
+
         for log_type in ["browser", "driver"]:
-            full_log = self.driver.get_log(log_type)
-            trimmed_log = [l for l in full_log if l["level"] not in ["DEBUG", "INFO"]]
             try:
+                full_log = self.driver.get_log(log_type)
+                trimmed_log = [l for l in full_log if l["level"] not in ["DEBUG", "INFO"]]
                 write_file("%s.log.json" % log_type, json.dumps(trimmed_log, indent=True))
                 write_file("%s.log.verbose.json" % log_type, json.dumps(full_log, indent=True))
             except Exception:
                 continue
-        iframes = self.driver.find_elements_by_css_selector("iframe")
-        for iframe in iframes:
-            pass
-            # TODO: Dump content out for debugging in the future.
-            # iframe_id = iframe.get_attribute("id")
-            # if iframe_id:
-            #     write_file("iframe_%s" % iframe_id, "My content")
 
 
 @nottest


### PR DESCRIPTION
E.g.
https://jenkins.galaxyproject.org/job/docker-selenium/1665/testReport/selenium_tests.test_library_to_collections/LibraryToCollectionsTestCase/test_list_creation/