### PR TITLE
Add download option to workflow editor menu

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -322,6 +322,10 @@ export default Backbone.View.extend({
                     self.workflow.clear_active_node();
                 },
                 "Auto Re-layout": layout_editor,
+                Download: {
+                    url: `${Galaxy.root}api/workflows/${self.options.id}/download?format=json-download`,
+                    action: function() {}
+                },
                 Close: close_editor
             });
         }


### PR DESCRIPTION
The PR adds a "download" workflow option to the dropdown menu (on the right) of the workflow editor screen. It fixes the feature request in https://github.com/galaxyproject/galaxy/issues/6566.

![download_opt](https://user-images.githubusercontent.com/3022518/44041735-cbce1184-9f1e-11e8-8d95-8495e11463ee.png)
