### PR TITLE
[18.05] Encode dataset ids when loading trackster visualizations

### DIFF
--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -954,17 +954,12 @@ class UsesVisualizationMixin(UsesLibraryMixinItems):
             def pack_track(track_dict):
                 dataset_id = track_dict['dataset_id']
                 hda_ldda = track_dict.get('hda_ldda', 'hda')
-                if hda_ldda == 'ldda':
-                    # HACK: need to encode library dataset ID because get_hda_or_ldda
-                    # only works for encoded datasets.
-                    dataset_id = trans.security.encode_id(dataset_id)
+                dataset_id = trans.security.encode_id(dataset_id)
                 dataset = self.get_hda_or_ldda(trans, hda_ldda, dataset_id)
-
                 try:
                     prefs = track_dict['prefs']
                 except KeyError:
                     prefs = {}
-
                 track_data_provider = trans.app.data_provider_registry.get_data_provider(trans,
                                                                                          original_dataset=dataset,
                                                                                          source='data')


### PR DESCRIPTION
Reported by `gulayse.ince@gmail.com`:
"When I want to visualize my saved tracks in Trackster it gives a message saying: Bed request, the server could not comply with the request since it is either malformed or otherwise incorrect. Invaild dataset id: 35250048."

Related to 3302b46775cdc76976a4bdc36353e014c6d5edbd.