### PR TITLE
[18.05] Fix broken collection_type_source tool and test.

### DIFF
--- a/lib/galaxy/tools/parser/output_objects.py
+++ b/lib/galaxy/tools/parser/output_objects.py
@@ -188,8 +188,8 @@ class ToolOutputCollectionStructure(object):
             raise ValueError("Cannot set both type and type_source on collection output.")
         if collection_type is None and structured_like is None and dataset_collector_descriptions is None and collection_type_source is None and collection_type_from_rules is None:
             raise ValueError("Output collection types must specify source of collection type information (e.g. structured_like or type_source).")
-        if dataset_collector_descriptions and (structured_like or collection_type_source or collection_type_from_rules):
-            raise ValueError("Cannot specify dynamic structure (discovered_datasets) and collection type source attributes such as structured_like or type_source.")
+        if dataset_collector_descriptions and (structured_like or collection_type_from_rules):
+            raise ValueError("Cannot specify dynamic structure (discovered_datasets) and collection type attributes structured_like or collection_type_from_rules.")
         self.dynamic = dataset_collector_descriptions is not None
 
     def collection_prototype(self, inputs, type_registry):


### PR DESCRIPTION
The tool wouldn't load after 8af243c176fd9c261277327750aaa71806add4ef and that caused the relevant tests to "SKIP" instead of failing outright.

./run_tests.sh -api test/api/test_tools.py:ToolsTestCase.test_map_over_collection_type_source