### PR TITLE
[18.05] Fix data_source.py for upload changes in 18.05 release cycle.

### DIFF
--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -706,7 +706,12 @@ def handle_compressed_file(
     return is_valid, ext, uncompressed, compressed_type
 
 
-def handle_uploaded_dataset_file(
+def handle_uploaded_dataset_file(*args, **kwds):
+    """Legacy wrapper about handle_uploaded_dataset_file_internal for tools using it."""
+    return handle_uploaded_dataset_file_internal(*args, **kwds)[0]
+
+
+def handle_uploaded_dataset_file_internal(
         filename,
         datatypes_registry,
         ext='auto',

--- a/lib/galaxy/datatypes/upload_util.py
+++ b/lib/galaxy/datatypes/upload_util.py
@@ -40,7 +40,7 @@ def handle_upload(
         if auto_decompress and is_zip(path) and not is_single_file_zip(path):
             stdout = 'ZIP file contained more than one file, only the first file was added to Galaxy.'
         try:
-            ext, converted_path, compression_type = sniff.handle_uploaded_dataset_file(
+            ext, converted_path, compression_type = sniff.handle_uploaded_dataset_file_internal(
                 path,
                 registry,
                 ext=requested_ext,

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1294,7 +1294,7 @@ class JobWrapper(HasResourceParameters):
                     if retry_internally and not self.external_output_metadata.external_metadata_set_successfully(dataset, self.sa_session):
                         # If Galaxy was expected to sniff type and didn't - do so.
                         if dataset.ext == "_sniff_":
-                            extension = sniff.handle_uploaded_dataset_file(dataset.dataset.file_name, self.app.datatypes_registry)[0]
+                            extension = sniff.handle_uploaded_dataset_file(dataset.dataset.file_name, self.app.datatypes_registry)
                             dataset.extension = extension
 
                         # call datatype.set_meta directly for the initial set_meta call during dataset creation

--- a/lib/galaxy_ext/metadata/set_metadata.py
+++ b/lib/galaxy_ext/metadata/set_metadata.py
@@ -44,7 +44,7 @@ def set_meta_with_tool_provided(dataset_instance, file_dict, set_meta_kwds, data
     if extension == "_sniff_":
         try:
             from galaxy.datatypes import sniff
-            extension = sniff.handle_uploaded_dataset_file(dataset_instance.dataset.external_filename, datatypes_registry)[0]
+            extension = sniff.handle_uploaded_dataset_file(dataset_instance.dataset.external_filename, datatypes_registry)
             # We need to both set the extension so it is available to set_meta
             # and record it in the metadata so it can be reloaded on the server
             # side and the model updated (see MetadataCollection.{from,to}_JSON_dict)


### PR DESCRIPTION
handle_uploaded_dataset_file was used by tools external to ``lib/`` include data_source.py and potentially tools in the tool shed. This restores the interface as a wrapper around a new method ``handle_uploaded_dataset_file_internal``.

Broken in https://github.com/galaxyproject/galaxy/commit/ef6f7f62ab679928045c816a3cb719fb3bcea507 I believe.

Fixes https://github.com/galaxyproject/galaxy/issues/6186 (I assume.)