### PR TITLE
Fix delete "Collection Only" option in history menu.

### DIFF
--- a/client/galaxy/scripts/mvc/history/hdca-li-edit.js
+++ b/client/galaxy/scripts/mvc/history/hdca-li-edit.js
@@ -41,7 +41,7 @@ var HDCAListItemEdit = _super.extend(
                         <span class="fa fa-times"></span>
                     </a>
                     <div class="dropdown-menu" role="menu">
-                            <a href="#" class="dropdown-item" delete-collection">
+                            <a href="#" class="dropdown-item delete-collection">
                                 ${_l("Collection Only")}
                             </a>
                             <a href="#" class="dropdown-item delete-collection-and-datasets">


### PR DESCRIPTION
Broken with https://github.com/galaxyproject/galaxy/commit/7cc01380afd017c5cac2af2b2d735b2265774a68.

Fixes https://github.com/galaxyproject/galaxy/issues/6280. I'll open a stable client update PR that includes some other fixes once merged into dev.