### PR TITLE
Workflow replacement parameters polish.

### DIFF
--- a/client/galaxy/scripts/mvc/tool/tool-form-composite.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-composite.js
@@ -127,21 +127,24 @@ var View = Backbone.View.extend({
         // identify and configure workflow parameters
         var wp_count = 0;
         this.wp_inputs = {};
+
+        function _ensureWorkflowParameter(wp_name) {
+            return self.wp_inputs[wp_name] = self.wp_inputs[wp_name] || {
+                label: wp_name,
+                name: wp_name,
+                type: "text",
+                color: `hsl( ${++wp_count * 100}, 70%, 30% )`,
+                style: "ui-form-wp-source",
+                links: []
+            };
+        }
+
         function _handleWorkflowParameter(value, callback) {
             var re = /\$\{(.+?)\}/g;
             var match;
             while ((match = re.exec(String(value)))) {
                 var wp_name = match[1];
-                callback(
-                    (self.wp_inputs[wp_name] = self.wp_inputs[wp_name] || {
-                        label: wp_name,
-                        name: wp_name,
-                        type: "text",
-                        color: `hsl( ${++wp_count * 100}, 70%, 30% )`,
-                        style: "ui-form-wp-source",
-                        links: []
-                    })
-                );
+                callback(_ensureWorkflowParameter(wp_name));
             }
         }
         _.each(this.steps, (step, i) => {
@@ -154,10 +157,8 @@ var View = Backbone.View.extend({
                     input.style = "ui-form-wp-target";
                 });
             });
-            _.each(step.post_job_actions, pja => {
-                _.each(pja.action_arguments, arg => {
-                    _handleWorkflowParameter(arg, () => {});
-                });
+            _.each(step.replacement_parameters, wp_name => {
+                _ensureWorkflowParameter(wp_name);
             });
         });
 

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -444,6 +444,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 step_model = {
                     'inputs' : [input.to_dict(trans) for input in inputs.values()]
                 }
+            step_model['replacement_parameters'] = step.module.get_replacement_parameters(step)
             step_model['step_type'] = step.type
             step_model['step_label'] = step.label
             step_model['step_name'] = step.module.get_name()

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -319,3 +319,67 @@ steps:
         seed_source_selector: set_seed
         seed: asdf
 """
+
+WORKFLOW_RENAME_ON_INPUT = """
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+steps:
+  - tool_id: cat
+    label: first_cat
+    state:
+      input1:
+        $link: input1
+    outputs:
+      out_file1:
+        rename: "#{input1 | basename} suffix"
+test_data:
+  input1:
+    value: 1.fasta
+    type: File
+    name: fasta1
+"""
+
+WORKFLOW_RENAME_ON_REPLACEMENT_PARAM = """
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+steps:
+  - tool_id: cat
+    label: first_cat
+    state:
+      input1:
+        $link: input1
+    outputs:
+      out_file1:
+        rename: "${replaceme} suffix"
+"""
+
+WORKFLOW_NESTED_REPLACEMENT_PARAMETER = """
+class: GalaxyWorkflow
+inputs:
+  - id: outer_input
+outputs:
+  - id: outer_output
+    source: nested_workflow#workflow_output
+steps:
+  - run:
+      class: GalaxyWorkflow
+      inputs:
+        - id: inner_input
+      outputs:
+        - id: workflow_output
+          source: first_cat#out_file1
+      steps:
+        - tool_id: cat
+          label: first_cat
+          state:
+            input1:
+              $link: inner_input
+          outputs:
+            out_file1:
+              rename: "${replaceme} suffix"
+    label: nested_workflow
+    connect:
+      inner_input: outer_input
+"""


### PR DESCRIPTION
- Selenium test case demonstrating their use in simple workflows.
- API test demonstrating they work with nested workflows from the run perspective.
- Update run variant of workflow ``to_dict`` to parse out replacement parameters to display on the backend and tweak the client to just accept these.
- Parse out replacement parameters for subworkflows recursively, include in new run output attribute.
- Selenium test case demonstrating subworkflow replacement parameters are now both rendered and used properly when submitted.
