### PR TITLE
Data Library -> Rule Builder fixes.

### DIFF
--- a/client/galaxy/scripts/mvc/collection/list-collection-creator.js
+++ b/client/galaxy/scripts/mvc/collection/list-collection-creator.js
@@ -1069,8 +1069,8 @@ var ruleBasedCollectionCreatorModal = function _ruleBasedCollectionCreatorModal(
     let title;
     if (importType == "datasets") {
         title = _l("Build Rules for Uploading Datasets");
-    } else if (elementsType == "datasets") {
-        title = _l("Build Rules for Creating Collection");
+    } else if (elementsType == "datasets" || elementsType == "library_datasets") {
+        title = _l("Build Rules for Creating Collection(s)");
     } else {
         title = _l("Build Rules for Uploading Collections");
     }

--- a/client/galaxy/scripts/mvc/rules/rule-definitions.js
+++ b/client/galaxy/scripts/mvc/rules/rule-definitions.js
@@ -659,7 +659,6 @@ const MAPPING_TARGETS = {
         help: _l(
             "If this is set, all rows with the same collection name will be joined into a collection and it is possible to create multiple collections at once."
         ),
-        modes: ["raw", "ftp"], // TODO: allow this in datasets mode.
         importType: "collections"
     },
     name: {


### PR DESCRIPTION
- Missed allowing collection name in library mode - I told Martin this possible because I thought it was and the library collection type modal text states it is possible but I didn't fix the switch in rule-definitions.js and notice the problems in createCollection associated with that. This fixes all of that.
- Fix to drop file type and genome selector when coming from libraries because this targets existing datasets - think this might have slipped back in a bad rebase on my part.
- Fix modal title when coming from data library folders.
- Improve text instructions when coming from a library.

Fixes #5967.