### PR TITLE
[18.05] Fix infinite loop in uploads

### DIFF
--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -393,8 +393,10 @@ class Ms2(Text):
         header_lines = []
         while True:
             line = contents.readline()
-            if line is None or len(line) == 0:
-                pass
+            if not line:
+                return False
+            if line.strip() == "":
+                continue
             elif line.startswith('H\t'):
                 header_lines.append(line)
             else:

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -290,6 +290,9 @@ def guess_ext(fname, sniff_order, is_binary=False):
     >>> from galaxy.datatypes.registry import example_datatype_registry_for_sample
     >>> datatypes_registry = example_datatype_registry_for_sample()
     >>> sniff_order = datatypes_registry.sniff_order
+    >>> fname = get_test_fname('empty.txt')
+    >>> guess_ext(fname, sniff_order)
+    'txt'
     >>> fname = get_test_fname('megablast_xml_parser_test1.blastxml')
     >>> guess_ext(fname, sniff_order)
     'blastxml'


### PR DESCRIPTION
If the upload get somehow interrupted and an empty file is created in `new_file_path`, `upload.py` is stuck in an infinite 100%-CPU loop due to the following `Ms2.sniff_prefix()` bug.