### PR TITLE
Modernize data manager testing and strip twill

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -66,6 +66,8 @@ class GalaxyInteractorApi(object):
         self.api_url = "%s/api" % kwds["galaxy_url"].rstrip("/")
         self.master_api_key = kwds["master_api_key"]
         self.api_key = self.__get_user_key(kwds.get("api_key"), kwds.get("master_api_key"), test_user=kwds.get("test_user"))
+        if kwds.get('user_api_key_is_admin_key', False):
+            self.master_api_key = self.api_key
         self.keep_outputs_dir = kwds["keep_outputs_dir"]
 
         self.uploads = {}

--- a/scripts/functional_tests.py
+++ b/scripts/functional_tests.py
@@ -87,6 +87,8 @@ class DataManagersGalaxyTestDriver(driver_util.GalaxyTestDriver):
             testing_shed_tools=self.testing_shed_tools,
             master_api_key=get_master_api_key(),
             user_api_key=get_user_api_key(),
+            user_email=self.app.config.admin_users_list[0],
+            create_admin=True,
         )
 
 

--- a/test/functional/test_data_managers.py
+++ b/test/functional/test_data_managers.py
@@ -1,10 +1,15 @@
 import logging
-import os.path
-import shutil
-import tempfile
 
-from galaxy.tools.verify.interactor import stage_data_in_history
-from .test_toolbox import ToolTestCase
+from .test_toolbox import (
+    build_tests as _build_tests,
+    ToolTestCase,
+)
+
+try:
+    from nose.tools import nottest
+except ImportError:
+    def nottest(x):
+        return x
 
 log = logging.getLogger(__name__)
 data_managers = None
@@ -13,42 +18,9 @@ data_managers = None
 class DataManagerToolTestCase(ToolTestCase):
     """Test case that runs Data Manager tests based on a `galaxy.tools.test.ToolTest`"""
 
-    def do_it(self, testdef):
-        """
-        Run through a tool test case.
-        """
-        tool_id = self.tool_id
 
-        self._handle_test_def_errors(testdef)
-
-        galaxy_interactor = self._galaxy_interactor(testdef)
-
-        test_history = galaxy_interactor.new_history()  # history where inputs will be put, if any
-
-        stage_data_in_history(galaxy_interactor, tool_id, testdef.test_data(), test_history)
-
-        galaxy_interactor.run_tool(testdef, test_history)  # test_history will have inputs only, outputs are placed in the specialized data manager history
-
-        # FIXME: Move history determination and switching into the interactor
-        data_manager_history = None
-        for assoc in reversed(test_history.user.data_manager_histories):
-            if not assoc.history.deleted:
-                data_manager_history = assoc.history
-                break
-        self.switch_history(id=self.security.encode_id(data_manager_history.id))
-        data_list = self.get_history_as_data_list()
-        # end
-
-        self.assertTrue(data_list)
-
-        self._verify_outputs(testdef, data_manager_history, tool_id, data_list, galaxy_interactor)
-
-        self.switch_history(id=self.security.encode_id(test_history.id))
-
-        galaxy_interactor.delete_history(test_history)
-
-
-def build_tests(tmp_dir=None, testing_shed_tools=False, master_api_key=None, user_api_key=None):
+@nottest
+def build_tests(tmp_dir=None, testing_shed_tools=False, master_api_key=None, user_api_key=None, create_admin=False, user_email=None):
     """
     If the module level variable `data_managers` is set, generate `DataManagerToolTestCase`
     classes for all of its tests and put them into this modules globals() so
@@ -59,52 +31,14 @@ def build_tests(tmp_dir=None, testing_shed_tools=False, master_api_key=None, use
         log.warning('data_managers was not set for Data Manager functional testing. Will not test.')
         return
 
-    # Push all the data_managers tests to module level
     G = globals()
 
-    # Eliminate all previous tests from G.
-    for key, val in G.items():
-        if key.startswith('TestForDataManagerTool_'):
-            del G[key]
-
-    # first we will loop through data table loc files and copy them to temporary location, then swap out filenames:
-    for data_table_name, data_table in data_managers.app.tool_data_tables.get_tables().items():
-        for filename, value in list(data_table.filenames.items()):
-            new_filename = tempfile.NamedTemporaryFile(prefix=os.path.basename(filename), dir=tmp_dir).name
-            try:
-                shutil.copy(filename, new_filename)
-            except IOError as e:
-                log.warning("Failed to copy '%s' to '%s', will create empty file at '%s': %s", filename, new_filename, new_filename, e)
-                open(new_filename, 'wb').close()
-            if 'filename' in value:
-                value['filename'] = new_filename
-            del data_table.filenames[filename]  # remove filename:value pair
-            data_table.filenames[new_filename] = value  # add new value by
-
-    for i, (data_manager_id, data_manager) in enumerate(data_managers.data_managers.items()):
-        tool = data_manager.tool
-        if not tool:
-            log.warning("No Tool has been specified for Data Manager: %s", data_manager_id)
-        if tool.tests:
-            # fixme data_manager.tool_shed_repository_info_dict should be filled when is toolshed based
-            tool_id = tool.id
-            # Create a new subclass of ToolTestCase, dynamically adding methods
-            # named test_tool_XXX that run each test defined in the tool config.
-            name = "TestForDataManagerTool_" + data_manager_id.replace(' ', '_')
-            baseclasses = (DataManagerToolTestCase, )
-            namespace = dict()
-            for j, testdef in enumerate(tool.tests):
-                def make_test_method(td):
-                    def test_tool(self):
-                        self.do_it(td)
-                    return test_tool
-                test_method = make_test_method(testdef)
-                test_method.__doc__ = "%s ( %s ) > %s" % (tool.name, tool.id, testdef.name)
-                namespace['test_tool_%06d' % j] = test_method
-                namespace['tool_id'] = tool_id
-                namespace['master_api_key'] = master_api_key
-                namespace['user_api_key'] = user_api_key
-            # Create a new class object, with name name, derived
-            # from baseclasses (which should be a tuple of classes) and with namespace dict.
-            new_class_obj = type(name, baseclasses, namespace)
-            G[name] = new_class_obj
+    _build_tests(testing_shed_tools=testing_shed_tools,
+                 master_api_key=master_api_key,
+                 user_api_key=user_api_key,
+                 name_prefix="TestForDataManagerTool_",
+                 baselass=DataManagerToolTestCase,
+                 user_email=user_email,
+                 create_admin=create_admin,
+                 G=G,
+                 contains='data_manager')

--- a/test/functional/test_toolbox.py
+++ b/test/functional/test_toolbox.py
@@ -10,9 +10,9 @@ except ImportError:
 
 from base.driver_util import setup_keep_outdir, target_url_parts
 from base.instrument import register_job_data
+from base.testcase import FunctionalTestCase  # noqa: I100,I201,I202
 from galaxy.tools import DataManagerTool  # noqa: I201
 from galaxy.tools.verify.interactor import GalaxyInteractorApi, verify_tool  # noqa: I201
-from .twilltestcase import TwillTestCase
 
 log = logging.getLogger(__name__)
 
@@ -22,12 +22,8 @@ toolbox = None
 TOOL_TYPES_NO_TEST = (DataManagerTool, )
 
 
-class ToolTestCase(TwillTestCase):
-    """Abstract test case that runs tests based on a `galaxy.tools.test.ToolTest`.
-
-    Ideally this would be FunctionalTestCase instead of a TwillTestCase but the
-    subclass DataManagerToolTestCase requires the use of Twill still.
-    """
+class ToolTestCase(FunctionalTestCase):
+    """Abstract test case that runs tests based on a `galaxy.tools.test.ToolTest`."""
 
     def do_it(self, tool_id=None, tool_version=None, test_index=0, resource_parameters={}):
         """
@@ -41,7 +37,16 @@ class ToolTestCase(TwillTestCase):
 
 
 @nottest
-def build_tests(app=None, testing_shed_tools=False, master_api_key=None, user_api_key=None):
+def build_tests(app=None,
+                testing_shed_tools=False,
+                master_api_key=None,
+                user_api_key=None,
+                name_prefix="TestForTool_",
+                baselass=ToolTestCase,
+                create_admin=False,
+                user_email=None,
+                G=None,
+                contains=None):
     """
     If the module level variable `toolbox` is set, generate `ToolTestCase`
     classes for all of its tests and put them into this modules globals() so
@@ -51,19 +56,24 @@ def build_tests(app=None, testing_shed_tools=False, master_api_key=None, user_ap
     # if app is None:
     host, port, url = target_url_parts()
     keep_outputs_dir = setup_keep_outdir()
+
     galaxy_interactor_kwds = {
         "galaxy_url": url,
         "master_api_key": master_api_key,
         "api_key": user_api_key,
         "keep_outputs_dir": keep_outputs_dir,
+        "user_api_key_is_admin_key": True,
     }
+    if create_admin and not user_api_key:
+        galaxy_interactor_kwds['test_user'] = user_email
     galaxy_interactor = GalaxyInteractorApi(**galaxy_interactor_kwds)
 
-    # Push all the toolbox tests to module level
-    G = globals()
+    if not G:
+        # Push all the toolbox tests to module level
+        G = globals()
 
     # Eliminate all previous tests from G.
-    for key, val in G.items():
+    for key, val in G.copy().items():
         if key.startswith('TestForTool_'):
             del G[key]
 
@@ -71,8 +81,10 @@ def build_tests(app=None, testing_shed_tools=False, master_api_key=None, user_ap
     for tool_id, tool_summary in tests_summary.items():
         # Create a new subclass of ToolTestCase, dynamically adding methods
         # named test_tool_XXX that run each test defined in the tool config.
-        name = "TestForTool_" + tool_id.replace(' ', '_')
-        baseclasses = (ToolTestCase, )
+        if contains and contains not in tool_id:
+                continue
+        name = name_prefix + tool_id.replace(' ', '_')
+        baseclasses = (baselass, )
         namespace = dict()
 
         all_versions_test_count = 0
@@ -95,7 +107,7 @@ def build_tests(app=None, testing_shed_tools=False, master_api_key=None, user_ap
                 namespace['tool_id'] = tool_id
                 namespace["galaxy_interactor"] = galaxy_interactor
                 namespace['master_api_key'] = master_api_key
-                namespace['user_api_key'] = user_api_key
+                namespace['user_api_key'] = user_api_key or galaxy_interactor.api_key
 
                 all_versions_test_count += 1
 


### PR DESCRIPTION
This allows running data manager tests via `sh run_tests.sh -data_managers` and re-uses everything from the ToolTestCase. Stripping twill has the nice side-effect that the tests also run on python 3.

Also allows looking up the test-data using the tool_dir is there if no repository_dir, that should be helpful for testing local tools.

xref: #1715