### PR TITLE
[18.05] Use object store to check for existence of extra_files_path

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1939,6 +1939,9 @@ class Dataset(StorableObject):
             self.external_extra_files_path = extra_files_path
     extra_files_path = property(get_extra_files_path, set_extra_files_path)
 
+    def extra_files_path_exists(self):
+        return self.object_store.exists(self, extra_dir=self._extra_files_path or "dataset_%d_files" % self.id, dir_only=True)
+
     def _calculate_size(self):
         if self.external_filename:
             try:
@@ -2126,6 +2129,9 @@ class DatasetInstance(object):
     @property
     def extra_files_path(self):
         return self.dataset.extra_files_path
+
+    def extra_files_path_exists(self):
+        return self.dataset.extra_files_path_exists()
 
     @property
     def datatype(self):

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -326,7 +326,7 @@ class DataManager(object):
             # moving a directory and the target already exists, we move the contents instead
             log.debug('Attempting to add entries for undeclared tables: %s.', ', '.join(data_tables_dict.keys()))
             for ref_file in out_data.values():
-                if os.path.exists(ref_file.extra_files_path):
+                if ref_file.extra_files_path_exists():
                     util.move_merge(ref_file.extra_files_path, self.data_managers.app.config.galaxy_data_manager_data_path)
             path_column_names = ['path']
             for data_table_name, data_table_values in data_tables_dict.items():


### PR DESCRIPTION
This should fix https://github.com/galaxyproject/galaxy/issues/6585 for now.
I will make the normal DiskObjectStore also raise ObjectNotFound in dev and figure out if anything else needs fixing.