### PR TITLE
Implement runtime parameters for subworkflows.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4183,7 +4183,8 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable):
     def create_subworkflow_invocation_for_step(self, step):
         assert step.type == "subworkflow"
         subworkflow_invocation = WorkflowInvocation()
-        return self.attach_subworkflow_invocation_for_step(step, subworkflow_invocation)
+        self.attach_subworkflow_invocation_for_step(step, subworkflow_invocation)
+        return subworkflow_invocation
 
     def attach_subworkflow_invocation_for_step(self, step, subworkflow_invocation):
         assert step.type == "subworkflow"
@@ -4502,6 +4503,7 @@ class WorkflowRequestInputParameter(Dictifiable):
     dict_collection_visible_keys = ['id', 'name', 'value', 'type']
     types = Bunch(
         REPLACEMENT_PARAMETERS='replacements',
+        STEP_PARAMETERS='step',
         META_PARAMETERS='meta',
         RESOURCE_PARAMETERS='resource',
     )

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -297,3 +297,25 @@ steps:
         seed_source_selector: set_seed
         seed: asdf
 """
+
+
+WORKFLOW_RUNTIME_PARAMETER_AFTER_PAUSE = """
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+steps:
+  - label: the_pause
+    type: pause
+    connect:
+      input:
+      - input1
+  - tool_id: random_lines1
+    runtime_inputs:
+      - num_lines
+    state:
+      input:
+        $link: the_pause
+      seed_source:
+        seed_source_selector: set_seed
+        seed: asdf
+"""

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -250,6 +250,38 @@ steps:
 """
 
 
+WORKFLOW_NESTED_RUNTIME_PARAMETER = """
+class: GalaxyWorkflow
+inputs:
+  - id: outer_input
+outputs:
+  - id: outer_output
+    source: nested_workflow#workflow_output
+steps:
+  - run:
+      class: GalaxyWorkflow
+      inputs:
+        - id: inner_input
+      outputs:
+        - id: workflow_output
+          source: random_lines#out_file1
+      steps:
+        - tool_id: random_lines1
+          label: random_lines
+          runtime_inputs:
+            - num_lines
+          state:
+            input:
+              $link: inner_input
+            seed_source:
+              seed_source_selector: set_seed
+              seed: asdf
+    label: nested_workflow
+    connect:
+      inner_input: outer_input
+"""
+
+
 WORKFLOW_RUNTIME_PARAMETER_SIMPLE = """
 class: GalaxyWorkflow
 inputs:

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -248,3 +248,20 @@ steps:
         - input2:
             $link: nested_workflow#workflow_output
 """
+
+
+WORKFLOW_RUNTIME_PARAMETER_SIMPLE = """
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+steps:
+  - tool_id: random_lines1
+    runtime_inputs:
+      - num_lines
+    state:
+      input:
+        $link: input1
+      seed_source:
+        seed_source_selector: set_seed
+        seed: asdf
+"""

--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -1028,7 +1028,7 @@ class NavigatesGalaxy(HasDriver):
         tool_link.wait_for_and_click()
 
     def tool_parameter_div(self, expanded_parameter_id):
-        return self.components.tool_form.parameter_div(parameter=expanded_parameter_id).wait_for_visible()
+        return self.components.tool_form.parameter_div(parameter=expanded_parameter_id).wait_for_clickable()
 
     def tool_parameter_edit_rules(self, expanded_parameter_id="rules"):
         rules_div_element = self.tool_parameter_div("rules")

--- a/test/galaxy_selenium/navigation.yml
+++ b/test/galaxy_selenium/navigation.yml
@@ -237,6 +237,8 @@ workflow_run:
 
   selectors: 
     input_div: "[step-label='${label}'] .select2-container"
+    # TODO: put step labels in the DOM ideally
+    subworkflow_step_icon: ".portlet-title-icon.fa-sitemap + span"
 
 workflow_editor:
 

--- a/test/galaxy_selenium/smart_components.py
+++ b/test/galaxy_selenium/smart_components.py
@@ -62,6 +62,9 @@ class SmartTarget(object):
     def wait_for_visible(self, **kwds):
         return self._has_driver.wait_for_visible(self._target, **kwds)
 
+    def wait_for_clickable(self, **kwds):
+        return self._has_driver.wait_for_clickable(self._target, **kwds)
+
     def wait_for_text(self, **kwds):
         return self._has_driver.wait_for_visible(self._target, **kwds).text
 

--- a/test/selenium_tests/test_workflow_run.py
+++ b/test/selenium_tests/test_workflow_run.py
@@ -2,6 +2,7 @@ import yaml
 from base import rules_test_data
 from base.populators import load_data_dict
 from base.workflow_fixtures import (
+    WORKFLOW_NESTED_RUNTIME_PARAMETER,
     WORKFLOW_NESTED_SIMPLE,
     WORKFLOW_RUNTIME_PARAMETER_SIMPLE,
     WORKFLOW_SIMPLE_CAT_TWICE,
@@ -43,20 +44,13 @@ class WorkflowRunTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.perform_upload(self.get_filename("1.txt"))
         self.wait_for_history()
         self.open_in_workflow_run(WORKFLOW_RUNTIME_PARAMETER_SIMPLE)
-        div = self.tool_parameter_div("num_lines")
+        self.tool_parameter_div("num_lines")
         self.screenshot("workflow_run_runtime_parameters_initial")
-        input_element = div.find_element_by_css_selector("input")
-        initial_value = input_element.get_attribute("value")
-        assert initial_value == "1", initial_value
-        input_element.clear()
-        input_element.send_keys("3")
+        self._set_num_lines_to_3("num_lines")
         self.screenshot("workflow_run_runtime_parameters_modified")
         self.workflow_run_submit()
 
-        self.history_panel_wait_for_hid_ok(2, allowed_force_refreshes=1)
-        history_id = self.current_history_id()
-        content = self.dataset_populator.get_history_dataset_content(history_id, hid=2)
-        assert len(content.split("\n")) == 3, content
+        self._assert_has_3_lines_after_run(hid=2)
 
     @selenium_test
     @managed_history
@@ -68,6 +62,21 @@ class WorkflowRunTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.screenshot("workflow_run_nested_collapsed")
         self.components.workflow_run.subworkflow_step_icon.wait_for_and_click()
         self.screenshot("workflow_run_nested_open")
+
+    @selenium_test
+    @managed_history
+    def test_subworkflow_runtime_parameters(self):
+        self.perform_upload(self.get_filename("1.txt"))
+        self.wait_for_history()
+        self.open_in_workflow_run(WORKFLOW_NESTED_RUNTIME_PARAMETER)
+        self.components.workflow_run.subworkflow_step_icon.wait_for_visible()
+        self.screenshot("workflow_run_nested_parameters_collapsed")
+        self.components.workflow_run.subworkflow_step_icon.wait_for_and_click()
+        self.screenshot("workflow_run_nested_parameters_open")
+        self._set_num_lines_to_3("1|num_lines")
+        self.workflow_run_submit()
+
+        self._assert_has_3_lines_after_run(hid=2)
 
     @selenium_test
     def test_execution_with_tool_upgrade(self):
@@ -124,3 +133,18 @@ class WorkflowRunTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.workflow_index_open()
         self.workflow_index_search_for(name)
         self.workflow_index_click_option("Run")
+
+    def _assert_has_3_lines_after_run(self, hid):
+        self.history_panel_wait_for_hid_ok(hid, allowed_force_refreshes=1)
+        history_id = self.current_history_id()
+        content = self.dataset_populator.get_history_dataset_content(history_id, hid=hid)
+        assert len([x for x in content.split("\n") if x]) == 3, content
+
+    def _set_num_lines_to_3(self, tour_id):
+        # for random_lines num_lines parameter as runtime parameter in workflow form.
+        div = self.tool_parameter_div(tour_id)
+        input_element = div.find_element_by_css_selector("input")
+        initial_value = input_element.get_attribute("value")
+        assert initial_value == "1", initial_value
+        input_element.clear()
+        input_element.send_keys("3")

--- a/test/unit/workflows/test_workflow_progress.py
+++ b/test/unit/workflows/test_workflow_progress.py
@@ -69,7 +69,7 @@ class WorkflowProgressTestCase(unittest.TestCase):
 
     def _new_workflow_progress(self):
         return WorkflowProgress(
-            self.invocation, self.inputs_by_step_id, MockModuleInjector(self.progress)
+            self.invocation, self.inputs_by_step_id, MockModuleInjector(self.progress), {}
         )
 
     def _set_previous_progress(self, outputs):
@@ -168,14 +168,15 @@ class WorkflowProgressTestCase(unittest.TestCase):
             (100, {"output": hda}),
             (101, UNSCHEDULED_STEP),
         ])
-        self.invocation.create_subworkflow_invocation_for_step(
+        subworkflow_invocation = self.invocation.create_subworkflow_invocation_for_step(
             self.invocation.workflow.step_by_index(1)
         )
         progress = self._new_workflow_progress()
         remaining_steps = progress.remaining_steps()
         (subworkflow_step, subworkflow_invocation_step) = remaining_steps[0]
-        subworkflow_progress = progress.subworkflow_progress(subworkflow_step)
+        subworkflow_progress = progress.subworkflow_progress(subworkflow_invocation, subworkflow_step, {})
         subworkflow = subworkflow_step.subworkflow
+        assert subworkflow_progress.workflow_invocation == subworkflow_invocation
         assert subworkflow_progress.workflow_invocation.workflow == subworkflow
 
         subworkflow_input_step = subworkflow.step_by_index(0)
@@ -207,7 +208,7 @@ class MockModuleInjector(object):
     def __init__(self, progress):
         self.progress = progress
 
-    def inject(self, step):
+    def inject(self, step, step_args={}):
         step.module = MockModule(self.progress)
 
 


### PR DESCRIPTION
Includes tests for singly nested workflows and parameters outside of conditionals. I think parameters in conditionals would work also, probably not doubly nested workflows - but we don't have any tests for those at this time at any level I don't think?

Implementation: When generating the form for subworkflow steps - the whole workflow is walked and checked for non-data runtime parameters. The resulting parameter inputs are wrapped using a proxy that modifies their to_dict to provide the workflow context. The API has been modified so that runtime parameters passed to subworkflow steps have their outer order_index chopped off and their inner index then remapped against the nested workflow. This also requires tracking more workflow inputs in the database - this a good thing for reproducibility and we were loosing some of this before.