### PR TITLE
[18.09] Use mapped-over collectionType when inferring collectionType through …

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -131,7 +131,7 @@ var Terminal = Backbone.Model.extend({
             this.node.markChanged();
             this.resetMappingIfNeeded();
             if (!connector.dragging) {
-                this.resetCollectionTypeSource();
+                connector.handle2.resetCollectionTypeSource();
             }
         }
     },

--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -456,7 +456,11 @@ var InputCollectionTerminal = BaseInputTerminal.extend({
             _.each(node.output_terminals, function(output_terminal) {
                 if (output_terminal.attributes.collection_type_source && !connector.dragging) {
                     if (other.isMappedOver()) {
-                        output_terminal.attributes.collection_type = other.terminalMapping.mapOver.collectionType;
+                        if (other.isCollection) {
+                            output_terminal.attributes.collection_type = other.terminalMapping.mapOver.append(other.collectionType).collectionType;
+                        } else {
+                            output_terminal.attributes.collection_type = other.terminalMapping.mapOver.collectionType;
+                        }
                     } else {
                         output_terminal.attributes.collection_type = other.attributes.collection_type;
                     }

--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -455,7 +455,11 @@ var InputCollectionTerminal = BaseInputTerminal.extend({
             let node = this.node;
             _.each(node.output_terminals, function(output_terminal) {
                 if (output_terminal.attributes.collection_type_source && !connector.dragging) {
-                    output_terminal.attributes.collection_type = other.attributes.collection_type;
+                    if (other.isMappedOver()) {
+                        output_terminal.attributes.collection_type = other.terminalMapping.mapOver.collectionType;
+                    } else {
+                        output_terminal.attributes.collection_type = other.attributes.collection_type;
+                    }
                     output_terminal.update(output_terminal.attributes);
                     }
             })


### PR DESCRIPTION
…format_source

Followup to https://github.com/galaxyproject/galaxy/pull/6741 -- once I updated the production server I noticed that the usecase I was trying to enable was still not working because the input was mapped over.