### PR TITLE
Add the newick extension for the Newick datatype, 

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -328,7 +328,8 @@
     </datatype>
     <!-- Phylogenetic tree datatypes -->
     <datatype extension="phyloxml" type="galaxy.datatypes.xml:Phyloxml" display_in_upload="true"/>
-    <datatype extension="nhx" type="galaxy.datatypes.data:Newick" display_in_upload="true"/>
+    <datatype extension="newick" type="galaxy.datatypes.data:Newick" display_in_upload="true"/>
+    <datatype extension="nhx" type="galaxy.datatypes.data:Newick" subclass="true" display_in_upload="true"/>
     <datatype extension="nex" type="galaxy.datatypes.data:Nexus" display_in_upload="true"/>
     <datatype extension="iqtree" type="galaxy.datatypes.text:IQTree"/>
     <datatype extension="mldist" type="galaxy.datatypes.mothur:SquareDistanceMatrix"/>

--- a/config/plugins/visualizations/phylocanvas/config/phylocanvas.xml
+++ b/config/plugins/visualizations/phylocanvas/config/phylocanvas.xml
@@ -5,6 +5,7 @@
     <data_sources>
         <data_source>
             <model_class>HistoryDatasetAssociation</model_class>
+            <test test_attr="ext" result_type="datatype">newick</test>
             <test test_attr="ext" result_type="datatype">nhx</test>
             <to_param param_attr="id">dataset_id</to_param>
         </data_source>

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -932,7 +932,7 @@ class Newick(Text):
     """New Hampshire/Newick Format"""
     edam_data = "data_0872"
     edam_format = "format_1910"
-    file_ext = "nhx"
+    file_ext = "newick"
 
     def __init__(self, **kwd):
         """Initialize foobar datatype"""

--- a/lib/galaxy/visualization/data_providers/phyloviz/__init__.py
+++ b/lib/galaxy/visualization/data_providers/phyloviz/__init__.py
@@ -26,7 +26,7 @@ class PhylovizDataProvider(BaseDataProvider):
         jsonDicts = []
         rval = {'dataset_type': self.dataset_type}
 
-        if file_ext == "nhx":  # parses newick files
+        if file_ext in ["newick", "nhx"]:  # parses newick files
             newickParser = Newick_Parser()
             jsonDicts, parseMsg = newickParser.parseFile(file_name)
         elif file_ext == "phyloxml":  # parses phyloXML files


### PR DESCRIPTION
setting the ```nhx``` extension as a subclass.  This allow for new tools to produce outputs using the ```newick``` extension, while preserving the behavior of existing tools that have produced outputs using the ```nhx``` extension.

I've tested the behavior of both of these extensions using 2 versions of the same tool, one that produces outputs using the ```nhx``` extension and another the produces outputs using the ```newick``` extension.  Both tools behaved as expected, and visualizations associated with each extension behaved as expected.