### PR TITLE
Prevent throwing an exception if a dataset doesn't exist (and never w…

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1258,7 +1258,7 @@ class JobWrapper(HasResourceParameters):
                             trynum = self.app.config.retry_job_output_collection
                         except (OSError, ObjectNotFound) as e:
                             trynum += 1
-                            log.warning('Error accessing %s, will retry: %s', dataset.dataset.file_name, e)
+                            log.warning('Error accessing dataset with ID %i, will retry: %s', dataset.dataset.id, e)
                             time.sleep(2)
                 if getattr(dataset, "hidden_beneath_collection_instance", None):
                     dataset.visible = False


### PR DESCRIPTION
…ill) due to a job error. This is an alternative (and better) solution to #6337 when jobs set metadata externally.

In short, if a job throws an error and thus doesn't create its output job, then any call to `dataset.dataset.file_name` will result in an error, at least if you use a nested data object store. You can see the error message caused by this in #6337 near the bottom of the comments. It's problematic that `log.warning()` line that I'm changing in this PR uses that function call, since it (A) prevents checking if the file is only absent due to NFS lag and (B) if the job truly did finish in an error then `Unable to finish job` is printed in the error field in the Galaxy history item rather than the actual error message printed to stderr.

It'd be nice if this and #6305 could get backported to 18.05 :)