### PR TITLE
Remove check_python_dependencies job from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   - TOX_ENV=qunit
   - TOX_ENV=py27-first_startup
   - TOX_ENV=py27-lint_docstring_include_list
-  - TOX_ENV=check_python_dependencies
 
 matrix:
   include:
@@ -33,9 +32,6 @@ matrix:
             - ack-grep
     - env: TOX_ENV=py34-unit
       addons: *py3_addons
-  allow_failures:
-    - env: TOX_ENV=check_python_dependencies
-
 
 install:
   - set -e


### PR DESCRIPTION
No need to run it on every pull request and merge.

It can be run locally via:
```
$ tox -e check_python_dependencies
```