### PR TITLE
py3 compat: fixes test_vcf, test_sniff_compressed*

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -62,8 +62,8 @@ CHUNK_SIZE = 65536  # 64k
 DATABASE_MAX_STRING_SIZE = 32768
 DATABASE_MAX_STRING_SIZE_PRETTY = '32K'
 
-gzip_magic = '\037\213'
-bz2_magic = 'BZh'
+gzip_magic = b'\x1f\x8b'
+bz2_magic = b'BZh'
 DEFAULT_ENCODING = os.environ.get('GALAXY_DEFAULT_ENCODING', 'utf-8')
 NULL_CHAR = '\000'
 BINARY_CHARS = [NULL_CHAR]

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -68,9 +68,8 @@ def check_gzip(file_path, check_content=True):
     # This method returns a tuple of booleans representing ( is_gzipped, is_valid )
     # Make sure we have a gzipped file
     try:
-        temp = open(file_path, "U")
-        magic_check = temp.read(2)
-        temp.close()
+        with open(file_path, "rb") as temp:
+            magic_check = temp.read(2)
         if magic_check != util.gzip_magic:
             return (False, False)
     except Exception:
@@ -100,9 +99,8 @@ def check_gzip(file_path, check_content=True):
 
 def check_bz2(file_path, check_content=True):
     try:
-        temp = open(file_path, "U")
-        magic_check = temp.read(3)
-        temp.close()
+        with open(file_path, "rb") as temp:
+            magic_check = temp.read(3)
         if magic_check != util.bz2_magic:
             return (False, False)
     except Exception:


### PR DESCRIPTION
Explicitly declare bz2 and gzip magic numbers as bytes, replace `mode="U"`

xref. #1715 