### PR TITLE
Allow API import/export of format 2 workflows.

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -382,6 +382,8 @@ class Configuration(object):
         # workflows built using these modules may not function in the
         # future.
         self.enable_beta_workflow_modules = string_as_bool(kwargs.get('enable_beta_workflow_modules', 'False'))
+        # Enable use of gxformat2 workflows.
+        self.enable_beta_workflow_format = string_as_bool(kwargs.get('enable_beta_workflow_format', 'False'))
         # These are not even beta - just experiments - don't use them unless
         # you want yours tools to be broken in the future.
         self.enable_beta_tool_formats = string_as_bool(kwargs.get('enable_beta_tool_formats', 'False'))

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -55,7 +55,7 @@ functools32==3.2.3.post2; python_version == '2.7'
 future==0.16.0
 futures==3.2.0; python_version == '2.6' or python_version == '2.7'
 galaxy-sequence-utils==1.1.3
-gxformat2==0.6.0
+gxformat2==0.7.1
 h5py==2.8.0
 html5lib==1.0.1
 idna==2.7

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -978,7 +978,8 @@ class WorkflowContentsManager(UsesAnnotations):
 
         # Create the model class for the step
         steps.append(step)
-        steps_by_external_id[step_dict['id']] = step
+        external_id = step_dict["id"]
+        steps_by_external_id[external_id] = step
         if 'workflow_outputs' in step_dict:
             workflow_outputs = step_dict['workflow_outputs']
             found_output_names = set([])
@@ -1052,7 +1053,10 @@ class WorkflowContentsManager(UsesAnnotations):
                     conn.input_step = step
                     conn.input_name = input_name
                     conn.output_name = conn_dict['output_name']
-                    conn.output_step = steps_by_external_id[conn_dict['id']]
+                    external_id = conn_dict['id']
+                    if external_id not in steps_by_external_id:
+                        raise KeyError("Failed to find external id %s in %s" % (external_id, steps_by_external_id.keys()))
+                    conn.output_step = steps_by_external_id[external_id]
 
                     input_subworkflow_step_index = conn_dict.get('input_subworkflow_step_id', None)
                     if input_subworkflow_step_index is not None:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -251,7 +251,7 @@ class WorkflowContentsManager(UsesAnnotations):
         so workflows can be extracted.
         """
         workflow_class = as_dict.get("class", None)
-        if workflow_class == "GalaxyWorkflow" or "$graph" in as_dict:
+        if workflow_class == "GalaxyWorkflow" or "$graph" in as_dict or "yaml_content" in as_dict:
             if not self.app.config.enable_beta_workflow_format:
                 raise exceptions.ConfigDoesNotAllowException("Format2 workflows not enabled.")
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2100,6 +2100,13 @@ mapping:
           Enable beta workflow modules that should not yet be considered part of Galaxy's
           stable API.
 
+      enable_beta_workflow_format:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Enable import and export of workflows as Galaxy Format 2 workflows.
+
       force_beta_workflow_scheduled_min_steps:
         type: int
         default: 250

--- a/run.sh
+++ b/run.sh
@@ -38,6 +38,7 @@ if [ ! -z "$GALAXY_RUN_WITH_TEST_TOOLS" ];
 then
     export GALAXY_CONFIG_OVERRIDE_TOOL_CONFIG_FILE="test/functional/tools/samples_tool_conf.xml"
     export GALAXY_CONFIG_ENABLE_BETA_WORKFLOW_MODULES="true"
+    export GALAXY_CONFIG_ENABLE_BETA_WORKFLOW_FORMAT="true"
     export GALAXY_CONFIG_OVERRIDE_ENABLE_BETA_TOOL_FORMATS="true"
     export GALAXY_CONFIG_OVERRIDE_WEBHOOKS_DIR="test/functional/webhooks"
 fi

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -38,18 +38,20 @@ outputs:
   outer_output:
     outputSource: second_cat/out_file1
 steps:
-  - tool_id: cat1
-    label: first_cat
+  first_cat:
+    tool_id: cat1
     in:
       input1: outer_input
-  - run:
+  nested_workflow:
+    run:
       class: GalaxyWorkflow
       inputs:
         - id: inner_input
       outputs:
         - source: 1#out_file1
       steps:
-        - tool_id: random_lines1
+        random:
+          tool_id: random_lines1
           state:
             num_lines: 1
             input:
@@ -57,11 +59,10 @@ steps:
             seed_source:
               seed_source_selector: set_seed
               seed: asdf
-    label: nested_workflow
     in:
       inner_input: first_cat/out_file1
-  - tool_id: cat1
-    label: second_cat
+  second_cat:
+    tool_id: cat1
     state:
       input1:
         $link: nested_workflow#1:out_file1
@@ -500,26 +501,23 @@ steps:
         workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 inputs:
-  - id: outer_input
+  outer_input: data
 steps:
-  - run:
+  inner_workflow:
+    run:
       class: GalaxyWorkflow
       inputs:
-        - id: inner_input
+        inner_input:
           type: collection
           collection_type: "list:paired"
       outputs:
-        - id: workflow_output
-          source: collection_type_source#list_output
+        workflow_output:
+          outputSource: collection_type_source/list_output
       steps:
-        - label: text_input1
-          type: input_collection
-          collection_type: "list:paired"
-        - tool_id: collection_type_source
-          label: collection_type_source
+        collection_type_source:
+          tool_id: collection_type_source
           in:
             input_collect: inner_input
-    label: inner_workflow
     in:
       inner_input: outer_input
 """)
@@ -586,7 +584,8 @@ steps:
             workflow_version_01 = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
-  - tool_id: multiple_versions
+  multiple:
+    tool_id: multiple_versions
     tool_version: "0.1"
     state:
       inttest: 0
@@ -598,7 +597,8 @@ steps:
             workflow_version_02 = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
-  - tool_id: multiple_versions
+  multiple:
+    tool_id: multiple_versions
     tool_version: "0.2"
     state:
       inttest: 1
@@ -634,11 +634,13 @@ steps:
         workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
-  - tool_id: job_properties
+  job_props:
+    tool_id: job_properties
     state:
       thebool: true
       failbool: true
-  - tool_id: identifier_multiple_in_conditional
+  identifier:
+    tool_id: identifier_multiple_in_conditional
     state:
       outer_cond:
         cond_param_outer: true
@@ -670,14 +672,15 @@ steps:
         workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
-  - tool_id: job_properties
+  job_props:
+    tool_id: job_properties
     state:
       thebool: true
       failbool: true
-  - tool_id: identifier_collection
-    state:
-      input1:
-        $link: 0#list_output
+  identifier:
+    tool_id: identifier_collection
+    in:
+      input1: job_props/list_output
 """)
         with self.dataset_populator.test_history() as history_id:
             invocation_id = self.__invoke_workflow(history_id, workflow_id)
@@ -704,16 +707,16 @@ steps:
             job_summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input_datasets
-    type: collection
+  input_datasets: collection
 steps:
-  - label: fail_identifier_1
+  fail_identifier_1:
     tool_id: fail_identifier
     state:
       failbool: true
     in:
       input1: input_datasets
-  - tool_id: identifier_collection
+  identifier:
+    tool_id: identifier_collection
     in:
       input1: fail_identifier_1/out_file1
 test_data:
@@ -784,27 +787,20 @@ test_data:
         with self.dataset_populator.test_history() as history_id:
             workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
+inputs:
+  test_input_1: data
+  test_input_2: data
+  test_input_3: data
 steps:
-  - label: test_input_1
-    type: input
-  - label: test_input_2
-    type: input
-  - label: test_input_3
-    type: input
-  - label: split_up
+  split_up:
     tool_id: collection_split_on_column
-    state:
-      input1:
-        $link: test_input_2
-  - label: min_repeat
+    in:
+      input1: test_input_2
+  min_repeat:
     tool_id: min_repeat
-    state:
-      queries:
-        - input:
-            $link: test_input_1
-      queries2:
-        - input2:
-            $link: split_up#split_output
+    in:
+      queries_0|input: test_input_1
+      queries2_0|input2: split_up/split_output
 """)
             hda1 = self.dataset_populator.new_dataset(history_id, content="samp1\t10.0\nsamp2\t20.0\n")
             hda2 = self.dataset_populator.new_dataset(history_id, content="samp1\t20.0\nsamp2\t40.0\n")
@@ -829,33 +825,27 @@ steps:
         with self.dataset_populator.test_history() as history_id:
             workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
+inputs:
+  text_input1: data
+  text_input2: data
 steps:
-  - label: text_input1
-    type: input
-  - label: text_input2
-    type: input
-  - label: cat_inputs
+  cat_inputs:
     tool_id: cat1
-    state:
-      input1:
-        $link: text_input1
-      queries:
-        - input2:
-            $link: text_input2
-  - label: split_up_1
+    in:
+      input1: text_input1
+      queries_0|input2: text_input2
+  split_up_1:
     tool_id: collection_split_on_column
-    state:
-      input1:
-        $link: cat_inputs#out_file1
-  - label: split_up_2
+    in:
+      input1: cat_inputs/out_file1
+  split_up_2:
     tool_id: collection_split_on_column
-    state:
-      input1:
-        $link: split_up_1#split_output
-  - tool_id: cat
-    state:
-      input1:
-        $link: split_up_2#split_output
+    in:
+      input1: split_up_1/split_output
+  cat_output:
+    tool_id: cat
+    in:
+      input1: split_up_2/split_output
 """)
             hda1 = self.dataset_populator.new_dataset(history_id, content="samp1\t10.0\nsamp2\t20.0\n")
             hda2 = self.dataset_populator.new_dataset(history_id, content="samp1\t30.0\nsamp2\t40.0\n")
@@ -875,25 +865,20 @@ steps:
         with self.dataset_populator.test_history() as history_id:
             self._run_jobs("""
 class: GalaxyWorkflow
+inputs:
+  input_fastqs: collection
+  reference: data
 steps:
-  - label: input_fastqs
-    type: input_collection
-  - label: reference
-    type: input
-  - label: map_over_mapper
+  map_over_mapper:
     tool_id: mapper
-    state:
-      input1:
-        $link: input_fastqs
-      reference:
-        $link: reference
-  - label: pileup
+    in:
+      input1: input_fastqs
+      reference: reference
+  pileup:
     tool_id: pileup
-    state:
-      input1:
-        $link: map_over_mapper#out_file1
-      reference:
-        $link: reference
+    in:
+      input1: map_over_mapper/out_file1
+      reference: reference
 test_data:
   input_fastqs:
     type: list
@@ -1018,16 +1003,16 @@ inputs:
   test_input_1: data
   test_input_2: data
 steps:
-  - label: first_cat
+  first_cat:
     tool_id: cat1
     in:
       input1: test_input_1
-  - label: zip_it
+  zip_it:
     tool_id: "__ZIP_COLLECTION__"
     in:
       input_forward: first_cat/out_file1
       input_reverse: test_input_2
-  - label: concat_pair
+  concat_pair:
     tool_id: collection_paired_test
     in:
       f1: zip_it/output
@@ -1050,12 +1035,13 @@ steps:
             self._run_jobs("""
 class: GalaxyWorkflow
 steps:
-  - tool_id: 'collection_creates_dynamic_nested'
-    label: 'nested'
+  nested:
+    tool_id: collection_creates_dynamic_nested
     state:
       sleep_time: 0
       foo: 'dummy'
-  - tool_id: '__FLATTEN__'
+  flatten:
+    tool_id: '__FLATTEN__'
     state:
       input:
         $link: nested#list_output
@@ -1083,19 +1069,20 @@ inputs:
   input_c: collection
 
 steps:
-  - label: mixed_collection
+  mixed_collection:
     tool_id: exit_code_from_file
     state:
        input:
          $link: input_c
 
-  - label: filtered_collection
+  filtered_collection:
     tool_id: "__FILTER_FAILED_DATASETS__"
     state:
       input:
         $link: mixed_collection#out_file1
 
-  - tool_id: cat1
+  cat:
+    tool_id: cat1
     state:
       input1:
         $link: filtered_collection
@@ -1141,8 +1128,8 @@ outputs:
   wf_output_1:
     outputSource: first_cat/out_file1
 steps:
-  - tool_id: cat1
-    label: first_cat
+  first_cat:
+    tool_id: cat1
     in:
       input1: input1
 """, test_data={"input1": "hello world"}, history_id=history_id)
@@ -1170,8 +1157,8 @@ outputs:
   wf_output_1:
     outputSource: first_cat/out_file1
 steps:
-  - tool_id: cat
-    label: first_cat
+  first_cat:
+    tool_id: cat
     in:
       input1: input1
 """, test_data="""
@@ -1210,8 +1197,8 @@ outputs:
   wf_output_1:
     outputSource: first_cat/out_file1
 steps:
-  - tool_id: cat
-    label: first_cat
+  first_cat:
+    tool_id: cat
     in:
       input1: input1
 """, test_data="""
@@ -1252,7 +1239,7 @@ outputs:
   wf_output_1:
     outputSource: split_up/paired_output
 steps:
-  - label: split_up
+  split_up:
     tool_id: collection_creates_pair
     in:
       input1: text_input
@@ -1334,11 +1321,12 @@ outputs:
   outer_output:
     outputSource: second_cat/out_file1
 steps:
-  - tool_id: cat1
-    label: first_cat
+  first_cat:
+    tool_id: cat1
     in:
       input1: outer_input
-  - run:
+  nested_workflow:
+    run:
       class: GalaxyWorkflow
       inputs:
         inner_input: data
@@ -1346,8 +1334,8 @@ steps:
         workflow_output:
           outputSource: random_lines/out_file1
       steps:
-        - tool_id: random_lines1
-          label: random_lines
+        random_lines:
+          tool_id: random_lines1
           state:
             num_lines: 2
             input:
@@ -1355,15 +1343,14 @@ steps:
             seed_source:
               seed_source_selector: set_seed
               seed: asdf
-    label: nested_workflow
     in:
       inner_input: first_cat/out_file1
-  - tool_id: split
-    label: split
+  split:
+    tool_id: split
     in:
       input1: nested_workflow/workflow_output
-  - tool_id: cat_list
-    label: second_cat
+  second_cat:
+    tool_id: cat_list
     in:
       input1: split/output
 
@@ -1392,11 +1379,12 @@ outputs:
   outer_output:
     outputSource: second_cat/out_file1
 steps:
-  - tool_id: cat1
-    label: first_cat
+  first_cat:
+    tool_id: cat1
     in:
       input1: outer_input
-  - run:
+  nested_workflow:
+    run:
       class: GalaxyWorkflow
       inputs:
         inner_input: data
@@ -1404,8 +1392,8 @@ steps:
         workflow_output:
           outputSource: inner_cat/out_file1
       steps:
-        - tool_id: random_lines1
-          label: random_lines
+        random_lines:
+          tool_id: random_lines1
           state:
             num_lines: 2
             input:
@@ -1413,20 +1401,18 @@ steps:
             seed_source:
               seed_source_selector: set_seed
               seed: asdf
-        - tool_id: split
-          label: split
+        split:
+          tool_id: split
           in:
             input1: random_lines/out_file1
-        - tool_id: cat1
-          label: inner_cat
+        inner_cat:
+          tool_id: cat1
           in:
             input1: split/output
-
-    label: nested_workflow
     in:
       inner_input: first_cat/out_file1
-  - tool_id: cat_list
-    label: second_cat
+  second_cat:
+    tool_id: cat_list
     in:
       input1: nested_workflow/workflow_output
 """, test_data="""
@@ -1449,11 +1435,12 @@ outputs:
   outer_output:
     outputSource: second_cat/out_file1
 steps:
-  - tool_id: cat1
-    label: first_cat
+  first_cat:
+    tool_id: cat1
     in:
       input1: outer_input
-  - run:
+  nested_workflow:
+    run:
       class: GalaxyWorkflow
       inputs:
         inner_input: data
@@ -1461,8 +1448,8 @@ steps:
         workflow_output:
           outputSource: split/output
       steps:
-        - tool_id: random_lines1
-          label: random_lines
+        random_lines:
+          tool_id: random_lines1
           state:
             num_lines: 2
             input:
@@ -1470,15 +1457,14 @@ steps:
             seed_source:
               seed_source_selector: set_seed
               seed: asdf
-        - tool_id: split
-          label: split
+        split:
+          tool_id: split
           in:
             input1: random_lines/out_file1
-    label: nested_workflow
     in:
       inner_input: first_cat/out_file1
-  - tool_id: cat_list
-    label: second_cat
+  second_cat:
+    tool_id: cat_list
     in:
       input1: nested_workflow/workflow_output
 """, test_data="""
@@ -1501,12 +1487,12 @@ outputs:
   count_list:
     outputSource: count_list/out_file1
 steps:
-  - tool_id: empty_list
-    label: empty_list
+  empty_list:
+    tool_id: empty_list
     in:
       input1: input1
-  - tool_id: random_lines1
-    label: random_lines
+  random_lines:
+    tool_id: random_lines1
     state:
       num_lines: 2
       input:
@@ -1514,8 +1500,8 @@ steps:
       seed_source:
         seed_source_selector: set_seed
         seed: asdf
-  - tool_id: count_list
-    label: count_list
+  count_list:
+    tool_id: count_list
     in:
       input1: random_lines/out_file1
 """, test_data="""
@@ -1533,7 +1519,8 @@ class: GalaxyWorkflow
 inputs:
   text_input1: collection
 steps:
-  - tool_id: collection_type_source_map_over
+  map_over:
+    tool_id: collection_type_source_map_over
     in:
       input_collect: text_input1
 """, test_data="""
@@ -1557,12 +1544,12 @@ outputs:
   count_multi_file:
     outputSource: count_multi_file/out_file1
 steps:
-  - tool_id: empty_list
-    label: empty_list
+  empty_list:
+    tool_id: empty_list
     in:
       input1: input1
-  - tool_id: random_lines1
-    label: random_lines
+  random_lines:
+    tool_id: random_lines1
     state:
       num_lines: 2
       input:
@@ -1570,8 +1557,8 @@ steps:
       seed_source:
         seed_source_selector: set_seed
         seed: asdf
-  - tool_id: count_multi_file
-    label: count_multi_file
+  count_multi_file:
+    tool_id: count_multi_file
     in:
       input1: random_lines/out_file1
 """, test_data="""
@@ -1731,12 +1718,12 @@ inputs:
     type: collection
     collection_type: list
 steps:
-  - tool_id: cat
-    label: first_cat
+  first_cat:
+    tool_id: cat
     in:
       input1: input1
-  - tool_id: cat
-    label: second_cat
+  second_cat:
+    tool_id: cat
     in:
       input1: first_cat/out_file1
 """)
@@ -1770,29 +1757,29 @@ class: GalaxyWorkflow
 inputs:
   test_input: data
 steps:
-- label: first_cat
-  tool_id: cat1
-  in:
-    input1: test_input
-- label: the_pause
-  type: pause
-  in:
-    input: first_cat/out_file1
-- label: second_cat
-  tool_id: cat1
-  in:
-    input1: the_pause
-- label: third_cat
-  tool_id: random_lines1
-  in:
-    $step: second_cat
-  state:
-    num_lines: 1
-    input:
-      $link: test_input
-    seed_source:
-      seed_source_selector: set_seed
-      seed: asdf
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: test_input
+  the_pause:
+    type: pause
+    in:
+      input: first_cat/out_file1
+  second_cat:
+    tool_id: cat1
+    in:
+      input1: the_pause
+  third_cat:
+    tool_id: random_lines1
+    in:
+      $step: second_cat
+    state:
+      num_lines: 1
+      input:
+        $link: test_input
+      seed_source:
+        seed_source_selector: set_seed
+        seed: asdf
 """, test_data={"test_input": "hello world"}, history_id=history_id, wait=False, round_trip_format_conversion=True)
             history_id = run_summary.history_id
             workflow_id = run_summary.workflow_id
@@ -1817,18 +1804,18 @@ class: GalaxyWorkflow
 inputs:
   text_input: text
 steps:
-- tool_id: validation_repeat
-  state:
-    r2:
-     - text:
-        $link: text_input
+  validation:
+    tool_id: validation_repeat
+    state:
+      r2:
+      - text:
+          $link: text_input
 """, test_data="""
 text_input:
   value: "abd"
   type: raw
 """, history_id=history_id, wait=True, round_trip_format_conversion=True)
-            time.sleep(10)
-            self.workflow_populator.wait_for_invocation(run_summary.workflow_id, run_summary.invocation_id)
+            self.wait_for_invocation_and_jobs(history_id, run_summary.workflow_id, run_summary.invocation_id)
             jobs = self._history_jobs(history_id)
             assert len(jobs) == 1
 
@@ -1839,11 +1826,12 @@ class: GalaxyWorkflow
 inputs:
   text_input: text
 steps:
-- tool_id: validation_repeat
-  state:
-    r2:
-     - text:
-        $link: text_input
+  validation:
+    tool_id: validation_repeat
+    state:
+      r2:
+      - text:
+          $link: text_input
 """, test_data="""
 text_input:
   value: ""
@@ -1858,16 +1846,16 @@ inputs:
   data_input: data
   text_input: text
 steps:
-- label: randomlines
-  tool_id: random_lines1
-  state:
-    num_lines: 1
-    input:
-      $link: data_input
-    seed_source:
-      seed_source_selector: set_seed
-      seed:
-        $link: text_input
+  randomlines:
+    tool_id: random_lines1
+    state:
+      num_lines: 1
+      input:
+        $link: data_input
+      seed_source:
+        seed_source_selector: set_seed
+        seed:
+          $link: text_input
 """, test_data="""
 data_input:
   value: 1.bed
@@ -2041,8 +2029,8 @@ outputs:
   wf_output_1:
     outputSource: output_filter/out_1
 steps:
-  - tool_id: output_filter
-    label: output_filter
+  output_filter:
+    tool_id: output_filter
     state:
       produce_out_1: False
       filter_text_1: '1'
@@ -2063,8 +2051,8 @@ inputs:
     type: collection
     collection_type: list
 steps:
-  - tool_id: cat
-    label: first_cat
+  first_cat:
+    tool_id: cat
     in:
       input1: input1
     outputs:
@@ -2098,8 +2086,8 @@ inputs:
     type: collection
     collection_type: list
 steps:
-  - tool_id: cat
-    label: first_cat
+  first_cat:
+    tool_id: cat
     in:
       input1: input1
     outputs:
@@ -2151,7 +2139,8 @@ input1:
 class: GalaxyWorkflow
 inputs: []
 steps:
-  - tool_id: create_2
+  create_2:
+    tool_id: create_2
     state:
       sleep_time: 0
     outputs:
@@ -2183,8 +2172,8 @@ class: GalaxyWorkflow
 inputs:
   input1: data
 steps:
-  - tool_id: fail_identifier
-    label: first_fail
+  first_fail:
+    tool_id: fail_identifier
     state:
       failbool: true
       input1:
@@ -2192,7 +2181,8 @@ steps:
     outputs:
       out_file1:
         rename: "cat1 out"
-  - tool_id: cat
+  cat:
+    tool_id: cat
     in:
       input1: first_fail/out_file1
     outputs:
@@ -2230,8 +2220,8 @@ class: GalaxyWorkflow
 inputs:
   input1: data
 steps:
-  - tool_id: cat
-    label: first_cat
+  first_cat:
+    tool_id: cat
     in:
       input1: input1
     outputs:
@@ -2256,8 +2246,8 @@ inputs:
   input1: data
   input2: data
 steps:
-  - tool_id: cat
-    label: first_cat
+  first_cat:
+    tool_id: cat
     state:
       input1:
         $link: input1
@@ -2290,7 +2280,8 @@ inputs:
   fasta_input: data
   fastq_input: data
 steps:
-  - tool_id: mapper2
+  mapping:
+    tool_id: mapper2
     state:
       fastq_input:
         fastq_input_selector: single
@@ -2328,7 +2319,8 @@ inputs:
   fasta_input: data
   fastq_inputs: data
 steps:
-  - tool_id: mapper2
+  mapping:
+    tool_id: mapper2
     state:
       fastq_input:
         fastq_input_selector: paired_collection
@@ -2370,7 +2362,8 @@ class: GalaxyWorkflow
 inputs:
   input1: data
 steps:
-  - tool_id: collection_creates_pair
+  create_pair:
+    tool_id: collection_creates_pair
     state:
       input1:
         $link: input1
@@ -2398,8 +2391,8 @@ inputs:
     type: data_collection_input
     collection_type: list
 steps:
-  - tool_id: cat
-    label: first_cat
+  first_cat:
+    tool_id: cat
     in:
       input1: input1
     outputs:
@@ -2431,7 +2424,7 @@ class: GalaxyWorkflow
 inputs:
   input1: data
 steps:
-  - label: first_cat
+  first_cat:
     tool_id: cat
     in:
       input1: input1
@@ -2442,7 +2435,7 @@ steps:
             - "group:condition:treated"
             - "group:type:single-read"
             - "machine:illumina"
-  - label: second_cat
+  second_cat:
     tool_id: cat
     in:
       input1: first_cat/out_file1
@@ -2474,7 +2467,8 @@ class: GalaxyWorkflow
 inputs:
   input1: data
 steps:
-  - tool_id: collection_creates_pair
+  create_pair:
+    tool_id: collection_creates_pair
     in:
       input1: input1
     outputs:
@@ -2502,8 +2496,8 @@ inputs:
     type: collection
     collection_type: list
 steps:
-  - tool_id: cat
-    label: first_cat
+  first_cat:
+    tool_id: cat
     in:
       input1: input1
     outputs:
@@ -2533,15 +2527,16 @@ class: GalaxyWorkflow
 inputs:
   input1: data
 steps:
-  - tool_id: cat
-    label: first_cat
+  first_cat:
+    tool_id: cat
     in:
       input1: input1
     outputs:
       out_file1:
         add_tags:
           - "name:foo"
-  - tool_id: collection_creates_pair
+  create_pair:
+    tool_id: collection_creates_pair
     in:
       input1: first_cat#out_file1
     outputs:
@@ -2603,15 +2598,15 @@ class: GalaxyWorkflow
 inputs:
   test_input: data
 steps:
-  - label: first_cat
+  first_cat:
     tool_id: cat1
     in:
       input1: test_input
-  - label: the_pause
+  the_pause:
     type: pause
     in:
       input: first_cat/out_file1
-  - label: second_cat
+  second_cat:
     tool_id: cat1
     in:
       input1: the_pause
@@ -2659,16 +2654,16 @@ outputs:
   wf_output_1:
     outputSource: third_cat/out_file1
 steps:
-  - tool_id: cat1
-    label: first_cat
+  first_cat:
+    tool_id: cat1
     in:
       input1: input1
-  - tool_id: cat1
-    label: second_cat
+  second_cat:
+    tool_id: cat1
     in:
       input1: first_cat/out_file1
-  - tool_id: cat1
-    label: third_cat
+  third_cat:
+    tool_id: cat1
     in:
       input1: second_cat/out_file1
     outputs:
@@ -2765,10 +2760,11 @@ steps:
             workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
- - tool_id: validation_repeat
-   state:
-     r2:
-      - text: "abd"
+  validation:
+    tool_id: validation_repeat
+    state:
+      r2:
+        - text: "abd"
 """)
             workflow_request = dict(
                 history="hist_id=%s" % history_id,
@@ -2792,10 +2788,11 @@ steps:
             self._run_jobs("""
 class: GalaxyWorkflow
 steps:
- - tool_id: validation_repeat
-   state:
-     r2:
-     - text: ""
+  validation:
+    tool_id: validation_repeat
+    state:
+      r2:
+      - text: ""
 """, history_id=history_id, wait=False, expected_response=400)
 
     def _run_validation_workflow_with_substitions(self, substitions):
@@ -2958,7 +2955,7 @@ class: GalaxyWorkflow
 inputs:
   input_c: collection
 steps:
-  - label: cat1
+  cat1:
     tool_id: cat1
     in:
        input1: input_c

--- a/test/api/test_workflows_from_yaml.py
+++ b/test/api/test_workflows_from_yaml.py
@@ -125,11 +125,12 @@ class: GalaxyWorkflow
 inputs:
   outer_input: data
 steps:
-  - tool_id: cat1
-    label: first_cat
+  first_cat:
+    tool_id: cat1
     in:
       input1: outer_input
-  - run:
+  nested_workflow:
+    run:
       class: GalaxyWorkflow
       inputs:
         inner_input: data
@@ -142,7 +143,6 @@ steps:
             seed_source:
               seed_source_selector: set_seed
               seed: asdf
-    label: nested_workflow
     in:
       inner_input: first_cat/out_file1
 """, client_convert=False)
@@ -200,18 +200,18 @@ $graph:
   inputs:
     outer_input: data
   steps:
-  - tool_id: cat
-    label: outer_cat
-    in:
-      input1: outer_input
-  - run: '#nested'
-    label: nested_workflow_1
-    in:
-      inner_input: outer_cat/out_file1
-  - run: '#nested'
-    label: nested_workflow_2
-    in:
-      inner_input: nested_workflow_1/inner_output
+    outer_cat:
+      tool_id: cat
+      in:
+        input1: outer_input
+    nested_workflow_1:
+      run: '#nested'
+      in:
+        inner_input: outer_cat/out_file1
+    nested_workflow_2:
+      run: '#nested'
+      in:
+        inner_input: nested_workflow_1/inner_output
 """
         history_id = self.dataset_populator.new_history()
         self._run_jobs(duplicate_subworkflow_invocate_wf, test_data={"outer_input": "hello world"}, history_id=history_id, client_convert=False)
@@ -222,18 +222,18 @@ $graph:
         workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
-  - label: test_input
+  test_input:
     type: input
-  - label: first_cat
+  first_cat:
     tool_id: cat1
     state:
       input1:
         $link: test_input
-  - label: the_pause
+  the_pause:
     type: pause
     in:
       input: first_cat/out_file1
-  - label: second_cat
+  second_cat:
     tool_id: cat1
     in:
       input1: the_pause
@@ -243,25 +243,22 @@ steps:
     def test_implicit_connections(self):
         workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
+inputs:
+  test_input: data
 steps:
-  - label: test_input
-    type: input
-  - label: first_cat
+  first_cat:
     tool_id: cat1
-    state:
-      input1:
-        $link: test_input
-  - label: the_pause
+    in:
+      input1: test_input
+  the_pause:
     type: pause
-    connect:
-      input:
-      - first_cat#out_file1
-  - label: second_cat
+    in:
+      input: first_cat/out_file1
+  second_cat:
     tool_id: cat1
-    state:
-      input1:
-        $link: the_pause
-  - label: third_cat
+    in:
+      input1: the_pause
+  third_cat:
     tool_id: cat1
     connect:
       $step: second_cat
@@ -276,7 +273,7 @@ steps:
         self._run_jobs("""
 class: GalaxyWorkflow
 steps:
-  - label: test_input
+  test_input:
     tool_id: disambiguate_cond
     state:
       p3:
@@ -291,7 +288,7 @@ steps:
         self._run_jobs("""
 class: GalaxyWorkflow
 steps:
-  - label: test_input
+  test_input:
     tool_id: disambiguate_cond
     state:
       p3:

--- a/test/api/test_workflows_from_yaml.py
+++ b/test/api/test_workflows_from_yaml.py
@@ -32,6 +32,8 @@ class WorkflowsFromYamlApiTestCase(BaseWorkflowsApiTestCase):
     def test_simple_upload(self):
         workflow = self._upload_and_download(WORKFLOW_SIMPLE_CAT_AND_RANDOM_LINES, client_convert=False)
 
+        assert workflow["annotation"].startswith("Simple workflow that ")
+
         tool_count = {'random_lines1': 0, 'cat1': 0}
         input_found = False
         for step in workflow['steps'].values():
@@ -51,6 +53,7 @@ class WorkflowsFromYamlApiTestCase(BaseWorkflowsApiTestCase):
 
         workflow_as_format2 = self._upload_and_download(WORKFLOW_SIMPLE_CAT_AND_RANDOM_LINES, client_convert=False, style="format2")
         assert workflow_as_format2["doc"].startswith("Simple workflow that")
+
 
 # FIXME:  This test fails on some machines due to (we're guessing) yaml.safe_loading
 # order being not guaranteed and inconsistent across platforms.  The workflow

--- a/test/api/test_workflows_from_yaml.py
+++ b/test/api/test_workflows_from_yaml.py
@@ -22,13 +22,13 @@ class WorkflowsFromYamlApiTestCase(BaseWorkflowsApiTestCase):
     def setUp(self):
         super(WorkflowsFromYamlApiTestCase, self).setUp()
 
-    def _upload_and_download(self, yaml_workflow):
-        workflow_id = self._upload_yaml_workflow(yaml_workflow)
+    def _upload_and_download(self, yaml_workflow, **kwds):
+        workflow_id = self._upload_yaml_workflow(yaml_workflow, **kwds)
         workflow = self._get("workflows/%s/download" % workflow_id).json()
         return workflow
 
     def test_simple_upload(self):
-        workflow = self._upload_and_download(WORKFLOW_SIMPLE_CAT_AND_RANDOM_LINES)
+        workflow = self._upload_and_download(WORKFLOW_SIMPLE_CAT_AND_RANDOM_LINES, client_convert=False)
 
         tool_count = {'random_lines1': 0, 'cat1': 0}
         input_found = False

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -201,6 +201,7 @@ def setup_galaxy_config(
         cleanup_job='onsuccess',
         data_manager_config_file=data_manager_config_file,
         enable_beta_tool_formats=True,
+        enable_beta_workflow_format=True,
         expose_dataset_path=True,
         file_path=file_path,
         ftp_upload_purge=False,

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -554,6 +554,7 @@ class BaseWorkflowPopulator(object):
         workflow_id = workflow["id"]
         if round_trip_conversion:
             workflow_yaml_wrapped = self.download_workflow(workflow_id, style="format2_wrapped_yaml")
+            assert "yaml_content" in workflow_yaml_wrapped, workflow_yaml_wrapped
             round_trip_converted_content = workflow_yaml_wrapped["yaml_content"]
             workflow_id = self.upload_yaml_workflow(round_trip_converted_content, client_convert=False, round_trip_conversion=False)
 
@@ -595,7 +596,7 @@ class BaseWorkflowPopulator(object):
         api_asserts.assert_status_code_is(response, 200)
         return response.json()
 
-    def run_workflow(self, has_workflow, test_data=None, history_id=None, wait=True, source_type=None, jobs_descriptions=None, expected_response=200, assert_ok=True, client_convert=None, round_trip_format_conversion=False):
+    def run_workflow(self, has_workflow, test_data=None, history_id=None, wait=True, source_type=None, jobs_descriptions=None, expected_response=200, assert_ok=True, client_convert=None, round_trip_format_conversion=False, raw_yaml=False):
         """High-level wrapper around workflow API, etc. to invoke format 2 workflows."""
         workflow_populator = self
 
@@ -608,7 +609,7 @@ class BaseWorkflowPopulator(object):
         if client_convert is None:
             client_convert = not round_trip_format_conversion
 
-        workflow_id = workflow_populator.upload_yaml_workflow(has_workflow, source_type=source_type, client_convert=client_convert, round_trip_format_conversion=round_trip_format_conversion)
+        workflow_id = workflow_populator.upload_yaml_workflow(has_workflow, source_type=source_type, client_convert=client_convert, round_trip_format_conversion=round_trip_format_conversion, raw_yaml=raw_yaml)
 
         if test_data is None:
             if jobs_descriptions is None:

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -547,6 +547,8 @@ class BaseWorkflowPopulator(object):
         return upload_response
 
     def upload_yaml_workflow(self, has_yaml, **kwds):
+        client_convert = kwds.pop("client_convert", True)
+        kwds["convert"] = client_convert
         workflow = convert_and_import_workflow(has_yaml, galaxy_interface=self, **kwds)
         return workflow["id"]
 

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -689,7 +689,7 @@ class WorkflowPopulator(BaseWorkflowPopulator, ImporterGalaxyInterface):
         }
         data.update(**kwds)
         upload_response = self._post("workflows", data=data)
-        assert upload_response.status_code == 200, upload_response
+        assert upload_response.status_code == 200, upload_response.content
         return upload_response.json()
 
 

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -2,10 +2,14 @@
 
 WORKFLOW_SIMPLE_CAT_AND_RANDOM_LINES = """
 class: GalaxyWorkflow
+doc: |
+  Simple workflow that no-op cats a file and then selects 10 random lines.
 inputs:
   - id: the_input
+    doc: input doc
 steps:
   - tool_id: cat1
+    doc: cat doc
     in:
       input1: the_input
   - tool_id: cat1


### PR DESCRIPTION
This builds on a set of Galaxy PRs #6746, #6807, #6811 and a series of [gxformat2](https://github.com/jmchilton/gxformat2) releases.

In addition to bringing in the latest changes to gxformat2 to allow these syntax changes (described below) and updating hundreds of lines of test workflows - this PR finally enables such workflows to work directly with the Galaxy API (switched on ``enable_beta_workflow_format``). When enabled, workflows imported from dictionaries will now be checked and if they look like a format2 workflow they will be pre-converted to a native format before import - uploading YAML wrapped in JSON to avoid dictionary handling changes is allowed also. Likewise, there is a couple new styles of download that attempt to extract format 2 workflows from the native representation (using new functionality added to recent versions of gxformat2). These can be downloaded as JSON or as YAML string content wrapped up in JSON in order to preserve the pretty YAML formatting and dictionary ordering implemented in gxformat2.

If the JSON wrapped YAML-in-strings seems odd - consider also an important future direction of this work is likely to store the original supplied YAML alongside the native representation of the workflow and then allow the workflow editor to operate a series of deltas to both in parallel. This can be done with a round trip aware YAML parsing/writer such as [ruamel.yaml](https://yaml.readthedocs.io/en/latest/) so that user comments and formatting as well as extraneous data in the YAML are preserved.

This PR continues to refine the workflow syntax toward a more concise and CWL compatible syntax. The following two code blocks are a before and after example demonstrating the syntax changes.

Before this series of PRs:

```yaml
class: GalaxyWorkflow
inputs:
  - id: input_fastqs
    type: collection
  - id: reference
outputs:
  - id: pileup_output
    source: pileup#out_file1
steps:
  - label: map_over_mapper
    tool_id: mapper
    state:
      input1:
        $link: input_fastqs
      reference:
        $link: reference
  - label: pileup
    tool_id: pileup
    state:
      input1:
        $link: map_over_mapper#out_file1
      reference:
        $link: reference
```

My recommended best practice after this PR is merged:

```yaml
class: GalaxyWorkflow
inputs:
  input_fastqs: collection
  reference: data
outputs:
  pileup_output:
    outputSource: pileup/out_file1
steps:
  map_over_mapper:
    tool_id: mapper
    in:
      input1: input_fastqs
      reference: reference
  pileup:
    tool_id: pileup
    in:
      input1: map_over_mapper/out_file1
      reference: reference
```

Prior to this pull request, all subworkflows (format-version 0.1 or 2) would be imported repeatedly - once per step that referenced them. This PR introduces a CWL-derived syntax for repeatedly referencing the same workflow and updates the Galaxy import functionality to properly resolve these references and import such workflows only once instead of once per step.

```yaml
$graph:
- id: nested
  class: GalaxyWorkflow
  inputs:
    inner_input: data
  outputs:
    inner_output:
      outputSource: inner_cat/out_file1
  steps:
    inner_cat:
      tool_id: cat
      in:
        input1: inner_input
        queries_0|input2: inner_input
- id: main
  class: GalaxyWorkflow
  inputs:
    outer_input: data
  steps:
    outer_cat:
      tool_id: cat
      in:
        input1: outer_input
    nested_workflow_1:
      run: '#nested'
      in:
       inner_input: outer_cat/out_file1
    nested_worklfow_2:
      run: '#nested'
      in:
        inner_input: nested_workflow_1/inner_output
```