### PR TITLE
Optimizations for dynamic output file collection.

### DIFF
--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -499,7 +499,8 @@ class JobContext(object):
         else:
             primary_data.link_to(filename)
 
-        primary_data.set_size()
+        # We are sure there are no extra files, so optimize things that follow by settting total size also.
+        primary_data.set_size(no_extra_files=True)
         # If match specified a name use otherwise generate one from
         # designation.
         primary_data.name = name
@@ -586,7 +587,8 @@ def collect_primary_datasets(tool, output, tool_provided_metadata, job_working_d
             sa_session.flush()
             # Move data from temp location to dataset location
             app.object_store.update_from_file(primary_data.dataset, file_name=filename, create=True)
-            primary_data.set_size()
+            # We are sure there are no extra files, so optimize things that follow by settting total size also.
+            primary_data.set_size(no_extra_files=True)
             # If match specified a name use otherwise generate one from
             # designation.
             primary_data.name = fields_match.name or "%s (%s)" % (outdata.name, designation)


### PR DESCRIPTION
During the set hid and update quota parts of this operation - skip a bunch of extra flushes and skip checking for extra files since these cannot be created in conjunction with dynamic file discovery currently.

Cut this part of that operation from about 50 seconds to 7 when creating a collection with 1000 elements on my laptop against a local postgres database.