### PR TITLE
Support for manual snpeffdb history uploads

### DIFF
--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -415,7 +415,16 @@ class SnpEffDb( Text ):
                 snpeff_version = m.groups()[0] + m.groups()[1]
             fh.close()
         except:
-            pass
+            try:
+                # In case this was a decompressed file manually uploaded to a user's history
+                with open(path, 'r') as fh:
+                    buf = fh.read(100)
+                    lines = buf.splitlines()
+                    m = re.match('^(SnpEff)\s+(\d+\.\d+).*$', lines[0].strip())
+                    if m:
+                        snpeff_version = m.groups()[0] + m.groups()[1]
+            except Exception:
+                pass
         return snpeff_version
 
     def set_meta( self, dataset, **kwd ):
@@ -461,6 +470,11 @@ class SnpEffDb( Text ):
                         fh.write("regulations: %s\n" % ','.join(regulations))
             except:
                 pass
+        # If this was a file uploaded manually by the user, get the snpeff version from it instead
+        if os.path.isfile(dataset.file_name):
+            snpeff_version = self.getSnpeffVersionFromFile(dataset.file_name)
+            if snpeff_version:
+                dataset.metadata.snpeff_version = snpeff_version
 
 
 class SnpSiftDbNSFP( Text ):

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -413,7 +413,6 @@ class SnpEffDb(Text):
     def getSnpeffVersionFromFile(self, path):
         snpeff_version = None
         try:
-<<<<<<< HEAD
             with gzip.open(path, 'rb') as fh:
                 buf = fh.read(100)
                 lines = buf.splitlines()
@@ -421,16 +420,6 @@ class SnpEffDb(Text):
                 if m:
                     snpeff_version = m.groups()[0] + m.groups()[1]
         except Exception:
-            pass
-=======
-            fh = gzip.open(path, 'rb')
-            buf = fh.read(100)
-            lines = buf.splitlines()
-            m = re.match('^(SnpEff)\s+(\d+\.\d+).*$', lines[0].strip())
-            if m:
-                snpeff_version = m.groups()[0] + m.groups()[1]
-            fh.close()
-        except:
             try:
                 # In case this was a decompressed file manually uploaded to a user's history
                 with open(path, 'r') as fh:
@@ -441,7 +430,6 @@ class SnpEffDb(Text):
                         snpeff_version = m.groups()[0] + m.groups()[1]
             except Exception:
                 pass
->>>>>>> 2b46df9058a02c9ad9c9a7da76558d7691f3e1d8
         return snpeff_version
 
     def set_meta(self, dataset, **kwd):


### PR DESCRIPTION
The snpeffdb snpeff_version was being set to SnpEff4.0 regardless of the version in the file.  The code assumed that the file was in the galaxy maintained data_dir location and not in the user's history.  Also had to add processing of the text file because it gets decompressed in the user's history.

Now, if a user uploads a snpEffectPredictor.bin file, it gets a snpeff version that was parsed from the file.