### PR TITLE
Allow resource selection for data managers

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -380,7 +380,7 @@ class JobConfiguration(ConfiguresHandlers):
 
         :returns: List of parameter elements.
         """
-        if tool_id and tool_type is 'default':
+        if tool_id and tool_type in ('default', 'manage_data'):
             # TODO: Only works with exact matches, should handle different kinds of ids
             # the way destination lookup does.
             resource_group = None


### PR DESCRIPTION
We used to restrict this to standard tools,
but there's no reason why this shouldn't work
for data manager tools. Fixes https://github.com/galaxyproject/galaxy/issues/6396