### PR TITLE
Add py34-unit (allowed to fail) job to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
   include:
     - env: TOX_ENV=py34-first_startup
       addons:
+        &py3_addons
         apt:
           packages:
             # For psutil, pyyaml, uwsgi...
@@ -33,7 +34,10 @@ matrix:
         apt:
           packages:
             - ack-grep
+    - env: TOX_ENV=py34-unit
+      addons: *py3_addons
   allow_failures:
+    - env: TOX_ENV=py34-unit
     - env: TOX_ENV=check_python_dependencies
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
   - set -e
   - pip install tox
   - |
-    if [ "$TOX_ENV" == "py27-first_startup" ]; then
+    if [ "$TOX_ENV" == "py27-first_startup" -o "$TOX_ENV" == "py34-first_startup" ]; then
         sh scripts/common_startup.sh
         wget -q https://github.com/jmchilton/galaxy-downloads/raw/master/db_gx_rev_0127.sqlite
         mv db_gx_rev_0127.sqlite database/universe.sqlite


### PR DESCRIPTION
Also speedup the py34-first_startup TravisCI job by skipping most database migrations, as for py27-first_startup.

xref. #1715