### PR TITLE
[WIP][18.01] Optimize Tool Build Endpoint

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1557,6 +1557,22 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName):
         return self._active_datasets_and_roles
 
     @property
+    def active_visible_datasets_and_roles(self):
+        if not hasattr(self, '_active_visible_datasets_and_roles'):
+            db_session = object_session(self)
+            query = (db_session.query(HistoryDatasetAssociation)
+                .filter(HistoryDatasetAssociation.table.c.history_id == self.id)
+                .filter(not_(HistoryDatasetAssociation.deleted))
+                .filter(HistoryDatasetAssociation.visible)
+                .order_by(HistoryDatasetAssociation.table.c.hid.asc())
+                .options(joinedload("dataset"),
+                         joinedload("dataset.actions"),
+                         joinedload("dataset.actions.role"),
+                         joinedload("tags")))
+            self._active_visible_datasets_and_roles = query.all()
+        return self._active_visible_datasets_and_roles
+
+    @property
     def active_contents(self):
         """ Return all active contents ordered by hid.
         """

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1573,6 +1573,20 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName):
         return self._active_visible_datasets_and_roles
 
     @property
+    def active_visible_dataset_collections(self):
+        if not hasattr(self, '_active_visible_dataset_collections'):
+            db_session = object_session(self)
+            query = (db_session.query(HistoryDatasetCollectionAssociation)
+                .filter(HistoryDatasetCollectionAssociation.table.c.history_id == self.id)
+                .filter(not_(HistoryDatasetCollectionAssociation.deleted))
+                .filter(HistoryDatasetCollectionAssociation.visible)
+                .order_by(HistoryDatasetCollectionAssociation.table.c.hid.asc())
+                .options(joinedload("collection"),
+                         joinedload("tags")))
+            self._active_visible_dataset_collections = query.all()
+        return self._active_visible_dataset_collections
+
+    @property
     def active_contents(self):
         """ Return all active contents ordered by hid.
         """

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3475,6 +3475,8 @@ class HistoryDatasetCollectionAssociation(DatasetCollectionInstance,
             def recursively_add_joined_loads(depth_collection_type, prefix):
                 if ":" not in depth_collection_type:
                     joined_loads.append(joinedload(prefix + "hda"))
+                    joined_loads.append(joinedload(prefix + "hda.dataset.actions"))
+                    joined_loads.append(joinedload(prefix + "hda.dataset.actions.role"))
                 else:
                     joined_loads.append(joinedload(prefix + "child_collection"))
                     joined_loads.append(joinedload(prefix + "child_collection.elements"))

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1494,7 +1494,7 @@ class BaseDataToolParameter(ToolParameter):
                         return match.hda
             else:
                 dataset_collection_matcher = DatasetCollectionMatcher(dataset_matcher)
-                for hdca in reversed(history.active_dataset_collections):
+                for hdca in reversed(history.active_visible_dataset_collections):
                     if dataset_collection_matcher.hdca_match(hdca, reduction=self.multiple):
                         return hdca
 
@@ -1608,7 +1608,7 @@ class DataToolParameter(BaseDataToolParameter):
     def match_collections(self, history, dataset_matcher, reduction=True):
         dataset_collection_matcher = DatasetCollectionMatcher(dataset_matcher)
 
-        for history_dataset_collection in history.active_dataset_collections:
+        for history_dataset_collection in history.active_visible_dataset_collections:
             if dataset_collection_matcher.hdca_match(history_dataset_collection, reduction=reduction):
                 yield history_dataset_collection
 
@@ -1834,7 +1834,7 @@ class DataToolParameter(BaseDataToolParameter):
 
         # add dataset collections
         dataset_collection_matcher = DatasetCollectionMatcher(dataset_matcher)
-        for hdca in history.active_dataset_collections:
+        for hdca in history.active_visible_dataset_collections:
             if dataset_collection_matcher.hdca_match(hdca, reduction=multiple):
                 append(d['options']['hdca'], hdca, hdca.name, 'hdca')
 
@@ -1882,7 +1882,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
     def match_multirun_collections(self, trans, history, dataset_matcher):
         dataset_collection_matcher = DatasetCollectionMatcher(dataset_matcher)
 
-        for history_dataset_collection in history.active_dataset_collections:
+        for history_dataset_collection in history.active_visible_dataset_collections:
             if not self._history_query(trans).can_map_over(history_dataset_collection):
                 continue
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1486,7 +1486,9 @@ class BaseDataToolParameter(ToolParameter):
         if history is not None:
             dataset_matcher = DatasetMatcher(trans, self, None, other_values)
             if isinstance(self, DataToolParameter):
-                for hda in reversed(history.active_datasets_and_roles):
+                for hda in reversed(history.active_visible_datasets_and_roles):
+                    # TODO: optimize to reuse DatasetMatcher between calls in here and
+                    # don't re-filter the same hdas from the above list.
                     match = dataset_matcher.hda_match(hda, check_security=False)
                     if match:
                         return match.hda
@@ -1811,7 +1813,9 @@ class DataToolParameter(BaseDataToolParameter):
 
         # add datasets
         hda_list = util.listify(other_values.get(self.name))
-        for hda in history.active_datasets_and_roles:
+        # we can restrict to visible datasets here I think, the DatasetMatcher will process non-visible datasets if
+        # passed a "value", but this is set to None above.
+        for hda in history.active_visible_datasets_and_roles:
             match = dataset_matcher.hda_match(hda, check_security=False)
             if match:
                 m = match.hda

--- a/lib/galaxy/tools/parameters/dataset_matcher.py
+++ b/lib/galaxy/tools/parameters/dataset_matcher.py
@@ -165,14 +165,15 @@ class DatasetCollectionMatcher(object):
         if reduction and dataset_collection.collection_type.find(":") > 0:
             return False
         else:
-            return self.dataset_collection_match(dataset_collection)
+            if history_dataset_collection_association.collection.populated_state != galaxy.model.DatasetCollection.populated_states.OK:
+                return False
+
+            if not history_dataset_collection_association.check_populated_with_prefetched_element_collection():
+                return False
+
+            return self.dataset_collection_match(history_dataset_collection_association.collection_with_prefetched_elements)
 
     def dataset_collection_match(self, dataset_collection):
-        # If dataset collection not yet populated, cannot determine if it
-        # would be a valid match for this parameter.
-        if not dataset_collection.populated:
-            return False
-
         valid = True
         for element in dataset_collection.elements:
             if not self.__valid_element(element):


### PR DESCRIPTION
Alternative to https://github.com/galaxyproject/galaxy/pull/5977, that was going down a path that would help histories with lists but not more general collection structures. This variant takes some of the ideas further but steps back a bit to help all kinds of collections.

The idea here is that I believe the slowness caused by rendering "simple" tool forms is mostly just going through and fetching all the datasets from all the collections to see if they match the input parameters. My hunch is that process is dominated by the actual fetching of data from the database - and not actually the Python checks. Slowness related to fetching of the data I think can be broken in to two big parts - the amount of data that is fetched, the number of queries used to fetch the data.

This PR does some things to reduce the amount of data to be fetched - when fetching datasets it skips fetching details on hidden datasets (oh which there might be hundreds of thousands in a large collection history). When fetching collections - this now skips collections whose top-level backbone is not yet populated and collections that are hidden - since subsequent Python processing was going to toss these collections anyway. These are two fine optimization but I doubt either is a serious source of slow down.

Other than that this should still fetch all the same rows from the database - but all of that happens in orders or magnitude fewer individual queries for large collection histories. To put this another way, if the problem is the amount of data and the time spend in the database finding the data - then this won't help a ton. If instead the problem is the number of database connections made - I suspect this will help a great deal.

For processing datasets, this does nothing really to reduce the number of queries - they should pretty much all be fetched in one query anyway. For checking elements of collections, this should vastly reduce the number of queries made however. Previously for each top-level collection object, a tag query for each collection, and then separate queries for the each layer of collection, each element of the collection, each dataset of each element of each collection, the actions and the roles for each dataset of each element. Now I think there is one joined query for the top-level collection object and tags for all collections at once, and then a separate single query to load in the full collection object for each of those collections - which brings in the datasets, roles, subcollections, etc...

So the number of queries to process collections is now linear in the number of collections with a tiny constant instead of linear in the number of constituent datasets plus linear in the number of collections each with slightly larger constants.
