### PR TITLE
Smarter Test Histories (Part I)

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -230,6 +230,9 @@ GALAXY_TEST_TOOL_PATH           Path defaulting to 'tools'.
 GALAXY_TEST_SHED_TOOL_CONF      Shed toolbox conf (defaults to
                                 config/shed_tool_conf.xml) used when testing
                                 installed to tools with -installed.
+GALAXY_TEST_HISTORY_ID          Some tests can target existing history ids, this option
+                                is fairly limited and not compatible with parrallel testing
+                                so should be limited to debugging one off tests.
 TOOL_SHED_TEST_HOST             Host to use for shed server setup for testing.
 TOOL_SHED_TEST_PORT             Port to use for shed server setup for testing.
 TOOL_SHED_TEST_FILE_DIR         Defaults to test/shed_functional/test_data.

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -10,6 +10,7 @@ from base.populators import (
     LibraryPopulator,
     load_data_dict,
     skip_without_tool,
+    uses_test_history,
 )
 
 
@@ -422,43 +423,42 @@ class ToolsTestCase(api.ApiTestCase):
             assert output2_content == "4\t5\t6\n1\t2\t3\n", output2_content
 
     @skip_without_tool("cat1")
-    def test_run_cat1(self):
-        with self.dataset_populator.test_history() as history_id:
-            # Run simple non-upload tool with an input data parameter.
-            history_id = self.dataset_populator.new_history()
-            new_dataset = self.dataset_populator.new_dataset(history_id, content='Cat1Test')
-            inputs = dict(
-                input1=dataset_to_param(new_dataset),
-            )
-            outputs = self._cat1_outputs(history_id, inputs=inputs)
-            self.assertEquals(len(outputs), 1)
-            output1 = outputs[0]
-            output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-            self.assertEqual(output1_content.strip(), "Cat1Test")
-
-    @skip_without_tool("cat1")
-    def test_run_cat1_use_cached_job(self):
-        with self.dataset_populator.test_history() as history_id:
-            # Run simple non-upload tool with an input data parameter.
-            new_dataset = self.dataset_populator.new_dataset(history_id, content='Cat1Test')
-            inputs = dict(
-                input1=dataset_to_param(new_dataset),
-            )
-            outputs_one = self._run_cat1(history_id, inputs=inputs, assert_ok=True, wait_for_job=True)
-            outputs_two = self._run_cat1(history_id, inputs=inputs, use_cached_job=False, assert_ok=True, wait_for_job=True)
-            outputs_three = self._run_cat1(history_id, inputs=inputs, use_cached_job=True, assert_ok=True, wait_for_job=True)
-            dataset_details = []
-            for output in [outputs_one, outputs_two, outputs_three]:
-                output_id = output['outputs'][0]['id']
-                dataset_details.append(self._get("datasets/%s" % output_id).json())
-            filenames = [dd['file_name'] for dd in dataset_details]
-            assert len(filenames) == 3, filenames
-            assert len(set(filenames)) <= 2, filenames
-
-    @skip_without_tool("cat1")
-    def test_run_cat1_listified_param(self):
+    @uses_test_history(require_new=False)
+    def test_run_cat1(self, history_id):
         # Run simple non-upload tool with an input data parameter.
-        history_id = self.dataset_populator.new_history()
+        new_dataset = self.dataset_populator.new_dataset(history_id, content='Cat1Test')
+        inputs = dict(
+            input1=dataset_to_param(new_dataset),
+        )
+        outputs = self._cat1_outputs(history_id, inputs=inputs)
+        self.assertEquals(len(outputs), 1)
+        output1 = outputs[0]
+        output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
+        self.assertEqual(output1_content.strip(), "Cat1Test")
+
+    @skip_without_tool("cat1")
+    @uses_test_history(require_new=True)
+    def test_run_cat1_use_cached_job(self, history_id):
+        # Run simple non-upload tool with an input data parameter.
+        new_dataset = self.dataset_populator.new_dataset(history_id, content='Cat1Test')
+        inputs = dict(
+            input1=dataset_to_param(new_dataset),
+        )
+        outputs_one = self._run_cat1(history_id, inputs=inputs, assert_ok=True, wait_for_job=True)
+        outputs_two = self._run_cat1(history_id, inputs=inputs, use_cached_job=False, assert_ok=True, wait_for_job=True)
+        outputs_three = self._run_cat1(history_id, inputs=inputs, use_cached_job=True, assert_ok=True, wait_for_job=True)
+        dataset_details = []
+        for output in [outputs_one, outputs_two, outputs_three]:
+            output_id = output['outputs'][0]['id']
+            dataset_details.append(self._get("datasets/%s" % output_id).json())
+        filenames = [dd['file_name'] for dd in dataset_details]
+        assert len(filenames) == 3, filenames
+        assert len(set(filenames)) <= 2, filenames
+
+    @skip_without_tool("cat1")
+    @uses_test_history(require_new=False)
+    def test_run_cat1_listified_param(self, history_id):
+        # Run simple non-upload tool with an input data parameter.
         new_dataset = self.dataset_populator.new_dataset(history_id, content='Cat1Testlistified')
         inputs = dict(
             input1=[dataset_to_param(new_dataset)],
@@ -470,10 +470,10 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEqual(output1_content.strip(), "Cat1Testlistified")
 
     @skip_without_tool("multiple_versions")
-    def test_run_by_versions(self):
+    @uses_test_history(require_new=False)
+    def test_run_by_versions(self, history_id):
         for version in ["0.1", "0.2"]:
             # Run simple non-upload tool with an input data parameter.
-            history_id = self.dataset_populator.new_history()
             inputs = dict()
             outputs = self._run_and_get_outputs(tool_id="multiple_versions", history_id=history_id, inputs=inputs, tool_version=version)
             self.assertEquals(len(outputs), 1)
@@ -482,10 +482,10 @@ class ToolsTestCase(api.ApiTestCase):
             self.assertEqual(output1_content.strip(), "Version " + version)
 
     @skip_without_tool("cat1")
-    def test_run_cat1_single_meta_wrapper(self):
+    @uses_test_history(require_new=False)
+    def test_run_cat1_single_meta_wrapper(self, history_id):
         # Wrap input in a no-op meta parameter wrapper like Sam is planning to
         # use for all UI API submissions.
-        history_id = self.dataset_populator.new_history()
         new_dataset = self.dataset_populator.new_dataset(history_id, content='123')
         inputs = dict(
             input1={'batch': False, 'values': [dataset_to_param(new_dataset)]},
@@ -497,8 +497,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEqual(output1_content.strip(), "123")
 
     @skip_without_tool("validation_default")
-    def test_validation(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_validation(self, history_id):
         inputs = {
             'select_param': "\" ; echo \"moo",
         }
@@ -506,8 +506,8 @@ class ToolsTestCase(api.ApiTestCase):
         self._assert_status_code_is(response, 400)
 
     @skip_without_tool("validation_empty_dataset")
-    def test_validation_empty_dataset(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_validation_empty_dataset(self, history_id):
         inputs = {
         }
         outputs = self._run_and_get_outputs('empty_output', history_id, inputs)
@@ -520,8 +520,8 @@ class ToolsTestCase(api.ApiTestCase):
         self._assert_status_code_is(response, 400)
 
     @skip_without_tool("validation_repeat")
-    def test_validation_in_repeat(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_validation_in_repeat(self, history_id):
         inputs = {
             'r1_0|text': "123",
             'r2_0|text': "",
@@ -530,8 +530,8 @@ class ToolsTestCase(api.ApiTestCase):
         self._assert_status_code_is(response, 400)
 
     @skip_without_tool("multi_select")
-    def test_select_legal_values(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_select_legal_values(self, history_id):
         inputs = {
             'select_ex': 'not_option',
         }
@@ -539,8 +539,8 @@ class ToolsTestCase(api.ApiTestCase):
         self._assert_status_code_is(response, 400)
 
     @skip_without_tool("column_param")
-    def test_column_legal_values(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_column_legal_values(self, history_id):
         new_dataset1 = self.dataset_populator.new_dataset(history_id, content='#col1\tcol2')
         inputs = {
             'input1': {"src": "hda", "id": new_dataset1["id"]},
@@ -555,8 +555,8 @@ class ToolsTestCase(api.ApiTestCase):
             assert final_job_state == "error"
 
     @skip_without_tool("collection_paired_test")
-    def test_collection_parameter(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=True)
+    def test_collection_parameter(self, history_id):
         hdca_id = self.__build_pair(history_id, ["123\n", "456\n"])
         inputs = {
             "f1": {"src": "hdca", "id": hdca_id},
@@ -569,8 +569,8 @@ class ToolsTestCase(api.ApiTestCase):
         assert contents.strip() == "123\n456", contents
 
     @skip_without_tool("collection_creates_pair")
-    def test_paired_collection_output(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_paired_collection_output(self, history_id):
         new_dataset1 = self.dataset_populator.new_dataset(history_id, content='123\n456\n789\n0ab')
         inputs = {
             "input1": {"src": "hda", "id": new_dataset1["id"]},
@@ -585,21 +585,21 @@ class ToolsTestCase(api.ApiTestCase):
         self._verify_element(history_id, element1, contents="456\n0ab\n", file_ext="txt", visible=False)
 
     @skip_without_tool("collection_creates_list")
-    def test_list_collection_output(self):
-        with self.dataset_populator.test_history() as history_id:
-            create_response = self.dataset_collection_populator.create_list_in_history(history_id, contents=["a\nb\nc\nd", "e\nf\ng\nh"])
-            hdca_id = create_response.json()["id"]
-            create = self.dataset_populator.run_collection_creates_list(history_id, hdca_id)
-            output_collection = self._assert_one_job_one_collection_run(create)
-            element0, element1 = self._assert_elements_are(output_collection, "data1", "data2")
-            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-            self._verify_element(history_id, element0, contents="identifier is data1\n", file_ext="txt")
-            self._verify_element(history_id, element1, contents="identifier is data2\n", file_ext="txt")
+    @uses_test_history(require_new=False)
+    def test_list_collection_output(self, history_id):
+        create_response = self.dataset_collection_populator.create_list_in_history(history_id, contents=["a\nb\nc\nd", "e\nf\ng\nh"])
+        hdca_id = create_response.json()["id"]
+        create = self.dataset_populator.run_collection_creates_list(history_id, hdca_id)
+        output_collection = self._assert_one_job_one_collection_run(create)
+        element0, element1 = self._assert_elements_are(output_collection, "data1", "data2")
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        self._verify_element(history_id, element0, contents="identifier is data1\n", file_ext="txt")
+        self._verify_element(history_id, element1, contents="identifier is data2\n", file_ext="txt")
 
     @skip_without_tool("collection_creates_list_2")
-    def test_list_collection_output_format_source(self):
+    @uses_test_history(require_new=False)
+    def test_list_collection_output_format_source(self, history_id):
         # test using format_source with a tool
-        history_id = self.dataset_populator.new_history()
         new_dataset1 = self.dataset_populator.new_dataset(history_id, content='#col1\tcol2')
         create_response = self.dataset_collection_populator.create_list_in_history(history_id, contents=["a\tb\nc\td", "e\tf\ng\th"])
         hdca_id = create_response.json()["id"]
@@ -617,8 +617,8 @@ class ToolsTestCase(api.ApiTestCase):
         self._verify_element(history_id, element1, contents="#col1\tcol2\ne\tf\ng\th\n", file_ext="txt")
 
     @skip_without_tool("collection_split_on_column")
-    def test_dynamic_list_output(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_dynamic_list_output(self, history_id):
         new_dataset1 = self.dataset_populator.new_dataset(history_id, content='samp1\t1\nsamp1\t3\nsamp2\t2\nsamp2\t4\n')
         inputs = {
             'input1': dataset_to_param(new_dataset1),
@@ -649,9 +649,9 @@ class ToolsTestCase(api.ApiTestCase):
         assert output_element_hda_0["metadata_column_types"] is not None
 
     @skip_without_tool("cat1")
-    def test_run_cat1_with_two_inputs(self):
+    @uses_test_history(require_new=False)
+    def test_run_cat1_with_two_inputs(self, history_id):
         # Run tool with an multiple data parameter and grouping (repeat)
-        history_id = self.dataset_populator.new_history()
         new_dataset1 = self.dataset_populator.new_dataset(history_id, content='Cat1Test')
         new_dataset2 = self.dataset_populator.new_dataset(history_id, content='Cat2Test')
         inputs = {
@@ -665,8 +665,11 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEqual(output1_content.strip(), "Cat1Test\nCat2Test")
 
     @skip_without_tool("cat1")
-    def test_multirun_cat1(self):
-        history_id, datasets = self._prepare_cat1_multirun()
+    @uses_test_history(require_new=False)
+    def test_multirun_cat1(self, history_id):
+        new_dataset1 = self.dataset_populator.new_dataset(history_id, content='123')
+        new_dataset2 = self.dataset_populator.new_dataset(history_id, content='456')
+        datasets = [dataset_to_param(new_dataset1), dataset_to_param(new_dataset2)]
         inputs = {
             "input1": {
                 'batch': True,
@@ -674,12 +677,6 @@ class ToolsTestCase(api.ApiTestCase):
             },
         }
         self._check_cat1_multirun(history_id, inputs)
-
-    def _prepare_cat1_multirun(self):
-        history_id = self.dataset_populator.new_history()
-        new_dataset1 = self.dataset_populator.new_dataset(history_id, content='123')
-        new_dataset2 = self.dataset_populator.new_dataset(history_id, content='456')
-        return history_id, [dataset_to_param(new_dataset1), dataset_to_param(new_dataset2)]
 
     def _check_cat1_multirun(self, history_id, inputs):
         outputs = self._cat1_outputs(history_id, inputs=inputs)
@@ -692,8 +689,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(output2_content.strip(), "456")
 
     @skip_without_tool("random_lines1")
-    def test_multirun_non_data_parameter(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_multirun_non_data_parameter(self, history_id):
         new_dataset1 = self.dataset_populator.new_dataset(history_id, content='123\n456\n789')
         inputs = {
             'input': dataset_to_param(new_dataset1),
@@ -821,8 +818,8 @@ class ToolsTestCase(api.ApiTestCase):
         )
 
     @skip_without_tool("cat1")
-    def test_map_over_collection(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_map_over_collection(self, history_id):
         hdca_id = self.__build_pair(history_id, ["123", "456"])
         inputs = {
             "input1": {'batch': True, 'values': [{'src': 'hdca', 'id': hdca_id}]},
@@ -830,27 +827,27 @@ class ToolsTestCase(api.ApiTestCase):
         self._run_and_check_simple_collection_mapping(history_id, inputs)
 
     @skip_without_tool("cat1")
-    def test_map_over_empty_collection(self):
-        with self.dataset_populator.test_history() as history_id:
-            hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[]).json()['id']
-            inputs = {
-                "input1": {'batch': True, 'values': [{'src': 'hdca', 'id': hdca_id}]},
-            }
-            create = self._run_cat1(history_id, inputs=inputs, assert_ok=True)
-            outputs = create['outputs']
-            jobs = create['jobs']
-            implicit_collections = create['implicit_collections']
-            self.assertEquals(len(jobs), 0)
-            self.assertEquals(len(outputs), 0)
-            self.assertEquals(len(implicit_collections), 1)
+    @uses_test_history(require_new=False)
+    def test_map_over_empty_collection(self, history_id):
+        hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[]).json()['id']
+        inputs = {
+            "input1": {'batch': True, 'values': [{'src': 'hdca', 'id': hdca_id}]},
+        }
+        create = self._run_cat1(history_id, inputs=inputs, assert_ok=True)
+        outputs = create['outputs']
+        jobs = create['jobs']
+        implicit_collections = create['implicit_collections']
+        self.assertEquals(len(jobs), 0)
+        self.assertEquals(len(outputs), 0)
+        self.assertEquals(len(implicit_collections), 1)
 
-            empty_output = implicit_collections[0]
-            assert empty_output["name"] == "Concatenate datasets on collection 1", empty_output
+        empty_output = implicit_collections[0]
+        assert empty_output["name"] == "Concatenate datasets on collection 1", empty_output
 
     @skip_without_tool("output_action_change_format")
-    def test_map_over_with_output_format_actions(self):
+    @uses_test_history(require_new=False)
+    def test_map_over_with_output_format_actions(self, history_id):
         for use_action in ["do", "dont"]:
-            history_id = self.dataset_populator.new_history()
             hdca_id = self.__build_pair(history_id, ["123", "456"])
             inputs = {
                 "input_cond|dispatch": use_action,
@@ -871,8 +868,8 @@ class ToolsTestCase(api.ApiTestCase):
             assert output2_details["file_ext"] == "txt" if (use_action == "do") else "data"
 
     @skip_without_tool("output_action_change_format_paired")
-    def test_map_over_with_nested_paired_output_format_actions(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_map_over_with_nested_paired_output_format_actions(self, history_id):
         hdca_id = self.__build_nested_list(history_id)
         inputs = {
             "input": {'batch': True, 'values': [dict(map_over_type='paired', src="hdca", id=hdca_id)]}
@@ -888,40 +885,40 @@ class ToolsTestCase(api.ApiTestCase):
             assert output["file_ext"] == "txt", output
 
     @skip_without_tool("output_filter_with_input")
-    def test_map_over_with_output_filter_no_filtering(self):
-        with self.dataset_populator.test_history() as history_id:
-            hdca_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
-            inputs = {
-                "input_1": {'batch': True, 'values': [{'src': 'hdca', 'id': hdca_id}]},
-                "produce_out_1": "true",
-                "filter_text_1": "foo",
-            }
-            create = self._run('output_filter_with_input', history_id, inputs).json()
-            jobs = create['jobs']
-            implicit_collections = create['implicit_collections']
-            self.assertEquals(len(jobs), 3)
-            self.assertEquals(len(implicit_collections), 3)
-            self._check_implicit_collection_populated(create)
+    @uses_test_history(require_new=False)
+    def test_map_over_with_output_filter_no_filtering(self, history_id):
+        hdca_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
+        inputs = {
+            "input_1": {'batch': True, 'values': [{'src': 'hdca', 'id': hdca_id}]},
+            "produce_out_1": "true",
+            "filter_text_1": "foo",
+        }
+        create = self._run('output_filter_with_input', history_id, inputs).json()
+        jobs = create['jobs']
+        implicit_collections = create['implicit_collections']
+        self.assertEquals(len(jobs), 3)
+        self.assertEquals(len(implicit_collections), 3)
+        self._check_implicit_collection_populated(create)
 
     @skip_without_tool("output_filter_with_input")
-    def test_map_over_with_output_filter_one_filtered(self):
-        with self.dataset_populator.test_history() as history_id:
-            hdca_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
-            inputs = {
-                "input_1": {'batch': True, 'values': [{'src': 'hdca', 'id': hdca_id}]},
-                "produce_out_1": "true",
-                "filter_text_1": "bar",
-            }
-            create = self._run('output_filter_with_input', history_id, inputs).json()
-            jobs = create['jobs']
-            implicit_collections = create['implicit_collections']
-            self.assertEquals(len(jobs), 3)
-            self.assertEquals(len(implicit_collections), 2)
-            self._check_implicit_collection_populated(create)
+    @uses_test_history(require_new=False)
+    def test_map_over_with_output_filter_one_filtered(self, history_id):
+        hdca_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
+        inputs = {
+            "input_1": {'batch': True, 'values': [{'src': 'hdca', 'id': hdca_id}]},
+            "produce_out_1": "true",
+            "filter_text_1": "bar",
+        }
+        create = self._run('output_filter_with_input', history_id, inputs).json()
+        jobs = create['jobs']
+        implicit_collections = create['implicit_collections']
+        self.assertEquals(len(jobs), 3)
+        self.assertEquals(len(implicit_collections), 2)
+        self._check_implicit_collection_populated(create)
 
     @skip_without_tool("Cut1")
-    def test_map_over_with_complex_output_actions(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_map_over_with_complex_output_actions(self, history_id):
         hdca_id = self._bed_list(history_id)
         inputs = {
             "columnList": "c1,c2,c3,c4,c5",
@@ -943,20 +940,20 @@ class ToolsTestCase(api.ApiTestCase):
         assert output2_content.startswith("chr1")
 
     @skip_without_tool("collection_creates_dynamic_list_of_pairs")
-    def test_map_over_with_discovered_output_collection_elements(self):
-        with self.dataset_populator.test_history() as history_id:
-            hdca_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
-            inputs = {
-                "input": {"batch": True, "values": [{"src": "hdca", "id": hdca_id}]}
-            }
-            create = self._run('collection_creates_dynamic_list_of_pairs', history_id, inputs).json()
-            implicit_collections = create['implicit_collections']
-            self.assertEquals(len(implicit_collections), 1)
-            self.assertEquals(implicit_collections[0]['collection_type'], 'list:list:paired')
-            self.assertEquals(implicit_collections[0]['elements'][0]['object']['element_count'], None)
-            self.dataset_populator.wait_for_job(create["jobs"][0]["id"], assert_ok=True)
-            hdca = self._get("histories/%s/contents/dataset_collections/%s" % (history_id, implicit_collections[0]['id'])).json()
-            self.assertEquals(hdca['elements'][0]['object']['elements'][0]['object']['elements'][0]['element_identifier'], 'forward')
+    @uses_test_history(require_new=False)
+    def test_map_over_with_discovered_output_collection_elements(self, history_id):
+        hdca_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
+        inputs = {
+            "input": {"batch": True, "values": [{"src": "hdca", "id": hdca_id}]}
+        }
+        create = self._run('collection_creates_dynamic_list_of_pairs', history_id, inputs).json()
+        implicit_collections = create['implicit_collections']
+        self.assertEquals(len(implicit_collections), 1)
+        self.assertEquals(implicit_collections[0]['collection_type'], 'list:list:paired')
+        self.assertEquals(implicit_collections[0]['elements'][0]['object']['element_count'], None)
+        self.dataset_populator.wait_for_job(create["jobs"][0]["id"], assert_ok=True)
+        hdca = self._get("histories/%s/contents/dataset_collections/%s" % (history_id, implicit_collections[0]['id'])).json()
+        self.assertEquals(hdca['elements'][0]['object']['elements'][0]['object']['elements'][0]['element_identifier'], 'forward')
 
     def _bed_list(self, history_id):
         bed1_contents = open(self.get_filename("1.bed"), "r").read()
@@ -981,8 +978,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(output2_content.strip(), "456")
 
     @skip_without_tool("identifier_single")
-    def test_identifier_in_map(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_identifier_in_map(self, history_id):
         hdca_id = self.__build_pair(history_id, ["123", "456"])
         inputs = {
             "input1": {'batch': True, 'values': [{'src': 'hdca', 'id': hdca_id}]},
@@ -1004,8 +1001,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(output2_content.strip(), "reverse")
 
     @skip_without_tool("identifier_single")
-    def test_identifier_outside_map(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_identifier_outside_map(self, history_id):
         new_dataset1 = self.dataset_populator.new_dataset(history_id, content='123', name="Plain HDA")
         inputs = {
             "input1": {'src': 'hda', 'id': new_dataset1["id"]},
@@ -1024,15 +1021,15 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(output1_content.strip(), "Plain HDA")
 
     @skip_without_tool("identifier_multiple")
-    def test_list_selectable_in_multidata_input(self):
-        with self.dataset_populator.test_history() as history_id:
-            self.dataset_collection_populator.create_list_in_history(history_id, contents=["123", "456"])
-            build = self._post("tools/identifier_multiple/build?history_id=%s" % history_id).json()
-            assert len(build['inputs'][0]['options']['hdca']) == 1
+    @uses_test_history(require_new=False)
+    def test_list_selectable_in_multidata_input(self, history_id):
+        self.dataset_collection_populator.create_list_in_history(history_id, contents=["123", "456"])
+        build = self._post("tools/identifier_multiple/build?history_id=%s" % history_id).json()
+        assert len(build['inputs'][0]['options']['hdca']) == 1
 
     @skip_without_tool("identifier_multiple")
-    def test_identifier_in_multiple_reduce(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_identifier_in_multiple_reduce(self, history_id):
         hdca_id = self.__build_pair(history_id, ["123", "456"])
         inputs = {
             "input1": {'src': 'hdca', 'id': hdca_id},
@@ -1051,8 +1048,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(output1_content.strip(), "forward\nreverse")
 
     @skip_without_tool("identifier_multiple_in_conditional")
-    def test_identifier_multiple_reduce_in_conditional(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_identifier_multiple_reduce_in_conditional(self, history_id):
         hdca_id = self.__build_pair(history_id, ["123", "456"])
         inputs = {
             "outer_cond|inner_cond|input1": {'src': 'hdca', 'id': hdca_id},
@@ -1071,8 +1068,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(output1_content.strip(), "forward\nreverse")
 
     @skip_without_tool("identifier_multiple_in_repeat")
-    def test_identifier_multiple_reduce_in_repeat(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_identifier_multiple_reduce_in_repeat(self, history_id):
         hdca_id = self.__build_pair(history_id, ["123", "456"])
         inputs = {
             "the_repeat_0|the_data|input1": {'src': 'hdca', 'id': hdca_id},
@@ -1091,8 +1088,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(output1_content.strip(), "forward\nreverse")
 
     @skip_without_tool("identifier_single_in_repeat")
-    def test_identifier_single_in_repeat(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_identifier_single_in_repeat(self, history_id):
         hdca_id = self.__build_pair(history_id, ["123", "456"])
         inputs = {
             "the_repeat_0|the_data|input1": {'batch': True, 'values': [{'src': 'hdca', 'id': hdca_id}]}
@@ -1112,8 +1109,8 @@ class ToolsTestCase(api.ApiTestCase):
         assert output1_content.strip() == "forward", output1_content
 
     @skip_without_tool("identifier_multiple_in_conditional")
-    def test_identifier_multiple_in_conditional(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_identifier_multiple_in_conditional(self, history_id):
         new_dataset1 = self.dataset_populator.new_dataset(history_id, content='123', name="Normal HDA1")
         inputs = {
             "outer_cond|inner_cond|input1": {'src': 'hda', 'id': new_dataset1["id"]},
@@ -1132,8 +1129,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(output1_content.strip(), "Normal HDA1")
 
     @skip_without_tool("identifier_multiple")
-    def test_identifier_with_multiple_normal_datasets(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_identifier_with_multiple_normal_datasets(self, history_id):
         new_dataset1 = self.dataset_populator.new_dataset(history_id, content='123', name="Normal HDA1")
         new_dataset2 = self.dataset_populator.new_dataset(history_id, content='456', name="Normal HDA2")
         inputs = {
@@ -1156,9 +1153,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(output1_content.strip(), "Normal HDA1\nNormal HDA2")
 
     @skip_without_tool("identifier_collection")
-    def test_identifier_with_data_collection(self):
-        history_id = self.dataset_populator.new_history()
-
+    @uses_test_history(require_new=False)
+    def test_identifier_with_data_collection(self, history_id):
         element_identifiers = self.dataset_collection_populator.list_identifiers(history_id)
 
         payload = dict(
@@ -1188,9 +1184,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(output1_content.strip(), '\n'.join([d['name'] for d in element_identifiers]))
 
     @skip_without_tool("identifier_in_actions")
-    def test_identifier_in_actions(self):
-        history_id = self.dataset_populator.new_history()
-
+    @uses_test_history(require_new=False)
+    def test_identifier_in_actions(self, history_id):
         element_identifiers = self.dataset_collection_populator.list_identifiers(history_id, contents=["1\t2"])
 
         payload = dict(
@@ -1218,8 +1213,8 @@ class ToolsTestCase(api.ApiTestCase):
         assert output_details["metadata_column_names"][1] == "data1", output_details
 
     @skip_without_tool("cat1")
-    def test_map_over_nested_collections(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_map_over_nested_collections(self, history_id):
         hdca_id = self.__build_nested_list(history_id)
         inputs = {
             "input1": {'batch': True, 'values': [dict(src="hdca", id=hdca_id)]},
@@ -1227,8 +1222,8 @@ class ToolsTestCase(api.ApiTestCase):
         self._check_simple_cat1_over_nested_collections(history_id, inputs)
 
     @skip_without_tool("collection_paired_structured_like")
-    def test_paired_input_map_over_nested_collections(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_paired_input_map_over_nested_collections(self, history_id):
         hdca_id = self.__build_nested_list(history_id)
         inputs = {
             "input1": {'batch': True, 'values': [dict(map_over_type='paired', src="hdca", id=hdca_id)]},
@@ -1245,8 +1240,8 @@ class ToolsTestCase(api.ApiTestCase):
         assert len(outer_elements) == 2
 
     @skip_without_tool("collection_paired_conditional_structured_like")
-    def test_paired_input_conditional_map_over_nested_collections(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_paired_input_conditional_map_over_nested_collections(self, history_id):
         hdca_id = self.__build_nested_list(history_id)
         inputs = {
             "cond|cond_param": "paired",
@@ -1286,8 +1281,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(outputs[0]["id"], first_object_forward_element["object"]["id"])
 
     @skip_without_tool("cat1")
-    def test_map_over_two_collections(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_map_over_two_collections(self, history_id):
         hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
         hdca2_id = self.__build_pair(history_id, ["789\n", "0ab\n"])
         inputs = {
@@ -1314,8 +1309,8 @@ class ToolsTestCase(api.ApiTestCase):
         self.assertEquals(len(response_object['implicit_collections']), 1)
 
     @skip_without_tool("cat1")
-    def test_map_over_two_collections_unlinked(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_map_over_two_collections_unlinked(self, history_id):
         hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
         hdca2_id = self.__build_pair(history_id, ["789\n", "0ab\n"])
         inputs = {
@@ -1366,8 +1361,8 @@ class ToolsTestCase(api.ApiTestCase):
             self.assertEquals(expected_contents, contents)
 
     @skip_without_tool("cat1")
-    def test_map_over_collected_and_individual_datasets(self):
-        history_id = self.dataset_populator.new_history()
+    @uses_test_history(require_new=False)
+    def test_map_over_collected_and_individual_datasets(self, history_id):
         hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
         new_dataset1 = self.dataset_populator.new_dataset(history_id, content='789')
         new_dataset2 = self.dataset_populator.new_dataset(history_id, content='0ab')
@@ -1387,86 +1382,86 @@ class ToolsTestCase(api.ApiTestCase):
 
     @skip_without_tool("identifier_source")
     def test_default_identifier_source_map_over(self):
-        history_id = self.dataset_populator.new_history()
-        input_a_hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("A", "A content")]).json()['id']
-        input_b_hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("B", "B content")]).json()['id']
-        inputs = {
-            "inputA": {'batch': True, 'values': [dict(src="hdca", id=input_a_hdca_id)]},
-            "inputB": {'batch': True, 'values': [dict(src="hdca", id=input_b_hdca_id)]},
-        }
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        create = self._run("identifier_source", history_id, inputs, assert_ok=True)
-        for implicit_collection in create['implicit_collections']:
-            if implicit_collection['output_name'] == 'outputA':
-                assert implicit_collection['elements'][0]['element_identifier'] == 'A'
-            else:
-                assert implicit_collection['elements'][0]['element_identifier'] == 'B'
+        with self.dataset_populator.test_history() as history_id:
+            input_a_hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("A", "A content")]).json()['id']
+            input_b_hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("B", "B content")]).json()['id']
+            inputs = {
+                "inputA": {'batch': True, 'values': [dict(src="hdca", id=input_a_hdca_id)]},
+                "inputB": {'batch': True, 'values': [dict(src="hdca", id=input_b_hdca_id)]},
+            }
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            create = self._run("identifier_source", history_id, inputs, assert_ok=True)
+            for implicit_collection in create['implicit_collections']:
+                if implicit_collection['output_name'] == 'outputA':
+                    assert implicit_collection['elements'][0]['element_identifier'] == 'A'
+                else:
+                    assert implicit_collection['elements'][0]['element_identifier'] == 'B'
 
     @skip_without_tool("collection_creates_pair")
     def test_map_over_collection_output(self):
-        history_id = self.dataset_populator.new_history()
-        create_response = self.dataset_collection_populator.create_list_in_history(history_id, contents=["a\nb\nc\nd", "e\nf\ng\nh"])
-        hdca_id = create_response.json()["id"]
-        inputs = {
-            "input1": {'batch': True, 'values': [dict(src="hdca", id=hdca_id)]},
-        }
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        create = self._run("collection_creates_pair", history_id, inputs, assert_ok=True)
-        jobs = create['jobs']
-        implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 2)
-        self.assertEquals(len(implicit_collections), 1)
-        implicit_collection = implicit_collections[0]
-        assert implicit_collection["collection_type"] == "list:paired", implicit_collection
-        outer_elements = implicit_collection["elements"]
-        assert len(outer_elements) == 2
-        element0, element1 = outer_elements
-        assert element0["element_identifier"] == "data1"
-        assert element1["element_identifier"] == "data2"
+        with self.dataset_populator.test_history() as history_id:
+            create_response = self.dataset_collection_populator.create_list_in_history(history_id, contents=["a\nb\nc\nd", "e\nf\ng\nh"])
+            hdca_id = create_response.json()["id"]
+            inputs = {
+                "input1": {'batch': True, 'values': [dict(src="hdca", id=hdca_id)]},
+            }
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            create = self._run("collection_creates_pair", history_id, inputs, assert_ok=True)
+            jobs = create['jobs']
+            implicit_collections = create['implicit_collections']
+            self.assertEquals(len(jobs), 2)
+            self.assertEquals(len(implicit_collections), 1)
+            implicit_collection = implicit_collections[0]
+            assert implicit_collection["collection_type"] == "list:paired", implicit_collection
+            outer_elements = implicit_collection["elements"]
+            assert len(outer_elements) == 2
+            element0, element1 = outer_elements
+            assert element0["element_identifier"] == "data1"
+            assert element1["element_identifier"] == "data2"
 
-        pair0, pair1 = element0["object"], element1["object"]
-        pair00, pair01 = pair0["elements"]
-        pair10, pair11 = pair1["elements"]
+            pair0, pair1 = element0["object"], element1["object"]
+            pair00, pair01 = pair0["elements"]
+            pair10, pair11 = pair1["elements"]
 
-        for pair in pair0, pair1:
-            assert "collection_type" in pair, pair
-            assert pair["collection_type"] == "paired", pair
+            for pair in pair0, pair1:
+                assert "collection_type" in pair, pair
+                assert pair["collection_type"] == "paired", pair
 
-        pair_ids = []
-        for pair_element in pair00, pair01, pair10, pair11:
-            assert "object" in pair_element
-            pair_ids.append(pair_element["object"]["id"])
+            pair_ids = []
+            for pair_element in pair00, pair01, pair10, pair11:
+                assert "object" in pair_element
+                pair_ids.append(pair_element["object"]["id"])
 
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        expected_contents = [
-            "a\nc\n",
-            "b\nd\n",
-            "e\ng\n",
-            "f\nh\n",
-        ]
-        for i in range(4):
-            contents = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=pair_ids[i])
-            self.assertEquals(expected_contents[i], contents)
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            expected_contents = [
+                "a\nc\n",
+                "b\nd\n",
+                "e\ng\n",
+                "f\nh\n",
+            ]
+            for i in range(4):
+                contents = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=pair_ids[i])
+                self.assertEquals(expected_contents[i], contents)
 
     @skip_without_tool("cat1")
     def test_cannot_map_over_incompatible_collections(self):
-        history_id = self.dataset_populator.new_history()
-        hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
-        hdca2_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
-        inputs = {
-            "input1": {
-                'batch': True,
-                'values': [{'src': 'hdca', 'id': hdca1_id}],
-            },
-            "queries_0|input2": {
-                'batch': True,
-                'values': [{'src': 'hdca', 'id': hdca2_id}],
-            },
-        }
-        run_response = self._run_cat1(history_id, inputs)
-        # TODO: Fix this error checking once switch over to new API decorator
-        # on server.
-        assert run_response.status_code >= 400
+        with self.dataset_populator.test_history() as history_id:
+            hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
+            hdca2_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
+            inputs = {
+                "input1": {
+                    'batch': True,
+                    'values': [{'src': 'hdca', 'id': hdca1_id}],
+                },
+                "queries_0|input2": {
+                    'batch': True,
+                    'values': [{'src': 'hdca', 'id': hdca2_id}],
+                },
+            }
+            run_response = self._run_cat1(history_id, inputs)
+            # TODO: Fix this error checking once switch over to new API decorator
+            # on server.
+            assert run_response.status_code >= 400
 
     @skip_without_tool("__FILTER_FROM_FILE__")
     def test_map_over_collection_structured_like(self):
@@ -1508,97 +1503,97 @@ class ToolsTestCase(api.ApiTestCase):
 
     @skip_without_tool("multi_data_param")
     def test_reduce_collections_legacy(self):
-        history_id = self.dataset_populator.new_history()
-        hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
-        hdca2_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
-        inputs = {
-            "f1": "__collection_reduce__|%s" % hdca1_id,
-            "f2": "__collection_reduce__|%s" % hdca2_id,
-        }
-        self._check_simple_reduce_job(history_id, inputs)
+        with self.dataset_populator.test_history() as history_id:
+            hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
+            hdca2_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
+            inputs = {
+                "f1": "__collection_reduce__|%s" % hdca1_id,
+                "f2": "__collection_reduce__|%s" % hdca2_id,
+            }
+            self._check_simple_reduce_job(history_id, inputs)
 
     @skip_without_tool("multi_data_param")
     def test_reduce_collections(self):
-        history_id = self.dataset_populator.new_history()
-        hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
-        hdca2_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
-        inputs = {
-            "f1": {'src': 'hdca', 'id': hdca1_id},
-            "f2": {'src': 'hdca', 'id': hdca2_id},
-        }
-        self._check_simple_reduce_job(history_id, inputs)
+        with self.dataset_populator.test_history() as history_id:
+            hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
+            hdca2_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
+            inputs = {
+                "f1": {'src': 'hdca', 'id': hdca1_id},
+                "f2": {'src': 'hdca', 'id': hdca2_id},
+            }
+            self._check_simple_reduce_job(history_id, inputs)
 
     @skip_without_tool("multi_data_param")
     def test_implicit_reduce_with_mapping(self):
-        history_id = self.dataset_populator.new_history()
-        hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
-        hdca2_id = self.dataset_collection_populator.create_list_of_list_in_history(history_id).json()["id"]
-        inputs = {
-            "f1": {'src': 'hdca', 'id': hdca1_id},
-            "f2": {
-                'batch': True,
-                'values': [{'src': 'hdca', 'map_over_type': 'list', 'id': hdca2_id}],
+        with self.dataset_populator.test_history() as history_id:
+            hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
+            hdca2_id = self.dataset_collection_populator.create_list_of_list_in_history(history_id).json()["id"]
+            inputs = {
+                "f1": {'src': 'hdca', 'id': hdca1_id},
+                "f2": {
+                    'batch': True,
+                    'values': [{'src': 'hdca', 'map_over_type': 'list', 'id': hdca2_id}],
+                }
             }
-        }
-        create = self._run("multi_data_param", history_id, inputs, assert_ok=True)
-        jobs = create['jobs']
-        implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(implicit_collections), 2)
-        output_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=implicit_collections[0]["hid"])
-        assert output_hdca["collection_type"] == "list"
+            create = self._run("multi_data_param", history_id, inputs, assert_ok=True)
+            jobs = create['jobs']
+            implicit_collections = create['implicit_collections']
+            self.assertEquals(len(jobs), 1)
+            self.assertEquals(len(implicit_collections), 2)
+            output_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=implicit_collections[0]["hid"])
+            assert output_hdca["collection_type"] == "list"
 
     @skip_without_tool("multi_data_repeat")
     def test_reduce_collections_in_repeat(self):
-        history_id = self.dataset_populator.new_history()
-        hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
-        inputs = {
-            "outer_repeat_0|f1": {'src': 'hdca', 'id': hdca1_id},
-        }
-        create = self._run("multi_data_repeat", history_id, inputs, assert_ok=True)
-        outputs = create['outputs']
-        jobs = create['jobs']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 1)
-        output1 = outputs[0]
-        output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        assert output1_content.strip() == "123\n456", output1_content
+        with self.dataset_populator.test_history() as history_id:
+            hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
+            inputs = {
+                "outer_repeat_0|f1": {'src': 'hdca', 'id': hdca1_id},
+            }
+            create = self._run("multi_data_repeat", history_id, inputs, assert_ok=True)
+            outputs = create['outputs']
+            jobs = create['jobs']
+            self.assertEquals(len(jobs), 1)
+            self.assertEquals(len(outputs), 1)
+            output1 = outputs[0]
+            output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
+            assert output1_content.strip() == "123\n456", output1_content
 
     @skip_without_tool("multi_data_repeat")
     def test_reduce_collections_in_repeat_legacy(self):
-        history_id = self.dataset_populator.new_history()
-        hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
-        inputs = {
-            "outer_repeat_0|f1": "__collection_reduce__|%s" % hdca1_id,
-        }
-        create = self._run("multi_data_repeat", history_id, inputs, assert_ok=True)
-        outputs = create['outputs']
-        jobs = create['jobs']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 1)
-        output1 = outputs[0]
-        output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        assert output1_content.strip() == "123\n456", output1_content
+        with self.dataset_populator.test_history() as history_id:
+            hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
+            inputs = {
+                "outer_repeat_0|f1": "__collection_reduce__|%s" % hdca1_id,
+            }
+            create = self._run("multi_data_repeat", history_id, inputs, assert_ok=True)
+            outputs = create['outputs']
+            jobs = create['jobs']
+            self.assertEquals(len(jobs), 1)
+            self.assertEquals(len(outputs), 1)
+            output1 = outputs[0]
+            output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
+            assert output1_content.strip() == "123\n456", output1_content
 
     @skip_without_tool("multi_data_param")
     def test_reduce_multiple_lists_on_multi_data(self):
-        history_id = self.dataset_populator.new_history()
-        hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
-        hdca2_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
-        inputs = {
-            "f1": [{'src': 'hdca', 'id': hdca1_id}, {'src': 'hdca', 'id': hdca2_id}],
-            "f2": [{'src': 'hdca', 'id': hdca1_id}],
-        }
-        create = self._run("multi_data_param", history_id, inputs, assert_ok=True)
-        outputs = create['outputs']
-        jobs = create['jobs']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 2)
-        output1, output2 = outputs
-        output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEquals(output1_content.strip(), "123\n456\nTestData123\nTestData123\nTestData123")
-        self.assertEquals(output2_content.strip(), "123\n456")
+        with self.dataset_populator.test_history() as history_id:
+            hdca1_id = self.__build_pair(history_id, ["123\n", "456\n"])
+            hdca2_id = self.dataset_collection_populator.create_list_in_history(history_id).json()["id"]
+            inputs = {
+                "f1": [{'src': 'hdca', 'id': hdca1_id}, {'src': 'hdca', 'id': hdca2_id}],
+                "f2": [{'src': 'hdca', 'id': hdca1_id}],
+            }
+            create = self._run("multi_data_param", history_id, inputs, assert_ok=True)
+            outputs = create['outputs']
+            jobs = create['jobs']
+            self.assertEquals(len(jobs), 1)
+            self.assertEquals(len(outputs), 2)
+            output1, output2 = outputs
+            output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
+            output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
+            self.assertEquals(output1_content.strip(), "123\n456\nTestData123\nTestData123\nTestData123")
+            self.assertEquals(output2_content.strip(), "123\n456")
 
     def _check_simple_reduce_job(self, history_id, inputs):
         create = self._run("multi_data_param", history_id, inputs, assert_ok=True)
@@ -1614,15 +1609,15 @@ class ToolsTestCase(api.ApiTestCase):
 
     @skip_without_tool("collection_paired_test")
     def test_subcollection_mapping(self):
-        history_id = self.dataset_populator.new_history()
-        hdca_list_id = self.__build_nested_list(history_id)
-        inputs = {
-            "f1": {
-                'batch': True,
-                'values': [{'src': 'hdca', 'map_over_type': 'paired', 'id': hdca_list_id}],
+        with self.dataset_populator.test_history() as history_id:
+            hdca_list_id = self.__build_nested_list(history_id)
+            inputs = {
+                "f1": {
+                    'batch': True,
+                    'values': [{'src': 'hdca', 'map_over_type': 'paired', 'id': hdca_list_id}],
+                }
             }
-        }
-        self._check_simple_subcollection_mapping(history_id, inputs)
+            self._check_simple_subcollection_mapping(history_id, inputs)
 
     def _check_simple_subcollection_mapping(self, history_id, inputs):
         # Following wait not really needed - just getting so many database
@@ -1639,21 +1634,21 @@ class ToolsTestCase(api.ApiTestCase):
 
     @skip_without_tool("collection_mixed_param")
     def test_combined_mapping_and_subcollection_mapping(self):
-        history_id = self.dataset_populator.new_history()
-        nested_list_id = self.__build_nested_list(history_id)
-        create_response = self.dataset_collection_populator.create_list_in_history(history_id, contents=["xxx\n", "yyy\n"])
-        list_id = create_response.json()["id"]
-        inputs = {
-            "f1": {
-                'batch': True,
-                'values': [{'src': 'hdca', 'map_over_type': 'paired', 'id': nested_list_id}],
-            },
-            "f2": {
-                'batch': True,
-                'values': [{'src': 'hdca', 'id': list_id}],
-            },
-        }
-        self._check_combined_mapping_and_subcollection_mapping(history_id, inputs)
+        with self.dataset_populator.test_history() as history_id:
+            nested_list_id = self.__build_nested_list(history_id)
+            create_response = self.dataset_collection_populator.create_list_in_history(history_id, contents=["xxx\n", "yyy\n"])
+            list_id = create_response.json()["id"]
+            inputs = {
+                "f1": {
+                    'batch': True,
+                    'values': [{'src': 'hdca', 'map_over_type': 'paired', 'id': nested_list_id}],
+                },
+                "f2": {
+                    'batch': True,
+                    'values': [{'src': 'hdca', 'id': list_id}],
+                },
+            }
+            self._check_combined_mapping_and_subcollection_mapping(history_id, inputs)
 
     def _check_combined_mapping_and_subcollection_mapping(self, history_id, inputs):
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
@@ -1720,35 +1715,37 @@ class ToolsTestCase(api.ApiTestCase):
         tool_ids = [_["id"] for _ in tools]
         return tool_ids
 
-    def test_group_tag_selection(self):
-        with self.dataset_populator.test_history() as history_id:
-            input_hdca_id = self.__build_group_list(history_id)
-            inputs = {
-                "input1": {"src": "hdca", "id": input_hdca_id},
-                "group": "condition:treated",
-            }
-            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-            response = self._run("collection_cat_group_tag", history_id, inputs, assert_ok=True)
-            outputs = response["outputs"]
-            self.assertEquals(len(outputs), 1)
-            output = outputs[0]
-            output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output)
-            self.assertEquals(output_content.strip(), "123\n456")
+    @skip_without_tool("collection_cat_group_tag_multiple")
+    @uses_test_history(require_new=False)
+    def test_group_tag_selection(self, history_id):
+        input_hdca_id = self.__build_group_list(history_id)
+        inputs = {
+            "input1": {"src": "hdca", "id": input_hdca_id},
+            "group": "condition:treated",
+        }
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        response = self._run("collection_cat_group_tag", history_id, inputs, assert_ok=True)
+        outputs = response["outputs"]
+        self.assertEquals(len(outputs), 1)
+        output = outputs[0]
+        output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output)
+        self.assertEquals(output_content.strip(), "123\n456")
 
-    def test_group_tag_selection_multiple(self):
-        with self.dataset_populator.test_history() as history_id:
-            input_hdca_id = self.__build_group_list(history_id)
-            inputs = {
-                "input1": {"src": "hdca", "id": input_hdca_id},
-                "groups": "condition:treated,type:single",
-            }
-            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-            response = self._run("collection_cat_group_tag_multiple", history_id, inputs, assert_ok=True)
-            outputs = response["outputs"]
-            self.assertEquals(len(outputs), 1)
-            output = outputs[0]
-            output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output)
-            self.assertEquals(output_content.strip(), "123\n456\n456\n0ab")
+    @skip_without_tool("collection_cat_group_tag_multiple")
+    @uses_test_history(require_new=False)
+    def test_group_tag_selection_multiple(self, history_id):
+        input_hdca_id = self.__build_group_list(history_id)
+        inputs = {
+            "input1": {"src": "hdca", "id": input_hdca_id},
+            "groups": "condition:treated,type:single",
+        }
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        response = self._run("collection_cat_group_tag_multiple", history_id, inputs, assert_ok=True)
+        outputs = response["outputs"]
+        self.assertEquals(len(outputs), 1)
+        output = outputs[0]
+        output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output)
+        self.assertEquals(output_content.strip(), "123\n456\n456\n0ab")
 
     def __build_group_list(self, history_id):
         response = self.dataset_collection_populator.upload_collection(history_id, "list", elements=[

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -6,6 +6,11 @@ import unittest
 from functools import wraps
 from operator import itemgetter
 
+try:
+    from nose.tools import nottest
+except ImportError:
+    def nottest(x):
+        return x
 import requests
 from pkg_resources import resource_string
 from six import StringIO
@@ -106,6 +111,22 @@ def summarize_instance_history_on_error(method):
             raise
 
     return wrapped_method
+
+
+@nottest
+def uses_test_history(**test_history_kwd):
+    """Can override require_new and cancel_executions using kwds to decorator.
+    """
+
+    def method_wrapper(method):
+        @wraps(method)
+        def wrapped_method(api_test_case, *args, **kwds):
+            with api_test_case.dataset_populator.test_history(**test_history_kwd) as history_id:
+                method(api_test_case, history_id, *args, **kwds)
+
+        return wrapped_method
+
+    return method_wrapper
 
 
 def _raise_skip_if(check):

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -233,13 +233,20 @@ class BaseDatasetPopulator(object):
 
     @contextlib.contextmanager
     def test_history(self, **kwds):
+        cleanup = "GALAXY_TEST_NO_CLEANUP" not in os.environ
+
         def wrap_up():
             cancel_executions = kwds.get("cancel_executions", True)
-            if cancel_executions:
+            if cleanup and cancel_executions:
                 self.cancel_history_jobs(history_id)
 
+        require_new = kwds.get("require_new", True)
         try:
-            history_id = self.new_history()
+            history_id = None
+            if not require_new:
+                history_id = kwds.get("GALAXY_TEST_HISTORY_ID", None)
+
+            history_id = history_id or self.new_history()
             yield history_id
             wrap_up()
         except Exception:

--- a/test/selenium_tests/framework.py
+++ b/test/selenium_tests/framework.py
@@ -93,6 +93,7 @@ def managed_history(f):
         finally:
             if "GALAXY_TEST_NO_CLEANUP" not in os.environ:
                 current_history_id = self.current_history_id()
+                self.dataset_populator.cancel_history_jobs(current_history_id)
                 self.api_delete("histories/%s" % current_history_id)
 
     return func_wrapper


### PR DESCRIPTION
- Cancel jobs when using ``test_history`` context for API/integration tests and ``@managed_history`` for Selenium tests. Should reduce the probability of a test interfering with other tests. (Progress toward  #6581).
- Allow ``test_history`` context to annotate whether new histories are needed by test.
  
  Usually tests should have new histories but we should still capture this information so we can target tests are particular histories for debugging interactively and so we could potentially reduce the number of new histories created when testing remote Galaxies (there have been complaints about this in the past).
- Introduce ``@use_test_history`` as a method decorator that wraps ``test_history`` for slightly simpler, flatter test cases.
- Transition more of ``test_tools.py`` to use the ``test_history`` context (via the new decorator).
