### PR TITLE
Rulebuilder: Special case auto URL schema detection for SRA inputs.

### DIFF
--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -1705,7 +1705,13 @@ export default {
                 const urlColumn = mappingAsDict.url.columns[0];
                 let url = data[dataIndex][urlColumn];
                 if (url.indexOf("://") == -1) {
-                    url = "http://" + url;
+                    // special case columns containing SRA links. EBI serves these a lot
+                    // faster over FTP.
+                    if(url.indexOf("ftp.sra.") !== -1) {
+                        url = "ftp://" + url;
+                    } else {
+                        url = "http://" + url;
+                    }
                 }
                 res["url"] = url;
                 res["src"] = "url";


### PR DESCRIPTION
@mblue9 has run some tests and this ftp prefix/protocol seems to serve the files considerably faster from EBI.

In general users should be defining these URLs with prefixes, so this is already a hack - so I have no problems being even a bit more hacky. We could extend it with other URL patterns if we find other data sources have similar issues.
