### PR TITLE
[18.05] Restore config comment

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -52,7 +52,9 @@ uwsgi:
   # --daemon and/or production deployments.
   master: false
 
-  # Path to the application's Python virtual environment.
+  # Path to the application's Python virtual environment.   If using
+  # Conda for Galaxy's framework dependencies (not tools!), do not set
+  # this.
   virtualenv: .venv
 
   # Path to the application's Python library.

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -52,9 +52,8 @@ uwsgi:
   # --daemon and/or production deployments.
   master: false
 
-  # Path to the application's Python virtual environment.   If using
-  # Conda for Galaxy's framework dependencies (not tools!), do not set
-  # this.
+  # Path to the application's Python virtual environment. If using Conda
+  # for Galaxy's framework dependencies (not tools!), do not set this.
   virtualenv: .venv
 
   # Path to the application's Python library.

--- a/config/reports.yml.sample
+++ b/config/reports.yml.sample
@@ -34,7 +34,9 @@ uwsgi:
   # --daemon and/or production deployments.
   master: false
 
-  # Path to the application's Python virtual environment.
+  # Path to the application's Python virtual environment.   If using
+  # Conda for Galaxy's framework dependencies (not tools!), do not set
+  # this.
   virtualenv: .venv
 
   # Path to the application's Python library.

--- a/config/reports.yml.sample
+++ b/config/reports.yml.sample
@@ -34,9 +34,8 @@ uwsgi:
   # --daemon and/or production deployments.
   master: false
 
-  # Path to the application's Python virtual environment.   If using
-  # Conda for Galaxy's framework dependencies (not tools!), do not set
-  # this.
+  # Path to the application's Python virtual environment. If using Conda
+  # for Galaxy's framework dependencies (not tools!), do not set this.
   virtualenv: .venv
 
   # Path to the application's Python library.

--- a/config/tool_shed.yml.sample
+++ b/config/tool_shed.yml.sample
@@ -34,7 +34,9 @@ uwsgi:
   # --daemon and/or production deployments.
   master: false
 
-  # Path to the application's Python virtual environment.
+  # Path to the application's Python virtual environment.   If using
+  # Conda for Galaxy's framework dependencies (not tools!), do not set
+  # this.
   virtualenv: .venv
 
   # Path to the application's Python library.

--- a/config/tool_shed.yml.sample
+++ b/config/tool_shed.yml.sample
@@ -34,9 +34,8 @@ uwsgi:
   # --daemon and/or production deployments.
   master: false
 
-  # Path to the application's Python virtual environment.   If using
-  # Conda for Galaxy's framework dependencies (not tools!), do not set
-  # this.
+  # Path to the application's Python virtual environment. If using Conda
+  # for Galaxy's framework dependencies (not tools!), do not set this.
   virtualenv: .venv
 
   # Path to the application's Python library.

--- a/lib/galaxy/webapps/config_manage.py
+++ b/lib/galaxy/webapps/config_manage.py
@@ -91,7 +91,7 @@ UWSGI_OPTIONS = OrderedDict([
         'type': 'bool',
     }),
     ('virtualenv', {
-        'desc': """Path to the application's Python virtual environment.""",
+        'desc': """Path to the application's Python virtual environment.   If using Conda for Galaxy's framework dependencies (not tools!), do not set this.""",
         'default': '.venv',
         'type': 'str',
     }),

--- a/lib/galaxy/webapps/config_manage.py
+++ b/lib/galaxy/webapps/config_manage.py
@@ -91,7 +91,7 @@ UWSGI_OPTIONS = OrderedDict([
         'type': 'bool',
     }),
     ('virtualenv', {
-        'desc': """Path to the application's Python virtual environment.   If using Conda for Galaxy's framework dependencies (not tools!), do not set this.""",
+        'desc': """Path to the application's Python virtual environment. If using Conda for Galaxy's framework dependencies (not tools!), do not set this.""",
         'default': '.venv',
         'type': 'str',
     }),


### PR DESCRIPTION
Partial backport of https://github.com/galaxyproject/galaxy/pull/6018. The text was initially added to the release_18.05 branch in commit a88e19064a38415d867f4c118dd6938d8e368632 (but only to `config/galaxy.yml.sample`), and unintentionally removed in https://github.com/galaxyproject/galaxy/pull/6152.