### PR TITLE
[18.05] Improve dialog message while waiting for rule builder job.

### DIFF
--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -364,8 +364,11 @@
         </rule-modal-footer>
     </state-div>
     <state-div v-else-if="state == 'wait'">
-        <rule-modal-header>
-            {{ l("Galaxy is waiting for collection creation, this dialog will close when this is complete.") }}
+        <rule-modal-header v-if="importType == 'datasets'">
+            {{ l("Datasets submitted to Galaxy for creation, this dialog will close when dataset creation is complete. You may close this dialog at any time, but you will not be informed of errors with dataset creation and you may have to refresh your history manually to view new datasets once complete.") }}
+        </rule-modal-header>
+        <rule-modal-header v-else-if="importType == 'collections'">
+            {{ l("Galaxy is waiting for collection creation, this dialog will close when this is complete. You may close this dialog at any time, but you will not be informed of errors with collection creation and you may have to refresh your history manually to view new collections once complete.") }}
         </rule-modal-header>
         <rule-modal-footer>
             <b-button @click="cancel" class="creator-cancel-btn" tabindex="-1">


### PR DESCRIPTION
Starts to address some of https://github.com/galaxyproject/galaxy/issues/6106 I think, but there is a lot of room to continue improvement.

> not every submission creates a collection

This has been fixed, there are separate messages for collection and dataset generation now.

> it is unclear you can close the modal safely

You can close at any time but there are potential downsides, these are listed in the message now.

> This would probably be better served as a toastr notification

If the rule builder catches the error properly (it is getting better at this), even at the end of a long upload job - keeping the modal open allows you to click "Okay" and get right back to where you were before - so you can fix the rules and resubmit. It also has more room to display the job standard error from Galaxy.

Certainly if there is polling that happens and a message is generated but the modal has been dismissed - it would be good to generate a toastr notification - this doesn't do that. It would also be good - if the failed collections had job standard error present - but right now I don't think there is a way to see job information for failed output collections in the history panel (only implicit mapped over collections that have datasets with this information available) - so this panel is giving us some real estate to print things not otherwise available.
