### PR TITLE
Added support for setting snpeff_version of a snpeffdb manually uploaded to a user's history.

### DIFF
--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -415,7 +415,16 @@ class SnpEffDb( Text ):
                 snpeff_version = m.groups()[0] + m.groups()[1]
             fh.close()
         except:
-            pass
+            try:
+                # In case this was a decompressed file manually uploaded to a user's history
+                with open(path, 'r') as fh:
+                    buf = fh.read(100)
+                    lines = buf.splitlines()
+                    m = re.match('^(SnpEff)\s+(\d+\.\d+).*$', lines[0].strip())
+                    if m:
+                        snpeff_version = m.groups()[0] + m.groups()[1]
+            except Exception:
+                pass
         return snpeff_version
 
     def set_meta( self, dataset, **kwd ):
@@ -461,6 +470,11 @@ class SnpEffDb( Text ):
                         fh.write("regulations: %s\n" % ','.join(regulations))
             except:
                 pass
+        # If this was a file uploaded manually by the user, get the snpeff version from it instead
+        if os.path.isfile(dataset.file_name):
+            snpeff_version = self.getSnpeffVersionFromFile(dataset.file_name)
+            if snpeff_version:
+                dataset.metadata.snpeff_version = snpeff_version
 
 
 class SnpSiftDbNSFP( Text ):


### PR DESCRIPTION
Prior to this change, the snpeff_version was always set to SnpEff4.0 because the only files the version check was made on were those in the data_dir that houses galaxy's snpeff databases. Thus, if a user uploaded a 4.3 .bin file, the version would be defaulted to 4.0 and not show up in the history dropdown of the snpeff eff tool.

Files affected: lib/galaxy/datatypes/text.py