### PR TITLE
[17.05] Resort to os.path.exists() also for paths not ending in .loc

### DIFF
--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -52,10 +52,8 @@ class ToolDataPathFiles(object):
         path = os.path.abspath(path)
         if path in self.tool_data_path_files:
             return True
-        elif self.tool_data_path not in path:
-            return os.path.exists(path)
         else:
-            return False
+            return os.path.exists(path)
 
 
 class ToolDataTableManager( object ):


### PR DESCRIPTION
Fix installation of gatk2 iuc's repo, which otherwise does not add the data tables to `config/shed_tool_data_table_conf.xml` .

Introduced in commit 43c9c287a9a3520d77cc9235dfbfa6ac6cf33227 .