### PR TITLE
[18.05] Update UCSC genome-test server URLs

### DIFF
--- a/cron/build_chrom_db.py
+++ b/cron/build_chrom_db.py
@@ -24,7 +24,7 @@ import parse_builds  # noqa: I100,I202
 
 
 def getchrominfo(url, db):
-    tableURL = "http://genome-test.cse.ucsc.edu/cgi-bin/hgTables?"
+    tableURL = "http://genome-test.gi.ucsc.edu/cgi-bin/hgTables?"
     URL = tableURL + urlencode({
         "clade": "",
         "org": "",
@@ -75,7 +75,7 @@ if __name__ == "__main__":
         outfile_name = dbpath + build + ".len"
         try:
             with open(outfile_name, "w") as outfile:
-                for chrominfo in getchrominfo("http://genome-test.cse.ucsc.edu/cgi-bin/hgTables?", build):
+                for chrominfo in getchrominfo("http://genome-test.gi.ucsc.edu/cgi-bin/hgTables?", build):
                     print("\t".join(chrominfo), file=outfile)
         except Exception as e:
             print("Failed to retrieve %s: %s" % (build, e))

--- a/cron/parse_builds_3_sites.py
+++ b/cron/parse_builds_3_sites.py
@@ -10,7 +10,7 @@ import requests
 
 sites = ['http://genome.ucsc.edu/cgi-bin/',
          'http://archaea.ucsc.edu/cgi-bin/',
-         'http://genome-test.cse.ucsc.edu/cgi-bin/']
+         'http://genome-test.gi.ucsc.edu/cgi-bin/']
 names = ['main', 'archaea', 'test']
 
 

--- a/tools/data_source/ucsc_tablebrowser_test.xml
+++ b/tools/data_source/ucsc_tablebrowser_test.xml
@@ -7,7 +7,7 @@
 <tool name="UCSC Test" id="ucsc_table_direct_test1" tool_type="data_source" version="1.0.0">
     <description>table browser</description>
     <command interpreter="python">data_source.py $output $__app__.config.output_size_limit</command>
-    <inputs action="http://genome-test.cse.ucsc.edu/cgi-bin/hgTables" check_values="false" method="get">
+    <inputs action="http://genome-test.gi.ucsc.edu/cgi-bin/hgTables" check_values="false" method="get">
         <display>go to UCSC Table Browser $GALAXY_URL</display>
         <param name="GALAXY_URL" type="baseurl" value="/tool_runner" />
         <param name="tool_id" type="hidden" value="ucsc_table_direct_test1" />

--- a/tools/data_source/ucsc_tablebrowser_test.xml
+++ b/tools/data_source/ucsc_tablebrowser_test.xml
@@ -4,7 +4,7 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="UCSC Test" id="ucsc_table_direct_test1" tool_type="data_source" version="1.0.0">
+<tool name="UCSC Test" id="ucsc_table_direct_test1" tool_type="data_source" version="1.0.1">
     <description>table browser</description>
     <command interpreter="python">data_source.py $output $__app__.config.output_size_limit</command>
     <inputs action="http://genome-test.gi.ucsc.edu/cgi-bin/hgTables" check_values="false" method="get">


### PR DESCRIPTION
`genome-test.cse.ucsc.edu` and `genome-test.soe.ucsc.edu` are migrating to `genome-test.gi.ucsc.edu` (this weekend)