### PR TITLE
[18.05] Fix job reruns for imported histories

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -12,6 +12,7 @@ from sqlalchemy import or_
 from galaxy import exceptions
 from galaxy import model
 from galaxy import util
+from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.jobs import JobSearch
 from galaxy.web import _future_expose_api as expose_api
 from galaxy.web import _future_expose_api_anonymous as expose_api_anonymous
@@ -26,6 +27,7 @@ class JobController(BaseAPIController, UsesLibraryMixinItems):
 
     def __init__(self, app):
         super(JobController, self).__init__(app)
+        self.dataset_manager = DatasetManager(app)
         self.job_search = JobSearch(app)
 
     @expose_api


### PR DESCRIPTION
Currently, re-running jobs from imported histories as non-admin fails. The reason is that the dataset access validation requires the dataset_manager which is currently unavailable, see: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/webapps/galaxy/api/jobs.py#L264. Reference: https://github.com/galaxyproject/galaxy/commit/07daa4d248ba5f42facb86a0e38370c54fb9e7b6#diff-e58bd24992974821caad88694ae22ed7L32