### PR TITLE
More Rule Builder Style Changes

### DIFF
--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -1,9 +1,9 @@
 <template>
     <state-div v-if="state == 'build'">
-        <!-- Different instructions if building up from individual datasets vs. 
+        <!-- Different instructions if building up from individual datasets vs.
              initial data import. -->
         <div class="header flex-row no-flex" v-if="ruleView == 'source'">
-            The is an advanced setting, below is a raw JSON description of the rules to apply to the tabular data used. The alternative graphical editor is recommended for most usages.
+            Below is a raw JSON description of the rules to apply to the tabular data. This is an advanced setting.
         </div>
         <div class="header flex-row no-flex" v-else-if="elementsType == 'datasets'">
             Use this form to describe rules for building a collection from the specified datasets.
@@ -182,7 +182,7 @@
                                  v-for="map in mapping"
                                  v-bind:index="map.index"
                                  v-bind:key="map.type">
-                                <column-selector 
+                                <column-selector
                                     :class="'rule-map-' + map.type.replace(/_/g, '-')"
                                     :label="mappingTargets()[map.type].label"
                                     :target.sync="map.columns"
@@ -195,7 +195,7 @@
                                 </column-selector>
                             </div>
                             <div class="buttons btn-group float-right rule-edit-buttons">
-                                <button type="button" class="dropdown-toggle btn btn-default" data-toggle="dropdown" style="margin-right: 5px;" v-if="unmappedTargets.length > 0">
+                                <button type="button" class="dropdown-toggle btn btn-default mr-1" data-toggle="dropdown" v-if="unmappedTargets.length > 0">
                                     <span class="fa fa-plus rule-add-mapping"></span> {{ "Add Definition" }}<span class="caret"></span>
                                 </button>
                                 <div class="dropdown-menu" role="menu">
@@ -280,8 +280,8 @@
                                         <rule-target-component :builder="this" rule-type="add_column_value" />
                                         <rule-target-component :builder="this" rule-type="add_column_substr" />
                                   </div>
-                                </div> 
-                            </div>                               
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -300,11 +300,14 @@
         </div>
         <div class="rule-footer footer flex-row no-flex vertically-spaced" v-if="ruleView == 'source'">
             <option-buttons-div>
+                <button @click="attemptRulePreview" class="btn btn-secondary rule-btn-cancel">
+                    {{ l("Cancel") }}
+                </button>
                 <button @click="resetSource" class="creator-reset-btn btn rule-btn-reset">
                     {{ l("Reset") }}
                 </button>
                <button @click="attemptRulePreview" class="btn btn-secondary rule-btn-okay">
-                    {{ l("Okay")}}
+                    {{ l("Apply")}}
                 </button>
             </option-buttons-div>
         </div>
@@ -341,7 +344,7 @@
             </div>
             <option-buttons-div>
                 <button @click="swapOrientation" class="creator-orient-btn btn rule-btn-reorient" tabindex="-1">
-                    {{ l("Re-orient") }}
+                    {{ l("Reorient") }}
                 </button>
                 <button @click="cancel" class="creator-cancel-btn btn rule-btn-cancel" tabindex="-1">
                     {{ l("Cancel") }}
@@ -430,16 +433,16 @@ const Select2 = {
 const ColumnSelector = {
     template: `
         <div class="rule-column-selector" v-if="!multiple || !ordered">
-            <label>
-                {{ label }}
-                <select2 :value="target" @input="handleInput" :multiple="multiple">
+            <label class="d-flex justify-content-end align-items-center">
+                <span class="mr-1">{{ label }}</span>
+                <div class="mr-1"><select2 :value="target" @input="handleInput" :multiple="multiple">
                     <option v-for="(col, index) in colHeaders" :value="index">{{ col }}</option>
-                </select2>
+                </select2></div>
                 <slot></slot>
             </label>
         </div>
         <div class="rule-column-selector" v-else>
-            {{ label }}
+            <span class="mr-1">{{ label }}</span>
             <slot></slot>
             <ol>
                 <li v-for="(targetEl, index) in target"
@@ -1666,5 +1669,8 @@ export default {
     flex: 3;
     display: flex;
     flex-direction: row-reverse;
+}
+.fa-edit, .fa-times, .fa-wrench{
+    cursor: pointer;
 }
 </style>

--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -336,7 +336,7 @@
                     </select2>
                 </div>
                 <div class="rule-footer-name-group" v-if="showCollectionNameInput">
-                    <input class="collection-name"
+                    <b-input class="collection-name"
                     :placeholder="namePlaceholder" :title="namePlaceholder" v-b-tooltip.hover.focus v-model="collectionName" />
                     <label>
                         {{ l("Name") }}:
@@ -568,14 +568,29 @@ const ColumnSelector = {
 
 const RegularExpressionInput = {
     template: `
-        <div><label>
-            Regular Expression
-            <input class="rule-regular-expression" type="text" :value="target" @input="$emit('update:target', $event.target.value)" />
-        </label></div>
+        <div>
+            <label for="regular_expression" v-b-tooltip.hover :title="title">{{ label }}</label>
+            <span v-b-popover.html="popoverContent" :title="popoverTitle" class="fa fa-question"></span>
+            <b-input v-b-tooltip.hover.focus :title="title" name="regular_expression" class="rule-regular-expression" type="text" :value="target" @input="$emit('update:target', $event.target.value)" />
+        </div>
     `,
     props: {
         target: {
             required: true
+        }
+    },
+    computed: {
+        label() {
+            return _l("Regular Expression");
+        },
+        title() {
+            return _l("Enter a regular expression.");
+        },
+        popoverTitle() {
+            return _l("Regular Expressions");
+        },
+        popoverContent() {
+            return _l(`Regular expressions are patterns used to match character combinations in strings. This input accepts Python-style regular expressions, find more information about these in <a href="https://pythonforbiologists.com/regular-expressions/">this Python for Biologists tutorial</a>.`);
         }
     }
 };

--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -343,9 +343,11 @@
                 </div>
             </div>
             <option-buttons-div>
+                <!--
                 <button @click="swapOrientation" class="creator-orient-btn btn rule-btn-reorient" tabindex="-1">
                     {{ l("Reorient") }}
                 </button>
+                -->
                 <button @click="cancel" class="creator-cancel-btn btn rule-btn-cancel" tabindex="-1">
                     {{ l("Cancel") }}
                 </button>

--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -571,7 +571,7 @@ const RegularExpressionInput = {
         <div>
             <label for="regular_expression" v-b-tooltip.hover :title="title">{{ label }}</label>
             <span v-b-popover.html="popoverContent" :title="popoverTitle" class="fa fa-question"></span>
-            <b-input v-b-tooltip.hover.focus :title="title" name="regular_expression" class="rule-regular-expression" type="text" :value="target" @input="$emit('update:target', $event.target.value)" />
+            <input v-b-tooltip.hover.focus.left :title="title" name="regular_expression" class="rule-regular-expression" type="text" :value="target" @input="$emit('update:target', $event.target.value)" />
         </div>
     `,
     props: {

--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -31,7 +31,7 @@
                                         :display-rule-type="displayRuleType"
                                         :builder="this">
                             <column-selector :target.sync="addSortingTarget" :col-headers="activeRuleColHeaders" />
-                            <label :title="titleNumericSort">
+                            <label v-b-tooltip.hover :title="titleNumericSort">
                                 <input type="checkbox" v-model="addSortingNumeric" />
                                 {{ l("Numeric sorting.") }}
                             </label>
@@ -119,7 +119,7 @@
                                         :builder="this">
                             <column-selector :target.sync="addFilterRegexTarget" :col-headers="activeRuleColHeaders" />
                             <regular-expression-input :target.sync="addFilterRegexExpression" />
-                            <label :title="titleInvertFilterRegex">
+                            <label v-b-tooltip.hover :title="titleInvertFilterRegex">
                                 <input type="checkbox" v-model="addFilterRegexInvert" />
                                 {{ l("Invert filter.") }}
                             </label>
@@ -129,7 +129,7 @@
                                         :builder="this">
                             <column-selector :target.sync="addFilterMatchesTarget" :col-headers="activeRuleColHeaders" />
                             <input type="text" v-model="addFilterMatchesValue" />
-                            <label :title="titleInvertFilterMatches">
+                            <label v-b-tooltip.hover :title="titleInvertFilterMatches">
                                 <input type="checkbox" v-model="addFilterMatchesInvert" />
                                 {{ l("Invert filter.") }}
                             </label>
@@ -163,7 +163,7 @@
                                 Filter how many rows?
                                 <input type="number" v-model="addFilterCountN" />
                             </label>
-                            <label :title="titleInvertFilterMatches">
+                            <label v-b-tooltip.hover :title="titleInvertFilterMatches">
                                 <input type="checkbox" v-model="addFilterCountInvert" />
                                 {{ l("Invert filter.") }}
                             </label>
@@ -172,7 +172,7 @@
                                         :display-rule-type="displayRuleType"
                                         :builder="this">
                             <column-selector :target.sync="addFilterEmptyTarget" :col-headers="activeRuleColHeaders" />
-                            <label :title="titleInvertFilterEmpty">
+                            <label v-b-tooltip.hover :title="titleInvertFilterEmpty">
                                 <input type="checkbox" v-model="addFilterEmptyInvert" />
                                 {{ l("Invert filter.") }}
                             </label>
@@ -185,17 +185,18 @@
                                 <column-selector
                                     :class="'rule-map-' + map.type.replace(/_/g, '-')"
                                     :label="mappingTargets()[map.type].label"
+                                    :help="mappingTargets()[map.type].help"
                                     :target.sync="map.columns"
                                     :ordered-edit.sync="map.editing"
                                     :col-headers="colHeaders"
                                     :multiple="mappingTargets()[map.type].multiple"
                                     :ordered="true"
                                     :value-as-list="true">
-                                    <span class="fa fa-times" @click="removeMapping(map.index)"></span>
+                                    <span v-b-tooltip.hover.focus :title="titleRemoveMapping" class="fa fa-times" @click="removeMapping(map.index)"></span>
                                 </column-selector>
                             </div>
-                            <div class="buttons btn-group float-right rule-edit-buttons">
-                                <button type="button" class="dropdown-toggle btn btn-default mr-1" data-toggle="dropdown" v-if="unmappedTargets.length > 0">
+                            <div class="buttons float-right rule-edit-buttons">
+                                <button v-b-tooltip.hover.focus :title="titleAddColumnDefinition" type="button" class="dropdown-toggle btn btn-default mr-1" data-toggle="dropdown" v-if="unmappedTargets.length > 0">
                                     <span class="fa fa-plus rule-add-mapping"></span> {{ "Add Definition" }}<span class="caret"></span>
                                 </button>
                                 <div class="dropdown-menu" role="menu">
@@ -209,13 +210,13 @@
                                       {{ mappingTargets()[target].label }}
                                     </a>
                                 </div>
-                                <button type="button" class="btn btn-default btn-secondary rule-mapping-ok" v-if="!hasActiveMappingEdit" @click="displayRuleType = null"> {{ l("Apply") }}</button>
+                                <b-button v-b-tooltip.hover.focus :title="titleApplyColumnDefinitions" class="rule-mapping-ok" v-if="!hasActiveMappingEdit" @click="displayRuleType = null">{{ l("Apply") }}</b-button>
                             </div>
                         </div>
                         <div class="rule-summary" v-if="displayRuleType == null">
                             <span class="title">
                                 {{ l("Rules") }}
-                                <span class="fa fa-wrench rule-builder-view-source" :title="titleViewSource" @click="viewSource"></span>
+                                <span v-b-tooltip.hover class="fa fa-wrench rule-builder-view-source" :title="titleViewSource" @click="viewSource"></span>
                             </span>
                             <div v-if="jaggedData" class="rule-warning">
                                 Rows contain differing numbers of columns, there was likely a problem parsing your data.
@@ -245,7 +246,7 @@
                             </ol>
                             <div class="rules-buttons">
                                 <div class="btn-group dropup">
-                                  <button type="button" class="rule-menu-rules-button primary-button dropdown-toggle" data-toggle="dropdown">
+                                  <button type="button" v-b-tooltip.hover.focus :title="titleRulesMenu" class="rule-menu-rules-button primary-button dropdown-toggle" data-toggle="dropdown">
                                     <span class="fa fa-plus"></span> {{ l("Rules") }}<span class="caret"></span>
                                   </button>
                                   <div class="dropdown-menu" role="menu">
@@ -257,7 +258,7 @@
                                   </div>
                                 </div>
                                 <div class="btn-group dropup">
-                                    <button type="button" class="rule-menu-filter-button primary-button dropdown-toggle" data-toggle="dropdown">
+                                    <button type="button" v-b-tooltip.hover.focus :title="titleFilterMenu" class="rule-menu-filter-button primary-button dropdown-toggle" data-toggle="dropdown">
                                         <span class="fa fa-plus"></span> {{ l("Filter") }}<span class="caret"></span>
                                     </button>
                                     <div class="dropdown-menu" role="menu">
@@ -269,7 +270,7 @@
                                   </div>
                                 </div>
                                 <div class="btn-group dropup">
-                                    <button type="button" class="rule-menu-column-button primary-button dropdown-toggle" data-toggle="dropdown">
+                                    <button type="button" v-b-tooltip.hover.focus :title="titleColumMenu" class="rule-menu-column-button primary-button dropdown-toggle" data-toggle="dropdown">
                                         <span class="fa fa-plus"></span> {{ l("Column") }}<span class="caret"></span>
                                     </button>
                                     <div class="dropdown-menu" role="menu">
@@ -300,15 +301,15 @@
         </div>
         <div class="rule-footer footer flex-row no-flex vertically-spaced" v-if="ruleView == 'source'">
             <option-buttons-div>
-                <button @click="cancelSourceEdit" class="btn btn-secondary rule-btn-cancel">
+                <b-button v-b-tooltip.hover.focus :title="titleSourceCancel" @click="cancelSourceEdit" class="rule-btn-cancel">
                     {{ l("Cancel") }}
-                </button>
-                <button @click="resetSource" class="creator-reset-btn btn rule-btn-reset">
+                </b-button>
+                <b-button v-b-tooltip.hover.focus :title="titleSourceReset" class="creator-reset-btn rule-btn-reset">
                     {{ l("Reset") }}
-                </button>
-               <button @click="attemptRulePreview" class="btn btn-secondary rule-btn-okay">
+                </b-button>
+               <b-button v-b-tooltip.hover.focus :title="titleSourceApply" @click="attemptRulePreview" class="rule-btn-okay">
                     {{ l("Apply")}}
-                </button>
+                </b-button>
             </option-buttons-div>
         </div>
         <div class="rule-footer footer flex-row no-flex vertically-spaced"
@@ -336,7 +337,7 @@
                 </div>
                 <div class="rule-footer-name-group" v-if="showCollectionNameInput">
                     <input class="collection-name"
-                    :placeholder="namePlaceholder" v-model="collectionName" />
+                    :placeholder="namePlaceholder" :title="namePlaceholder" v-b-tooltip.hover.focus v-model="collectionName" />
                     <label>
                         {{ l("Name") }}:
                     </label>
@@ -348,15 +349,15 @@
                     {{ l("Reorient") }}
                 </button>
                 -->
-                <button @click="cancel" class="creator-cancel-btn btn rule-btn-cancel" tabindex="-1">
+                <button @click="cancel" class="creator-cancel-btn rule-btn-cancel" tabindex="-1">
                     {{ l("Cancel") }}
                 </button>
-                <button @click="resetRulesAndState" :title="titleReset" class="creator-reset-btn btn rule-btn-reset">
+                <b-button v-b-tooltip.hover.focus @click="resetRulesAndState" :title="titleReset" class="creator-reset-btn rule-btn-reset">
                     {{ l("Reset") }}
-                </button>
-                <button @click="createCollection" :title="titleFinish" class="create-collection btn btn-secondary btn-primary rule-btn-okay" v-bind:class="{ disabled: !validInput }">
+                </b-button>
+                <b-button v-b-tooltip.hover.focus @click="createCollection" :title="titleFinish" class="create-collection rule-btn-okay" variant="primary" v-bind:class="{ disabled: !validInput }">
                     {{ finishButtonTitle }}
-                </button>
+                </b-button>
             </option-buttons-div>
         </div>
     </state-div>
@@ -366,9 +367,9 @@
         </div>
         <div class="rule-footer footer flex-row no-flex">
             <option-buttons-div>
-                <button @click="cancel" class="creator-cancel-btn btn" tabindex="-1">
+                <b-button @click="cancel" class="creator-cancel-btn" tabindex="-1">
                     {{ l("Close") }}
-                </button>
+                </b-button>
             </option-buttons-div>
         </div>
     </state-div>
@@ -388,6 +389,9 @@ import UploadUtils from "mvc/upload/upload-utils";
 import JobStatesModel from "mvc/history/job-states-model";
 import RuleDefs from "mvc/rules/rule-definitions";
 import Vue from "vue";
+import BootstrapVue from 'bootstrap-vue'
+
+Vue.use(BootstrapVue);
 
 const RULES = RuleDefs.RULES;
 const MAPPING_TARGETS = RuleDefs.MAPPING_TARGETS;
@@ -436,8 +440,8 @@ const ColumnSelector = {
     template: `
         <div class="rule-column-selector" v-if="!multiple || !ordered">
             <label class="d-flex justify-content-end align-items-center">
-                <span class="mr-1">{{ label }}</span>
-                <div class="mr-1"><select2 :value="target" @input="handleInput" :multiple="multiple">
+                <span class="mr-1" v-b-tooltip.hover :title="help">{{ label }}</span>
+                <div class="mr-1" v-b-tooltip.hover.focus :title="title"><select2 :value="target" @input="handleInput" :multiple="multiple">
                     <option v-for="(col, index) in colHeaders" :value="index">{{ col }}</option>
                 </select2></div>
                 <slot></slot>
@@ -484,6 +488,9 @@ const ColumnSelector = {
             type: String,
             default: _l("From Column")
         },
+        help: {
+            required: false,
+        },
         colHeaders: {
             type: Array,
             required: true
@@ -522,6 +529,9 @@ const ColumnSelector = {
                 }
             }
             return remaining;
+        },
+        title() {
+            return _l("Select a column");
         }
     },
     methods: {
@@ -574,8 +584,8 @@ const RuleDisplay = {
     template: `
         <li class="rule">
             <span class="rule-display">{{ title }}
-                <span class="fa fa-edit" @click="edit"></span>
-                <span class="fa fa-times" @click="remove"></span>
+                <span v-b-tooltip.hover :title="editTitle" class="fa fa-edit" @click="edit"></span>
+                <span v-b-tooltip.hover :title="removeTitle" class="fa fa-times" @click="remove"></span>
             </span>
             <span class="rule-warning" v-if="rule.warn">
                 {{ rule.warn }}
@@ -599,7 +609,9 @@ const RuleDisplay = {
         title() {
             const ruleType = this.rule.type;
             return RULES[ruleType].display(this.rule, this.colHeaders);
-        }
+        },
+        editTitle() { return _l("Edit this rule."); },
+        removeTitle() { return _l("Remove this rule."); }    
     },
     methods: {
         edit() {
@@ -613,10 +625,10 @@ const RuleDisplay = {
 
 const IdentifierDisplay = {
     template: `
-      <li class="rule" :title="help">
-        Set {{ columnsLabel }} as {{ typeDisplay }}
-        <span class="fa fa-edit" @click="edit"></span>
-        <span class="fa fa-times" @click="remove"></span>
+      <li class="rule">
+        <span v-b-tooltip.hover :title="help">Set {{ columnsLabel }} as {{ typeDisplay }}</span>
+        <span v-b-tooltip.hover :title="titleEdit" class="fa fa-edit" @click="edit"></span>
+        <span v-b-tooltip.hover :title="titleRemove" class="fa fa-times" @click="remove"></span>
       </li>
     `,
     props: {
@@ -646,6 +658,12 @@ const IdentifierDisplay = {
         },
         help() {
             return MAPPING_TARGETS[this.type].help || "";
+        },
+        titleEdit() {
+            return _l("Edit column definitions.");
+        },
+        titleRemove() {
+            return _l("Remove this column definitions.");
         },
         columnsLabel() {
             let columnNames;
@@ -773,6 +791,15 @@ export default {
             titleViewSource: _l(
                 "Advanced Option: View and or edit the JSON representation of the rules to apply to this tabular data."
             ),
+            titleSourceCancel: _l("Stop editing rules and dismiss changes."),
+            titleSourceReset: _l("Reset text area to current set of rules."),
+            titleSourceApply: _l("Apply changes to rule source and return to rule preview."),
+            titleRulesMenu: _l("General rules to apply."),
+            titleFilterMenu: _l("Rules that filter rows from the data."),
+            titleColumMenu: _l("Rules that add generate new columns."),
+            titleRemoveMapping: _l("Remove column definition assignment."),
+            titleApplyColumnDefinitions: _l("Apply these column definitions and return to rules preview."),
+            titleAddColumnDefinition: _l("Assign a new piece of metadata as being derived from that a column of the table."),
             namePlaceholder: _l("Enter a name for your new collection"),
             activeRuleIndex: null,
             addColumnRegexTarget: 0,

--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -195,8 +195,8 @@
                                     <span v-b-tooltip.hover.focus :title="titleRemoveMapping" class="fa fa-times" @click="removeMapping(map.index)"></span>
                                 </column-selector>
                             </div>
-                            <div class="buttons float-right rule-edit-buttons">
-                                <button v-b-tooltip.hover.focus :title="titleAddColumnDefinition" type="button" class="dropdown-toggle btn btn-default mr-1" data-toggle="dropdown" v-if="unmappedTargets.length > 0">
+                            <div class="buttons rule-edit-buttons d-flex justify-content-end">
+                                <button v-b-tooltip.hover.focus.bottom :title="titleAddColumnDefinition" type="button" class="dropdown-toggle btn btn-primary mr-1" data-toggle="dropdown" v-if="unmappedTargets.length > 0">
                                     <span class="fa fa-plus rule-add-mapping"></span> {{ "Add Definition" }}<span class="caret"></span>
                                 </button>
                                 <div class="dropdown-menu" role="menu">
@@ -210,7 +210,7 @@
                                       {{ mappingTargets()[target].label }}
                                     </a>
                                 </div>
-                                <b-button v-b-tooltip.hover.focus :title="titleApplyColumnDefinitions" class="rule-mapping-ok" v-if="!hasActiveMappingEdit" @click="displayRuleType = null">{{ l("Apply") }}</b-button>
+                                <b-button v-b-tooltip.hover.focus.bottom :title="titleApplyColumnDefinitions" class="rule-mapping-ok" v-if="!hasActiveMappingEdit" @click="displayRuleType = null">{{ l("Apply") }}</b-button>
                             </div>
                         </div>
                         <div class="rule-summary" v-if="displayRuleType == null">
@@ -246,7 +246,7 @@
                             </ol>
                             <div class="rules-buttons">
                                 <div class="btn-group dropup">
-                                  <button type="button" v-b-tooltip.hover.focus :title="titleRulesMenu" class="rule-menu-rules-button primary-button dropdown-toggle" data-toggle="dropdown">
+                                  <button type="button" v-b-tooltip.hover.focus.bottom :title="titleRulesMenu" class="rule-menu-rules-button primary-button dropdown-toggle" data-toggle="dropdown">
                                     <span class="fa fa-plus"></span> {{ l("Rules") }}<span class="caret"></span>
                                   </button>
                                   <div class="dropdown-menu" role="menu">
@@ -258,7 +258,7 @@
                                   </div>
                                 </div>
                                 <div class="btn-group dropup">
-                                    <button type="button" v-b-tooltip.hover.focus :title="titleFilterMenu" class="rule-menu-filter-button primary-button dropdown-toggle" data-toggle="dropdown">
+                                    <button type="button" v-b-tooltip.hover.focus.bottom :title="titleFilterMenu" class="rule-menu-filter-button primary-button dropdown-toggle" data-toggle="dropdown">
                                         <span class="fa fa-plus"></span> {{ l("Filter") }}<span class="caret"></span>
                                     </button>
                                     <div class="dropdown-menu" role="menu">
@@ -270,7 +270,7 @@
                                   </div>
                                 </div>
                                 <div class="btn-group dropup">
-                                    <button type="button" v-b-tooltip.hover.focus :title="titleColumMenu" class="rule-menu-column-button primary-button dropdown-toggle" data-toggle="dropdown">
+                                    <button type="button" v-b-tooltip.hover.focus.bottom :title="titleColumMenu" class="rule-menu-column-button primary-button dropdown-toggle" data-toggle="dropdown">
                                         <span class="fa fa-plus"></span> {{ l("Column") }}<span class="caret"></span>
                                     </button>
                                     <div class="dropdown-menu" role="menu">
@@ -440,15 +440,15 @@ const ColumnSelector = {
     template: `
         <div class="rule-column-selector" v-if="!multiple || !ordered">
             <label class="d-flex justify-content-end align-items-center">
-                <span class="mr-1" v-b-tooltip.hover :title="help">{{ label }}</span>
-                <div class="mr-1" v-b-tooltip.hover.focus :title="title"><select2 :value="target" @input="handleInput" :multiple="multiple">
+                <span class="mr-auto" v-b-tooltip.hover :title="help">{{ label }}</span>
+                <div class="mr-1" v-b-tooltip.hover :title="title"><select2 :value="target" @input="handleInput" :multiple="multiple">
                     <option v-for="(col, index) in colHeaders" :value="index">{{ col }}</option>
                 </select2></div>
                 <slot></slot>
             </label>
         </div>
         <div class="rule-column-selector" v-else>
-            <span class="mr-1">{{ label }}</span>
+            <span>{{ label }}</span>
             <slot></slot>
             <ol>
                 <li v-for="(targetEl, index) in target"
@@ -583,9 +583,10 @@ const RegularExpressionInput = {
 const RuleDisplay = {
     template: `
         <li class="rule">
-            <span class="rule-display">{{ title }}
-                <span v-b-tooltip.hover :title="editTitle" class="fa fa-edit" @click="edit"></span>
-                <span v-b-tooltip.hover :title="removeTitle" class="fa fa-times" @click="remove"></span>
+            <span class="rule-display">
+                <span class="mr-1">{{ title }}</span>
+                <span v-b-tooltip.hover :title="editTitle" class="fa fa-edit mr-1" @click="edit"></span>
+                <span v-b-tooltip.hover :title="removeTitle" class="fa fa-times map" @click="remove"></span>
             </span>
             <span class="rule-warning" v-if="rule.warn">
                 {{ rule.warn }}
@@ -611,7 +612,7 @@ const RuleDisplay = {
             return RULES[ruleType].display(this.rule, this.colHeaders);
         },
         editTitle() { return _l("Edit this rule."); },
-        removeTitle() { return _l("Remove this rule."); }    
+        removeTitle() { return _l("Remove this rule."); }
     },
     methods: {
         edit() {
@@ -660,10 +661,10 @@ const IdentifierDisplay = {
             return MAPPING_TARGETS[this.type].help || "";
         },
         titleEdit() {
-            return _l("Edit column definitions.");
+            return _l("Edit column definition");
         },
         titleRemove() {
-            return _l("Remove this column definitions.");
+            return _l("Remove this column definition");
         },
         columnsLabel() {
             let columnNames;
@@ -710,9 +711,9 @@ const RuleComponent = {
     template: `
     <div v-if="ruleType == displayRuleType" class="rule-editor" :class="typeToClass">
         <slot></slot>
-        <div class="buttons float-right rule-edit-buttons">
-           <button type="button" class="btn rule-editor-cancel" @click="cancel">{{ cancelLabel }}</button>
-           <button type="button" class="btn btn-secondary btn-primary rule-editor-ok" @click="okay">{{ applyLabel }}</button>
+        <div class="buttons rule-edit-buttons d-flex justify-content-end">
+           <button type="button" class="btn rule-editor-cancel mr-1" @click="cancel">{{ cancelLabel }}</button>
+           <button type="button" class="btn btn-primary rule-editor-ok" @click="okay">{{ applyLabel }}</button>
         </div>
     </div>`,
     data: function() {
@@ -781,25 +782,25 @@ export default {
             waitingJobState: "new",
             titleReset: _l("Undo all reordering and discards"),
             titleNumericSort: _l(
-                "By default columns will be sorted lexiographically, check this option if the columns are numeric values and should be sorted as numbers."
+                "By default columns will be sorted lexiographically, check this option if the columns are numeric values and should be sorted as numbers"
             ),
             titleInvertFilterRegex: _l(
-                "Remove rows not matching the specified regular expression at specified column."
+                "Remove rows not matching the specified regular expression at specified column"
             ),
-            titleInvertFilterEmpty: _l("Remove rows that have non-empty values at specified column."),
-            titleInvertFilterMatches: _l("Remove rows not matching supplied value."),
+            titleInvertFilterEmpty: _l("Remove rows that have non-empty values at specified column"),
+            titleInvertFilterMatches: _l("Remove rows not matching supplied value"),
             titleViewSource: _l(
-                "Advanced Option: View and or edit the JSON representation of the rules to apply to this tabular data."
+                "Advanced Option: View and or edit the JSON representation of the rules to apply to this tabular data"
             ),
-            titleSourceCancel: _l("Stop editing rules and dismiss changes."),
-            titleSourceReset: _l("Reset text area to current set of rules."),
-            titleSourceApply: _l("Apply changes to rule source and return to rule preview."),
-            titleRulesMenu: _l("General rules to apply."),
-            titleFilterMenu: _l("Rules that filter rows from the data."),
-            titleColumMenu: _l("Rules that add generate new columns."),
-            titleRemoveMapping: _l("Remove column definition assignment."),
-            titleApplyColumnDefinitions: _l("Apply these column definitions and return to rules preview."),
-            titleAddColumnDefinition: _l("Assign a new piece of metadata as being derived from that a column of the table."),
+            titleSourceCancel: _l("Stop editing rules and dismiss changes"),
+            titleSourceReset: _l("Reset text area to current set of rules"),
+            titleSourceApply: _l("Apply changes to rule source and return to rule preview"),
+            titleRulesMenu: _l("General rules to apply"),
+            titleFilterMenu: _l("Rules that filter rows from the data"),
+            titleColumMenu: _l("Rules that generate new columns"),
+            titleRemoveMapping: _l("Remove column definition assignment"),
+            titleApplyColumnDefinitions: _l("Apply these column definitions and return to rules preview"),
+            titleAddColumnDefinition: _l("Assign a new piece of metadata as being derived from a column of the table"),
             namePlaceholder: _l("Enter a name for your new collection"),
             activeRuleIndex: null,
             addColumnRegexTarget: 0,
@@ -903,9 +904,9 @@ export default {
         },
         titleFinish() {
             if (this.elementsType == "datasets") {
-                return _l("Create new collection from specified rules and datasets.");
+                return _l("Create new collection from specified rules and datasets");
             } else {
-                return _l("Upload collection using specified rules.");
+                return _l("Upload collection using specified rules");
             }
         },
         finishButtonTitle() {

--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -196,7 +196,7 @@
                                 </column-selector>
                             </div>
                             <div class="buttons rule-edit-buttons d-flex justify-content-end">
-                                <button v-b-tooltip.hover.focus.bottom :title="titleAddColumnDefinition" type="button" class="dropdown-toggle btn btn-primary mr-1" data-toggle="dropdown" v-if="unmappedTargets.length > 0">
+                                <button v-b-tooltip.hover.focus :title="titleAddColumnDefinition" type="button" class="dropdown-toggle btn btn-primary mr-1" data-toggle="dropdown" v-if="unmappedTargets.length > 0">
                                     <span class="fa fa-plus rule-add-mapping"></span> {{ "Add Definition" }}<span class="caret"></span>
                                 </button>
                                 <div class="dropdown-menu" role="menu">

--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -300,7 +300,7 @@
         </div>
         <div class="rule-footer footer flex-row no-flex vertically-spaced" v-if="ruleView == 'source'">
             <option-buttons-div>
-                <button @click="attemptRulePreview" class="btn btn-secondary rule-btn-cancel">
+                <button @click="cancelSourceEdit" class="btn btn-secondary rule-btn-cancel">
                     {{ l("Cancel") }}
                 </button>
                 <button @click="resetSource" class="creator-reset-btn btn rule-btn-reset">
@@ -1118,6 +1118,10 @@ export default {
                 return;
             }
             this.updateFromSource(asJson);
+            this.ruleView = "normal";
+        },
+        cancelSourceEdit() {
+            this.ruleSourceError = null;
             this.ruleView = "normal";
         },
         updateFromSource(asJson) {

--- a/client/galaxy/scripts/mvc/rules/rule-definitions.js
+++ b/client/galaxy/scripts/mvc/rules/rule-definitions.js
@@ -351,13 +351,13 @@ const RULES = {
             const which = rule.which;
             const invert = rule.invert;
             if (which == "first" && !invert) {
-                return `Filter out first ${rule.count} row(s).}`;
+                return `Filter out first ${rule.count} row(s).`;
             } else if (which == "first" && invert) {
-                return `Keep only first ${rule.count} row(s).}`;
+                return `Keep only first ${rule.count} row(s).`;
             } else if (which == "last" && !invert) {
-                return `Filter out last ${rule.count} row(s).}`;
+                return `Filter out last ${rule.count} row(s).`;
             } else {
-                return `Keep only last ${rule.count} row(s).}`;
+                return `Keep only last ${rule.count} row(s).`;
             }
         },
         init: (component, rule) => {

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "bibtex-parse-js": "^0.0.24",
     "bootstrap": "^4.1.0",
     "bootstrap-tour": "https://github.com/sorich87/bootstrap-tour.git#6a1028fb562f9aa68c451f0901f8cfeb43cad140",
+    "bootstrap-vue": "^2.0.0-rc.8",
     "d3": "3",
     "font-awesome": "^4.7.0",
     "gulp-sass": "^3.1.0",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -86,6 +86,13 @@ let buildconfig = {
                         options: "$"
                     }
                 ]
+            },
+            {
+                test: /\.css$/,
+                use: [
+                    'style-loader',
+                    'css-loader'
+                ]
             }
         ]
     },


### PR DESCRIPTION
Opening a new PR on top of #5909, because that has all green checkboxes and Jenkins is being very crabby lately.

This extends that PR, brings in more style and wording improvements from @martenson, adds a working cancel button to the rule source editor, and disables the "Reorient" mode - which doesn't work well and was kind of a developer experiment I was hoping to disable before 18.05 if it didn't work out.