### PR TITLE
Optimize safe_walk to call realpath a lot less for typical calls...

### DIFF
--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -24,6 +24,7 @@ from os.path import (
     dirname,
     exists,
     isabs,
+    islink,
     join,
     normpath,
     pardir,
@@ -59,7 +60,7 @@ def safe_path(path, whitelist=None):
     return any(__contains(dirname(path), path, whitelist=whitelist))
 
 
-def safe_contains(prefix, path, whitelist=None):
+def safe_contains(prefix, path, whitelist=None, real=None):
     """Ensure a path is contained within another path.
 
     Given any two filesystem paths, ensure that ``path`` is contained in ``prefix``. If ``path`` exists (either as an
@@ -80,7 +81,23 @@ def safe_contains(prefix, path, whitelist=None):
     :rtype:             bool
     :returns:           ``True`` if ``path`` is contained within ``prefix`` or ``whitelist``, ``False`` otherwise.
     """
-    return any(__contains(prefix, path, whitelist=whitelist))
+    return any(__contains(prefix, path, whitelist=whitelist, real=real))
+
+
+class _SafeContainsDirectoryChecker(object):
+
+    def __init__(self, dirpath, prefix, whitelist=None):
+        self.whitelist = whitelist
+        self.dirpath = dirpath
+        self.prefix = prefix
+        self.real_dirpath = realpath(join(prefix, dirpath))
+
+    def check(self, filename):
+        dirpath_path = join(self.real_dirpath, filename)
+        if islink(dirpath_path):
+            return safe_contains(self.prefix, filename, whitelist=self.whitelist)
+        else:
+            return safe_contains(self.prefix, filename, whitelist=self.whitelist, real=dirpath_path)
 
 
 def safe_makedirs(path):
@@ -127,17 +144,33 @@ def safe_walk(path, whitelist=None):
     :rtype:             iterator
     :returns:           Iterator of "safe" ``os.walk()`` tuples found under ``path``
     """
-    _check = partial(safe_contains, path, whitelist=whitelist)
     for i, elems in enumerate(walk(path, followlinks=bool(whitelist)), start=1):
         dirpath, dirnames, filenames = elems
+        _check = _SafeContainsDirectoryChecker(dirpath, path, whitelist=None).check
+
         if whitelist and i % WALK_MAX_DIRS == 0:
             raise RuntimeError(
                 'Breaking out of walk of %s after %s iterations (most likely infinite symlink recursion) at: %s' %
                 (path, WALK_MAX_DIRS, dirpath))
         _prefix = partial(join, dirpath)
-        yield (dirpath,
-               map(basename, filter(_check, map(_prefix, dirnames))),
-               map(basename, filter(_check, map(_prefix, filenames))))
+
+        prune = False
+        for index, dname in enumerate(dirnames):
+            if not _check(join(dirpath, dname)):
+                prune = True
+                break
+        if prune:
+            dirnames = map(basename, filter(_check, map(_prefix, dirnames)))
+
+        prune = False
+        for index, filename in enumerate(filenames):
+            if not _check(join(dirpath, filename)):
+                prune = True
+                break
+        if prune:
+            filenames = map(basename, filter(_check, map(_prefix, filenames)))
+
+        yield (dirpath, dirnames, filenames)
 
 
 def unsafe_walk(path, whitelist=None, username=None):
@@ -324,12 +357,14 @@ def __listify(item):
 
 def __walk(path):
     for dirpath, dirnames, filenames in walk(path):
-        for name in dirnames + filenames:
+        for name in dirnames:
+            yield join(dirpath, name)
+        for name in filenames:
             yield join(dirpath, name)
 
 
-def __contains(prefix, path, whitelist=None):
-    real = realpath(join(prefix, path))
+def __contains(prefix, path, whitelist=None, real=None):
+    real = real or realpath(join(prefix, path))
     yield not relpath(real, prefix).startswith(pardir)
     for wldir in whitelist or []:
         # a path is under the whitelist if the relative path between it and the whitelist does not have to go up (..)


### PR DESCRIPTION
There are other smaller optimizations in there but the big thing is just when walking over many files in a directory - just call realpath on the dirpath and respect a filename onto that as the realpath as long as the file is not a link.

Cuts the time required to load 100,000 FTP files into the rule builder in half on my macbook - could imagine the gains to be even bigger on a network file system?