### PR TITLE
[18.09] Drop gulp plugin staging task from default tasks

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -131,4 +131,4 @@ gulp.task("watch-style", function() {
 
 gulp.task("staging", ["stage-libs", "fonts"]);
 
-gulp.task("default", ["scripts", "libs", "plugins"]);
+gulp.task("default", ["scripts", "libs"]);


### PR DESCRIPTION
It's all done in python now via common_startup, along with the other build invocations.  We may (likely) eventually want this back in client-land via package scripts, but that isn't the paradigm that we're using in this release.

Mixing the two methods along with switching branches around is problematic due to attempting to copy over symlinks sometimes.  Even though nobody should really see this other than developers switching around, it makes sense to disable this for the release since we don't need both methods.

xref #6344, particularly https://github.com/galaxyproject/galaxy/pull/6344#issuecomment-397767622 for more discussion about future plans, but we're just not quite there yet.