### PR TITLE
Remove extract_genomic_dna tool from tool sample.

### DIFF
--- a/config/tool_conf.xml.sample
+++ b/config/tool_conf.xml.sample
@@ -95,7 +95,6 @@
     <tool file="maf/maf_by_block_number.xml" />
     <tool file="maf/maf_reverse_complement.xml" />
     <tool file="maf/maf_filter.xml" />
-    <tool file="extract/extract_genomic_dna.xml" />
   </section>
   <section id="bxops" name="Operate on Genomic Intervals" version="">
     <tool file="filters/wiggle_to_simple.xml" />


### PR DESCRIPTION
It has serious issues and a better version from the IUC is available at https://toolshed.g2.bx.psu.edu/repository?repository_id=5e1b70f8c4a31a72&changeset_revision=e400dcbc60d0.

Alternative to https://github.com/galaxyproject/galaxy/pull/5618 until the tool is migrated out of Galaxy in some fashion. Keeping it in the code but not in the sample for now means existing deployers who want to keep it get to without making any changes but it prevents new deployers from having to figure out it is broken and a better version is available.