### PR TITLE
[18.05] Fix parsing last argument when running functional tests.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -303,6 +303,7 @@ then
     xunit_report_file="xunit-${BUILD_NUMBER}.xml"
 fi
 
+run_default_functional_tests="1"
 # Loop through and consume the main arguments.
 # Some loops will consume more than one argument (there are extra "shift"s in some cases).
 while :
@@ -339,7 +340,7 @@ do
           test_script="./scripts/functional_tests.py"
           report_file="./run_api_tests.html"
           if [ $# -gt 1 ]; then
-        	  api_script=$2
+              api_script=$2
               shift 2
           else
               api_script="./test/api"
@@ -520,6 +521,9 @@ do
           shift
           ;;
       --)
+          # Do not default to running the functional tests in this case, caller
+          # is opting to run specific tests so don't interfere with that by default.
+          unset run_default_functional_tests;
           shift
           break
           ;;
@@ -529,7 +533,13 @@ do
           exit 1
           ;;
       *)
-          break;
+          if [ -n "$1" ]; then
+            test_target="$1"
+            shift
+          fi
+          # Maybe we shouldn't break here but for now to pass more than one argument to the
+          # underlying test driver (scripts/nosetests.py) use -- instead.
+          break
           ;;
     esac
 done
@@ -573,10 +583,12 @@ elif [ -n "$unit_extra" ]; then
     extra_args="--with-doctest $unit_extra"
 elif [ -n "$integration_extra" ]; then
     extra_args="$integration_extra"
-elif [ -n "$1" ] ; then
-    extra_args="$1"
-else
+elif [ -n "$test_target" ] ; then
+    extra_args="$test_target"
+elif [ -n "$run_default_functional_tests" ] ; then
     extra_args='--exclude="^get" functional'
+else
+    extra_args=""
 fi
 
 if [ -n "$xunit_report_file" ]; then


### PR DESCRIPTION
Causes Planemo to double test tools reported by @nsoranzo.

~I noticed when testing this that ``run_tests.sh`` doesn't run the full tool tests suite for the toolbox anymore. I think it is unrelated to these changes but probably related to the external tool testing changes in 18.05. I'll see what the behavior was in 18.01 and try to restore it.~ Never mind 18.01 had the same behavior, this PR I think restores 18.01 default behaviors more or less except the ones broken.