### PR TITLE
Order data parameters before unlinked multiplication

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -203,7 +203,7 @@ class JobSearch(object):
                     return []
 
         for k, v in wildcard_param_dump.items():
-            wildcard_value = json.dumps(v).replace('"id": "__id_wildcard__"', '"id": %')
+            wildcard_value = json.dumps(v, sort_keys=True).replace('"id": "__id_wildcard__"', '"id": %')
             a = aliased(model.JobParameter)
             conditions.append(and_(
                 model.Job.id == a.job_id,
@@ -239,7 +239,7 @@ class JobSearch(object):
                     a = aliased(model.JobParameter)
                     job_parameter_conditions.append(and_(
                         a.name == k,
-                        a.value == json.dumps(v)
+                        a.value == json.dumps(v, sort_keys=True)
                     ))
             else:
                 job_parameter_conditions = [model.Job.id == job]

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -203,7 +203,7 @@ def params_to_strings(params, param_values, app, nested=False):
     for key, value in param_values.items():
         if key in params:
             value = params[key].value_to_basic(value, app)
-        rval[key] = value if nested else str(dumps(value))
+        rval[key] = value if nested else str(dumps(value, sort_keys=True))
     return rval
 
 

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -77,9 +77,9 @@ def process_key(incoming_key, d):
     if len(key_parts) == 1:
         # Regular parameter
         d[incoming_key] = object()
-    elif key_parts[0].rsplit('_', maxsplit=1)[-1].isdigit():
+    elif key_parts[0].rsplit('_', 1)[-1].isdigit():
         # Repeat
-        input_name_index = key_parts[0].rsplit('_', maxsplit=1)
+        input_name_index = key_parts[0].rsplit('_', 1)
         input_name, index = input_name_index
         if input_name not in d:
             d[input_name] = []

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import copy
 import itertools
 import logging
+from collections import OrderedDict
 
 from galaxy import (
     exceptions,
@@ -10,6 +11,7 @@ from galaxy import (
     util
 )
 from galaxy.util import permutations
+from . import visit_input_values
 
 log = logging.getLogger(__name__)
 
@@ -70,6 +72,28 @@ def expand_workflow_inputs(inputs):
     return params, params_keys
 
 
+def process_key(incoming_key, d):
+    key_parts = incoming_key.split('|')
+    if len(key_parts) == 1:
+        # Regular parameter
+        d[incoming_key] = object()
+    elif key_parts[0].rsplit('_', maxsplit=1)[-1].isdigit():
+        # Repeat
+        input_name_index = key_parts[0].rsplit('_', maxsplit=1)
+        input_name, index = input_name_index
+        if input_name not in d:
+            d[input_name] = []
+        subdict = {}
+        d[input_name].append(subdict)
+        process_key("|".join(key_parts[1:]), d=subdict)
+    else:
+        # Section / Conditional
+        input_name = key_parts[0]
+        subdict = {}
+        d[input_name] = subdict
+        process_key("|".join(key_parts[1:]), d=subdict)
+
+
 def expand_meta_parameters(trans, tool, incoming):
     """
     Take in a dictionary of raw incoming parameters and expand to a list
@@ -83,6 +107,25 @@ def expand_meta_parameters(trans, tool, incoming):
             to_remove.append(key)
     for key in to_remove:
         incoming.pop(key)
+
+    # If we're going to multiply input dataset combinations
+    # order matters, so the following reorders incoming
+    # according to tool.inputs (which is ordered).
+    incoming_copy = incoming.copy()
+    nested_dict = {}
+    for incoming_key in incoming_copy:
+        if not incoming_key.startswith('__'):
+            process_key(incoming_key, d=nested_dict)
+
+    reordered_incoming = OrderedDict()
+
+    def visitor(input, value, prefix, prefixed_name, prefixed_label, error, **kwargs):
+        if prefixed_name in incoming_copy:
+            reordered_incoming[prefixed_name] = incoming_copy[prefixed_name]
+            del incoming_copy[prefixed_name]
+
+    visit_input_values(inputs=tool.inputs, input_values=nested_dict, callback=visitor)
+    reordered_incoming.update(incoming_copy)
 
     def classifier(input_key):
         value = incoming[input_key]
@@ -111,7 +154,7 @@ def expand_meta_parameters(trans, tool, incoming):
 
     # Stick an unexpanded version of multirun keys so they can be replaced,
     # by expand_mult_inputs.
-    incoming_template = incoming.copy()
+    incoming_template = reordered_incoming
 
     expanded_incomings = permutations.expand_multi_inputs(incoming_template, classifier)
     if collections_to_match.has_collections():

--- a/lib/galaxy/util/permutations.py
+++ b/lib/galaxy/util/permutations.py
@@ -6,6 +6,8 @@ first.
 Maybe this doesn't make sense and maybe much of this stuff could be replaced
 with itertools product and permutations. These are open questions.
 """
+from collections import OrderedDict
+
 from galaxy.exceptions import MessageException
 from galaxy.util.bunch import Bunch
 
@@ -40,9 +42,9 @@ def expand_multi_inputs(inputs, classifier, key_filter=None):
 def __split_inputs(inputs, classifier, key_filter):
     key_filter = key_filter or (lambda x: True)
 
-    single_inputs = {}
-    matched_multi_inputs = {}
-    multiplied_multi_inputs = {}
+    single_inputs = OrderedDict()
+    matched_multi_inputs = OrderedDict()
+    multiplied_multi_inputs = OrderedDict()
 
     for input_key in filter(key_filter, inputs):
         input_type, expanded_val = classifier(input_key)


### PR DESCRIPTION
The 2 failed tests [here](https://jenkins.galaxyproject.org/job/docker-api-py3/30/testReport/junit/) fail randomly, and at least the first one relies in the order of implicit collections.