### PR TITLE
Pause jobs with invalid inputs

### DIFF
--- a/client/galaxy/scripts/mvc/dataset/dataset-li.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li.js
@@ -502,7 +502,8 @@ DatasetListItemView.prototype.templates = (() => {
         "dataset"
     );
     summaryTemplates[STATES.PAUSED] = BASE_MVC.wrapTemplate(
-        ["<div>", _l('This job is paused. Use the "Resume Paused Jobs" in the history menu to resume'), "</div>"],
+        ["<div>", _l('This job is paused. Use the "Resume Paused Jobs" in the history menu to resume'), "</div>",
+        '<div><%- dataset.misc_info %></div>'],
         "dataset"
     );
     summaryTemplates[STATES.ERROR] = BASE_MVC.wrapTemplate(

--- a/client/galaxy/scripts/mvc/dataset/dataset-li.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li.js
@@ -503,7 +503,7 @@ DatasetListItemView.prototype.templates = (() => {
     );
     summaryTemplates[STATES.PAUSED] = BASE_MVC.wrapTemplate(
         ["<div>", _l('This job is paused. Use the "Resume Paused Jobs" in the history menu to resume'), "</div>",
-        '<div><%- dataset.misc_info %></div>'],
+        '<div class="info"><%- dataset.misc_info %></div>'],
         "dataset"
     );
     summaryTemplates[STATES.ERROR] = BASE_MVC.wrapTemplate(

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import os
 import time
+from collections import defaultdict
 
 from six.moves.queue import (
     Empty,
@@ -237,20 +238,16 @@ class JobHandlerQueue(Monitors):
                 .join(model.JobToInputDatasetAssociation) \
                 .join(model.HistoryDatasetAssociation) \
                 .join(model.Dataset) \
-                .filter(and_((model.Job.state == model.Job.states.NEW),
-                             or_((model.HistoryDatasetAssociation._state == model.HistoryDatasetAssociation.states.FAILED_METADATA),
-                                 (model.HistoryDatasetAssociation.deleted == true()),
-                                 (model.Dataset.state != model.Dataset.states.OK),
-                                 (model.Dataset.deleted == true())))).subquery()
+                .filter(and_(model.Job.state == model.Job.states.NEW,
+                             model.Dataset.state.in_(model.Dataset.non_ready_states))).subquery()
             ldda_not_ready = self.sa_session.query(model.Job.id).enable_eagerloads(False) \
                 .join(model.JobToInputLibraryDatasetAssociation) \
                 .join(model.LibraryDatasetDatasetAssociation) \
                 .join(model.Dataset) \
                 .filter(and_((model.Job.state == model.Job.states.NEW),
                         or_((model.LibraryDatasetDatasetAssociation._state != null()),
-                            (model.LibraryDatasetDatasetAssociation.deleted == true()),
-                            (model.Dataset.state != model.Dataset.states.OK),
-                            (model.Dataset.deleted == true())))).subquery()
+                            (model.Dataset.state.in_(model.Dataset.non_ready_states)),
+                            ))).subquery()
             if self.app.config.user_activation_on:
                 jobs_to_check = self.sa_session.query(model.Job).enable_eagerloads(False) \
                     .outerjoin(model.User) \
@@ -267,6 +264,8 @@ class JobHandlerQueue(Monitors):
                                  ~model.Job.table.c.id.in_(hda_not_ready),
                                  ~model.Job.table.c.id.in_(ldda_not_ready))) \
                     .order_by(model.Job.id).all()
+            # Filter jobs with invalid input states
+            jobs_to_check = self.__filter_jobs_with_invalid_input_states(jobs_to_check)
             # Fetch all "resubmit" jobs
             resubmit_jobs = self.sa_session.query(model.Job).enable_eagerloads(False) \
                 .filter(and_((model.Job.state == model.Job.states.RESUBMITTED),
@@ -365,6 +364,47 @@ class JobHandlerQueue(Monitors):
         self.sa_session.flush()
         # Done with the session
         self.sa_session.remove()
+
+    def __filter_jobs_with_invalid_input_states(self, jobs):
+        """
+        Takes  list of jobs and filters out jobs whose input datasets are in invalid state and
+        set these jobs and their dependent jobs to paused.
+        """
+        job_ids_to_check = [j.id for j in jobs]
+        queries = []
+        for job_to_input, input_association in [(model.JobToInputDatasetAssociation, model.HistoryDatasetAssociation),
+                                                (model.JobToInputLibraryDatasetAssociation, model.LibraryDatasetDatasetAssociation)]:
+            q = self.sa_session.query(
+                model.Job.id,
+                input_association.deleted,
+                input_association._state,
+                input_association.name,
+                model.Dataset.deleted,
+                model.Dataset.state,
+            ).join(job_to_input) \
+                .join(input_association) \
+                .join(model.Dataset) \
+                .filter(model.Job.id.in_(job_ids_to_check)) \
+                .filter(or_(model.Dataset.deleted == true(),
+                            model.Dataset.state != model.Dataset.states.OK,
+                            input_association.deleted == true(),
+                            input_association._state == input_association.states.FAILED_METADATA
+                            )).all()
+            queries.extend(q)
+        jobs_with_invalid_input_states = defaultdict(list)
+        for (job_id, hda_deleted, hda_state, hda_name, dataset_deleted, dataset_state) in queries:
+            if hda_deleted or dataset_deleted:
+                jobs_with_invalid_input_states[job_id].append("Input dataset '%s' was deleted before the job started" % (hda_name))
+            elif hda_state == model.HistoryDatasetAssociation.states.FAILED_METADATA:
+                jobs_with_invalid_input_states[job_id].append("Input dataset '%s' failed to properly set metadata" % (hda_name))
+            elif dataset_state != model.Dataset.states.OK:
+                jobs_with_invalid_input_states[job_id].append("Input dataset '%s' is in %s state" % (hda_name, dataset_state))
+        for job_id in sorted(jobs_with_invalid_input_states.keys()):
+            pause_string = ", ".join(jobs_with_invalid_input_states[job_id])
+            pause_string = "%s. To resume this job fix the input dataset(s)." % pause_string
+            job, job_wrapper = self.job_pair_for_id(job_id)
+            job_wrapper.pause(job=job, message=pause_string)
+        return [j for j in jobs if j.id not in jobs_with_invalid_input_states]
 
     def __check_job_state(self, job):
         """

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1517,8 +1517,12 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName):
     def resume_paused_jobs(self):
         for dataset in self.datasets:
             job = dataset.creating_job
-            if job is not None and job.state == Job.states.PAUSED:
-                job.set_state(Job.states.NEW)
+            if job is not None:
+                if job.state == Job.states.PAUSED:
+                    job.set_state(Job.states.NEW)
+                if job.state in (Job.states.NEW, Job.states.PAUSED):
+                    # Reset any message
+                    dataset.info = None
 
     @hybrid.hybrid_property
     def disk_size(self):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -822,6 +822,15 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable):
                 dataset.peek = 'Job deleted'
                 dataset.info = 'Job output deleted by user before job completed'
 
+    def resume(self, flush=True):
+        if self.state == self.states.PAUSED:
+            self.set_state(self.states.NEW)
+            object_session(self).add(self)
+            for dataset in self.output_datasets:
+                dataset.info = None
+            if flush:
+                object_session(self).flush()
+
     def to_dict(self, view='collection', system_details=False):
         rval = super(Job, self).to_dict(view=view)
         rval['tool_id'] = self.tool_id
@@ -1515,14 +1524,18 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName):
             dataset.mark_unhidden()
 
     def resume_paused_jobs(self):
-        for dataset in self.datasets:
-            job = dataset.creating_job
-            if job is not None:
-                if job.state == Job.states.PAUSED:
-                    job.set_state(Job.states.NEW)
-                if job.state in (Job.states.NEW, Job.states.PAUSED):
-                    # Reset any message
-                    dataset.info = None
+        job = None
+        for i, job in self.paused_jobs:
+            job.resume(flush=False)
+        if job is not None:
+            # We'll flush once if there was a paused job
+            object_session(job).flush()
+
+    @property
+    def paused_jobs(self):
+        db_session = object_session(self)
+        return db_session.query(Job).filter(Job.history_id == self.id,
+                                            Job.state == Job.states.PAUSED).all()
 
     @hybrid.hybrid_property
     def disk_size(self):

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -1561,6 +1561,8 @@ steps:
         $link: first_cat#out_file1
 """)
             DELETED = 0
+            PAUSED_1 = 3
+            PAUSED_2 = 5
             hdca1 = self.dataset_collection_populator.create_list_in_history(history_id,
                                                                              contents=[("sample1-1", "1 2 3")]).json()
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
@@ -1578,8 +1580,8 @@ steps:
             self.dataset_populator.wait_for_history(history_id, assert_ok=False)
             contents = self.__history_contents(history_id)
             assert contents[DELETED]['deleted']
-            assert contents[3]['state'] == 'paused'
-            assert contents[5]['state'] == 'paused'
+            assert contents[PAUSED_1]['state'] == 'paused'
+            assert contents[PAUSED_2]['state'] == 'paused'
 
     def test_run_with_implicit_connection(self):
         with self.dataset_populator.test_history() as history_id:

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -1577,7 +1577,7 @@ steps:
             self._assert_status_code_is(r, 200)
             # If this starts failing we may have prevented running workflows on collections with deleted members,
             # in which case we can disable this test.
-            self.dataset_populator.wait_for_history(history_id, assert_ok=False)
+            self.dataset_populator.wait_for_history_jobs(history_id, assert_ok=False)
             contents = self.__history_contents(history_id)
             assert contents[DELETED]['deleted']
             assert contents[PAUSED_1]['state'] == 'paused'


### PR DESCRIPTION
Otherwise these jobs may hang around forever/until the admin
does a cleanup. This is probably preferable for users as well,
as the pause message gives a hint of why their job didn't start
running. Fixes #6022
and would minimize maintenance as outlined in #5944.

I'm working on tests, but one easy way to test this is create a collection
through the list builder interface, then delete the source HDAs.
Then run a workflow on the collection and without this commit
the outputs get created but the job just hangs around indefinetely.
With the PR the steps consuming the collection and the subsequent jobs
will be paused.

This should also help with deleting histories for running workflows and other edge cases.