### PR TITLE
Convert tool parameter XML attribute 'hidden' into the correct boolean Python type

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -94,7 +94,7 @@ class ToolParameter(Dictifiable):
         self.argument = input_source.get("argument")
         self.name = self.__class__.parse_name(input_source)
         self.type = input_source.get("type")
-        self.hidden = input_source.get("hidden", False)
+        self.hidden = input_source.get_bool("hidden", False)
         self.refresh_on_change = input_source.get_bool("refresh_on_change", False)
         self.optional = input_source.parse_optional()
         self.is_dynamic = False


### PR DESCRIPTION
Previously it was converted into a string, and in the logical predicates
any non-empty value would always evaluate to True.
This fix allows using the 'hidden' attribute in parameterized XML
macros with 'true' or 'false' passed as a macros parameter. This
in turns allows hiding some form fields (after setting default values)
based on choices picked in conditional switches.

This would still require documenting the 'hidden' attribute in the Galaxy Tool XML Wiki.
The need for this feature is related to #4572. The idea here is that for some parameters
certain default values have been "validated" for certain choices of a "master" parameter switch
used in a conditional, and the validated parameters must be frozen for the user.

It would be even better to have an attribute 'disabled' that would make the form field visible
but read-only like many UI frameworks allow to do. That will require more work though. 