### PR TITLE
[18.05] Fixes for the Cgroup metric plugin

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -665,16 +665,13 @@ model.JobImportHistoryArchive.table = Table(
     Column("history_id", Integer, ForeignKey("history.id"), index=True),
     Column("archive_dir", TEXT))
 
-
-JOB_METRIC_MAX_LENGTH = 1023
-
 model.JobMetricText.table = Table(
     "job_metric_text", metadata,
     Column("id", Integer, primary_key=True),
     Column("job_id", Integer, ForeignKey("job.id"), index=True),
     Column("plugin", Unicode(255)),
     Column("metric_name", Unicode(255)),
-    Column("metric_value", Unicode(JOB_METRIC_MAX_LENGTH)))
+    Column("metric_value", Unicode(model.JOB_METRIC_MAX_LENGTH)))
 
 model.TaskMetricText.table = Table(
     "task_metric_text", metadata,
@@ -682,7 +679,7 @@ model.TaskMetricText.table = Table(
     Column("task_id", Integer, ForeignKey("task.id"), index=True),
     Column("plugin", Unicode(255)),
     Column("metric_name", Unicode(255)),
-    Column("metric_value", Unicode(JOB_METRIC_MAX_LENGTH)))
+    Column("metric_value", Unicode(model.JOB_METRIC_MAX_LENGTH)))
 
 model.JobMetricNumeric.table = Table(
     "job_metric_numeric", metadata,
@@ -690,7 +687,7 @@ model.JobMetricNumeric.table = Table(
     Column("job_id", Integer, ForeignKey("job.id"), index=True),
     Column("plugin", Unicode(255)),
     Column("metric_name", Unicode(255)),
-    Column("metric_value", Numeric(22, 7)))
+    Column("metric_value", Numeric(model.JOB_METRIC_PRECISION, model.JOB_METRIC_SCALE)))
 
 model.TaskMetricNumeric.table = Table(
     "task_metric_numeric", metadata,
@@ -698,7 +695,7 @@ model.TaskMetricNumeric.table = Table(
     Column("task_id", Integer, ForeignKey("task.id"), index=True),
     Column("plugin", Unicode(255)),
     Column("metric_name", Unicode(255)),
-    Column("metric_value", Numeric(22, 7)))
+    Column("metric_value", Numeric(model.JOB_METRIC_PRECISION, model.JOB_METRIC_SCALE)))
 
 
 model.GenomeIndexToolData.table = Table(

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1270,7 +1270,7 @@ def nice_size(size):
     >>> nice_size(100000000)
     '95.4 MB'
     """
-    words = ['bytes', 'KB', 'MB', 'GB', 'TB']
+    words = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']
     prefix = ''
     try:
         size = float(size)


### PR DESCRIPTION
I have taken a crack at fixing up a few of the limitations in the Cgroup metrics plugin as mentioned in #5610.

**tl;dr:**

1. Multi-line params (as output by `cgget`) are now stored with metric name `<key>.<subkey>` where `<subkey>` is the first word on a tab-indented line, and `<key>` is the param name from the most-recently-seen non-tab-indented line. The value is the remainder of the line (everything after the first word). Previously only one such parameter - `memory.oom-control` - was supported, by explicitly parsing the value and storing the subvalues under their subkeys. As a result, the following metric names changed:
    - `oom_kill_disable` → `memory.oom-control.oom_kill_disable`
    - `under_oom` → `memory.oom-control.under_oom`
2. Numeric metrics are now stored in `job_metric_numeric` (previously, all were stored in `job_metric_text`). This necessitated inspecting the size of values to ensure they didn't overflow the field.
3. Fixed a minor bug where formatting was happening on the name of certain params instead of the value.

A few outstanding (non-bug) items are in #5988.

**boring details:**

`cgget` output looks, for example, like this:

```
/:
cpuacct.stat: user 548172275
	system 32419700
cpuacct.usage_percpu: 227252272047480 325990399756032 213873980390153 259087830060284 185335618982052 178626804974651 165549147337174 180012433452466 156792729993848 173895140853753 160752306032460 169932578463259 145762446277323 168911466976668 156523491460693 171629148950803 193624709701014 108445679641186 176671369386974 159898848729991 184339241835105 199199613081838 198777375609024 178297810917806 201860594211217 170461436328846 176008821854888 157078308519548 176168710773113 154191698712420 190393055704580 150022095522731 
cpuacct.usage: 5815367166539380

/:
memory.kmem.tcp.max_usage_in_bytes: 0
memory.kmem.tcp.failcnt: 0
memory.kmem.tcp.usage_in_bytes: 57344
memory.kmem.tcp.limit_in_bytes: 2251799813685247
memory.memsw.failcnt: 0
memory.limit_in_bytes: 9223372036854771712
memory.numa_stat: total=17304933 N0=3779583 N1=13525350
	file=17175813 N0=3744130 N1=13431683
	anon=129120 N0=35453 N1=93667
	unevictable=0 N0=0 N1=0
memory.oom_control: oom_kill_disable 0
	under_oom 0
memory.kmem.slabinfo: slabinfo - version: 2.1
	# name            <active_objs> <num_objs> <objsize> <objperslab> <pagesperslab> : tunables <limit> <batchcount> <sharedfactor> : slabdata <active_slabs> <num_slabs> <sharedavail>
	kmalloc-512            8      8    512    8    1 : tunables   54   27    8 : slabdata      1      1      0
	kmalloc-256           16     16    256   16    1 : tunables  120   60    8 : slabdata      1      1      0
	sock_inode_cache       5      5    704    5    1 : tunables   54   27    8 : slabdata      1      1      0
	radix_tree_node        7      7    576    7    1 : tunables   54   27    8 : slabdata      1      1      0
	proc_inode_cache      36     36    672    6    1 : tunables   54   27    8 : slabdata      6      6      0
	dentry              1176   1176    192   21    1 : tunables  120   60    8 : slabdata     56     56      0
	kmalloc-1024           4      4   1024    4    1 : tunables   54   27    8 : slabdata      1      1      0
	kmalloc-192           16     21    192   21    1 : tunables  120   60    8 : slabdata      1      1      0
	inode_cache           54     54    600    6    1 : tunables   54   27    8 : slabdata      9      9      0
	pid                   32     32    128   32    1 : tunables  120   60    8 : slabdata      1      1      0
	signal_cache          20     20   1024    4    1 : tunables   54   27    8 : slabdata      5      5      0
	sighand_cache          3      3   2112    3    2 : tunables   24   12    8 : slabdata      1      1      0
	fs_cache              16     63     64   63    1 : tunables  120   60    8 : slabdata      1      1      0
	files_cache           11     11    704   11    2 : tunables   54   27    8 : slabdata      1      1      0
	task_struct           20     20   3840    1    1 : tunables   24   12    8 : slabdata     20     20      0
	kmalloc-96            16     32    128   32    1 : tunables  120   60    8 : slabdata      1      1      0
	kmalloc-2048           4      4   2048    2    1 : tunables   24   12    8 : slabdata      2      2      0
	mm_struct              7      7   1088    7    2 : tunables   24   12    8 : slabdata      1      1      0
	anon_vma             200    200     80   50    1 : tunables  120   60    8 : slabdata      4      4    120
	anon_vma_chain       252    256     64   64    1 : tunables  120   60    8 : slabdata      4      4    120
	vm_area_struct       475    475    208   19    1 : tunables  120   60    8 : slabdata     25     25    360
	kmalloc-64            64     64     64   64    1 : tunables  120   60    8 : slabdata      1      1      0
	cred_jar             231    231    192   21    1 : tunables  120   60    8 : slabdata     11     11     60

```

This makes parsing somewhat difficult, as you can't tell if you're reading a multi-line param until you read past the first line. I don't think there's a defined format for a param's value except that any subsequent line of a multi-line param is indented by `cgget` with a tab. Thankfully, most multi-line params tend to follow a format of `<subkey> <value>\n`. There are some notable exceptions like `memory.numa_stat` and `memory.kmem.slabinfo`, but I'm ignoring them (and, if you do enable the plugin's `verbose` mode, they will be stored, just in a less than ideal manner).

Because the first line of the value of a multi-line param is on the same line as the key, it's necessary to "go back" and make the first line's key into a `<key>.<subkey>` after determining (on the second line) that a multi-line param is being read. Sure, there are other ways (read ahead instead of fixing backward, or read the file in reverse), but this worked well enough.

P.S. thanks @scholtalbers for writing this plugin, it's going to be a pretty big deal for us! I've just gotten Slurm upgraded so that we can make full use of it.