### PR TITLE
[18.01] Hack paster args to not duplicate pid file stuff for RUN_ALL.

### DIFF
--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -117,6 +117,6 @@ find_server() {
         server_args="$server_args $uwsgi_args"
     else
         run_server="python"
-        server_args="./scripts/paster.py serve $server_config $paster_args"
+        server_args="./scripts/paster.py serve $server_config --pid-file $PID_FILE --log-file $LOG_FILE $paster_args"
     fi
 }

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -21,7 +21,7 @@ parse_common_args() {
                 ;;
             --stop-daemon|stop)
                 common_startup_args="$common_startup_args --stop-daemon"
-                paster_args="$paster_args --pid-file $PID_FILE --stop-daemon"
+                paster_args="$paster_args --stop-daemon"
                 uwsgi_args="$uwsgi_args --stop $PID_FILE"
                 stop_daemon_arg_set=1
                 shift
@@ -39,7 +39,7 @@ parse_common_args() {
                 shift
                 ;;
             --daemon|start)
-                paster_args="$paster_args --pid-file $PID_FILE --log-file $LOG_FILE --daemon"
+                paster_args="$paster_args --daemon"
                 # --daemonize2 waits until after the application has loaded
                 # to daemonize, thus it stops if any errors are found
                 uwsgi_args="--master --daemonize2 $LOG_FILE --pidfile2 $PID_FILE $uwsgi_args"


### PR DESCRIPTION
Starting galaxy with RUN_ALL and using paste would attempt to use `galaxy.pid` and `galaxy.log` for every server process due to the duplicated args in `paster_args`. This was discussed on gitter with @natefoo and @jmchilton .