### PR TITLE
[18.05] Fix warning in CONVERTER_bam_to_bigwig_0 and CONVERTER_sam_to_bigwig_0

### DIFF
--- a/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bam_to_bigwig_converter.xml
@@ -4,23 +4,22 @@
         <requirement type="package" version="357">ucsc-bedgraphtobigwig</requirement>
         <requirement type="package" version="2.27.1">bedtools</requirement>
     </requirements>
-    <command><![CDATA[
-        bedtools genomecov -bg -split -ibam '$input' -g '$chromInfo'
+    <command detect_errors="aggressive"><![CDATA[
+bedtools genomecov -bg -split -ibam '$input'
+| LC_COLLATE=C sort -k1,1 -k2,2n
 
-        | LC_COLLATE=C sort -k1,1 -k2,2n
+## Streaming the bedgraph file to wigToBigWig is fast but very memory intensive; hence, this
+## should only be used on systems with large RAM.
+## | wigToBigWig stdin '$chromInfo' '$output'
 
-        ## Streaming the bedgraph file to wigToBigWig is fast but very memory intensive; hence, this
-        ## should only be used on systems with large RAM.
-        ## | wigToBigWig stdin '$chromInfo' '$output'
-
-        ## This can be used anywhere.
-        > temp.bg && bedGraphToBigWig temp.bg '$chromInfo' '$output']]>
-    </command>
+## This can be used anywhere.
+> temp.bg && bedGraphToBigWig temp.bg '$chromInfo' '$output'
+    ]]></command>
     <inputs>
-        <param format="bam,unsorted.bam" name="input" type="data" label="Choose BAM file"/>
+        <param name="input" type="data" format="bam,unsorted.bam" label="Choose BAM file"/>
     </inputs>
     <outputs>
-        <data format="bigwig" name="output"/>
+        <data name="output" format="bigwig"/>
     </outputs>
     <help>
     </help>

--- a/lib/galaxy/datatypes/converters/sam_to_bigwig_converter.xml
+++ b/lib/galaxy/datatypes/converters/sam_to_bigwig_converter.xml
@@ -1,26 +1,24 @@
-<tool id="CONVERTER_sam_to_bigwig_0" name="Convert SAM to BigWig" version="1.0.1" hidden="true">
+<tool id="CONVERTER_sam_to_bigwig_0" name="Convert SAM to BigWig" version="1.0.2" hidden="true">
     <requirements>
         <requirement type="package" version="357">ucsc-bedgraphtobigwig</requirement>
         <requirement type="package" version="1.6">samtools</requirement>
         <requirement type="package" version="2.27.1">bedtools</requirement>
     </requirements>
-    <command>
-<![CDATA[
-        samtools view -bh '$input' | bedtools genomecov -bg -split -ibam stdin -g '$chromInfo'
+    <command detect_errors="aggressive"><![CDATA[
+samtools view -bh '$input' | bedtools genomecov -bg -split -ibam stdin
 
-        ## Streaming the bedgraph file to wigToBigWig is fast but very memory intensive; hence, this
-        ## should only be used on systems with large RAM.
-        ## | wigToBigWig stdin '$chromInfo' '$output'
+## Streaming the bedgraph file to wigToBigWig is fast but very memory intensive; hence, this
+## should only be used on systems with large RAM.
+## | wigToBigWig stdin '$chromInfo' '$output'
 
-        ## This can be used anywhere.
-        > temp.bg && bedGraphToBigWig temp.bg '$chromInfo' '$output'
-]]>
-    </command>
+## This can be used anywhere.
+> temp.bg && bedGraphToBigWig temp.bg '$chromInfo' '$output'
+    ]]></command>
     <inputs>
-        <param format="bam" name="input" type="data" label="Choose BAM file"/>
+        <param name="input" type="data" format="sam" label="Choose BAM file"/>
     </inputs>
     <outputs>
-        <data format="bigwig" name="output"/>
+        <data name="output" format="bigwig"/>
     </outputs>
     <help>
     </help>


### PR DESCRIPTION
Since v2.27.0 (see https://github.com/arq5x/bedtools2/commit/4d188435777cfbd6ada7394ee78fde37f07c9a75 ), `bedtools genomecov` emits this warning:
```
*****
*****WARNING: Genome (-g) files are ignored when BAM input is provided.
*****
```
if both `-ibam` and `-g` option are specified, which causes the converters to always fail.

Also:
- Add `detect_errors="aggressive"` to `<command/>` to prevent future warnings from creating other issues.
- Fix input format in `CONVERTER_sam_to_bigwig_0`.