### PR TITLE
Redirect unidentified routes in admin panel

### DIFF
--- a/client/galaxy/scripts/apps/admin.js
+++ b/client/galaxy/scripts/apps/admin.js
@@ -20,6 +20,7 @@ window.app = function app(options, bootstrapped) {
     /** Routes */
     var AdminRouter = Router.extend({
         routes: {
+            "(/)admin(/)" : "home",
             "(/)admin(/)users": "show_users",
             "(/)admin(/)roles": "show_roles",
             "(/)admin(/)groups": "show_groups",
@@ -29,11 +30,22 @@ window.app = function app(options, bootstrapped) {
             "(/)admin(/)forms": "show_forms",
             "(/)admin(/)form(/)(:form_id)": "show_form",
             "(/)admin/data_tables": "show_data_tables",
-            "(/)admin/data_types": "show_data_types"
+            "(/)admin/data_types": "show_data_types",
+            "*notFound": "not_found"
         },
 
         authenticate: function() {
             return Galaxy.user && Galaxy.user.id && Galaxy.user.get("is_admin");
+        },
+
+        not_found: function() {
+            window.location.href = `${Galaxy.root}${Backbone.history.getFragment()}`;
+        },
+
+        home: function() {
+            this.page
+                .$("#galaxy_main")
+                .prop("src", `${Galaxy.root}admin/center?message=${options.message}&status=${options.status}`);
         },
 
         show_users: function() {

--- a/client/galaxy/scripts/apps/admin.js
+++ b/client/galaxy/scripts/apps/admin.js
@@ -43,7 +43,7 @@ window.app = function app(options, bootstrapped) {
         },
 
         not_found: function() {
-            window.location.href = `${Galaxy.root}${Backbone.history.getFragment()}`;
+            window.location.href = window.location.href;
         },
 
         home: function() {

--- a/client/galaxy/scripts/apps/admin.js
+++ b/client/galaxy/scripts/apps/admin.js
@@ -1,3 +1,5 @@
+import * as Backbone from "backbone";
+import * as _ from "underscore";
 import _l from "utils/localization";
 import jQuery from "jquery";
 var $ = jQuery;
@@ -13,6 +15,8 @@ import DataTables from "components/admin/DataTables.vue";
 import DataTypes from "components/admin/DataTypes.vue";
 import Vue from "vue";
 
+/* global Galaxy */
+
 window.app = function app(options, bootstrapped) {
     window.Galaxy = new GalaxyApp.GalaxyApp(options, bootstrapped);
     Galaxy.debug("admin app");
@@ -20,7 +24,7 @@ window.app = function app(options, bootstrapped) {
     /** Routes */
     var AdminRouter = Router.extend({
         routes: {
-            "(/)admin(/)" : "home",
+            "(/)admin(/)": "home",
             "(/)admin(/)users": "show_users",
             "(/)admin(/)roles": "show_roles",
             "(/)admin(/)groups": "show_groups",

--- a/client/galaxy/scripts/apps/panels/admin-panel.js
+++ b/client/galaxy/scripts/apps/panels/admin-panel.js
@@ -7,8 +7,6 @@ var AdminPanel = Backbone.View.extend({
         this.root = options.root;
         this.config = options.config;
         this.settings = options.settings;
-        this.message = options.message;
-        this.status = options.status;
         this.model = new Backbone.Model({
             title: `Galaxy version ${Galaxy.config.version_major}`
         });
@@ -173,9 +171,6 @@ var AdminPanel = Backbone.View.extend({
             });
             self.$el.append($section);
         });
-        this.page
-            .$("#galaxy_main")
-            .prop("src", `${this.root}admin/center?message=${this.message}&status=${this.status}`);
     },
 
     _templateSection: function(options) {

--- a/client/galaxy/scripts/apps/panels/admin-panel.js
+++ b/client/galaxy/scripts/apps/panels/admin-panel.js
@@ -1,4 +1,10 @@
+import * as Backbone from "backbone";
+import * as _ from "underscore";
+
 import _l from "utils/localization";
+
+/* global Galaxy */
+/* global $ */
 
 var AdminPanel = Backbone.View.extend({
     initialize: function(page, options) {


### PR DESCRIPTION
Potential follow-up for #6447 to redirect missing routes from the admin to the analysis app. Currently, analysis routes in the masthead are unavailable in the admin app.