### PR TITLE
Enable automatic reload of dynamic job rules on change

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -291,6 +291,11 @@ galaxy:
   # wider range of scenarios than the watchdog default.
   #watch_tools: false
 
+  # Set to True to enable monitoring of dynamic job rules. If changes
+  # are found, rules are automatically reloaded. Takes the same values
+  # as the 'watch_tools' option.
+  #watch_job_rules: false
+
   # Enable Galaxy to fetch Docker containers registered with quay.io
   # generated from tool requirements resolved through conda. These
   # containers (when available) have been generated using mulled -

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -446,6 +446,18 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~
+``watch_job_rules``
+~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Set to True to enable monitoring of dynamic job rules. If changes
+    are found, rules are automatically reloaded. Takes the same values
+    as the 'watch_tools' option.
+:Default: ``false``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``enable_beta_mulled_containers``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -467,6 +467,7 @@ class Configuration(object):
         self.check_upload_content = string_as_bool(kwargs.get('check_upload_content', True))
         self.watch_tools = kwargs.get('watch_tools', 'false')
         self.watch_tool_data_dir = kwargs.get('watch_tool_data_dir', 'false')
+        self.watch_job_rules = kwargs.get('watch_job_rules', 'false')
         # On can mildly speed up Galaxy startup time by disabling index of help,
         # not needed on production systems but useful if running many functional tests.
         self.index_tool_help = string_as_bool(kwargs.get("index_tool_help", True))

--- a/lib/galaxy/util/watcher.py
+++ b/lib/galaxy/util/watcher.py
@@ -128,6 +128,8 @@ class EventHandler(FileSystemEventHandler):
         path = getattr(event, 'dest_path', None) or event.src_path
         path = os.path.abspath(path)
         callback = self.watcher.file_callbacks.get(path, None)
+        if os.path.basename(path).startswith('.'):
+            return
         if callback:
             ext_ok = self._extension_check(path, path)
         else:

--- a/lib/galaxy/util/watcher.py
+++ b/lib/galaxy/util/watcher.py
@@ -1,0 +1,170 @@
+# TODO: this is largely copied from galaxy.tools.toolbox.galaxy and generalized, the tool-oriented watchers in that
+# module should probably be updated to use this where possible
+
+from __future__ import absolute_import
+
+import logging
+import os.path
+import time
+
+try:
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+    from watchdog.observers.polling import PollingObserver
+    can_watch = True
+except ImportError:
+    Observer = None
+    FileSystemEventHandler = object
+    PollingObserver = None
+    can_watch = False
+
+from galaxy.util.hash_util import md5_hash_file
+from galaxy.web.stack import register_postfork_function
+
+log = logging.getLogger(__name__)
+
+
+def get_observer_class(config_name, config_value, default, monitor_what_str):
+    """
+    """
+    config_value = config_value or default
+    config_value = str(config_value).lower()
+    if config_value in ("true", "yes", "on", "auto"):
+        expect_observer = True
+        observer_class = Observer
+    elif config_value == "polling":
+        expect_observer = True
+        observer_class = PollingObserver
+    elif config_value in ('false', 'no', 'off'):
+        expect_observer = False
+        observer_class = None
+    else:
+        message = "Unrecognized value for %s config option: %s" % (config_name, config_value)
+        raise Exception(message)
+
+    if expect_observer and observer_class is None:
+        message = "Watchdog library unavailable, cannot monitor %s." % monitor_what_str
+        if config_value == "auto":
+            log.info(message)
+        else:
+            raise Exception(message)
+
+    return observer_class
+
+
+def get_watcher(config, config_name, default="False", monitor_what_str=None, watcher_class=None,
+                event_handler_class=None, **kwargs):
+    config_value = getattr(config, config_name, None)
+    observer_class = get_observer_class(config_name, config_value, default=default, monitor_what_str=monitor_what_str)
+    if observer_class is not None:
+        watcher_class = watcher_class or Watcher
+        event_handler_class = event_handler_class or EventHandler
+        return watcher_class(observer_class, event_handler_class, **kwargs)
+    else:
+        return NullWatcher()
+
+
+class Watcher(object):
+
+    def __init__(self, observer_class, event_handler_class, **kwargs):
+        self.monitored_dirs = {}
+        self.path_hash = {}
+        self.file_callbacks = {}
+        self.dir_callbacks = {}
+        self.extensions = {}
+        self.observer = observer_class()
+        self.event_handler = event_handler_class(self)
+        self.start()
+
+    def start(self):
+        register_postfork_function(self.observer.start)
+
+    def shutdown(self):
+        self.observer.stop()
+        self.observer.join()
+
+    def monitor(self, dir, recursive=False):
+        self.observer.schedule(self.event_handler, dir, recursive=recursive)
+
+    def watch_file(self, file, callback=None):
+        file = os.path.abspath(file)
+        dir = os.path.dirname(file)
+        if dir not in self.monitored_dirs:
+            if callback is not None:
+                self.file_callbacks[file] = callback
+            self.monitored_dirs[dir] = dir
+            self.monitor(dir)
+            log.debug("Watching for changes to file: %s", file)
+
+    def watch_directory(self, dir, callback=None, recursive=False, extensions=None):
+        dir = os.path.abspath(dir)
+        if dir not in self.monitored_dirs:
+            if callback is not None:
+                self.dir_callbacks[dir] = callback
+            if extensions:
+                self.extensions[dir] = extensions
+            self.monitored_dirs[dir] = dir
+            self.monitor(dir, recursive=recursive)
+            log.debug("Watching for changes in directory%s: %s", ' (recursively)' if recursive else '', dir)
+
+
+class EventHandler(FileSystemEventHandler):
+
+    def __init__(self, watcher):
+        self.watcher = watcher
+
+    def on_any_event(self, event):
+        self._handle(event)
+
+    def _extension_check(self, key, path):
+        if key not in self.watcher.extensions:
+            return True
+        for ext in self.watcher.extensions[key]:
+            if path.endswith(ext):
+                return True
+        return False
+
+    def _handle(self, event):
+        # modified events will only have src path, move events will
+        # have dest_path and src_path but we only care about dest. So
+        # look at dest if it exists else use src.
+        path = getattr(event, 'dest_path', None) or event.src_path
+        path = os.path.abspath(path)
+        callback = self.watcher.file_callbacks.get(path, None)
+        if callback:
+            ext_ok = self._extension_check(path, path)
+        else:
+            # reversed sort for getting the most specific dir first
+            for key in reversed(sorted(self.watcher.dir_callbacks.keys())):
+                if os.path.commonprefix([path, key]) == key:
+                    callback = self.watcher.dir_callbacks[key]
+                    ext_ok = self._extension_check(key, path)
+                    break
+        if not callback or not ext_ok:
+            return
+        cur_hash = md5_hash_file(path)
+        if cur_hash:
+            if self.watcher.path_hash.get(path) == cur_hash:
+                return
+            else:
+                time.sleep(0.5)
+                if cur_hash != md5_hash_file(path):
+                    # We're still modifying the file, it'll be picked up later
+                    return
+                self.watcher.path_hash[path] = cur_hash
+                callback(path=path)
+
+
+class NullWatcher(object):
+
+    def start(self):
+        pass
+
+    def shutdown(self):
+        pass
+
+    def watch_file(self, *args, **kwargs):
+        pass
+
+    def watch_directory(self, *args, **kwargs):
+        pass

--- a/lib/galaxy/util/watcher.py
+++ b/lib/galaxy/util/watcher.py
@@ -88,26 +88,26 @@ class Watcher(object):
     def monitor(self, dir, recursive=False):
         self.observer.schedule(self.event_handler, dir, recursive=recursive)
 
-    def watch_file(self, file, callback=None):
-        file = os.path.abspath(file)
-        dir = os.path.dirname(file)
-        if dir not in self.monitored_dirs:
+    def watch_file(self, file_path, callback=None):
+        file_path = os.path.abspath(file_path)
+        dir_path = os.path.dirname(file_path)
+        if dir_path not in self.monitored_dirs:
             if callback is not None:
-                self.file_callbacks[file] = callback
-            self.monitored_dirs[dir] = dir
-            self.monitor(dir)
-            log.debug("Watching for changes to file: %s", file)
+                self.file_callbacks[file_path] = callback
+            self.monitored_dirs[dir_path] = dir_path
+            self.monitor(dir_path)
+            log.debug("Watching for changes to file: %s", file_path)
 
-    def watch_directory(self, dir, callback=None, recursive=False, ignore_extensions=None):
-        dir = os.path.abspath(dir)
-        if dir not in self.monitored_dirs:
+    def watch_directory(self, dir_path, callback=None, recursive=False, ignore_extensions=None):
+        dir_path = os.path.abspath(dir_path)
+        if dir_path not in self.monitored_dirs:
             if callback is not None:
-                self.dir_callbacks[dir] = callback
+                self.dir_callbacks[dir_path] = callback
             if ignore_extensions:
-                self.ignore_extensions[dir] = ignore_extensions
-            self.monitored_dirs[dir] = dir
-            self.monitor(dir, recursive=recursive)
-            log.debug("Watching for changes in directory%s: %s", ' (recursively)' if recursive else '', dir)
+                self.ignore_extensions[dir_path] = ignore_extensions
+            self.monitored_dirs[dir_path] = dir_path
+            self.monitor(dir_path, recursive=recursive)
+            log.debug("Watching for changes in directory%s: %s", ' (recursively)' if recursive else '', dir_path)
 
 
 class EventHandler(FileSystemEventHandler):

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -355,6 +355,15 @@ mapping:
           a less efficient monitoring scheme that may work in wider range of scenarios
           than the watchdog default.
 
+      watch_job_rules:
+        type: str
+        default: false
+        required: false
+        desc: |
+          Set to True to enable monitoring of dynamic job rules. If changes are
+          found, rules are automatically reloaded. Takes the same values as the
+          'watch_tools' option.
+
       enable_beta_mulled_containers:
         type: bool
         default: false

--- a/lib/galaxy/webapps/galaxy/config_watchers.py
+++ b/lib/galaxy/webapps/galaxy/config_watchers.py
@@ -1,11 +1,19 @@
+import sys
+from functools import partial
+from os.path import dirname
+
 from galaxy.queue_worker import (
     reload_data_managers,
+    reload_job_rules,
     reload_toolbox,
 )
 from galaxy.tools.toolbox.watcher import (
     get_tool_conf_watcher,
     get_tool_data_dir_watcher,
     get_tool_watcher,
+)
+from galaxy.util.watcher import (
+    get_watcher,
 )
 
 
@@ -25,12 +33,22 @@ class ConfigWatchers(object):
         self.data_manager_config_watcher = get_tool_conf_watcher(reload_callback=lambda: reload_data_managers(self.app))
         self.tool_data_watcher = get_tool_data_dir_watcher(self.app.tool_data_tables, config=self.app.config)
         self.tool_watcher = get_tool_watcher(self, app.config)
+        if self.app.is_job_handler:
+            self.job_rule_watcher = get_watcher(app.config, 'watch_job_rules', monitor_what_str='job rules')
+        else:
+            self.job_rule_watcher = get_watcher(app.config, '__invalid__')
         self.start()
 
     def start(self):
         [self.tool_config_watcher.watch_file(config) for config in self.tool_config_paths]
         [self.data_manager_config_watcher.watch_file(config) for config in self.data_manager_configs]
         [self.tool_data_watcher.watch_directory(tool_data_path) for tool_data_path in self.tool_data_paths]
+        for job_rules_directory in self.job_rules_paths:
+            self.job_rule_watcher.watch_directory(
+                job_rules_directory,
+                callback=partial(reload_job_rules, self.app),
+                recursive=True,
+                extensions=('.py',))
 
     def shutdown(self):
         self.tool_config_watcher.shutdown()
@@ -71,3 +89,19 @@ class ConfigWatchers(object):
             if self.app.config.migrated_tools_config not in tool_config_paths:
                 tool_config_paths.append(self.app.config.migrated_tools_config)
         return tool_config_paths
+
+    @property
+    def job_rules_paths(self):
+        job_rules_paths = []
+        default = 'galaxy.jobs.rules'
+        rules_module_name = default
+        if self.app.job_config.dynamic_params is not None:
+            rules_module_name = self.app.job_config.dynamic_params.get('rules_module', default)
+        rules_module = sys.modules.get(rules_module_name, None)
+        if not rules_module:
+            # if using a non-default module, it's not imported until a JobRunnerMapper is instantiated when the first
+            # JobWrapper is created
+            rules_module = __import__(rules_module_name)
+        job_rules_dir = dirname(rules_module.__file__)
+        job_rules_paths.append(job_rules_dir)
+        return job_rules_paths

--- a/lib/galaxy/webapps/galaxy/config_watchers.py
+++ b/lib/galaxy/webapps/galaxy/config_watchers.py
@@ -48,7 +48,7 @@ class ConfigWatchers(object):
                 job_rules_directory,
                 callback=partial(reload_job_rules, self.app),
                 recursive=True,
-                extensions=('.py',))
+                ignore_extensions=('.pyc', '.pyo', '.pyd'))
 
     def shutdown(self):
         self.tool_config_watcher.shutdown()

--- a/lib/galaxy/webapps/galaxy/config_watchers.py
+++ b/lib/galaxy/webapps/galaxy/config_watchers.py
@@ -33,7 +33,7 @@ class ConfigWatchers(object):
         self.data_manager_config_watcher = get_tool_conf_watcher(reload_callback=lambda: reload_data_managers(self.app))
         self.tool_data_watcher = get_tool_data_dir_watcher(self.app.tool_data_tables, config=self.app.config)
         self.tool_watcher = get_tool_watcher(self, app.config)
-        if self.app.is_job_handler:
+        if getattr(self.app, 'is_job_handler', False):
             self.job_rule_watcher = get_watcher(app.config, 'watch_job_rules', monitor_what_str='job rules')
         else:
             self.job_rule_watcher = get_watcher(app.config, '__invalid__')


### PR DESCRIPTION
usegalaxy.eu has a handy microservice ([usegalaxy-eu/jcaas](https://github.com/usegalaxy-eu/jcaas/)) for rapid job config changes, which is a great feature that I want, but I'd prefer not to use a web service if possible. I've instead gone the route of making job rules dynamically reloadable when their contents change.

This is configurable with the `watch_job_rules` option in `galaxy.yml` and is disabled by default so as not to change the current behavior.

This largely steals the tool config watcher code and results in some duplication, but unfortunately I don't have the bandwidth to properly refactor it right now.