### PR TITLE
[18.05] Fix Location of Plugin Static Content In Documentation for 18.05

### DIFF
--- a/doc/source/admin/special_topics/interactive_environments.rst
+++ b/doc/source/admin/special_topics/interactive_environments.rst
@@ -190,7 +190,7 @@ proxying to GIE and other visualization plugin static content.
 
 .. code-block:: nginx
 
-    location ~ ^/plugins/(?<plug_type>.+?)/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
+    location ~ ^/static/plugins/(?<plug_type>.+?)/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
         alias /path/to/galaxy-dist/config/plugins/$plug_type/$vis_name/static/$static_file;
     }
 


### PR DESCRIPTION
Same as #6601, but for the 18.05 branch.