### PR TITLE
Disable file name text field after upload

### DIFF
--- a/client/galaxy/scripts/mvc/upload/default/default-row.js
+++ b/client/galaxy/scripts/mvc/upload/default/default-row.js
@@ -220,6 +220,7 @@ export default Backbone.View.extend({
         this.model.set("enabled", status == "init");
         var enabled = this.model.get("enabled");
         this.$text_content.attr("disabled", !enabled);
+        this.$title.attr("disabled", !enabled);
         if (enabled) {
             this.select_genome.enable();
             this.select_extension.enable();

--- a/client/galaxy/style/scss/upload.scss
+++ b/client/galaxy/style/scss/upload.scss
@@ -96,6 +96,7 @@
                 word-wrap: break-word;
                 font-size: $font-size-sm;
                 float: left;
+                background: inherit;
             }
             /* Add back in lenght of extension, genome, and settings. */
             .upload-title-extended {

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -10185,7 +10185,8 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
       width: 130px;
       word-wrap: break-word;
       font-size: 0.7rem;
-      float: left; }
+      float: left;
+      background: inherit; }
     .upload-view-default .upload-box .upload-row .upload-title-extended, .upload-view-composite .upload-box .upload-row .upload-title-extended {
       width: 380px;
       word-wrap: break-word;


### PR DESCRIPTION
Addition to #6758. Disables text field after upload to avoid confusion.