### PR TITLE
Support for Enhancements to gxformat2 (part II)

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -55,7 +55,7 @@ functools32==3.2.3.post2; python_version == '2.7'
 future==0.16.0
 futures==3.2.0; python_version == '2.6' or python_version == '2.7'
 galaxy-sequence-utils==1.1.3
-gxformat2==0.3.0
+gxformat2==0.6.0
 h5py==2.8.0
 html5lib==1.0.1
 idna==2.7

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -77,8 +77,8 @@ class: GalaxyWorkflow
 inputs:
   - id: outer_input
 outputs:
-  - id: outer_output
-    source: second_cat#out_file1
+  outer_output:
+    outputSource: second_cat/out_file1
 steps:
   - tool_id: cat1
     label: first_cat
@@ -993,7 +993,7 @@ outer_input:
   value: 1.bed
   type: File
 """
-            self._run_jobs(WORKFLOW_NESTED_REPLACEMENT_PARAMETER, test_data=test_data, history_id=history_id, round_trip_format_conversion=True)
+            self._run_jobs(WORKFLOW_NESTED_REPLACEMENT_PARAMETER, test_data=test_data, history_id=history_id)
             details = self.dataset_populator.get_history_dataset_details(history_id)
             assert details["name"] == "moocow suffix"
 
@@ -1188,8 +1188,8 @@ class: GalaxyWorkflow
 inputs:
   - id: input1
 outputs:
-  - id: wf_output_1
-    source: first_cat#out_file1
+  wf_output_1:
+    outputSource: first_cat/out_file1
 steps:
   - tool_id: cat1
     label: first_cat
@@ -1217,8 +1217,8 @@ inputs:
     type: data_collection_input
     collection_type: list
 outputs:
-  - id: wf_output_1
-    source: first_cat#out_file1
+  wf_output_1:
+    outputSource: first_cat/out_file1
 steps:
   - tool_id: cat
     label: first_cat
@@ -1257,8 +1257,8 @@ class: GalaxyWorkflow
 inputs:
   - id: input1
 outputs:
-  - id: wf_output_1
-    source: first_cat#out_file1
+  wf_output_1:
+    outputSource: first_cat/out_file1
 steps:
   - tool_id: cat
     label: first_cat
@@ -1299,8 +1299,8 @@ class: GalaxyWorkflow
 inputs:
   - id: text_input
 outputs:
-  - id: wf_output_1
-    source: split_up#paired_output
+  wf_output_1:
+    outputSource: split_up/paired_output
 steps:
   - label: split_up
     tool_id: collection_creates_pair
@@ -1381,8 +1381,8 @@ class: GalaxyWorkflow
 inputs:
   - id: outer_input
 outputs:
-  - id: outer_output
-    source: second_cat#out_file1
+  outer_output:
+    outputSource: second_cat/out_file1
 steps:
   - tool_id: cat1
     label: first_cat
@@ -1393,8 +1393,8 @@ steps:
       inputs:
         - id: inner_input
       outputs:
-        - id: workflow_output
-          source: random_lines#out_file1
+        workflow_output:
+          outputSource: random_lines/out_file1
       steps:
         - tool_id: random_lines1
           label: random_lines
@@ -1439,8 +1439,8 @@ class: GalaxyWorkflow
 inputs:
   - id: outer_input
 outputs:
-  - id: outer_output
-    source: second_cat#out_file1
+  outer_output:
+    outputSource: second_cat/out_file1
 steps:
   - tool_id: cat1
     label: first_cat
@@ -1451,8 +1451,8 @@ steps:
       inputs:
         - id: inner_input
       outputs:
-        - id: workflow_output
-          source: inner_cat#out_file1
+        workflow_output:
+          outputSource: inner_cat/out_file1
       steps:
         - tool_id: random_lines1
           label: random_lines
@@ -1496,8 +1496,8 @@ class: GalaxyWorkflow
 inputs:
   - id: outer_input
 outputs:
-  - id: outer_output
-    source: second_cat#out_file1
+  outer_output:
+    outputSource: second_cat/out_file1
 steps:
   - tool_id: cat1
     label: first_cat
@@ -1508,8 +1508,8 @@ steps:
       inputs:
         - id: inner_input
       outputs:
-        - id: workflow_output
-          source: split#output
+        workflow_output:
+          outputSource: split/output
       steps:
         - tool_id: random_lines1
           label: random_lines
@@ -1548,8 +1548,8 @@ class: GalaxyWorkflow
 inputs:
   - id: input1
 outputs:
-  - id: count_list
-    source: count_list#out_file1
+  count_list:
+    outputSource: count_list/out_file1
 steps:
   - tool_id: empty_list
     label: empty_list
@@ -1604,8 +1604,8 @@ class: GalaxyWorkflow
 inputs:
   - id: input1
 outputs:
-  - id: count_multi_file
-    source: count_multi_file#out_file1
+  count_multi_file:
+    outputSource: count_multi_file/out_file1
 steps:
   - tool_id: empty_list
     label: empty_list
@@ -2092,8 +2092,8 @@ outer_input:
 class: GalaxyWorkflow
 inputs: []
 outputs:
-  - id: wf_output_1
-    source: output_filter#out_1
+  wf_output_1:
+    outputSource: output_filter/out_1
 steps:
   - tool_id: output_filter
     label: output_filter
@@ -2711,8 +2711,8 @@ class: GalaxyWorkflow
 inputs:
   - id: input1
 outputs:
-  - id: wf_output_1
-    source: third_cat#out_file1
+  wf_output_1:
+    outputSource: third_cat/out_file1
 steps:
   - tool_id: cat1
     label: first_cat

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -986,17 +986,14 @@ test_data:
     @skip_without_tool("cat")
     def test_run_subworkflow_replacment_parameters(self):
         with self.dataset_populator.test_history() as history_id:
-            workflow_run_description = """%s
-
-test_data:
-  replacement_parameters:
-    replaceme: moocow
-  outer_input:
-    value: 1.bed
-    type: File
-""" % WORKFLOW_NESTED_REPLACEMENT_PARAMETER
-            self._run_jobs(workflow_run_description, history_id=history_id)
-
+            test_data = """
+replacement_parameters:
+  replaceme: moocow
+outer_input:
+  value: 1.bed
+  type: File
+"""
+            self._run_jobs(WORKFLOW_NESTED_REPLACEMENT_PARAMETER, test_data=test_data, history_id=history_id, round_trip_format_conversion=True)
             details = self.dataset_populator.get_history_dataset_details(history_id)
             assert details["name"] == "moocow suffix"
 
@@ -1196,13 +1193,9 @@ outputs:
 steps:
   - tool_id: cat1
     label: first_cat
-    state:
-      input1:
-        $link: input1
-
-test_data:
-  input1: "hello world"
-""", history_id=history_id)
+    in:
+      input1: input1
+""", test_data={"input1": "hello world"}, history_id=history_id)
             workflow_id = summary.workflow_id
             invocation_id = summary.invocation_id
             invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
@@ -1229,17 +1222,16 @@ outputs:
 steps:
   - tool_id: cat
     label: first_cat
-    state:
-      input1:
-        $link: input1
-test_data:
-  input1:
-    type: list
-    name: the_dataset_list
-    elements:
-      - identifier: el1
-        value: 1.fastq
-        type: File
+    in:
+      input1: input1
+""", test_data="""
+input1:
+  type: list
+  name: the_dataset_list
+  elements:
+    - identifier: el1
+      value: 1.fastq
+      type: File
 """, history_id=history_id)
             workflow_id = summary.workflow_id
             invocation_id = summary.invocation_id
@@ -1270,20 +1262,19 @@ outputs:
 steps:
   - tool_id: cat
     label: first_cat
-    state:
-      input1:
-        $link: input1
-test_data:
-  input1:
-    type: list
-    name: the_dataset_list
-    elements:
-      - identifier: el1
-        value: 1.fastq
-        type: File
-      - identifier: el2
-        value: 1.fastq
-        type: File
+    in:
+      input1: input1
+""", test_data="""
+input1:
+  type: list
+  name: the_dataset_list
+  elements:
+    - identifier: el1
+      value: 1.fastq
+      type: File
+    - identifier: el2
+      value: 1.fastq
+      type: File
 """, history_id=history_id)
             workflow_id = summary.workflow_id
             invocation_id = summary.invocation_id
@@ -1305,28 +1296,27 @@ test_data:
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_jobs("""
 class: GalaxyWorkflow
+inputs:
+  - id: text_input
 outputs:
   - id: wf_output_1
     source: split_up#paired_output
 steps:
-  - label: text_input
-    type: input
   - label: split_up
     tool_id: collection_creates_pair
-    state:
-      input1:
-        $link: text_input
-test_data:
-  text_input:
-    type: list
-    name: the_dataset_list
-    elements:
-      - identifier: el1
-        value: 1.fastq
-        type: File
-      - identifier: el2
-        value: 1.fastq
-        type: File
+    in:
+      input1: text_input
+""", test_data="""
+text_input:
+  type: list
+  name: the_dataset_list
+  elements:
+    - identifier: el1
+      value: 1.fastq
+      type: File
+    - identifier: el2
+      value: 1.fastq
+      type: File
 """, history_id=history_id)
             workflow_id = summary.workflow_id
             invocation_id = summary.invocation_id
@@ -1346,20 +1336,19 @@ test_data:
 
     def test_workflow_run_input_mapping_with_subworkflows(self):
         with self.dataset_populator.test_history() as history_id:
-            summary = self._run_jobs("""%s
-
-test_data:
-  outer_input:
-    type: list
-    name: the_dataset_list
-    elements:
-      - identifier: el1
-        value: 1.fastq
-        type: File
-      - identifier: el2
-        value: 1.fastq
-        type: File
-""" % WORKFLOW_NESTED_SIMPLE, history_id=history_id)
+            test_data = """
+outer_input:
+  type: list
+  name: the_dataset_list
+  elements:
+    - identifier: el1
+      value: 1.fastq
+      type: File
+    - identifier: el2
+      value: 1.fastq
+      type: File
+"""
+            summary = self._run_jobs(WORKFLOW_NESTED_SIMPLE, test_data=test_data, history_id=history_id)
             workflow_id = summary.workflow_id
             invocation_id = summary.invocation_id
             invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
@@ -1397,9 +1386,8 @@ outputs:
 steps:
   - tool_id: cat1
     label: first_cat
-    state:
-      input1:
-        $link: outer_input
+    in:
+      input1: outer_input
   - run:
       class: GalaxyWorkflow
       inputs:
@@ -1418,18 +1406,16 @@ steps:
               seed_source_selector: set_seed
               seed: asdf
     label: nested_workflow
-    connect:
-      inner_input: first_cat#out_file1
+    in:
+      inner_input: first_cat/out_file1
   - tool_id: split
     label: split
-    state:
-      input1:
-        $link: nested_workflow#workflow_output
+    in:
+      input1: nested_workflow/workflow_output
   - tool_id: cat_list
     label: second_cat
-    state:
-      input1:
-        $link: split#output
+    in:
+      input1: split/output
 
 test_data:
   outer_input:
@@ -1458,9 +1444,8 @@ outputs:
 steps:
   - tool_id: cat1
     label: first_cat
-    state:
-      input1:
-        $link: outer_input
+    in:
+      input1: outer_input
   - run:
       class: GalaxyWorkflow
       inputs:
@@ -1480,28 +1465,24 @@ steps:
               seed: asdf
         - tool_id: split
           label: split
-          state:
-            input1:
-              $link: random_lines#out_file1
+          in:
+            input1: random_lines/out_file1
         - tool_id: cat1
           label: inner_cat
-          state:
-            input1:
-              $link: split#output
+          in:
+            input1: split/output
 
     label: nested_workflow
-    connect:
-      inner_input: first_cat#out_file1
+    in:
+      inner_input: first_cat/out_file1
   - tool_id: cat_list
     label: second_cat
-    state:
-      input1:
-        $link: nested_workflow#workflow_output
-
-test_data:
-  outer_input:
-    value: 1.bed
-    type: File
+    in:
+      input1: nested_workflow/workflow_output
+""", test_data="""
+outer_input:
+  value: 1.bed
+  type: File
 """, history_id=history_id, wait=True)
             self.assertEqual("chr6\t108722976\t108723115\tCCDS5067.1_cds_0_0_chr6_108722977_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n", self.dataset_populator.get_history_dataset_content(history_id))
 
@@ -1520,9 +1501,8 @@ outputs:
 steps:
   - tool_id: cat1
     label: first_cat
-    state:
-      input1:
-        $link: outer_input
+    in:
+      input1: outer_input
   - run:
       class: GalaxyWorkflow
       inputs:
@@ -1542,22 +1522,19 @@ steps:
               seed: asdf
         - tool_id: split
           label: split
-          state:
-            input1:
-              $link: random_lines#out_file1
+          in:
+            input1: random_lines/out_file1
     label: nested_workflow
-    connect:
-      inner_input: first_cat#out_file1
+    in:
+      inner_input: first_cat/out_file1
   - tool_id: cat_list
     label: second_cat
-    state:
-      input1:
-        $link: nested_workflow#workflow_output
-
-test_data:
-  outer_input:
-    value: 1.bed
-    type: File
+    in:
+      input1: nested_workflow/workflow_output
+""", test_data="""
+outer_input:
+  value: 1.bed
+  type: File
 """, history_id=history_id, wait=True)
             self.assertEqual("chr6\t108722976\t108723115\tCCDS5067.1_cds_0_0_chr6_108722977_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n", self.dataset_populator.get_history_dataset_content(history_id))
 
@@ -1576,9 +1553,8 @@ outputs:
 steps:
   - tool_id: empty_list
     label: empty_list
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
   - tool_id: random_lines1
     label: random_lines
     state:
@@ -1590,14 +1566,12 @@ steps:
         seed: asdf
   - tool_id: count_list
     label: count_list
-    state:
-      input1:
-        $link: random_lines#out_file1
-
-test_data:
-  input1:
-    value: 1.bed
-    type: File
+    in:
+      input1: random_lines/out_file1
+""", test_data="""
+input1:
+  value: 1.bed
+  type: File
 """, history_id=history_id, wait=True)
             self.assertEqual("0\n", self.dataset_populator.get_history_dataset_content(history_id))
 
@@ -1610,13 +1584,12 @@ steps:
   - label: text_input1
     type: input_collection
   - tool_id: collection_type_source_map_over
-    state:
-      input_collect:
-        $link: text_input1
-test_data:
-  text_input1:
-    type: "list:paired"
-        """, history_id=history_id)
+    in:
+      input_collect: text_input1
+""", test_data="""
+text_input1:
+  type: "list:paired"
+""", history_id=history_id)
             hdca = self.dataset_populator.get_history_collection_details(history_id=jobs_summary.history_id, hid=1)
             assert hdca['collection_type'] == 'list:paired'
             assert len(hdca['elements'][0]['object']["elements"]) == 2
@@ -1636,9 +1609,8 @@ outputs:
 steps:
   - tool_id: empty_list
     label: empty_list
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
   - tool_id: random_lines1
     label: random_lines
     state:
@@ -1650,14 +1622,12 @@ steps:
         seed: asdf
   - tool_id: count_multi_file
     label: count_multi_file
-    state:
-      input1:
-        $link: random_lines#out_file1
-
-test_data:
-  input1:
-    value: 1.bed
-    type: File
+    in:
+      input1: random_lines/out_file1
+""", test_data="""
+input1:
+  value: 1.bed
+  type: File
 """, history_id=history_id, wait=True)
             self.assertEqual("0\n", self.dataset_populator.get_history_dataset_content(history_id))
 
@@ -1813,14 +1783,12 @@ inputs:
 steps:
   - tool_id: cat
     label: first_cat
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
   - tool_id: cat
     label: second_cat
-    state:
-      input1:
-        $link: first_cat#out_file1
+    in:
+      input1: first_cat/out_file1
 """)
             DELETED = 0
             PAUSED_1 = 3
@@ -1854,19 +1822,16 @@ steps:
   type: input
 - label: first_cat
   tool_id: cat1
-  state:
-    input1:
-      $link: test_input
+  in:
+    input1: test_input
 - label: the_pause
   type: pause
-  connect:
-    input:
-    - first_cat#out_file1
+  in:
+    input: first_cat/out_file1
 - label: second_cat
   tool_id: cat1
-  state:
-    input1:
-      $link: the_pause
+  in:
+    input1: the_pause
 - label: third_cat
   tool_id: random_lines1
   connect:
@@ -1878,9 +1843,7 @@ steps:
     seed_source:
       seed_source_selector: set_seed
       seed: asdf
-test_data:
-  test_input: "hello world"
-""", history_id=history_id, wait=False)
+""", test_data={"test_input": "hello world"}, history_id=history_id, wait=False)
             history_id = run_summary.history_id
             workflow_id = run_summary.workflow_id
             invocation_id = run_summary.invocation_id
@@ -1910,10 +1873,10 @@ steps:
     r2:
      - text:
         $link: text_input
-test_data:
-  text_input:
-    value: "abd"
-    type: raw
+""", test_data="""
+text_input:
+  value: "abd"
+  type: raw
 """, history_id=history_id, wait=True)
             time.sleep(10)
             self.workflow_populator.wait_for_invocation(run_summary.workflow_id, run_summary.invocation_id)
@@ -1933,10 +1896,10 @@ steps:
     r2:
      - text:
         $link: text_input
-test_data:
-  text_input:
-    value: ""
-    type: raw
+""", test_data="""
+text_input:
+  value: ""
+  type: raw
 """, history_id=history_id, wait=True, assert_ok=False)
 
     def test_run_with_text_connection(self):
@@ -1959,13 +1922,13 @@ steps:
       seed_source_selector: set_seed
       seed:
         $link: text_input
-test_data:
-  data_input:
-    value: 1.bed
-    type: File
-  text_input:
-    value: asdf
-    type: raw
+""", test_data="""
+data_input:
+  value: 1.bed
+  type: File
+text_input:
+  value: asdf
+  type: raw
 """, history_id=history_id)
 
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
@@ -1999,14 +1962,12 @@ test_data:
     @skip_without_tool('cat1')
     def test_nested_workflow_rerun_with_use_cached_job(self):
         with self.dataset_populator.test_history() as history_id_one, self.dataset_populator.test_history() as history_id_two:
-            workflow_run_description = """%s
-
-test_data:
-  outer_input:
-    value: 1.bed
-    type: File
-""" % WORKFLOW_NESTED_SIMPLE
-            run_jobs_summary = self._run_jobs(workflow_run_description, history_id=history_id_one)
+            test_data = """
+outer_input:
+  value: 1.bed
+  type: File
+"""
+            run_jobs_summary = self._run_jobs(WORKFLOW_NESTED_SIMPLE, test_data=test_data, history_id=history_id_one)
             workflow_request = run_jobs_summary.workflow_request
             # We copy the inputs to a new history and re-run the workflow
             inputs = json.loads(workflow_request['inputs'])
@@ -2139,8 +2100,7 @@ steps:
     state:
       produce_out_1: False
       filter_text_1: '1'
-test_data: {}
-    """, history_id=history_id, wait=False)
+""", test_data={}, history_id=history_id, wait=False)
             self.wait_for_invocation_and_jobs(history_id, run_object.workflow_id, run_object.invocation_id)
             contents = self.__history_contents(history_id)
             assert len(contents) == 1
@@ -2159,20 +2119,19 @@ inputs:
 steps:
   - tool_id: cat
     label: first_cat
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
     outputs:
       out_file1:
         rename: "my new name"
-test_data:
-  input1:
-    type: list
-    name: the_dataset_list
-    elements:
-      - identifier: el1
-        value: 1.fastq
-        type: File
+""", test_data="""
+input1:
+  type: list
+  name: the_dataset_list
+  elements:
+    - identifier: el1
+      value: 1.fastq
+      type: File
 """, history_id=history_id)
             content = self.dataset_populator.get_history_dataset_details(history_id, hid=4, wait=True, assert_ok=True)
             name = content["name"]
@@ -2195,20 +2154,19 @@ inputs:
 steps:
   - tool_id: cat
     label: first_cat
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
     outputs:
       out_file1:
         rename: "#{input1} suffix"
-test_data:
-  input1:
-    type: list
-    name: the_dataset_list
-    elements:
-      - identifier: el1
-        value: 1.fastq
-        type: File
+""", test_data="""
+input1:
+  type: list
+  name: the_dataset_list
+  elements:
+    - identifier: el1
+      value: 1.fastq
+      type: File
 """, history_id=history_id)
             content = self.dataset_populator.get_history_collection_details(history_id, hid=3, wait=True, assert_ok=True)
             name = content["name"]
@@ -2224,17 +2182,16 @@ inputs:
   - id: input1
 steps:
   - tool_id: collection_creates_pair
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
     outputs:
       paired_output:
         rename: "my new name"
-test_data:
-  input1:
-    value: 1.fasta
-    type: File
-    name: fasta1
+""", test_data="""
+input1:
+  value: 1.fasta
+  type: File
+  name: fasta1
 """, history_id=history_id)
             details1 = self.dataset_populator.get_history_collection_details(history_id, hid=4, wait=True, assert_ok=True)
 
@@ -2256,8 +2213,7 @@ steps:
         rename: "my new name"
       out_file2:
         rename: "my other new name"
-test_data: {}
-""", history_id=history_id)
+""", test_data={}, history_id=history_id)
         details1 = self.dataset_populator.get_history_dataset_details(history_id, hid=1, wait=True, assert_ok=True)
         details2 = self.dataset_populator.get_history_dataset_details(history_id, hid=2)
 
@@ -2291,17 +2247,16 @@ steps:
       out_file1:
         rename: "cat1 out"
   - tool_id: cat
-    state:
-      input1:
-        $link: first_fail#out_file1
+    in:
+      input1: first_fail/out_file1
     outputs:
       out_file1:
         rename: "#{input1} suffix"
-test_data:
-  input1:
-    value: 1.fasta
-    type: File
-    name: fail
+""", test_data="""
+input1:
+  value: 1.fasta
+  type: File
+  name: fail
 """, history_id=history_id, wait=True, assert_ok=False)
             content = self.dataset_populator.get_history_dataset_details(history_id, hid=2, wait=True, assert_ok=False)
             name = content["name"]
@@ -2331,17 +2286,16 @@ inputs:
 steps:
   - tool_id: cat
     label: first_cat
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
     outputs:
       out_file1:
         rename: "#{input1} #{input1 | upper} suffix"
-test_data:
-  input1:
-    value: 1.fasta
-    type: File
-    name: '#{input1}'
+""", test_data="""
+input1:
+  value: 1.fasta
+  type: File
+  name: '#{input1}'
 """, history_id=history_id)
             content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
             name = content["name"]
@@ -2367,15 +2321,15 @@ steps:
     outputs:
       out_file1:
         rename: "#{queries_0.input2| basename} suffix"
-test_data:
-  input1:
-    value: 1.fasta
-    type: File
-    name: fasta1
-  input2:
-    value: 1.fasta
-    type: File
-    name: fasta2
+""", test_data="""
+input1:
+  value: 1.fasta
+  type: File
+  name: fasta1
+input2:
+  value: 1.fasta
+  type: File
+  name: fasta2
 """, history_id=history_id)
             content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
             name = content["name"]
@@ -2403,17 +2357,17 @@ steps:
         # Wish it was qualified for conditionals but it doesn't seem to be. -John
         # rename: "#{fastq_input.fastq_input1 | basename} suffix"
         rename: "#{fastq_input1 | basename} suffix"
-test_data:
-  fasta_input:
-    value: 1.fasta
-    type: File
-    name: fasta1
-    file_type: fasta
-  fastq_input:
-    value: 1.fastqsanger
-    type: File
-    name: fastq1
-    file_type: fastqsanger
+""", test_data="""
+fasta_input:
+  value: 1.fasta
+  type: File
+  name: fasta1
+  file_type: fasta
+fastq_input:
+  value: 1.fastqsanger
+  type: File
+  name: fastq1
+  file_type: fastqsanger
 """, history_id=history_id)
             content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
             name = content["name"]
@@ -2441,22 +2395,22 @@ steps:
         # Wish it was qualified for conditionals but it doesn't seem to be. -John
         # rename: "#{fastq_input.fastq_input1 | basename} suffix"
         rename: "#{fastq_input1} suffix"
-test_data:
-  fasta_input:
-    value: 1.fasta
-    type: File
-    name: fasta1
-    file_type: fasta
-  fastq_inputs:
-    type: list
-    name: the_dataset_pair
-    elements:
-      - identifier: forward
-        value: 1.fastq
-        type: File
-      - identifier: reverse
-        value: 1.fastq
-        type: File
+""", test_data="""
+fasta_input:
+  value: 1.fasta
+  type: File
+  name: fasta1
+  file_type: fasta
+fastq_inputs:
+  type: list
+  name: the_dataset_pair
+  elements:
+    - identifier: forward
+      value: 1.fastq
+      type: File
+    - identifier: reverse
+      value: 1.fastq
+      type: File
 """, history_id=history_id)
             content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
             name = content["name"]
@@ -2477,11 +2431,11 @@ steps:
     outputs:
       paired_output:
         hide: true
-test_data:
-  input1:
-    value: 1.fasta
-    type: File
-    name: fasta1
+""", test_data="""
+input1:
+  value: 1.fasta
+  type: File
+  name: fasta1
 """, history_id=history_id)
             details1 = self.dataset_populator.get_history_collection_details(history_id, hid=4, wait=True, assert_ok=True)
 
@@ -2506,14 +2460,14 @@ steps:
     outputs:
       out_file1:
         hide: true
-test_data:
-  input1:
-    type: list
-    name: the_dataset_list
-    elements:
-      - identifier: el1
-        value: 1.fastq
-        type: File
+""", test_data="""
+input1:
+  type: list
+  name: the_dataset_list
+  elements:
+    - identifier: el1
+      value: 1.fastq
+      type: File
 """, history_id=history_id)
 
             content = self.dataset_populator.get_history_dataset_details(history_id, hid=4, wait=True, assert_ok=True)
@@ -2534,9 +2488,8 @@ inputs:
 steps:
   - label: first_cat
     tool_id: cat
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
     outputs:
       out_file1:
         add_tags:
@@ -2546,14 +2499,13 @@ steps:
             - "machine:illumina"
   - label: second_cat
     tool_id: cat
-    state:
-      input1:
-        $link: first_cat#out_file1
-test_data:
-  input1:
-    value: 1.fasta
-    type: File
-    name: fasta1
+    in:
+      input1: first_cat/out_file1
+""", test_data="""
+input1:
+  value: 1.fasta
+  type: File
+  name: fasta1
 """, history_id=history_id)
 
             details0 = self.dataset_populator.get_history_dataset_details(history_id, hid=2, wait=True, assert_ok=True)
@@ -2578,18 +2530,17 @@ inputs:
   - id: input1
 steps:
   - tool_id: collection_creates_pair
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
     outputs:
       paired_output:
         add_tags:
             - "name:foo"
-test_data:
-  input1:
-    value: 1.fasta
-    type: File
-    name: fasta1
+""", test_data="""
+input1:
+  value: 1.fasta
+  type: File
+  name: fasta1
 """, history_id=history_id)
             details1 = self.dataset_populator.get_history_collection_details(history_id, hid=4, wait=True, assert_ok=True)
 
@@ -2608,21 +2559,20 @@ inputs:
 steps:
   - tool_id: cat
     label: first_cat
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
     outputs:
       out_file1:
         add_tags:
             - "name:foo"
-test_data:
-  input1:
-    type: list
-    name: the_dataset_list
-    elements:
-      - identifier: el1
-        value: 1.fastq
-        type: File
+""", test_data="""
+input1:
+  type: list
+  name: the_dataset_list
+  elements:
+    - identifier: el1
+      value: 1.fastq
+      type: File
 """, history_id=history_id)
             details1 = self.dataset_populator.get_history_collection_details(history_id, hid=3, wait=True, assert_ok=True)
 
@@ -2640,26 +2590,24 @@ inputs:
 steps:
   - tool_id: cat
     label: first_cat
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
     outputs:
       out_file1:
         add_tags:
           - "name:foo"
   - tool_id: collection_creates_pair
-    state:
-      input1:
-        $link: first_cat#out_file1
+    in:
+      input1: first_cat#out_file1
     outputs:
       paired_output:
         remove_tags:
           - "name:foo"
-test_data:
-  input1:
-    value: 1.fasta
-    type: File
-    name: fasta1
+""", test_data="""
+input1:
+  value: 1.fasta
+  type: File
+  name: fasta1
 """, history_id=history_id)
             details_dataset_with_tag = self.dataset_populator.get_history_dataset_details(history_id, hid=2, wait=True, assert_ok=True)
 
@@ -2707,24 +2655,21 @@ test_data:
     def test_run_with_delayed_runtime_pja(self):
         workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
+inputs:
+  - id: test_input
 steps:
-  - label: test_input
-    type: input
   - label: first_cat
     tool_id: cat1
-    state:
-      input1:
-        $link: test_input
+    in:
+      input1: test_input
   - label: the_pause
     type: pause
-    connect:
-      input:
-      - first_cat#out_file1
+    in:
+      input: first_cat/out_file1
   - label: second_cat
     tool_id: cat1
-    state:
-      input1:
-        $link: the_pause
+    in:
+      input1: the_pause
 """)
         downloaded_workflow = self._download_workflow(workflow_id)
         uuid_dict = dict((int(index), step["uuid"]) for index, step in downloaded_workflow["steps"].items())
@@ -2771,25 +2716,20 @@ outputs:
 steps:
   - tool_id: cat1
     label: first_cat
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
   - tool_id: cat1
     label: second_cat
-    state:
-      input1:
-        $link: first_cat#out_file1
+    in:
+      input1: first_cat/out_file1
   - tool_id: cat1
     label: third_cat
-    state:
-      input1:
-        $link: second_cat#out_file1
+    in:
+      input1: second_cat/out_file1
     outputs:
       out_file1:
         delete_intermediate_datasets: true
-test_data:
-  input1: "hello world"
-""", history_id=history_id)
+""", test_data={"input1": "hello world"}, history_id=history_id)
             hda1 = self.dataset_populator.get_history_dataset_details(history_id, hid=1)
             hda2 = self.dataset_populator.get_history_dataset_details(history_id, hid=2)
             hda3 = self.dataset_populator.get_history_dataset_details(history_id, hid=3)
@@ -3076,17 +3016,16 @@ inputs:
 steps:
   - label: cat1
     tool_id: cat1
-    state:
-       input1:
-         $link: input_c
-test_data:
-  input_c:
-    type: list
-    elements:
-      - identifier: i1
-        content: "0"
-      - identifier: i2
-        content: "1"
+    in:
+       input1: input_c
+""", test_data="""
+input_c:
+  type: list
+  elements:
+    - identifier: i1
+      content: "0"
+    - identifier: i2
+      content: "1"
 """, history_id=history_id, wait=True, assert_ok=True)
         workflow_id = summary.workflow_id
         invocation_id = summary.invocation_id

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -33,7 +33,7 @@ from galaxy.exceptions import error_codes  # noqa: I201
 NESTED_WORKFLOW_AUTO_LABELS = """
 class: GalaxyWorkflow
 inputs:
-  - id: outer_input
+  outer_input: data
 outputs:
   outer_output:
     outputSource: second_cat/out_file1
@@ -1016,11 +1016,10 @@ test_data:
         with self.dataset_populator.test_history() as history_id:
             workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
+inputs:
+  test_input_1: data
+  test_input_2: data
 steps:
-  - label: test_input_1
-    type: input
-  - label: test_input_2
-    type: input
   - label: first_cat
     tool_id: cat1
     state:
@@ -1088,8 +1087,8 @@ test_data: {}
             summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - type: collection
-    label: input_c
+  input_c: collection
+
 steps:
   - label: mixed_collection
     tool_id: exit_code_from_file
@@ -1144,7 +1143,7 @@ test_data:
             summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 outputs:
   wf_output_1:
     outputSource: first_cat/out_file1
@@ -1171,7 +1170,7 @@ steps:
             summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1:
     type: data_collection_input
     collection_type: list
 outputs:
@@ -1213,7 +1212,7 @@ input1:
             summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 outputs:
   wf_output_1:
     outputSource: first_cat/out_file1
@@ -1255,7 +1254,7 @@ input1:
             summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: text_input
+  text_input: data
 outputs:
   wf_output_1:
     outputSource: split_up/paired_output
@@ -1337,7 +1336,7 @@ outer_input:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: outer_input
+  outer_input: data
 outputs:
   outer_output:
     outputSource: second_cat/out_file1
@@ -1349,7 +1348,7 @@ steps:
   - run:
       class: GalaxyWorkflow
       inputs:
-        - id: inner_input
+        inner_input: data
       outputs:
         workflow_output:
           outputSource: random_lines/out_file1
@@ -1395,7 +1394,7 @@ test_data:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: outer_input
+  outer_input: data
 outputs:
   outer_output:
     outputSource: second_cat/out_file1
@@ -1407,7 +1406,7 @@ steps:
   - run:
       class: GalaxyWorkflow
       inputs:
-        - id: inner_input
+        inner_input: data
       outputs:
         workflow_output:
           outputSource: inner_cat/out_file1
@@ -1452,7 +1451,7 @@ outer_input:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: outer_input
+  outer_input: data
 outputs:
   outer_output:
     outputSource: second_cat/out_file1
@@ -1464,7 +1463,7 @@ steps:
   - run:
       class: GalaxyWorkflow
       inputs:
-        - id: inner_input
+        inner_input: data
       outputs:
         workflow_output:
           outputSource: split/output
@@ -1504,7 +1503,7 @@ outer_input:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 outputs:
   count_list:
     outputSource: count_list/out_file1
@@ -1538,9 +1537,9 @@ input1:
         with self.dataset_populator.test_history() as history_id:
             jobs_summary = self._run_jobs("""
 class: GalaxyWorkflow
+inputs:
+  text_input1: collection
 steps:
-  - label: text_input1
-    type: input_collection
   - tool_id: collection_type_source_map_over
     in:
       input_collect: text_input1
@@ -1560,7 +1559,7 @@ text_input1:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 outputs:
   count_multi_file:
     outputSource: count_multi_file/out_file1
@@ -1735,8 +1734,8 @@ input1:
             workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
-    type: data_collection_input
+  input1:
+    type: collection
     collection_type: list
 steps:
   - tool_id: cat
@@ -1775,9 +1774,9 @@ steps:
         with self.dataset_populator.test_history() as history_id:
             run_summary = self._run_jobs("""
 class: GalaxyWorkflow
+inputs:
+  test_input: data
 steps:
-- label: test_input
-  type: input
 - label: first_cat
   tool_id: cat1
   in:
@@ -1823,8 +1822,7 @@ steps:
             run_summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - label: text_input
-    type: text
+  text_input: text
 steps:
 - tool_id: validation_repeat
   state:
@@ -1846,8 +1844,7 @@ text_input:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - label: text_input
-    type: text
+  text_input: text
 steps:
 - tool_id: validation_repeat
   state:
@@ -1865,10 +1862,8 @@ text_input:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - label: data_input
-    type: data
-  - label: text_input
-    type: text
+  data_input: data
+  text_input: text
 steps:
 - label: randomlines
   tool_id: random_lines1
@@ -2071,8 +2066,8 @@ steps:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
-    type: data_collection_input
+  input1:
+    type: collection
     collection_type: list
 steps:
   - tool_id: cat
@@ -2106,8 +2101,8 @@ input1:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
-    type: data_collection_input
+  input1:
+    type: collection
     collection_type: list
 steps:
   - tool_id: cat
@@ -2137,7 +2132,7 @@ input1:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: collection_creates_pair
     in:
@@ -2193,7 +2188,7 @@ steps:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: fail_identifier
     label: first_fail
@@ -2240,7 +2235,7 @@ input1:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: cat
     label: first_cat
@@ -2265,8 +2260,8 @@ input1:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
-  - id: input2
+  input1: data
+  input2: data
 steps:
   - tool_id: cat
     label: first_cat
@@ -2299,8 +2294,8 @@ input2:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: fasta_input
-  - id: fastq_input
+  fasta_input: data
+  fastq_input: data
 steps:
   - tool_id: mapper2
     state:
@@ -2337,8 +2332,8 @@ fastq_input:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: fasta_input
-  - id: fastq_inputs
+  fasta_input: data
+  fastq_inputs: data
 steps:
   - tool_id: mapper2
     state:
@@ -2380,7 +2375,7 @@ fastq_inputs:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: collection_creates_pair
     state:
@@ -2412,9 +2407,8 @@ inputs:
 steps:
   - tool_id: cat
     label: first_cat
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
     outputs:
       out_file1:
         hide: true
@@ -2442,7 +2436,7 @@ input1:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - label: first_cat
     tool_id: cat
@@ -2485,7 +2479,7 @@ input1:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: collection_creates_pair
     in:
@@ -2511,8 +2505,8 @@ input1:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
-    type: data_collection_input
+  input1:
+    type: collection
     collection_type: list
 steps:
   - tool_id: cat
@@ -2544,7 +2538,7 @@ input1:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: cat
     label: first_cat
@@ -2614,7 +2608,7 @@ input1:
         workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 inputs:
-  - id: test_input
+  test_input: data
 steps:
   - label: first_cat
     tool_id: cat1
@@ -2667,7 +2661,7 @@ steps:
             self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 outputs:
   wf_output_1:
     outputSource: third_cat/out_file1
@@ -2969,8 +2963,7 @@ steps:
         summary = self._run_jobs("""
 class: GalaxyWorkflow
 inputs:
-  - type: collection
-    label: input_c
+  input_c: collection
 steps:
   - label: cat1
     tool_id: cat1

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -30,48 +30,6 @@ from base.workflow_fixtures import (  # noqa: I100
 from galaxy.exceptions import error_codes  # noqa: I201
 
 
-SIMPLE_NESTED_WORKFLOW_YAML = """
-class: GalaxyWorkflow
-inputs:
-  - id: outer_input
-outputs:
-  - id: outer_output
-    source: second_cat#out_file1
-steps:
-  - tool_id: cat1
-    label: first_cat
-    in:
-      input1: outer_input
-  - run:
-      class: GalaxyWorkflow
-      inputs:
-        - id: inner_input
-      outputs:
-        - id: workflow_output
-          source: random_lines#out_file1
-      steps:
-        - tool_id: random_lines1
-          label: random_lines
-          state:
-            num_lines: 1
-            input:
-              $link: inner_input
-            seed_source:
-              seed_source_selector: set_seed
-              seed: asdf
-    label: nested_workflow
-    in:
-      inner_input: first_cat/out_file1
-  - tool_id: cat1
-    label: second_cat
-    state:
-      input1:
-        $link: nested_workflow#workflow_output
-      queries:
-        - input2:
-            $link: nested_workflow#workflow_output
-"""
-
 NESTED_WORKFLOW_AUTO_LABELS = """
 class: GalaxyWorkflow
 inputs:

--- a/test/api/test_workflows_from_yaml.py
+++ b/test/api/test_workflows_from_yaml.py
@@ -114,7 +114,7 @@ input1: "hello world"
         workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
 inputs:
-  - id: outer_input
+  outer_input: data
 steps:
   - tool_id: cat1
     label: first_cat
@@ -123,7 +123,7 @@ steps:
   - run:
       class: GalaxyWorkflow
       inputs:
-        - id: inner_input
+        inner_input: data
       steps:
         - tool_id: random_lines1
           state:

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -589,12 +589,17 @@ class BaseWorkflowPopulator(object):
             return content
 
         workflow_id = workflow_populator.upload_yaml_workflow(has_workflow, source_type=source_type)
-        if jobs_descriptions is None:
-            assert source_type != "path"
-            jobs_descriptions = yaml.safe_load(has_workflow)
 
         if test_data is None:
+            if jobs_descriptions is None:
+                assert source_type != "path"
+                jobs_descriptions = yaml.safe_load(has_workflow)
+
             test_data = jobs_descriptions.get("test_data", {})
+
+        if not isinstance(test_data, dict):
+            test_data = yaml.safe_load(test_data)
+
         parameters = test_data.pop('step_parameters', {})
         replacement_parameters = test_data.pop("replacement_parameters", {})
         inputs, label_map, has_uploads = load_data_dict(history_id, test_data, self.dataset_populator, self.dataset_collection_populator)

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -26,7 +26,7 @@ steps:
 WORKFLOW_SIMPLE_CAT_TWICE = """
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: cat
     label: first_cat
@@ -39,7 +39,7 @@ steps:
 WORKFLOW_WITH_OLD_TOOL_VERSION = """
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: multiple_versions
     tool_version: "0.0.1"
@@ -51,7 +51,7 @@ steps:
 WORKFLOW_WITH_INVALID_STATE = """
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: multiple_versions
     tool_version: "0.0.1"
@@ -62,9 +62,9 @@ steps:
 
 WORKFLOW_WITH_OUTPUT_COLLECTION = """
 class: GalaxyWorkflow
+inputs:
+  text_input: data
 steps:
-  - label: text_input
-    type: input
   - label: split_up
     tool_id: collection_creates_pair
     in:
@@ -150,8 +150,7 @@ steps:
 WORKFLOW_WITH_RULES_1 = """
 class: GalaxyWorkflow
 inputs:
-  - type: collection
-    label: input_c
+  input_c: collection
 steps:
   - label: apply
     tool_id: __APPLY_RULES__
@@ -190,8 +189,7 @@ test_data:
 WORKFLOW_WITH_RULES_2 = """
 class: GalaxyWorkflow
 inputs:
-  - type: collection
-    label: input_c
+  input_c: collection
 steps:
   - label: apply
     tool_id: __APPLY_RULES__
@@ -225,7 +223,7 @@ test_data:
 WORKFLOW_NESTED_SIMPLE = """
 class: GalaxyWorkflow
 inputs:
-  - id: outer_input
+  outer_input: data
 outputs:
   outer_output:
     outputSource: second_cat/out_file1
@@ -237,7 +235,7 @@ steps:
   - run:
       class: GalaxyWorkflow
       inputs:
-        - id: inner_input
+        inner_input: data
       outputs:
         workflow_output:
           outputSource: random_lines/out_file1
@@ -268,7 +266,7 @@ steps:
 WORKFLOW_NESTED_RUNTIME_PARAMETER = """
 class: GalaxyWorkflow
 inputs:
-  - id: outer_input
+  outer_input: data
 outputs:
   outer_output:
     outputSource: nested_workflow/workflow_output
@@ -276,7 +274,7 @@ steps:
   - run:
       class: GalaxyWorkflow
       inputs:
-        - id: inner_input
+        inner_input: data
       outputs:
         workflow_output:
           outputSource: random_lines#out_file1
@@ -300,7 +298,7 @@ steps:
 WORKFLOW_WITH_OUTPUT_ACTIONS = """
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: cat1
     label: first_cat
@@ -319,7 +317,7 @@ steps:
 WORKFLOW_RUNTIME_PARAMETER_SIMPLE = """
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: random_lines1
     runtime_inputs:
@@ -336,7 +334,7 @@ steps:
 WORKFLOW_RUNTIME_PARAMETER_AFTER_PAUSE = """
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - label: the_pause
     type: pause
@@ -356,7 +354,7 @@ steps:
 WORKFLOW_RENAME_ON_INPUT = """
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: cat
     label: first_cat
@@ -376,7 +374,7 @@ test_data:
 WORKFLOW_RENAME_ON_REPLACEMENT_PARAM = """
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 steps:
   - tool_id: cat
     label: first_cat
@@ -391,7 +389,7 @@ steps:
 WORKFLOW_NESTED_REPLACEMENT_PARAMETER = """
 class: GalaxyWorkflow
 inputs:
-  - id: outer_input
+  outer_input: data
 outputs:
   outer_output:
     outputSource: nested_workflow/workflow_output
@@ -399,7 +397,7 @@ steps:
   - run:
       class: GalaxyWorkflow
       inputs:
-        - id: inner_input
+        inner_input: data
       outputs:
         workflow_output:
           outputSource: first_cat/out_file1
@@ -419,7 +417,7 @@ steps:
 WORKFLOW_WITH_OUTPUTS = """
 class: GalaxyWorkflow
 inputs:
-  - id: input1
+  input1: data
 outputs:
   wf_output_1:
     outputSource: first_cat/out_file1

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -1,4 +1,28 @@
 
+
+WORKFLOW_SIMPLE_CAT_AND_RANDOM_LINES = """
+class: GalaxyWorkflow
+inputs:
+  - id: the_input
+steps:
+  - tool_id: cat1
+    in:
+      input1: the_input
+  - tool_id: cat1
+    in:
+      input1: 1/out_file1
+  - tool_id: random_lines1
+    label: random_line_label
+    state:
+      num_lines: 10
+      seed_source:
+        seed_source_selector: set_seed
+        seed: asdf
+    in:
+      input: 2/out_file1
+"""
+
+
 WORKFLOW_SIMPLE_CAT_TWICE = """
 class: GalaxyWorkflow
 inputs:
@@ -6,12 +30,9 @@ inputs:
 steps:
   - tool_id: cat
     label: first_cat
-    state:
-      input1:
-        $link: input1
-      queries:
-        - input2:
-            $link: input1
+    in:
+      input1: input1
+      queries_0|input2: input1
 """
 
 
@@ -46,13 +67,11 @@ steps:
     type: input
   - label: split_up
     tool_id: collection_creates_pair
-    state:
-      input1:
-        $link: text_input
+    in:
+      input1: text_input
   - tool_id: collection_paired_test
-    state:
-      f1:
-        $link: split_up#paired_output
+    in:
+      f1: split_up/paired_output
 test_data:
   text_input: |
     a
@@ -83,9 +102,8 @@ steps:
       input1:
         $link: cat_inputs#out_file1
   - tool_id: cat_list
-    state:
-      input1:
-        $link: split_up#split_output
+    in:
+      input1: split_up/split_output
 test_data:
   text_input1: |
     samp1\t10.0
@@ -99,15 +117,14 @@ test_data:
 WORKFLOW_SIMPLE_MAPPING = """
 class: GalaxyWorkflow
 inputs:
-  - id: input1
-    type: data_collection_input
+  input1:
+    type: collection
     collection_type: list
 steps:
   - tool_id: cat
     label: cat
-    state:
-      input1:
-        $link: input1
+    in:
+      input1: input1
 """
 
 
@@ -192,9 +209,8 @@ steps:
             columns: [0, 1]
   - tool_id: collection_creates_list
     label: copy_list
-    state:
-      input1:
-        $link: apply#output
+    in:
+      input1: apply/output
 test_data:
   input_c:
     type: list
@@ -216,9 +232,8 @@ outputs:
 steps:
   - tool_id: cat1
     label: first_cat
-    state:
-      input1:
-        $link: outer_input
+    in:
+      input1: outer_input
   - run:
       class: GalaxyWorkflow
       inputs:
@@ -237,8 +252,8 @@ steps:
               seed_source_selector: set_seed
               seed: asdf
     label: nested_workflow
-    connect:
-      inner_input: first_cat#out_file1
+    in:
+      inner_input: first_cat/out_file1
   - tool_id: cat1
     label: second_cat
     state:
@@ -277,8 +292,27 @@ steps:
               seed_source_selector: set_seed
               seed: asdf
     label: nested_workflow
-    connect:
+    in:
       inner_input: outer_input
+"""
+
+
+WORKFLOW_WITH_OUTPUT_ACTIONS = """
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+steps:
+  - tool_id: cat1
+    label: first_cat
+    outputs:
+       out_file1:
+         hide: true
+         rename: "the new value"
+    in:
+      input1: input1
+  - tool_id: cat1
+    in:
+      input1: first_cat/out_file1
 """
 
 
@@ -306,9 +340,8 @@ inputs:
 steps:
   - label: the_pause
     type: pause
-    connect:
-      input:
-      - input1
+    in:
+      input: input1
   - tool_id: random_lines1
     runtime_inputs:
       - num_lines
@@ -373,13 +406,30 @@ steps:
       steps:
         - tool_id: cat
           label: first_cat
-          state:
-            input1:
-              $link: inner_input
+          in:
+            input1: inner_input
           outputs:
             out_file1:
               rename: "${replaceme} suffix"
     label: nested_workflow
-    connect:
+    in:
       inner_input: outer_input
+"""
+
+WORKFLOW_WITH_OUTPUTS = """
+class: GalaxyWorkflow
+inputs:
+  - id: input1
+outputs:
+  - id: wf_output_1
+    source: first_cat#out_file1
+steps:
+  - tool_id: cat1
+    label: first_cat
+    state:
+      input1:
+        $link: input1
+      queries:
+        - input2:
+            $link: input1
 """

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -227,8 +227,8 @@ class: GalaxyWorkflow
 inputs:
   - id: outer_input
 outputs:
-  - id: outer_output
-    source: second_cat#out_file1
+  outer_output:
+    outputSource: second_cat/out_file1
 steps:
   - tool_id: cat1
     label: first_cat
@@ -239,8 +239,8 @@ steps:
       inputs:
         - id: inner_input
       outputs:
-        - id: workflow_output
-          source: random_lines#out_file1
+        workflow_output:
+          outputSource: random_lines/out_file1
       steps:
         - tool_id: random_lines1
           label: random_lines
@@ -270,16 +270,16 @@ class: GalaxyWorkflow
 inputs:
   - id: outer_input
 outputs:
-  - id: outer_output
-    source: nested_workflow#workflow_output
+  outer_output:
+    outputSource: nested_workflow/workflow_output
 steps:
   - run:
       class: GalaxyWorkflow
       inputs:
         - id: inner_input
       outputs:
-        - id: workflow_output
-          source: random_lines#out_file1
+        workflow_output:
+          outputSource: random_lines#out_file1
       steps:
         - tool_id: random_lines1
           label: random_lines
@@ -393,16 +393,16 @@ class: GalaxyWorkflow
 inputs:
   - id: outer_input
 outputs:
-  - id: outer_output
-    source: nested_workflow#workflow_output
+  outer_output:
+    outputSource: nested_workflow/workflow_output
 steps:
   - run:
       class: GalaxyWorkflow
       inputs:
         - id: inner_input
       outputs:
-        - id: workflow_output
-          source: first_cat#out_file1
+        workflow_output:
+          outputSource: first_cat/out_file1
       steps:
         - tool_id: cat
           label: first_cat
@@ -421,8 +421,8 @@ class: GalaxyWorkflow
 inputs:
   - id: input1
 outputs:
-  - id: wf_output_1
-    source: first_cat#out_file1
+  wf_output_1:
+    outputSource: first_cat/out_file1
 steps:
   - tool_id: cat1
     label: first_cat


### PR DESCRIPTION
Further extends #6807 and #6746 with more Format 2 workflow tweaks.

This:

 - Switches most format 2 workflows to use test_data separation and ``in`` keyword for connections introduced in #6807.
 - Uses new id map based workflow input and output definitions.
 - Revs gxformat2 to allow these enhancements and to handle subworkflows, post job actions, and pause steps.

The id map based approach replaces arrays for inputs and outputs. Like CWL both are allowed, but also like CWL the newer id map based approach is probably preferred.

For an input definition, the following diff describes the change:

```diff
 inputs:
-  - id: input1
-    type: data_collection_input
+  input1:
+    type: collection
     collection_type: list
```

For simpler data inputs without extra modifiers, a simpler map can be used:

```diff
 inputs:
-  - id: input1
+  input1: data
```


For an output definition, the following diff describes the change:

```diff
 workflow_outputs:
-  - id: outer_output
-    source: second_cat#out_file1
+  outer_output:
+    outputSource: second_cat/out_file1
```

While not particularly more concise, it does bring the syntax inline with CWL - which uses ``outputSource`` on workflow steps instead of ``source``.
