### PR TITLE
Look up collection_type if collection_type_source is set

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-connector.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-connector.js
@@ -1,3 +1,5 @@
+import * as Toastr from "libs/toastr";
+
 function Connector(handle1, handle2) {
     this.canvas = null;
     this.dragging = false;
@@ -30,8 +32,11 @@ $.extend(Connector.prototype, {
         }
         $(this.canvas).remove();
     },
-    destroyIfInvalid: function() {
+    destroyIfInvalid: function(warn) {
         if (this.handle1 && this.handle2 && !this.handle2.attachable(this.handle1)) {
+            if (warn) {
+                Toastr.warning("Destroying a connection because collection type has changed.");
+            }
             this.destroy();
         }
     },

--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -131,6 +131,7 @@ var Terminal = Backbone.Model.extend({
         if (this.node) {
             this.node.markChanged();
             this.resetMappingIfNeeded();
+            this.resetCollectionTypeSource();
         }
     },
     redraw: function() {
@@ -174,6 +175,18 @@ var Terminal = Backbone.Model.extend({
     },
     resetMapping: function() {
         this.terminalMapping.disableMapOver();
+    },
+
+    resetCollectionTypeSource: function() {
+        let node = this.node;
+        _.each(node.output_terminals, function(output_terminal) {
+            let type_source = output_terminal.attributes.collection_type_source;
+            if (type_source) {
+                output_terminal.attributes.collection_type = null;
+                output_terminal.collectionType = ANY_COLLECTION_TYPE_DESCRIPTION;
+                output_terminal.update(output_terminal.attributes);
+            }
+        });
     },
 
     resetMappingIfNeeded: function() {} // Subclasses should override this...

--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -438,6 +438,14 @@ var InputCollectionTerminal = BaseInputTerminal.extend({
         var other = connector.handle1;
         if (!other) {
             return;
+        } else {
+            let node = this.node;
+            _.each(node.output_terminals, function(output_terminal) {
+                if (output_terminal.attributes.collection_type_source) {
+                    output_terminal.attributes.collection_type = other.attributes.collection_type;
+                    output_terminal.update(output_terminal.attributes);
+                    }
+            })
         }
 
         var effectiveMapOver = this._effectiveMapOver(other);

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -215,6 +215,8 @@ def test_subworkflow_new_outputs():
 
 def __new_subworkflow_module():
     trans = MockTrans()
+    mock_tool = __mock_tool(id="cat1", version="1.0")
+    trans.app.toolbox.tools["cat1"] = mock_tool
     workflow = yaml_to_model(TEST_WORKFLOW_YAML)
     stored_workflow = trans.save_workflow(workflow)
     workflow_id = trans.app.security.encode_id(stored_workflow.id)
@@ -273,8 +275,19 @@ def __mock_tool(
     tool = bunch.Bunch(
         id=id,
         version=version,
+        name=id,
         inputs={},
+        outputs={'out_file1': bunch.Bunch(collection=None,
+                                          format='input',
+                                          format_source=None,
+                                          change_format=[])},
         params_from_strings=mock.Mock(),
         check_and_update_param_values=mock.Mock(),
+        to_json=_to_json
     )
+
     return tool
+
+
+def _to_json(*args, **kwargs):
+    return "{}"


### PR DESCRIPTION
We do this in the wf-editor and in the backend, so this works for
subworkflows. This should make quite some tools more usable in a
workflow scenario and fixes the noodle being of the wrong type 
when connecting subworkflow outputs. Should fix
- https://github.com/galaxyproject/galaxy/issues/6514
- https://github.com/galaxyproject/galaxy/issues/6012
- https://github.com/galaxyproject/galaxy/issues/6569
- https://github.com/galaxyproject/galaxy/issues/1889

and perhaps more issues related to this.