### PR TITLE
Fix for rendering multiple dependent dynamic select lists

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -965,7 +965,7 @@ class SelectToolParameter(ToolParameter):
             return []
 
     def to_dict(self, trans, other_values={}):
-        d = super(SelectToolParameter, self).to_dict(trans)
+        d = super(SelectToolParameter, self).to_dict(trans, other_values)
 
         # Get options, value.
         options = self.get_options(trans, other_values)


### PR DESCRIPTION
where choosing an option in the first refreshes the options in the second.  

This fixes the problem I discovered when building this tool https://github.com/galaxyproject/tools-iuc/tree/master/tools/meme_chip, and it now continues to support the example for using this feature documented here https://docs.galaxyproject.org/en/latest/dev/schema.html#dynamic-options.  

If this is merged, I will add some fixes to the tool above so that the centrimo option can be used.  This will require this tool to be merged though: https://github.com/galaxyproject/tools-iuc/pull/1772