### PR TITLE
Increase yarn's network timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ ifndef YARN
 	@echo "Could not find yarn, which is required to build the Galaxy client.\nTo install yarn, please visit \033[0;34mhttps://yarnpkg.com/en/docs/install\033[0m for instructions, and package information for all platforms.\n"
 	false;
 else
-	cd client && yarn install --check-files
+	cd client && yarn install --network-timeout 120000 --check-files
 endif
 	
 


### PR DESCRIPTION
This should (hopefully) make the selenium docker yarn setup fail on timeouts less often.

I was working on a prebuilt docker container with all current node_modules preinstalled, but I think the maintenance of that might be more trouble than it's worth, especially if this fixes the travis builds.

 (edit: removed wrong link above, that's a separate problem)