### PR TITLE
Add utility function to create history entries

### DIFF
--- a/client/galaxy/scripts/layout/data.js
+++ b/client/galaxy/scripts/layout/data.js
@@ -47,7 +47,7 @@ export default class Data {
                         "files_0|space_to_tab": options.space_to_tab ? "Yes" : null,
                         "files_0|to_posix_lines": options.to_posix_lines ? "Yes" : null,
                         "files_0|dbkey": options.genome || null,
-                        "files_0|file_type": options.extension || null,
+                        "files_0|file_type": options.extension || "auto",
                         "files_0|url_paste": options.url_paste
                     })
                 }

--- a/client/galaxy/scripts/layout/data.js
+++ b/client/galaxy/scripts/layout/data.js
@@ -46,7 +46,7 @@ export default class Data {
                         "files_0|NAME": options.file_name,
                         "files_0|space_to_tab": options.space_to_tab ? "Yes" : null,
                         "files_0|to_posix_lines": options.to_posix_lines ? "Yes" : null,
-                        "files_0|dbkey": options.genome || null,
+                        "files_0|dbkey": options.genome || "?",
                         "files_0|file_type": options.extension || "auto",
                         "files_0|url_paste": options.url_paste
                     })

--- a/client/galaxy/scripts/layout/data.js
+++ b/client/galaxy/scripts/layout/data.js
@@ -16,4 +16,42 @@ export default class Data {
             }
         }).$mount(vm);
     }
+
+    /**
+     * Creates a history dataset by submitting an upload request
+     */
+    create(options) {
+        let history_panel = Galaxy.currHistoryPanel;
+        let history_id = options.history_id;
+        if (!history_id && history_panel) {
+            history_id = history_panel.model.get("id");
+        }
+        $.uploadpost({
+            url: `${Galaxy.root}api/tools`,
+            success: (response) => {
+                if (history_panel) {
+                    history_panel.refreshContents();
+                }
+                if (options.success) {
+                    options.success(response);
+                }
+            },
+            error: options.error,
+            data: {
+                payload: {
+                    tool_id: "upload1",
+                    history_id: history_id,
+                    inputs: JSON.stringify({
+                        "files_0|type": "upload_dataset",
+                        "files_0|NAME": options.file_name,
+                        "files_0|space_to_tab": options.space_to_tab ? "Yes" : null,
+                        "files_0|to_posix_lines": options.to_posix_lines ? "Yes" : null,
+                        "files_0|dbkey": options.genome || null,
+                        "files_0|file_type": options.extension || null,
+                        "files_0|url_paste": options.url_paste
+                    })
+                }
+            }
+        });
+    }
 }


### PR DESCRIPTION
This PR provides a utility function enabling UI plugins to create history datasets.
```
Galaxy.data.create({
     url_paste: "Example Content",
     success: (response) => {window.console.log(response)}
});
```