### PR TITLE
[18.05] Visualization static staging

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -246,4 +246,7 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
         echo "ERROR: Galaxy client build failed. See ./client/README.md for more information, including how to get help."
         exit 1
     fi
+else
+    echo "Regenerating static plugin directories."
+    python ./scripts/plugin_staging.py
 fi

--- a/scripts/get_uwsgi_args.py
+++ b/scripts/get_uwsgi_args.py
@@ -23,7 +23,7 @@ ALIASES = {
     'module': ('mount',),   # mount is not actually an alias for module, but we don't want to set module if mount is set
 }
 DEFAULT_ARGS = {
-    '_all_': ('pythonpath', 'threads', 'buffer-size', 'http', 'static-map', 'die-on-term', 'hook-master-start', 'enable-threads'),
+    '_all_': ('pythonpath', 'threads', 'buffer-size', 'http', 'static-map', 'static-safe', 'die-on-term', 'hook-master-start', 'enable-threads'),
     'galaxy': ('py-call-osafterfork',),
     'reports': (),
     'tool_shed': (),
@@ -92,6 +92,8 @@ def _get_uwsgi_args(cliargs, kwargs):
         'http': 'localhost:{port}'.format(port=DEFAULT_PORTS[cliargs.app]),
         'static-map': ('/static/style={here}/static/style/blue'.format(here=os.getcwd()),
                        '/static={here}/static'.format(here=os.getcwd())),
+        'static-safe': ('{here}/config/plugins/visualizations'.format(here=os.getcwd()),
+                        '{here}/config/plugins/interactive_environments'.format(here=os.getcwd())),
         'die-on-term': True,
         'enable-threads': True,
         'hook-master-start': ('unix_signal:2 gracefully_kill_them_all',

--- a/scripts/plugin_staging.py
+++ b/scripts/plugin_staging.py
@@ -2,13 +2,13 @@ import glob
 import os
 import shutil
 
-GXY_ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../'))
+GXY_ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 
 
 def link_up_static(f):
     src = os.path.join(GXY_ROOT, 'config/plugins', f)
     dest = os.path.join(GXY_ROOT, 'static/plugins', f)
-    dest_parent = os.path.abspath(os.path.join(dest, "../"))
+    dest_parent = os.path.abspath(os.path.join(dest, os.pardir))
     if os.path.exists(dest):
         # We have to clear out the old staged or linked static to relink.
         if os.path.islink(dest):

--- a/scripts/plugin_staging.py
+++ b/scripts/plugin_staging.py
@@ -1,0 +1,30 @@
+import glob
+import os
+import shutil
+
+GXY_ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../'))
+
+
+def link_up_static(f):
+    src = os.path.join(GXY_ROOT, 'config/plugins', f)
+    dest = os.path.join(GXY_ROOT, 'static/plugins', f)
+    dest_parent = os.path.abspath(os.path.join(dest, "../"))
+    # We have to clear out the old staged or linked static to relink.
+    if os.path.exists(dest):
+        if os.path.islink(dest):
+            os.unlink(dest)
+        else:
+            shutil.rmtree(dest)
+    elif not os.path.exists(dest_parent):
+        os.makedirs(dest_parent)
+    os.symlink(src, dest)
+
+
+if __name__ == "__main__":
+    # This is not awesome, but it's temporary, and it supports two-tier plugin static.
+    for f in glob.glob(os.path.join(GXY_ROOT, 'config/plugins/*/*/static')):
+        f = os.path.relpath(f, os.path.join(GXY_ROOT, 'config/plugins'))
+        link_up_static(f)
+    for f in glob.glob(os.path.join(GXY_ROOT, 'config/plugins/*/*/*/static')):
+        f = os.path.relpath(f, os.path.join(GXY_ROOT, 'config/plugins'))
+        link_up_static(f)

--- a/scripts/plugin_staging.py
+++ b/scripts/plugin_staging.py
@@ -9,22 +9,20 @@ def link_up_static(f):
     src = os.path.join(GXY_ROOT, 'config/plugins', f)
     dest = os.path.join(GXY_ROOT, 'static/plugins', f)
     dest_parent = os.path.abspath(os.path.join(dest, "../"))
-    # We have to clear out the old staged or linked static to relink.
     if os.path.exists(dest):
+        # We have to clear out the old staged or linked static to relink.
         if os.path.islink(dest):
             os.unlink(dest)
         else:
             shutil.rmtree(dest)
     elif not os.path.exists(dest_parent):
+        # Create parent dir structure to symlink directly to static.
         os.makedirs(dest_parent)
     os.symlink(src, dest)
 
 
 if __name__ == "__main__":
     # This is not awesome, but it's temporary, and it supports two-tier plugin static.
-    for f in glob.glob(os.path.join(GXY_ROOT, 'config/plugins/*/*/static')):
-        f = os.path.relpath(f, os.path.join(GXY_ROOT, 'config/plugins'))
-        link_up_static(f)
-    for f in glob.glob(os.path.join(GXY_ROOT, 'config/plugins/*/*/*/static')):
+    for f in glob.glob(os.path.join(GXY_ROOT, 'config/plugins/*/*/static')) + glob.glob(os.path.join(GXY_ROOT, 'config/plugins/*/*/*/static')):
         f = os.path.relpath(f, os.path.join(GXY_ROOT, 'config/plugins'))
         link_up_static(f)


### PR DESCRIPTION
In #5810, we shifted to staging visualization plugins into the predefined static route.  This happened at client build time, for simplicity in implementation and use.  Unfortunately we don't *do* a client build yet as a part of the release-branch startup, so 18.05 isn't staging this stuff.

Instead of requiring the node environment, I put together a python script that does the same globbing as the gulp task, but uses symlinks instead of copying files, to keep it fast.  If people have concerns about this, I can easily swap it to a `copytree()`, but if this works well we may want to just drop the gulp plugin staging as well (or convert it to do the same thing).  This stages both repo-included plugins and those locally deployed, something #6297 did not do.

One note is that after this has run, the gulp plugin staging won't overwrite these symlinks once they're in place.  Seems to be 100% fine, since they do effectively the same way, but it should be cleaned up down the road.