### PR TITLE
Allow formatting statsd data for influxdb

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1040,11 +1040,11 @@ galaxy:
   # between them within the same aggregator.
   #statsd_prefix: galaxy
 
-  # If you are using telegraf to collect these metrics and then sending them to
-  # InfluxDB, Galaxy can provide more nicely tagged metrics. Instead of sending
-  # prefix + dot-separated-path, Galaxy will send prefix with a tag path set to
-  # the page url
-  #statsd_influxdb: False
+  # If you are using telegraf to collect these metrics and then sneding
+  # them to InfluxDB, Galaxy can provide more nicely tagged metrics.
+  # Instead of sending prefix + dot-separated-path, Galaxy will send
+  # prefix with a tag path set to the page url
+  #statsd_influxdb: false
 
   # Log to graphite Graphite is an external statistics aggregator
   # (https://github.com/graphite-project/carbon) Enabling the following

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1040,7 +1040,7 @@ galaxy:
   # between them within the same aggregator.
   #statsd_prefix: galaxy
 
-  # If you are using telegraf to collect these metrics and then sneding
+  # If you are using telegraf to collect these metrics and then sending
   # them to InfluxDB, Galaxy can provide more nicely tagged metrics.
   # Instead of sending prefix + dot-separated-path, Galaxy will send
   # prefix with a tag path set to the page url

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1040,7 +1040,7 @@ galaxy:
   # between them within the same aggregator.
   #statsd_prefix: galaxy
 
-  # If you are using telegraf to collect these metrics and then sneding them to
+  # If you are using telegraf to collect these metrics and then sending them to
   # InfluxDB, Galaxy can provide more nicely tagged metrics. Instead of sending
   # prefix + dot-separated-path, Galaxy will send prefix with a tag path set to
   # the page url

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1040,6 +1040,12 @@ galaxy:
   # between them within the same aggregator.
   #statsd_prefix: galaxy
 
+  # If you are using telegraf to collect these metrics and then sneding them to
+  # InfluxDB, Galaxy can provide more nicely tagged metrics. Instead of sending
+  # prefix + dot-separated-path, Galaxy will send prefix with a tag path set to
+  # the page url
+  #statsd_influxdb: False
+
   # Log to graphite Graphite is an external statistics aggregator
   # (https://github.com/graphite-project/carbon) Enabling the following
   # options will cause galaxy to log request timing and other statistics

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2175,7 +2175,7 @@
 
 :Description:
     If you are using telegraf to collect these metrics and then
-    sneding them to InfluxDB, Galaxy can provide more nicely tagged
+    sending them to InfluxDB, Galaxy can provide more nicely tagged
     metrics. Instead of sending prefix + dot-separated-path, Galaxy
     will send prefix with a tag path set to the page url
 :Default: ``false``

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2169,6 +2169,19 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~
+``statsd_influxdb``
+~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    If you are using telegraf to collect these metrics and then
+    sneding them to InfluxDB, Galaxy can provide more nicely tagged
+    metrics. Instead of sending prefix + dot-separated-path, Galaxy
+    will send prefix with a tag path set to the page url
+:Default: ``false``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~~~
 ``graphite_host``
 ~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -627,6 +627,7 @@ class Configuration(object):
         self.statsd_host = kwargs.get('statsd_host', '')
         self.statsd_port = int(kwargs.get('statsd_port', 8125))
         self.statsd_prefix = kwargs.get('statsd_prefix', 'galaxy')
+        self.statsd_influxdb = string_as_bool(kwargs.get('statsd_influxdb', False))
         # Statistics and profiling with graphite
         self.graphite_host = kwargs.get('graphite_host', '')
         self.graphite_port = int(kwargs.get('graphite_port', 2003))

--- a/lib/galaxy/web/framework/middleware/statsd.py
+++ b/lib/galaxy/web/framework/middleware/statsd.py
@@ -23,17 +23,24 @@ class StatsdMiddleware(object):
                  application,
                  statsd_host,
                  statsd_port,
-                 statsd_prefix):
+                 statsd_prefix,
+                 statsd_influxdb):
         if not statsd:
             raise ImportError("Statsd middleware configured, but no statsd python module found. "
                            "Please install the python statsd module to use this functionality.")
         self.application = application
+        self.metric_infix = ''
+        if self.statsd_influxdb:
+            statsd_prefix = statsd_prefix.strip(',')
+            self.metric_infix = ',path='
         self.statsd_client = statsd.StatsClient(statsd_host, statsd_port, prefix=statsd_prefix)
 
     def __call__(self, environ, start_response):
         start_time = time.time()
         req = self.application(environ, start_response)
         dt = int((time.time() - start_time) * 1000)
-        self.statsd_client.timing(environ.get('controller_action_key', None) or environ.get('PATH_INFO', "NOPATH").strip('/').replace('/', '.'), dt)
-        self.statsd_client.timing('__global__', dt)
+
+        page = environ.get('controller_action_key', None) or environ.get('PATH_INFO', "NOPATH").strip('/').replace('/', '.')
+        self.statsd_client.timing(self.metric_infix + page, dt)
+        self.statsd_client.timing(self.metric_infix + '__global__', dt)
         return req

--- a/lib/galaxy/web/framework/middleware/statsd.py
+++ b/lib/galaxy/web/framework/middleware/statsd.py
@@ -30,7 +30,7 @@ class StatsdMiddleware(object):
                            "Please install the python statsd module to use this functionality.")
         self.application = application
         self.metric_infix = ''
-        if self.statsd_influxdb:
+        if statsd_influxdb:
             statsd_prefix = statsd_prefix.strip(',')
             self.metric_infix = ',path='
         self.statsd_client = statsd.StatsClient(statsd_host, statsd_port, prefix=statsd_prefix)

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -968,7 +968,8 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         app = wrap_if_allowed(app, stack, StatsdMiddleware,
                               args=(statsd_host,
                                     conf.get('statsd_port', 8125),
-                                    conf.get('statsd_prefix', 'galaxy')))
+                                    conf.get('statsd_prefix', 'galaxy'),
+                                    conf.get('statsd_influxdb', False)))
         log.debug("Enabling 'statsd' middleware")
     # graphite request timing and profiling
     graphite_host = conf.get('graphite_host', None)

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1623,7 +1623,7 @@ mapping:
         default: false
         required: false
         desc: |
-          If you are using telegraf to collect these metrics and then sneding
+          If you are using telegraf to collect these metrics and then sending
           them to InfluxDB, Galaxy can provide more nicely tagged metrics.
           Instead of sending prefix + dot-separated-path, Galaxy will send
           prefix with a tag path set to the page url

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1618,6 +1618,16 @@ mapping:
           useful if you are running multiple Galaxy instances and want to segment
           statistics between them within the same aggregator.
 
+      statsd_influxdb:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          If you are using telegraf to collect these metrics and then sneding
+          them to InfluxDB, Galaxy can provide more nicely tagged metrics.
+          Instead of sending prefix + dot-separated-path, Galaxy will send
+          prefix with a tag path set to the page url
+
       graphite_host:
         type: str
         required: false


### PR DESCRIPTION
Turn this mess:

![auswahl_388](https://user-images.githubusercontent.com/458683/37677152-1c02edca-2c72-11e8-980a-a163bd3be0b0.png)

Into this! (I.e. only one thing in your measurement list which is *way*  #nicer.)f

![auswahl_389](https://user-images.githubusercontent.com/458683/37677162-201a110e-2c72-11e8-8d3b-78dbe7e109a9.png)

xref https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd#influx-statsd

I'd actually been including the (duplicate) `__global__` into the plotted points because it was too hard to write a regex to exclude it. This makes that a snap, just `page = "__global__"` and the same with `!=`