### PR TITLE
Implement ``group:`` tags (toward multi-factor analysis with group tagging)

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -202,7 +202,7 @@ class DatasetCollectionManager(object):
         tags = tags or {}
         implicit_inputs = implicit_inputs or []
         for _, v in implicit_inputs:
-            for tag in [t for t in v.tags if t.user_tname == 'name']:
+            for tag in v.auto_propagated_tags:
                 tags[tag.value] = tag
         for _, tag in tags.items():
             dataset_collection_instance.tags.append(tag.copy(cls=model.HistoryDatasetCollectionTagAssociation))

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -305,7 +305,7 @@ class TagManager(object):
         """Get name, value pair from a tag string."""
         # Use regular expression to parse name, value.
         reg_exp = re.compile("[" + self.key_value_separators + "]")
-        name_value_pair = reg_exp.split(tag_str)
+        name_value_pair = reg_exp.split(tag_str, 1)
         # Add empty slot if tag does not have value.
         if len(name_value_pair) < 2:
             name_value_pair.append(None)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -71,6 +71,8 @@ MAX_IN_FILTER_LENGTH = 100
 JOB_METRIC_MAX_LENGTH = 1023
 JOB_METRIC_PRECISION = 26
 JOB_METRIC_SCALE = 7
+# Tags that get automatically propagated from inputs to outputs when running jobs.
+AUTO_PROPAGATED_TAGS = ["name"]
 
 
 class NoConverterException(Exception):
@@ -127,6 +129,10 @@ class HasTags(object):
             new_tag_assoc = source_tag_assoc.copy()
             new_tag_assoc.user = target_user
             self.tags.append(new_tag_assoc)
+
+    @property
+    def auto_propagated_tags(self):
+        return [t for t in self.tags if t.user_tname in AUTO_PROPAGATED_TAGS]
 
 
 class HasName(object):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -72,7 +72,7 @@ JOB_METRIC_MAX_LENGTH = 1023
 JOB_METRIC_PRECISION = 26
 JOB_METRIC_SCALE = 7
 # Tags that get automatically propagated from inputs to outputs when running jobs.
-AUTO_PROPAGATED_TAGS = ["name"]
+AUTO_PROPAGATED_TAGS = ["name", "group"]
 
 
 class NoConverterException(Exception):

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -206,7 +206,7 @@ class DefaultToolAction(object):
             if not data:
                 continue
 
-            for tag in [t for t in data.tags if t.user_tname == 'name']:
+            for tag in data.auto_propagated_tags:
                 preserved_tags[tag.value] = tag
 
         # grap tags from incoming HDCAs
@@ -215,7 +215,7 @@ class DefaultToolAction(object):
                 # if sub-collection mapping, this will be an DC not an HDCA
                 # (e.g. part of collection not a collection instance) and thus won't have tags.
                 if hasattr(collection, "tags"):
-                    for tag in [t for t in collection.tags if t.user_tname == 'name']:
+                    for tag in collection.auto_propagated_tags:
                         preserved_tags[tag.value] = tag
 
         return history, inp_data, inp_dataset_collections, preserved_tags


### PR DESCRIPTION
See #5457 for an example of how tool authors may consume such tags and how users might define them. This PR simply makes sure they will auto-propagate through an analysis the way ``name:`` tags do.

xref #3979 
xref #5462
xref Many long conversations about the future of multi-factor analyses in Galaxy at the GCC that we didn't take any notes or create any issues out of.


Adds an API test case to verify both name tagging and group tagging auto propagate for simple tools (more tests could be added #5403).
