### PR TITLE
psycopg2-binary handling tweak

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -189,7 +189,7 @@ if [ $FETCH_WHEELS -eq 1 ]; then
     if [ -n "$GALAXY_CONDITIONAL_DEPENDENCIES" ]; then
         if pip list --format=columns | grep "psycopg2[\(\ ]*2.7.3" > /dev/null; then
             echo "An older version of psycopg2 (non-binary, version 2.7.3) has been detected.  Galaxy now uses psycopg2-binary, which will be installed after removing psycopg2."
-            pip uninstall -y psycopg2==2.7.3
+            pip uninstall -y psycopg2 psycopg2-binary
         fi
         echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
     fi


### PR DESCRIPTION
If `psycopg2-binary` is installed, uninstalling/reinstalling `psycopg2` (as might happen if switching between development branches, or between stable and dev) will leave `psycopg2-binary` installed (per pip) but in a broken state.  If we're removing `psycopg2`, the only safe move is to remove `psycopg2-binary` at the same time, leaving the necessary libraries to be correctly reinstalled afterwards.

If you see a failure in dev startup based on missing psycopg2 after the merge of #5698, the easiest thing to do to fix it is something like:
```
source .venv/bin/activate
pip uninstall -y psycopg2 psycopg2-binary
```

And then restart your Galaxy to let dependency handling do the rest.