### PR TITLE
Small Optimizations to Adding Datasets to History

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1455,7 +1455,9 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName):
         set_genome = genome_build not in [None, '?']
         for i, dataset in enumerate(datasets):
             dataset.hid = base_hid + i
-            dataset.history = self
+            # Don't let SA manage this.
+            delattr(dataset, "history")
+            dataset.history_id = cached_id(self)
             if set_genome:
                 self.genome_build = genome_build
         for dataset in datasets:

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2541,10 +2541,10 @@ def db_next_hid(self, n=1):
     trans = conn.begin()
     try:
         if "postgres" not in session.bind.dialect.name:
-            next_hid = select([table.c.hid_counter], table.c.id == self.id, for_update=True).scalar()
+            next_hid = select([table.c.hid_counter], table.c.id == model.cached_id(self), for_update=True).scalar()
             table.update(table.c.id == self.id).execute(hid_counter=(next_hid + n))
         else:
-            stmt = table.update().where(table.c.id == self.id).values(hid_counter=(table.c.hid_counter + n)).returning(table.c.hid_counter)
+            stmt = table.update().where(table.c.id == model.cached_id(self)).values(hid_counter=(table.c.hid_counter + n)).returning(table.c.hid_counter)
             next_hid = conn.execute(stmt).scalar() - n
         trans.commit()
         return next_hid

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -808,10 +808,10 @@ class OutputCollections(object):
                     for value in elements.values():
                         # Either a HDA (if) or a DatasetCollection or a recursive dict.
                         if getattr(value, "history_content_type", None) == "dataset":
-                            assert value.history is not None
+                            assert value.history is not None or value.history_id is not None
                         elif hasattr(value, "dataset_instances"):
                             for dataset in value.dataset_instances:
-                                assert dataset.history is not None
+                                assert dataset.history is not None or dataset.history_id is not None
                         else:
                             assert value["src"] == "new_collection"
                             check_elements(value["elements"])

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -478,8 +478,6 @@ class DefaultToolAction(object):
                 datasets_to_persist.append(data)
         # Set HID and add to history.
         # This is brand new and certainly empty so don't worry about quota.
-        # TOOL OPTIMIZATION NOTE - from above loop to the job create below 99%+
-        # of execution time happens within in history.add_datasets.
         history.add_datasets(trans.sa_session, datasets_to_persist, set_hid=set_output_hid, quota=False, flush=False)
 
         # Add all the children to their parents


### PR DESCRIPTION
Refactored out of https://github.com/galaxyproject/galaxy/pull/6563, the timings I had on that PR was that eliminating these queries reduced the time to execute 10 jobs each creating 10 datasets by about 10%. Also eliminate an ancient note about optimization stuff that is almost certainly no longer correct.