### PR TITLE
Fix JobWrapper.get_destination_configuration() so that it actually checks the JobDestination params

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -714,7 +714,7 @@ class JobWrapper(HasResourceParameters):
         self._create_working_directory()
         # the path rewriter needs destination params, so it cannot be set up until after the destination has been
         # resolved
-        self.dataset_path_rewriter = None
+        self.__dataset_path_rewriter = None
         self.output_paths = None
         self.output_hdas_and_paths = None
         self.tool_provided_job_metadata = None
@@ -731,13 +731,19 @@ class JobWrapper(HasResourceParameters):
         self.__user_system_pwent = None
         self.__galaxy_system_pwent = None
 
-    def _job_dataset_path_rewriter(self, working_directory):
-        outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
-        if outputs_to_working_directory:
-            dataset_path_rewriter = OutputsToWorkingDirectoryPathRewriter(working_directory)
-        else:
-            dataset_path_rewriter = NullDatasetPathRewriter()
-        return dataset_path_rewriter
+    @property
+    def _job_dataset_path_rewriter(self):
+        if self.__dataset_path_rewriter is None:
+            outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
+            if outputs_to_working_directory:
+                self.__dataset_path_rewriter = OutputsToWorkingDirectoryPathRewriter(self.working_directory)
+            else:
+                self.__dataset_path_rewriter = NullDatasetPathRewriter()
+        return self.__dataset_path_rewriter
+
+    @property
+    def dataset_path_rewriter(self):
+        return self._job_dataset_path_rewriter
 
     @property
     def cleanup_job(self):
@@ -803,10 +809,7 @@ class JobWrapper(HasResourceParameters):
 
         :returns: ``JobDestination``
         """
-        dest = self.job_runner_mapper.get_job_destination(self.params)
-        if self.dataset_path_rewriter is None:
-            self.dataset_path_rewriter = self._job_dataset_path_rewriter(self.working_directory)
-        return dest
+        return self.job_runner_mapper.get_job_destination(self.params)
 
     def get_job(self):
         return self.sa_session.query(model.Job).get(self.job_id)
@@ -1872,15 +1875,18 @@ class TaskWrapper(JobWrapper):
     def __init__(self, task, queue):
         super(TaskWrapper, self).__init__(task.job, queue)
         self.task_id = task.id
-        working_directory = task.working_directory
-        self.working_directory = working_directory
-        job_dataset_path_rewriter = self._job_dataset_path_rewriter(self.working_directory)
-        self.dataset_path_rewriter = TaskPathRewriter(working_directory, job_dataset_path_rewriter)
+        self.working_directory = task.working_directory
         if task.prepare_input_files_cmd is not None:
             self.prepare_input_files_cmds = [task.prepare_input_files_cmd]
         else:
             self.prepare_input_files_cmds = None
         self.status = task.states.NEW
+
+    @property
+    def dataset_path_rewriter(self):
+        if self.__dataset_path_rewriter is None:
+            self.__dataset_path_rewriter = TaskPathRewriter(self.working_directory, self._job_dataset_path_rewriter)
+        return self.__dataset_path_rewriter
 
     def can_split(self):
         # Should the job handler split this job up? TaskWrapper should

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -714,7 +714,7 @@ class JobWrapper(HasResourceParameters):
         self._create_working_directory()
         # the path rewriter needs destination params, so it cannot be set up until after the destination has been
         # resolved
-        self.__dataset_path_rewriter = None
+        self._dataset_path_rewriter = None
         self.output_paths = None
         self.output_hdas_and_paths = None
         self.tool_provided_job_metadata = None
@@ -733,13 +733,13 @@ class JobWrapper(HasResourceParameters):
 
     @property
     def _job_dataset_path_rewriter(self):
-        if self.__dataset_path_rewriter is None:
+        if self._dataset_path_rewriter is None:
             outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
             if outputs_to_working_directory:
-                self.__dataset_path_rewriter = OutputsToWorkingDirectoryPathRewriter(self.working_directory)
+                self._dataset_path_rewriter = OutputsToWorkingDirectoryPathRewriter(self.working_directory)
             else:
-                self.__dataset_path_rewriter = NullDatasetPathRewriter()
-        return self.__dataset_path_rewriter
+                self._dataset_path_rewriter = NullDatasetPathRewriter()
+        return self._dataset_path_rewriter
 
     @property
     def dataset_path_rewriter(self):
@@ -1884,9 +1884,9 @@ class TaskWrapper(JobWrapper):
 
     @property
     def dataset_path_rewriter(self):
-        if self.__dataset_path_rewriter is None:
-            self.__dataset_path_rewriter = TaskPathRewriter(self.working_directory, self._job_dataset_path_rewriter)
-        return self.__dataset_path_rewriter
+        if self._dataset_path_rewriter is None:
+            self._dataset_path_rewriter = TaskPathRewriter(self.working_directory, self._job_dataset_path_rewriter)
+        return self._dataset_path_rewriter
 
     def can_split(self):
         # Should the job handler split this job up? TaskWrapper should

--- a/lib/galaxy/jobs/mapper.py
+++ b/lib/galaxy/jobs/mapper.py
@@ -224,6 +224,7 @@ class JobRunnerMapper(object):
             job_destination = self.__handle_dynamic_job_destination(raw_job_destination)
         else:
             job_destination = raw_job_destination
+        log.debug("(%s) Mapped job to destination id: %s", self.job_wrapper.job_id, job_destination.id)
         self.cached_job_destination = job_destination
 
     def get_job_destination(self, params):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -874,12 +874,14 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable):
         if self.workflow_invocation_step:
             self.workflow_invocation_step.update()
 
-    def get_destination_configuration(self, config, key, default=None):
+    def get_destination_configuration(self, dest_params, config, key, default=None):
         """ Get a destination parameter that can be defaulted back
         in specified config if it needs to be applied globally.
         """
         param_unspecified = object()
         config_value = (self.destination_params or {}).get(key, param_unspecified)
+        if config_value is param_unspecified:
+            config_value = dest_params.get(key, param_unspecified)
         if config_value is param_unspecified:
             config_value = getattr(config, key, param_unspecified)
         if config_value is param_unspecified:


### PR DESCRIPTION
I believe this was the original intent, but I could be wrong. Currently, when this method is called it only checks the persisted `destination_params` on the `Job` object and falls back to the app config. But I assume it should also be looking at the job destination's params. Because the params are persisted to the `Job` fairly late, you can't really use destination params for things like `outputs_to_working_directory` as intended.

With this change, it will now check the persisted params, followed by the destination params, and finally, the app config.