### PR TITLE
Ignore seemingly harmless error when tearing down Selenium tests.

### DIFF
--- a/test/selenium_tests/framework.py
+++ b/test/selenium_tests/framework.py
@@ -298,7 +298,10 @@ class SeleniumTestCase(FunctionalTestCase, NavigatesGalaxy, UsesApiTestCaseMixin
         try:
             self.driver.close()
         except Exception as e:
-            exception = e
+            if "cannot kill Chrome" in str(e):
+                print("Ignoring likely harmless error in Selenium shutdown %s" % e)
+            else:
+                exception = e
 
         try:
             self.display.stop()


### PR DESCRIPTION
Causes otherwise passing tests to fail for not particular reason. Cannot find a Selenium issue for this but it has been reported on in their IRC - seems like just a very rare, transient issue.

xref https://jenkins.galaxyproject.org/job/docker-selenium/1830/testReport/junit/selenium_tests.test_saved_histories/SavedHistoriesTestCase/test_delete_and_undelete_history/