### PR TITLE
Move the memory statement below _galaxy_setup_environment

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -27,13 +27,13 @@ _galaxy_setup_environment() {
 $integrity_injection
 $slots_statement
 export GALAXY_SLOTS
-$memory_statement
 GALAXY_VIRTUAL_ENV="$galaxy_virtual_env"
 _GALAXY_VIRTUAL_ENV="$galaxy_virtual_env"
 PRESERVE_GALAXY_ENVIRONMENT="$preserve_python_environment"
 GALAXY_LIB="$galaxy_lib"
 _galaxy_setup_environment "$PRESERVE_GALAXY_ENVIRONMENT"
 GALAXY_PYTHON=`command -v python`
+$memory_statement
 $instrument_pre_commands
 cd $working_directory
 $command


### PR DESCRIPTION
This is done  to ensure that a non-standard PATH to, for example, a SLURM install will be applied if set in environment_setup_file for 'scontrol' call in the job shell script. This was discovered by me and a fix was proposed by mvdbeek.