### PR TITLE
Configure object store for datasets in job handler instead of web thread.

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -296,6 +296,20 @@ galaxy:
   # as the 'watch_tools' option.
   #watch_job_rules: false
 
+  # As of 18.09, Galaxy defaults to setting up the object store
+  # configuration for output datasets during the job queue step in job
+  # handlers. This should generally provide for more robust job
+  # submission, more configurability, and a better user experience but
+  # may in some cases slightly slow down the job handler job setup
+  # process. On the off chance that an admin would like to or need to
+  # optimize job handlers at the expense of user experience and web
+  # handling this option will remain for some time by setting this
+  # option to true. This behavior however should be considered
+  # deprecated and this option will likely be removed in future versions
+  # of Galaxy. For more information see
+  # https://github.com/galaxyproject/galaxy/issues/6513.
+  #legacy_eager_objectstore_initialization: false
+
   # Enable Galaxy to fetch Docker containers registered with quay.io
   # generated from tool requirements resolved through conda. These
   # containers (when available) have been generated using mulled -

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -458,6 +458,27 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``legacy_eager_objectstore_initialization``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    As of 18.09, Galaxy defaults to setting up the object store
+    configuration for output datasets during the job queue step in job
+    handlers. This should generally provide for more robust job
+    submission, more configurability, and a better user experience but
+    may in some cases slightly slow down the job handler job setup
+    process. On the off chance that an admin would like to or need to
+    optimize job handlers at the expense of user experience and web
+    handling this option will remain for some time by setting this
+    option to true. This behavior however should be considered
+    deprecated and this option will likely be removed in future
+    versions of Galaxy. For more information see
+    https://github.com/galaxyproject/galaxy/issues/6513.
+:Default: ``false``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``enable_beta_mulled_containers``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -374,6 +374,9 @@ class Configuration(object):
         self.enable_beta_ts_api_install = string_as_bool(kwargs.get('enable_beta_ts_api_install', 'True'))
         # The transfer manager and deferred job queue
         self.enable_beta_job_managers = string_as_bool(kwargs.get('enable_beta_job_managers', 'False'))
+        # Set this to go back to setting the object store in the tool request instead of
+        # in the job handler.
+        self.legacy_eager_objectstore_initialization = string_as_bool(kwargs.get('legacy_eager_objectstore_initialization', 'False'))
         # These workflow modules should not be considered part of Galaxy's
         # public API yet - the module state definitions may change and
         # workflows built using these modules may not function in the

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -28,6 +28,7 @@ from galaxy.exceptions import ObjectInvalid, ObjectNotFound
 from galaxy.jobs.actions.post import ActionBox
 from galaxy.jobs.mapper import JobRunnerMapper
 from galaxy.jobs.runners import BaseJobRunner, JobState
+from galaxy.objectstore import ObjectStorePopulator
 from galaxy.util import safe_makedirs, unicodify
 from galaxy.util.bunch import Bunch
 from galaxy.util.expressions import ExpressionContext
@@ -707,11 +708,11 @@ class JobWrapper(HasResourceParameters):
         self.write_version_cmd = None
         self.version_string = ""
         self.__galaxy_lib_dir = None
-        # With job outputs in the working directory, we need the working
-        # directory to be set before prepare is run, or else premature deletion
-        # and job recovery fail.
-        # Create the working dir if necessary
-        self._create_working_directory()
+        # If the job has an object_store_id ensure working directory is setup, otherwise
+        # wait for that to be assigned before configuring it. Either way the working
+        # directory does not to be configured on this object before prepare() is called.
+        if job.object_store_id:
+            self._create_working_directory(job=job)
         # the path rewriter needs destination params, so it cannot be set up until after the destination has been
         # resolved
         self._dataset_path_rewriter = None
@@ -895,8 +896,9 @@ class JobWrapper(HasResourceParameters):
             self.write_version_cmd = None
         return self.extra_filenames
 
-    def _create_working_directory(self):
-        job = self.get_job()
+    def _create_working_directory(self, job=None):
+        if job is None:
+            job = self.get_job()
         try:
             self.app.object_store.create(
                 job, base_dir='job_work', dir_only=True, obj_dir=True)
@@ -931,7 +933,7 @@ class JobWrapper(HasResourceParameters):
         date_str = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
         arc_dir = os.path.join(base, date_str)
         shutil.move(self.working_directory, arc_dir)
-        self._create_working_directory()
+        self._create_working_directory(job=job)
         log.debug('(%s) Previous working directory moved to %s',
                   self.job_id, arc_dir)
 
@@ -1163,11 +1165,36 @@ class JobWrapper(HasResourceParameters):
 
     def enqueue(self):
         job = self.get_job()
+        self._set_object_store_ids(job)
         # Change to queued state before handing to worker thread so the runner won't pick it up again
         self.change_state(model.Job.states.QUEUED, flush=False, job=job)
         # Persist the destination so that the job will be included in counts if using concurrency limits
         self.set_job_destination(self.job_destination, None, flush=False, job=job)
         self.sa_session.flush()
+
+    def _set_object_store_ids(self, job):
+        if self.app.config.legacy_eager_objectstore_initialization:
+            return
+
+        if job.object_store_id:
+            # We aren't setting this during job creation anymore, but some existing
+            # jobs may have this set. Skip this following code if that is the case.
+            return
+
+        object_store_populator = ObjectStorePopulator(self.app)
+
+        # Ideally we would do this without loading the actual job association objects but
+        # change_state isn't yet optimized to do that anyway so we need to do that
+        # anyway. In the future though - this should be done with a custom query
+        # that just loads Dataset.ids, passes them through object store code, and sets
+        # object_store_id on those ids with a multi-update afterward. State below
+        # needs to happen the same way.
+        for dataset_assoc in job.output_datasets + job.output_library_datasets:
+            dataset = dataset_assoc.dataset
+            object_store_populator.set_object_store_id(dataset)
+
+        job.object_store_id = object_store_populator.object_store_id
+        self._create_working_directory(job=job)
 
     def finish(
         self,

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1161,6 +1161,14 @@ class JobWrapper(HasResourceParameters):
             dest_params, self.app.config, key, default
         )
 
+    def enqueue(self):
+        job = self.get_job()
+        # Change to queued state before handing to worker thread so the runner won't pick it up again
+        self.change_state(model.Job.states.QUEUED, flush=False, job=job)
+        # Persist the destination so that the job will be included in counts if using concurrency limits
+        self.set_job_destination(self.job_destination, None, flush=False, job=job)
+        self.sa_session.flush()
+
     def finish(
         self,
         stdout,

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1187,12 +1187,12 @@ class JobWrapper(HasResourceParameters):
 
         object_store_populator = ObjectStorePopulator(self.app)
 
-        # Ideally we would do this without loading the actual job association objects but
-        # change_state isn't yet optimized to do that anyway so we need to do that
-        # anyway. In the future though - this should be done with a custom query
-        # that just loads Dataset.ids, passes them through object store code, and sets
-        # object_store_id on those ids with a multi-update afterward. State below
-        # needs to happen the same way.
+        # Ideally we would do this without loading the actual job association
+        # objects but change_state isn't yet optimized to do that so we need to
+        # do that anyway. In the future though - this should be done with a
+        # custom query that just loads Dataset.ids, passes them through object
+        # store code, and sets object_store_id on those ids with a multi-update
+        # afterward. State below needs to happen the same way.
         for dataset_assoc in job.output_datasets + job.output_library_datasets:
             dataset = dataset_assoc.dataset
             object_store_populator.set_object_store_id(dataset)

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -119,12 +119,7 @@ class BaseJobRunner(object):
         """Add a job to the queue (by job identifier), indicate that the job is ready to run.
         """
         put_timer = ExecutionTimer()
-        job = job_wrapper.get_job()
-        # Change to queued state before handing to worker thread so the runner won't pick it up again
-        job_wrapper.change_state(model.Job.states.QUEUED, flush=False, job=job)
-        # Persist the destination so that the job will be included in counts if using concurrency limits
-        job_wrapper.set_job_destination(job_wrapper.job_destination, None, flush=False, job=job)
-        self.sa_session.flush()
+        job_wrapper.enqueue()
         self.mark_as_queued(job_wrapper)
         log.debug("Job [%s] queued %s" % (job_wrapper.job_id, put_timer))
 

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -808,3 +808,24 @@ def _create_object_in_session(obj):
         object_session(obj).flush()
     else:
         raise Exception(NO_SESSION_ERROR_MESSAGE)
+
+
+class ObjectStorePopulator(object):
+    """ Small helper for interacting with the object store and making sure all
+    datasets from a job end up with the same object_store_id.
+    """
+
+    def __init__(self, app):
+        self.object_store = app.object_store
+        self.object_store_id = None
+
+    def set_object_store_id(self, data):
+        # Create an empty file immediately.  The first dataset will be
+        # created in the "default" store, all others will be created in
+        # the same store as the first.
+        data.dataset.object_store_id = self.object_store_id
+        try:
+            self.object_store.create(data.dataset)
+        except ObjectInvalid:
+            raise Exception('Unable to create output dataset: object store is full')
+        self.object_store_id = data.dataset.object_store_id  # these will be the same thing after the first output

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -420,7 +420,7 @@ def create_job(trans, params, tool, json_file_path, outputs, folder=None, histor
             else:
                 job.add_output_dataset(output_name, dataset)
             # Create an empty file immediately
-            if not dataset.dataset.external_filename:
+            if not dataset.dataset.external_filename and trans.app.config.legacy_eager_objectstore_initialization:
                 dataset.dataset.object_store_id = object_store_id
                 try:
                     trans.app.object_store.create(dataset.dataset)

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -371,7 +371,7 @@ mapping:
         desc: |
           As of 18.09, Galaxy defaults to setting up the object store configuration
           for output datasets during the job queue step in job handlers. This should generally
-          provide for more robust job submission, more configurablity, and a better
+          provide for more robust job submission, more configurability, and a better
           user experience but may in some cases slightly slow down the job handler job
           setup process. On the off chance that an admin would like to or need to optimize job
           handlers at the expense of user experience and web handling this option will remain

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -364,6 +364,21 @@ mapping:
           found, rules are automatically reloaded. Takes the same values as the
           'watch_tools' option.
 
+      legacy_eager_objectstore_initialization:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          As of 18.09, Galaxy defaults to setting up the object store configuration
+          for output datasets during the job queue step in job handlers. This should generally
+          provide for more robust job submission, more configurablity, and a better
+          user experience but may in some cases slightly slow down the job handler job
+          setup process. On the off chance that an admin would like to or need to optimize job
+          handlers at the expense of user experience and web handling this option will remain
+          for some time by setting this option to true. This behavior however should be
+          considered deprecated and this option will likely be removed in future versions of
+          Galaxy. For more information see https://github.com/galaxyproject/galaxy/issues/6513.
+
       enable_beta_mulled_containers:
         type: bool
         default: false

--- a/test/unit/jobs/test_job_wrapper.py
+++ b/test/unit/jobs/test_job_wrapper.py
@@ -29,6 +29,7 @@ class BaseWrapperTestCase(UsesApp):
         job.id = 345
         job.tool_id = TEST_TOOL_ID
         job.user = User()
+        job.object_store_id = "foo"
         self.model_objects = {Job: {345: job}}
         self.app.model.context = MockContext(self.model_objects)
 

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -133,6 +133,7 @@ class MockAppConfig(Bunch):
         self.migrated_tools_config = "/tmp/migrated_tools_conf.xml"
         self.preserve_python_environment = "always"
         self.enable_beta_gdpr = False
+        self.legacy_eager_objectstore_initialization = True
 
         # set by MockDir
         self.root = root


### PR DESCRIPTION
This is good for a few reasons:

* It speeds up the bottleneck that is the job creation code in the web thread (the job handler is much easier to parallelize). Skipping the flush for all those datasets and skipping the disk write per dataset should really speed things up nicely when submitting large numbers of jobs and jobs with a large number of inputs. Fixes https://github.com/galaxyproject/galaxy/issues/6513 and important progress on #4959.
* This prevents a disk slow down from grinding the web response to a halt. We don't want the handler to freeze up either - but if something is going to freeze it is a better user experience and easier to recover from the job handler freezing while their are disk problems.
* This allows per-job-handler object store configurations - simply configure different job handlers with different object store configurations. This is also a huge step toward per-job-destination object stores (see #6552 that builds on this PR to add that feature).

Updated: Rebased with some fixes and removed the refactoring toward per-job-destination commit since it has been merged into a single commit that actually adds that feature as part of #6552.
