### PR TITLE
[18.01] Fix non-strict tabular relabel operation

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2593,7 +2593,7 @@ class RelabelFromFileTool(DatabaseOperationTool):
             for i, dce in enumerate(hdca.collection.elements):
                 dce_object = dce.element_object
                 element_identifier = dce.element_identifier
-                default = element_identifier if strict else None
+                default = None if strict else element_identifier
                 new_label = new_labels_dict.get(element_identifier, default)
                 if not new_label:
                     raise Exception("Failed to find new label for identifier [%s]" % element_identifier)

--- a/lib/galaxy/tools/relabel_from_file.xml
+++ b/lib/galaxy/tools/relabel_from_file.xml
@@ -96,6 +96,7 @@
                     </element>
                 </collection>
             </param>
+            <param name="strict" value="true" />
             <param name="how_select" value="tabular" />
             <param name="labels" value="new_labels_2.txt" ftype="tabular" />
         </test>


### PR DESCRIPTION
The logic was the wrong way round unfortunately, in strict mode we set the new_label to None and otherwise to element_identifier.