### PR TITLE
Optimizations for history copying.

### DIFF
--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -34,7 +34,7 @@ class HDCAManager(
     foreign_key_name = 'history_dataset_collection_association'
 
     tag_assoc = model.HistoryDatasetCollectionTagAssociation
-    annotation_assoc = model.HistoryDatasetCollectionAnnotationAssociation
+    annotation_assoc = model.HistoryDatasetCollectionAssociationAnnotationAssociation
 
     def __init__(self, app):
         """

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5101,7 +5101,7 @@ class VisualizationAnnotationAssociation(object):
     pass
 
 
-class HistoryDatasetCollectionAnnotationAssociation(object):
+class HistoryDatasetCollectionAssociationAnnotationAssociation(object):
     pass
 
 

--- a/lib/galaxy/model/item_attrs.py
+++ b/lib/galaxy/model/item_attrs.py
@@ -128,6 +128,8 @@ class UsesAnnotations(object):
             annotation_assoc = annotation_assoc.filter_by(history=item)
         elif item.__class__ == galaxy.model.HistoryDatasetAssociation:
             annotation_assoc = annotation_assoc.filter_by(hda=item)
+        elif item.__class__ == galaxy.model.HistoryDatasetCollectionAssociation:
+            annotation_assoc = annotation_assoc.filter_by(history_dataset_collection=item)
         elif item.__class__ == galaxy.model.StoredWorkflow:
             annotation_assoc = annotation_assoc.filter_by(stored_workflow=item)
         elif item.__class__ == galaxy.model.WorkflowStep:

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1321,7 +1321,7 @@ model.VisualizationAnnotationAssociation.table = Table(
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
     Column("annotation", TEXT, index=True))
 
-model.HistoryDatasetCollectionAnnotationAssociation.table = Table(
+model.HistoryDatasetCollectionAssociationAnnotationAssociation.table = Table(
     "history_dataset_collection_annotation_association", metadata,
     Column("id", Integer, primary_key=True),
     Column("history_dataset_collection_id", Integer,
@@ -2120,8 +2120,8 @@ simple_mapping(model.HistoryDatasetCollectionAssociation,
     tags=relation(model.HistoryDatasetCollectionTagAssociation,
         order_by=model.HistoryDatasetCollectionTagAssociation.table.c.id,
         backref='dataset_collections'),
-    annotations=relation(model.HistoryDatasetCollectionAnnotationAssociation,
-        order_by=model.HistoryDatasetCollectionAnnotationAssociation.table.c.id,
+    annotations=relation(model.HistoryDatasetCollectionAssociationAnnotationAssociation,
+        order_by=model.HistoryDatasetCollectionAssociationAnnotationAssociation.table.c.id,
         backref="dataset_collections"),
     ratings=relation(model.HistoryDatasetCollectionRatingAssociation,
         order_by=model.HistoryDatasetCollectionRatingAssociation.table.c.id,
@@ -2468,7 +2468,7 @@ annotation_mapping(model.StoredWorkflowAnnotationAssociation, stored_workflow=mo
 annotation_mapping(model.WorkflowStepAnnotationAssociation, workflow_step=model.WorkflowStep)
 annotation_mapping(model.PageAnnotationAssociation, page=model.Page)
 annotation_mapping(model.VisualizationAnnotationAssociation, visualization=model.Visualization)
-annotation_mapping(model.HistoryDatasetCollectionAnnotationAssociation,
+annotation_mapping(model.HistoryDatasetCollectionAssociationAnnotationAssociation,
     history_dataset_collection=model.HistoryDatasetCollectionAssociation)
 annotation_mapping(model.LibraryDatasetCollectionAnnotationAssociation,
     library_dataset_collection=model.LibraryDatasetCollectionAssociation)

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -513,7 +513,7 @@ class FileParameter(MetadataParameter):
         if value:
             new_value = galaxy.model.MetadataFile(dataset=target_context.parent, name=self.spec.name)
             object_session(target_context.parent).add(new_value)
-            object_session(target_context.parent).flush()
+            object_session(target_context.parent).flush([new_value])
             shutil.copy(value.file_name, new_value.file_name)
             return self.unwrap(new_value)
         return None
@@ -563,7 +563,7 @@ class FileParameter(MetadataParameter):
         if object_session(dataset):
             mf = galaxy.model.MetadataFile(name=self.spec.name, dataset=dataset, **kwds)
             object_session(dataset).add(mf)
-            object_session(dataset).flush()  # flush to assign id
+            object_session(dataset).flush([mf])  # flush to assign id
             return mf
         else:
             # we need to make a tmp file that is accessable to the head node,
@@ -766,7 +766,7 @@ class JobExternalOutputMetadataWrapper(object):
                 json.dump(override_metadata, open(metadata_files.filename_override_metadata, 'wt+'))
                 # add to session and flush
                 sa_session.add(metadata_files)
-                sa_session.flush()
+                sa_session.flush([metadata_files])
             metadata_files_list.append(metadata_files)
         args = '"%s" "%s" %s %s' % (metadata_path_on_compute(datatypes_config),
                                     job_metadata,

--- a/test/unit/test_galaxy_mapping.py
+++ b/test/unit/test_galaxy_mapping.py
@@ -69,7 +69,7 @@ class MappingTests(unittest.TestCase):
         dataset_collection = model.DatasetCollection(collection_type="paired")
         history_dataset_collection = model.HistoryDatasetCollectionAssociation(collection=dataset_collection)
         self.persist(history_dataset_collection)
-        persist_and_check_annotation(model.HistoryDatasetCollectionAnnotationAssociation, history_dataset_collection=history_dataset_collection)
+        persist_and_check_annotation(model.HistoryDatasetCollectionAssociationAnnotationAssociation, history_dataset_collection=history_dataset_collection)
 
         library_dataset_collection = model.LibraryDatasetCollectionAssociation(collection=dataset_collection)
         self.persist(library_dataset_collection)

--- a/test/unit/test_model_copy.py
+++ b/test/unit/test_model_copy.py
@@ -1,0 +1,134 @@
+import contextlib
+import os
+import threading
+
+import galaxy.datatypes.registry
+import galaxy.model
+import galaxy.model.mapping as mapping
+from galaxy.model.metadata import MetadataTempFile
+from galaxy.util import ExecutionTimer
+from .test_objectstore import DISK_TEST_CONFIG, TestConfig
+
+
+datatypes_registry = galaxy.datatypes.registry.Registry()
+datatypes_registry.load_datatypes()
+galaxy.model.set_datatypes_registry(datatypes_registry)
+
+NUM_DATASETS = 3
+NUM_COLLECTIONS = 1
+SLOW_QUERY_LOG_THRESHOLD = 1000
+INCLUDE_METADATA_FILE = True
+THREAD_LOCAL_LOG = threading.local()
+
+
+def test_history_dataset_copy(num_datasets=NUM_DATASETS, include_metadata_file=INCLUDE_METADATA_FILE):
+    with _setup_mapping_and_user() as (test_config, object_store, model, old_history):
+        for i in range(num_datasets):
+            hda_path = test_config.write("moo", "test_metadata_original_%d" % i)
+            _create_hda(model, object_store, old_history, hda_path, include_metadata_file=include_metadata_file)
+
+        model.context.flush()
+
+        history_copy_timer = ExecutionTimer()
+        new_history = old_history.copy(target_user=old_history.user)
+        print("history copied %s" % history_copy_timer)
+        assert new_history.name == "HistoryCopyHistory1"
+        assert new_history.user == old_history.user
+        for i, hda in enumerate(new_history.active_datasets):
+            assert hda.get_size() == 3
+            if include_metadata_file:
+                _check_metadata_file(hda)
+            annotation_str = hda.get_item_annotation_str(model.context, old_history.user, hda)
+            assert annotation_str == "annotation #%d" % hda.hid, annotation_str
+
+
+def test_history_collection_copy(list_size=NUM_DATASETS):
+    with _setup_mapping_and_user() as (test_config, object_store, model, old_history):
+        for i in range(NUM_COLLECTIONS):
+            hdas = []
+            for i in range(list_size * 2):
+                hda_path = test_config.write("moo", "test_metadata_original_%d" % i)
+                hda = _create_hda(model, object_store, old_history, hda_path, visible=False, include_metadata_file=False)
+                hdas.append(hda)
+
+            list_elements = []
+            list_collection = model.DatasetCollection(collection_type="list:paired")
+            for j in range(list_size):
+                paired_collection = model.DatasetCollection(collection_type="paired")
+                forward_dce = model.DatasetCollectionElement(collection=paired_collection, element=hdas[j * 2])
+                reverse_dce = model.DatasetCollectionElement(collection=paired_collection, element=hdas[j * 2 + 1])
+                paired_collection.elements = [forward_dce, reverse_dce]
+                paired_collection_element = model.DatasetCollectionElement(collection=list_collection, element=paired_collection)
+                list_elements.append(paired_collection_element)
+                model.context.add_all([forward_dce, reverse_dce, paired_collection_element])
+            list_collection.elements = list_elements
+            history_dataset_collection = model.HistoryDatasetCollectionAssociation(collection=list_collection)
+            history_dataset_collection.user = old_history.user
+            model.context.add(history_dataset_collection)
+
+            model.context.flush()
+            old_history.add_dataset_collection(history_dataset_collection)
+            history_dataset_collection.add_item_annotation(model.context, old_history.user, history_dataset_collection, "annotation #%d" % history_dataset_collection.hid)
+
+        model.context.flush()
+        annotation_str = history_dataset_collection.get_item_annotation_str(model.context, old_history.user, history_dataset_collection)
+
+        # Saving magic SA invocations for detecting full flushes that may harm performance.
+        # from sqlalchemy import event
+        # @event.listens_for(model.context, "before_flush")
+        # def track_instances_before_flush(session, context, instances):
+        #     if not instances:
+        #         print("FULL FLUSH...")
+        #     else:
+        #         print("Flushing just %s" % instances)
+
+        history_copy_timer = ExecutionTimer()
+        new_history = old_history.copy(target_user=old_history.user)
+        print("history copied %s" % history_copy_timer)
+
+        for i, hda in enumerate(new_history.active_datasets):
+            assert hda.get_size() == 3
+            annotation_str = hda.get_item_annotation_str(model.context, old_history.user, hda)
+            assert annotation_str == "annotation #%d" % hda.hid, annotation_str
+
+        assert len(new_history.active_dataset_collections) == NUM_COLLECTIONS
+        for hdca in new_history.active_dataset_collections:
+            annotation_str = hdca.get_item_annotation_str(model.context, old_history.user, hdca)
+            assert annotation_str == "annotation #%d" % hdca.hid, annotation_str
+
+
+@contextlib.contextmanager
+def _setup_mapping_and_user():
+    with TestConfig(DISK_TEST_CONFIG) as (test_config, object_store):
+        # Start the database and connect the mapping
+        model = mapping.init("/tmp", "sqlite:///:memory:", create_tables=True, object_store=object_store, slow_query_log_threshold=SLOW_QUERY_LOG_THRESHOLD, thread_local_log=THREAD_LOCAL_LOG)
+
+        u = model.User(email="historycopy@example.com", password="password")
+        h1 = model.History(name="HistoryCopyHistory1", user=u)
+        model.context.add_all([u, h1])
+        model.context.flush()
+        yield test_config, object_store, model, h1
+
+
+def _create_hda(model, object_store, history, path, visible=True, include_metadata_file=False):
+    hda = model.HistoryDatasetAssociation(extension="bam", create_dataset=True, sa_session=model.context)
+    hda.visible = visible
+    model.context.add(hda)
+    model.context.flush([hda])
+    object_store.update_from_file(hda, file_name=path, create=True)
+    if include_metadata_file:
+        hda.metadata.from_JSON_dict(json_dict={"bam_index": MetadataTempFile.from_JSON({"kwds": {}, "filename": path})})
+        _check_metadata_file(hda)
+    hda.set_size()
+    history.add_dataset(hda)
+    hda.add_item_annotation(model.context, history.user, hda, "annotation #%d" % hda.hid)
+    return hda
+
+
+def _check_metadata_file(hda):
+    assert hda.metadata.bam_index.id
+    copied_index = hda.metadata.bam_index.file_name
+    assert os.path.exists(copied_index)
+    with open(copied_index, "r") as f:
+        assert f.read() == "moo"
+    assert copied_index.endswith("metadata_%d.dat" % hda.id)


### PR DESCRIPTION
Use only one unqualified flush to prevent constant repeated invalidation off all SA objects just to get a single ID for a new object.

Some random timings:

Before optimization:

10 datasets - with a MetadataFile metadata parameter
history copied (390.457 ms)
history copied (398.501 ms)
history copied (360.997 ms)

10 datasets  - without a MetadataFile metadata parameter
history copied (291.972 ms)
history copied (276.479 ms)
history copied (272.323 ms)

after optimization:

10 datasets - with a MetadataFile metadata parameter
history copied (230.171 ms)
history copied (218.215 ms)
history copied (226.205 ms)

10 datasets - without a MetadataFile metadata parameter
history copied (66.360 ms)
history copied (70.126 ms)
history copied (65.166 ms)

Also fixes HDCA annotations which seem to have been completely non-functional on the backend.