### PR TITLE
Update BioViz URL 

### DIFF
--- a/display_applications/igb/bam.xml
+++ b/display_applications/igb/bam.xml
@@ -1,6 +1,6 @@
 <display id="igb_bam" version="0.0.0" name="display in IGB">
     <link id="View" name="View">
-        <url>http://bioviz.org/igb/galaxy.html?version=${bam_file.dbkey}&amp;feature_url_0=${bam_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${bam_file.url}&amp;query_url=${bam_file.url}&amp;server_url=galaxy</url>
+        <url>http://bioviz.org/galaxy.html?version=${bam_file.dbkey}&amp;feature_url_0=${bam_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${bam_file.url}&amp;query_url=${bam_file.url}&amp;server_url=galaxy</url>
         <param type="data" name="bam_file_for_name" viewable="False"/>
         <param type="template" name="niceName" viewable="False" strip="True">
             #import re

--- a/display_applications/igb/bb.xml
+++ b/display_applications/igb/bb.xml
@@ -1,6 +1,6 @@
 <display id="igb_bb" version="1.0.0" name="display in IGB">
     <link id="View" name="View">
-        <url>http://bioviz.org/igb/galaxy.html?version=${bigbed_file.dbkey}&amp;loadresidues=false&amp;feature_url_0=${bigbed_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${bigbed_file.url}&amp;query_url=${bigbed_file.url}&amp;server_url=galaxy</url>
+        <url>http://bioviz.org/galaxy.html?version=${bigbed_file.dbkey}&amp;loadresidues=false&amp;feature_url_0=${bigbed_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${bigbed_file.url}&amp;query_url=${bigbed_file.url}&amp;server_url=galaxy</url>
         <param type="data" name="bigbed_file_for_name" viewable="False"/>
         <param type="template" name="niceName" viewable="False" strip="True">
             #import re

--- a/display_applications/igb/bed.xml
+++ b/display_applications/igb/bed.xml
@@ -9,7 +9,7 @@
         </param>
         <param type="data" name="bed_file" url="${niceName}.bed" />
         <param type="template" name="bioviz" strip="True" >
-            http://bioviz.org/igb/galaxy.html?version=${bed_file.dbkey}&amp;loadresidues=false&amp;feature_url_0=${bed_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${bed_file.url}&amp;query_url=${bed_file.url}&amp;server_url=galaxy
+            http://bioviz.org/galaxy.html?version=${bed_file.dbkey}&amp;loadresidues=false&amp;feature_url_0=${bed_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${bed_file.url}&amp;query_url=${bed_file.url}&amp;server_url=galaxy
         </param>
     </link>
 </display>

--- a/display_applications/igb/bedgraph.xml
+++ b/display_applications/igb/bedgraph.xml
@@ -9,7 +9,7 @@
         </param>
         <param type="data" name="bedgraph_file" url="${niceName}.bed.bedgraph" />
         <param type="template" name="bioviz" strip="True" >
-            http://bioviz.org/igb/galaxy.html?version=${bedgraph_file.dbkey}&amp;loadresidues=false&amp;feature_url_0=${bedgraph_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${bedgraph_file.url}&amp;query_url=${bedgraph_file.url}&amp;server_url=galaxy
+            http://bioviz.org/galaxy.html?version=${bedgraph_file.dbkey}&amp;loadresidues=false&amp;feature_url_0=${bedgraph_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${bedgraph_file.url}&amp;query_url=${bedgraph_file.url}&amp;server_url=galaxy
         </param>
     </link>
 </display>

--- a/display_applications/igb/bigwig.xml
+++ b/display_applications/igb/bigwig.xml
@@ -1,6 +1,6 @@
 <display id="igb_bigwig" version="1.0.0" name="display in IGB">
     <link id="View" name="View">
-        <url>http://bioviz.org/igb/galaxy.html?version=${bigwig_file.dbkey}&amp;loadresidues=false&amp;feature_url_0=${bigwig_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${bigwig_file.url}&amp;query_url=${bigwig_file.url}&amp;server_url=galaxy</url>
+        <url>http://bioviz.org/galaxy.html?version=${bigwig_file.dbkey}&amp;loadresidues=false&amp;feature_url_0=${bigwig_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${bigwig_file.url}&amp;query_url=${bigwig_file.url}&amp;server_url=galaxy</url>
         <param type="data" name="bigwig_file_for_name" viewable="False"/>
         <param type="template" name="niceName" viewable="False" strip="True">
             #import re

--- a/display_applications/igb/gtf.xml
+++ b/display_applications/igb/gtf.xml
@@ -9,7 +9,7 @@
         </param>
         <param type="data" name="gtf_file" url="${niceName}.gtf" />
         <param type="template" name="bioviz" strip="True" >
-             http://bioviz.org/igb/galaxy.html?version=${gtf_file.dbkey}&amp;loadresidues=false&amp;feature_url_0=${gtf_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${gtf_file.url}&amp;query_url=${gtf_file.url}&amp;server_url=galaxy
+             http://bioviz.org/galaxy.html?version=${gtf_file.dbkey}&amp;loadresidues=false&amp;feature_url_0=${gtf_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${gtf_file.url}&amp;query_url=${gtf_file.url}&amp;server_url=galaxy
         </param>
     </link>
 </display>

--- a/display_applications/igb/wig.xml
+++ b/display_applications/igb/wig.xml
@@ -1,6 +1,6 @@
 <display id="igb_wig" version="1.0.0" name="display in IGB">
     <link id="View" name="View">
-        <url>http://bioviz.org/igb/galaxy.html?version=${wig_file.dbkey}&amp;${position}&amp;loadresidues=false&amp;feature_url_0=${wig_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${wig_file.url}&amp;query_url=${wig_file.url}&amp;server_url=galaxy</url>
+        <url>http://bioviz.org/galaxy.html?version=${wig_file.dbkey}&amp;${position}&amp;loadresidues=false&amp;feature_url_0=${wig_file.url}&amp;sym_name_0=${niceName}&amp;sym_method_0=${wig_file.url}&amp;query_url=${wig_file.url}&amp;server_url=galaxy</url>
         <param type="data" name="wig_file_for_name" viewable="False"/>
         <param type="template" name="niceName" viewable="False" strip="True">
             #import re


### PR DESCRIPTION
IGB BioViz bridge page galaxy.html is moving from http://bioviz.org/igb/galaxy.html to http://bioviz.org/galaxy.html.