### PR TITLE
[18.05] unquote the tool_version in the tools API

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -1,7 +1,7 @@
 import logging
 from json import dumps
 
-from six.moves.urllib.parse import unquote_plus
+from six.moves.urllib.parse import unquote
 
 import galaxy.queue_worker
 from galaxy import exceptions, managers, util, web
@@ -512,7 +512,9 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
     # -- Helper methods --
     #
     def _get_tool(self, id, tool_version=None, user=None):
-        id = unquote_plus(id)
+        id = unquote(id)
+        if tool_version:
+            tool_version = unquote(tool_version)
         tool = self.app.toolbox.get_tool(id, tool_version)
         if not tool:
             raise exceptions.ObjectNotFound("Could not find tool with id '%s'." % id)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -9,7 +9,7 @@ import os
 
 import requests
 from markupsafe import escape
-from six.moves.urllib.parse import unquote_plus
+from six.moves.urllib.parse import unquote
 from sqlalchemy import desc, false, or_, true
 from sqlalchemy.orm import joinedload
 
@@ -546,7 +546,9 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
     # -- Helper methods --
     #
     def _get_tool(self, id, tool_version=None, user=None):
-        id = unquote_plus(id)
+        id = unquote(id)
+        if tool_version:
+            tool_version = unquote(tool_version)
         tool = self.app.toolbox.get_tool(id, tool_version)
         if not tool or not tool.allow_user_access(user):
             raise exceptions.ObjectNotFound("Could not find tool with id '%s'" % id)


### PR DESCRIPTION
if the tool version includes '+', which is a recommended way
of versioning per https://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html#tool-versions
this would fail the comparison down the line in the toolbox.get_tool() method

this commit also downgrades the unquote_plus to unquote for tool_id
for similar reasons since it also contains the version

ping @mvdbeek 

fixes #6701 