### PR TITLE
[18.01] Client related readme/makefile clarifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,11 +43,8 @@ opened using [this form](https://github.com/galaxyproject/galaxy/issues/new).
 * Make sure you have a free [GitHub](https://github.com/) account.
 
 * Fork the [galaxy repository](https://github.com/galaxyproject/galaxy) on
-  GitHub to make your changes.  (While many Galaxy instances track
-  [galaxy-dist](https://bitbucket.org/galaxy/galaxy-dist), active development
-  happens in the galaxy GitHub repository and this is where pull requests
-  should be made).  To keep your copy up to date with respect to the main
-  repository, you need to frequently [sync your
+  GitHub to make your changes.  To keep your copy up to date with respect to
+  the main repository, you need to frequently [sync your
   fork](https://help.github.com/articles/syncing-a-fork/):
   ```
     $ git remote add upstream https://github.com/galaxyproject/galaxy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,15 +16,15 @@ Hub](https://galaxyproject.org).
 If you have an idea for a feature to add or an approach for a bugfix, it is
 best to communicate with Galaxy developers early. The primary venue for this is
 the [GitHub issue tracker](https://github.com/galaxyproject/galaxy/issues).
-Browse through existing GitHub issues and and if one seems related, comment on
-it.  For more direct communication, Galaxy developers are generally available
-via [IRC](https://galaxyproject.org/get-involved),
+Browse through existing GitHub issues and if one seems related, comment on it.
+For more direct communication, Galaxy developers are generally available via
+[IRC](https://galaxyproject.org/get-involved),
 [Gitter](https://gitter.im/galaxyproject/Lobby) and on the [development mailing
 list](http://dev.list.galaxyproject.org).
 
 If you're looking to help but aren't sure where to start, we also maintain a
 [tag](https://github.com/galaxyproject/galaxy/issues?q=is%3Aissue+is%3Aopen+label%3Afriendliness%2Ffriendly)
-on Github for smaller issues we believe would make the best entry points for
+on GitHub for smaller issues we believe would make the best entry points for
 new developers.
 
 ## Reporting a new issue
@@ -71,7 +71,7 @@ If no existing Galaxy issue seems appropriate, a new issue can be opened using
 * If your changes modify code please ensure the resulting files conform to
   Galaxy [style guidelines](https://galaxyproject.org/develop/best-practices).
 
-* If you are working on the Galaxy Client (the user interface -- javascript,
+* If you are working on the Galaxy Client (the user interface -- JavaScript,
   styles, etc.), see more information in the [client readme](client/README.md).
 
 * Galaxy contains hundreds of tests of different types and complexity and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,21 +14,23 @@ Hub](https://galaxyproject.org).
 ## Before you Begin
 
 If you have an idea for a feature to add or an approach for a bugfix, it is
-best to communicate with Galaxy developers early. The most common venues for
-this are [GitHub issues](https://github.com/galaxyproject/galaxy/issues).
-Browse through existing GitHub issues and Trello cards and if one seems
-related, comment on it. We also maintain a
-[tag](https://github.com/galaxyproject/galaxy/issues?q=is%3Aissue+is%3Aopen+label%3Afriendliness%2Ffriendly)
-on Github for smaller issues we believe would make the best entry points for
-new developers.  Galaxy developers are generally available via
-[IRC](https://galaxyproject.org/get-involved),
+best to communicate with Galaxy developers early. The primary venue for this is
+the [GitHub issue tracker](https://github.com/galaxyproject/galaxy/issues).
+Browse through existing GitHub issues and and if one seems related, comment on
+it.  For more direct communication, Galaxy developers are generally available
+via [IRC](https://galaxyproject.org/get-involved),
 [Gitter](https://gitter.im/galaxyproject/Lobby) and on the [development mailing
 list](http://dev.list.galaxyproject.org).
 
+If you're looking to help but aren't sure where to start, we also maintain a
+[tag](https://github.com/galaxyproject/galaxy/issues?q=is%3Aissue+is%3Aopen+label%3Afriendliness%2Ffriendly)
+on Github for smaller issues we believe would make the best entry points for
+new developers.
+
 ## Reporting a new issue
 
-If no existing Galaxy issue/Trello card seems appropriate, a new issue can be
-opened using [this form](https://github.com/galaxyproject/galaxy/issues/new).
+If no existing Galaxy issue seems appropriate, a new issue can be opened using
+[this form](https://github.com/galaxyproject/galaxy/issues/new).
 
 ## How to Contribute
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,29 @@
 # Contributing
 
-Galaxy welcomes new development!
-This document briefly describes how to contribute to the [core
-galaxy project](https://github.com/galaxyproject/galaxy) -
-also checkout our 2013 Galaxy Community
-Conference presentation on the topic
+Galaxy welcomes new development!  This document briefly describes how to
+contribute to the [core galaxy
+project](https://github.com/galaxyproject/galaxy) - also checkout our 2013
+Galaxy Community Conference presentation on the topic
 ([video](https://vimeo.com/channels/581875/73486255),
-[presentation](https://depot.galaxyproject.org/hub/attachments/documents/presentations/gcc2013/BakerContribute.pdf)). For
-information on contributing more broadly to the Galaxy ecosystem and a
+[presentation](https://depot.galaxyproject.org/hub/attachments/documents/presentations/gcc2013/BakerContribute.pdf)).
+For information on contributing more broadly to the Galaxy ecosystem and a
 deeper discussion of some of these points - please see the
-[Develop](https://galaxyproject.org/develop) section of the
-[Galaxy Community Hub](https://galaxyproject.org).
+[Develop](https://galaxyproject.org/develop) section of the [Galaxy Community
+Hub](https://galaxyproject.org).
 
 ## Before you Begin
 
-If you have an idea for a feature to add or an approach for a bugfix,
-it is best to communicate with Galaxy developers early. The most
-common venues for this are
-[GitHub issues](https://github.com/galaxyproject/galaxy/issues).
-Browse through existing GitHub issues and Trello cards and if one seems related,
-comment on it. We also maintain a [tag](https://github.com/galaxyproject/galaxy/issues?q=is%3Aissue+is%3Aopen+label%3Afriendliness%2Ffriendly) on Github for
-smaller issues we believe would make the best entry points for new
-developers.
-Galaxy developers are generally available via
-[IRC](https://galaxyproject.org/get-involved), [Gitter](https://gitter.im/galaxyproject/Lobby)
-and on the [development mailing list](http://dev.list.galaxyproject.org).
+If you have an idea for a feature to add or an approach for a bugfix, it is
+best to communicate with Galaxy developers early. The most common venues for
+this are [GitHub issues](https://github.com/galaxyproject/galaxy/issues).
+Browse through existing GitHub issues and Trello cards and if one seems
+related, comment on it. We also maintain a
+[tag](https://github.com/galaxyproject/galaxy/issues?q=is%3Aissue+is%3Aopen+label%3Afriendliness%2Ffriendly)
+on Github for smaller issues we believe would make the best entry points for
+new developers.  Galaxy developers are generally available via
+[IRC](https://galaxyproject.org/get-involved),
+[Gitter](https://gitter.im/galaxyproject/Lobby) and on the [development mailing
+list](http://dev.list.galaxyproject.org).
 
 ## Reporting a new issue
 
@@ -33,23 +32,23 @@ opened using [this form](https://github.com/galaxyproject/galaxy/issues/new).
 
 ## How to Contribute
 
-* All changes to the [core galaxy project](https://github.com/galaxyproject/galaxy)
-  should be made through pull requests to this repository (with just two
-  exceptions outlined below).
+* All changes to the [core galaxy
+  project](https://github.com/galaxyproject/galaxy) should be made through pull
+  requests to this repository (with just two exceptions outlined below).
 
-* If you are new to Git, the [Try Git](http://try.github.com/) tutorial is a good places to start.
-  More learning resources are listed at https://help.github.com/articles/good-resources-for-learning-git-and-github/ .
+* If you are new to Git, the [Try Git](http://try.github.com/) tutorial is a
+  good places to start.  More learning resources are listed at
+  https://help.github.com/articles/good-resources-for-learning-git-and-github/
 
 * Make sure you have a free [GitHub](https://github.com/) account.
 
 * Fork the [galaxy repository](https://github.com/galaxyproject/galaxy) on
-  GitHub to make your changes.
-  (While many Galaxy instances track
+  GitHub to make your changes.  (While many Galaxy instances track
   [galaxy-dist](https://bitbucket.org/galaxy/galaxy-dist), active development
   happens in the galaxy GitHub repository and this is where pull requests
-  should be made).
-  To keep your copy up to date with respect to the main repository, you need to
-  frequently [sync your fork](https://help.github.com/articles/syncing-a-fork/):
+  should be made).  To keep your copy up to date with respect to the main
+  repository, you need to frequently [sync your
+  fork](https://help.github.com/articles/syncing-a-fork/):
   ```
     $ git remote add upstream https://github.com/galaxyproject/galaxy
     $ git fetch upstream
@@ -59,39 +58,40 @@ opened using [this form](https://github.com/galaxyproject/galaxy/issues/new).
 
 * Choose the correct branch to develop your changes against.
 
-  * Additions of new features to the code base should be pushed to the `dev` branch (`git
-    checkout dev`).
+  * Additions of new features to the code base should be pushed to the `dev`
+    branch (`git checkout dev`).
 
   * Most bug fixes to previously release components (things in galaxy-dist)
-    should be made against the recent `release_XX.XX` branch (`git checkout release_XX.XX`).
+    should be made against the recent `release_XX.XX` branch (`git checkout
+    release_XX.XX`).
 
-  * Serious security problems should not be fixed via pull request - please
-    see [the Galaxy security policies](SECURITY_POLICY.md) for information
-    about responsibly disclosing security issues.
+  * Serious security problems should not be fixed via pull request - please see
+    [the Galaxy security policies](SECURITY_POLICY.md) for information about
+    responsibly disclosing security issues.
 
 * If your changes modify code please ensure the resulting files conform to
   Galaxy [style guidelines](https://galaxyproject.org/develop/best-practices).
 
-* If you are working on the Galaxy Client (the user interface -- javascript
-  styles), see more information in the [client readme](client/README.md).
+* If you are working on the Galaxy Client (the user interface -- javascript,
+  styles, etc.), see more information in the [client readme](client/README.md).
 
-* Galaxy contains hundreds of tests of different types and complexity
-  and running each is difficult and probably not reasonable at this
-  time (someday we will provide a holistic test procedure to make this
-  possible). For now, please just review the [running tests
-  documentation](https://galaxyproject.org/admin/running-tests)
-  and run any that seem relevant. Developers reviewing your pull
-  request will be happy to help guide you to running the most relevant
-  tests as part of the pull request review process and may request the
-  output of these tests. You can run the continuous integration tests locally
-  using `tox`, example: `tox -e py27-lint,py27-unit`.
+* Galaxy contains hundreds of tests of different types and complexity and
+  running each is difficult and probably not reasonable at this time (someday
+  we will provide a holistic test procedure to make this possible). For now,
+  please just review the [running tests
+  documentation](https://galaxyproject.org/admin/running-tests) and run any
+  that seem relevant. Developers reviewing your pull request will be happy to
+  help guide you to running the most relevant tests as part of the pull request
+  review process and may request the output of these tests. You can run the
+  continuous integration tests locally using `tox`, example: `tox -e
+  py27-lint,py27-unit`.
 
 * Commit and push your changes to your
   [fork](https://help.github.com/articles/pushing-to-a-remote/).
 
 * Open a [pull
-  request](https://help.github.com/articles/creating-a-pull-request/)
-  with these changes. You pull request message ideally should include:
+  request](https://help.github.com/articles/creating-a-pull-request/) with
+  these changes. You pull request message ideally should include:
 
    * A description of why the changes should be made.
 
@@ -102,16 +102,16 @@ opened using [this form](https://github.com/galaxyproject/galaxy/issues/new).
 * The pull request should pass all the continuous integration tests which are
   automatically run by GitHub using e.g. Travis CI.
 
-* Your pull request will be handled according to
-  [some rules](doc/source/project/organization.rst#handling-pull-requests).
+* Your pull request will be handled according to [some
+  rules](doc/source/project/organization.rst#handling-pull-requests).
 
 ## A Quick Note about Tools
 
-  For the most part, Galaxy tools should be published to the
-  [Tool Shed](https://galaxyproject.org/toolshed) and not in this
-  repository directly. If you are looking for migrated
-  core tools that used to exist in this repository - please checkout
-  the [tools-iuc](https://github.com/galaxyproject/tools-iuc)
-  repository on GitHub.
+  For the most part, Galaxy tools should be published to the [Tool
+  Shed](https://galaxyproject.org/toolshed) and not in this repository
+  directly. If you are looking for migrated core tools that used to exist in
+  this repository - please checkout the
+  [tools-iuc](https://github.com/galaxyproject/tools-iuc) repository on GitHub.
 
-  More information about tool development can be found [on the comunity hub](https://galaxyproject.org/develop).
+  More information about tool development can be found [on the comunity
+  hub](https://galaxyproject.org/develop).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ opened using [this form](https://github.com/galaxyproject/galaxy/issues/new).
 * If your changes modify code please ensure the resulting files conform to
   Galaxy [style guidelines](https://galaxyproject.org/develop/best-practices).
 
-* If you are working on Galaxy Client (the user interface -- javascript
+* If you are working on the Galaxy Client (the user interface -- javascript
   styles), see more information in the [client readme](client/README.md).
 
 * Galaxy contains hundreds of tests of different types and complexity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,9 +69,11 @@ opened using [this form](https://github.com/galaxyproject/galaxy/issues/new).
     see [the Galaxy security policies](SECURITY_POLICY.md) for information
     about responsibly disclosing security issues.
 
-* If your changes modify code - please ensure the resulting files
-  conform to Galaxy [style
-  guidelines](https://galaxyproject.org/develop/best-practices).
+* If your changes modify code please ensure the resulting files conform to
+  Galaxy [style guidelines](https://galaxyproject.org/develop/best-practices).
+
+* If you are working on Galaxy Client (the user interface -- javascript
+  styles), see more information in the [client readme](client/README.md).
 
 * Galaxy contains hundreds of tests of different types and complexity
   and running each is difficult and probably not reasonable at this

--- a/Makefile
+++ b/Makefile
@@ -158,10 +158,10 @@ client: node-deps ## Rebuild client-side artifacts for local development.
 	cd client && yarn run build
 	@echo $(CLIENT_COMMIT_WARNING)
 
-client-production: node-deps ## Rebuild client-side artifacts for a production deployment (or committing to the repository).
+client-production: node-deps ## Rebuild client-side artifacts for a production deployment without sourcemaps.
 	cd client && yarn run build-production
 
-client-production-maps: node-deps ## Rebuild client-side artifacts for a production deployment, and include sourcemaps to aid in debugging efforts.
+client-production-maps: node-deps ## Rebuild client-side artifacts for a production deployment with sourcemaps.
 	cd client && yarn run build-production-maps
 
 client-format: node-deps ## Reformat client code

--- a/client/README.md
+++ b/client/README.md
@@ -26,24 +26,26 @@ There are many moving parts to the client build system, but the entrypoint for
 most people is the 'client' rule in the Makefile at the root of the Galaxy
 repository.  Execute the following to perform a complete build suitable for
 local development, including dependency staging, style building, script
-processing and bundling.
+processing and bundling.  This is a development-specific build which includes
+extra debugging features, and excludes several production optimizations made
+during the build process.
 
     make client
 
-Note: Don't commit the files that 'make client' creates.  This is a
-development-specific build which includes extra debugging features, and
-excludes several production optimizations made during the build process.
-
-For a production build, suitable for committing to the repository, or deploying
-to a live server, use the following:
+For a production build, suitable for deploying to a live server, use the following:
 
     make client-production
 
 And, lastly, if you want a production build that includes sourcemaps to allow
-for perusal of the page-level javascript to facilitate live-server debugging,
-use:
+for inspection of live javascript to facilitate debugging, use:
 
     make client-production-maps
+
+Important Note: The development branch of Galaxy does not include client script
+artifacts, and these should not be committed.  When issuing a PR to a stable
+branch, please run "make client-production-maps", and include those artifacts.
+Or, if you'd rather, include only the /client source changes and build
+artifacts can be added by maintainers on merge.
 
 
 Automatic Rebuilding (Watch Mode)

--- a/client/README.md
+++ b/client/README.md
@@ -14,7 +14,7 @@ nodejs.org and yarnpkg.com.
 The Galaxy client build has necessarily grown more complex in the past several
 years, but we're still trying to keep things as simple as possible for
 developers (everyone, really).  If you're having any trouble with building the
-client after following the instructions below please create an issue on Github
+client after following the instructions below please create an issue on GitHub
 or reach out for help directly on Gitter at
 https://gitter.im/galaxyproject/Lobby.
 


### PR DESCRIPTION
Made the client README slightly easier to find.  Updated the Makefile comments to reflect the sourcemap compromise.  Minor tweaks to client README.

Also did a text reflow in CONTRIBUTING to standardize line breaks.

xref https://github.com/galaxyproject/galaxy/issues/5483
