### PR TITLE
Remove duplicate metric sending

### DIFF
--- a/lib/galaxy/web/framework/middleware/graphite.py
+++ b/lib/galaxy/web/framework/middleware/graphite.py
@@ -47,7 +47,6 @@ class GraphiteMiddleware(object):
         dt = int((time.time() - start_time) * 1000)
         try:
             self.graphite_client.send(environ.get('controller_action_key', None) or environ.get('PATH_INFO', "NOPATH").strip('/').replace('/', '.'), dt)
-            self.graphite_client.send('__global__', dt)
         except graphitesend.GraphiteSendException:
             log.exception("Graphite Error")
         return req

--- a/lib/galaxy/web/framework/middleware/statsd.py
+++ b/lib/galaxy/web/framework/middleware/statsd.py
@@ -42,5 +42,4 @@ class StatsdMiddleware(object):
 
         page = environ.get('controller_action_key', None) or environ.get('PATH_INFO', "NOPATH").strip('/').replace('/', '.')
         self.statsd_client.timing(self.metric_infix + page, dt)
-        self.statsd_client.timing(self.metric_infix + '__global__', dt)
         return req


### PR DESCRIPTION
I added this *terrible* feature in #4758 because there was no other solution at the time. With the advent of #5742 and all of our metrics now under tags in a single "measurement", rather than spread across N measurements, this feature is no longer needed and we can save the bandwidth/computation time/etc and just not send it.

Here is the preferred current grafana configuration which is a lot less hassle.

![auswahl_067](https://user-images.githubusercontent.com/458683/39423543-e8c64a50-4c61-11e8-98b5-f4508707d49c.png)
