### PR TITLE
Allow running scripts/galaxy-main without Galaxy on sys.path

### DIFF
--- a/scripts/galaxy-main
+++ b/scripts/galaxy-main
@@ -170,6 +170,8 @@ class GalaxyConfigBuilder(object):
     """
 
     def __init__(self, args=None, **kwds):
+        self.config_file = None
+        self.config_section = None
         self.app_name = kwds.get("app") or (args and args.app) or DEFAULT_CONFIG_SECTION
         config_file = kwds.get("config_file", None) or (args and args.config_file)
         # If given app_conf_path - use that - else we need to ensure we have a

--- a/scripts/galaxy-main
+++ b/scripts/galaxy-main
@@ -34,11 +34,6 @@ from logging.config import fileConfig
 from six.moves.configparser import ConfigParser
 
 try:
-    from galaxy.util import unicodify
-except ImportError:
-    unicodify = None
-
-try:
     from daemonize import Daemonize
 except ImportError:
     Daemonize = None
@@ -48,13 +43,21 @@ try:
 except ImportError:
     uwsgi = None
 
-REQUIRES_DAEMONIZE_MESSAGE = "Attempted to use Galaxy in daemon mode, but daemonize is unavailable."
-
 log = logging.getLogger(__name__)
 
 real_file = os.path.realpath(__file__)
 GALAXY_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(real_file), os.pardir))
 GALAXY_LIB_DIR = os.path.join(GALAXY_ROOT_DIR, "lib")
+try:
+    sys.path.insert(1, GALAXY_LIB_DIR)
+except Exception:
+    log.exception("Failed to add Galaxy to sys.path")
+    raise
+from galaxy.util import unicodify
+from galaxy.web.stack import get_app_kwds
+
+REQUIRES_DAEMONIZE_MESSAGE = "Attempted to use Galaxy in daemon mode, but daemonize is unavailable."
+
 DEFAULT_INI_APP = "main"
 DEFAULT_CONFIG_SECTION = "galaxy"
 DEFAULT_INIS = ["config/galaxy.yml", "config/galaxy.ini", "universe_wsgi.ini", "config/galaxy.yml.sample"]
@@ -206,7 +209,6 @@ class GalaxyConfigBuilder(object):
         return self.config_file.endswith('.ini') or self.config_file.endswith('.ini.sample')
 
     def app_kwds(self):
-        from galaxy.web.stack import get_app_kwds
         kwds = get_app_kwds(self.app_name, app_name=self.app_name)
         if 'config_file' not in kwds:
             kwds['config_file'] = self.config_file
@@ -239,15 +241,6 @@ class GalaxyConfigBuilder(object):
 
 def main():
     arg_parser = ArgumentParser(description=DESCRIPTION)
-    try:
-        sys.path.insert(1, GALAXY_LIB_DIR)
-    except Exception:
-        log.exception("Failed to add Galaxy to sys.path")
-        raise
-    global unicodify
-    if unicodify is None:
-        _util = __import__('galaxy.util', globals(), locals(), ['unicodify'])
-        unicodify = _util.unicodify
     GalaxyConfigBuilder.populate_options(arg_parser)
     args = arg_parser.parse_args()
     if args.ini_path and not args.config_file:

--- a/scripts/galaxy-main
+++ b/scripts/galaxy-main
@@ -33,7 +33,10 @@ from logging.config import fileConfig
 
 from six.moves.configparser import ConfigParser
 
-from galaxy.util import unicodify
+try:
+    from galaxy.util import unicodify
+except ImportError:
+    unicodify = None
 
 try:
     from daemonize import Daemonize
@@ -239,6 +242,10 @@ def main():
     except Exception:
         log.exception("Failed to add Galaxy to sys.path")
         raise
+    global unicodify
+    if unicodify is None:
+        _util = __import__('galaxy.util', globals(), locals(), ['unicodify'])
+        unicodify = _util.unicodify
     GalaxyConfigBuilder.populate_options(arg_parser)
     args = arg_parser.parse_args()
     if args.ini_path and not args.config_file:

--- a/test/integration/test_scripts.py
+++ b/test/integration/test_scripts.py
@@ -160,6 +160,9 @@ class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
         # TODO: test creating a smaller database - e.g. tool install database based on fresh
         # config file.
 
+    def test_galaxy_main(self):
+        self._scripts_check_argparse_help("galaxy-main")
+
     def test_runtime_stats(self):
         self._skip_if_not_postgres()
         self._scripts_check_argparse_help("runtime_stats.py")


### PR DESCRIPTION
Fixes an issue that arose in #6565 from adding a galaxy lib import.

Also fix a bug where attributes in the config builder were accessed before they were set.