### PR TITLE
Condor jobs running without tty prevent hostname from functioning

### DIFF
--- a/lib/galaxy/jobs/metrics/instrumenters/hostname.py
+++ b/lib/galaxy/jobs/metrics/instrumenters/hostname.py
@@ -23,7 +23,7 @@ class HostnamePlugin(InstrumentPlugin):
         pass
 
     def pre_execute_instrument(self, job_directory):
-        return "hostname -f > '%s'" % self.__instrument_hostname_path(job_directory)
+        return "echo \"$(hostname -f)\" > '%s'" % self.__instrument_hostname_path(job_directory)
 
     def job_properties(self, job_id, job_directory):
         with open(self.__instrument_hostname_path(job_directory)) as f:


### PR DESCRIPTION
if anyone has a better solution, I am *all* ears.

![auswahl_117](https://user-images.githubusercontent.com/458683/39821646-2e62911c-5398-11e8-96c1-20edc8378160.png)
