### PR TITLE
Implement dataset permissions api

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -103,10 +103,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
         :returns:   dictionary containing new permissions
         """
         hda_ldda = kwargs.get('hda_ldda', 'hda')
-        try:
-            hda = self.get_hda_or_ldda(trans, hda_ldda=hda_ldda, dataset_id=dataset_id)
-        except Exception as e:
-            return str(e)
+        hda = self.get_hda_or_ldda(trans, hda_ldda=hda_ldda, dataset_id=dataset_id)
 
         access = payload.get('access', [])
         manage = payload.get('manage', [])

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -139,7 +139,6 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
         else:
             raise galaxy_exceptions.InsufficientPermissionsException('You are not authorized to change this dataset\'s permissions.')
 
-
     def _dataset_state(self, trans, dataset, **kwargs):
         """
         Returns state of dataset.

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -99,8 +99,6 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
         POST /api/datasets/{encoded_dataset_id}/permissions
         Updates permissions of a dataset.
 
-        , hda_ldda='hda', manage_ids=[], access_ids=[]
-
         :rtype:     dict
         :returns:   dictionary containing new permissions
         """

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -96,7 +96,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
     @web._future_expose_api
     def set_permissions(self, trans, dataset_id, payload, **kwargs):
         """
-        POST /api/datasets/{encoded_dataset_id}/permissions
+        POST /api/datasets/{encoded_dataset_id}/set_permissions
         Updates permissions of a dataset.
 
         :rtype:     dict

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -440,6 +440,7 @@ def populate_api_routes(webapp, app):
     # route for creating/getting converted datasets
     webapp.mapper.connect('/api/datasets/{dataset_id}/converted', controller='datasets', action='converted', ext=None)
     webapp.mapper.connect('/api/datasets/{dataset_id}/converted/{ext}', controller='datasets', action='converted')
+    webapp.mapper.connect('/api/datasets/{dataset_id}/set_permissions', controller='datasets', action='set_permissions', conditions=dict(method=['POST']))
 
     # API refers to usages and invocations - these mean the same thing but the
     # usage routes should be considered deprecated.


### PR DESCRIPTION
Copies the code mostly from

https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/webapps/galaxy/controllers/dataset.py#L486-L511

except exchanging the returned plain messages for more appropriate exceptions. In support of https://github.com/galaxyproject/galaxy/issues/5894