### PR TITLE
WIP: Set object_store ids when recovering jobs after restart

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -962,6 +962,7 @@ class DefaultJobDispatcher(object):
     def recover(self, job, job_wrapper):
         runner_name = (job.job_runner_name.split(":", 1))[0]
         log.debug("recovering job %d in %s runner" % (job.get_id(), runner_name))
+        job_wrapper._set_object_store_ids(job)
         try:
             self.job_runners[runner_name].recover(job, job_wrapper)
         except KeyError:


### PR DESCRIPTION
I was seeing a lot of these events after restarting a handlers while a job was still running (on dev).
```
galaxy.jobs.handler DEBUG 2018-08-17 07:59:26,312 [p:3997,w:0,m:2] [MainThread] recovering job 40255 in cli runner
Traceback (most recent call last):
  File "lib/galaxy/main.py", line 279, in <module>
    main()
  File "lib/galaxy/main.py", line 275, in main
    app_loop(args, log)
  File "lib/galaxy/main.py", line 125, in app_loop
    log=log,
  File "lib/galaxy/main.py", line 94, in load_galaxy_app
    **kwds
  File "lib/galaxy/app.py", line 208, in __init__
    self.application_stack.register_postfork_function(self.job_manager.start)
  File "lib/galaxy/web/stack/__init__.py", line 280, in register_postfork_function
    f(*args, **kwargs)
  File "lib/galaxy/jobs/manager.py", line 41, in start
    self.job_handler.start()
  File "lib/galaxy/jobs/handler.py", line 54, in start
    self.job_queue.start()
  File "lib/galaxy/jobs/handler.py", line 98, in start
    self.__check_jobs_at_startup()
  File "lib/galaxy/jobs/handler.py", line 185, in __check_jobs_at_startup
    self.dispatcher.recover(job, job_wrapper)
  File "lib/galaxy/jobs/handler.py", line 967, in recover
    try:
  File "lib/galaxy/jobs/runners/cli.py", line 238, in recover
    ajs = AsynchronousJobState(files_dir=job_wrapper.working_directory, job_wrapper=job_wrapper)
AttributeError: 'JobWrapper' object has no attribute 'working_directory'
```

I suspect that was due to 7882a067c8cbcf564aff605b91beea8d7849fb00, but I'm not sure about that and I'm not sure that's the right fix. WIP because at the minimum we should have an integraton test for this (such an integration test would have also found the issue we had last year with no registry being available when restarting handlers ...)