### PR TITLE
Remove subclass="true" from Phylip datatype definition

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -497,7 +497,7 @@
     <datatype extension="ncbi" type="galaxy.datatypes.data:Text" subclass="true"/>
     <datatype extension="nexus" type="galaxy.datatypes.data:Text" subclass="true"/>
     <datatype extension="nexusnon" type="galaxy.datatypes.data:Text" subclass="true"/>
-    <datatype extension="phylip" type="galaxy.datatypes.phylip:Phylip" subclass="true" display_in_upload="true"/>
+    <datatype extension="phylip" type="galaxy.datatypes.phylip:Phylip" display_in_upload="true"/>
     <datatype extension="phylipnon" type="galaxy.datatypes.data:Text" subclass="true"/>
     <datatype extension="pir" type="galaxy.datatypes.data:Text" subclass="true"/>
     <datatype extension="staden" type="galaxy.datatypes.data:Text" subclass="true"/>


### PR DESCRIPTION
Introduced in commit 3e63b63720c7c5b2fc672f1bfa9b66bb38851f54 .