### PR TITLE
[18.01] Correct access for FTP files in composite datatype

### DIFF
--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -214,7 +214,10 @@ class UploadDataset(Group):
         if dataset_name is None:
             filenames = list()
             for composite_file in context.get('files', []):
-                filenames.append(composite_file.get('file_data', {}).get('filename', ''))
+                if not composite_file.get('ftp_files', ''):
+                    filenames.append(composite_file.get('file_data', {}).get('filename', ''))
+                else:
+                    filenames.append(composite_file.get('ftp_files', [])[0])
             dataset_name = os.path.commonprefix(filenames).rstrip('.') or None
         if dataset_name is None:
             dataset_name = 'Uploaded Composite Dataset (%s)' % self.get_file_type(context)


### PR DESCRIPTION
Saw this on 18.01 (@bgruening was this happening before as well?)

Whenever we tried to:

- upload a composite file (analyze75 specifically)
- with files from FTP
- after selecting files and clicking upload 

We got a stack trace like:

```
Traceback (most recent call last):
  File "lib/galaxy/tools/__init__.py", line 1363, in handle_single_execution
    completed_job=completed_job,
  File "lib/galaxy/tools/__init__.py", line 1444, in execute
    return self.tool_action.execute(self, trans, incoming=incoming, set_output_hid=set_output_hid, history=history, **kwargs)
  File "lib/galaxy/tools/actions/upload.py", line 26, in execute
    uploaded_datasets = upload_common.get_uploaded_datasets(trans, '', incoming, precreated_datasets, dataset_upload_inputs, history=history)
  File "lib/galaxy/tools/actions/upload_common.py", line 337, in get_uploaded_datasets
    uploaded_datasets.extend(dataset_upload_input.get_uploaded_datasets(trans, params))
  File "lib/galaxy/tools/parameters/grouping.py", line 565, in get_uploaded_datasets
    dataset.precreated_name = dataset.name = self.get_composite_dataset_name(context)
  File "lib/galaxy/tools/parameters/grouping.py", line 217, in get_composite_dataset_name
    filenames.append(composite_file.get('file_data', {}).get('filename', ''))
AttributeError: 'NoneType' object has no attribute 'get'
```