### PR TITLE
Respect unavailable display peek

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1375,11 +1375,13 @@ class JobWrapper(HasResourceParameters):
                             return path
 
                         dataset.metadata.from_JSON_dict(output_filename, path_rewriter=path_rewriter)
+                    line_count = context.get('line_count', None)
                     try:
-                        assert context.get('line_count', None) is not None
-                        dataset.set_peek(line_count=context['line_count'])
-                    except Exception:
-                        dataset.set_peek()
+                        # Certain datatype's set_peek methods contain a line_count argument
+                        dataset_assoc.dataset.set_peek(line_count=line_count)
+                    except TypeError:
+                        # ... and others don't
+                        dataset_assoc.dataset.set_peek()
                 else:
                     # Handle purged datasets.
                     dataset.blurb = "empty"

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -54,7 +54,6 @@ from galaxy.util.sanitize_html import sanitize_html
 from galaxy.web.form_builder import (AddressField, CheckboxField, HistoryField,
                                      PasswordField, SelectField, TextArea, TextField, WorkflowField,
                                      WorkflowMappingField)
-from galaxy.web.framework.helpers import to_unicode
 
 log = logging.getLogger(__name__)
 
@@ -2753,7 +2752,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
                     uuid=(lambda uuid: str(uuid) if uuid else None)(hda.dataset.uuid),
                     hid=hda.hid,
                     file_ext=hda.ext,
-                    peek=(lambda hda: hda.display_peek() if hda.peek and hda.peek != 'no peek' else None)(hda),
+                    peek=unicodify(hda.display_peek()) if hda.peek and hda.peek != 'no peek' else None,
                     model_class=self.__class__.__name__,
                     name=hda.name,
                     deleted=hda.deleted,
@@ -2779,8 +2778,6 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
 
         if hda.extended_metadata is not None:
             rval['extended_metadata'] = hda.extended_metadata.data
-
-        rval['peek'] = to_unicode(hda.display_peek())
 
         for name, spec in hda.metadata.spec.items():
             val = hda.metadata.get(name)

--- a/tools/stats/filtering.xml
+++ b/tools/stats/filtering.xml
@@ -4,7 +4,7 @@
     <edam_operation>operation_0335</edam_operation>
   </edam_operations>
   <command>
-    python '$__tool_directory__/filtering.py' $input $out_file1 '$inputs' ${input.metadata.columns} "${input.metadata.column_types}" $header_lines
+    python '$__tool_directory__/filtering.py' '$input' '$out_file1' '$inputs' ${input.metadata.columns} "${input.metadata.column_types}" $header_lines
   </command>
   <configfiles>
     <inputs name="inputs" />


### PR DESCRIPTION
This fixes the following exception when running the Filter1 tool via the API

```
galaxy.datatypes.tabular ERROR 2018-08-12 22:53:42,939 make_html_peek_rows failed on HDA 64
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/datatypes/tabular.py", line 186, in make_html_peek_rows
    dataset.set_peek()
  File "/Users/mvandenb/src/galaxy/lib/galaxy/model/__init__.py", line 2264, in set_peek
    return self.datatype.set_peek(self)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/datatypes/tabular.py", line 57, in set_peek
    super(TabularData, self).set_peek(dataset, line_count=line_count, WIDTH=WIDTH, skipchars=skipchars, line_wrap=False)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/datatypes/data.py", line 813, in set_peek
    dataset.peek = get_file_peek(dataset.file_name, WIDTH=WIDTH, skipchars=skipchars, line_wrap=line_wrap)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/datatypes/data.py", line 1029, in get_file_peek
    with compression_utils.get_fileobj(file_name, "U") as temp:
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/compression_utils.py", line 29, in get_fileobj
    return get_fileobj_raw(filename, mode, compressed_formats)[1]
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/compression_utils.py", line 58, in get_fileobj_raw
    return compressed_format, io.open(filename, mode, encoding='utf-8')
FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmpan_4qaow/tmpfzus9jhv/tmplqjtbp5c/database/files/000/dataset_40.dat'
```