### PR TITLE
[18.09] All extracted datasets should be visible

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2490,6 +2490,7 @@ class ExtractDatasetCollectionTool(DatabaseOperationTool):
             raise Exception("Invalid tool parameters.")
         extracted = extracted_element.element_object
         extracted_o = extracted.copy(copy_tags=tags, new_name=extracted_element.element_identifier)
+        extracted_o.visible = True
         self._add_datasets_to_history(history, [extracted_o])
 
         out_data["output"] = extracted_o


### PR DESCRIPTION
HDAs in a HDCA are hidden, but if we extract them we do want to see them.