### PR TITLE
[18.05] Alter the type of extra_data column of OIDC table.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4727,10 +4727,6 @@ class UserAuthnzToken(UserMixin):
         return self.extra_data.get('access_token', None) if self.extra_data is not None else None
 
     def set_extra_data(self, extra_data=None):
-        # Note: the following unicode conversion is a temporary solution for a
-        # database binding error (InterfaceError: (sqlite3.InterfaceError)).
-        if extra_data is not None:
-            extra_data = str(extra_data)
         if super(UserAuthnzToken, self).set_extra_data(extra_data):
             self.trans.sa_session.add(self)
             self.trans.sa_session.flush()

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -129,7 +129,7 @@ model.UserAuthnzToken.table = Table(
     Column('user_id', Integer, ForeignKey("galaxy_user.id"), index=True),
     Column('uid', VARCHAR(255)),
     Column('provider', VARCHAR(32)),
-    Column('extra_data', TEXT),
+    Column('extra_data', JSONType, nullable=True),
     Column('lifetime', Integer),
     Column('assoc_type', VARCHAR(64)))
 

--- a/lib/galaxy/model/migrate/versions/0141_add_oidc_tables.py
+++ b/lib/galaxy/model/migrate/versions/0141_add_oidc_tables.py
@@ -7,6 +7,8 @@ import logging
 
 from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table, TEXT, VARCHAR
 
+from galaxy.model.custom_types import JSONType
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
@@ -51,7 +53,7 @@ oidc_user_authnz_tokens = Table(
     Column('user_id', Integer, ForeignKey("galaxy_user.id"), index=True),
     Column('uid', VARCHAR(255)),
     Column('provider', VARCHAR(32)),
-    Column('extra_data', TEXT),
+    Column('extra_data', JSONType, nullable=True),
     Column('lifetime', Integer),
     Column('assoc_type', VARCHAR(64)))
 


### PR DESCRIPTION
This is a follow-up from #6017 where we could not alter the column using a migration script since there exist a different migration script merged on dev. 

