### PR TITLE
[18.01] Use subworkflow index when setting auto-label

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -361,7 +361,7 @@ class SubWorkflowModule(WorkflowModule):
         subworkflow_progress = subworkflow_invoker.progress
         outputs = {}
         for workflow_output in subworkflow.workflow_outputs:
-            workflow_output_label = workflow_output.label or "%s:%s" % (step.order_index, workflow_output.output_name)
+            workflow_output_label = workflow_output.label or "%s:%s" % (workflow_output.workflow_step.order_index, workflow_output.output_name)
             replacement = subworkflow_progress.get_replacement_workflow_output(workflow_output)
             outputs[workflow_output_label] = replacement
         progress.set_step_outputs(invocation_step, outputs)

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -65,6 +65,47 @@ steps:
             $link: nested_workflow#workflow_output
 """
 
+NESTED_WORKFLOW_AUTO_LABELS = """
+class: GalaxyWorkflow
+inputs:
+  - id: outer_input
+outputs:
+  - id: outer_output
+    source: second_cat#out_file1
+steps:
+  - tool_id: cat1
+    label: first_cat
+    state:
+      input1:
+        $link: outer_input
+  - run:
+      class: GalaxyWorkflow
+      inputs:
+        - id: inner_input
+      outputs:
+        - source: 1#out_file1
+      steps:
+        - tool_id: random_lines1
+          state:
+            num_lines: 1
+            input:
+              $link: inner_input
+            seed_source:
+              seed_source_selector: set_seed
+              seed: asdf
+    label: nested_workflow
+    connect:
+      inner_input: first_cat#out_file1
+  - tool_id: cat1
+    label: second_cat
+    state:
+      input1:
+        $link: nested_workflow#1:out_file1
+      queries:
+        - input2:
+            $link: nested_workflow#1:out_file1
+"""
+
 
 class BaseWorkflowsApiTestCase(api.ApiTestCase):
     # TODO: Find a new file for this class.
@@ -1001,6 +1042,23 @@ test_data:
 
         content = self.dataset_populator.get_history_dataset_content(history_id)
         self.assertEqual("chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\nchr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n", content)
+
+    def test_run_subworkflow_auto_labels(self):
+            history_id = self.dataset_populator.new_history()
+            workflow_run_description = """%s
+
+test_data:
+  outer_input:
+    value: 1.bed
+    type: File
+""" % NESTED_WORKFLOW_AUTO_LABELS
+            job_summary = self._run_jobs(workflow_run_description, history_id=history_id)
+            assert len(job_summary.jobs) == 4, "4 jobs expected, got %d jobs" % len(job_summary.jobs)
+
+            content = self.dataset_populator.get_history_dataset_content(history_id)
+            self.assertEqual(
+                "chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\nchr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n",
+                content)
 
     @skip_without_tool("cat1")
     @skip_without_tool("collection_paired_test")

--- a/test/base/workflows_format_2/converter.py
+++ b/test/base/workflows_format_2/converter.py
@@ -133,7 +133,7 @@ def _python_to_workflow(as_python, conversion_context):
         if "label" in output and "id" in output:
             raise Exception("label and id are aliases for outputs, may only define one")
         if "label" not in output and "id" not in output:
-            raise Exception("Output must define a label.")
+            label = ""
 
         raw_label = output.pop("label", None)
         raw_id = output.pop("id", None)


### PR DESCRIPTION
Previously this would reference the parent workflow index, while the
get_data module would use the subworkflow index. This means defining
workflows worked fine, but executing would fail when trying to find the
output to replace. Using the subworkflow index here seems like the
correct thing to do.

Fixes #6560 and includes a test case that fails without the fix.