### PR TITLE
[18.05] Don't delete referenced Datasets when purging users

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -1490,7 +1490,6 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
         # Purging a deleted User deletes all of the following:
         # - History where user_id = User.id
         #    - HistoryDatasetAssociation where history_id = History.id
-        #    - Dataset where HistoryDatasetAssociation.dataset_id = Dataset.id
         # - UserGroupAssociation where user_id == User.id
         # - UserRoleAssociation where user_id == User.id EXCEPT FOR THE PRIVATE ROLE
         # - UserAddress where user_id == User.id
@@ -1506,11 +1505,6 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                 trans.sa_session.refresh(h)
                 for hda in h.active_datasets:
                     # Delete HistoryDatasetAssociation
-                    d = trans.sa_session.query(trans.app.model.Dataset).get(hda.dataset_id)
-                    # Delete Dataset
-                    if not d.deleted:
-                        d.deleted = True
-                        trans.sa_session.add(d)
                     hda.deleted = True
                     trans.sa_session.add(hda)
                 h.deleted = True


### PR DESCRIPTION
Previously when purging users, *all* of their referenced datasets, including those that are shared with/by other users, and library datasets, would be marked as deleted. The cleanup scripts would subsequently purge active data. Which is bad.

This bug likely goes back a long time (probably the whole way).

I fixed it here to honor the message "Purging Histories and Datasets must be handled via the cleanup_datasets.py script". As a new feature on dev we should probably add an "immediate" option to the UI/API, such that:

- delete = "mark user deleted"
- purge = the above + "mark all the associations deleted and the user purged"
- immediate purge = the above + mark all associations purged and delete/purge unreferenced datasets