### PR TITLE
[18.05] Add the canonical URL to grt config

### DIFF
--- a/scripts/grt/grt.yml.sample
+++ b/scripts/grt/grt.yml.sample
@@ -1,11 +1,13 @@
 grt:
-    # Go to https://telescope.galaxyproject.org to obtain an Instance ID and API key
+    # Register at https://telescope.galaxyproject.org to obtain an Instance ID and API key
     instance_id: 
     api_key: 
+
     # Galaxy Project offers a public galactic-radio-telescope instance, however
     # you are free to run your own if you need. We would love it if you were
     # willing and able to contribute your data publicly.
-    url: http://localhost:8080
+    url: https://telescope.galaxyproject.org/grt-admin/
+
     # Are you willing to share your toolbox? I.e. what tools are installed.
     # If your instance is public, this can help us direct users to your
     # instance. If you elect to not send your entire toolbox, we will still


### PR DESCRIPTION
The base url you might be able to devise, but the `/grt-admin/` part you probably wouldn't