### PR TITLE
[WIP] Optimize permission loading and checking collection parameters.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3311,6 +3311,42 @@ class DatasetCollection(Dictifiable, UsesAnnotations):
         return top_level_populated
 
     @property
+    def dataset_action_tuples(self):
+        if not hasattr(self, '_dataset_action_tuples'):
+            db_session = object_session(self)
+
+            dc = alias(DatasetCollection.table)
+            de = alias(DatasetCollectionElement.table)
+            hda = alias(HistoryDatasetAssociation.table)
+            dataset = alias(Dataset.table)
+            dataset_permission = alias(DatasetPermissions.table)
+
+            select_from = dc.outerjoin(de, de.c.dataset_collection_id == dc.c.id)
+
+            depth_collection_type = self.collection_type
+            while ":" in depth_collection_type:
+                child_collection = alias(DatasetCollection.table)
+                child_collection_element = alias(DatasetCollectionElement.table)
+                select_from = select_from.outerjoin(child_collection, child_collection.c.id == de.c.child_collection_id)
+                select_from = select_from.outerjoin(child_collection_element, child_collection_element.c.dataset_collection_id == child_collection.c.id)
+
+                de = child_collection_element
+                depth_collection_type = depth_collection_type.split(":", 1)[1]
+
+            select_from = select_from.outerjoin(hda, hda.c.id == de.c.hda_id).outerjoin(dataset, hda.c.dataset_id == dataset.c.id)
+            select_from = select_from.outerjoin(dataset_permission, dataset.c.id == dataset_permission.c.dataset_id)
+
+            select_stmt = select([dataset_permission.c.action, dataset_permission.c.role_id]).select_from(select_from).where(dc.c.id == self.id).distinct()
+
+            _dataset_action_tuples = []
+            for _dataset_action_tuple in db_session.execute(select_stmt).fetchall():
+                _dataset_action_tuples.append(_dataset_action_tuple)
+
+            self._dataset_action_tuples = _dataset_action_tuples
+
+        return self._dataset_action_tuples
+
+    @property
     def waiting_for_elements(self):
         top_level_waiting = self.populated_state == DatasetCollection.populated_states.NEW
         if not top_level_waiting and self.has_subcollections:

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -54,6 +54,12 @@ class DefaultToolAction(object):
         if current_user_roles is None:
             current_user_roles = trans.get_current_user_roles()
         input_datasets = odict()
+        all_permissions = {}
+
+        def record_permission(action, role_id):
+            if action not in all_permissions:
+                all_permissions[action] = set()
+            all_permissions[action].add(role_id)
 
         def visitor(input, value, prefix, parent=None, **kwargs):
 
@@ -74,6 +80,11 @@ class DefaultToolAction(object):
 
                 if not trans.app.security_agent.can_access_dataset(current_user_roles, data.dataset):
                     raise Exception("User does not have permission to use a dataset (%s) provided for input." % data.id)
+                permissions = trans.app.security_agent.get_permissions(data.dataset)
+                for action, roles in permissions.values():
+                    for role in roles:
+                        record_permission(action.action, role.id)
+
                 return data
             if isinstance(input, DataToolParameter):
                 if isinstance(value, list):
@@ -124,25 +135,28 @@ class DefaultToolAction(object):
                 if not value:
                     return
 
-                dataset_instances = []
+                collection = None
                 if hasattr(value, 'child_collection'):
                     # if we are mapping a collection over a tool, we only require the child_collection
-                    dataset_instances = value.child_collection.dataset_instances
+                    collection = value.child_collection
                 else:
                     # else the tool takes a collection as input so we need everything
-                    dataset_instances = value.collection.dataset_instances
+                    collection = value.collection
 
-                for i, v in enumerate(dataset_instances):
-                    data = v
-                    if not trans.app.security_agent.can_access_dataset(current_user_roles, data.dataset):
-                        raise Exception("User does not have permission to use a dataset (%s) provided for input." % data.id)
+                action_tuples = collection.dataset_action_tuples
+                if not trans.app.security_agent.can_access_datasets(current_user_roles, action_tuples):
+                    raise Exception("User does not have permission to use a dataset provided for input.")
+                for action, role_id in action_tuples:
+                    record_permission(action, role_id)
+
+                for i, v in enumerate(collection.dataset_instances):
                     # Skipping implicit conversion stuff for now, revisit at
                     # some point and figure out if implicitly converting a
                     # dataset collection makes senese.
-                    input_datasets[prefix + input.name + str(i + 1)] = data
+                    input_datasets[prefix + input.name + str(i + 1)] = v
 
         tool.visit_inputs(param_values, visitor)
-        return input_datasets
+        return input_datasets, all_permissions
 
     def collect_input_dataset_collections(self, tool, param_values):
         def append_to_key(the_dict, key, value):
@@ -198,7 +212,7 @@ class DefaultToolAction(object):
         # input datasets can process these normally.
         inp_dataset_collections = self.collect_input_dataset_collections(tool, incoming)
         # Collect any input datasets from the incoming parameters
-        inp_data = self._collect_input_datasets(tool, incoming, trans, history=history, current_user_roles=current_user_roles)
+        inp_data, all_permissions = self._collect_input_datasets(tool, incoming, trans, history=history, current_user_roles=current_user_roles)
 
         # grap tags from incoming HDAs
         preserved_tags = {}
@@ -218,7 +232,7 @@ class DefaultToolAction(object):
                     for tag in [t for t in collection.tags if t.user_tname == 'name']:
                         preserved_tags[tag.value] = tag
 
-        return history, inp_data, inp_dataset_collections, preserved_tags
+        return history, inp_data, inp_dataset_collections, preserved_tags, all_permissions
 
     def execute(self, tool, trans, incoming=None, return_job=False, set_output_hid=True, history=None, job_params=None, rerun_remap_job_id=None, execution_cache=None, dataset_collection_elements=None, completed_job=None):
         """
@@ -232,7 +246,7 @@ class DefaultToolAction(object):
         if execution_cache is None:
             execution_cache = ToolExecutionCache(trans)
         current_user_roles = execution_cache.current_user_roles
-        history, inp_data, inp_dataset_collections, preserved_tags = self._collect_inputs(tool, trans, incoming, history, current_user_roles)
+        history, inp_data, inp_dataset_collections, preserved_tags, all_permissions = self._collect_inputs(tool, trans, incoming, history, current_user_roles)
 
         # Build name for output datasets based on tool name and input names
         on_text = self._get_on_text(inp_data)
@@ -272,7 +286,7 @@ class DefaultToolAction(object):
             # Determine output dataset permission/roles list
             existing_datasets = [inp for inp in inp_data.values() if inp]
             if existing_datasets:
-                output_permissions = app.security_agent.guess_derived_permissions_for_datasets(existing_datasets)
+                output_permissions = app.security_agent.guess_derived_permissions(all_permissions)
             else:
                 # No valid inputs, we will use history defaults
                 output_permissions = app.security_agent.history_get_default_permissions(history)
@@ -482,7 +496,7 @@ class DefaultToolAction(object):
         job_setup_timer = ExecutionTimer()
         # Create the job object
         job, galaxy_session = self._new_job_for_session(trans, tool, history)
-        self._record_inputs(trans, tool, job, incoming, inp_data, inp_dataset_collections, current_user_roles)
+        self._record_inputs(trans, tool, job, incoming, inp_data, inp_dataset_collections)
         self._record_outputs(job, out_data, output_collections)
         job.object_store_id = object_store_populator.object_store_id
         if job_params:
@@ -642,7 +656,7 @@ class DefaultToolAction(object):
             job.tool_version = "1.0.0"
         return job, galaxy_session
 
-    def _record_inputs(self, trans, tool, job, incoming, inp_data, inp_dataset_collections, current_user_roles):
+    def _record_inputs(self, trans, tool, job, incoming, inp_data, inp_dataset_collections):
         # FIXME: Don't need all of incoming here, just the defined parameters
         #        from the tool. We need to deal with tools that pass all post
         #        parameters to the command as a special case.
@@ -682,7 +696,7 @@ class DefaultToolAction(object):
 
         for name, value in tool.params_to_strings(incoming, trans.app).items():
             job.add_parameter(name, value)
-        self._check_input_data_access(trans, job, inp_data, current_user_roles)
+        self._record_input_datasets(trans, job, inp_data)
 
     def _record_outputs(self, job, out_data, output_collections):
         out_collections = output_collections.out_collections
@@ -695,20 +709,15 @@ class DefaultToolAction(object):
             job.add_output_dataset_collection(name, dataset_collection_instance)
             dataset_collection_instance.job = job
 
-    def _check_input_data_access(self, trans, job, inp_data, current_user_roles):
-        access_timer = ExecutionTimer()
+    def _record_input_datasets(self, trans, job, inp_data):
         for name, dataset in inp_data.items():
             if dataset:
-                if not trans.app.security_agent.can_access_dataset(current_user_roles, dataset.dataset):
-                    raise Exception("User does not have permission to use a dataset (%s) provided for input." % dataset.id)
                 if dataset in trans.sa_session:
                     job.add_input_dataset(name, dataset=dataset)
                 else:
                     job.add_input_dataset(name, dataset_id=dataset.id)
             else:
                 job.add_input_dataset(name, None)
-        job_str = job.log_str()
-        log.info("Verified access to datasets for %s %s" % (job_str, access_timer))
 
     def get_output_name(self, output, dataset, tool, on_text, trans, incoming, history, params, job_params):
         if output.label:

--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -17,7 +17,7 @@ class ModelOperationToolAction(DefaultToolAction):
             execution_cache = ToolExecutionCache(trans)
 
         current_user_roles = execution_cache.current_user_roles
-        history, inp_data, inp_dataset_collections, _ = self._collect_inputs(tool, trans, incoming, history, current_user_roles)
+        history, inp_data, inp_dataset_collections, _, _ = self._collect_inputs(tool, trans, incoming, history, current_user_roles)
 
         tool.check_inputs_ready(inp_data, inp_dataset_collections)
 
@@ -26,7 +26,7 @@ class ModelOperationToolAction(DefaultToolAction):
             execution_cache = ToolExecutionCache(trans)
 
         current_user_roles = execution_cache.current_user_roles
-        history, inp_data, inp_dataset_collections, preserved_tags = self._collect_inputs(tool, trans, incoming, history, current_user_roles)
+        history, inp_data, inp_dataset_collections, preserved_tags, all_permissions = self._collect_inputs(tool, trans, incoming, history, current_user_roles)
 
         # Build name for output datasets based on tool name and input names
         on_text = self._get_on_text(inp_data)
@@ -55,7 +55,7 @@ class ModelOperationToolAction(DefaultToolAction):
         #
         job, galaxy_session = self._new_job_for_session(trans, tool, history)
         self._produce_outputs(trans, tool, out_data, output_collections, incoming=incoming, history=history, tags=preserved_tags)
-        self._record_inputs(trans, tool, job, incoming, inp_data, inp_dataset_collections, current_user_roles)
+        self._record_inputs(trans, tool, job, incoming, inp_data, inp_dataset_collections)
         self._record_outputs(job, out_data, output_collections)
         job.state = job.states.OK
         trans.sa_session.add(job)


### PR DESCRIPTION
We were checking permissions twice it seems like to me (once when collecting the inputs into a big odict and once right before setting up the jobtoinput associations), so now only do it once. Also - avoid loading dataset permissions for each individual dataset in a collection - work with summary sets of role ids.

I still need to collect data but this really better speed up large collection operation job submissions, I'll try to get some data.