### PR TITLE
Integrate tagging into the rule builder.

### DIFF
--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -343,6 +343,10 @@
                         <option v-for="(col, index) in genomes" :value="col['id']"">{{ col["text"] }}</option>
                     </select2>
                 </div>
+                <label v-if="showAddNameTag">
+                    {{ l("Add nametag for name") }}:
+                </label>
+                <input type="checkbox" v-model="addNameTag" v-if="showAddNameTag"/>
                 <div class="rule-footer-name-group" v-if="showCollectionNameInput">
                     <b-input class="collection-name"
                     :placeholder="namePlaceholder" :title="namePlaceholder" v-b-tooltip.hover v-model="collectionName" />
@@ -932,6 +936,7 @@ export default {
             genomes: [],
             genome: null,
             hideSourceItems: this.defaultHideSourceItems,
+            addNameTag: false,
             orientation: orientation
         };
     },
@@ -1005,6 +1010,12 @@ export default {
                 this.importType == "collections" &&
                 this.elementsType != "collection_contents" &&
                 !this.mappingAsDict.collection_name
+            );
+        },
+        showAddNameTag() {
+            return (
+                this.importType == "collections" &&
+                this.elementsType != "collection_contents"
             );
         },
         titleFinish() {
@@ -1464,6 +1475,9 @@ export default {
                             collection_type: collectionType,
                             name: collectionName
                         };
+                        if (this.addNameTag) {
+                            target["tags"] = ["name:" + collectionName];
+                        }
                         targets.push(target);
                     }
                 } else {
@@ -1738,6 +1752,29 @@ export default {
                 const infoColumn = mappingAsDict.info.columns[0];
                 const info = data[dataIndex][infoColumn];
                 res["info"] = info;
+            }
+            const tags = [];
+            if (mappingAsDict.tags) {
+                const tagColumns = mappingAsDict.tags.columns;
+                for (var tagColumn of tagColumns) {
+                    const tag = data[dataIndex][tagColumn];
+                    tags.push(tag);
+                }
+            }
+            if (mappingAsDict.group_tags) {
+                const groupTagColumns = mappingAsDict.group_tags.columns;
+                for (var groupTagColumn of groupTagColumns) {
+                    const tag = data[dataIndex][groupTagColumn];
+                    tags.push("group:" + tag);
+                }
+            }
+            if (mappingAsDict.name_tag) {
+                const nameTagColumn = mappingAsDict.name_tag.columns[0];
+                const nameTag = data[dataIndex][nameTagColumn];
+                tags.push("name:" + nameTag);
+            }
+            if (tags.length > 0) {
+                res["tags"] = tags;
             }
             return res;
         }

--- a/client/galaxy/scripts/mvc/rules/rule-definitions.js
+++ b/client/galaxy/scripts/mvc/rules/rule-definitions.js
@@ -726,6 +726,30 @@ const MAPPING_TARGETS = {
         modes: ["raw", "ftp", "datasets", "library_datasets"],
         importType: "collections"
     },
+    name_tag: {
+        label: _l("Name Tag"),
+        help: _l(
+            "Add a name tag or hash tag based on the specified column value for imported datasets."
+        ),
+        importType: "datasets",
+        modes: ["raw", "ftp"]
+    },
+    tags: {
+        multiple: true,
+        label: _l("General Purpose Tag(s)"),
+        help: _l(
+            "Add a general purpose tag based on the specified column value, use : to separate key-value pairs if desired. These tags are not propagated to derived datasets the way name and group tags are."
+        ),
+        modes: ["raw", "ftp", "library_datasets"],
+    },
+    group_tags: {
+        multiple: true,
+        label: _l("Group Tag(s)"),
+        help: _l(
+            "Add a group tag based on the specified column value, use : to separate key-value pairs. These tags are propagated to derived datasets and may be useful for factorial experiments."
+        ),
+        modes: ["raw", "ftp", "library_datasets"],
+    },
     name: {
         label: _l("Name"),
         importType: "datasets"

--- a/lib/galaxy/tools/actions/upload.py
+++ b/lib/galaxy/tools/actions/upload.py
@@ -121,7 +121,8 @@ def _precreate_fetched_hdas(trans, history, target, outputs):
         uploaded_dataset = Bunch(
             type='file', name=name, file_type=file_type, dbkey=dbkey
         )
-        data = upload_common.new_upload(trans, '', uploaded_dataset, library_bunch=None, history=history)
+        tag_list = item.get("tags", [])
+        data = upload_common.new_upload(trans, '', uploaded_dataset, library_bunch=None, history=history, tag_list=tag_list)
         outputs.append(data)
         item["object_id"] = data.id
 
@@ -136,11 +137,12 @@ def _precreate_fetched_collection_instance(trans, history, target, outputs):
     if not name:
         return
 
+    tags = target.get("tags", [])
     collections_service = trans.app.dataset_collections_service
     collection_type_description = collections_service.collection_type_descriptions.for_collection_type(collection_type)
     structure = UninitializedTree(collection_type_description)
     hdca = collections_service.precreate_dataset_collection_instance(
-        trans, history, name, structure=structure
+        trans, history, name, structure=structure, tags=tags
     )
     outputs.append(hdca)
     # Following flushed needed for an ID.

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -274,11 +274,16 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, state
     return ldda
 
 
-def new_upload(trans, cntrller, uploaded_dataset, library_bunch=None, history=None, state=None):
+def new_upload(trans, cntrller, uploaded_dataset, library_bunch=None, history=None, state=None, tag_list=None):
     if library_bunch:
-        return __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, state)
+        upload_target_dataset_instance = __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, state)
     else:
-        return __new_history_upload(trans, uploaded_dataset, history=history, state=state)
+        upload_target_dataset_instance = __new_history_upload(trans, uploaded_dataset, history=history, state=state)
+
+    if tag_list:
+        trans.app.tag_handler.add_tags_from_list(trans.user, upload_target_dataset_instance, tag_list)
+
+    return upload_target_dataset_instance
 
 
 def get_uploaded_datasets(trans, cntrller, params, dataset_upload_inputs, library_bunch=None, history=None):

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -95,6 +95,7 @@ def _fetch_target(upload_config, target):
         dbkey = item.get("dbkey", "?")
         requested_ext = item.get("ext", "auto")
         info = item.get("info", None)
+        tags = item.get("tags", [])
         object_id = item.get("object_id", None)
         link_data_only = upload_config.link_data_only
         if "link_data_only" in item:
@@ -146,6 +147,8 @@ def _fetch_target(upload_config, target):
             rval["info"] = info
         if object_id is not None:
             rval["object_id"] = object_id
+        if tags:
+            rval["tags"] = tags
         return rval
 
     elements = elements_tree_map(_resolve_src, items)

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -407,7 +407,7 @@ class JobContext(object):
             dataset_name = fields_match.name or designation
 
             link_data = discovered_file.match.link_data
-
+            tag_list = discovered_file.match.tag_list
             dataset = self.create_dataset(
                 ext=ext,
                 designation=designation,
@@ -417,6 +417,7 @@ class JobContext(object):
                 filename=filename,
                 metadata_source_name=metadata_source_name,
                 link_data=link_data,
+                tag_list=tag_list,
             )
             log.debug(
                 "(%s) Created dynamic collection dataset for path [%s] with element identifier [%s] for output [%s] %s",
@@ -473,6 +474,7 @@ class JobContext(object):
         library_folder=None,
         link_data=False,
         primary_data=None,
+        tag_list=[],
     ):
         app = self.app
         sa_session = self.sa_session
@@ -493,6 +495,10 @@ class JobContext(object):
             metadata_source = self.inp_data[metadata_source_name]
 
         sa_session.flush()
+
+        if tag_list:
+            app.tag_handler.add_tags_from_list(self.job.user, primary_data, tag_list)
+
         # Move data from temp location to dataset location
         if not link_data:
             app.object_store.update_from_file(primary_data.dataset, file_name=filename, create=True)
@@ -872,6 +878,10 @@ class JsonCollectedDatasetMatch(object):
     @property
     def link_data(self):
         return bool(self.as_dict.get("link_data_only", False))
+
+    @property
+    def tag_list(self):
+        return self.as_dict.get("tags", [])
 
     @property
     def object_id(self):

--- a/test/api/test_dataset_collections.py
+++ b/test/api/test_dataset_collections.py
@@ -189,12 +189,13 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
         self._assert_status_code_is(create_response, 400)
 
     def test_upload_collection(self):
-        elements = [{"src": "files", "dbkey": "hg19", "info": "my cool bed"}]
+        elements = [{"src": "files", "dbkey": "hg19", "info": "my cool bed", "tags": ["name:data1", "group:condition:treated", "machine:illumina"]}]
         targets = [{
             "destination": {"type": "hdca"},
             "elements": elements,
             "collection_type": "list",
             "name": "Test upload",
+            "tags": ["name:collection1"]
         }]
         payload = {
             "history_id": self.history_id,
@@ -204,10 +205,16 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
         self.dataset_populator.fetch(payload)
         hdca = self._assert_one_collection_created_in_history()
         self.assertEquals(hdca["name"], "Test upload")
+        hdca_tags = hdca["tags"]
+        assert len(hdca_tags) == 1
+        assert "name:collection1" in hdca_tags
         assert len(hdca["elements"]) == 1, hdca
         element0 = hdca["elements"][0]
         assert element0["element_identifier"] == "4.bed"
-        assert element0["object"]["file_size"] == 61
+        dataset0 = element0["object"]
+        assert dataset0["file_size"] == 61
+        dataset_tags = dataset0["tags"]
+        assert len(dataset_tags) == 3, dataset0
 
     def test_upload_nested(self):
         elements = [{"name": "samp1", "elements": [{"src": "files", "dbkey": "hg19", "info": "my cool bed"}]}]

--- a/test/api/test_tools_upload.py
+++ b/test/api/test_tools_upload.py
@@ -227,10 +227,15 @@ class ToolsUploadTestCase(api.ApiTestCase):
             datasets = run_response.json()["outputs"]
             assert datasets[0].get("genome_build") == "hg19", datasets[0]
 
-    def test_fetch_dbkey(self):
+    def test_fetch_metadata(self):
         table = ONE_TO_SIX_WITH_SPACES
-        details = self._upload_and_get_details(table, api='fetch', dbkey="hg19")
+        details = self._upload_and_get_details(table, api='fetch', dbkey="hg19", info="cool upload", tags=["name:data", "group:type:paired-end"])
         assert details.get("genome_build") == "hg19"
+        assert details.get("misc_info") == "cool upload", details
+        tags = details.get("tags")
+        assert len(tags) == 2, details
+        assert "group:type:paired-end" in tags
+        assert "name:data" in tags
 
     def test_upload_multiple_files_1(self):
         with self.dataset_populator.test_history() as history_id:


### PR DESCRIPTION
- Allow specifying name tags, group tags (added in https://github.com/galaxyproject/galaxy/pull/6491), and "general" or generic tags on stand-alone datasets and collection content datasets.
- Allow reusing the collection name as a name tag during upload for the whole collection. In this context I think the name tag is especially useful and will typically be the same name as the collection so the UI is kept simple by making it a checkbox.

Ideas tracked on https://github.com/galaxyproject/galaxy/issues/5822.

Builds on #6499. 
