### PR TITLE
Make simple lists selectable again in multidata inputs

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1867,7 +1867,7 @@ class DataToolParameter(BaseDataToolParameter):
             match = dataset_collection_matcher.hdca_match(hdca)
             if match:
                 subcollection_type = None
-                if multiple:
+                if multiple and hdca.collection.collection_type != 'list':
                     collection_type_description = self._history_query(trans).can_map_over(hdca)
                     if collection_type_description:
                         subcollection_type = collection_type_description.collection_type

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -969,6 +969,13 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(output1_content.strip(), "Plain HDA")
 
     @skip_without_tool("identifier_multiple")
+    def test_list_selectable_in_multidata_input(self):
+        with self.dataset_populator.test_history() as history_id:
+            self.dataset_collection_populator.create_list_in_history(history_id, contents=["123", "456"])
+            build = self._post("tools/identifier_multiple/build?history_id=%s" % history_id).json()
+            assert len(build['inputs'][0]['options']['hdca']) == 1
+
+    @skip_without_tool("identifier_multiple")
     def test_identifier_in_multiple_reduce(self):
         history_id = self.dataset_populator.new_history()
         hdca_id = self.__build_pair(history_id, ["123", "456"])


### PR DESCRIPTION
This broke in https://github.com/galaxyproject/galaxy/pull/6255 and fixes https://github.com/galaxyproject/usegalaxy-playbook/issues/114#issuecomment-394810485.