### PR TITLE
Move tests to pytest setup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 branch = True
 include = lib/galaxy/*
+disable_warnings = include-ignored

--- a/lib/galaxy/jobs/runners/util/kill.py
+++ b/lib/galaxy/jobs/runners/util/kill.py
@@ -23,7 +23,7 @@ def _psutil_kill_pid(pid):
     """
     try:
         parent = Process(pid)
-        for child in parent.get_children(recursive=True):
+        for child in parent.children(recursive=True):
             child.kill()
         parent.kill()
     except NoSuchProcess:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-log_cli = true
+addopts = --doctest-continue-on-failure
 log_level = DEBUG
 python_paths = lib
 markers =

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,7 @@
 [pytest]
-log_cli=true
-log_level=DEBUG
-python_paths=lib
+log_cli = true
+log_level = DEBUG
+python_paths = lib
+markers =
+  data_manager: marks test as a data_manager test
+  tool: marks test as a tool test

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -273,6 +273,7 @@ DOCKER_DEFAULT_IMAGE='galaxy/testing-base:18.09.0'
 
 test_script="./scripts/functional_tests.py"
 report_file="run_functional_tests.html"
+coverage_arg=""
 xunit_report_file=""
 structured_data_report_file=""
 with_framework_test_tools_arg=""
@@ -368,6 +369,7 @@ do
               api_script="./test/api"
               shift 1
           fi
+          coverage_file="api_coverage.xml"
           ;;
       -selenium|--selenium)
           with_framework_test_tools_arg="-with_framework_test_tools"
@@ -425,6 +427,7 @@ do
           with_framework_test_tools_arg="-with_framework_test_tools"
           test_script="pytest"
           report_file="run_framework_tests.html"
+          coverage_file="framework_coverage.xml"
           framework_test=1;
           shift 1
           ;;
@@ -433,6 +436,7 @@ do
           with_framework_test_tools_arg="-with_main_tools"
           test_script="pytest"
           report_file="run_framework_tests.html"
+          coverage_file="main_tools_coverage.xml"
           framework_test=1;
           shift 1
           ;;
@@ -440,6 +444,7 @@ do
           marker="-m data_manager"
           test_script="pytest"
           report_file="run_data_managers_tests.html"
+          coverage_file="data_managers_coverage.xml"
           data_managers_test=1;
           shift 1
           ;;
@@ -448,6 +453,7 @@ do
           marker="-m tool"
           test_script="pytest"
           report_file="run_migrated_tests.html"
+          coverage_file="migrated_coverage.xml"
           migrated_test=1;
           shift
           ;;
@@ -456,6 +462,7 @@ do
           marker="-m tool"
           test_script="pytest"
           report_file="run_installed_tests.html"
+          coverage_file="installed_coverage.xml"
           installed_test=1;
           shift
           ;;
@@ -515,6 +522,7 @@ do
               unit_extra="$unit_extra lib test/unit"
               shift 1
           fi
+          coverage_file="unit_coverage.xml"
           ;;
       -i|-integration|--integration)
           test_script="pytest"
@@ -525,6 +533,7 @@ do
           else
               integration_extra="./test/integration"
               shift 1
+          coverage_file="integration_coverage.xml"
           fi
           ;;
       --no_cleanup)
@@ -613,7 +622,7 @@ elif [ -n "$api_script" ]; then
 elif [ -n "$section_id" ]; then
     extra_args=`python tool_list.py $section_id`
 elif [ -n "$unit_extra" ]; then
-    extra_args="--with-doctest $unit_extra"
+    extra_args="$unit_extra"
 elif [ -n "$integration_extra" ]; then
     extra_args="$integration_extra"
 elif [ -n "$test_target" ] ; then
@@ -651,7 +660,10 @@ if [ "$with_framework_test_tools_arg" ]; then
     export GALAXY_TEST_TOOL_CONF
 fi
 if [ "$test_script" = 'pytest' ]; then
-    python -m "$test_script" -v --html "$report_file" $xunit_args $extra_args "$@"
+    if [ "$coverage_arg" = "--with_coverage" ]; then
+        coverage_arg="--cov-report term --cov-report xml:cov-unit.xml --cov=lib"
+    fi
+    "$test_script" -v --html "$report_file" $coverage_arg  $xunit_args $extra_args "$@"
 else
     python $test_script $coverage_arg -v --with-nosehtml --html-report-file $report_file $xunit_args $structured_data_args $extra_args "$@"
 fi

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -506,12 +506,13 @@ do
           ;;
       -u|-unit|--unit)
           report_file="run_unit_tests.html"
-          test_script="./scripts/nosetests.py"
+          test_script="pytest"
+          unit_extra='--doctest-modules --ignore lib/galaxy/webapps/tool_shed/controllers --ignore lib/galaxy/jobs/runners/chronos.py --ignore lib/galaxy/webapps/tool_shed/model/migrate --ignore lib/galaxy/util/jstree.py'
           if [ $# -gt 1 ]; then
-              unit_extra=$2
+              unit_extra="$unit_extra $2"
               shift 2
           else
-              unit_extra='--exclude=functional --exclude="^get" --exclude=controllers --exclude=runners --exclude dictobj --exclude=jstree lib test/unit'
+              unit_extra="$unit_extra lib test/unit"
               shift 1
           fi
           ;;

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -638,13 +638,13 @@ else
     structured_data_args=""
 fi
 if [ "$with_framework_test_tools_arg" ]; then
-    if [ "$with_framework_test_tools_arg" == "-with_framework_test_tools" ]; then
+    if [ "$with_framework_test_tools_arg" = "-with_framework_test_tools" ]; then
         GALAXY_TEST_TOOL_CONF="config/tool_conf.xml.sample,test/functional/tools/samples_tool_conf.xml"
-    elif [ "$with_framework_test_tools_arg" == "-migrated" ]; then
+    elif [ "$with_framework_test_tools_arg" = "-migrated" ]; then
         GALAXY_TEST_TOOL_CONF="config/migrated_tools_conf.xml"
-    elif [ "$with_framework_test_tools_arg" == "-shed" ]; then
+    elif [ "$with_framework_test_tools_arg" = "-shed" ]; then
         GALAXY_TEST_TOOL_CONF="config/shed_tool_conf.xml"
-    elif [ "$with_framework_test_tools_arg" == "-with_main_tools" ]; then
+    elif [ "$with_framework_test_tools_arg" = "-with_main_tools" ]; then
         GALAXY_TEST_TOOL_CONF="config/tool_conf.xml.main"
     fi
     export GALAXY_TEST_TOOL_CONF

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -428,6 +428,14 @@ do
           framework_test=1;
           shift 1
           ;;
+      -main|-main_tools|--main_tools)
+          marker="-m tool"
+          with_framework_test_tools_arg="-with_main_tools"
+          test_script="pytest"
+          report_file="run_framework_tests.html"
+          framework_test=1;
+          shift 1
+          ;;
       -d|-data_managers|--data_managers)
           marker="-m data_manager"
           test_script="pytest"
@@ -636,6 +644,8 @@ if [ "$with_framework_test_tools_arg" ]; then
         GALAXY_TEST_TOOL_CONF="config/migrated_tools_conf.xml"
     elif [ "$with_framework_test_tools_arg" == "-shed" ]; then
         GALAXY_TEST_TOOL_CONF="config/shed_tool_conf.xml"
+    elif [ "$with_framework_test_tools_arg" == "-with_main_tools" ]; then
+        GALAXY_TEST_TOOL_CONF="config/tool_conf.xml.main"
     fi
     export GALAXY_TEST_TOOL_CONF
 fi

--- a/test/functional/known_broken_tools.txt
+++ b/test/functional/known_broken_tools.txt
@@ -1,0 +1,11 @@
+# Deprecated, IUC provides same tool, kept for backwards compat?
+Extract genomic DNA 1
+# Relies on data table, but data table not available
+Interval2Maf1
+Interval2Maf_pairwise1
+maf_stats1
+Interval_Maf_Merged_Fasta2
+# No dependency available
+hgv_lps
+# Some weird parameter issue
+maf_by_block_number1

--- a/test/functional/test_toolbox_pytest.py
+++ b/test/functional/test_toolbox_pytest.py
@@ -17,6 +17,8 @@ class DefaultGalaxyTestDriver(driver_util.GalaxyTestDriver):
     Just populate non-shed tool tests and run tests. Works
     for tool tests, regular twill tests, and API testing.
     """
+    conda_auto_init = True
+    conda_auto_install = True
 
     def build_tests(self):
         """Build framework tool test methods."""

--- a/test/unit/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
+++ b/test/unit/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
@@ -97,7 +97,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     def test_brokenDestYML(self, l):
         self.assertRaises(JobMappingException, map_tool_to_destination, runJob, theApp, vanillaTool, "user@email.com", True, broken_default_dest_path, job_conf_path)
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'No global default destination specified in config!'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
@@ -110,7 +110,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         self.assertRaises(JobMappingException, map_tool_to_destination, emptyJob, theApp, vanillaTool, "user@email.com", True, path, job_conf_path)
         self.assertRaises(JobMappingException, map_tool_to_destination, emptyJob, theApp, vanillaTool, "user@email.com", True, priority_path, job_conf_path)
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Loading file: input1' + script_dir + '/data/test.empty'),
@@ -129,7 +129,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         self.assertRaises(JobMappingException, map_tool_to_destination, zeroJob, theApp, vanillaTool, "user@email.com", True, path, job_conf_path)
         self.assertRaises(JobMappingException, map_tool_to_destination, zeroJob, theApp, vanillaTool, "user@email.com", True, priority_path, job_conf_path)
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Total size: 0.00 B'),
@@ -146,7 +146,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         self.assertRaises(JobMappingException, map_tool_to_destination, failJob, theApp, vanillaTool, "user@email.com", True, path, job_conf_path)
         self.assertRaises(JobMappingException, map_tool_to_destination, failJob, theApp, vanillaTool, "user@email.com", True, priority_path, job_conf_path)
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Loading file: input1' + script_dir + '/data/test1.full'),
@@ -167,7 +167,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         priority_job = map_tool_to_destination(runJob, theApp, vanillaTool, "user@email.com", True, priority_path, job_conf_path)
         self.assertEquals(priority_job, 'Destination1_high')
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Loading file: input1' + script_dir + '/data/test3.full'),
@@ -190,7 +190,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         priority_job = map_tool_to_destination(runJob, theApp, defaultTool, "user@email.com", True, priority_path, job_conf_path)
         self.assertEquals(priority_job, 'cluster_default_high')
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Tool 'test_tooldefault' not specified in config. Using default destination."),
@@ -209,7 +209,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         priority_job = map_tool_to_destination(argJob, theApp, argTool, "user@email.com", True, priority_path, job_conf_path)
         self.assertEquals(priority_job, 'Destination6_med')
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Running 'test_arguments' with 'Destination6'."),
@@ -226,7 +226,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         priority_job = map_tool_to_destination(argNotFoundJob, theApp, argTool, "user@email.com", True, priority_path, job_conf_path)
         self.assertEquals(priority_job, 'cluster_default_high')
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Running 'test_arguments' with 'cluster_default'."),
@@ -243,7 +243,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         priority_job = map_tool_to_destination(runJob, theApp, unTool, "user@email.com", True, priority_path, job_conf_path)
         self.assertEquals(priority_job, 'cluster_default_high')
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Tool 'unregistered' not specified in config. Using default destination."),
@@ -262,7 +262,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         priority_job = map_tool_to_destination(dbJob, theApp, dbTool, "user@email.com", True, priority_path, job_conf_path)
         self.assertEquals(priority_job, 'Destination4_high')
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Loading file: input1' + script_dir + '/data/test.fasta'),
@@ -283,7 +283,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         priority_job = map_tool_to_destination(dbcountJob, theApp, dbTool, "user@email.com", True, priority_path, job_conf_path)
         self.assertEquals(priority_job, 'Destination4_high')
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Loading file: input1' + script_dir + '/data/test.fasta'),
@@ -302,7 +302,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         job = map_tool_to_destination(runJob, theApp, noVBTool, "user@email.com", True, no_verbose_path, job_conf_path)
         self.assertEquals(job, 'Destination1')
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Running 'test_no_verbose' with 'Destination1'.")
         )
 
@@ -311,7 +311,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         job = map_tool_to_destination(runJob, theApp, usersTool, "user@email.com", True, users_test_path, job_conf_path)
         self.assertEquals(job, 'special_cluster')
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Running 'test_users' with 'special_cluster'."),
         )
 
@@ -320,7 +320,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         job = map_tool_to_destination(runJob, theApp, usersTool, "userblah@email.com", True, users_test_path, job_conf_path)
         self.assertEquals(job, 'lame_cluster')
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Running 'test_users' with 'lame_cluster'.")
         )
 
@@ -329,12 +329,12 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_no_file(self, l):
         self.assertRaises(IOError, dt.parse_yaml, path="")
-        l.check()
+        l.check_present()
 
     @log_capture()
     def test_bad_nice(self, l):
         dt.parse_yaml(path=yt.ivYMLTest11, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG',
              "Running config validation..."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG',
@@ -349,7 +349,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_no_tool_name(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest3, job_conf_path=job_conf_path, test=True), yt.iv3dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Malformed YML; expected job name, but found a list instead!'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -358,7 +358,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_no_rule_type(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest4, job_conf_path=job_conf_path, test=True), yt.ivDict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No rule_type found for rule 1 in 'spades'."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -367,7 +367,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_no_rule_lower_bound(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest51, job_conf_path=job_conf_path, test=True), yt.ivDict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Missing bounds for rule 1 in 'spades'. Ignoring rule."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -376,7 +376,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_no_rule_upper_bound(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest52, job_conf_path=job_conf_path, test=True), yt.ivDict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Missing bounds for rule 1 in 'spades'. Ignoring rule."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -385,7 +385,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_no_rule_arg(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest53, job_conf_path=job_conf_path, test=True), yt.ivDict53)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Found a fail_message for rule 1 in 'spades', but destination is not 'fail'! Setting destination to 'fail'."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -394,7 +394,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_bad_rule_type(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest6, job_conf_path=job_conf_path, test=True), yt.ivDict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Unrecognized rule_type 'iencs' found in 'spades'. Ignoring..."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -403,7 +403,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_no_err_msg(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest91, job_conf_path=job_conf_path, test=True), yt.iv91dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No nice_value found for rule 1 in 'spades'. Setting nice_value to 0."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Missing a fail_message for rule 1 in 'spades'. Adding generic fail_message."),
@@ -413,7 +413,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_no_default_dest(self, l):
         dt.parse_yaml(path=yt.ivYMLTest7, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'No global default destination specified in config!'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -422,7 +422,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_invalid_category(self, l):
         dt.parse_yaml(path=yt.ivYMLTest8, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'No global default destination specified in config!'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Unrecognized category 'ice_cream' found in config file!"),
@@ -432,7 +432,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_arguments_no_err_msg(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest12, job_conf_path=job_conf_path, test=True), yt.iv12dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG',
              "Missing a fail_message for rule 1 in 'spades'. Adding generic fail_message."),
@@ -442,7 +442,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_arguments_no_args(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest131, job_conf_path=job_conf_path, test=True), yt.iv131dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG',
              "No arguments found for rule 1 in 'spades' despite being of type arguments. Ignoring rule."),
@@ -452,7 +452,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_arguments_no_arg(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest132, job_conf_path=job_conf_path, test=True), yt.iv132dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Found a fail_message for rule 1 in 'spades', but destination is not 'fail'! Setting destination to 'fail'."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -461,14 +461,14 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_bool_for_multiple_jobs(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest133, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Missing a fail_message for rule 1 in 'smalt'.")
         )
 
     @log_capture()
     def test_return_rule_for_multiple_jobs(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest133, job_conf_path=job_conf_path, test=True), yt.iv133dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Missing a fail_message for rule 1 in 'smalt'. Adding generic fail_message."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -477,14 +477,14 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_bool_for_no_destination(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest134, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No destination specified for rule 1 in 'spades'.")
         )
 
     @log_capture()
     def test_return_rule_for_no_destination(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest134, job_conf_path=job_conf_path, test=True), yt.iv134dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No destination specified for rule 1 in 'spades'. Ignoring..."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -493,7 +493,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_rule_for_reversed_bounds(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest135, job_conf_path=job_conf_path, test=True), yt.iv135dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "lower_bound exceeds upper_bound for rule 1 in 'spades'. Reversing bounds."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -502,14 +502,14 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_bool_for_missing_tool_fields(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest136, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Tool 'spades' does not have rules nor a default_destination!")
         )
 
     @log_capture()
     def test_return_rule_for_missing_tool_fields(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest136, job_conf_path=job_conf_path, test=True), yt.iv136dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Tool 'spades' does not have rules nor a default_destination!"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -518,14 +518,14 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_bool_for_blank_tool(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest137, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Config section for tool 'spades' is blank!")
         )
 
     @log_capture()
     def test_return_rule_for_blank_tool(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest137, job_conf_path=job_conf_path, test=True), yt.iv137dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Config section for tool 'spades' is blank!"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -534,7 +534,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_bool_for_malformed_users(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest138, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Entry '123' in users for rule 1 in tool 'spades' is in an invalid format!"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Supplied email 'invaliduser.email@com' for rule 1 in tool 'spades' is in an invalid format!")
         )
@@ -542,7 +542,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_rule_for_malformed_users(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest138, job_conf_path=job_conf_path, test=True), yt.iv138dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Entry '123' in users for rule 1 in tool 'spades' is in an invalid format! Ignoring entry."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Supplied email 'invaliduser.email@com' for rule 1 in tool 'spades' is in an invalid format! Ignoring email."),
@@ -552,14 +552,14 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_bool_for_no_users(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest139, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Couldn't find a list under 'users:'!")
         )
 
     @log_capture()
     def test_return_rule_for_no_users(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest139, job_conf_path=job_conf_path, test=True), yt.iv139dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Couldn't find a list under 'users:'! Ignoring rule."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -568,7 +568,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_bool_for_malformed_user_email(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest140, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Supplied email 'invalid.user2@com' for rule 2 in tool 'spades' is in an invalid format!"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Supplied email 'invalid.user1@com' for rule 2 in tool 'spades' is in an invalid format!"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No valid user emails were specified for rule 2 in tool 'spades'!")
@@ -577,7 +577,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_rule_for_malformed_user_email(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest140, job_conf_path=job_conf_path, test=True), yt.iv140dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Supplied email 'invalid.user2@com' for rule 2 in tool 'spades' is in an invalid format! Ignoring email."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Supplied email 'invalid.user1@com' for rule 2 in tool 'spades' is in an invalid format! Ignoring email."),
@@ -588,7 +588,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_bool_for_empty_users(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest141, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Entry 'None' in users for rule 2 in tool 'spades' is in an invalid format!"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Entry 'None' in users for rule 2 in tool 'spades' is in an invalid format!"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No valid user emails were specified for rule 2 in tool 'spades'!")
@@ -597,7 +597,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_rule_for_empty_users(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest141, job_conf_path=job_conf_path, test=True), yt.iv141dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Entry 'None' in users for rule 2 in tool 'spades' is in an invalid format! Ignoring entry."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Entry 'None' in users for rule 2 in tool 'spades' is in an invalid format! Ignoring entry."),
@@ -608,7 +608,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_bool_for_bad_num_input_datasets_bounds(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest142, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Error: lower_bound is set to Infinity, but must be lower than upper_bound!"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "lower_bound exceeds upper_bound for rule 1 in 'smalt'.")
         )
@@ -616,7 +616,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_rule_for_bad_num_input_datasets_bound(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest142, job_conf_path=job_conf_path, test=True), yt.iv142dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Error: lower_bound is set to Infinity, but must be lower than upper_bound! Setting lower_bound to 0!"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -625,14 +625,14 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_return_bool_for_worse_num_input_datasets_bounds(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest143, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Error: lower_bound is set to Infinity, but must be lower than upper_bound!")
         )
 
     @log_capture()
     def test_return_rule_for_worse_num_input_datasets_bound(self, l):
         self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest143, job_conf_path=job_conf_path, test=True), yt.iv143dict)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Error: lower_bound is set to Infinity, but must be lower than upper_bound! Setting lower_bound to 0!"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -641,7 +641,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_tool_without_low_default_destination(self, l):
         dt.parse_yaml(path=yt.ivYMLTest146, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No default_priority section found in config. Setting 'med' as default priority."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Invalid priority 'low' for rule 1 in 'smalt'. Ignoring..."),
@@ -651,7 +651,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_tool_with_invalid_priority_destination(self, l):
         dt.parse_yaml(path=yt.ivYMLTest147, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No default_priority section found in config. Setting 'med' as default priority."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Invalid priority 'mine' for rule 1 in 'smalt'. Ignoring..."),
@@ -661,7 +661,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_not_all_priorities_in_tool(self, l):
         dt.parse_yaml(path=yt.ivYMLTest149, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No default_priority section found in config. Setting 'med' as default priority."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -670,7 +670,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_rule_destination_not_in_job_conf(self, l):
         dt.parse_yaml(path=yt.ivYMLTest150, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No default_priority section found in config. Setting 'med' as default priority."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Destination for 'blegh', rule 1: 'fake_destination' does not exist in job configuration. Ignoring..."),
@@ -680,7 +680,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_tool_default_destination_not_in_job_conf_with_no_rules(self, l):
         dt.parse_yaml(path=yt.ivYMLTest151, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No default_priority section found in config. Setting 'med' as default priority."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination for 'blah': 'not_true_destination' does not appear in the job configuration."),
@@ -691,7 +691,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_default_destination_not_in_job_conf(self, l):
         dt.parse_yaml(path=yt.ivYMLTest152, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination 'no_such_dest' does not appear in the job configuration."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No default_priority section found in config. Setting 'med' as default priority."),
@@ -701,7 +701,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_rule_destination_without_priority_not_in_job_conf(self, l):
         dt.parse_yaml(path=yt.ivYMLTest153, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No default_priority section found in config. Setting 'med' as default priority."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Destination for 'blegh', rule 1: 'fake_destination' does not exist in job configuration. Ignoring..."),
@@ -711,7 +711,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_tool_default_destination_without_priority_not_in_job_conf_with_no_rules(self, l):
         dt.parse_yaml(path=yt.ivYMLTest154, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No default_priority section found in config. Setting 'med' as default priority."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination for 'blah': 'not_true_destination' does not appear in the job configuration."),
@@ -722,7 +722,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_default_destination_without_priority_not_in_job_conf(self, l):
         dt.parse_yaml(path=yt.ivYMLTest155, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination 'no_such_dest' does not appear in the job configuration."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -731,7 +731,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_tool_rule_priority_does_not_exist(self, l):
         dt.parse_yaml(path=yt.ivYMLTest156, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No default_priority section found in config. Setting 'med' as default priority."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Invalid priority 'notAPriority' for rule 1 in 'aTool'. Ignoring..."),
@@ -741,7 +741,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_tool_default_destination_priority_does_not_exist(self, l):
         dt.parse_yaml(path=yt.ivYMLTest157, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No default_priority section found in config. Setting 'med' as default priority."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Invalid default destination priority 'notAPriority' for 'aTool'."),
@@ -751,7 +751,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_tool_default_destination_not_in_job_conf(self, l):
         dt.parse_yaml(path=yt.ivYMLTest158, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No default_priority section found in config. Setting 'med' as default priority."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination for 'blah': 'not_true_destination' does not appear in the job configuration."),
@@ -761,7 +761,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_tool_default_destination_without_priority_not_in_job_conf(self, l):
         dt.parse_yaml(path=yt.ivYMLTest159, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination for 'blah': 'not_true_destination' does not appear in the job configuration."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -770,7 +770,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_empty_priority_dict(self, l):
         dt.parse_yaml(path=yt.ivYMLTest163, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No global default destinations specified in config!"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -779,7 +779,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_default_dest_is_string_but_priorities_used_in_rule(self, l):
         dt.parse_yaml(path=yt.ivYMLTest161, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Invalid priority 'med' for rule 1 in 'blah'. Ignoring..."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -788,7 +788,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_default_dest_is_string_but_priorities_used_in_tool_default_dest(self, l):
         dt.parse_yaml(path=yt.ivYMLTest162, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Invalid default destination priority 'med' for 'blah'."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -797,7 +797,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_typo_in_str_default_dest(self, l):
         dt.parse_yaml(path=yt.ivYMLTest164, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination 'cluster-kow' does not appear in the job configuration. Did you mean 'cluster_low'?"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -806,7 +806,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_typo_in_dict_default_dest(self, l):
         dt.parse_yaml(path=yt.ivYMLTest165, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination 'cluster_kow' does not appear in the job configuration. Did you mean 'cluster_low'?"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -815,7 +815,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_typo_in_dict_tool_default_dest(self, l):
         dt.parse_yaml(path=yt.ivYMLTest166, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination for 'blah': 'cluster_defaut' does not appear in the job configuration. Did you mean 'cluster_default'?"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -824,7 +824,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_typo_in_str_tool_default_dest(self, l):
         dt.parse_yaml(path=yt.ivYMLTest167, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination for 'blah': 'Destination_3_med' does not appear in the job configuration. Did you mean 'Destination3_med'?"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -833,7 +833,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_typo_in_str_tool_rule_dest(self, l):
         dt.parse_yaml(path=yt.ivYMLTest168, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Destination for 'blah', rule 1: 'thig' does not exist in job configuration. Did you mean 'things'? Ignoring..."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -842,7 +842,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_typo_in_dict_tool_rule_dest(self, l):
         dt.parse_yaml(path=yt.ivYMLTest169, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Destination for 'blah', rule 1: 'even_lamerr_cluster' does not exist in job configuration. Did you mean 'even_lamer_cluster'? Ignoring..."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -851,7 +851,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_typo_in_case(self, l):
         dt.parse_yaml(path=yt.ivYMLTest170, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination 'destinationf' does not appear in the job configuration. Did you mean 'DestinationF'?"),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -860,7 +860,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_invalid_verbose_value(self, l):
         dt.parse_yaml(path=yt.ivYMLTest171, job_conf_path=job_conf_path, test=True)
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Verbose value 'notavalue' is not True or False! Falling back to verbose..."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.')
@@ -869,14 +869,14 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_invalid_default_dest_valid_tool_default_dest_bool(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest172, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination 'fake_destination' does not appear in the job configuration."),
         )
 
     @log_capture()
     def test_valid_default_dest_invalid_tool_default_dest_bool(self, l):
         self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest173, job_conf_path=job_conf_path, test=True, return_bool=True))
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Default destination for 'blah': 'fake_destination' does not appear in the job configuration."),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Tool 'blah' does not have rules nor a default_destination!"),
         )
@@ -900,7 +900,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         self.assertTrue(dt.parse_yaml(yt.vYMLTest164, job_conf_path=job_conf_path, test=True, return_bool=True))
         self.assertEqual(dt.parse_yaml(yt.vYMLTest164, job_conf_path=job_conf_path, test=True), yt.vdictTest164_yml)
 
-        l.check(
+        l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Finished config validation.'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),

--- a/tox.ini
+++ b/tox.ini
@@ -42,8 +42,6 @@ setenv =
     GALAXY_VIRTUAL_ENV={envdir}
     GALAXY_ENABLE_BETA_COMPRESSED_GENBANK_SNIFFING=1
 deps =
-    nose
-    NoseHTML
     mock
     mock-ssh-server
 
@@ -65,8 +63,6 @@ whitelist_externals = bash
 setenv =
     GALAXY_VIRTUAL_ENV={envdir}
 deps =
-    nose
-    NoseHTML
     mock
     mock-ssh-server
 


### PR DESCRIPTION
This moves unit, framework, data manager tools, migrated tools to use pytest, and includes some fixes necessary for tests to pass reliably.
Also contains some enhancements for using pytest to run tool tests:
  - We mark tools that should be skipped instead of not collecting them at all
  - We mark tools or data managers tools, so that they can be selected using the `-m` switch
And finally I've added an additional test target for tools in tool_conf.xml.sample and tool_conf.xml.main (And I've fixed those tools in https://github.com/galaxyproject/galaxy/pull/6627)