### PR TITLE
[18.05] Improve data initialization of rule builder for long term support.

### DIFF
--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -285,7 +285,7 @@
                                     </button>
                                     <div class="dropdown-menu" role="menu">
                                         <rule-target-component :builder="this" rule-type="add_column_basename" />
-                                        <rule-target-component :builder="this" rule-type="add_column_metadata" v-if="elementsType == 'collection_contents'"/>
+                                        <rule-target-component :builder="this" rule-type="add_column_metadata" v-if="metadataOptions"/>
                                         <rule-target-component :builder="this" rule-type="add_column_regex" />
                                         <rule-target-component :builder="this" rule-type="add_column_concatenate" />
                                         <rule-target-component :builder="this" rule-type="add_column_rownum" />
@@ -830,6 +830,27 @@ export default {
                         value: "identifier0"
                     });
                 }
+            } else if (this.elementsType == "datasets") {
+                rules.push(
+                    {
+                        type: "add_column_metadata",
+                        value: "hid"
+                    },
+                    {
+                        type: "add_column_metadata",
+                        value: "name"
+                    }
+                );
+            } else if (this.elementsType == "library_datasets") {
+                rules.push({
+                    type: "add_column_metadata",
+                    value: "name"
+                });
+            } else if (this.elementsType == "ftp") {
+                rules.push({
+                    type: "add_column_metadata",
+                    value: "path"
+                });
             }
         }
         return {
@@ -1058,14 +1079,14 @@ export default {
         },
         hotData() {
             let data, sources, columns;
-            if (this.elementsType == "datasets") {
-                data = this.initialElements.map(el => [el["hid"], el["name"]]);
+            if (
+                this.elementsType == "datasets" ||
+                this.elementsType == "library_datasets" ||
+                this.elementsType == "ftp"
+            ) {
+                data = this.initialElements.map(el => []);
                 sources = this.initialElements.slice();
-                columns = ["new", "new"];
-            } else if (this.elementsType == "library_datasets") {
-                data = this.initialElements.map(el => [el["name"]]);
-                sources = this.initialElements.slice();
-                columns = ["new"];
+                columns = [];
             } else if (this.elementsType == "collection_contents") {
                 const collection = this.initialElements;
                 if (collection) {
@@ -1131,7 +1152,7 @@ export default {
             return asDict;
         },
         metadataOptions() {
-            const metadataOptions = {};
+            let metadataOptions = {};
             if (this.elementsType == "collection_contents") {
                 let collectionType;
                 if (this.initialElements) {
@@ -1150,6 +1171,15 @@ export default {
                         metadataOptions["identifier" + index] = _l("Paired Identifier");
                     }
                 }
+            } else if ( this.elementsType == "ftp" ) {
+                metadataOptions["path"] = _l("Path");
+            } else if ( this.elementsType == "library_datasets" ) {
+                metadataOptions["name"] = _l("Name");
+            } else if ( this.elementsType == "datasets" ) {
+                metadataOptions["hid"] = _l("History ID (hid)");
+                metadataOptions["name"] = _l("Name");
+            } else {
+                metadataOptions = null;
             }
             return metadataOptions;
         },

--- a/client/galaxy/scripts/mvc/collection/list-collection-creator.js
+++ b/client/galaxy/scripts/mvc/collection/list-collection-creator.js
@@ -1138,6 +1138,10 @@ function createCollectionViaRules(selection, defaultHideSourceItems) {
         elements = selection.toJSON();
         elementsType = "datasets";
         importType = "collections";
+    } else if (selection.elements) {
+        elementsType = selection.selectionType;
+        importType = selection.dataType || "collections";
+        elements = selection.elements;
     } else {
         const hasNonWhitespaceChars = RegExp(/[^\s]/);
         // Have pasted data, data from a history dataset, or FTP list.

--- a/client/galaxy/scripts/mvc/rules/rule-definitions.js
+++ b/client/galaxy/scripts/mvc/rules/rule-definitions.js
@@ -166,11 +166,22 @@ const RULES = {
         },
         apply: (rule, data, sources, columns) => {
             const ruleValue = rule.value;
-            const identifierIndex = parseInt(ruleValue.substring("identifier".length));
-            function newRow(row, index) {
-                const newRow = row.slice();
-                newRow.push(sources[index]["identifiers"][identifierIndex]);
-                return newRow;
+            let newRow;
+            if (ruleValue.startsWith("identifier")) {
+                const identifierIndex = parseInt(ruleValue.substring("identifier".length));
+                newRow = (row, index) => {
+                    const newRow = row.slice();
+                    newRow.push(sources[index]["identifiers"][identifierIndex]);
+                    return newRow;
+                };
+            } else if (ruleValue == "hid" || ruleValue == "name" || ruleValue == "path") {
+                newRow = (row, index) => {
+                    const newRow = row.slice();
+                    newRow.push(sources[index][ruleValue]);
+                    return newRow;
+                };
+            } else {
+                return { error: `Unknown metadata type [${ruleValue}}]` };
             }
             data = data.map(newRow);
             columns.push(NEW_COLUMN);

--- a/client/galaxy/scripts/mvc/upload/collection/rules-input-view.js
+++ b/client/galaxy/scripts/mvc/upload/collection/rules-input-view.js
@@ -8,6 +8,7 @@ export default Backbone.View.extend({
     initialize: function(app) {
         this.app = app;
         this.options = app.options;
+        this.ftpFiles = [];
         this.ftpUploadSite = app.currentFtp();
         this.setElement(this._template());
         this.btnBuild = new Ui.Button({
@@ -100,6 +101,7 @@ export default Backbone.View.extend({
         } else if (selectionType == "ftp") {
             UploadUtils.getRemoteFiles(ftp_files => {
                 this._setPreview(ftp_files.map(file => file["path"]).join("\n"));
+                this.ftpFiles = ftp_files;
             });
         }
         this._updateScreen();
@@ -137,13 +139,15 @@ export default Backbone.View.extend({
 
     _buildSelection: function(content) {
         const selectionType = this.selectionType;
-        const selection = { content: content };
+        const selection = {};
         if (selectionType == "dataset" || selectionType == "paste") {
             selection.selectionType = "raw";
+            selection.content = content;
         } else if (selectionType == "ftp") {
             selection.selectionType = "ftp";
+            selection.elements = this.ftpFiles;
+            selection.ftpUploadSite = this.ftpUploadSite;
         }
-        selection.ftpUploadSite = this.ftpUploadSite;
         selection.dataType = this.dataType;
         Galaxy.currHistoryPanel.buildCollection("rules", selection, true);
         this.app.modal.hide();


### PR DESCRIPTION
A mistake was made in the rush to rule-builder-all-the-stuffs - libraries, hdas, and FTP all initialized a different set of columns from the data (which is probably fine) but with no indication this was happening in the underlying rules (which is definitely not fine).

To understand why this was a mistake and see why in the long term this hurts reproducibility, take loading rules for HDAs from the history panel as an example. In the initial implementation it would pre-initialize two columns - one for "hid" and one for "name" - any rules that were generated from there would start with an implicit assumption of two columns. This is a problem because if someone saves some rules and we (Galaxy developers) decide later on that name tag should be in the initial list but HID doesn't make sense and make that change - we basically are breaking all existing rules to support a very logical change in behavior. Likewise, Galaxy produces a hash with last modified date and size for each FTP entry - this is data we have and could stick in the rule builder by default - but if we change that over time existing FTP rules will break.

It would be much more sustainable to instead include the initial column generation information in the initial rules generated - so that each of these modalities start in reality with an empty table and the initial set of rules describe what metadata to pull initial columns from. This way if you save a set of rules it will include the initial column choices, and if they are pasted in at some later point where columns are picked differently - the rules will still work because you are replacing the initial column definitions.

The initial rules implementation didn't have this concept of loading columns from metadata - but this was added to support loading existing identifiers as part of the "Apply Rules to Existing Collection" tool. This commit extends that idea to do the same thing (but with different columns) when loading data from HDAs, FTP, and data libraries.