### PR TITLE
Mapping over from_param fixes

### DIFF
--- a/lib/galaxy/dataset_collections/subcollections.py
+++ b/lib/galaxy/dataset_collections/subcollections.py
@@ -20,6 +20,6 @@ def _split_dataset_collection(dataset_collection, collection_type):
         if child_collection.collection_type == collection_type:
             split_elements.append(element)
         else:
-            split_elements.extend(_split_dataset_collection(element.child_collection, element.child_collection.collection_type))
+            split_elements.extend(_split_dataset_collection(element.child_collection, collection_type))
 
     return split_elements

--- a/lib/galaxy/tools/parser/output_actions.py
+++ b/lib/galaxy/tools/parser/output_actions.py
@@ -243,7 +243,10 @@ class FromParamToolOutputActionOption(ToolOutputActionOption):
                 # if this is an HDCA for instance let reverse.ext grab
                 # the reverse element and then continue for loop to grab
                 # dataset extension
-                value = value.collection[attr_name].element_object
+                try:
+                    value = value.collection[attr_name].element_object
+                except KeyError:
+                    value = value.child_collection[attr_name].element_object
             elif hasattr(value, "collection") and value in COLLECTION_ATTRIBUTES:
                 value = getattr(value.collection, attr_name)
             else:

--- a/lib/galaxy/tools/parser/output_actions.py
+++ b/lib/galaxy/tools/parser/output_actions.py
@@ -11,9 +11,6 @@ from galaxy import util
 
 log = logging.getLogger(__name__)
 
-# Attributes tool developer may want to query on dataset collections.
-COLLECTION_ATTRIBUTES = ["collection_type"]
-
 
 class ToolOutputActionGroup(object):
     """
@@ -239,7 +236,7 @@ class FromParamToolOutputActionOption(ToolOutputActionOption):
                 value = value[0]
             elif isinstance(value, dict):
                 value = value[attr_name]
-            elif hasattr(value, "collection") and value not in COLLECTION_ATTRIBUTES:
+            elif hasattr(value, "collection"):
                 # if this is an HDCA for instance let reverse.ext grab
                 # the reverse element and then continue for loop to grab
                 # dataset extension
@@ -247,8 +244,6 @@ class FromParamToolOutputActionOption(ToolOutputActionOption):
                     value = value.collection[attr_name].element_object
                 except KeyError:
                     value = value.child_collection[attr_name].element_object
-            elif hasattr(value, "collection") and value in COLLECTION_ATTRIBUTES:
-                value = getattr(value.collection, attr_name)
             else:
                 value = getattr(value, attr_name)
         options = [[str(value)]]

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -815,6 +815,23 @@ class ToolsTestCase(api.ApiTestCase):
             assert output1_details["file_ext"] == "txt" if (use_action == "do") else "data"
             assert output2_details["file_ext"] == "txt" if (use_action == "do") else "data"
 
+    @skip_without_tool("output_action_change_format_paired")
+    def test_map_over_with_nested_paired_output_format_actions(self):
+        history_id = self.dataset_populator.new_history()
+        hdca_id = self.__build_nested_list(history_id)
+        inputs = {
+            "input": {'batch': True, 'values': [dict(map_over_type='paired', src="hdca", id=hdca_id)]}
+        }
+        create = self._run('output_action_change_format_paired', history_id, inputs).json()
+        outputs = create['outputs']
+        jobs = create['jobs']
+        implicit_collections = create['implicit_collections']
+        self.assertEquals(len(jobs), 2)
+        self.assertEquals(len(outputs), 2)
+        self.assertEquals(len(implicit_collections), 1)
+        for output in outputs:
+            assert output["file_ext"] == "txt"
+
     @skip_without_tool("output_filter_with_input")
     def test_map_over_with_output_filter_no_filtering(self):
         with self.dataset_populator.test_history() as history_id:

--- a/test/functional/tools/output_action_change_format_paired.xml
+++ b/test/functional/tools/output_action_change_format_paired.xml
@@ -1,0 +1,32 @@
+<tool id="output_action_change_format_paired" name="output_action_change_paired" version="1.0.0">
+    <command>
+        printf "1\t2\n" > out1;
+    </command>
+    <inputs>
+        <param type="data_collection" name="input" format="data" collection_type="paired" />
+    </inputs>
+    <outputs>
+        <data name="out1" from_work_dir="out1">
+            <actions>
+                <action type="format">
+                    <option type="from_param" name="input" param_attribute="forward.ext" />
+                </action>
+            </actions>
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input">
+                <collection type="paired">
+                    <element name="forward" value="simple_line.txt" ftype="txt" />
+                    <element name="reverse" value="simple_line.txt" ftype="txt" />
+                </collection>
+            </param>
+            <output name="out1" ftype="txt">
+                <assert_contents>
+                    <has_line line="1&#009;2" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -106,6 +106,7 @@
   <tool file="fail_writing_work_dir_file.xml" />
   <tool file="tool_directory.xml" />
   <tool file="output_action_change_format.xml" />
+  <tool file="output_action_change_format_paired.xml" />
   <tool file="collection_paired_test.xml" />
   <tool file="collection_paired_structured_like.xml" />
   <tool file="collection_paired_conditional_structured_like.xml" />


### PR DESCRIPTION
We have this `from_param` parameter that can be used for output datasets actions, which allows us to pick up any parameter from an input dataset / collection. We didn't correctly pick out the correct collection level when mapping over collections over a collection input (e.g list:pair collection over pair input), this fixes that. 

This should fix https://github.com/galaxyproject/tools-iuc/issues/1563 and https://github.com/galaxyproject/tools-iuc/issues/1911.