### PR TITLE
Downgrade the warning to an info

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -663,7 +663,7 @@ class DistributedObjectStore(NestedObjectStore):
             # distributed object store, or if the object's store id is invalid,
             # try to locate the object
             log.debug('The backend object store ID (%s) for %s object with ID %s is invalid'
-                        % (obj.object_store_id, obj.__class__.__name__, obj.id))
+                      % (obj.object_store_id, obj.__class__.__name__, obj.id))
             for id, store in self.backends.items():
                 if store.exists(obj, **kwargs):
                     log.warning('%s object with ID %s found in backend object store with ID %s'

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -662,7 +662,7 @@ class DistributedObjectStore(NestedObjectStore):
             # if this instance has been switched from a non-distributed to a
             # distributed object store, or if the object's store id is invalid,
             # try to locate the object
-            log.warning('The backend object store ID (%s) for %s object with ID %s is invalid'
+            log.debug('The backend object store ID (%s) for %s object with ID %s is invalid'
                         % (obj.object_store_id, obj.__class__.__name__, obj.id))
             for id, store in self.backends.items():
                 if store.exists(obj, **kwargs):

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -656,21 +656,22 @@ class DistributedObjectStore(NestedObjectStore):
             return default
 
     def __get_store_id_for(self, obj, **kwargs):
-        if obj.object_store_id is not None and obj.object_store_id in self.backends:
-            return obj.object_store_id
-        else:
-            # if this instance has been switched from a non-distributed to a
-            # distributed object store, or if the object's store id is invalid,
-            # try to locate the object
-            log.debug('The backend object store ID (%s) for %s object with ID %s is invalid'
-                      % (obj.object_store_id, obj.__class__.__name__, obj.id))
-            for id, store in self.backends.items():
-                if store.exists(obj, **kwargs):
-                    log.warning('%s object with ID %s found in backend object store with ID %s'
-                                % (obj.__class__.__name__, obj.id, id))
-                    obj.object_store_id = id
-                    _create_object_in_session(obj)
-                    return id
+        if obj.object_store_id is not None:
+            if obj.object_store_id in self.backends:
+                return obj.object_store_id
+            else:
+                log.warning('The backend object store ID (%s) for %s object with ID %s is invalid'
+                            % (obj.object_store_id, obj.__class__.__name__, obj.id))
+        # if this instance has been switched from a non-distributed to a
+        # distributed object store, or if the object's store id is invalid,
+        # try to locate the object
+        for id, store in self.backends.items():
+            if store.exists(obj, **kwargs):
+                log.warning('%s object with ID %s found in backend object store with ID %s'
+                            % (obj.__class__.__name__, obj.id, id))
+                obj.object_store_id = id
+                _create_object_in_session(obj)
+                return id
         return None
 
 


### PR DESCRIPTION
Since this is driving me insane in sentry. We changed to a distributed object store and see this for most dataset accesses.

![auswahl_382](https://user-images.githubusercontent.com/458683/37588010-dd34fc06-2b58-11e8-9bf1-ebd59b260395.png)
