### PR TITLE
Fix error with data managers when trying to move_merge inexistant extra_files dir

### DIFF
--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -326,7 +326,8 @@ class DataManager(object):
             # moving a directory and the target already exists, we move the contents instead
             log.debug('Attempting to add entries for undeclared tables: %s.', ', '.join(data_tables_dict.keys()))
             for ref_file in out_data.values():
-                util.move_merge(ref_file.extra_files_path, self.data_managers.app.config.galaxy_data_manager_data_path)
+                if os.path.exists(ref_file.extra_files_path):
+                    util.move_merge(ref_file.extra_files_path, self.data_managers.app.config.galaxy_data_manager_data_path)
             path_column_names = ['path']
             for data_table_name, data_table_values in data_tables_dict.items():
                 data_table = self.data_managers.app.tool_data_tables.get(data_table_name, None)
@@ -373,7 +374,8 @@ class DataManager(object):
                     if e.errno != errno.EEXIST:
                         raise e
             # moving a directory and the target already exists, we move the contents instead
-            util.move_merge(source, target)
+            if os.path.exists(source):
+                util.move_merge(source, target)
 
             if move_dict.get('relativize_symlinks', False):
                 util.relativize_symlinks(target)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1418,7 +1418,7 @@ def move_merge(source, target):
     if os.path.isdir(source) and os.path.exists(target) and os.path.isdir(target):
         for name in os.listdir(source):
             move_merge(os.path.join(source, name), os.path.join(target, name))
-    elif os.path.exists(source):
+    else:
         return shutil.move(source, target)
 
 

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1418,7 +1418,7 @@ def move_merge(source, target):
     if os.path.isdir(source) and os.path.exists(target) and os.path.isdir(target):
         for name in os.listdir(source):
             move_merge(os.path.join(source, name), os.path.join(target, name))
-    else:
+    elif os.path.exists(source):
         return shutil.move(source, target)
 
 


### PR DESCRIPTION
Hi,
I'm playing with the @blankenberg's [data_manager_manual](https://github.com/galaxyproject/tools-iuc/tree/master/data_managers/data_manager_manual) and I encountered an error when trying to use it: datasets were red, with an "Unable to finish job" error.
In the logs I had this exception:

```
Traceback (most recent call last):
  File "/galaxy-central/lib/galaxy/jobs/runners/__init__.py", line 686, in finish_job
    self._finish_or_resubmit_job(job_state, stdout, stderr, exit_code)
  File "/galaxy-central/lib/galaxy/jobs/runners/__init__.py", line 433, in _finish_or_resubmit_job
    job_state.job_wrapper.finish(stdout, stderr, exit_code, check_output_detected_state=check_output_detected_state)
  File "/galaxy-central/lib/galaxy/jobs/__init__.py", line 1402, in finish
    self.tool.exec_after_process(self.queue.app, inp_data, out_data, param_dict, job=job)
  File "/galaxy-central/lib/galaxy/tools/__init__.py", line 2238, in exec_after_process
    data_manager.process_result(out_data)
  File "/galaxy-central/lib/galaxy/tools/data_manager/manager.py", line 329, in process_result
    util.move_merge(ref_file.extra_files_path, self.data_managers.app.config.galaxy_data_manager_data_path)
  File "/galaxy-central/lib/galaxy/util/__init__.py", line 1403, in move_merge
    return shutil.move(source, target)
  File "/usr/lib/python2.7/shutil.py", line 302, in move
    copy2(src, real_dst)
  File "/usr/lib/python2.7/shutil.py", line 130, in copy2
    copyfile(src, dst)
  File "/usr/lib/python2.7/shutil.py", line 82, in copyfile
    with open(src, 'rb') as fsrc:
IOError: [Errno 2] No such file or directory: '/export/galaxy-central/database/files/000/dataset_16_files'
```

So the problem is that I use it to simply add preexisting data to some data table, which means dataset_16_files doesn't exist.

Here's a tiny patch for it, it works with it now

If it's possible, it would be cool to backport it in 18.01