### PR TITLE
add dcd datatype for molecular dynamics

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -574,6 +574,7 @@
     <datatype extension="pdb" type="galaxy.datatypes.molecules:PDB" display_in_upload="true"/>
     <datatype extension="pdbqt" type="galaxy.datatypes.molecules:PDBQT" display_in_upload="true"/>
     <datatype extension="trr" type="galaxy.datatypes.binary:Trr" display_in_upload="true"/>
+    <datatype extension="dcd" type="galaxy.datatypes.binary:Dcd" display_in_upload="true"/>
     <datatype extension="grd" type="galaxy.datatypes.molecules:grd" display_in_upload="true"/>
     <datatype extension="grd.tgz" type="galaxy.datatypes.molecules:grdtgz" display_in_upload="true"/>
     <!-- mothur formats -->
@@ -725,6 +726,7 @@
     <sniffer type="galaxy.datatypes.binary:ICM"/>
     <sniffer type="galaxy.datatypes.binary:Idat"/>
     <sniffer type="galaxy.datatypes.binary:Trr"/>
+    <sniffer type="galaxy.datatypes.binary:Dcd"/>
     <sniffer type="galaxy.datatypes.annotation:Augustus"/>
     <sniffer type="galaxy.datatypes.triples:Rdf"/>
     <sniffer type="galaxy.datatypes.blast:BlastXml"/>


### PR DESCRIPTION

xref: https://www.charmm.org/charmm/documentation/by-version/c42b1/params/doc/io/
xref: http://www.ks.uiuc.edu/Research/vmd/plugins/molfile/dcdplugin.html

A datatype for molecular dynamics simulations run using CHARMM and NAMD. 
