### PR TITLE
[WIP] [18.05] Increase upload api chunk handling size

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/uploads.py
+++ b/lib/galaxy/webapps/galaxy/api/uploads.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 class UploadsAPIController(BaseAPIController):
 
-    READ_CHUNK_SIZE = 2 ** 16
+    READ_CHUNK_SIZE = 1024 * 1024
 
     @expose_api_anonymous
     def index(self, trans, **kwd):


### PR DESCRIPTION
Attempt to improve upload performance by increasing the chunksize from 65KB to 1MB.