### PR TITLE
[18.05] Fix grid pagination style

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1060,7 +1060,7 @@ div.debug {
     -webkit-border-radius: 0.5em;
     font-style: italic;
 }
-.page-link a,
+.page-link-grid a,
 .inactive-link {
     padding: 0px 7px 0px 7px;
     color: #555;

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -13279,7 +13279,7 @@ div.debug {
   -webkit-border-radius: 0.5em;
   font-style: italic; }
 
-.page-link a,
+.page-link-grid a,
 .inactive-link {
   padding: 0px 7px 0px 7px;
   color: #555; }


### PR DESCRIPTION
Is this the proper fix @guerler ? The other cases for `page-link` seem to be in the legacy grid, is it used somewhere?

reported by @natefoo 