### PR TITLE
Use tool_version instead of version parameter

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -94,12 +94,12 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
 
                 io_details   - if true, parameters and inputs are returned
                 link_details - if true, hyperlink to the tool is returned
-                version      - if provided return this tool version
+                tool_version - if provided return this tool version
         """
         io_details = util.string_as_bool(kwd.get('io_details', False))
         link_details = util.string_as_bool(kwd.get('link_details', False))
-        version = kwd.get('version')
-        tool = self._get_tool(id, user=trans.user, tool_version=version)
+        tool_version = kwd.get('tool_version')
+        tool = self._get_tool(id, user=trans.user, tool_version=tool_version)
         return tool.to_dict(trans, io_details=io_details, link_details=link_details)
 
     @expose_api_anonymous

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -142,10 +142,10 @@ class ToolsTestCase(api.ApiTestCase):
             assert output_details["state"] == "error", output_details
             assert "has not sent back a URL parameter" in output_details["misc_info"], output_details
 
-    def _show_valid_tool(self, tool_id, version=None):
+    def _show_valid_tool(self, tool_id, tool_version=None):
         data = dict(io_details=True)
-        if version:
-            data['version'] = version
+        if tool_version:
+            data['tool_version'] = tool_version
         tool_show_response = self._get("tools/%s" % tool_id, data=data)
         self._assert_status_code_is(tool_show_response, 200)
         tool_info = tool_show_response.json()
@@ -522,7 +522,7 @@ class ToolsTestCase(api.ApiTestCase):
     @skip_without_tool("multiple_versions")
     @uses_test_history(require_new=False)
     def test_show_with_wrong_tool_version_in_tool_id(self, history_id):
-        tool_info = self._show_valid_tool("multiple_versions", version="0.01")
+        tool_info = self._show_valid_tool("multiple_versions", tool_version="0.01")
         # Return last version
         assert tool_info['version'] == "0.2"
 


### PR DESCRIPTION
To be consistent with other routes that accept this parameter.

Followup to https://github.com/galaxyproject/galaxy/pull/6702