### PR TITLE
[18.09] Increase the maximum number of stderr lines that will be scanned for slurm warnings

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -204,7 +204,7 @@ class SlurmJobRunner(DRMAAJobRunner):
         return False
 
 
-def _remove_spurious_top_lines(rfh, ajs, maxlines=2):
+def _remove_spurious_top_lines(rfh, ajs, maxlines=3):
     bad = []
     putback = None
     for i in range(maxlines):


### PR DESCRIPTION
Apparently it's possible to have all 3 warning messages. xref #6705.