### PR TITLE
[18.05] Fix optional="True" inputs

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -859,9 +859,7 @@ class SelectToolParameter(ToolParameter):
             if is_runtime_value(context_value) or has_runtime_datasets(trans, context_value):
                 workflow_building_mode = workflow_building_modes.ENABLED
                 break
-        if not legal_values:
-            if not workflow_building_mode:
-                raise ValueError("Parameter %s requires a value, but has no legal values defined." % self.name)
+        if not legal_values and workflow_building_mode:
             if self.multiple:
                 # While it is generally allowed that a select value can be '',
                 # we do not allow this to be the case in a dynamically
@@ -880,6 +878,8 @@ class SelectToolParameter(ToolParameter):
             if self.optional:
                 return None
             raise ValueError("An invalid option was selected for %s, please verify." % (self.name))
+        elif not legal_values:
+            raise ValueError("Parameter %s requires a value, but has no legal values defined." % self.name)
         if isinstance(value, list):
             if not self.multiple:
                 raise ValueError("Multiple values provided but parameter %s is not expecting multiple values." % self.name)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1327,9 +1327,7 @@ class DrillDownSelectToolParameter(SelectToolParameter):
 
     def from_json(self, value, trans, other_values={}):
         legal_values = self.get_legal_values(trans, other_values)
-        if not legal_values:
-            if not trans.workflow_building_mode:
-                raise ValueError("Parameter %s requires a value, but has no legal values defined." % self.name)
+        if not legal_values and trans.workflow_building_mode:
             if self.multiple:
                 if value == '':  # No option selected
                     value = None
@@ -1340,6 +1338,8 @@ class DrillDownSelectToolParameter(SelectToolParameter):
             if self.optional:
                 return None
             raise ValueError("An invalid option was selected for %s, please verify." % (self.name))
+        elif not legal_values:
+            raise ValueError("Parameter %s requires a value, but has no legal values defined." % self.name)
         if not isinstance(value, list):
             value = [value]
         if len(value) > 1 and not self.multiple:

--- a/test/functional/tools/empty_select.xml
+++ b/test/functional/tools/empty_select.xml
@@ -1,0 +1,23 @@
+<tool id="empty_select" name="empty_select" version="1.0.0">
+    <description>multi_select</description>
+    <command><![CDATA[
+touch '$output'
+#if $select_optional:
+    && echo '$select_optional' > '$output'
+#end if
+    ]]></command>
+    <inputs>
+        <param name="select_optional" type="select" optional="true">
+        </param>
+    </inputs>
+    <outputs>
+        <data format="txt" name="output" />
+    </outputs>
+    <tests>
+        <test>
+            <output name="output" md5="d41d8cd98f00b204e9800998ecf8427e" />
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>


### PR DESCRIPTION
This reverts commit 91e97b60968d6813bd7a28d0d60e778b288ac385.

The commit to revert causes https://github.com/galaxyproject/galaxy/issues/6219, where the
`optional="True"` flag is not repected anymore. This is because we raise an exception before checking that `value` may be legitimately `None`.