### PR TITLE
[18.05] Fix api/tools/{tool_id}/build, failed to retrieve history

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1822,7 +1822,7 @@ class Tool(Dictifiable):
 
         return tool_dict
 
-    def to_json(self, trans, kwd={}, job=None, workflow_building_mode=False):
+    def to_json(self, trans, kwd={}, job=None, tool=None, workflow_building_mode=False):
         """
         Recursively creates a tool dictionary containing repeats, dynamic options and updated states.
         """
@@ -1830,17 +1830,19 @@ class Tool(Dictifiable):
         history = None
         if workflow_building_mode is workflow_building_modes.USE_HISTORY or workflow_building_mode is workflow_building_modes.DISABLED:
             # We don't need a history when exporting a workflow for the workflow editor or when downloading a workflow
-            try:
-                if history_id is not None:
-                    history = self.history_manager.get_owned(trans.security.decode_id(history_id), trans.user, current_history=trans.history)
-                else:
-                    history = trans.get_history()
-                if history is None and job is not None:
-                    history = self.history_manager.get_owned(job.history.id, trans.user, current_history=trans.history)
-                if history is None:
-                    raise exceptions.MessageException('History unavailable. Please specify a valid history id')
-            except Exception as e:
-                raise exceptions.MessageException('[history_id=%s] Failed to retrieve history. %s.' % (history_id, str(e)))
+            if tool is None:
+                # We don't need a history to display tool model
+                try:
+                    if history_id is not None:
+                        history = self.history_manager.get_owned(trans.security.decode_id(history_id), trans.user, current_history=trans.history)
+                    else:
+                        history = trans.get_history()
+                    if history is None and job is not None:
+                        history = self.history_manager.get_owned(job.history.id, trans.user, current_history=trans.history)
+                    if history is None:
+                        raise exceptions.MessageException('History unavailable. Please specify a valid history id')
+                except Exception as e:
+                    raise exceptions.MessageException('[history_id=%s] Failed to retrieve history. %s.' % (history_id, str(e)))
 
         # build request context
         request_context = WorkRequestContext(app=trans.app, user=trans.user, history=history, workflow_building_mode=workflow_building_mode)

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -104,7 +104,7 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
             kwd = kwd.get('payload')
         tool_version = kwd.get('tool_version', None)
         tool = self._get_tool(id, tool_version=tool_version, user=trans.user)
-        return tool.to_json(trans, kwd.get('inputs', kwd))
+        return tool.to_json(trans, kwd.get('inputs', kwd), tool=tool)
 
     @expose_api
     @web.require_admin


### PR DESCRIPTION
Hello everyone,
The api call to the function build in [/lib/galaxy/webapps/galaxy/api/tools.py#L98](https://github.com/ValentinChCloud/galaxy/blob/release_18.05/lib/galaxy/webapps/galaxy/api/tools.py#L98), with an api_key  seems broken.

You can try with FASTQ to FASTA format tool
```
https://usegalaxy.org/api/tools/toolshed.g2.bx.psu.edu/repos/devteam/fastq_to_fasta/cshl_fastq_to_fasta/1.0.1/build?key=your_key_id
```
it returns
```
{"err_msg": "[history_id=None] Failed to retrieve history. History unavailable. Please specify a valid history id.", "err_code": 0}
```
This issue looks very similar to #1988 , the only input parameter that is specified to give to the function is a tool_id in this case .
The function [to_json](https://github.com/ValentinChCloud/galaxy/blob/fix-tools-api/lib/galaxy/tools/__init__.py#L1825) is now call in function [build in lib/galaxy/webapps/galaxy/api/tools.py](https://github.com/ValentinChCloud/galaxy/blob/fix-tools-api/lib/galaxy/webapps/galaxy/api/tools.py#L107) with a parameter named tool , if present we don't need an history as for workflow ( seems to be good for me, because it's a bit weird to need an history to get informations on a tool, am I right?)

I have made a little fix based on  #2668.








