### PR TITLE
[18.05] Fix "filter empty" rule in Python rule handling framework.

### DIFF
--- a/lib/galaxy/util/rules_dsl.py
+++ b/lib/galaxy/util/rules_dsl.py
@@ -296,7 +296,8 @@ class AddFilterEmptyRuleDefinition(BaseRuleDefinition):
         target_column = rule["target_column"]
 
         def _filter(index):
-            return not invert if len(data[target_column]) == 0 else invert
+            non_empty = len(data[index][target_column]) != 0
+            return not invert if non_empty else invert
 
         return _filter_index(_filter, data), _filter_index(_filter, sources)
 

--- a/test/unit/test_rule_utils.py
+++ b/test/unit/test_rule_utils.py
@@ -11,11 +11,22 @@ def test_rules():
             initial = test_case["initial"]
             final_data, final_sources = rule_set.apply(initial["data"], initial["sources"])
             expected_final = test_case["final"]
-            for final_row, expected_final_row in zip(final_data, expected_final["data"]):
+            expected_final_data = expected_final["data"]
+            msg = "Incorrect number of rows, %s != %s" % (final_data, expected_final_data)
+            assert len(expected_final_data) == len(final_data), msg
+            for final_row, expected_final_row in zip(final_data, expected_final_data):
                 msg = "%s != %s" % (final_row, expected_final_row)
                 assert len(final_row) == len(expected_final_row), msg
                 for final_val, expected_final_val in zip(final_row, expected_final_row):
                     assert final_val == expected_final_val, msg
+            expected_final_sources = expected_final.get("sources", None)
+            if expected_final_sources:
+                msg = "Incorrect number of sources, %s != %s" % (expected_final_sources, final_sources)
+                assert len(expected_final_sources) == len(final_sources), msg
+                for final_source, expected_final_source in zip(final_sources, expected_final_sources):
+                    msg = "%s != %s" % (final_source, expected_final_source)
+                    assert final_source == expected_final_source, msg
+
         elif "error" in test_case:
             assert rule_set.has_errors, "rule [%s] does not contain errors" % test_case
         else:


### PR DESCRIPTION
Also address limitations in Python half of the testing framework for the rules spec to catch this. The JS framework uses a deepEquals assertion and so the existing spec definition test passed already and confirms this is not a problem in the JS handling.
