### PR TITLE
Allow using the rule based collection builders right from libraries.

### DIFF
--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -204,7 +204,6 @@
                                         v-bind:index="target"
                                         v-bind:key="target"
                                         class="dropdown-item"
-                                        href="#"
                                         :class="'rule-add-mapping-' + target.replace(/_/g, '-')"
                                         @click="addIdentifier(target)">
                                       {{ mappingTargets()[target].label }}
@@ -241,7 +240,7 @@
                                                     v-on:mouseout.native="map.columns.forEach((col) => unhighlightColumn(col))"
                                                     :col-headers="colHeaders" />
                                 <div v-if="mapping.length == 0">
-                                    One or more column definitions must be specified. These are required to specify how to build collections and datasets from rows and columns of the table. <a href="#" @click="displayRuleType = 'mapping'">Click here</a> to manage column definitions.
+                                    One or more column definitions must be specified. These are required to specify how to build collections and datasets from rows and columns of the table. <a class="force-link-style" @click="displayRuleType = 'mapping'">Click here</a> to manage column definitions.
                                 </div>
                             </ol>
                             <div class="rules-buttons">
@@ -254,7 +253,7 @@
                                     <rule-target-component :builder="this" rule-type="remove_columns" />
                                     <rule-target-component :builder="this" rule-type="split_columns" />
                                     <rule-target-component :builder="this" rule-type="swap_columns" />
-                                    <a href="#" class="dropdown-item rule-link rule-link-mapping" @click="displayRuleType = 'mapping'">Add / Modify Column Definitions</a>
+                                    <a class="dropdown-item rule-link rule-link-mapping" @click="displayRuleType = 'mapping'">Add / Modify Column Definitions</a>
                                   </div>
                                 </div>
                                 <div class="btn-group dropup">
@@ -708,7 +707,7 @@ const IdentifierDisplay = {
 };
 
 const RuleTargetComponent = {
-    template: `<a class="rule-link dropdown-item" href="#" :class="linkClassName" @click="builder.addNewRule(ruleType)">{{title}}</a>`,
+    template: `<a class="rule-link dropdown-item" :class="linkClassName" @click="builder.addNewRule(ruleType)">{{title}}</a>`,
     props: {
         ruleType: {
             type: String,
@@ -1734,5 +1733,10 @@ export default {
 .fa-times,
 .fa-wrench {
     cursor: pointer;
+}
+/* Galaxy's drops underline on a without href, but I cannot use href="#" in this component
+   because it interferes with the library router. */
+a.force-link-style {
+    text-decoration: underline !important;
 }
 </style>

--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -383,7 +383,7 @@
 <script>
 import axios from "axios";
 import _l from "utils/localization";
-import HotTable from "vue-handsontable-official";
+import HotTable from "@handsontable/vue";
 import Popover from "mvc/ui/ui-popover";
 import UploadUtils from "mvc/upload/upload-utils";
 import JobStatesModel from "mvc/history/job-states-model";
@@ -1592,6 +1592,8 @@ export default {
 };
 </script>
 
+<style src="../../../node_modules/handsontable/dist/handsontable.full.css">
+</style>
 <style>
 .table-column {
     width: 100%;

--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -2,25 +2,25 @@
     <state-div v-if="state == 'build'">
         <!-- Different instructions if building up from individual datasets vs.
              initial data import. -->
-        <div class="header flex-row no-flex" v-if="ruleView == 'source'">
+        <rule-modal-header v-if="ruleView == 'source'">
             Below is a raw JSON description of the rules to apply to the tabular data. This is an advanced setting.
-        </div>
-        <div class="header flex-row no-flex" v-else-if="elementsType == 'datasets' || elementsType == 'library_datasets'">
+        </rule-modal-header>
+        <rule-modal-header v-else-if="elementsType == 'datasets' || elementsType == 'library_datasets'">
             Use this form to describe rules for building a collection from the specified datasets.
-        </div>
+        </rule-modal-header>
         <!-- This modality allows importing individual datasets, multiple collections,
              and requires a data source - note that. -->
-        <div class="header flex-row no-flex" v-else-if="importType == 'datasets'">
+        <rule-modal-header v-else-if="importType == 'datasets'">
             Use this form to describe rules for import datasets. At least one column should be defined to a source to fetch data from (URLs, FTP files, etc...).
-        </div>
-        <div class="header flex-row no-flex" v-else>
-            Use this form to describe rules for import datasets. At least one column should be defined to a source to fetch data from (URLs, FTP files, etc...). Be sure to specify at least one column as a list identifier - specify more to created nested list structures. Specify a column to serve as "collection name" to group datasets into multiple collections.
-        </div>
-        <div class="middle flex-row flex-row-container" v-if="ruleView == 'source'">
-            <p class="alert-message" v-if="ruleSourceError">{{ ruleSourceError }}</p>
+        </rule-modal-header>
+        <rule-modal-header v-else>
+            Use this form to describe rules for import datasets. At least one column should be defined to a source to fetch data from (URLs, FTP files, etc...). <b>Be sure to specify at least one column as a list identifier</b> - specify more to created nested list structures. Specify a column to serve as "collection name" to group datasets into multiple collections.
+        </rule-modal-header>
+        <rule-modal-middle v-if="ruleView == 'source'">
+            <p class="errormessagelarge" v-if="ruleSourceError">{{ ruleSourceError }}</p>
             <textarea class="rule-source" v-model="ruleSource"></textarea>
-        </div>
-        <div class="middle flex-row flex-row-container" v-else>
+        </rule-modal-middle>
+        <rule-modal-middle v-else>
             <!-- column-headers -->
             <div class="rule-builder-body vertically-spaced"
                  v-bind:class="{ 'flex-column-container': vertical }" v-if="ruleView == 'normal'">
@@ -297,23 +297,20 @@
                     </hot-table>
                 </div>
             </div>
-        </div>
-        <div class="rule-footer footer flex-row no-flex vertically-spaced" v-if="ruleView == 'source'">
-            <option-buttons-div>
-                <b-button v-b-tooltip.hover.focus :title="titleSourceCancel" @click="cancelSourceEdit" class="rule-btn-cancel">
-                    {{ l("Cancel") }}
-                </b-button>
-                <b-button v-b-tooltip.hover.focus :title="titleSourceReset" class="creator-reset-btn rule-btn-reset">
-                    {{ l("Reset") }}
-                </b-button>
-               <b-button v-b-tooltip.hover.focus :title="titleSourceApply" @click="attemptRulePreview" class="rule-btn-okay">
-                    {{ l("Apply")}}
-                </b-button>
-            </option-buttons-div>
-        </div>
-        <div class="rule-footer footer flex-row no-flex vertically-spaced"
-             v-else-if="ruleView == 'normal'">
-            <div class="rule-footer-inputs">
+        </rule-modal-middle>
+        <rule-modal-footer v-if="ruleView == 'source'">
+            <b-button v-b-tooltip.hover.focus :title="titleSourceCancel" @click="cancelSourceEdit" class="rule-btn-cancel">
+                {{ l("Cancel") }}
+            </b-button>
+            <b-button v-b-tooltip.hover.focus :title="titleSourceReset" class="creator-reset-btn rule-btn-reset">
+                {{ l("Reset") }}
+            </b-button>
+           <b-button v-b-tooltip.hover.focus :title="titleSourceApply" @click="attemptRulePreview" class="rule-btn-okay">
+                {{ l("Apply")}}
+            </b-button>
+        </rule-modal-footer>
+        <rule-modal-footer v-else-if="ruleView == 'normal'">
+            <div class="rule-footer-inputs" slot="inputs">
                 <label v-if="elementsType == 'datasets'">
                     {{ l("Hide original elements") }}:
                 </label>
@@ -342,51 +339,44 @@
                     </label>
                 </div>
             </div>
-            <option-buttons-div>
-                <!--
-                <button @click="swapOrientation" class="creator-orient-btn btn rule-btn-reorient" tabindex="-1">
-                    {{ l("Reorient") }}
-                </button>
-                -->
-                <b-button v-b-tooltip.hover.focus :help="titleCancel" @click="cancel" class="creator-cancel-btn rule-btn-cancel" tabindex="-1">
-                    {{ l("Cancel") }}
-                </b-button>
-                <b-button v-b-tooltip.hover.focus @click="resetRulesAndState" :title="titleReset" class="creator-reset-btn rule-btn-reset">
-                    {{ l("Reset") }}
-                </b-button>
-                <b-button v-b-tooltip.hover.focus @click="createCollection" :title="titleFinish" class="create-collection rule-btn-okay" variant="primary" v-bind:class="{ disabled: !validInput }">
-                    {{ finishButtonTitle }}
-                </b-button>
-            </option-buttons-div>
-        </div>
+
+            <b-button v-b-tooltip.hover.focus :help="titleCancel" @click="cancel" class="creator-cancel-btn rule-btn-cancel" tabindex="-1">
+                {{ l("Cancel") }}
+            </b-button>
+            <b-button v-b-tooltip.hover.focus @click="resetRulesAndState" :title="titleReset" class="creator-reset-btn rule-btn-reset">
+                {{ l("Reset") }}
+            </b-button>
+            <b-button v-b-tooltip.hover.focus @click="createCollection" :title="titleFinish" class="create-collection rule-btn-okay" variant="primary" :disabled="!validInput">
+                {{ finishButtonTitle }}
+            </b-button>
+        </rule-modal-footer>
     </state-div>
     <state-div v-else-if="state == 'wait'">
-        <div class="header flex-row no-flex">
+        <rule-modal-header>
             {{ l("Galaxy is waiting for collection creation, this dialog will close when this is complete.") }}
-        </div>
-        <div class="rule-footer footer flex-row no-flex">
-            <option-buttons-div>
-                <b-button @click="cancel" class="creator-cancel-btn" tabindex="-1">
-                    {{ l("Close") }}
-                </b-button>
-            </option-buttons-div>
-        </div>
+        </rule-modal-header>
+        <rule-modal-footer>
+            <b-button @click="cancel" class="creator-cancel-btn" tabindex="-1">
+                {{ l("Close") }}
+            </b-button>
+        </rule-modal-footer>
     </state-div>
     <state-div v-else-if="state == 'error'">
         <!-- TODO: steal styling from paired collection builder warning... -->
-        <div>
-            {{ errorMessage }}
-        </div>
-        <div class="rule-footer footer flex-row no-flex">
-            <option-buttons-div>
-                <b-button v-b-tooltip.hover.focus :title="titleCancel" @click="cancel" class="creator-cancel-btn" tabindex="-1">
-                    {{ l("Close") }}
-                </b-button>
-                <b-button v-b-tooltip.hover.focus :title="titleErrorOkay" @click="state = 'build'" tabindex="-1">
-                    {{ l("Okay") }}
-                </b-button>
-            </option-buttons-div>
-        </div>
+        <rule-modal-header>
+            A problem was encountered.
+        </rule-modal-header>
+        <rule-modal-middle>
+            <p class="errormessagelarge">{{ errorMessage }}</p>
+        </rule-modal-middle>
+        <rule-modal-footer>
+            <b-button v-b-tooltip.hover.focus :title="titleCancel" @click="cancel" class="creator-cancel-btn" tabindex="-1">
+                {{ l("Close") }}
+            </b-button>
+            <b-button v-b-tooltip.hover.focus :title="titleErrorOkay" @click="state = 'build'" tabindex="-1">
+                {{ l("Okay") }}
+            </b-button>
+        </rule-modal-footer>
     </state-div>
 </template>
 <script>
@@ -781,11 +771,30 @@ const RuleComponent = {
 };
 
 const StateDiv = {
-    template: `<div class="rule-collection-creator collection-creator flex-row-container"><slot></slot></div>`
+    template: `
+        <div class="rule-collection-creator collection-creator flex-row-container">
+            <slot></slot>
+        </div>`
 };
 
-const OptionButtonsDiv = {
-    template: `<div class="actions clear vertically-spaced"><div class="main-options float-right"><slot></slot></div></div>`
+const RuleModalHeader = {
+    template: `<div class="header flex-row no-flex"><slot></slot></div>`
+};
+
+const RuleModalMiddle = {
+    template: `<div class="middle flex-row flex-row-container"><slot></slot></div>`
+}
+
+const RuleModalFooter = {
+    template: `   
+        <div class="rule-footer footer flex-row no-flex">
+            <slot name="inputs"></slot>
+            <div class="actions clear vertically-spaced">
+                <div class="main-options float-right">
+                    <slot></slot>
+                </div>
+            </div>
+        </div>`
 };
 
 export default {
@@ -1624,7 +1633,9 @@ export default {
         ColumnSelector,
         RegularExpressionInput,
         StateDiv,
-        OptionButtonsDiv,
+        RuleModalHeader,
+        RuleModalMiddle,
+        RuleModalFooter,
         Select2
     }
 };

--- a/client/galaxy/scripts/mvc/collection/list-collection-creator.js
+++ b/client/galaxy/scripts/mvc/collection/list-collection-creator.js
@@ -1170,5 +1170,6 @@ export default {
     collectionCreatorModal: collectionCreatorModal,
     listCollectionCreatorModal: listCollectionCreatorModal,
     createListCollection: createListCollection,
-    createCollectionViaRules: createCollectionViaRules
+    createCollectionViaRules: createCollectionViaRules,
+    ruleBasedCollectionCreatorModal: ruleBasedCollectionCreatorModal
 };

--- a/client/galaxy/scripts/mvc/library/library-foldertoolbar-view.js
+++ b/client/galaxy/scripts/mvc/library/library-foldertoolbar-view.js
@@ -1241,7 +1241,8 @@ var FolderToolbarView = Backbone.View.extend({
             data: [
                 { id: "list", text: "List" },
                 { id: "paired", text: "Paired" },
-                { id: "list:paired", text: "List of Pairs" }
+                { id: "list:paired", text: "List of Pairs" },
+                { id: "rules", text: "From Rules" }
             ],
             value: "list",
             onchange: collectionType => {
@@ -1351,6 +1352,14 @@ var FolderToolbarView = Backbone.View.extend({
             PAIRED_CREATOR.pairedCollectionCreatorModal(elements, {
                 historyId: history_id,
                 title: modal_title,
+                defaultHideSourceItems: true
+            });
+        } else if (this.collectionType === "rules") {
+            const creationFn = (elements, collectionType, name, hideSourceItems) => {
+                return this.createHDCA(elements, collectionType, name, hideSourceItems, history_id);
+            };
+            LIST_CREATOR.ruleBasedCollectionCreatorModal(collection_elements, "library_datasets", "collections", {
+                creationFn: creationFn,
                 defaultHideSourceItems: true
             });
         }
@@ -1844,6 +1853,9 @@ var FolderToolbarView = Backbone.View.extend({
                 "</li>",
                 "<li>",
                 "List of Pairs: Advanced collection containing any number of Pairs; imagine as Pair-type collections inside of a List-type collection.",
+                "</li>",
+                "<li>",
+                "From Rules: Use Galaxy's rule builder to describe collections. This is more of an advanced feature that allows building any number of collections or any type.",
                 "</li>",
                 "</ul>",
                 "</div>",

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
   },
   "license": "AFL-3.0",
   "dependencies": {
+    "@handsontable/vue": "^2.0.0-beta1",
     "amdi18n-loader": "^0.6.1",
     "axios": "^0.17.0",
     "backbone": "1.3",
@@ -21,6 +22,7 @@
     "d3": "3",
     "font-awesome": "^4.7.0",
     "gulp-sass": "^3.1.0",
+    "handsontable": "^2.0.0",
     "jquery": "2",
     "jquery-migrate": "~1.4",
     "jquery-mousewheel": "^3.1.13",
@@ -34,8 +36,7 @@
     "raven-js": "^3.17.0",
     "requirejs": "2",
     "underscore": "^1.8.3",
-    "vue": "2.5.16",
-    "vue-handsontable-official": "^1.0.0"
+    "vue": "2.5.16"
   },
   "scripts": {
     "watch": "gulp staging && concurrently \"yarn run webpack-watch\" \"yarn run gulp watch\" \"yarn run style-watch\"",
@@ -67,6 +68,7 @@
   "devDependencies": {
     "babel-core": "^6.24.0",
     "babel-loader": "^7.1.1",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.0",
     "babel-plugin-transform-vue-template": "^0.3.1",
     "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -71,7 +71,7 @@ let buildconfig = {
             },
             {
                 test: /\.js$/,
-                exclude: [/(node_modules\/(?!(vue-handsontable-official)\/)|bower_components)/, libsBase],
+                exclude: [/(node_modules\/(?!(handsontable)\/)|bower_components)/, libsBase],
                 loader: "babel-loader"
             },
             {


### PR DESCRIPTION
Fuses recent additions allowing creation of collections from libraries (#5080) and creating arbitrary collections from the rule builder (#5365).

Requested by @mblue9 on https://github.com/galaxyproject/galaxy/issues/5381#issuecomment-378107183 who is providing awesome feedback on the new rule based collection builder. She lays out the potential for this to save dozens of clicks when importing collections from libraries.