### PR TITLE
Remove `trans` from OIDC-related types

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -129,7 +129,7 @@ class AuthnzManager(object):
         if cloudauthz.provider == "aws":
             success, message, backend = self._get_authnz_backend(cloudauthz.authn.provider)
             strategy = Strategy(trans, Storage, backend.config)
-            on_the_fly_config(trans)
+            on_the_fly_config(trans.app, trans.sa_session)
             try:
                 config['id_token'] = cloudauthz.authn.get_id_token(strategy)
             except requests.exceptions.HTTPError as e:

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -129,7 +129,7 @@ class AuthnzManager(object):
         if cloudauthz.provider == "aws":
             success, message, backend = self._get_authnz_backend(cloudauthz.authn.provider)
             strategy = Strategy(trans, Storage, backend.config)
-            on_the_fly_config(trans.app, trans.sa_session)
+            on_the_fly_config(trans.sa_session)
             try:
                 config['id_token'] = cloudauthz.authn.get_id_token(strategy)
             except requests.exceptions.HTTPError as e:

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -237,7 +237,7 @@ class Storage(object):
 
 def on_the_fly_config(trans):
     trans.app.model.PSACode.sa_session = trans.sa_session
-    trans.app.model.UserAuthnzToken.trans = trans
+    trans.app.model.UserAuthnzToken.sa_session = trans.sa_session
     trans.app.model.PSANonce.sa_session = trans.sa_session
     trans.app.model.PSAPartial.sa_session = trans.sa_session
     trans.app.model.PSAAssociation.sa_session = trans.sa_session

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -240,7 +240,7 @@ def on_the_fly_config(trans):
     trans.app.model.UserAuthnzToken.trans = trans
     trans.app.model.PSANonce.trans = trans
     trans.app.model.PSAPartial.trans = trans
-    trans.app.model.PSAAssociation.trans = trans
+    trans.app.model.PSAAssociation.sa_session = trans.sa_session
 
 
 def contains_required_data(response=None, is_new=False, **kwargs):

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -236,7 +236,7 @@ class Storage(object):
 
 
 def on_the_fly_config(trans):
-    trans.app.model.PSACode.trans = trans
+    trans.app.model.PSACode.sa_session = trans.sa_session
     trans.app.model.UserAuthnzToken.trans = trans
     trans.app.model.PSANonce.trans = trans
     trans.app.model.PSAPartial.trans = trans

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -123,13 +123,13 @@ class PSAAuthnz(IdentityProvider):
         self.config['user'] = user
 
     def authenticate(self, trans):
-        on_the_fly_config(trans.app, trans.sa_session)
+        on_the_fly_config(trans.sa_session)
         strategy = Strategy(trans, Storage, self.config)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
         return do_auth(backend)
 
     def callback(self, state_token, authz_code, trans, login_redirect_url):
-        on_the_fly_config(trans.app, trans.sa_session)
+        on_the_fly_config(trans.sa_session)
         self.config[setting_name('LOGIN_REDIRECT_URL')] = login_redirect_url
         strategy = Strategy(trans, Storage, self.config)
         strategy.session_set(BACKENDS_NAME[self.config['provider']] + '_state', state_token)
@@ -142,7 +142,7 @@ class PSAAuthnz(IdentityProvider):
         return redirect_url, self.config.get('user', None)
 
     def disconnect(self, provider, trans, disconnect_redirect_url=None, association_id=None):
-        on_the_fly_config(trans.app, trans.sa_session)
+        on_the_fly_config(trans.sa_session)
         self.config[setting_name('DISCONNECT_REDIRECT_URL')] =\
             disconnect_redirect_url if disconnect_redirect_url is not None else ()
         strategy = Strategy(trans, Storage, self.config)
@@ -235,12 +235,12 @@ class Storage(object):
         return exception.__class__ is IntegrityError
 
 
-def on_the_fly_config(app, sa_session):
-    app.model.PSACode.sa_session = sa_session
-    app.model.UserAuthnzToken.sa_session = sa_session
-    app.model.PSANonce.sa_session = sa_session
-    app.model.PSAPartial.sa_session = sa_session
-    app.model.PSAAssociation.sa_session = sa_session
+def on_the_fly_config(sa_session):
+    PSACode.sa_session = sa_session
+    UserAuthnzToken.sa_session = sa_session
+    PSANonce.sa_session = sa_session
+    PSAPartial.sa_session = sa_session
+    PSAAssociation.sa_session = sa_session
 
 
 def contains_required_data(response=None, is_new=False, **kwargs):

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -238,7 +238,7 @@ class Storage(object):
 def on_the_fly_config(trans):
     trans.app.model.PSACode.sa_session = trans.sa_session
     trans.app.model.UserAuthnzToken.trans = trans
-    trans.app.model.PSANonce.trans = trans
+    trans.app.model.PSANonce.sa_session = trans.sa_session
     trans.app.model.PSAPartial.trans = trans
     trans.app.model.PSAAssociation.sa_session = trans.sa_session
 

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -239,7 +239,7 @@ def on_the_fly_config(trans):
     trans.app.model.PSACode.sa_session = trans.sa_session
     trans.app.model.UserAuthnzToken.trans = trans
     trans.app.model.PSANonce.sa_session = trans.sa_session
-    trans.app.model.PSAPartial.trans = trans
+    trans.app.model.PSAPartial.sa_session = trans.sa_session
     trans.app.model.PSAAssociation.sa_session = trans.sa_session
 
 

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -123,13 +123,13 @@ class PSAAuthnz(IdentityProvider):
         self.config['user'] = user
 
     def authenticate(self, trans):
-        on_the_fly_config(trans)
+        on_the_fly_config(trans.app, trans.sa_session)
         strategy = Strategy(trans, Storage, self.config)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
         return do_auth(backend)
 
     def callback(self, state_token, authz_code, trans, login_redirect_url):
-        on_the_fly_config(trans)
+        on_the_fly_config(trans.app, trans.sa_session)
         self.config[setting_name('LOGIN_REDIRECT_URL')] = login_redirect_url
         strategy = Strategy(trans, Storage, self.config)
         strategy.session_set(BACKENDS_NAME[self.config['provider']] + '_state', state_token)
@@ -142,7 +142,7 @@ class PSAAuthnz(IdentityProvider):
         return redirect_url, self.config.get('user', None)
 
     def disconnect(self, provider, trans, disconnect_redirect_url=None, association_id=None):
-        on_the_fly_config(trans)
+        on_the_fly_config(trans.app, trans.sa_session)
         self.config[setting_name('DISCONNECT_REDIRECT_URL')] =\
             disconnect_redirect_url if disconnect_redirect_url is not None else ()
         strategy = Strategy(trans, Storage, self.config)
@@ -235,12 +235,12 @@ class Storage(object):
         return exception.__class__ is IntegrityError
 
 
-def on_the_fly_config(trans):
-    trans.app.model.PSACode.sa_session = trans.sa_session
-    trans.app.model.UserAuthnzToken.sa_session = trans.sa_session
-    trans.app.model.PSANonce.sa_session = trans.sa_session
-    trans.app.model.PSAPartial.sa_session = trans.sa_session
-    trans.app.model.PSAAssociation.sa_session = trans.sa_session
+def on_the_fly_config(app, sa_session):
+    app.model.PSACode.sa_session = sa_session
+    app.model.UserAuthnzToken.sa_session = sa_session
+    app.model.PSANonce.sa_session = sa_session
+    app.model.PSAPartial.sa_session = sa_session
+    app.model.PSAAssociation.sa_session = sa_session
 
 
 def contains_required_data(response=None, is_new=False, **kwargs):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4836,9 +4836,8 @@ class PSANonce(NonceMixin):
 
 class PSAPartial(PartialMixin):
 
-    # This static property is of type: galaxy.web.framework.webapp.GalaxyWebTransaction
-    # and it is set in: galaxy.authnz.psa_authnz.PSAAuthnz
-    trans = None
+    # This static property is set at: galaxy.authnz.psa_authnz.PSAAuthnz
+    sa_session = None
 
     def __init__(self, token, data, next_step, backend):
         self.token = token
@@ -4847,18 +4846,18 @@ class PSAPartial(PartialMixin):
         self.backend = backend
 
     def save(self):
-        self.trans.sa_session.add(self)
-        self.trans.sa_session.flush()
+        self.sa_session.add(self)
+        self.sa_session.flush()
 
     @classmethod
     def load(cls, token):
-        return cls.trans.sa_session.query(cls).filter(cls.token == token).first()
+        return cls.sa_session.query(cls).filter(cls.token == token).first()
 
     @classmethod
     def destroy(cls, token):
         partial = cls.load(token)
         if partial:
-            cls.trans.sa_session.delete(partial)
+            cls.sa_session.delete(partial)
 
 
 class UserAuthnzToken(UserMixin):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4811,9 +4811,8 @@ class PSACode(CodeMixin):
 
 class PSANonce(NonceMixin):
 
-    # This static property is of type: galaxy.web.framework.webapp.GalaxyWebTransaction
-    # and it is set in: galaxy.authnz.psa_authnz.PSAAuthnz
-    trans = None
+    # This static property is set at: galaxy.authnz.psa_authnz.PSAAuthnz
+    sa_session = None
 
     def __init__(self, server_url, timestamp, salt):
         self.server_url = server_url
@@ -4821,17 +4820,17 @@ class PSANonce(NonceMixin):
         self.salt = salt
 
     def save(self):
-        self.trans.sa_session.add(self)
-        self.trans.sa_session.flush()
+        self.sa_session.add(self)
+        self.sa_session.flush()
 
     @classmethod
     def use(cls, server_url, timestamp, salt):
         try:
-            return cls.trans.sa_session.query(cls).filter_by(server_url=server_url, timestamp=timestamp, salt=salt)[0]
+            return cls.sa_session.query(cls).filter_by(server_url=server_url, timestamp=timestamp, salt=salt)[0]
         except IndexError:
             instance = cls(server_url=server_url, timestamp=timestamp, salt=salt)
-            cls.trans.sa_session.add(instance)
-            cls.trans.sa_session.flush()
+            cls.sa_session.add(instance)
+            cls.sa_session.flush()
             return instance
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4863,9 +4863,8 @@ class PSAPartial(PartialMixin):
 class UserAuthnzToken(UserMixin):
     __table_args__ = (UniqueConstraint('provider', 'uid'),)
 
-    # This static property is of type: galaxy.web.framework.webapp.GalaxyWebTransaction
-    # and it is set in: galaxy.authnz.psa_authnz.PSAAuthnz
-    trans = None
+    # This static property is set at: galaxy.authnz.psa_authnz.PSAAuthnz
+    sa_session = None
 
     def __init__(self, provider, uid, extra_data=None, lifetime=None, assoc_type=None, user=None):
         self.provider = provider
@@ -4884,12 +4883,12 @@ class UserAuthnzToken(UserMixin):
 
     def set_extra_data(self, extra_data=None):
         if super(UserAuthnzToken, self).set_extra_data(extra_data):
-            self.trans.sa_session.add(self)
-            self.trans.sa_session.flush()
+            self.sa_session.add(self)
+            self.sa_session.flush()
 
     def save(self):
-        self.trans.sa_session.add(self)
-        self.trans.sa_session.flush()
+        self.sa_session.add(self)
+        self.sa_session.flush()
 
     @classmethod
     def username_max_length(cls):
@@ -4903,12 +4902,12 @@ class UserAuthnzToken(UserMixin):
 
     @classmethod
     def changed(cls, user):
-        cls.trans.sa_session.add(user)
-        cls.trans.sa_session.flush()
+        cls.sa_session.add(user)
+        cls.sa_session.flush()
 
     @classmethod
     def user_query(cls):
-        return cls.trans.sa_session.query(cls.user_model())
+        return cls.sa_session.query(cls.user_model())
 
     @classmethod
     def user_exists(cls, *args, **kwargs):
@@ -4923,8 +4922,8 @@ class UserAuthnzToken(UserMixin):
         model = cls.user_model()
         instance = model(*args, **kwargs)
         instance.set_random_password()
-        cls.trans.sa_session.add(instance)
-        cls.trans.sa_session.flush()
+        cls.sa_session.add(instance)
+        cls.sa_session.flush()
         return instance
 
     @classmethod
@@ -4939,13 +4938,13 @@ class UserAuthnzToken(UserMixin):
     def get_social_auth(cls, provider, uid):
         uid = str(uid)
         try:
-            return cls.trans.sa_session.query(cls).filter_by(provider=provider, uid=uid)[0]
+            return cls.sa_session.query(cls).filter_by(provider=provider, uid=uid)[0]
         except IndexError:
             return None
 
     @classmethod
     def get_social_auth_for_user(cls, user, provider=None, id=None):
-        qs = cls.trans.sa_session.query(cls).filter_by(user_id=user.id)
+        qs = cls.sa_session.query(cls).filter_by(user_id=user.id)
         if provider:
             qs = qs.filter_by(provider=provider)
         if id:
@@ -4956,8 +4955,8 @@ class UserAuthnzToken(UserMixin):
     def create_social_auth(cls, user, uid, provider):
         uid = str(uid)
         instance = cls(user=user, uid=uid, provider=provider)
-        cls.trans.sa_session.add(instance)
-        cls.trans.sa_session.flush()
+        cls.sa_session.add(instance)
+        cls.sa_session.flush()
         return instance
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4794,21 +4794,20 @@ class PSAAssociation(AssociationMixin):
 class PSACode(CodeMixin):
     __table_args__ = (UniqueConstraint('code', 'email'),)
 
-    # This static property is of type: galaxy.web.framework.webapp.GalaxyWebTransaction
-    # and it is set in: galaxy.authnz.psa_authnz.PSAAuthnz
-    trans = None
+    # This static property is set at: galaxy.authnz.psa_authnz.PSAAuthnz
+    sa_session = None
 
     def __init__(self, email, code):
         self.email = email
         self.code = code
 
     def save(self):
-        self.trans.sa_session.add(self)
-        self.trans.sa_session.flush()
+        self.sa_session.add(self)
+        self.sa_session.flush()
 
     @classmethod
     def get_code(cls, code):
-        return cls.trans.sa_session.query(cls).filter(cls.code == code).first()
+        return cls.sa_session.query(cls).filter(cls.code == code).first()
 
 
 class PSANonce(NonceMixin):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4753,9 +4753,8 @@ class UserOpenID(object):
 
 class PSAAssociation(AssociationMixin):
 
-    # This static property is of type: galaxy.web.framework.webapp.GalaxyWebTransaction
-    # and it is set in: galaxy.authnz.psa_authnz.PSAAuthnz
-    trans = None
+    # This static property is set at: galaxy.authnz.psa_authnz.PSAAuthnz
+    sa_session = None
 
     def __init__(self, server_url=None, handle=None, secret=None, issued=None, lifetime=None, assoc_type=None):
         self.server_url = server_url
@@ -4766,29 +4765,29 @@ class PSAAssociation(AssociationMixin):
         self.assoc_type = assoc_type
 
     def save(self):
-        self.trans.sa_session.add(self)
-        self.trans.sa_session.flush()
+        self.sa_session.add(self)
+        self.sa_session.flush()
 
     @classmethod
     def store(cls, server_url, association):
         try:
-            assoc = cls.trans.sa_session.query(cls).filter_by(server_url=server_url, handle=association.handle)[0]
+            assoc = cls.sa_session.query(cls).filter_by(server_url=server_url, handle=association.handle)[0]
         except IndexError:
             assoc = cls(server_url=server_url, handle=association.handle)
         assoc.secret = base64.encodestring(association.secret).decode()
         assoc.issued = association.issued
         assoc.lifetime = association.lifetime
         assoc.assoc_type = association.assoc_type
-        cls.trans.sa_session.add(assoc)
-        cls.trans.sa_session.flush()
+        cls.sa_session.add(assoc)
+        cls.sa_session.flush()
 
     @classmethod
     def get(cls, *args, **kwargs):
-        return cls.trans.sa_session.query(cls).filter_by(*args, **kwargs)
+        return cls.sa_session.query(cls).filter_by(*args, **kwargs)
 
     @classmethod
     def remove(cls, ids_to_delete):
-        cls.trans.sa_session.query(cls).filter(cls.id.in_(ids_to_delete)).delete(synchronize_session='fetch')
+        cls.sa_session.query(cls).filter(cls.id.in_(ids_to_delete)).delete(synchronize_session='fetch')
 
 
 class PSACode(CodeMixin):


### PR DESCRIPTION
In oidc-related types (i.e., `PSAAssociation`, `PSACode`, `PSANonce`, `PSAPartial`, and `UserAuthnzToken`), `trans` is used only for database access (i.e., `trans.sa_session`). Hence this PR replaces `trans` with `sa_session` in these types.

ping @jmchilton  