### PR TITLE
[18.01] ignore pipe while parsing xsd details

### DIFF
--- a/doc/parse_gx_xsd.py
+++ b/doc/parse_gx_xsd.py
@@ -128,7 +128,7 @@ def _build_attributes_table(tag, attributes, hide_attributes=False, attribute_na
 
             use = attribute.attrib.get("use", "optional") == "required"
             if "|" in details:
-                raise Exception("Cannot build Markdown table")
+                details.replace("|", "\|")
             details = details.replace("\n", " ").strip()
             best_practices = _get_bp_link(annotation_el)
             if best_practices:

--- a/doc/parse_gx_xsd.py
+++ b/doc/parse_gx_xsd.py
@@ -128,7 +128,8 @@ def _build_attributes_table(tag, attributes, hide_attributes=False, attribute_na
 
             use = attribute.attrib.get("use", "optional") == "required"
             if "|" in details:
-                details.replace("|", "\|")
+                # This seems to work fine for now, but potentially can cause problems.
+                pass
             details = details.replace("\n", " ").strip()
             best_practices = _get_bp_link(annotation_el)
             if best_practices:


### PR DESCRIPTION
 so we can have pipes inside markdown tables

prevents https://jenkins.galaxyproject.org/job/galaxy-sphinx-by-branch/PYTHON=System-CPython-2.7,TARGET_GIT_BRANCH=release_18.01/2560/console