### PR TITLE
Strip API keys option from admin panel left side

### DIFF
--- a/client/galaxy/scripts/apps/panels/admin-panel.js
+++ b/client/galaxy/scripts/apps/panels/admin-panel.js
@@ -81,12 +81,6 @@ var AdminPanel = Backbone.View.extend({
                         title: _l("Forms"),
                         url: "admin/forms",
                         target: "__use_router__"
-                    },
-                    {
-                        title: _l("API keys"),
-                        url: "admin/api_keys",
-                        target: "__use_router__",
-                        id: "admin-link-api-keys"
                     }
                 ]
             },

--- a/test/galaxy_selenium/navigation.yml
+++ b/test/galaxy_selenium/navigation.yml
@@ -293,7 +293,6 @@ admin:
       quotas: '#admin-link-quotas'
       groups: '#admin-link-groups'
       roles: '#admin-link-roles'
-      api_keys: '#admin-link-api-keys'
       impersonate: '#admin-link-impersonate'
 
   selectors:


### PR DESCRIPTION
 This is all in the user management grid now.  I don't know if this got added back in a bad merge or if it was erroneously left in, but this fixes #6625 