### PR TITLE
Make `interactor._{get,post,put,...}` less repetitive

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -537,11 +537,15 @@ class GalaxyInteractorApi(object):
 
     def _post(self, path, data=None, files=None, key=None, admin=False, anon=False):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
-        return requests.post("%s/%s" % (self.api_url, path), params=params, data=data, files=files)
+        # no params for POST
+        data.update(params)
+        return requests.post("%s/%s" % (self.api_url, path), data=data, files=files)
 
     def _delete(self, path, data=None, key=None, admin=False, anon=False):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
-        return requests.delete("%s/%s" % (self.api_url, path), params=params, data=data)
+        # no data for DELETE
+        params.update(data)
+        return requests.delete("%s/%s" % (self.api_url, path), params=params)
 
     def _patch(self, path, data=None, key=None, admin=False, anon=False):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
@@ -553,6 +557,7 @@ class GalaxyInteractorApi(object):
 
     def _get(self, path, data={}, key=None, admin=False, anon=False):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
+        # no data for GET
         params.update(data)
         if path.startswith("/api"):
             path = path[len("/api"):]

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -555,7 +555,7 @@ class GalaxyInteractorApi(object):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
         return requests.put("%s/%s" % (self.api_url, path), params=params, data=data)
 
-    def _get(self, path, data={}, key=None, admin=False, anon=False):
+    def _get(self, path, data=None, key=None, admin=False, anon=False):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
         # no data for GET
         params.update(data)

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -553,10 +553,11 @@ class GalaxyInteractorApi(object):
 
     def _get(self, path, data={}, key=None, admin=False, anon=False):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
+        params.update(data)
         if path.startswith("/api"):
             path = path[len("/api"):]
         url = "%s/%s" % (self.api_url, path)
-        return requests.get(url, params=params, data=data)
+        return requests.get(url, params=params)
 
 
 class RunToolException(Exception):

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -525,54 +525,38 @@ class GalaxyInteractorApi(object):
 
         return fetcher
 
-    def _post(self, path, data={}, files=None, key=None, admin=False, anon=False):
+    def __inject_api_key(self, data, key, admin, anon):
+        if data is None:
+            data = {}
+        params = {}
         if not anon:
             if not key:
                 key = self.api_key if not admin else self.master_api_key
-            data = data.copy()
-            data['key'] = key
-        return requests.post("%s/%s" % (self.api_url, path), data=data, files=files)
+            params['key'] = key
+        return params, data
 
-    def _delete(self, path, data={}, key=None, admin=False, anon=False):
-        if not anon:
-            if not key:
-                key = self.api_key if not admin else self.master_api_key
-            data = data.copy()
-            data['key'] = key
-        return requests.delete("%s/%s" % (self.api_url, path), params=data)
+    def _post(self, path, data=None, files=None, key=None, admin=False, anon=False):
+        params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
+        return requests.post("%s/%s" % (self.api_url, path), params=params, data=data, files=files)
 
-    def _patch(self, path, data={}, key=None, admin=False, anon=False):
-        if not anon:
-            if not key:
-                key = self.api_key if not admin else self.master_api_key
-            params = dict(key=key)
-            data = data.copy()
-            data['key'] = key
-        else:
-            params = {}
+    def _delete(self, path, data=None, key=None, admin=False, anon=False):
+        params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
+        return requests.delete("%s/%s" % (self.api_url, path), params=params, data=data)
+
+    def _patch(self, path, data=None, key=None, admin=False, anon=False):
+        params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
         return requests.patch("%s/%s" % (self.api_url, path), params=params, data=data)
 
-    def _put(self, path, data={}, key=None, admin=False, anon=False):
-        if not anon:
-            if not key:
-                key = self.api_key if not admin else self.master_api_key
-            params = dict(key=key)
-            data = data.copy()
-            data['key'] = key
-        else:
-            params = {}
+    def _put(self, path, data=None, key=None, admin=False, anon=False):
+        params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
         return requests.put("%s/%s" % (self.api_url, path), params=params, data=data)
 
     def _get(self, path, data={}, key=None, admin=False, anon=False):
-        if not anon:
-            if not key:
-                key = self.api_key if not admin else self.master_api_key
-            data = data.copy()
-            data['key'] = key
+        params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
         if path.startswith("/api"):
             path = path[len("/api"):]
         url = "%s/%s" % (self.api_url, path)
-        return requests.get(url, params=data)
+        return requests.get(url, params=params, data=data)
 
 
 class RunToolException(Exception):

--- a/test/api/test_libraries.py
+++ b/test/api/test_libraries.py
@@ -34,7 +34,7 @@ class LibrariesApiTestCase(api.ApiTestCase, TestsDatasets):
         self._assert_has_keys(library, "deleted")
         assert library["deleted"] is True
         # Test undeleting
-        data = json.dumps(dict(undelete=True))
+        data = dict(undelete=True)
         create_response = self._delete("libraries/%s" % library["id"], data=data, admin=True)
         library = create_response.json()
         self._assert_status_code_is(create_response, 200)

--- a/test/api/test_libraries.py
+++ b/test/api/test_libraries.py
@@ -34,7 +34,7 @@ class LibrariesApiTestCase(api.ApiTestCase, TestsDatasets):
         self._assert_has_keys(library, "deleted")
         assert library["deleted"] is True
         # Test undeleting
-        data = dict(undelete='true')
+        data = json.dumps(dict(undelete=True))
         create_response = self._delete("libraries/%s" % library["id"], data=data, admin=True)
         library = create_response.json()
         self._assert_status_code_is(create_response, 200)

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -25,7 +25,7 @@ class ToolsTestCase(api.ApiTestCase):
         assert "upload1" in tool_ids
 
     def test_no_panel_index(self):
-        index = self._get("tools", data=json.dumps(dict(in_panel=False)))
+        index = self._get("tools", data=dict(in_panel=False))
         tools_index = index.json()
         # No need to flatten out sections, with in_panel=False, only tools are
         # returned.

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -25,7 +25,7 @@ class ToolsTestCase(api.ApiTestCase):
         assert "upload1" in tool_ids
 
     def test_no_panel_index(self):
-        index = self._get("tools", data=dict(in_panel="false"))
+        index = self._get("tools", data=json.dumps(dict(in_panel=False)))
         tools_index = index.json()
         # No need to flatten out sections, with in_panel=False, only tools are
         # returned.


### PR DESCRIPTION
Also inject api key into params, so that we can use `json.dumps` for the
payload instead of writing json strings in python.