### PR TITLE
This fixes display of the tour index names -- previously unnoticed since

### DIFF
--- a/client/galaxy/scripts/mvc/tours.js
+++ b/client/galaxy/scripts/mvc/tours.js
@@ -32,7 +32,7 @@ Select any tour to get started (and remember, you can click 'End Tour' at any ti
     <% _.each(tourtag.tours, function(tour) { %>
         <li class="list-group-item">
             <a href="/tours/<%- tour.id %>" class="tourItem" data-tour.id=<%- tour.id %>>
-                <%- tour.name || tour.id %>
+                <%- tour.attributes.name || tour.id %>
             </a>
              - <%- tour.attributes.description || "No description given." %>
              <% _.each(tour.attributes.tags, function(tag) { %>


### PR DESCRIPTION
the id was displaying fine as the fallback.

ping @moskalenko 