### PR TITLE
Drop old charts building from makefile/package scripts 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,10 +166,6 @@ client-test: client ## Run qunit tests via Karma
 client-test-watch: client ## Watch and run qunit tests on changes via Karma
 	cd client && yarn run test-watch
 
-charts: node-deps ## Rebuild charts
-	cd client && yarn run build-charts
-
-
 # Release Targets
 release-create-rc: release-ensure-upstream ## Create a release-candidate branch
 	git checkout dev

--- a/client/galaxy/scripts/mvc/collection/collection-model.js
+++ b/client/galaxy/scripts/mvc/collection/collection-model.js
@@ -65,7 +65,7 @@ var DatasetCollectionElementMixin = {
         // instead of this.id.
         const object = attributes.object;
         let elementId = this.elementId;
-        if(object) {
+        if (object) {
             elementId = attributes.object.id;
             delete attributes.object.id;
         }

--- a/client/package.json
+++ b/client/package.json
@@ -49,8 +49,6 @@
     "gulp-production-maps": "GXY_BUILD_SOURCEMAPS=1 NODE_ENV=production gulp",
     "build-toolshed": "grunt --app=toolshed",
     "jshint": "jshint --exclude='galaxy/scripts/libs/**' galaxy/scripts/**/*.js",
-    "build-charts": "webpack -p --config ../config/plugins/visualizations/charts/webpack.config.js",
-    "build-scatterplot": "NODE_PATH=./node_modules webpack -p --config ../config/plugins/visualizations/scatterplot/webpack.config.js",
     "prettier": "prettier --write --tab-width 4 --print-width 120 \"galaxy/scripts/{,!(libs)/**/}/{*.js,*.vue}\""
   },
   "devDependencies": {


### PR DESCRIPTION
This is no longer necessary (and we removed the other part of the config already) -- charts are individually packed using parcel.

This addresses the failing build attempt (in that we shouldn't have the option) in #5736.