### PR TITLE
[18.05] GDPR Compliance Mode

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1322,7 +1322,7 @@ galaxy:
   # delete user admin action to permanently redact their username and
   # password, but not to delete data associated with the account as this
   # is not currently easily implementable.  You are responsible for
-  # removing the data from backups.  This automatically disabled
+  # removing personal data from backups.  This automatically disabled
   # expose_user_email and expose_user_name
   #gdpr_compliance_mode: false
 

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1292,8 +1292,8 @@ galaxy:
   # correct user show up. This makes less sense on large public Galaxy
   # instances where that data shouldn't be exposed.  For semi-public
   # Galaxies, it may make sense to expose just the username and not
-  # email, or vice versa.  If gdpr_compliance_mode is set to True, then
-  # this option will be overridden and set to False.
+  # email, or vice versa.  If gdpr_compliance is set to True, then this
+  # option will be overridden and set to False.
   #expose_user_name: false
 
   # Expose user list.  Setting this to True will expose the user list to
@@ -1302,8 +1302,8 @@ galaxy:
   # correct user show up. This makes less sense on large public Galaxy
   # instances where that data shouldn't be exposed.  For semi-public
   # Galaxies, it may make sense to expose just the username and not
-  # email, or vice versa.  If gdpr_compliance_mode is set to True, then
-  # this option will be overridden and set to False.
+  # email, or vice versa.  If gdpr_compliance is set to True, then this
+  # option will be overridden and set to False.
   #expose_user_email: false
 
   # Whitelist for local network addresses for "Upload from URL" dialog.
@@ -1317,14 +1317,16 @@ galaxy:
   #fetch_url_whitelist: null
 
   # Enables GDPR Compliance mode. This makes several changes to the way
-  # Galaxy logs and exposes data externally such as removing
-  # emails/usernames from logs and bug reports. It also causes the
-  # delete user admin action to permanently redact their username and
-  # password, but not to delete data associated with the account as this
-  # is not currently easily implementable.  You are responsible for
-  # removing personal data from backups.  This automatically disabled
-  # expose_user_email and expose_user_name
-  #gdpr_compliance_mode: false
+  # Galaxy logs and exposes data externally such as removing emails and
+  # usernames from logs and bug reports. It also causes the delete user
+  # admin action to permanently redact their username and password, but
+  # not to delete data associated with the account as this is not
+  # currently easily implementable.  You are responsible for removing
+  # personal data from backups.  This forces expose_user_email and
+  # expose_user_name to be false, and forces user_deletion to be true to
+  # support the right to erasure.  Please read the GDPR section under
+  # the special topics area of the admin documentation.
+  #gdpr_compliance: false
 
   # Enable the new interface for installing tools from Tool Shed via the
   # API. Admin menu will list both if enabled.

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1292,7 +1292,8 @@ galaxy:
   # correct user show up. This makes less sense on large public Galaxy
   # instances where that data shouldn't be exposed.  For semi-public
   # Galaxies, it may make sense to expose just the username and not
-  # email, or vice versa.
+  # email, or vice versa.  If gdpr_compliance_mode is set to True, then
+  # this option will be overridden and set to False.
   #expose_user_name: false
 
   # Expose user list.  Setting this to True will expose the user list to
@@ -1301,7 +1302,8 @@ galaxy:
   # correct user show up. This makes less sense on large public Galaxy
   # instances where that data shouldn't be exposed.  For semi-public
   # Galaxies, it may make sense to expose just the username and not
-  # email, or vice versa.
+  # email, or vice versa.  If gdpr_compliance_mode is set to True, then
+  # this option will be overridden and set to False.
   #expose_user_email: false
 
   # Whitelist for local network addresses for "Upload from URL" dialog.
@@ -1316,7 +1318,12 @@ galaxy:
 
   # Enables GDPR Compliance mode. This makes several changes to the way
   # Galaxy logs and exposes data externally such as removing
-  # emails/usernames from logs and bug reports.
+  # emails/usernames from logs and bug reports. It also causes the
+  # delete user admin action to permanently redact their username and
+  # password, but not to delete data associated with the account as this
+  # is not currently easily implementable.  You are responsible for
+  # removing the data from backups.  This automatically disabled
+  # expose_user_email and expose_user_name
   #gdpr_compliance_mode: false
 
   # Enable the new interface for installing tools from Tool Shed via the

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1314,6 +1314,11 @@ galaxy:
   # 10.10.10.10,10.0.1.0/24,fd00::/8
   #fetch_url_whitelist: null
 
+  # Enables GDPR Compliance mode. This makes several changes to the way
+  # Galaxy logs and exposes data externally such as removing
+  # emails/usernames from logs and bug reports.
+  #gdpr_compliance_mode: false
+
   # Enable the new interface for installing tools from Tool Shed via the
   # API. Admin menu will list both if enabled.
   #enable_beta_ts_api_install: true

--- a/config/reports.yml.sample
+++ b/config/reports.yml.sample
@@ -127,6 +127,7 @@ reports:
   # Enables GDPR Compliance mode. This makes several changes to the way
   # Galaxy logs and exposes data externally such as removing
   # emails/usernames from logs and bug reports.  You are responsible for
-  # removing personal data from backups.
-  #gdpr_compliance_mode: false
+  # removing personal data from backups.  Please read the GDPR section
+  # under the special topics area of the admin documentation.
+  #gdpr_compliance: false
 

--- a/config/reports.yml.sample
+++ b/config/reports.yml.sample
@@ -124,3 +124,9 @@ reports:
   # Mail
   #error_email_to: your_bugs@bx.psu.edu
 
+  # Enables GDPR Compliance mode. This makes several changes to the way
+  # Galaxy logs and exposes data externally such as removing
+  # emails/usernames from logs and bug reports.  You are responsible for
+  # removing personal data from backups.
+  #gdpr_compliance_mode: false
+

--- a/config/tool_shed.yml.sample
+++ b/config/tool_shed.yml.sample
@@ -263,3 +263,9 @@ tool_shed:
   # Serving static files (needed if running standalone)
   #static_style_dir: static/style/blue
 
+  # Enables GDPR Compliance mode. This makes several changes to the way
+  # Galaxy logs and exposes data externally such as removing
+  # emails/usernames from logs and bug reports.  You are responsible for
+  # removing personal data from backups.
+  #gdpr_compliance_mode: false
+

--- a/config/tool_shed.yml.sample
+++ b/config/tool_shed.yml.sample
@@ -176,6 +176,24 @@ tool_shed:
   # header 'GX_SECRET' that is identical the one below
   #remote_user_secret: changethisinproductiontoo
 
+  # If use_remote_user is enabled and your external authentication
+  # method just returns bare usernames, set a default mail domain to be
+  # appended to usernames, to become your Galaxy usernames (email
+  # addresses).
+  #remote_user_maildomain: null
+
+  # If use_remote_user is enabled, the header that the upstream proxy
+  # provides the remote username in defaults to HTTP_REMOTE_USER (the
+  # 'HTTP_' is prepended by WSGI).  This option allows you to change the
+  # header.  Note, you still need to prepend 'HTTP_' to the header in
+  # this option, but your proxy server should *not* include 'HTTP_' at
+  # the beginning of the header name.
+  #remote_user_header: HTTP_REMOTE_USER
+
+  # If use_remote_user is enabled, you can set this to a URL that will
+  # log your users out.
+  #remote_user_logout_href: null
+
   # Configuration for debugging middleware
   #debug: false
 
@@ -196,6 +214,13 @@ tool_shed:
 
   # Force everyone to log in (disable anonymous access)
   #require_login: false
+
+  # Allow unregistered users to create new accounts (otherwise, they
+  # will have to be created by an admin).
+  #allow_user_creation: true
+
+  # Allow administrators to delete accounts.
+  #allow_user_deletion: false
 
   # For use by email messages sent from the tool shed
   #smtp_server: smtp.your_tool_shed_server
@@ -266,6 +291,91 @@ tool_shed:
   # Enables GDPR Compliance mode. This makes several changes to the way
   # Galaxy logs and exposes data externally such as removing
   # emails/usernames from logs and bug reports.  You are responsible for
-  # removing personal data from backups.
-  #gdpr_compliance_mode: false
+  # removing personal data from backups.  Please read the GDPR section
+  # under the special topics area of the admin documentation.
+  #gdpr_compliance: false
+
+  # For help on configuring the Advanced proxy features, see:
+  # http://usegalaxy.org/production  Apache can handle file downloads
+  # (Galaxy-to-user) via mod_xsendfile.  Set this to True to inform
+  # Galaxy that mod_xsendfile is enabled upstream.
+  #apache_xsendfile: false
+
+  # The same download handling can be done by nginx using X-Accel-
+  # Redirect.  This should be set to the path defined in the nginx
+  # config as an internal redirect with access to Galaxy's data files
+  # (see documentation linked above).
+  #nginx_x_accel_redirect_base: null
+
+  # This value overrides the action set on the file upload form, e.g.
+  # the web path where the nginx_upload_module has been configured to
+  # intercept upload requests.
+  #nginx_upload_path: null
+
+  # E-mail domains blacklist is used for filtering out users that are
+  # using disposable email address during the registration.  If their
+  # address domain matches any domain in the blacklist, they are refused
+  # the registration.
+  #blacklist_file: config/disposable_email_blacklist.conf
+
+  # Append "/{brand}" to the "Galaxy" text in the masthead.
+  #brand: null
+
+  # Citation related caching.  Tool citations information maybe fetched
+  # from external sources such as http://dx.doi.org/ by Galaxy - the
+  # following parameters can be used to control the caching used to
+  # store this information.
+  #citation_cache_type: file
+
+  # Citation related caching.  Tool citations information maybe fetched
+  # from external sources such as http://dx.doi.org/ by Galaxy - the
+  # following parameters can be used to control the caching used to
+  # store this information.
+  #citation_cache_data_dir: database/citations/data
+
+  # Citation related caching.  Tool citations information maybe fetched
+  # from external sources such as http://dx.doi.org/ by Galaxy - the
+  # following parameters can be used to control the caching used to
+  # store this information.
+  #citation_cache_lock_dir: database/citations/lock
+
+  # If proxy-prefix is enabled and you're running more than one Galaxy
+  # instance behind one hostname, you will want to set this to the same
+  # path as the prefix in the filter above.  This value becomes the
+  # "path" attribute set in the cookie so the cookies from each instance
+  # will not clobber each other.
+  #cookie_path: null
+
+  # Enable authentication via OpenID.  Allows users to log in to their
+  # Galaxy account by authenticating with an OpenID provider.
+  #enable_openid: false
+
+  # Turn on logging of user actions to the database.  Actions currently
+  # logged are grid views, tool searches, and use of "recently" used
+  # tools menu.  The log_events and log_actions functionality will
+  # eventually be merged.
+  #log_actions: true
+
+  # Password expiration period (in days). Users are required to change
+  # their password every x days. Users will be redirected to the change
+  # password screen when they log in after their password expires. Enter
+  # 0 to disable password expiration.
+  #password_expiration_period: 0
+
+  # Log to Sentry Sentry is an open source logging and error aggregation
+  # platform.  Setting sentry_dsn will enable the Sentry middleware and
+  # errors will be sent to the indicated sentry instance.  This
+  # connection string is available in your sentry instance under
+  # <project_name> -> Settings -> API Keys.
+  #sentry_dsn: null
+
+  # Galaxy Session Timeout This provides a timeout (in minutes) after
+  # which a user will have to log back in. A duration of 0 disables this
+  # feature.
+  #session_duration: 0
+
+  # The URL linked by the "Terms and Conditions" link in the "Help"
+  # menu, as well as on the user registration and login forms and in the
+  # activation emails.
+  #terms_url: null
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2693,8 +2693,8 @@
     have the correct user show up. This makes less sense on large
     public Galaxy instances where that data shouldn't be exposed.  For
     semi-public Galaxies, it may make sense to expose just the
-    username and not email, or vice versa.  If gdpr_compliance_mode is
-    set to True, then this option will be overridden and set to False.
+    username and not email, or vice versa.  If gdpr_compliance is set
+    to True, then this option will be overridden and set to False.
 :Default: ``false``
 :Type: bool
 
@@ -2710,8 +2710,8 @@
     have the correct user show up. This makes less sense on large
     public Galaxy instances where that data shouldn't be exposed.  For
     semi-public Galaxies, it may make sense to expose just the
-    username and not email, or vice versa.  If gdpr_compliance_mode is
-    set to True, then this option will be overridden and set to False.
+    username and not email, or vice versa.  If gdpr_compliance is set
+    to True, then this option will be overridden and set to False.
 :Default: ``false``
 :Type: bool
 
@@ -2733,19 +2733,22 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~
-``gdpr_compliance_mode``
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
+``gdpr_compliance``
+~~~~~~~~~~~~~~~~~~~
 
 :Description:
     Enables GDPR Compliance mode. This makes several changes to the
     way Galaxy logs and exposes data externally such as removing
-    emails/usernames from logs and bug reports. It also causes the
+    emails and usernames from logs and bug reports. It also causes the
     delete user admin action to permanently redact their username and
     password, but not to delete data associated with the account as
     this is not currently easily implementable.  You are responsible
-    for removing personal data from backups.  This automatically
-    disabled expose_user_email and expose_user_name
+    for removing personal data from backups.  This forces
+    expose_user_email and expose_user_name to be false, and forces
+    user_deletion to be true to support the right to erasure.  Please
+    read the GDPR section under the special topics area of the admin
+    documentation.
 :Default: ``false``
 :Type: bool
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2693,7 +2693,8 @@
     have the correct user show up. This makes less sense on large
     public Galaxy instances where that data shouldn't be exposed.  For
     semi-public Galaxies, it may make sense to expose just the
-    username and not email, or vice versa.
+    username and not email, or vice versa.  If gdpr_compliance_mode is
+    set to True, then this option will be overridden and set to False.
 :Default: ``false``
 :Type: bool
 
@@ -2709,7 +2710,8 @@
     have the correct user show up. This makes less sense on large
     public Galaxy instances where that data shouldn't be exposed.  For
     semi-public Galaxies, it may make sense to expose just the
-    username and not email, or vice versa.
+    username and not email, or vice versa.  If gdpr_compliance_mode is
+    set to True, then this option will be overridden and set to False.
 :Default: ``false``
 :Type: bool
 
@@ -2738,7 +2740,12 @@
 :Description:
     Enables GDPR Compliance mode. This makes several changes to the
     way Galaxy logs and exposes data externally such as removing
-    emails/usernames from logs and bug reports.
+    emails/usernames from logs and bug reports. It also causes the
+    delete user admin action to permanently redact their username and
+    password, but not to delete data associated with the account as
+    this is not currently easily implementable.  You are responsible
+    for removing the data from backups.  This automatically disabled
+    expose_user_email and expose_user_name
 :Default: ``false``
 :Type: bool
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2744,8 +2744,8 @@
     delete user admin action to permanently redact their username and
     password, but not to delete data associated with the account as
     this is not currently easily implementable.  You are responsible
-    for removing the data from backups.  This automatically disabled
-    expose_user_email and expose_user_name
+    for removing personal data from backups.  This automatically
+    disabled expose_user_email and expose_user_name
 :Default: ``false``
 :Type: bool
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2731,6 +2731,18 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~
+``gdpr_compliance_mode``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Enables GDPR Compliance mode. This makes several changes to the
+    way Galaxy logs and exposes data externally such as removing
+    emails/usernames from logs and bug reports.
+:Default: ``false``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``enable_beta_ts_api_install``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/reports_options.rst
+++ b/doc/source/admin/reports_options.rst
@@ -153,15 +153,16 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~
-``gdpr_compliance_mode``
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
+``gdpr_compliance``
+~~~~~~~~~~~~~~~~~~~
 
 :Description:
     Enables GDPR Compliance mode. This makes several changes to the
     way Galaxy logs and exposes data externally such as removing
     emails/usernames from logs and bug reports.  You are responsible
-    for removing personal data from backups.
+    for removing personal data from backups.  Please read the GDPR
+    section under the special topics area of the admin documentation.
 :Default: ``false``
 :Type: bool
 

--- a/doc/source/admin/reports_options.rst
+++ b/doc/source/admin/reports_options.rst
@@ -153,4 +153,17 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~
+``gdpr_compliance_mode``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Enables GDPR Compliance mode. This makes several changes to the
+    way Galaxy logs and exposes data externally such as removing
+    emails/usernames from logs and bug reports.  You are responsible
+    for removing personal data from backups.
+:Default: ``false``
+:Type: bool
+
+
 

--- a/doc/source/admin/special_topics/gdpr_compliance.rst
+++ b/doc/source/admin/special_topics/gdpr_compliance.rst
@@ -1,8 +1,8 @@
 GDPR Compliance
 ===============
 
-With the new GDPR regulations that are in effect as of May 25, 2018, there are
-some extra steps you as an admin need to take to protect your Galaxy.
+To comply with the European Union law known as General Data Protection Regulation or [GDPR](http://eur-lex.europa.eu/legal-content/en/TXT/?uri=CELEX:32016R0679) starting on May 25, 2018 there are
+some extra steps you as an admin need to take to protect information of users in your Galaxy.
 
 Audience
 --------
@@ -10,14 +10,13 @@ Audience
 Anyone with users from the EU.
 
 The Galaxy Project cares about privacy preserving regulations and meeting the
-requirements within. Many smaller companies in the US are choosing to block the
-EU completely, this is obviously not ideal. We have attempted to make
-compliance as easy as possible so you can continue to serve EU users.
+requirements of law. We have attempted to make compliance as easy as possible
+so you can continue to serve EU users.
 
 Configuration
 -------------
 
-The Galaxy GDPR compliance is behind the ``gdpr_compliance`` flag available in
+The Galaxy GDPR compliance is enabled by switching the ``gdpr_compliance`` flag available in
 the configuration of Galaxy, Reports, and the Tool Shed. If you intend to serve
 users from anywhere in the EU, you should set this to true. This has some
 important implications of which you must be aware:
@@ -25,13 +24,12 @@ important implications of which you must be aware:
 Log Redaction
 -------------
 
-We attempt to redact all occurances of username or email in the logs. Instead
+We attempt to redact all occurences of ``username`` or ``email`` in the logs. Instead
 we opt to log the user ID number which cannot be reversed into personally
 identifying information (PII) without access to the database. This is to
 pseudonymise the data and reduce risk of PII being leaked.
 
-We may change this redaction method to use encoded user IDs in the future once
-we can obtain more legal advice.
+We may change this redaction method to use encoded user IDs in the future.
 
 You can configure the location of the compliance log like so:
 
@@ -94,9 +92,9 @@ Which will produce logging events like this:
 User Deletion
 -------------
 
-User deletion is forced on when ``gdpr_compliance`` is enabled, as you must be
-able to comply with the right to erasure. When users are deleted, their PII is
-obscured. In practice this means:
+User deletion is always enabled when ``gdpr_compliance`` is enabled to comply with
+the right to erasure. When users are deleted, their PII is obscured.
+In practice this means:
 
 - username
 - email
@@ -130,4 +128,4 @@ their username will be redacted as well.
 This will break any future updates for Galaxies consuming the tool and they
 will be stuck on the old version. Additionally due to how Galaxy builds
 toolshed repository paths on disk, it will break any access even if you try and
-install again from this tool.
+install again from this repository owned by a redacted user.

--- a/doc/source/admin/special_topics/gdpr_compliance.rst
+++ b/doc/source/admin/special_topics/gdpr_compliance.rst
@@ -14,3 +14,50 @@ requirements within. Many smaller companies in the US are choosing to block the
 EU completely, this is obviously not ideal. We have attempted to make
 compliance as easy as possible so you can continue to serve EU users.
 
+Configuration
+-------------
+
+The Galaxy GDPR compliance is behind the ``gdpr_compliance`` flag available in
+the configuration of Galaxy, Reports, and the Tool Shed. If you intend to serve
+users from anywhere in the EU, you should set this to true. This has some
+important implications of which you must be aware.
+
+Log Redaction
+-------------
+
+We attempt to redact all occurances of username or email in the logs. Instead
+we opt to log the user ID number which cannot be reversed into personally
+identifying information (PII) without access to the database. This is to
+pseudonymise the data and reduce risk of PII being leaked.
+
+We may change this redaction method to use encoded user IDs in the future once
+we can obtain more legal advice.
+
+User Deletion
+-------------
+
+User deletion is forced on when ``gdpr_compliance`` is enabled, as you must be
+able to comply with the right to erasure. When users are deleted, their PII is
+obscured. In practice this means:
+
+- username
+- email
+- user_address (when supplied)
+
+All have their values that consitute PII permanently redacted with a one-way
+hash function.
+
+Backups
+-------
+
+You are responsible for ensuring that backups are deleted, or re-executing the
+deletion process for all affected users following a restore.
+
+We have added a "compliance log" which should aid in this by logging the user's
+ID number, allowing you to re-delete them following a restoration.
+
+Tool Shed Specific
+------------------
+
+If a user has published a tool in your toolshed, when deleting their account it
+will be broken for everyone who is using it.

--- a/doc/source/admin/special_topics/gdpr_compliance.rst
+++ b/doc/source/admin/special_topics/gdpr_compliance.rst
@@ -1,0 +1,16 @@
+GDPR Compliance
+===============
+
+With the new GDPR regulations that are in effect as of May 25, 2018, there are
+some extra steps you as an admin need to take to protect your Galaxy.
+
+Audience
+--------
+
+Anyone with users from the EU.
+
+The Galaxy Project cares about privacy preserving regulations and meeting the
+requirements within. Many smaller companies in the US are choosing to block the
+EU completely, this is obviously not ideal. We have attempted to make
+compliance as easy as possible so you can continue to serve EU users.
+

--- a/doc/source/admin/special_topics/gdpr_compliance.rst
+++ b/doc/source/admin/special_topics/gdpr_compliance.rst
@@ -24,7 +24,7 @@ important implications of which you must be aware:
 Log Redaction
 -------------
 
-We attempt to redact all occurences of ``username`` or ``email`` in the logs. Instead
+We attempt to redact all occurrences of ``username`` or ``email`` in the logs. Instead
 we opt to log the user ID number which cannot be reversed into personally
 identifying information (PII) without access to the database. This is to
 pseudonymise the data and reduce risk of PII being leaked.
@@ -100,7 +100,7 @@ In practice this means:
 - email
 - user_address (when supplied)
 
-All have their values that consitute PII permanently redacted with a one-way
+All have their values that constitute PII permanently redacted with a one-way
 hash function.
 
 This does not automatically remove their histories or datasets or any data they

--- a/doc/source/admin/special_topics/index.rst
+++ b/doc/source/admin/special_topics/index.rst
@@ -14,3 +14,4 @@ Special Topics
    webhooks
    performance_tracking
    bug_reports
+   gdpr_compliance

--- a/lib/galaxy/auth/__init__.py
+++ b/lib/galaxy/auth/__init__.py
@@ -15,7 +15,7 @@ class AuthManager(object):
 
     def __init__(self, app):
         self.__app = app
-        self.gdpr_compliant = app.config.gdpr_compliance_mode
+        self.redact_username_in_logs = app.config.redact_username_in_logs
         self.authenticators = get_authenticators(app.config.auth_config_file)
 
     def check_registration_allowed(self, email, username, password):

--- a/lib/galaxy/auth/__init__.py
+++ b/lib/galaxy/auth/__init__.py
@@ -119,7 +119,7 @@ class AuthManager(object):
                     if not passed_filter:
                         continue  # skip to next
                 options = authenticator.options
-                options['gdpr_compliant'] = self.gdpr_compliant
+                options['redact_username_in_logs'] = self.redact_username_in_logs
                 yield authenticator.plugin, options
         except Exception:
             log.exception("Active Authenticators Failure")

--- a/lib/galaxy/auth/__init__.py
+++ b/lib/galaxy/auth/__init__.py
@@ -15,6 +15,7 @@ class AuthManager(object):
 
     def __init__(self, app):
         self.__app = app
+        self.gdpr_compliant = app.config.gdpr_compliance_mode
         self.authenticators = get_authenticators(app.config.auth_config_file)
 
     def check_registration_allowed(self, email, username, password):
@@ -117,7 +118,9 @@ class AuthManager(object):
                     passed_filter = eval(filter_str, {"__builtins__": None}, {'str': str})
                     if not passed_filter:
                         continue  # skip to next
-                yield authenticator.plugin, authenticator.options
+                options = authenticator.options
+                options['gdpr_compliant'] = self.gdpr_compliant
+                yield authenticator.plugin, options
         except Exception:
             log.exception("Active Authenticators Failure")
             raise

--- a/lib/galaxy/auth/providers/alwaysreject.py
+++ b/lib/galaxy/auth/providers/alwaysreject.py
@@ -26,7 +26,7 @@ class AlwaysReject(AuthProvider):
         """
         See abstract method documentation.
         """
-        log.debug("User: %s, ALWAYSREJECT: None" % (user.id if options['gdpr_compliant'] else user.email))
+        log.debug("User: %s, ALWAYSREJECT: None" % (user.id if options['redact_username_in_logs'] else user.email))
         return None
 
 

--- a/lib/galaxy/auth/providers/alwaysreject.py
+++ b/lib/galaxy/auth/providers/alwaysreject.py
@@ -26,7 +26,7 @@ class AlwaysReject(AuthProvider):
         """
         See abstract method documentation.
         """
-        log.debug("User: %s, ALWAYSREJECT: None" % (user.id if options.gdpr_compliant else user.email))
+        log.debug("User: %s, ALWAYSREJECT: None" % (user.id if options['gdpr_compliant'] else user.email))
         return None
 
 

--- a/lib/galaxy/auth/providers/alwaysreject.py
+++ b/lib/galaxy/auth/providers/alwaysreject.py
@@ -26,7 +26,7 @@ class AlwaysReject(AuthProvider):
         """
         See abstract method documentation.
         """
-        log.debug("User: %s, ALWAYSREJECT: None" % (user.email))
+        log.debug("User: %s, ALWAYSREJECT: None" % (user.id if options.gdpr_compliant else user.email))
         return None
 
 

--- a/lib/galaxy/auth/providers/ldap_ad.py
+++ b/lib/galaxy/auth/providers/ldap_ad.py
@@ -189,7 +189,7 @@ class LDAP(AuthProvider):
         """
         See abstract method documentation.
         """
-        if not options['gdpr_compliant']:
+        if not options['redact_username_in_logs']:
             log.debug("LDAP authenticate: email is %s" % email)
             log.debug("LDAP authenticate: username is %s" % username)
 
@@ -230,7 +230,7 @@ class LDAP(AuthProvider):
                 # The "Who am I?" extended operation is not supported by this LDAP server
                 pass
             else:
-                if not options['gdpr_compliant']:
+                if not options['redact_username_in_logs']:
                     log.debug("LDAP authenticate: whoami is %s", whoami)
 
                 if whoami is None:

--- a/lib/galaxy/auth/providers/ldap_ad.py
+++ b/lib/galaxy/auth/providers/ldap_ad.py
@@ -189,8 +189,10 @@ class LDAP(AuthProvider):
         """
         See abstract method documentation.
         """
-        log.debug("LDAP authenticate: email is %s" % email)
-        log.debug("LDAP authenticate: username is %s" % username)
+        if not options.gdpr_compliant:
+            log.debug("LDAP authenticate: email is %s" % email)
+            log.debug("LDAP authenticate: username is %s" % username)
+
         log.debug("LDAP authenticate: options are %s" % options)
 
         failure_mode, params = self.ldap_search(email, username, options)
@@ -228,7 +230,9 @@ class LDAP(AuthProvider):
                 # The "Who am I?" extended operation is not supported by this LDAP server
                 pass
             else:
-                log.debug("LDAP authenticate: whoami is %s", whoami)
+                if not options.gdpr_compliant:
+                    log.debug("LDAP authenticate: whoami is %s", whoami)
+
                 if whoami is None:
                     raise RuntimeError('LDAP authenticate: anonymous bind')
         except Exception:

--- a/lib/galaxy/auth/providers/ldap_ad.py
+++ b/lib/galaxy/auth/providers/ldap_ad.py
@@ -189,7 +189,7 @@ class LDAP(AuthProvider):
         """
         See abstract method documentation.
         """
-        if not options.gdpr_compliant:
+        if not options['gdpr_compliant']:
             log.debug("LDAP authenticate: email is %s" % email)
             log.debug("LDAP authenticate: username is %s" % username)
 
@@ -230,7 +230,7 @@ class LDAP(AuthProvider):
                 # The "Who am I?" extended operation is not supported by this LDAP server
                 pass
             else:
-                if not options.gdpr_compliant:
+                if not options['gdpr_compliant']:
                     log.debug("LDAP authenticate: whoami is %s", whoami)
 
                 if whoami is None:

--- a/lib/galaxy/auth/providers/localdb.py
+++ b/lib/galaxy/auth/providers/localdb.py
@@ -25,7 +25,7 @@ class LocalDB(AuthProvider):
         See abstract method documentation.
         """
         user_ok = user.check_password(password)
-        log.debug("User: %s, LOCALDB: %s" % (user.id if options['gdpr_compliant'] else user.email, user_ok))
+        log.debug("User: %s, LOCALDB: %s" % (user.id if options['redact_username_in_logs'] else user.email, user_ok))
         return user_ok
 
 

--- a/lib/galaxy/auth/providers/localdb.py
+++ b/lib/galaxy/auth/providers/localdb.py
@@ -25,7 +25,8 @@ class LocalDB(AuthProvider):
         See abstract method documentation.
         """
         user_ok = user.check_password(password)
-        log.debug("User: %s, LOCALDB: %s" % (user.id if options.gdpr_compliant else user.email, user_ok))
+        print(options)
+        log.debug("User: %s, LOCALDB: %s" % (user.id if options['gdpr_compliant'] else user.email, user_ok))
         return user_ok
 
 

--- a/lib/galaxy/auth/providers/localdb.py
+++ b/lib/galaxy/auth/providers/localdb.py
@@ -25,7 +25,7 @@ class LocalDB(AuthProvider):
         See abstract method documentation.
         """
         user_ok = user.check_password(password)
-        log.debug("User: %s, LOCALDB: %s" % (user.email, user_ok))
+        log.debug("User: %s, LOCALDB: %s" % (user.id if options.gdpr_compliant else user.email, user_ok))
         return user_ok
 
 

--- a/lib/galaxy/auth/providers/localdb.py
+++ b/lib/galaxy/auth/providers/localdb.py
@@ -25,7 +25,6 @@ class LocalDB(AuthProvider):
         See abstract method documentation.
         """
         user_ok = user.check_password(password)
-        print(options)
         log.debug("User: %s, LOCALDB: %s" % (user.id if options['gdpr_compliant'] else user.email, user_ok))
         return user_ok
 

--- a/lib/galaxy/auth/providers/pam_auth.py
+++ b/lib/galaxy/auth/providers/pam_auth.py
@@ -61,7 +61,7 @@ class PAM(AuthProvider):
         auto_register_username = None
         auto_register_email = None
         force_fail = False
-        if not options['gdpr_compliant']:
+        if not options['redact_username_in_logs']:
             log.debug("use username: {} use email {} email {} username {}".format(options.get('login-use-username'), options.get('login-use-email', False), email, username))
         # check email based login first because if email exists in Galaxy DB
         # we will be given the "public name" as username
@@ -139,10 +139,10 @@ class PAM(AuthProvider):
             authenticated = p_auth.authenticate(pam_username, password, service=pam_service)
 
         if authenticated:
-            log.debug('PAM authentication successful for {}'.format('redacted' if options['gdpr_compliant'] else pam_username))
+            log.debug('PAM authentication successful for {}'.format('redacted' if options['redact_username_in_logs'] else pam_username))
             return True, auto_register_email, auto_register_username
         else:
-            log.debug('PAM authentication failed for {}'.format('redacted' if options['gdpr_compliant'] else pam_username))
+            log.debug('PAM authentication failed for {}'.format('redacted' if options['redact_username_in_logs'] else pam_username))
             return False, '', ''
 
     def authenticate_user(self, user, password, options):

--- a/lib/galaxy/auth/providers/pam_auth.py
+++ b/lib/galaxy/auth/providers/pam_auth.py
@@ -61,7 +61,7 @@ class PAM(AuthProvider):
         auto_register_username = None
         auto_register_email = None
         force_fail = False
-        if not options.gdpr_compliant:
+        if not options['gdpr_compliant']:
             log.debug("use username: {} use email {} email {} username {}".format(options.get('login-use-username'), options.get('login-use-email', False), email, username))
         # check email based login first because if email exists in Galaxy DB
         # we will be given the "public name" as username
@@ -139,10 +139,10 @@ class PAM(AuthProvider):
             authenticated = p_auth.authenticate(pam_username, password, service=pam_service)
 
         if authenticated:
-            log.debug('PAM authentication successful for {}'.format('redacted' if options.gdpr_compliant else pam_username))
+            log.debug('PAM authentication successful for {}'.format('redacted' if options['gdpr_compliant'] else pam_username))
             return True, auto_register_email, auto_register_username
         else:
-            log.debug('PAM authentication failed for {}'.format('redacted' if options.gdpr_compliant else pam_username))
+            log.debug('PAM authentication failed for {}'.format('redacted' if options['gdpr_compliant'] else pam_username))
             return False, '', ''
 
     def authenticate_user(self, user, password, options):

--- a/lib/galaxy/auth/providers/pam_auth.py
+++ b/lib/galaxy/auth/providers/pam_auth.py
@@ -61,7 +61,8 @@ class PAM(AuthProvider):
         auto_register_username = None
         auto_register_email = None
         force_fail = False
-        log.debug("use username: {} use email {} email {} username {}".format(options.get('login-use-username'), options.get('login-use-email', False), email, username))
+        if not options.gdpr_compliant:
+            log.debug("use username: {} use email {} email {} username {}".format(options.get('login-use-username'), options.get('login-use-email', False), email, username))
         # check email based login first because if email exists in Galaxy DB
         # we will be given the "public name" as username
         if string_as_bool(options.get('login-use-email', False)) and email is not None:
@@ -138,10 +139,10 @@ class PAM(AuthProvider):
             authenticated = p_auth.authenticate(pam_username, password, service=pam_service)
 
         if authenticated:
-            log.debug('PAM authentication successful for {}'.format(pam_username))
+            log.debug('PAM authentication successful for {}'.format('redacted' if options.gdpr_compliant else pam_username))
             return True, auto_register_email, auto_register_username
         else:
-            log.debug('PAM authentication failed for {}'.format(pam_username))
+            log.debug('PAM authentication failed for {}'.format('redacted' if options.gdpr_compliant else pam_username))
             return False, '', ''
 
     def authenticate_user(self, user, password, options):

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -229,8 +229,13 @@ class Configuration(object):
         self.tour_config_dir = resolve_path(kwargs.get("tour_config_dir", "config/plugins/tours"), self.root)
         self.webhooks_dirs = resolve_path(kwargs.get("webhooks_dir", "config/plugins/webhooks"), self.root)
 
-        self.expose_user_name = kwargs.get("expose_user_name", False)
-        self.expose_user_email = kwargs.get("expose_user_email", False)
+        self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", "False"))
+        if self.gdpr_compliance_mode:
+            self.expose_user_name = False
+            self.expose_user_email = False
+        else:
+            self.expose_user_name = kwargs.get("expose_user_name", False)
+            self.expose_user_email = kwargs.get("expose_user_email", False)
         self.password_expiration_period = timedelta(days=int(kwargs.get("password_expiration_period", 0)))
 
         # Check for tools defined in the above non-shed tool configs (i.e., tool_conf.xml) tht have
@@ -286,7 +291,6 @@ class Configuration(object):
             for ip in kwargs.get("fetch_url_whitelist", "").split(',')
             if len(ip.strip()) > 0
         ]
-        self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", "False"))
         self.allow_user_creation = string_as_bool(kwargs.get("allow_user_creation", "True"))
         self.allow_user_deletion = string_as_bool(kwargs.get("allow_user_deletion", "False"))
         self.allow_user_dataset_purge = string_as_bool(kwargs.get("allow_user_dataset_purge", "True"))

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -705,6 +705,21 @@ class Configuration(object):
             self.redact_user_address_during_deletion = True
             self.allow_user_deletion = True
 
+            LOGGING_CONFIG_DEFAULT['formatters']['brief'] = {
+                'format': '%(asctime)s %(levelname)-8s %(name)-15s %(message)s'
+            }
+            LOGGING_CONFIG_DEFAULT['handlers']['compliance_log'] = {
+                'class': 'logging.handlers.RotatingFileHandler',
+                'formatter': 'brief',
+                'filename': 'compliance.log',
+                'backupCount': 0,
+            }
+            LOGGING_CONFIG_DEFAULT['loggers']['COMPLIANCE'] = {
+                'handlers': ['compliance_log'],
+                'level': 'DEBUG',
+                'qualname': 'COMPLIANCE'
+            }
+
     @property
     def sentry_dsn_public(self):
         """

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -286,6 +286,7 @@ class Configuration(object):
             for ip in kwargs.get("fetch_url_whitelist", "").split(',')
             if len(ip.strip()) > 0
         ]
+        self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", "False"))
         self.allow_user_creation = string_as_bool(kwargs.get("allow_user_creation", "True"))
         self.allow_user_deletion = string_as_bool(kwargs.get("allow_user_deletion", "False"))
         self.allow_user_dataset_purge = string_as_bool(kwargs.get("allow_user_dataset_purge", "True"))

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -691,8 +691,8 @@ class Configuration(object):
         self.redact_user_address_during_deletion = False
         # GDPR compliance mode changes values on a number of variables. Other
         # policies could change (non)overlapping subsets of these variables.
-        self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", False))
-        if self.gdpr_compliance_mode:
+        self.gdpr_compliance = string_as_bool(kwargs.get("gdpr_compliance", False))
+        if self.gdpr_compliance:
             self.expose_user_name = False
             self.expose_user_email = False
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -688,6 +688,7 @@ class Configuration(object):
         self.redact_username_in_logs = False
         self.redact_email_in_job_name = False
         self.redact_user_details_in_bugreport = False
+        self.redact_user_address_during_deletion = False
         # GDPR compliance mode changes values on a number of variables. Other
         # policies could change (non)overlapping subsets of these variables.
         self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", False))
@@ -701,6 +702,7 @@ class Configuration(object):
             self.redact_username_in_logs = True
             self.redact_email_in_job_name = True
             self.redact_user_details_in_bugreport = True
+            self.redact_user_address_during_deletion = True
 
     @property
     def sentry_dsn_public(self):

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -703,6 +703,7 @@ class Configuration(object):
             self.redact_email_in_job_name = True
             self.redact_user_details_in_bugreport = True
             self.redact_user_address_during_deletion = True
+            self.allow_user_deletion = True
 
     @property
     def sentry_dsn_public(self):

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -229,13 +229,9 @@ class Configuration(object):
         self.tour_config_dir = resolve_path(kwargs.get("tour_config_dir", "config/plugins/tours"), self.root)
         self.webhooks_dirs = resolve_path(kwargs.get("webhooks_dir", "config/plugins/webhooks"), self.root)
 
-        self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", "False"))
-        if self.gdpr_compliance_mode:
-            self.expose_user_name = False
-            self.expose_user_email = False
-        else:
-            self.expose_user_name = kwargs.get("expose_user_name", False)
-            self.expose_user_email = kwargs.get("expose_user_email", False)
+        self.expose_user_name = kwargs.get("expose_user_name", False)
+        self.expose_user_email = kwargs.get("expose_user_email", False)
+
         self.password_expiration_period = timedelta(days=int(kwargs.get("password_expiration_period", 0)))
 
         # Check for tools defined in the above non-shed tool configs (i.e., tool_conf.xml) tht have
@@ -684,6 +680,27 @@ class Configuration(object):
         self.citation_cache_lock_dir = self.resolve_path(kwargs.get("citation_cache_lock_dir", "database/citations/locks"))
 
         self.containers_conf = parse_containers_config(self.containers_config_file)
+
+        # Compliance/Policy variables
+        self.redact_username_during_deletion = False
+        self.redact_email_during_deletion = False
+        self.redact_ip_address = False
+        self.redact_username_in_logs = False
+        self.redact_email_in_job_name = False
+        self.redact_user_details_in_bugreport = False
+        # GDPR compliance mode changes values on a number of variables. Other
+        # policies could change (non)overlapping subsets of these variables.
+        self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", False))
+        if self.gdpr_compliance_mode:
+            self.expose_user_name = False
+            self.expose_user_email = False
+
+            self.redact_username_during_deletion = True
+            self.redact_email_during_deletion = True
+            self.redact_ip_address = True
+            self.redact_username_in_logs = True
+            self.redact_email_in_job_name = True
+            self.redact_user_details_in_bugreport = True
 
     @property
     def sentry_dsn_public(self):

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -66,7 +66,7 @@ class BaseJobRunner(object):
         """Start the job runner
         """
         self.app = app
-        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
+        self.redact_email_in_job_name = self.app.config.redact_email_in_job_name
         self.sa_session = app.model.context
         self.nworkers = nworkers
         runner_param_specs = self.DEFAULT_SPECS.copy()
@@ -451,7 +451,7 @@ class JobState(object):
         self.runner_state_handled = False
         self.job_wrapper = job_wrapper
         self.job_destination = job_destination
-        self.gdpr_compliant = self.job_wrapper.app.config.gdpr_compliance_mode
+        self.redact_email_in_job_name = self.job_wrapper.app.config.redact_email_in_job_name
 
         self.cleanup_file_attributes = ['job_file', 'output_file', 'error_file', 'exit_code_file']
 
@@ -466,7 +466,7 @@ class JobState(object):
             job_name = 'g%s' % id_tag
             if self.job_wrapper.tool.old_id:
                 job_name += '_%s' % self.job_wrapper.tool.old_id
-            if not self.gdpr_compliant and self.job_wrapper.user:
+            if not self.redact_email_in_job_name and self.job_wrapper.user:
                 job_name += '_%s' % self.job_wrapper.user
             self.job_name = ''.join(x if x in (string.ascii_letters + string.digits + '_') else '_' for x in job_name)
 

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -66,6 +66,7 @@ class BaseJobRunner(object):
         """Start the job runner
         """
         self.app = app
+        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
         self.sa_session = app.model.context
         self.nworkers = nworkers
         runner_param_specs = self.DEFAULT_SPECS.copy()
@@ -75,7 +76,6 @@ class BaseJobRunner(object):
             log.debug('Loading %s with params: %s', self.runner_name, kwargs)
         self.runner_params = RunnerParams(specs=runner_param_specs, params=kwargs)
         self.runner_state_handlers = build_state_handlers()
-        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
 
     def _init_worker_threads(self):
         """Start ``nworkers`` worker threads.
@@ -451,6 +451,7 @@ class JobState(object):
         self.runner_state_handled = False
         self.job_wrapper = job_wrapper
         self.job_destination = job_destination
+        self.gdpr_compliant = self.job_wrapper.app.config.gdpr_compliance_mode
 
         self.cleanup_file_attributes = ['job_file', 'output_file', 'error_file', 'exit_code_file']
 

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -75,6 +75,7 @@ class BaseJobRunner(object):
             log.debug('Loading %s with params: %s', self.runner_name, kwargs)
         self.runner_params = RunnerParams(specs=runner_param_specs, params=kwargs)
         self.runner_state_handlers = build_state_handlers()
+        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
 
     def _init_worker_threads(self):
         """Start ``nworkers`` worker threads.
@@ -464,7 +465,7 @@ class JobState(object):
             job_name = 'g%s' % id_tag
             if self.job_wrapper.tool.old_id:
                 job_name += '_%s' % self.job_wrapper.tool.old_id
-            if self.job_wrapper.user:
+            if not self.gdpr_compliant and self.job_wrapper.user:
                 job_name += '_%s' % self.job_wrapper.user
             self.job_name = ''.join(x if x in (string.ascii_letters + string.digits + '_') else '_' for x in job_name)
 

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -451,7 +451,10 @@ class JobState(object):
         self.runner_state_handled = False
         self.job_wrapper = job_wrapper
         self.job_destination = job_destination
-        self.redact_email_in_job_name = self.job_wrapper.app.config.redact_email_in_job_name
+
+        self.redact_email_in_job_name = True
+        if self.job_wrapper:
+            self.redact_email_in_job_name = self.job_wrapper.app.config.redact_email_in_job_name
 
         self.cleanup_file_attributes = ['job_file', 'output_file', 'error_file', 'exit_code_file']
 

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -92,6 +92,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
 
         self._init_monitor_thread()
         self._init_worker_threads()
+        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
 
     def url_to_destination(self, url):
         """Convert a legacy URL to a job destination"""
@@ -389,7 +390,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
         job_name = 'g%s' % galaxy_id_tag
         if job_wrapper.tool.old_id:
             job_name += '_%s' % job_wrapper.tool.old_id
-        if external_runjob_script is None:
+        if not self.gdpr_compliant and external_runjob_script is None:
             job_name += '_%s' % job_wrapper.user
         job_name = ''.join(x if x in (string.ascii_letters + string.digits + '_') else '_' for x in job_name)
         if self.restrict_job_name_length:

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -92,7 +92,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
 
         self._init_monitor_thread()
         self._init_worker_threads()
-        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
+        self.redact_email_in_job_name = self.app.config.redact_email_in_job_name
 
     def url_to_destination(self, url):
         """Convert a legacy URL to a job destination"""
@@ -390,7 +390,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
         job_name = 'g%s' % galaxy_id_tag
         if job_wrapper.tool.old_id:
             job_name += '_%s' % job_wrapper.tool.old_id
-        if not self.gdpr_compliant and external_runjob_script is None:
+        if not self.redact_email_in_job_name and external_runjob_script is None:
             job_name += '_%s' % job_wrapper.user
         job_name = ''.join(x if x in (string.ascii_letters + string.digits + '_') else '_' for x in job_name)
         if self.restrict_job_name_length:

--- a/lib/galaxy/tools/error_reports/plugins/biostars.py
+++ b/lib/galaxy/tools/error_reports/plugins/biostars.py
@@ -18,14 +18,13 @@ class BiostarsPlugin(ErrorPlugin):
 
     def __init__(self, **kwargs):
         self.app = kwargs['app']
-        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
         self.verbose = string_as_bool(kwargs.get('verbose', True))
         self.user_submission = string_as_bool(kwargs.get('user_submission', True))
 
     def submit_report(self, dataset, job, tool, **kwargs):
         """Doesn't do anything, just shows a link to submit on biostars.
         """
-        # This class specifically does nothing special for GDPR compliance
+        # This class specifically does nothing special for compliance purposes
         # because the user is willingly posting their data on a public
         # first/third-party site. Maybe should do something about the dialog
         # linking to the biostars privacy policy during the "submit to

--- a/lib/galaxy/tools/error_reports/plugins/biostars.py
+++ b/lib/galaxy/tools/error_reports/plugins/biostars.py
@@ -18,12 +18,19 @@ class BiostarsPlugin(ErrorPlugin):
 
     def __init__(self, **kwargs):
         self.app = kwargs['app']
+        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
         self.verbose = string_as_bool(kwargs.get('verbose', True))
         self.user_submission = string_as_bool(kwargs.get('user_submission', True))
 
     def submit_report(self, dataset, job, tool, **kwargs):
         """Doesn't do anything, just shows a link to submit on biostars.
         """
+        # This class specifically does nothing special for GDPR compliance
+        # because the user is willingly posting their data on a public
+        # first/third-party site. Maybe should do something about the dialog
+        # linking to the biostars privacy policy during the "submit to
+        # biostars" dialog?
+
         try:
             assert biostar.biostar_enabled(self.app), ValueError("Biostar is not configured for this galaxy instance")
             assert self.app.config.biostar_enable_bug_reports, ValueError("Biostar is not configured to allow bug reporting for this galaxy instance")

--- a/lib/galaxy/tools/error_reports/plugins/email.py
+++ b/lib/galaxy/tools/error_reports/plugins/email.py
@@ -17,7 +17,7 @@ class EmailPlugin(ErrorPlugin):
 
     def __init__(self, **kwargs):
         self.app = kwargs['app']
-        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
+        self.redact_user_details_in_bugreport = self.app.config.redact_user_details_in_bugreport
         self.verbose = string_as_bool(kwargs.get('verbose', True))
         self.user_submission = string_as_bool(kwargs.get('user_submission', True))
 
@@ -26,7 +26,7 @@ class EmailPlugin(ErrorPlugin):
         """
         try:
             error_reporter = EmailErrorReporter(dataset.id, self.app)
-            error_reporter.send_report(user=job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None), gdpr_compliant=self.gdpr_compliant)
+            error_reporter.send_report(user=job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None), redact_user_details_in_bugreport=self.redact_user_details_in_bugreport)
             return ("Your error report has been sent", "success")
         except Exception as e:
             return ("An error occurred sending the report by email: %s" % str(e), "danger")

--- a/lib/galaxy/tools/error_reports/plugins/email.py
+++ b/lib/galaxy/tools/error_reports/plugins/email.py
@@ -17,6 +17,7 @@ class EmailPlugin(ErrorPlugin):
 
     def __init__(self, **kwargs):
         self.app = kwargs['app']
+        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
         self.verbose = string_as_bool(kwargs.get('verbose', True))
         self.user_submission = string_as_bool(kwargs.get('user_submission', True))
 
@@ -25,7 +26,7 @@ class EmailPlugin(ErrorPlugin):
         """
         try:
             error_reporter = EmailErrorReporter(dataset.id, self.app)
-            error_reporter.send_report(user=job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None))
+            error_reporter.send_report(user=job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None), gdpr_compliant=self.gdpr_compliant)
             return ("Your error report has been sent", "success")
         except Exception as e:
             return ("An error occurred sending the report by email: %s" % str(e), "danger")

--- a/lib/galaxy/tools/error_reports/plugins/github.py
+++ b/lib/galaxy/tools/error_reports/plugins/github.py
@@ -17,6 +17,7 @@ class GithubPlugin(ErrorPlugin):
 
     def __init__(self, **kwargs):
         self.app = kwargs['app']
+        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
         self.verbose = string_as_bool(kwargs.get('verbose', False))
         self.user_submission = string_as_bool(kwargs.get('user_submission', False))
         try:
@@ -69,7 +70,7 @@ class GithubPlugin(ErrorPlugin):
 
             # We'll re-use the email error reporter's template since github supports HTML
             error_reporter = EmailErrorReporter(dataset.id, self.app)
-            error_reporter.create_report(job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None))
+            error_reporter.create_report(job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None), gdpr_compliant=self.gdpr_compliant)
 
             # The HTML report
             error_message = error_reporter.html_report

--- a/lib/galaxy/tools/error_reports/plugins/github.py
+++ b/lib/galaxy/tools/error_reports/plugins/github.py
@@ -17,7 +17,7 @@ class GithubPlugin(ErrorPlugin):
 
     def __init__(self, **kwargs):
         self.app = kwargs['app']
-        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
+        self.redact_user_details_in_bugreport = self.app.config.redact_user_details_in_bugreport
         self.verbose = string_as_bool(kwargs.get('verbose', False))
         self.user_submission = string_as_bool(kwargs.get('user_submission', False))
         try:
@@ -70,7 +70,7 @@ class GithubPlugin(ErrorPlugin):
 
             # We'll re-use the email error reporter's template since github supports HTML
             error_reporter = EmailErrorReporter(dataset.id, self.app)
-            error_reporter.create_report(job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None), gdpr_compliant=self.gdpr_compliant)
+            error_reporter.create_report(job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None), redact_user_details_in_bugreport=self.redact_user_details_in_bugreport)
 
             # The HTML report
             error_message = error_reporter.html_report

--- a/lib/galaxy/tools/error_reports/plugins/json.py
+++ b/lib/galaxy/tools/error_reports/plugins/json.py
@@ -20,7 +20,7 @@ class JsonPlugin(ErrorPlugin):
     def __init__(self, **kwargs):
         self.app = kwargs['app']
         self.verbose = string_as_bool(kwargs.get('verbose', False))
-        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
+        self.redact_user_details_in_bugreport = self.app.config.redact_user_details_in_bugreport
         self.user_submission = string_as_bool(kwargs.get('user_submission', False))
         self.report_directory = kwargs.get("directory", tempfile.gettempdir())
         if not os.path.exists(self.report_directory):
@@ -44,7 +44,7 @@ class JsonPlugin(ErrorPlugin):
                 'tool_version': job.tool_version,
                 'tool_xml': str(tool.config_file) if tool else None
             }
-            if self.gdpr_compliant:
+            if self.redact_user_details_in_bugreport:
                 data['user'] = {
                     'id': job.get_user().id
                 }

--- a/lib/galaxy/tools/error_reports/plugins/json.py
+++ b/lib/galaxy/tools/error_reports/plugins/json.py
@@ -20,6 +20,7 @@ class JsonPlugin(ErrorPlugin):
     def __init__(self, **kwargs):
         self.app = kwargs['app']
         self.verbose = string_as_bool(kwargs.get('verbose', False))
+        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
         self.user_submission = string_as_bool(kwargs.get('user_submission', False))
         self.report_directory = kwargs.get("directory", tempfile.gettempdir())
         if not os.path.exists(self.report_directory):
@@ -40,12 +41,17 @@ class JsonPlugin(ErrorPlugin):
                 'exit_code': job.exit_code,
                 'stdout': job.stdout,
                 'handler': job.handler,
-                'user': job.get_user().to_dict(),
                 'tool_version': job.tool_version,
                 'tool_xml': str(tool.config_file) if tool else None
             }
-            if 'email' in kwargs:
-                data['email'] = kwargs['email']
+            if self.gdpr_compliant:
+                data['user'] = {
+                    'id': job.get_user().id
+                }
+            else:
+                data['user'] = job.get_user().to_dict()
+                if 'email' in kwargs:
+                    data['email'] = kwargs['email']
 
             if 'message' in kwargs:
                 data['message'] = kwargs['message']

--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -29,6 +29,7 @@ class SentryPlugin(ErrorPlugin):
 
     def __init__(self, **kwargs):
         self.app = kwargs['app']
+        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
         self.verbose = string_as_bool(kwargs.get('verbose', False))
         self.user_submission = string_as_bool(kwargs.get('user_submission', False))
         self.custom_dsn = kwargs.get('custom_dsn', None)
@@ -61,8 +62,11 @@ class SentryPlugin(ErrorPlugin):
                 'tool_version': unicodify(job.tool_version),
                 'tool_xml': unicodify(tool.config_file) if tool else None
             }
-            if 'email' in kwargs:
-                extra['email'] = unicodify(kwargs['email'])
+            if self.gdpr_compliant:
+                extra['email'] = 'gdpr-redacted'
+            else:
+                if 'email' in kwargs:
+                    extra['email'] = unicodify(kwargs['email'])
 
             # User submitted message
             extra['message'] = unicodify(kwargs.get('message', ''))
@@ -86,13 +90,20 @@ class SentryPlugin(ErrorPlugin):
                 # The above does not work when handlers are separate from the web handlers
                 url = None
 
-            if user:
-                # User information here also places email links + allows seeing
-                # a list of affected users in the tags/filtering.
-                context['user'] = {
-                    'name': user.username,
-                    'email': user.email,
-                }
+            if self.gdpr_compliant:
+                if user:
+                    # Opauqe identifier
+                    context['user'] = {
+                        'id': user.id
+                    }
+            else:
+                if user:
+                    # User information here also places email links + allows seeing
+                    # a list of affected users in the tags/filtering.
+                    context['user'] = {
+                        'name': user.username,
+                        'email': user.email,
+                    }
 
             context['request'] = {'url': url}
 

--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -29,7 +29,7 @@ class SentryPlugin(ErrorPlugin):
 
     def __init__(self, **kwargs):
         self.app = kwargs['app']
-        self.gdpr_compliant = self.app.config.gdpr_compliance_mode
+        self.redact_user_details_in_bugreport = self.app.config.redact_user_details_in_bugreport
         self.verbose = string_as_bool(kwargs.get('verbose', False))
         self.user_submission = string_as_bool(kwargs.get('user_submission', False))
         self.custom_dsn = kwargs.get('custom_dsn', None)
@@ -62,8 +62,8 @@ class SentryPlugin(ErrorPlugin):
                 'tool_version': unicodify(job.tool_version),
                 'tool_xml': unicodify(tool.config_file) if tool else None
             }
-            if self.gdpr_compliant:
-                extra['email'] = 'gdpr-redacted'
+            if self.redact_user_details_in_bugreport:
+                extra['email'] = 'redacted'
             else:
                 if 'email' in kwargs:
                     extra['email'] = unicodify(kwargs['email'])
@@ -90,7 +90,7 @@ class SentryPlugin(ErrorPlugin):
                 # The above does not work when handlers are separate from the web handlers
                 url = None
 
-            if self.gdpr_compliant:
+            if self.redact_user_details_in_bugreport:
                 if user:
                     # Opauqe identifier
                     context['user'] = {

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -154,7 +154,7 @@ class ErrorReporter(object):
             roles = []
         return self.app.security_agent.can_access_dataset(roles, self.hda.dataset)
 
-    def create_report(self, user, email='', message='', gdpr_compliant=False, **kwd):
+    def create_report(self, user, email='', message='', redact_user_details_in_bugreport=False, **kwd):
         hda = self.hda
         job = self.job
         host = web.url_for('/', qualified=True)
@@ -163,7 +163,7 @@ class ErrorReporter(object):
         hda_id_encoded = self.app.security.encode_id(hda.id)
         hda_show_params_link = web.url_for(controller="dataset", action="show_params", dataset_id=hda_id_encoded, qualified=True)
         # Build the email message
-        if self.gdpr_compliant:
+        if self.redact_user_details_in_bugreport:
             # This is sub-optimal but it is hard to solve fully. This affects
             # the github posting method more than the traditional email plugin.
             # There is no way around CCing the person with the traditional
@@ -172,13 +172,13 @@ class ErrorReporter(object):
             #
             # A secondary system with access to the github issue and access to
             # the galaxy database can shuttle email back and forth between
-            # github comments and user-emails. Something like
-            # https://github.com/erasche/github-issue-to-mailgun-gateway
+            # github comments and user-emails.
+            #
             # Thus preventing issue helpers from every knowing the identity of
             # the bug reporter (and preventing information about the bug
             # reporter from leaving the EU until it hits email directly to the
             # user.)
-            email_str = 'gdpr-redacted'
+            email_str = 'redacted'
             if user:
                 email_str += ' (user: %s)' % user.id
         else:

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -154,7 +154,7 @@ class ErrorReporter(object):
             roles = []
         return self.app.security_agent.can_access_dataset(roles, self.hda.dataset)
 
-    def create_report(self, user, email='', message='', **kwd):
+    def create_report(self, user, email='', message='', gdpr_compliant=False, **kwd):
         hda = self.hda
         job = self.job
         host = web.url_for('/', qualified=True)
@@ -163,10 +163,29 @@ class ErrorReporter(object):
         hda_id_encoded = self.app.security.encode_id(hda.id)
         hda_show_params_link = web.url_for(controller="dataset", action="show_params", dataset_id=hda_id_encoded, qualified=True)
         # Build the email message
-        if user and user.email != email:
-            email_str = "'%s' (providing preferred contact email '%s')" % (user.email, email)
+        if self.gdpr_compliant:
+            # This is sub-optimal but it is hard to solve fully. This affects
+            # the github posting method more than the traditional email plugin.
+            # There is no way around CCing the person with the traditional
+            # email bug report plugin, however with the GitHub plugin we can
+            # submit to GH without putting the email in the bug report.
+            #
+            # A secondary system with access to the github issue and access to
+            # the galaxy database can shuttle email back and forth between
+            # github comments and user-emails. Something like
+            # https://github.com/erasche/github-issue-to-mailgun-gateway
+            # Thus preventing issue helpers from every knowing the identity of
+            # the bug reporter (and preventing information about the bug
+            # reporter from leaving the EU until it hits email directly to the
+            # user.)
+            email_str = 'gdpr-redacted'
+            if user:
+                email_str += ' (user: %s)' % user.id
         else:
-            email_str = "'%s'" % (email or 'anonymously')
+            if user and user.email != email:
+                email_str = "'%s' (providing preferred contact email '%s')" % (user.email, email)
+            else:
+                email_str = "'%s'" % (email or 'anonymously')
 
         report_variables = dict(
             host=host,

--- a/lib/galaxy/visualization/plugins/interactive_environments.py
+++ b/lib/galaxy/visualization/plugins/interactive_environments.py
@@ -47,7 +47,7 @@ class InteractiveEnvironmentRequest(object):
         self.attr.viz_id = plugin.name
         self.attr.history_id = trans.security.encode_id(trans.history.id)
         self.attr.galaxy_config = trans.app.config
-        self.attr.gdpr_compliant = trans.app.config.gdpr_compliance_mode
+        self.attr.redact_username_in_logs = trans.app.config.redact_username_in_logs
         self.attr.galaxy_root_dir = os.path.abspath(self.attr.galaxy_config.root)
         self.attr.root = web.url_for("/")
         self.attr.app_root = self.attr.root + "plugins/interactive_environments/" + self.attr.viz_id + "/static/"
@@ -401,7 +401,7 @@ class InteractiveEnvironmentRequest(object):
         """
         raw_cmd = self.docker_cmd(image, env_override=env_override, volumes=volumes)
         redacted_command = raw_cmd
-        if self.attr.gdpr_compliant:
+        if self.attr.redact_username_in_logs:
             def make_safe(param):
                 if 'USER_EMAIL' in param:
                     return re.sub('USER_EMAIL=[^ ]*', 'USER_EMAIL=*********', param)

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2008,7 +2008,7 @@ mapping:
           shouldn't be exposed.  For semi-public Galaxies, it may make sense to expose
           just the username and not email, or vice versa.
 
-          If gdpr_compliance_mode is set to True, then this option will be
+          If gdpr_compliance is set to True, then this option will be
           overridden and set to False.
 
       expose_user_email:
@@ -2023,7 +2023,7 @@ mapping:
           shouldn't be exposed.  For semi-public Galaxies, it may make sense to expose
           just the username and not email, or vice versa.
 
-          If gdpr_compliance_mode is set to True, then this option will be
+          If gdpr_compliance is set to True, then this option will be
           overridden and set to False.
 
       fetch_url_whitelist:
@@ -2038,22 +2038,25 @@ mapping:
           It should be a comma separated list of IP addresses or IP address/mask, e.g.
           10.10.10.10,10.0.1.0/24,fd00::/8
 
-      gdpr_compliance_mode:
+      gdpr_compliance:
         type: bool
         default: false
         required: false
         desc: |
           Enables GDPR Compliance mode. This makes several changes to the way
-          Galaxy logs and exposes data externally such as removing
-          emails/usernames from logs and bug reports. It also causes the delete
-          user admin action to permanently redact their username and password,
-          but not to delete data associated with the account as this is not
+          Galaxy logs and exposes data externally such as removing emails and
+          usernames from logs and bug reports. It also causes the delete user
+          admin action to permanently redact their username and password, but
+          not to delete data associated with the account as this is not
           currently easily implementable.
 
           You are responsible for removing personal data from backups.
 
-          This automatically disabled expose_user_email and expose_user_name
+          This forces expose_user_email and expose_user_name to be false, and
+          forces user_deletion to be true to support the right to erasure.
 
+          Please read the GDPR section under the special topics area of the
+          admin documentation.
       enable_beta_ts_api_install:
         type: bool
         default: true
@@ -2695,4 +2698,3 @@ mapping:
         required: false
         desc: |
           persistent_communication_rooms is a comma-separated list of rooms that should be always available.
-

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2008,6 +2008,9 @@ mapping:
           shouldn't be exposed.  For semi-public Galaxies, it may make sense to expose
           just the username and not email, or vice versa.
 
+          If gdpr_compliance_mode is set to True, then this option will be
+          overridden and set to False.
+
       expose_user_email:
         type: bool
         default: false
@@ -2019,6 +2022,9 @@ mapping:
           This makes less sense on large public Galaxy instances where that data
           shouldn't be exposed.  For semi-public Galaxies, it may make sense to expose
           just the username and not email, or vice versa.
+
+          If gdpr_compliance_mode is set to True, then this option will be
+          overridden and set to False.
 
       fetch_url_whitelist:
         type: str
@@ -2043,6 +2049,8 @@ mapping:
           user admin action to permanently delete all information stored on a
           user, removing all related rows from the database. (You are
           responsible for removing the data from backups.)
+
+          This automatically disabled expose_user_email and expose_user_name
 
       enable_beta_ts_api_install:
         type: bool

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2039,7 +2039,10 @@ mapping:
         desc: |
           Enables GDPR Compliance mode. This makes several changes to the way
           Galaxy logs and exposes data externally such as removing
-          emails/usernames from logs and bug reports.
+          emails/usernames from logs and bug reports. It also causes the delete
+          user admin action to permanently delete all information stored on a
+          user, removing all related rows from the database. (You are
+          responsible for removing the data from backups.)
 
       enable_beta_ts_api_install:
         type: bool

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2032,6 +2032,15 @@ mapping:
           It should be a comma separated list of IP addresses or IP address/mask, e.g.
           10.10.10.10,10.0.1.0/24,fd00::/8
 
+      gdpr_compliance_mode:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Enables GDPR Compliance mode. This makes several changes to the way
+          Galaxy logs and exposes data externally such as removing
+          emails/usernames from logs and bug reports.
+
       enable_beta_ts_api_install:
         type: bool
         default: true

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -906,7 +906,7 @@ mapping:
           - $locale (complete format string for the server locale),
           - $iso8601 (complete format string as specified by ISO 8601 international
             standard).
-         
+
       default_locale:
         type: str
         default: auto

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2050,7 +2050,7 @@ mapping:
           but not to delete data associated with the account as this is not
           currently easily implementable.
 
-          You are responsible for removing the data from backups.
+          You are responsible for removing personal data from backups.
 
           This automatically disabled expose_user_email and expose_user_name
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2046,9 +2046,11 @@ mapping:
           Enables GDPR Compliance mode. This makes several changes to the way
           Galaxy logs and exposes data externally such as removing
           emails/usernames from logs and bug reports. It also causes the delete
-          user admin action to permanently delete all information stored on a
-          user, removing all related rows from the database. (You are
-          responsible for removing the data from backups.)
+          user admin action to permanently redact their username and password,
+          but not to delete data associated with the account as this is not
+          currently easily implementable.
+
+          You are responsible for removing the data from backups.
 
           This automatically disabled expose_user_email and expose_user_name
 

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -1444,6 +1444,23 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             if self.app.config.redact_username_during_deletion:
                 user.username = uname_hash
 
+            # Redact user addresses as well
+            if self.app.config.redact_user_address_during_deletion:
+                user_addresses = trans.sa_session.query(trans.app.model.UserAddress) \
+                    .filter(trans.app.model.UserAddress.user_id == user.id).all()
+
+                for addr in user_addresses:
+                    addr.desc = new_secure_hash(addr.desc + pseudorandom_value)
+                    addr.name = new_secure_hash(addr.name + pseudorandom_value)
+                    addr.institution = new_secure_hash(addr.institution + pseudorandom_value)
+                    addr.address = new_secure_hash(addr.address + pseudorandom_value)
+                    addr.city = new_secure_hash(addr.city + pseudorandom_value)
+                    addr.state = new_secure_hash(addr.state + pseudorandom_value)
+                    addr.postal_code = new_secure_hash(addr.postal_code + pseudorandom_value)
+                    addr.country = new_secure_hash(addr.country + pseudorandom_value)
+                    addr.phone = new_secure_hash(addr.phone + pseudorandom_value)
+                    trans.sa_session.add(addr)
+
             trans.sa_session.add(user)
             trans.sa_session.flush()
             message += ' %s ' % user.email

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -39,6 +39,7 @@ from tool_shed.util.web_util import escape
 
 
 log = logging.getLogger(__name__)
+gdpr_log = logging.getLogger('GDPR')
 
 
 class UserListGrid(grids.Grid):
@@ -1412,6 +1413,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             user.deleted = True
 
             if gdpr_compliant:
+                gdpr_log.info('delete-user-event: %s' % user_id)
                 # Maybe there is some case in the future where an admin needs
                 # to prove that a user was using a server for some reason (e.g.
                 # a court case.) So we make this painfully hard to recover (and

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -1412,7 +1412,6 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
 
             compliance_log.info('delete-user-event: %s' % user_id)
 
-
             # Maybe there is some case in the future where an admin needs
             # to prove that a user was using a server for some reason (e.g.
             # a court case.) So we make this painfully hard to recover (and
@@ -1439,7 +1438,6 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                 if self.app.config.redact_email_during_deletion:
                     role.name = role.name.replace(user.email, email_hash)
                     role.description = role.description.replace(user.email, email_hash)
-
 
             if self.app.config.redact_email_during_deletion:
                 user.email = email_hash

--- a/lib/galaxy/webapps/reports/config.py
+++ b/lib/galaxy/webapps/reports/config.py
@@ -59,6 +59,7 @@ class Configuration(object):
         if self.gdpr_compliance:
             self.redact_username_in_logs = True
             self.redact_email_in_job_name = True
+            self.allow_user_deletion = True
 
     def get(self, key, default):
         return self.config_dict.get(key, default)

--- a/lib/galaxy/webapps/reports/config.py
+++ b/lib/galaxy/webapps/reports/config.py
@@ -52,6 +52,14 @@ class Configuration(object):
         # Error logging with sentry
         self.sentry_dsn = kwargs.get('sentry_dsn', None)
 
+        # Security/Policy Compliance
+        self.redact_username_in_logs = False
+        self.redact_email_in_job_name = False
+        self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", False))
+        if self.gdpr_compliance_mode:
+            self.redact_username_in_logs = True
+            self.redact_email_in_job_name = True
+
     def get(self, key, default):
         return self.config_dict.get(key, default)
 

--- a/lib/galaxy/webapps/reports/config.py
+++ b/lib/galaxy/webapps/reports/config.py
@@ -55,8 +55,8 @@ class Configuration(object):
         # Security/Policy Compliance
         self.redact_username_in_logs = False
         self.redact_email_in_job_name = False
-        self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", False))
-        if self.gdpr_compliance_mode:
+        self.gdpr_compliance = string_as_bool(kwargs.get("gdpr_compliance", False))
+        if self.gdpr_compliance:
             self.redact_username_in_logs = True
             self.redact_email_in_job_name = True
 

--- a/lib/galaxy/webapps/reports/config_schema.yml
+++ b/lib/galaxy/webapps/reports/config_schema.yml
@@ -102,7 +102,7 @@ mapping:
         desc: |
           Mail
 
-      gdpr_compliance_mode:
+      gdpr_compliance:
         type: bool
         default: false
         required: false
@@ -112,3 +112,6 @@ mapping:
           emails/usernames from logs and bug reports.
 
           You are responsible for removing personal data from backups.
+
+          Please read the GDPR section under the special topics area of the
+          admin documentation.

--- a/lib/galaxy/webapps/reports/config_schema.yml
+++ b/lib/galaxy/webapps/reports/config_schema.yml
@@ -101,3 +101,14 @@ mapping:
         default: your_bugs@bx.psu.edu
         desc: |
           Mail
+
+      gdpr_compliance_mode:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Enables GDPR Compliance mode. This makes several changes to the way
+          Galaxy logs and exposes data externally such as removing
+          emails/usernames from logs and bug reports.
+
+          You are responsible for removing personal data from backups.

--- a/lib/galaxy/webapps/tool_shed/config.py
+++ b/lib/galaxy/webapps/tool_shed/config.py
@@ -143,12 +143,14 @@ class Configuration(object):
         self.password_expiration_period = timedelta(days=int(kwargs.get("password_expiration_period", 0)))
 
         # Security/Policy Compliance
+        self.redact_username_during_deletion = False
+        self.redact_email_during_deletion = False
         self.redact_username_in_logs = False
-        self.redact_email_in_job_name = False
         self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", False))
         if self.gdpr_compliance_mode:
+            self.redact_username_during_deletion = True
+            self.redact_email_during_deletion = True
             self.redact_username_in_logs = True
-            self.redact_email_in_job_name = True
 
     @property
     def shed_tool_data_path(self):

--- a/lib/galaxy/webapps/tool_shed/config.py
+++ b/lib/galaxy/webapps/tool_shed/config.py
@@ -151,6 +151,7 @@ class Configuration(object):
             self.redact_username_during_deletion = True
             self.redact_email_during_deletion = True
             self.redact_username_in_logs = True
+            self.allow_user_deletion = True
 
     @property
     def shed_tool_data_path(self):

--- a/lib/galaxy/webapps/tool_shed/config.py
+++ b/lib/galaxy/webapps/tool_shed/config.py
@@ -142,6 +142,14 @@ class Configuration(object):
         self.citation_cache_lock_dir = resolve_path(kwargs.get("citation_cache_lock_dir", "database/tool_shed_citations/locks"), self.root)
         self.password_expiration_period = timedelta(days=int(kwargs.get("password_expiration_period", 0)))
 
+        # Security/Policy Compliance
+        self.redact_username_in_logs = False
+        self.redact_email_in_job_name = False
+        self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", False))
+        if self.gdpr_compliance_mode:
+            self.redact_username_in_logs = True
+            self.redact_email_in_job_name = True
+
     @property
     def shed_tool_data_path(self):
         return self.tool_data_path

--- a/lib/galaxy/webapps/tool_shed/config.py
+++ b/lib/galaxy/webapps/tool_shed/config.py
@@ -146,8 +146,8 @@ class Configuration(object):
         self.redact_username_during_deletion = False
         self.redact_email_during_deletion = False
         self.redact_username_in_logs = False
-        self.gdpr_compliance_mode = string_as_bool(kwargs.get("gdpr_compliance_mode", False))
-        if self.gdpr_compliance_mode:
+        self.gdpr_compliance = string_as_bool(kwargs.get("gdpr_compliance", False))
+        if self.gdpr_compliance:
             self.redact_username_during_deletion = True
             self.redact_email_during_deletion = True
             self.redact_username_in_logs = True

--- a/lib/galaxy/webapps/tool_shed/config_schema.yml
+++ b/lib/galaxy/webapps/tool_shed/config_schema.yml
@@ -385,3 +385,14 @@ mapping:
         required: false
         desc: |
           Serving static files (needed if running standalone)
+
+      gdpr_compliance_mode:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Enables GDPR Compliance mode. This makes several changes to the way
+          Galaxy logs and exposes data externally such as removing
+          emails/usernames from logs and bug reports.
+
+          You are responsible for removing personal data from backups.

--- a/lib/galaxy/webapps/tool_shed/config_schema.yml
+++ b/lib/galaxy/webapps/tool_shed/config_schema.yml
@@ -430,7 +430,7 @@ mapping:
         desc: |
           Serving static files (needed if running standalone)
 
-      gdpr_compliance_mode:
+      gdpr_compliance:
         type: bool
         default: false
         required: false
@@ -440,6 +440,9 @@ mapping:
           emails/usernames from logs and bug reports.
 
           You are responsible for removing personal data from backups.
+
+          Please read the GDPR section under the special topics area of the
+          admin documentation.
 
       apache_xsendfile:
         type: bool

--- a/lib/galaxy/webapps/tool_shed/config_schema.yml
+++ b/lib/galaxy/webapps/tool_shed/config_schema.yml
@@ -199,6 +199,34 @@ mapping:
           secret shared between the upstream proxy server, and Galaxy is required.
           If anyone other than the Galaxy user is using the server, then apache/nginx
           should pass a value in the header 'GX_SECRET' that is identical the one below
+
+      remote_user_maildomain:
+        type: str
+        default: null
+        required: false
+        desc: |
+          If use_remote_user is enabled and your external authentication
+          method just returns bare usernames, set a default mail domain to be appended
+          to usernames, to become your Galaxy usernames (email addresses).
+
+      remote_user_header:
+        type: str
+        default: HTTP_REMOTE_USER
+        required: false
+        desc: |
+          If use_remote_user is enabled, the header that the upstream proxy provides
+          the remote username in defaults to HTTP_REMOTE_USER (the 'HTTP_' is prepended
+          by WSGI).  This option allows you to change the header.  Note, you still need
+          to prepend 'HTTP_' to the header in this option, but your proxy server should
+          *not* include 'HTTP_' at the beginning of the header name.
+
+      remote_user_logout_href:
+        type: str
+        default: null
+        required: false
+        desc: |
+          If use_remote_user is enabled, you can set this to a URL that will log your
+          users out.
       
       debug:
         type: bool
@@ -243,6 +271,22 @@ mapping:
         required: false
         desc: |
           Force everyone to log in (disable anonymous access)
+
+      allow_user_creation:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          Allow unregistered users to create new accounts (otherwise, they will have to
+          be created by an admin).
+
+      allow_user_deletion:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Allow administrators to delete accounts.
+
       
       smtp_server:
         type: str
@@ -396,3 +440,140 @@ mapping:
           emails/usernames from logs and bug reports.
 
           You are responsible for removing personal data from backups.
+
+      apache_xsendfile:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          For help on configuring the Advanced proxy features, see:
+          http://usegalaxy.org/production
+
+          Apache can handle file downloads (Galaxy-to-user) via mod_xsendfile.  Set
+          this to True to inform Galaxy that mod_xsendfile is enabled upstream.
+
+      nginx_x_accel_redirect_base:
+        type: str
+        default: null
+        required: false
+        desc: |
+          The same download handling can be done by nginx using X-Accel-Redirect.  This
+          should be set to the path defined in the nginx config as an internal redirect
+          with access to Galaxy's data files (see documentation linked above).
+
+      nginx_upload_path:
+        type: str
+        default: null
+        required: false
+        desc: |
+          This value overrides the action set on the file upload form, e.g. the web
+          path where the nginx_upload_module has been configured to intercept upload
+          requests.
+
+      blacklist_file:
+        type: str
+        default: config/disposable_email_blacklist.conf
+        required: false
+        desc: |
+          E-mail domains blacklist is used for filtering out users that are using
+          disposable email address during the registration.  If their address domain
+          matches any domain in the blacklist, they are refused the registration.
+
+      brand:
+        type: str
+        default: null
+        required: false
+        desc: |
+          Append "/{brand}" to the "Galaxy" text in the masthead.
+
+      citation_cache_type:
+        type: str
+        default: file
+        required: false
+        desc: |
+          Citation related caching.  Tool citations information maybe fetched from
+          external sources such as http://dx.doi.org/ by Galaxy - the following
+          parameters can be used to control the caching used to store this information.
+
+      citation_cache_data_dir:
+        type: str
+        default: database/citations/data
+        required: false
+        desc: |
+          Citation related caching.  Tool citations information maybe fetched from
+          external sources such as http://dx.doi.org/ by Galaxy - the following
+          parameters can be used to control the caching used to store this information.
+
+      citation_cache_lock_dir:
+        type: str
+        default: database/citations/lock
+        required: false
+        desc: |
+          Citation related caching.  Tool citations information maybe fetched from
+          external sources such as http://dx.doi.org/ by Galaxy - the following
+          parameters can be used to control the caching used to store this information.
+
+      cookie_path:
+        type: str
+        default: null
+        required: false
+        desc: |
+          If proxy-prefix is enabled and you're running more than one Galaxy instance
+          behind one hostname, you will want to set this to the same path as the prefix
+          in the filter above.  This value becomes the "path" attribute set in the
+          cookie so the cookies from each instance will not clobber each other.
+
+      enable_openid:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Enable authentication via OpenID.  Allows users to log in to their Galaxy
+          account by authenticating with an OpenID provider.
+
+      log_actions:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          Turn on logging of user actions to the database.  Actions currently logged
+          are grid views, tool searches, and use of "recently" used tools menu.  The
+          log_events and log_actions functionality will eventually be merged.
+
+      password_expiration_period:
+        type: int
+        default: 0
+        required: false
+        desc: |
+          Password expiration period (in days). Users are required to change their
+          password every x days. Users will be redirected to the change password
+          screen when they log in after their password expires. Enter 0 to disable
+          password expiration.
+
+      sentry_dsn:
+        type: str
+        default: null
+        required: false
+        desc: |
+          Log to Sentry
+          Sentry is an open source logging and error aggregation platform.  Setting
+          sentry_dsn will enable the Sentry middleware and errors will be sent to the
+          indicated sentry instance.  This connection string is available in your
+          sentry instance under <project_name> -> Settings -> API Keys.
+
+      session_duration:
+        type: int
+        default: 0
+        required: false
+        desc: |
+          Galaxy Session Timeout
+          This provides a timeout (in minutes) after which a user will have to log back in.
+          A duration of 0 disables this feature.
+
+      terms_url:
+        type: str
+        default: null
+        required: false
+        desc: |
+          The URL linked by the "Terms and Conditions" link in the "Help" menu, as well
+          as on the user registration and login forms and in the activation emails.

--- a/lib/galaxy/webapps/tool_shed/controllers/admin.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/admin.py
@@ -1,13 +1,13 @@
 import logging
 
 import tool_shed.grids.admin_grids as admin_grids
-from galaxy.web.framework.helpers import grids
 from galaxy import (
     util,
     web
 )
 from galaxy.util import inflector
 from galaxy.web.base.controller import BaseUIController
+from galaxy.web.framework.helpers import grids
 from tool_shed.metadata import repository_metadata_manager
 from tool_shed.util import (
     metadata_util,

--- a/lib/galaxy/webapps/tool_shed/controllers/admin.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/admin.py
@@ -1,6 +1,7 @@
 import logging
 
 import tool_shed.grids.admin_grids as admin_grids
+from galaxy.web.framework.helpers import grids
 from galaxy import (
     util,
     web
@@ -27,6 +28,10 @@ class AdminController(BaseUIController, Admin):
     manage_category_grid = admin_grids.ManageCategoryGrid()
     repository_grid = admin_grids.AdminRepositoryGrid()
     repository_metadata_grid = admin_grids.RepositoryMetadataGrid()
+
+    delete_operation = grids.GridOperation("Delete", condition=(lambda item: not item.deleted), allow_multiple=True)
+    undelete_operation = grids.GridOperation("Undelete", condition=(lambda item: item.deleted and not item.purged), allow_multiple=True)
+    purge_operation = grids.GridOperation("Purge", condition=(lambda item: item.deleted and not item.purged), allow_multiple=True)
 
     @web.expose
     @web.require_admin

--- a/lib/tool_shed/util/admin_util.py
+++ b/lib/tool_shed/util/admin_util.py
@@ -1,14 +1,17 @@
 import logging
+import time
 
 from sqlalchemy import false, func
 
 from galaxy import util, web
 from galaxy.util import inflector
+from galaxy.util.hash_util import new_secure_hash
 from galaxy.web.form_builder import CheckboxField
 from tool_shed.util.web_util import escape
 
 
 log = logging.getLogger(__name__)
+compliance_log = logging.getLogger('COMPLIANCE')
 
 
 class Admin(object):
@@ -706,6 +709,27 @@ class Admin(object):
         for user_id in ids:
             user = get_user(trans, user_id)
             user.deleted = True
+
+            compliance_log.info('delete-user-event: %s' % user_id)
+            # See lib/galaxy/webapps/tool_shed/controllers/admin.py
+            pseudorandom_value = str(int(time.time()))
+            email_hash = new_secure_hash(user.email + pseudorandom_value)
+            uname_hash = new_secure_hash(user.username + pseudorandom_value)
+            for role in user.all_roles():
+                print(role, self.app.config.redact_username_during_deletion, self.app.config.redact_email_during_deletion)
+                if self.app.config.redact_username_during_deletion:
+                    role.name = role.name.replace(user.username, uname_hash)
+                    role.description = role.description.replace(user.username, uname_hash)
+
+                if self.app.config.redact_email_during_deletion:
+                    role.name = role.name.replace(user.email, email_hash)
+                    role.description = role.description.replace(user.email, email_hash)
+
+            if self.app.config.redact_email_during_deletion:
+                user.email = email_hash
+            if self.app.config.redact_username_during_deletion:
+                user.username = uname_hash
+
             trans.sa_session.add(user)
             trans.sa_session.flush()
             message += " %s " % user.email
@@ -833,6 +857,7 @@ class Admin(object):
                 return self.create_new_user(trans, **kwd)
             elif operation == "manage roles and groups":
                 return self.manage_roles_and_groups_for_user(trans, **kwd)
+
         if trans.app.config.allow_user_deletion:
             if self.delete_operation not in self.user_list_grid.operations:
                 self.user_list_grid.operations.append(self.delete_operation)

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -132,7 +132,7 @@ class MockAppConfig(Bunch):
 
         self.migrated_tools_config = "/tmp/migrated_tools_conf.xml"
         self.preserve_python_environment = "always"
-        self.gdpr_compliance_mode = False
+        self.gdpr_compliance = False
 
         # set by MockDir
         self.root = root

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -123,6 +123,9 @@ class MockAppConfig(Bunch):
 
         self.umask = 0o77
 
+        # Compliance related config
+        self.redact_email_in_job_name = False
+
         # Follow two required by GenomeBuilds
         self.len_file_path = os.path.join('tool-data', 'shared', 'ucsc', 'chrom')
         self.builds_file_path = os.path.join('tool-data', 'shared', 'ucsc', 'builds.txt.sample')

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -129,6 +129,7 @@ class MockAppConfig(Bunch):
 
         self.migrated_tools_config = "/tmp/migrated_tools_conf.xml"
         self.preserve_python_environment = "always"
+        self.gdpr_compliance_mode = False
 
         # set by MockDir
         self.root = root


### PR DESCRIPTION
Targeting 18.05 instead of dev because these rules come into effect this month. I know new features in frozen releases is generally against policy, but need to meet legal requirements probably outweighs. :(

- [x] remove usernames from logs (replace with user IDs. Currently unencoded, might want to encode to better meet "pseudonymization" requirement? Not sure this is necessary) 
- [x] enhance deletion of users
  - based on conversations in EU, plan is to remove/obscure username + email in the object
  - [x] Need to do this for roles as well.
  - [x] Update param doc in light of these discussions
- ~~#1023~~ ~~#2324 for obtaining consent before we can process their jobs again?~~
- [ ] script for transferring data to another server (does not need to be in this PR)
- [x] Toolshed compliance
- [x]  :sob: 