### PR TITLE
[18.05] Set the level for SLOREQs to 'warning'

### DIFF
--- a/lib/galaxy/web/framework/middleware/sentry.py
+++ b/lib/galaxy/web/framework/middleware/sentry.py
@@ -85,6 +85,7 @@ class Sentry(object):
                 'request_id': environ.get('request_id', 'Unknown'),
                 'request_duration_millis': dt * 1000
             },
+            level="warning",
             tags={
                 'type': 'sloreq',
                 'action_key': cak


### PR DESCRIPTION
Considering it a bug since it makes it difficult to segment errors in sentry without this.