### PR TITLE
[18.09] Generic tooltip hide for onclick faIconButtons

### DIFF
--- a/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
@@ -104,7 +104,6 @@ var DatasetListItemEdit = _super.extend(
                 faIcon: "fa-times",
                 classes: "delete-btn",
                 onclick: function() {
-                    self.$el.find(".icon-btn.delete-btn").tooltip('dispose');
                     self.model["delete"]();
                 }
             });

--- a/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
@@ -104,6 +104,7 @@ var DatasetListItemEdit = _super.extend(
                 faIcon: "fa-times",
                 classes: "delete-btn",
                 onclick: function() {
+                    self.$el.find(".icon-btn.delete-btn").tooltip("dispose");
                     self.model["delete"]();
                 }
             });

--- a/client/galaxy/scripts/ui/fa-icon-button.js
+++ b/client/galaxy/scripts/ui/fa-icon-button.js
@@ -1,6 +1,5 @@
 import jQuery from "jquery";
 import * as _ from "underscore";
-("use_strict");
 
 var $ = jQuery;
 //============================================================================
@@ -43,12 +42,11 @@ var faIconButton = options => {
     ].join("");
     var $button = $(html).tooltip(options.tooltipConfig);
     if (_.isFunction(options.onclick)) {
-        let wrapped = _.wrap(options.onclick, function(func) {
+        $button.click(function(ev){
             $button.tooltip("hide");
             $button.parent().attr('tabindex', -1).focus();
-            func.apply(this, arguments);
+            options.onclick.apply(this, arguments);
         });
-        $button.click(wrapped);
     }
     return $button;
 };

--- a/client/galaxy/scripts/ui/fa-icon-button.js
+++ b/client/galaxy/scripts/ui/fa-icon-button.js
@@ -42,9 +42,12 @@ var faIconButton = options => {
     ].join("");
     var $button = $(html).tooltip(options.tooltipConfig);
     if (_.isFunction(options.onclick)) {
-        $button.click(function(ev){
+        $button.click(function(ev) {
             $button.tooltip("hide");
-            $button.parent().attr('tabindex', -1).focus();
+            $button
+                .parent()
+                .attr("tabindex", -1)
+                .focus();
             options.onclick.apply(this, arguments);
         });
     }

--- a/client/galaxy/scripts/ui/fa-icon-button.js
+++ b/client/galaxy/scripts/ui/fa-icon-button.js
@@ -45,6 +45,7 @@ var faIconButton = options => {
     if (_.isFunction(options.onclick)) {
         let wrapped = _.wrap(options.onclick, function(func) {
             $button.tooltip("hide");
+            $button.blur();
             func.apply(this, arguments);
         });
         $button.click(wrapped);

--- a/client/galaxy/scripts/ui/fa-icon-button.js
+++ b/client/galaxy/scripts/ui/fa-icon-button.js
@@ -45,7 +45,7 @@ var faIconButton = options => {
     if (_.isFunction(options.onclick)) {
         let wrapped = _.wrap(options.onclick, function(func) {
             $button.tooltip("hide");
-            $button.blur();
+            $button.parent().attr('tabindex', -1).focus();
             func.apply(this, arguments);
         });
         $button.click(wrapped);

--- a/client/galaxy/scripts/ui/fa-icon-button.js
+++ b/client/galaxy/scripts/ui/fa-icon-button.js
@@ -1,4 +1,5 @@
 import jQuery from "jquery";
+import * as _ from "underscore";
 ("use_strict");
 
 var $ = jQuery;
@@ -42,7 +43,11 @@ var faIconButton = options => {
     ].join("");
     var $button = $(html).tooltip(options.tooltipConfig);
     if (_.isFunction(options.onclick)) {
-        $button.click(options.onclick);
+        let wrapped = _.wrap(options.onclick, function(func) {
+            $button.tooltip("hide");
+            func.apply(this, arguments);
+        });
+        $button.click(wrapped);
     }
     return $button;
 };


### PR DESCRIPTION
@martenson After I merged #6744 I looked at it more -- this change should make the core faIconButton click handler responsible for hiding tooltips on click, so we don't have to have individual onclick functions doing it.  This fixes other stuck tooltips that were using faIconButtons, too.

I was torn about before/after the click handler, but before makes it that much snappier and the interface *feels* better to me.