### PR TITLE
Keep newly broken tool in toolbox

### DIFF
--- a/client/galaxy/scripts/mvc/tool/tool-form-base.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-base.js
@@ -86,6 +86,12 @@ export default FormBase.extend({
                     .append(this._footer())
             );
         }
+        options.tool_errors &&
+            this.message.update({
+                status: 'danger',
+                message: options.tool_errors,
+                persistent: true
+            });
         this.show_message &&
             this.message.update({
                 status: "success",

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -437,6 +437,7 @@ class Tool(Dictifiable):
         self.populate_tool_shed_info()
         # add tool resource parameters
         self.populate_resource_parameters(tool_source)
+        self.tool_errors = None
         # Parse XML element containing configuration
         try:
             self.parse(tool_source, guid=guid)
@@ -1920,6 +1921,7 @@ class Tool(Dictifiable):
             'versions'      : self.tool_versions,
             'requirements'  : [{'name' : r.name, 'version' : r.version} for r in self.requirements],
             'errors'        : state_errors,
+            'tool_errors'   : self.tool_errors,
             'state_inputs'  : params_to_strings(self.inputs, state_inputs, self.app),
             'job_id'        : trans.security.encode_id(job.id) if job else None,
             'job_remap'     : self._get_job_remap(job),

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -753,7 +753,10 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             except Exception:
                 # If the tool is broken but still exists we can load it from the cache
                 tool = self.load_tool_from_cache(config_file, recover_tool=True)
-                if not tool:
+                if tool:
+                    log.exception("Tool '%s' is not valid:" % config_file)
+                    tool.tool_errors = 'Current on-disk tool is not valid'
+                else:
                     raise
             if tool.tool_shed_repository or not guid:
                 self.add_tool_to_cache(tool, config_file)

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -748,26 +748,40 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         if use_cached:
             tool = self.load_tool_from_cache(config_file)
         if not tool or guid and guid != tool.guid:
-            tool = self.create_tool(config_file=config_file, repository_id=repository_id, guid=guid, **kwds)
+            try:
+                tool = self.create_tool(config_file=config_file, repository_id=repository_id, guid=guid, **kwds)
+            except Exception:
+                # If the tool is broken but still exists we can load it from the cache
+                tool = self.load_tool_from_cache(config_file, recover_tool=True)
+                if not tool:
+                    raise
             if tool.tool_shed_repository or not guid:
                 self.add_tool_to_cache(tool, config_file)
+            self.watch_tool(tool)
+        return tool
+
+    def watch_tool(self, tool):
         if not tool.id.startswith("__"):
             # do not monitor special tools written to tmp directory - no reason
             # to monitor such a large directory.
             if self._tool_watcher:
-                self._tool_watcher.watch_file(config_file, tool.id)
+                self._tool_watcher.watch_file(tool.config_file, tool.id)
             if self._tool_config_watcher:
                 [self._tool_config_watcher.watch_file(macro_path) for macro_path in tool._macro_paths]
-        return tool
 
     def add_tool_to_cache(self, tool, config_file):
         tool_cache = getattr(self.app, 'tool_cache', None)
         if tool_cache:
             self.app.tool_cache.cache_tool(config_file, tool)
 
-    def load_tool_from_cache(self, config_file):
+    def load_tool_from_cache(self, config_file, recover_tool=False):
         tool_cache = getattr(self.app, 'tool_cache', None)
-        tool = tool_cache and tool_cache.get_tool(config_file)
+        tool = None
+        if tool_cache:
+            if recover_tool:
+                tool = tool_cache.get_removed_tool(config_file)
+            else:
+                tool = tool_cache.get_tool(config_file)
         return tool
 
     def load_hidden_lib_tool(self, path):

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -207,6 +207,7 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         tool = toolbox.get_tool('test_tool')
         assert tool is not None
         assert tool.version == "1.0"
+        assert tool.tool_errors is None
         # Tool is loaded, now let's break it
         tool_path = tool.config_file
         with open(tool.config_file, 'w') as out:
@@ -215,12 +216,14 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         tool = self.app.toolbox.get_tool("test_tool")
         assert tool is not None
         assert tool.version == "1.0"
+        assert tool.tool_errors == 'Current on-disk tool is not valid'
         # Tool is still loaded, lets restore it with a new version
         self._init_tool(filename="simple_tool.xml", version="2.0")
         time.sleep(1.5)
         tool = self.app.toolbox.get_tool("test_tool")
         assert tool is not None
         assert tool.version == "2.0"
+        assert tool.tool_errors is None
         assert tool_path == tool.config_file
 
     def test_enforce_tool_profile(self):

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -200,6 +200,29 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
 
         assert tool.version == "3.0"
 
+    def test_tool_reload_for_broken_tool(self):
+        self._init_tool(filename="simple_tool.xml", version="1.0")
+        self._add_config("""<toolbox><tool file="simple_tool.xml"/></toolbox>""")
+        toolbox = self.toolbox
+        tool = toolbox.get_tool('test_tool')
+        assert tool is not None
+        assert tool.version == "1.0"
+        # Tool is loaded, now let's break it
+        tool_path = tool.config_file
+        with open(tool.config_file, 'w') as out:
+            out.write('certainly not a valid tool')
+        time.sleep(1.5)
+        tool = self.app.toolbox.get_tool("test_tool")
+        assert tool is not None
+        assert tool.version == "1.0"
+        # Tool is still loaded, lets restore it with a new version
+        self._init_tool(filename="simple_tool.xml", version="2.0")
+        time.sleep(1.5)
+        tool = self.app.toolbox.get_tool("test_tool")
+        assert tool is not None
+        assert tool.version == "2.0"
+        assert tool_path == tool.config_file
+
     def test_enforce_tool_profile(self):
         self._init_tool(filename="old_tool.xml", version="1.0", profile="17.01", tool_id="test_old_tool_profile")
         self._init_tool(filename="new_tool.xml", version="2.0", profile="27.01", tool_id="test_new_tool_profile")


### PR DESCRIPTION
That's handy when developing tools and you messed up something so bad
the tool isn't valid anymore. We retrieve the non-broken previous
version from the tool cache.

Still needs some visual feedback in the tool form, so that you're not left wondering why nothing happens when you change the tool ...

Closes https://github.com/galaxyproject/galaxy/issues/6584