### PR TITLE
Clarify code used in output <filter> tags

### DIFF
--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -3901,7 +3901,12 @@ tool ultimately creates. If the code, when executed, returns ``True``,
 the output dataset is retained. In these code blocks the tool parameters appear
 as Python variables and are thus referred to without the $ used for the Cheetah
 template (used in the ``<command>`` tag). Variables that are part of
-conditionals are accessed using a hash named after the conditional.
+conditionals are accessed using a dictionary named after the conditional. Boolean
+parameters appear as booleans, not the value of their ``truevalue`` and
+``falsevalue`` attributes. In the example below, ``options["selection_mode"`` would
+appear as ``$options.selection_mode`` in Cheetah. Similarly ``options["vcf_output"]``
+would appear as ``$options.vcf_output`` having the values ``'--vcf'`` when true and
+``''`` when false in Cheetah.
 
 ### Example
 

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -3903,7 +3903,7 @@ as Python variables and are thus referred to without the $ used for the Cheetah
 template (used in the ``<command>`` tag). Variables that are part of
 conditionals are accessed using a dictionary named after the conditional. Boolean
 parameters appear as booleans, not the value of their ``truevalue`` and
-``falsevalue`` attributes. In the example below, ``options["selection_mode"`` would
+``falsevalue`` attributes. In the example below, ``options["selection_mode"]`` would
 appear as ``$options.selection_mode`` in Cheetah. Similarly ``options["vcf_output"]``
 would appear as ``$options.vcf_output`` having the values ``'--vcf'`` when true and
 ``''`` when false in Cheetah.


### PR DESCRIPTION
Add extra detail to the explanation of how the Python code to ``<filter>`` tags works in outputs.