### PR TITLE
Allow #if $datasets #end if pattern for file lists

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -354,7 +354,7 @@ class DatasetListWrapper(list, ToolParameterValueWrapper, HasDatasets):
 
     def __bool__(self):
         # Fail `#if $param` checks in cheetah if optional input is not provided
-        return len(self) > 0
+        return any(self)
     __nonzero__ = __bool__
 
 

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -352,6 +352,11 @@ class DatasetListWrapper(list, ToolParameterValueWrapper, HasDatasets):
     def __str__(self):
         return ','.join(map(str, self))
 
+    def __bool__(self):
+        # Fail `#if $param` checks in cheetah if optional input is not provided
+        return len(self) > 0
+    __nonzero__ = __bool__
+
 
 class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
 

--- a/test/functional/tools/multi_data_optional.xml
+++ b/test/functional/tools/multi_data_optional.xml
@@ -1,11 +1,13 @@
 <tool id="multi_data_optional" name="multi_data_optional" version="0.1.0">
   <command>
-    touch $out1;
+touch '$out1';
+#if $input1
     #for $input in $input1
-    #if $input
-    cat $input >> $out1;
-    #end if
+        #if $input
+            cat '$input' >> '$out1';
+        #end if
     #end for
+#end if
   </command>
   <inputs>
     <param name="input1" type="data" format="txt" multiple="true" label="Data 1" optional="true" />

--- a/test/functional/tools/multi_data_optional.xml
+++ b/test/functional/tools/multi_data_optional.xml
@@ -7,6 +7,8 @@ touch '$out1';
             cat '$input' >> '$out1';
         #end if
     #end for
+#else
+    echo "No input selected" >> '$out1'
 #end if
   </command>
   <inputs>
@@ -22,6 +24,13 @@ touch '$out1';
         <assert_contents>
           <has_line line="This is a line of text." />
           <has_line line="This is a different line of text." />
+        </assert_contents>
+      </output>
+    </test>
+    <test>
+      <output name="out1">
+        <assert_contents>
+          <has_line line="No input selected" />
         </assert_contents>
       </output>
     </test>


### PR DESCRIPTION
Otherwise the following exception occurs:
```
Traceback (most recent call last):
  File "/home/wolffj/src/galaxy/lib/galaxy/jobs/runners/__init__.py", line 191, in prepare_job
    job_wrapper.prepare()
  File "/home/wolffj/src/galaxy/lib/galaxy/jobs/__init__.py", line 858, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "/home/wolffj/src/galaxy/lib/galaxy/tools/evaluation.py", line 435, in build
    raise e
AttributeError: 'DatasetListWrapper' object has no attribute 'value'
```

This is because DatasetListWrapper inherits `__bool__` from ToolParameterValueWrapper
which defines bool as
```
    def __bool__(self):
        return bool(self.value)
    __nonzero__ = __bool__
```
while DatasetListWrapper has no `value` attribute.

Fixes https://github.com/galaxyproject/galaxy/issues/6314 reported by
@joachimwolff (many thanks for the detailed report!).