### PR TITLE
Pin the version of node we use in CI, etc....

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -237,7 +237,7 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
     if [ -n "$VIRTUAL_ENV" ]; then
         if ! in_venv "$(command -v node)"; then
             echo "Installing node into $VIRTUAL_ENV with nodeenv."
-            nodeenv -p
+            nodeenv -n 9.11.1 -p
         fi
         if ! in_venv "$(command -v yarn)"; then
             echo "Installing yarn into $VIRTUAL_ENV with npm."


### PR DESCRIPTION
Our dependencies won't resolve under node 10 currently (because of upath at least https://github.com/anodynos/upath/blob/master/package.json#L43 but maybe other packages as well).