### PR TITLE
Restore log_destination = stdout configuration option.

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -723,7 +723,16 @@ class Configuration(object):
                 'qualname': 'COMPLIANCE'
             }
 
-        if kwargs.get("log_destination", None):
+        log_destination = kwargs.get("log_destination", None)
+        if log_destination == "stdout":
+            LOGGING_CONFIG_DEFAULT['handlers']['console'] = {
+                'class': 'logging.StreamHandler',
+                'formatter': 'stack',
+                'level': 'DEBUG',
+                'stream': 'ext://sys.stdout',
+                'filters': ['stack']
+            }
+        elif log_destination:
             LOGGING_CONFIG_DEFAULT['handlers']['console'] = {
                 'class': 'logging.FileHandler',
                 'formatter': 'stack',


### PR DESCRIPTION
Implementation in 17.09 was here https://github.com/galaxyproject/galaxy/blob/release_17.09/lib/galaxy/config.py#L910. This option set to stdout is used by the test framework output Galaxy logs to stdout. As far as I can tell log_destination was removed in 18.01 and the effect was to sort of default to stdout - but when we fixed log_destination for files and backported recently https://github.com/galaxyproject/galaxy/commit/bc95f2563601635cfa1daa686b3d5c4e3ebb51ea - test output became written to a file called "stdout". This commit should restore the 17.09 behavior for both files and stdout configuration of this logging.