### PR TITLE
[18.01] Fix Jupyter notebook renaming

### DIFF
--- a/config/plugins/interactive_environments/jupyter/static/js/jupyter.js
+++ b/config/plugins/interactive_environments/jupyter/static/js/jupyter.js
@@ -90,7 +90,7 @@ function keep_alive(){
         }
     };
     console.log("IE keepalive worker starting");
-    IES.spin(notebook_access_url, false, success, timeout_error, timeout_error, spin_state);
+    IES.spin(notebook_keepalive_url, false, success, timeout_error, timeout_error, spin_state);
 }
 
 

--- a/config/plugins/interactive_environments/jupyter/templates/jupyter.mako
+++ b/config/plugins/interactive_environments/jupyter/templates/jupyter.mako
@@ -44,6 +44,7 @@ ie_request.launch(
 # Access URLs for the notebook from within galaxy.
 notebook_access_url = ie_request.url_template('${PROXY_URL}/ipython/notebooks/ipython_galaxy_notebook.ipynb')
 notebook_login_url = ie_request.url_template('${PROXY_URL}/ipython/login?next=${PROXY_PREFIX}%2Fipython%2Ftree')
+notebook_keepalive_url = ie_request.url_template('${PROXY_URL}/ipython/tree')
 
 %>
 <html>
@@ -56,6 +57,7 @@ ${ ie.load_default_js() }
 ${ ie.default_javascript_variables() }
 var notebook_login_url = '${ notebook_login_url }';
 var notebook_access_url = '${ notebook_access_url }';
+var notebook_keepalive_url = '${ notebook_keepalive_url }';
 ${ ie.plugin_require_config() }
 
 // Load notebook


### PR DESCRIPTION
@Delphine-L noticed this one, if you rename a notebook, it effectively kills the IE because the keepalive requests were being made to the notebook URL, which is no longer valid after the rename.

As a bonus, this allows you to stop your notebook, and create and run new ones as long as your container is alive.