### PR TITLE
[18.01] Correct uWSGI UNIX domain socket syntax in docs

### DIFF
--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -231,7 +231,7 @@ To use the native uWSGI protocol, set the `socket` option:
 
 ```yaml
     # listening options
-    socket: unix:///srv/galaxy/var/uwsgi.sock
+    socket: /srv/galaxy/var/uwsgi.sock
 ```
 
 Here we've used a UNIX domain socket because there's less overhead than a TCP socket and it can be secured by filesystem


### PR DESCRIPTION
[As reported on Biostar](https://biostar.usegalaxy.org/p/27723/). This was maybe the cause of @pvanheus's [issue](http://pvh.wp.sanbi.ac.za/2018/03/18/galaxy-18-01-install/) with the socket as well.