### PR TITLE
Add delay attribute to grid handler

### DIFF
--- a/client/galaxy/scripts/mvc/grid/grid-template.js
+++ b/client/galaxy/scripts/mvc/grid/grid-template.js
@@ -175,8 +175,10 @@ export default {
                     // Check for row wrapping
                     tmpl += `<td ${nowrap}>`;
 
-                    // Link
-                    if (link) {
+                    // Determine cell content
+                    if (column.delayed) {
+                        tmpl += `<div class="delayed-value-${column.key}" data-id="${item.encode_id}" data-value="${value}"><span class="fa fa-spinner fa-spin"></span></div>`;
+                    } else if (link) {
                         if (options.operations.length !== 0) {
                             tmpl += `<div id="${id}" class="${cls}" style="float: left;">`;
                         }

--- a/client/galaxy/scripts/mvc/grid/grid-view.js
+++ b/client/galaxy/scripts/mvc/grid/grid-view.js
@@ -267,13 +267,13 @@ export default Backbone.View.extend({
             var button = self.$(`#grid-${item.encode_id}-popup`).off();
             var popup = new PopupMenu(button);
             _.each(options.operations, operation => {
-                self._add_operation(popup, operation, item);
+                self.add_operation(popup, operation, item);
             });
         });
     },
 
     /** Add an operation to the items menu */
-    _add_operation: function(popup, operation, item) {
+    add_operation: function(popup, operation, item) {
         var self = this;
         var settings = item.operation_config[operation.label];
         if (settings.allowed && operation.allow_popup) {

--- a/client/galaxy/scripts/mvc/history/history-list.js
+++ b/client/galaxy/scripts/mvc/history/history-list.js
@@ -20,7 +20,7 @@ var HistoryGridView = GridView.extend({
         const fetchDetails = $.makeArray(
             this.$el.find(".delayed-value-datasets_by_state").map((i, el) => {
                 return () => {
-                    const historyId = $(el).data("history-id");
+                    const historyId = $(el).data("id");
                     const url = `${
                         Galaxy.root
                     }api/histories/${historyId}?keys=nice_size,contents_active,contents_states`;
@@ -45,8 +45,8 @@ var HistoryGridView = GridView.extend({
                         if (hidden) {
                             stateHtml += `<div class="count-box state-color-hidden" title="Hidden datasets">${hidden}</div> `;
                         }
-                        $(`.delayed-value-datasets_by_state[data-history-id='${historyId}']`).html(stateHtml);
-                        $(`.delayed-value-disk_size[data-history-id='${historyId}']`).html(req["nice_size"]);
+                        $(`.delayed-value-datasets_by_state[data-id='${historyId}']`).html(stateHtml);
+                        $(`.delayed-value-disk_size[data-id='${historyId}']`).html(req["nice_size"]);
                     };
                     var xhr = jQuery.ajax(options);
                     return xhr;
@@ -73,7 +73,7 @@ var HistoryGridView = GridView.extend({
             });
     },
     /** Add an operation to the items menu */
-    _add_operation: function(popup, operation, item) {
+    add_operation: function(popup, operation, item) {
         var self = this;
         var settings = item.operation_config[operation.label];
         if (operation.label == "Copy") {
@@ -81,23 +81,7 @@ var HistoryGridView = GridView.extend({
                 self._showCopyDialog(id);
             };
         }
-        if (settings.allowed && operation.allow_popup) {
-            popup.addItem({
-                html: operation.label,
-                href: settings.url_args,
-                target: settings.target,
-                confirmation_text: operation.confirm,
-                func: function(e) {
-                    e.preventDefault();
-                    var label = $(e.target).html();
-                    if (operation.onclick) {
-                        operation.onclick(item.encode_id);
-                    } else {
-                        self.execute(this.findItemByHtml(label));
-                    }
-                }
-            });
-        }
+        GridView.prototype.add_operation.call(this, popup, operation, item);
     }
 });
 

--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -295,6 +295,7 @@ class Grid(object):
                 'sortable'          : column.sortable,
                 'label'             : column.label,
                 'filterable'        : column.filterable,
+                'delayed'           : column.delayed,
                 'is_text'           : isinstance(column, TextColumn),
                 'extra'             : extra
             })
@@ -402,7 +403,8 @@ class GridColumn(object):
     def __init__(self, label, key=None, model_class=None, method=None, format=None,
                  link=None, attach_popup=False, visible=True, nowrap=False,
                  # Valid values for filterable are ['standard', 'advanced', None]
-                 filterable=None, sortable=True, label_id_prefix=None, target=None):
+                 filterable=None, sortable=True, label_id_prefix=None, target=None,
+                 delayed=False):
         """Create a grid column."""
         self.label = label
         self.key = key
@@ -415,6 +417,7 @@ class GridColumn(object):
         self.attach_popup = attach_popup
         self.visible = visible
         self.filterable = filterable
+        self.delayed = delayed
         # Column must have a key to be sortable.
         self.sortable = (self.key is not None and sortable)
         self.label_id_prefix = label_id_prefix or ''
@@ -422,7 +425,7 @@ class GridColumn(object):
     def get_value(self, trans, grid, item):
         if self.method:
             value = getattr(grid, self.method)(trans, item)
-        elif self.key:
+        elif self.key and hasattr(item, self.key):
             value = getattr(item, self.key)
         else:
             value = None

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -44,10 +44,6 @@ class NameColumn(grids.TextColumn):
 class HistoryListGrid(grids.Grid):
 
     # Custom column types
-    class DelayedValueColumn(grids.GridColumn):
-        def get_value(self, trans, grid, history):
-            return '<div class="delayed-value-%s" data-history-id="%s"><span class="fa fa-spinner fa-spin"></span></div>' % (self.key, trans.security.encode_id(history.id))
-
     class ItemCountColumn(grids.GridColumn):
         def get_value(self, trans, grid, history):
             return str(history.hid_counter - 1)
@@ -89,11 +85,11 @@ class HistoryListGrid(grids.Grid):
     columns = [
         HistoryListNameColumn("Name", key="name", attach_popup=True, filterable="advanced"),
         ItemCountColumn("Items", key="item_count", sortable=False),
-        DelayedValueColumn("Datasets", key="datasets_by_state", sortable=False, nowrap=True),
+        grids.GridColumn("Datasets", key="datasets_by_state", sortable=False, nowrap=True, delayed=True),
         grids.IndividualTagsColumn("Tags", key="tags", model_tag_association_class=model.HistoryTagAssociation,
                                    filterable="advanced", grid_name="HistoryListGrid"),
         grids.SharingStatusColumn("Sharing", key="sharing", filterable="advanced", sortable=False, use_shared_with_count=True),
-        DelayedValueColumn("Size on Disk", key="disk_size", sortable=False),
+        grids.GridColumn("Size on Disk", key="disk_size", sortable=False, delayed=True),
         grids.GridColumn("Created", key="create_time", format=time_ago),
         grids.GridColumn("Last Updated", key="update_time", format=time_ago),
         DeletedColumn("Status", key="deleted", filterable="advanced")


### PR DESCRIPTION
Minor adjustment to the handling of delayed values/cell contents for grids. Instead of building the spinner html in the backend, the content is handled at the front-end, and the `delayed` feature becomes reusable for other grids.