### PR TITLE
Do not encode a rendered Mako template

### DIFF
--- a/lib/galaxy/visualization/plugins/plugin.py
+++ b/lib/galaxy/visualization/plugins/plugin.py
@@ -26,8 +26,6 @@ class ServesTemplatesPluginMixin(object):
 
     #: default number of templates to search for plugin template lookup
     DEFAULT_TEMPLATE_COLLECTION_SIZE = 10
-    #: default encoding of plugin templates
-    DEFAULT_TEMPLATE_ENCODING = 'utf-8'
 
     def _set_up_template_plugin(self, template_cache_dir, additional_template_paths=None, **kwargs):
         """
@@ -48,7 +46,7 @@ class ServesTemplatesPluginMixin(object):
         return os.path.join(self.path, 'templates')
 
     def _build_template_lookup(self, template_cache_dir, additional_template_paths=None,
-                               collection_size=DEFAULT_TEMPLATE_COLLECTION_SIZE, output_encoding=DEFAULT_TEMPLATE_ENCODING):
+                               collection_size=DEFAULT_TEMPLATE_COLLECTION_SIZE):
         """
         Build a mako template filename lookup for the plugin.
         """
@@ -58,8 +56,7 @@ class ServesTemplatesPluginMixin(object):
         return mako.lookup.TemplateLookup(
             directories=template_lookup_paths,
             module_directory=template_cache_dir,
-            collection_size=collection_size,
-            output_encoding=output_encoding)
+            collection_size=collection_size)
 
 
 class VisualizationPlugin(ServesTemplatesPluginMixin):

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -931,7 +931,6 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
     def fill_template_mako(self, filename, template_lookup=None, **kwargs):
         template_lookup = template_lookup or self.webapp.mako_template_lookup
         template = template_lookup.get_template(filename)
-        template.output_encoding = 'utf-8'
 
         data = dict(caller=self, t=self, trans=self, h=helpers, util=util, request=self.request, response=self.response, app=self.app)
         data.update(self.template_context)
@@ -940,7 +939,6 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
 
     def stream_template_mako(self, filename, **kwargs):
         template = self.webapp.mako_template_lookup.get_template(filename)
-        template.output_encoding = 'utf-8'
         data = dict(caller=self, t=self, trans=self, h=helpers, util=util, request=self.request, response=self.response, app=self.app)
         data.update(self.template_context)
         data.update(kwargs)

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -186,7 +186,6 @@ class MockTrans(object):
 
     def fill_template(self, filename, template_lookup=None, **kwargs):
         template = template_lookup.get_template(filename)
-        template.output_encoding = 'utf-8'
         kwargs.update(h=MockTemplateHelpers())
         return template.render(**kwargs)
 

--- a/test/unit/visualizations/plugins/test_VisualizationsRegistry.py
+++ b/test/unit/visualizations/plugins/test_VisualizationsRegistry.py
@@ -5,7 +5,7 @@ import os
 import re
 import unittest
 
-from six import string_types
+from six import text_type
 
 from galaxy import model
 from galaxy.visualization.plugins import plugin
@@ -198,7 +198,7 @@ class VisualizationsRegistry_TestCase(unittest.TestCase):
         # should return the (new) api key for the above user (see the template above)
         response = jupyter._render({}, trans=trans)
         response.strip()
-        self.assertIsInstance(response, string_types)
+        self.assertIsInstance(response, text_type)
         self.assertTrue('-' in response)
         ie_request, api_key = response.split('-')
 


### PR DESCRIPTION
Fix 1 error and 2 failures in unit tests under Python 3, e.g.:

```
FAIL: test_render (unit.visualizations.plugins.test_VisualizationPlugin.VisualizationsPlugin_TestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/galaxyproject/galaxy/test/unit/visualizations/plugins/test_VisualizationPlugin.py", line 180, in test_render
    self.assertIsInstance(response, string_types)
AssertionError: b'\nTrue\n' is not an instance of (<class 'str'>,)
```

xref. #1715