### PR TITLE
[18.05] Backport tool version select fixes

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -446,6 +446,9 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 for tool in self._tools_by_id.values():
                     if tool.old_id == tool_id:
                         rval.append(tool)
+                # if we don't have a lineage_map for this tool we need to sort by version,
+                # so that the last tool in rval is the newest tool.
+                rval.sort(key=lambda t: t.version)
             if rval:
                 if get_all_versions:
                     return rval

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -455,8 +455,8 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                         for tool in rval:
                             if tool.version == tool_version:
                                 return tool
-                    # No tool matches by version, simply return the first available tool found
-                    return rval[0]
+                    # No tool matches by version, simply return the newest matching tool
+                    return rval[-1]
             # We now likely have a Toolshed guid passed in, but no supporting database entries
             # If the tool exists by exact id and is loaded then provide exact match within a list
             if tool_id in self._tools_by_id:

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -94,10 +94,12 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
 
                 io_details   - if true, parameters and inputs are returned
                 link_details - if true, hyperlink to the tool is returned
+                version      - if provided return this tool version
         """
         io_details = util.string_as_bool(kwd.get('io_details', False))
         link_details = util.string_as_bool(kwd.get('link_details', False))
-        tool = self._get_tool(id, user=trans.user)
+        version = kwd.get('version')
+        tool = self._get_tool(id, user=trans.user, tool_version=version)
         return tool.to_dict(trans, io_details=io_details, link_details=link_details)
 
     @expose_api_anonymous

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -94,12 +94,12 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
 
                 io_details   - if true, parameters and inputs are returned
                 link_details - if true, hyperlink to the tool is returned
-                version      - if provided return this tool version
+                tool_version - if provided return this tool version
         """
         io_details = util.string_as_bool(kwd.get('io_details', False))
         link_details = util.string_as_bool(kwd.get('link_details', False))
-        version = kwd.get('version')
-        tool = self._get_tool(id, user=trans.user, tool_version=version)
+        tool_version = kwd.get('tool_version')
+        tool = self._get_tool(id, user=trans.user, tool_version=tool_version)
         return tool.to_dict(trans, io_details=io_details, link_details=link_details)
 
     @expose_api_anonymous

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -140,8 +140,11 @@ class ToolsTestCase(api.ApiTestCase):
             assert output_details["state"] == "error", output_details
             assert "has not sent back a URL parameter" in output_details["misc_info"], output_details
 
-    def _show_valid_tool(self, tool_id):
-        tool_show_response = self._get("tools/%s" % tool_id, data=dict(io_details=True))
+    def _show_valid_tool(self, tool_id, version=None):
+        data = dict(io_details=True)
+        if version:
+            data['version'] = version
+        tool_show_response = self._get("tools/%s" % tool_id, data=data)
         self._assert_status_code_is(tool_show_response, 200)
         tool_info = tool_show_response.json()
         self._assert_has_keys(tool_info, "inputs", "outputs", "panel_section_id")
@@ -435,6 +438,13 @@ class ToolsTestCase(api.ApiTestCase):
             output1 = outputs[0]
             output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
             self.assertEqual(output1_content.strip(), "Version " + version)
+
+    @skip_without_tool("multiple_versions")
+    @uses_test_history(require_new=False)
+    def test_show_with_wrong_tool_version_in_tool_id(self, history_id):
+        tool_info = self._show_valid_tool("multiple_versions", version="0.01")
+        # Return last version
+        assert tool_info['version'] == "0.2"
 
     @skip_without_tool("cat1")
     def test_run_cat1_single_meta_wrapper(self):

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -140,10 +140,10 @@ class ToolsTestCase(api.ApiTestCase):
             assert output_details["state"] == "error", output_details
             assert "has not sent back a URL parameter" in output_details["misc_info"], output_details
 
-    def _show_valid_tool(self, tool_id, version=None):
+    def _show_valid_tool(self, tool_id, tool_version=None):
         data = dict(io_details=True)
-        if version:
-            data['version'] = version
+        if tool_version:
+            data['tool_version'] = tool_version
         tool_show_response = self._get("tools/%s" % tool_id, data=data)
         self._assert_status_code_is(tool_show_response, 200)
         tool_info = tool_show_response.json()
@@ -442,7 +442,7 @@ class ToolsTestCase(api.ApiTestCase):
     @skip_without_tool("multiple_versions")
     @uses_test_history(require_new=False)
     def test_show_with_wrong_tool_version_in_tool_id(self, history_id):
-        tool_info = self._show_valid_tool("multiple_versions", version="0.01")
+        tool_info = self._show_valid_tool("multiple_versions", tool_version="0.01")
         # Return last version
         assert tool_info['version'] == "0.2"
 

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -440,8 +440,7 @@ class ToolsTestCase(api.ApiTestCase):
             self.assertEqual(output1_content.strip(), "Version " + version)
 
     @skip_without_tool("multiple_versions")
-    @uses_test_history(require_new=False)
-    def test_show_with_wrong_tool_version_in_tool_id(self, history_id):
+    def test_show_with_wrong_tool_version_in_tool_id(self):
         tool_info = self._show_valid_tool("multiple_versions", tool_version="0.01")
         # Return last version
         assert tool_info['version'] == "0.2"

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -272,6 +272,21 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         assert test_tool.repository_owner is None
         assert test_tool.installed_changeset_revision is None
 
+    def test_tool_shed_request_version(self):
+        self._init_tool()
+        self._setup_two_versions_in_config(section=False)
+        self._setup_two_versions()
+
+        test_tool = self.toolbox.get_tool("test_tool", tool_version="0.1")
+        assert test_tool.version == '0.1'
+
+        test_tool = self.toolbox.get_tool("test_tool", tool_version="0.2")
+        assert test_tool.version == '0.2'
+
+        # there is no version 3, return newest version
+        test_tool = self.toolbox.get_tool("test_tool", tool_version="3")
+        assert test_tool.version == '0.2'
+
     def test_load_file_in_section(self):
         self._init_tool_in_section()
 


### PR DESCRIPTION
That's a backport of https://github.com/galaxyproject/galaxy/pull/6702 and https://github.com/galaxyproject/galaxy/pull/6710.
Without this you would get the oldest tool version if the tool version didn't match, instead of the newest as intended