### PR TITLE
[18.01] Fix SQL query for "workflows shared with me" as part of workflow index.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -143,12 +143,13 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
                     item['show_in_tool_panel'] = True
                     break
             rval.append(item)
-        for wf_sa in trans.sa_session.query(trans.app.model.StoredWorkflowUserShareAssociation).options(
+        for wf_sa in trans.sa_session.query(model.StoredWorkflowUserShareAssociation).join(
+                model.StoredWorkflowUserShareAssociation.stored_workflow).options(
                 joinedload("stored_workflow").joinedload("latest_workflow").undefer("step_count").lazyload("steps")).options(
                 joinedload("stored_workflow").joinedload("user")).options(
-                joinedload("stored_workflow").joinedload("tags")).filter_by(user=trans.user).filter(
-                trans.app.model.StoredWorkflow.deleted == false()).order_by(
-                desc(trans.app.model.StoredWorkflow.update_time)).all():
+                joinedload("stored_workflow").joinedload("tags")).filter(model.StoredWorkflowUserShareAssociation.user == trans.user).filter(
+                model.StoredWorkflow.deleted == false()).order_by(
+                desc(model.StoredWorkflow.update_time)).all():
             item = wf_sa.stored_workflow.to_dict(value_mapper={'id': trans.security.encode_id})
             encoded_id = trans.security.encode_id(wf_sa.stored_workflow.id)
             item['url'] = url_for('workflow', id=encoded_id)


### PR DESCRIPTION
Before and after queries here:

https://gist.github.com/jmchilton/dc57bca60178341d9ce0f6cf6d4bd36f

You can see that before the joined load of the stored workflow wasn't being registered by SQLalchemy properly and so it was joining that table twice - once using the proper index and another time just walking the whole table. The filter and order by were being applied to the unconditional version - kind of like saying give me all the workflows and the right workflows and I will check all the workflows to see if this one is deleted instead of just the subset of workflows that are actually being shared with the target user.

Fixes https://github.com/galaxyproject/galaxy/pull/5777.