### PR TITLE
[18.05] Downgrade python-genomespaceclient to 0.2

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/Pipfile
+++ b/lib/galaxy/dependencies/pipfiles/default/Pipfile
@@ -49,7 +49,7 @@ svgwrite = "*"
 pyparsing = "*"
 "Fabric3" = "*"
 paramiko = "*"
-python-genomespaceclient = "*"
+python-genomespaceclient = "<1.0"
 social_auth_core = {version = "==1.5.0", extras = ['openidconnect']}
 
 [requires]

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -92,7 +92,7 @@ pyperclip==1.6.0
 pysam==0.14.1
 python-cinderclient==2.0.1
 python-dateutil==2.7.2
-python-genomespaceclient==1.0.0
+python-genomespaceclient==0.2
 python-glanceclient==2.6.0
 python-keystoneclient==3.10.0
 python-lzo==1.11


### PR DESCRIPTION
As per @nuwang in galaxyproject/usegalaxy-playbook#100, 1.0.0 is not compatible with the tools in Galaxy.

Related: I am not sure how this is supposed to work with pipenv but as far as I can tell there is no way to downgrade a requirement and only affect the dependencies of the requirement you are changing (just as there is no way to upgrade a single requirement). pipenv is basically worthless for stable software.