### PR TITLE
[18.05] Fix matches_any() checks for dynamic compressed types.

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -692,6 +692,7 @@ class Data(object):
         """
         self_datatype = self
 
+        target_datatypes = tuple(datatype if isclass(datatype) else datatype.__class__ for datatype in target_datatypes)
         if hasattr(self, "uncompressed_datatype_class"):
             # Compare using uncompressed datatype instead of self and filter comparisons
             # to only uncompressed datatypes corresponding to supplied compressed datatypes.
@@ -701,10 +702,9 @@ class Data(object):
                     potential_uncompressed_types.append(target_datatype.uncompressed_datatype_class)
 
             self_datatype = self.uncompressed_datatype_class
-            target_datatypes = potential_uncompressed_types
+            target_datatypes = tuple(potential_uncompressed_types)
 
-        datatype_classes = tuple(datatype if isclass(datatype) else datatype.__class__ for datatype in target_datatypes)
-        return isinstance(self_datatype, datatype_classes)
+        return isinstance(self_datatype, target_datatypes)
 
     def merge(split_files, output_file):
         """

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -690,8 +690,21 @@ class Data(object):
         Check if this datatype is of any of the target_datatypes or is
         a subtype thereof.
         """
+        self_datatype = self
+
+        if hasattr(self, "uncompressed_datatype_class"):
+            # Compare using uncompressed datatype instead of self and filter comparisons
+            # to only uncompressed datatypes corresponding to supplied compressed datatypes.
+            potential_uncompressed_types = []
+            for target_datatype in target_datatypes:
+                if hasattr(target_datatype, "uncompressed_datatype_class") and target_datatype.compressed_format == self.compressed_format:
+                    potential_uncompressed_types.append(target_datatype.uncompressed_datatype_class)
+
+            self_datatype = self.uncompressed_datatype_class
+            target_datatypes = potential_uncompressed_types
+
         datatype_classes = tuple(datatype if isclass(datatype) else datatype.__class__ for datatype in target_datatypes)
-        return isinstance(self, datatype_classes)
+        return isinstance(self_datatype, datatype_classes)
 
     def merge(split_files, output_file):
         """

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -326,6 +326,18 @@ class Registry(object):
                                         # Disable sniff on this type unless in validate_mode().
                                         attributes["sniff_compressed"] = False
 
+                                    attributes["uncompressed_datatype_class"] = datatype_class
+
+                                    def matches_any(self, target_datatypes):
+                                        potential_uncompressed_types = []
+                                        for target_datatype in target_datatypes:
+                                            if hasattr(target_datatype, "uncompressed_datatype_class") and target_datatype.compressed_format == attributes["compressed_format"]:
+                                                potential_uncompressed_types.append(target_datatype.uncompressed_datatype_class)
+
+                                        return datatype_instance.matches_any(potential_uncompressed_types)
+
+                                    attributes["matches_any"] = matches_any
+
                                     compressed_datatype_class = type(auto_compressed_type_name, (datatype_class, binary.CompressedArchive, ), attributes)
                                     if edam_format:
                                         compressed_datatype_class.edam_format = edam_format

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -327,17 +327,6 @@ class Registry(object):
                                         attributes["sniff_compressed"] = False
 
                                     attributes["uncompressed_datatype_class"] = datatype_class
-
-                                    def matches_any(self, target_datatypes):
-                                        potential_uncompressed_types = []
-                                        for target_datatype in target_datatypes:
-                                            if hasattr(target_datatype, "uncompressed_datatype_class") and target_datatype.compressed_format == attributes["compressed_format"]:
-                                                potential_uncompressed_types.append(target_datatype.uncompressed_datatype_class)
-
-                                        return datatype_instance.matches_any(potential_uncompressed_types)
-
-                                    attributes["matches_any"] = matches_any
-
                                     compressed_datatype_class = type(auto_compressed_type_name, (datatype_class, binary.CompressedArchive, ), attributes)
                                     if edam_format:
                                         compressed_datatype_class.edam_format = edam_format


### PR DESCRIPTION
Check for matches by making sure compressed datatypes match and then using matches_any on the uncompressed datatype. This way for instance ``fastqsanger.gz`` "matches_any" a ``fastq.gz``, but doesn't "matches_any" a fastqsanger. This should fix implicit conversion and such (fixes #6088).

I don't feel great about this, this is first instance of datatypes overriding the default ``matches_any()`` behavior but on balance I think it is the right thing to do.

This is really getting in the weeds here but other ideas I had included to build the compressed class by taking the parent class of the target datatype and re-adding all the matching methods from the target datatype - this would have fixed some false positive matches_any behavior (e.g. fastqsanger.gz matching a fastqsanger) but it would leave around problematic matches like "fastqsanger.gz is-a fastq" and introduced false negatives (e.g. fastqsanger.gz not matching a fastq.gz) or doing something similar with annotations on the actual classes (but that would have similar problems). One could imagine fixing these short comings of that more complicated approach by building all compressed classes after all the uncompressed classes are built and walking the whole datatype hierarchy and trying to pick up leafs vs. interior nodes and recreating the hierarchy that way. That would be much more complicated however and would lean into some of my least favorite aspects of Galaxy datatypes being so heavily dictated by Python classes and not declarative structures like the XML that can be externally reasoned about.

Another alternative I think is to give up on dynamic classes for compressed types and stick with completely custom type hierarchies on per compressed class basis. That process requires some pretty tricky Python type hierarchies on its own that must be custom built and were error prone I think (for instance the genbank.gz PR I believe was likely broken in the same way as this was because the gz datatype descended from the genbank type even though it wasn't a proper is-a relationship and matches_any wasn't overridden to reflect this). The dynamic compressed datatype PR was too clean without this change but I think it still eliminated so much boilerplate that it was worth doing despite this new change I'm suggesting here.
