### PR TITLE
More correct, more efficient collection operations.

### DIFF
--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -144,6 +144,14 @@ class MetadataCollection(object):
                 rval[key] = self.spec[key].param.make_copy(value, target_context=self, source_context=to_copy)
         return rval
 
+    @property
+    def requires_dataset_id(self):
+        for key in self.spec:
+            if isinstance(self.spec[key].param, FileParameter):
+                return True
+
+        return False
+
     def from_JSON_dict(self, filename=None, path_rewriter=None, json_dict=None):
         dataset = self.parent
         if filename is not None:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2523,7 +2523,6 @@ class FilterDatasetsTool(DatabaseOperationTool):
         new_elements = odict()
         for dce in elements_to_copy:
             element_identifier = dce.element_identifier
-            copied_value = dce.element_object.copy()
             if getattr(dce.element_object, "history_content_type", None) == "dataset":
                 copied_value = dce.element_object.copy(force_flush=False)
                 copied_value.visible = False
@@ -2811,7 +2810,6 @@ class FilterFromFileTool(DatabaseOperationTool):
             in_filter_file = element_identifier in filtered_identifiers
             passes_filter = in_filter_file if how_filter == "remove_if_absent" else not in_filter_file
 
-            copied_value = dce_object.copy()
             if getattr(copied_value, "history_content_type", None) == "dataset":
                 copied_value = dce_object.copy(force_flush=False)
                 copied_value.visible = False

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2810,7 +2810,7 @@ class FilterFromFileTool(DatabaseOperationTool):
             in_filter_file = element_identifier in filtered_identifiers
             passes_filter = in_filter_file if how_filter == "remove_if_absent" else not in_filter_file
 
-            if getattr(copied_value, "history_content_type", None) == "dataset":
+            if getattr(dce_object, "history_content_type", None) == "dataset":
                 copied_value = dce_object.copy(force_flush=False)
                 copied_value.visible = False
             else:

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -1464,14 +1464,14 @@ class ToolsTestCase(api.ApiTestCase):
                 "input": {'values': [dict(src="hdca", id=hdca_id)]},
                 "how|filter_source": {'batch': True, 'values': [dict(src="hdca", id=hdca_id)]}
             }
-            self._run("__FILTER_FROM_FILE__", history_id, inputs, assert_ok=True)
+            implicit_collections = self._run("__FILTER_FROM_FILE__", history_id, inputs, assert_ok=True)['implicit_collections']
+            discarded_collection, filtered_collection = implicit_collections
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             history_contents = self.dataset_populator._get_contents_request(history_id).json()
             # We should have a final collection count of 3 (2 nested collections, plus the input collection)
             new_collections = len([c for c in history_contents if c['history_content_type'] == 'dataset_collection']) - 1
             assert new_collections == 2, "Expected to generate 4 new, filtered collections, but got %d collections" % new_collections
-            filtered_collection = history_contents[7]
-            assert filtered_collection['collection_type'] == 'list:list', filtered_collection
+            assert filtered_collection['collection_type'] == discarded_collection['collection_type'] == 'list:list', filtered_collection
             collection_details = self.dataset_populator.get_history_collection_details(history_id, hid=filtered_collection['hid'])
             assert collection_details['element_count'] == 2
             first_collection_level = collection_details['elements'][0]


### PR DESCRIPTION
We were copying datasets and not assigning them new HIDs in some cases (the newer collection operations apply_rules, tag_from_file were doing the right thing here but it looks like we didn't go back and fix older operations).

With the uniform handling of dataset copying in place - I used the much more efficient history.add_datasets instead of history.add_dataset.

This also optimizes the actual HDA copying by eliminating some extra flushes. hda.copy() would flush to get an HDA before copying metadata but this is only needed if there are FileParameter metadata types (e.g. bams) so I made that flush conditional as well as the final one. So for most datatypes - this eliminates two extra flushes per dataset copied.