### PR TITLE
[18.09] Allow starting Galaxy under gunicorn when using galaxy.ini

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/Pipfile
+++ b/lib/galaxy/dependencies/pipfiles/default/Pipfile
@@ -41,6 +41,7 @@ bleach = "*"
 "bz2file" = {version = "*", markers = "python_version < '3.3'"}
 ipaddress = {version = "*", markers = "python_version < '3.3'"}
 boltons = "*"
+gunicorn = "*"
 Paste = "*"
 docutils = "*"
 Routes = "*"

--- a/lib/galaxy/dependencies/pipfiles/default/Pipfile
+++ b/lib/galaxy/dependencies/pipfiles/default/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
+gunicorn = "*"
 lxml = "!=4.2.2"
 mock = "*"
 NoseHTML = "*"
@@ -41,7 +42,6 @@ bleach = "*"
 "bz2file" = {version = "*", markers = "python_version < '3.3'"}
 ipaddress = {version = "*", markers = "python_version < '3.3'"}
 boltons = "*"
-gunicorn = "*"
 Paste = "*"
 docutils = "*"
 Routes = "*"

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -10,6 +10,7 @@ chardet==3.0.4
 commonmark==0.5.4
 docutils==0.14
 funcsigs==1.0.2; python_version < '3.3'
+gunicorn==19.9.0
 idna==2.7
 imagesize==1.1.0; python_version != '3.3.*'
 jinja2==2.10

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -54,7 +54,6 @@ functools32==3.2.3.post2; python_version == '2.7'
 future==0.16.0
 futures==3.2.0; python_version == '2.6' or python_version == '2.7'
 galaxy-sequence-utils==1.1.3
-gunicorn==19.9.0
 h5py==2.8.0
 html5lib==1.0.1
 idna==2.7

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -54,6 +54,7 @@ functools32==3.2.3.post2; python_version == '2.7'
 future==0.16.0
 futures==3.2.0; python_version == '2.6' or python_version == '2.7'
 galaxy-sequence-utils==1.1.3
+gunicorn==19.9.0
 h5py==2.8.0
 html5lib==1.0.1
 idna==2.7

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -157,6 +157,10 @@ find_server() {
         fi
         server_args="$server_args $uwsgi_args"
         pid_log_paster_args=""
+    elif [ "$APP_WEBSERVER" = "gunicorn" ];
+    then
+        export GUNICORN_CMD_ARGS=${GUNICORN_CMD_ARGS:-"--bind=localhost:8080"}
+        server_args="$APP_WEBSERVER --pythonpath lib --paste \"$server_config\""
     else
         run_server="python"
         server_args="./scripts/paster.py serve \"$server_config\" $paster_args"

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -159,7 +159,7 @@ find_server() {
         pid_log_paster_args=""
     elif [ "$APP_WEBSERVER" = "gunicorn" ];
     then
-        export GUNICORN_CMD_ARGS=${GUNICORN_CMD_ARGS:-"--bind=localhost:8080"}
+        export GUNICORN_CMD_ARGS="${GUNICORN_CMD_ARGS:-\"--bind=localhost:8080\"}"
         server_args="$APP_WEBSERVER --pythonpath lib --paste \"$server_config\""
     else
         run_server="python"


### PR DESCRIPTION
and starting Galaxy with `APP_WEBSERVER=gunicorn sh run.sh`.
Additional gunicorn cmdline arguments can be passed using
`GUNICORN_CMD_ARGS`. In a first pass this will allow
running planemo {serve, test} under python 3, as Paste
has some problems under python 3:

```
galaxy.web.stack INFO 2018-09-29 22:16:00,216 Galaxy server instance 'main' is running
Traceback (most recent call last):
  File "./scripts/paster.py", line 27, in <module>
    serve.run()
  File "/tmp/tmpv5tow6c8/galaxy-dev/lib/galaxy/util/pastescript/serve.py", line 1055, in run
    invoke(command, command_name, options, args[1:])
  File "/tmp/tmpv5tow6c8/galaxy-dev/lib/galaxy/util/pastescript/serve.py", line 1061, in invoke
    exit_code = runner.run(args)
  File "/tmp/tmpv5tow6c8/galaxy-dev/lib/galaxy/util/pastescript/serve.py", line 226, in run
    result = self.command()
  File "/tmp/tmpv5tow6c8/galaxy-dev/lib/galaxy/util/pastescript/serve.py", line 676, in command
    serve()
  File "/tmp/tmpv5tow6c8/galaxy-dev/lib/galaxy/util/pastescript/serve.py", line 653, in serve
    server(app)
  File "/tmp/tmpv5tow6c8/galaxy-dev/lib/galaxy/util/pastescript/loadwsgi.py", line 232, in server_wrapper
    **context.local_conf)
  File "/tmp/tmpv5tow6c8/galaxy-dev/lib/galaxy/util/pastescript/loadwsgi.py", line 90, in fix_call
    val = callable(*args, **kw)
  File "/home/travis/.planemo/gx_venv_3_release_18.09/lib/python3.6/site-packages/paste/httpserver.py", line 1353, in server_runner
    for name, value in kwargs.items():
RuntimeError: dictionary changed size during iteration
```

That said gunicorn is a nice pure-python alternative to paste going
forward.

It's a bit of a stretch to call this a bug and include it in 18.09, 
but this should go long ways in verifying that tools are python 3 compatible.