### PR TITLE
Lock pysam to 0.14.1 in Pipfile.

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/Pipfile
+++ b/lib/galaxy/dependencies/pipfiles/default/Pipfile
@@ -15,7 +15,7 @@ SQLAlchemy-Utils = "*"
 Mercurial = {version = "<=3.7.3", markers = "python_version < '3'"}
 pycrypto = "*"
 uWSGI = "*"
-pysam = "*"
+pysam = "==0.14.1"
 bdbag = "*"
 bleach = "*"
 "bz2file" = {version = "*", markers = "python_version < '3.3'"}


### PR DESCRIPTION
The generated requirements already specify this version, so I think the built requirements.txt/etc are good to go without more changes.

xref: https://github.com/galaxyproject/galaxy/pull/5786#issuecomment-376627378