### PR TITLE
Another attempt to skip flakey Selenium tests.

### DIFF
--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -2,6 +2,7 @@ import contextlib
 import json
 import os
 import time
+import unittest
 from functools import wraps
 from operator import itemgetter
 
@@ -33,10 +34,11 @@ def flakey(method):
     def wrapped_method(test_case, *args, **kwargs):
         try:
             method(test_case, *args, **kwargs)
+        except unittest.SkipTest:
+            raise
         except Exception:
             if SKIP_FLAKEY_TESTS_ON_ERROR:
-                from nose.plugins.skip import SkipTest
-                raise SkipTest()
+                raise unittest.SkipTest("Error encountered during test marked as @flakey.")
             else:
                 raise
 

--- a/test/selenium_tests/test_library_to_collections.py
+++ b/test/selenium_tests/test_library_to_collections.py
@@ -1,4 +1,4 @@
-from base.populators import flakey
+import unittest
 
 from .framework import (
     selenium_test,
@@ -6,12 +6,12 @@ from .framework import (
 )
 
 
+@unittest.skip
 class LibraryToCollectionsTestCase(SeleniumTestCase):
 
     requires_admin = True
 
     @selenium_test
-    @flakey
     def test_list_creation(self):
         self.admin_login()
         self.perform_upload(self.get_filename("1.bed"))


### PR DESCRIPTION
- Flakey was throwing nose's SkipTest but the Selenium framework was catching unittest's, fix that to use unittest version in both places.
- The problematic test is still throwing exceptions in the tearDown which is still causing build failures, flakey is insufficient as a result - just skip the whole test.