### PR TITLE
[18.05] Fix for building doubly nested collections.

### DIFF
--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -1537,6 +1537,7 @@ export default {
                                 subcollection[subElementProp] = childCollectionElements;
                                 subcollection.collection_type = collectionTypeAtDepth;
                                 elementsAtDepth = childCollectionElements;
+                                identifiersAtDepth = identifiersAtDepth[identifier];
                             }
                         }
                     }


### PR DESCRIPTION
The late addition of validation code added for identifier uniqueness checking broke this I think.

Might fix #6044 but hard to say because my exception was a bit different than that one (I only have one pair though).