### PR TITLE
[18.05] More compressed datatype sniffing fixes.

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -117,15 +117,6 @@ class Data(object):
         self.composite_files = self.composite_files.copy()
         self.display_applications = odict()
 
-    @property
-    def validate_mode(self):
-        """Indicate that a sniffer should run, even if disabled.
-
-        Some sniffers (e.g. fastq.gz) work but are not enabled for certain reasons, but when running a sniffer to
-        "validate" a selected filetype, those sniffers should be enabled.
-        """
-        return os.environ.get('GALAXY_SNIFFER_VALIDATE_MODE', '0') == '1'
-
     def get_raw_data(self, dataset):
         """Returns the full data. To stream it open the file_name and read/write as needed"""
         try:

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -142,7 +142,7 @@ class Registry(object):
                 sniff_compressed_types = galaxy.util.string_as_bool_or_none(elem.get("sniff_compressed_types", "None"))
                 if sniff_compressed_types is None:
                     sniff_compressed_types = getattr(self.config, "sniff_compressed_dynamic_datatypes_default", True)
-                    # Make sure this is set in the elems we write out so the config option is passed ot the upload
+                    # Make sure this is set in the elems we write out so the config option is passed to the upload
                     # tool which does not have a config object.
                     elem.set("sniff_compressed_types", str(sniff_compressed_types))
                 mimetype = elem.get('mimetype', None)
@@ -513,11 +513,7 @@ class Registry(object):
                                                 del self.sniff_order[conflict_loc]
                                                 self.log.debug("Removed conflicting sniffer for datatype '%s'" % dtype)
                                             break
-                                    if conflict:
-                                        if override:
-                                            self.sniff_order.append(aclass)
-                                            self.log.debug("Loaded sniffer for datatype '%s'" % dtype)
-                                    else:
+                                    if not conflict or override:
                                         if compressed_sniffers and aclass.__class__ in compressed_sniffers:
                                             for compressed_sniffer in compressed_sniffers[aclass.__class__]:
                                                 self.sniff_order.append(compressed_sniffer)

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -140,6 +140,11 @@ class Registry(object):
                 type_extension = elem.get('type_extension', None)
                 auto_compressed_types = galaxy.util.listify(elem.get('auto_compressed_types', ''))
                 sniff_compressed_types = galaxy.util.string_as_bool_or_none(elem.get("sniff_compressed_types", "None"))
+                if sniff_compressed_types is None:
+                    sniff_compressed_types = getattr(self.config, "sniff_compressed_dynamic_datatypes_default", True)
+                    # Make sure this is set in the elems we write out so the config option is passed ot the upload
+                    # tool which does not have a config object.
+                    elem.set("sniff_compressed_types", str(sniff_compressed_types))
                 mimetype = elem.get('mimetype', None)
                 display_in_upload = galaxy.util.string_as_bool(elem.get('display_in_upload', False))
                 # If make_subclass is True, it does not necessarily imply that we are subclassing a datatype that is contained
@@ -321,9 +326,6 @@ class Registry(object):
                                     else:
                                         raise Exception("Unknown auto compression type [%s]" % auto_compressed_type)
                                     attributes["file_ext"] = compressed_extension
-                                    if sniff_compressed_types is None:
-                                        sniff_compressed_types = getattr(self.config, "sniff_compressed_dynamic_datatypes_default", True)
-
                                     attributes["uncompressed_datatype_instance"] = datatype_instance
                                     compressed_datatype_class = type(auto_compressed_type_name, (datatype_class, dynamic_parent, ), attributes)
                                     if edam_format:

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -460,6 +460,9 @@ def guess_ext(fname, sniff_order, is_binary=False):
     >>> fname = get_test_fname('1.phyloxml')
     >>> guess_ext(fname, sniff_order)
     'phyloxml'
+    >>> fname = get_test_fname('1.fastqsanger.gz')
+    >>> guess_ext(fname, sniff_order)  # See test_datatype_registry for more compressed type tests.
+    'fastqsanger.gz'
     """
     file_prefix = FilePrefix(fname)
     file_ext = run_sniffers_raw(file_prefix, sniff_order, is_binary)
@@ -612,13 +615,6 @@ def build_sniff_from_prefix(klass):
             if not file_prefix.compressed_format:
                 # This not a compressed file we are looking but the type expects it to be
                 # must return False.
-                return False
-
-            if not getattr(klass, "sniff_compressed", True) and not self.validate_mode():
-                # This datatype indicates that it shouldn't be auto-sniffed so return False.
-                # Do not take this shortcut if validate_mode is True, in that case we aren't
-                # trying to find a datatype for a file we are trying to verify a datatype
-                # selection and so should execute the underlying sniff_prefix.
                 return False
 
         if hasattr(self, "compressed_format"):

--- a/lib/galaxy/datatypes/test/1.fastqsanger.bz2
+++ b/lib/galaxy/datatypes/test/1.fastqsanger.bz2
@@ -1,0 +1,1 @@
+../../../../test-data/1.fastqsanger.bz2

--- a/lib/galaxy/datatypes/test/1.fastqsanger.gz
+++ b/lib/galaxy/datatypes/test/1.fastqsanger.gz
@@ -1,0 +1,1 @@
+../../../../test-data/1.fastqsanger.gz

--- a/test/unit/datatypes/test_datatypes_registry.py
+++ b/test/unit/datatypes/test_datatypes_registry.py
@@ -1,3 +1,4 @@
+from galaxy.datatypes import sniff
 from galaxy.datatypes.registry import example_datatype_registry_for_sample
 
 
@@ -80,3 +81,36 @@ def test_matches_any():
     # Test mismatches in multiple args.
     assert not fasta_datatype.matches_any([fastq_datatype, h5_datatype])
     assert not fasta_datatype.matches_any([fastq_datatype.__class__, h5_datatype.__class__])
+
+
+def test_sniff_compressed_dynamic_datatypes_default_on():
+    # With auto sniffing on, verify the sniffers work and the files match what is expected
+    # when coming from guess_ext.
+    datatypes_registry = example_datatype_registry_for_sample(sniff_compressed_dynamic_datatypes_default=True)
+
+    fastqsangergz_datatype = datatypes_registry.get_datatype_by_extension('fastqsanger.gz')
+    fname = sniff.get_test_fname('1.fastqsanger.gz')
+    assert fastqsangergz_datatype.sniff(fname)
+
+    sniff_order = datatypes_registry.sniff_order
+    fname = sniff.get_test_fname('1.fastqsanger.gz')
+    assert sniff.guess_ext(fname, sniff_order) == 'fastqsanger.gz'
+    fname = sniff.get_test_fname('1.fastqsanger.bz2')
+    assert sniff.guess_ext(fname, sniff_order) == 'fastqsanger.bz2'
+
+
+def test_sniff_compressed_dynamic_datatypes_default_off():
+    # Redo last tests with auto compressed sniffing disabled and they should not longer result from guess_ext.
+    datatypes_registry = example_datatype_registry_for_sample(sniff_compressed_dynamic_datatypes_default=False)
+
+    # sniffer still returns True for these files...
+    fastqsangergz_datatype = datatypes_registry.get_datatype_by_extension('fastqsanger.gz')
+    fname = sniff.get_test_fname('1.fastqsanger.gz')
+    assert fastqsangergz_datatype.sniff(fname)
+
+    # but they don't report as matching the specified sniff_order.
+    sniff_order = datatypes_registry.sniff_order
+    fname = sniff.get_test_fname('1.fastqsanger.gz')
+    assert 'fastq' not in sniff.guess_ext(fname, sniff_order)
+    fname = sniff.get_test_fname('1.fastqsanger.bz2')
+    assert 'fastq' not in sniff.guess_ext(fname, sniff_order)

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -144,11 +144,7 @@ def add_file(dataset, registry, output_path):
         except sniff.InappropriateDatasetContentError as exc:
             raise UploadProblemException(str(exc))
     elif dataset.file_type == 'auto':
-        # Link mode can't decompress anyway, so enable sniffing for keep-compressed datatypes even when auto_decompress
-        # is enabled
-        os.environ['GALAXY_SNIFFER_VALIDATE_MODE'] = '1'
         ext = sniff.guess_ext(dataset.path, registry.sniff_order, is_binary=is_binary)
-        os.environ.pop('GALAXY_SNIFFER_VALIDATE_MODE')
     else:
         ext = dataset.file_type
 
@@ -159,11 +155,9 @@ def add_file(dataset, registry, output_path):
     if dataset.file_type != 'auto':
         datatype = registry.get_datatype_by_extension(dataset.file_type)
         # Enable sniffer "validate mode" (prevents certain sniffers from disabling themselves)
-        os.environ['GALAXY_SNIFFER_VALIDATE_MODE'] = '1'
         if hasattr(datatype, 'sniff') and not datatype.sniff(dataset.path):
             stdout = ("Warning: The file 'Type' was set to '{ext}' but the file does not appear to be of that"
                       " type".format(ext=dataset.file_type))
-        os.environ.pop('GALAXY_SNIFFER_VALIDATE_MODE')
 
     # Handle unsniffable binaries
     if is_binary and ext == 'binary':


### PR DESCRIPTION
Fixes at least 4 more bugs related to sniffing of compressed datatypes.

- Incorrect parsing of default auto sniff flag value.
- Not respecting flag value when adding to dict of compressed sniffers.
- Not checking the right value when checking for compressed datatype instances to add to sniff order.
- Not filtering out the sniffers from being automatically added during the default stage of sniffer handling where all types with sniff are added at the end.

This last point is the most complicated. I added a hack with #6091 so that the compressed sniffers would only return True if in validation mode or explicitly enabled. I'm not convinced that approach worked at all and regardless of its technical correctness I'm definitely convinced it was a bad approach.

The better, cleaner approach is to just always let the sniffer return its truth regardless of validation mode or not and instead only add it to the list of sniffers if it should be enabled. This is what I was assuming would happen but I found this method ``append_to_sniff_order`` that was adding sniffers back in that aren't explicitly enabled. I had no idea Galaxy did this, but since we put effort into determining whether these dynamic sniffers belong in the sniffer order and if so where they belong, we should exclude them from being added by this method ``append_to_sniff_order``. I've done that.

This also eliminates the ``validate_mode hack`` which isn't needed after switching to this more intuitive, less broken behavior. From Gitter:

```
John Chilton @jmchilton 12:36
@natefoo "# Link mode can't decompress anyway, so enable sniffing for keep-compressed datatypes even when auto_decompress is enabled" Did you test this hack? I get the thought process but it seems like it results in uploaded fastq.gz files defaulting to fastqcssanger.gz? Maybe it didn't at some point though?

Nate Coraor @natefoo 12:38
ummmmmmmmmmmm maybe probably not

John Chilton @jmchilton 12:39
I have four fixes for compressed datatypes that all fall apart because of this hack... can I just use the configured sniff order or do you want me to try to preserve this and write a test case

Nate Coraor @natefoo 12:40
nah go ahead and de-hack

John Chilton @jmchilton 12:41
There is a good argument to be made for making the behavior more consistent anyway right? Cool thanks

Nate Coraor @natefoo 12:46
yeah
```