### PR TITLE
[18.05] Fix append() for ANY_COLLECTION_TYPE type description in WF editor.

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -39,7 +39,7 @@ var ANY_COLLECTION_TYPE_DESCRIPTION = {
         return "AnyCollectionType[]";
     },
     append: function() {
-        throw "Cannot append to ANY_COLLECTION_TYPE_DESCRIPTION";
+        return ANY_COLLECTION_TYPE_DESCRIPTION;
     },
     equal: function(other) {
         return other === this;


### PR DESCRIPTION
Append means take a collection type and extend it by the current type - so appending to ``list`` to ``paired`` -> ``list:paired`` for instance. ``ANY_COLLECTION_TYPE`` is a representation of incomplete information - it means this type description might be any kind of collection type (the way we use "input" to mean any kind of datatype in the editor) - you might think of it like ``*``. This fix is saying we didn't know what the collection type we are appending to (``*``) so we don't know the type of collection we are creating (``*``).

This is really a second order approximation of what a correct solution would be - a first order approximation would somehow represent the result of append being at least of "depth" specified (``list:*`` or ``*:list`` instead of ``*`` for instance when appending ``list`` to ``ANY_COLLECTION_TYPE`` (``*``) ). A not approximation would be to do that but use ``ANY_COLLECTION_TYPE`` much less frequently by capturing type_source information and propagating it throughout the workflow properly. But these increasingly non-local things are harder things to do, this incorrect fix will hopefully allow a more valid workflows to be edited that currently cannot be so I think it is good (and will prevent the JS error). Another way to think about this is that in the presence of incomplete information we are replacing some false negatives (valid workflows that cannot be edited) with some false possible (some invalid workflows at runtime that can be edited).

"Fixes" #5205.