### PR TITLE
[18.01] Revert "Remove bam to bai converter"

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -18,6 +18,7 @@
       <display file="igb/bam.xml" />
       <display file="iobio/bam.xml" />
     </datatype>
+    <datatype extension="bai" type="galaxy.datatypes.binary:Binary" subclass="true" display_in_upload="false"/>
     <datatype extension="qname_input_sorted.bam" type="galaxy.datatypes.binary:BamInputSorted" mimetype="application/octet-stream" display_in_upload="false" description="A binary file compressed in the BGZF format with a '.bam' file extension and sorted based on the aligner output." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM">
     </datatype>
     <datatype extension="qname_sorted.bam" type="galaxy.datatypes.binary:BamQuerynameSorted" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension and sorted by queryname." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM">

--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -9,6 +9,7 @@
     <datatype extension="axt" type="galaxy.datatypes.sequence:Axt" display_in_upload="true" description="blastz pairwise alignment format.  Each alignment block in an axt file contains three lines: a summary line and 2 sequence lines.  Blocks are separated from one another by blank lines.  The summary line contains chromosomal position and size information about the alignment. It consists of 9 required fields." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Axt"/>
     <datatype extension="fli" type="galaxy.datatypes.tabular:FeatureLocationIndex" display_in_upload="false"/>
     <datatype extension="bam" type="galaxy.datatypes.binary:Bam" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM">
+      <converter file="bam_to_bai.xml" target_datatype="bai"/>
       <converter file="bam_to_bigwig_converter.xml" target_datatype="bigwig"/>
       <converter file="to_qname_sorted_bam.xml" target_datatype="qname_sorted.bam"/>
       <display file="ucsc/bam.xml" />

--- a/lib/galaxy/datatypes/converters/bam_to_bai.xml
+++ b/lib/galaxy/datatypes/converters/bam_to_bai.xml
@@ -1,0 +1,14 @@
+<tool id="CONVERTER_Bam_Bai_0" name="Bam to Bai" version="1.0.0" hidden="true">
+    <requirements>
+        <requirement type="package">samtools</requirement>
+    </requirements>
+    <command>samtools index '$input1' '$output1'</command>
+    <inputs>
+        <param format="bam" name="input1" type="data" label="Choose BAM"/>
+    </inputs>
+    <outputs>
+        <data format="bai" name="output1"/>
+    </outputs>
+    <help>
+    </help>
+</tool>


### PR DESCRIPTION
This reverts commit 7e2727bc0a74868198e7e457f99df3d1e39f1ddb from xref: #4598

More discussion on gitter, but it turns out we actually do need the converter for trackster (for now).  Fixes #5167, 