### PR TITLE
[18.09] allow making all datasets within history public, when sharing

### DIFF
--- a/client/galaxy/scripts/components/Sharing.vue
+++ b/client/galaxy/scripts/components/Sharing.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-if="ready">
         <h2>Share or Publish {{model_class}} `{{item.title}}`</h2>
-        <b-alert variant="danger" :show="err_msg">
+        <b-alert :show="show_danger" variant="danger" dismissible>
             {{ err_msg }}
         </b-alert>
         </br>
@@ -141,7 +141,10 @@ export default {
             return `${Galaxy.root}${this.model_class_lc}/set_slug_async/?id=${this.id}`;
         },
         has_possible_members(){
-            return ["history"].indexOf(this.model_class_lc) > -1;;
+            return ["history"].indexOf(this.model_class_lc) > -1;
+        },
+        show_danger(){
+            return this.err_msg !== null;
         }
     },
     data() {
@@ -159,7 +162,7 @@ export default {
                 users_shared_with: []
             },
             share_fields: ["email", { key: "id", label: "" }],
-            make_members_public: false,
+            make_members_public: false
         };
     },
     created: function() {
@@ -203,6 +206,9 @@ export default {
                 .post(`${Galaxy.root}api/${this.plural_name_lc}/${this.id}/sharing`, data)
                 .then(response => {
                     Object.assign(this.item, response.data);
+                    if (response.data.skipped){
+                       this.err_msg = "Some of the items within this object were not published due to an error.";
+                    }
                 })
                 .catch(error => (this.err_msg = error.response.data.err_msg));
         },

--- a/client/galaxy/scripts/components/Sharing.vue
+++ b/client/galaxy/scripts/components/Sharing.vue
@@ -53,9 +53,17 @@
             <div v-else>
                 <p>This {{model_class_lc}} is currently restricted so that only you and the users listed below can access it. You can:</p>
                 <b-button @click="setSharing('make_accessible_via_link')">Make {{model_class}} Accessible via Link</b-button>
+                <span v-if="has_possible_members" class="chkk">
+                Also make all objects within the {{model_class}} accessible.
+                <input type="checkbox" v-model="make_members_public" id="chk_make_members_public">
+                </span>
                 <div class="toolParamHelp">Generates a web link that you can share with other people so that they can view and import the {{model_class_lc}}.</div>
                 <br/>
                 <b-button id="make_accessible_and_publish" @click="setSharing('make_accessible_and_publish')">Make {{model_class}} Accessible and Publish</b-button>
+                <span v-if="has_possible_members" class="chkk">
+                Also make all objects within the {{model_class}} accessible.
+                <input type="checkbox" v-model="make_members_public" id="chk_make_members_public">
+                </span>
                 <div class="toolParamHelp">Makes the {{model_class_lc}} accessible via link (see above) and publishes the {{model_class_lc}} to Galaxy's <a :href="published_url" target="_top">Published {{plural_name}}</a> section, where it is publicly listed and searchable.</div>
             </div>
             <br/><br/>
@@ -131,6 +139,9 @@ export default {
         },
         slug_url() {
             return `${Galaxy.root}${this.model_class_lc}/set_slug_async/?id=${this.id}`;
+        },
+        has_possible_members(){
+            return ["history"].indexOf(this.model_class_lc) > -1;;
         }
     },
     data() {
@@ -147,7 +158,8 @@ export default {
                 published: false,
                 users_shared_with: []
             },
-            share_fields: ["email", { key: "id", label: "" }]
+            share_fields: ["email", { key: "id", label: "" }],
+            make_members_public: false,
         };
     },
     created: function() {
@@ -180,11 +192,15 @@ export default {
                 .catch(error => (this.err_msg = error.response.data.err_msg));
         },
         setSharing: function(action, user_id) {
-            axios
-                .post(`${Galaxy.root}api/${this.plural_name_lc}/${this.id}/sharing`, {
+            let data = {
                     action: action,
                     user_id: user_id
-                })
+                }
+            if (this.has_possible_members){
+                data.make_members_public = this.make_members_public;
+            }
+            axios
+                .post(`${Galaxy.root}api/${this.plural_name_lc}/${this.id}/sharing`, data)
                 .then(response => {
                     Object.assign(this.item, response.data);
                 })
@@ -233,3 +249,8 @@ export default {
     }
 };
 </script>
+<style>
+.chkk{
+    display: inline-block;
+}
+</style>

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1533,6 +1533,10 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName):
         return new_history
 
     @property
+    def has_possible_members(self):
+        return True
+
+    @property
     def activatable_datasets(self):
         # This needs to be a list
         return [hda for hda in self.datasets if not hda.dataset.deleted]

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -1459,9 +1459,10 @@ class SharableMixin(object):
                     try:
                         trans.app.security_agent.make_dataset_public(hda.dataset)
                     except Exception:
-                        log.warning("Unable to make dataset with id: %s public.".format(dataset.id)
+                        log.warning("Unable to make dataset with id: %s public.").format(dataset.id)
                         skipped = True
                 else:
+                    log.warning("User without permissions tried to make dataset with id: %s public.").format(dataset.id)
                     skipped = True
         return item, skipped
 


### PR DESCRIPTION
addresses part of https://github.com/galaxyproject/galaxy/issues/5894

This is written to be minimalistic and targets 18.09 as it has been identified as major bug by @nekrut.

notes: 
- the UI is horrendous, but not much worse than it was before
- this is limited to histories at the moment
- this is a one-off operation so notable behavior is that if you create a new dataset in the shared history, it still won't be public when there are default permissions set on history
- this does not handle the reverse (when unpublishing it is not making your datasets restricted, since we do not know what were their permissions before. Should it just make it private?)
- naively works with collections, needs checking
- needs tests

cc @bgruening @jmchilton @mvdbeek 