### PR TITLE
[18.05] Fix sniff validation for dynamic compressed types.

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -323,7 +323,9 @@ class Registry(object):
                                     if sniff_compressed_types is None:
                                         sniff_compressed_types = getattr(self.config, "sniff_compressed_dynamic_datatypes_default", True)
                                     if not sniff_compressed_types:
-                                        attributes["sniff_prefix"] = lambda self, file_prefix: False
+                                        # Disable sniff on this type unless in validate_mode().
+                                        attributes["sniff_compressed"] = False
+
                                     compressed_datatype_class = type(auto_compressed_type_name, (datatype_class, binary.CompressedArchive, ), attributes)
                                     if edam_format:
                                         compressed_datatype_class.edam_format = edam_format


### PR DESCRIPTION
This was broken in a bad PR merge/rebase process since the validation mode didn't exist when the initial dynamic compressed types PR was opened.

Should fix #6074.