### PR TITLE
[18.05] Dropdown active color tweaks

### DIFF
--- a/client/galaxy/style/scss/galaxy_bootstrap/variables.scss
+++ b/client/galaxy/style/scss/galaxy_bootstrap/variables.scss
@@ -172,7 +172,6 @@ $headings-line-height: 1.1; // default 1.2
 $dropdown-link-hover-color: white;
 $dropdown-link-hover-bg: $brand-primary;
 $dropdown-link-active-color: black;
-$dropdown-link-active-bg: $brand-success;
 
 // BOOTSTRAP 4 STYLE REFACTORING BREAK POINT
 // Anything that is actually used should be moved above this line and

--- a/client/galaxy/style/scss/galaxy_bootstrap/variables.scss
+++ b/client/galaxy/style/scss/galaxy_bootstrap/variables.scss
@@ -171,7 +171,7 @@ $headings-line-height: 1.1; // default 1.2
 // Increase contrast of dropdown items
 $dropdown-link-hover-color: white;
 $dropdown-link-hover-bg: $brand-primary;
-$dropdown-link-active-color: black;
+$dropdown-link-active-color: $gray-dark;
 
 // BOOTSTRAP 4 STYLE REFACTORING BREAK POINT
 // Anything that is actually used should be moved above this line and

--- a/client/galaxy/style/scss/galaxy_bootstrap/variables.scss
+++ b/client/galaxy/style/scss/galaxy_bootstrap/variables.scss
@@ -171,7 +171,7 @@ $headings-line-height: 1.1; // default 1.2
 // Increase contrast of dropdown items
 $dropdown-link-hover-color: white;
 $dropdown-link-hover-bg: $brand-primary;
-$dropdown-link-active-color: $gray-dark;
+$dropdown-link-active-color: gold;
 
 // BOOTSTRAP 4 STYLE REFACTORING BREAK POINT
 // Anything that is actually used should be moved above this line and

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -2315,7 +2315,7 @@ input[type="button"].btn-block {
     text-decoration: none;
     background-color: #25537b; }
   .dropdown-item.active, ul.dropdown-menu li > a.active, .dropdown-item:active, ul.dropdown-menu li > a:active {
-    color: black;
+    color: #333333;
     text-decoration: none;
     background-color: #25537b; }
   .dropdown-item.disabled, ul.dropdown-menu li > a.disabled, .dropdown-item:disabled, ul.dropdown-menu li > a:disabled {

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -2317,7 +2317,7 @@ input[type="button"].btn-block {
   .dropdown-item.active, ul.dropdown-menu li > a.active, .dropdown-item:active, ul.dropdown-menu li > a:active {
     color: black;
     text-decoration: none;
-    background-color: #21ba21; }
+    background-color: #25537b; }
   .dropdown-item.disabled, ul.dropdown-menu li > a.disabled, .dropdown-item:disabled, ul.dropdown-menu li > a:disabled {
     color: #868e96;
     background-color: transparent; }

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -2315,7 +2315,7 @@ input[type="button"].btn-block {
     text-decoration: none;
     background-color: #25537b; }
   .dropdown-item.active, ul.dropdown-menu li > a.active, .dropdown-item:active, ul.dropdown-menu li > a:active {
-    color: #333333;
+    color: gold;
     text-decoration: none;
     background-color: #25537b; }
   .dropdown-item.disabled, ul.dropdown-menu li > a.disabled, .dropdown-item:disabled, ul.dropdown-menu li > a:disabled {


### PR DESCRIPTION
This removes the very bright success green from a dropdown click, and switches the active black to the gray-dark we use elsewhere.  It only flashes for a second on click, but that green color was so bright it was incredibly jarring, to me.

I tried experimenting with various other lighter/darker versions for active-bg (the flash) like:
```
$dropdown-link-active-bg: saturate(lighten($brand-primary, 5%), 10%);
$dropdown-link-active-bg: darken($brand-primary, 15%);
```

But what looks best, to me, and still indicates a click, is simply leaving the bootstrap default for the background.  The text already toggles from light to dark indicating the active state, to let you know you actually clicked.