### PR TITLE
Exclude the JS GIE proxy's node modules from linting

### DIFF
--- a/.ci/flake8_blacklist.txt
+++ b/.ci/flake8_blacklist.txt
@@ -8,5 +8,6 @@ doc/build
 doc/source/conf.py
 eggs
 lib/galaxy/util/jstree.py
+lib/galaxy/web/proxy/js/node_modules
 static/maps
 static/scripts


### PR DESCRIPTION
This only occurs in development and only if you've installed the proxy dependencies.