### PR TITLE
Upload collections directly for tests.

### DIFF
--- a/lib/galaxy/tools/actions/upload.py
+++ b/lib/galaxy/tools/actions/upload.py
@@ -66,7 +66,10 @@ class FetchUploadToolAction(BaseUploadToolAction):
         def replace_file_srcs(request_part):
             if isinstance(request_part, dict):
                 if request_part.get("src", None) == "files":
-                    path_def = next(files_iter)
+                    try:
+                        path_def = next(files_iter)
+                    except StopIteration:
+                        path_def = None
                     if path_def is None or path_def["file_data"] is None:
                         raise RequestParameterMissingException("Failed to find uploaded file matching target with src='files'")
                     request_part["path"] = path_def["file_data"]["local_filename"]

--- a/lib/galaxy/tools/data_fetch.xml
+++ b/lib/galaxy/tools/data_fetch.xml
@@ -18,6 +18,7 @@
       <sanitizer sanitize="False">
       </sanitizer>
     </param>
+    <param name="file_count" type="hidden" value="auto" />
     <upload_dataset name="files">
       <param name="file_data" type="file" label="File" ajax-upload="true" file_type_name="">
       </param>

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -396,6 +396,7 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
             'inputs': {
                 'request_version': request_version,
                 'request_json': request,
+                'file_count': str(len(files_payload))
             },
         }
         create_payload.update(files_payload)

--- a/test/api/test_dataset_collections.py
+++ b/test/api/test_dataset_collections.py
@@ -92,8 +92,8 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
         assert pair_1_element_1["element_index"] == 0
 
     def test_list_download(self):
-        fetch_repsonse = self.dataset_collection_populator.create_list_in_history(self.history_id, direct_upload=True).json()
-        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_repsonse)
+        fetch_response = self.dataset_collection_populator.create_list_in_history(self.history_id, direct_upload=True).json()
+        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
         returned_dce = dataset_collection["elements"]
         assert len(returned_dce) == 3, dataset_collection
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
@@ -106,8 +106,8 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
             assert "%s/%s.%s" % (collection_name, element['element_identifier'], element['object']['file_ext']) == zip_path
 
     def test_pair_download(self):
-        fetch_repsonse = self.dataset_collection_populator.create_pair_in_history(self.history_id, direct_upload=True).json()
-        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_repsonse)
+        fetch_response = self.dataset_collection_populator.create_pair_in_history(self.history_id, direct_upload=True).json()
+        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
         returned_dce = dataset_collection["elements"]
         assert len(returned_dce) == 2, dataset_collection
         hdca_id = dataset_collection['id']
@@ -121,8 +121,8 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
             assert "%s/%s.%s" % (collection_name, element['element_identifier'], element['object']['file_ext']) == zip_path
 
     def test_list_pair_download(self):
-        fetch_repsonse = self.dataset_collection_populator.create_list_of_pairs_in_history(self.history_id).json()
-        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_repsonse)
+        fetch_response = self.dataset_collection_populator.create_list_of_pairs_in_history(self.history_id).json()
+        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
         returned_dce = dataset_collection["elements"]
         assert len(returned_dce) == 1, dataset_collection
         list_collection_name = dataset_collection['name']

--- a/test/api/test_dataset_collections.py
+++ b/test/api/test_dataset_collections.py
@@ -92,8 +92,8 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
         assert pair_1_element_1["element_index"] == 0
 
     def test_list_download(self):
-        dataset_collection = self.dataset_collection_populator.create_list_in_history(self.history_id).json()
-        self.dataset_collection_populator.wait_for_dataset_collection(dataset_collection, assert_ok=True)
+        fetch_repsonse = self.dataset_collection_populator.create_list_in_history(self.history_id, direct_upload=True).json()
+        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_repsonse)
         returned_dce = dataset_collection["elements"]
         assert len(returned_dce) == 3, dataset_collection
         create_response = self._download_dataset_collection(history_id=self.history_id, hdca_id=dataset_collection['id'])
@@ -106,8 +106,8 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
             assert "%s/%s.%s" % (collection_name, element['element_identifier'], element['object']['file_ext']) == zip_path
 
     def test_pair_download(self):
-        dataset_collection = self.dataset_collection_populator.create_pair_in_history(self.history_id).json()
-        self.dataset_collection_populator.wait_for_dataset_collection(dataset_collection, assert_ok=True)
+        fetch_repsonse = self.dataset_collection_populator.create_pair_in_history(self.history_id, direct_upload=True).json()
+        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_repsonse)
         returned_dce = dataset_collection["elements"]
         assert len(returned_dce) == 2, dataset_collection
         hdca_id = dataset_collection['id']
@@ -121,8 +121,8 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
             assert "%s/%s.%s" % (collection_name, element['element_identifier'], element['object']['file_ext']) == zip_path
 
     def test_list_pair_download(self):
-        dataset_collection = self.dataset_collection_populator.create_list_of_pairs_in_history(self.history_id).json()
-        self.dataset_collection_populator.wait_for_dataset_collection(dataset_collection, assert_ok=True)
+        fetch_repsonse = self.dataset_collection_populator.create_list_of_pairs_in_history(self.history_id).json()
+        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_repsonse)
         returned_dce = dataset_collection["elements"]
         assert len(returned_dce) == 1, dataset_collection
         list_collection_name = dataset_collection['name']

--- a/test/api/test_jobs.py
+++ b/test/api/test_jobs.py
@@ -506,13 +506,13 @@ class JobsApiTestCase(api.ApiTestCase):
         if not history_id:
             history_id = self.dataset_populator.new_history()
         if collection_type == 'list':
-            create_reposonse = self.dataset_collection_populator.create_list_in_history(history_id).json()
+            fetch_response = self.dataset_collection_populator.create_list_in_history(history_id, direct_upload=True).json()
         elif collection_type == 'pair':
-            create_reposonse = self.dataset_collection_populator.create_pair_in_history(history_id).json()
+            fetch_response = self.dataset_collection_populator.create_pair_in_history(history_id, direct_upload=True).json()
         elif collection_type == 'list:pair':
-            create_reposonse = self.dataset_collection_populator.create_list_of_pairs_in_history(history_id).json()
-        self.dataset_collection_populator.wait_for_dataset_collection(create_reposonse)
-        return history_id, create_reposonse['id']
+            fetch_response = self.dataset_collection_populator.create_list_of_pairs_in_history(history_id).json()
+        self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
+        return history_id, fetch_response["outputs"][0]['id']
 
     def __jobs_index(self, **kwds):
         jobs_response = self._get("jobs", **kwds)

--- a/test/api/test_libraries.py
+++ b/test/api/test_libraries.py
@@ -233,7 +233,7 @@ class LibrariesApiTestCase(api.ApiTestCase, TestsDatasets):
         self._assert_status_code_is(folder_response, 200)
         folder_id = folder_response.json()[0]['id']
         history_id = self.dataset_populator.new_history()
-        hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=["xxx", "yyy"]).json()["id"]
+        hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=["xxx", "yyy"], direct_upload=True).json()["outputs"][0]["id"]
         payload = {'from_hdca_id': hdca_id, 'create_type': 'file', 'folder_id': folder_id}
         create_response = self._post("libraries/%s/contents" % library['id'], payload)
         self._assert_status_code_is(create_response, 200)
@@ -241,7 +241,7 @@ class LibrariesApiTestCase(api.ApiTestCase, TestsDatasets):
     def test_create_datasets_in_folder_from_collection(self):
         library = self.library_populator.new_private_library("ForCreateDatasetsFromCollection")
         history_id = self.dataset_populator.new_history()
-        hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=["xxx", "yyy"]).json()["id"]
+        hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=["xxx", "yyy"], direct_upload=True).json()["outputs"][0]["id"]
         folder_response = self._create_folder(library)
         self._assert_status_code_is(folder_response, 200)
         folder_id = folder_response.json()[0]['id']
@@ -251,7 +251,7 @@ class LibrariesApiTestCase(api.ApiTestCase, TestsDatasets):
         assert len(create_response.json()) == 2
         # Also test that anything different from a flat dataset collection list
         # is refused
-        hdca_pair_id = self.dataset_collection_populator.create_list_of_pairs_in_history(history_id).json()['id']
+        hdca_pair_id = self.dataset_collection_populator.create_list_of_pairs_in_history(history_id).json()["outputs"][0]['id']
         payload = {'from_hdca_id': hdca_pair_id}
         create_response = self._post("folders/%s/contents" % folder_id, payload)
         self._assert_status_code_is(create_response, 501)

--- a/test/api/test_workflow_extraction.py
+++ b/test/api/test_workflow_extraction.py
@@ -133,7 +133,7 @@ test_data:
 """)
         job_id = self._job_id_for_tool(jobs_summary.jobs, "collection_paired_test")
         downloaded_workflow = self._extract_and_download_workflow(
-            dataset_collection_ids=[jobs_summary.inputs["text_input1"]["hid"]],
+            dataset_collection_ids=["1"],
             job_ids=[job_id],
         )
         self.__check_workflow(
@@ -172,7 +172,7 @@ test_data:
         job1_id = self._job_id_for_tool(jobs_summary.jobs, "cat1")
         job2_id = self._job_id_for_tool(jobs_summary.jobs, "cat_collection")
         downloaded_workflow = self._extract_and_download_workflow(
-            dataset_collection_ids=[jobs_summary.inputs["text_input1"]["hid"]],
+            dataset_collection_ids=["1"],
             job_ids=[job1_id, job2_id],
         )
         print(jobs_summary.inputs["text_input1"])
@@ -273,7 +273,7 @@ test_data:
         tool_ids = ["cat1", "collection_creates_pair", "cat_collection", "cat_list"]
         job_ids = [functools.partial(self._job_id_for_tool, jobs_summary.jobs)(_) for _ in tool_ids]
         downloaded_workflow = self._extract_and_download_workflow(
-            dataset_collection_ids=["3"],
+            dataset_collection_ids=["1"],
             job_ids=job_ids,
         )
         self.__check_workflow(

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -943,7 +943,7 @@ test_data:
             def filter_jobs_by_tool(tool_id):
                 return [j for j in summary.jobs if j["tool_id"] == tool_id]
 
-            assert len(filter_jobs_by_tool("upload1")) == 2, jobs
+            assert len(filter_jobs_by_tool("__DATA_FETCH__")) == 1, jobs
             assert len(filter_jobs_by_tool("exit_code_from_file")) == 2, jobs
             assert len(filter_jobs_by_tool("__FILTER_FAILED_DATASETS__")) == 1, jobs
             # Follow proves one job was filtered out of the result of cat1
@@ -1393,7 +1393,7 @@ test_data:
   text_input1:
     type: "list:paired"
         """, history_id=history_id)
-            hdca = self.dataset_populator.get_history_collection_details(history_id=jobs_summary.history_id, hid=5)
+            hdca = self.dataset_populator.get_history_collection_details(history_id=jobs_summary.history_id, hid=1)
             assert hdca['collection_type'] == 'list:paired'
             assert len(hdca['elements'][0]['object']["elements"]) == 2
 

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -688,8 +688,15 @@ class BaseDatasetCollectionPopulator(object):
         return self.__create(payload)
 
     def create_list_of_pairs_in_history(self, history_id, **kwds):
-        pair1 = self.create_pair_in_history(history_id, **kwds).json()["id"]
-        return self.create_list_from_pairs(history_id, [pair1])
+        return self.upload_collection(history_id, "list:paired", elements=[
+            {
+                "name": "test0",
+                "elements": [
+                    {"src": "pasted", "paste_content": "TestData123", "name": "forward"},
+                    {"src": "pasted", "paste_content": "TestData123", "name": "reverse"},
+                ]
+            }
+        ])
 
     def create_list_of_list_in_history(self, history_id, **kwds):
         # create_nested_collection will generate nested collection from just datasets,
@@ -723,13 +730,108 @@ class BaseDatasetCollectionPopulator(object):
         )
         return self.__create(payload)
 
+    def upload_collection(self, history_id, collection_type, elements, **kwds):
+        payload = self.__create_payload_fetch(history_id, collection_type, contents=elements, **kwds)
+        return self.__create(payload)
+
     def create_list_payload(self, history_id, **kwds):
         return self.__create_payload(history_id, identifiers_func=self.list_identifiers, collection_type="list", **kwds)
 
     def create_pair_payload(self, history_id, **kwds):
         return self.__create_payload(history_id, identifiers_func=self.pair_identifiers, collection_type="paired", **kwds)
 
-    def __create_payload(self, history_id, identifiers_func, collection_type, **kwds):
+    def __create_payload(self, *args, **kwds):
+        direct_upload = kwds.pop("direct_upload", False)
+        if direct_upload:
+            return self.__create_payload_fetch(*args, **kwds)
+        else:
+            return self.__create_payload_collection(*args, **kwds)
+
+    def __create_payload_fetch(self, history_id, collection_type, **kwds):
+        files = []
+        contents = None
+        if "contents" in kwds:
+            contents = kwds["contents"]
+            del kwds["contents"]
+
+        elements = []
+        if contents is None:
+            if collection_type == "paired":
+                contents = [("forward", "TestData123"), ("reverse", "TestData123")]
+            elif collection_type == "list":
+                contents = ["TestData123", "TestData123", "TestData123"]
+            else:
+                raise Exception("Unknown collection_type %s" % collection_type)
+
+        if isinstance(contents, list):
+            for i, contents_level in enumerate(contents):
+                # If given a full colleciton definition pass as is.
+                if isinstance(contents_level, dict):
+                    elements.append(contents_level)
+                    continue
+
+                element = {"src": "pasted", "ext": "txt"}
+                # Else older style list of contents or element ID and contents,
+                # convert to fetch API.
+                if isinstance(contents_level, tuple):
+                    # (element_identifier, contents)
+                    element_identifier = contents_level[0]
+                    dataset_contents = contents_level[1]
+                else:
+                    dataset_contents = contents_level
+                    if collection_type == "list":
+                        element_identifier = "data%d" % i
+                    elif collection_type == "paired" and i == 0:
+                        element_identifier = "forward"
+                    else:
+                        element_identifier = "reverse"
+                element["name"] = element_identifier
+                element["paste_content"] = dataset_contents
+                elements.append(element)
+
+        # Endpoint doesn't yet respect {src: "pasted"} so simulate with multi-part uploads.
+        def paste_content_to_simluated_files(contents):
+            if isinstance(contents, list):
+                for el in contents:
+                    paste_content_to_simluated_files(el)
+            elif isinstance(contents, dict) and "paste_content" in contents:
+                contents["src"] = "files"
+                paste_content = contents.pop("paste_content")
+                # Emulate paste data behavior of adding newline.
+                if paste_content and not paste_content.endswith("\n"):
+                    paste_content += "\n"
+                files.append(paste_content)
+            elif isinstance(contents, dict):
+                for value in contents.values():
+                    paste_content_to_simluated_files(value)
+
+        paste_content_to_simluated_files(elements)
+        name = kwds.get("name", "Test Dataset Collection")
+
+        files_request_part = {}
+        for i, content in enumerate(files):
+            files_request_part["files_%d|file_data" % i] = StringIO(content)
+
+        targets = [{
+            "destination": {"type": "hdca"},
+            "elements": elements,
+            "collection_type": collection_type,
+            "name": name,
+        }]
+        payload = dict(
+            history_id=history_id,
+            targets=json.dumps(targets),
+            __files=files_request_part,
+        )
+        return payload
+
+    def wait_for_fetched_collection(self, fetch_repsonse):
+        self.dataset_populator.wait_for_job(fetch_repsonse["jobs"][0]["id"], assert_ok=True)
+        initial_dataset_collection = fetch_repsonse["outputs"][0]
+        dataset_collection = self.dataset_populator.get_history_collection_details(initial_dataset_collection["history_id"], hid=initial_dataset_collection["hid"])
+        return dataset_collection
+
+    def __create_payload_collection(self, history_id, identifiers_func, collection_type, **kwds):
         contents = None
         if "contents" in kwds:
             contents = kwds["contents"]
@@ -775,7 +877,13 @@ class BaseDatasetCollectionPopulator(object):
         return element_identifiers
 
     def __create(self, payload):
-        return self._create_collection(payload)
+        # Create a colleciton - either from existing datasets using collection creation API
+        # or from direct uploads with the fetch API. Dispatch on "targets" keyword in payload
+        # to decide which to use.
+        if "targets" not in payload:
+            return self._create_collection(payload)
+        else:
+            return self.dataset_populator.fetch(payload)
 
     def __datasets(self, history_id, count, contents=None):
         datasets = []
@@ -839,12 +947,13 @@ def load_data_dict(history_id, test_data, dataset_populator, dataset_collection_
             if "name" in value:
                 new_collection_kwds["name"] = value["name"]
             if collection_type == "list:paired":
-                hdca = dataset_collection_populator.create_list_of_pairs_in_history(history_id, **new_collection_kwds).json()
+                fetch_repsonse = dataset_collection_populator.create_list_of_pairs_in_history(history_id, contents=elements, **new_collection_kwds).json()
             elif collection_type == "list":
-                hdca = dataset_collection_populator.create_list_in_history(history_id, contents=elements, **new_collection_kwds).json()
+                fetch_repsonse = dataset_collection_populator.create_list_in_history(history_id, contents=elements, direct_upload=True, **new_collection_kwds).json()
             else:
-                hdca = dataset_collection_populator.create_pair_in_history(history_id, contents=elements, **new_collection_kwds).json()
-            label_map[key] = dataset_populator.ds_entry(hdca)
+                fetch_repsonse = dataset_collection_populator.create_pair_in_history(history_id, contents=elements or None, direct_upload=True, **new_collection_kwds).json()
+            hdca = dataset_populator.ds_entry(fetch_repsonse["outputs"][0])
+            label_map[key] = hdca
             inputs[key] = hdca
             has_uploads = True
         elif is_dict and "type" in value:

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -225,7 +225,7 @@ class BaseDatasetPopulator(object):
 
     @contextlib.contextmanager
     def test_history(self, **kwds):
-        # TODO: In the future allow targetting a specfic history here
+        # TODO: In the future allow targeting a specific history here
         # and/or deleting everything in the resulting history when done.
         # These would be cool options for remote Galaxy test execution.
         try:
@@ -765,7 +765,7 @@ class BaseDatasetCollectionPopulator(object):
 
         if isinstance(contents, list):
             for i, contents_level in enumerate(contents):
-                # If given a full colleciton definition pass as is.
+                # If given a full collection definition pass as is.
                 if isinstance(contents_level, dict):
                     elements.append(contents_level)
                     continue
@@ -825,9 +825,9 @@ class BaseDatasetCollectionPopulator(object):
         )
         return payload
 
-    def wait_for_fetched_collection(self, fetch_repsonse):
-        self.dataset_populator.wait_for_job(fetch_repsonse["jobs"][0]["id"], assert_ok=True)
-        initial_dataset_collection = fetch_repsonse["outputs"][0]
+    def wait_for_fetched_collection(self, fetch_response):
+        self.dataset_populator.wait_for_job(fetch_response["jobs"][0]["id"], assert_ok=True)
+        initial_dataset_collection = fetch_response["outputs"][0]
         dataset_collection = self.dataset_populator.get_history_collection_details(initial_dataset_collection["history_id"], hid=initial_dataset_collection["hid"])
         return dataset_collection
 
@@ -947,12 +947,12 @@ def load_data_dict(history_id, test_data, dataset_populator, dataset_collection_
             if "name" in value:
                 new_collection_kwds["name"] = value["name"]
             if collection_type == "list:paired":
-                fetch_repsonse = dataset_collection_populator.create_list_of_pairs_in_history(history_id, contents=elements, **new_collection_kwds).json()
+                fetch_response = dataset_collection_populator.create_list_of_pairs_in_history(history_id, contents=elements, **new_collection_kwds).json()
             elif collection_type == "list":
-                fetch_repsonse = dataset_collection_populator.create_list_in_history(history_id, contents=elements, direct_upload=True, **new_collection_kwds).json()
+                fetch_response = dataset_collection_populator.create_list_in_history(history_id, contents=elements, direct_upload=True, **new_collection_kwds).json()
             else:
-                fetch_repsonse = dataset_collection_populator.create_pair_in_history(history_id, contents=elements or None, direct_upload=True, **new_collection_kwds).json()
-            hdca = dataset_populator.ds_entry(fetch_repsonse["outputs"][0])
+                fetch_response = dataset_collection_populator.create_pair_in_history(history_id, contents=elements or None, direct_upload=True, **new_collection_kwds).json()
+            hdca = dataset_populator.ds_entry(fetch_response["outputs"][0])
             label_map[key] = hdca
             inputs[key] = hdca
             has_uploads = True

--- a/test/integration/test_scripts.py
+++ b/test/integration/test_scripts.py
@@ -166,7 +166,7 @@ class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
             raise unittest.SkipTest("Test only valid for postgres")
 
     def _scripts_check_argparse_help(self, script):
-        # Test imports and argparse repsonse to --help with 0 exit code.
+        # Test imports and argparse response to --help with 0 exit code.
         output = self._scripts_check_output(script, ["--help"])
         # Test -h, --help in printed output message.
         assert "-h, --help" in output


### PR DESCRIPTION
Should speed up the tests and make it easier to write collection tests for some of these mapping issues. Also fixes a problem with the data fetch tool.