### PR TITLE
Various fixes for mapping over collections

### DIFF
--- a/lib/galaxy/dataset_collections/structure.py
+++ b/lib/galaxy/dataset_collections/structure.py
@@ -183,6 +183,9 @@ def dict_map(func, input_dict):
 def get_structure(dataset_collection_instance, collection_type_description, leaf_subcollection_type=None):
     if leaf_subcollection_type:
         collection_type_description = collection_type_description.effective_collection_type_description(leaf_subcollection_type)
+        if hasattr(dataset_collection_instance, 'child_collection'):
+            collection_type_description = collection_type_description.collection_type_description_factory.for_collection_type(leaf_subcollection_type)
+            return UnitializedTree(collection_type_description)
 
     collection = dataset_collection_instance.collection
     return Tree.for_dataset_collection(collection, collection_type_description)

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -797,8 +797,11 @@ class OutputCollections(object):
                 raise Exception("Could not determine collection type to create.")
             if collection_type_source not in input_collections:
                 raise Exception("Could not find collection type source with name [%s]." % collection_type_source)
-
-            collection_type = input_collections[collection_type_source].collection.collection_type
+            collection_type_description = self.tool.inputs[collection_type_source]._history_query(self.trans).can_map_over(input_collections[collection_type_source])
+            if collection_type_description:
+                collection_type = collection_type_description.collection_type
+            else:
+                collection_type = input_collections[collection_type_source].collection.collection_type
 
         if "elements" in element_kwds:
             def check_elements(elements):

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -797,7 +797,22 @@ class OutputCollections(object):
                 raise Exception("Could not determine collection type to create.")
             if collection_type_source not in input_collections:
                 raise Exception("Could not find collection type source with name [%s]." % collection_type_source)
-            collection_type_description = self.tool.inputs[collection_type_source]._history_query(self.trans).can_map_over(input_collections[collection_type_source])
+
+            # Using the collection_type_source string we get the DataCollectionToolParameter
+            data_param = self.tool.inputs
+            groups = collection_type_source.split('|')
+            for group in groups:
+                values = group.split('_')
+                if values[-1].isdigit():
+                    key = ("_".join(values[0:-1]))
+                    # We don't care about the repeat index, we just need to find the correct DataCollectionToolParameter
+                else:
+                    key = group
+                if isinstance(data_param, odict):
+                    data_param = data_param.get(key)
+                else:
+                    data_param = data_param.inputs.get(key)
+            collection_type_description = data_param._history_query(self.trans).can_map_over(input_collections[collection_type_source])
             if collection_type_description:
                 collection_type = collection_type_description.collection_type
             else:

--- a/lib/galaxy/tools/parameters/history_query.py
+++ b/lib/galaxy/tools/parameters/history_query.py
@@ -53,4 +53,4 @@ class HistoryQuery(object):
             # See note about the way this is sorted above.
             if collection_type_description.is_subcollection_of_type(hdca_collection_type):
                 return collection_type_description
-            return False
+        return False

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -1359,6 +1359,26 @@ test_data:
 """, history_id=history_id, wait=True)
             self.assertEqual("0\n", self.dataset_populator.get_history_dataset_content(history_id))
 
+    @skip_without_tool("collection_type_source_map_over")
+    def test_mapping_and_subcollection_mapping(self):
+        with self.dataset_populator.test_history() as history_id:
+            jobs_summary = self._run_jobs("""
+class: GalaxyWorkflow
+steps:
+  - label: text_input1
+    type: input_collection
+  - tool_id: collection_type_source_map_over
+    state:
+      input_collect:
+        $link: text_input1
+test_data:
+  text_input1:
+    type: "list:paired"
+        """, history_id=history_id)
+            hdca = self.dataset_populator.get_history_collection_details(history_id=jobs_summary.history_id, hid=5)
+            assert hdca['collection_type'] == 'list:paired'
+            assert len(hdca['elements'][0]['object']["elements"]) == 2
+
     @skip_without_tool("empty_list")
     @skip_without_tool("count_multi_file")
     @skip_without_tool("random_lines1")

--- a/test/functional/tools/collection_type_source_map_over.xml
+++ b/test/functional/tools/collection_type_source_map_over.xml
@@ -1,0 +1,16 @@
+<tool id="collection_type_source_map_over" name="collection_type_source_map_over" version="0.1.0">
+  <command>
+    mkdir output;
+    #for $key in $input_collect.keys()#
+    cat "$input_collect[$key]" >> output/"$key";
+    #end for#
+  </command>
+  <inputs>
+    <param name="input_collect" type="data_collection" collection_type="list,paired" label="Input Collect" help="Input collection..." />
+  </inputs>
+  <outputs>
+    <collection name="list_output" type_source="input_collect" label="Duplicate List">
+      <discover_datasets pattern="__name__" directory="output" visible="true" />
+    </collection>
+  </outputs>
+</tool>

--- a/test/functional/tools/for_workflows/cat_collection.xml
+++ b/test/functional/tools/for_workflows/cat_collection.xml
@@ -1,10 +1,10 @@
 <tool id="cat_collection" name="Concatenate dataset collection (for test workflows)">
     <description>tail-to-head</description>
     <command>
-        cat #for $q in $input1# $q #end for# > $out_file1
+cat #for $q in $input1# '$q' #end for# >'$out_file1'
     </command>
     <inputs>
-        <param name="input1" type="data_collection" label="Concatenate Dataset" collection_type="paired" />
+        <param name="input1" type="data_collection" label="Concatenate Dataset" collection_type="list,paired" />
     </inputs>
     <outputs>
         <data name="out_file1" format="input" />

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -126,6 +126,7 @@
   <tool file="collection_creates_dynamic_nested_from_json_elements.xml" />
   <tool file="collection_creates_dynamic_list_of_pairs.xml" />
   <tool file="collection_type_source.xml" />
+  <tool file="collection_type_source_map_over.xml" />
   <tool file="collection_creates_list_fail.xml" />
   <tool file="collection_creates_dynamic_nested_fail.xml" />
   <tool file="cheetah_casting.xml" />


### PR DESCRIPTION
- cb97f89d129cf7f0b7cf7146c0c15309b3dcb0c7 fixes mapping over when multiple collection types, like `collection_type="list,paired"` are allowed in a input section
- 9b19d5c267900409b5aace9f2c554b2da13ce8e7 fixes wrong collection structure when mapping over
- 258ccb89bd5190e703f9d1705ec888b65ce77724 fixes mapping over in conjunction with dynamically discovered output collections