### PR TITLE
[18.01] Only try to determine GIE container ports once at launch, then hand off to readiness check

### DIFF
--- a/lib/galaxy/containers/__init__.py
+++ b/lib/galaxy/containers/__init__.py
@@ -105,6 +105,32 @@ class Container(with_metaclass(ABCMeta, object)):
         :rtpe:      bool
         """
 
+    def map_port(self, port):
+        """Map a given container port to a host address/port.
+
+        For legacy reasons, if port is ``None``, the first port (if any) will be returned
+
+        :param  port:   Container port to map
+        :type   port:   int
+        :returns:       Mapping to host address/port for given container port
+        :rtype:         :class:`ContainerPort` instance
+        """
+        mapping = None
+        for mapping in self.ports:
+            if port == mapping.port:
+                return mapping
+            if port is None:
+                log.warning("Container %s (%s): Don't know how to map ports to containers with multiple exposed ports "
+                            "when a specific port is not requested. Arbitrarily choosing first: %s",
+                            self.name, self.id, mapping)
+                return mapping
+        else:
+            if port is None:
+                log.warning("Container %s (%s): No exposed ports found!", self.name, self.id)
+            else:
+                log.warning("Container %s (%s): No mapping found for port: %s", self.name, self.id, port)
+        return None
+
 
 class ContainerInterface(with_metaclass(ABCMeta, object)):
 

--- a/lib/galaxy/webapps/galaxy/controllers/interactive_environments.py
+++ b/lib/galaxy/webapps/galaxy/controllers/interactive_environments.py
@@ -39,4 +39,18 @@ class InteractiveEnvironmentsController(BaseUIController):
             log.error('Invalid container interface key: %s', proxy_map.container_interface)
             return None
         container = interface.get_container(proxy_map.container_ids[0])
+        if not proxy_map.port > 0:
+            # a negative port means it failed to be determined at launch time; the negated negative port is the
+            # container port
+            log.debug("Container %s (%s) mapping for port %s is not set in the proxy, attempting to get port mapping "
+                      "now", container.name, container.id, -proxy_map.port)
+            mapping = container.map_port(-proxy_map.port)
+            if mapping:
+                log.info("Container %s (%s) port %s accessible at: %s:%s", container.name, container.id,
+                         -proxy_map.port, mapping.hostaddr, mapping.hostport)
+                self.app.proxy_manager.update_proxy(trans, host=mapping.hostaddr, port=mapping.hostport)
+            else:
+                log.warning("Container %s (%s) mapping for port %s cannot be determined!", container.name, container.id,
+                            -proxy_map.port)
+                return False
         return container.is_ready()


### PR DESCRIPTION
This replaces a quick hack I'd added that doesn't work properly. Instead, if the initial attempt to determine the port fails, the negated in-container port is stored in the proxy map, and then the readiness check will attempt to map the port if it's not mapped.