### PR TITLE
Add API endpoint to fetch a history's workflow invocations.

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -181,22 +181,49 @@ class WorkflowsManager(object):
         trans.sa_session.flush()
         return workflow_invocation_step
 
-    def build_invocations_query(self, trans, decoded_stored_workflow_id):
+    def build_invocations_query(self, trans, stored_workflow_id=None, history_id=None, user_id=None):
         """Get invocations owned by the current user."""
-        stored_workflow = trans.sa_session.query(
-            self.app.model.StoredWorkflow
-        ).get(decoded_stored_workflow_id)
-        if not stored_workflow:
-            raise exceptions.ObjectNotFound()
-        invocations = trans.sa_session.query(
-            model.WorkflowInvocation
-        ).filter_by(
-            workflow_id=stored_workflow.latest_workflow_id
-        )
-        return [inv for inv in invocations if self.check_security(trans,
-                                                                  inv,
-                                                                  check_ownership=True,
-                                                                  check_accessible=False)]
+        sa_session = trans.sa_session
+        invocations_query = sa_session.query(model.WorkflowInvocation)
+        if stored_workflow_id is not None:
+            stored_workflow = sa_session.query(model.StoredWorkflow).get(stored_workflow_id)
+            if not stored_workflow:
+                raise exceptions.ObjectNotFound()
+            invocations_query = invocations_query.join(
+                model.Workflow
+            ).filter(
+                model.Workflow.table.c.stored_workflow_id == stored_workflow_id
+            )
+
+        if user_id is not None:
+            invocations_query = invocations_query.join(
+                model.History
+            ).filter(
+                model.History.table.c.user_id == user_id
+            )
+
+        if history_id is not None:
+            invocations_query = invocations_query.filter(
+                model.WorkflowInvocation.table.c.history_id == history_id
+            )
+
+        return [inv for inv in invocations_query if self.check_security(trans,
+                                                                        inv,
+                                                                        check_ownership=True,
+                                                                        check_accessible=False)]
+
+    def serialize_workflow_invocation(self, invocation, **kwd):
+        app = self.app
+        view = kwd.get("view", "element")
+        step_details = util.string_as_bool(kwd.get('step_details', False))
+        legacy_job_state = util.string_as_bool(kwd.get('legacy_job_state', False))
+        as_dict = invocation.to_dict(view, step_details=step_details, legacy_job_state=legacy_job_state)
+        return app.security.encode_all_ids(as_dict, recursive=True)
+
+    def serialize_workflow_invocations(self, invocations, **kwd):
+        if "view" not in kwd:
+            kwd["view"] = "collection"
+        return list(map(lambda i: self.serialize_workflow_invocation(i, **kwd), invocations))
 
 
 CreatedWorkflow = namedtuple("CreatedWorkflow", ["stored_workflow", "workflow", "missing_tools"])

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4287,7 +4287,7 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable):
         else:
             raise Exception("Unknown output type encountered")
 
-    def to_dict(self, view='collection', value_mapper=None, step_details=False):
+    def to_dict(self, view='collection', value_mapper=None, step_details=False, legacy_job_state=False):
         rval = super(WorkflowInvocation, self).to_dict(view=view, value_mapper=value_mapper)
         if view == 'element':
             steps = []
@@ -4296,7 +4296,19 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable):
                     v = step.to_dict(view='element')
                 else:
                     v = step.to_dict(view='collection')
-                steps.append(v)
+                if legacy_job_state:
+                    step_jobs = step.jobs
+                    if step_jobs:
+                        for step_job in step_jobs:
+                            v_clone = v.copy()
+                            v_clone["state"] = step_job.state
+                            v_clone["job_id"] = step_job.id
+                            steps.append(v_clone)
+                    else:
+                        v["state"] = None
+                        steps.append(v)
+                else:
+                    steps.append(v)
             rval['steps'] = steps
 
             inputs = {}

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4438,6 +4438,10 @@ class WorkflowInvocationStep(Dictifiable):
         # Following no longer makes sense...
         # rval['state'] = self.job.state if self.job is not None else None
         if view == 'element':
+            jobs = []
+            for job in self.jobs:
+                jobs.append(job.to_dict())
+
             outputs = {}
             for output_assoc in self.output_datasets:
                 name = output_assoc.output_name
@@ -4457,6 +4461,7 @@ class WorkflowInvocationStep(Dictifiable):
 
             rval['outputs'] = outputs
             rval['output_collections'] = output_collections
+            rval['jobs'] = jobs
         return rval
 
 

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -20,7 +20,8 @@ from galaxy import (
 from galaxy.managers import (
     citations,
     histories,
-    users
+    users,
+    workflows,
 )
 from galaxy.util import (
     restore_text,
@@ -49,6 +50,7 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
         super(HistoriesController, self).__init__(app)
         self.citations_manager = citations.CitationsManager(app)
         self.user_manager = users.UserManager(app)
+        self.workflow_manager = workflows.WorkflowsManager(app)
         self.manager = histories.HistoryManager(app)
         self.serializer = histories.HistorySerializer(app)
         self.deserializer = histories.HistoryDeserializer(app)

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -473,6 +473,13 @@ def populate_api_routes(webapp, app):
             action='index_invocations',
             conditions=dict(method=['GET'])
         )
+        webapp.mapper.connect(
+            'list_invocations',
+            '/api/invocations',
+            controller='workflows',
+            action='index_invocations',
+            conditions=dict(method=['GET'])
+        )
 
         webapp.mapper.connect(
             'workflow_%s_contents' % name,

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -198,8 +198,8 @@ class BaseWorkflowsApiTestCase(api.ApiTestCase):
         workflow_inputs = workflow_show_resposne.json()["inputs"]
         return workflow_inputs
 
-    def _invocation_details(self, workflow_id, invocation_id):
-        invocation_details_response = self._get("workflows/%s/usage/%s" % (workflow_id, invocation_id))
+    def _invocation_details(self, workflow_id, invocation_id, **kwds):
+        invocation_details_response = self._get("workflows/%s/usage/%s" % (workflow_id, invocation_id), data=kwds)
         self._assert_status_code_is(invocation_details_response, 200)
         invocation_details = invocation_details_response.json()
         return invocation_details
@@ -2933,6 +2933,77 @@ steps:
         self._assert_has_keys(invocation_tool_step_response.json(), "id", "order_index", "job_id")
 
         assert invocation_tool_step_response.json()["job_id"] == job_id
+
+    def test_invocation_with_collection_mapping(self):
+        workflow_id, invocation_id = self._run_mapping_workflow()
+
+        usage_details = self._invocation_details(workflow_id, invocation_id)
+        # Assert some high-level things about the structure of data returned.
+        self._assert_has_keys(usage_details, "inputs", "steps", "workflow_id")
+
+        invocation_steps = usage_details["steps"]
+        invocation_input_step, invocation_tool_step = None, None
+        for invocation_step in invocation_steps:
+            self._assert_has_keys(invocation_step, "workflow_step_id", "order_index", "id")
+            order_index = invocation_step["order_index"]
+            assert order_index in [0, 1]
+            if invocation_step["order_index"] == 0:
+                assert invocation_input_step is None
+                invocation_input_step = invocation_step
+            else:
+                assert invocation_tool_step is None
+                invocation_tool_step = invocation_step
+
+        # Tool steps have non-null job_ids (deprecated though they may be)
+        assert invocation_input_step.get("job_id", None) is None
+        assert invocation_tool_step.get("job_id", None) is None
+        assert invocation_tool_step["state"] == "scheduled"
+
+        usage_details = self._invocation_details(workflow_id, invocation_id, legacy_job_state="true")
+        # Assert some high-level things about the structure of data returned.
+        self._assert_has_keys(usage_details, "inputs", "steps", "workflow_id")
+
+        invocation_steps = usage_details["steps"]
+        invocation_input_step = None
+        invocation_tool_steps = []
+        for invocation_step in invocation_steps:
+            self._assert_has_keys(invocation_step, "workflow_step_id", "order_index", "id")
+            order_index = invocation_step["order_index"]
+            assert order_index in [0, 1]
+            if invocation_step["order_index"] == 0:
+                assert invocation_input_step is None
+                invocation_input_step = invocation_step
+            else:
+                invocation_tool_steps.append(invocation_step)
+
+        assert len(invocation_tool_steps) == 2
+        assert invocation_tool_steps[0]["state"] == "ok"
+
+    def _run_mapping_workflow(self):
+        history_id = self.dataset_populator.new_history()
+        summary = self._run_jobs("""
+class: GalaxyWorkflow
+inputs:
+  - type: collection
+    label: input_c
+steps:
+  - label: cat1
+    tool_id: cat1
+    state:
+       input1:
+         $link: input_c
+test_data:
+  input_c:
+    type: list
+    elements:
+      - identifier: i1
+        content: "0"
+      - identifier: i2
+        content: "1"
+""", history_id=history_id, wait=True, assert_ok=True)
+        workflow_id = summary.workflow_id
+        invocation_id = summary.invocation_id
+        return workflow_id, invocation_id
 
     @skip_without_tool("cat1")
     def test_invocations_accessible_imported_workflow(self):

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -2902,15 +2902,37 @@ steps:
         invocation_id = usage["id"]
         usage_details = self._invocation_details(workflow_id, invocation_id)
         # Assert some high-level things about the structure of data returned.
-        self._assert_has_keys(usage_details, "inputs", "steps")
+        self._assert_has_keys(usage_details, "inputs", "steps", "workflow_id")
+
+        # stored_workflow vs workflow thing makes following state false.
+        # assert usage_details["workflow_id"] == workflow_id
+
+        # Wait for the invocation to be fully scheduled, so we have details on all steps.
+        self._wait_for_invocation_state(workflow_id, invocation_id, 'scheduled')
+        usage_details = self._invocation_details(workflow_id, invocation_id)
+
         invocation_steps = usage_details["steps"]
-        for step in invocation_steps:
-            self._assert_has_keys(step, "workflow_step_id", "order_index", "id")
-        an_invocation_step = invocation_steps[0]
-        step_id = an_invocation_step["id"]
-        step_response = self._get("workflows/%s/usage/%s/steps/%s" % (workflow_id, invocation_id, step_id))
-        self._assert_status_code_is(step_response, 200)
-        self._assert_has_keys(step_response.json(), "id", "order_index")
+        invocation_input_step, invocation_tool_step = None, None
+        for invocation_step in invocation_steps:
+            self._assert_has_keys(invocation_step, "workflow_step_id", "order_index", "id")
+            order_index = invocation_step["order_index"]
+            assert order_index in [0, 1, 2], order_index
+            if order_index == 0:
+                invocation_input_step = invocation_step
+            elif order_index == 2:
+                invocation_tool_step = invocation_step
+
+        # Tool steps have non-null job_ids (deprecated though they may be)
+        assert invocation_input_step.get("job_id", None) is None
+        job_id = invocation_tool_step.get("job_id", None)
+        assert job_id is not None
+
+        invocation_tool_step_id = invocation_tool_step["id"]
+        invocation_tool_step_response = self._get("workflows/%s/invocations/%s/steps/%s" % (workflow_id, invocation_id, invocation_tool_step_id))
+        self._assert_status_code_is(invocation_tool_step_response, 200)
+        self._assert_has_keys(invocation_tool_step_response.json(), "id", "order_index", "job_id")
+
+        assert invocation_tool_step_response.json()["job_id"] == job_id
 
     @skip_without_tool("cat1")
     def test_invocations_accessible_imported_workflow(self):


### PR DESCRIPTION
Refactor toward managers to allow unified serialization of invocations and such. Add test case.

In service of #5142 I suppose, builds on #6559 (cherry-picked into dev).

Next up... I want to add a jobs_summary API that matches collections (https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/webapps/galaxy/api/history_contents.py#L183) - this should allow effective summary of job states for fully scheduled workflows. One can then imagine a progress bar for whats steps are scheduled and below it a progress bar for what job states are - this second one built on this new API I'm planning and that could probably completely reuse the collection summary code on the client. 