### PR TITLE
Fix/slurm out of memory warning exit code 0:125

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -134,7 +134,7 @@ class SlurmJobRunner(DRMAAJobRunner):
                         return
                     except Exception:
                         ajs.fail_message = "This job failed due to a cluster node failure, and an attempt to resubmit the job failed."
-                elif slurm_state in ('OUT_OF_MEMORY') and exit_code in ("0:125", None):
+                elif slurm_state in ('OUT_OF_MEMORY') and exit_code == '0:125':
                     log.debug("(%s/%s) SLURM reported job OUT_OF_MEMORY with exit code 0:125. We are assuming success!",
                         ajs.job_wrapper.get_id_tag(), ajs.job_id)
                     drmaa_state = self.drmaa_job_states.DONE


### PR DESCRIPTION
We receive these warning messages (OUT_OF_MEMORY but with exit code 0:125) a lot on our cluster and the jobs are to be considered successful 
https://bugs.schedmd.com/show_bug.cgi?id=3820#c62
