### PR TITLE
CI - ignore node_modules anywhere

### DIFF
--- a/.ci/flake8_blacklist.txt
+++ b/.ci/flake8_blacklist.txt
@@ -2,7 +2,7 @@
 .tox
 .venv
 .venv3
-client/node_modules
+node_modules
 database
 doc/build
 doc/source/conf.py


### PR DESCRIPTION
Since we use them in multiple places and not always 'client' (proxy, plugins, etc).