### PR TITLE
Update to latest galaxy-lib.

### DIFF
--- a/lib/galaxy/containers/docker.py
+++ b/lib/galaxy/containers/docker.py
@@ -14,7 +14,11 @@ try:
 except ImportError:
     docker = None
 
-import requests.exceptions
+try:
+    from requests.exceptions import ConnectionError, ReadTimeout
+except ImportError:
+    ConnectionError = None
+    ReadTimeout = None
 from six import string_types
 from six.moves import shlex_quote
 
@@ -272,12 +276,12 @@ class DockerAPIClient(object):
                 if tries > 1:
                     log.info('%s() succeeded on attempt %s', qualname, tries)
                 return r
-            except requests.exceptions.ConnectionError as exc:
+            except ConnectionError as exc:
                 reinit = True
             except docker.errors.APIError as exc:
                 if not DockerAPIClient._should_retry_request(exc.response.status_code):
                     raise
-            except requests.exceptions.ReadTimeout as exc:
+            except ReadTimeout as exc:
                 reinit = True
                 retry_time = 0
             finally:

--- a/lib/galaxy/tools/linters/general.py
+++ b/lib/galaxy/tools/linters/general.py
@@ -1,7 +1,10 @@
 """This module contains a linting functions for general aspects of the tool."""
 import re
 
+import packaging.version
+
 ERROR_VERSION_MSG = "Tool version is missing or empty."
+WARN_VERSION_MSG = "Tool version [%s] is not compliant with PEP 440."
 VALID_VERSION_MSG = "Tool defines a version [%s]."
 
 ERROR_NAME_MSG = "Tool name is missing or empty."
@@ -21,8 +24,11 @@ lint_tool_types = ["*"]
 def lint_general(tool_source, lint_ctx):
     """Check tool version, name, and id."""
     version = tool_source.parse_version()
+    parsed_version = packaging.version.parse(version)
     if not version:
         lint_ctx.error(ERROR_VERSION_MSG)
+    elif isinstance(parsed_version, packaging.version.LegacyVersion):
+        lint_ctx.warn(WARN_VERSION_MSG % version)
     else:
         lint_ctx.valid(VALID_VERSION_MSG % version)
 

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -228,7 +228,9 @@ class GalaxyInteractorApi(object):
 
     @nottest
     def test_data_path(self, tool_id, filename):
-        return self._get("tools/%s/test_data_path?filename=%s" % (tool_id, filename)).json()
+        response = self._get("tools/%s/test_data_path?filename=%s" % (tool_id, filename), admin=True)
+        assert response.status_code == 200
+        return response.json()
 
     def __output_id(self, output_data):
         # Allow data structure coming out of tools API - {id: <id>, output_name: <name>, etc...}


### PR DESCRIPTION
- Add linting for PEP440 compliance. https://github.com/galaxyproject/galaxy-lib/pull/106
- Improved abstraction usage in tool test data handling. https://github.com/galaxyproject/galaxy-lib/pull/105
- Make requests an optional dependency when loading galaxy.containers (still required at runtime).