### PR TITLE
[minor] Fix incorrect import in display_common.mako.

### DIFF
--- a/templates/display_common.mako
+++ b/templates/display_common.mako
@@ -6,7 +6,7 @@
 ## used across webapps, and each webapp has its own model.
 
 <%! from galaxy import model %>
-<% from galaxy import unicodify %>
+<%! from galaxy.util import unicodify %>
 
 ## Get display name for a class.
 <%def name="get_class_display_name( a_class )">


### PR DESCRIPTION
Broke a few Selenium tests, not sure which commit broke this but it was fairly recent because these tests were passing two weeks ago.

This appears in the logs for test_workflow_management.py Selenium tests:

```
Error - <type 'exceptions.TypeError'>: 'Undefined' object is not callable
URL: http://127.0.0.1:9350/workflow/display_by_id?id=adb5f5c93f827949
File '/Users/john/workspace/galaxy/lib/galaxy/web/framework/middleware/error.py', line 154 in __call__
  app_iter = self.application(environ, sr_checker)
File '/Users/john/workspace/galaxy/.venv/lib/python2.7/site-packages/paste/recursive.py', line 85 in __call__
  return self.application(environ, start_response)
File '/Users/john/workspace/galaxy/.venv/lib/python2.7/site-packages/paste/httpexceptions.py', line 640 in __call__
  return self.application(environ, start_response)
File '/Users/john/workspace/galaxy/lib/galaxy/web/framework/base.py', line 143 in __call__
  return self.handle_request(environ, start_response)
File '/Users/john/workspace/galaxy/lib/galaxy/web/framework/base.py', line 222 in handle_request
  body = method(trans, **kwargs)
File '/Users/john/workspace/galaxy/lib/galaxy/webapps/galaxy/controllers/workflow.py', line 244 in display_by_id
  return self._display(trans, stored_workflow)
File '/Users/john/workspace/galaxy/lib/galaxy/webapps/galaxy/controllers/workflow.py', line 269 in _display
  user_item_rating=user_item_rating, ave_item_rating=ave_item_rating, num_ratings=num_ratings)
File '/Users/john/workspace/galaxy/lib/galaxy/web/framework/webapp.py', line 940 in fill_template_mako
  return template.render(**data)
File '/Users/john/workspace/galaxy/.venv/lib/python2.7/site-packages/mako/template.py', line 462 in render
  return runtime._render(self, self.callable_, args, data)
File '/Users/john/workspace/galaxy/.venv/lib/python2.7/site-packages/mako/runtime.py', line 838 in _render
  **_kwargs_for_callable(callable_, data))
File '/Users/john/workspace/galaxy/.venv/lib/python2.7/site-packages/mako/runtime.py', line 873 in _render_context
  _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
File '/Users/john/workspace/galaxy/.venv/lib/python2.7/site-packages/mako/runtime.py', line 899 in _exec_template
  callable_(context, *args, **kwargs)
File '/private/var/folders/78/zxz5mz4d0jn53xf0l06j7ppc0000gp/T/tmpdPzP5u/tmpuWmQzW/tmpJeTZwc/database/compiled_templates_FRp0Go/base/base_panels.mako.py', line 71 in render_body
  __M_writer(unicode(self.title()))
File '/private/var/folders/78/zxz5mz4d0jn53xf0l06j7ppc0000gp/T/tmpdPzP5u/tmpuWmQzW/tmpJeTZwc/database/compiled_templates_FRp0Go/display_base.mako.py', line 165 in render_title
  __M_writer(filters.html_escape(unicode(get_item_name( item ) )))
File '/private/var/folders/78/zxz5mz4d0jn53xf0l06j7ppc0000gp/T/tmpdPzP5u/tmpuWmQzW/tmpJeTZwc/database/compiled_templates_FRp0Go/display_common.mako.py', line 199 in render_get_item_name
  return unicodify(item_name)
TypeError: 'Undefined' object is not callable
```
