### PR TITLE
Fixes for phenotype association tools

### DIFF
--- a/tools/phenotype_association/gpass.xml
+++ b/tools/phenotype_association/gpass.xml
@@ -1,21 +1,21 @@
 <tool id="hgv_gpass" name="GPASS" version="1.0.0">
-  <description>significant single-SNP associations in case-control studies</description>
+    <description>significant single-SNP associations in case-control studies</description>
     <requirements>
         <requirement type="package">gpass</requirement>
     </requirements>
 
     <command>
 perl '$__tool_directory__/gpass.pl' '${input1.extra_files_path}/${input1.metadata.base_name}.map' '${input1.extra_files_path}/${input1.metadata.base_name}.ped' '$output' $fdr
-  </command>
+    </command>
 
-  <inputs>
-    <param name="input1" type="data" format="lped" label="Dataset"/>
-    <param name="fdr" type="float" value="0.05" label="FDR"/>
-  </inputs>
+    <inputs>
+        <param name="input1" type="data" format="lped" label="Dataset"/>
+        <param name="fdr" type="float" value="0.05" label="FDR"/>
+    </inputs>
 
-  <outputs>
-    <data name="output" format="tabular" />
-  </outputs>
+    <outputs>
+        <data name="output" format="tabular" />
+    </outputs>
 
 
   <!-- we need to be able to set the seed for the random number generator
@@ -33,7 +33,7 @@ perl '$__tool_directory__/gpass.pl' '${input1.extra_files_path}/${input1.metadat
   </tests>
   -->
 
-  <help>
+    <help>
 **Dataset formats**
 
 The input dataset must be in lped_ format, and the output is tabular_.
@@ -64,8 +64,8 @@ The program has two main functionalities:
    a proper FDR in terms of "proportion of false positive loci".
 
 2. Approximate the significance of a list of candidate SNPs, adjusting for
-   multiple comparisons. If you have isolated a few SNPs of interest and want 
-   to know their significance in a GWAS, you can supply the GWAS data and let 
+   multiple comparisons. If you have isolated a few SNPs of interest and want
+   to know their significance in a GWAS, you can supply the GWAS data and let
    the program specifically test those SNPs.
 
 
@@ -107,8 +107,8 @@ Otherwise use permutation.
 Zhang Y, Liu JS. (2010)
 Fast and accurate significance approximation for genome-wide association studies.
 Submitted.
-  </help>
-  <citations>
-    <citation type="doi">10.1198/jasa.2011.ap10657</citation>
-  </citations>
+    </help>
+    <citations>
+        <citation type="doi">10.1198/jasa.2011.ap10657</citation>
+    </citations>
 </tool>

--- a/tools/phenotype_association/gpass.xml
+++ b/tools/phenotype_association/gpass.xml
@@ -1,8 +1,11 @@
 <tool id="hgv_gpass" name="GPASS" version="1.0.0">
   <description>significant single-SNP associations in case-control studies</description>
+    <requirements>
+        <requirement type="package">gpass</requirement>
+    </requirements>
 
-  <command interpreter="perl">
-    gpass.pl ${input1.extra_files_path}/${input1.metadata.base_name}.map ${input1.extra_files_path}/${input1.metadata.base_name}.ped $output $fdr
+    <command>
+perl '$__tool_directory__/gpass.pl' '${input1.extra_files_path}/${input1.metadata.base_name}.map' '${input1.extra_files_path}/${input1.metadata.base_name}.ped' '$output' $fdr
   </command>
 
   <inputs>
@@ -14,9 +17,6 @@
     <data name="output" format="tabular" />
   </outputs>
 
-  <requirements>
-    <requirement type="package">gpass</requirement>
-  </requirements>
 
   <!-- we need to be able to set the seed for the random number generator
   <tests>
@@ -107,7 +107,6 @@ Otherwise use permutation.
 Zhang Y, Liu JS. (2010)
 Fast and accurate significance approximation for genome-wide association studies.
 Submitted.
-
   </help>
   <citations>
     <citation type="doi">10.1198/jasa.2011.ap10657</citation>

--- a/tools/phenotype_association/lps.xml
+++ b/tools/phenotype_association/lps.xml
@@ -1,8 +1,11 @@
 <tool id="hgv_lps" name="LPS" version="1.0.0">
   <description>LASSO-Patternsearch algorithm</description>
+    <requirements>
+        <requirement type="package">lps_tool</requirement>
+    </requirements>
 
-  <command interpreter="bash">
-    lps_tool_wrapper.sh $lambda_fac $input_file $label_column $output_file $log_file
+    <command>
+bash '$__tool_directory__/lps_tool_wrapper.sh' $lambda_fac '$input_file' $label_column '$output_file' '$log_file'
     Initialization 0
     #if $advanced.options == "true":
       Sample $advanced.sample
@@ -47,14 +50,10 @@
         <option value="false" selected="true">Hide advanced options</option>
         <option value="true">Show advanced options</option>
       </param>
-      <when value="false">
-        <!-- no options -->
-      </when>
+            <when value="false" />
       <when value="true">
         <!-- HARDCODED: 'Sample' we don't support passing an array -->
-        <param name="sample" type="float" value="1.0" label="Sample fraction" help="Sample this fraction of the data set.">
-          <validator type="in_range" message="0.0 &lt;= sample &lt;= 1.0" min="0.0" max="1.0"/>
-        </param>
+                <param name="sample" type="float" min="0.0" max="1.0" value="1.0" label="Sample fraction" help="Sample this fraction of the data set" />
         <!-- HARDCODED: 'Initialization' = 0 :: Initialize at beta=0 -->
         <param name="verbosity" type="select" format="integer" label="Verbosity">
           <option value="0" selected="true">Little output</option>
@@ -65,44 +64,33 @@
           <option value="0" selected="true">Don't standardize</option>
           <option value="1">Standardize</option>
         </param>
-        <param name="initialLambda" type="float" value="0.8" label="Initial lambda" help="First value of lambda to be used in the continuation scheme, expressed as a fraction of lambda_max.">
-          <validator type="in_range" message="0.0 &lt; initialLambda &lt; 1.0" min="0.0" max="1.0"/>
-        </param>
+                <param name="initialLambda" type="float" min="0.0" max="1.0" value="0.8" label="Initial lambda" help="First value of lambda to be used in the continuation scheme, expressed as a fraction of lambda_max" />
         <conditional name="continuation">
           <param name="continuation" type="select" format="integer" label="Continuation" help="Use continuation strategy to start with a larger value of lambda, decreasing it successively to lambda_fac.">
             <option value="0" selected="true">Don't use continuation</option>
             <option value="1">Use continuation</option>
           </param>
-          <when value="0">
-            <!-- no options -->
-          </when>
+                    <when value="0" />
           <when value="1">
             <param name="continuationSteps" type="integer" value="5" label="Continuation steps" help="Number of lambda values to use in continuation &lt;em&gt;prior&lt;/em&gt; to target value lambda_fac."/>
-
             <param name="accurateIntermediates" type="select" format="integer" label="Accurate intermediates" help="Indicates whether accurate solutions are required for lambda values other than the target value lambda_fac.">
               <option value="0" selected="true">Don't need accurate intemediates</option>
               <option value="1">Calculate accurate intermediates</option>
             </param>
           </when>
         </conditional> <!-- name="continuation" -->
-        <param name="printFreq" type="integer" value="1" label="Print frequency" help="Print a progress report every NI iterations, where NI is the supplied value of this parameter.">
-          <validator type="in_range" message="printFreq &gt;= 1" min="1"/>
-        </param>
+                <param name="printFreq" type="integer" min="1" value="1" label="Print frequency" help="Print a progress report every NI iterations, where NI is the supplied value of this parameter" />
         <conditional name="newton">
           <param name="newton" type="select" format="integer" label="Projected Newton steps">
             <option value="0" selected="true">No Newton steps</option>
             <option value="1">Try projected Newton steps</option>
           </param>
-          <when value="0">
-            <!-- no options -->
-          </when>
+                    <when value="0" />
           <when value="1">
             <param name="newtonThreshold" type="integer" value="500" label="Newton threshold" help="Maximum size of free variable subvector for Newton."/>
           </when>
         </conditional>
-        <param name="hessianSampleFraction" type="float" value="1.0" label="Hessian sample fraction" help="Fraction of terms to use in approximate Hessian calculation.">
-          <validator type="in_range" message="0.01 &lt; hessianSampleFraction &lt;= 1.00" min="0.01" max="1.00"/>
-        </param>
+                <param name="hessianSampleFraction" type="float" min="0.01" max="1.00" value="1.0" label="Hessian sample fraction" help="Fraction of terms to use in approximate Hessian calculation" />
         <!-- HARDCODED: 'BB' = 0 :: don't use Barzilai-Borwein steps -->
         <!-- HARDCODED: 'Monotone' = 0 :: don't force monotonicity -->
         <param name="fullGradient" type="select" format="integer" label="Partial gradient vector selection">
@@ -110,16 +98,12 @@
           <option value="1">Use full gradient vector at every step</option>
           <option value="2">Randomly selected partial gradient, without regard to current active set ("unbiased")</option>
         </param>
-        <param name="gradientFraction" type="float" value="0.1" label="Gradient fraction" help="Fraction of inactive gradient vector to evaluate.">
-          <validator type="in_range" message="0.0 &lt; gradientFraction &lt;= 1" min="0.0" max="1.0"/>
-        </param>
+                <param name="gradientFraction" type="float" min="0.0" max="1.0" value="0.1" label="Gradient fraction" help="Fraction of inactive gradient vector to evaluate" />
         <param name="initialAlpha" type="float" value="1.0" label="Initial value of alpha"/>
         <param name="alphaIncrease" type="float" value="2.0" label="Alpha increase" help="Factor by which to increase alpha after descent not obtained."/>
         <param name="alphaDecrease" type="float" value="0.8" label="Alpha decrease" help="Factor by which to decrease alpha after successful first-order step."/>
         <param name="alphaMax" type="float" value="1e12" label="Alpha max" help="Maximum value of alpha; terminate with error if we exceed this."/>
-        <param name="c1" type="float" value="1e-3" help="Parameter defining the margin by which the first-order step is required to decrease before being taken.">
-          <validator type="in_range" message="0.0 &lt; c1 &lt; 1.0" min="0.0" max="1.0"/>
-        </param>
+                <param name="c1" type="float" min="0.0" max="1.0" value="1e-3" help="Parameter defining the margin by which the first-order step is required to decrease before being taken" />
         <param name="maxIter" type="integer" value="10000" label="Maximum number of iterations" help="Terminate with error if we exceed this."/>
         <param name="stopTol" type="float" value="1e-6" label="Stop tolerance" help="Convergence tolerance for target value of lambda."/>
         <param name="intermediateTol" type="float" value="1e-4" label="Intermediate tolerance" help="Convergence tolerance for intermediate values of lambda."/>
@@ -135,10 +119,6 @@
     <data name="output_file" format="tabular" label="${tool.name} on ${on_string}: results"/>
     <data name="log_file" format="txt" label="${tool.name} on ${on_string}: log"/>
   </outputs>
-
-  <requirements>
-    <requirement type="package">lps_tool</requirement>
-  </requirements>
 
   <tests>
     <test>
@@ -168,7 +148,7 @@
       <param name="stopTol" value="1e-6"/>
       <param name="intermediateTol" value="1e-6"/>
       <param name="finalOnly" value="0"/>
-      <output name="ouput_file" file="lps_arrhythmia_beta.tabular"/>
+            <output name="output_file" file="lps_arrhythmia_beta.tabular"/>
       <output name="log_file" file="lps_arrhythmia_log.txt"/>
     </test>
   </tests>
@@ -270,18 +250,6 @@ Website: http://pages.cs.wisc.edu/~swright/LPS/
       number of iterations required:     43
     etc.
 
------
-
-**References**
-
-Koh K, Kim S-J, Boyd S. (2007)
-An interior-point method for large-scale l1-regularized logistic regression.
-Journal of Machine Learning Research. 8:1519-1555.
-
-Shi W, Wahba G, Wright S, Lee K, Klein R, Klein B. (2008)
-LASSO-Patternsearch algorithm with application to ophthalmology and genomic data.
-Stat Interface. 1(1):137-153.
-
 <!--
 Wright S, Novak R, Figueiredo M. (2009)
 Sparse reconstruction via separable approximation.
@@ -299,25 +267,18 @@ Wright S. (2010)
 Accelerated block-coordinate relaxation for regularized optimization.
 Technical Report. University of Wisconsin. August 10, 2010.
 -->
-
   </help>
   <citations>
-    <citation type="bibtex">@ARTICLE{Kim07aninterior-point,
+        <citation type="bibtex">
+@ARTICLE{Kim07aninterior-point,
     author = {Seung-jean Kim and Kwangmoo Koh and Michael Lustig and Stephen Boyd and Dimitry Gorinevsky},
     title = {An interior-point method for large-scale l1-regularized logistic regression},
     journal = {Journal of Machine Learning Research},
     year = {2007},
     volume = {8},
     pages = {1519--1555},
-}</citation>
-    <citation type="bibtex">@ARTICLE{Shi08lasso-patternsearchalgorithm,
-    author = {Weiliang Shi and Grace Wahba and Stephen Wright and Kristine Lee and Ronald Klein and Barbara Klein},
-    title = {LASSO-Patternsearch Algorithm with Application to Ophthalmology and Genomic Data},
-    journal= {Stat Interface},
-    year = {2008},
-    volume = {1},
-    number = {1},
-    pages = {137--153}
-}</citation>
+}
+        </citation>
+        <citation type="doi">10.4310/SII.2008.v1.n1.a12</citation>
   </citations>
 </tool>

--- a/tools/phenotype_association/lps.xml
+++ b/tools/phenotype_association/lps.xml
@@ -1,159 +1,159 @@
 <tool id="hgv_lps" name="LPS" version="1.0.0">
-  <description>LASSO-Patternsearch algorithm</description>
+    <description>LASSO-Patternsearch algorithm</description>
     <requirements>
         <requirement type="package">lps_tool</requirement>
     </requirements>
 
     <command>
 bash '$__tool_directory__/lps_tool_wrapper.sh' $lambda_fac '$input_file' $label_column '$output_file' '$log_file'
-    Initialization 0
-    #if $advanced.options == "true":
-      Sample $advanced.sample
-      Verbosity $advanced.verbosity
-      Standardize $advanced.standardize
-      initialLambda $advanced.initialLambda
-      #if $advanced.continuation.continuation == "1":
+Initialization 0
+#if $advanced.options == "true":
+    Sample $advanced.sample
+    Verbosity $advanced.verbosity
+    Standardize $advanced.standardize
+    initialLambda $advanced.initialLambda
+    #if $advanced.continuation.continuation == "1":
         Continuation $advanced.continuation.continuation
         continuationSteps $advanced.continuation.continuationSteps
         accurateIntermediates $advanced.continuation.accurateIntermediates
-      #end if
-      printFreq $advanced.printFreq
-      #if $advanced.newton.newton == "1":
+    #end if
+    printFreq $advanced.printFreq
+    #if $advanced.newton.newton == "1":
         Newton $advanced.newton.newton
         NewtonThreshold $advanced.newton.newtonThreshold
-      #end if
-      HessianSampleFraction $advanced.hessianSampleFraction
-      BB 0
-      Monotone 0
-      FullGradient $advanced.fullGradient
-      GradientFraction $advanced.gradientFraction
-      InitialAlpha $advanced.initialAlpha
-      AlphaIncrease $advanced.alphaIncrease
-      AlphaDecrease $advanced.alphaDecrease
-      AlphaMax $advanced.alphaMax
-      c1 $advanced.c1
-      MaxIter $advanced.maxIter
-      StopTol $advanced.stopTol
-      IntermediateTol $advanced.intermediateTol
-      FinalOnly $advanced.finalOnly
     #end if
-  </command>
+    HessianSampleFraction $advanced.hessianSampleFraction
+    BB 0
+    Monotone 0
+    FullGradient $advanced.fullGradient
+    GradientFraction $advanced.gradientFraction
+    InitialAlpha $advanced.initialAlpha
+    AlphaIncrease $advanced.alphaIncrease
+    AlphaDecrease $advanced.alphaDecrease
+    AlphaMax $advanced.alphaMax
+    c1 $advanced.c1
+    MaxIter $advanced.maxIter
+    StopTol $advanced.stopTol
+    IntermediateTol $advanced.intermediateTol
+    FinalOnly $advanced.finalOnly
+#end if
+    </command>
 
-  <inputs>
-    <param name="input_file" type="data" format="tabular" label="Dataset"/>
-    <param name="label_column" type="data_column" data_ref="input_file" numerical="true" label="Label column" help="Column containing outcome labels: +1 or -1."/>
-    <param name="lambda_fac" label="Lambda_fac" type="float" value="0.03" help="Target value of the regularization parameter, expressed as a fraction of the calculated lambda_max.">
-      <validator type="in_range" message="0.00 &lt; lambda_fac &lt;= 1.00" min="0.00" max="1.00"/>
-    </param>
-    <conditional name="advanced">
-      <param name="options" type="select" label="Advanced Options">
-        <option value="false" selected="true">Hide advanced options</option>
-        <option value="true">Show advanced options</option>
-      </param>
-            <when value="false" />
-      <when value="true">
-        <!-- HARDCODED: 'Sample' we don't support passing an array -->
-                <param name="sample" type="float" min="0.0" max="1.0" value="1.0" label="Sample fraction" help="Sample this fraction of the data set" />
-        <!-- HARDCODED: 'Initialization' = 0 :: Initialize at beta=0 -->
-        <param name="verbosity" type="select" format="integer" label="Verbosity">
-          <option value="0" selected="true">Little output</option>
-          <option value="1">More output</option>
-          <option value="2">Still more output</option>
+    <inputs>
+        <param name="input_file" type="data" format="tabular" label="Dataset"/>
+        <param name="label_column" type="data_column" data_ref="input_file" numerical="true" label="Label column" help="Column containing outcome labels: +1 or -1."/>
+        <param name="lambda_fac" label="Lambda_fac" type="float" value="0.03" help="Target value of the regularization parameter, expressed as a fraction of the calculated lambda_max.">
+            <validator type="in_range" message="0.00 &lt; lambda_fac &lt;= 1.00" min="0.00" max="1.00"/>
         </param>
-        <param name="standardize" type="select" format="integer" label="Standardize" help="Scales and shifts each column so that it has mean zero and variance 1.">
-          <option value="0" selected="true">Don't standardize</option>
-          <option value="1">Standardize</option>
-        </param>
-                <param name="initialLambda" type="float" min="0.0" max="1.0" value="0.8" label="Initial lambda" help="First value of lambda to be used in the continuation scheme, expressed as a fraction of lambda_max" />
-        <conditional name="continuation">
-          <param name="continuation" type="select" format="integer" label="Continuation" help="Use continuation strategy to start with a larger value of lambda, decreasing it successively to lambda_fac.">
-            <option value="0" selected="true">Don't use continuation</option>
-            <option value="1">Use continuation</option>
-          </param>
-                    <when value="0" />
-          <when value="1">
-            <param name="continuationSteps" type="integer" value="5" label="Continuation steps" help="Number of lambda values to use in continuation &lt;em&gt;prior&lt;/em&gt; to target value lambda_fac."/>
-            <param name="accurateIntermediates" type="select" format="integer" label="Accurate intermediates" help="Indicates whether accurate solutions are required for lambda values other than the target value lambda_fac.">
-              <option value="0" selected="true">Don't need accurate intemediates</option>
-              <option value="1">Calculate accurate intermediates</option>
+        <conditional name="advanced">
+            <param name="options" type="select" label="Advanced Options">
+                <option value="false" selected="true">Hide advanced options</option>
+                <option value="true">Show advanced options</option>
             </param>
-          </when>
-        </conditional> <!-- name="continuation" -->
-                <param name="printFreq" type="integer" min="1" value="1" label="Print frequency" help="Print a progress report every NI iterations, where NI is the supplied value of this parameter" />
-        <conditional name="newton">
-          <param name="newton" type="select" format="integer" label="Projected Newton steps">
-            <option value="0" selected="true">No Newton steps</option>
-            <option value="1">Try projected Newton steps</option>
-          </param>
+            <when value="false" />
+            <when value="true">
+                <!-- HARDCODED: 'Sample' we don't support passing an array -->
+                <param name="sample" type="float" min="0.0" max="1.0" value="1.0" label="Sample fraction" help="Sample this fraction of the data set" />
+                <!-- HARDCODED: 'Initialization' = 0 :: Initialize at beta=0 -->
+                <param name="verbosity" type="select" format="integer" label="Verbosity">
+                    <option value="0" selected="true">Little output</option>
+                    <option value="1">More output</option>
+                    <option value="2">Still more output</option>
+                </param>
+                <param name="standardize" type="select" format="integer" label="Standardize" help="Scales and shifts each column so that it has mean zero and variance 1.">
+                    <option value="0" selected="true">Don't standardize</option>
+                    <option value="1">Standardize</option>
+                </param>
+                <param name="initialLambda" type="float" min="0.0" max="1.0" value="0.8" label="Initial lambda" help="First value of lambda to be used in the continuation scheme, expressed as a fraction of lambda_max" />
+                <conditional name="continuation">
+                    <param name="continuation" type="select" format="integer" label="Continuation" help="Use continuation strategy to start with a larger value of lambda, decreasing it successively to lambda_fac.">
+                        <option value="0" selected="true">Don't use continuation</option>
+                        <option value="1">Use continuation</option>
+                    </param>
                     <when value="0" />
-          <when value="1">
-            <param name="newtonThreshold" type="integer" value="500" label="Newton threshold" help="Maximum size of free variable subvector for Newton."/>
-          </when>
-        </conditional>
+                    <when value="1">
+                        <param name="continuationSteps" type="integer" value="5" label="Continuation steps" help="Number of lambda values to use in continuation &lt;em&gt;prior&lt;/em&gt; to target value lambda_fac."/>
+                        <param name="accurateIntermediates" type="select" format="integer" label="Accurate intermediates" help="Indicates whether accurate solutions are required for lambda values other than the target value lambda_fac.">
+                            <option value="0" selected="true">Don't need accurate intemediates</option>
+                            <option value="1">Calculate accurate intermediates</option>
+                        </param>
+                    </when>
+                </conditional> <!-- name="continuation" -->
+                <param name="printFreq" type="integer" min="1" value="1" label="Print frequency" help="Print a progress report every NI iterations, where NI is the supplied value of this parameter" />
+                <conditional name="newton">
+                    <param name="newton" type="select" format="integer" label="Projected Newton steps">
+                        <option value="0" selected="true">No Newton steps</option>
+                        <option value="1">Try projected Newton steps</option>
+                    </param>
+                    <when value="0" />
+                    <when value="1">
+                        <param name="newtonThreshold" type="integer" value="500" label="Newton threshold" help="Maximum size of free variable subvector for Newton."/>
+                    </when>
+                </conditional>
                 <param name="hessianSampleFraction" type="float" min="0.01" max="1.00" value="1.0" label="Hessian sample fraction" help="Fraction of terms to use in approximate Hessian calculation" />
-        <!-- HARDCODED: 'BB' = 0 :: don't use Barzilai-Borwein steps -->
-        <!-- HARDCODED: 'Monotone' = 0 :: don't force monotonicity -->
-        <param name="fullGradient" type="select" format="integer" label="Partial gradient vector selection">
-          <option value="0">Use randomly selected partial gradient, including current active components ("biased")</option>
-          <option value="1">Use full gradient vector at every step</option>
-          <option value="2">Randomly selected partial gradient, without regard to current active set ("unbiased")</option>
-        </param>
+                <!-- HARDCODED: 'BB' = 0 :: don't use Barzilai-Borwein steps -->
+                <!-- HARDCODED: 'Monotone' = 0 :: don't force monotonicity -->
+                <param name="fullGradient" type="select" format="integer" label="Partial gradient vector selection">
+                    <option value="0">Use randomly selected partial gradient, including current active components ("biased")</option>
+                    <option value="1">Use full gradient vector at every step</option>
+                    <option value="2">Randomly selected partial gradient, without regard to current active set ("unbiased")</option>
+                </param>
                 <param name="gradientFraction" type="float" min="0.0" max="1.0" value="0.1" label="Gradient fraction" help="Fraction of inactive gradient vector to evaluate" />
-        <param name="initialAlpha" type="float" value="1.0" label="Initial value of alpha"/>
-        <param name="alphaIncrease" type="float" value="2.0" label="Alpha increase" help="Factor by which to increase alpha after descent not obtained."/>
-        <param name="alphaDecrease" type="float" value="0.8" label="Alpha decrease" help="Factor by which to decrease alpha after successful first-order step."/>
-        <param name="alphaMax" type="float" value="1e12" label="Alpha max" help="Maximum value of alpha; terminate with error if we exceed this."/>
+                <param name="initialAlpha" type="float" value="1.0" label="Initial value of alpha"/>
+                <param name="alphaIncrease" type="float" value="2.0" label="Alpha increase" help="Factor by which to increase alpha after descent not obtained."/>
+                <param name="alphaDecrease" type="float" value="0.8" label="Alpha decrease" help="Factor by which to decrease alpha after successful first-order step."/>
+                <param name="alphaMax" type="float" value="1e12" label="Alpha max" help="Maximum value of alpha; terminate with error if we exceed this."/>
                 <param name="c1" type="float" min="0.0" max="1.0" value="1e-3" help="Parameter defining the margin by which the first-order step is required to decrease before being taken" />
-        <param name="maxIter" type="integer" value="10000" label="Maximum number of iterations" help="Terminate with error if we exceed this."/>
-        <param name="stopTol" type="float" value="1e-6" label="Stop tolerance" help="Convergence tolerance for target value of lambda."/>
-        <param name="intermediateTol" type="float" value="1e-4" label="Intermediate tolerance" help="Convergence tolerance for intermediate values of lambda."/>
-        <param name="finalOnly" type="select" format="integer" label="Final only">
-          <option value="0" selected="true">Return information for all intermediate values</option>
-          <option value="1">Just return information at the last lambda</option>
-        </param>
-      </when> <!-- value="advanced" -->
-    </conditional> <!-- name="advanced" -->
-  </inputs>
+                <param name="maxIter" type="integer" value="10000" label="Maximum number of iterations" help="Terminate with error if we exceed this."/>
+                <param name="stopTol" type="float" value="1e-6" label="Stop tolerance" help="Convergence tolerance for target value of lambda."/>
+                <param name="intermediateTol" type="float" value="1e-4" label="Intermediate tolerance" help="Convergence tolerance for intermediate values of lambda."/>
+                <param name="finalOnly" type="select" format="integer" label="Final only">
+                    <option value="0" selected="true">Return information for all intermediate values</option>
+                    <option value="1">Just return information at the last lambda</option>
+                </param>
+            </when> <!-- value="advanced" -->
+        </conditional> <!-- name="advanced" -->
+    </inputs>
 
-  <outputs>
-    <data name="output_file" format="tabular" label="${tool.name} on ${on_string}: results"/>
-    <data name="log_file" format="txt" label="${tool.name} on ${on_string}: log"/>
-  </outputs>
+    <outputs>
+        <data name="output_file" format="tabular" label="${tool.name} on ${on_string}: results"/>
+        <data name="log_file" format="txt" label="${tool.name} on ${on_string}: log"/>
+    </outputs>
 
-  <tests>
-    <test>
-      <param name="input_file" value="lps_arrhythmia.tabular"/>
-      <param name="label_column" value="280"/>
-      <param name="lambda_fac" value="0.03"/>
-      <param name="options" value="true"/>
-      <param name="sample" value="1.0"/>
-      <param name="verbosity" value="1"/>
-      <param name="standardize" value="0"/>
-      <param name="initialLambda" value="0.9"/>
-      <param name="continuation" value="1"/>
-      <param name="continuationSteps" value="10"/>
-      <param name="accurateIntermediates" value="0"/>
-      <param name="printFreq" value="1"/>
-      <param name="newton" value="1"/>
-      <param name="newtonThreshold" value="500"/>
-      <param name="hessianSampleFraction" value="1.0"/>
-      <param name="fullGradient" value="1"/>
-      <param name="gradientFraction" value="0.5"/>
-      <param name="initialAlpha" value="1.0"/>
-      <param name="alphaIncrease" value="2.0"/>
-      <param name="alphaDecrease" value="0.8"/>
-      <param name="alphaMax" value="1e12"/>
-      <param name="c1" value="1e-3"/>
-      <param name="maxIter" value="2500"/>
-      <param name="stopTol" value="1e-6"/>
-      <param name="intermediateTol" value="1e-6"/>
-      <param name="finalOnly" value="0"/>
+    <tests>
+        <test>
+            <param name="input_file" value="lps_arrhythmia.tabular"/>
+            <param name="label_column" value="280"/>
+            <param name="lambda_fac" value="0.03"/>
+            <param name="options" value="true"/>
+            <param name="sample" value="1.0"/>
+            <param name="verbosity" value="1"/>
+            <param name="standardize" value="0"/>
+            <param name="initialLambda" value="0.9"/>
+            <param name="continuation" value="1"/>
+            <param name="continuationSteps" value="10"/>
+            <param name="accurateIntermediates" value="0"/>
+            <param name="printFreq" value="1"/>
+            <param name="newton" value="1"/>
+            <param name="newtonThreshold" value="500"/>
+            <param name="hessianSampleFraction" value="1.0"/>
+            <param name="fullGradient" value="1"/>
+            <param name="gradientFraction" value="0.5"/>
+            <param name="initialAlpha" value="1.0"/>
+            <param name="alphaIncrease" value="2.0"/>
+            <param name="alphaDecrease" value="0.8"/>
+            <param name="alphaMax" value="1e12"/>
+            <param name="c1" value="1e-3"/>
+            <param name="maxIter" value="2500"/>
+            <param name="stopTol" value="1e-6"/>
+            <param name="intermediateTol" value="1e-6"/>
+            <param name="finalOnly" value="0"/>
             <output name="output_file" file="lps_arrhythmia_beta.tabular"/>
-      <output name="log_file" file="lps_arrhythmia_log.txt"/>
-    </test>
-  </tests>
+            <output name="log_file" file="lps_arrhythmia_log.txt"/>
+        </test>
+    </tests>
 
-  <help>
+    <help>
 **Dataset formats**
 
 The input and output datasets are tabular_.  The columns are described below.
@@ -267,8 +267,8 @@ Wright S. (2010)
 Accelerated block-coordinate relaxation for regularized optimization.
 Technical Report. University of Wisconsin. August 10, 2010.
 -->
-  </help>
-  <citations>
+    </help>
+    <citations>
         <citation type="bibtex">
 @ARTICLE{Kim07aninterior-point,
     author = {Seung-jean Kim and Kwangmoo Koh and Michael Lustig and Stephen Boyd and Dimitry Gorinevsky},
@@ -280,5 +280,5 @@ Technical Report. University of Wisconsin. August 10, 2010.
 }
         </citation>
         <citation type="doi">10.4310/SII.2008.v1.n1.a12</citation>
-  </citations>
+    </citations>
 </tool>

--- a/tools/phenotype_association/master2gd_snp.xml
+++ b/tools/phenotype_association/master2gd_snp.xml
@@ -1,15 +1,17 @@
-<tool id="master2gd_snp" name="MasterVar to gd_snp" hidden="false" version="1.0.0">
+<tool id="master2gd_snp" name="MasterVar to gd_snp" version="1.0.0">
   <description>Convert from MasterVar to gd_snp table</description>
-  <command interpreter="perl">
+    <command>
+perl '$__tool_directory__/master2gd_snp.pl' '$input1' -name='$indName' -build=${input1.metadata.dbkey}
     #if $snptab.tab2 == "yes" 
-      #if $snptab.colsOnly == "addColsOnly" #master2gd_snp.pl $input1 -tab=$snptab.input2 -name=$indName -build=${input1.metadata.dbkey} -addColsOnly > $out_file1 
-      #else #master2gd_snp.pl $input1 -tab=$snptab.input2 -name=$indName -build=${input1.metadata.dbkey} > $out_file1
+    -tab='$snptab.input2'
+    #if $snptab.colsOnly == "addColsOnly"
+        -addColsOnly
       #end if
-    #else #master2gd_snp.pl $input1 -name=$indName -build=${input1.metadata.dbkey} > $out_file1
     #end if
+> '$out_file1'
   </command>
   <inputs>
-    <param format="tab" name="input1" type="data" label="Complete Genomics MasterVar dataset" />
+        <param name="input1" type="data" format="tabular" label="Complete Genomics MasterVar dataset" />
     <conditional name="snptab">
       <param name="tab2" type="select" label="Append to gd_snp table in history">
         <option value="yes">yes</option>
@@ -22,20 +24,19 @@
         <option value="addColsOnly">yes</option>
       </param>
       </when>
-      <when value="no"> <!-- do nothing -->
-      </when>
+            <when value="no" />
     </conditional>
-    <param name="indName" type="text" size="20" label="Label for new individual/group" value="na" />
+        <param name="indName" type="text" value="na" label="Label for new individual/group" />
   </inputs>
   <outputs>
-  <data format="gd_snp" name="out_file1" />
+        <data name="out_file1" format="gd_snp" />
   </outputs>
   <tests>
     <test>
-      <param name='input1' value='masterVarTest.txt' ftype='tab' />
-      <param name='tab2' value='no' />
-      <param name='indName' value='na' />
-      <output name="output" file="master2snp_output.txt" />
+            <param name="input1" value="masterVarTest.txt" ftype="tabular" />
+            <param name="tab2" value="no" />
+            <param name="indName" value="na" />
+            <output name="out_file1" file="master2snp_output.txt" />
     </test>
   </tests>
 
@@ -64,7 +65,6 @@ appear only in the MasterVar file they can either be skipped or backfilled with
 "-1" (unknown) for previous individuals/groups in the gd_snp dataset. 
 Positions homozygous for the reference are skipped.
 
-
 -----
 
 **Examples**
@@ -81,6 +81,5 @@ Positions homozygous for the reference are skipped.
    chr1    41980   A       G       -1      0       1       0       76
    chr1    53205   G       C       -1      30      7       1       93
    etc.
-
 </help>
 </tool>

--- a/tools/phenotype_association/master2gd_snp.xml
+++ b/tools/phenotype_association/master2gd_snp.xml
@@ -1,46 +1,46 @@
 <tool id="master2gd_snp" name="MasterVar to gd_snp" version="1.0.0">
-  <description>Convert from MasterVar to gd_snp table</description>
+    <description>Convert from MasterVar to gd_snp table</description>
     <command>
 perl '$__tool_directory__/master2gd_snp.pl' '$input1' -name='$indName' -build=${input1.metadata.dbkey}
-    #if $snptab.tab2 == "yes" 
+#if $snptab.tab2 == "yes"
     -tab='$snptab.input2'
     #if $snptab.colsOnly == "addColsOnly"
         -addColsOnly
-      #end if
     #end if
+#end if
 > '$out_file1'
-  </command>
-  <inputs>
+    </command>
+    <inputs>
         <param name="input1" type="data" format="tabular" label="Complete Genomics MasterVar dataset" />
-    <conditional name="snptab">
-      <param name="tab2" type="select" label="Append to gd_snp table in history">
-        <option value="yes">yes</option>
-        <option value="no" selected="true">no</option>
-      </param>
-      <when value="yes">
-      <param format="gd_snp" name="input2" type="data" label="gd_snp table" />
-      <param name="colsOnly" type="select" label="Skip new SNPs">
-        <option value="" selected="true">no</option>
-        <option value="addColsOnly">yes</option>
-      </param>
-      </when>
+        <conditional name="snptab">
+            <param name="tab2" type="select" label="Append to gd_snp table in history">
+                <option value="yes">yes</option>
+                <option value="no" selected="true">no</option>
+            </param>
+            <when value="yes">
+                <param format="gd_snp" name="input2" type="data" label="gd_snp table" />
+                <param name="colsOnly" type="select" label="Skip new SNPs">
+                    <option value="" selected="true">no</option>
+                    <option value="addColsOnly">yes</option>
+                </param>
+            </when>
             <when value="no" />
-    </conditional>
+        </conditional>
         <param name="indName" type="text" value="na" label="Label for new individual/group" />
-  </inputs>
-  <outputs>
+    </inputs>
+    <outputs>
         <data name="out_file1" format="gd_snp" />
-  </outputs>
-  <tests>
-    <test>
+    </outputs>
+    <tests>
+        <test>
             <param name="input1" value="masterVarTest.txt" ftype="tabular" />
             <param name="tab2" value="no" />
             <param name="indName" value="na" />
             <output name="out_file1" file="master2snp_output.txt" />
-    </test>
-  </tests>
+        </test>
+    </tests>
 
-  <help>
+    <help>
 **Dataset formats**
 
 The input dataset is in the MasterVar_ format provided by the Complete Genomics
@@ -59,10 +59,10 @@ The output dataset is a gd_snp_ table.  (`Dataset missing?`_)
 
 This converts a Complete Genomics MasterVar file to gd_snp format,
 so it can be used with the genome diversity tools.
-It can either 
-start a new dataset or append to an old one. When appending, if any new SNPs 
-appear only in the MasterVar file they can either be skipped or backfilled with 
-"-1" (unknown) for previous individuals/groups in the gd_snp dataset. 
+It can either
+start a new dataset or append to an old one. When appending, if any new SNPs
+appear only in the MasterVar file they can either be skipped or backfilled with
+"-1" (unknown) for previous individuals/groups in the gd_snp dataset.
 Positions homozygous for the reference are skipped.
 
 -----
@@ -81,5 +81,5 @@ Positions homozygous for the reference are skipped.
    chr1    41980   A       G       -1      0       1       0       76
    chr1    53205   G       C       -1      30      7       1       93
    etc.
-</help>
+    </help>
 </tool>

--- a/tools/phenotype_association/master2pg.xml
+++ b/tools/phenotype_association/master2pg.xml
@@ -1,26 +1,26 @@
 <tool id="master2pgSnp" name="MasterVar to pgSnp" version="1.0.0">
-  <description>Convert from MasterVar to pgSnp format</description>
+    <description>Convert from MasterVar to pgSnp format</description>
     <command>
 perl '$__tool_directory__/master2pg.pl' $indel '$input1' > '$out_file1'
-  </command>
-  <inputs>
+    </command>
+    <inputs>
         <param name="input1" type="data" format="tabular" label="Complete Genomics MasterVar dataset" />
-    <param name="indel" type="select" label="Convert indels">
-      <option value="" selected="true">no</option>
-      <option value="indel">yes</option>
-    </param>
-  </inputs>
-  <outputs>
+        <param name="indel" type="select" label="Convert indels">
+            <option value="" selected="true">no</option>
+            <option value="indel">yes</option>
+        </param>
+    </inputs>
+    <outputs>
         <data name="out_file1" format="interval" />
-  </outputs>
-  <tests>
-    <test>
+    </outputs>
+    <tests>
+        <test>
             <param name="input1" value="masterVarTest.txt" ftype="tabular" />
             <param name="indel" value="" />
             <output name="out_file1" file="masterVar_output.txt" />
-    </test>
-  </tests>
-  <help>
+        </test>
+    </tests>
+    <help>
 **Dataset formats**
 
 The input dataset is in the MasterVar_ format provided by the Complete Genomics 
@@ -60,5 +60,5 @@ Positions homozygous for the reference are skipped.
    chr1    52237   52238   G       1       7       63
    chr1    53205   53206   C/G     2       7,30    93,127
    etc.
-</help>
+    </help>
 </tool>

--- a/tools/phenotype_association/master2pg.xml
+++ b/tools/phenotype_association/master2pg.xml
@@ -1,26 +1,25 @@
-<tool id="master2pgSnp" name="MasterVar to pgSnp" hidden="false" version="1.0.0">
+<tool id="master2pgSnp" name="MasterVar to pgSnp" version="1.0.0">
   <description>Convert from MasterVar to pgSnp format</description>
-  <command interpreter="perl">
-    master2pg.pl $indel $input1 > $out_file1
+    <command>
+perl '$__tool_directory__/master2pg.pl' $indel '$input1' > '$out_file1'
   </command>
   <inputs>
-    <param format="tab" name="input1" type="data" label="Complete Genomics MasterVar dataset" />
+        <param name="input1" type="data" format="tabular" label="Complete Genomics MasterVar dataset" />
     <param name="indel" type="select" label="Convert indels">
       <option value="" selected="true">no</option>
       <option value="indel">yes</option>
     </param>
   </inputs>
   <outputs>
-  <data format="interval" name="out_file1" />
+        <data name="out_file1" format="interval" />
   </outputs>
   <tests>
     <test>
-      <param name='input1' value='masterVarTest.txt' ftype='tab' />
-      <param name='indel' value="" />
-      <output name="output" file="masterVar_output.txt" />
+            <param name="input1" value="masterVarTest.txt" ftype="tabular" />
+            <param name="indel" value="" />
+            <output name="out_file1" file="masterVar_output.txt" />
     </test>
   </tests>
-
   <help>
 **Dataset formats**
 
@@ -61,6 +60,5 @@ Positions homozygous for the reference are skipped.
    chr1    52237   52238   G       1       7       63
    chr1    53205   53206   C/G     2       7,30    93,127
    etc.
-
 </help>
 </tool>


### PR DESCRIPTION
- Replace non-existent `tab` format with `tabular` in 2 tools
- Remove deprecated `interpreter` attribute of `<command>`
- Single-quote `text` and `data` parameters inside the command
- Fix wrong `name` attribute of `output` in 3 tests
- Linting and cleanups
- Fix indentation
