### PR TITLE
[18.09] Don't attempt len(None), ensure stdout/stderr are strings in Job(Like).set_streams().

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -222,8 +222,8 @@ class JobLike(object):
         return self.text_metrics + self.numeric_metrics
 
     def set_streams(self, stdout, stderr):
-        stdout = galaxy.util.unicodify(stdout)
-        stderr = galaxy.util.unicodify(stderr)
+        stdout = galaxy.util.unicodify(stdout) or u''
+        stderr = galaxy.util.unicodify(stderr) or u''
         if (len(stdout) > galaxy.util.DATABASE_MAX_STRING_SIZE):
             stdout = galaxy.util.shrink_string_by_size(stdout, galaxy.util.DATABASE_MAX_STRING_SIZE, join_by="\n..\n", left_larger=True, beginning_on_size_error=True)
             log.info("stdout for %s %d is greater than %s, only a portion will be logged to database", type(self), self.id, galaxy.util.DATABASE_MAX_STRING_SIZE_PRETTY)


### PR DESCRIPTION
Pulsar jobs that finish ok but with no stdout are failing with the following exception on usegalaxy.org:

```pytb
Traceback (most recent call last):
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/runners/pulsar.py", line 514, in finish_job
    remote_metadata_directory=remote_metadata_directory,
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/__init__.py", line 1445, in finish
    job.set_streams(job.stdout, job.stderr)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/model/__init__.py", line 227, in set_streams
    if (len(stdout) > galaxy.util.DATABASE_MAX_STRING_SIZE):
TypeError: object of type 'NoneType' has no len()
```

Possibly due to #6565 although I'm not sure how exactly.