### PR TITLE
Fix Location of Plugin Static Content in Documentation

### DIFF
--- a/doc/source/admin/special_topics/interactive_environments.rst
+++ b/doc/source/admin/special_topics/interactive_environments.rst
@@ -190,7 +190,7 @@ proxying to GIE and other visualization plugin static content.
 
 .. code-block:: nginx
 
-    location ~ ^/plugins/(?<plug_type>.+?)/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
+    location ~ ^/static/plugins/(?<plug_type>.+?)/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
         alias /path/to/galaxy-dist/config/plugins/$plug_type/$vis_name/static/$static_file;
     }
 


### PR DESCRIPTION
From release 18.01 to 18.05 the location of interactive environment static content changed from `plugins/interactive_environments/` to `static/plugins/interactive_environments/` (mentioned in #6460 and #6464).

This pull request makes the documentation for proxying static plugin content match the above change.

It would also be helpful to have this change backported to the `release_18.05` branch.