### PR TITLE
Add hostname metric

### DIFF
--- a/config/job_metrics_conf.xml.sample
+++ b/config/job_metrics_conf.xml.sample
@@ -42,7 +42,7 @@
   <!-- <cgroup /> -->
   <!-- <cgroup verbose="true" /> -->
 
-  <!-- Uncomment to record hostname - linux only -->
+  <!-- Uncomment to record hostname - *nix only -->
   <!-- <hostname /> -->
 
   <!-- <collectl /> -->

--- a/config/job_metrics_conf.xml.sample
+++ b/config/job_metrics_conf.xml.sample
@@ -42,6 +42,9 @@
   <!-- <cgroup /> -->
   <!-- <cgroup verbose="true" /> -->
 
+  <!-- Uncomment to record hostname - linux only -->
+  <!-- <hostname /> -->
+
   <!-- <collectl /> -->
   <!-- Collectl (http://collectl.sourceforge.net/) is a powerful monitoring
        utility capable of gathering numerous system and process level

--- a/lib/galaxy/jobs/metrics/instrumenters/cgroup.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/cgroup.py
@@ -2,8 +2,8 @@
 import logging
 
 from galaxy.util import asbool, nice_size
-from ..instrumenters import InstrumentPlugin
-from ...metrics import formatting
+from . import InstrumentPlugin
+from .. import formatting
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/jobs/metrics/instrumenters/collectl.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/collectl.py
@@ -9,8 +9,8 @@ from ..collectl import (
     processes,
     subsystems
 )
-from ..instrumenters import InstrumentPlugin
-from ...metrics import formatting
+from . import InstrumentPlugin
+from .. import formatting
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/jobs/metrics/instrumenters/collectl.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/collectl.py
@@ -4,13 +4,13 @@ import os
 import shutil
 
 from galaxy import util
+from . import InstrumentPlugin
+from .. import formatting
 from ..collectl import (
     cli,
     processes,
     subsystems
 )
-from . import InstrumentPlugin
-from .. import formatting
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/jobs/metrics/instrumenters/core.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/core.py
@@ -2,8 +2,8 @@
 import logging
 import time
 
-from ..instrumenters import InstrumentPlugin
-from ...metrics import formatting
+from . import InstrumentPlugin
+from .. import formatting
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/jobs/metrics/instrumenters/cpuinfo.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/cpuinfo.py
@@ -3,8 +3,8 @@ import logging
 import re
 
 from galaxy import util
-from ..instrumenters import InstrumentPlugin
-from ...metrics import formatting
+from . import InstrumentPlugin
+from .. import formatting
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/jobs/metrics/instrumenters/env.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/env.py
@@ -2,8 +2,8 @@
 import logging
 import re
 
-from ..instrumenters import InstrumentPlugin
-from ...metrics import formatting
+from . import InstrumentPlugin
+from .. import formatting
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/jobs/metrics/instrumenters/hostname.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/hostname.py
@@ -1,8 +1,8 @@
 """The module describes the ``cpuinfo`` job metrics plugin."""
 import logging
 
-from ..instrumenters import InstrumentPlugin
-from ...metrics import formatting
+from . import InstrumentPlugin
+from .. import formatting
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/jobs/metrics/instrumenters/hostname.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/hostname.py
@@ -1,0 +1,36 @@
+"""The module describes the ``cpuinfo`` job metrics plugin."""
+import logging
+
+from ..instrumenters import InstrumentPlugin
+from ...metrics import formatting
+
+log = logging.getLogger(__name__)
+
+
+class HostnameFormatter(formatting.JobMetricFormatter):
+
+    def format(self, key, value):
+        return key, value
+
+
+class HostnamePlugin(InstrumentPlugin):
+    """ Gather hostname
+    """
+    plugin_type = "hostname"
+    formatter = HostnameFormatter()
+
+    def __init__(self, **kwargs):
+        pass
+
+    def pre_execute_instrument(self, job_directory):
+        return "hostname -f > '%s'" % self.__instrument_hostname_path(job_directory)
+
+    def job_properties(self, job_id, job_directory):
+        with open(self.__instrument_hostname_path(job_directory)) as f:
+            return {'hostname': f.read().strip()}
+
+    def __instrument_hostname_path(self, job_directory):
+        return self._instrument_file_path(job_directory, "hostname")
+
+
+__all__ = ('HostnamePlugin', )

--- a/lib/galaxy/jobs/metrics/instrumenters/meminfo.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/meminfo.py
@@ -3,8 +3,8 @@ import re
 import sys
 
 from galaxy import util
-from ..instrumenters import InstrumentPlugin
-from ...metrics import formatting
+from . import InstrumentPlugin
+from .. import formatting
 
 if sys.version_info > (3,):
     long = int

--- a/lib/galaxy/jobs/metrics/instrumenters/uname.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/uname.py
@@ -1,6 +1,6 @@
 """The module describes the ``uname`` job metrics plugin."""
-from ..instrumenters import InstrumentPlugin
-from ...metrics import formatting
+from . import InstrumentPlugin
+from .. import formatting
 
 
 class UnameFormatter(formatting.JobMetricFormatter):


### PR DESCRIPTION
We tried the env metric with `HOSTNAME` but this isn't set for us for the htcondor runner. We originally had been using env+hostname, but this was always set to the value of the head node which is wrong. So we tried `unset HOSTNAME` before launching galaxy and now it's just not set at all.

So this seemed like the easy solution.