### PR TITLE
[18.09] Strip all control characters from rules

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -34,6 +34,7 @@ except ImportError:
     # For Pulsar on Windows (which does not use the function that uses grp)
     grp = None
 
+from boltons.iterutils import remap
 from six import binary_type, iteritems, PY2, string_types, text_type
 from six.moves import email_mime_multipart, email_mime_text, xrange, zip
 from six.moves.urllib import (
@@ -1011,6 +1012,19 @@ def smart_str(s, encoding=DEFAULT_ENCODING, strings_only=False, errors='strict')
 def strip_control_characters(s):
     """Strip unicode control characters from a string."""
     return "".join(c for c in unicodify(s) if unicodedata.category(c)[0] != "C")
+
+
+def strip_control_characters_nested(item):
+    """Recursively strips control characters from lists, dicts, tuples."""
+
+    def visit(path, key, value):
+        if isinstance(key, string_types):
+            key = strip_control_characters(key)
+        if isinstance(value, string_types):
+            value = strip_control_characters(value)
+        return key, value
+
+    return remap(item, visit)
 
 
 def object_to_string(obj):

--- a/lib/galaxy/util/rules_dsl.py
+++ b/lib/galaxy/util/rules_dsl.py
@@ -5,6 +5,8 @@ import re
 import six
 from six.moves import map
 
+from galaxy.util import strip_control_characters_nested
+
 
 def _ensure_rule_contains_keys(rule, keys):
     for key, instance_class in keys.items():
@@ -492,7 +494,7 @@ def flat_map(f, items):
 class RuleSet(object):
 
     def __init__(self, rule_set_as_dict):
-        self.raw_rules = rule_set_as_dict["rules"]
+        self.raw_rules = strip_control_characters_nested(rule_set_as_dict["rules"])
         self.raw_mapping = rule_set_as_dict.get("mapping", [])
 
     @property

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,0 +1,17 @@
+from galaxy import util
+
+
+def test_strip_control_characters():
+    s = '\x00bla'
+    assert util.strip_control_characters(s) == 'bla'
+
+
+def test_strip_control_characters_nested():
+    s = '\x00bla'
+    stripped_s = 'bla'
+    l = [s]
+    t = (s, 'blub')
+    d = {42: s}
+    assert util.strip_control_characters_nested(l)[0] == stripped_s
+    assert util.strip_control_characters_nested(t)[0] == stripped_s
+    assert util.strip_control_characters_nested(d)[42] == stripped_s


### PR DESCRIPTION
Similar to 366701cfb23d8de31eac3c4312c6accca2e74ef1, which is valid on its own, but here we just apply it to all rules.

Otherwise we crash for rules like this:
```
{
  "rules": [
    {
      "type": "add_column_metadata",
      "value": "identifier0"
    },
    {
      "type": "add_column_regex",
      "target_column": 0,
      "expression": "(.*)",
      "replacement": "\\1bla"
    },
    {
      "type": "add_column_regex",
      "target_column": 1,
      "expression": "(.*)",
      "replacement": "group:\\1"
    },
    {
      "type": "add_column_regex",
      "target_column": 2,
      "expression": "group:(.*)",
      "replacement": "\u0000bla:blub:\\1:2"
    }
  ],
  "mapping": [
    {
      "type": "list_identifiers",
      "columns": [
        3
      ],
      "editing": false
    }
  ]
}
```