### PR TITLE
Updated example to work with 18.01

### DIFF
--- a/contrib/galaxy_supervisor.conf
+++ b/contrib/galaxy_supervisor.conf
@@ -23,8 +23,7 @@ autostart       = true
 autorestart     = true
 startsecs       = 20
 user            = galaxy
-environment     = PATH=/home/galaxy/galaxy/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,PYTHONHOME=/home/galaxy/galaxy/.venv
-numprocs        = 1
+environment     = PATH=/home/galaxy/galaxy/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 stopsignal      = INT
 startretries    = 15
 
@@ -38,7 +37,7 @@ autostart       = true
 autorestart     = true
 startsecs       = 20
 user            = galaxy
-environment     = PYTHONHOME=/home/galaxy/galaxy/.venv
+environment     = PATH=/home/galaxy/galaxy/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,VIRTUAL_ENV=/home/galaxy/galaxy/.venv
 startretries    = 15
 
 [group:galaxy]


### PR DESCRIPTION
As per discussions with @mvdbeek, PYTHON_HOME breaks installations using conda. The PATH change is necessary to make tool installation (using using `hg`) and tool running work.