### PR TITLE
[18.01] More tool state performance fixes.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1822,6 +1822,7 @@ class Tool(object, Dictifiable):
         if self.input_translator:
             self.input_translator.translate(params)
 
+        set_dataset_matcher_factory(request_context, self)
         # create tool state
         state_inputs = {}
         state_errors = {}
@@ -1830,7 +1831,6 @@ class Tool(object, Dictifiable):
         # create tool model
         tool_model = self.to_dict(request_context)
         tool_model['inputs'] = []
-        set_dataset_matcher_factory(request_context, self, state_inputs)
         self.populate_model(request_context, self.inputs, state_inputs, tool_model['inputs'])
         unset_dataset_matcher_factory(request_context)
 


### PR DESCRIPTION
Fix performance problems that can be encountered when matching collection inputs. It would use the old style matching to find an initial value to plug into the tool state - if there were no collections that matched or there were some big collections toward the top of the history that did not match this could completely undo performance fixes in #5997.

More Pythonic input type conditional logic.