### PR TITLE
Add period to the list of allowed characters in user names

### DIFF
--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -604,7 +604,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
             user.set_random_password(length=12)
             user.external = True
             # Replace invalid characters in the username
-            for char in [x for x in username if x not in string.ascii_lowercase + string.digits + '-']:
+            for char in [x for x in username if x not in string.ascii_lowercase + string.digits + '-' + '.']:
                 username = username.replace(char, '-')
             # Find a unique username - user can change it later
             if self.sa_session.query(self.app.model.User).filter_by(username=username).first():


### PR DESCRIPTION
A lot of email addresses contain periods. The usernames created from them currently have periods replaced by dashes, which creates problems for real user jobs. Let's add period to the list of characters allowed in the usernames.