### PR TITLE
Add resume job api

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -208,6 +208,27 @@ class JobController(BaseAPIController, UsesLibraryMixinItems):
         else:
             return False
 
+    @expose_api
+    def resume(self, trans, id, **kwd):
+        """
+        * PUT /api/jobs/{id}/resume
+            Resumes a paused job
+
+        :type   id: string
+        :param  id: Encoded job id
+
+        :rtype:     dictionary
+        :returns:   dictionary containing output dataset associations
+        """
+        job = self.__get_job(trans, id)
+        if not job:
+            raise exceptions.ObjectNotFound("Could not access job with id '%s'" % id)
+        if job.state == job.states.PAUSED:
+            job.resume()
+        else:
+            exceptions.RequestParameterInvalidException("Job with id '%s' is not paused" % (job.tool_id))
+        return self.__dictify_associations(trans, job.output_datasets, job.output_library_datasets)
+
     @expose_api_anonymous
     def build_for_rerun(self, trans, id, **kwd):
         """

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -787,6 +787,7 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect('job_inputs', '/api/jobs/{id}/inputs', controller='jobs', action='inputs', conditions=dict(method=['GET']))
     webapp.mapper.connect('job_outputs', '/api/jobs/{id}/outputs', controller='jobs', action='outputs', conditions=dict(method=['GET']))
     webapp.mapper.connect('build_for_rerun', '/api/jobs/{id}/build_for_rerun', controller='jobs', action='build_for_rerun', conditions=dict(method=['GET']))
+    webapp.mapper.connect('resume', '/api/jobs/{id}/resume', controller='jobs', action='resume', conditions=dict(method=['PUT']))
     webapp.mapper.connect('job_error', '/api/jobs/{id}/error', controller='jobs', action='error', conditions=dict(method=['POST']))
 
     # Job files controllers. Only for consumption by remote job runners.


### PR DESCRIPTION
We didn't have a way to resume a specific job via the API, this adds that (and also contains #6070 and #6036, should be clearer after those are merged) and also should make resuming many jobs in a history quicker.