### PR TITLE
[18.01] Backport 5724: upgrade clone failure logging to error

### DIFF
--- a/lib/tool_shed/util/hg_util.py
+++ b/lib/tool_shed/util/hg_util.py
@@ -62,7 +62,7 @@ def clone_repository(repository_clone_url, repository_file_dir, ctx_rev):
         error_message = 'Error cloning repository: %s' % e
         if isinstance(e, subprocess.CalledProcessError):
             error_message += "\nOutput was:\n%s" % stdouterr
-        log.debug(error_message)
+        log.error(error_message)
         return False, error_message
 
 


### PR DESCRIPTION
Backport of https://github.com/galaxyproject/galaxy/pull/5724

When a failed clone logs as log.debug() this is invisible to a production Galaxy admin. This change upgrades the logging to 'log.error()'.