### PR TITLE
[18.01] Fix metadata setting for CRAM files

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -563,6 +563,7 @@ class CRAM(Binary):
     def set_index_file(self, dataset, index_file):
         try:
             pysam.index(dataset.file_name, index_file.file_name)
+            return True
         except Exception as exc:
             log.warning('%s, set_index_file Exception: %s', self, exc)
             return False


### PR DESCRIPTION
Should fix https://github.com/galaxyproject/galaxy/issues/5801.
Broken in https://github.com/galaxyproject/galaxy/pull/5037