### PR TITLE
[18.01] Fix /api/whoami for master API key.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -36,7 +36,10 @@ class ConfigurationController(BaseAPIController):
         :rtype:   dict
         """
         current_user = self.user_manager.current_user(trans)
-        return current_user.to_dict()
+        rval = None
+        if current_user:  # None for master API key for instance
+            rval = current_user.to_dict()
+        return rval
 
     @expose_api_anonymous_and_sessionless
     def index(self, trans, **kwd):


### PR DESCRIPTION
Just yield a null JSON response instead of the internal server error that happens currently.