### PR TITLE
[18.05] Alter the type of extra_data column of OIDC table.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4619,10 +4619,6 @@ class UserAuthnzToken(UserMixin):
         return self.extra_data.get('access_token', None) if self.extra_data is not None else None
 
     def set_extra_data(self, extra_data=None):
-        # Note: the following unicode conversion is a temporary solution for a
-        # database binding error (InterfaceError: (sqlite3.InterfaceError)).
-        if extra_data is not None:
-            extra_data = str(extra_data)
         if super(UserAuthnzToken, self).set_extra_data(extra_data):
             self.trans.sa_session.add(self)
             self.trans.sa_session.flush()

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -129,7 +129,7 @@ model.UserAuthnzToken.table = Table(
     Column('user_id', Integer, ForeignKey("galaxy_user.id"), index=True),
     Column('uid', VARCHAR(255)),
     Column('provider', VARCHAR(32)),
-    Column('extra_data', TEXT),
+    Column('extra_data', JSONType, nullable=True),
     Column('lifetime', Integer),
     Column('assoc_type', VARCHAR(64)))
 

--- a/lib/galaxy/model/migrate/versions/0142_alter_oidc_extradata_column.py
+++ b/lib/galaxy/model/migrate/versions/0142_alter_oidc_extradata_column.py
@@ -1,0 +1,37 @@
+"""
+Migration script to alter the type of `extra_data` column of `oidc_user_authnz_tokens` table from TEXT to JSON.
+"""
+from __future__ import print_function
+
+import logging
+
+from sqlalchemy import MetaData, Table, TEXT
+
+from galaxy.model.custom_types import JSONType
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        table = Table("oidc_user_authnz_tokens", metadata, autoload=True)
+        table.c.extra_data.alter(type=JSONType, nullable=True)
+    except Exception as e:
+        log.exception("Altering the `extra_data` column type from TEXT to JSON failed: %s" % str(e))
+
+
+def downgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        table = Table("oidc_user_authnz_tokens", metadata, autoload=True)
+        table.c.extra_data.alter(type=TEXT)
+    except Exception as e:
+        log.exception("Altering the `extra_data` column type from JSON to TEXT failed: %s" % str(e))


### PR DESCRIPTION
The `extra_data` column of `oidc_user_authnz_tokens` table contains a JSON object with all the info related to a user authentication. This PR changes this column type to `JSONType`. 