### PR TITLE
bootstrap4 regression fix - extra large rule builder modal.

### DIFF
--- a/client/galaxy/scripts/mvc/collection/list-collection-creator.js
+++ b/client/galaxy/scripts/mvc/collection/list-collection-creator.js
@@ -1033,8 +1033,9 @@ const collectionCreatorModalSetup = function _collectionCreatorModalSetup(option
         modal.show({
             title: options.title || _l("Create a collection"),
             body: el,
-            width: "80%",
+            width: "85%",
             height: "100%",
+            xlarge: true,
             closing_events: true
         });
     };

--- a/client/galaxy/scripts/mvc/ui/ui-modal.js
+++ b/client/galaxy/scripts/mvc/ui/ui-modal.js
@@ -10,6 +10,7 @@ export var View = Backbone.View.extend({
         backdrop: true,
         height: null,
         width: null,
+        xlarge: false, /* BS4 max-width already expanded in Galaxy, expand even more if true. */
         closing_events: false,
         closing_callback: null,
         title_separator: true
@@ -128,6 +129,9 @@ export var View = Backbone.View.extend({
         }
         if (this.options.width) {
             this.$dialog.css("width", this.options.width);
+        }
+        if (this.options.xlarge) {
+            this.$dialog.css("max-width", "3000px");
         }
     },
 


### PR DESCRIPTION
Make the rule builder expand to larger screens more aggressively again, the BS4 branch capped the width at like 900px - make this much larger.

Fixes https://github.com/galaxyproject/galaxy/projects/10#card-8949949.