### PR TITLE
[18.05] Pin handsontable to the requested peer dependency

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "d3": "3",
     "font-awesome": "^4.7.0",
     "gulp-sass": "^3.1.0",
-    "handsontable": "^2.0.0",
+    "handsontable": "^0.38.1",
     "jquery": "2",
     "jquery-migrate": "~1.4",
     "jquery-mousewheel": "^3.1.13",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4623,9 +4623,9 @@ handlebars@~3.0.0:
   optionalDependencies:
     uglify-js "~2.3"
 
-handsontable@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/handsontable/-/handsontable-2.0.0.tgz#b22fbd61d3193eb63b9c798e73843f55856ef022"
+handsontable@^0.38.1:
+  version "0.38.1"
+  resolved "https://registry.yarnpkg.com/handsontable/-/handsontable-0.38.1.tgz#b8829ef4a82c4aad7d09472b71b6b6aa19baa6ce"
   dependencies:
     moment "2.20.1"
     numbro "1.11.0"
@@ -6657,9 +6657,13 @@ mocha@^5.0.5:
     mkdirp "0.5.1"
     supports-color "4.4.0"
 
-moment@2.20.1, moment@2.x:
+moment@2.20.1:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
+
+moment@2.x:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.1.tgz#529a2e9bf973f259c9643d237fda84de3a26e8ad"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes #5978.  Peer dependencies are a little annoying, but we should keep them pinned to the requested versions for compatibility.