### PR TITLE
[18.01] uWSGI: Log listening URLs at startup.

### DIFF
--- a/lib/galaxy/web/stack/__init__.py
+++ b/lib/galaxy/web/stack/__init__.py
@@ -204,12 +204,11 @@ class UWSGIApplicationStack(MessageApplicationStack):
 
     @staticmethod
     def _socket_opt_to_str(opt, val):
-        listeners = []
         try:
             if val.startswith('='):
                 val = uwsgi.opt.get('shared-socket', [])[int(val.split('=')[1])]
             proto = opt if opt != 'socket' else 'uwsgi'
-            if proto == 'uwsgi' and not ':' in val:
+            if proto == 'uwsgi' and ':' not in val:
                 return 'uwsgi://' + val
             else:
                 proto = proto + '://'

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -175,6 +175,7 @@ uwsgi_app_factory = uwsgi_app
 def postfork_setup():
     from galaxy.app import app
     app.control_worker.bind_and_start()
+    app.application_stack.log_startup()
 
 
 def populate_api_routes(webapp, app):

--- a/scripts/galaxy-main
+++ b/scripts/galaxy-main
@@ -94,6 +94,7 @@ def load_galaxy_app(
         **kwds
     )
     app.control_worker.bind_and_start()
+    app.application_stack.log_startup()
     return app
 
 


### PR DESCRIPTION
Without these familiar messages, it's not obvious that the server is running and listening.

In development I toyed around with attempting to log something other than localhost when listening to all addresses, but ultimately decided to keep it simple(r).

If you run mules and don't use log file separation, these messages will appear before the mule loads its application and thus will be easily missed.

xref #5729 