### PR TITLE
Refresh an expired OIDC ID token

### DIFF
--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -40,6 +40,8 @@ AUTH_PIPELINE = (
     # defined).
     'social_core.pipeline.social_auth.auth_allowed',
 
+    'galaxy.authnz.psa_authnz.contains_required_data',
+
     # Checks if the current social-account is already associated in the site.
     'social_core.pipeline.social_auth.social_user',
 
@@ -235,6 +237,11 @@ class Storage:
     @classmethod
     def is_integrity_error(cls, exception):
         return exception.__class__ is IntegrityError
+
+def contains_required_data(request=None, is_new=False, response=None, **kwargs):
+    if is_new and response is not None and isinstance(response, dict):
+        if not response.get("id_token"):
+            return False
 
 
 def allowed_to_disconnect(name=None, user=None, user_storage=None, strategy=None,

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -243,6 +243,41 @@ class Storage:
 
 
 def contains_required_data(response=None, is_new=False, **kwargs):
+    """
+    This function is called as part of authentication and authorization
+    pipeline before user is authenticated or authorized (see AUTH_PIPELINE).
+
+    This function asserts if all the data required by Galaxy for a user
+    is provided. It raises an exception if any of the required data is missing,
+    and returns void if otherwise.
+
+    :type  response: dict
+    :param response:    a dictionary containing decoded response from
+                        OIDC backend that contain the following keys
+                        among others:
+                        -   id_token;       see: http://openid.net/specs/openid-connect-core-1_0.html#IDToken
+                        -   access_token;   see: https://tools.ietf.org/html/rfc6749#section-1.4
+                        -   refresh_token;  see: https://tools.ietf.org/html/rfc6749#section-1.5
+                        -   token_type;     see: https://tools.ietf.org/html/rfc6750#section-6.1.1
+                        -   scope;          see: http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+                        -   expires_in;     is the expiration time of the access and ID tokens in seconds since
+                                            the response was generated.
+
+    :type  is_new: bool
+    :param is_new: has the user been authenticated?
+
+    :param kwargs:      may contain the following keys among others:
+                        -   uid:        user ID
+                        -   user:       Galaxy user; if user is already authenticated
+                        -   backend:    the backend that is used for user authentication.
+                        -   storage:    an instance of Storage class.
+                        -   strategy:   an instance of the Strategy class.
+                        -   state:      the state code received from identity provider.
+                        -   details:    details about the user's third-party identity as requested in `scope`.
+
+    :rtype:  void
+    :return: Raises an exception if any of the required arguments is missing, and pass if all are given.
+    """
     hint_msg = "Visit the identity provider's permitted applications page " \
                "(e.g., visit `https://myaccount.google.com/u/0/permissions` " \
                "for Google), then revoke the access of this Galaxy instance, " \

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -1,11 +1,11 @@
 import six
-from galaxy.exceptions import MalformedContents
 from social_core.actions import do_auth, do_complete, do_disconnect
 from social_core.backends.utils import get_backend
 from social_core.strategy import BaseStrategy
 from social_core.utils import module_member, setting_name
 from sqlalchemy.exc import IntegrityError
 
+from galaxy.exceptions import MalformedContents
 from ..authnz import IdentityProvider
 from ..model import PSAAssociation, PSACode, PSANonce, PSAPartial, UserAuthnzToken
 
@@ -238,6 +238,7 @@ class Storage:
     @classmethod
     def is_integrity_error(cls, exception):
         return exception.__class__ is IntegrityError
+
 
 def contains_required_data(response=None, is_new=False, **kwargs):
     hint_msg = "Visit the identity provider's permitted applications page " \

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -41,6 +41,8 @@ AUTH_PIPELINE = (
     # defined).
     'social_core.pipeline.social_auth.auth_allowed',
 
+    # Checks if the decoded response contains all the required fields such
+    # as an ID token or a refresh token.
     'galaxy.authnz.psa_authnz.contains_required_data',
 
     # Checks if the current social-account is already associated in the site.

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4790,7 +4790,11 @@ class UserAuthnzToken(UserMixin):
         self.lifetime = lifetime
         self.assoc_type = assoc_type
 
-    def get_id_token(self):
+    def get_id_token(self, strategy):
+        if self.access_token_expired():
+            # Access and ID tokens have same expiration time;
+            # hence, if one is expired, the other is expired too.
+            self.refresh_token(strategy)
         return self.extra_data.get('id_token', None) if self.extra_data is not None else None
 
     def get_access_token(self):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4797,9 +4797,6 @@ class UserAuthnzToken(UserMixin):
             self.refresh_token(strategy)
         return self.extra_data.get('id_token', None) if self.extra_data is not None else None
 
-    def get_access_token(self):
-        return self.extra_data.get('access_token', None) if self.extra_data is not None else None
-
     def set_extra_data(self, extra_data=None):
         if super(UserAuthnzToken, self).set_extra_data(extra_data):
             self.trans.sa_session.add(self)


### PR DESCRIPTION
This PR implements the following:
1- makes sure an OAuth2.0 _refresh token_  is provided when authenticating a user;
2- when returning an OIDC _ID tokne_, first checks if token has not expired, and it is, it refreshes the token, and returns a valid token. 