### PR TITLE
Update to latest galaxy-lib.

### DIFF
--- a/lib/galaxy/tools/cwl/cwltool_deps.py
+++ b/lib/galaxy/tools/cwl/cwltool_deps.py
@@ -28,6 +28,11 @@ except (ImportError, SyntaxError):
     pathmapper = None
 
 try:
+    from cwltool.context import LoadingContext  # Introduced in cwltool 1.0.20180615183820
+except (ImportError, SyntaxError):
+    LoadingContext = None
+
+try:
     from cwltool import load_tool
 except (ImportError, SyntaxError):
     load_tool = None
@@ -76,6 +81,7 @@ __all__ = (
     'main',
     'ref_resolver',
     'load_tool',
+    'LoadingContext',
     'workflow',
     'process',
     'pathmapper',

--- a/lib/galaxy/tools/cwl/parser.py
+++ b/lib/galaxy/tools/cwl/parser.py
@@ -320,6 +320,21 @@ class CommandLineToolProxy(ToolProxy):
                     return hint["dockerPull"]
         return None
 
+    def software_requirements(self):
+        # Roughest imaginable pass at parsing requirements, really need to take in specs, handle
+        # multiple versions, etc...
+        tool = self._tool.tool
+        reqs_and_hints = tool.get("requirements", []) + tool.get("hints", [])
+        requirements = []
+        for hint in reqs_and_hints:
+            if hint["class"] == "SoftwareRequirement":
+                packages = hint.get("packages", [])
+                for package in packages:
+                    versions = package.get("version", [])
+                    first_version = None if not versions else versions[0]
+                    requirements.append((package["package"], first_version))
+        return requirements
+
     @property
     def requirements(self):
         return getattr(self._tool, "requirements", [])

--- a/lib/galaxy/tools/cwl/schema.py
+++ b/lib/galaxy/tools/cwl/schema.py
@@ -7,6 +7,7 @@ from six.moves.urllib.parse import urldefrag
 from .cwltool_deps import (
     ensure_cwltool_available,
     load_tool,
+    LoadingContext,
     schema_salad,
     workflow,
 )
@@ -53,6 +54,12 @@ class SchemaLoader(object):
         return process_def
 
     def tool(self, **kwds):
+        # cwl.workflow.defaultMakeTool() method was renamed to default_make_tool() in
+        # https://github.com/common-workflow-language/cwltool/commit/886a6ac41c685f20d39e352f9c657e59f3312265
+        try:
+            default_make_tool = workflow.default_make_tool
+        except AttributeError:
+            default_make_tool = workflow.defaultMakeTool
         process_definition = kwds.get("process_definition", None)
         if process_definition is None:
             raw_process_reference = kwds.get("raw_process_reference", None)
@@ -60,15 +67,27 @@ class SchemaLoader(object):
                 raw_process_reference = self.raw_process_reference(kwds["path"])
             process_definition = self.process_definition(raw_process_reference)
 
-        make_tool = kwds.get("make_tool", workflow.defaultMakeTool)
-        tool = load_tool.make_tool(
-            process_definition.document_loader,
-            process_definition.avsc_names,
-            process_definition.metadata,
-            process_definition.raw_process_reference.uri,
-            make_tool,
-            {"strict": self._strict},
-        )
+        args = {"strict": self._strict}
+        make_tool = kwds.get("make_tool", default_make_tool)
+        if LoadingContext is not None:
+            args["construct_tool_object"] = make_tool
+            loading_context = LoadingContext(args)
+            tool = load_tool.make_tool(
+                process_definition.document_loader,
+                process_definition.avsc_names,
+                process_definition.metadata,
+                process_definition.raw_process_reference.uri,
+                loading_context,
+            )
+        else:
+            tool = load_tool.make_tool(
+                process_definition.document_loader,
+                process_definition.avsc_names,
+                process_definition.metadata,
+                process_definition.raw_process_reference.uri,
+                make_tool,
+                args
+            )
         return tool
 
 

--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -12,6 +12,7 @@ import packaging.version
 import six
 from six.moves import shlex_quote
 
+from galaxy.tools.deps.commands import CommandLineException
 from galaxy.util import (
     smart_str,
     unicodify
@@ -246,7 +247,8 @@ class CondaContext(installable.InstallableContext):
         Return the process exit code (i.e. 0 in case of success).
         """
         create_base_args = [
-            "-y"
+            "-y",
+            "--quiet"
         ]
         if allow_local and self.use_local:
             create_base_args.extend(["--use-local"])
@@ -506,10 +508,14 @@ def best_search_result(conda_target, conda_context, channels_override=None, offl
     else:
         search_cmd.extend(conda_context._override_channels_args)
     search_cmd.append(conda_target.package)
-    res = commands.execute(search_cmd)
-    res = unicodify(res)
-    hits = json.loads(res).get(conda_target.package, [])
-    hits = sorted(hits, key=lambda hit: packaging.version.parse(hit['version']), reverse=True)
+    try:
+        res = commands.execute(search_cmd)
+        res = unicodify(res)
+        hits = json.loads(res).get(conda_target.package, [])
+        hits = sorted(hits, key=lambda hit: packaging.version.parse(hit['version']), reverse=True)
+    except CommandLineException:
+        log.error("Could not execute: '%s'", search_cmd)
+        hits = []
 
     if len(hits) == 0:
         return (None, None)

--- a/lib/galaxy/tools/deps/docker_util.py
+++ b/lib/galaxy/tools/deps/docker_util.py
@@ -35,7 +35,7 @@ def logs_command(
     container,
     **kwds
 ):
-    return command_list("logs", **kwds)
+    return command_list("logs", [container], **kwds)
 
 
 def build_command(

--- a/lib/galaxy/tools/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tools/deps/mulled/mulled_build.py
@@ -197,7 +197,6 @@ def mull_targets(
     involucro_args = [
         '-f', '%s/invfile.lua' % DIRNAME,
         '-set', "CHANNELS='%s'" % channels,
-        '-set', "TEST=%s" % shlex_quote(test),
         '-set', "TARGETS='%s'" % target_str,
         '-set', "REPO='%s'" % repo,
         '-set', "BINDS='%s'" % bind_str,
@@ -215,6 +214,8 @@ def mull_targets(
         involucro_args.extend(["-set", "SINGULARITY_IMAGE_NAME='%s'" % singularity_image_name])
         involucro_args.extend(["-set", "SINGULARITY_IMAGE_DIR='%s'" % singularity_image_dir])
         involucro_args.extend(["-set", "USER_ID='%s:%s'" % (os.getuid(), os.getgid())])
+    if test:
+        involucro_args.extend(["-set", "TEST=%s" % shlex_quote(test)])
     if conda_version is not None:
         verbose = "--verbose" if verbose else "--quiet"
         involucro_args.extend(["-set", "PREINSTALL='conda install %s --yes conda=%s'" % (verbose, conda_version)])

--- a/lib/galaxy/tools/lint.py
+++ b/lib/galaxy/tools/lint.py
@@ -12,15 +12,15 @@ LEVEL_WARN = "warn"
 LEVEL_ERROR = "error"
 
 
-def lint_tool_source(tool_source, level=LEVEL_ALL, fail_level=LEVEL_WARN, extra_modules=[], skip_types=[]):
-    lint_context = LintContext(level=level, skip_types=skip_types)
+def lint_tool_source(tool_source, level=LEVEL_ALL, fail_level=LEVEL_WARN, extra_modules=[], skip_types=[], name=None):
+    lint_context = LintContext(level=level, skip_types=skip_types, object_name=name)
     lint_tool_source_with(lint_context, tool_source, extra_modules)
 
     return not lint_context.failed(fail_level)
 
 
-def lint_xml(tool_xml, level=LEVEL_ALL, fail_level=LEVEL_WARN, extra_modules=[], skip_types=[]):
-    lint_context = LintContext(level=level, skip_types=skip_types)
+def lint_xml(tool_xml, level=LEVEL_ALL, fail_level=LEVEL_WARN, extra_modules=[], skip_types=[], name=None):
+    lint_context = LintContext(level=level, skip_types=skip_types, object_name=name)
     lint_xml_with(lint_context, tool_xml, extra_modules)
 
     return not lint_context.failed(fail_level)
@@ -63,9 +63,10 @@ def lint_xml_with(lint_context, tool_xml, extra_modules=[]):
 # be moved to galaxy.util.lint.
 class LintContext(object):
 
-    def __init__(self, level, skip_types=[]):
+    def __init__(self, level, skip_types=[], object_name=None):
         self.skip_types = skip_types
         self.level = level
+        self.object_name = object_name
         self.found_errors = False
         self.found_warns = False
 

--- a/lib/galaxy/tools/linters/stdio.py
+++ b/lib/galaxy/tools/linters/stdio.py
@@ -32,34 +32,12 @@ def lint_stdio(tool_source, lint_ctx):
 
 
 def _lint_exit_code(child, lint_ctx):
-    for key, value in child.attrib.items():
-        if key == "range":
-            # TODO: validate
-            pass
-        elif key == "level":
-            _lint_level(value, lint_ctx)
-        elif key == "description":
-            pass
-        else:
+    for key in child.attrib.keys():
+        if key not in ["description", "level", "range"]:
             lint_ctx.warn("Unknown attribute [%s] encountered on exit_code tag." % key)
 
 
 def _lint_regex(child, lint_ctx):
-    for key, value in child.attrib.items():
-        if key == "source":
-            if value not in ["stderr", "stdout", "both"]:
-                lint_ctx.error("Unknown error code level encountered [%s]" % value)
-        elif key == "level":
-            _lint_level(value, lint_ctx)
-        elif key == "match":
-            # TODO: validate
-            pass
-        elif key == "description":
-            pass
-        else:
+    for key in child.attrib.keys():
+        if key not in ["description", "level", "match", "source"]:
             lint_ctx.warn("Unknown attribute [%s] encountered on regex tag." % key)
-
-
-def _lint_level(level_value, lint_ctx):
-    if level_value not in ["warning", "fatal", "log"]:
-        lint_ctx.error("Unknown error code level encountered [%s]" % level_value)

--- a/lib/galaxy/tools/linters/tests.py
+++ b/lib/galaxy/tools/linters/tests.py
@@ -33,7 +33,7 @@ def lint_tsts(tool_xml, lint_ctx):
                 lint_ctx.warn("Found output tag without a name defined.")
             else:
                 if name not in output_data_names:
-                    lint_ctx.warn("Found output tag with unknown name [%s], valid names [%s]" % (name, output_data_names))
+                    lint_ctx.error("Found output tag with unknown name [%s], valid names [%s]" % (name, output_data_names))
 
         for output_collection in test.findall("output_collection"):
             found_output_test = True

--- a/lib/galaxy/tools/parser/cwl.py
+++ b/lib/galaxy/tools/parser/cwl.py
@@ -140,8 +140,10 @@ class CwlToolSource(ToolSource):
         if docker_identifier:
             containers.append({"type": "docker",
                                "identifier": docker_identifier})
+
+        software_requirements = self.tool_proxy.software_requirements()
         return requirements.parse_requirements_from_dict(dict(
-            requirements=[],  # TODO: enable via extensions
+            requirements=list(map(lambda r: {"name": r[0], "version": r[1], "type": "package"}, software_requirements)),
             containers=containers,
         ))
 


### PR DESCRIPTION
Includes:

- Updates to target newer cwltool (https://github.com/galaxyproject/galaxy-lib/pull/129 / https://github.com/galaxyproject/galaxy-lib/pull/134 / https://github.com/galaxyproject/galaxy-lib/commit/c68f729f55ac810a5507f38a59995af9a9247ba6). 
- Galaxy collection syntax for workflow testing code (https://github.com/galaxyproject/galaxy-lib/pull/120).
- Support for filetype testing in workflow testing code (https://github.com/galaxyproject/galaxy-lib/pull/119).
- Support for using URIs when testing workflows (https://github.com/galaxyproject/galaxy-lib/pull/118).
- Mulled update to make make ``--test`` optional for involucro (https://github.com/galaxyproject/galaxy-lib/pull/130).
- Report a lint error if test output name does not match tool outputs  (https://github.com/galaxyproject/galaxy-lib/pull/128).
- Support passing a name through to the lint context so that error messages can be more useful  (https://github.com/galaxyproject/galaxy-lib/pull/121).
- Library support for parsing CWL SoftwareRequirements as Galaxy requirements (https://github.com/galaxyproject/galaxy-lib/pull/115).
- Fix for docker logs command generation (https://github.com/galaxyproject/galaxy-lib/pull/113).
