### PR TITLE
Return the return code produced by the tool script so the resource ma…

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -37,5 +37,7 @@ cd $working_directory
 $memory_statement
 $instrument_pre_commands
 $command
-echo $? > $exit_code_path
+return_code=$?
+echo $return_code > $exit_code_path
 $instrument_post_commands
+sh -c "exit $return_code"


### PR DESCRIPTION
…nager can see it.

This allows resource managers (e.g., slurm) to see the exit code produced by jobs and set the job state accordingly. This is nice in cases where Galaxy needs to run `scontrol` to check on a job state. Currently, it sees that failed jobs finished successfully...which means that it then looks for their non-existent output files. Half the time this then freezes the job handlers, which produce a bunch of errors like:

    ObjectNotFound: objectstore, _call_method failed: get_filename on <galaxy.model.Dataset object at 0x7f1e436eead0>, kwargs: {}

I mentioned this on gitter and I suspect that this change will prevent the above from happening. I'm testing this at the moment and will report back.