### PR TITLE
[18.05] Fix matches_any() checks for dynamic compressed types.

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -88,7 +88,7 @@
       <converter file="fasta_to_fai.xml" target_datatype="fai"/>
       <display file="igv/genome_fasta.xml" inherit="true"/>
     </datatype>
-    <datatype extension="fastq" type="galaxy.datatypes.sequence:Fastq" display_in_upload="true" description="FASTQ format is a text-based format for storing both a biological sequence (usually nucleotide sequence) and its corresponding quality scores." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Fastq">
+    <datatype extension="fastq" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:Fastq" display_in_upload="true" description="FASTQ format is a text-based format for storing both a biological sequence (usually nucleotide sequence) and its corresponding quality scores." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Fastq">
       <converter file="fastq_to_fqtoc.xml" target_datatype="fqtoc"/>
     </datatype>
     <datatype extension="fastqsanger" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqSanger" display_in_upload="true">

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -159,6 +159,34 @@ class CompressedArchive(Binary):
             return "Compressed binary file (%s)" % (nice_size(dataset.get_size()))
 
 
+class DynamicCompressedArchive(CompressedArchive):
+
+    def matches_any(self, target_datatypes):
+        """Treat two aspects of compressed datatypes separately.
+        """
+        compressed_target_datatypes = []
+        uncompressed_target_datatypes = []
+
+        for target_datatype in target_datatypes:
+            if hasattr(target_datatype, "uncompressed_datatype_instance") and target_datatype.compressed_format == self.compressed_format:
+                uncompressed_target_datatypes.append(target_datatype.uncompressed_datatype_instance)
+            else:
+                compressed_target_datatypes.append(target_datatype)
+
+        # TODO: Add gz and bz2 as proper datatypes and use those instances instead of
+        # CompressedArchive() in the following check.
+        return self.uncompressed_datatype_instance.matches_any(uncompressed_target_datatypes) or \
+            CompressedArchive().matches_any(compressed_target_datatypes)
+
+
+class GzDynamicCompressedArchive(DynamicCompressedArchive):
+    compressed_format = "gzip"
+
+
+class Bz2DynamicCompressedArchive(DynamicCompressedArchive):
+    compressed_format = "bz2"
+
+
 class CompressedZipArchive(CompressedArchive):
     """
         Class describing an compressed binary file

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -287,12 +287,8 @@ def guess_ext(fname, sniff_order, is_binary=False):
     Returns an extension that can be used in the datatype factory to
     generate a data for the 'fname' file
 
-    >>> from galaxy.datatypes import registry
-    >>> from galaxy.util.bunch import Bunch
-    >>> sample_conf = os.path.join(util.galaxy_directory(), "config", "datatypes_conf.xml.sample")
-    >>> config = Bunch(sniff_compressed_dynamic_datatypes_default=True)
-    >>> datatypes_registry = registry.Registry(config)
-    >>> datatypes_registry.load_datatypes(root_dir=util.galaxy_directory(), config=sample_conf)
+    >>> from galaxy.datatypes.registry import example_datatype_registry_for_sample
+    >>> datatypes_registry = example_datatype_registry_for_sample()
     >>> sniff_order = datatypes_registry.sniff_order
     >>> fname = get_test_fname('megablast_xml_parser_test1.blastxml')
     >>> guess_ext(fname, sniff_order)

--- a/test/unit/datatypes/test_datatypes_registry.py
+++ b/test/unit/datatypes/test_datatypes_registry.py
@@ -1,0 +1,51 @@
+from galaxy.datatypes.registry import example_datatype_registry_for_sample
+
+
+def test_matches_any():
+    datatypes_registry = example_datatype_registry_for_sample()
+    data_datatype = datatypes_registry.get_datatype_by_extension('data')
+    fasta_datatype = datatypes_registry.get_datatype_by_extension('fasta')
+    fastq_datatype = datatypes_registry.get_datatype_by_extension('fastq')
+    fastqsanger_datatype = datatypes_registry.get_datatype_by_extension('fastqsanger')
+    fastqgz_datatype = datatypes_registry.get_datatype_by_extension('fastq.gz')
+    fastqbz2_datatype = datatypes_registry.get_datatype_by_extension('fastq.bz2')
+    fastqsangergz_datatype = datatypes_registry.get_datatype_by_extension('fastqsanger.gz')
+    fastqsangerbz2_datatype = datatypes_registry.get_datatype_by_extension('fastqsanger.bz2')
+    h5_datatype = datatypes_registry.get_datatype_by_extension('h5')
+    mz5_datatype = datatypes_registry.get_datatype_by_extension('mz5')
+
+    # Test empty list behavior.
+    assert not fasta_datatype.matches_any([])
+
+    # Test direct match with self.
+    assert fastq_datatype.matches_any([fastq_datatype])
+    assert fastq_datatype.matches_any([fastq_datatype.__class__])
+
+    # Test plain mismatches.
+    assert not fasta_datatype.matches_any([fastq_datatype])
+    assert not fasta_datatype.matches_any([fastq_datatype.__class__])
+    assert not fastq_datatype.matches_any([fasta_datatype])
+    assert not fastq_datatype.matches_any([fasta_datatype.__class__])
+
+    # Test simple match behavior of data.
+    assert fasta_datatype.matches_any([data_datatype])
+    assert not data_datatype.matches_any([fasta_datatype])
+
+    # Test inheritance.
+    assert fastqsanger_datatype.matches_any([fastq_datatype])
+    assert fastqsanger_datatype.matches_any([fastq_datatype.__class__])
+
+    # Test dynamic subclass handling.
+    assert not h5_datatype.matches_any([mz5_datatype])
+    assert mz5_datatype.matches_any([h5_datatype])
+
+    # Test compressed datatype handling.
+    assert not data_datatype.matches_any([fastqsangergz_datatype])
+    assert not fastq_datatype.matches_any([fastqsangergz_datatype])
+    assert not fastqsanger_datatype.matches_any([fastqsangergz_datatype])
+    assert fastqsangergz_datatype.matches_any([data_datatype])
+    assert not fastqsangergz_datatype.matches_any([fastqsanger_datatype])
+    assert fastqsangergz_datatype.matches_any([fastqgz_datatype])
+    assert not fastqsangerbz2_datatype.matches_any([fastqgz_datatype])
+    assert not fastqsangerbz2_datatype.matches_any([fastqsangergz_datatype])
+    assert fastqsangerbz2_datatype.matches_any([fastqbz2_datatype])

--- a/test/unit/datatypes/test_datatypes_registry.py
+++ b/test/unit/datatypes/test_datatypes_registry.py
@@ -34,18 +34,49 @@ def test_matches_any():
     # Test inheritance.
     assert fastqsanger_datatype.matches_any([fastq_datatype])
     assert fastqsanger_datatype.matches_any([fastq_datatype.__class__])
+    assert not fastq_datatype.matches_any([fastqsanger_datatype])
+    assert not fastq_datatype.matches_any([fastqsanger_datatype.__class__])
 
     # Test dynamic subclass handling.
     assert not h5_datatype.matches_any([mz5_datatype])
     assert mz5_datatype.matches_any([h5_datatype])
 
-    # Test compressed datatype handling.
+    # Test compressed datatype handling - matching direct.
+    assert fastqsangergz_datatype.matches_any([fastqsangergz_datatype])
+    assert fastqsangergz_datatype.matches_any([fastqsangergz_datatype.__class__])
+    assert fastqsangerbz2_datatype.matches_any([fastqsangerbz2_datatype])
+    assert fastqsangerbz2_datatype.matches_any([fastqsangerbz2_datatype.__class__])
+
+    # Test compressed datatype handling - matching in compressed hierarchy.
+    assert fastqsangergz_datatype.matches_any([fastqgz_datatype])
+    assert fastqsangergz_datatype.matches_any([fastqgz_datatype.__class__])
+    assert fastqsangerbz2_datatype.matches_any([fastqbz2_datatype])
+    assert fastqsangerbz2_datatype.matches_any([fastqbz2_datatype.__class__])
+
+    # Test compressed datatype handling - matching as raw compressed data.
+    assert fastqsangergz_datatype.matches_any([data_datatype])
+    assert fastqsangergz_datatype.matches_any([data_datatype.__class__])
+    assert fastqsangerbz2_datatype.matches_any([data_datatype])
+    assert fastqsangerbz2_datatype.matches_any([data_datatype.__class__])
+
+    # Test compressed datatype handling - everything else mismatches.
     assert not data_datatype.matches_any([fastqsangergz_datatype])
     assert not fastq_datatype.matches_any([fastqsangergz_datatype])
     assert not fastqsanger_datatype.matches_any([fastqsangergz_datatype])
-    assert fastqsangergz_datatype.matches_any([data_datatype])
+    assert not fastqgz_datatype.matches_any([fastqsangergz_datatype])
+    assert not fastqgz_datatype.matches_any([fastqsangergz_datatype.__class__])
     assert not fastqsangergz_datatype.matches_any([fastqsanger_datatype])
-    assert fastqsangergz_datatype.matches_any([fastqgz_datatype])
     assert not fastqsangerbz2_datatype.matches_any([fastqgz_datatype])
+    assert not fastqsangerbz2_datatype.matches_any([fastqgz_datatype.__class__])
     assert not fastqsangerbz2_datatype.matches_any([fastqsangergz_datatype])
-    assert fastqsangerbz2_datatype.matches_any([fastqbz2_datatype])
+    assert not fastqsangerbz2_datatype.matches_any([fastqsangergz_datatype.__class__])
+
+    # Test matches after first arg.
+    assert fasta_datatype.matches_any([fastq_datatype, data_datatype])
+    assert fasta_datatype.matches_any([fastq_datatype, h5_datatype, data_datatype])
+    assert fastqsangerbz2_datatype.matches_any([fastqsangergz_datatype.__class__, fastqsangerbz2_datatype])
+    assert fastqsangerbz2_datatype.matches_any([fastqsangergz_datatype.__class__, fastqsangerbz2_datatype.__class__])
+
+    # Test mismatches in multiple args.
+    assert not fasta_datatype.matches_any([fastq_datatype, h5_datatype])
+    assert not fasta_datatype.matches_any([fastq_datatype.__class__, h5_datatype.__class__])


### PR DESCRIPTION
See huge conversation on #6093. Now with relevant tests that should be pretty readable and hopefully clarify all the behavior is as intended.

Also fixes missing fastq.gz/bz2 datatypes dropped in 18.05 it seems. #5794 was ... lacking.