### PR TITLE
[18.05] Container resolvers conf fix

### DIFF
--- a/lib/galaxy/tools/deps/containers.py
+++ b/lib/galaxy/tools/deps/containers.py
@@ -224,7 +224,9 @@ class ContainerRegistry(object):
         return self.__parse_resolver_conf_xml(plugin_source)
 
     def __parse_resolver_conf_xml(self, plugin_source):
-        extra_kwds = {}
+        extra_kwds = {
+            'app_info': self.app_info
+        }
         return plugin_config.load_plugins(self.resolver_classes, plugin_source, extra_kwds)
 
     def __default_containers_resolvers(self):


### PR DESCRIPTION
Fixes this error when trying to use the new cache directory option added in #6122.

```pytb
Traceback (most recent call last):
  File "./scripts/galaxy-main", line 279, in <module>
    main()
  File "./scripts/galaxy-main", line 275, in main
    app_loop(args, log)
  File "./scripts/galaxy-main", line 125, in app_loop
    log=log,
  File "./scripts/galaxy-main", line 94, in load_galaxy_app
    **kwds
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/app.py", line 129, in __init__
    self._configure_toolbox()
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/config.py", line 1030, in _configure_toolbox
    self.container_finder = containers.ContainerFinder(app_info)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/deps/containers.py", line 76, in __init__
    self.container_registry = ContainerRegistry(app_info)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/deps/containers.py", line 214, in __init__
    self.container_resolvers = self.__build_container_resolvers(app_info)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/deps/containers.py", line 224, in __build_container_resolvers
    return self.__parse_resolver_conf_xml(plugin_source)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/deps/containers.py", line 228, in __parse_resolver_conf_xml
    return plugin_config.load_plugins(self.resolver_classes, plugin_source, extra_kwds)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/util/plugin_config.py", line 36, in load_plugins
    return __load_plugins_from_element(plugins_dict, source, extra_kwds)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/util/plugin_config.py", line 55, in __load_plugins_from_element
    plugin = plugin_klazz(**plugin_kwds)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/deps/container_resolvers/mulled.py", line 246, in __init__
    self.cache_directory = kwds.get("cache_directory", os.path.join(app_info.container_image_cache_path, "singularity", "mulled"))
AttributeError: 'NoneType' object has no attribute 'container_image_cache_path'
```