### PR TITLE
[18.05] More password encoding handling fixes.

### DIFF
--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -6,6 +6,8 @@ from operator import xor
 from os import urandom
 from struct import Struct
 
+import six
+
 from galaxy.util import safe_str_cmp, smart_str
 
 SALT_LENGTH = 12
@@ -31,7 +33,7 @@ def check_password(guess, hashed):
             return True
     else:
         # Passwords were originally encoded with sha1 and hexed
-        if safe_str_cmp(hashlib.sha1(guess).hexdigest(), hashed):
+        if safe_str_cmp(hashlib.sha1(smart_str(guess)).hexdigest(), hashed):
             return True
     # Password does not match
     return False
@@ -42,16 +44,28 @@ def hash_password_PBKDF2(password):
     salt = b64encode(urandom(SALT_LENGTH))
     # Apply the pbkdf2 encoding
     hashed = pbkdf2_bin(smart_str(password), salt, COST_FACTOR, KEY_LENGTH, getattr(hashlib, HASH_FUNCTION))
+    hashed_b64 = b64encode(hashed)
+    if six.PY3:
+        salt = salt.decode('utf-8')
+        hashed_b64 = hashed_b64.decode('utf-8')
     # Format
-    return 'PBKDF2${0}${1}${2}${3}'.format(HASH_FUNCTION, COST_FACTOR, salt, b64encode(hashed))
+    return 'PBKDF2${0}${1}${2}${3}'.format(HASH_FUNCTION, COST_FACTOR, salt, hashed_b64)
 
 
 def check_password_PBKDF2(guess, hashed):
     # Split the database representation to extract cost_factor and salt
     name, hash_function, cost_factor, salt, encoded_original = hashed.split('$', 5)
+    if six.PY3:
+        guess = bytes(guess, 'utf-8')
+        salt = bytes(salt, 'utf-8')
+    else:
+        guess = smart_str(guess)
+    hashed_guess = pbkdf2_bin(guess, salt, int(cost_factor), KEY_LENGTH, getattr(hashlib, hash_function))
     # Hash the guess using the same parameters
     hashed_guess = pbkdf2_bin(smart_str(guess), salt, int(cost_factor), KEY_LENGTH, getattr(hashlib, hash_function))
     encoded_guess = b64encode(hashed_guess)
+    if six.PY3:
+        encoded_guess = encoded_guess.decode('utf-8')
     return safe_str_cmp(encoded_original, encoded_guess)
 
 
@@ -72,12 +86,15 @@ def pbkdf2_bin(data, salt, iterations=1000, keylen=24, hashfunc=None):
     def _pseudorandom(x, mac=mac):
         h = mac.copy()
         h.update(x)
-        return [ord(_) for _ in h.digest()]
+        digest = h.digest()
+        if six.PY2:
+            digest = [ord(_) for _ in digest]
+        return digest
     buf = []
     for block in range(1, -(-keylen // mac.digest_size) + 1):
         rv = u = _pseudorandom(salt + _pack_int(block))
         for _ in range(iterations - 1):
-            u = _pseudorandom(''.join(map(chr, u)))
+            u = _pseudorandom(bytearray(u))
             rv = starmap(xor, zip(rv, u))
         buf.extend(rv)
-    return ''.join(map(chr, buf))[:keylen]
+    return bytearray(buf)[:keylen]

--- a/test/unit/test_security_passwords.py
+++ b/test/unit/test_security_passwords.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+from galaxy.security import passwords
+
+
+def test_hash_and_check():
+    simple_pass = "my simple pass"
+    complex_pass = u"à strange ünicode ڃtring"
+    not_pass_simple = "not simple pass"
+    not_pass_complex = u"à strange ün ڃtring"
+
+    simple_pass_hash = passwords.hash_password(simple_pass)
+    complex_pass_hash = passwords.hash_password(complex_pass)
+
+    assert passwords.check_password(simple_pass, simple_pass_hash)
+    assert passwords.check_password(complex_pass, complex_pass_hash)
+
+    assert not passwords.check_password(complex_pass, simple_pass_hash)
+    assert not passwords.check_password(not_pass_complex, simple_pass_hash)
+    assert not passwords.check_password(not_pass_simple, simple_pass_hash)
+
+    assert not passwords.check_password(simple_pass, complex_pass_hash)
+    assert not passwords.check_password(not_pass_complex, complex_pass_hash)
+    assert not passwords.check_password(not_pass_simple, complex_pass_hash)
+
+
+def test_hash_consistent():
+    # Make sure hashes created for earlier Galaxies continue to work in the future.
+    simple_pass = "my simple pass"
+    complex_pass = u"à strange ünicode ڃtring"
+
+    # Check hashes built in Python 2 for 18.05.
+    simple_pass_hash = 'PBKDF2$sha256$10000$LlkhoImT15LZAcFB$/afKJrFX9GXt6VEpB+omae19A2S4kBEY'
+    complex_pass_hash = 'PBKDF2$sha256$10000$rg2gPThkJycziB0s$/BJ7AfuaYjpo5hhUvCMhf4TTrhsrOIH1'
+
+    # Check hashes built in Python 3 for 18.05.
+    simple_pass_hash_2 = 'PBKDF2$sha256$10000$vOIv7wGXS2/rGhDu$wS/5NwGSZm1ECv/vSEZb7jKjYSzXWZDL'
+    complex_pass_hash_2 = 'PBKDF2$sha256$10000$q1av/Clyujm5Fdc6$Dh7o1KTMn/YQYc5NurN+aVaF3uaI8iOv'
+
+    # Check older sha1 passwords that may still be the database as well.
+    simple_pass_hash_old = '58f17339ffdb71050734d2fbdd41b870423fe433'
+    complex_pass_hash_old = 'b567602039213afc0db026eedd72bd3ee2e57092'
+
+    assert passwords.check_password(simple_pass, simple_pass_hash)
+    assert passwords.check_password(complex_pass, complex_pass_hash)
+
+    assert passwords.check_password(simple_pass, simple_pass_hash_2)
+    assert passwords.check_password(complex_pass, complex_pass_hash_2)
+
+    assert passwords.check_password(simple_pass, simple_pass_hash_old)
+    assert passwords.check_password(complex_pass, complex_pass_hash_old)
+
+    assert not passwords.check_password(complex_pass, simple_pass_hash_old)
+    assert not passwords.check_password(simple_pass, complex_pass_hash_old)


### PR DESCRIPTION
Fix handling comparison of older SHA1 hashes in Python 2 (this is why I'm targeting 18.05 I guess) and fix the handling of both for Python 3.

The previous iteration gave me some errors in Python 3, I brought in and adapted @mvdbeek's Python 3 fixes to fix these:

```
======================================================================
ERROR: test_security_passwords.test_hash_and_check
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/john/workspace/galaxy-lib/.tox/py34/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/john/workspace/galaxy-lib/tests/test_security_passwords.py", line 12, in test_hash_and_check
    simple_pass_hash = passwords.hash_password(simple_pass)
  File "/Users/john/workspace/galaxy-lib/galaxy/security/passwords.py", line 21, in hash_password
    return hash_password_PBKDF2(password)
  File "/Users/john/workspace/galaxy-lib/galaxy/security/passwords.py", line 44, in hash_password_PBKDF2
    hashed = pbkdf2_bin(smart_str(password), salt, COST_FACTOR, KEY_LENGTH, getattr(hashlib, HASH_FUNCTION))
  File "/Users/john/workspace/galaxy-lib/galaxy/security/passwords.py", line 78, in pbkdf2_bin
    rv = u = _pseudorandom(salt + _pack_int(block))
  File "/Users/john/workspace/galaxy-lib/galaxy/security/passwords.py", line 75, in _pseudorandom
    return [ord(_) for _ in h.digest()]
  File "/Users/john/workspace/galaxy-lib/galaxy/security/passwords.py", line 75, in <listcomp>
    return [ord(_) for _ in h.digest()]
TypeError: ord() expected string of length 1, but int found

======================================================================
ERROR: test_security_passwords.test_hash_consistent
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/john/workspace/galaxy-lib/.tox/py34/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/john/workspace/galaxy-lib/tests/test_security_passwords.py", line 38, in test_hash_consistent
    assert passwords.check_password(simple_pass, simple_pass_hash)
  File "/Users/john/workspace/galaxy-lib/galaxy/security/passwords.py", line 30, in check_password
    if check_password_PBKDF2(guess, hashed):
  File "/Users/john/workspace/galaxy-lib/galaxy/security/passwords.py", line 53, in check_password_PBKDF2
    hashed_guess = pbkdf2_bin(smart_str(guess), salt, int(cost_factor), KEY_LENGTH, getattr(hashlib, hash_function))
  File "/Users/john/workspace/galaxy-lib/galaxy/security/passwords.py", line 78, in pbkdf2_bin
    rv = u = _pseudorandom(salt + _pack_int(block))
TypeError: Can't convert 'bytes' object to str implicitly
```

Added tests that all now pass in Python 3 - including generating some passwords in Python 3 and verifying they pass when checked in Python 2 and vice versa.