### PR TITLE
[18.01] Fix/default role type on auto created roles

### DIFF
--- a/lib/galaxy/security/__init__.py
+++ b/lib/galaxy/security/__init__.py
@@ -777,7 +777,7 @@ class GalaxyRBACAgent(RBACAgent):
         return role
 
     def get_role(self, name, type=None):
-        type = type or self.model.Role.types.ADMIN
+        type = type or self.model.Role.types.SYSTEM
         # will raise exception if not found
         return self.sa_session.query(self.model.Role) \
             .filter(and_(self.model.Role.table.c.name == name,
@@ -785,7 +785,7 @@ class GalaxyRBACAgent(RBACAgent):
             .one()
 
     def create_role(self, name, description, in_users, in_groups, create_group_for_role=False, type=None):
-        type = type or self.model.Role.types.ADMIN
+        type = type or self.model.Role.types.SYSTEM
         role = self.model.Role(name=name, description=description, type=type)
         self.sa_session.add(role)
         # Create the UserRoleAssociations


### PR DESCRIPTION
Original PR #5572 - this shows the proper changed files again..

As per comment here: https://github.com/galaxyproject/galaxy/commit/8be4addaa995b6a4cf2c9bad1d2d4b88a4b0ce78#r27671595

There are two more instances that would create "admin" roles (I have actually no clue what the difference between the SYSTEM and ADMIN type is):
- https://github.com/galaxyproject/galaxy/blob/62826a116054030ba50b801f3923a24768de197c/lib/galaxy/webapps/galaxy/api/roles.py#L72
- https://github.com/galaxyproject/galaxy/blob/0d8520fe2df1c24c625d27ee8308b4daff0565dc/lib/galaxy/webapps/galaxy/controllers/admin.py#L985