### PR TITLE
Bugfix in upload_common -- ensure hda is added to a session 

### DIFF
--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -173,11 +173,11 @@ def __new_history_upload(trans, uploaded_dataset, history=None, state=None):
                                                     history=history,
                                                     create_dataset=True,
                                                     sa_session=trans.sa_session)
+    trans.sa_session.add(hda)
     if state:
         hda.state = state
     else:
         hda.state = hda.states.QUEUED
-    trans.sa_session.add(hda)
     trans.sa_session.flush()
     history.add_dataset(hda, genome_build=uploaded_dataset.dbkey)
     permissions = trans.app.security_agent.history_get_default_permissions(history)


### PR DESCRIPTION
... prior to state setting.   I'm not exactly sure how we haven't seen it before now, but it shouldn't change any functionality and it prevents the subsequent state setting from blowing up when trying to retrieve a nonexistent object_session.

Ping @VJalili -- this should fix the problem you were seeing when trying to use this code. 