### PR TITLE
Add a job destination param for overriding the Singularity image path

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -509,6 +509,11 @@
           <!-- Following command can be used to tweak singularity command. -->
           <!-- <param id="singularity_cmd">/usr/local/custom_docker/docker</param> -->
 
+          <!-- By default, images will be searched for, built, and cached in
+               database/container_cache/singularity/mulled. This path can be
+               overridden. -->
+          <!-- <param id="singularity_images_dir">/cvmfs/singularity.galaxyproject.org</param> -->
+
           <!-- If deployer wants to use singularity for isolation, but does not
                trust tool's specified container - a destination wide override
                can be set. This will cause all jobs on this destination to use

--- a/lib/galaxy/tools/deps/container_resolvers/explicit.py
+++ b/lib/galaxy/tools/deps/container_resolvers/explicit.py
@@ -13,7 +13,7 @@ class ExplicitContainerResolver(ContainerResolver):
 
     resolver_type = "explicit"
 
-    def resolve(self, enabled_container_types, tool_info):
+    def resolve(self, enabled_container_types, tool_info, destination_info):
         """Find a container explicitly mentioned in tool description.
 
         This ignores the tool requirements and assumes the tool author crafted

--- a/lib/galaxy/tools/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tools/deps/container_resolvers/mulled.py
@@ -224,7 +224,7 @@ class CachedMulledDockerContainerResolver(ContainerResolver):
         self.namespace = namespace
         self.hash_func = hash_func
 
-    def resolve(self, enabled_container_types, tool_info):
+    def resolve(self, enabled_container_types, tool_info, destination_info):
         if tool_info.requires_galaxy_python_environment:
             return None
 
@@ -246,12 +246,13 @@ class CachedMulledSingularityContainerResolver(ContainerResolver):
         self.cache_directory = os.path.join(app_info.container_image_cache_path, "singularity", "mulled")
         self.hash_func = hash_func
 
-    def resolve(self, enabled_container_types, tool_info):
+    def resolve(self, enabled_container_types, tool_info, destination_info):
         if tool_info.requires_galaxy_python_environment:
             return None
 
         targets = mulled_targets(tool_info)
-        return singularity_cached_container_description(targets, self.cache_directory, hash_func=self.hash_func)
+        cache_directory = destination_info.get("singularity_image_dir", self.cache_directory)
+        return singularity_cached_container_description(targets, cache_directory, hash_func=self.hash_func)
 
     def __str__(self):
         return "CachedMulledSingularityContainerResolver[cache_directory=%s]" % self.cache_directory
@@ -269,7 +270,7 @@ class MulledDockerContainerResolver(ContainerResolver):
         self.namespace = namespace
         self.hash_func = hash_func
 
-    def resolve(self, enabled_container_types, tool_info):
+    def resolve(self, enabled_container_types, tool_info, destination_info):
         if tool_info.requires_galaxy_python_environment:
             return None
 
@@ -356,7 +357,7 @@ class BuildMulledDockerContainerResolver(ContainerResolver):
         }
         self.auto_init = self._get_config_option("auto_init", DEFAULT_CHANNELS, prefix="involucro")
 
-    def resolve(self, enabled_container_types, tool_info):
+    def resolve(self, enabled_container_types, tool_info, destination_info):
         if tool_info.requires_galaxy_python_environment:
             return None
 
@@ -403,7 +404,7 @@ class BuildMulledSingularityContainerResolver(ContainerResolver):
         }
         self.auto_init = self._get_config_option("auto_init", DEFAULT_CHANNELS, prefix="involucro")
 
-    def resolve(self, enabled_container_types, tool_info):
+    def resolve(self, enabled_container_types, tool_info, destination_info):
         if tool_info.requires_galaxy_python_environment:
             return None
 
@@ -416,7 +417,8 @@ class BuildMulledSingularityContainerResolver(ContainerResolver):
             involucro_context=self._get_involucro_context(),
             **self._mulled_kwds
         )
-        return singularity_cached_container_description(targets, self.cache_directory, hash_func=self.hash_func)
+        cache_directory = destination_info.get("singularity_image_dir", self.cache_directory)
+        return singularity_cached_container_description(targets, cache_directory, hash_func=self.hash_func)
 
     def _get_involucro_context(self):
         involucro_context = InvolucroContext(**self._involucro_context_kwds)

--- a/lib/galaxy/tools/deps/containers.py
+++ b/lib/galaxy/tools/deps/containers.py
@@ -78,11 +78,12 @@ class ContainerFinder(object):
     def __enabled_container_types(self, destination_info):
         return [t for t in ALL_CONTAINER_TYPES if self.__container_type_enabled(t, destination_info)]
 
-    def find_best_container_description(self, enabled_container_types, tool_info):
+    def find_best_container_description(self, enabled_container_types, tool_info, destination_info):
         """Regardless of destination properties - find best container for tool.
 
         Given container types and container.ToolInfo description of the tool."""
-        container_description = self.container_registry.find_best_container_description(enabled_container_types, tool_info)
+        container_description = self.container_registry.find_best_container_description(enabled_container_types,
+                tool_info, destination_info)
         return container_description
 
     def find_container(self, tool_info, destination_info, job_info):
@@ -124,7 +125,8 @@ class ContainerFinder(object):
                     return container
 
         # Otherwise lets see if we can find container for the tool.
-        container_description = self.find_best_container_description(enabled_container_types, tool_info)
+        container_description = self.find_best_container_description(enabled_container_types, tool_info,
+                destination_info)
         container = __destination_container(container_description)
         if container:
             return container
@@ -245,13 +247,13 @@ class ContainerRegistry(object):
         import galaxy.tools.deps.container_resolvers
         return plugin_config.plugins_dict(galaxy.tools.deps.container_resolvers, 'resolver_type')
 
-    def find_best_container_description(self, enabled_container_types, tool_info):
+    def find_best_container_description(self, enabled_container_types, tool_info, destination_info):
         """Yield best container description of supplied types matching tool info."""
         for container_resolver in self.container_resolvers:
             if hasattr(container_resolver, "container_type"):
                 if container_resolver.container_type not in enabled_container_types:
                     continue
-            container_description = container_resolver.resolve(enabled_container_types, tool_info)
+            container_description = container_resolver.resolve(enabled_container_types, tool_info, destination_info)
             log.info("Checking with container resolver [%s] found description [%s]" % (container_resolver, container_description))
             if container_description:
                 assert container_description.type in enabled_container_types


### PR DESCRIPTION
This allows us to use stuff in e.g. `/cvmfs/singularity.galaxyproject.org` without having to support the `/singularity/mulled` that is automatically appended when using the `container_image_cache_path` option in the global config.