### PR TITLE
Improve startup interoperability with Conda

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -52,7 +52,8 @@ uwsgi:
   # --daemon and/or production deployments.
   master: false
 
-  # Path to the application's Python virtual environment.
+  # Path to the application's Python virtual environment. If using Conda for
+  # Galaxy's framework dependencies (not tools!), do not set this.
   virtualenv: .venv
 
   # Path to the application's Python library.

--- a/create_db.sh
+++ b/create_db.sh
@@ -1,12 +1,9 @@
 #!/bin/sh
 
 cd `dirname $0`
-: ${GALAXY_VIRTUAL_ENV:=.venv}
 
-if [ -d "$GALAXY_VIRTUAL_ENV" ];
-then
-    printf "Activating virtualenv at $GALAXY_VIRTUAL_ENV\n"
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
-fi
+. ./scripts/common_startup_functions.sh
+
+setup_python
 
 python ./scripts/create_db.py $@

--- a/doc/source/admin/framework_dependencies.rst
+++ b/doc/source/admin/framework_dependencies.rst
@@ -172,16 +172,35 @@ Conda
 ^^^^^
 
 `Conda`_ and `virtualenv`_ are incompatible. However, Conda provides its own environment separation functionality in the
-form of `Conda environments`_.  Starting Galaxy with Conda Python will cause ``--skip-venv`` to be implicitly set, and
-the currently active Conda environment will be used to install Galaxy framework dependencies instead.
+form of `Conda environments`_.  Starting Galaxy with Conda Python will cause Galaxy to create a ``_galaxy_YY.MM``
+environment into which Galaxy framework dependencies will be installed.
+
+To instruct Galaxy to use a different environment name, set the ``$GALAXY_CONDA_ENV`` environment variable.
+
+If you use the recommended setup of sourcing ``$CONDA_ROOT/etc/profile.d/conda.sh`` as of Conda 4.4, Conda Python is not
+automatically added to your ``$PATH``, so Galaxy will not use Conda for its framework dependencies unless you start it
+with an environment activated that has Conda Python installed. This is because Galaxy defaults to creating a virtualenv
+unless the ``python`` on ``$PATH`` is Conda Python.
+
+.. tip::
+
+    If you would like to force Galaxy to use Conda with Conda 4.4 or later, the simplest method is:
+
+        1. Ensure ``.venv`` does not exist.
+        2. Activate the base environment with ``conda activate base``
+
+    Galaxy will not install in to the base environment.
 
 .. caution::
 
-    Be sure to create and activate a Conda environment for Galaxy prior to installing packages and/or starting Galaxy or
-    else they will be installed in the Conda root environment.
+    Versions of Galaxy prior to 18.05 could install in to the base/root Conda environment. Consult the correct version
+    of the documentation for your version of Galaxy.
+
+**Installing dependencies with conda (instead of pip)**
 
 Because Conda package names typically match PyPI package names, you can install Conda versions of what dependencies are
-available from conda-forge_ and Bioconda_ using a script provided with Galaxy:
+available from conda-forge_ and Bioconda_ using a script provided with Galaxy, **but this is not necessary**. If you do
+not run the script, the dependencies will simply be installed via pip.
 
 .. code-block:: console
 
@@ -235,10 +254,6 @@ Next, activate the environment and run ``pip`` to fetch the remaining dependenci
     #...
     Installing collected packages: SQLAlchemy, ...
     Successfully installed SQLAlchemy-1.0.15 ...
-
-``run.sh`` is not currently compatible with running without a virtualenv. In this case, you should start with uWSGI
-directly. Be sure to uncomment the required options in the ``uwsgi`` section of ``galaxy.yml`` since ``run.sh`` normally
-sets these for you on the command line:
 
 .. code-block:: console
 

--- a/extract_dataset_parts.sh
+++ b/extract_dataset_parts.sh
@@ -1,13 +1,10 @@
 #!/bin/sh
 
 cd `dirname $0`
-: ${GALAXY_VIRTUAL_ENV:=.venv}
 
-if [ -d "$GALAXY_VIRTUAL_ENV" ];
-then
-    printf "Activating virtualenv at $GALAXY_VIRTUAL_ENV\n"
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
-fi
+. ./scripts/common_startup_functions.sh
+
+setup_python
 
 for file in $1/split_info*.json
 do

--- a/lib/galaxy/dependencies/conda-file.sh
+++ b/lib/galaxy/dependencies/conda-file.sh
@@ -6,12 +6,8 @@
 #
 # You should use this script like so:
 #
-# conda create -n <env> --file <(lib/galaxy/dependencies/conda-file.sh)
-#
-# Ensure you have enabled the bioconda and conda-forge repositories first!:
-#
-# conda config --add channels conda-forge
-# conda config --add channels bioconda
+# conda create --override-channels -c bioconda -c conda-forge -c defaults \
+#     -n <env> --file <(lib/galaxy/dependencies/conda-file.sh) python=2.7
 
 here=$(dirname $0)
 
@@ -23,7 +19,8 @@ fi
 
 printf "Filtering out Galaxy requirements not available from Conda:" >&2
 egrep -iv $( \
-    conda create -n _gx_test_env --dry-run --file <(sed 's/;.*//' $here/pinned-requirements.txt) python=2.7 2>&1 \
-    | grep '^\s*-' | grep -v https: | awk '{print $NF}' | paste -s -d'|' \
+    conda create --override-channels -c bioconda -c conda-forge -c defaults \
+        -n _gx_test_env --dry-run --file <(sed 's/;.*//' $here/pinned-requirements.txt) python=2.7 2>&1 \
+        | grep '^\s*-' | grep -v https: | awk '{print $NF}' | paste -s -d'|' \
 ) $here/pinned-requirements.txt | sed 's/;.*//'
 printf " done\n" >&2

--- a/manage_db.sh
+++ b/manage_db.sh
@@ -6,12 +6,9 @@
 #######
 
 cd `dirname $0`
-: ${GALAXY_VIRTUAL_ENV:=.venv}
 
-if [ -d "$GALAXY_VIRTUAL_ENV" ];
-then
-    printf "Activating virtualenv at $GALAXY_VIRTUAL_ENV\n"
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
-fi
+. ./scripts/common_startup_functions.sh
+
+setup_python
 
 python ./scripts/manage_db.py $@

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -542,12 +542,9 @@ if [ -z "$skip_common_startup" ]; then
     ./scripts/common_startup.sh $skip_venv $no_create_venv $no_replace_pip $replace_pip $skip_client_build --dev-wheels || exit 1
 fi
 
-GALAXY_VIRTUAL_ENV="${GALAXY_VIRTUAL_ENV:-.venv}"
-if [ -z "$skip_venv" -a -d "$GALAXY_VIRTUAL_ENV" ];
-then
-    printf "Activating virtualenv at $GALAXY_VIRTUAL_ENV\n"
-    . "$GALAXY_VIRTUAL_ENV/bin/activate"
-fi
+. ./scripts/common_startup_functions.sh
+
+setup_python
 
 if [ -n "$migrated_test" ] ; then
     [ -n "$test_id" ] && class=":TestForTool_$test_id" || class=""

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -182,7 +182,7 @@ if [ $SET_VENV -eq 1 -a -z "$VIRTUAL_ENV" -a -z "$CONDA_DEFAULT_ENV" ]; then
 fi
 
 # this shouldn't happen, but check just in case
-if [ -z "$VIRTUAL_ENV" -a "$CONDA_DEFAULT_ENV" = "base" ]; then
+if [ -z "$VIRTUAL_ENV" ] && [ "$CONDA_DEFAULT_ENV" = "base" -o "$CONDA_DEFAULT_ENV" = "root" ]; then
     echo "ERROR: Conda is in 'base' environment, refusing to continue"
     exit 1
 fi

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -1,20 +1,18 @@
 #!/bin/sh
 set -e
 
+# The caller may do this as well, but since common_startup.sh can be called independently, we need to do it here
+. ./scripts/common_startup_functions.sh
+
 SET_VENV=1
 for arg in "$@"; do
-    [ "$arg" = "--skip-venv" ] && SET_VENV=0
+    if [ "$arg" = "--skip-venv" ]; then
+        SET_VENV=0
+        skip_venv=1  # for common startup functions
+    fi
 done
 
-# Conda Python is in use, do not use virtualenv
-if python -V 2>&1 | grep -q -e 'Anaconda' -e 'Continuum Analytics' ; then
-    CONDA_ALREADY_INSTALLED=1
-elif python -c 'import sys; print(sys.version.replace("\n", " "))' | grep -q -e 'packaged by conda-forge' ; then
-    CONDA_ALREADY_INSTALLED=1
-else
-    CONDA_ALREADY_INSTALLED=0
-fi
-
+USE_CONDA=0
 DEV_WHEELS=0
 FETCH_WHEELS=1
 CREATE_VENV=1
@@ -53,6 +51,18 @@ RMFILES="
 in_venv() {
     case $1 in
         $VIRTUAL_ENV*)
+            return 0
+            ;;
+        ''|*)
+            return 1
+            ;;
+    esac
+}
+
+# return true if $1 is in $CONDA_PREFIX else false
+in_conda_env() {
+    case $1 in
+        $CONDA_PREFIX*)
             return 0
             ;;
         ''|*)
@@ -108,16 +118,34 @@ if [ ! -f "$GALAXY_CONFIG_FILE" ]; then
 fi
 
 : ${GALAXY_VIRTUAL_ENV:=.venv}
+# GALAXY_CONDA_ENV is not set here because we don't want to execute the Galaxy version check if we don't need to
+
+# Locate `conda` and set $CONDA_EXE (if needed). If `python` is Conda Python and $GALAXY_VIRTUAL_ENV does not exist,
+# virtualenv will not be used. setup_python calls this as well but in this case we need it done beforehand.
+set_conda_exe
 
 if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 ]; then
     if [ ! -d "$GALAXY_VIRTUAL_ENV" ]
     then
-        if [ $CONDA_ALREADY_INSTALLED -eq 1 ]; then
-            echo "There is no existing Galaxy virtualenv and Conda is available, so we are skipping virtualenv creation.  Please be aware that this may cause missing dependencies."
-            SET_VENV=0
+        if [ -n "$CONDA_EXE" ]; then
+            echo "Found Conda, virtualenv will not be used."
+            echo "To use a virtualenv instead, create one with a non-Conda Python 2.7 at $GALAXY_VIRTUAL_ENV"
+            : ${GALAXY_CONDA_ENV:="_galaxy_$(get_galaxy_major_version)"}
+            if [ "$CONDA_DEFAULT_ENV" != "$GALAXY_CONDA_ENV" ]; then
+                if ! check_conda_env "$GALAXY_CONDA_ENV"; then
+                    echo "Creating Conda environment for Galaxy: $GALAXY_CONDA_ENV"
+                    echo "To avoid this, use the --no-create-venv flag or set \$GALAXY_CONDA_ENV to an"
+                    echo "existing environment before starting Galaxy."
+                    $CONDA_EXE create --yes --name "$GALAXY_CONDA_ENV" 'python=2.7' 'pip>=9'
+                    unset __CONDA_INFO
+                fi
+            fi
         else
             # If .venv does not exist, and there is no conda available, attempt to create it.
             # Ensure Python is a supported version before creating .venv
+            echo "Creating Python virtual environment for Galaxy: $GALAXY_VIRTUAL_ENV"
+            echo "To avoid this, use the --no-create-venv flag or set \$GALAXY_VIRTUAL_ENV to an"
+            echo "existing environment before starting Galaxy."
             python ./scripts/check_python.py || exit 1
             if command -v virtualenv >/dev/null; then
                 virtualenv -p "$(command -v python)" "$GALAXY_VIRTUAL_ENV"
@@ -148,27 +176,17 @@ if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 ]; then
     fi
 fi
 
-if [ $SET_VENV -eq 1 ]; then
-    # If there is a .venv/ directory, assume it contains a virtualenv that we
-    # should run this instance in.
-    if [ -d "$GALAXY_VIRTUAL_ENV" ];
-    then
-        echo "Activating virtualenv at $GALAXY_VIRTUAL_ENV"
-        . "$GALAXY_VIRTUAL_ENV/bin/activate"
-        # Because it's a virtualenv, we assume $PYTHONPATH is unnecessary for
-        # anything in the venv to work correctly, and having it set can cause
-        # problems when there are conflicts with Galaxy's dependencies outside
-        # the venv (e.g. virtualenv-burrito's pip and six).
-        #
-        # If you are skipping the venv setup we shall assume you know what
-        # you're doing and will deal with any conflicts.
-        unset PYTHONPATH
-    fi
+# activate virtualenv or conda env, sets $GALAXY_VIRTUAL_ENV and $GALAXY_CONDA_ENV
+setup_python
 
-    if [ -z "$VIRTUAL_ENV" ]; then
-        echo "ERROR: A virtualenv cannot be found. Please create a virtualenv in $GALAXY_VIRTUAL_ENV, or activate one."
-        exit 1
-    fi
+if [ $SET_VENV -eq 1 -a -z "$VIRTUAL_ENV" -a -z "$CONDA_DEFAULT_ENV" ]; then
+    echo "ERROR: A virtualenv cannot be found. Please create a virtualenv in $GALAXY_VIRTUAL_ENV, or activate one."
+    exit 1
+fi
+
+if [ -z "$VIRTUAL_ENV" -a "$CONDA_DEFAULT_ENV" = "base" ]; then
+    echo "ERROR: Conda is in 'base' environment, refusing to continue"
+    exit 1
 fi
 
 : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
@@ -226,6 +244,11 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
         if ! in_venv "$(command -v yarn)"; then
             echo "Installing yarn into $VIRTUAL_ENV with npm."
             npm install --global yarn
+        fi
+    elif [ -n "$CONDA_DEFAULT_ENV" -a -n "$CONDA_EXE" ]; then
+        if ! in_conda_env "$(command -v yarn)"; then
+            echo "Installing yarn into '$CONDA_DEFAULT_ENV' Conda environment with conda."
+            $CONDA_EXE install --yes --override-channels --channel conda-forge --channel defaults --name $CONDA_DEFAULT_ENV yarn
         fi
     else
         echo "WARNING: Galaxy client build needed but there is no virtualenv enabled. Build may fail."

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+__CONDA_INFO=
+
 parse_common_args() {
     INITIALIZE_TOOL_DEPENDENCIES=1
     # Pop args meant for common_startup.sh
@@ -69,12 +71,35 @@ run_common_start_up() {
 setup_python() {
     # If there is a .venv/ directory, assume it contains a virtualenv that we
     # should run this instance in.
-    GALAXY_VIRTUAL_ENV="${GALAXY_VIRTUAL_ENV:-.venv}"
-    if [ -d "$GALAXY_VIRTUAL_ENV" -a -z "$skip_venv" ];
-    then
+    : ${GALAXY_VIRTUAL_ENV:=.venv}
+    # $GALAXY_CONDA_ENV isn't set here to avoid running the version check if not using Conda
+    # Ensure $CONDA_EXE is set
+    set_conda_exe
+    if [ -d "$GALAXY_VIRTUAL_ENV" -a -z "$skip_venv" ]; then
         [ -n "$PYTHONPATH" ] && { echo 'Unsetting $PYTHONPATH'; unset PYTHONPATH; }
         echo "Activating virtualenv at $GALAXY_VIRTUAL_ENV"
         . "$GALAXY_VIRTUAL_ENV/bin/activate"
+    elif [ -n "$CONDA_EXE" -a -z "$skip_venv" ] && \
+         check_conda_env ${GALAXY_CONDA_ENV:="_galaxy_$(get_galaxy_major_version)"}; then
+        # You almost surely have pip >= 8.1 and running `conda install ... pip>=8.1` every time is slow
+        REPLACE_PIP=0
+        [ -n "$PYTHONPATH" ] && { echo 'Unsetting $PYTHONPATH'; unset PYTHONPATH; }
+        if [ "$CONDA_DEFAULT_ENV" != "$GALAXY_CONDA_ENV" ]; then
+            echo "Activating Conda environment: $GALAXY_CONDA_ENV"
+            # Dash is actually supported by 4.4, but not with `. /path/to/activate`, only `conda activate`, which we
+            # can't load unless we know the path to <conda_root>/etc/profile.d/conda.sh
+			if ! command -v source >/dev/null; then
+				echo "WARNING: Your shell is not supported with Conda, attempting to use environment"
+				echo "         '$GALAXY_CONDA_ENV' with manual environment setup. To avoid this"
+				echo "         message, use a supported shell or activate the environment before"
+				echo "         starting Galaxy."
+                PATH="$(get_conda_env_path $GALAXY_CONDA_ENV)/bin:$PATH"
+                CONDA_DEFAULT_ENV="$GALAXY_CONDA_ENV"
+                CONDA_PREFIX="$(get_conda_root_path)"
+			else
+				source activate "$GALAXY_CONDA_ENV"
+			fi
+        fi
     fi
 
     # If you are using --skip-venv we assume you know what you are doing but warn
@@ -119,4 +144,65 @@ find_server() {
         run_server="python"
         server_args="./scripts/paster.py serve $server_config $paster_args"
     fi
+}
+
+get_galaxy_major_version() {
+    PYTHONPATH='lib' python -c 'from galaxy.version import VERSION_MAJOR; print(VERSION_MAJOR)'
+}
+
+# Prior to Conda 4.4, the setup method was to add <conda_root>/bin to $PATH. Beginning with 4.4, that method is still
+# possible, but the preferred method is to source <conda_root>/etc/profile.d/conda.sh. If the new method is used, the
+# base environment will *not* be on $PATH, unlike previous versions, and `conda` is a shell function not available to
+# subshells (e.g. scripts). Additionally, in Conda >= 4.4 (and sometimes in Conda < 4.4 due to bugs), an activated
+# non-root/base environment will not have a symlink to `conda`. Beginning with 4.5, $CONDA_EXE will be set to the path
+# to the `conda` script in the base environment. Thus in Conda 4.4, it may not be possible to locate `conda` even if you
+# are using Conda.
+set_conda_exe() {
+    if python -V 2>&1 | grep -q -e 'Anaconda' -e 'Continuum Analytics' || \
+       python -c 'import sys; print(sys.version.replace("\n", " "))' | grep -q -e 'packaged by conda-forge' ; then
+        : ${CONDA_EXE:=$(command -v conda)}
+        if [ -z "$CONDA_EXE" ]; then
+            echo "WARNING: \`python\` is from conda, but the \`conda\` command cannot be found."
+            pydir="$(dirname $(command -v python))"
+            for CONDA_EXE in $pydir/conda $pydir/../../../bin/conda; do
+                [ -x "$CONDA_EXE" ] && break || unset CONDA_EXE
+            done
+            if [ -z "$CONDA_EXE" ]; then
+                echo "WARNING: Unable to guess conda location, if you are using Conda 4.4, upgrade to"
+                echo "         Conda 4.5 or activate the base environment prior to starting Galaxy:"
+                echo "         $ conda activate base"
+            else
+                echo "Guessed conda location: $CONDA_EXE"
+                PATH="$(dirname $CONDA_EXE):$PATH"
+            fi
+        else
+            echo "Using conda at: $CONDA_EXE"
+        fi
+    fi
+}
+
+set_conda_info() {
+    # cache conda info to avoid the cost of running it multiple times
+    if [ -z "$__CONDA_INFO" -o "$1" = "reset" ]; then
+        __CONDA_INFO="$(${CONDA_EXE:-conda} info --json)"
+    fi
+}
+
+get_conda_root_path() {
+    set_conda_info
+    printf "%s" "$__CONDA_INFO" \
+        | python -c "import json, sys; print(json.load(sys.stdin)['root_prefix'])"
+}
+
+check_conda_env() {
+    # envs listed in ~/.conda/environments.txt show up in envs.txt but can't be activated by name. =/
+    set_conda_info
+    printf "%s" "$__CONDA_INFO" \
+        | python -c "import json, os.path, sys; info=json.load(sys.stdin); sys.exit(0 if '$1' in [os.path.basename(p) for p in info['envs'] if os.path.dirname(p) in info['envs_dirs']] else 1)"
+}
+
+get_conda_env_path() {
+    set_conda_info
+    printf "%s" "$__CONDA_INFO" \
+        | python -c "import json, os.path, sys; info=json.load(sys.stdin); print([p for p in info['envs'] if os.path.basename(p) == '$1' and os.path.dirname(p) in info['envs_dirs']][0])"
 }

--- a/scripts/get_uwsgi_args.py
+++ b/scripts/get_uwsgi_args.py
@@ -23,7 +23,7 @@ ALIASES = {
     'module': ('mount',),   # mount is not actually an alias for module, but we don't want to set module if mount is set
 }
 DEFAULT_ARGS = {
-    '_all_': ('virtualenv', 'pythonpath', 'threads', 'buffer-size', 'http', 'static-map', 'die-on-term', 'hook-master-start', 'enable-threads'),
+    '_all_': ('pythonpath', 'threads', 'buffer-size', 'http', 'static-map', 'die-on-term', 'hook-master-start', 'enable-threads'),
     'galaxy': ('py-call-osafterfork',),
     'reports': (),
     'tool_shed': (),
@@ -86,7 +86,6 @@ def _get_uwsgi_args(cliargs, kwargs):
     uwsgi_kwargs = load_app_properties(config_file=config_file, config_section='uwsgi')
     args = []
     defaults = {
-        'virtualenv': os.environ.get('VIRTUAL_ENV', './.venv'),
         'pythonpath': 'lib',
         'threads': '4',
         'buffer-size': '16384',  # https://github.com/galaxyproject/galaxy/issues/1530
@@ -102,6 +101,9 @@ def _get_uwsgi_args(cliargs, kwargs):
     __add_config_file_arg(args, config_file, cliargs.app)
     if not __arg_set('module', uwsgi_kwargs):
         __add_arg(args, 'module', 'galaxy.webapps.{app}.buildapp:uwsgi_app()'.format(app=cliargs.app))
+    # only include virtualenv if it's set/exists, otherwise this breaks conda-env'd Galaxy
+    if not __arg_set('virtualenv', uwsgi_kwargs) and ('VIRTUAL_ENV' in os.environ or os.path.exists('.venv')):
+        __add_arg(args, 'virtualenv', os.environ.get('VIRTUAL_ENV', '.venv'))
     for arg in DEFAULT_ARGS['_all_'] + DEFAULT_ARGS[cliargs.app]:
         if not __arg_set(arg, uwsgi_kwargs):
             __add_arg(args, arg, defaults[arg])


### PR DESCRIPTION
``run.sh`` was semi-broken with Conda older than 4.4 (or 4.4 and later with Conda Python on `$PATH`) installed. This change attempts to deal with Conda in a similar way to how it deals with virtualenvs.

- If the directory in `$GALAXY_VIRTUAL_ENV` (default: `.venv`) exists, Conda is ignored and the venv is used.
- If the `python` on `$PATH` is not Conda Python, a virtualenv is created in `$GALAXY_VIRTUAL_ENV` and used
- If the `python` on `$PATH` is Conda Python, the environment named in `$GALAXY_CONDA_ENV` (default: `_galaxy_YY.MM`) is created and used.

One nice byproduct of this is if you choose to use Conda, you can switch between releases and not have to constantly rewrite .venv as you do it. Also, the version comes from `galaxy.version.VERSION_MAJOR`, not your git branch, so there will only be one auto-created env per release.