### PR TITLE
Remove installation of python-lzo system dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ matrix:
           packages:
             # For psutil, pyyaml, uwsgi...
             - libpython3.4-dev
-            # For python-lzo
-            - liblzo2-dev
-            - zlib1g-dev
     - env: TOX_ENV=validate_test_tools
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - set -e
   - pip install tox
   - |
-    if [ "$TOX_ENV" == "py27-first_startup" -o "$TOX_ENV" == "py34-first_startup" ]; then
+    if [ "$TOX_ENV" == "py27-first_startup" ]; then
         sh scripts/common_startup.sh
         wget -q https://github.com/jmchilton/galaxy-downloads/raw/master/db_gx_rev_0127.sqlite
         mv db_gx_rev_0127.sqlite database/universe.sqlite


### PR DESCRIPTION
for testing under Python 3. We have Python 3 wheels now, thanks @natefoo !

Also revert commit e49ee43, which was not making `py34-first_startup` faster because it was creating a Python2 virtual environment just for the final database migrations.
It is probably useful to test all the database migrations somewhere anyway.

xref. #1715