### PR TITLE
[18.05] Docker fixes - release 18.05 edition.

### DIFF
--- a/.ci/jenkins/selenium/run_tests.sh
+++ b/.ci/jenkins/selenium/run_tests.sh
@@ -17,12 +17,18 @@ fi
 mkdir -p "$GALAXY_TEST_ERRORS_DIRECTORY"
 mkdir -p "$GALAXY_TEST_SCREENSHOTS_DIRECTORY"
 
-# /etc/passwd hack needed as long as make client requires git.
-# https://github.com/galaxyproject/galaxy/issues/5912
-docker run -v /etc/passwd:/etc/passwd -v `pwd`:`pwd`:rw -w `pwd` -u $UID $GALAXY_TEST_CLIENT_BUILD_IMAGE /bin/bash -c 'make client-production-maps'
+mkdir -p ~/.jenkins-yarn-cache
+YARN_CACHE_FOLDER=~/.jenkins-yarn-cache
+
+# Set git environment variables to enable Git. https://github.com/galaxyproject/galaxy/issues/5912
+# Setup volume and environment variable to cache this users yarn build.
+docker run -e GIT_COMMITTER_NAME=Jenkins -e GIT_COMMITTER_EMAIL=jenkins@galaxyproject.org \
+           -e YARN_CACHE_FOLDER=$YARN_CACHE_FOLDER -v $YARN_CACHE_FOLDER:$YARN_CACHE_FOLDER:rw \
+           -v `pwd`:`pwd`:rw -w `pwd` -u $UID $GALAXY_TEST_CLIENT_BUILD_IMAGE \
+           /bin/bash -c 'make client-production-maps'
 
 # Start Selenium server in the test Docker container.
-DOCKER_RUN_EXTRA_ARGS="-e USE_SELENIUM=1 -e GALAXY_TEST_SELENIUM_RETRIES=${GALAXY_TEST_SELENIUM_RETRIES} -e GALAXY_TEST_ERRORS_DIRECTORY=${GALAXY_TEST_ERRORS_DIRECTORY} -e GALAXY_TEST_SCREENSHOTS_DIRECTORY=${GALAXY_TEST_SCREENSHOTS_DIRECTORY} ${DOCKER_RUN_EXTRA_ARGS}"
+DOCKER_RUN_EXTRA_ARGS="-v $YARN_CACHE_FOLDER:$YARN_CACHE_FOLDER -e YARN_CACHE_FOLDER=$YARN_CACHE_FOLDER -e USE_SELENIUM=1 -e GALAXY_TEST_SELENIUM_RETRIES=${GALAXY_TEST_SELENIUM_RETRIES} -e GALAXY_TEST_ERRORS_DIRECTORY=${GALAXY_TEST_ERRORS_DIRECTORY} -e GALAXY_TEST_SCREENSHOTS_DIRECTORY=${GALAXY_TEST_SCREENSHOTS_DIRECTORY} ${DOCKER_RUN_EXTRA_ARGS}"
 export DOCKER_RUN_EXTRA_ARGS
 
 ./run_tests.sh --dockerize --db postgres --external_tmp --clean_pyc --skip_flakey_fails --selenium "$@"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -257,7 +257,7 @@ exists() {
     type "$1" >/dev/null 2>/dev/null
 }
 
-DOCKER_DEFAULT_IMAGE='galaxy/testing-base:18.01.4'
+DOCKER_DEFAULT_IMAGE='galaxy/testing-base:18.05.3'
 
 test_script="./scripts/functional_tests.py"
 report_file="run_functional_tests.html"

--- a/test/docker/base/Dockerfile
+++ b/test/docker/base/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
 MAINTAINER John Chilton <jmchilton@gmail.com>
 
-ARG CHROME_VERSION="google-chrome-stable"
-ARG CHROME_DRIVER_VERSION="2.35"
+ARG CHROME_VERSION="google-chrome-beta"
+ARG CHROME_DRIVER_VERSION="2.38"
 
 # TODO: merge with first ENV statement.
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -30,10 +30,10 @@ RUN apt-get update -y && apt-get install -y software-properties-common apt-trans
     apt-get update -y && \
     apt-get install -y libpq-dev postgresql postgresql-client \
             ansible wget mysql-server="${MYSQL_MAJOR}"* libmysqlclient-dev="${MYSQL_MAJOR}"* \
-            slurm-llnl libmunge-dev slurm-drmaa-dev ant atop axel bioperl cmake curl \
-            g++ gcc gfortran git-core htop iftop iotop ipython libffi-dev liblapack-dev \
+            slurm-llnl libmunge-dev slurm-drmaa-dev ant cmake curl \
+            g++ gcc gfortran git-core libffi-dev liblapack-dev \
             libncurses5-dev libopenblas-dev libpam0g-dev libpq-dev libsparsehash-dev make \
-            mercurial nginx-extras nmon patch postgresql postgresql \
+            mercurial nginx-extras patch postgresql postgresql \
             postgresql-client python-boto python-dev \
             python-prettytable python-psycopg2 python-virtualenv python-pip \
             rsync slurm-drmaa-dev swig sysstat unzip \

--- a/test/docker/base/ansible_vars.yml
+++ b/test/docker/base/ansible_vars.yml
@@ -19,7 +19,8 @@ galaxy_config_file: "{{ galaxy_server_dir }}/config/galaxy.ini"
 configure_docker: no
 postgresql_bin_dir: /usr/lib/postgresql/9.5/bin
 galaxy_manage_database: no
-
+# avoid some packages unneeded packages install by ansible-galaxy-os
+install_maintainance_packages: false
 galaxy_user_name: "root"
 galaxy_extras_install_packages: true
 galaxy_job_conf_path: "/etc/galaxy/job_conf.xml"

--- a/test/docker/base/run_test_wrapper.sh
+++ b/test/docker/base/run_test_wrapper.sh
@@ -3,20 +3,8 @@ set -e
 
 if [ ! -z "$USE_SELENIUM" ];
 then
-    sudo -E -u seluser /opt/bin/entry_point.sh &
-    # TODO:...
-    while ! curl -s "http://localhost:4444";
-    do
-        printf "."
-        sleep 4;
-    done;
-    GALAXY_TEST_SELENIUM_REMOTE=1
-    GALAXY_TEST_SELENIUM_REMOTE_HOST=localhost
-    GALAXY_TEST_SELENIUM_REMOTE_PORT=4444
-
-    export GALAXY_TEST_SELENIUM_REMOTE
-    export GALAXY_TEST_SELENIUM_REMOTE_HOST
-    export GALAXY_TEST_SELENIUM_REMOTE_PORT
+    # Start Selenium.
+    sudo -H -E -u seluser /opt/bin/entry_point.sh &
 fi
 
 echo "Deleting galaxy user - it may not exist and this is fine."
@@ -75,6 +63,22 @@ sudo -E -u "#${GALAXY_TEST_UID}" GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION="$GA
 echo "Upgrading tool shed database... $TOOL_SHED_CONFIG_OVERRIDE_DATABASE_CONNECTION"
 sudo -E -u "#${GALAXY_TEST_UID}" TOOL_SHED_CONFIG_OVERRIDE_DATABASE_CONNECTION="$TOOL_SHED_TEST_DBURI" sh manage_db.sh upgrade tool_shed
 
+# Ensure Selenium is running before starting tests.
+if [ ! -z "$USE_SELENIUM" ];
+then
+    while ! curl -s "http://localhost:4444";
+    do
+        printf "."
+        sleep 4;
+    done;
+    GALAXY_TEST_SELENIUM_REMOTE=1
+    GALAXY_TEST_SELENIUM_REMOTE_HOST=localhost
+    GALAXY_TEST_SELENIUM_REMOTE_PORT=4444
+
+    export GALAXY_TEST_SELENIUM_REMOTE
+    export GALAXY_TEST_SELENIUM_REMOTE_HOST
+    export GALAXY_TEST_SELENIUM_REMOTE_PORT
+fi
 
 if [ -z "$GALAXY_NO_TESTS" ];
 then


### PR DESCRIPTION
- Rev to new container with 18.05 Python dependencies pre-installed.
- Enable caching of Yarn stuffs to speed up the start of tests.
- Redo fix for git not working in node container - was mounting /etc/passwd but that wasn't compatible with Mac OS X, setting these environment variables are.
- Rearrange startup script a bit to make it load faster (wait for Selenium right before the tests not before waiting for DB).
- Fix random error in logs related to Selenium trying to read something in /root by passing -H to set the Selenium user's home directory.