### PR TITLE
Python 3 fixes from GCC-BOSC-2018

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1002,8 +1002,7 @@ def get_file_peek(file_name, is_multi_byte=False, WIDTH=256, LINE_COUNT=5, skipc
     :type  is_multi_byte: bool
 
     >>> fname = get_test_fname('4.bed')
-    >>> get_file_peek(fname, LINE_COUNT=1)
-    u'chr22\\t30128507\\t31828507\\tuc003bnx.1_cds_2_0_chr22_29227_f\\t0\\t+\\n'
+    >>> assert get_file_peek(fname, LINE_COUNT=1) == u'chr22\\t30128507\\t31828507\\tuc003bnx.1_cds_2_0_chr22_29227_f\\t0\\t+\\n'
     """
     # Set size for file.readline() to a negative number to force it to
     # read until either a newline or EOF.  Needed for datasets with very

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -105,7 +105,7 @@ def convert_newlines(fname, in_place=True, tmp_dir=None, tmp_prefix="gxupload"):
     to Posix line endings.
 
     >>> fname = get_test_fname('temp.txt')
-    >>> open(fname, 'wt').write("1 2\\r3 4")
+    >>> write_result = open(fname, 'wt').write("1 2\\r3 4")
     >>> convert_newlines(fname, tmp_prefix="gxtest", tmp_dir=tempfile.gettempdir())
     (2, None)
     >>> open(fname).read()
@@ -133,7 +133,7 @@ def sep2tabs(fname, in_place=True, patt="\\s+", tmp_dir=None, tmp_prefix="gxuplo
     Transforms in place a 'sep' separated file to a tab separated one
 
     >>> fname = get_test_fname('temp.txt')
-    >>> open(fname, 'wt').write("1 2\\n3 4\\n")
+    >>> write_result = open(fname, 'wt').write("1 2\\n3 4\\n")
     >>> sep2tabs(fname)
     (2, None)
     >>> open(fname).read()
@@ -170,7 +170,7 @@ def convert_newlines_sep2tabs(fname, in_place=True, patt="\\s+", tmp_dir=None, t
     so that files do not need to be read twice
 
     >>> fname = get_test_fname('temp.txt')
-    >>> open(fname, 'wt').write("1 2\\r3 4")
+    >>> write_result = open(fname, 'wt').write("1 2\\r3 4")
     >>> convert_newlines_sep2tabs(fname, tmp_prefix="gxtest", tmp_dir=tempfile.gettempdir())
     (2, None)
     >>> open(fname).read()

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -596,10 +596,11 @@ class FilePrefix(object):
 
     def line_iterator(self):
         s = self.string_io()
+        s_len = len(s.getvalue())
         for line in s:
             if line.endswith("\n") or line.endswith("\r"):
                 yield line
-            elif s.pos == s.len and not self.truncated:
+            elif s.tell() == s_len and not self.truncated:
                 # At the end, return the last line if it wasn't truncated when reading it in.
                 yield line
 

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -105,7 +105,8 @@ def convert_newlines(fname, in_place=True, tmp_dir=None, tmp_prefix="gxupload"):
     to Posix line endings.
 
     >>> fname = get_test_fname('temp.txt')
-    >>> write_result = open(fname, 'wt').write("1 2\\r3 4")
+    >>> with open(fname, 'wt') as fh:
+    ...     fh.write("1 2\\r3 4")
     >>> convert_newlines(fname, tmp_prefix="gxtest", tmp_dir=tempfile.gettempdir())
     (2, None)
     >>> open(fname).read()
@@ -133,7 +134,8 @@ def sep2tabs(fname, in_place=True, patt="\\s+", tmp_dir=None, tmp_prefix="gxuplo
     Transforms in place a 'sep' separated file to a tab separated one
 
     >>> fname = get_test_fname('temp.txt')
-    >>> write_result = open(fname, 'wt').write("1 2\\n3 4\\n")
+    >>> with open(fname, 'wt') as fh:
+    ...     fh.write("1 2\\n3 4\\n")
     >>> sep2tabs(fname)
     (2, None)
     >>> open(fname).read()
@@ -170,7 +172,8 @@ def convert_newlines_sep2tabs(fname, in_place=True, patt="\\s+", tmp_dir=None, t
     so that files do not need to be read twice
 
     >>> fname = get_test_fname('temp.txt')
-    >>> write_result = open(fname, 'wt').write("1 2\\r3 4")
+    >>> with open(fname, 'wt') as fh:
+    ...     fh.write("1 2\\r3 4")
     >>> convert_newlines_sep2tabs(fname, tmp_prefix="gxtest", tmp_dir=tempfile.gettempdir())
     (2, None)
     >>> open(fname).read()

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -265,8 +265,7 @@ class TextToolParameter(ToolParameter):
     >>> p = TextToolParameter(None, XML('<param name="_name" type="text" value="default" />'))
     >>> print(p.name)
     _name
-    >>> sorted(p.to_dict(trans).items())
-    [('area', False), ('argument', None), ('datalist', []), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('model_class', 'TextToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'text'), ('value', u'default')]
+    >>> assert sorted(p.to_dict(trans).items()) == [('area', False), ('argument', None), ('datalist', []), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('model_class', 'TextToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'text'), ('value', u'default')]
     """
 
     def __init__(self, tool, input_source):
@@ -310,10 +309,8 @@ class IntegerToolParameter(TextToolParameter):
     >>> p = IntegerToolParameter(None, XML('<param name="_name" type="integer" value="10" />'))
     >>> print(p.name)
     _name
-    >>> sorted(p.to_dict(trans).items())
-    [('area', False), ('argument', None), ('datalist', []), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('max', None), ('min', None), ('model_class', 'IntegerToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'integer'), ('value', u'10')]
-    >>> type(p.from_json("10", trans))
-    <type 'int'>
+    >>> assert sorted(p.to_dict(trans).items()) == [('area', False), ('argument', None), ('datalist', []), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('max', None), ('min', None), ('model_class', 'IntegerToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'integer'), ('value', u'10')]
+    >>> assert type(p.from_json("10", trans)) == int
     >>> type(p.from_json("_string", trans))
     Traceback (most recent call last):
         ...
@@ -386,10 +383,8 @@ class FloatToolParameter(TextToolParameter):
     >>> p = FloatToolParameter(None, XML('<param name="_name" type="float" value="3.141592" />'))
     >>> print(p.name)
     _name
-    >>> sorted(p.to_dict(trans).items())
-    [('area', False), ('argument', None), ('datalist', []), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('max', None), ('min', None), ('model_class', 'FloatToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'float'), ('value', u'3.141592')]
-    >>> type(p.from_json("36.1", trans))
-    <type 'float'>
+    >>> assert sorted(p.to_dict(trans).items()) == [('area', False), ('argument', None), ('datalist', []), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('max', None), ('min', None), ('model_class', 'FloatToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'float'), ('value', u'3.141592')]
+    >>> assert type(p.from_json("36.1", trans)) == float
     >>> type(p.from_json("_string", trans))
     Traceback (most recent call last):
         ...
@@ -462,8 +457,7 @@ class BooleanToolParameter(ToolParameter):
     >>> p = BooleanToolParameter(None, XML('<param name="_name" type="boolean" checked="yes" truevalue="_truevalue" falsevalue="_falsevalue" />'))
     >>> print(p.name)
     _name
-    >>> sorted(p.to_dict(trans).items())
-    [('argument', None), ('falsevalue', '_falsevalue'), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('model_class', 'BooleanToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('truevalue', '_truevalue'), ('type', 'boolean'), ('value', 'true')]
+    >>> assert sorted(p.to_dict(trans).items()) == [('argument', None), ('falsevalue', '_falsevalue'), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('model_class', 'BooleanToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('truevalue', '_truevalue'), ('type', 'boolean'), ('value', 'true')]
     >>> print(p.from_json('true'))
     True
     >>> print(p.to_param_dict_string(True))
@@ -676,8 +670,7 @@ class HiddenToolParameter(ToolParameter):
     >>> p = HiddenToolParameter(None, XML('<param name="_name" type="hidden" value="_value"/>'))
     >>> print(p.name)
     _name
-    >>> sorted(p.to_dict(trans).items())
-    [('argument', None), ('help', ''), ('hidden', True), ('is_dynamic', False), ('label', ''), ('model_class', 'HiddenToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'hidden'), ('value', u'_value')]
+    >>> assert sorted(p.to_dict(trans).items()) == [('argument', None), ('help', ''), ('hidden', True), ('is_dynamic', False), ('label', ''), ('model_class', 'HiddenToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'hidden'), ('value', u'_value')]
     """
 
     def __init__(self, tool, input_source):
@@ -704,8 +697,7 @@ class ColorToolParameter(ToolParameter):
     _name
     >>> print(p.to_param_dict_string("#fdeada"))
     #fdeada
-    >>> sorted(p.to_dict(trans).items())
-    [('argument', None), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('model_class', 'ColorToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'color'), ('value', u'#ffffff')]
+    >>> assert sorted(p.to_dict(trans).items()) == [('argument', None), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('model_class', 'ColorToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'color'), ('value', u'#ffffff')]
     >>> p = ColorToolParameter(None, XML('<param name="_name" type="color" value="#ffffff" rgb="True"/>'))
     >>> print(p.to_param_dict_string("#fdeada"))
     (253, 234, 218)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -735,8 +735,7 @@ class BaseURLToolParameter(HiddenToolParameter):
     >>> p = BaseURLToolParameter(None, XML('<param name="_name" type="base_url" value="_value"/>'))
     >>> print(p.name)
     _name
-    >>> sorted(p.to_dict(trans).items())
-    [('argument', None), ('help', ''), ('hidden', True), ('is_dynamic', False), ('label', ''), ('model_class', 'BaseURLToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'base_url'), ('value', u'_value')]
+    >>> assert sorted(p.to_dict(trans).items()) == [('argument', None), ('help', ''), ('hidden', True), ('is_dynamic', False), ('label', ''), ('model_class', 'BaseURLToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'base_url'), ('value', u'_value')]
     """
 
     def __init__(self, tool, input_source):

--- a/lib/galaxy/tools/util/maf_utilities.py
+++ b/lib/galaxy/tools/util/maf_utilities.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 import logging
 import os
 import resource
-import string
 import sys
 import tempfile
 from copy import deepcopy
@@ -19,6 +18,11 @@ import bx.interval_index_file
 import bx.intervals
 from six.moves import xrange
 
+try:
+    from string import maketrans
+except ImportError:
+    maketrans = str.maketrans
+
 assert sys.version_info[:2] >= (2, 6)
 
 log = logging.getLogger(__name__)
@@ -26,13 +30,6 @@ is_py3k = sys.version_info >= (3, 0)
 
 GAP_CHARS = ['-']
 SRC_SPLIT_CHAR = '.'
-
-
-def maketrans(x, y):
-    if is_py3k:
-        return str.maketrans(x, y)
-    else:
-        return string.maketrans(x, y)
 
 
 def src_split(src):

--- a/lib/galaxy/tools/util/maf_utilities.py
+++ b/lib/galaxy/tools/util/maf_utilities.py
@@ -8,7 +8,12 @@ from __future__ import print_function
 import logging
 import os
 import resource
-import string
+
+try:
+    from string import maketrans
+except ImportError:
+    maketrans = str.maketrans
+
 import sys
 import tempfile
 from copy import deepcopy
@@ -138,7 +143,7 @@ class TempFileHandler(object):
 # an object corresponding to a reference layered alignment
 class RegionAlignment(object):
 
-    DNA_COMPLEMENT = string.maketrans("ACGTacgt", "TGCAtgca")
+    DNA_COMPLEMENT = maketrans("ACGTacgt", "TGCAtgca")
     MAX_SEQUENCE_SIZE = sys.maxsize  # Maximum length of sequence allowed
 
     def __init__(self, size, species=[], temp_file_handler=None):
@@ -222,7 +227,7 @@ class GenomicRegionAlignment(RegionAlignment):
 
 class SplicedAlignment(object):
 
-    DNA_COMPLEMENT = string.maketrans("ACGTacgt", "TGCAtgca")
+    DNA_COMPLEMENT = maketrans("ACGTacgt", "TGCAtgca")
 
     def __init__(self, exon_starts, exon_ends, species=[], temp_file_handler=None):
         if not isinstance(exon_starts, list):

--- a/lib/galaxy/tools/util/maf_utilities.py
+++ b/lib/galaxy/tools/util/maf_utilities.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 from copy import deepcopy
 from errno import EMFILE
+
 import bx.align.maf
 import bx.interval_index_file
 import bx.intervals

--- a/lib/galaxy/tools/util/maf_utilities.py
+++ b/lib/galaxy/tools/util/maf_utilities.py
@@ -26,7 +26,6 @@ except ImportError:
 assert sys.version_info[:2] >= (2, 6)
 
 log = logging.getLogger(__name__)
-is_py3k = sys.version_info >= (3, 0)
 
 GAP_CHARS = ['-']
 SRC_SPLIT_CHAR = '.'

--- a/lib/galaxy/tools/util/maf_utilities.py
+++ b/lib/galaxy/tools/util/maf_utilities.py
@@ -13,7 +13,6 @@ try:
     from string import maketrans
 except ImportError:
     maketrans = str.maketrans
-
 import sys
 import tempfile
 from copy import deepcopy

--- a/lib/galaxy/tools/util/maf_utilities.py
+++ b/lib/galaxy/tools/util/maf_utilities.py
@@ -8,16 +8,11 @@ from __future__ import print_function
 import logging
 import os
 import resource
-
-try:
-    from string import maketrans
-except ImportError:
-    maketrans = str.maketrans
+import string
 import sys
 import tempfile
 from copy import deepcopy
 from errno import EMFILE
-
 import bx.align.maf
 import bx.interval_index_file
 import bx.intervals
@@ -26,10 +21,17 @@ from six.moves import xrange
 assert sys.version_info[:2] >= (2, 6)
 
 log = logging.getLogger(__name__)
-
+is_py3k = sys.version_info >= (3, 0)
 
 GAP_CHARS = ['-']
 SRC_SPLIT_CHAR = '.'
+
+
+def maketrans(x, y):
+    if is_py3k:
+        return str.maketrans(x, y)
+    else:
+        return string.maketrans(x, y)
 
 
 def src_split(src):


### PR DESCRIPTION
Several fixes where I added assert instead of relying on doctest have trouble comparing values.
Changes in the returned values by python causing issues with doctest.
Changes in IOString properties.
Also includes a work around for importing maketrans.

Helps with #1715 