### PR TITLE
Optimize object store interaction during job creation.

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -129,7 +129,7 @@ class ObjectStore(object):
         """
         Set an object store identifier (``object_store_id``) for the supplied object.
 
-        For simple object stores this may no be needed and so a no-op default
+        For simple object stores this may not be needed and so a no-op default
         method is provided by this class.
         """
 
@@ -492,7 +492,7 @@ class NestedObjectStore(ObjectStore):
     def create(self, obj, **kwargs):
         """Create a backing file in a random backend."""
         self.set_object_store_id(obj)
-        return self._call_method('create', obj, **kwargs)
+        return self._call_method('create', obj, False, False, **kwargs)
 
     def set_object_store_id(self, obj):
         """Set the object store ID (backend) to use."""

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -361,15 +361,10 @@ class DefaultToolAction(object):
                     dataset_collection_elements[name].hda = data
                 trans.sa_session.add(data)
                 if not completed_job:
-                    trans.app.security_agent.set_all_dataset_permissions(data.dataset, output_permissions, new=True)
+                    trans.app.security_agent.set_all_dataset_permissions(data.dataset, output_permissions, new=True, flush=False)
             data.copy_tags_to(preserved_tags)
-
-            # Must flush before setting object store id currently.
-            # TODO: optimize this.
-
-            trans.sa_session.flush()
             if not completed_job:
-                object_store_populator.set_object_store_id(data)
+                object_store_populator.register(data)
 
             # This may not be neccesary with the new parent/child associations
             data.designation = name
@@ -491,6 +486,14 @@ class DefaultToolAction(object):
             parent_dataset.children.append(child_dataset)
 
         log.info("Added output datasets to history %s" % add_datasets_timer)
+
+        create_files_timer = ExecutionTimer()
+        # This flush is needed to assign IDs to all the output datasets so the object store
+        # can be used to create empty files needed before the job is created and dispatched.
+        trans.sa_session.flush()
+        object_store_populator.create_datasets()
+        log.info("Flushed and created output datasets in object store %s" % create_files_timer)
+
         job_setup_timer = ExecutionTimer()
         # Create the job object
         job, galaxy_session = self._new_job_for_session(trans, tool, history)
@@ -761,17 +764,24 @@ class ObjectStorePopulator(object):
     def __init__(self, app):
         self.object_store = app.object_store
         self.object_store_id = None
+        self.objects = []
 
-    def set_object_store_id(self, data):
+    def register(self, data):
         # Create an empty file immediately.  The first dataset will be
         # created in the "default" store, all others will be created in
         # the same store as the first.
-        data.dataset.object_store_id = self.object_store_id
+        dataset = data.dataset
+        dataset.object_store_id = self.object_store_id
+        self.objects.append(dataset)
         try:
-            self.object_store.create(data.dataset)
+            self.object_store.set_object_store_id(dataset)
         except ObjectInvalid:
-            raise Exception('Unable to create output dataset: object store is full')
-        self.object_store_id = data.dataset.object_store_id  # these will be the same thing after the first output
+            raise Exception('Unable to set object store id for output dataset: object store is full')
+        self.object_store_id = dataset.object_store_id  # these will be the same thing after the first output
+
+    def create_datasets(self):
+        for obj in self.objects:
+            self.object_store.create(obj)
 
 
 class OutputCollections(object):

--- a/test/unit/tools/test_actions.py
+++ b/test/unit/tools/test_actions.py
@@ -260,9 +260,11 @@ class MockObjectStore(object):
 
     def create(self, dataset):
         self.created_datasets.append(dataset)
+        if hasattr(dataset, "object_store_id") and dataset.object_store_id:
+            assert dataset.object_store_id == self.object_store_id
         if self.first_create:
             self.first_create = False
-            assert dataset.object_store_id is None
-            dataset.object_store_id = self.object_store_id
-        else:
-            assert dataset.object_store_id == self.object_store_id
+            self.set_object_store_id(dataset)
+
+    def set_object_store_id(self, dataset):
+        self.object_store_id = self.object_store_id


### PR DESCRIPTION
Redo of #1957, which I don't remember why was marked as WIP - maybe not enough test coverage for different object stores? I'll try to go through them and see if this makes sense in every case. Commit message from 2016:

Previously object_store_id on datasets was set as part of create - and create requires an object ID and therefore by extension a database flush. Together, this required a flush per output dataset while creating jobs.

This commit splits the object_store_id setting out from create - so that datasets can set an object_store_id during dataset creation and before flushing. The upshot is that flushing the database can now be done once for all datasets instead of once per dataset.

This optimization will in particular help executing tools with many outputs. For instance, the time to create a job for the sample tool create_10.xml which has 10 outputs dropped from 1086.074 ms to 230.539 ms with this change.

Before:

```
galaxy.tools DEBUG 2016-03-21 01:28:51,785 Validated and populated state for tool request (37.990 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:51,885 Handled output named out_file1 for tool create_10 (85.515 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:51,972 Handled output named out_file2 for tool create_10 (86.611 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,045 Handled output named out_file3 for tool create_10 (72.657 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,135 Handled output named out_file4 for tool create_10 (90.179 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,210 Handled output named out_file5 for tool create_10 (74.831 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,277 Handled output named out_file6 for tool create_10 (66.720 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,349 Handled output named out_file7 for tool create_10 (71.524 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,429 Handled output named out_file8 for tool create_10 (79.768 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,517 Handled output named out_file9 for tool create_10 (87.794 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,627 Handled output named out_file10 for tool create_10 (110.615 ms)
galaxy.tools.actions INFO 2016-03-21 01:28:52,720 Verified access to datasets for Job[unflushed,tool_id=create_10] (7.573 ms)
galaxy.tools.execute DEBUG 2016-03-21 01:28:52,845 Tool [create_10] created job [19] (1060.070 ms)
galaxy.tools.execute DEBUG 2016-03-21 01:28:52,871 Executed 1 job(s) for tool create_10 request: (1086.074 ms)
```

After:

```
galaxy.tools DEBUG 2016-03-21 01:30:05,284 Validated and populated state for tool request (44.121 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,299 Handled output named out_file1 for tool create_10 (1.674 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,301 Handled output named out_file2 for tool create_10 (0.983 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,302 Handled output named out_file3 for tool create_10 (1.046 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,302 Handled output named out_file4 for tool create_10 (0.490 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,303 Handled output named out_file5 for tool create_10 (0.469 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,304 Handled output named out_file6 for tool create_10 (0.512 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,304 Handled output named out_file7 for tool create_10 (0.465 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,305 Handled output named out_file8 for tool create_10 (0.462 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,305 Handled output named out_file9 for tool create_10 (0.488 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,306 Handled output named out_file10 for tool create_10 (0.446 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,393 Created output datasets in object store (0.958 ms)
galaxy.tools.actions INFO 2016-03-21 01:30:05,395 Verified access to datasets for Job[unflushed,tool_id=create_10] (0.359 ms)
galaxy.tools.execute DEBUG 2016-03-21 01:30:05,491 Tool [create_10] created job [20] (207.226 ms)
galaxy.tools.execute DEBUG 2016-03-21 01:30:05,515 Executed 1 job(s) for tool create_10 request: (230.539 ms)
```

2018 Update:

Before:

```
galaxy.tools DEBUG 2018-07-11 10:42:41,022 Validated and populated state for tool request (29.381 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,098 Handled output named out_file1 for tool create_10 (39.768 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,134 Handled output named out_file2 for tool create_10 (36.049 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,158 Handled output named out_file3 for tool create_10 (23.248 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,189 Handled output named out_file4 for tool create_10 (30.977 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,214 Handled output named out_file5 for tool create_10 (24.703 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,241 Handled output named out_file6 for tool create_10 (27.051 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,266 Handled output named out_file7 for tool create_10 (24.537 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,286 Handled output named out_file8 for tool create_10 (20.224 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,314 Handled output named out_file9 for tool create_10 (27.965 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,338 Handled output named out_file10 for tool create_10 (23.216 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,349 Added output datasets to history (11.667 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,389 Verified access to datasets for Job[unflushed,tool_id=create_10] (12.976 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,391 Setup for job Job[unflushed,tool_id=create_10] complete, ready to flush (41.107 ms)
galaxy.tools.actions INFO 2018-07-11 10:42:41,554 Flushed transaction for job Job[id=796,tool_id=create_10] (163.344 ms)
galaxy.tools.execute DEBUG 2018-07-11 10:42:41,554 Tool [create_10] created job [796] (508.126 ms)
galaxy.tools.execute DEBUG 2018-07-11 10:42:41,568 Executed 1 job(s) for tool create_10 request: (545.887 ms)
```

```
galaxy.tools DEBUG 2018-07-11 10:43:11,661 Validated and populated state for tool request (30.725 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,719 Handled output named out_file1 for tool create_10 (28.891 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,749 Handled output named out_file2 for tool create_10 (30.141 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,772 Handled output named out_file3 for tool create_10 (22.289 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,800 Handled output named out_file4 for tool create_10 (28.049 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,823 Handled output named out_file5 for tool create_10 (23.349 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,850 Handled output named out_file6 for tool create_10 (26.663 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,872 Handled output named out_file7 for tool create_10 (22.054 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,895 Handled output named out_file8 for tool create_10 (22.321 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,921 Handled output named out_file9 for tool create_10 (25.864 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,944 Handled output named out_file10 for tool create_10 (23.588 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,956 Added output datasets to history (11.594 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,984 Verified access to datasets for Job[unflushed,tool_id=create_10] (13.128 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:11,985 Setup for job Job[unflushed,tool_id=create_10] complete, ready to flush (29.103 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:12,121 Flushed transaction for job Job[id=797,tool_id=create_10] (135.326 ms)
galaxy.tools.execute DEBUG 2018-07-11 10:43:12,121 Tool [create_10] created job [797] (444.143 ms)
galaxy.tools.execute DEBUG 2018-07-11 10:43:12,129 Executed 1 job(s) for tool create_10 request: (467.166 ms)
```

```
galaxy.tools DEBUG 2018-07-11 10:43:40,914 Validated and populated state for tool request (32.204 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:40,967 Handled output named out_file1 for tool create_10 (29.785 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:40,997 Handled output named out_file2 for tool create_10 (29.449 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,030 Handled output named out_file3 for tool create_10 (32.614 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,054 Handled output named out_file4 for tool create_10 (23.970 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,084 Handled output named out_file5 for tool create_10 (29.455 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,108 Handled output named out_file6 for tool create_10 (24.020 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,134 Handled output named out_file7 for tool create_10 (26.043 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,157 Handled output named out_file8 for tool create_10 (22.831 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,180 Handled output named out_file9 for tool create_10 (22.608 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,206 Handled output named out_file10 for tool create_10 (26.423 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,219 Added output datasets to history (12.136 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,240 Verified access to datasets for Job[unflushed,tool_id=create_10] (4.538 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,241 Setup for job Job[unflushed,tool_id=create_10] complete, ready to flush (22.113 ms)
galaxy.tools.actions INFO 2018-07-11 10:43:41,379 Flushed transaction for job Job[id=798,tool_id=create_10] (137.643 ms)
galaxy.tools.execute DEBUG 2018-07-11 10:43:41,379 Tool [create_10] created job [798] (451.823 ms)
galaxy.tools.execute DEBUG 2018-07-11 10:43:41,384 Executed 1 job(s) for tool create_10 request: (469.798 ms)
```

After:

```
galaxy.tools DEBUG 2018-07-11 10:40:27,010 Validated and populated state for tool request (25.209 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,070 Handled output named out_file1 for tool create_10 (0.919 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,072 Handled output named out_file2 for tool create_10 (0.678 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,072 Handled output named out_file3 for tool create_10 (0.625 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,073 Handled output named out_file4 for tool create_10 (0.656 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,074 Handled output named out_file5 for tool create_10 (0.536 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,074 Handled output named out_file6 for tool create_10 (0.523 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,075 Handled output named out_file7 for tool create_10 (0.619 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,076 Handled output named out_file8 for tool create_10 (0.520 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,076 Handled output named out_file9 for tool create_10 (0.511 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,077 Handled output named out_file10 for tool create_10 (0.505 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,086 Added output datasets to history (9.083 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,200 Flushed and created output datasets in object store (114.165 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,232 Verified access to datasets for Job[unflushed,tool_id=create_10] (9.520 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,233 Setup for job Job[unflushed,tool_id=create_10] complete, ready to flush (32.752 ms)
galaxy.tools.actions INFO 2018-07-11 10:40:27,353 Flushed transaction for job Job[id=794,tool_id=create_10] (119.376 ms)
galaxy.tools.execute DEBUG 2018-07-11 10:40:27,353 Tool [create_10] created job [794] (303.204 ms)
galaxy.tools.execute DEBUG 2018-07-11 10:40:27,368 Executed 1 job(s) for tool create_10 request: (357.917 ms)
```

```
galaxy.tools DEBUG 2018-07-11 10:41:04,795 Validated and populated state for tool request (26.054 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,823 Handled output named out_file1 for tool create_10 (0.746 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,824 Handled output named out_file2 for tool create_10 (0.564 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,825 Handled output named out_file3 for tool create_10 (0.536 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,825 Handled output named out_file4 for tool create_10 (0.534 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,826 Handled output named out_file5 for tool create_10 (0.538 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,827 Handled output named out_file6 for tool create_10 (0.533 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,827 Handled output named out_file7 for tool create_10 (0.564 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,828 Handled output named out_file8 for tool create_10 (0.659 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,829 Handled output named out_file9 for tool create_10 (0.726 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,830 Handled output named out_file10 for tool create_10 (0.732 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,842 Added output datasets to history (11.760 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,924 Flushed and created output datasets in object store (82.721 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,950 Verified access to datasets for Job[unflushed,tool_id=create_10] (8.627 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:04,951 Setup for job Job[unflushed,tool_id=create_10] complete, ready to flush (26.823 ms)
galaxy.tools.actions INFO 2018-07-11 10:41:05,039 Flushed transaction for job Job[id=795,tool_id=create_10] (87.433 ms)
galaxy.tools.execute DEBUG 2018-07-11 10:41:05,039 Tool [create_10] created job [795] (230.128 ms)
galaxy.tools.execute DEBUG 2018-07-11 10:41:05,052 Executed 1 job(s) for tool create_10 request: (256.591 ms)
```
