### PR TITLE
Improve robustness of tour Selenium test.

### DIFF
--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -1286,7 +1286,8 @@ class NavigatesGalaxy(HasDriver):
             self.run_tour_step(step, i, tour_callback)
 
     def tour_wait_for_clickable_element(self, selector):
-        wait = self.wait()
+        timeout = self.timeout_for(wait_type=WAIT_TYPES.JOB_COMPLETION)
+        wait = self.wait(timeout=timeout)
         timeout_message = self._timeout_message("sizzle (jQuery) selector [%s] to become clickable" % selector)
         element = wait.until(
             sizzle.sizzle_selector_clickable(selector),
@@ -1295,7 +1296,8 @@ class NavigatesGalaxy(HasDriver):
         return element
 
     def tour_wait_for_element_present(self, selector):
-        wait = self.wait()
+        timeout = self.timeout_for(wait_type=WAIT_TYPES.JOB_COMPLETION)
+        wait = self.wait(timeout=timeout)
         timeout_message = self._timeout_message("sizzle (jQuery) selector [%s] to become present" % selector)
         element = wait.until(
             sizzle.sizzle_presence_of_selector(selector),


### PR DESCRIPTION
Give the URL upload jobs a bit more time to complete. https://github.com/galaxyproject/galaxy/issues/6581 might also improve this - I'm not sure.


```shell
. .venv/bin/activate
make client
nosetests test/selenium_tests/test_stock_tours.py
```
