### PR TITLE
[18.01] Skip dataset conversion validation at TS install

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1606,7 +1606,9 @@ class DataToolParameter(BaseDataToolParameter):
         for name, conv_extension in input_source.parse_conversion_tuples():
             assert None not in [name, conv_extension], 'A name (%s) and type (%s) are required for explicit conversion' % (name, conv_extension)
             conv_type = tool.app.datatypes_registry.get_datatype_by_extension(conv_extension.lower())
-            if conv_type is None:
+            if conv_type is None and not isinstance(tool.app, ValidationContext):
+                # We only raise an error if we're currently loading the tool.
+                # ValidationContext's are usually set up without access to datatypes
                 raise ValueError("Datatype class not found for extension '%s', which is used as 'type' attribute in conversion of data parameter '%s'" % (conv_type, self.name))
             self.conversions.append((name, conv_extension, [conv_type]))
 


### PR DESCRIPTION
During TS installation tools will be loaded using ValidationContext
that only has the bare minimum required for loading tools. Notably
it does not have acces to the loaded datatypes, and therefore we can't
validate the conversion tag used for example in freebayes.
If we're dealing with a ValidationContext we now ignore missing
conversion targets.

This should fix a problem when trying to install freebayes that makes use of the conversion tag.
Alternatively the ValidationContext could get the app's datatype registry, but I think we'd probably want to always install the tool, even if there is a datatype missing. 