### PR TITLE
Fix remaining selenium py3 test failures

### DIFF
--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -700,7 +700,7 @@ class IndividualTagsColumn(CommunityTagsColumn):
         if isinstance(column_filter, list):
             # Collapse list of tags into a single string; this is redundant but effective. TODO: fix this by iterating over tags.
             column_filter = ",".join(column_filter)
-        raw_tags = trans.app.tag_handler.parse_tags(column_filter.encode("utf-8"))
+        raw_tags = trans.app.tag_handler.parse_tags(column_filter)
         clause_list = []
         for name, value in raw_tags:
             if name:

--- a/lib/galaxy/webapps/galaxy/controllers/tag.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tag.py
@@ -44,7 +44,7 @@ class TagsController(BaseUIController, UsesTagsMixin):
         # Apply tag.
         item = self._get_item(trans, item_class, trans.security.decode_id(item_id))
         user = trans.user
-        self.get_tag_handler(trans).apply_item_tags(user, item, new_tag.encode('utf-8'))
+        self.get_tag_handler(trans).apply_item_tags(user, item, new_tag)
         trans.sa_session.flush()
         # Log.
         params = dict(item_id=item.id, item_class=item_class, tag=new_tag)


### PR DESCRIPTION
Should fix

```
selenium.webdriver.remote.remote_connection DEBUG 2018-08-16 19:17:13,852 Finished Request
galaxy.web.framework.decorators ERROR 2018-08-16 19:17:13,858 Uncaught exception in exposed API method:
Traceback (most recent call last):
  File "/galaxy/lib/galaxy/web/framework/decorators.py", line 157, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "/galaxy/lib/galaxy/web/framework/decorators.py", line 77, in decorator
    return func(self, trans, *args, **kwargs)
  File "/galaxy/lib/galaxy/webapps/galaxy/controllers/history.py", line 317, in list
    return self.stored_list_grid(trans, **kwargs)
  File "/galaxy/lib/galaxy/web/framework/helpers/grids.py", line 139, in __call__
    query = column.filter(trans, trans.user, query, column_filter)
  File "/galaxy/lib/galaxy/web/framework/helpers/grids.py", line 664, in filter
    query = query.filter(self.get_filter(trans, user, column_filter))
  File "/galaxy/lib/galaxy/web/framework/helpers/grids.py", line 703, in get_filter
    raw_tags = trans.app.tag_handler.parse_tags(column_filter.encode("utf-8"))
  File "/galaxy/lib/galaxy/managers/tags.py", line 260, in parse_tags
    raw_tags = reg_exp.split(tag_str)
TypeError: cannot use a string pattern on a bytes-like object
```

xref. #1715 