### PR TITLE
Warn job runner plugin writers not to emulate condor.py.

### DIFF
--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -1,5 +1,14 @@
-"""
-Job control via the Condor DRM.
+"""Job control via the Condor DRM via CLI.
+
+This plugin has been used in production and isn't unstable but shouldn't be taken as an
+example of how to write Galaxy job runners that interface with a DRM using command-line
+invocations. When writing new job runners that leverage command-line calls for submitting
+and checking the status of jobs please check out the CLI runner (cli.py in this directory)
+start by writing a new job plugin in for that (see examples in
+/galaxy/jobs/runners/util/cli/job). That approach will result in less boilerplate and allow
+greater reuse of the DRM specific hooks you'll need to write. Ideally this plugin would
+have been written to target that framework, but we don't have the bandwidth to rewrite
+it at this time.
 """
 import logging
 import os


### PR DESCRIPTION
Better to write a CLI plugin I think (https://github.com/galaxyproject/galaxy/pull/6751#issuecomment-425079201).