### PR TITLE
[18.05] Allow invalid optional param values for tools profile versions < 18.09

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -879,6 +879,10 @@ class SelectToolParameter(ToolParameter):
                 return None
             raise ValueError("An invalid option was selected for %s, please verify." % (self.name))
         elif not legal_values:
+            if self.optional and self.tool.profile < 18.09:
+                # Covers optional parameters with default values that reference other optional parameters.
+                # These will have a value but no legal_values.
+                return None
             raise ValueError("Parameter %s requires a value, but has no legal values defined." % self.name)
         if isinstance(value, list):
             if not self.multiple:


### PR DESCRIPTION
For tools with profile < 18.09 we return None for provided, but illegal
default values. This can happen when referencing columns of an optional
dataset for instance, as experienced in https://github.com/galaxyproject/tools-iuc/pull/1842.
This used to pass prior to 18.05 because we would always return the
value if there were no legal values. This was changed in
https://github.com/galaxyproject/galaxy/commit/9febc519944dcfb5c8907b8a302fd6aff6f0f79f
where we would only allow this in workflow building mode.