### PR TITLE
Implement authnz API endpoints

### DIFF
--- a/config/oidc_backends_config.xml.sample
+++ b/config/oidc_backends_config.xml.sample
@@ -3,7 +3,7 @@
     <provider name="Google">
         <client_id> ... </client_id>
         <client_secret> ... </client_secret>
-        <redirect_uri>http://localhost:8080/authnz/google/callback</redirect_uri>
+        <redirect_uri>http://localhost:8080/api/authnz/google/callback</redirect_uri>
 
         <!-- <prompt>select_account</prompt> -->
         <!--The value of this parameter (i.e., prompt) specifies whether the Google authorization server should prompt

--- a/lib/galaxy/webapps/galaxy/api/authnz.py
+++ b/lib/galaxy/webapps/galaxy/api/authnz.py
@@ -108,7 +108,7 @@ class OIDC(BaseAPIController):
         trans.handle_user_login(user)
         return {"message": message}
 
-    @web.expose
+    @web.expose_api
     @web.require_login("authenticate against the selected identity provider")
     def disconnect(self, trans, provider, **kwargs):
         """

--- a/lib/galaxy/webapps/galaxy/api/authnz.py
+++ b/lib/galaxy/webapps/galaxy/api/authnz.py
@@ -8,12 +8,12 @@ import logging
 
 from galaxy import web
 from galaxy.web import url_for
-from galaxy.web.base.controller import BaseUIController
+from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)
 
 
-class OIDC(BaseUIController):
+class OIDC(BaseAPIController):
 
     @web.expose
     @web.require_login("list third-party identities")
@@ -42,7 +42,7 @@ class OIDC(BaseUIController):
             log.debug(msg)
             return trans.show_error_message(msg)
         success, message, redirect_uri = trans.app.authnz_manager.authenticate(provider, trans)
-        return trans.response.send_redirect(web.url_for(redirect_uri))
+        return redirect_uri
 
     @web.expose
     def callback(self, trans, provider, **kwargs):
@@ -73,18 +73,7 @@ class OIDC(BaseUIController):
                                             "identity provider. Please try again, and if the problem persists, "
                                             "contact the Galaxy instance admin.".format(provider))
         trans.handle_user_login(user)
-        return trans.fill_template('/user/login.mako',
-                                   login=user.username,
-                                   header="",
-                                   use_panels=False,
-                                   redirect_url=redirect_url,
-                                   redirect=redirect_url,
-                                   refresh_frames='refresh_frames',
-                                   message="You are now logged in as `{}.`".format(user.username),
-                                   status='done',
-                                   openid_providers=trans.app.openid_providers,
-                                   form_input_auto_focus=True,
-                                   active_view="user")
+        return {"message": message}
 
     @web.expose
     @web.require_login("authenticate against the selected identity provider")
@@ -99,4 +88,4 @@ class OIDC(BaseUIController):
             return trans.show_error_message(message)
         if redirect_url is None:
             redirect_url = url_for('/')
-        return trans.response.send_redirect(redirect_url)
+        return redirect_url

--- a/lib/galaxy/webapps/galaxy/api/authnz.py
+++ b/lib/galaxy/webapps/galaxy/api/authnz.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import logging
 
 from galaxy import web
+from galaxy.exceptions import MessageException
 from galaxy.web import url_for
 from galaxy.web.base.controller import BaseAPIController
 
@@ -38,9 +39,8 @@ class OIDC(BaseAPIController):
     @web.expose
     def login(self, trans, provider):
         if not trans.app.config.enable_oidc:
-            msg = "Login to Galaxy using third-party identities is not enabled on this Galaxy instance."
-            log.debug(msg)
-            return trans.show_error_message(msg)
+            raise MessageException(
+                err_msg = "Login to Galaxy using third-party identities is not enabled on this Galaxy instance.")
         success, message, redirect_uri = trans.app.authnz_manager.authenticate(provider, trans)
         return redirect_uri
 
@@ -48,30 +48,30 @@ class OIDC(BaseAPIController):
     def callback(self, trans, provider, **kwargs):
         user = trans.user.username if trans.user is not None else 'anonymous'
         if not bool(kwargs):
-            log.error("OIDC callback received no data for provider `{}` and user `{}`".format(provider, user))
-            return trans.show_error_message(
-                'Did not receive any information from the `{}` identity provider to complete user `{}` authentication '
-                'flow. Please try again, and if the problem persists, contact the Galaxy instance admin. Also note '
-                'that this endpoint is to receive authentication callbacks only, and should not be called/reached by '
-                'a user.'.format(provider, user))
+            raise MessageException(
+                err_msg = "Did not receive any information from the `{}` identity provider to complete user `{}` "
+                          "authentication flow. Please try again, and if the problem persists, contact the Galaxy "
+                          "instance admin. Also note that this endpoint is to receive authentication callbacks only, "
+                          "and should not be called/reached by a user.".format(provider, user))
         if 'error' in kwargs:
-            log.error("Error handling authentication callback from `{}` identity provider for user `{}` login request."
-                      " Error message: {}".format(provider, user, kwargs.get('error', 'None')))
-            return trans.show_error_message('Failed to handle authentication callback from {}. '
-                                            'Please try again, and if the problem persists, contact '
-                                            'the Galaxy instance admin'.format(provider))
+            raise MessageException(
+                err_msg = "Failed to handle authentication callback from {}. Please try again, and if the problem "
+                          "persists, contact the Galaxy instance admin".format(provider),
+                provider_returned_error = kwargs.get('error', 'None'))
+
         success, message, (redirect_url, user) = trans.app.authnz_manager.callback(provider,
                                                                                    kwargs['state'],
                                                                                    kwargs['code'],
                                                                                    trans,
                                                                                    login_redirect_url=url_for('/'))
         if success is False:
-            return trans.show_error_message(message)
+            raise MessageException(err_msg = message)
         user = user if user is not None else trans.user
         if user is None:
-            return trans.show_error_message("An unknown error occurred when handling the callback from `{}` "
-                                            "identity provider. Please try again, and if the problem persists, "
-                                            "contact the Galaxy instance admin.".format(provider))
+            raise MessageException(
+                err_msg = "An unknown error occurred when handling the callback from `{}` identity provider. "
+                          "Please try again, and if the problem persists, contact the admin of this Galaxy "
+                          "instance.".format(provider))
         trans.handle_user_login(user)
         return {"message": message}
 
@@ -85,7 +85,7 @@ class OIDC(BaseAPIController):
                                                                              trans,
                                                                              disconnect_redirect_url=url_for('/'))
         if success is False:
-            return trans.show_error_message(message)
+            raise MessageException(err_msg = message)
         if redirect_url is None:
             redirect_url = url_for('/')
         return redirect_url

--- a/lib/galaxy/webapps/galaxy/api/authnz.py
+++ b/lib/galaxy/webapps/galaxy/api/authnz.py
@@ -7,6 +7,9 @@ from __future__ import absolute_import
 import logging
 
 from galaxy import web
+from galaxy.web import (
+    _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
+)
 from galaxy.exceptions import MessageException
 from galaxy.web import url_for
 from galaxy.web.base.controller import BaseAPIController
@@ -36,7 +39,7 @@ class OIDC(BaseAPIController):
             rtv.append({'id': trans.app.security.encode_id(authnz.id), 'provider': authnz.provider})
         return rtv
 
-    @web.expose
+    @expose_api_anonymous_and_sessionless
     def login(self, trans, provider):
         if not trans.app.config.enable_oidc:
             raise MessageException(
@@ -44,7 +47,7 @@ class OIDC(BaseAPIController):
         success, message, redirect_uri = trans.app.authnz_manager.authenticate(provider, trans)
         return redirect_uri
 
-    @web.expose
+    @expose_api_anonymous_and_sessionless
     def callback(self, trans, provider, **kwargs):
         user = trans.user.username if trans.user is not None else 'anonymous'
         if not bool(kwargs):

--- a/lib/galaxy/webapps/galaxy/api/authnz.py
+++ b/lib/galaxy/webapps/galaxy/api/authnz.py
@@ -1,5 +1,5 @@
 """
-OAuth 2.0 and OpenID Connect Authentication and Authorization Controller.
+OpenID Connect (OIDC) Authentication and Authorization (authnz) API.
 """
 
 from __future__ import absolute_import
@@ -41,6 +41,19 @@ class OIDC(BaseAPIController):
 
     @expose_api_anonymous_and_sessionless
     def login(self, trans, provider):
+        """
+        GET /api/authnz/{provider}/login
+            returns a URL to be used to initiate a user authentication on the given provider.
+
+        :type  trans: galaxy.web.framework.webapp.GalaxyWebTransaction
+        :param trans: Galaxy web transaction.
+
+        :type  provider: string
+        :param provider: The name of the provider which should be used to authenticate a user.
+
+        :rtype:  string
+        :return: A URL that should be to initiated a user authentication process.
+        """
         if not trans.app.config.enable_oidc:
             raise MessageException(
                 err_msg = "Login to Galaxy using third-party identities is not enabled on this Galaxy instance.")
@@ -49,6 +62,23 @@ class OIDC(BaseAPIController):
 
     @expose_api_anonymous_and_sessionless
     def callback(self, trans, provider, **kwargs):
+        """
+        GET /api/authnz/{provider}/callback
+            This API handles an OIDC identity provider (e.g., Google) callback, which is
+            initiated as a result of calling the URL returned from the `/api/authnz/{provider}/login`.
+
+        :type  trans: galaxy.web.framework.webapp.GalaxyWebTransaction
+        :param trans: Galaxy web transaction.
+
+        :type  provider: string
+        :param provider: The name of the provider which should be used to authenticate a user.
+
+        :param kwargs: keyword arguments returned from the OIDC identity provider. It must contain
+        `state` and `code` arguments, among others.
+
+        :rtype:  string
+        :return: a success/error message as a result of handling the callback.
+        """
         user = trans.user.username if trans.user is not None else 'anonymous'
         if not bool(kwargs):
             raise MessageException(
@@ -81,6 +111,22 @@ class OIDC(BaseAPIController):
     @web.expose
     @web.require_login("authenticate against the selected identity provider")
     def disconnect(self, trans, provider, **kwargs):
+        """
+        Get /api/authnz/{provider}/disconnect
+            Disconnects the logged-in user from the given identity provider (`provider`).
+            For details, see the `disconnect` function in the following path `lib/authnz/psa_authnz.py`.
+
+        :type  trans: galaxy.web.framework.webapp.GalaxyWebTransaction
+        :param trans: Galaxy web transaction.
+
+        :type  provider: string
+        :param provider: The name of the provider which should be used to authenticate a user.
+
+        :param kwargs:
+
+        :rtype:
+        :return:
+        """
         if trans.user is None:
             # Only logged in users are allowed here.
             return

--- a/lib/galaxy/webapps/galaxy/api/authnz.py
+++ b/lib/galaxy/webapps/galaxy/api/authnz.py
@@ -7,10 +7,10 @@ from __future__ import absolute_import
 import logging
 
 from galaxy import web
+from galaxy.exceptions import MessageException
 from galaxy.web import (
     _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
 )
-from galaxy.exceptions import MessageException
 from galaxy.web import url_for
 from galaxy.web.base.controller import BaseAPIController
 
@@ -56,7 +56,7 @@ class OIDC(BaseAPIController):
         """
         if not trans.app.config.enable_oidc:
             raise MessageException(
-                err_msg = "Login to Galaxy using third-party identities is not enabled on this Galaxy instance.")
+                err_msg="Login to Galaxy using third-party identities is not enabled on this Galaxy instance.")
         success, message, redirect_uri = trans.app.authnz_manager.authenticate(provider, trans)
         return redirect_uri
 
@@ -82,15 +82,15 @@ class OIDC(BaseAPIController):
         user = trans.user.username if trans.user is not None else 'anonymous'
         if not bool(kwargs):
             raise MessageException(
-                err_msg = "Did not receive any information from the `{}` identity provider to complete user `{}` "
-                          "authentication flow. Please try again, and if the problem persists, contact the Galaxy "
-                          "instance admin. Also note that this endpoint is to receive authentication callbacks only, "
-                          "and should not be called/reached by a user.".format(provider, user))
+                err_msg="Did not receive any information from the `{}` identity provider to complete user `{}` "
+                        "authentication flow. Please try again, and if the problem persists, contact the Galaxy "
+                        "instance admin. Also note that this endpoint is to receive authentication callbacks only, "
+                        "and should not be called/reached by a user.".format(provider, user))
         if 'error' in kwargs:
             raise MessageException(
-                err_msg = "Failed to handle authentication callback from {}. Please try again, and if the problem "
-                          "persists, contact the Galaxy instance admin".format(provider),
-                provider_returned_error = kwargs.get('error', 'None'))
+                err_msg="Failed to handle authentication callback from {}. Please try again, and if the problem "
+                        "persists, contact the Galaxy instance admin".format(provider),
+                provider_returned_error=kwargs.get('error', 'None'))
 
         success, message, (redirect_url, user) = trans.app.authnz_manager.callback(provider,
                                                                                    kwargs['state'],
@@ -98,13 +98,13 @@ class OIDC(BaseAPIController):
                                                                                    trans,
                                                                                    login_redirect_url=url_for('/'))
         if success is False:
-            raise MessageException(err_msg = message)
+            raise MessageException(err_msg=message)
         user = user if user is not None else trans.user
         if user is None:
             raise MessageException(
-                err_msg = "An unknown error occurred when handling the callback from `{}` identity provider. "
-                          "Please try again, and if the problem persists, contact the admin of this Galaxy "
-                          "instance.".format(provider))
+                err_msg="An unknown error occurred when handling the callback from `{}` identity provider. "
+                        "Please try again, and if the problem persists, contact the admin of this Galaxy "
+                        "instance.".format(provider))
         trans.handle_user_login(user)
         return {"message": message}
 
@@ -134,7 +134,7 @@ class OIDC(BaseAPIController):
                                                                              trans,
                                                                              disconnect_redirect_url=url_for('/'))
         if success is False:
-            raise MessageException(err_msg = message)
+            raise MessageException(err_msg=message)
         if redirect_url is None:
             redirect_url = url_for('/')
         return redirect_url

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -66,12 +66,6 @@ def app_factory(global_conf, load_app_kwds={}, **kwargs):
     # Force /activate to go to the controller
     webapp.add_route('/activate', controller='user', action='activate')
 
-    # Authentication endpoints.
-    webapp.add_route('/authnz/', controller='authnz', action='index', provider=None)
-    webapp.add_route('/authnz/{provider}/login', controller='authnz', action='login', provider=None)
-    webapp.add_route('/authnz/{provider}/callback', controller='authnz', action='callback', provider=None)
-    webapp.add_route('/authnz/{provider}/disconnect', controller='authnz', action='disconnect', provider=None)
-
     # These two routes handle our simple needs at the moment
     webapp.add_route('/async/{tool_id}/{data_id}/{data_secret}', controller='async', action='index', tool_id=None, data_id=None, data_secret=None)
     webapp.add_route('/{controller}/{action}', action='index')
@@ -229,6 +223,27 @@ def populate_api_routes(webapp, app):
                            name_prefix='group_',
                            path_prefix='/api/groups/{group_id}',
                            parent_resources=dict(member_name='group', collection_name='groups'))
+
+    webapp.mapper.connect('authnz',
+                          '/api/authnz/',
+                          controller='authnz',
+                          action='index')
+    webapp.mapper.connect('authnz_login',
+                          '/api/authnz/{provider}/login',
+                          controller='authnz',
+                          action='login',
+                          conditions = dict(method=["GET"]))
+    webapp.mapper.connect('authnz_callback',
+                          '/api/authnz/{provider}/callback',
+                          controller='authnz',
+                          action='callback',
+                          conditions=dict(method=["GET"]))
+    webapp.mapper.connect('authnz_disconnect',
+                          '/api/authnz/{provider}/disconnect',
+                          controller='authnz',
+                          action='disconnect',
+                          conditions = dict(method=["GET"]))
+
     webapp.mapper.resource('role',
                            'roles',
                            controller='group_roles',

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -232,7 +232,7 @@ def populate_api_routes(webapp, app):
                           '/api/authnz/{provider}/login',
                           controller='authnz',
                           action='login',
-                          conditions = dict(method=["GET"]))
+                          conditions=dict(method=["GET"]))
     webapp.mapper.connect('authnz_callback',
                           '/api/authnz/{provider}/callback',
                           controller='authnz',
@@ -242,7 +242,7 @@ def populate_api_routes(webapp, app):
                           '/api/authnz/{provider}/disconnect',
                           controller='authnz',
                           action='disconnect',
-                          conditions = dict(method=["GET"]))
+                          conditions=dict(method=["GET"]))
 
     webapp.mapper.resource('role',
                            'roles',


### PR DESCRIPTION
Authnz was initially implemented as a controller; however, to adhere with the design decisions of the new login architecture, the controllers are replaced by API endpoints. 

The core functionality remains intact; however, some interactions are changed. For instance, previously the `login` controller was redirecting to the given IdP, while the new `login` API returns a URL to be called to initiate authentication. 

ping @guerler @dannon 