### PR TITLE
Do not append '/' to 'js' in GIE static path, this breaks uWSGI static routing

### DIFF
--- a/config/plugins/interactive_environments/common/templates/ie.mako
+++ b/config/plugins/interactive_environments/common/templates/ie.mako
@@ -24,7 +24,7 @@ ${h.js( 'libs/jquery/jquery',
 require.config({
     baseUrl: app_root,
     paths: {
-        "plugin" : app_root + "js/",
+        "plugin" : app_root + "js",
         "galaxy.interactive_environments": "${h.url_for('/static/scripts/galaxy.interactive_environments')}",
     },
     urlArgs: "v=${app.server_starttime}",


### PR DESCRIPTION
Because it creates a path like `/plugins/interactive_environments/jupyter/static/js//jupyter.js`