### PR TITLE
[18.01] Expunge jobs as being created in web threads.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1347,7 +1347,7 @@ class Tool(object, Dictifiable):
             return dict(out_data=execution_tracker.output_datasets,
                         num_jobs=len(execution_tracker.successful_jobs),
                         job_errors=execution_tracker.execution_errors,
-                        jobs=execution_tracker.successful_jobs,
+                        job_dicts=execution_tracker.successful_jobs,
                         output_collections=execution_tracker.output_collections,
                         implicit_collections=execution_tracker.implicit_collections)
 

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -64,7 +64,6 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
             message = EXECUTION_SUCCESS_MESSAGE % (tool.id, job.id, job_timer)
             log.debug(message)
             execution_tracker.record_success(execution_slice, job, result)
-            trans.sa_session.flush()
             trans.sa_session.expunge(job)
         else:
             execution_tracker.record_error(result)
@@ -373,12 +372,19 @@ class ExecutionTracker(object):
         # TODO: successful_jobs need to be inserted in the correct place...
         self.successful_jobs.append(job.to_dict(view='collection'))  # dictify so can be detached.
         self.output_datasets.extend(outputs)
+        sa_session = self.trans.sa_session
+        # TODO: in 18.05 after SA upgrade, try bulk_save_objects or a batch insert method to create
+        # these JobToOutputDatasetCollectionAssociation, ImplicitCollectionJobsJobAssociation rows
+        # instead of adding them to the SA session and ignoring them (in this thread).
         for job_output in job.output_dataset_collection_instances:
             self.output_collections.append((job_output.name, job_output.dataset_collection_instance))
         if self.implicit_collections:
             implicit_collection_jobs = None
             for output_name, collection_instance in self.implicit_collections.items():
-                job.add_output_dataset_collection(output_name, collection_instance)
+                output_assoc = model.JobToOutputDatasetCollectionAssociation(output_name, collection_instance)
+                output_assoc.job_id = job.id
+                sa_session.add(output_assoc)
+
                 if implicit_collection_jobs is None:
                     implicit_collection_jobs = collection_instance.implicit_collection_jobs
 
@@ -386,7 +392,7 @@ class ExecutionTracker(object):
             job_assoc.order_index = execution_slice.job_index
             job_assoc.implicit_collection_jobs = implicit_collection_jobs
             job_assoc.job_id = job.id
-            self.trans.sa_session.add(job_assoc)
+            sa_session.add(job_assoc)
 
 
 # Seperate these because workflows need to track their jobs belong to the invocation

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -372,8 +372,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
             output_dict['output_name'] = output_name
             outputs.append(trans.security.encode_dict_ids(output_dict, skip_startswith="metadata_"))
 
-        for job in vars.get('jobs', []):
-            rval['jobs'].append(self.encode_all_ids(trans, job.to_dict(view='collection'), recursive=True))
+        for job_dict in vars.get('job_dicts', []):
+            rval['jobs'].append(self.encode_all_ids(trans, job_dict, recursive=True))
 
         for output_name, collection_instance in vars.get('output_collections', []):
             history = target_history or trans.history

--- a/test/unit/tools/test_execution.py
+++ b/test/unit/tools/test_execution.py
@@ -156,7 +156,7 @@ class ToolExecutionTestCase(TestCase, tools_support.UsesApp, tools_support.UsesT
 
     def __assert_executed(self, vars):
         self.__assert_no_errors(vars)
-        assert len(vars['jobs']) > 0
+        assert len(vars['job_dicts']) > 0
 
     def __assert_no_errors(self, vars):
         assert "job_errors" in vars
@@ -185,7 +185,9 @@ class MockAction(object):
             if num_calls > self.error_message_after_excution:
                 return None, "Test Error Message"
 
-        return galaxy.model.Job(), odict(dict(out1="1"))
+        job = galaxy.model.Job()
+        trans.sa_session.add(job)
+        return job, odict(dict(out1="1"))
 
     def raise_exception(self, after_execution=0):
         self.exception_after_exection = after_execution


### PR DESCRIPTION
When mapping over huge collections with limited memory, this should keep the number (and hence size) of the objects in memory lower as well as the size of the SA session (and the state management it needs to do).