### PR TITLE
[18.09] Undo auto-propagation of group tags.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -75,7 +75,7 @@ JOB_METRIC_MAX_LENGTH = 1023
 JOB_METRIC_PRECISION = 26
 JOB_METRIC_SCALE = 7
 # Tags that get automatically propagated from inputs to outputs when running jobs.
-AUTO_PROPAGATED_TAGS = ["name", "group"]
+AUTO_PROPAGATED_TAGS = ["name"]
 
 
 class NoConverterException(Exception):

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -2627,11 +2627,8 @@ test_data:
 
             details1 = self.dataset_populator.get_history_dataset_details(history_id, hid=3, wait=True, assert_ok=True)
             tags = details1["tags"]
-            assert len(tags) == 3, details1
+            assert len(tags) == 1, details1
             assert "name:treated1fb" in tags, tags
-            assert "group:condition:treated" in tags, tags
-            assert "group:type:single-read" in tags, tags
-            assert "machine:illumina" not in tags, tags
 
     @skip_without_tool("collection_creates_pair")
     def test_run_add_tag_on_collection_output(self):


### PR DESCRIPTION
@mvdbeek and I discussed this in the Galaxy project gitter a few weeks ago and decided the propagation is too aggressive and should likely be done manually at the end of a workflow for now - using for instance the set tags collection operation tool.