### PR TITLE
[18.01] Handle Slurm 17.11's OUT_OF_MEMORY job state

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -26,6 +26,10 @@ SLURM_MEMORY_LIMIT_EXCEEDED_PARTIAL_WARNINGS = [': Exceeded job memory limit at 
                                                 ': Exceeded step memory limit at some point.']
 SLURM_MEMORY_LIMIT_SCAN_SIZE = 16 * 1024 * 1024  # 16MB
 
+# These messages are returned to the user
+OUT_OF_MEMORY_MSG = 'This job was terminated because it used more memory than it was allocated.'
+PROBABLY_OUT_OF_MEMORY_MSG = 'This job was cancelled probably because it used more memory than it was allocated.'
+
 
 class SlurmJobRunner(DRMAAJobRunner):
     runner_name = "SlurmRunner"
@@ -33,7 +37,7 @@ class SlurmJobRunner(DRMAAJobRunner):
 
     def _complete_terminal_job(self, ajs, drmaa_state, **kwargs):
         def _get_slurm_state_with_sacct(job_id, cluster):
-            cmd = ['sacct', '-n', '-o state']
+            cmd = ['sacct', '-n', '-o state%-32']
             if cluster:
                 cmd.extend(['-M', cluster])
             cmd.extend(['-j', job_id])
@@ -49,8 +53,8 @@ class SlurmJobRunner(DRMAAJobRunner):
             # Second line is for 'job_id.batch' (only available after the batch job is complete)
             # Following lines are for the steps 'job_id.0', 'job_id.1', ... (but Galaxy does not use steps)
             first_line = stdout.splitlines()[0]
-            # Strip whitespaces and the final '+' (if present)
-            return first_line.strip().rstrip('+')
+            # Strip whitespaces and the final '+' (if present), only return the first word
+            return first_line.strip().rstrip('+').split()[0]
 
         def _get_slurm_state():
             cmd = ['scontrol', '-o']
@@ -106,11 +110,15 @@ class SlurmJobRunner(DRMAAJobRunner):
                         return
                     except Exception:
                         ajs.fail_message = "This job failed due to a cluster node failure, and an attempt to resubmit the job failed."
+                elif slurm_state == 'OUT_OF_MEMORY':
+                    log.info('(%s/%s) Job hit memory limit (SLURM state: OUT_OF_MEMORY)', ajs.job_wrapper.get_id_tag(), ajs.job_id)
+                    ajs.fail_message = OUT_OF_MEMORY_MSG
+                    ajs.runner_state = ajs.runner_states.MEMORY_LIMIT_REACHED
                 elif slurm_state == 'CANCELLED':
                     # Check to see if the job was killed for exceeding memory consumption
                     check_memory_limit_msg = self.__check_memory_limit(ajs.error_file)
                     if check_memory_limit_msg:
-                        log.info('(%s/%s) Job hit memory limit', ajs.job_wrapper.get_id_tag(), ajs.job_id)
+                        log.info('(%s/%s) Job hit memory limit (SLURM state: CANCELLED)', ajs.job_wrapper.get_id_tag(), ajs.job_id)
                         ajs.fail_message = check_memory_limit_msg
                         ajs.runner_state = ajs.runner_states.MEMORY_LIMIT_REACHED
                     else:
@@ -161,9 +169,9 @@ class SlurmJobRunner(DRMAAJobRunner):
                 for line in f.readlines():
                     stripped_line = line.strip()
                     if stripped_line == SLURM_MEMORY_LIMIT_EXCEEDED_MSG:
-                        return 'This job was terminated because it used more memory than it was allocated.'
+                        return OUT_OF_MEMORY_MSG
                     elif any(_ in stripped_line for _ in SLURM_MEMORY_LIMIT_EXCEEDED_PARTIAL_WARNINGS):
-                        return 'This job was cancelled probably because it used more memory than it was allocated.'
+                        return PROBABLY_OUT_OF_MEMORY_MSG
         except Exception:
             log.exception('Error reading end of %s:', efile_path)
 


### PR DESCRIPTION
Also, only use the first word of the state (if the job is cancelled, the `sacct` state will be `CANCELLED by <UID>`), and make the state field long enough so the state is not truncated (apparently there's no do-not-truncate argument to `sacct`).

Jobs that fail for `OUT_OF_MEMORY` will not be detected until after they expire due to `MinJobAge`. A fix for this will need to be made in slurm-drmaa, see: natefoo/slurm-drmaa#12