### PR TITLE
Fix ftp_upload_purge in galaxy.yml

### DIFF
--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -141,7 +141,12 @@ def add_file(dataset, registry, output_path):
         # Move the dataset to its "real" path. converted_path is a tempfile so we move it even if purge_source is False.
         if purge_source or converted_path:
             try:
-                shutil.move(converted_path or dataset.path, output_path)
+                # If user has indicated that the original file to be purged and have converted_path tempfile
+                if purge_source and converted_path:
+                    shutil.move(converted_path, output_path)
+                    os.remove(dataset.path)
+                else:
+                    shutil.move(converted_path or dataset.path, output_path)
             except OSError as e:
                 # We may not have permission to remove the input
                 if e.errno != errno.EACCES:


### PR DESCRIPTION
Pull request to fix issue #6492 where uploaded ftp files were not being purged even when being set in galaxy.yml with flag [ftp_upload_purge](https://docs.galaxyproject.org/en/latest/admin/options.html?highlight=ftp_upload_purge#ftp-upload-purge) .

New code  covers case where both purge_source and converted_path are set to True hence need to move the converted_path to 'real' path AND remove the original dataset from FTP dir.
