### PR TITLE
Allow Consuming Tags in the Apply Rules Tool

### DIFF
--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -1182,6 +1182,7 @@ export default {
                         metadataOptions["identifier" + index] = _l("Paired Identifier");
                     }
                 }
+                metadataOptions["tags"] = _l("Tags");
             } else if (this.elementsType == "ftp") {
                 metadataOptions["path"] = _l("Path");
             } else if (this.elementsType == "library_datasets") {
@@ -1189,6 +1190,7 @@ export default {
             } else if (this.elementsType == "datasets") {
                 metadataOptions["hid"] = _l("History ID (hid)");
                 metadataOptions["name"] = _l("Name");
+                metadataOptions["tags"] = _l("Tags");
             } else {
                 metadataOptions = null;
             }
@@ -1682,7 +1684,8 @@ export default {
                     // sources are the elements
                     // TOOD: right thing is probably this: data.push([]);
                     data.push([]);
-                    sources.push({ identifiers: identifiers, dataset: elementObject });
+                    const source = { identifiers: identifiers, dataset: elementObject, tags: elementObject.tags };
+                    sources.push(source);
                 } else {
                     const restCollectionType = collectionType.slice(collectionTypeLevelSepIndex + 1);
                     let elementObj = this.populateElementsFromCollectionDescription(

--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -59,6 +59,18 @@
                                 </select>
                             </label>
                         </rule-component>
+                        <rule-component rule-type="add_column_group_tag_value"
+                                        :display-rule-type="displayRuleType"
+                                        :builder="this">
+                            <label>
+                                {{ l("Value") }}
+                                <input type="text" v-model="addColumnGroupTagValueValue" />
+                            </label>
+                            <label>
+                                {{ l("Default") }}
+                                <input type="text" v-model="addColumnGroupTagValueDefault" />
+                            </label>
+                        </rule-component>
                         <rule-component rule-type="add_column_regex"
                                         :display-rule-type="displayRuleType"
                                         :builder="this">
@@ -286,6 +298,7 @@
                                     <div class="dropdown-menu" role="menu">
                                         <rule-target-component :builder="this" rule-type="add_column_basename" />
                                         <rule-target-component :builder="this" rule-type="add_column_metadata" v-if="metadataOptions"/>
+                                        <rule-target-component :builder="this" rule-type="add_column_group_tag_value" v-if="hasTagsMetadata"/>
                                         <rule-target-component :builder="this" rule-type="add_column_regex" />
                                         <rule-target-component :builder="this" rule-type="add_column_concatenate" />
                                         <rule-target-component :builder="this" rule-type="add_column_rownum" />
@@ -901,6 +914,8 @@ export default {
             addColumnRegexGroupCount: null,
             addColumnRegexType: "global",
             addColumnMetadataValue: 0,
+            addColumnGroupTagValueValue: "",
+            addColumnGroupTagValueDefault: "",
             addColumnConcatenateTarget0: 0,
             addColumnConcatenateTarget1: 0,
             addColumnRownumStart: 1,
@@ -1190,11 +1205,14 @@ export default {
             } else if (this.elementsType == "datasets") {
                 metadataOptions["hid"] = _l("History ID (hid)");
                 metadataOptions["name"] = _l("Name");
-                metadataOptions["tags"] = _l("Tags");
             } else {
                 metadataOptions = null;
             }
             return metadataOptions;
+        },
+        hasTagsMetadata() {
+            // TODO: allow for dataset, library_datasets also - here and just above in metadataOptions.
+            return this.elementsType == "collection_contents";
         },
         collectionType() {
             let identifierColumns = [];
@@ -1682,7 +1700,6 @@ export default {
                 if (collectionTypeLevelSepIndex === -1) {
                     // Flat collection at this depth.
                     // sources are the elements
-                    // TOOD: right thing is probably this: data.push([]);
                     data.push([]);
                     const source = { identifiers: identifiers, dataset: elementObject, tags: elementObject.tags };
                     sources.push(source);

--- a/client/galaxy/scripts/mvc/rules/rule-definitions.js
+++ b/client/galaxy/scripts/mvc/rules/rule-definitions.js
@@ -174,6 +174,14 @@ const RULES = {
                     newRow.push(sources[index]["identifiers"][identifierIndex]);
                     return newRow;
                 };
+            } else if (ruleValue == "tags") {
+                newRow = (row, index) => {
+                    const newRow = row.slice();
+                    const tags = sources[index]["tags"];
+                    tags.sort();
+                    newRow.push(tags.join(","));
+                    return newRow;
+                };
             } else if (ruleValue == "hid" || ruleValue == "name" || ruleValue == "path") {
                 newRow = (row, index) => {
                     const newRow = row.slice();

--- a/client/galaxy/scripts/mvc/rules/rule-definitions.js
+++ b/client/galaxy/scripts/mvc/rules/rule-definitions.js
@@ -167,7 +167,7 @@ const RULES = {
         apply: (rule, data, sources, columns) => {
             const ruleValue = rule.value;
             let newRow;
-            if (ruleValue.startsWith("identifier")) {
+            if (ruleValue.indexOf("identifier") == 0) {
                 const identifierIndex = parseInt(ruleValue.substring("identifier".length));
                 newRow = (row, index) => {
                     const newRow = row.slice();

--- a/client/galaxy/scripts/mvc/rules/rule-definitions.js
+++ b/client/galaxy/scripts/mvc/rules/rule-definitions.js
@@ -196,6 +196,47 @@ const RULES = {
             return { data, columns };
         }
     },
+    add_column_group_tag_value: {
+        title: _l("Add Column from Group Tag Value"),
+        display: (rule, colHeaders) => {
+            return `Add column for value of group tag ${rule.value}.`;
+        },
+        init: (component, rule) => {
+            if (!rule) {
+                component.addColumnGroupTagValueValue = null;
+                component.addColumnGroupTagValueDefault = '';
+            } else {
+                component.addColumnGroupTagValueValue = rule.value;
+                component.addColumnGroupTagValueDefault = rule.default_value;
+            }
+        },
+        save: (component, rule) => {
+            rule.value = component.addColumnGroupTagValueValue;
+            rule.default_value = component.addColumnGroupTagValueDefault;
+        },
+        apply: (rule, data, sources, columns) => {
+            const ruleValue = rule.value;
+            const groupTagPrefix = `group:${ruleValue}:`;
+            const newRow = (row, index) => {
+                const newRow = row.slice();
+                const tags = sources[index]["tags"];
+                tags.sort();
+                let groupTagValue = rule.default_value;
+                for (let index in tags) {
+                    const tag = tags[index];
+                    if ( tag.indexOf(groupTagPrefix) == 0 ) {
+                        groupTagValue = tag.substr(groupTagPrefix.length);
+                        break;
+                    }
+                }
+                newRow.push(groupTagValue);
+                return newRow;
+            };
+            data = data.map(newRow);
+            columns.push(NEW_COLUMN);
+            return { data, columns };
+        }
+    },
     add_column_regex: {
         title: _l("Using a Regular Expression"),
         display: (rule, colHeaders) => {

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -492,7 +492,8 @@ class DatasetCollectionManager(object):
             identifiers = parent_identifiers + [element.element_identifier]
             if not element.is_collection:
                 data.append([])
-                sources.append({"identifiers": identifiers, "dataset": element_object})
+                source = {"identifiers": identifiers, "dataset": element_object, "tags": element.make_tag_string_list()}
+                sources.append(source)
             else:
                 child_collection_type_description = collection_type_description.child_collection_type_description()
                 element_data, element_sources = self.__init_rule_data(

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -492,7 +492,7 @@ class DatasetCollectionManager(object):
             identifiers = parent_identifiers + [element.element_identifier]
             if not element.is_collection:
                 data.append([])
-                source = {"identifiers": identifiers, "dataset": element_object, "tags": element.make_tag_string_list()}
+                source = {"identifiers": identifiers, "dataset": element_object, "tags": element_object.make_tag_string_list()}
                 sources.append(source)
             else:
                 child_collection_type_description = collection_type_description.child_collection_type_description()

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2707,7 +2707,6 @@ class ApplyRulesTool(DatabaseOperationTool):
     tool_type = 'apply_rules'
 
     def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
-        log.info(incoming)
         hdca = incoming["input"]
         rule_set = RuleSet(incoming["rules"])
         copied_datasets = []

--- a/lib/galaxy/util/rules_dsl.py
+++ b/lib/galaxy/util/rules_dsl.py
@@ -95,6 +95,34 @@ class AddColumnMetadataRuleDefinition(BaseRuleDefinition):
         return new_rows, sources
 
 
+class AddColumnGroupTagValueRuleDefinition(BaseRuleDefinition):
+    rule_type = "add_column_group_tag_value"
+
+    def validate_rule(self, rule):
+        _ensure_rule_contains_keys(rule, {"value": six.string_types})
+
+    def apply(self, rule, data, sources):
+        rule_value = rule["value"]
+        tag_prefix = "group:%s:" % rule_value
+
+        new_rows = []
+        for index, row in enumerate(data):
+            group_tag_value = None
+            source = sources[index]
+            tags = source["tags"]
+            for tag in sorted(tags):
+                if tag.startswith(tag_prefix):
+                    group_tag_value = tag[len(tag_prefix):]
+                    break
+
+            if group_tag_value is None:
+                group_tag_value = rule.get("default_value", "")
+
+            new_rows.append(row + [group_tag_value])
+
+        return new_rows, sources
+
+
 class AddColumnConcatenateRuleDefinition(BaseRuleDefinition):
     rule_type = "add_column_concatenate"
 
@@ -536,6 +564,7 @@ class RuleSet(object):
 
 RULES_DEFINITION_CLASSES = [
     AddColumnMetadataRuleDefinition,
+    AddColumnGroupTagValueRuleDefinition,
     AddColumnConcatenateRuleDefinition,
     AddColumnBasenameRuleDefinition,
     AddColumnRegexRuleDefinition,

--- a/lib/galaxy/util/rules_dsl.py
+++ b/lib/galaxy/util/rules_dsl.py
@@ -75,11 +75,22 @@ class AddColumnMetadataRuleDefinition(BaseRuleDefinition):
 
     def apply(self, rule, data, sources):
         rule_value = rule["value"]
-        identifier_index = int(rule_value[len("identifier"):])
+        if rule_value.startswith("identifier"):
+            identifier_index = int(rule_value[len("identifier"):])
 
-        new_rows = []
-        for index, row in enumerate(data):
-            new_rows.append(row + [sources[index]["identifiers"][identifier_index]])
+            new_rows = []
+            for index, row in enumerate(data):
+                new_rows.append(row + [sources[index]["identifiers"][identifier_index]])
+
+        elif rule_value == "tags":
+
+            def sorted_tags(index):
+                tags = sorted(sources[index]["tags"])
+                return [",".join(tags)]
+
+            new_rows = []
+            for index, row in enumerate(data):
+                new_rows.append(row + sorted_tags(index))
 
         return new_rows, sources
 

--- a/lib/galaxy/util/rules_dsl.py
+++ b/lib/galaxy/util/rules_dsl.py
@@ -296,7 +296,8 @@ class AddFilterEmptyRuleDefinition(BaseRuleDefinition):
         target_column = rule["target_column"]
 
         def _filter(index):
-            return not invert if len(data[target_column]) == 0 else invert
+            non_empty = len(data[index][target_column]) != 0
+            return not invert if non_empty else invert
 
         return _filter_index(_filter, data), _filter_index(_filter, sources)
 

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -353,6 +353,9 @@ class ToolsTestCase(api.ApiTestCase):
     def test_apply_rules_3(self):
         self._apply_rules_and_check(rules_test_data.EXAMPLE_3)
 
+    def test_apply_rules_4(self):
+        self._apply_rules_and_check(rules_test_data.EXAMPLE_4)
+
     @skip_without_tool("multi_select")
     def test_multi_select_as_list(self):
         with self.dataset_populator.test_history() as history_id:

--- a/test/base/data/rules_dsl_spec.yml
+++ b/test/base/data/rules_dsl_spec.yml
@@ -403,6 +403,15 @@
     data: [["moo", "cow"], ["meow", "cat"], ["bark", "dog"]]
 
 - rules:
+    - type: add_column_metadata
+      value: tags
+  initial:
+    data: [["moo"], ["meow"], ["bark"]]
+    sources: [{"identifiers": ["cow"], "tags": ["farm"]}, {"identifiers": ["cat"], "tags": ["house"]}, {"identifiers": ["dog"], "tags": ["house", "firestation"]}]
+  final:
+    data: [["moo", "farm"], ["meow", "house"], ["bark", "firestation,house"]]
+
+- rules:
     - type: invalid_rule_type
   error: true
 

--- a/test/base/data/rules_dsl_spec.yml
+++ b/test/base/data/rules_dsl_spec.yml
@@ -325,6 +325,7 @@
   final:
     data: [["20", "dog"], ["30", "cat"]]
     sources: [4, 5]
+
 - rules:
     - type: add_filter_compare
       target_column: 0
@@ -336,6 +337,7 @@
   final:
     data: [["13", "rat"], ["20", "dog"], ["30", "cat"]]
     sources: [3, 4, 5]
+
 - rules:
     - type: sort
       numeric: false
@@ -346,6 +348,7 @@
   final:
     data: [["bark", "dog"], ["meow", "cat"], ["moo", "cow"]]
     sources: [3, 2, 1]
+
 - rules:
     - type: sort
       numeric: false
@@ -356,6 +359,7 @@
   final:
     data: [["meow", "cat"], ["moo", "cow"], ["bark", "dog"]]
     sources: [2, 1, 3]
+
 - rules:
     - type: sort
       numeric: false
@@ -366,6 +370,7 @@
   final:
     data: [["bark", "Dog"], ["meow", "cat"], ["moo", "cow"]]
     sources: [3, 2, 1]
+
 - rules:
     - type: swap_columns
       target_column_0: 0
@@ -376,6 +381,7 @@
   final:
     data: [["cow", "moo"], ["cat", "meow"], ["Dog", "bark"]]
     sources: [1, 2, 3]
+
 - rules:
     - type: split_columns
       target_columns_0: [0]
@@ -386,28 +392,43 @@
   final:
     data: [["moo", "A"], ["cow", "A"], ["meow", "B"], ["cat", "B"], ["bark", "C"], ["Dog", "C"]]
     sources: [1, 1, 2, 2, 3, 3]
+
+- rules:
+    - type: add_column_metadata
+      value: identifier0
+  initial:
+    data: [["moo"], ["meow"], ["bark"]]
+    sources: [{"identifiers": ["cow"]}, {"identifiers": ["cat"]}, {"identifiers": ["dog"]}]
+  final:
+    data: [["moo", "cow"], ["meow", "cat"], ["bark", "dog"]]
+
 - rules:
     - type: invalid_rule_type
   error: true
+
 - rules:
     - type: add_filter_compare
       target_column: 0
       value: 13
       compare_type: invalid_compare_type
   error: true
+
 - rules:
     - type: add_column_concatenate
       target_column: 0
   error: true
+
 - rules:
     - type: add_column_basename
       target_column_0: 0
   error: true
+
 - rules:
     - type: add_column_regex
       target_column: 0
       regex: '(o)+'
   error: true
+
 - rules:
     - type: add_column_regex
       target_column: 0

--- a/test/base/data/rules_dsl_spec.yml
+++ b/test/base/data/rules_dsl_spec.yml
@@ -412,6 +412,38 @@
     data: [["moo", "farm"], ["meow", "house"], ["bark", "firestation,house"]]
 
 - rules:
+    - type: add_column_group_tag_value
+      value: where
+      default_value: ''
+  initial:
+    data: [["moo"], ["meow"], ["bark"]]
+    sources: [{"identifiers": ["cow"], "tags": ["group:where:farm"]}, {"identifiers": ["cat"], "tags": ["group:where:house"]}, {"identifiers": ["dog"], "tags": ["group:where:house"]}]
+  final:
+    data: [["moo", "farm"], ["meow", "house"], ["bark", "house"]]
+
+- doc: Test add_column_group_tag_value default value.
+  rules:
+    - type: add_column_group_tag_value
+      value: where
+      default_value: 'barn'
+  initial:
+    data: [["moo"], ["meow"], ["bark"]]
+    sources: [{"identifiers": ["cow"], "tags": []}, {"identifiers": ["cat"], "tags": ["group:where:house"]}, {"identifiers": ["dog"], "tags": ["group:where:firestation"]}]
+  final:
+    data: [["moo", "barn"], ["meow", "house"], ["bark", "firestation"]]
+
+- doc: Test add_column_group_tag_value sorts and grabs first tag value if multiple present.
+  rules:
+    - type: add_column_group_tag_value
+      value: where
+      default_value: 'barn'
+  initial:
+    data: [["moo"], ["meow"], ["bark"]]
+    sources: [{"identifiers": ["cow"], "tags": []}, {"identifiers": ["cat"], "tags": ["group:where:house", "group:where:kittenpile"]}, {"identifiers": ["dog"], "tags": ["group:where:house", "group:where:firestation"]}]
+  final:
+    data: [["moo", "barn"], ["meow", "house"], ["bark", "firestation"]]
+
+- rules:
     - type: invalid_rule_type
   error: true
 

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -917,13 +917,20 @@ def load_data_dict(history_id, test_data, dataset_populator, dataset_collection_
             elements_data = value.get("elements", [])
             elements = []
             for element_data in elements_data:
-                identifier = element_data["identifier"]
+                # Adapt differences between test_data dict and fetch API description.
+                if "name" not in element_data:
+                    identifier = element_data["identifier"]
+                    element_data["name"] = identifier
                 input_type = element_data.get("type", "raw")
+                content = None
                 if input_type == "File":
                     content = read_test_data(element_data)
                 else:
                     content = element_data["content"]
-                elements.append((identifier, content))
+                if content is not None:
+                    element_data["src"] = "pasted"
+                    element_data["paste_content"] = content
+                elements.append(element_data)
             # TODO: make this collection_type
             collection_type = value["type"]
             new_collection_kwds = {}

--- a/test/base/rules_test_data.py
+++ b/test/base/rules_test_data.py
@@ -30,6 +30,21 @@ def check_example_3(hdca, dataset_populator):
     assert first_element["element_identifier"] == "test0forward"
 
 
+def check_example_4(hdca, dataset_populator):
+    assert hdca["collection_type"] == "list:list"
+    assert hdca["element_count"] == 2
+    first_collection_level = hdca["elements"][0]
+    assert first_collection_level["element_identifier"] == "single", hdca
+    assert first_collection_level["element_type"] == "dataset_collection"
+    second_collection_level = first_collection_level["object"]
+    assert "elements" in second_collection_level, hdca
+    assert len(second_collection_level["elements"]) == 1, hdca
+    i1_element = second_collection_level["elements"][0]
+    assert "object" in i1_element, hdca
+    assert "element_identifier" in i1_element
+    assert i1_element["element_identifier"] == "i1", hdca
+
+
 EXAMPLE_1 = {
     "rules": {
         "rules": [
@@ -129,4 +144,49 @@ EXAMPLE_3 = {
     },
     "check": check_example_3,
     "output_hid": 7,
+}
+
+# Nesting with group tags.
+EXAMPLE_4 = {
+    "rules": {
+        "rules": [
+            {
+                "type": "add_column_metadata",
+                "value": "identifier0",
+            },
+            {
+                "type": "add_column_group_tag_value",
+                "value": "type",
+                "default_value": "unused"
+            }
+        ],
+        "mapping": [
+            {
+                "type": "list_identifiers",
+                "columns": [1, 0],
+            }
+        ],
+    },
+    "test_data": {
+        "type": "list",
+        "elements": [
+            {
+                "identifier": "i1",
+                "content": "0",
+                "tags": ["random", "group:type:single"]
+            },
+            {
+                "identifier": "i2",
+                "content": "1",
+                "tags": ["random", "group:type:paired"]
+            },
+            {
+                "identifier": "i3",
+                "content": "2",
+                "tags": ["random", "group:type:paired"]
+            },
+        ]
+    },
+    "check": check_example_4,
+    "output_hid": 8,
 }

--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -1023,6 +1023,8 @@ class NavigatesGalaxy(HasDriver):
             tool_link = self.components.tool_panel.outer_tool_link(tool_id=tool_id)
         else:
             tool_link = self.components.tool_panel.tool_link(tool_id=tool_id)
+        tool_element = tool_link.wait_for_present()
+        self.driver.execute_script("arguments[0].scrollIntoView(true);", tool_element)
         tool_link.wait_for_and_click()
 
     def tool_parameter_div(self, expanded_parameter_id):

--- a/test/galaxy_selenium/smart_components.py
+++ b/test/galaxy_selenium/smart_components.py
@@ -78,6 +78,9 @@ class SmartTarget(object):
     def wait_for_absent(self, **kwds):
         self._has_driver.wait_for_absent(self._target, **kwds)
 
+    def wait_for_present(self, **kwds):
+        return self._has_driver.wait_for_present(self._target, **kwds)
+
     def assert_absent(self, **kwds):
         self._has_driver.assert_absent(self._target, **kwds)
 

--- a/test/selenium_tests/test_tool_form.py
+++ b/test/selenium_tests/test_tool_form.py
@@ -179,6 +179,11 @@ class LoggedInToolFormTestCase(SeleniumTestCase):
         self.screenshot("tool_apply_rules_example_3_final")
 
     @selenium_test
+    def test_run_apply_rules_4(self):
+        self._apply_rules_and_check(rules_test_data.EXAMPLE_4)
+        self.screenshot("tool_apply_rules_example_4_final")
+
+    @selenium_test
     @managed_history
     def test_run_apply_rules_tutorial(self):
         self.home()

--- a/test/unit/test_rule_utils.py
+++ b/test/unit/test_rule_utils.py
@@ -11,11 +11,22 @@ def test_rules():
             initial = test_case["initial"]
             final_data, final_sources = rule_set.apply(initial["data"], initial["sources"])
             expected_final = test_case["final"]
-            for final_row, expected_final_row in zip(final_data, expected_final["data"]):
+            expected_final_data = expected_final["data"]
+            msg = "Incorrect number of rows, %s != %s" % (final_data, expected_final_data)
+            assert len(expected_final_data) == len(final_data), msg
+            for final_row, expected_final_row in zip(final_data, expected_final_data):
                 msg = "%s != %s" % (final_row, expected_final_row)
                 assert len(final_row) == len(expected_final_row), msg
                 for final_val, expected_final_val in zip(final_row, expected_final_row):
                     assert final_val == expected_final_val, msg
+            expected_final_sources = expected_final.get("sources", None)
+            if expected_final_sources:
+                msg = "Incorrect number of sources, %s != %s" % (expected_final_sources, final_sources)
+                assert len(expected_final_sources) == len(final_sources), msg
+                for final_source, expected_final_source in zip(final_sources, expected_final_sources):
+                    msg = "%s != %s" % (final_source, expected_final_source)
+                    assert final_source == expected_final_source, msg
+
         elif "error" in test_case:
             assert rule_set.has_errors, "rule [%s] does not contain errors" % test_case
         else:


### PR DESCRIPTION
A few small polish, bug fix commits and then two primary commits to allow using tags more effectively in the Apply Rules tool.

The previously merged PR https://github.com/galaxyproject/galaxy/pull/6500 allowed setting tags from metadata when importing new collections using the rule builder. 4d83746 included in this PR then lets dataset tags already present to be loaded in when modifying the collection with the "Apply Rules" tool (added in 18.05 as part of https://github.com/galaxyproject/galaxy/pull/5819). This allows filtering a collection based on tags and re-organizing the nesting structure of a collection based on tags.

18.09 will introduce a new kind of tags - group tags (added in https://github.com/galaxyproject/galaxy/pull/6491) that like name tags will be auto-propagated but won't be used for naming but instead of categorizing datasets in a factorial analysis. #6500 added support for populating datasets with such tags when importing them using the rule builder and #5457 will add support for tools to effectively consume these group tags. 5807230 included in this PR now lets the user very easily use these tags with the "Apply Rules" tool. This allows certain kinds of filtering and re-organization using group tags specifically that are technically possible after the previous commit be implemented by users in one step instead of several. For instance, if datasets in a collection have different group tags such as ``group:type:single`` and ``group:type:paired-end`` - a single rule can now be used to populate a column containing either ``single`` or ``paired-end``. This will likely be the most common tagging operation with the Apply Rules tool and would require 3 rules without this change.
