### PR TITLE
[WIP] Define kaiju_db and kraken_db as compound datatypes

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -186,6 +186,8 @@
     <datatype extension="gatk_tranche" type="galaxy.datatypes.tabular:Tabular" subclass="true" display_in_upload="true"/>
     <datatype extension="gatk_recal" type="galaxy.datatypes.tabular:Tabular" subclass="true" display_in_upload="true"/>
     <datatype extension="jpg" type="galaxy.datatypes.images:Jpg" mimetype="image/jpeg"/>
+    <datatype extension="kaiju_db" type="galaxy.datatypes.seq_db:KaijuDB" mimetype="text/html" display_in_upload="false"/>
+    <datatype extension="kraken_db" type="galaxy.datatypes.seq_db:KaijuDB" mimetype="text/html" diplay_in_upload="false"/>
     <datatype extension="tiff" type="galaxy.datatypes.images:Tiff" mimetype="image/tiff" display_in_upload="true"/>
     <datatype extension="tf2" type="galaxy.datatypes.images:Tiff" subclass="true" display_in_upload="false"/>
     <datatype extension="tf8" type="galaxy.datatypes.images:Tiff" subclass="true" display_in_upload="false"/>

--- a/lib/galaxy/datatypes/seq_db.py
+++ b/lib/galaxy/datatypes/seq_db.py
@@ -1,0 +1,90 @@
+"""Sequence database datatypes (e.g. kmer fingerprints)."""
+from .data import Data
+
+
+class KaijuDB(Data):
+    """Compound datatype for multi-file Kaiju database."""
+    file_ext = 'kaiju_db'
+    allow_datatype_change = False
+    composite_type = 'basic'
+
+    def __init__(self, **kwd):
+        Data.__init__(self, **kwd)
+        self.add_composite_file('kaiju_library.fmi', is_binary=True)  # database
+        self.add_composite_file('nodes.dmp', optional=True)  # NCBI taxonomy
+        self.add_composite_file('names.dmp', optional=True)  # NCBI taxonomy
+
+    def set_peek(self, dataset, is_multi_byte=False):
+        """Set the peek and blurb text."""
+        if not dataset.dataset.purged:
+            dataset.peek = "Kaiju database (multiple files)"
+            dataset.blurb = "Kaiju database (multiple files)"
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def display_peek(self, dataset):
+        """Create HTML content, used for displaying peek."""
+        try:
+            return dataset.peek
+        except Exception:
+            return "Kaiju database (multiple files)"
+
+    def display_data(self, trans, data, preview=False, filename=None,
+                     to_ext=None, size=None, offset=None, **kwd):
+        """Display data in the central pane via the "eye" icon."""
+        return "Kaiju database (multiple files)"
+
+    def merge(split_files, output_file):
+        """Merge Kaiju databases (not implemented)."""
+        raise NotImplementedError("Merging Kaiju databases is not supported")
+
+    def split(cls, input_datasets, subdir_generator_function, split_params):
+        """Split a Kaiju database (not implemented)."""
+        if split_params is None:
+            return None
+        raise NotImplementedError("Can't split Kaiju databases")
+
+
+class KrakenDB(Data):
+    """Compound datatype for multi-file Kraken database."""
+    file_ext = 'kraken_db'
+    allow_datatype_change = False
+    composite_type = 'basic'
+
+    def __init__(self, **kwd):
+        Data.__init__(self, **kwd)
+        self.add_composite_file('database.kdb', is_binary=True)  # kmer database
+        self.add_composite_file('database.idx', is_binary=True)  # index
+        # TODO: Can we add taxonomy/names.dmp and taxonomy/nodes.dmp here?
+
+    def set_peek(self, dataset, is_multi_byte=False):
+        """Set the peek and blurb text."""
+        if not dataset.dataset.purged:
+            dataset.peek = "Kraken database (multiple files)"
+            dataset.blurb = "Kraken database (multiple files)"
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def display_peek(self, dataset):
+        """Create HTML content, used for displaying peek."""
+        try:
+            return dataset.peek
+        except Exception:
+            return "Kraken database (multiple files)"
+
+    def display_data(self, trans, data, preview=False, filename=None,
+                     to_ext=None, size=None, offset=None, **kwd):
+        """Display data in the central pane via the "eye" icon."""
+        return "Kraken database (multiple files)"
+
+    def merge(split_files, output_file):
+        """Merge Kraken databases (not implemented)."""
+        raise NotImplementedError("Merging Kraken databases is not supported")
+
+    def split(cls, input_datasets, subdir_generator_function, split_params):
+        """Split a Kraken database (not implemented)."""
+        if split_params is None:
+            return None
+        raise NotImplementedError("Can't split Kraken databases")


### PR DESCRIPTION
This is a work-in-progress (WIP), creating the pull request now for visibility and any early feedback (e.g. class names, datatype names).

I am working on a Galaxy wrapper for a colleuages' new tool ``kodoja``, which builds on ``kraken`` (wrapped for Galaxy by IUC) and ``kaiju``  (not yet wrapped in Galaxy), both of which can build their own multi-file databases (which include NCBI taxonomy files).

In order to fully support these tools in Galaxy, I think we need to add multi-file datatypes for these two kinds of sequence based datatypes. There are clear parallels in my mind with BLAST databases, where we started with SysAdmin provided entries via ``*.loc`` files before defining the extra datatypes and adding tool support to build and use them as history entries.

In the short term I am planning to work on a branch of https://github.com/abaizan/kodoja_galaxy testing against my Galaxy ``kk_bb`` branch which has the two new datatypes. A similar plan would work for enhancing the ``kraken`` wrappers to allow users to build databases and use them from their history.