### PR TITLE
[18.05] Make sure that the workflow step has a proper state available

### DIFF
--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -1211,7 +1211,7 @@ class UsesStoredWorkflowMixin(SharableItemSecurityMixin, UsesAnnotations):
         module_injector = WorkflowModuleInjector(trans)
         for step in stored_workflow.latest_workflow.steps:
             try:
-                module_injector.inject(step)
+                module_injector.inject(step, exact_tools=False)
             except exceptions.ToolMissingException:
                 pass
 


### PR DESCRIPTION
Fixes #6353. This PR fixes a regression, by allowing the displaying controller endpoints to produce complete workflow states despite missing tools or step state errors. The shared controller mixin is used in pages and workflows.