### PR TITLE
[18.01] Fix tool state performance for large collections.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1558,6 +1558,22 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName):
         return self._active_datasets_and_roles
 
     @property
+    def active_visible_datasets_and_roles(self):
+        if not hasattr(self, '_active_visible_datasets_and_roles'):
+            db_session = object_session(self)
+            query = (db_session.query(HistoryDatasetAssociation)
+                .filter(HistoryDatasetAssociation.table.c.history_id == self.id)
+                .filter(not_(HistoryDatasetAssociation.deleted))
+                .filter(HistoryDatasetAssociation.visible)
+                .order_by(HistoryDatasetAssociation.table.c.hid.asc())
+                .options(joinedload("dataset"),
+                         joinedload("dataset.actions"),
+                         joinedload("dataset.actions.role"),
+                         joinedload("tags")))
+            self._active_visible_datasets_and_roles = query.all()
+        return self._active_visible_datasets_and_roles
+
+    @property
     def active_contents(self):
         """ Return all active contents ordered by hid.
         """

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1574,6 +1574,20 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName):
         return self._active_visible_datasets_and_roles
 
     @property
+    def active_visible_dataset_collections(self):
+        if not hasattr(self, '_active_visible_dataset_collections'):
+            db_session = object_session(self)
+            query = (db_session.query(HistoryDatasetCollectionAssociation)
+                .filter(HistoryDatasetCollectionAssociation.table.c.history_id == self.id)
+                .filter(not_(HistoryDatasetCollectionAssociation.deleted))
+                .filter(HistoryDatasetCollectionAssociation.visible)
+                .order_by(HistoryDatasetCollectionAssociation.table.c.hid.asc())
+                .options(joinedload("collection"),
+                         joinedload("tags")))
+            self._active_visible_dataset_collections = query.all()
+        return self._active_visible_dataset_collections
+
+    @property
     def active_contents(self):
         """ Return all active contents ordered by hid.
         """

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -56,6 +56,10 @@ from galaxy.tools.parameters.basic import (
     ToolParameter,
     workflow_building_modes,
 )
+from galaxy.tools.parameters.dataset_matcher import (
+    set_dataset_matcher_factory,
+    unset_dataset_matcher_factory,
+)
 from galaxy.tools.parameters.grouping import Conditional, ConditionalWhen, Repeat, Section, UploadDataset
 from galaxy.tools.parameters.input_translation import ToolInputTranslator
 from galaxy.tools.parameters.meta import expand_meta_parameters
@@ -1826,7 +1830,9 @@ class Tool(object, Dictifiable):
         # create tool model
         tool_model = self.to_dict(request_context)
         tool_model['inputs'] = []
+        set_dataset_matcher_factory(request_context, self, state_inputs)
         self.populate_model(request_context, self.inputs, state_inputs, tool_model['inputs'])
+        unset_dataset_matcher_factory(request_context)
 
         # create tool help
         tool_help = ''

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1486,7 +1486,7 @@ class BaseDataToolParameter(ToolParameter):
             dataset_matcher_factory = get_dataset_matcher_factory(trans)
             dataset_matcher = dataset_matcher_factory.dataset_matcher(self, other_values)
             if isinstance(self, DataToolParameter):
-                for hda in reversed(history.active_datasets_and_roles):
+                for hda in reversed(history.active_visible_datasets_and_roles):
                     match = dataset_matcher.hda_match(hda)
                     if match:
                         return match.hda
@@ -1805,7 +1805,8 @@ class DataToolParameter(BaseDataToolParameter):
 
         # add datasets
         hda_list = util.listify(other_values.get(self.name))
-        for hda in history.active_datasets_and_roles:
+        # Prefetch all at once, big list of visible, non-deleted datasets.
+        for hda in history.active_visible_datasets_and_roles:
             match = dataset_matcher.hda_match(hda)
             if match:
                 m = match.hda

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1603,13 +1603,6 @@ class DataToolParameter(BaseDataToolParameter):
                     raise ValueError("Datatype class not found for extension '%s', which is used as 'type' attribute in conversion of data parameter '%s'" % (conv_type, self.name))
                 self.conversions.append((name, conv_extension, [conv_type]))
 
-    def match_collections(self, history, dataset_matcher, reduction=True):
-        dataset_collection_matcher = DatasetCollectionMatcher(dataset_matcher)
-
-        for history_dataset_collection in history.active_dataset_collections:
-            if dataset_collection_matcher.hdca_match(history_dataset_collection, reduction=reduction):
-                yield history_dataset_collection
-
     def from_json(self, value, trans, other_values={}):
         if trans.workflow_building_mode is workflow_building_modes.ENABLED:
             return None

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -26,8 +26,7 @@ from galaxy.util.expressions import ExpressionContext
 from galaxy.web import url_for
 from . import validation
 from .dataset_matcher import (
-    DatasetCollectionMatcher,
-    DatasetMatcher
+    get_dataset_matcher_factory,
 )
 from .sanitize import ToolParameterSanitizer
 from ..parameters import (
@@ -1484,14 +1483,15 @@ class BaseDataToolParameter(ToolParameter):
             return None
         history = trans.history
         if history is not None:
-            dataset_matcher = DatasetMatcher(trans, self, other_values)
+            dataset_matcher_factory = get_dataset_matcher_factory(trans)
+            dataset_matcher = dataset_matcher_factory.dataset_matcher(self, other_values)
             if isinstance(self, DataToolParameter):
                 for hda in reversed(history.active_datasets_and_roles):
                     match = dataset_matcher.hda_match(hda)
                     if match:
                         return match.hda
             else:
-                dataset_collection_matcher = DatasetCollectionMatcher(dataset_matcher)
+                dataset_collection_matcher = dataset_matcher_factory.dataset_collection_matcher(dataset_matcher)
                 for hdca in reversed(history.active_dataset_collections):
                     if dataset_collection_matcher.hdca_match(hdca, reduction=self.multiple):
                         return hdca
@@ -1790,7 +1790,8 @@ class DataToolParameter(BaseDataToolParameter):
             return d
 
         # prepare dataset/collection matching
-        dataset_matcher = DatasetMatcher(trans, self, other_values)
+        dataset_matcher_factory = get_dataset_matcher_factory(trans)
+        dataset_matcher = dataset_matcher_factory.dataset_matcher(self, other_values)
         multiple = self.multiple
 
         # build and append a new select option
@@ -1822,7 +1823,7 @@ class DataToolParameter(BaseDataToolParameter):
                 append(d['options']['hda'], hda, '(%s) %s' % (hda_state, hda.name), 'hda', True)
 
         # add dataset collections
-        dataset_collection_matcher = DatasetCollectionMatcher(dataset_matcher)
+        dataset_collection_matcher = dataset_matcher_factory.dataset_collection_matcher(dataset_matcher)
         for hdca in history.active_dataset_collections:
             if dataset_collection_matcher.hdca_match(hdca, reduction=multiple):
                 append(d['options']['hdca'], hdca, hdca.name, 'hdca')
@@ -1859,18 +1860,15 @@ class DataCollectionToolParameter(BaseDataToolParameter):
         dataset_collection_type_descriptions = trans.app.dataset_collections_service.collection_type_descriptions
         return history_query.HistoryQuery.from_parameter(self, dataset_collection_type_descriptions)
 
-    def match_collections(self, trans, history, dataset_matcher):
+    def match_collections(self, trans, history, dataset_collection_matcher):
         dataset_collections = trans.app.dataset_collections_service.history_dataset_collections(history, self._history_query(trans))
-        dataset_collection_matcher = DatasetCollectionMatcher(dataset_matcher)
 
         for dataset_collection_instance in dataset_collections:
             if not dataset_collection_matcher.hdca_match(dataset_collection_instance):
                 continue
             yield dataset_collection_instance
 
-    def match_multirun_collections(self, trans, history, dataset_matcher):
-        dataset_collection_matcher = DatasetCollectionMatcher(dataset_matcher)
-
+    def match_multirun_collections(self, trans, history, dataset_collection_matcher):
         for history_dataset_collection in history.active_dataset_collections:
             if not self._history_query(trans).can_map_over(history_dataset_collection):
                 continue
@@ -1947,10 +1945,12 @@ class DataCollectionToolParameter(BaseDataToolParameter):
             return d
 
         # prepare dataset/collection matching
-        dataset_matcher = DatasetMatcher(trans, self, other_values)
+        dataset_matcher_factory = get_dataset_matcher_factory(trans)
+        dataset_matcher = dataset_matcher_factory.dataset_matcher(self, other_values)
+        dataset_collection_matcher = dataset_matcher_factory.dataset_collection_matcher(dataset_matcher)
 
         # append directly matched collections
-        for hdca in self.match_collections(trans, history, dataset_matcher):
+        for hdca in self.match_collections(trans, history, dataset_collection_matcher):
             d['options']['hdca'].append({
                 'id'   : trans.security.encode_id(hdca.id),
                 'hid'  : hdca.hid,
@@ -1960,7 +1960,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
             })
 
         # append matching subcollections
-        for hdca in self.match_multirun_collections(trans, history, dataset_matcher):
+        for hdca in self.match_multirun_collections(trans, history, dataset_collection_matcher):
             subcollection_type = self._history_query(trans).can_map_over(hdca).collection_type
             d['options']['hdca'].append({
                 'id'   : trans.security.encode_id(hdca.id),

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1492,7 +1492,7 @@ class BaseDataToolParameter(ToolParameter):
                         return match.hda
             else:
                 dataset_collection_matcher = dataset_matcher_factory.dataset_collection_matcher(dataset_matcher)
-                for hdca in reversed(history.active_dataset_collections):
+                for hdca in reversed(history.active_visible_dataset_collections):
                     if dataset_collection_matcher.hdca_match(hdca, reduction=self.multiple):
                         return hdca
 
@@ -1825,7 +1825,7 @@ class DataToolParameter(BaseDataToolParameter):
 
         # add dataset collections
         dataset_collection_matcher = dataset_matcher_factory.dataset_collection_matcher(dataset_matcher)
-        for hdca in history.active_dataset_collections:
+        for hdca in history.active_visible_dataset_collections:
             if dataset_collection_matcher.hdca_match(hdca, reduction=multiple):
                 append(d['options']['hdca'], hdca, hdca.name, 'hdca')
 
@@ -1870,7 +1870,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
             yield dataset_collection_instance
 
     def match_multirun_collections(self, trans, history, dataset_collection_matcher):
-        for history_dataset_collection in history.active_dataset_collections:
+        for history_dataset_collection in history.active_visible_dataset_collections:
             if not self._history_query(trans).can_map_over(history_dataset_collection):
                 continue
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1487,7 +1487,7 @@ class BaseDataToolParameter(ToolParameter):
             dataset_matcher = DatasetMatcher(trans, self, None, other_values)
             if isinstance(self, DataToolParameter):
                 for hda in reversed(history.active_datasets_and_roles):
-                    match = dataset_matcher.hda_match(hda, check_security=False)
+                    match = dataset_matcher.hda_match(hda)
                     if match:
                         return match.hda
             else:
@@ -1812,7 +1812,7 @@ class DataToolParameter(BaseDataToolParameter):
         # add datasets
         hda_list = util.listify(other_values.get(self.name))
         for hda in history.active_datasets_and_roles:
-            match = dataset_matcher.hda_match(hda, check_security=False)
+            match = dataset_matcher.hda_match(hda)
             if match:
                 m = match.hda
                 hda_list = [h for h in hda_list if h != m and h != hda]

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1484,7 +1484,7 @@ class BaseDataToolParameter(ToolParameter):
             return None
         history = trans.history
         if history is not None:
-            dataset_matcher = DatasetMatcher(trans, self, None, other_values)
+            dataset_matcher = DatasetMatcher(trans, self, other_values)
             if isinstance(self, DataToolParameter):
                 for hda in reversed(history.active_datasets_and_roles):
                     match = dataset_matcher.hda_match(hda)
@@ -1797,7 +1797,7 @@ class DataToolParameter(BaseDataToolParameter):
             return d
 
         # prepare dataset/collection matching
-        dataset_matcher = DatasetMatcher(trans, self, None, other_values)
+        dataset_matcher = DatasetMatcher(trans, self, other_values)
         multiple = self.multiple
 
         # build and append a new select option
@@ -1954,7 +1954,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
             return d
 
         # prepare dataset/collection matching
-        dataset_matcher = DatasetMatcher(trans, self, None, other_values)
+        dataset_matcher = DatasetMatcher(trans, self, other_values)
 
         # append directly matched collections
         for hdca in self.match_collections(trans, history, dataset_matcher):

--- a/lib/galaxy/tools/parameters/dataset_matcher.py
+++ b/lib/galaxy/tools/parameters/dataset_matcher.py
@@ -14,11 +14,10 @@ class DatasetMatcher(object):
     and permission handling.
     """
 
-    def __init__(self, trans, param, value, other_values):
+    def __init__(self, trans, param, other_values):
         self.trans = trans
         self.param = param
         self.tool = param.tool
-        self.value = value
         filter_value = None
         if param.options and other_values:
             try:
@@ -65,22 +64,13 @@ class DatasetMatcher(object):
         """
         dataset = hda.dataset
         valid_state = dataset.state in self.valid_input_states
-        if valid_state and (not ensure_visible or hda.visible or (self.selected(hda) and not hda.implicitly_converted_parent_datasets)):
+        if valid_state and (not ensure_visible or hda.visible):
             # If we are sending data to an external application, then we need to make sure there are no roles
             # associated with the dataset that restrict its access from "public".
             require_public = self.tool and self.tool.tool_type == 'data_destination'
             if require_public and not self.trans.app.security_agent.dataset_is_public(dataset):
                 return False
             return self.valid_hda_match(hda, check_implicit_conversions=check_implicit_conversions)
-
-    def selected(self, hda):
-        """ Given value for DataToolParameter, is this HDA "selected".
-        """
-        value = self.value
-        if value and str(value[0]).isdigit():
-            return hda.id in map(int, value)
-        else:
-            return value and hda in value
 
     def filter(self, hda):
         """ Filter out this value based on other values for job (if

--- a/lib/galaxy/tools/parameters/dataset_matcher.py
+++ b/lib/galaxy/tools/parameters/dataset_matcher.py
@@ -67,7 +67,7 @@ class DatasetMatcherFactory(object):
             type_name = type(input).__name__
             if "DataToolParameter" in type_name:
                 self._data_inputs.append(input)
-            elif "DatasetCollectionToolParameter" in type_name:
+            elif "DataCollectionToolParameter" in type_name:
                 self._data_inputs.append(input)
 
         tool.visit_inputs(param_values, visitor)

--- a/lib/galaxy/tools/parameters/dataset_matcher.py
+++ b/lib/galaxy/tools/parameters/dataset_matcher.py
@@ -71,8 +71,6 @@ class DatasetMatcher(object):
             require_public = self.tool and self.tool.tool_type == 'data_destination'
             if require_public and not self.trans.app.security_agent.dataset_is_public(dataset):
                 return False
-            if self.filter(hda):
-                return False
             return self.valid_hda_match(hda, check_implicit_conversions=check_implicit_conversions)
 
     def selected(self, hda):

--- a/test/unit/tools/test_data_parameters.py
+++ b/test/unit/tools/test_data_parameters.py
@@ -1,5 +1,4 @@
 from galaxy import model
-from galaxy.util import bunch
 from .test_parameter_parsing import BaseParameterTestCase
 from ..unittest_utils import galaxy_mock
 
@@ -39,9 +38,9 @@ class DataToolParameterTestCase(BaseParameterTestCase):
         assert field['options']['hda'][0]['name'] == "hda2"
         assert field['options']['hda'][1]['name'] == "hda1"
 
-        hda2.datatype_matches = False
+        hda2.extension = 'data'
         field = self._simple_field()
-        assert len(field['options']['hda']) == 1
+        assert len(field['options']['hda']) == 1, field
         assert field['options']['hda'][0]['name'] == "hda1"
 
     def test_field_display_hidden_hdas_only_if_selected(self):
@@ -66,7 +65,7 @@ class DataToolParameterTestCase(BaseParameterTestCase):
 
     def test_field_implicit_conversion_new(self):
         hda1 = MockHistoryDatasetAssociation(name="hda1", id=1)
-        hda1.datatype_matches = False
+        hda1.extension = 'data'
         hda1.conversion_destination = ("tabular", None)
         self.stub_active_datasets(hda1)
         field = self._simple_field()
@@ -76,7 +75,7 @@ class DataToolParameterTestCase(BaseParameterTestCase):
 
     def test_field_implicit_conversion_existing(self):
         hda1 = MockHistoryDatasetAssociation(name="hda1", id=1)
-        hda1.datatype_matches = False
+        hda1.extension = 'data'
         hda1.conversion_destination = ("tabular", MockHistoryDatasetAssociation(name="hda1converted", id=2))
         self.stub_active_datasets(hda1)
         field = self._simple_field()
@@ -124,7 +123,7 @@ class DataToolParameterTestCase(BaseParameterTestCase):
 
     def test_get_initial_with_previously_converted_data(self):
         hda1 = MockHistoryDatasetAssociation(name="hda1", id=1)
-        hda1.datatype_matches = False
+        hda1.extension = 'data'
         converted = MockHistoryDatasetAssociation(name="hda1converted", id=2)
         hda1.conversion_destination = ("tabular", converted)
         self.stub_active_datasets(hda1)
@@ -132,10 +131,10 @@ class DataToolParameterTestCase(BaseParameterTestCase):
 
     def test_get_initial_with_to_be_converted_data(self):
         hda1 = MockHistoryDatasetAssociation(name="hda1", id=1)
-        hda1.datatype_matches = False
+        hda1.extension = 'data'
         hda1.conversion_destination = ("tabular", None)
         self.stub_active_datasets(hda1)
-        assert hda1 == self.param.get_initial_value(self.trans, {})
+        assert hda1 == self.param.get_initial_value(self.trans, {}), hda1
 
     def _new_hda(self):
         hda = model.HistoryDatasetAssociation()
@@ -170,7 +169,7 @@ class DataToolParameterTestCase(BaseParameterTestCase):
             optional_text = ""
             if self.optional:
                 optional_text = 'optional="True"'
-            template_xml = '''<param name="data2" type="data" ext="txt" %s %s></param>'''
+            template_xml = '''<param name="data2" type="data" format="txt" %s %s></param>'''
             param_str = template_xml % (multi_text, optional_text)
             self._param = self._parameter_for(tool=self.mock_tool, xml=param_str)
 
@@ -190,11 +189,8 @@ class MockHistoryDatasetAssociation(object):
         self.deleted = False
         self.dataset = test_dataset
         self.visible = True
-        self.datatype_matches = True
         self.conversion_destination = (None, None)
-        self.datatype = bunch.Bunch(
-            matches_any=lambda formats: self.datatype_matches,
-        )
+        self.extension = "txt"
         self.dbkey = "hg19"
         self.implicitly_converted_parent_datasets = False
         self.name = name

--- a/test/unit/tools/test_data_parameters.py
+++ b/test/unit/tools/test_data_parameters.py
@@ -156,6 +156,7 @@ class DataToolParameterTestCase(BaseParameterTestCase):
 
     def stub_active_datasets(self, *hdas):
         self.test_history._active_datasets_and_roles = [h for h in hdas if not h.deleted]
+        self.test_history._active_visible_datasets_and_roles = [h for h in hdas if not h.deleted and h.visible]
 
     def _simple_field(self, **kwds):
         return self.param.to_dict(trans=self.trans, **kwds)

--- a/test/unit/tools/test_dataset_matcher.py
+++ b/test/unit/tools/test_dataset_matcher.py
@@ -13,32 +13,6 @@ from ..tools_support import UsesApp
 
 class DatasetMatcherTestCase(TestCase, UsesApp):
 
-    def test_hda_accessible(self):
-        # Cannot access errored or discard datasets.
-        self.mock_hda.dataset.state = model.Dataset.states.ERROR
-        assert not self.test_context.hda_accessible(self.mock_hda)
-
-        self.mock_hda.dataset.state = model.Dataset.states.DISCARDED
-        assert not self.test_context.hda_accessible(self.mock_hda)
-
-        # Can access datasets in other states.
-        self.mock_hda.dataset.state = model.Dataset.states.OK
-        assert self.test_context.hda_accessible(self.mock_hda)
-
-        self.mock_hda.dataset.state = model.Dataset.states.QUEUED
-        assert self.test_context.hda_accessible(self.mock_hda)
-
-        # Cannot access dataset if security agent says no.
-        self.app.security_agent.can_access_dataset = lambda roles, dataset: False
-        assert not self.test_context.hda_accessible(self.mock_hda)
-
-    def test_selected(self):
-        self.test_context.value = []
-        assert not self.test_context.selected(self.mock_hda)
-
-        self.test_context.value = [self.mock_hda]
-        assert self.test_context.selected(self.mock_hda)
-
     def test_hda_mismatches(self):
         # Datasets not visible are not "valid" for param.
         self.mock_hda.visible = False
@@ -46,13 +20,13 @@ class DatasetMatcherTestCase(TestCase, UsesApp):
 
         # Datasets that don't match datatype are not valid.
         self.mock_hda.visible = True
-        self.mock_hda.datatype_matches = False
+        self.mock_hda.extension = 'data'
         assert not self.test_context.hda_match(self.mock_hda)
 
     def test_valid_hda_direct_match(self):
         # Datasets that visible and matching are valid
         self.mock_hda.visible = True
-        self.mock_hda.datatype_matches = True
+        self.mock_hda.extension = 'txt'
         hda_match = self.test_context.hda_match(self.mock_hda, check_implicit_conversions=False)
         assert hda_match
 
@@ -64,7 +38,7 @@ class DatasetMatcherTestCase(TestCase, UsesApp):
     def test_valid_hda_implicit_convered(self):
         # Find conversion returns an HDA to an already implicitly converted
         # dataset.
-        self.mock_hda.datatype_matches = False
+        self.mock_hda.extension = 'data'
         converted_hda = model.HistoryDatasetAssociation()
         self.mock_hda.conversion_destination = ("tabular", converted_hda)
         hda_match = self.test_context.hda_match(self.mock_hda)
@@ -77,7 +51,7 @@ class DatasetMatcherTestCase(TestCase, UsesApp):
     def test_hda_match_implicit_can_convert(self):
         # Find conversion returns a target extension to convert to, but not
         # a previously implicitly converted dataset.
-        self.mock_hda.datatype_matches = False
+        self.mock_hda.extension = 'data'
         self.mock_hda.conversion_destination = ("tabular", None)
         hda_match = self.test_context.hda_match(self.mock_hda)
 
@@ -87,7 +61,7 @@ class DatasetMatcherTestCase(TestCase, UsesApp):
         assert hda_match.target_ext == "tabular"
 
     def test_hda_match_properly_skips_conversion(self):
-        self.mock_hda.datatype_matches = False
+        self.mock_hda.extension = 'data'
         self.mock_hda.conversion_destination = ("tabular", bunch.Bunch())
         hda_match = self.test_context.hda_match(self.mock_hda, check_implicit_conversions=False)
         assert not hda_match
@@ -148,20 +122,18 @@ class DatasetMatcherTestCase(TestCase, UsesApp):
             option_xml = ""
             if self.filtered_param:
                 option_xml = '''<options><filter type="data_meta" ref="data1" key="dbkey" /></options>'''
-            param_xml = XML('''<param name="data2" type="data" ext="txt">%s</param>''' % option_xml)
+            param_xml = XML('''<param name="data2" type="data" format="txt">%s</param>''' % option_xml)
             self.param = basic.DataToolParameter(
                 self.tool,
                 param_xml,
             )
-
-            self._test_context = dataset_matcher.DatasetMatcher(
-                trans=bunch.Bunch(
-                    app=self.app,
-                    get_current_user_roles=lambda: self.current_user_roles,
-                    workflow_building_mode=True,
-                ),
+            trans = bunch.Bunch(
+                app=self.app,
+                get_current_user_roles=lambda: self.current_user_roles,
+                workflow_building_mode=True,
+            )
+            self._test_context = dataset_matcher.get_dataset_matcher_factory(trans).dataset_matcher(
                 param=self.param,
-                value=[],
                 other_values=self.other_values
             )
 


### PR DESCRIPTION
See commits for details I tried to keep them pretty clean and focused. The tl;dr however is:

- Load many fewer datasets and fewer collections. 
- When possible use summary information from custom crafted postgres queries instead of loading datasets to check things like are the dataset states okay, are the extensions compatible with a tool parameter, is the collection "populated".
- Cache more.

This implements #5987 for the biggest performance fixes by far - in short "when possible" collections are summarized and their summaries are checked against input parameters instead of individual datasets. Based on my reading of the code, I believe this will work for "most" tools - but there are some tools that will require checking every dataset. Namely tools that contain a data parameter with an ``<options`` element insider the data parameter. Mostly ``<options`` are placed in select parameters and those are fine - the kind of pattern that you do see in some tools that forces whole collection loading still is typically something like:

```xml
<param name="reference_genome" type="select" label="Using reference genome">
  <options from_data_table="all_fasta">
    <filter type="data_meta" key="dbkey" ref="expt" column="1"/>
  </options>
```

This pattern does appear on some older devteam mappers, but for the most part IUC tools don't seem to use it much.

Unfortunately, I think even something like this data parameter from the gemini suite would trigger a full collection load:

```xml
        <param name="infile" type="data" format="vcf" label="VCF file to be loaded in the GEMINI database" help="Only \
build 37 (aka hg19) of the human genome is supported.">
            <options>
                <filter type="add_value" value="hg19" />
                <filter type="add_value" value="Homo_sapiens_nuHg19_mtrCRS" />
                <filter type="add_value" value="hg_g1k_v37" />
            </options>
        </param>
```

Both of these cases should be possible to roll into the summary approach also - if we can translate HistoryDatasetAssociation method calls to database column queries. But I think this is a solid start and should make large collections a lot more usable within the tool form for a vast majority of tools.

Also - there are some refactoring/cleanup commits in here which normally I wouldn't include in a bug fix PR but the dataset matcher concept is quite a mess and required major surgery to implement this so I thought these were needed.
