### PR TITLE
removing binary as input for python compatibility

### DIFF
--- a/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -82,7 +82,7 @@ class ToolPanelManager(object):
         lock = threading.Lock()
         lock.acquire(True)
         try:
-            fh = open(config_filename, 'wb')
+            fh = open(config_filename, 'w')
             fh.write('<?xml version="1.0"?>\n<toolbox tool_path="%s">\n' % str(tool_path))
             for elem in config_elems:
                 fh.write(xml_util.xml_to_string(elem, use_indent=True))


### PR DESCRIPTION
tested for python 2 and 3

Fixes 1 failure in unit tests.

xref. #1715