### PR TITLE
Add conda to PATH when executing conda commands

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -230,6 +230,7 @@ class CondaContext(installable.InstallableContext):
                 kwds['stdout'] = open(stdout_path, 'w')
                 cmd_string += " > '%s'" % stdout_path
             conda_exec_home = env['HOME'] = tempfile.mkdtemp(prefix='conda_exec_home_')  # We don't want to pollute ~/.conda, which may not even be writable
+            env['PATH'] = "%s:%s" % (os.path.join(self.conda_prefix, 'bin'), os.environ['PATH'])
             log.debug("Executing command: %s", cmd_string)
             return self.shell_exec(cmd, env=env, **kwds)
         except Exception:

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -44,6 +44,7 @@ DEFAULT_CONDARC_OVERRIDE = "_condarc"
 # (for old R packages)
 DEFAULT_ENSURE_CHANNELS = "iuc,bioconda,conda-forge,defaults"
 CONDA_SOURCE_CMD = """[ "$CONDA_DEFAULT_ENV" = "%s" ] ||
+export PATH="%s/bin":$PATH
 MAX_TRIES=3
 COUNT=0
 while [ $COUNT -lt $MAX_TRIES ]; do
@@ -408,6 +409,7 @@ class MergedCondaDependency(Dependency):
         else:
             return CONDA_SOURCE_CMD % (
                 self.environment_path,
+                self.conda_context.conda_prefix,
                 self.activate,
                 self.environment_path
             )
@@ -477,6 +479,7 @@ class CondaDependency(Dependency):
         else:
             return CONDA_SOURCE_CMD % (
                 self.environment_path,
+                self.conda_context.conda_prefix,
                 self.activate,
                 self.environment_path
             )


### PR DESCRIPTION
This helps with errors like

```
ModuleNotFoundError: No module named 'conda.cli'
```

if only referencing the conda binary. This fixes local
conda when using the testing framework.

I'm not quite sure why this only affects local framework tests, but it also doesn't seem to harm anything.