### PR TITLE
[18.05] Specify standard HTTPTransport for Sentry

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -193,7 +193,7 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
 
             def postfork_sentry_client():
                 import raven
-                self.sentry_client = raven.Client(self.config.sentry_dsn)
+                self.sentry_client = raven.Client(self.config.sentry_dsn, transport=raven.transport.HTTPTransport)
 
             self.application_stack.register_postfork_function(postfork_sentry_client)
 

--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -41,7 +41,7 @@ class SentryPlugin(ErrorPlugin):
         # if they've set a custom one, override.
         if self.custom_dsn:
             import raven
-            self.sentry = raven.Client(self.custom_dsn)
+            self.sentry = raven.Client(self.custom_dsn, transport=raven.transport.HTTPTransport)
 
     def submit_report(self, dataset, job, tool, **kwargs):
         """Submit the error report to sentry


### PR DESCRIPTION
This should play nicer with a wider array of uwsgi configurations.