### PR TITLE
OIDC controller index

### DIFF
--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -67,6 +67,7 @@ def app_factory(global_conf, load_app_kwds={}, **kwargs):
     webapp.add_route('/activate', controller='user', action='activate')
 
     # Authentication endpoints.
+    webapp.add_route('/authnz/', controller='authnz', action='index', provider=None)
     webapp.add_route('/authnz/{provider}/login', controller='authnz', action='login', provider=None)
     webapp.add_route('/authnz/{provider}/callback', controller='authnz', action='callback', provider=None)
     webapp.add_route('/authnz/{provider}/disconnect', controller='authnz', action='disconnect', provider=None)

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -16,6 +16,26 @@ log = logging.getLogger(__name__)
 class OIDC(BaseUIController):
 
     @web.expose
+    @web.require_login("list third-party identities")
+    def index(self, trans, **kwargs):
+        """
+        GET /api/authnz/
+            returns a list of third-party identities associated with the user.
+
+        :type  trans: galaxy.web.framework.webapp.GalaxyWebTransaction
+        :param trans: Galaxy web transaction.
+
+        :param kwargs: empty dict
+
+        :rtype: list of dicts
+        :return: a list of third-party identities associated with the user account.
+        """
+        rtv = []
+        for authnz in trans.user.social_auth:
+            rtv.append({'id': trans.app.security.encode_id(authnz.id), 'provider': authnz.provider})
+        return rtv
+
+    @web.expose
     def login(self, trans, provider):
         if not trans.app.config.enable_oidc:
             msg = "Login to Galaxy using third-party identities is not enabled on this Galaxy instance."


### PR DESCRIPTION
Add `index` to the OIDC-based authentication controller to list all the third-party identities associated with a user. 