### PR TITLE
Improvements to Cloud Storage Manager

### DIFF
--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -194,7 +194,8 @@ class CloudManager(sharable.SharableModelManager):
 
         job_errors = output.get('job_errors', [])
         if job_errors:
-            raise ValueError('Cannot copy given object(s) from {}.'.format(provider))
+            raise ValueError('Following error occurred while uploading the given object(s) from {}: {}'.format(
+                provider, job_errors))
         else:
             for d in output['out_data']:
                 datasets.append(d[1].dataset)

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -8,6 +8,7 @@ import logging
 from galaxy.exceptions import (
     AuthenticationFailed,
     ItemAccessibilityException,
+    MessageException,
     ObjectNotFound,
     RequestParameterInvalidException,
     RequestParameterMissingException
@@ -210,7 +211,10 @@ class CloudManager(sharable.SharableModelManager):
 
         datasets = []
         for obj in objects:
-            key = bucket_obj.get(obj)
+            try:
+                key = bucket_obj.get(obj)
+            except Exception as e:
+                raise MessageException("The following error occurred while getting the object {}: {}".format(obj, str(e)))
             if key is None:
                 raise ObjectNotFound("Could not get the object `{}`.".format(obj))
 

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -189,9 +189,8 @@ class CloudManager(sharable.SharableModelManager):
 
             params = Params(inputs, sanitize=False)
             incoming = params.__dict__
-            upload_tool = trans.app.toolbox.get_tool('upload1')
             history = trans.sa_session.query(trans.app.model.History).get(history_id)
-            output = upload_tool.handle_input(trans, incoming, history=history)
+            output = trans.app.toolbox.get_tool('upload1').handle_input(trans, incoming, history=history)
 
             job_errors = output.get('job_errors', [])
             if job_errors:

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -166,31 +166,33 @@ class CloudManager(sharable.SharableModelManager):
         Implements the logic of uploading a file from a cloud-based storage (e.g., Amazon S3)
         and persisting it as a Galaxy dataset.
 
-        :type  trans: galaxy.web.framework.webapp.GalaxyWebTransaction
-        :param trans: Galaxy web transaction
+        :type  trans:       galaxy.web.framework.webapp.GalaxyWebTransaction
+        :param trans:       Galaxy web transaction
 
-        :type  history_id: string
-        :param history_id: the (encoded) id of history to which the object should be uploaded to.
+        :type  history_id:  string
+        :param history_id:  the (encoded) id of history to which the object should be uploaded to.
 
-        :type  provider: string
-        :param provider: the name of cloud-based resource provided. A list of supported providers is given in
-        `SUPPORTED_PROVIDERS` variable.
+        :type  provider:    string
+        :param provider:    the name of cloud-based resource provided. A list of supported providers is given in
+                            `SUPPORTED_PROVIDERS` variable.
 
-        :type  bucket: string
-        :param bucket: the name of a bucket from which data should be uploaded (e.g., a bucket name on AWS S3).
+        :type  bucket:      string
+        :param bucket:      the name of a bucket from which data should be uploaded (e.g., a bucket name on AWS S3).
 
-        :type  objects: list of string
-        :param objects: the name of objects to be uploaded.
+        :type  objects:     list of string
+        :param objects:     the name of objects to be uploaded.
 
         :type  credentials: dict
         :param credentials: a dictionary containing all the credentials required to authenticated to the
-        specified provider (e.g., {"secret_key": YOUR_AWS_SECRET_TOKEN, "access_key": YOUR_AWS_ACCESS_TOKEN}).
+                            specified provider (e.g., {"secret_key": YOUR_AWS_SECRET_TOKEN,
+                            "access_key": YOUR_AWS_ACCESS_TOKEN}).
 
-        :type  input_args: dict
-        :param input_args: a [Optional] a dictionary of input parameters: dbkey, file_type, space_to_tab, to_posix_lines
+        :type  input_args:  dict
+        :param input_args:  a [Optional] a dictionary of input parameters:
+                            dbkey, file_type, space_to_tab, to_posix_lines (see galaxy/webapps/galaxy/api/cloud.py)
 
-        :rtype:  list of galaxy.model.Dataset
-        :return: a list of datasets created for the uploaded files.
+        :rtype:             list of galaxy.model.Dataset
+        :return:            a list of datasets created for the uploaded files.
         """
         if CloudProviderFactory is None:
             raise Exception(NO_CLOUDBRIDGE_ERROR_MESSAGE)
@@ -232,39 +234,39 @@ class CloudManager(sharable.SharableModelManager):
         Implements the logic of downloading dataset(s) from a given history to a given cloud-based storage
         (e.g., Amazon S3).
 
-        :type  trans: galaxy.web.framework.webapp.GalaxyWebTransaction
-        :param trans: Galaxy web transaction
+        :type  trans:               galaxy.web.framework.webapp.GalaxyWebTransaction
+        :param trans:               Galaxy web transaction
 
-        :type  history_id: string
-        :param history_id: the (encoded) id of history from which the object should be downloaded.
+        :type  history_id:          string
+        :param history_id:          the (encoded) id of history from which the object should be downloaded.
 
-        :type  provider: string
-        :param provider: the name of cloud-based resource provided. A list of supported providers
-                         is given in `SUPPORTED_PROVIDERS` variable.
+        :type  provider:            string
+        :param provider:            the name of cloud-based resource provided. A list of supported providers
+                                    is given in `SUPPORTED_PROVIDERS` variable.
 
-        :type  bucket: string
-        :param bucket: the name of a bucket to which data should be downloaded (e.g., a bucket
-                       name on AWS S3).
+        :type  bucket:              string
+        :param bucket:              the name of a bucket to which data should be downloaded (e.g., a bucket
+                                    name on AWS S3).
 
-        :type  credentials: dict
-        :param credentials: a dictionary containing all the credentials required to authenticated
-                            to the specified provider (e.g., {"secret_key": YOUR_AWS_SECRET_TOKEN,
-                            "access_key": YOUR_AWS_ACCESS_TOKEN}).
+        :type  credentials:         dict
+        :param credentials:         a dictionary containing all the credentials required to authenticated
+                                    to the specified provider (e.g., {"secret_key": YOUR_AWS_SECRET_TOKEN,
+                                    "access_key": YOUR_AWS_ACCESS_TOKEN}).
 
-        :type  dataset_ids: set
-        :param dataset_ids: [Optional] The list of (decoded) dataset ID(s) belonging to the given
-                            history which should be downloaded to the given provider. If not provided,
-                            Galaxy downloads all the datasets belonging to the given history.
+        :type  dataset_ids:         set
+        :param dataset_ids:         [Optional] The list of (decoded) dataset ID(s) belonging to the given
+                                    history which should be downloaded to the given provider. If not provided,
+                                    Galaxy downloads all the datasets belonging to the given history.
 
-        :type  overwrite_existing: boolean
-        :param overwrite_existing: [Optional] If set to "True", and an object with same name of the
-                                   dataset to be downloaded already exist in the bucket, Galaxy replaces
-                                   the existing object with the dataset to be downloaded. If set to
-                                   "False", Galaxy appends datetime to the dataset name to prevent
-                                   overwriting the existing object.
+        :type  overwrite_existing:  boolean
+        :param overwrite_existing:  [Optional] If set to "True", and an object with same name of the
+                                    dataset to be downloaded already exist in the bucket, Galaxy replaces
+                                    the existing object with the dataset to be downloaded. If set to
+                                    "False", Galaxy appends datetime to the dataset name to prevent
+                                    overwriting the existing object.
 
-        :rtype:  list
-        :return: A list of labels for the objects that were uploaded.
+        :rtype:                     list
+        :return:                    A list of labels for the objects that were uploaded.
         """
         if CloudProviderFactory is None:
             raise Exception(NO_CLOUDBRIDGE_ERROR_MESSAGE)

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -201,23 +201,23 @@ class CloudManager(sharable.SharableModelManager):
 
         return datasets
 
-    def copy_to(self, trans, history_id, provider, bucket, credentials, dataset_ids=None, overwrite_existing=False):
+    def download(self, trans, history_id, provider, bucket, credentials, dataset_ids=None, overwrite_existing=False):
         """
-        Implements the logic of copying dataset(s) belonging to a given history to a given cloud-based storage
+        Implements the logic of downloading dataset(s) from a given history to a given cloud-based storage
         (e.g., Amazon S3).
 
         :type  trans: galaxy.web.framework.webapp.GalaxyWebTransaction
         :param trans: Galaxy web transaction
 
         :type  history_id: string
-        :param history_id: the (encoded) id of history from which the object should be copied.
+        :param history_id: the (encoded) id of history from which the object should be downloaded.
 
         :type  provider: string
         :param provider: the name of cloud-based resource provided. A list of supported providers
                          is given in `SUPPORTED_PROVIDERS` variable.
 
         :type  bucket: string
-        :param bucket: the name of a bucket to which data should be copied (e.g., a bucket
+        :param bucket: the name of a bucket to which data should be downloaded (e.g., a bucket
                        name on AWS S3).
 
         :type  credentials: dict
@@ -227,13 +227,13 @@ class CloudManager(sharable.SharableModelManager):
 
         :type  dataset_ids: set
         :param dataset_ids: [Optional] The list of (decoded) dataset ID(s) belonging to the given
-                            history which should be copied to the given provider. If not provided,
-                            Galaxy copies all the datasets belonging to the given history.
+                            history which should be downloaded to the given provider. If not provided,
+                            Galaxy downloads all the datasets belonging to the given history.
 
         :type  overwrite_existing: boolean
         :param overwrite_existing: [Optional] If set to "True", and an object with same name of the
-                                   dataset to be copied already exist in the bucket, Galaxy replaces
-                                   the existing object with the dataset to be copied. If set to
+                                   dataset to be downloaded already exist in the bucket, Galaxy replaces
+                                   the existing object with the dataset to be downloaded. If set to
                                    "False", Galaxy appends datetime to the dataset name to prevent
                                    overwriting the existing object.
 
@@ -249,7 +249,7 @@ class CloudManager(sharable.SharableModelManager):
             raise ObjectNotFound("Could not find the specified bucket `{}`.".format(bucket))
 
         history = trans.sa_session.query(trans.app.model.History).get(history_id)
-        uploaded = []
+        downloaded = []
         for hda in history.datasets:
             if dataset_ids is None or hda.dataset.id in dataset_ids:
                 object_label = hda.name
@@ -257,5 +257,5 @@ class CloudManager(sharable.SharableModelManager):
                     object_label += "-" + datetime.datetime.now().strftime("%y-%m-%d-%H-%M-%S")
                 created_obj = bucket_obj.create_object(object_label)
                 created_obj.upload_from_file(hda.dataset.get_file_name())
-                uploaded.append(object_label)
-        return uploaded
+                downloaded.append(object_label)
+        return downloaded

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -4,10 +4,6 @@ Manager and serializer for cloud-based storages.
 
 import datetime
 import logging
-import os
-import random
-import string
-from cgi import FieldStorage
 
 from galaxy.exceptions import (
     AuthenticationFailed,
@@ -37,6 +33,7 @@ SUPPORTED_PROVIDERS = "{aws, azure, openstack}"
 
 # TODO: this configuration should be set in a config file.
 SINGED_URL_TTL = 3600
+
 
 class CloudManager(sharable.SharableModelManager):
 

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -40,7 +40,8 @@ class CloudManager(sharable.SharableModelManager):
     def __init__(self, app, *args, **kwargs):
         super(CloudManager, self).__init__(app, *args, **kwargs)
 
-    def _configure_provider(self, provider, credentials):
+    @staticmethod
+    def _configure_provider(provider, credentials):
         """
         Given a provider name and required credentials, it configures and returns a cloudbridge
         connection to the provider.

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -35,6 +35,8 @@ NO_CLOUDBRIDGE_ERROR_MESSAGE = (
 
 SUPPORTED_PROVIDERS = "{aws, azure, openstack}"
 
+# TODO: this configuration should be set in a config file.
+SINGED_URL_TTL = 3600
 
 class CloudManager(sharable.SharableModelManager):
 
@@ -184,7 +186,7 @@ class CloudManager(sharable.SharableModelManager):
             'files_0|space_to_tab': None,
             'files_0|to_posix_lines': 'Yes',
             'files_0|NAME': obj,
-            'files_0|url_paste': key.generate_url(expires_in=3600),
+            'files_0|url_paste': key.generate_url(expires_in=SINGED_URL_TTL),
         }
 
         params = Params(inputs, sanitize=False)

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -195,7 +195,7 @@ class CloudManager(sharable.SharableModelManager):
 
         job_errors = output.get('job_errors', [])
         if job_errors:
-            raise ValueError('Cannot upload a dataset.')
+            raise ValueError('Cannot copy given object(s) from {}.'.format(provider))
         else:
             for d in output['out_data']:
                 datasets.append(d[1].dataset)

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -161,7 +161,7 @@ class CloudManager(sharable.SharableModelManager):
             'files_0|url_paste': key.generate_url(expires_in=SINGED_URL_TTL),
         }
 
-    def upload(self, trans, history_id, provider, bucket, objects, credentials, input_args={}):
+    def upload(self, trans, history_id, provider, bucket, objects, credentials, input_args=None):
         """
         Implements the logic of uploading a file from a cloud-based storage (e.g., Amazon S3)
         and persisting it as a Galaxy dataset.
@@ -194,6 +194,9 @@ class CloudManager(sharable.SharableModelManager):
         """
         if CloudProviderFactory is None:
             raise Exception(NO_CLOUDBRIDGE_ERROR_MESSAGE)
+
+        if input_args is None:
+            input_args = {}
 
         connection = self._configure_provider(provider, credentials)
         try:

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -138,7 +138,7 @@ class CloudManager(sharable.SharableModelManager):
         space_to_tab = None
         if input_args.get('space_to_tab', "").lower() == "true":
             space_to_tab = "Yes"
-        elif input_args.get('space_to_tab', "").lower() != "false":
+        elif input_args.get('space_to_tab', "").lower() not in ["false", ""]:
             raise RequestParameterInvalidException(
                 "The valid values for `space_to_tab` argument are `true` and `false`; received {}".format(
                     input_args.get('space_to_tab')))
@@ -146,7 +146,7 @@ class CloudManager(sharable.SharableModelManager):
         to_posix_lines = None
         if input_args.get('to_posix_lines', "").lower() == "true":
             to_posix_lines = "Yes"
-        elif input_args.get('to_posix_lines', "").lower() != "false":
+        elif input_args.get('to_posix_lines', "").lower() not in ["false", ""]:
             raise RequestParameterInvalidException(
                 "The valid values for `to_posix_lines` argument are `true` and `false`; received {}".format(
                     input_args.get('to_posix_lines')))

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -132,33 +132,33 @@ class CloudManager(sharable.SharableModelManager):
         except ProviderConnectionException as e:
             raise AuthenticationFailed("Could not authenticate to the '{}' provider. {}".format(provider, e))
 
-    def copy_from(self, trans, history_id, provider, bucket, obj, credentials):
+    def upload(self, trans, history_id, provider, bucket, obj, credentials):
         """
-        Implements the logic of copying a file from a cloud-based storage (e.g., Amazon S3)
+        Implements the logic of uploading a file from a cloud-based storage (e.g., Amazon S3)
         and persisting it as a Galaxy dataset.
 
         :type  trans: galaxy.web.framework.webapp.GalaxyWebTransaction
         :param trans: Galaxy web transaction
 
         :type  history_id: string
-        :param history_id: the (encoded) id of history to which the object should be downloaded to.
+        :param history_id: the (encoded) id of history to which the object should be uploaded to.
 
         :type  provider: string
         :param provider: the name of cloud-based resource provided. A list of supported providers is given in
         `SUPPORTED_PROVIDERS` variable.
 
         :type  bucket: string
-        :param bucket: the name of a bucket from which data should be downloaded (e.g., a bucket name on AWS S3).
+        :param bucket: the name of a bucket from which data should be uploaded (e.g., a bucket name on AWS S3).
 
         :type  obj: string
-        :param obj: the name of an object to be downloaded.
+        :param obj: the name of an object to be uploaded.
 
         :type  credentials: dict
         :param credentials: a dictionary containing all the credentials required to authenticated to the
         specified provider (e.g., {"secret_key": YOUR_AWS_SECRET_TOKEN, "access_key": YOUR_AWS_ACCESS_TOKEN}).
 
         :rtype:  list of galaxy.model.Dataset
-        :return: a list of datasets created for the downloaded files.
+        :return: a list of datasets created for the uploaded files.
         """
         if CloudProviderFactory is None:
             raise Exception(NO_CLOUDBRIDGE_ERROR_MESSAGE)

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -40,19 +40,19 @@ class CloudController(BaseAPIController):
         return 'Not Implemented'
 
     @expose_api
-    def copy_from(self, trans, payload, **kwargs):
+    def upload(self, trans, payload, **kwargs):
         """
-        * POST /api/cloud/storage/copy-from
-            Copies a given object from a given cloud-based bucket to a Galaxy history.
+        * POST /api/cloud/storage/upload
+            Uploads a given object from a given cloud-based bucket to a Galaxy history.
         :type  trans: galaxy.web.framework.webapp.GalaxyWebTransaction
         :param trans: Galaxy web transaction
 
         :type  payload: dict
         :param payload: A dictionary structure containing the following keys:
-            *   history_id:    the (encoded) id of history to which the object should be copied to.
+            *   history_id:    the (encoded) id of history to which the object should be uploaded to.
             *   provider:      the name of a cloud-based resource provided (e.g., `aws`, `azure`, or `openstack`).
-            *   bucket:        the name of a bucket from which data should be copied from (e.g., a bucket name on AWS S3).
-            *   object:        the name of an object to be copied.
+            *   bucket:        the name of a bucket from which data should be uploaded from (e.g., a bucket name on AWS S3).
+            *   object:        the name of an object to be uploaded.
             *   credentials:   a dictionary containing all the credentials required to authenticated to the
             specified provider (e.g., {"secret_key": YOUR_AWS_SECRET_TOKEN, "access_key": YOUR_AWS_ACCESS_TOKEN}).
 
@@ -94,12 +94,12 @@ class CloudController(BaseAPIController):
         except exceptions.MalformedId as e:
             raise ActionInputError('Invalid history ID. {}'.format(e))
 
-        datasets = self.cloud_manager.copy_from(trans=trans,
-                                                history_id=history_id,
-                                                provider=provider,
-                                                bucket=bucket,
-                                                obj=obj,
-                                                credentials=credentials)
+        datasets = self.cloud_manager.upload(trans=trans,
+                                             history_id=history_id,
+                                             provider=provider,
+                                             bucket=bucket,
+                                             obj=obj,
+                                             credentials=credentials)
         rtv = []
         for dataset in datasets:
             rtv.append(self.datasets_serializer.serialize_to_view(dataset, view='summary'))

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -98,7 +98,6 @@ class CloudController(BaseAPIController):
             raise ActionInputError('The `objects` should be a list, but received an object of type {} instead.'.format(
                 type(objects)))
 
-
         datasets = self.cloud_manager.upload(trans=trans,
                                              history_id=history_id,
                                              provider=provider,

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -43,7 +43,7 @@ class CloudController(BaseAPIController):
     def upload(self, trans, payload, **kwargs):
         """
         * POST /api/cloud/storage/upload
-            Uploads a given object from a given cloud-based bucket to a Galaxy history.
+            Uploads given objects from a given cloud-based bucket to a Galaxy history.
         :type  trans: galaxy.web.framework.webapp.GalaxyWebTransaction
         :param trans: Galaxy web transaction
 
@@ -52,7 +52,7 @@ class CloudController(BaseAPIController):
             *   history_id:    the (encoded) id of history to which the object should be uploaded to.
             *   provider:      the name of a cloud-based resource provided (e.g., `aws`, `azure`, or `openstack`).
             *   bucket:        the name of a bucket from which data should be uploaded from (e.g., a bucket name on AWS S3).
-            *   object:        the name of an object to be uploaded.
+            *   objects:       a list of the names of objects to be uploaded.
             *   credentials:   a dictionary containing all the credentials required to authenticated to the
             specified provider (e.g., {"secret_key": YOUR_AWS_SECRET_TOKEN, "access_key": YOUR_AWS_ACCESS_TOKEN}).
 
@@ -78,9 +78,9 @@ class CloudController(BaseAPIController):
         if bucket is None:
             missing_arguments.append("bucket")
 
-        obj = payload.get("object", None)
-        if obj is None:
-            missing_arguments.append("object")
+        objects = payload.get("objects", None)
+        if objects is None:
+            missing_arguments.append("objects")
 
         credentials = payload.get("credentials", None)
         if credentials is None:
@@ -94,11 +94,16 @@ class CloudController(BaseAPIController):
         except exceptions.MalformedId as e:
             raise ActionInputError('Invalid history ID. {}'.format(e))
 
+        if not isinstance(objects, list):
+            raise ActionInputError('The `objects` should be a list, but received an object of type {} instead.'.format(
+                type(objects)))
+
+
         datasets = self.cloud_manager.upload(trans=trans,
                                              history_id=history_id,
                                              provider=provider,
                                              bucket=bucket,
-                                             obj=obj,
+                                             objects=objects,
                                              credentials=credentials)
         rtv = []
         for dataset in datasets:

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -94,12 +94,12 @@ class CloudController(BaseAPIController):
         except exceptions.MalformedId as e:
             raise ActionInputError('Invalid history ID. {}'.format(e))
 
-        datasets = self.cloud_manager.download(trans=trans,
-                                               history_id=history_id,
-                                               provider=provider,
-                                               bucket=bucket,
-                                               obj=obj,
-                                               credentials=credentials)
+        datasets = self.cloud_manager.copy_from(trans=trans,
+                                                history_id=history_id,
+                                                provider=provider,
+                                                bucket=bucket,
+                                                obj=obj,
+                                                credentials=credentials)
         rtv = []
         for dataset in datasets:
             rtv.append(self.datasets_serializer.serialize_to_view(dataset, view='summary'))

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -55,6 +55,29 @@ class CloudController(BaseAPIController):
             *   objects:       a list of the names of objects to be uploaded.
             *   credentials:   a dictionary containing all the credentials required to authenticated to the
             specified provider (e.g., {"secret_key": YOUR_AWS_SECRET_TOKEN, "access_key": YOUR_AWS_ACCESS_TOKEN}).
+            *   input_args     [Optional; default value is an empty dict] a dictionary containing the following keys:
+
+                                **   `dbkey`:           [Optional; default value: is `?`]
+                                                        Sets the genome (e.g., `hg19`) of the objects being
+                                                        uploaded to Galaxy.
+
+                                **   `file_type`:       [Optional; default value is `auto`]
+                                                        Sets the Galaxy datatype (e.g., `bam`) for the
+                                                        objects being uploaded to Galaxy. See the following
+                                                        link for a complete list of Galaxy data types:
+                                                        https://galaxyproject.org/learn/datatypes/
+
+                                **   `space_to_tab`:    [Optional; default value is `False`]
+                                                        A boolean value ("true" or "false") that sets if spaces
+                                                        should be converted to tab in the objects being
+                                                        uploaded to Galaxy. Applicable only if `to_posix_lines`
+                                                        is True
+
+                                **   `to_posix_lines`:  [Optional; default value is `Yes`]
+                                                        A boolean value ("true" or "false"); if "Yes", converts
+                                                        universal line endings to POSIX line endings. Set to
+                                                        "False" if you upload a gzip, bz2 or zip archive
+                                                        containing a binary file.
 
         :param kwargs:
 
@@ -103,7 +126,8 @@ class CloudController(BaseAPIController):
                                              provider=provider,
                                              bucket=bucket,
                                              objects=objects,
-                                             credentials=credentials)
+                                             credentials=credentials,
+                                             input_args=payload.get("input_args", {}))
         rtv = []
         for dataset in datasets:
             rtv.append(self.datasets_serializer.serialize_to_view(dataset, view='summary'))

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -106,10 +106,10 @@ class CloudController(BaseAPIController):
         return rtv
 
     @expose_api
-    def copy_to(self, trans, payload, **kwargs):
+    def download(self, trans, payload, **kwargs):
         """
-        * POST /api/cloud/storage/copy-to
-            Copies a given dataset in a given history to a given cloud-based bucket. Each dataset is named
+        * POST /api/cloud/storage/download
+            Downloads a given dataset in a given history to a given cloud-based bucket. Each dataset is named
             using the label assigned to the dataset in the given history (see `HistoryDatasetAssociation.name`).
             If no dataset ID is given, this API copies all the datasets belonging to a given history to a given
             cloud-based bucket.
@@ -118,26 +118,26 @@ class CloudController(BaseAPIController):
 
         :type  payload: dictionary
         :param payload: A dictionary structure containing the following keys:
-            *   history_id              the (encoded) id of history from which the object should be copied.
+            *   history_id              the (encoded) id of history from which the object should be downloaed.
             *   provider:               the name of a cloud-based resource provider (e.g., `aws`, `azure`, or `openstack`).
-            *   bucket:                 the name of a bucket to which data should be copied (e.g., a bucket name on AWS S3).
+            *   bucket:                 the name of a bucket to which data should be downloaded (e.g., a bucket name on AWS S3).
             *   credentials:            a dictionary containing all the credentials required to authenticated to the
                                         specified provider (e.g., {"secret_key": YOUR_AWS_SECRET_TOKEN,
                                         "access_key": YOUR_AWS_ACCESS_TOKEN}).
             *   dataset_ids:            [Optional; default: None]
                                         A list of encoded dataset IDs belonging to the specified history
-                                        that should be copied to the given bucket. If not provided, Galaxy copies
+                                        that should be downloaded to the given bucket. If not provided, Galaxy downloads
                                         all the datasets belonging the specified history.
             *   overwrite_existing:     [Optional; default: False]
                                         A boolean value. If set to "True", and an object with same name of the dataset
-                                        to be copied already exist in the bucket, Galaxy replaces the existing object
-                                        with the dataset to be copied. If set to "False", Galaxy appends datetime
+                                        to be downloaded already exist in the bucket, Galaxy replaces the existing object
+                                        with the dataset to be downloaded. If set to "False", Galaxy appends datetime
                                         to the dataset name to prevent overwriting an existing object.
 
         :param kwargs:
 
         :rtype:  dictionary
-        :return: Information about the copied datasets, including uploaded_dataset_labels
+        :return: Information about the downloaded datasets, including downloaded_dataset_labels
                  and destination bucket name.
         """
         missing_arguments = []
@@ -180,12 +180,12 @@ class CloudController(BaseAPIController):
                 raise ActionInputError("The following provided dataset IDs are invalid, please correct them and retry. "
                                        "{}".format(invalid_dataset_ids))
 
-        uploaded = self.cloud_manager.copy_to(trans=trans,
-                                              history_id=history_id,
-                                              provider=provider,
-                                              bucket=bucket,
-                                              credentials=credentials,
-                                              dataset_ids=dataset_ids,
-                                              overwrite_existing=payload.get("overwrite_existing", False))
-        return {'uploaded_dataset_labels': uploaded,
+        uploaded = self.cloud_manager.download(trans=trans,
+                                               history_id=history_id,
+                                               provider=provider,
+                                               bucket=bucket,
+                                               credentials=credentials,
+                                               dataset_ids=dataset_ids,
+                                               overwrite_existing=payload.get("overwrite_existing", False))
+        return {'downloaded_dataset_labels': uploaded,
                 'bucket_name': bucket}

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -127,7 +127,7 @@ class CloudController(BaseAPIController):
                                              bucket=bucket,
                                              objects=objects,
                                              credentials=credentials,
-                                             input_args=payload.get("input_args", {}))
+                                             input_args=payload.get("input_args", None))
         rtv = []
         for dataset in datasets:
             rtv.append(self.datasets_serializer.serialize_to_view(dataset, view='summary'))

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -251,10 +251,10 @@ def populate_api_routes(webapp, app):
                           controller='cloud',
                           action='upload',
                           conditions=dict(method=["POST"]))
-    webapp.mapper.connect('cloud_storage_copy_to',
-                          '/api/cloud/storage/copy-to',
+    webapp.mapper.connect('cloud_storage_download',
+                          '/api/cloud/storage/download',
                           controller='cloud',
-                          action='copy_to',
+                          action='download',
                           conditions=dict(method=["POST"]))
 
     _add_item_tags_controller(webapp,

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -246,10 +246,10 @@ def populate_api_routes(webapp, app):
                           controller='cloud',
                           action='index',
                           conditions=dict(method=["GET"]))
-    webapp.mapper.connect('cloud_storage_copy_from',
-                          '/api/cloud/storage/copy-from',
+    webapp.mapper.connect('cloud_storage_upload',
+                          '/api/cloud/storage/upload',
                           controller='cloud',
-                          action='copy_from',
+                          action='upload',
                           conditions=dict(method=["POST"]))
     webapp.mapper.connect('cloud_storage_copy_to',
                           '/api/cloud/storage/copy-to',


### PR DESCRIPTION
To copy an object from cloud, the cloud manager currently stages the object first, then pass the staged object to the upload tool. Hence, the manager's copy function would return only after a given object is staged (downloaded). This design can cause request timeout when copying big files from a cloud-based storage to Galaxy. 

This PR solves that issue by passing a _singed url_ of the object to copied from cloud, to upload tool. Hence, the copy process is handled as a job, avoiding request timeout. 
