### PR TITLE
Fix last consistently failing Selenium test.

### DIFF
--- a/test/base/rules_test_data.py
+++ b/test/base/rules_test_data.py
@@ -128,5 +128,5 @@ EXAMPLE_3 = {
         "type": "list:paired",
     },
     "check": check_example_3,
-    "output_hid": 7,
+    "output_hid": 6,
 }


### PR DESCRIPTION
Target HID here changed when we went to building lists of pairs directly with upload 2.0 instead of from individual pairs and the HDCA API.