### PR TITLE
[18.01]  Use app.datatypes_registry in ValidationContext.from_app() 

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -502,11 +502,7 @@ class Registry(object):
 
     def get_datatype_by_extension(self, ext):
         """Returns a datatype object based on an extension"""
-        try:
-            builder = self.datatypes_by_extension[ext]
-        except KeyError:
-            builder = None
-        return builder
+        return self.datatypes_by_extension.get(ext, None)
 
     def change_datatype(self, data, ext):
         data.extension = ext

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -35,7 +35,6 @@ from ..parameters import (
     history_query
 )
 from ..parser import get_input_source as ensure_input_source
-from ..repositories import ValidationContext
 
 log = logging.getLogger(__name__)
 
@@ -1436,36 +1435,30 @@ class BaseDataToolParameter(ToolParameter):
     def __init__(self, tool, input_source, trans):
         super(BaseDataToolParameter, self).__init__(tool, input_source)
         self.refresh_on_change = True
-
-    def _datatypes_registry(self, trans):
         # Find datatypes_registry
         if self.tool is None:
             if trans:
                 # Must account for "Input Dataset" types, which while not a tool still need access to the real registry.
                 # A handle to the transaction (and thus app) will be given by the module.
-                datatypes_registry = trans.app.datatypes_registry
+                self.datatypes_registry = trans.app.datatypes_registry
             else:
                 # This occurs for things such as unit tests
                 import galaxy.datatypes.registry
-                datatypes_registry = galaxy.datatypes.registry.Registry()
-                datatypes_registry.load_datatypes()
+                self.datatypes_registry = galaxy.datatypes.registry.Registry()
+                self.datatypes_registry.load_datatypes()
         else:
-            if isinstance(self.tool.app, ValidationContext):
-                datatypes_registry = {}
-            else:
-                datatypes_registry = self.tool.app.datatypes_registry
-        return datatypes_registry
+            self.datatypes_registry = self.tool.app.datatypes_registry  # can be None if self.tool.app is a ValidationContext
 
     def _parse_formats(self, trans, input_source):
-        datatypes_registry = self._datatypes_registry(trans)
-        formats = []
-        # Build list of classes for supported data formats
+        """
+        Build list of classes for supported data formats
+        """
         self.extensions = input_source.get('format', 'data').split(",")
-        normalized_extensions = [extension.strip().lower() for extension in self.extensions]
-        if datatypes_registry:
-            # Skip during validation since no datatypes are loaded
+        formats = []
+        if self.datatypes_registry:  # This may be None when self.tool.app is a ValidationContext
+            normalized_extensions = [extension.strip().lower() for extension in self.extensions]
             for extension in normalized_extensions:
-                datatype = datatypes_registry.get_datatype_by_extension(extension)
+                datatype = self.datatypes_registry.get_datatype_by_extension(extension)
                 if datatype is not None:
                     formats.append(datatype)
                 else:
@@ -1604,10 +1597,11 @@ class DataToolParameter(BaseDataToolParameter):
         self.conversions = []
         for name, conv_extension in input_source.parse_conversion_tuples():
             assert None not in [name, conv_extension], 'A name (%s) and type (%s) are required for explicit conversion' % (name, conv_extension)
-            conv_type = tool.app.datatypes_registry.get_datatype_by_extension(conv_extension.lower())
-            if conv_type is None:
-                raise ValueError("Datatype class not found for extension '%s', which is used as 'type' attribute in conversion of data parameter '%s'" % (conv_type, self.name))
-            self.conversions.append((name, conv_extension, [conv_type]))
+            if self.datatypes_registry:
+                conv_type = self.datatypes_registry.get_datatype_by_extension(conv_extension.lower())
+                if conv_type is None:
+                    raise ValueError("Datatype class not found for extension '%s', which is used as 'type' attribute in conversion of data parameter '%s'" % (conv_type, self.name))
+                self.conversions.append((name, conv_extension, [conv_type]))
 
     def match_collections(self, history, dataset_matcher, reduction=True):
         dataset_collection_matcher = DatasetCollectionMatcher(dataset_matcher)
@@ -1783,9 +1777,8 @@ class DataToolParameter(BaseDataToolParameter):
         # create dictionary and fill default parameters
         d = super(DataToolParameter, self).to_dict(trans)
         extensions = self.extensions
-        datatypes_registry = self._datatypes_registry(trans)
-        all_edam_formats = datatypes_registry.edam_formats if hasattr(datatypes_registry, 'edam_formats') else {}
-        all_edam_data = datatypes_registry.edam_data if hasattr(datatypes_registry, 'edam_formats') else {}
+        all_edam_formats = self.datatypes_registry.edam_formats if hasattr(self.datatypes_registry, 'edam_formats') else {}
+        all_edam_data = self.datatypes_registry.edam_data if hasattr(self.datatypes_registry, 'edam_formats') else {}
         edam_formats = [all_edam_formats.get(ext, None) for ext in extensions]
         edam_data = [all_edam_data.get(ext, None) for ext in extensions]
 

--- a/lib/galaxy/tools/repositories.py
+++ b/lib/galaxy/tools/repositories.py
@@ -4,7 +4,6 @@ import shutil
 import tempfile
 from contextlib import contextmanager
 
-from galaxy.datatypes.registry import Registry
 from galaxy.tools.data import ToolDataTableManager
 from galaxy.util.bunch import Bunch
 from galaxy.util.dbkeys import GenomeBuilds
@@ -31,7 +30,7 @@ class ValidationContext(object):
         self.config.tool_data_table_config = os.path.join(self.temporary_path, 'tool_data_table_conf.xml')
         self.config.shed_tool_data_table_config = os.path.join(self.temporary_path, 'shed_tool_data_table_conf.xml')
         self.tool_data_tables = tool_data_tables
-        self.datatypes_registry = registry or Registry()
+        self.datatypes_registry = registry
         self.hgweb_config_manager = hgweb_config_manager
         self.config.len_file_path = os.path.join(self.temporary_path, 'chromlen.txt')
         # If the builds file path is set to None, tools/__init__.py will load the default.
@@ -60,6 +59,7 @@ class ValidationContext(object):
                                tool_data_path=work_dir,
                                shed_tool_data_path=work_dir,
                                tool_data_tables=tool_data_tables,
+                               registry=app.datatypes_registry,
                                hgweb_config_manager=getattr(app, 'hgweb_config_manager', None)
                                ) as app:
             yield app


### PR DESCRIPTION
Also:
- Handle an empty `datatypes_registry`
- small refactorings.

Alternative to https://github.com/galaxyproject/galaxy/pull/5802.