### PR TITLE
[18.05] OIDC options do not follow declared default

### DIFF
--- a/config/oidc_backends_config.xml.sample
+++ b/config/oidc_backends_config.xml.sample
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <OIDC>
-    <provider name="Google">
-        <client_id> ... </client_id>
-        <client_secret> ... </client_secret>
-        <redirect_uri>http://localhost:8080/authnz/google/callback</redirect_uri>
+    <!--<provider name="Google">-->
+        <!--<client_id> ... </client_id>-->
+        <!--<client_secret> ... </client_secret>-->
+        <!--<redirect_uri>http://localhost:8080/authnz/google/callback</redirect_uri>-->
 
         <!-- <prompt>select_account</prompt> -->
         <!--The value of this parameter (i.e., prompt) specifies whether the Google authorization server should prompt
@@ -15,5 +15,5 @@
          If you want the consent screen to be shown to the new users only, and re-authorization happen without
          asking for user's consent, then remove this attribute.
         -->
-    </provider>
+    <!--</provider>-->
 </OIDC>

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -210,8 +210,8 @@ class Configuration(object):
         self.len_file_path = resolve_path(kwargs.get("len_file_path", os.path.join(self.tool_data_path, 'shared', 'ucsc', 'chrom')), self.root)
         # Galaxy OIDC settings.
         self.enable_oidc = kwargs.get("enable_oidc", False)
-        self.oidc_config = kwargs.get('oidc_config_file', None)
-        self.oidc_backends_config = kwargs.get("oidc_backends_config_file", None)
+        self.oidc_config = kwargs.get('oidc_config_file', "config/oidc_config.xml")
+        self.oidc_backends_config = kwargs.get("oidc_backends_config_file", "config/oidc_backends_config.xml")
         # The value of migrated_tools_config is the file reserved for containing only those tools that have been eliminated from the distribution
         # and moved to the tool shed.
         self.integrated_tool_panel_config = resolve_path(kwargs.get('integrated_tool_panel_config', 'integrated_tool_panel.xml'), self.root)


### PR DESCRIPTION
In `config_schema` it is declared that they are strings set to `config/..`. However in config.py this is not respected and their defalut value is None. If you turn on enable_oidc *without* also uncommenting the config paths, then your Galaxy will crash.