### PR TITLE
py3: Fix the dynamic tool destination unit test

### DIFF
--- a/lib/galaxy/jobs/dynamic_tool_destination.py
+++ b/lib/galaxy/jobs/dynamic_tool_destination.py
@@ -529,7 +529,7 @@ class RuleValidator(object):
         """
 
         if "upper_bound" in rule and "lower_bound" in rule:
-            if rule["rule_type"] == "file_size":
+            if rule["rule_type"] in ("file_size", "records"):
                 upper_bound = str_to_bytes(rule["upper_bound"])
                 lower_bound = str_to_bytes(rule["lower_bound"])
             else:
@@ -543,6 +543,8 @@ class RuleValidator(object):
                     error += " Setting lower_bound to 0!"
                     lower_bound = 0
                     rule["lower_bound"] = 0
+                else:
+                    lower_bound = float('inf')
                 if verbose:
                     log.debug(error)
                 valid_rule = False


### PR DESCRIPTION
Strings are greater than Integers in py2, but in py3 the comparison is invalid, so I assume setting the upper bound to float('inf') should be correct. The records rule also accepts file size units, so I guess passing this to `str_to_bytes` is fine.
Does that make sense @ericenns ?

xref. #1715