### PR TITLE
Prevent errors when a library dataset has been purged from disk

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2174,6 +2174,8 @@ class DatasetInstance(object):
     state = property(get_dataset_state, set_dataset_state)
 
     def get_file_name(self):
+        if self.dataset.purged:
+            return ""
         return self.dataset.get_file_name()
 
     def set_file_name(self, filename):


### PR DESCRIPTION
This should fix at least some errors like the one here: https://github.com/galaxyproject/galaxy/issues/1765#issuecomment-234014000

The cause at least in the local case I'm looking at now is that a dataset was placed by a user in the data library. It was subsequently deleted and purged (including from disk). However, library datasets still try to fetch a dataset's name even if they're marked as purged. This prevents that and therefore allows one to render data library contents.