### PR TITLE
Allow rule based operations on existing collections.

### DIFF
--- a/client/galaxy/scripts/components/RulesDisplay.vue
+++ b/client/galaxy/scripts/components/RulesDisplay.vue
@@ -1,0 +1,119 @@
+<template>
+    <div>
+        <ol class="rules">
+            <rule-display-preview
+              v-for="(rule, index) in rules"
+              v-bind:rule="rule"
+              v-bind:index="index"
+              v-bind:key="index"
+              :col-headers="columnData.colHeadersPerRule[index]" />
+            <identifier-display-preview v-for="(map, index) in mapping"
+                                        v-bind="map"
+                                        v-bind:index="index"
+                                        v-bind:key="map.type"
+                                        :col-headers="colHeaders" />
+        </ol>
+    </div>
+</template>
+<script>
+import RuleDefs from "mvc/rules/rule-definitions";
+import _l from "utils/localization";
+
+// read-only variants of the components for displaying these rules and mappings in builder widget.
+const RuleDisplayPreview = {
+    template: `
+        <li class="rule">
+            <span class="rule-display">{{ title }}
+            </span>
+            <span class="rule-warning" v-if="rule.warn">
+                {{ rule.warn }}
+            </span>
+            <span class="rule-error" v-if="rule.error">
+                <span class="alert-message">{{ rule.error }}</span>
+            </span>
+        </li>
+    `,
+    props: {
+        rule: {
+            required: true,
+            type: Object
+        },
+        colHeaders: {
+            type: Array,
+            required: false
+        }
+    },
+    computed: {
+        title() {
+            const ruleType = this.rule.type;
+            return RuleDefs.RULES[ruleType].display(this.rule, this.colHeaders);
+        }
+    },
+    methods: {}
+};
+
+const IdentifierDisplayPreview = {
+    template: `
+      <li class="rule" :title="help">
+        Set {{ columnsLabel }} as {{ typeDisplay }}
+      </li>
+    `,
+    props: {
+        type: {
+            type: String,
+            required: true
+        },
+        columns: {
+            required: true
+        },
+        colHeaders: {
+            type: Array,
+            required: true
+        }
+    },
+    computed: {
+        typeDisplay() {
+            return RuleDefs.MAPPING_TARGETS[this.type].label;
+        },
+        help() {
+            return RuleDefs.MAPPING_TARGETS[this.type].help || "";
+        },
+        columnsLabel() {
+            return RuleDefs.columnDisplay(this.columns, this.colHeaders);
+        }
+    }
+};
+
+export default {
+    data: function() {
+        return {};
+    },
+    computed: {
+        mapping: function() {
+            return this.inputRules ? this.inputRules.mapping : [];
+        },
+        rules: function() {
+            return this.inputRules ? this.inputRules.rules : [];
+        },
+        columnData: function() {
+            const colHeadersPerRule = [];
+            const hotData = RuleDefs.applyRules([], [], [], this.rules, colHeadersPerRule);
+            return { colHeadersPerRule: colHeadersPerRule, columns: hotData.columns };
+        },
+        colHeaders: function() {
+            const columns = this.columnData.columns;
+            return RuleDefs.colHeadersFor([], columns);
+        }
+    },
+    props: {
+        inputRules: {
+            required: false,
+            type: Object
+        }
+    },
+    components: {
+        RuleDisplayPreview,
+        IdentifierDisplayPreview
+    }
+};
+</script>

--- a/client/galaxy/scripts/mocha/tests/rules_tests.js
+++ b/client/galaxy/scripts/mocha/tests/rules_tests.js
@@ -11,44 +11,29 @@ function applyRules(rules, data, sources) {
             columns.push("new");
         }
     }
-    for (var ruleIndex in rules) {
-        const rule = rules[ruleIndex];
-        rule.error = null;
-        rule.warn = null;
-
-        var ruleType = rule.type;
-        const ruleDef = RULES[ruleType];
-        const res = ruleDef.apply(rule, data, sources, columns);
-        if (res.error) {
-            throw res.error;
-        } else {
-            if (res.warn) {
-                rule.warn = res.warn;
-            }
-            data = res.data || data;
-            sources = res.sources || sources;
-            columns = res.columns || columns;
-        }
-    }
-    return { data, sources, columns };
+    return RuleDefs.applyRules(data, sources, columns, rules);
 }
 
 function itShouldConform(specTestCase, i) {
     it("should pass conformance test case " + i, function() {
         chai.assert.property(specTestCase, "rules");
-        chai.assert.property(specTestCase, "initial");
-        chai.assert.property(specTestCase, "final");
+        if (specTestCase.initial) {
+            chai.assert.property(specTestCase, "final");
 
-        const rules = specTestCase.rules;
-        const initial = specTestCase.initial;
-        const expectedFinal = specTestCase.final;
+            const rules = specTestCase.rules;
+            const initial = specTestCase.initial;
+            const expectedFinal = specTestCase.final;
 
-        const final = applyRules(rules, initial.data, initial.sources);
-        const finalData = final.data;
-        const finalSources = final.sources;
-        chai.assert.deepEqual(finalData, expectedFinal.data);
-        if (expectedFinal.sources !== undefined) {
-            chai.assert.deepEqual(finalSources, expectedFinal.sources);
+            const final = applyRules(rules, initial.data, initial.sources);
+            const finalData = final.data;
+            const finalSources = final.sources;
+            chai.assert.deepEqual(finalData, expectedFinal.data);
+            if (expectedFinal.sources !== undefined) {
+                chai.assert.deepEqual(finalSources, expectedFinal.sources);
+            }
+        } else {
+            chai.assert(specTestCase.error);
+            // TODO: test these...
         }
     });
 }

--- a/client/galaxy/scripts/mvc/collection/list-collection-creator.js
+++ b/client/galaxy/scripts/mvc/collection/list-collection-creator.js
@@ -1090,7 +1090,9 @@ var ruleBasedCollectionCreatorModal = function _ruleBasedCollectionCreatorModal(
             creationFn: options.creationFn,
             oncancel: options.oncancel,
             oncreate: options.oncreate,
-            defaultHideSourceItems: options.defaultHideSourceItems
+            defaultHideSourceItems: options.defaultHideSourceItems,
+            saveRulesFn: options.saveRulesFn,
+            initialRules: options.initialRules
         }
     }).$mount(vm);
     return deferred;
@@ -1128,7 +1130,8 @@ function createListCollection(contents, defaultHideSourceItems) {
 
 function createCollectionViaRules(selection, defaultHideSourceItems) {
     let elements, elementsType, importType;
-    if (!selection.selectionType) {
+    const selectionType = selection.selectionType;
+    if (!selectionType) {
         // Have HDAs from the history panel.
         elements = selection.toJSON();
         elementsType = "datasets";

--- a/client/galaxy/scripts/mvc/collection/list-collection-creator.js
+++ b/client/galaxy/scripts/mvc/collection/list-collection-creator.js
@@ -1069,6 +1069,8 @@ var ruleBasedCollectionCreatorModal = function _ruleBasedCollectionCreatorModal(
     let title;
     if (importType == "datasets") {
         title = _l("Build Rules for Uploading Datasets");
+    } else if (elementsType == "collection_contents") {
+        title = _l("Build Rules for Applying to Existing Collection");
     } else if (elementsType == "datasets") {
         title = _l("Build Rules for Creating Collection");
     } else {

--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -85,11 +85,13 @@ export default Backbone.View.extend({
         // render visibility
         this.$el[this.model.get("hidden") ? "hide" : "show"]();
         // render preview view for collapsed fields
+        // allow at least newlines to render properly after escape
+        const html = _.escape(this.model.get("text_value")).replace(/\n/g, "<br />");
         this.$preview[
             (this.field.collapsed && this.model.get("collapsible_preview")) || this.model.get("disabled")
                 ? "show"
                 : "hide"
-        ]().html(_.escape(this.model.get("text_value")));
+        ]().html(html);
         // render error messages
         var error_text = this.model.get("error_text");
         this.$error[error_text ? "show" : "hide"]();
@@ -106,7 +108,14 @@ export default Backbone.View.extend({
                 style: this.model.get("style")
             });
         // render collapsible options
-        if (!this.model.get("disabled") && this.model.get("collapsible_value") !== undefined) {
+        const workflowRuntimeCompatible =
+            this.field.workflowRuntimeCompatible === undefined ? true : this.field.workflowRuntimeCompatible;
+        if (
+            workflowRuntimeCompatible &&
+            !this.model.get("disabled") &&
+            this.model.get("collapsible_value") !== undefined
+        ) {
+            console.log(this.field);
             var collapsible_state = this.field.collapsed ? "enable" : "disable";
             this.$title_text.hide();
             this.$collapsible.show();

--- a/client/galaxy/scripts/mvc/form/form-parameters.js
+++ b/client/galaxy/scripts/mvc/form/form-parameters.js
@@ -7,6 +7,7 @@ import SelectContent from "mvc/ui/ui-select-content";
 import SelectLibrary from "mvc/ui/ui-select-library";
 import SelectFtp from "mvc/ui/ui-select-ftp";
 import SelectGenomeSpace from "mvc/ui/ui-select-genomespace";
+import RulesEdit from "mvc/ui/ui-rules-edit";
 import ColorPicker from "mvc/ui/ui-color-picker";
 // create form view
 export default Backbone.Model.extend({
@@ -30,6 +31,7 @@ export default Backbone.Model.extend({
         library_data: "_fieldLibrary",
         ftpfile: "_fieldFtp",
         upload: "_fieldUpload",
+        rules: "_fieldRulesEdit",
         genomespacefile: "_fieldGenomeSpace"
     },
 
@@ -215,10 +217,17 @@ export default Backbone.Model.extend({
     /** GenomeSpace file select field
      */
     _fieldGenomeSpace: function(input_def) {
-        var self = this;
         return new SelectGenomeSpace.View({
             id: `field-${input_def.id}`,
             onchange: input_def.onchange
+        });
+    },
+
+    _fieldRulesEdit: function(input_def) {
+        return new RulesEdit.View({
+            id: `field-${input_def.id}`,
+            onchange: input_def.onchange,
+            target: input_def.target
         });
     },
 

--- a/client/galaxy/scripts/mvc/form/form-view.js
+++ b/client/galaxy/scripts/mvc/form/form-view.js
@@ -25,10 +25,13 @@ export default Backbone.View.extend({
         var self = this;
         this.data.matchModel(new_model, (node, input_id) => {
             var input = self.input_list[input_id];
+            var field = self.field_list[input_id];
+            if (field.refreshDefinition) {
+                field.refreshDefinition(node);
+            }
             if (input && input.options) {
                 if (!_.isEqual(input.options, node.options)) {
                     input.options = node.options;
-                    var field = self.field_list[input_id];
                     if (field.update) {
                         var new_options = [];
                         if (["data", "data_collection", "drill_down"].indexOf(input.type) != -1) {

--- a/client/galaxy/scripts/mvc/rules/rule-definitions.js
+++ b/client/galaxy/scripts/mvc/rules/rule-definitions.js
@@ -630,7 +630,7 @@ const RULES = {
             };
 
             data = flatMap(splitRow, data);
-            sources = flatMap(src => [src, src], data);
+            sources = flatMap(src => [src, src], sources);
             return { data, sources };
         }
     }

--- a/client/galaxy/scripts/mvc/rules/rule-definitions.js
+++ b/client/galaxy/scripts/mvc/rules/rule-definitions.js
@@ -1,6 +1,8 @@
 import _l from "utils/localization";
 import pyre from "pyre-to-regexp";
 
+const NEW_COLUMN = "new";
+
 const multiColumnsToString = function(targetColumns, colHeaders) {
     if (targetColumns.length == 0) {
         return `no columns`;
@@ -11,6 +13,16 @@ const multiColumnsToString = function(targetColumns, colHeaders) {
         // https://stackoverflow.com/questions/16251822/array-to-comma-separated-string-and-for-last-tag-use-the-and-instead-of-comma
         return `columns ${[targetHeaders.slice(0, -1).join(", "), targetHeaders.slice(-1)[0]].join(" and ")}`;
     }
+};
+
+const removeColumns = function(columns, targetColumns) {
+    const newColumns = [];
+    for (let index in columns) {
+        if (targetColumns.indexOf(index) === -1) {
+            newColumns.push(columns[index]);
+        }
+    }
+    return newColumns;
 };
 
 const applyRegex = function(regex, target, data, replacement, groupCount) {
@@ -71,13 +83,16 @@ const RULES = {
         save: (component, rule) => {
             rule.target_column = component.addColumnBasenameTarget;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             // https://github.com/kgryte/regex-basename-posix/blob/master/lib/index.js
             //const re = /^(?:\/?|)(?:[\s\S]*?)((?:\.{1,2}|[^\/]+?|)(?:\.[^.\/]*|))(?:[\/]*)$/;
             // https://stackoverflow.com/questions/8376525/get-value-of-a-string-after-a-slash-in-javascript
             const re = "[^/]*$";
             const target = rule.target_column;
-            return applyRegex(re, target, data);
+            const rval = applyRegex(re, target, data);
+            columns.push(NEW_COLUMN);
+            rval.columns = columns;
+            return rval;
         }
     },
     add_column_rownum: {
@@ -95,7 +110,7 @@ const RULES = {
         save: (component, rule) => {
             rule.start = component.addColumnRownumStart;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             let rownum = rule.start;
             function newRow(row) {
                 const newRow = row.slice();
@@ -104,7 +119,8 @@ const RULES = {
                 return newRow;
             }
             data = data.map(newRow);
-            return { data };
+            columns.push(NEW_COLUMN);
+            return { data, columns };
         }
     },
     add_column_value: {
@@ -122,7 +138,7 @@ const RULES = {
         save: (component, rule) => {
             rule.value = component.addColumnValue;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const addValue = rule.value;
             function newRow(row) {
                 const newRow = row.slice();
@@ -130,7 +146,36 @@ const RULES = {
                 return newRow;
             }
             data = data.map(newRow);
-            return { data };
+            columns.push(NEW_COLUMN);
+            return { data, columns };
+        }
+    },
+    add_column_metadata: {
+        title: _l("Add Column from Metadata"),
+        display: (rule, colHeaders) => {
+            return `Add column for ${rule.value}.`;
+        },
+        init: (component, rule) => {
+            if (!rule) {
+                component.addColumnMetadataValue = null;
+            } else {
+                component.addColumnMetadataValue = rule.value;
+            }
+        },
+        save: (component, rule) => {
+            rule.value = component.addColumnMetadataValue;
+        },
+        apply: (rule, data, sources, columns) => {
+            const ruleValue = rule.value;
+            const identifierIndex = parseInt(ruleValue.substring("identifier".length));
+            function newRow(row, index) {
+                const newRow = row.slice();
+                newRow.push(sources[index]["identifiers"][identifierIndex]);
+                return newRow;
+            }
+            data = data.map(newRow);
+            columns.push(NEW_COLUMN);
+            return { data, columns };
         }
     },
     add_column_regex: {
@@ -168,9 +213,12 @@ const RULES = {
                 rule.group_count = component.addColumnRegexGroupCount;
             }
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const target = rule.target_column;
-            return applyRegex(rule.expression, target, data, rule.replacement, rule.group_count);
+            const rval = applyRegex(rule.expression, target, data, rule.replacement, rule.group_count);
+            columns.push(NEW_COLUMN);
+            rval.columns = columns;
+            return rval;
         }
     },
     add_column_concatenate: {
@@ -193,7 +241,7 @@ const RULES = {
             rule.target_column_0 = component.addColumnConcatenateTarget0;
             rule.target_column_1 = component.addColumnConcatenateTarget1;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const target0 = rule.target_column_0;
             const target1 = rule.target_column_1;
             function newRow(row) {
@@ -202,7 +250,8 @@ const RULES = {
                 return newRow;
             }
             data = data.map(newRow);
-            return { data };
+            columns.push(NEW_COLUMN);
+            return { data, columns };
         }
     },
     add_column_substr: {
@@ -241,7 +290,7 @@ const RULES = {
             rule.length = component.addColumnSubstrLength;
             rule.substr_type = component.addColumnSubstrType;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const target = rule.target_column;
             const length = rule.length;
             const type = rule.substr_type;
@@ -269,6 +318,7 @@ const RULES = {
                 return newRow;
             }
             data = data.map(newRow);
+            columns.push(NEW_COLUMN);
             return { data };
         }
     },
@@ -288,7 +338,7 @@ const RULES = {
         save: (component, rule) => {
             rule.target_columns = component.removeColumnTargets;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const targets = rule.target_columns;
             function newRow(row) {
                 const newRow = [];
@@ -300,7 +350,8 @@ const RULES = {
                 return newRow;
             }
             data = data.map(newRow);
-            return { data };
+            columns = removeColumns(columns, targets);
+            return { data, columns };
         }
     },
     add_filter_regex: {
@@ -326,7 +377,7 @@ const RULES = {
             rule.expression = component.addFilterRegexExpression;
             rule.invert = component.addFilterRegexInvert;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const regex = String(rule.expression);
             var regExp;
             try {
@@ -376,7 +427,7 @@ const RULES = {
             rule.which = component.addFilterCountWhich;
             rule.invert = component.addFilterCountInvert;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const count = rule.count;
             const invert = rule.invert;
             const which = rule.which;
@@ -413,7 +464,7 @@ const RULES = {
             rule.target_column = component.addFilterEmptyTarget;
             rule.invert = component.addFilterEmptyInvert;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const target = rule.target_column;
             const invert = rule.invert;
             const filterFunction = function(el, index) {
@@ -446,7 +497,7 @@ const RULES = {
             rule.value = component.addFilterMatchesValue;
             rule.invert = component.addFilterMatchesInvert;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const target = rule.target_column;
             const invert = rule.invert;
             const value = rule.value;
@@ -482,7 +533,7 @@ const RULES = {
             rule.value = component.addFilterCompareValue;
             rule.compare_type = component.addFilterCompareType;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const target = rule.target_column;
             const compare_type = rule.compare_type;
             const value = rule.value;
@@ -524,7 +575,7 @@ const RULES = {
             rule.target_column = component.addSortingTarget;
             rule.numeric = component.addSortingNumeric;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const target = rule.target_column;
             const numeric = rule.numeric;
 
@@ -577,7 +628,7 @@ const RULES = {
             rule.target_column_0 = component.swapColumnsTarget0;
             rule.target_column_1 = component.swapColumnsTarget1;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const target0 = rule.target_column_0;
             const target1 = rule.target_column_1;
             function newRow(row) {
@@ -587,7 +638,10 @@ const RULES = {
                 return newRow;
             }
             data = data.map(newRow);
-            return { data };
+            const tempColumn = columns[target0];
+            columns[target0] = columns[target1];
+            columns[target1] = tempColumn;
+            return { data, columns };
         }
     },
     split_columns: {
@@ -608,7 +662,7 @@ const RULES = {
             rule.target_columns_0 = component.splitColumnsTargets0;
             rule.target_columns_1 = component.splitColumnsTargets1;
         },
-        apply: (rule, data, sources) => {
+        apply: (rule, data, sources, columns) => {
             const targets0 = rule.target_columns_0;
             const targets1 = rule.target_columns_1;
 
@@ -628,10 +682,10 @@ const RULES = {
                 }
                 return [newRow0, newRow1];
             };
-
             data = flatMap(splitRow, data);
             sources = flatMap(src => [src, src], sources);
-            return { data, sources };
+            columns = removeColumns(columns, targets0);
+            return { data, sources, columns };
         }
     }
 };
@@ -659,7 +713,7 @@ const MAPPING_TARGETS = {
         help: _l(
             "If this is set, all rows with the same collection name will be joined into a collection and it is possible to create multiple collections at once."
         ),
-        modes: ["raw", "ftp"], // TODO: allow this in datasets mode.
+        modes: ["raw", "ftp"], // TODO: allow this in datasets mode & tool builder modes
         importType: "collections"
     },
     name: {
@@ -697,7 +751,69 @@ const MAPPING_TARGETS = {
     }
 };
 
+const columnDisplay = function(columns, colHeaders) {
+    let columnNames;
+    if (typeof columns == "object") {
+        columnNames = columns.map(idx => colHeaders[idx]);
+    } else {
+        columnNames = [colHeaders[columns]];
+    }
+    if (columnNames.length == 2) {
+        return "columns " + columnNames[0] + " and " + columnNames[1];
+    } else if (columnNames.length > 2) {
+        return "columns " + columnNames.slice(0, -1).join(", ") + ", and " + columnNames[columnNames.length - 1];
+    } else {
+        return "column " + columnNames[0];
+    }
+};
+
+const colHeadersFor = function(data, columns) {
+    if (data.length == 0) {
+        if (columns) {
+            return columns.map((el, i) => String.fromCharCode(65 + i));
+        } else {
+            return [];
+        }
+    } else {
+        return data[0].map((el, i) => String.fromCharCode(65 + i));
+    }
+};
+
+const applyRules = function(data, sources, columns, rules, colHeadersPerRule) {
+    var colHeadersPerRule = colHeadersPerRule || [];
+    let hasRuleError = false;
+    for (var ruleIndex in rules) {
+        const ruleHeaders = colHeadersFor(data, columns);
+        colHeadersPerRule[ruleIndex] = ruleHeaders;
+        const rule = rules[ruleIndex];
+        rule.error = null;
+        rule.warn = null;
+        if (hasRuleError) {
+            rule.warn = _l("Skipped due to previous errors.");
+            continue;
+        }
+        var ruleType = rule.type;
+        const ruleDef = RULES[ruleType];
+        const res = ruleDef.apply(rule, data, sources, columns);
+        if (res.error) {
+            hasRuleError = true;
+            rule.error = res.error;
+        } else {
+            if (res.warn) {
+                rule.warn = res.warn;
+            }
+            data = res.data || data;
+            sources = res.sources || sources;
+            columns = res.columns || columns;
+        }
+    }
+    return { data, sources, columns };
+};
+
 export default {
+    applyRules: applyRules,
+    columnDisplay: columnDisplay,
+    colHeadersFor: colHeadersFor,
     RULES: RULES,
     MAPPING_TARGETS: MAPPING_TARGETS
 };

--- a/client/galaxy/scripts/mvc/tool/tool-form.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form.js
@@ -280,6 +280,17 @@ var View = Backbone.View.extend({
                 this.form.highlight(input_id);
                 return false;
             }
+            if (input_field.validate) {
+                // wish there was a way to just reset this input field
+                const reset = () => {
+                    this.form.trigger("reset");
+                };
+                const validateObject = input_field.validate(reset);
+                if (!validateObject.valid) {
+                    this.form.highlight(input_id, validateObject.message);
+                    return false;
+                }
+            }
             if (input_value && input_value.batch) {
                 var n = input_value.values.length;
                 var src = n > 0 && input_value.values[0] && input_value.values[0].src;

--- a/client/galaxy/scripts/mvc/ui/ui-rules-edit.js
+++ b/client/galaxy/scripts/mvc/ui/ui-rules-edit.js
@@ -1,0 +1,169 @@
+import axios from "axios";
+import _l from "utils/localization";
+import Utils from "utils/utils";
+import Ui from "mvc/ui/ui-misc";
+import Vue from "vue";
+import ListCollectionCreator from "mvc/collection/list-collection-creator";
+import RulesDisplay from "components/RulesDisplay.vue";
+
+/**
+ * Bridge rule based builder and the tool form.
+ */
+var View = Backbone.View.extend({
+    // initialize
+    initialize: function(options) {
+        // link this
+        this.options = options;
+        this.target = options.target;
+        this.reset = null;
+        const view = this;
+
+        // create insert new list element button
+        this.browse_button = new Ui.ButtonIcon({
+            title: _l("Edit"),
+            icon: "fa fa-edit",
+            tooltip: _l("Edit Rules"),
+            onclick: () => {
+                if (view.target) {
+                    view._fetcCollectionAndEdit();
+                } else {
+                    view._showRuleEditor(null);
+                }
+            }
+        });
+
+        // add change event. fires on trigger
+        this.on("change", () => {
+            if (options.onchange) {
+                options.onchange(this.value());
+            }
+        });
+
+        // create elements
+        this.setElement(this._template(options));
+        this.$(".ui-rules-edit-button").append(this.browse_button.$el);
+        var rulesDisplayInstance = Vue.extend(RulesDisplay);
+        var vm = document.createElement("div");
+        this.$(".ui-rules-preview").append(vm);
+        this.instance = new rulesDisplayInstance({
+            propsData: {
+                initialRules: {
+                    rules: [],
+                    mapping: []
+                }
+            }
+        });
+        this.instance.$mount(vm);
+        this.workflowRuntimeCompatible = false;
+    },
+
+    _fetcCollectionAndEdit: function() {
+        const view = this;
+        const url = `${Galaxy.root}api/dataset_collections/${view.target.id}?instance_type=history`;
+        axios
+            .get(url)
+            .then(response => this._showCollection(response))
+            .catch(view._renderFetchError);
+    },
+
+    _showCollection: function(response) {
+        const elements = response.data;
+        this._showRuleEditor(elements);
+    },
+
+    _showRuleEditor: function(elements) {
+        const elementsType = "collection_contents";
+        const importType = "collections";
+        let value = this._value;
+        const options = {
+            saveRulesFn: rules => this._handleRulesSave(rules),
+            initialRules: value
+        };
+        ListCollectionCreator.ruleBasedCollectionCreatorModal(elements, elementsType, importType, options).done(
+            () => {}
+        );
+    },
+
+    _handleRulesSave: function(rules) {
+        this._setValue(rules);
+    },
+
+    _renderFetchError: function(e) {
+        console.log(e);
+        console.log("problem fetching collection");
+    },
+
+    /** Main Template */
+    _template: function(options) {
+        return `
+            <div class="ui-rules-edit">
+                <span class="ui-rules-preview" />
+                <span class="ui-rules-edit-button" />
+            </div>
+        `;
+    },
+
+    /** Return/Set currently selected genomespace filename */
+    value: function(new_value) {
+        // check if new_value is defined
+        if (new_value !== undefined) {
+            this._setValue(new_value);
+        } else {
+            return this._getValue();
+        }
+    },
+
+    // update
+    refreshDefinition: function(input_def) {
+        self.target = input_def.target;
+        // refresh
+        this._refresh();
+    },
+
+    // refresh
+    _refresh: function() {},
+
+    // get value
+    _getValue: function() {
+        return this._value;
+    },
+
+    // set value
+    _setValue: function(new_value) {
+        if (new_value) {
+            if (typeof new_value == "string") {
+                new_value = JSON.parse(new_value);
+            }
+            this._value = new_value;
+            this.trigger("change");
+            this.instance.inputRules = new_value;
+            if (this.reset) {
+                this.reset();
+                this.reset = null;
+            }
+        }
+    },
+
+    validate: function(reset) {
+        const value = this._value;
+        let message = null;
+        if (!value || value.rules.length === 0) {
+            message = "No rules defined, define at least one rule.";
+        } else if (value.mapping.length === 0) {
+            message = "No collection identifiers defined, specify at least one collection identifier.";
+        } else {
+            for (let rule of value.rules) {
+                if (rule.error) {
+                    message = "One or more rules in error.";
+                    break;
+                }
+            }
+        }
+        this.reset = reset;
+        return { valid: !message, message: message };
+    }
+});
+
+export default {
+    View: View
+};

--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -1,5 +1,7 @@
 // TODO; tie into Galaxy state?
 window.workflow_globals = window.workflow_globals || {};
+import * as Toastr from "libs/toastr";
+
 function CollectionTypeDescription(collectionType) {
     this.collectionType = collectionType;
     this.isCollection = true;
@@ -524,6 +526,7 @@ var OutputCollectionTerminal = Terminal.extend({
         if (newCollectionType.collectionType != this.collectionType.collectionType) {
             _.each(this.connectors, connector => {
                 // TODO: consider checking if connection valid before removing...
+                Toastr.warning("Destroying a connection because collection type has changed.");
                 connector.destroy();
             });
         }

--- a/config/tool_conf.xml.main
+++ b/config/tool_conf.xml.main
@@ -33,6 +33,7 @@
     <tool file="${model_tools_path}/relabel_from_file.xml" />
     <tool file="${model_tools_path}/filter_from_file.xml" />
     <tool file="${model_tools_path}/sort_collection_list.xml" />
+    <tool file="${model_tools_path}/apply_rules.xml" />
   </section>
   <section id="textutil" name="Text Manipulation">
     <tool file="filters/fixedValueColumn.xml" />

--- a/config/tool_conf.xml.sample
+++ b/config/tool_conf.xml.sample
@@ -35,6 +35,7 @@
     <tool file="${model_tools_path}/filter_from_file.xml" />
     <tool file="${model_tools_path}/sort_collection_list.xml" />
     <tool file="${model_tools_path}/tag_collection_from_file.xml" />
+    <tool file="${model_tools_path}/apply_rules.xml" />
   </section>
   <section id="liftOver" name="Lift-Over">
     <tool file="extract/liftOver_wrapper.xml" />

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -94,7 +94,6 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         self._configure_security()
         # Tag handler
         self.tag_handler = GalaxyTagManager(self.model.context)
-        # Dataset Collection Plugins
         self.dataset_collections_service = DatasetCollectionManager(self)
         self.history_manager = HistoryManager(self)
         self.dependency_resolvers_view = DependencyResolversView(self)

--- a/lib/galaxy/dataset_collections/type_description.py
+++ b/lib/galaxy/dataset_collections/type_description.py
@@ -39,12 +39,22 @@ class CollectionTypeDescription(object):
     'list'
     >>> nested_type_description.effective_collection_type_description(paired_type_description).collection_type
     'list'
+    >>> nested_type_description.child_collection_type()
+    'paired'
     """
 
     def __init__(self, collection_type, collection_type_description_factory):
         self.collection_type = collection_type
         self.collection_type_description_factory = collection_type_description_factory
         self.__has_subcollections = self.collection_type.find(":") > 0
+
+    def child_collection_type(self):
+        rank_collection_type = self.rank_collection_type()
+        return self.collection_type[len(rank_collection_type) + 1:]
+
+    def child_collection_type_description(self):
+        child_collection_type = self.child_collection_type()
+        return self.collection_type_description_factory.for_collection_type(child_collection_type)
 
     def effective_collection_type_description(self, subcollection_type):
         effective_collection_type = self.effective_collection_type(subcollection_type)

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -162,11 +162,15 @@ class DatasetCollectionManager(object):
             raise RequestParameterInvalidException(ERROR_NO_COLLECTION_TYPE)
 
         collection_type_description = self.collection_type_descriptions.for_collection_type(collection_type)
-
+        has_subcollections = collection_type_description.has_subcollections()
         # If we have elements, this is an internal request, don't need to load
         # objects from identifiers.
         if elements is None:
             elements = self._element_identifiers_to_elements(trans, collection_type_description, element_identifiers)
+        else:
+            if has_subcollections:
+                # Nested collection - recursively create collections as needed.
+                self.__recursively_create_collections_for_elements(trans, elements)
         # else if elements is set, it better be an ordered dict!
 
         if elements is not self.ELEMENTS_UNINITIALIZED:
@@ -184,7 +188,7 @@ class DatasetCollectionManager(object):
     def _element_identifiers_to_elements(self, trans, collection_type_description, element_identifiers):
         if collection_type_description.has_subcollections():
             # Nested collection - recursively create collections and update identifiers.
-            self.__recursively_create_collections(trans, element_identifiers)
+            self.__recursively_create_collections_for_identifiers(trans, element_identifiers)
         new_collection = False
         for element_identifier in element_identifiers:
             if element_identifier.get("src") == "new_collection" and element_identifier.get('collection_type') == '':
@@ -310,10 +314,10 @@ class DatasetCollectionManager(object):
             context.flush()
         return dataset_collection_instance
 
-    def __recursively_create_collections(self, trans, element_identifiers):
+    def __recursively_create_collections_for_identifiers(self, trans, element_identifiers):
         for index, element_identifier in enumerate(element_identifiers):
             try:
-                if not element_identifier["src"] == "new_collection":
+                if element_identifier.get("src", None) != "new_collection":
                     # not a new collection, keep moving...
                     continue
             except KeyError:
@@ -330,6 +334,30 @@ class DatasetCollectionManager(object):
             element_identifier["__object__"] = collection
 
         return element_identifiers
+
+    def __recursively_create_collections_for_elements(self, trans, elements):
+        if elements is self.ELEMENTS_UNINITIALIZED:
+            return
+
+        new_elements = odict.odict()
+        for key, element in elements.items():
+            if isinstance(element, model.DatasetCollection):
+                continue
+
+            if element.get("src", None) != "new_collection":
+                continue
+
+            # element is a dict with src new_collection and
+            # and odict of named elements
+            collection_type = element.get("collection_type", None)
+            sub_elements = element["elements"]
+            collection = self.create_dataset_collection(
+                trans=trans,
+                collection_type=collection_type,
+                elements=sub_elements,
+            )
+            new_elements[key] = collection
+        elements.update(new_elements)
 
     def __load_elements(self, trans, element_identifiers):
         elements = odict.odict()
@@ -396,6 +424,77 @@ class DatasetCollectionManager(object):
         collection_id = int(trans.app.security.decode_id(encoded_id))
         collection = trans.sa_session.query(trans.app.model.DatasetCollection).get(collection_id)
         return collection
+
+    def apply_rules(self, hdca, rule_set, handle_dataset):
+        hdca_collection = hdca.collection
+        collection_type = hdca_collection.collection_type
+        elements = hdca_collection.elements
+        collection_type_description = self.collection_type_descriptions.for_collection_type(collection_type)
+        initial_data, initial_sources = self.__init_rule_data(elements, collection_type_description)
+        data, sources = rule_set.apply(initial_data, initial_sources)
+
+        collection_type = rule_set.collection_type
+        collection_type_description = self.collection_type_descriptions.for_collection_type(collection_type)
+        elements = self._build_elements_from_rule_data(collection_type_description, rule_set, data, sources, handle_dataset)
+        return elements
+
+    def _build_elements_from_rule_data(self, collection_type_description, rule_set, data, sources, handle_dataset):
+        identifier_columns = rule_set.identifier_columns
+        elements = odict.odict()
+        for data_index, row_data in enumerate(data):
+            # For each row, find place in depth for this element.
+            collection_type_at_depth = collection_type_description
+            elements_at_depth = elements
+
+            for i, identifier_column in enumerate(identifier_columns):
+                identifier = row_data[identifier_column]
+
+                if i + 1 == len(identifier_columns):
+                    # At correct final position in nested structure for this dataset.
+                    if collection_type_at_depth.collection_type == "paired":
+                        if identifier.lower() in ["f", "1", "r1", "forward"]:
+                            identifier = "forward"
+                        elif identifier.lower() in ["r", "2", "r2", "reverse"]:
+                            identifier = "reverse"
+                        else:
+                            raise Exception("Unknown indicator of paired status encountered - only values of F, R, 1, 2, R1, R2, forward, or reverse are allowed.")
+
+                    elements_at_depth[identifier] = handle_dataset(sources[data_index]["dataset"])
+                else:
+                    collection_type_at_depth = collection_type_at_depth.child_collection_type_description()
+                    found = False
+                    if identifier in elements_at_depth:
+                        elements_at_depth = elements_at_depth[identifier]["elements"]
+                        found = True
+
+                    if not found:
+                        sub_collection = {}
+                        sub_collection["src"] = "new_collection"
+                        sub_collection["collection_type"] = collection_type_at_depth.collection_type
+                        sub_collection["elements"] = odict.odict()
+                        elements_at_depth[identifier] = sub_collection
+                        elements_at_depth = sub_collection["elements"]
+
+        return elements
+
+    def __init_rule_data(self, elements, collection_type_description, parent_identifiers=None):
+        parent_identifiers = parent_identifiers or []
+        data, sources = [], []
+        for element in elements:
+            element_object = element.element_object
+            identifiers = parent_identifiers + [element.element_identifier]
+            if not element.is_collection:
+                data.append([])
+                sources.append({"identifiers": identifiers, "dataset": element_object})
+            else:
+                child_collection_type = collection_type_description.child_collection_type()
+                element_data, element_sources = self.__init_rule_data(
+                    element_object.elements, child_collection_type, identifiers
+                )
+                data.extend(element_data)
+                sources.extend(element_sources)
+
+        return data, sources
 
     def __get_history_collection_instance(self, trans, id, check_ownership=False, check_accessible=True):
         instance_id = int(trans.app.security.decode_id(id))

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -80,6 +80,7 @@ from galaxy.util.expressions import ExpressionContext
 from galaxy.util.json import json_fix
 from galaxy.util.json import safe_loads
 from galaxy.util.odict import odict
+from galaxy.util.rules_dsl import RuleSet
 from galaxy.util.template import fill_template
 from galaxy.version import VERSION_MAJOR
 from galaxy.web import url_for
@@ -2650,6 +2651,29 @@ class RelabelFromFileTool(DatabaseOperationTool):
                 raise Exception("Invalid new colleciton identifier [%s]" % key)
         output_collections.create_collection(
             next(iter(self.outputs.values())), "output", elements=new_elements
+        )
+
+
+class ApplyRulesTool(DatabaseOperationTool):
+    tool_type = 'apply_rules'
+
+    def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
+        log.info(incoming)
+        hdca = incoming["input"]
+        rule_set = RuleSet(incoming["rules"])
+
+        def copy_dataset(dataset):
+            copied_dataset = dataset.copy()
+            copied_dataset.visible = False
+            history.add_dataset(copied_dataset, set_hid=True)
+            return copied_dataset
+
+        new_elements = self.app.dataset_collections_service.apply_rules(
+            hdca, rule_set, copy_dataset
+        )
+        log.info(new_elements)
+        output_collections.create_collection(
+            next(iter(self.outputs.values())), "output", collection_type=rule_set.collection_type, elements=new_elements
         )
 
 

--- a/lib/galaxy/tools/apply_rules.xml
+++ b/lib/galaxy/tools/apply_rules.xml
@@ -21,7 +21,7 @@ form, a dynamic preview of the processing will be available in a tabular data vi
 may be used in workflows as well where no such preview can be generated.
 
 This tool is an advanced feature but has a lot of flexibility - it can be used to process collections
-with arbitrary nesting and can do many be used to do many kinds of filtering, re-sorting, nesting, 
+with arbitrary nesting and can do many kinds of filtering, re-sorting, nesting,
 flattening, and arbitrary combinations thereof not possible with Galaxy's other, more simple 
 collection operation tools.
 

--- a/lib/galaxy/tools/apply_rules.xml
+++ b/lib/galaxy/tools/apply_rules.xml
@@ -13,4 +13,24 @@
         <collection name="output" format_source="input" type_from_rules="rules" label="${on_string} (re-organized)" >
         </collection>
     </outputs>
+    <help><![CDATA[
+
+This tool allows one to process an existing Galaxy dataset collection's metadata as tabular data, 
+apply a series of rules to it, and generate a new collection. When used interactively in the tool
+form, a dynamic preview of the processing will be available in a tabular data viewer but this tool
+may be used in workflows as well where no such preview can be generated.
+
+This tool is an advanced feature but has a lot of flexibility - it can be used to process collections
+with arbitrary nesting and can do many be used to do many kinds of filtering, re-sorting, nesting, 
+flattening, and arbitrary combinations thereof not possible with Galaxy's other, more simple 
+collection operation tools.
+
+More information about the rule processor in general can be found `here
+<https://github.com/jmchilton/training-material/blob/rules/topics/introduction/tutorials/galaxy-intro-rules/tutorial.md>`__ (this link is to documentation that is pretty rough still).
+
+.. class:: infomark
+
+This tool will create new history datasets from your collection but your quota usage will not increase.
+
+      ]]></help>
 </tool>

--- a/lib/galaxy/tools/apply_rules.xml
+++ b/lib/galaxy/tools/apply_rules.xml
@@ -1,0 +1,16 @@
+ <tool id="__APPLY_RULES__"
+      name="Apply Rule to Collection"
+      version="1.0.0"
+      tool_type="apply_rules_to_collection">
+    <type class="ApplyRulesTool" module="galaxy.tools" />
+    <action module="galaxy.tools.actions.model_operations"
+            class="ModelOperationToolAction"/>
+    <inputs>
+        <param type="data_collection" name="input" label="Input Collection" />
+        <param type="rules" name="rules" data_ref="input" label="Rules" />
+    </inputs>
+    <outputs>
+        <collection name="output" format_source="input" type_from_rules="rules" label="${on_string} (re-organized)" >
+        </collection>
+    </outputs>
+</tool>

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2168,8 +2168,11 @@ class RulesListToolParameter(BaseJsonToolParameter):
             raise ValueError("No column definitions defined for rules parameter.")
 
     def to_text(self, value):
-        rule_set = RuleSet(value)
-        return rule_set.display
+        if value:
+            rule_set = RuleSet(value)
+            return rule_set.display
+        else:
+            return ""
 
 
 parameter_types = dict(

--- a/lib/galaxy/tools/parser/output_objects.py
+++ b/lib/galaxy/tools/parser/output_objects.py
@@ -175,19 +175,21 @@ class ToolOutputCollectionStructure(object):
         self,
         collection_type,
         collection_type_source=None,
+        collection_type_from_rules=None,
         structured_like=None,
         dataset_collector_descriptions=None,
     ):
         self.collection_type = collection_type
         self.collection_type_source = collection_type_source
+        self.collection_type_from_rules = collection_type_from_rules
         self.structured_like = structured_like
         self.dataset_collector_descriptions = dataset_collector_descriptions
         if collection_type and collection_type_source:
             raise ValueError("Cannot set both type and type_source on collection output.")
-        if collection_type is None and structured_like is None and dataset_collector_descriptions is None and collection_type_source is None:
-            raise ValueError("Output collection types must be specify type of structured_like")
-        if dataset_collector_descriptions and structured_like:
-            raise ValueError("Cannot specify dynamic structure (discovered_datasets) and structured_like attribute.")
+        if collection_type is None and structured_like is None and dataset_collector_descriptions is None and collection_type_source is None and collection_type_from_rules is None:
+            raise ValueError("Output collection types must specify source of collection type information (e.g. structured_like or type_source).")
+        if dataset_collector_descriptions and (structured_like or collection_type_source or collection_type_from_rules):
+            raise ValueError("Cannot specify dynamic structure (discovered_datasets) and collection type source attributes such as structured_like or type_source.")
         self.dynamic = dataset_collector_descriptions is not None
 
     def collection_prototype(self, inputs, type_registry):

--- a/lib/galaxy/tools/parser/xml.py
+++ b/lib/galaxy/tools/parser/xml.py
@@ -260,6 +260,7 @@ class XmlToolSource(ToolSource):
             default_format = collection_elem.get("format", "data")
             collection_type = collection_elem.get("type", None)
             collection_type_source = collection_elem.get("type_source", None)
+            collection_type_from_rules = collection_elem.get("type_from_rules", None)
             structured_like = collection_elem.get("structured_like", None)
             inherit_format = False
             inherit_metadata = False
@@ -276,6 +277,7 @@ class XmlToolSource(ToolSource):
             structure = ToolOutputCollectionStructure(
                 collection_type=collection_type,
                 collection_type_source=collection_type_source,
+                collection_type_from_rules=collection_type_from_rules,
                 structured_like=structured_like,
                 dataset_collector_descriptions=dataset_collector_descriptions,
             )

--- a/lib/galaxy/util/rules_dsl.py
+++ b/lib/galaxy/util/rules_dsl.py
@@ -1,0 +1,553 @@
+import abc
+import itertools
+import re
+
+import six
+from six.moves import map
+
+
+def _ensure_rule_contains_keys(rule, keys):
+    for key, instance_class in keys.items():
+        if key not in rule:
+            raise ValueError("Rule of type [%s] does not contain key [%s]." % (rule["type"], key))
+        value = rule[key]
+        if not isinstance(value, instance_class):
+            raise ValueError("Rule of type [%s] does not contain correct value type for key [%s]." % (rule["type"], key))
+
+
+def _ensure_key_value_in(rule, key, values):
+    value = rule[key]
+    if value not in values:
+        raise ValueError("Invalid value [%s] for [%s] encountered." % (value, key))
+
+
+def _ensure_valid_pattern(expression):
+    re.compile(expression)
+
+
+def apply_regex(regex, target, data, replacement=None, group_count=None):
+    pattern = re.compile(regex)
+
+    def new_row(row):
+        source = row[target]
+        if replacement is None:
+            match = pattern.search(source)
+            if not match:
+                raise Exception("Problem apply regular expression [%s] to [%s]." % (regex, source))
+
+            if group_count:
+                if len(match.groups()) != group_count + 1:
+                    raise Exception("Problem apply regular expression.")
+
+                result = row + [match.groups()[1:len(match.groups())]]
+            else:
+                result = row + [match.group(0)]
+        else:
+            result = row + [pattern.search(source).expand(replacement)]
+
+        return result
+
+    new_data = list(map(new_row, data))
+    return new_data
+
+
+@six.add_metaclass(abc.ABCMeta)
+class BaseRuleDefinition(object):
+
+    @abc.abstractproperty
+    def rule_type(self):
+        """Short string describing type of rule (plugin class) to use."""
+
+    @abc.abstractmethod
+    def validate_rule(self, rule):
+        """Validate dictified rule definition of this type."""
+
+    @abc.abstractmethod
+    def apply(self, rule, data, sources):
+        """Apply validated, dictified rule definition to supplied data."""
+
+
+class AddColumnMetadataRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_column_metadata"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {"value": six.string_types})
+
+    def apply(self, rule, data, sources):
+        rule_value = rule["value"]
+        identifier_index = int(rule_value[len("identifier"):])
+
+        new_rows = []
+        for index, row in enumerate(data):
+            new_rows.append(row + [sources[index]["identifiers"][identifier_index]])
+
+        return new_rows, sources
+
+
+class AddColumnConcatenateRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_column_concatenate"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {"target_column_0": int, "target_column_1": int})
+
+    def apply(self, rule, data, sources):
+        column_0 = rule["target_column_0"]
+        column_1 = rule["target_column_1"]
+
+        new_rows = []
+        for index, row in enumerate(data):
+            new_rows.append(row + [row[column_0] + row[column_1]])
+
+        return new_rows, sources
+
+
+class AddColumnBasenameRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_column_basename"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {"target_column": int})
+
+    def apply(self, rule, data, sources):
+        column = rule["target_column"]
+        re = r"[^/]*$"
+        return apply_regex(re, column, data), sources
+
+
+class AddColumnRegexRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_column_regex"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {"target_column": int, "expression": six.string_types})
+        _ensure_valid_pattern(rule["expression"])
+
+    def apply(self, rule, data, sources):
+        target = rule["target_column"]
+        expression = rule["expression"]
+        replacement = rule.get("replacement")
+        group_count = rule.get("rule_count")
+
+        return apply_regex(expression, target, data, replacement, group_count), sources
+
+
+class AddColumnRownumRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_column_rownum"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {"start": int})
+
+    def apply(self, rule, data, sources):
+        start = rule["start"]
+
+        new_rows = []
+        for index, row in enumerate(data):
+            new_rows.append(row + ["%d" % (index + start)])
+
+        return new_rows, sources
+
+
+class AddColumnValueRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_column_value"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {"value": six.string_types})
+
+    def apply(self, rule, data, sources):
+        value = rule["value"]
+
+        new_rows = []
+        for index, row in enumerate(data):
+            new_rows.append(row + [str(value)])
+
+        return new_rows, sources
+
+
+class AddColumnSubstrRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_column_substr"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {
+            "target_column": int,
+            "length": int,
+            "substr_type": six.string_types,
+        })
+        _ensure_key_value_in(rule, "substr_type", ["keep_prefix", "drop_prefix", "keep_suffix", "drop_suffix"])
+
+    def apply(self, rule, data, sources):
+        target = rule["target_column"]
+        length = rule["length"]
+        substr_type = rule["substr_type"]
+
+        def new_row(row):
+            original_value = row[target]
+            start = 0
+            end = len(original_value)
+
+            if substr_type == "keep_prefix":
+                end = length
+            elif substr_type == "drop_prefix":
+                start = length
+            elif substr_type == "keep_suffix":
+                start = end - length
+                if start < 0:
+                    start = 0
+            else:
+                end = end - length
+                if end < 0:
+                    end = 0
+
+            return row + [original_value[start:end]]
+
+        return list(map(new_row, data)), sources
+
+
+class RemoveColumnsRuleDefinition(BaseRuleDefinition):
+    rule_type = "remove_columns"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {
+            "target_columns": list,
+        })
+
+    def apply(self, rule, data, sources):
+        target_columns = rule["target_columns"]
+
+        def new_row(row):
+            new = []
+            for index, val in enumerate(row):
+                if index not in target_columns:
+                    new.append(val)
+            return new
+
+        return list(map(new_row, data)), sources
+
+
+def _filter_index(func, iterable):
+    result = []
+    for index, x in enumerate(iterable):
+        if func(index):
+            result.append(x)
+
+    return result
+
+
+class AddFilterRegexRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_filter_regex"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {
+            "target_column": int,
+            "invert": bool,
+            "expression": six.string_types,
+        })
+        _ensure_valid_pattern(rule["expression"])
+
+    def apply(self, rule, data, sources):
+        target_column = rule["target_column"]
+        invert = rule["invert"]
+        regex = rule["expression"]
+
+        def _filter(index):
+            row = data[index]
+            val = row[target_column]
+            pattern = re.compile(regex)
+            return not invert if pattern.search(val) else invert
+
+        return _filter_index(_filter, data), _filter_index(_filter, sources)
+
+
+class AddFilterCountRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_filter_count"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {
+            "count": int,
+            "invert": bool,
+            "which": six.string_types,
+        })
+        _ensure_key_value_in(rule, "which", ["first", "last"])
+
+    def apply(self, rule, data, sources):
+        num_rows = len(data)
+        invert = rule["invert"]
+        n = rule["count"]
+        which = rule["which"]
+
+        def _filter(index):
+            if which == "first":
+                matches = index >= n
+            else:
+                matches = index < (num_rows - n)
+            return not invert if matches else invert
+
+        return _filter_index(_filter, data), _filter_index(_filter, sources)
+
+
+class AddFilterEmptyRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_filter_empty"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {
+            "target_column": int,
+            "invert": bool
+        })
+
+    def apply(self, rule, data, sources):
+        invert = rule["invert"]
+        target_column = rule["target_column"]
+
+        def _filter(index):
+            return not invert if len(data[target_column]) == 0 else invert
+
+        return _filter_index(_filter, data), _filter_index(_filter, sources)
+
+
+class AddFilterMatchesRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_filter_matches"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {
+            "target_column": int,
+            "invert": bool,
+            "value": six.string_types,
+        })
+
+    def apply(self, rule, data, sources):
+        invert = rule["invert"]
+        target_column = rule["target_column"]
+        value = rule["value"]
+
+        def _filter(index):
+            row = data[index]
+            val = row[target_column]
+            return not invert if val == value else invert
+
+        return _filter_index(_filter, data), _filter_index(_filter, sources)
+
+
+class AddFilterCompareRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_filter_compare"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {
+            "target_column": int,
+            "value": int,
+            "compare_type": six.string_types,
+        })
+        _ensure_key_value_in(rule, "compare_type", ["less_than", "less_than_equal", "greater_than", "greater_than_equal"])
+
+    def apply(self, rule, data, sources):
+        target_column = rule["target_column"]
+        value = rule["value"]
+        compare_type = rule["compare_type"]
+
+        def _filter(index):
+            row = data[index]
+            target_value = float(row[target_column])
+            if compare_type == "less_than":
+                matches = target_value < value
+            elif compare_type == "less_than_equal":
+                matches = target_value <= value
+            elif compare_type == "greater_than":
+                matches = target_value > value
+            elif compare_type == "greater_than_equal":
+                matches = target_value >= value
+
+            return matches
+
+        return _filter_index(_filter, data), _filter_index(_filter, sources)
+
+
+class SortRuleDefinition(BaseRuleDefinition):
+    rule_type = "sort"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {
+            "target_column": int,
+            "numeric": bool,
+        })
+
+    def apply(self, rule, data, sources):
+        target = rule["target_column"]
+        numeric = rule["numeric"]
+
+        sortable = zip(data, sources)
+
+        def sort_func(a, b):
+            a_val = a[0][target]
+            b_val = b[0][target]
+            if numeric:
+                a_val = float(a_val)
+                b_val = float(b_val)
+
+            if a_val < b_val:
+                return -1
+            elif b_val < a_val:
+                return 1
+            else:
+                return 0
+
+        sorted_data = sorted(sortable, sort_func)
+
+        new_data = []
+        new_sources = []
+
+        for (row, source) in sorted_data:
+            new_data.append(row)
+            new_sources.append(source)
+
+        return new_data, new_sources
+
+
+class SwapColumnsRuleDefinition(BaseRuleDefinition):
+    rule_type = "swap_columns"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {
+            "target_column_0": int,
+            "target_column_1": int,
+        })
+
+    def apply(self, rule, data, sources):
+        target_column_0 = rule["target_column_0"]
+        target_column_1 = rule["target_column_1"]
+
+        def new_row(row):
+            row_copy = row[:]
+            row_copy[target_column_0] = row[target_column_1]
+            row_copy[target_column_1] = row[target_column_0]
+            return row_copy
+
+        return list(map(new_row, data)), sources
+
+
+class SplitColumnsRuleDefinition(BaseRuleDefinition):
+    rule_type = "split_columns"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {
+            "target_columns_0": list,
+            "target_columns_1": list,
+        })
+
+    def apply(self, rule, data, sources):
+        target_columns_0 = rule["target_columns_0"]
+        target_columns_1 = rule["target_columns_1"]
+
+        def split_row(row):
+            new_row_0 = []
+            new_row_1 = []
+            for index, el in enumerate(row):
+                if index in target_columns_0:
+                    new_row_0.append(el)
+                elif index in target_columns_1:
+                    new_row_1.append(el)
+                else:
+                    new_row_0.append(el)
+                    new_row_1.append(el)
+
+            return [new_row_0, new_row_1]
+
+        data = flat_map(split_row, data)
+        sources = flat_map(lambda x: [x, x], sources)
+
+        return data, sources
+
+
+def flat_map(f, items):
+    return list(itertools.chain.from_iterable(map(f, items)))
+
+
+class RuleSet(object):
+
+    def __init__(self, rule_set_as_dict):
+        self.raw_rules = rule_set_as_dict["rules"]
+        self.raw_mapping = rule_set_as_dict.get("mapping", [])
+
+    @property
+    def rules(self):
+        return self.raw_rules
+
+    def _rules_with_definitions(self):
+        for rule in self.raw_rules:
+            yield (rule, RULES_DEFINITIONS[rule["type"]])
+
+    def apply(self, data, sources):
+        for rule, rule_definition in self._rules_with_definitions():
+            rule_definition.validate_rule(rule)
+            data, sources = rule_definition.apply(rule, data, sources)
+
+        return data, sources
+
+    @property
+    def has_errors(self):
+        errored = False
+        try:
+            for rule, rule_definition in self._rules_with_definitions():
+                rule_definition.validate_rule(rule)
+        except Exception:
+            errored = True
+        return errored
+
+    @property
+    def mapping_as_dict(self):
+        as_dict = {}
+        for mapping in self.raw_mapping:
+            as_dict[mapping["type"]] = mapping
+
+        return as_dict
+
+    # Rest of this is generic, things here are Galaxy collection specific, think about about
+    # subclass of RuleSet for collection creation.
+    @property
+    def identifier_columns(self):
+        mapping_as_dict = self.mapping_as_dict
+        identifier_columns = []
+        if "list_identifiers" in mapping_as_dict:
+            identifier_columns.extend(mapping_as_dict["list_identifiers"]["columns"])
+        if "paired_identifier" in mapping_as_dict:
+            identifier_columns.append(mapping_as_dict["paired_identifier"]["columns"][0])
+
+        return identifier_columns
+
+    @property
+    def collection_type(self):
+        mapping_as_dict = self.mapping_as_dict
+        list_columns = mapping_as_dict.get("list_identifiers", {"columns": []})["columns"]
+        collection_type = ":".join(map(lambda c: "list", list_columns))
+        if "paired_identifier" in mapping_as_dict:
+            if collection_type:
+                collection_type += ":paired"
+            else:
+                collection_type = "paired"
+        return collection_type
+
+    @property
+    def display(self):
+        message = "Rules:\n"
+        message += "".join(["- %s\n" % r for r in self.raw_rules])
+        message += "Column Definitions:\n"
+        message += "".join(["- %s\n" % m for m in self.raw_mapping])
+        return message
+
+
+RULES_DEFINITION_CLASSES = [
+    AddColumnMetadataRuleDefinition,
+    AddColumnConcatenateRuleDefinition,
+    AddColumnBasenameRuleDefinition,
+    AddColumnRegexRuleDefinition,
+    AddColumnRownumRuleDefinition,
+    AddColumnValueRuleDefinition,
+    AddColumnSubstrRuleDefinition,
+    RemoveColumnsRuleDefinition,
+    AddFilterRegexRuleDefinition,
+    AddFilterCountRuleDefinition,
+    AddFilterEmptyRuleDefinition,
+    AddFilterMatchesRuleDefinition,
+    AddFilterCompareRuleDefinition,
+    SortRuleDefinition,
+    SwapColumnsRuleDefinition,
+    SplitColumnsRuleDefinition,
+]
+RULES_DEFINITIONS = {}
+for rule_class in RULES_DEFINITION_CLASSES:
+    RULES_DEFINITIONS[rule_class.rule_type] = rule_class()

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -663,8 +663,6 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
 
         Schedule the workflow specified by `workflow_id` to run.
         """
-        # /usage is awkward in this context but is consistent with the rest of
-        # this module. Would prefer to redo it all to use /invocation(s).
         # Get workflow + accessibility check.
         stored_workflow = self.__get_stored_accessible_workflow(trans, workflow_id)
         workflow = stored_workflow.latest_workflow

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -41,6 +41,7 @@ from galaxy.tools.parameters.wrapped import make_dict_copy
 from galaxy.util.bunch import Bunch
 from galaxy.util.json import safe_loads
 from galaxy.util.odict import odict
+from galaxy.util.rules_dsl import RuleSet
 from tool_shed.util import common_util
 
 log = logging.getLogger(__name__)
@@ -718,7 +719,17 @@ class ToolModule(WorkflowModule):
                 extra_kwds = {}
                 if tool_output.collection:
                     extra_kwds["collection"] = True
-                    extra_kwds["collection_type"] = tool_output.structure.collection_type
+                    collection_type = tool_output.structure.collection_type
+                    if not collection_type and tool_output.structure.collection_type_from_rules:
+                        rule_param = tool_output.structure.collection_type_from_rules
+                        if rule_param in self.state.inputs:
+                            rule_json_str = self.state.inputs[rule_param]
+                            if rule_json_str:  # initialized to None...
+                                rules = rule_json_str
+                                if rules:
+                                    rule_set = RuleSet(rules)
+                                    collection_type = rule_set.collection_type
+                    extra_kwds["collection_type"] = collection_type
                     extra_kwds["collection_type_source"] = tool_output.structure.collection_type_source
                     formats = ['input']  # TODO: fix
                 elif tool_output.format_source is not None:

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -10,6 +10,7 @@ import yaml
 from requests import delete, put
 
 from base import api  # noqa: I100,I202
+from base import rules_test_data  # noqa: I100
 from base.populators import (  # noqa: I100
     DatasetCollectionPopulator,
     DatasetPopulator,
@@ -24,6 +25,7 @@ from base.workflow_fixtures import (  # noqa: I100
     WORKFLOW_WITH_DYNAMIC_OUTPUT_COLLECTION,
     WORKFLOW_WITH_OUTPUT_COLLECTION,
     WORKFLOW_WITH_OUTPUT_COLLECTION_MAPPING,
+    WORKFLOW_WITH_RULES_1,
 )
 from galaxy.exceptions import error_codes  # noqa: I201
 from galaxy.tools.verify.test_data import TestDataResolver
@@ -871,6 +873,13 @@ steps:
             self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
             content = self.dataset_populator.get_history_dataset_content(history_id)
             self.assertEqual(content.strip(), "samp1\t10.0\nsamp2\t20.0\nsamp1\t20.0\nsamp2\t40.0")
+
+    @skip_without_tool("__APPLY_RULES__")
+    def test_workflow_run_apply_rules(self):
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs(WORKFLOW_WITH_RULES_1, history_id=history_id, wait=True, assert_ok=True)
+            output_content = self.dataset_populator.get_history_collection_details(history_id, hid=6)
+            rules_test_data.check_example_2(output_content, self.dataset_populator)
 
     def test_filter_failed_mapping(self):
         with self.dataset_populator.test_history() as history_id:

--- a/test/base/data/rules_dsl_spec.yml
+++ b/test/base/data/rules_dsl_spec.yml
@@ -356,4 +356,50 @@
   final:
     data: [["bark", "Dog"], ["meow", "cat"], ["moo", "cow"]]
     sources: [3, 2, 1]
-
+- rules:
+    - type: swap_columns
+      target_column_0: 0
+      target_column_1: 1
+  initial:
+    data: [["moo", "cow"], ["meow", "cat"], ["bark", "Dog"]]
+    sources: [1, 2, 3]
+  final:
+    data: [["cow", "moo"], ["cat", "meow"], ["Dog", "bark"]]
+    sources: [1, 2, 3]
+- rules:
+    - type: split_columns
+      target_columns_0: [0]
+      target_columns_1: [1]
+  initial:
+    data: [["moo", "cow", "A"], ["meow", "cat", "B"], ["bark", "Dog", "C"]]
+    sources: [1, 2, 3]
+  final:
+    data: [["moo", "A"], ["cow", "A"], ["meow", "B"], ["cat", "B"], ["bark", "C"], ["Dog", "C"]]
+    sources: [1, 1, 2, 2, 3, 3]
+- rules:
+    - type: invalid_rule_type
+  error: true
+- rules:
+    - type: add_filter_compare
+      target_column: 0
+      value: 13
+      compare_type: invalid_compare_type
+  error: true
+- rules:
+    - type: add_column_concatenate
+      target_column: 0
+  error: true
+- rules:
+    - type: add_column_basename
+      target_column_0: 0
+  error: true
+- rules:
+    - type: add_column_regex
+      target_column: 0
+      regex: '(o)+'
+  error: true
+- rules:
+    - type: add_column_regex
+      target_column: 0
+      expression: '(o+'
+  error: true

--- a/test/base/rules_test_data.py
+++ b/test/base/rules_test_data.py
@@ -1,0 +1,132 @@
+# Common test data for rule testing meant to be shared between API and Selenium tests.
+from pkg_resources import resource_string
+
+RULES_DSL_SPEC_STR = resource_string(__name__, "data/rules_dsl_spec.yml")
+
+
+def check_example_1(hdca, dataset_populator):
+    assert hdca["collection_type"] == "list"
+    assert hdca["element_count"] == 2
+
+    first_dce = hdca["elements"][0]
+    first_hda = first_dce["object"]
+    assert first_hda["hid"] > 3
+
+
+def check_example_2(hdca, dataset_populator):
+    assert hdca["collection_type"] == "list:list"
+    assert hdca["element_count"] == 2
+    first_collection_level = hdca["elements"][0]
+    assert first_collection_level["element_type"] == "dataset_collection"
+    second_collection_level = first_collection_level["object"]
+    assert second_collection_level["collection_type"] == "list"
+    assert second_collection_level["elements"][0]["element_type"] == "hda"
+
+
+def check_example_3(hdca, dataset_populator):
+    assert hdca["collection_type"] == "list"
+    assert hdca["element_count"] == 2
+    first_element = hdca["elements"][0]
+    assert first_element["element_identifier"] == "test0forward"
+
+
+EXAMPLE_1 = {
+    "rules": {
+        "rules": [
+            {
+                "type": "add_column_metadata",
+                "value": "identifier0",
+            }
+        ],
+        "mapping": [
+            {
+                "type": "list_identifiers",
+                "columns": [0],
+            }
+        ],
+    },
+    "test_data": {
+        "type": "list",
+        "elements": [
+            {
+                "identifier": "i1",
+                "content": "0"
+            },
+            {
+                "identifier": "i2",
+                "content": "1"
+            },
+        ]
+    },
+    "check": check_example_1,
+    "output_hid": 6,
+}
+
+
+EXAMPLE_2 = {
+    "rules": {
+        "rules": [
+            {
+                "type": "add_column_metadata",
+                "value": "identifier0",
+            },
+            {
+                "type": "add_column_metadata",
+                "value": "identifier0",
+            }
+        ],
+        "mapping": [
+            {
+                "type": "list_identifiers",
+                "columns": [0, 1],
+            }
+        ],
+    },
+    "test_data": {
+        "type": "list",
+        "elements": [
+            {
+                "identifier": "i1",
+                "content": "0"
+            },
+            {
+                "identifier": "i2",
+                "content": "1"
+            },
+        ]
+    },
+    "check": check_example_2,
+    "output_hid": 6,
+}
+
+# Flatten
+EXAMPLE_3 = {
+    "rules": {
+        "rules": [
+            {
+                "type": "add_column_metadata",
+                "value": "identifier0",
+            },
+            {
+                "type": "add_column_metadata",
+                "value": "identifier1",
+            },
+            {
+                "type": "add_column_concatenate",
+                "target_column_0": 0,
+                "target_column_1": 1,
+            }
+        ],
+        "mapping": [
+            {
+                "type": "list_identifiers",
+                "columns": [2],
+            }
+        ],
+    },
+    "test_data": {
+        "type": "list:paired",
+    },
+    "check": check_example_3,
+    "output_hid": 7,
+}

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -130,6 +130,82 @@ steps:
 """
 
 
+WORKFLOW_WITH_RULES_1 = """
+class: GalaxyWorkflow
+inputs:
+  - type: collection
+    label: input_c
+steps:
+  - label: apply
+    tool_id: __APPLY_RULES__
+    state:
+      input:
+        $link: input_c
+      rules:
+        rules:
+          - type: add_column_metadata
+            value: identifier0
+          - type: add_column_metadata
+            value: identifier0
+        mapping:
+          - type: list_identifiers
+            columns: [0, 1]
+  - tool_id: random_lines1
+    label: random_lines
+    state:
+      num_lines: 1
+      input:
+        $link: apply#output
+      seed_source:
+        seed_source_selector: set_seed
+        seed: asdf
+test_data:
+  input_c:
+    type: list
+    elements:
+      - identifier: i1
+        content: "0"
+      - identifier: i2
+        content: "1"
+"""
+
+
+WORKFLOW_WITH_RULES_2 = """
+class: GalaxyWorkflow
+inputs:
+  - type: collection
+    label: input_c
+steps:
+  - label: apply
+    tool_id: __APPLY_RULES__
+    state:
+      input:
+        $link: input_c
+      rules:
+        rules:
+          - type: add_column_metadata
+            value: identifier0
+          - type: add_column_metadata
+            value: identifier0
+        mapping:
+          - type: list_identifiers
+            columns: [0, 1]
+  - tool_id: collection_creates_list
+    label: copy_list
+    state:
+      input1:
+        $link: apply#output
+test_data:
+  input_c:
+    type: list
+    elements:
+      - identifier: i1
+        content: "0"
+      - identifier: i2
+        content: "1"
+"""
+
+
 WORKFLOW_NESTED_SIMPLE = """
 class: GalaxyWorkflow
 inputs:

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -185,5 +185,6 @@
   <tool file="${model_tools_path}/relabel_from_file.xml" />
   <tool file="${model_tools_path}/filter_from_file.xml" />
   <tool file="${model_tools_path}/tag_collection_from_file.xml" />
+  <tool file="${model_tools_path}/apply_rules.xml" />
 
 </toolbox>

--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -1018,8 +1018,12 @@ class NavigatesGalaxy(HasDriver):
     def workflow_run_submit(self):
         self.wait_for_and_click_selector("button.btn-primary")
 
-    def tool_open(self, tool_id):
-        self.wait_for_and_click_selector('a[href$="tool_runner?tool_id=%s"]' % tool_id)
+    def tool_open(self, tool_id, outer=False):
+        if outer:
+            tool_link = self.components.tool_panel.outer_tool_link(tool_id=tool_id)
+        else:
+            tool_link = self.components.tool_panel.tool_link(tool_id=tool_id)
+        tool_link.wait_for_and_click()
 
     def tool_parameter_div(self, expanded_parameter_id):
         return self.components.tool_form.parameter_div(parameter=expanded_parameter_id).wait_for_visible()

--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -766,6 +766,19 @@ class NavigatesGalaxy(HasDriver):
                 self.screenshot(screenshot_name)
         rule_builder.mapping_ok.wait_for_and_click()
 
+    def rule_builder_set_source(self, json):
+        rule_builder = self.components.rule_builder
+        rule_builder.view_source.wait_for_and_click()
+        self.rule_builder_enter_source_text(json)
+        rule_builder.main_button_ok.wait_for_and_click()
+        rule_builder.view_source.wait_for_visible()
+
+    def rule_builder_enter_source_text(self, json):
+        rule_builder = self.components.rule_builder
+        text_area_elem = rule_builder.source.wait_for_visible()
+        text_area_elem.clear()
+        text_area_elem.send_keys(json)
+
     def workflow_editor_click_option(self, option_label):
         self.workflow_editor_click_options()
         menu_element = self.workflow_editor_options_menu_element()
@@ -1009,7 +1022,12 @@ class NavigatesGalaxy(HasDriver):
         self.wait_for_and_click_selector('a[href$="tool_runner?tool_id=%s"]' % tool_id)
 
     def tool_parameter_div(self, expanded_parameter_id):
-        return self.wait_for_selector("div.ui-form-element[tour_id$='%s']" % expanded_parameter_id)
+        return self.components.tool_form.parameter_div(parameter=expanded_parameter_id).wait_for_visible()
+
+    def tool_parameter_edit_rules(self, expanded_parameter_id="rules"):
+        rules_div_element = self.tool_parameter_div("rules")
+        edit_button_element = rules_div_element.find_element_by_css_selector("i.fa-edit")
+        edit_button_element.click()
 
     def tool_set_value(self, expanded_parameter_id, value, expected_type=None, test_data_resolver=None):
         div_element = self.tool_parameter_div(expanded_parameter_id)

--- a/test/galaxy_selenium/navigation.yml
+++ b/test/galaxy_selenium/navigation.yml
@@ -159,6 +159,12 @@ history_panel:
     new_name: 'Unnamed history'
     new_size: '(empty)'
 
+tool_panel:
+
+  selectors:
+    tool_link: 'a[href$$="tool_runner?tool_id=${tool_id}"]'
+    outer_tool_link: '.toolTitleNoSection a[href$$="tool_runner?tool_id=${tool_id}"]'
+
 multi_history_view:
 
   selectors:

--- a/test/galaxy_selenium/navigation.yml
+++ b/test/galaxy_selenium/navigation.yml
@@ -215,6 +215,7 @@ tool_form:
     reference: '.citations-formatted .formatted-reference'
     show_bibtex: 'button.citations-to-bibtex'
     bibtex_area: '.citations-bibtex textarea'
+    parameter_div: 'div.ui-form-element[tour_id="${parameter}"]'
 
   labels:
     generate_tour: 'Generate Tour'

--- a/test/selenium_tests/test_tool_form.py
+++ b/test/selenium_tests/test_tool_form.py
@@ -1,4 +1,7 @@
-from base.populators import flakey
+import json
+
+from base import rules_test_data
+from base.populators import flakey, load_data_dict
 from galaxy_selenium.navigates_galaxy import retry_call_during_transitions
 
 from .framework import (
@@ -153,3 +156,45 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.tool_open("environment_variables")
         self.tool_set_value("inttest", inttest_value)
         self.tool_form_execute()
+
+
+class LoggedInToolFormTestCase(SeleniumTestCase):
+
+    ensure_registered = True
+
+    @selenium_test
+    def test_run_apply_rules_1(self):
+        self._apply_rules_and_check(rules_test_data.EXAMPLE_1)
+        self.screenshot("tool_apply_rules_example_1_final")
+
+    @selenium_test
+    def test_run_apply_rules_2(self):
+        self._apply_rules_and_check(rules_test_data.EXAMPLE_2)
+        self.screenshot("tool_apply_rules_example_2_final")
+
+    @selenium_test
+    def test_run_apply_rules_3(self):
+        self._apply_rules_and_check(rules_test_data.EXAMPLE_3)
+        self.screenshot("tool_apply_rules_example_3_final")
+
+    def _apply_rules_and_check(self, example):
+        rule_builder = self.components.rule_builder
+
+        self.home()
+        history_id = self.current_history_id()
+        inputs, _, _ = load_data_dict(history_id, {"input": example["test_data"]}, self.dataset_populator, self.dataset_collection_populator)
+        self.dataset_populator.wait_for_history(history_id)
+        self.home()
+        self.tool_open("__APPLY_RULES__")
+        self.screenshot("tool_apply_rules_landing")
+        self.tool_parameter_edit_rules()
+        rule_builder._.wait_for_visible()
+        self.screenshot("tool_apply_rules_builder_landing")
+        self.rule_builder_set_source(json.dumps(example["rules"]))
+        self.screenshot("tool_apply_rules_after")
+        rule_builder.main_button_ok.wait_for_and_click()
+        self.tool_form_execute()
+        output_hid = example["output_hid"]
+        self.history_panel_wait_for_hid_ok(output_hid)
+        output_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=output_hid, wait=False)
+        example["check"](output_hdca, self.dataset_populator)

--- a/test/selenium_tests/test_tool_form.py
+++ b/test/selenium_tests/test_tool_form.py
@@ -185,7 +185,7 @@ class LoggedInToolFormTestCase(SeleniumTestCase):
         inputs, _, _ = load_data_dict(history_id, {"input": example["test_data"]}, self.dataset_populator, self.dataset_collection_populator)
         self.dataset_populator.wait_for_history(history_id)
         self.home()
-        self.tool_open("__APPLY_RULES__")
+        self.tool_open("__APPLY_RULES__", outer=True)  # may appear twice in panel, grab top-level link
         self.screenshot("tool_apply_rules_landing")
         self.tool_parameter_edit_rules()
         rule_builder._.wait_for_visible()

--- a/test/selenium_tests/test_uploads.py
+++ b/test/selenium_tests/test_uploads.py
@@ -246,11 +246,8 @@ PRJDA60709  SAMD00016382    DRX000480   ftp.sra.ebi.ac.uk/vol1/fastq/DRR000/DRR0
         rule_builder = self.components.rule_builder
         rule_builder.view_source.wait_for_and_click()
 
-        text_area_elem = rule_builder.source.wait_for_visible()
-
         content = self._read_rules_test_data_file("uniprot.json")
-        text_area_elem.clear()
-        text_area_elem.send_keys(content)
+        self.rule_builder_enter_source_text(content)
         self.screenshot("rules_example_5_2_source")
         rule_builder.main_button_ok.wait_for_and_click()
         rule_builder.view_source.wait_for_visible()

--- a/test/selenium_tests/test_workflow_editor.py
+++ b/test/selenium_tests/test_workflow_editor.py
@@ -1,3 +1,5 @@
+import json
+
 from base.workflow_fixtures import (
     WORKFLOW_NESTED_SIMPLE,
     WORKFLOW_SIMPLE_CAT_TWICE,
@@ -5,6 +7,8 @@ from base.workflow_fixtures import (
     WORKFLOW_WITH_INVALID_STATE,
     WORKFLOW_WITH_OLD_TOOL_VERSION,
     WORKFLOW_WITH_OUTPUT_COLLECTION,
+    WORKFLOW_WITH_RULES_1,
+    WORKFLOW_WITH_RULES_2,
 )
 
 from .framework import (
@@ -147,6 +151,71 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         self.screenshot("workflow_editor_simple_nested")
 
     @selenium_test
+    def test_rendering_rules_workflow_1(self):
+        self.open_in_workflow_editor(WORKFLOW_WITH_RULES_1)
+        rule_output = "apply#output"
+        random_lines_input = "random_lines#input"
+
+        self.workflow_editor_maximize_center_pane()
+        self.screenshot("workflow_editor_rules_1")
+        self.assert_connected(rule_output, random_lines_input)
+        self.assert_input_mapped(random_lines_input)
+        self.workflow_editor_destroy_connection(random_lines_input)
+        self.assert_not_connected(rule_output, random_lines_input)
+        self.assert_input_not_mapped(random_lines_input)
+        self.workflow_editor_connect(rule_output, random_lines_input)
+        self.assert_connected(rule_output, random_lines_input)
+        self.assert_input_mapped(random_lines_input)
+
+    @selenium_test
+    def test_rendering_rules_workflow_2(self):
+        self.open_in_workflow_editor(WORKFLOW_WITH_RULES_2)
+        self.workflow_editor_maximize_center_pane(collapse_right=False)
+
+        editor = self.components.workflow_editor
+        rule_builder = self.components.rule_builder
+
+        rule_output = "apply#output"
+        copy_list_input = "copy_list#input1"
+
+        apply_node = editor.node._(label="apply")
+
+        self.assert_connected(rule_output, copy_list_input)
+        self.assert_input_mapped(copy_list_input)
+        self.workflow_editor_destroy_connection(copy_list_input)
+        self.assert_not_connected(rule_output, copy_list_input)
+        self.assert_input_not_mapped(copy_list_input)
+        self.workflow_editor_connect(rule_output, copy_list_input)
+        self.assert_connected(rule_output, copy_list_input)
+        self.assert_input_mapped(copy_list_input)
+
+        apply_node.title.wait_for_and_click()
+        self.screenshot("workflow_editor_rules_2_form")
+        self.tool_parameter_edit_rules()
+        rule_builder._.wait_for_visible()
+        self.screenshot("workflow_editor_rules_2_builder")
+        new_rules = dict(
+            rules=[{"type": "add_column_metadata", "value": "identifier0"}],
+            mapping=[{"type": "list_identifiers", "columns": [0]}],
+        )
+        self.rule_builder_set_source(json.dumps(new_rules))
+        rule_builder.main_button_ok.wait_for_and_click()
+        apply_node.title.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        # screenshot should have async warning about connection removed
+        self.screenshot("workflow_editor_rules_2_after_change")
+        self.assert_input_not_mapped(copy_list_input)
+        # changing output collection type remove outbound connections, so this
+        # this needs to be re-connected. Remove this re-connection if we upgrade
+        # the workflow editor to try to re-establish the connection with different
+        # mapping.
+        self.workflow_editor_connect(rule_output, copy_list_input)
+        self.assert_connected(rule_output, copy_list_input)
+        # Regardless - this rules now say to connect a list to a list instead of a list
+        # to a list:list, so there should be no mapping anymore even after connected.
+        self.assert_input_not_mapped(copy_list_input)
+
+    @selenium_test
     def test_save_as(self):
         name = self.workflow_upload_yaml_with_random_name(WORKFLOW_SIMPLE_CAT_TWICE)
         self.workflow_index_open()
@@ -196,9 +265,11 @@ steps:
         self.workflow_editor_click_option("Save")
         self.workflow_editor_click_option("Close")
 
-    def workflow_editor_maximize_center_pane(self):
-        self.components._.left_panel_collapse.wait_for_and_click()
-        self.components._.right_panel_collapse.wait_for_and_click()
+    def workflow_editor_maximize_center_pane(self, collapse_left=True, collapse_right=True):
+        if collapse_left:
+            self.components._.left_panel_collapse.wait_for_and_click()
+        if collapse_right:
+            self.components._.right_panel_collapse.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_RENDER)
 
     def workflow_editor_connect(self, source, sink, screenshot_partial=None):

--- a/test/selenium_tests/test_workflow_run.py
+++ b/test/selenium_tests/test_workflow_run.py
@@ -1,9 +1,11 @@
 import yaml
+from base import rules_test_data
 from base.populators import load_data_dict
 from base.workflow_fixtures import (
     WORKFLOW_SIMPLE_CAT_TWICE,
     WORKFLOW_WITH_DYNAMIC_OUTPUT_COLLECTION,
     WORKFLOW_WITH_OLD_TOOL_VERSION,
+    WORKFLOW_WITH_RULES_1,
 )
 
 from .framework import (
@@ -54,6 +56,18 @@ class WorkflowRunTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.history_panel_wait_for_hid_ok(7, allowed_force_refreshes=1)
         content = self.dataset_populator.get_history_dataset_content(history_id, hid=7)
         self.assertEqual("10.0\n30.0\n20.0\n40.0\n", content)
+
+    @selenium_test
+    @managed_history
+    def test_execution_with_rules(self):
+        history_id, inputs = self.workflow_run_setup_inputs(WORKFLOW_WITH_RULES_1)
+        self.open_in_workflow_run(WORKFLOW_WITH_RULES_1)
+        self.workflow_run_specify_inputs(inputs)
+        self.screenshot("workflow_run_rules")
+        self.workflow_run_submit()
+        self.history_panel_wait_for_hid_ok(6, allowed_force_refreshes=1)
+        output_content = self.dataset_populator.get_history_collection_details(history_id, hid=6)
+        rules_test_data.check_example_2(output_content, self.dataset_populator)
 
     def open_in_workflow_run(self, yaml_content):
         name = self.workflow_upload_yaml_with_random_name(yaml_content)

--- a/test/unit/test_rule_utils.py
+++ b/test/unit/test_rule_utils.py
@@ -1,0 +1,22 @@
+import yaml
+from base import rules_test_data
+
+from galaxy.util import rules_dsl
+
+
+def test_rules():
+    for test_case in yaml.safe_load(rules_test_data.RULES_DSL_SPEC_STR):
+        rule_set = rules_dsl.RuleSet(test_case)
+        if "initial" in test_case:
+            initial = test_case["initial"]
+            final_data, final_sources = rule_set.apply(initial["data"], initial["sources"])
+            expected_final = test_case["final"]
+            for final_row, expected_final_row in zip(final_data, expected_final["data"]):
+                msg = "%s != %s" % (final_row, expected_final_row)
+                assert len(final_row) == len(expected_final_row), msg
+                for final_val, expected_final_val in zip(final_row, expected_final_row):
+                    assert final_val == expected_final_val, msg
+        elif "error" in test_case:
+            assert rule_set.has_errors, "rule [%s] does not contain errors" % test_case
+        else:
+            raise Exception("Problem with test case definition [%s]." % test_case)

--- a/test/unit/tools/test_parsing.py
+++ b/test/unit/tools/test_parsing.py
@@ -425,6 +425,22 @@ class DataSourceLoaderTestCase(BaseLoaderTestCase):
         assert not self._tool_source.parse_hidden()
 
 
+class ApplyRulesToolLoaderTestCase(BaseLoaderTestCase):
+    source_file_name = os.path.join(os.getcwd(), "lib/galaxy/tools/apply_rules.xml")
+    source_contents = None
+
+    def test_tool_type(self):
+        tool_module = self._tool_source.parse_tool_module()
+        assert tool_module[0] == "galaxy.tools"
+        assert tool_module[1] == "ApplyRulesTool"
+        assert self._tool_source.parse_tool_type() == "apply_rules_to_collection"
+
+    def test_outputs(self):
+        outputs, output_collections = self._tool_source.parse_outputs(object())
+        assert len(outputs) == 1
+        assert len(output_collections) == 1
+
+
 class SpecialToolLoaderTestCase(BaseLoaderTestCase):
     source_file_name = os.path.join(os.getcwd(), "lib/galaxy/tools/imp_exp/exp_history_to_archive.xml")
     source_contents = None


### PR DESCRIPTION
Allow the rules DSL & GUI component (#5365) to operate on existing collections - this enables very flexible filtering, sorting, relabelling, grouping, flattening, and general re-organization of existing collections (e.g. the outputs of tools). This is implemented as a collection operation tool so that it should be executable interactively in the tool form and in a batch fashion as part of workflow executions.

For this to be tracked properly as a tool execution and to work properly in the tool form, I've implemented a new tool framework parameter type (including tool form integration) called "rules". Right now there is just one tool that uses this parameter type - but one can imagine other operations using the rule builder - e.g. creating collections from samplesheets as the first step in an automated workflow using the tool framework instead of the upload API.

This can thought of as a more GUI friendly alternative to some of my proposed collection operations (#2496 , #1313) in the past that consumed JavaScript expressions. This alternative approach is much easier to visualize for GUI based manipulation and is simpler than learning JavaScript if one does not know how to program, but the ubiquity of JavaScript would provide its owns benefits. Hopefully in the long run both approaches prove useful within the Galaxy ecosystem.

- [X] ~Outline the collection operation tool and parameter plumbing. Backend basics. (1 Day)~
- [X] ~Implement simplest tool form parameter. (1 Day)~
- [X] ~Connect tool form parameter to rule based builder component, including callback. (1 Day)~
- [X] ~Simplest rule working in API to create flat and nested collections. (1 Days)~
- [X] ~Simplest rule working GUI.~ (1/2 Day)
- [X] ~Preload collection identifiers as columns the first time the rules widget is loaded.~
- [x] ~Selenium test case for no-op tool. (1 Day)~
- [X] ~Flatten use case working API (1/2 Day)~
- [X] ~Flatten use case - GUI + Selenium. (1/2 Day)~
- [x] ~Swap the frontend to use Python-like regexes so these two approaches give the same results. (2 Days)~
- [x] ~Develop specification framework for rules DSL that can be used to test frontend JS and backend Python.~
- [x] Backend implementation of remaining rule types: (2 Days)
  - [x] add_column_basename
  - [x] add_column_rownum
  - [x] add_column_value
  - [x] add_column_metadata
  - [x] add_column_regex
  - [x] add_column_concatenate
  - [x] add_column_substr
  - [x] remove_columns
  - [x] add_filter_regex
  - [x] add_filter_count
  - [x] add_filter_empty
  - [x] add_filter_matches
  - [x] add_filter_compare
  - [x] sort
  - [x] swap_columns
  - [x] split_columns
- [x] ~Rework output collection type of this tool - it can be anything but it is determinable based on the content of the rules parameter - the workflow editor needs to be able to leverage this information. (2 Days)~ 
   - [x] ~Changing the collection type in the editor breaks the workflow connection - this is better than nothing but it'd be good if there was a warning or if it would attempt to re-establish the connection and alter the mapping if needed.~ (Added a async warning about this in the editor - obviously it'd be better if we had a more permanent warning mechanism for workflow changes but the UI framework isn't there yet.)
- [X] ~Testing rules in workflows in the API. 1 Day.~
- [X] ~Testing rules editor in workflow editor in the GUI (selenium).~ 1 Day.
- [x] ~Conformance tests for the rules language and a way to run them against both the Python and ES6 implementations (attempt to get regex working same in JS and Python). This is a tricky aspect of doing this on the backend this way.~ 2 Days
- [x] ~Testing run rules tool in workflows in the GUI (selenium).~ 1 Day.
- [X] ~Prevent workflow runtime edit of this parameter.~
- [x] Pretty validation on the backend and frontend. 1 Day.
- [x] Pretty display of rules in the...
    - [X] Tool form.
    - [x] Workflow summary.

xref https://github.com/galaxyproject/galaxy/issues/5381 (third bullet point)