### PR TITLE
Stop listening to history changes after job submission

### DIFF
--- a/client/galaxy/scripts/mvc/tool/tool-form-base.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-base.js
@@ -70,6 +70,11 @@ export default FormBase.extend({
                 self.deferred.reset();
                 self.deferred.execute(process => {
                     self.model.get("postchange")(process, self);
+                    if (self.model.get("listen_to_history")) {
+                        process.then(() => {
+                            self.stopListening(parent.Galaxy.currHistoryPanel.collection);
+                        });
+                    }
                 });
             }
         });


### PR DESCRIPTION
This PR removes the history change listener of the regular tool form after successful job submission. Currently, history changes still trigger a background event while the form success message is shown.