### PR TITLE
document config for sniffing compressed files, enable by default

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -408,7 +408,7 @@ galaxy:
   # configured/overridden on a per-datatype basis in the
   # datatypes_conf.xml file. With this option set to False the
   # compressed datatypes will be unpacked before sniffing.
-  #sniff_compressed_dynamic_datatypes_default: false
+  #sniff_compressed_dynamic_datatypes_default: true
 
   # Disable the 'Auto-detect' option for file uploads
   #datatypes_disable_auto: false

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -404,6 +404,12 @@ galaxy:
   # one file).
   #datatypes_config_file: config/datatypes_conf.xml
 
+  # Enable sniffing of compressed datatypes. This can be
+  # configured/overridden on a per-datatype basis in the
+  # datatypes_conf.xml file. With this option set to False the
+  # compressed datatypes will be unpacked before sniffing.
+  #sniff_compressed_dynamic_datatypes_default: false
+
   # Disable the 'Auto-detect' option for file uploads
   #datatypes_disable_auto: false
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -679,6 +679,19 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``sniff_compressed_dynamic_datatypes_default``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Enable sniffing of compressed datatypes. This can be
+    configured/overridden on a per-datatype basis in the
+    datatypes_conf.xml file. With this option set to False the
+    compressed datatypes will be unpacked before sniffing.
+:Default: ``false``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``datatypes_disable_auto``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -688,7 +688,7 @@
     configured/overridden on a per-datatype basis in the
     datatypes_conf.xml file. With this option set to False the
     compressed datatypes will be unpacked before sniffing.
-:Default: ``false``
+:Default: ``true``
 :Type: bool
 
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -466,7 +466,7 @@ class Configuration(object):
         # allow_path_paste value.
         self.allow_library_path_paste = string_as_bool(kwargs.get('allow_library_path_paste', self.allow_path_paste))
         self.disable_library_comptypes = kwargs.get('disable_library_comptypes', '').lower().split(',')
-        self.sniff_compressed_dynamic_datatypes_default = string_as_bool(kwargs.get("sniff_compressed_dynamic_datatypes_default", False))
+        self.sniff_compressed_dynamic_datatypes_default = string_as_bool(kwargs.get("sniff_compressed_dynamic_datatypes_default", True))
         self.check_upload_content = string_as_bool(kwargs.get('check_upload_content', True))
         self.watch_tools = kwargs.get('watch_tools', 'false')
         self.watch_tool_data_dir = kwargs.get('watch_tool_data_dir', 'false')

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -528,7 +528,7 @@ mapping:
 
       sniff_compressed_dynamic_datatypes_default:
         type: bool
-        default: false
+        default: true
         required: false
         desc: |
           Enable sniffing of compressed datatypes. This can be configured/overridden

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -526,6 +526,17 @@ mapping:
           multiple files, the last definition is used (though the first sniffer is used
           so limit sniffer definitions to one file).
 
+      sniff_compressed_dynamic_datatypes_default:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Enable sniffing of compressed datatypes. This can be configured/overridden
+          on a per-datatype basis in the datatypes_conf.xml file.
+          With this option set to False the compressed datatypes will be unpacked
+          before sniffing.
+
+
       datatypes_disable_auto:
         type: bool
         default: false

--- a/test/api/test_tools_upload.py
+++ b/test/api/test_tools_upload.py
@@ -9,6 +9,7 @@ from base.constants import (
 from base.populators import (
     DatasetPopulator,
     skip_without_datatype,
+    uses_test_history,
 )
 
 from galaxy.tools.verify.test_data import TestDataResolver
@@ -91,9 +92,14 @@ class ToolsUploadTestCase(api.ApiTestCase):
         assert details["state"] == "ok"
         assert details["file_ext"] == "fastqsanger.gz", details
 
-    def test_fetch_compressed_auto_decompress_target(self):
+    @uses_test_history(require_new=True)
+    def test_fetch_compressed_auto_decompress_target(self, history_id):
         fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
-        details = self._upload_and_get_details(open(fastqgz_path, "rb"), api="fetch", assert_ok=False, auto_decompress=True)
+        details = self._upload_and_get_details(open(fastqgz_path, "rb"),
+                                               api="fetch",
+                                               history_id=history_id,
+                                               assert_ok=False,
+                                               auto_decompress=True)
         assert details["state"] == "ok"
         assert details["file_ext"] == "fastqsanger", details
 
@@ -122,10 +128,15 @@ class ToolsUploadTestCase(api.ApiTestCase):
         details = self._upload_and_get_details(open(bedgz_path, "rb"), file_type="auto", assert_ok=False, auto_decompress=False)
         assert details["file_ext"] == "bed.gz", details
 
-    def test_fetch_compressed_with_auto(self):
+    @uses_test_history(require_new=True)
+    def test_fetch_compressed_with_auto(self, history_id):
         # TODO: this should definitely be fixed to allow auto decompression via that API.
         fastqgz_path = TestDataResolver().get_filename("4.bed.gz")
-        details = self._upload_and_get_details(open(fastqgz_path, "rb"), api="fetch", auto_decompress=True, assert_ok=False)
+        details = self._upload_and_get_details(open(fastqgz_path, "rb"),
+                                               api="fetch",
+                                               history_id=history_id,
+                                               auto_decompress=True,
+                                               assert_ok=False)
         assert details["state"] == "ok"
         assert details["file_ext"] == "bed"
 
@@ -452,9 +463,9 @@ class ToolsUploadTestCase(api.ApiTestCase):
         assert_ok = upload_kwds.get("assert_ok", True)
         return self.dataset_populator.get_history_dataset_details(history_id, dataset=new_dataset, assert_ok=assert_ok)
 
-    def _upload(self, content, api="upload1", **upload_kwds):
+    def _upload(self, content, api="upload1", history_id=None, **upload_kwds):
         assert_ok = upload_kwds.get("assert_ok", True)
-        history_id = self.dataset_populator.new_history()
+        history_id = history_id or self.dataset_populator.new_history()
         if api == "upload1":
             new_dataset = self.dataset_populator.new_dataset(history_id, content=content, **upload_kwds)
         else:

--- a/test/api/test_tools_upload.py
+++ b/test/api/test_tools_upload.py
@@ -105,6 +105,7 @@ class ToolsUploadTestCase(api.ApiTestCase):
         assert details["file_ext"] == "fastqsanger.gz", details
 
     def test_upload_decompress_off_with_auto_by_default(self):
+        # UNSTABLE_FLAG: This might default to a bed.gz datatype in the future.
         bedgz_path = TestDataResolver().get_filename("4.bed.gz")
         details = self._upload_and_get_details(open(bedgz_path, "rb"), file_type="auto")
         assert details["state"] == "ok"
@@ -125,12 +126,14 @@ class ToolsUploadTestCase(api.ApiTestCase):
         assert details["file_size"] == 161, details
 
     def test_upload_auto_decompress_off(self):
+        # UNSTABLE_FLAG: This might default to a bed.gz datatype in the future.
         bedgz_path = TestDataResolver().get_filename("4.bed.gz")
         details = self._upload_and_get_details(open(bedgz_path, "rb"), file_type="auto", assert_ok=False, auto_decompress=False)
         assert details["file_ext"] == "binary", details
 
     @uses_test_history(require_new=True)
     def test_fetch_compressed_with_auto(self, history_id):
+        # UNSTABLE_FLAG: This might default to a bed.gz datatype in the future.
         # TODO: this should definitely be fixed to allow auto decompression via that API.
         fastqgz_path = TestDataResolver().get_filename("4.bed.gz")
         details = self._upload_and_get_details(open(fastqgz_path, "rb"),

--- a/test/api/test_tools_upload.py
+++ b/test/api/test_tools_upload.py
@@ -79,18 +79,17 @@ class ToolsUploadTestCase(api.ApiTestCase):
         result_content = self._upload_and_get_content(table, api="fetch", space_to_tab=True)
         self.assertEquals(result_content, ONE_TO_SIX_WITH_TABS)
 
-    def test_fetch_compressed_requires_explicit_type(self):
+    def test_fetch_compressed_with_explicit_type(self):
         fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
         details = self._upload_and_get_details(open(fastqgz_path, "rb"), api="fetch", ext="fastqsanger.gz")
         assert details["state"] == "ok"
         assert details["file_ext"] == "fastqsanger.gz"
 
-    def test_fetch_compressed_with_auto_binary(self):
-        # UNSTABLE_FLAG: this might decompress automatically or fallback to fastqsanger.gz or gz datatype in the future.
+    def test_fetch_compressed_default(self):
         fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
         details = self._upload_and_get_details(open(fastqgz_path, "rb"), api="fetch", assert_ok=False)
         assert details["state"] == "ok"
-        assert details["file_ext"] == "binary", details
+        assert details["file_ext"] == "fastqsanger.gz", details
 
     def test_fetch_compressed_auto_decompress_target(self):
         fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
@@ -102,7 +101,7 @@ class ToolsUploadTestCase(api.ApiTestCase):
         bedgz_path = TestDataResolver().get_filename("4.bed.gz")
         details = self._upload_and_get_details(open(bedgz_path, "rb"), file_type="auto")
         assert details["state"] == "ok"
-        assert details["file_ext"] == "bed", details
+        assert details["file_ext"] == "bed.gz", details
 
     def test_upload_decompresses_if_uncompressed_type_selected(self):
         fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
@@ -119,13 +118,12 @@ class ToolsUploadTestCase(api.ApiTestCase):
         assert details["file_size"] == 161, details
 
     def test_upload_auto_decompress_off(self):
-        # UNSTABLE_FLAG: This might default to a gz or bed.gz datatype in the future.
         bedgz_path = TestDataResolver().get_filename("4.bed.gz")
         details = self._upload_and_get_details(open(bedgz_path, "rb"), file_type="auto", assert_ok=False, auto_decompress=False)
-        assert details["file_ext"] == "binary", details
+        assert details["file_ext"] == "bed.gz", details
 
     def test_fetch_compressed_with_auto(self):
-        # UNSTABLE_FLAG and TODO: this should definitely be fixed to allow auto decompression via that API.
+        # TODO: this should definitely be fixed to allow auto decompression via that API.
         fastqgz_path = TestDataResolver().get_filename("4.bed.gz")
         details = self._upload_and_get_details(open(fastqgz_path, "rb"), api="fetch", auto_decompress=True, assert_ok=False)
         assert details["state"] == "ok"

--- a/test/api/test_tools_upload.py
+++ b/test/api/test_tools_upload.py
@@ -92,16 +92,17 @@ class ToolsUploadTestCase(api.ApiTestCase):
         assert details["file_ext"] == "fastqsanger.gz", details
 
     def test_fetch_compressed_auto_decompress_target(self):
+        # TODO: this should definitely be fixed to allow auto decompression via that API.
         fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
         details = self._upload_and_get_details(open(fastqgz_path, "rb"), api="fetch", assert_ok=False, auto_decompress=True)
         assert details["state"] == "ok"
-        assert details["file_ext"] == "fastqsanger", details
+        assert details["file_ext"] == "fastqsanger.gz", details
 
-    def test_upload_decompresses_auto_by_default(self):
+    def test_upload_decompress_off_with_auto_by_default(self):
         bedgz_path = TestDataResolver().get_filename("4.bed.gz")
         details = self._upload_and_get_details(open(bedgz_path, "rb"), file_type="auto")
         assert details["state"] == "ok"
-        assert details["file_ext"] == "bed.gz", details
+        assert details["file_ext"] == "bed", details
 
     def test_upload_decompresses_if_uncompressed_type_selected(self):
         fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
@@ -120,7 +121,7 @@ class ToolsUploadTestCase(api.ApiTestCase):
     def test_upload_auto_decompress_off(self):
         bedgz_path = TestDataResolver().get_filename("4.bed.gz")
         details = self._upload_and_get_details(open(bedgz_path, "rb"), file_type="auto", assert_ok=False, auto_decompress=False)
-        assert details["file_ext"] == "bed.gz", details
+        assert details["file_ext"] == "binary", details
 
     def test_fetch_compressed_with_auto(self):
         # TODO: this should definitely be fixed to allow auto decompression via that API.


### PR DESCRIPTION
Me and @natefoo think that it is time to switch the default of this config option to True. At least for Main.

In addition I suspect there is a bug in data_source tools that prevent/avoid uncompressing uploaded archives and thus causing issues like https://github.com/galaxyproject/galaxy/issues/6334.

ping @jmchilton 