### PR TITLE
Multiview history panel-control fix.  

### DIFF
--- a/client/galaxy/scripts/mvc/history/multi-panel.js
+++ b/client/galaxy/scripts/mvc/history/multi-panel.js
@@ -136,9 +136,11 @@ var HistoryViewColumn = Backbone.View.extend(baseMVC.LoggableMixin).extend({
             isCurrentHistory: this.currentHistory
         });
         return $(`
-            <div class="panel-controls no-gutters clear row justify-content-between mb-1">
-                ${this.controlsLeftTemplate({ history: data, view: this })}
-                ${this.controlsRightTemplate({ history: data, view: this })}
+            <div class="panel-controls mb-1">
+                <div class="flex-row flex-column-container no-gutters justify-content-between">
+                    ${this.controlsLeftTemplate({ history: data, view: this })}
+                    ${this.controlsRightTemplate({ history: data, view: this })}
+                </div>
             </div>
             <div class="inner flex-row flex-column-container">
                 <div id="history-${data.id}" class="history-column history-panel flex-column"></div>


### PR DESCRIPTION
Forces the panel control sizing correctly, instead of being smushed up in the flex column (issue was on Chrome, worked fine in Firefox)

Fixes #5910 (linked wrong multiview issue at first)