### PR TITLE
[18.09] Catch any failures encountered while pausing/stopping jobs whose inputs are terminal and non-ok

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1851,9 +1851,10 @@ class JobWrapper(HasResourceParameters):
                 # to the object store from jobs - be sure that file is cleaned up. This
                 # is a bit of hack - our object store abstractions would be stronger
                 # and more consistent if tools weren't writing there directly.
-                target = dataset.file_name
-                if os.path.exists(target):
-                    os.remove(target)
+                try:
+                    dataset.full_delete()
+                except ObjectNotFound:
+                    pass
 
     def __link_file_check(self):
         """ outputs_to_working_directory breaks library uploads where data is

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -415,11 +415,17 @@ class JobHandlerQueue(Monitors):
             pause_message = ", ".join(jobs_to_pause[job_id])
             pause_message = "%s. To resume this job fix the input dataset(s)." % pause_message
             job, job_wrapper = self.job_pair_for_id(job_id)
-            job_wrapper.pause(job=job, message=pause_message)
+            try:
+                job_wrapper.pause(job=job, message=pause_message)
+            except Exception:
+                log.exception("(%s) Caught exception while attempting to pause job.", job_id)
         for job_id in sorted(jobs_to_fail):
             fail_message = ", ".join(jobs_to_fail[job_id])
             job, job_wrapper = self.job_pair_for_id(job_id)
-            job_wrapper.fail(fail_message)
+            try:
+                job_wrapper.fail(fail_message)
+            except Exception:
+                log.exception("(%s) Caught exception while attempting to fail job.", job_id)
         jobs_to_ignore.update(jobs_to_pause)
         jobs_to_ignore.update(jobs_to_fail)
         return [j for j in jobs if j.id not in jobs_to_ignore]


### PR DESCRIPTION
So that it doesn't interrupt processing other jobs. That was discovered because attempting to delete purged job outputs on failure was raising `ObjectNotFound` since dataset object store assignment is done later now (as of #6550). So also, catch that `ObjectNotFound`.

There's another case (hence WIP): while checking jobs at startup, an attempt is made to write the per-job registry file. This accesses the job wrapper's `working_directory` method, which raises an exception if the job's `object_store_id` is not set. This was causing one of our handlers to cycle (there's no exception handling above the startup job check so it crashes the entire application) after upgrading to 18.09. As per [the comment in __write_registry_file_if_absent](https://github.com/galaxyproject/galaxy/blob/7481d97a33ba7fb2a003ae2ad51414c04ae826b0/lib/galaxy/jobs/handler.py#L113) we should just remove this anyway, but maybe there would be additional problems elsewhere?

@jmchilton was there a specific reason you weren't using the dataset's delete method? The only thing I can think is that you only want to delete the local file and not the dataset in the object store. But wouldn't you want to delete it in the object store anyway?