### PR TITLE
[18.05] Lock dependency on Sphinx to <1.7.

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/develop/Pipfile
+++ b/lib/galaxy/dependencies/pipfiles/develop/Pipfile
@@ -19,7 +19,7 @@ selenium = "*"
 testfixtures = "*"
 watchdog = "*"
 pygithub3 = {version = "*", markers = "python_version < '3'"}
-Sphinx = "*"
+Sphinx = "<1.7"  # Docs do not build with sphinx 1.7 for some reason, can't find issue.
 sphinx_rtd_theme = "*"
 lxml = "*"
 recommonmark = "*"

--- a/lib/galaxy/dependencies/pipfiles/develop/Pipfile.lock
+++ b/lib/galaxy/dependencies/pipfiles/develop/Pipfile.lock
@@ -295,11 +295,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:5a1c9a0fec678c24b9a2f5afba240c04668edb7f45c67ce2ed008996b3f21ae2",
-                "sha256:7a606d77618a753adb79e13605166e3cf6a0e5678526e044236fc1ac43650910"
+                "sha256:832bed0dc6099c2abca957d90ff55bc1a6ec4425c13fc144adbae68a970e3775",
+                "sha256:d5b91b4dad56ffc9f19425ebaa7bc23290a0a2e9035781d5bc54822384663277"
             ],
             "index": "galaxy",
-            "version": "==1.7.2"
+            "version": "==1.6.7"
         },
         "sphinx-rtd-theme": {
             "hashes": [

--- a/lib/galaxy/dependencies/pipfiles/develop/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/develop/pinned-requirements.txt
@@ -29,7 +29,7 @@ selenium==3.11.0
 six==1.11.0
 snowballstemmer==1.2.1
 sphinx-rtd-theme==0.3.0
-sphinx==1.7.2
+sphinx==1.6.7
 sphinxcontrib-websupport==1.0.1
 testfixtures==6.0.0
 twill==0.9.1; python_version < '3'


### PR DESCRIPTION
Galaxy does not build docs with 1.7 for me, @martenson, or Jenkins.