### PR TITLE
Fix bam to bigwig error detection.

### DIFF
--- a/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
@@ -1,10 +1,10 @@
-<tool id="CONVERTER_bam_to_bigwig_0" name="Convert BAM to BigWig" version="1.0.1" hidden="true">
+<tool id="CONVERTER_bam_to_bigwig_0" name="Convert BAM to BigWig" version="1.0.2" hidden="true">
     <!--  <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
         <requirement type="package" version="357">ucsc-bedgraphtobigwig</requirement>
         <requirement type="package" version="2.27.1">bedtools</requirement>
     </requirements>
-    <command><![CDATA[
+    <command detect_errors="aggressive"><![CDATA[
         bedtools genomecov -bg -split -ibam '$input' -g '$chromInfo'
 
         | LC_COLLATE=C sort -k1,1 -k2,2n


### PR DESCRIPTION
As per the [documentation](https://docs.galaxyproject.org/en/master/dev/schema.html#tool-command) leaving the tool without `detect_errors` and without a `profile` set to greater than or equal to `16.04` invokes the old behaviour where any output to `stderr` denotes failure. When provided with a BAM format input file and the `-g` option, `bedtools` outputs a warning to `stderr` stating that it will ignore the provided genome, triggering a tool failure.