### PR TITLE
[18.05] History view 'import' button display based on ownership.

### DIFF
--- a/client/galaxy/scripts/components/HistoryView.vue
+++ b/client/galaxy/scripts/components/HistoryView.vue
@@ -6,7 +6,7 @@
                     <span v-if="historyData.user_is_owner == false" >
                         <button id="import" class="btn btn-secondary">Import and start using history</button>
                     </span>
-                    <span v-if="historyData.history_is_current == false">
+                    <span v-if="historyData.user_is_owner && historyData.history_is_current == false">
                         <button id="switch-history" class="btn btn-secondary" v-on:click="switchHistory">Switch to this history</button>
                     </span>
                     <button id="show-structure" class="btn btn-secondary" v-on:click="showStructure">Show structure</button>


### PR DESCRIPTION
Only show 'switch to this history' when the active user is the history owner.  It was mentioned on gitter that this was confusing, and shouldn't be an option unless you're the owner.

The underlying security code at the endpoint in question works fine and actually prevents non-owner non-admin from switching to that history, but this option should only show up for owners.