### PR TITLE
Fix undefined success_message

### DIFF
--- a/client/galaxy/scripts/mvc/form/form-wrapper.js
+++ b/client/galaxy/scripts/mvc/form/form-wrapper.js
@@ -80,7 +80,7 @@ var View = Backbone.View.extend({
                     form.data.matchModel(response, (input, input_id) => {
                         form.field_list[input_id].value(input.value);
                     });
-                    self._showMessage(form, success_message);
+                    self._showMessage(form, response.message);
                 }
             })
             .fail(response => {


### PR DESCRIPTION
You can see this when clicking on "Generate new API key". This is fairly inconsequential, since for some reason no message is being shown even with the fix. Possibly `_showMessage` doesn't do what it's supposed to do ?