### PR TITLE
Fix default job script by moving env setup

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -4,6 +4,8 @@ $headers
 
 _galaxy_setup_environment() {
     local _use_framework_galaxy="$1"
+    _GALAXY_JOB_HOME_DIR="$working_directory/home"
+    _GALAXY_JOB_TMP_DIR=$tmp_dir_creation_statement
     $env_setup_commands
     if [ "$GALAXY_LIB" != "None" -a "$_use_framework_galaxy" = "True" ]; then
         if [ -n "$PYTHONPATH" ]; then
@@ -13,8 +15,6 @@ _galaxy_setup_environment() {
         fi
         export PYTHONPATH
     fi
-    _GALAXY_JOB_HOME_DIR="$working_directory/home"
-    _GALAXY_JOB_TMP_DIR=$tmp_dir_creation_statement
     # These don't get cleaned on a re-run but may in the future.
     [ -z "$_GALAXY_JOB_TMP_DIR" -a ! -f "$_GALAXY_JOB_TMP_DIR" ] || mkdir -p "$_GALAXY_JOB_TMP_DIR"
     [ -z "$_GALAXY_JOB_HOME_DIR" -a ! -f "$_GALAXY_JOB_HOME_DIR" ] || mkdir -p "$_GALAXY_JOB_HOME_DIR"

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -3,8 +3,8 @@
 $headers
 
 _galaxy_setup_environment() {
-    $env_setup_commands
     local _use_framework_galaxy="$1"
+    $env_setup_commands
     if [ "$GALAXY_LIB" != "None" -a "$_use_framework_galaxy" = "True" ]; then
         if [ -n "$PYTHONPATH" ]; then
             PYTHONPATH="$GALAXY_LIB:$PYTHONPATH"

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -3,6 +3,7 @@
 $headers
 
 _galaxy_setup_environment() {
+    $env_setup_commands
     local _use_framework_galaxy="$1"
     if [ "$GALAXY_LIB" != "None" -a "$_use_framework_galaxy" = "True" ]; then
         if [ -n "$PYTHONPATH" ]; then
@@ -14,7 +15,6 @@ _galaxy_setup_environment() {
     fi
     _GALAXY_JOB_HOME_DIR="$working_directory/home"
     _GALAXY_JOB_TMP_DIR=$tmp_dir_creation_statement
-    $env_setup_commands
     # These don't get cleaned on a re-run but may in the future.
     [ -z "$_GALAXY_JOB_TMP_DIR" -a ! -f "$_GALAXY_JOB_TMP_DIR" ] || mkdir -p "$_GALAXY_JOB_TMP_DIR"
     [ -z "$_GALAXY_JOB_HOME_DIR" -a ! -f "$_GALAXY_JOB_HOME_DIR" ] || mkdir -p "$_GALAXY_JOB_HOME_DIR"


### PR DESCRIPTION
The part where pythonpath was evaluated totally ignored any variables set in the env setup. That is now fixed. All credits go to @mvdbeek for finding the cause of the issue and proposing the solution.