### PR TITLE
Fix color of workflow panel background

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -694,6 +694,10 @@ div.form-row-error-message {
     margin-top: 5px;
 }
 
+.workflow-right {
+    background: white;
+}
+
 .workflow-right .right-content .section-row {
     margin-bottom: 10px;
 }

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -12964,6 +12964,9 @@ div.form-row-error-message {
   padding-bottom: 10px;
   margin-top: 5px; }
 
+.workflow-right {
+  background: white; }
+
 .workflow-right .right-content .section-row {
   margin-bottom: 10px; }
 


### PR DESCRIPTION
This is a minor fix for the background color in the workflow editor's tool panel. It is a temporary fix and will be revised in the upcoming style overhaul PR.