### PR TITLE
[18.01] Fix model operation tools that produce standalone datasets.

### DIFF
--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -69,5 +69,12 @@ class ModelOperationToolAction(DefaultToolAction):
 
     def _produce_outputs(self, trans, tool, out_data, output_collections, incoming, history, tags):
         tool.produce_outputs(trans, out_data, output_collections, incoming, history=history, tags=tags)
+        mapped_over_elements = output_collections.dataset_collection_elements
+        if mapped_over_elements:
+            for name, value in out_data.items():
+                if name in mapped_over_elements:
+                    value.visible = False
+                    mapped_over_elements[name].hda = value
+
         trans.sa_session.add_all(out_data.values())
         trans.sa_session.flush()

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -168,7 +168,11 @@ class ToolsTestCase(api.ApiTestCase):
                 }
             }
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-            self._run("__UNZIP_COLLECTION__", history_id, inputs, assert_ok=True)
+            response = self._run("__UNZIP_COLLECTION__", history_id, inputs, assert_ok=True)
+            implicit_collections = response["implicit_collections"]
+            self.assertEquals(len(implicit_collections), 2)
+            unzipped_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=implicit_collections[0]["hid"])
+            assert unzipped_hdca["elements"][0]["element_type"] == "hda", unzipped_hdca
 
     def test_zip_inputs(self):
         with self.dataset_populator.test_history() as history_id:


### PR DESCRIPTION
Broken in 78babab6455f4cd1c51aed0b1ddf6b4b29ad6d03 in the 18.01 branch. Should only affect unzip I think - fixes #5780 - probably need to rebuild collections though, collections built in the meantime are going to be broken in the DB.

Includes test case modification that causes it to fail against 18.01 currently.

xref 78babab6455f4cd1c51aed0b1ddf6b4b29ad6d03