### PR TITLE
Remove empty log messages

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -327,9 +327,8 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                             # If the tool is not defined in integrated_tool_panel.xml, append it to the tool panel.
                             panel_dict.append_tool(tool)
                             log_msg = "Loaded tool id: %s, version: %s into tool panel...." % (tool.id, tool.version)
-        if not hasattr(self.app, 'tool_cache') or tool_id in self.app.tool_cache._new_tool_ids:
-            if len(log_msg) > 0:
-                log.debug(log_msg)
+        if log_msg and (not hasattr(self.app, 'tool_cache') or tool_id in self.app.tool_cache._new_tool_ids):
+            log.debug(log_msg)
 
     def _load_tool_panel(self):
         execution_timer = ExecutionTimer()

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -328,7 +328,8 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                             panel_dict.append_tool(tool)
                             log_msg = "Loaded tool id: %s, version: %s into tool panel...." % (tool.id, tool.version)
         if not hasattr(self.app, 'tool_cache') or tool_id in self.app.tool_cache._new_tool_ids:
-            log.debug(log_msg)
+            if len(log_msg) > 0:
+                log.debug(log_msg)
 
     def _load_tool_panel(self):
         execution_timer = ExecutionTimer()


### PR DESCRIPTION
e.g.

```
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,005
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,005
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,005
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,006
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,007
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,007
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,008
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,008
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,008
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,009 Loaded tool id: toolshed.g2.bx.psu.edu/repos/iuc/mothur_hcluster/mothur_hcluster/1.36.1.0, version: 1.36.1.0 into tool panel....
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,009
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,010
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,010
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,011
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,011
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,011
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,012
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,013
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,013
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,013
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,014
galaxy.tools.toolbox.base DEBUG 2018-09-25 03:21:20,014
```