### PR TITLE
Fix the --log-file option in the job handlers

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -723,6 +723,16 @@ class Configuration(object):
                 'qualname': 'COMPLIANCE'
             }
 
+        if kwargs.get("log_destination", None):
+            LOGGING_CONFIG_DEFAULT['handlers']['console'] = {
+                'class': 'logging.FileHandler',
+                'formatter': 'stack',
+                'level': 'DEBUG',
+                'filename': kwargs['log_destination'],
+                'filters': ['stack']
+            }
+
+
     @property
     def sentry_dsn_public(self):
         """

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -732,7 +732,6 @@ class Configuration(object):
                 'filters': ['stack']
             }
 
-
     @property
     def sentry_dsn_public(self):
         """


### PR DESCRIPTION
Since 18.01 (I skipped that release, otherwise I would have made this PR then) the `--log-file` option to `lib/galaxy/main.py` has been ignored. You can reproduce this easily with the stock `bgruening/galaxy-stable` docker images for release 18.01 or 18.05, where the logs are written to `/var/log/supervisord/hander*` rather than `/home/galaxy/logs/handler*`. This small PR fixes that issue. While one could remove the `--log-file` option and simply use the `galaxy.yaml`, it's unclear if that'd facilitate the current behavior where every job handler can easily write its log to a different file.