### PR TITLE
[17.09] Fix 2 typos in the docs

### DIFF
--- a/config/local_conda_mapping.yml.sample
+++ b/config/local_conda_mapping.yml.sample
@@ -1,2 +1,2 @@
 # See $GALAXY_ROOT/lib/galaxy/tools/deps/resolvers/default_conda_mapping.yml for example mapping - 
-# additional site-specific mappings can be added to config/conda_mapping.yml.
+# additional site-specific mappings can be added to config/local_conda_mapping.yml.

--- a/doc/source/admin/cluster.md
+++ b/doc/source/admin/cluster.md
@@ -66,7 +66,7 @@ Additionally some of the runners including DRMAA may use the ``cluster_files_dir
 cluster_files_directory = database/pbs
 ```
 
-You may also find that attribute caching in your filesystem causes problems with job completion since it interferes with Galaxy detecting the presence and correct sizes of output files. In NFS caching can be disabled with the `-noac` mount option on Linux (on the Galaxy server), but this may have a significant impact on performance since all attributes will have to be read from the file server upon every file access. You should try the `retry_output_collection` option in `galaxy.ini` first to see if this solves the problem.
+You may also find that attribute caching in your filesystem causes problems with job completion since it interferes with Galaxy detecting the presence and correct sizes of output files. In NFS caching can be disabled with the `-noac` mount option on Linux (on the Galaxy server), but this may have a significant impact on performance since all attributes will have to be read from the file server upon every file access. You should try the `retry_job_output_collection` option in `galaxy.ini` first to see if this solves the problem.
 
 ## Runner Configuration
 


### PR DESCRIPTION
The one in `cluster.md` was reported by alk__ on IRC.