### PR TITLE
[18.01] Fix collection element count getting lost during collection copies.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3134,11 +3134,13 @@ class DatasetCollection(object, Dictifiable, UsesAnnotations):
         id=None,
         collection_type=None,
         populated=True,
+        element_count=None
     ):
         self.id = id
         self.collection_type = collection_type
         if not populated:
             self.populated_state = DatasetCollection.populated_states.NEW
+        self.element_count = element_count
 
     @property
     def populated(self):
@@ -3211,6 +3213,7 @@ class DatasetCollection(object, Dictifiable, UsesAnnotations):
     def copy(self, destination=None, element_destination=None):
         new_collection = DatasetCollection(
             collection_type=self.collection_type,
+            element_count=self.element_count
         )
         for element in self.elements:
             element.copy_to_collection(


### PR DESCRIPTION
From @lecorguille on #5975

> Curiously, under my session, I don't have the number of dataset displayed in grey. I just have a list instead of a list of 810 items

This should fix that for new collections.

As an aside, 18.01 has a database migration that fixes this value for all existing collections but if that has been run already and you want to set the missing values I think something like can be used to clean up things - but probably the missing sizes aren't a signficant problem

```sql
 UPDATE dataset_collection SET element_count = 
   (SELECT (CASE WHEN count(*) > 0 THEN count(*) ELSE 0 END) 
    FROM dataset_collection_element
    WHERE   dataset_collection_element.dataset_collection_id = dataset_collection.id)
```
