### PR TITLE
[18.05] Increase sleep if encountering (DB locking) exception

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -213,6 +213,9 @@ class JobHandlerQueue(Monitors):
                     self.__monitor_step()
             except Exception:
                 log.exception("Exception in monitor_step")
+                # With sqlite backends we can run into locked databases occasionally
+                # To avoid that the monitor step locks again we backoff a little longer.
+                self._monitor_sleep(5)
             self._monitor_sleep(1)
 
     def __monitor_step(self):


### PR DESCRIPTION
This is really dirty but allows planemo test on travis to pass. xref https://github.com/galaxyproject/tools-iuc/pull/1929, a passing job is here https://travis-ci.org/mvdbeek/tools-iuc/jobs/389609106 