### PR TITLE
Fixes for uploading empty files to Galaxy.

### DIFF
--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -393,8 +393,10 @@ class Ms2(Text):
         header_lines = []
         while True:
             line = contents.readline()
-            if line is None or len(line) == 0:
-                pass
+            if not line:
+                return False
+            if line.strip() == "":
+                continue
             elif line.startswith('H\t'):
                 header_lines.append(line)
             else:

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -290,6 +290,9 @@ def guess_ext(fname, sniff_order, is_binary=False):
     >>> from galaxy.datatypes.registry import example_datatype_registry_for_sample
     >>> datatypes_registry = example_datatype_registry_for_sample()
     >>> sniff_order = datatypes_registry.sniff_order
+    >>> fname = get_test_fname('empty.txt')
+    >>> guess_ext(fname, sniff_order)
+    'txt'
     >>> fname = get_test_fname('megablast_xml_parser_test1.blastxml')
     >>> guess_ext(fname, sniff_order)
     'blastxml'

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -108,7 +108,7 @@ def add_file(dataset, registry, output_path):
     if not os.path.exists(dataset.path):
         raise UploadProblemException('Uploaded temporary file (%s) does not exist.' % dataset.path)
 
-    if not os.path.getsize(dataset.path) > 0:
+    if check_content and not os.path.getsize(dataset.path) > 0:
         raise UploadProblemException('The uploaded file is empty')
 
     stdout, ext, datatype, is_binary, converted_path = handle_upload(


### PR DESCRIPTION
Don't enable it by default, but if check content is off it should be allowed. Also if an empty file is sniffed - don't hang indefinitely - which is what happen now a proteomics datatype sniffer.

#GCCBOSC #CoFEST