### PR TITLE
Handle driver shutdown, show all tests in pytest

### DIFF
--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -1,0 +1,8 @@
+def pytest_unconfigure(config):
+    try:
+        # This needs to be run if no test were run.
+        from .test_toolbox_pytest import DRIVER
+        DRIVER.tear_down()
+        print("Galaxy test driver shutdown succesfull")
+    except Exception:
+        pass

--- a/test/functional/test_data_managers.py
+++ b/test/functional/test_data_managers.py
@@ -37,7 +37,7 @@ def build_tests(tmp_dir=None, testing_shed_tools=False, master_api_key=None, use
                  master_api_key=master_api_key,
                  user_api_key=user_api_key,
                  name_prefix="TestForDataManagerTool_",
-                 baselass=DataManagerToolTestCase,
+                 baseclass=DataManagerToolTestCase,
                  user_email=user_email,
                  create_admin=create_admin,
                  G=G,

--- a/test/functional/test_toolbox.py
+++ b/test/functional/test_toolbox.py
@@ -42,7 +42,7 @@ def build_tests(app=None,
                 master_api_key=None,
                 user_api_key=None,
                 name_prefix="TestForTool_",
-                baselass=ToolTestCase,
+                baseclass=ToolTestCase,
                 create_admin=False,
                 user_email=None,
                 G=None,
@@ -84,7 +84,7 @@ def build_tests(app=None,
         if contains and contains not in tool_id:
                 continue
         name = name_prefix + tool_id.replace(' ', '_')
-        baseclasses = (baselass, )
+        baseclasses = (baseclass, )
         namespace = dict()
 
         all_versions_test_count = 0
@@ -108,6 +108,7 @@ def build_tests(app=None,
                 namespace["galaxy_interactor"] = galaxy_interactor
                 namespace['master_api_key'] = master_api_key
                 namespace['user_api_key'] = user_api_key or galaxy_interactor.api_key
+                namespace['test_count'] = count
 
                 all_versions_test_count += 1
 

--- a/test/functional/test_toolbox_pytest.py
+++ b/test/functional/test_toolbox_pytest.py
@@ -46,7 +46,7 @@ def cases():
             test_class.runTest = lambda : None
             test_instance = test_class()
             for index in range(test_instance.test_count):
-                yield (test_name[len(TEST_PREFIX):] + "|%d" % index, test_instance, index)
+                yield (test_name[len(TEST_PREFIX):] + "_test_%d" % (index + 1), test_instance, index)
 
 
 def idfn(val):


### PR DESCRIPTION
This is pretty hackish as fixtures can't be used during test discovery.
To properly shut down the driver I've added a conftest.py file that will
be called when quitting pytest. We might be able to handle this a
little better if we wrote a full plugin, but for now this works.

Also now reports all test indexes, so you can select e.g test 2 of a
tool.