### PR TITLE
[18.05] Remove defunct sharing column link

### DIFF
--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -848,12 +848,6 @@ class SharingStatusColumn(GridColumn):
 
         return item.users_shared_with
 
-    def get_link(self, trans, grid, item):
-        is_shared = self._is_shared(item)
-        if not item.deleted and (is_shared or item.importable or item.published):
-            return dict(operation="share or publish", id=item.id)
-        return None
-
     def filter(self, trans, user, query, column_filter):
         """ Modify query to filter histories by sharing status. """
         if column_filter == "All":


### PR DESCRIPTION
Resolves #5025. This is a minor regression and has to be revisited when we transformed the grid components to vue. This should be handled at the front-end in the future. For now however this PR removes the useless link.