### PR TITLE
Add Seurat datatype: rdata.seurat

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -503,6 +503,7 @@
     <datatype extension="cel" type="galaxy.datatypes.binary:Cel" display_in_upload="true"/>
     <datatype extension="rdata" type="galaxy.datatypes.binary:RData" display_in_upload="true" description="Stored data from an R session"/>
     <datatype extension="rdata.sce" type="galaxy.datatypes.binary:RData" description="Stored RDS from a SingleCellObject" subclass="true" />
+    <datatype extension="rdata.seurat" type="galaxy.datatypes.binary:RData" description="Stored RDS from a Seurat Object" subclass="true" />
     <datatype extension="oxlicg" type="galaxy.datatypes.binary:OxliCountGraph" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="oxling" type="galaxy.datatypes.binary:OxliNodeGraph" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="oxlits" type="galaxy.datatypes.binary:OxliTagSet" mimetype="application/octet-stream" display_in_upload="true"/>


### PR DESCRIPTION
This PR adds a datatype for R's Seurat RDS object, similar to the SingleCellExperiment RDS datatype already added (extends the RData datatype)

xref: https://github.com/galaxyproject/galaxy/pull/5716

At some point in the future an RDS datatype could maybe be added, instead of extending RData, as proposed here: https://github.com/galaxyproject/galaxy/pull/5716#issuecomment-416757214.