### PR TITLE
Implement the API version of the Docker containers interface

### DIFF
--- a/config/containers_conf.yml.sample
+++ b/config/containers_conf.yml.sample
@@ -90,6 +90,13 @@ containers:
 
         # All of the `docker` interface type arguments are supported. Additionally:
 
+        # [`-H`/`--host] Daemon socket(s) to connect to. This can be a list, which allows failing over to another
+        # manager when one is down, e.g.:
+        #   host:
+        #     - tcp://swarm1.example.org:2376
+        #     - tcp://swarm2.example.org:2376
+        #host: null
+
         # [`--resverve-cpu` and `--limit-cpu`] Reserve the given number of CPUs when containers are run to prevent other
         # containers from being scheduled on the same node once all of its CPUs are allocated. Additionally, prevent
         # container from using more than the given number of CPUs.

--- a/config/containers_conf.yml.sample
+++ b/config/containers_conf.yml.sample
@@ -1,232 +1,271 @@
 ---
 # Galaxy container interface configuration file
 #
-# To configure the location of this file, use the `containers_config_file`
-# setting in galaxy.ini
+# To configure the location of this file, use the `containers_config_file` setting in galaxy.yml. Additionally, the
+# containers interface is only used if `enable_beta_containers_interface` is set in galaxy.yml.
 
 ###
 ### Container Interfaces
 ###
 
-## Define container interfaces beneath the top-level `containers` dictionary. By # default, a single `_default_`
-## container of type `docker` is defined:
+# Define container interfaces beneath the top-level `containers` dictionary. By default, a single `_default_` interface
+# of type `docker` is defined, equivalent to:
 
 #containers:
-#  _default_:
-#    type: docker
+#    _default_:
+#        type: docker
 
-## Additional options can be specified are specific to the container type:
+# The interface name is arbitrary and allows multiple distinct configurations to be defined. The name can be any string,
+# but `_default_` is used if a component that uses the containers interface does not specify an interface. Currently
+# only Galaxy Interactive Environments use the containers interface, and do not have a way to specify which interface to
+# use, so configure under the `_default_` key for now.
 
-#containers:
-#  _default_:
-#    type: docker
-#    host: docker.example.org:2376
-#    force_tlsverify: yes
-
-## Keys in `containers` are used to map container consumers to specific # container consumers. If a mapping is not
-## configured, the _default_ # configuration will be used. An example of multiple container configurations would be:
+# Additional options can be specified are specific to the container type:
 
 #containers:
-#  _default_:
-#    type: docker
-#    ... additional options ...
-#  example_swarm:
-#    type: docker_swarm
-#    ... additional options ...
+#    _default_:
+#        type: docker
+#        host: docker.example.org:2376
+#        force_tlsverify: yes
+
+# Keys in `containers` are used to map container consumers to specific # container consumers. If a mapping is not
+# configured, the _default_ configuration will be used. An example of multiple container configurations would be:
+
+#containers:
+#    _default_:
+#        type: docker
+#        ... additional options ...
+#    example_swarm:
+#        type: docker_swarm
+#        ... additional options ...
 #
 
 ###
 ### Container Types and Supported Options
 ###
 
-## Command-line equivalent arguments are in [brackets] (if applicable)
+# Command-line equivalent arguments are in [brackets] (if applicable)
 
-### All types
-##
-## The following options are applicable to all container types:
-##
+containers:
 
-#containers:
-#  _default_:
-#    type: ...
+    #
+    # Supported options for all container types
+    #
 
-## [`--name` (partial)] Prepend this string to the name of containers created
-#    name_prefix: galaxy_
+    _default_:
 
-## Prefix to prepend to 
+        # [`--name` (partial)] Prepend this string to the name of containers created
+        #name_prefix: galaxy_
 
-### `docker` and `docker_cli` types
-##
-## `docker_cli` interacts with Docker via its command-line interface. In the future `docker` will use the API (currently
-## it's an alias for `docker_cli`)
-##
+    #
+    # Supported options for `docker` container type
+    #
 
-#containers:
-#  _default_:
-#    type: docker
+    local_docker:
 
-## [`-H`/`--host] Daemon socket(s) to connect to
-#    host: null
+        type: docker
 
-## [`--tlsverify`] Use TLS and verify the remote
-#    force_tlsverify: no
+        # [`-H`/`--host] Daemon socket(s) to connect to
+        #host: null
 
-## [`--cpus`] Number of CPUs (default 0.000)
-#    cpus: null
+        # [`--tlsverify`] Use TLS and verify the remote
+        #force_tlsverify: no
 
-## [`-m`/`--memory`] Memory limit
-#    memory: null
+        # [`--cpus`] Number of CPUs (default 0.000)
+        #cpus: null
 
-## Default image to run if one is not provided to the run method
-#    image: null
+        # [`-m`/`--memory`] Memory limit
+        #memory: null
 
-### `docker_swarm` and `docker_swarm_cli` types
-##
-## All of the `docker` type arguments are supported. Additionally:
-##
+        # Default image to run if one is not provided to the run method
+        #image: null
 
-#containers:
-#  _default_:
-#    type: docker_swarm
+    #
+    # Supported options for `docker_swarm` container type
+    #
 
-## [`--resverve-cpu` and `--limit-cpu`] Reserve the given number of CPUs when containers are run to prevent other
-## containers from being scheduled on the same node once all of its CPUs are allocated. Additionally, prevent container
-## from using more than the given number of CPUs
-#    cpus: null
+    swarm:
 
-## [`--resverve-memory` and `--limit-memory`] Reserve the given amount of memory when containers are run to prevent
-## other containers from being scheduled on the same node once all of its memory is allocated. Additionally, prevent
-## container from using more than the given amount of memory
-#    memory: null
+        type: docker_swarm
 
-## If set, only nodes whose names begin with this string will be visible to and managed by the swarm manager. Note that
-## regardless of whether this is set, the swarm manager will not attempt to control manager nodes
-#    node_prefix: null
+        # All of the `docker` interface type arguments are supported. Additionally:
 
-# Convert image from name[:tag] form to name@digest form when possible, to
-# avoid dependency on the image registry (e.g. Docker Hub or wherever the image
-# was pulled from) at service creation time. For details see:
-#  https://github.com/docker/docker/issues/31427
-#    resolve_image_digest: no
+        # [`--resverve-cpu` and `--limit-cpu`] Reserve the given number of CPUs when containers are run to prevent other
+        # containers from being scheduled on the same node once all of its CPUs are allocated. Additionally, prevent
+        # container from using more than the given number of CPUs.
+        #cpus: null
 
-# If a container run request is received that defines volumes to attach, should those volumes be ignored? Swarm mode
-# does not support mounting volumes.
-#    ignore_volumes: no
+        # [`--resverve-memory` and `--limit-memory`] Reserve the given amount of memory when containers are run to
+        # prevent other containers from being scheduled on the same node once all of its memory is allocated.
+        # Additionally, prevent container from using more than the given amount of memory.
+        #memory: null
 
-## For the following `service_create_*_constraint` options, if set, the swarm manager automatically sets a corresponding
-## label on nodes it spawns for services with the given constraints.
+        # If set, only nodes whose names begin with this string will be visible to and managed by the swarm manager.
+        # Note that regardless of whether this is set, the swarm manager will not attempt to control manager nodes
+        #node_prefix: null
 
-## [`--constraint node.labels._galaxy_image=={image}`]
-## Automatically create a constraint based on the requested image name when new services are created (the image name is
-## the resolved form if `resolve_image_digest` is set). This is useful if your nodes do not all have all of the possible
-## images you'll want to run.
-#    service_create_image_constraint: no
+        # Convert image from name[:tag] form to name@digest form when possible, to avoid dependency on the image
+        # registry (e.g. Docker Hub or wherever the image was pulled from) at service creation time. For details see:
+        #  https://github.com/docker/docker/issues/31427
+        #resolve_image_digest: no
 
-## [`--constraint node.labels._galaxy_cpus=={cpus}`]
-## Automatically create a constraint based on the requested number of CPUs (or 1, if `cpus` is unset). This is useful if
-## you are spawning nodes with a mixture of CPU counts and want to prevent (for example) 1-cpu services from being
-## scheduled on 2-cpu nodes when 2-cpu jobs are waiting.
-#    service_create_cpus_constraint: no
+        # If a container run request is received that defines volumes to attach, should those volumes be ignored? Swarm
+        # mode does not support mounting volumes.
+        #ignore_volumes: no
 
-## Use the swarm manager to manage services on this swarm. Even if your swarm is static, using the manager is
-## recommended as the manager will automatically remove services after they have terminated.
-#    managed: yes
+        #
+        # For the following `service_create_*_constraint` options, if set, the swarm manager automatically sets a
+        # corresponding label on nodes it spawns for services with the given constraints.
+        #
 
-## Automatically start the swarm manager when new services are created. Useful if you want to run the swarm manager but
-## control it separately from Galaxy.
-#    manager_autostart: yes
+        # [`--constraint node.labels._galaxy_image=={image}`] Automatically create a constraint based on the requested
+        # image name when new services are created (the image name is the resolved form if `resolve_image_digest` is
+        # set). This is useful if your nodes do not all have all of the possible images you'll want to run. Note: It's
+        # currently only possible for nodes to have a single image constraint defined. If your nodes have multiple
+        # images available, do not use this option.
+        #service_create_image_constraint: no
 
-### `docker_swarm` swarm manager options
+        # [`--constraint node.labels._galaxy_cpus=={cpus}`] Automatically create a constraint based on the requested
+        # number of CPUs (or 1, if `cpus` is unset). This is useful if you are spawning nodes with a mixture of CPU
+        # counts and want to prevent (for example) 1-cpu services from being scheduled on 2-cpu nodes when 2-cpu jobs
+        # are waiting.
+        #service_create_cpus_constraint: no
 
-## Galaxy can manage a Docker swarm using a built-in daemon and callouts to commands to add/remove nodes from your swarm.
-## These options are set on `docker_swarm` type containers underneath a `manager_conf` key, like so:
+        #
+        # Galaxy can manage a Docker swarm using a built-in daemon and callouts to commands to add/remove nodes from
+        # your swarm.
+        #
 
-#containers:
-#  _default_:
-#    type: docker_swarm
-#    manager_conf:
-#      spawn_command: openstack server create ...
-#      ...
+        # Use the swarm manager to manage services on this swarm. Even if your swarm is static, using the manager is
+        # recommended as the manager will automatically remove services after they have terminated.
+        #managed: yes
 
-## When the swarm manager daemonizes, it writes a pid file so that only one manager will run at a time. This is the path
-## to that pid file. {xdg_data_home} will be templated automatically and defaults to ~/.local/share as per the XDG
-## specification
-#      pid_file: '{xdg_data_home}/galaxy_swarm_manager.pid'
+        # Automatically start the swarm manager when new services are created. Useful if you want to run the swarm
+        # manager but control it separately from Galaxy.
+        #manager_autostart: yes
 
-## Program output will be written to the log
-#      log_file: '{xdg_data_home}/galaxy_swarm_manager.log'
+        # Configuration dictionary for the swarm manager
+        manager_conf:
 
-## Level of log messages (levels should be Python logging module level names (case insensitive)
-#      log_level: INFO
+            #
+            # In order to use the swarm manager for more than just service cleanup, (e.g. its node spawn and destroy
+            # features), you'll need to configure the `cpus` option in the interface. Otherwise, there are no limits on
+            # the number of services that will be assigned to a given node, so the swarm manager has no way to determine
+            # that more nodes should be spawned.
+            #
+            # Each service consumes one "slot", and the number of slots available on a node is its number of CPUs
+            # divided by the value of `cpus`.
+            #
 
-## Log message format
-#      log_format: %(name)s %(levelname)s %(asctime)s %(message)s
+            # When the swarm manager daemonizes, it writes a pid file so that only one manager will run at a time. This
+            # is the path to that pid file. {xdg_data_home} will be templated automatically and defaults to
+            # ~/.local/share as per the XDG specification
+            #pid_file: '{xdg_data_home}/galaxy_swarm_manager.pid'
 
-## Limits:
-##
-## - service_wait_count_limit: number of services that should be waiting for each set of unique constraints before
-##   attempting to spawn a node
-## - service_wait_time_limit: number of seconds a service should be waiting before attempting to spawn a node
-## - node_idle_limit: number of seconds a node should be idle before terminating it
-## - slots_min_limit: minimum number of worker slots that should be started and active
-## - slots_min_spare: number of spare (unused) worker slots that should be started and active
-#      service_wait_count_limit: 0
-#      service_wait_time_limit: 5
-#      node_idle_limit: 120
-#      slots_min_limit: 0
-#      slots_min_spare: 0
+            # Program output will be written to the log
+            #log_file: '{xdg_data_home}/galaxy_swarm_manager.log'
 
-# Each set of limits can also be set on a per-constraint basis under the `limits` list. Each member of `limits` is a
-# dictionary with at least the key `constraints`, whose value is a list of constraint strings matching constraint
-# strings that jobs will be created with, either by the use of `service_create_*_constraint` or manually setting
-# constraints. Other keys match the `node_*` and `slots_*` limits above. Any limits unset will default to the "global"
-# limits as set above, or their defaults. For example:
-#      limits:
-#        - constraints:
-#          - node.labels._galaxy_image==bgruening/docker-jupyter-notebook:16.01.1
-#          - node.labels._galaxy_cpus==1
-#        slots_min_limit: 2
-#        slots_min_spare: 1
+            # Level of log messages (levels are Python logging module level names (case insensitive))
+            #log_level: INFO
 
-# Amount of time to wait for a spawning node to appear in `docker node ls` before considering it failed
-#      spawn_wait_time: 30
+            # Log message format
+            #log_format: %(name)s %(levelname)s %(asctime)s %(message)s
 
-## Command to run to spawn new nodes. This command should join the node to the swarm. It is run once per unique set
-## of constraints of waiting services. Can include template variables:
-##  - {cpus}: Number of CPUs needed by the requested service(s) or minimum limits
-##  - {slots}: Number of "slots" needed by the requested service(s) or minimum limits, where slots are CPU fractions
-#i#   determined by use of the "cpus" option in the `docker_swarm` section.
-##  - {image}: Image requested by service
-##  - {service_ids}: Comma-separated list of service ids with these constraints currently waiting
-##  - {service_count}: Number of services with these constraints currently waiting
-## If this command does not block until the node is joined to the swarm, make sure it at least completes that step in
-## `spawn_wait_time` once it returns control. How the `spawn_command` exits controls the swarm manager's behavior:
-##  - return code: 0, output: space-separated list of spawned nodes:
-##    Swarm manager will wait for the nodes to appear in the swarm and manage them. You are responsible for ensuring
-##    the names returned match the name as it will appear in the output of `docker node ls`.
-##  - return code: 0, output: empty:
-##    Refusing to allocate nodes and the swarm manager should not attempt to spawn nodes for the given service(s)
-##    again.
-##  - return code: 2, output: anything (it will be logged as a message)
-##    Refusing to allocate nodes and the swarm manager should attempt to spawn nodes for the given service(s) again.
-##    This is useful for controlling the maximum number of nodes that will be spawned.
-#       spawn_command: /bin/true
+            # List of services' environment variables that should be logged when performing periodic service logging. By
+            # default, none are logged, but `USER_EMAIL` is useful for GIE containers to log the user who is running the
+            # container.
+            #log_environment_variables:
+            #    - USER_EMAIL
 
-## Command to run to destroy idle nodes. Can include template variables:
-##   - {nodes}: Space-separated list of node names to destroy
-## This command should block until at least the point at which any nodes being destroyed no longer appear in
-## `docker node ls`. It should return the names of nodes destroyed, separated by spaces.
-#      destroy_command: /bin/true
+            # Command to run to spawn new nodes. This command should join the node to the swarm. It is run once per
+            # unique set of constraints of waiting services. Can include template variables:
+            #
+            #  - {cpus}: Number of CPUs needed by the requested service(s) or minimum limits
+            #  - {slots}: Number of "slots" needed by the requested service(s) or minimum limits, where slots are CPU
+            #             fractions determined by use of the "cpus" option in the `docker_swarm` section.
+            #  - {image}: Image requested by service
+            #  - {service_ids}: Comma-separated list of service ids with these constraints currently waiting
+            #  - {service_count}: Number of services with these constraints currently waiting
+            #
+            # If this command does not block until the node is joined to the swarm, make sure it at least completes that
+            # step in `spawn_wait_time` once it returns control. How the `spawn_command` exits controls the swarm
+            # manager's behavior:
+            #
+            #  - return code: 0, output: space-separated list of spawned nodes:
+            #    Swarm manager will wait for the nodes to appear in the swarm and manage them. You are responsible for ensuring
+            #    the names returned match the name as it will appear in the output of `docker node ls`.
+            #  - return code: 0, output: empty:
+            #    Refusing to allocate nodes and the swarm manager should not attempt to spawn nodes for the given service(s)
+            #    again. This is useful for controlling the maximum number of nodes that will be spawned.
+            #  - return code: 2, output: anything (it will be logged as a message)
+            #    Refusing/failed to allocate nodes but the swarm manager should attempt to spawn nodes for the given
+            #    service(s) again.
+            #
+            #spawn_command: /bin/true
 
-## Command to run if either of the above commands failed (e.g. to notify an administrator). Can include template
-## variables:
-##  - {failed_command}: Command line of the command that failed
-#      command_failure_command: /bin/true
+            # Command to run to destroy idle nodes. Can include template variables:
+            #
+            #   - {nodes}: Space-separated list of node names to destroy
+            #
+            # This command should block until at least the point at which any nodes being destroyed no longer appear in
+            # the swarm. It should return the names of nodes destroyed, separated by spaces.
+            #
+            #destroy_command: /bin/true
 
-## Number of times to retry spawn/destroy commands before considering them to have failed, and seconds to wait between
-## retries
-#      command_retries: 0
-#      command_retry_wait: 10
+            # Command to run if either of the above commands failed (e.g. to notify an administrator). Can include
+            # template variables:
+            #
+            #  - {failed_command}: Command line of the command that failed
+            #
+            #command_failure_command: /bin/true
 
-## Stop the swarm manager daemon when there are no services or nodes to manage
-#      terminate_when_idle: yes
+            # Number of times to retry spawn/destroy commands before considering them to have failed, and seconds to
+            # wait between retries.
+            #command_retries: 0
+            #command_retry_wait: 10
+
+            # Amount of time to wait for a spawning node to appear in the swarm before considering it failed
+            #spawn_wait_time: 30
+
+            # Stop the swarm manager daemon when there are no services or nodes to manage
+            #terminate_when_idle: yes
+
+            #
+            # Limits control when the swarm manager will spawn and terminate nodes.
+            #
+
+            # Number of services that must be waiting to run before attempting to spawn a node. If using constraints,
+            # then waiting services are grouped by constraint.
+            #service_wait_count_limit: 0
+
+            # Number of seconds a service must be waiting before attempting to spawn a node.
+            #service_wait_time_limit: 5
+
+            # Number of seconds a node must be idle before terminating it.
+            #node_idle_limit: 120
+
+            # Minimum number of worker slots that should be started and active.
+            #slots_min_limit: 0
+
+            # Number of spare (unused) worker slots that should be started and active
+            #slots_min_spare: 0
+
+            #
+            # Each set of limits can also be set on a per-constraint basis under the `limits` list. Each member of
+            # `limits` is a dictionary dictionary with at least the key `constraints`, whose value is a list of
+            # constraint strings matching constraint strings that jobs will be created with, either by the use of
+            # `service_create_*_constraint` or manually setting constraints. Other keys match the `node_*` and `slots_*`
+            # limits above. Any limits unset will default to the "global" limits as set above, or their defaults.
+            #
+            # If you are using constraints, you should at least define them in the limits section, even if using all
+            # "global" values for the limits. This allows the swarm manager to know what node types to keep around if
+            # you're using `slots_min_limit`.
+            #
+
+            # Limits section example:
+            #limits:
+            #    constraints:
+            #        - node.labels._galaxy_image==bgruening/docker-jupyter-notebook:16.01.1
+            #        - node.labels._galaxy_cpus==1
+            #    slots_min_limit: 2
+            #    slots_min_spare: 1

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -10,6 +10,7 @@ import galaxy.queues
 import galaxy.quota
 import galaxy.security
 from galaxy import config, jobs
+from galaxy.containers import build_container_interfaces
 from galaxy.jobs import metrics as job_metrics
 from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.folders import FolderManager
@@ -205,6 +206,13 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         from galaxy.workflow import scheduling_manager
         # Must be initialized after job_config.
         self.workflow_scheduling_manager = scheduling_manager.WorkflowSchedulingManager(self)
+
+        self.containers = {}
+        if self.config.enable_beta_containers_interface:
+            self.containers = build_container_interfaces(
+                self.config.containers_config_file,
+                containers_conf=self.config.containers_conf
+            )
 
         # Configure handling of signals
         handlers = {}

--- a/lib/galaxy/containers/__init__.py
+++ b/lib/galaxy/containers/__init__.py
@@ -44,6 +44,39 @@ class ContainerPort(namedtuple('ContainerPort', ('port', 'protocol', 'hostaddr',
     :vartype    hostport:   int
     """
 
+class ContainerVolume(with_metaclass(ABCMeta, object)):
+    default_mode = "rw"
+    valid_modes = frozenset(["ro", "rw"])
+
+    def __init__(self, path, host_path=None, mode=None):
+        self.path = path
+        self.host_path = host_path
+        self.mode = mode or self.default_mode
+        if not self.mode_is_valid:
+            raise ValueError("Invalid container volume mode: %s" % mode)
+
+    @abstractmethod
+    def from_str(cls, as_str):
+        """Classmethod to convert from this container type's string representation.
+
+        :param  as_str: string representation of volume
+        :type   as_str: str
+        """
+
+    @abstractmethod
+    def __str__(self):
+        """Return this container type's string representation of the volume.
+        """
+
+    @abstractmethod
+    def to_native(self):
+        """Return this container type's native representation of the volume.
+        """
+
+    @property
+    def mode_is_valid(self):
+        return self.mode in self.valid_modes
+
 
 class Container(with_metaclass(ABCMeta, object)):
 
@@ -107,9 +140,9 @@ class Container(with_metaclass(ABCMeta, object)):
 
 
 class ContainerInterface(with_metaclass(ABCMeta, object)):
-
     container_type = None
     container_class = None
+    volume_class = None
     conf_defaults = {
         'name_prefix': 'galaxy_',
     }

--- a/lib/galaxy/containers/__init__.py
+++ b/lib/galaxy/containers/__init__.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import errno
 import inspect
-import json
 import logging
 import shlex
 import subprocess
@@ -348,21 +347,6 @@ def parse_containers_config(containers_config_file):
         else:
             raise
     return conf
-
-
-def pretty_format(obj):
-    """Attempt to format an object for display.
-
-    Intended for API versions of the interface to provide a readable log output when performing operations similar to
-    formatted CLI commands.
-
-    If serialization fails, the object's string representation will be returned instead.
-    """
-    try:
-        return json.dumps(obj, sort_keys=True, indent=4, separators=(',', ': '))
-    except TypeError:
-        log.warning("JSON serialization failed for object: %s", str(obj))
-        return str(obj)
 
 
 def _get_interface_modules():

--- a/lib/galaxy/containers/__init__.py
+++ b/lib/galaxy/containers/__init__.py
@@ -45,6 +45,7 @@ class ContainerPort(namedtuple('ContainerPort', ('port', 'protocol', 'hostaddr',
     :vartype    hostport:   int
     """
 
+
 class ContainerVolume(with_metaclass(ABCMeta, object)):
     default_mode = "rw"
     valid_modes = frozenset(["ro", "rw"])

--- a/lib/galaxy/containers/__init__.py
+++ b/lib/galaxy/containers/__init__.py
@@ -47,14 +47,13 @@ class ContainerPort(namedtuple('ContainerPort', ('port', 'protocol', 'hostaddr',
 
 
 class ContainerVolume(with_metaclass(ABCMeta, object)):
-    default_mode = "rw"
     valid_modes = frozenset(["ro", "rw"])
 
     def __init__(self, path, host_path=None, mode=None):
         self.path = path
         self.host_path = host_path
-        self.mode = mode or self.default_mode
-        if not self.mode_is_valid:
+        self.mode = mode
+        if mode and not self.mode_is_valid:
             raise ValueError("Invalid container volume mode: %s" % mode)
 
     @abstractmethod

--- a/lib/galaxy/containers/__init__.py
+++ b/lib/galaxy/containers/__init__.py
@@ -46,6 +46,7 @@ class ContainerPort(namedtuple('ContainerPort', ('port', 'protocol', 'hostaddr',
 
 
 class ContainerVolume(with_metaclass(ABCMeta, object)):
+
     valid_modes = frozenset(["ro", "rw"])
 
     def __init__(self, path, host_path=None, mode=None):
@@ -140,6 +141,7 @@ class Container(with_metaclass(ABCMeta, object)):
 
 
 class ContainerInterface(with_metaclass(ABCMeta, object)):
+
     container_type = None
     container_class = None
     volume_class = None

--- a/lib/galaxy/containers/__init__.py
+++ b/lib/galaxy/containers/__init__.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import errno
 import inspect
+import json
 import logging
 import shlex
 import subprocess
@@ -299,7 +300,7 @@ class ContainerInterfaceConfig(dict):
         except KeyError:
             raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, name))
 
-    def get(self, name, default):
+    def get(self, name, default=None):
         try:
             return self[name]
         except KeyError:
@@ -347,6 +348,21 @@ def parse_containers_config(containers_config_file):
         else:
             raise
     return conf
+
+
+def pretty_format(obj):
+    """Attempt to format an object for display.
+
+    Intended for API versions of the interface to provide a readable log output when performing operations similar to
+    formatted CLI commands.
+
+    If serialization fails, the object's string representation will be returned instead.
+    """
+    try:
+        return json.dumps(obj, sort_keys=True, indent=4, separators=(',', ': '))
+    except TypeError:
+        log.warning("JSON serialization failed for object: %s", str(obj))
+        return str(obj)
 
 
 def _get_interface_modules():

--- a/lib/galaxy/containers/docker.py
+++ b/lib/galaxy/containers/docker.py
@@ -271,9 +271,14 @@ class DockerAPIInterface(DockerInterface):
                 spec_kwopts[param] = value
             else:
                 spec_kwopts.update(DockerAPIInterface._kwopt_to_params(map_spec, key, value))
+        # TODO: make this cleaner
         spec_opts = []
         spec_kwopts = {}
         option_map = getattr(self, option_map_name + '_option_map')
+        # set defaults
+        for key in filter(lambda k: option_map[k].get('default'), option_map.keys()):
+            map_spec = option_map[key]
+            _kwopt_to_arg(map_spec, key, map_spec['default'])
         # don't allow kwopts that start with _, those are reserved for "child" classes
         for kwopt in filter(lambda k: not k.startswith('_') and k in option_map, kwopts.keys()):
             map_spec = option_map[kwopt]

--- a/lib/galaxy/containers/docker.py
+++ b/lib/galaxy/containers/docker.py
@@ -221,10 +221,7 @@ class DockerAPIClient(object):
             try:
                 r = f(*args, **kwargs)
                 if tries:
-                    log.info('%s() succeeded after %s tries',
-                        DockerAPIClient._qualname(f),
-                        tries,
-                    )
+                    log.info('%s() succeeded after %s tries', DockerAPIClient._qualname(f), tries)
                 return r
             except requests.exceptions.ConnectionError as exc:
                 pass
@@ -237,12 +234,7 @@ class DockerAPIClient(object):
                     raise
             tries += 1
             log.error("Caught exception on %s() (attempt: %s), will retry in %s seconds: %s: %s",
-                DockerAPIClient._qualname(f),
-                tries,
-                retry,
-                exc.__class__.__name__,
-                exc,
-            )
+                      DockerAPIClient._qualname(f), tries, retry, exc.__class__.__name__, exc)
             sleep(retry)
 
     @staticmethod

--- a/lib/galaxy/containers/docker.py
+++ b/lib/galaxy/containers/docker.py
@@ -37,6 +37,7 @@ log = logging.getLogger(__name__)
 
 
 class DockerInterface(ContainerInterface):
+
     container_class = DockerContainer
     volume_class = DockerVolume
     conf_defaults = {

--- a/lib/galaxy/containers/docker.py
+++ b/lib/galaxy/containers/docker.py
@@ -327,7 +327,6 @@ class DockerAPIInterface(DockerInterface):
         :returns:       The return value of `docker.APIClient.create_host_config()`
         :rtype:         dict
         """
-        host_config_kwopts = {}
         if 'publish_port_random' in kwopts:
             port = int(kwopts.pop('publish_port_random'))
             kwopts['port_bindings'] = {port: None}

--- a/lib/galaxy/containers/docker.py
+++ b/lib/galaxy/containers/docker.py
@@ -16,10 +16,7 @@ import requests.exceptions
 from six import string_types
 from six.moves import shlex_quote
 
-from galaxy.containers import (
-    ContainerInterface,
-    pretty_format
-)
+from galaxy.containers import ContainerInterface
 from galaxy.containers.docker_decorators import (
     docker_columns,
     docker_json
@@ -33,6 +30,7 @@ from galaxy.exceptions import (
     ContainerImageNotFound,
     ContainerNotFound
 )
+from galaxy.util.json import safe_dumps_formatted
 
 log = logging.getLogger(__name__)
 
@@ -426,8 +424,8 @@ class DockerAPIInterface(DockerInterface):
         command = command or None
         log.debug("Creating docker container with image '%s' for command: %s", image, command)
         host_config = self._create_host_config(kwopts)
-        log.debug("Docker container host configuration:\n%s", pretty_format(host_config))
-        log.debug("Docker container creation parameters:\n%s", pretty_format(kwopts))
+        log.debug("Docker container host configuration:\n%s", safe_dumps_formatted(host_config))
+        log.debug("Docker container creation parameters:\n%s", safe_dumps_formatted(kwopts))
         try:
             container = self._client.create_container(
                 image,

--- a/lib/galaxy/containers/docker.py
+++ b/lib/galaxy/containers/docker.py
@@ -226,7 +226,11 @@ class DockerAPIClient(object):
                 if tries:
                     log.info('%s() succeeded after %s tries', DockerAPIClient._qualname(f), tries)
                 return r
-            except (requests.exceptions.ConnectionError, docker.errors.APIError) as exc:
+            except requests.exceptions.ConnectionError as exc:
+                pass
+            except docker.errors.APIError as exc:
+                if exc.response.status_code < 500:
+                    raise
                 pass
             except requests.exceptions.ReadTimeout as exc:
                 retry_time = 0

--- a/lib/galaxy/containers/docker_model.py
+++ b/lib/galaxy/containers/docker_model.py
@@ -256,7 +256,7 @@ class DockerService(Container):
 
     @property
     def state(self):
-	"""If one of this service's tasks desired state is running, return that task state, otherwise, return the state
+        """If one of this service's tasks desired state is running, return that task state, otherwise, return the state
         of a non-running task.
 
         This is imperfect because it doesn't attempt to provide useful information for replicas > 1 tasks, but it suits
@@ -711,7 +711,7 @@ class DockerTask(object):
     def current_state_time(self):
         # Docker API returns a stamp w/ higher second precision than Python takes
         stamp = self.inspect['Status']['Timestamp']
-        return pretty_print_time_interval(time=stamp[:stamp.index('.')+7], precise=True, utc=stamp[-1] == 'Z')
+        return pretty_print_time_interval(time=stamp[:stamp.index('.') + 7], precise=True, utc=stamp[-1] == 'Z')
 
     @property
     def desired_state(self):

--- a/lib/galaxy/containers/docker_model.py
+++ b/lib/galaxy/containers/docker_model.py
@@ -527,7 +527,9 @@ class DockerNode(object):
     def non_terminal_tasks(self):
         r = []
         for task in self.tasks:
-            if not task.terminal:
+            # ensure the task has a service - it is possible for "phantom" tasks to exist (service is removed, no
+            # container is running, but the task still shows up in the node's task list)
+            if not task.terminal and task.service is not None:
                 r.append(task)
         return r
 

--- a/lib/galaxy/containers/docker_model.py
+++ b/lib/galaxy/containers/docker_model.py
@@ -295,6 +295,15 @@ class DockerService(Container):
         return True
 
     @property
+    def node(self):
+        """Same caveats as :meth:`state`.
+        """
+        for task in self.tasks:
+            if task.node is not None:
+                return task.node
+        return None
+
+    @property
     def image(self):
         if self._image is None:
             self._image = self.inspect['Spec']['TaskTemplate']['ContainerSpec']['Image']

--- a/lib/galaxy/containers/docker_model.py
+++ b/lib/galaxy/containers/docker_model.py
@@ -5,6 +5,12 @@ from __future__ import absolute_import
 
 import logging
 
+try:
+    import docker
+except ImportError:
+    from galaxy.util.bunch import Bunch
+    docker = Bunch(errors=Bunch(NotFound=None))
+
 from galaxy.containers import (
     Container,
     ContainerPort,

--- a/lib/galaxy/containers/docker_model.py
+++ b/lib/galaxy/containers/docker_model.py
@@ -169,7 +169,7 @@ class DockerService(Container):
         self._tasks = []
         if inspect:
             self._name = name or inspect['Spec']['Name']
-            self._image = image or inspect[0]['Spec']['TaskTemplate']['ContainerSpec']['Image']
+            self._image = image or inspect['Spec']['TaskTemplate']['ContainerSpec']['Image']
 
     @classmethod
     def from_cli(cls, docker_interface, s, task_list):
@@ -202,7 +202,7 @@ class DockerService(Container):
         #         ]
         rval = []
         try:
-            port_mappings = self.inspect[0]['Endpoint']['Ports']
+            port_mappings = self.inspect['Endpoint']['Ports']
         except (IndexError, KeyError) as exc:
             log.warning("Failed to get ports for container %s from `docker service inspect` output at "
                         "[0]['Endpoint']['Ports']: %s: %s", self.id, exc.__class__.__name__, str(exc))
@@ -255,13 +255,13 @@ class DockerService(Container):
     @property
     def image(self):
         if self._image is None:
-            self._image = self.inspect[0]['Spec']['TaskTemplate']['ContainerSpec']['Image']
+            self._image = self.inspect['Spec']['TaskTemplate']['ContainerSpec']['Image']
         return self._image
 
     @property
     def cpus(self):
         try:
-            cpus = self.inspect[0]['Spec']['TaskTemplate']['Resources']['Limits']['NanoCPUs'] / 1000000000.0
+            cpus = self.inspect['Spec']['TaskTemplate']['Resources']['Limits']['NanoCPUs'] / 1000000000.0
             if cpus == int(cpus):
                 cpus = int(cpus)
             return cpus
@@ -270,7 +270,7 @@ class DockerService(Container):
 
     @property
     def constraints(self):
-        constraints = self.inspect[0]['Spec']['TaskTemplate']['Placement'].get('Constraints', [])
+        constraints = self.inspect['Spec']['TaskTemplate']['Placement'].get('Constraints', [])
         return DockerServiceConstraints.from_constraint_string_list(constraints)
 
     def in_state(self, desired, current):

--- a/lib/galaxy/containers/docker_model.py
+++ b/lib/galaxy/containers/docker_model.py
@@ -69,15 +69,23 @@ class DockerAttributeContainer(object):
 class DockerVolume(ContainerVolume):
     @classmethod
     def from_str(cls, as_str):
+        """Construct an instance from a string as would be passed to `docker run --volume`.
+
+        A string in the format ``<host_path>:<mode>`` is supported for legacy purposes even though it is not valid
+        Docker volume syntax.
+        """
         if not as_str:
             raise ValueError("Failed to parse Docker volume from %s" % as_str)
         parts = as_str.split(":", 2)
         kwds = dict(path=parts[0])
         if len(parts) == 1:
-            pass  # auto-generated volume
+            # auto-generated volume
+            kwds["host_path"] = kwds.pop("path")
         elif len(parts) == 2:
-            if DockerVolume.valid_mode(parts[1]):
+            # /host_path:mode is not (or is no longer?) valid Docker volume syntax
+            if parts[1] in DockerVolume.valid_modes:
                 kwds["mode"] = parts[1]
+                kwds["host_path"] = kwds["path"]
             else:
                 kwds["host_path"] = parts[1]
         elif len(parts) == 3:

--- a/lib/galaxy/containers/docker_swarm.py
+++ b/lib/galaxy/containers/docker_swarm.py
@@ -166,7 +166,7 @@ class DockerSwarmInterface(DockerInterface):
         for node_dict in self.node_ls(id=id, name=name):
             node_id = node_dict['ID']
             node = DockerNode(self, node_id, inspect=node_dict)
-            if self._node_prefix and not node_name.startswith(self._node_prefix):
+            if self._node_prefix and not node.name.startswith(self._node_prefix):
                 continue
             yield node
 
@@ -458,7 +458,6 @@ class DockerSwarmAPIInterface(DockerSwarmInterface, DockerAPIInterface):
 
     def node_update(self, node_id, **kwopts):
         node = DockerNode.from_id(self, node_id)
-        version = node.version
         spec = node.inspect['Spec']
         if 'label_add' in kwopts:
             kwopts['labels'] = spec.get('Labels', {})

--- a/lib/galaxy/containers/docker_swarm.py
+++ b/lib/galaxy/containers/docker_swarm.py
@@ -13,6 +13,7 @@ except ImportError:
     docker = Bunch(types=Bunch(
         ContainerSpec=None,
         RestartPolicy=None,
+        Resources=None,
         Placement=None,
     ))
 

--- a/lib/galaxy/containers/docker_swarm.py
+++ b/lib/galaxy/containers/docker_swarm.py
@@ -8,7 +8,12 @@ import logging
 try:
     import docker
 except ImportError:
-    docker = None
+    from galaxy.util.bunch import Bunch
+    docker = Bunch(types=Bunch(
+        ContainerSpec=None,
+        RestartPolicy=None,
+        Placement=None,
+    ))
 
 from galaxy.containers import (
     docker_swarm_manager,
@@ -404,7 +409,6 @@ class DockerSwarmAPIInterface(DockerSwarmInterface, DockerAPIInterface):
             return {'name': name}
         return None
 
-    #
     #
     # docker subcommands
     #

--- a/lib/galaxy/containers/docker_swarm.py
+++ b/lib/galaxy/containers/docker_swarm.py
@@ -17,10 +17,7 @@ except ImportError:
 
 import requests
 
-from galaxy.containers import (
-    docker_swarm_manager,
-    pretty_format
-)
+from galaxy.containers import docker_swarm_manager
 from galaxy.containers.docker import (
     DockerAPIInterface,
     DockerCLIInterface,
@@ -35,6 +32,7 @@ from galaxy.containers.docker_model import (
     IMAGE_CONSTRAINT
 )
 from galaxy.exceptions import ContainerRunError
+from galaxy.util.json import safe_dumps_formatted
 
 log = logging.getLogger(__name__)
 
@@ -418,10 +416,10 @@ class DockerSwarmAPIInterface(DockerSwarmInterface, DockerAPIInterface):
         endpoint_spec = self._create_docker_api_spec('endpoint_spec', docker.types.EndpointSpec, kwopts)
         task_template = self._create_docker_api_spec('task_template', docker.types.TaskTemplate, kwopts)
         self.set_kwopts_name(kwopts)
-        log.debug("Docker service task template:\n%s", pretty_format(task_template))
-        log.debug("Docker service endpoint specification:\n%s", pretty_format(endpoint_spec))
-        log.debug("Docker service mode:\n%s", pretty_format(service_mode))
-        log.debug("Docker service creation parameters:\n%s", pretty_format(kwopts))
+        log.debug("Docker service task template:\n%s", safe_dumps_formatted(task_template))
+        log.debug("Docker service endpoint specification:\n%s", safe_dumps_formatted(endpoint_spec))
+        log.debug("Docker service mode:\n%s", safe_dumps_formatted(service_mode))
+        log.debug("Docker service creation parameters:\n%s", safe_dumps_formatted(kwopts))
         try:
             service = self._client.create_service(task_template, mode=service_mode, endpoint_spec=endpoint_spec, **kwopts)
         except requests.exceptions.ReadTimeout:

--- a/lib/galaxy/containers/docker_swarm_manager.py
+++ b/lib/galaxy/containers/docker_swarm_manager.py
@@ -184,12 +184,16 @@ class SwarmManager(object):
                 log.info('node %s (%s) state: %s, %s tasks (%s terminal)', node.name, node.id, node.state,
                          len(node.tasks), len([t for t in node.tasks if t.terminal]))
                 for task in node.tasks:
-                    env_str = ''
-                    if envs.get(task.service.id):
-                        env_str = ' [' + ', '.join(envs.get(task.service.id, [])) + ']'
-                    log.info('node %s (%s) service %s (%s) task %s (%s)%s state: %s %s', node.name, node.id,
-                             task.service.name, task.service.id, task.slot, task.id, env_str, task.state,
-                             task.current_state_time)
+                    if not task.service:
+                        log.warning('node %s (%s) task %s (%s) has no service! state: %s %s', node.name, node.id,
+                                    task.slot, task.id, task.state, task.current_state_time)
+                    else:
+                        env_str = ''
+                        if envs.get(task.service.id):
+                            env_str = ' [' + ', '.join(envs.get(task.service.id, [])) + ']'
+                        log.info('node %s (%s) service %s (%s) task %s (%s)%s state: %s %s', node.name, node.id,
+                                 task.service.name, task.service.id, task.slot, task.id, env_str, task.state,
+                                 task.current_state_time)
             self._last_log = time.time()
 
     def _terminate_if_idle(self):

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -10,6 +10,7 @@ pbs_python
 drmaa
 statsd
 graphitesend
+docker
 azure-storage==0.32.0
 # PyRods not in PyPI
 python-ldap==2.4.44

--- a/lib/galaxy/tools/deps/docker_util.py
+++ b/lib/galaxy/tools/deps/docker_util.py
@@ -23,6 +23,7 @@ DEFAULT_RUN_EXTRA_ARGUMENTS = None
 
 
 class DockerVolume(object):
+    # TODO: this class has been refactored in to `galaxy.containers`, things that use this should use that instead
 
     def __init__(self, path, to_path=None, how=DEFAULT_VOLUME_MOUNT_TYPE):
         self.from_path = path
@@ -60,6 +61,12 @@ class DockerVolume(object):
 
     def __str__(self):
         return ":".join([self.from_path, self.to_path, self.how])
+
+    def to_docker_api(self):
+        return {self.from_path: {
+            'bind': self.to_path,
+            'mode': self.how
+        }}
 
 
 def kill_command(

--- a/lib/galaxy/tools/deps/docker_util.py
+++ b/lib/galaxy/tools/deps/docker_util.py
@@ -22,53 +22,6 @@ DEFAULT_SET_USER = "$UID"
 DEFAULT_RUN_EXTRA_ARGUMENTS = None
 
 
-class DockerVolume(object):
-    # TODO: this class has been refactored in to `galaxy.containers`, things that use this should use that instead
-
-    def __init__(self, path, to_path=None, how=DEFAULT_VOLUME_MOUNT_TYPE):
-        self.from_path = path
-        self.to_path = to_path or path
-        if not DockerVolume.__valid_how(how):
-            raise ValueError("Invalid way to specify Docker volume %s" % how)
-        self.how = how
-
-    @staticmethod
-    def volumes_from_str(volumes_as_str):
-        if not volumes_as_str:
-            return []
-        volume_strs = [v.strip() for v in volumes_as_str.split(",")]
-        return [DockerVolume.volume_from_str(_) for _ in volume_strs]
-
-    @staticmethod
-    def volume_from_str(as_str):
-        if not as_str:
-            raise ValueError("Failed to parse Docker volume from %s" % as_str)
-        parts = as_str.split(":", 2)
-        kwds = dict(path=parts[0])
-        if len(parts) == 2:
-            if DockerVolume.__valid_how(parts[1]):
-                kwds["how"] = parts[1]
-            else:
-                kwds["to_path"] = parts[1]
-        elif len(parts) == 3:
-            kwds["to_path"] = parts[1]
-            kwds["how"] = parts[2]
-        return DockerVolume(**kwds)
-
-    @staticmethod
-    def __valid_how(how):
-        return how in ["ro", "rw"]
-
-    def __str__(self):
-        return ":".join([self.from_path, self.to_path, self.how])
-
-    def to_docker_api(self):
-        return {self.from_path: {
-            'bind': self.to_path,
-            'mode': self.how
-        }}
-
-
 def kill_command(
     container,
     signal=None,

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -383,14 +383,17 @@ def shrink_string_by_size(value, size, join_by="..", left_larger=True, beginning
     return value
 
 
-def pretty_print_time_interval(time=False, precise=False):
+def pretty_print_time_interval(time=False, precise=False, utc=False):
     """
     Get a datetime object or a int() Epoch timestamp and return a
     pretty string like 'an hour ago', 'Yesterday', '3 months ago',
     'just now', etc
     credit: http://stackoverflow.com/questions/1551382/user-friendly-time-format-in-python
     """
-    now = datetime.now()
+    if utc:
+        now = datetime.utcnow()
+    else:
+        now = datetime.now()
     if type(time) is int:
         diff = now - datetime.fromtimestamp(time)
     elif isinstance(time, datetime):

--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -85,6 +85,18 @@ def safe_dumps(*args, **kwargs):
     return dumped
 
 
+def safe_dumps_formatted(obj):
+    """Attempt to format an object for display.
+
+    If serialization fails, the object's string representation will be returned instead.
+    """
+    try:
+        return safe_dumps(obj, sort_keys=True, indent=4, separators=(',', ': '))
+    except TypeError:
+        log.warning("JSON serialization failed for object: %s", str(obj))
+        return str(obj)
+
+
 # Methods for handling JSON-RPC
 
 def validate_jsonrpc_request(request, regular_methods, notification_methods):

--- a/lib/galaxy/visualization/plugins/interactive_environments.py
+++ b/lib/galaxy/visualization/plugins/interactive_environments.py
@@ -261,7 +261,7 @@ class InteractiveEnvironmentRequest(object):
             return self.attr.container_interface.volume_class(
                 container_path,
                 host_path=host_path,
-                mode=kwds.get('mode'))
+                mode=kwds.get('mode', 'ro'))
 
     def _get_env_for_run(self, env_override=None):
         if env_override is None:

--- a/lib/galaxy/visualization/plugins/interactive_environments.py
+++ b/lib/galaxy/visualization/plugins/interactive_environments.py
@@ -17,8 +17,8 @@ from six.moves import configparser, shlex_quote
 
 from galaxy import model, web
 from galaxy.containers import build_container_interfaces
+from galaxy.containers.docker_model import DockerVolume
 from galaxy.managers import api_keys
-from galaxy.tools.deps.docker_util import DockerVolume
 from galaxy.util import string_as_bool_or_none
 from galaxy.util.bunch import Bunch
 
@@ -491,7 +491,7 @@ class InteractiveEnvironmentRequest(object):
         :type env_override: dict
         :param env_override: dictionary of environment variables to add.
 
-        :type volumes: list of galaxy.tools.deps.docker_util.DockerVolume
+        :type volumes: list of :class:`galaxy.containers.docker_model.DockerVolume`s
         :param volumes: dictionary of docker volume mounts
 
         """

--- a/lib/galaxy/visualization/plugins/interactive_environments.py
+++ b/lib/galaxy/visualization/plugins/interactive_environments.py
@@ -170,12 +170,8 @@ class InteractiveEnvironmentRequest(object):
             # TODO: don't hardcode this, and allow for mapping
             key = '_default_'
         if key:
-            containers = build_container_interfaces(
-                self.attr.galaxy_config.containers_config_file,
-                containers_conf=self.attr.galaxy_config.containers_conf,
-            )
             try:
-                self.attr.container_interface = containers[key]
+                self.attr.container_interface = self.trans.app.containers[key]
             except KeyError:
                 log.error("Unable to load '%s' container interface: invalid key", key)
 

--- a/lib/galaxy/visualization/plugins/interactive_environments.py
+++ b/lib/galaxy/visualization/plugins/interactive_environments.py
@@ -16,7 +16,6 @@ import yaml
 from six.moves import configparser, shlex_quote
 
 from galaxy import model, web
-from galaxy.containers import build_container_interfaces
 from galaxy.containers.docker_model import DockerVolume
 from galaxy.managers import api_keys
 from galaxy.util import string_as_bool_or_none

--- a/lib/galaxy/webapps/galaxy/controllers/interactive_environments.py
+++ b/lib/galaxy/webapps/galaxy/controllers/interactive_environments.py
@@ -3,7 +3,6 @@ API check for whether the current session's interactive environment launch is re
 """
 import logging
 
-from galaxy.containers import build_container_interfaces
 from galaxy.web import expose, json
 from galaxy.web.base.controller import BaseUIController
 
@@ -29,12 +28,8 @@ class InteractiveEnvironmentsController(BaseUIController):
             # not using the new containers interface
             return True
 
-        container_interfaces = build_container_interfaces(
-            self.app.config.containers_config_file,
-            containers_conf=self.app.config.containers_conf,
-        )
         try:
-            interface = container_interfaces[proxy_map.container_interface]
+            interface = self.app.containers[proxy_map.container_interface]
         except KeyError:
             log.error('Invalid container interface key: %s', proxy_map.container_interface)
             return None

--- a/scripts/docker_swarm_manager.py
+++ b/scripts/docker_swarm_manager.py
@@ -580,8 +580,13 @@ def _swarm_manager_daemon(pidfile, logfile, swarm_manager_conf, docker_interface
 
 def _swarm_manager(conf, docker_interface):
     swarm_manager = SwarmManager(conf, docker_interface)
-    log.debug("swarm manager loaded, running...")
-    swarm_manager.run()
+    while True:
+        try:
+            log.info("swarm manager loaded, running...")
+            swarm_manager.run()
+        except Exception:
+            log.exception("exception raised to run loop:")
+            log.error("restarting due to fatal error")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Initially when I'd started work on adding Docker Swarm support for GIEs, I was just augmenting the existing (command line) docker calls in the GIE module. Before long, the this grew in to creating a library for interacting with containerization systems. I moved the command line work over to the new library and expanded it, adding a generalized parser for the command line's column output, among other things.

Although this worked at the time, the correct route would've been to use the Docker API, but I fell a bit for the sunk cost fallacy and finished things up using the command line. The command line stuff is now incompatible with at least some commands in the latest docker versions.

Soooooo, I've finally implemented the API versions of the Docker and Docker Swarm interfaces and deprecated the command line interfaces, to be removed in the release after 18.05.

This also includes some general stability improvements for the swarm manager, and it touches the tool dependency docker util slightly, as there was already a model for a docker volume in there. Rather than duplicate, I moved that model over to the containers lib.