### PR TITLE
More, better workflow run Selenium tests.

### DIFF
--- a/client/galaxy/scripts/mvc/tool/tool-form-composite.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-composite.js
@@ -434,6 +434,9 @@ var View = Backbone.View.extend({
                         step
                     )
                 );
+                if(step.step_label) {
+                    form.$el.attr("step-label", step.step_label);
+                }
             }
             self.forms[step.index] = form;
             self._append(self.$steps, form.$el);

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -14,6 +14,7 @@ from base.populators import (  # noqa: I100
     DatasetCollectionPopulator,
     DatasetPopulator,
     flakey,
+    load_data_dict,
     skip_without_tool,
     wait_on,
     WorkflowPopulator
@@ -102,11 +103,8 @@ class BaseWorkflowsApiTestCase(api.ApiTestCase):
                 ds_map[key] = label_map[label]
         return dumps(ds_map)
 
-    def _ds_entry(self, hda):
-        src = 'hda'
-        if 'history_content_type' in hda and hda['history_content_type'] == "dataset_collection":
-            src = 'hdca'
-        return dict(src=src, id=hda["id"])
+    def _ds_entry(self, history_content):
+        return self.dataset_populator.ds_entry(history_content)
 
     def _workflow_inputs(self, uploaded_workflow_id):
         workflow_show_resposne = self._get("workflows/%s" % uploaded_workflow_id)
@@ -137,62 +135,7 @@ class BaseWorkflowsApiTestCase(api.ApiTestCase):
             jobs_descriptions = yaml.safe_load(has_workflow)
 
         test_data = jobs_descriptions.get("test_data", {})
-
-        label_map = {}
-        inputs = {}
-        has_uploads = False
-
-        for key, value in test_data.items():
-            is_dict = isinstance(value, dict)
-            if is_dict and ("elements" in value or value.get("type", None) in ["list:paired", "list", "paired"]):
-                elements_data = value.get("elements", [])
-                elements = []
-                for element_data in elements_data:
-                    identifier = element_data["identifier"]
-                    input_type = element_data.get("type", "raw")
-                    if input_type == "File":
-                        content = read_test_data(element_data)
-                    else:
-                        content = element_data["content"]
-                    elements.append((identifier, content))
-                # TODO: make this collection_type
-                collection_type = value["type"]
-                new_collection_kwds = {}
-                if "name" in value:
-                    new_collection_kwds["name"] = value["name"]
-                if collection_type == "list:paired":
-                    hdca = self.dataset_collection_populator.create_list_of_pairs_in_history(history_id, **new_collection_kwds).json()
-                elif collection_type == "list":
-                    hdca = self.dataset_collection_populator.create_list_in_history(history_id, contents=elements, **new_collection_kwds).json()
-                else:
-                    hdca = self.dataset_collection_populator.create_pair_in_history(history_id, contents=elements, **new_collection_kwds).json()
-                label_map[key] = self._ds_entry(hdca)
-                inputs[key] = hdca
-                has_uploads = True
-            elif is_dict and "type" in value:
-                input_type = value["type"]
-                if input_type == "File":
-                    content = read_test_data(value)
-                    new_dataset_kwds = {
-                        "content": content
-                    }
-                    if "name" in value:
-                        new_dataset_kwds["name"] = value["name"]
-                    if "file_type" in value:
-                        new_dataset_kwds["file_type"] = value["file_type"]
-                    hda = self.dataset_populator.new_dataset(history_id, **new_dataset_kwds)
-                    label_map[key] = self._ds_entry(hda)
-                    has_uploads = True
-                elif input_type == "raw":
-                    label_map[key] = value["value"]
-                    inputs[key] = value["value"]
-            elif not is_dict:
-                has_uploads = True
-                hda = self.dataset_populator.new_dataset(history_id, content=value)
-                label_map[key] = self._ds_entry(hda)
-                inputs[key] = hda
-            else:
-                raise ValueError("Invalid test_data def %" % test_data)
+        inputs, label_map, has_uploads = load_data_dict(history_id, test_data, self.dataset_populator, self.dataset_collection_populator)
         workflow_request = dict(
             history="hist_id=%s" % history_id,
             workflow_id=workflow_id,

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -10,11 +10,13 @@ import requests
 from pkg_resources import resource_string
 from six import StringIO
 
+from galaxy.tools.verify.test_data import TestDataResolver
 from . import api_asserts
 from .workflows_format_2 import (
     convert_and_import_workflow,
     ImporterGalaxyInterface,
 )
+
 
 # Simple workflow that takes an input and call cat wrapper on it.
 workflow_str = resource_string(__name__, "data/test_workflow_1.ga")
@@ -366,6 +368,12 @@ class BaseDatasetPopulator(object):
         if suffix:
             url = "%s%s" % (url, suffix)
         return self._get(url, data=data)
+
+    def ds_entry(self, history_content):
+        src = 'hda'
+        if 'history_content_type' in history_content and history_content['history_content_type'] == "dataset_collection":
+            src = 'hdca'
+        return dict(src=src, id=history_content["id"])
 
 
 class DatasetPopulator(BaseDatasetPopulator):
@@ -792,6 +800,73 @@ class DatasetCollectionPopulator(BaseDatasetCollectionPopulator):
     def _create_collection(self, payload):
         create_response = self.galaxy_interactor.post("dataset_collections", data=payload)
         return create_response
+
+
+def load_data_dict(history_id, test_data, dataset_populator, dataset_collection_populator):
+
+    def read_test_data(test_dict):
+        test_data_resolver = TestDataResolver()
+        filename = test_data_resolver.get_filename(test_dict["value"])
+        content = open(filename, "r").read()
+        return content
+
+    inputs = {}
+    label_map = {}
+    has_uploads = False
+
+    for key, value in test_data.items():
+        is_dict = isinstance(value, dict)
+        if is_dict and ("elements" in value or value.get("type", None) in ["list:paired", "list", "paired"]):
+            elements_data = value.get("elements", [])
+            elements = []
+            for element_data in elements_data:
+                identifier = element_data["identifier"]
+                input_type = element_data.get("type", "raw")
+                if input_type == "File":
+                    content = read_test_data(element_data)
+                else:
+                    content = element_data["content"]
+                elements.append((identifier, content))
+            # TODO: make this collection_type
+            collection_type = value["type"]
+            new_collection_kwds = {}
+            if "name" in value:
+                new_collection_kwds["name"] = value["name"]
+            if collection_type == "list:paired":
+                hdca = dataset_collection_populator.create_list_of_pairs_in_history(history_id, **new_collection_kwds).json()
+            elif collection_type == "list":
+                hdca = dataset_collection_populator.create_list_in_history(history_id, contents=elements, **new_collection_kwds).json()
+            else:
+                hdca = dataset_collection_populator.create_pair_in_history(history_id, contents=elements, **new_collection_kwds).json()
+            label_map[key] = dataset_populator.ds_entry(hdca)
+            inputs[key] = hdca
+            has_uploads = True
+        elif is_dict and "type" in value:
+            input_type = value["type"]
+            if input_type == "File":
+                content = read_test_data(value)
+                new_dataset_kwds = {
+                    "content": content
+                }
+                if "name" in value:
+                    new_dataset_kwds["name"] = value["name"]
+                if "file_type" in value:
+                    new_dataset_kwds["file_type"] = value["file_type"]
+                hda = dataset_populator.new_dataset(history_id, **new_dataset_kwds)
+                label_map[key] = dataset_populator.ds_entry(hda)
+                has_uploads = True
+            elif input_type == "raw":
+                label_map[key] = value["value"]
+                inputs[key] = value["value"]
+        elif not is_dict:
+            has_uploads = True
+            hda = dataset_populator.new_dataset(history_id, content=value)
+            label_map[key] = dataset_populator.ds_entry(hda)
+            inputs[key] = hda
+        else:
+            raise ValueError("Invalid test_data def %" % test_data)
+
+    return inputs, label_map, has_uploads
 
 
 def wait_on_state(state_func, desc="state", skip_states=["running", "queued", "new", "ready"], assert_ok=False, timeout=DEFAULT_TIMEOUT):

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -53,6 +53,46 @@ steps:
     state:
       f1:
         $link: split_up#paired_output
+test_data:
+  text_input: |
+    a
+    b
+    c
+    d
+"""
+
+
+WORKFLOW_WITH_DYNAMIC_OUTPUT_COLLECTION = """
+class: GalaxyWorkflow
+steps:
+  - label: text_input1
+    type: input
+  - label: text_input2
+    type: input
+  - label: cat_inputs
+    tool_id: cat1
+    state:
+      input1:
+        $link: text_input1
+      queries:
+        - input2:
+            $link: text_input2
+  - label: split_up
+    tool_id: collection_split_on_column
+    state:
+      input1:
+        $link: cat_inputs#out_file1
+  - tool_id: cat_list
+    state:
+      input1:
+        $link: split_up#split_output
+test_data:
+  text_input1: |
+    samp1\t10.0
+    samp2\t20.0
+  text_input2: |
+    samp1\t30.0
+    samp2\t40.0
 """
 
 

--- a/test/galaxy_selenium/navigation.yml
+++ b/test/galaxy_selenium/navigation.yml
@@ -224,6 +224,11 @@ workflows:
     new_button: '#new-workflow'
     import_button: '#import-workflow'
 
+workflow_run:
+
+  selectors: 
+    input_div: "[step-label='${label}'] .select2-container"
+
 workflow_editor:
 
   node:

--- a/test/selenium_tests/framework.py
+++ b/test/selenium_tests/framework.py
@@ -509,9 +509,9 @@ def get_remote_driver():
 class SeleniumSessionGetPostMixin:
     """Mixin for adapting Galaxy testing populators helpers to Selenium session backed bioblend."""
 
-    def _get(self, route):
+    def _get(self, route, data={}):
         full_url = self.selenium_test_case.build_url("api/" + route, for_selenium=False)
-        response = requests.get(full_url, cookies=self.selenium_test_case.selenium_to_requests_cookies())
+        response = requests.get(full_url, data=data, cookies=self.selenium_test_case.selenium_to_requests_cookies())
         return response
 
     def _post(self, route, data={}):

--- a/test/selenium_tests/framework.py
+++ b/test/selenium_tests/framework.py
@@ -382,6 +382,12 @@ class SeleniumTestCase(FunctionalTestCase, NavigatesGalaxy, UsesApiTestCaseMixin
     def workflow_populator(self):
         return SeleniumSessionWorkflowPopulator(self)
 
+    def workflow_upload_yaml_with_random_name(self, content, **kwds):
+        workflow_populator = self.workflow_populator
+        name = self._get_random_name()
+        workflow_populator.upload_yaml_workflow(content, name=name, **kwds)
+        return name
+
     def ensure_visualization_available(self, hid, visualization_name):
         """Skip or fail a test if visualization for file doesn't appear.
 

--- a/test/selenium_tests/test_workflow_editor.py
+++ b/test/selenium_tests/test_workflow_editor.py
@@ -276,8 +276,8 @@ steps:
         sink_mapping_icon.wait_for_absent_or_hidden()
 
     def workflow_index_open_with_name(self, name):
-        self.workflow_index_search_for(name)
         self.workflow_index_open()
+        self.workflow_index_search_for(name)
         self.workflow_index_click_option("Edit")
 
     def workflow_upload_yaml_with_random_name(self, content):

--- a/test/selenium_tests/test_workflow_run.py
+++ b/test/selenium_tests/test_workflow_run.py
@@ -1,5 +1,8 @@
+import yaml
+from base.populators import load_data_dict
 from base.workflow_fixtures import (
     WORKFLOW_SIMPLE_CAT_TWICE,
+    WORKFLOW_WITH_DYNAMIC_OUTPUT_COLLECTION,
     WORKFLOW_WITH_OLD_TOOL_VERSION,
 )
 
@@ -39,9 +42,35 @@ class WorkflowRunTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.assert_warning_message(contains="different versions")
         self.screenshot("workflow_run_tool_upgrade")
 
+    @selenium_test
+    @managed_history
+    def test_execution_with_multiple_inputs(self):
+        history_id, inputs = self.workflow_run_setup_inputs(WORKFLOW_WITH_DYNAMIC_OUTPUT_COLLECTION)
+        self.open_in_workflow_run(WORKFLOW_WITH_DYNAMIC_OUTPUT_COLLECTION)
+        self.workflow_run_specify_inputs(inputs)
+        self.screenshot("workflow_run_two_inputs")
+        self.workflow_run_submit()
+
+        self.history_panel_wait_for_hid_ok(7, allowed_force_refreshes=1)
+        content = self.dataset_populator.get_history_dataset_content(history_id, hid=7)
+        self.assertEqual("10.0\n30.0\n20.0\n40.0\n", content)
+
     def open_in_workflow_run(self, yaml_content):
         name = self.workflow_upload_yaml_with_random_name(yaml_content)
         self.workflow_run_with_name(name)
+
+    def workflow_run_setup_inputs(self, content):
+        history_id = self.current_history_id()
+        test_data = yaml.safe_load(content)["test_data"]
+        inputs, _, _ = load_data_dict(history_id, test_data, self.dataset_populator, self.dataset_collection_populator)
+        self.dataset_populator.wait_for_history(history_id)
+        return history_id, inputs
+
+    def workflow_run_specify_inputs(self, inputs):
+        workflow_run = self.components.workflow_run
+        for label, value in inputs.items():
+            input_div_element = workflow_run.input_div(label=label).wait_for_visible()
+            self.select2_set_value(input_div_element, "%d: " % value["hid"])
 
     def workflow_run_with_name(self, name):
         self.workflow_index_open()

--- a/test/selenium_tests/test_workflow_run.py
+++ b/test/selenium_tests/test_workflow_run.py
@@ -4,6 +4,7 @@ from base.workflow_fixtures import (
 )
 
 from .framework import (
+    managed_history,
     selenium_test,
     SeleniumTestCase,
     UsesHistoryItemAssertions,
@@ -15,30 +16,34 @@ class WorkflowRunTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
     ensure_registered = True
 
     @selenium_test
+    @managed_history
     def test_simple_execution(self):
         self.perform_upload(self.get_filename("1.fasta"))
         self.wait_for_history()
-
-        workflow_populator = self.workflow_populator
-        workflow_populator.upload_yaml_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
-        self.workflow_index_open()
-        self.workflow_index_click_option("Run")
-
-        self.screenshot("workflow_manage_run_simple")
+        self.open_in_workflow_run(WORKFLOW_SIMPLE_CAT_TWICE)
+        self.screenshot("workflow_run_simple_ready")
         self.workflow_run_submit()
-
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+        self.screenshot("workflow_run_simple_submitted")
         self.history_panel_wait_for_hid_ok(2, allowed_force_refreshes=1)
         self.history_panel_click_item_title(hid=2, wait=True)
         self.assert_item_summary_includes(2, "2 sequences")
+        self.screenshot("workflow_run_simple_complete")
 
     @selenium_test
     def test_execution_with_tool_upgrade(self):
-        workflow_populator = self.workflow_populator
-        workflow_populator.upload_yaml_workflow(WORKFLOW_WITH_OLD_TOOL_VERSION, exact_tools=True)
-
-        self.workflow_index_open()
-        self.workflow_index_click_option("Run")
+        name = self.workflow_upload_yaml_with_random_name(WORKFLOW_WITH_OLD_TOOL_VERSION, exact_tools=True)
+        self.workflow_run_with_name(name)
         self.sleep_for(self.wait_types.UX_TRANSITION)
         # Check that this tool form contains a warning about different versions.
         self.assert_warning_message(contains="different versions")
-        self.screenshot("workflow_manage_run_tool_upgrade")
+        self.screenshot("workflow_run_tool_upgrade")
+
+    def open_in_workflow_run(self, yaml_content):
+        name = self.workflow_upload_yaml_with_random_name(yaml_content)
+        self.workflow_run_with_name(name)
+
+    def workflow_run_with_name(self, name):
+        self.workflow_index_open()
+        self.workflow_index_search_for(name)
+        self.workflow_index_click_option("Run")


### PR DESCRIPTION
- Improve the abstractions used by some API tests to allow them to be shared with Selenium testing.
- Improve robustness of Selenium workflow tests so that they don't need to assume a fresh user is executing the test.
- Add a new Selenium workflow test that actually specifies inputs (the existing test just assumes the history only has one dataset and that is selected by default).
- Implement better abstractions for these tests to enable more testing, more easily. These are being used here a bit and downstream in #5819.
- Small bug fix to improve performance of workflow editor tests from #5882.
