### PR TITLE
Sharing.vue bootstrapping and a bugfix

### DIFF
--- a/client/galaxy/scripts/components/Sharing.vue
+++ b/client/galaxy/scripts/components/Sharing.vue
@@ -11,7 +11,7 @@
                 <label/>
                 <input class="form-control" type="text" v-model="new_username"/>
             </form>
-            <button type="submit" class="btn btn-primary" @click="setUsername()">Set Username</button>
+            <b-button type="submit" variant="primary" @click="setUsername()">Set Username</b-button>
         </div>
         <div v-else>
             <br/>
@@ -34,55 +34,47 @@
                 </div>
                 <div v-if="!item.published">
                     <!-- Item is importable but not published. User can disable importable or publish. -->
-                    <button @click="setSharing('disable_link_access')">Disable Access to {{model_class}} Link</button>
+                    <b-button @click="setSharing('disable_link_access')">Disable Access to {{model_class}} Link</b-button>
                     <div class="toolParamHelp">Disables {{model_class_lc}}'s link so that it is not accessible.</div>
                     <br/>
-                    <button @click="setSharing('publish')">Publish {{model_class}}</button>
+                    <b-button @click="setSharing('publish')">Publish {{model_class}}</b-button>
                     <div class="toolParamHelp">Publishes the {{model_class_lc}} to Galaxy's <a :href="published_url" target="_top">Published {{plural_name}}</a> section, where it is publicly listed and searchable.</div>
                     <br/>
                 </div>
                 <div v-else>
                     <!-- Item is importable and published. User can unpublish or disable import and unpublish. -->
-                    <button @click="setSharing('disable_link_access_and_unpublish')">Disable Access to {{model_class}} via Link and Unpublish</button>
+                    <b-button @click="setSharing('disable_link_access_and_unpublish')">Disable Access to {{model_class}} via Link and Unpublish</b-button>
                     <div class="toolParamHelp">Disables this {{model_class_lc}}'s link so that it is not accessible and removes {{model_class_lc}} from Galaxy's <a :href="published_url" target="_top">Published {{plural_name}}</a> section so that it is not publicly listed or searchable.</div>
                     <br/>
-                    <button @click="setSharing('unpublish')">Unpublish {{model_class}}</button>
+                    <b-button @click="setSharing('unpublish')">Unpublish {{model_class}}</b-button>
                     <div class="toolParamHelp">Removes this {{model_class_lc}} from Galaxy's <a :href="published_url" target="_top">Published {{plural_name}}</a> section so that it is not publicly listed or searchable.</div>
                 </div>
             </div>
             <div v-else>
                 <p>This {{model_class_lc}} is currently restricted so that only you and the users listed below can access it. You can:</p>
-                <button @click="setSharing('make_accessible_via_link')">Make {{model_class}} Accessible via Link</button>
+                <b-button @click="setSharing('make_accessible_via_link')">Make {{model_class}} Accessible via Link</b-button>
                 <div class="toolParamHelp">Generates a web link that you can share with other people so that they can view and import the {{model_class_lc}}.</div>
                 <br/>
-                <button @click="setSharing('make_accessible_and_publish')">Make {{model_class}} Accessible and Publish</button>
+                <b-button @click="setSharing('make_accessible_and_publish')">Make {{model_class}} Accessible and Publish</b-button>
                 <div class="toolParamHelp">Makes the {{model_class_lc}} accessible via link (see above) and publishes the {{model_class_lc}} to Galaxy's <a :href="published_url" target="_top">Published {{plural_name}}</a> section, where it is publicly listed and searchable.</div>
             </div>
             <br/><br/>
             <h3>Share {{model_class}} with Individual Users</h3>
             <div>
                 <div v-if="item.users_shared_with && item.users_shared_with.length > 0">
-                    <p>
-                        The following users will see this {{model_class_lc}} in their {{model_class_lc}} list and will be able to view, import and run it.
-                        <br/>
-                        <table class="colored" border="0" cellspacing="0" cellpadding="0" width="100%">
-                            <tr class="header">
-                                <th>Email</th>
-                                <th/>
-                            </tr>
-                            <tr v-for="user in item.users_shared_with">
-                                <td>{{user.email}}</td>
-                                <td><button @click="setSharing('unshare_user', user.id)">Remove</button></td>
-                            </tr>
-                        </table>
-                    </p>
+                    <b-table small caption-top :fields="share_fields" :items="item.users_shared_with">
+                        <template slot="table-caption"> The following users will see this {{model_class_lc}} in their {{model_class_lc}} list and will be able to view, import and run it. </template>
+                        <template slot="id" slot-scope="cell">
+                            <b-button size="sm" @click.stop="setSharing('unshare_user', cell.value )">Remove</b-button>
+                        </template>
+                    </b-table>
                 </div>
                 <div v-else>
                     <p>You have not shared this {{model_class_lc}} with any users.</p>
                 </div>
-                <a id="share_with_a_user" class="action-button" :href="share_url">
+                <b-button :href="share_url">
                     <span>Share with a user</span>
-                </a>
+                </b-button>
             </div>
         </div>
     </div>
@@ -154,7 +146,8 @@ export default {
                 importable: false,
                 published: false,
                 users_shared_with: []
-            }
+            },
+            share_fields: ["email", { key: "id", label: "" }]
         };
     },
     created: function() {

--- a/client/galaxy/scripts/components/Sharing.vue
+++ b/client/galaxy/scripts/components/Sharing.vue
@@ -1,9 +1,9 @@
 <template>
     <div v-if="ready">
         <h2>Share or Publish {{model_class}} `{{item.title}}`</h2>
-        <div v-if="err_msg" class="ui-message ui-show alert alert-danger">
+        <b-alert variant="danger" :show="err_msg">
             {{ err_msg }}
-        </div>
+        </b-alert>
         </br>
         <div v-if="!has_username">
             <div>To make a {{model_class_lc}} accessible via link or publish it, you must create a public username:</div>
@@ -91,6 +91,11 @@
 <script>
 import axios from "axios";
 import async_save_text from "utils/async-save-text";
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+
+Vue.use(BootstrapVue);
+
 export default {
     props: {
         id: {
@@ -235,9 +240,3 @@ export default {
     }
 };
 </script>
-
-<style>
-.ui-show {
-    display: block;
-}
-</style>

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -352,7 +352,7 @@ class SharableModelSerializer(base.ModelSerializer,
             return item.name
 
     def serialize_username_and_slug(self, item, key, **context):
-        if not (item.user and item.slug and self.SINGLE_CHAR_ABBR):
+        if not (item.user and item.user.username and item.slug and self.SINGLE_CHAR_ABBR):
             return None
         return ('/').join(('u', item.user.username, self.SINGLE_CHAR_ABBR, item.slug))
 


### PR DESCRIPTION
I started tinkering a bit more with layout changes, but didn't want to go too far in this.  Swapping to bs-vue alerts, buttons, and tables is a good start.  Overall layout changes (b-container, etc) may be more sweeping, and we can revisit those.

Also fixed a bug I ran into along the way where username was null and the manager died.