### PR TITLE
[18.05] Use RetryActionExecutor when executing commands via paramiko

### DIFF
--- a/lib/galaxy/jobs/runners/util/cli/shell/rsh.py
+++ b/lib/galaxy/jobs/runners/util/cli/shell/rsh.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import paramiko
+from pulsar.managers.util.retry import RetryActionExecutor
 
 from galaxy.util.bunch import Bunch
 from .local import LocalShell
@@ -56,11 +57,14 @@ class ParamikoShell(object):
         self.private_key = private_key
         self.port = int(port) if port else port
         self.timeout = int(timeout) if timeout else timeout
-        self.ssh = paramiko.SSHClient()
-        self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.ssh = None
+        self.retry_action_executor = RetryActionExecutor(max_retries=100, interval_max=300)
         self.connect()
 
     def connect(self):
+        log.info("Attempting establishment of new paramiko SSH channel")
+        self.ssh = paramiko.SSHClient()
+        self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         self.ssh.connect(hostname=self.hostname,
                          port=self.port,
                          username=self.username,
@@ -69,13 +73,18 @@ class ParamikoShell(object):
                          timeout=self.timeout)
 
     def execute(self, cmd, timeout=60):
-        try:
-            _, stdout, stderr = self._execute(cmd, timeout)
-        except paramiko.SSHException as e:
-            log.error(e)
-            time.sleep(10)
-            self.connect()
-            _, stdout, stderr = self._execute(cmd, timeout)
+
+        def retry():
+            try:
+                _, stdout, stderr = self._execute(cmd, timeout)
+            except paramiko.SSHException as e:
+                log.error(e)
+                time.sleep(10)
+                self.connect()
+                _, stdout, stderr = self._execute(cmd, timeout)
+            return stdout, stderr
+
+        stdout, stderr = self.retry_action_executor.execute(retry)
         return_code = stdout.channel.recv_exit_status()
         return Bunch(stdout=stdout.read(), stderr=stderr.read(), returncode=return_code)
 


### PR DESCRIPTION
This should work around issues like

```
galaxy.jobs.runners ERROR 2018-05-16 10:15:55,522 [p:13768,w:0,m:1] [ShellRunner.work_thread-3] (34130) Unhandled exception calling queue_job
Traceback (most recent call last):
  File "lib/galaxy/jobs/runners/__init__.py", line 112, in run_next
    method(arg)
  File "lib/galaxy/jobs/runners/cli.py", line 94, in queue_job
    chmod_out = shell.execute("chmod +x %s" % tool_script)
  File "lib/galaxy/jobs/runners/util/cli/shell/rsh.py", line 77, in execute
    self.connect()
  File "lib/galaxy/jobs/runners/util/cli/shell/rsh.py", line 69, in connect
    timeout=self.timeout)
  File "/bioinfo/guests/mvandenb/galaxy/.venv/local/lib/python2.7/site-packages/paramiko/client.py", line 424, in connect
    passphrase,
  File "/bioinfo/guests/mvandenb/galaxy/.venv/local/lib/python2.7/site-packages/paramiko/client.py", line 714, in _auth
    raise saved_exception
SSHException: not a valid OPENSSH private key file
```

that can intermittently occur with rapid submission of many small jobs.