### PR TITLE
Make problematic test test_library_to_collections more robust.

### DIFF
--- a/test/selenium_tests/test_library_to_collections.py
+++ b/test/selenium_tests/test_library_to_collections.py
@@ -30,9 +30,9 @@ class LibraryToCollectionsTestCase(SharedStateSeleniumTestCase):
     def setup_shared_state(self):
         self.admin_login()
         self.perform_upload(self.get_filename("1.bed"))
-        self.wait_for_history()
+        self.history_panel_wait_for_hid_ok(1, allowed_force_refreshes=1)
         self.perform_upload(self.get_filename("2.bed"))
-        self.wait_for_history()
+        self.history_panel_wait_for_hid_ok(2, allowed_force_refreshes=1)
 
         self.name = self._get_random_name(prefix="testcontents")
 


### PR DESCRIPTION
Now that #5701 has been merged we have some more clues on the problem with this test. It is dying on the second upload being changed here. I suspect what is happening is that we are waiting on a history to become okay but we make that check before the first upload has even finished - so there is some chance the history is okay because it is empty - so we are reopening the home page in the middle of the first upload and this is causing something odd to happen - something is popping up an empty alert (the last lines in the console logs are related to chunking - so that might explain why this test in particular has gotten so bad in the last week or so). I'm not sure what is causing that alert but it isn't what we are testing with this test so it is best to really just wait on the uploads directly - as we do in other tests (see test_uploads.py for instance).

``history_panel_wait_for_hid_ok`` is a stronger assertion and is generally more robust and has better error reporting anyway so this should be a stability win all around.