### PR TITLE
Use `extras` to specify additional social_auth_core dependencies

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/Pipfile
+++ b/lib/galaxy/dependencies/pipfiles/default/Pipfile
@@ -50,8 +50,7 @@ pyparsing = "*"
 "Fabric3" = "*"
 paramiko = "*"
 python-genomespaceclient = "*"
-social_auth_core = "==1.5.0"
-pyjwkest = "==1.4.0"
+social_auth_core = {version = "==1.5.0", extras = ['openidconnect']}
 
 [requires]
 python_version = "2.7"

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -19,19 +19,19 @@ chardet==3.0.4
 cheetah3==3.1.0
 cliff==2.11.0
 cloudbridge==0.3.3
-cmd2==0.8.3
-contextlib2==0.5.5
+cmd2==0.8.4
+contextlib2==0.5.5; python_version < '3.5'
 cryptography==2.2.2
 debtcollector==1.19.0
 decorator==4.2.1
-deprecation==2.0
+deprecation==2.0.1
 dictobj==0.4
 docopt==0.6.2
 docutils==0.14
 dogpile.cache==0.6.5
-enum34==1.1.6
+enum34==1.1.6; python_version < '3.4'
 fabric3==1.14.post1
-funcsigs==1.0.2; python_version == '2.7' or python_version == '2.6'
+funcsigs==1.0.2; python_version < '3.3'
 functools32==3.2.3.post2; python_version == '2.7'
 future==0.16.0
 futures==3.2.0; python_version == '2.7' or python_version == '2.6'
@@ -53,7 +53,7 @@ markupsafe==1.0
 mercurial==3.7.3; python_version < '3'
 monotonic==1.4
 msgpack==0.5.6
-munch==2.3.0
+munch==2.3.1
 netaddr==0.7.19
 netifaces==0.10.6
 nose==1.3.7
@@ -63,7 +63,7 @@ openstacksdk==0.12.0
 os-client-config==1.29.0
 os-service-types==1.2.0
 osc-lib==1.10.0
-oslo.config==6.0.1
+oslo.config==6.0.2
 oslo.i18n==3.20.0
 oslo.serialization==2.25.0
 oslo.utils==3.36.0
@@ -73,7 +73,7 @@ parsley==1.3
 paste==2.0.3
 pastedeploy==1.5.2
 pastescript==2.0.2
-pbr==4.0.1
+pbr==4.0.2
 positional==1.2.1
 prettytable==0.7.2
 psutil==5.4.3
@@ -100,7 +100,7 @@ python-neutronclient==6.1.0
 python-novaclient==7.0.0
 python-openid==2.2.5
 python-swiftclient==3.3.0
-pytz==2018.3
+pytz==2018.4
 pyyaml==3.12
 repoze.lru==0.7
 requests-oauthlib==0.8.0
@@ -118,7 +118,7 @@ sqlalchemy-utils==0.33.2
 sqlalchemy==1.2.6
 sqlparse==0.2.4
 stevedore==1.28.0
-subprocess32==3.2.7
+subprocess32==3.2.7; python_version < '3.0'
 svgwrite==1.1.12
 tempita==0.5.2
 tzlocal==1.5.1
@@ -127,6 +127,7 @@ urllib3==1.22
 uwsgi==2.0.17
 vine==1.1.4
 warlock==1.2.0
+wcwidth==0.1.7; sys_platform != 'win32'
 webencodings==0.5.1
 webob==1.4.2
 whoosh==2.7.4

--- a/lib/galaxy/dependencies/pipfiles/develop/Pipfile.lock
+++ b/lib/galaxy/dependencies/pipfiles/develop/Pipfile.lock
@@ -192,10 +192,10 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:56b7a8ba7d64bf6135a9dfefb85a80d95924b3fde5ed6343a1a1d464a040dae3",
-                "sha256:de75cf1d510542c746beeff66b52241eb12c8f95f2ef846ee50ed5d72392caa4"
+                "sha256:4e8a0ed6a8705a26768f4c3da26026013b157821fe5f95881599556ea9d91c19",
+                "sha256:dae4aaa78eafcad10ce2581fc34d694faa616727837fd8e55c1a00951ad6744f"
             ],
-            "version": "==4.0.1"
+            "version": "==4.0.2"
         },
         "pygithub3": {
             "hashes": [
@@ -226,17 +226,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:07edfc3d4d2705a20a6e99d97f0c4b61c800b8232dc1c04d87e8554f130148dd",
-                "sha256:3a47ff71597f821cd84a162e71593004286e5be07a340fd462f0d33a760782b5",
-                "sha256:410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0",
-                "sha256:5bd55c744e6feaa4d599a6cbd8228b4f8f9ba96de2c38d56f08e534b3c9edf0d",
-                "sha256:61242a9abc626379574a166dc0e96a66cd7c3b27fc10868003fa210be4bff1c9",
-                "sha256:887ab5e5b32e4d0c86efddd3d055c1f363cbaa583beb8da5e22d2fa2f64d51ef",
-                "sha256:ba18e6a243b3625513d85239b3e49055a2f0318466e0b8a92b8fb8ca7ccdf55f",
-                "sha256:ed6509d9af298b7995d69a440e2822288f2eca1681b8cce37673dbb10091e5fe",
-                "sha256:f93ddcdd6342f94cea379c73cddb5724e0d6d0a1c91c9bdef364dc0368ba4fda"
+                "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555",
+                "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
             ],
-            "version": "==2018.3"
+            "version": "==2018.4"
         },
         "pyyaml": {
             "hashes": [

--- a/lib/galaxy/dependencies/pipfiles/develop/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/develop/pinned-requirements.txt
@@ -17,11 +17,11 @@ nose==1.3.7
 nosehtml==0.4.4
 packaging==17.1
 pathtools==0.1.2
-pbr==4.0.1
+pbr==4.0.2
 pygithub3==0.5.1; python_version < '3'
 pygments==2.2.0
 pyparsing==2.2.0
-pytz==2018.3
+pytz==2018.4
 pyyaml==3.12
 recommonmark==0.4.0
 requests==2.18.4

--- a/lib/galaxy/dependencies/pipfiles/flake8/Pipfile.lock
+++ b/lib/galaxy/dependencies/pipfiles/flake8/Pipfile.lock
@@ -56,6 +56,8 @@
         },
         "pycodestyle": {
             "hashes": [
+                "sha256:1ec08a51c901dfe44921576ed6e4c1f5b7ecbad403f871397feedb5eb8e4fa14",
+                "sha256:5ff2fbcbab997895ba9ead77e1b38b3ebc2e5c3b8a6194ef918666e4c790a00e",
                 "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
                 "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
             ],

--- a/lib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
@@ -1,5 +1,5 @@
 configparser==3.5.0; python_version < '3.2'
-enum34==1.1.6; python_version <= '2.7'
+enum34==1.1.6; python_version < '3.4'
 flake8-import-order==0.17.1
 flake8==3.5.0
 mccabe==0.6.1

--- a/lib/galaxy/dependencies/pipfiles/update.sh
+++ b/lib/galaxy/dependencies/pipfiles/update.sh
@@ -34,13 +34,16 @@ ENVS="develop
 flake8
 default"
 
-for env in $ENVS
-do
-        cd "$THIS_DIRECTORY/$env"
-        pipenv lock
-        # Strip out hashes and trailing whitespace for unhashed version
-        # of this requirements file, needed for pipenv < 11.1.2
-        pipenv lock -r | sed 's/--hash[^[:space:]]*//g' | sed 's/[[:space:]]*$//' > pinned-requirements.txt
+for env in $ENVS; do
+    cd "$THIS_DIRECTORY/$env"
+    pipenv lock
+    # Strip out hashes and trailing whitespace for unhashed version
+    # of this requirements file, needed for pipenv < 11.1.2
+    pipenv lock -r | sed -e 's/--hash[^[:space:]]*//g' -e 's/[[:space:]]*$//' > pinned-requirements.txt
+    # Fix oscillating environment markers
+    sed -i.orig -e "s/^cffi==\([^;]*\).*$/cffi==\1/" \
+                -e "s/^enum34==\([^;]*\).*$/enum34==\1; python_version < '3.4'/" \
+                -e "s/^funcsigs==\([^;]*\).*$/funcsigs==\1; python_version < '3.3'/" pinned-requirements.txt
 done
 
 if [ "$commit" -eq "1" ];


### PR DESCRIPTION
Also:
- Fix oscillating environment markers due to slight differences in how packages specify their requirements
- Update requirements files with `make update-dependencies`