### PR TITLE
[WIP] More Job Scheduling Optimizations

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -246,6 +246,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.database_create_tables = string_as_bool(kwargs.get("database_create_tables", "True"))
         self.database_query_profiling_proxy = string_as_bool(kwargs.get("database_query_profiling_proxy", "False"))
         self.database_encoding = kwargs.get("database_encoding", None)  # Create new databases with this encoding.
+        self.database_log_query_counts = string_as_bool(kwargs.get("database_log_query_counts", False))
         self.thread_local_log = None
         if string_as_bool(kwargs.get("enable_per_request_sql_debugging", "False")):
             self.thread_local_log = threading.local()
@@ -854,7 +855,8 @@ def init_models_from_config(config, map_install_models=False, object_store=None,
         trace_logger=trace_logger,
         use_pbkdf2=config.get_bool('use_pbkdf2', True),
         slow_query_log_threshold=config.slow_query_log_threshold,
-        thread_local_log=config.thread_local_log
+        thread_local_log=config.thread_local_log,
+        log_query_counts=config.database_log_query_counts,
     )
     return model
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5113,6 +5113,8 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable, RepresentById):
             for step in self.steps:
                 if step.workflow_step.type == 'tool':
                     for job in step.jobs:
+                        if job is None:
+                            continue
                         for step_input in step.workflow_step.input_connections:
                             output_step_type = step_input.output_step.type
                             if output_step_type in ['data_input', 'data_collection_input']:

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2826,7 +2826,7 @@ model.WorkflowInvocation.update = _workflow_invocation_update
 
 def init(file_path, url, engine_options=None, create_tables=False, map_install_models=False,
         database_query_profiling_proxy=False, object_store=None, trace_logger=None, use_pbkdf2=True,
-        slow_query_log_threshold=0, thread_local_log=None):
+        slow_query_log_threshold=0, thread_local_log=None, log_query_counts=False):
     """Connect mappings to the database"""
     if engine_options is None:
         engine_options = {}
@@ -2837,7 +2837,7 @@ def init(file_path, url, engine_options=None, create_tables=False, map_install_m
     # Use PBKDF2 password hashing?
     model.User.use_pbkdf2 = use_pbkdf2
     # Load the appropriate db module
-    engine = build_engine(url, engine_options, database_query_profiling_proxy, trace_logger, slow_query_log_threshold, thread_local_log=thread_local_log)
+    engine = build_engine(url, engine_options, database_query_profiling_proxy, trace_logger, slow_query_log_threshold, thread_local_log=thread_local_log, log_query_counts=log_query_counts)
 
     # Connect the metadata to the database.
     metadata.bind = engine

--- a/lib/galaxy/model/orm/engine_factory.py
+++ b/lib/galaxy/model/orm/engine_factory.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import time
 
 from sqlalchemy import create_engine, event
@@ -6,8 +7,24 @@ from sqlalchemy.engine import Engine
 
 log = logging.getLogger(__name__)
 
+QUERY_COUNT_LOCAL = threading.local()
 
-def build_engine(url, engine_options, database_query_profiling_proxy=False, trace_logger=None, slow_query_log_threshold=0, thread_local_log=None):
+
+def reset_request_query_counts():
+    QUERY_COUNT_LOCAL.times = []
+
+
+def log_request_query_counts(req_id):
+    try:
+        times = QUERY_COUNT_LOCAL.times
+        if times:
+            log.info("Executed [%s] SQL requests in for web request [%s] (%f(s)ms)" % (len(times), req_id, sum(times) * 1000.))
+    except AttributeError:
+        # Didn't record anything so don't worry.
+        pass
+
+
+def build_engine(url, engine_options, database_query_profiling_proxy=False, trace_logger=None, slow_query_log_threshold=0, thread_local_log=None, log_query_counts=False):
     # Should we use the logging proxy?
     if database_query_profiling_proxy:
         import galaxy.model.orm.logging_connection_proxy as logging_connection_proxy
@@ -18,7 +35,7 @@ def build_engine(url, engine_options, database_query_profiling_proxy=False, trac
         proxy = logging_connection_proxy.TraceLoggerProxy(trace_logger)
     else:
         proxy = None
-    if slow_query_log_threshold or thread_local_log:
+    if slow_query_log_threshold or thread_local_log or log_query_counts:
         @event.listens_for(Engine, "before_execute")
         def before_execute(conn, clauseelement, multiparams, params):
             conn.info.setdefault('query_start_time', []).append(time.time())
@@ -29,6 +46,12 @@ def build_engine(url, engine_options, database_query_profiling_proxy=False, trac
             total = time.time() - conn.info['query_start_time'].pop(-1)
             if total > slow_query_log_threshold:
                 log.debug("Slow query: %f(s)\n%s\nParameters: %s" % (total, statement, parameters))
+            if log_query_counts:
+                try:
+                    QUERY_COUNT_LOCAL.times.append(total)
+                except AttributeError:
+                    # Not a web thread.
+                    pass
             if thread_local_log is not None:
                 try:
                     if thread_local_log.log:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1485,7 +1485,7 @@ class Tool(Dictifiable):
                         output_collections=execution_tracker.output_collections,
                         implicit_collections=execution_tracker.implicit_collections)
 
-    def handle_single_execution(self, trans, rerun_remap_job_id, execution_slice, history, execution_cache=None, completed_job=None, collection_info=None):
+    def handle_single_execution(self, trans, rerun_remap_job_id, execution_slice, history, execution_cache=None, completed_job=None, collection_info=None, flush_job=True):
         """
         Return a pair with whether execution is successful as well as either
         resulting output data or an error message indicating the problem.
@@ -1500,6 +1500,7 @@ class Tool(Dictifiable):
                 dataset_collection_elements=execution_slice.dataset_collection_elements,
                 completed_job=completed_job,
                 collection_info=collection_info,
+                flush_job=flush_job,
             )
         except webob.exc.HTTPFound as e:
             # if it's a webob redirect exception, pass it up the stack

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -287,7 +287,10 @@ class DefaultToolAction(object):
         if execution_cache is None:
             execution_cache = ToolExecutionCache(trans)
         current_user_roles = execution_cache.current_user_roles
+        inputs_timer = ExecutionTimer()
         history, inp_data, inp_dataset_collections, preserved_tags, all_permissions = self._collect_inputs(tool, trans, incoming, history, current_user_roles, collection_info)
+        log.info("Collected inputs for tool execute %s" % inputs_timer)
+        setup_timer = ExecutionTimer()
         # Build name for output datasets based on tool name and input names
         on_text = self._get_on_text(inp_data)
 
@@ -453,6 +456,8 @@ class DefaultToolAction(object):
             # Flush all datasets at once.
             return data
 
+        log.info("setup execute %s" % setup_timer)
+
         for name, output in tool.outputs.items():
             if not filter_output(output, incoming):
                 handle_output_timer = ExecutionTimer()
@@ -500,6 +505,7 @@ class DefaultToolAction(object):
                         })
 
                     history.add_datasets(trans.sa_session, created_element_datasets, set_hid=set_output_hid, quota=False, flush=True)
+                    create_collection_timer = ExecutionTimer()
                     if output.dynamic_structure:
                         assert not element_identifiers  # known_outputs must have been empty
                         element_kwds = dict(elements=collections_manager.ELEMENTS_UNINITIALIZED)
@@ -510,6 +516,7 @@ class DefaultToolAction(object):
                         name=name,
                         **element_kwds
                     )
+                    log.info("Created actual collection for output named %s for tool %s %s" % (name, tool.id, create_collection_timer))
                     log.info("Handled collection output named %s for tool %s %s" % (name, tool.id, handle_output_timer))
                 else:
                     handle_output(name, output)

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -274,7 +274,7 @@ class DefaultToolAction(object):
                         preserved_tags[tag.value] = tag
         return history, inp_data, inp_dataset_collections, preserved_tags, all_permissions
 
-    def execute(self, tool, trans, incoming=None, return_job=False, set_output_hid=True, history=None, job_params=None, rerun_remap_job_id=None, execution_cache=None, dataset_collection_elements=None, completed_job=None, collection_info=None):
+    def execute(self, tool, trans, incoming=None, return_job=False, set_output_hid=True, history=None, job_params=None, rerun_remap_job_id=None, execution_cache=None, dataset_collection_elements=None, completed_job=None, collection_info=None, flush_job=True):
         """
         Executes a tool, creating job and tool outputs, associating them, and
         submitting the job to the job queue. If history is not specified, use
@@ -581,9 +581,14 @@ class DefaultToolAction(object):
             trans.sa_session.flush()
             trans.response.send_redirect(url_for(controller='tool_runner', action='redirect', redirect_url=redirect_url))
         else:
-            # Dispatch to a job handler. enqueue() is responsible for flushing the job
-            app.job_manager.enqueue(job, tool=tool)
-            trans.log_event("Added job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id)
+            if flush_job:
+                job_flush_timer = ExecutionTimer()
+                trans.sa_session.flush()
+                log.info("Flushed transaction for job %s %s" % (job.log_str(), job_flush_timer))
+
+                # Dispatch to a job handler. enqueue() is responsible for flushing the job
+                app.job_manager.enqueue(job, tool=tool)
+                trans.log_event("Added job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id)
             return job, out_data
 
     def _remap_job_on_rerun(self, trans, galaxy_session, rerun_remap_job_id, current_job, out_data):

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -63,7 +63,7 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
             del params['__workflow_resource_params__']
         if validate_outputs:
             params['__validate_outputs__'] = True
-        job, result = tool.handle_single_execution(trans, rerun_remap_job_id, execution_slice, history, execution_cache, completed_job, collection_info)
+        job, result = tool.handle_single_execution(trans, rerun_remap_job_id, execution_slice, history, execution_cache, completed_job, collection_info, flush_job=False)
         if job:
             message = EXECUTION_SUCCESS_MESSAGE % (tool.id, job.id, job_timer)
             log.debug(message)
@@ -96,6 +96,13 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
             break
         else:
             execute_single_job(execution_slice, completed_jobs[i])
+
+    full_flush_timer = ExecutionTimer()
+    trans.sa_session.flush()
+    for job in execution_tracker.successful_jobs:
+        # Put the job in the queue if tracking in memory
+        app.job_manager.enqueue(job, tool=tool)
+        trans.log_event("Added job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id)
 
     if has_remaining_jobs:
         raise PartialJobExecution(execution_tracker)

--- a/lib/galaxy/web/framework/middleware/sqldebug.py
+++ b/lib/galaxy/web/framework/middleware/sqldebug.py
@@ -3,6 +3,8 @@ Per-request SQL debugging middleware.
 """
 import logging
 
+from galaxy.model.orm.engine_factory import log_request_query_counts, reset_request_query_counts
+
 log = logging.getLogger(__name__)
 
 
@@ -19,4 +21,8 @@ class SQLDebugMiddleware(object):
             if galaxy.app.app.model.thread_local_log:
                 galaxy.app.app.model.thread_local_log.log = True
 
-        return self.application(environ, start_response)
+        try:
+            reset_request_query_counts()
+            return self.application(environ, start_response)
+        finally:
+            log_request_query_counts(environ.get("PATH_INFO"))

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -6,6 +6,7 @@ from json import dumps, loads
 from galaxy import exceptions, managers, util, web
 from galaxy.managers.collections_util import dictify_dataset_collection_instance
 from galaxy.tools import global_tool_errors
+from galaxy.util import ExecutionTimer
 from galaxy.util.json import safe_dumps
 from galaxy.web import (
     expose_api,
@@ -525,8 +526,9 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         # I think it should be a top-level parameter, but because the selector is implemented
         # as a regular tool parameter we accept both.
         use_cached_job = payload.get('use_cached_job', False) or util.string_as_bool(inputs.get('use_cached_job', 'false'))
+        handle_input_timer = ExecutionTimer()
         vars = tool.handle_input(trans, incoming, history=target_history, use_cached_job=use_cached_job)
-
+        log.info("tool.handle_input called for API request %s" % handle_input_timer)
         # TODO: check for errors and ensure that output dataset(s) are available.
         output_datasets = vars.get('out_data', [])
         rval = {'outputs': [], 'output_collections': [], 'jobs': [], 'implicit_collections': []}

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1331,17 +1331,16 @@ class ToolModule(WorkflowModule):
 
         # Combine workflow and runtime post job actions into the effective post
         # job actions for this execution.
-        flush_required = False
         effective_post_job_actions = self._effective_post_job_actions(step)
         for pja in effective_post_job_actions:
             if pja.action_type in ActionBox.immediate_actions or isinstance(self.tool, DatabaseOperationTool):
                 ActionBox.execute(self.trans.app, self.trans.sa_session, pja, job, replacement_dict)
             else:
-                pjaa = model.PostJobActionAssociation(pja, job_id=job.id)
+                if job.id:
+                    pjaa = model.PostJobActionAssociation(pja, job_id=job.id)
+                else:
+                    pjaa = model.PostJobActionAssociation(pja, job=job)
                 self.trans.sa_session.add(pjaa)
-                flush_required = True
-        if flush_required:
-            self.trans.sa_session.flush()
 
     def __restore_step_meta_runtime_state(self, step_runtime_state):
         if RUNTIME_POST_JOB_ACTIONS_KEY in step_runtime_state:

--- a/test/unit/tools/test_execution.py
+++ b/test/unit/tools/test_execution.py
@@ -211,6 +211,9 @@ class MockTrans(object):
     def get_current_user_roles(self):
         return []
 
+    def log_event(self, *args, **kwds):
+        pass
+
 
 class MockCollectionService(object):
 


### PR DESCRIPTION
Work on #4959, like #6380 & #6548  but a better set of optimizations - dropped a few things that didn't pan out and added some nice newer optimizations that are better.

Below are some timings for a collection mapping job that creates 100 datasets (10 collections of 10). This branch is getting very close to resulting in a 10x speed up in creating jobs. They are a bit interconnect though still and I want tests for the permission handling changes - so I think I want #6461 in before getting too far with this. Obviously though my initial results are that #6550 is a really nice optimization in its own right and gets us half way there.

dev

galaxy.tools.execute DEBUG 2018-08-01 14:35:00,126 Executed 10 job(s) for tool create_10 request: (13434.709 ms)

dev with populate object store in job handler (PR #6550):

galaxy.tools.execute DEBUG 2018-08-01 14:37:53,418 Executed 10 job(s) for tool create_10 request: (6131.476 ms)

dev + PR#6550 + permission optimization:

galaxy.tools.execute DEBUG 2018-08-01 14:42:08,823 Executed 10 job(s) for tool create_10 request: (5202.416 ms)

dev + PR#6550 + permission optimization + add_datasets query opts:

galaxy.tools.execute DEBUG 2018-08-01 14:33:10,409 Executed 10 job(s) for tool create_10 request: (4712.302 ms)

dev + PR#6550 + permission optimization + add_datasets query opts + flush once:

galaxy.tools.execute DEBUG 2018-08-01 15:14:11,361 Executed 10 job(s) for tool create_10 request: (1549.116 ms)
