### PR TITLE
[18.05] "Fix" rule builder to auto decompress uploaded files.

### DIFF
--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -1448,7 +1448,8 @@ export default {
                     axios
                         .post(`${Galaxy.root}api/tools/fetch`, {
                             history_id: historyId,
-                            targets: targets
+                            targets: targets,
+                            auto_decompress: true,
                         })
                         .then(this.refreshAndWait)
                         .catch(this.renderFetchError);

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -701,7 +701,7 @@ def handle_compressed_file(
             # Replace the compressed file with the uncompressed file
             shutil.move(uncompressed, filename)
             uncompressed = filename
-    elif not is_compressed:
+    elif not is_compressed or not check_content:
         is_valid = True
     return is_valid, ext, uncompressed, compressed_type
 
@@ -739,7 +739,7 @@ def handle_uploaded_dataset_file(
         # This needs to be checked again after decompression
         is_binary = check_binary(converted_path)
 
-        if not is_binary and convert_to_posix_lines:
+        if not is_binary and (convert_to_posix_lines or convert_spaces_to_tabs):
             # Convert universal line endings to Posix line endings, spaces to tabs (if desired)
             if convert_spaces_to_tabs:
                 convert_fxn = convert_newlines_sep2tabs

--- a/lib/galaxy/datatypes/upload_util.py
+++ b/lib/galaxy/datatypes/upload_util.py
@@ -1,5 +1,11 @@
+import os
+
 from galaxy.datatypes import sniff
-from galaxy.datatypes.binary import Binary
+from galaxy.util.checkers import (
+    check_binary,
+    is_single_file_zip,
+    is_zip,
+)
 
 
 class UploadProblemException(Exception):
@@ -8,40 +14,76 @@ class UploadProblemException(Exception):
         self.message = message
 
 
-def handle_unsniffable_binary_check(data_type, ext, path, name, is_binary, requested_ext, check_content, registry):
-    """Return modified values of data_type and ext if unsniffable binary encountered.
+def handle_upload(
+    registry,
+    path,  # dataset.path
+    requested_ext,  # dataset.file_type
+    name,  # dataset.name,
+    tmp_prefix,
+    tmp_dir,
+    check_content,
+    link_data_only,
+    in_place,
+    auto_decompress,
+    convert_to_posix_lines,
+    convert_spaces_to_tabs,
+):
+    stdout = None
+    converted_path = None
 
-    Throw UploadProblemException if content problems or extension mismatches occur.
+    # Does the first 1K contain a null?
+    is_binary = check_binary(path)
 
-    Precondition: check_binary called returned True.
-    """
-    if is_binary or registry.is_extension_unsniffable_binary(requested_ext):
-        # We have a binary dataset, but it is not Bam, Sff or Pdf
-        data_type = 'binary'
-        parts = name.split(".")
-        if len(parts) > 1:
-            ext = parts[-1].strip().lower()
-            is_ext_unsniffable_binary = registry.is_extension_unsniffable_binary(ext)
-            if check_content and not is_ext_unsniffable_binary:
-                raise UploadProblemException('The uploaded binary file contains inappropriate content')
+    # Decompress if needed/desired and determine/validate filetype. If a keep-compressed datatype is explicitly selected
+    # or if autodetection is selected and the file sniffs as a keep-compressed datatype, it will not be decompressed.
+    if not link_data_only:
+        if auto_decompress and is_zip(path) and not is_single_file_zip(path):
+            stdout = 'ZIP file contained more than one file, only the first file was added to Galaxy.'
+        try:
+            ext, converted_path, compression_type = sniff.handle_uploaded_dataset_file(
+                path,
+                registry,
+                ext=requested_ext,
+                tmp_prefix=tmp_prefix,
+                tmp_dir=tmp_dir,
+                in_place=in_place,
+                check_content=check_content,
+                is_binary=is_binary,
+                auto_decompress=auto_decompress,
+                uploaded_file_ext=os.path.splitext(name)[1].lower().lstrip('.'),
+                convert_to_posix_lines=convert_to_posix_lines,
+                convert_spaces_to_tabs=convert_spaces_to_tabs,
+            )
+        except sniff.InappropriateDatasetContentError as exc:
+            raise UploadProblemException(str(exc))
+    elif requested_ext == 'auto':
+        ext = sniff.guess_ext(path, registry.sniff_order, is_binary=is_binary)
+    else:
+        ext = requested_ext
 
-            elif is_ext_unsniffable_binary and requested_ext != ext:
-                err_msg = "You must manually set the 'File Format' to '%s' when uploading %s files." % (ext, ext)
-                raise UploadProblemException(err_msg)
-    return data_type, ext
+    # The converted path will be the same as the input path if no conversion was done (or in-place conversion is used)
+    converted_path = None if converted_path == path else converted_path
 
+    # Validate datasets where the filetype was explicitly set using the filetype's sniffer (if any)
+    if requested_ext != 'auto':
+        datatype = registry.get_datatype_by_extension(requested_ext)
+        # Enable sniffer "validate mode" (prevents certain sniffers from disabling themselves)
+        if check_content and hasattr(datatype, 'sniff') and not datatype.sniff(path):
+            stdout = ("Warning: The file 'Type' was set to '{ext}' but the file does not appear to be of that"
+                      " type".format(ext=requested_ext))
 
-def handle_sniffable_binary_check(data_type, ext, path, registry):
-    """Return modified values of data_type and ext if sniffable binary encountered.
+    # Handle unsniffable binaries
+    if is_binary and ext == 'binary':
+        upload_ext = os.path.splitext(name)[1].lower().lstrip('.')
+        if registry.is_extension_unsniffable_binary(upload_ext):
+            stdout = ("Warning: The file's datatype cannot be determined from its contents and was guessed based on"
+                     " its extension, to avoid this warning, manually set the file 'Type' to '{ext}' when uploading"
+                     " this type of file".format(ext=upload_ext))
+            ext = upload_ext
+        else:
+            stdout = ("The uploaded binary file format cannot be determined automatically, please set the file 'Type'"
+                      " manually")
 
-    Precondition: check_binary called returned True.
-    """
-    # Sniff the data type
-    guessed_ext = sniff.guess_ext(path, registry.sniff_order)
-    # Set data_type only if guessed_ext is a binary datatype
-    datatype = registry.get_datatype_by_extension(guessed_ext)
-    if isinstance(datatype, Binary):
-        data_type = guessed_ext
-        ext = guessed_ext
+    datatype = registry.get_datatype_by_extension(ext)
 
-    return data_type, ext
+    return stdout, ext, datatype, is_binary, converted_path

--- a/test/api/test_tools_upload.py
+++ b/test/api/test_tools_upload.py
@@ -83,12 +83,20 @@ class ToolsUploadTestCase(api.ApiTestCase):
         fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
         details = self._upload_and_get_details(open(fastqgz_path, "rb"), api="fetch", ext="fastqsanger.gz")
         assert details["state"] == "ok"
+        assert details["file_ext"] == "fastqsanger.gz"
 
-    def test_fetch_compressed_with_auto_fails(self):
+    def test_fetch_compressed_with_auto_binary(self):
         # UNSTABLE_FLAG: this might decompress automatically or fallback to fastqsanger.gz or gz datatype in the future.
         fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
         details = self._upload_and_get_details(open(fastqgz_path, "rb"), api="fetch", assert_ok=False)
-        assert details["state"] == "error"
+        assert details["state"] == "ok"
+        assert details["file_ext"] == "binary", details
+
+    def test_fetch_compressed_auto_decompress_target(self):
+        fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
+        details = self._upload_and_get_details(open(fastqgz_path, "rb"), api="fetch", assert_ok=False, auto_decompress=True)
+        assert details["state"] == "ok"
+        assert details["file_ext"] == "fastqsanger", details
 
     def test_upload_decompresses_auto_by_default(self):
         bedgz_path = TestDataResolver().get_filename("4.bed.gz")
@@ -120,7 +128,8 @@ class ToolsUploadTestCase(api.ApiTestCase):
         # UNSTABLE_FLAG and TODO: this should definitely be fixed to allow auto decompression via that API.
         fastqgz_path = TestDataResolver().get_filename("4.bed.gz")
         details = self._upload_and_get_details(open(fastqgz_path, "rb"), api="fetch", auto_decompress=True, assert_ok=False)
-        assert details["state"] == "error"
+        assert details["state"] == "ok"
+        assert details["file_ext"] == "bed"
 
     @skip_without_datatype("rdata")
     def test_rdata_not_decompressed(self):

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -2,7 +2,7 @@
 
 This file checks upload options that require different non-default Galaxy
 configuration options. More vanilla upload options and behaviors are tested
-with the API test framework (located in test_tools.py).
+with the API test framework (located in test_tools_upload.py).
 
 These options include:
  - The config options ``check_upload_content`` and ``allow_path_paste``.

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -16,12 +16,7 @@ from six.moves.urllib.request import urlopen
 from galaxy import util
 from galaxy.datatypes import sniff
 from galaxy.datatypes.registry import Registry
-from galaxy.datatypes.upload_util import UploadProblemException
-from galaxy.util.checkers import (
-    check_binary,
-    is_single_file_zip,
-    is_zip,
-)
+from galaxy.datatypes.upload_util import handle_upload, UploadProblemException
 
 assert sys.version_info[:2] >= (2, 7)
 
@@ -65,8 +60,6 @@ def add_file(dataset, registry, output_path):
     ext = None
     compression_type = None
     line_count = None
-    converted_path = None
-    stdout = None
     link_data_only_str = dataset.get('link_data_only', 'copy_files')
     if link_data_only_str not in ['link_to_files', 'copy_files']:
         raise UploadProblemException("Invalid setting '%s' for option link_data_only - upload request misconfigured" % link_data_only_str)
@@ -118,60 +111,20 @@ def add_file(dataset, registry, output_path):
     if not os.path.getsize(dataset.path) > 0:
         raise UploadProblemException('The uploaded file is empty')
 
-    # Does the first 1K contain a null?
-    is_binary = check_binary(dataset.path)
-
-    # Decompress if needed/desired and determine/validate filetype. If a keep-compressed datatype is explicitly selected
-    # or if autodetection is selected and the file sniffs as a keep-compressed datatype, it will not be decompressed.
-    if not link_data_only:
-        if auto_decompress and is_zip(dataset.path) and not is_single_file_zip(dataset.path):
-            stdout = 'ZIP file contained more than one file, only the first file was added to Galaxy.'
-        try:
-            ext, converted_path, compression_type = sniff.handle_uploaded_dataset_file(
-                dataset.path,
-                registry,
-                ext=dataset.file_type,
-                tmp_prefix='data_id_%s_upload_' % dataset.dataset_id,
-                tmp_dir=output_adjacent_tmpdir(output_path),
-                in_place=in_place,
-                check_content=check_content,
-                is_binary=is_binary,
-                auto_decompress=auto_decompress,
-                uploaded_file_ext=os.path.splitext(dataset.name)[1].lower().lstrip('.'),
-                convert_to_posix_lines=dataset.to_posix_lines,
-                convert_spaces_to_tabs=dataset.space_to_tab,
-            )
-        except sniff.InappropriateDatasetContentError as exc:
-            raise UploadProblemException(str(exc))
-    elif dataset.file_type == 'auto':
-        ext = sniff.guess_ext(dataset.path, registry.sniff_order, is_binary=is_binary)
-    else:
-        ext = dataset.file_type
-
-    # The converted path will be the same as the input path if no conversion was done (or in-place conversion is used)
-    converted_path = None if converted_path == dataset.path else converted_path
-
-    # Validate datasets where the filetype was explicitly set using the filetype's sniffer (if any)
-    if dataset.file_type != 'auto':
-        datatype = registry.get_datatype_by_extension(dataset.file_type)
-        # Enable sniffer "validate mode" (prevents certain sniffers from disabling themselves)
-        if check_content and hasattr(datatype, 'sniff') and not datatype.sniff(dataset.path):
-            stdout = ("Warning: The file 'Type' was set to '{ext}' but the file does not appear to be of that"
-                      " type".format(ext=dataset.file_type))
-
-    # Handle unsniffable binaries
-    if is_binary and ext == 'binary':
-        upload_ext = os.path.splitext(dataset.name)[1].lower().lstrip('.')
-        if registry.is_extension_unsniffable_binary(upload_ext):
-            stdout = ("Warning: The file's datatype cannot be determined from its contents and was guessed based on"
-                     " its extension, to avoid this warning, manually set the file 'Type' to '{ext}' when uploading"
-                     " this type of file".format(ext=upload_ext))
-            ext = upload_ext
-        else:
-            stdout = ("The uploaded binary file format cannot be determined automatically, please set the file 'Type'"
-                      " manually")
-
-    datatype = registry.get_datatype_by_extension(ext)
+    stdout, ext, datatype, is_binary, converted_path = handle_upload(
+        registry=registry,
+        path=dataset.path,
+        requested_ext=dataset.file_type,
+        name=dataset.name,
+        tmp_prefix='data_id_%s_upload_' % dataset.dataset_id,
+        tmp_dir=output_adjacent_tmpdir(output_path),
+        check_content=check_content,
+        link_data_only=link_data_only,
+        in_place=in_place,
+        auto_decompress=auto_decompress,
+        convert_to_posix_lines=dataset.to_posix_lines,
+        convert_spaces_to_tabs=dataset.space_to_tab,
+    )
 
     # Strip compression extension from name
     if compression_type and not getattr(datatype, 'compressed', False) and dataset.name.endswith('.' + compression_type):

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -124,7 +124,7 @@ def add_file(dataset, registry, output_path):
     # Decompress if needed/desired and determine/validate filetype. If a keep-compressed datatype is explicitly selected
     # or if autodetection is selected and the file sniffs as a keep-compressed datatype, it will not be decompressed.
     if not link_data_only:
-        if is_zip(dataset.path) and not is_single_file_zip(dataset.path):
+        if auto_decompress and is_zip(dataset.path) and not is_single_file_zip(dataset.path):
             stdout = 'ZIP file contained more than one file, only the first file was added to Galaxy.'
         try:
             ext, converted_path, compression_type = sniff.handle_uploaded_dataset_file(
@@ -155,7 +155,7 @@ def add_file(dataset, registry, output_path):
     if dataset.file_type != 'auto':
         datatype = registry.get_datatype_by_extension(dataset.file_type)
         # Enable sniffer "validate mode" (prevents certain sniffers from disabling themselves)
-        if hasattr(datatype, 'sniff') and not datatype.sniff(dataset.path):
+        if check_content and hasattr(datatype, 'sniff') and not datatype.sniff(dataset.path):
             stdout = ("Warning: The file 'Type' was set to '{ext}' but the file does not appear to be of that"
                       " type".format(ext=dataset.file_type))
 


### PR DESCRIPTION
Mentioned in other issues and on Slack but it sounds like this is important use case. It can be considered a fix in that the different parts of the UI behave very differently and that is confusing. Also the work arounds for dealing with large collections of compressed data are not quite there yet so this is really needed. This includes a few different fixes for @natefoo's big upload refactoring this release as well and synchronization of the upload.py and data_fetch.py code (the PR is more red than green). If you are wondering why upload.py and data_fetch didn't share more in common earlier - it is because @natefoo and I both had big competing, concurrent refactorings of upload.py this release but his won out - so my synchronizations of data_fetch and upload.py never made it.
