### PR TITLE
[18.09] Fix page editor height for flex panels.

### DIFF
--- a/templates/webapps/galaxy/page/editor.mako
+++ b/templates/webapps/galaxy/page/editor.mako
@@ -54,7 +54,7 @@
         </div>
     </div>
 
-    <div class="unified-panel-body">
+    <div class="unified-panel-body h-100">
         <textarea name="page_content">${ content }</textarea>
     </div>
 


### PR DESCRIPTION
I didn't track it down to a commit, but my guess is this went wonky with the parent elements being flex-based.  I don't want to change `unified-panel-body` across the app at this point, since this is the only place I see a problem currently, so I've added the extra class to set height to full for the editor content panel.