### PR TITLE
Fix for merging of HDA & DCE models into one model in the client.

### DIFF
--- a/client/galaxy/scripts/mvc/collection/collection-model.js
+++ b/client/galaxy/scripts/mvc/collection/collection-model.js
@@ -60,10 +60,17 @@ var DatasetCollectionElementMixin = {
 
     /** merge the attributes of the sub-object 'object' into this model */
     _mergeObject: function(attributes) {
-        // if we don't preserve and correct ids here, the element id becomes the object id
-        // and collision in backbone's _byId will occur and only
+        // Don't let the dataset ID replace the DCE's ID so record it as the
+        // element_id and when fetching dataset details below use the element_id
+        // instead of this.id.
+        const object = attributes.object;
+        let elementId = this.elementId;
+        if(object) {
+            elementId = attributes.object.id;
+            delete attributes.object.id;
+        }
         _.extend(attributes, attributes.object, {
-            element_id: attributes.id
+            element_id: elementId
         });
         delete attributes.object;
         return attributes;
@@ -123,7 +130,16 @@ var DatasetDCE = DATASET_MODEL.DatasetAssociation.extend(
                     // (a little silly since this api endpoint *also* points at hdas)
                     return `${Galaxy.root}api/datasets`;
                 }
-                return `${Galaxy.root}api/histories/${this.get("history_id")}/contents/${this.get("id")}`;
+                const datasetId = this._getDatasetId();
+                const url = `${Galaxy.root}api/histories/${this.get("history_id")}/contents/${datasetId}`;
+                return url;
+            },
+
+            _getDatasetId: function() {
+                // I'm a DCE acting as dataset, this URL needs to be the dataset URL so
+                // use element_id instead of id. See note above in _mergeObject and
+                // discussion on #3782 for more context.
+                return this.get("element_id");
             },
 
             defaults: _.extend(

--- a/client/galaxy/scripts/mvc/dataset/dataset-model.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-model.js
@@ -54,9 +54,13 @@ var DatasetAssociation = Backbone.Model.extend(BASE_MVC.LoggableMixin).extend(
                 this._setUpListeners();
             },
 
+            _getDatasetId: function() {
+                return this.get("id");
+            },
+
             /** returns misc. web urls for rendering things like re-run, display, etc. */
             _generateUrls: function() {
-                var id = this.get("id");
+                const id = this._getDatasetId();
                 if (!id) {
                     return {};
                 }


### PR DESCRIPTION
I wish they weren't merged together like this but they are so try to to handle the IDs in a less buggy way.

It should fix https://github.com/galaxyproject/galaxy/issues/3782 if I understand the problem (*Narrator's Voice: He does not understand the problem*).