### PR TITLE
[18.05] Add file missing file required for converting bz2 compressed files.

### DIFF
--- a/lib/galaxy/datatypes/converters/bz2_to_uncompressed.xml
+++ b/lib/galaxy/datatypes/converters/bz2_to_uncompressed.xml
@@ -1,6 +1,6 @@
-<tool id="CONVERTER_gz_to_uncompressed" name="Convert compressed file to uncompressed." version="1.0.0" hidden="true" profile="17.09">
+<tool id="CONVERTER_bz2_to_uncompressed" name="Convert compressed file to uncompressed." version="1.0.0" hidden="true" profile="17.09">
   <command><![CDATA[
-    cp '$ext_config' 'galaxy.json' && gzip -dcf '$input1' > '$output1'
+    cp '$ext_config' 'galaxy.json' && bzip2 -dcf '$input1' > '$output1'
   ]]></command>
   <configfiles>
       <configfile name="ext_config">{"output1": {


### PR DESCRIPTION
Should have been included with #5794.