### PR TITLE
Convert user_is_admin and user_can_do_run_as to properties

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -28,7 +28,7 @@ def validate_server_directory_upload(trans, server_dir):
     if server_dir in [None, 'None', '']:
         raise RequestParameterInvalidException("Invalid or unspecified server_dir parameter")
 
-    if trans.user_is_admin():
+    if trans.user_is_admin:
         import_dir = trans.app.config.library_import_dir
         import_dir_desc = 'library_import_dir'
         if not import_dir:
@@ -61,7 +61,7 @@ def validate_path_upload(trans):
     if not trans.app.config.allow_library_path_paste:
         raise ConfigDoesNotAllowException('"allow_path_paste" is not set to True in the Galaxy configuration file')
 
-    if not trans.user_is_admin():
+    if not trans.user_is_admin:
         raise AdminRequiredException('Uploading files via filesystem paths can only be performed by administrators')
 
 
@@ -262,7 +262,7 @@ class LibraryActions(object):
         return uploaded_dataset
 
     def _create_folder(self, trans, parent_id, library_id, **kwd):
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
         try:
             parent_folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(trans.security.decode_id(parent_id))

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -51,7 +51,7 @@ def security_check(trans, item, check_ownership=False, check_accessible=False):
     """
 
     # all items are accessible to an admin
-    if trans.user_is_admin():
+    if trans.user_is_admin:
         return item
 
     # Verify ownership: there is a current user and that user is the same as the item's

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -119,11 +119,13 @@ class ProvidesUserContext(object):
             roles = []
         return roles
 
+    @property
     def user_is_admin(self):
         if self.api_inherit_admin:
             return True
         return self.user and self.user.email in self.app.config.admin_users_list
 
+    @property
     def user_can_do_run_as(self):
         run_as_users = [user for user in self.app.config.get("api_allow_run_as", "").split(",") if user]
         if not run_as_users:

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -348,7 +348,7 @@ class DatasetAssociationManager(base.ModelManager,
             dataset = dataset_assoc.dataset
 
         current_user_roles = trans.get_current_user_roles()
-        can_manage = trans.app.security_agent.can_manage_dataset(current_user_roles, dataset) or trans.user_is_admin()
+        can_manage = trans.app.security_agent.can_manage_dataset(current_user_roles, dataset) or trans.user_is_admin
         if not can_manage:
             raise exceptions.InsufficientPermissionsException('You do not have proper permissions to manage permissions on this dataset.')
 

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -69,7 +69,7 @@ class FolderManager(object):
         :rtype:     LibraryFolder
         """
         # all folders are accessible to an admin
-        if trans.user_is_admin():
+        if trans.user_is_admin:
             return folder
         if check_manageable:
             folder = self.check_manageable(trans, folder)
@@ -138,7 +138,7 @@ class FolderManager(object):
         """
         parent_folder = self.get(trans, parent_folder_id)
         current_user_roles = trans.get_current_user_roles()
-        if not (trans.user_is_admin() or trans.app.security_agent.can_add_library_item(current_user_roles, parent_folder)):
+        if not (trans.user_is_admin or trans.app.security_agent.can_add_library_item(current_user_roles, parent_folder)):
             raise InsufficientPermissionsException('You do not have proper permission to create folders under given folder.')
         new_folder = trans.app.model.LibraryFolder(name=new_folder_name, description=new_folder_description)
         # We are associating the last used genome build with folders, so we will always
@@ -169,7 +169,7 @@ class FolderManager(object):
         :raises: ItemAccessibilityException, InsufficientPermissionsException
         """
         changed = False
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             if not self.check_manageable(trans, folder):
                 raise InsufficientPermissionsException("You do not have proper permission to update the library folder.")
         if folder.deleted is True:
@@ -199,7 +199,7 @@ class FolderManager(object):
 
         :raises: ItemAccessibilityException
         """
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             folder = self.check_manageable(trans, folder)
         if undelete:
             folder.deleted = False
@@ -236,7 +236,7 @@ class FolderManager(object):
         """
         Return true if the user has permissions to add item to the given folder.
         """
-        if trans.user_is_admin():
+        if trans.user_is_admin:
             return True
         current_user_roles = trans.get_current_user_roles()
         add_roles = set(trans.app.security_agent.get_roles_for_action(folder, trans.app.security_agent.permitted_actions.LIBRARY_ADD))

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -50,7 +50,7 @@ class LibraryManager(object):
         """
         Create a new library.
         """
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             raise exceptions.ItemAccessibilityException('Only administrators can create libraries.')
         else:
             library = trans.app.model.Library(name=name, description=description, synopsis=synopsis)
@@ -65,7 +65,7 @@ class LibraryManager(object):
         Update the given library
         """
         changed = False
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             raise exceptions.ItemAccessibilityException('Only administrators can update libraries.')
         if library.deleted:
             raise exceptions.RequestParameterInvalidException('You cannot modify a deleted library. Undelete it first.')
@@ -90,7 +90,7 @@ class LibraryManager(object):
         """
         Mark given library deleted/undeleted based on the flag.
         """
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             raise exceptions.ItemAccessibilityException('Only administrators can delete and undelete libraries.')
         if undelete:
             library.deleted = False
@@ -115,7 +115,7 @@ class LibraryManager(object):
                   libraries later on.
         :rtype:   dict
         """
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         query = trans.sa_session.query(trans.app.model.Library)
         library_access_action = trans.app.security_agent.permitted_actions.LIBRARY_ACCESS.action
         restricted_library_ids = {lp.library_id for lp in (
@@ -174,7 +174,7 @@ class LibraryManager(object):
         :rtype:     Library
         """
         # all libraries are accessible to an admin
-        if trans.user_is_admin():
+        if trans.user_is_admin:
             return library
         if check_accessible:
             library = self.check_accessible(trans, library)
@@ -213,7 +213,7 @@ class LibraryManager(object):
         library_dict = library.to_dict(view='element', value_mapper={'id': trans.security.encode_id, 'root_folder_id': trans.security.encode_id})
         library_dict['public'] = False if (restricted_library_ids and library.id in restricted_library_ids) else True
         library_dict['create_time_pretty'] = pretty_print_time_interval(library.create_time, precise=True)
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             if prefetched_ids:
                 library_dict['can_user_add'] = True if (allowed_library_add_ids and library.id in allowed_library_add_ids) else False
                 library_dict['can_user_modify'] = True if (allowed_library_modify_ids and library.id in allowed_library_modify_ids) else False

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -134,7 +134,7 @@ class LibraryDatasetsManager(object):
         :returns:   the original library dataset
         :rtype:     galaxy.model.LibraryDataset
         """
-        if trans.user_is_admin():
+        if trans.user_is_admin:
             # all operations are available to an admin
             return ld
         if check_accessible:
@@ -174,7 +174,7 @@ class LibraryDatasetsManager(object):
         """
         if ld.deleted:
             raise ObjectNotFound('Library dataset with the id provided is deleted.')
-        elif trans.user_is_admin():
+        elif trans.user_is_admin:
             return ld
         if not trans.app.security_agent.can_modify_library_item(trans.get_current_user_roles(), ld):
             raise InsufficientPermissionsException('You do not have proper permission to modify this library dataset.')
@@ -214,12 +214,12 @@ class LibraryDatasetsManager(object):
         rval['full_path'] = full_path
         rval['file_size'] = util.nice_size(int(ldda.get_size()))
         rval['date_uploaded'] = ldda.create_time.strftime("%Y-%m-%d %I:%M %p")
-        rval['can_user_modify'] = trans.user_is_admin() or trans.app.security_agent.can_modify_library_item(current_user_roles, ld)
+        rval['can_user_modify'] = trans.user_is_admin or trans.app.security_agent.can_modify_library_item(current_user_roles, ld)
         rval['is_unrestricted'] = trans.app.security_agent.dataset_is_public(ldda.dataset)
         rval['tags'] = self.tag_manager.get_tags_str(ldda.tags)
 
         #  Manage dataset permission is always attached to the dataset itself, not the the ld or ldda to maintain consistency
-        rval['can_user_manage'] = trans.user_is_admin() or trans.app.security_agent.can_manage_dataset(current_user_roles, ldda.dataset)
+        rval['can_user_manage'] = trans.user_is_admin or trans.app.security_agent.can_manage_dataset(current_user_roles, ldda.dataset)
         return rval
 
     def _build_path(self, trans, folder):

--- a/lib/galaxy/managers/rbac_secured.py
+++ b/lib/galaxy/managers/rbac_secured.py
@@ -173,7 +173,7 @@ class ManageDatasetRBACPermission(DatasetRBACPermission):
 
     # ---- interface
     def is_permitted(self, dataset, user, trans=None):
-        if trans and trans.user_is_admin():
+        if trans and trans.user_is_admin:
             return True
 
         # anonymous users cannot manage permissions on datasets
@@ -232,7 +232,7 @@ class AccessDatasetRBACPermission(DatasetRBACPermission):
 
     # ---- interface
     def is_permitted(self, dataset, user, trans=None):
-        if trans and trans.user_is_admin():
+        if trans and trans.user_is_admin:
             return True
 
         current_roles = self._roles(dataset)

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -113,7 +113,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         if user is None:
             # Anonymous session or master_api_key used, if master_api_key is detected
             # return True.
-            rval = bool(trans and trans.user_is_admin())
+            rval = bool(trans and trans.user_is_admin)
             return rval
         return bool(admin_emails and user.email in admin_emails)
 

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -81,7 +81,7 @@ class WorkflowsManager(object):
         stored_workflow = self.get_stored_workflow(trans, workflow_id)
 
         # check to see if user has permissions to selected workflow
-        if stored_workflow.user != trans.user and not trans.user_is_admin() and not stored_workflow.published:
+        if stored_workflow.user != trans.user and not trans.user_is_admin and not stored_workflow.published:
             if trans.sa_session.query(trans.app.model.StoredWorkflowUserShareAssociation).filter_by(user=trans.user, stored_workflow=stored_workflow).count() == 0:
                 message = "Workflow is not owned by or shared with current user"
                 raise exceptions.ItemAccessibilityException(message)
@@ -109,7 +109,7 @@ class WorkflowsManager(object):
         if isinstance(has_workflow, model.WorkflowInvocation):
             # We use the the owner of the history that is associated to the invocation as a proxy
             # for the owner of the invocation.
-            if trans.user != has_workflow.history.user and not trans.user_is_admin():
+            if trans.user != has_workflow.history.user and not trans.user_is_admin:
                 raise exceptions.ItemOwnershipException()
             else:
                 return True
@@ -121,7 +121,7 @@ class WorkflowsManager(object):
         else:
             stored_workflow = has_workflow
 
-        if stored_workflow.user != trans.user and not trans.user_is_admin():
+        if stored_workflow.user != trans.user and not trans.user_is_admin:
             if check_ownership:
                 raise exceptions.ItemOwnershipException()
             # else check_accessible...

--- a/lib/galaxy/security/__init__.py
+++ b/lib/galaxy/security/__init__.py
@@ -254,8 +254,8 @@ class GalaxyRBACAgent(RBACAgent):
         else:
             is_public_item = False
         # Admins can always choose from all non-deleted roles
-        if trans.user_is_admin() or trans.app.config.expose_user_email:
-            if trans.user_is_admin():
+        if trans.user_is_admin or trans.app.config.expose_user_email:
+            if trans.user_is_admin:
                 db_query = trans.sa_session.query(trans.app.model.Role).filter(self.model.Role.table.c.deleted == false())
             else:
                 # User is not an admin but the configuration exposes all private roles to all users.
@@ -320,7 +320,7 @@ class GalaxyRBACAgent(RBACAgent):
         """
         Return a sorted list of legitimate roles that can be associated with a permission on
         item where item is a Library or a Dataset.  The cntrller param is the controller from
-        which the request is sent.  We cannot use trans.user_is_admin() because the controller is
+        which the request is sent.  We cannot use trans.user_is_admin because the controller is
         what is important since admin users do not necessarily have permission to do things
         on items outside of the admin view.
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1813,7 +1813,7 @@ class Tool(Dictifiable):
             }
 
         # If an admin user, expose the path to the actual tool config XML file.
-        if trans.user_is_admin():
+        if trans.user_is_admin:
             tool_dict['config_file'] = os.path.abspath(self.config_file)
 
         # Add link details.

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -185,7 +185,7 @@ def __new_history_upload(trans, uploaded_dataset, history=None, state=None):
 
 def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, state=None):
     current_user_roles = trans.get_current_user_roles()
-    if not ((trans.user_is_admin() and cntrller in ['library_admin', 'api']) or trans.app.security_agent.can_add_library_item(current_user_roles, library_bunch.folder)):
+    if not ((trans.user_is_admin and cntrller in ['library_admin', 'api']) or trans.app.security_agent.can_add_library_item(current_user_roles, library_bunch.folder)):
         # This doesn't have to be pretty - the only time this should happen is if someone's being malicious.
         raise Exception("User is not authorized to add datasets to this library.")
     folder = library_bunch.folder

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -369,7 +369,7 @@ class UploadDataset(Group):
                                 continue  # non-url line, ignore
 
                             if "file://" in line:
-                                if not trans.user_is_admin():
+                                if not trans.user_is_admin:
                                     raise AdminRequiredException()
                                 elif not trans.app.config.allow_path_paste:
                                     raise ConfigDoesNotAllowException()

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -952,7 +952,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         Use cache if present, store to cache otherwise.
         Note: The cached tool's to_dict is specific to the calls from toolbox.
         """
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             to_dict = self._tool_to_dict_cache.get(tool.id, None)
             if not to_dict:
                 to_dict = tool.to_dict(trans, link_details=True)

--- a/lib/galaxy/tools/toolbox/filters/examples.py.sample
+++ b/lib/galaxy/tools/toolbox/filters/examples.py.sample
@@ -11,7 +11,7 @@ def restrict_upload_to_admins( context, tool ):
         tool_filters = examples:restrict_upload_to_admins
     """
     if tool.name == "Upload File":
-        return context.trans.user_is_admin()
+        return context.trans.user_is_admin
     return True
 
 

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -431,7 +431,7 @@ class UsesLibraryMixin(object):
 
     def get_library(self, trans, id, check_ownership=False, check_accessible=True):
         l = self.get_object(trans, id, 'Library')
-        if check_accessible and not (trans.user_is_admin() or trans.app.security_agent.can_access_library(trans.get_current_user_roles(), l)):
+        if check_accessible and not (trans.user_is_admin or trans.app.security_agent.can_access_library(trans.get_current_user_roles(), l)):
             error("LibraryFolder is not accessible to the current user")
         return l
 
@@ -462,7 +462,7 @@ class UsesLibraryMixinItems(SharableItemSecurityMixin):
     def can_current_user_add_to_library_item(self, trans, item):
         if not trans.user:
             return False
-        return ((trans.user_is_admin()) or
+        return ((trans.user_is_admin) or
                 (trans.app.security_agent.can_add_library_item(trans.get_current_user_roles(), item)))
 
     def check_user_can_add_to_library_item(self, trans, item, check_accessible=True):
@@ -475,7 +475,7 @@ class UsesLibraryMixinItems(SharableItemSecurityMixin):
             return False
 
         current_user_roles = trans.get_current_user_roles()
-        if trans.user_is_admin():
+        if trans.user_is_admin:
             return True
 
         if check_accessible:

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -86,7 +86,7 @@ def require_login(verb="perform this action", use_panels=False, webapp='galaxy')
 def require_admin(func):
     @wraps(func)
     def decorator(self, trans, *args, **kwargs):
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             msg = "You must be an administrator to access this feature."
             user = trans.get_user()
             if not trans.app.config.admin_users_list:
@@ -138,7 +138,7 @@ def expose_api(func, to_json=True, user_required=True):
 
         # Perform api_run_as processing, possibly changing identity
         if 'payload' in kwargs and isinstance(kwargs['payload'], dict) and 'run_as' in kwargs['payload']:
-            if not trans.user_can_do_run_as():
+            if not trans.user_can_do_run_as:
                 error_message = 'User does not have permissions to run jobs as another user'
                 return error
             try:
@@ -148,7 +148,7 @@ def expose_api(func, to_json=True, user_required=True):
                 return "Malformed user id ( %s ) specified, unable to decode." % str(kwargs['payload']['run_as'])
             try:
                 user = trans.sa_session.query(trans.app.model.User).get(decoded_user_id)
-                trans.api_inherit_admin = trans.user_is_admin()
+                trans.api_inherit_admin = trans.user_is_admin
                 trans.set_user(user)
             except Exception:
                 trans.response.status = 400
@@ -263,7 +263,7 @@ def _future_expose_api(func, to_json=True, user_required=True, user_or_session_r
         # TODO: Refactor next block out into a helper procedure.
         # Perform api_run_as processing, possibly changing identity
         if 'payload' in kwargs and 'run_as' in kwargs['payload']:
-            if not trans.user_can_do_run_as():
+            if not trans.user_can_do_run_as:
                 error_code = error_codes.USER_CANNOT_RUN_AS
                 return __api_error_response(trans, err_code=error_code, status_code=403)
             try:
@@ -274,7 +274,7 @@ def _future_expose_api(func, to_json=True, user_required=True, user_or_session_r
                 return __api_error_response(trans, err_code=error_code, err_msg=error_message, status_code=400)
             try:
                 user = trans.sa_session.query(trans.app.model.User).get(decoded_user_id)
-                trans.api_inherit_admin = trans.user_is_admin()
+                trans.api_inherit_admin = trans.user_is_admin
                 trans.set_user(user)
             except Exception:
                 error_code = error_codes.USER_INVALID_RUN_AS

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -49,7 +49,7 @@ class ConfigurationController(BaseAPIController):
 
         Note: a more complete list is returned if the user is an admin.
         """
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         serialization_params = self._parse_serialization_params(kwd, 'all')
         return self.get_config_dict(trans, is_admin, **serialization_params)
 

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -53,7 +53,7 @@ class FolderContentsController(BaseAPIController, UsesLibraryMixin, UsesLibraryM
         :raises: MalformedId, InconsistentDatabase, ObjectNotFound,
              InternalServerError
         """
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         deleted = kwd.get('include_deleted', 'missing')
         current_user_roles = trans.get_current_user_roles()
         try:
@@ -190,7 +190,7 @@ class FolderContentsController(BaseAPIController, UsesLibraryMixin, UsesLibraryM
         :type:      list
         """
         current_user_roles = trans.get_current_user_roles()
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         content_items = []
         for subfolder in folder.folders:
             if subfolder.deleted:

--- a/lib/galaxy/webapps/galaxy/api/folders.py
+++ b/lib/galaxy/webapps/galaxy/api/folders.py
@@ -97,7 +97,7 @@ class FoldersController(BaseAPIController, UsesLibraryMixin, UsesLibraryMixinIte
         :raises: InsufficientPermissionsException
         """
         current_user_roles = trans.get_current_user_roles()
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         decoded_folder_id = self.folder_manager.cut_and_decode(trans, encoded_folder_id)
         folder = self.folder_manager.get(trans, decoded_folder_id)
 
@@ -153,7 +153,7 @@ class FoldersController(BaseAPIController, UsesLibraryMixin, UsesLibraryMixinIte
         """
         if payload:
             kwd.update(payload)
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
         decoded_folder_id = self.folder_manager.cut_and_decode(trans, encoded_folder_id)
         folder = self.folder_manager.get(trans, decoded_folder_id)

--- a/lib/galaxy/webapps/galaxy/api/forms.py
+++ b/lib/galaxy/webapps/galaxy/api/forms.py
@@ -19,7 +19,7 @@ class FormDefinitionAPIController(BaseAPIController):
         GET /api/forms
         Displays a collection (list) of forms.
         """
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             trans.response.status = 403
             return "You are not authorized to view the list of forms."
         query = trans.sa_session.query(trans.app.model.FormDefinition)
@@ -46,7 +46,7 @@ class FormDefinitionAPIController(BaseAPIController):
             form_definition = trans.sa_session.query(trans.app.model.FormDefinition).get(decoded_form_definition_id)
         except Exception:
             form_definition = None
-        if not form_definition or not trans.user_is_admin():
+        if not form_definition or not trans.user_is_admin:
             trans.response.status = 400
             return "Invalid form definition id ( %s ) specified." % str(form_definition_id)
         item = form_definition.to_dict(view='element', value_mapper={'id': trans.security.encode_id, 'form_definition_current_id': trans.security.encode_id})
@@ -59,7 +59,7 @@ class FormDefinitionAPIController(BaseAPIController):
         POST /api/forms
         Creates a new form.
         """
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             trans.response.status = 403
             return "You are not authorized to create a new form."
         xml_text = payload.get('xml_text', None)

--- a/lib/galaxy/webapps/galaxy/api/groups.py
+++ b/lib/galaxy/webapps/galaxy/api/groups.py
@@ -22,7 +22,7 @@ class GroupAPIController(BaseAPIController):
         """
         rval = []
         for group in trans.sa_session.query(trans.app.model.Group).filter(trans.app.model.Group.table.c.deleted == false()):
-            if trans.user_is_admin():
+            if trans.user_is_admin:
                 item = group.to_dict(value_mapper={'id': trans.security.encode_id})
                 encoded_id = trans.security.encode_id(group.id)
                 item['url'] = url_for('group', id=encoded_id)
@@ -36,7 +36,7 @@ class GroupAPIController(BaseAPIController):
         Creates a new group.
         """
         log.info("groups payload%s\n" % (payload))
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             trans.response.status = 403
             return "You are not authorized to create a new group."
         name = payload.get('name', None)

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -448,7 +448,7 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
             current_user_roles = trans.get_current_user_roles()
 
             def traverse(folder):
-                admin = trans.user_is_admin()
+                admin = trans.user_is_admin
                 rval = []
                 for subfolder in folder.active_folders:
                     if not admin:
@@ -634,7 +634,7 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
     def __update_dataset(self, trans, history_id, id, payload, **kwd):
         # anon user: ensure that history ids match up and the history is the current,
         #   check for uploading, and use only the subset of attribute keys manipulatable by anon users
-        anonymous_user = not trans.user_is_admin() and trans.user is None
+        anonymous_user = not trans.user_is_admin and trans.user is None
         if anonymous_user:
             hda = self.hda_manager.by_id(self.decode_id(id))
             if hda.history != trans.history:

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -64,7 +64,7 @@ class JobController(BaseAPIController, UsesLibraryMixinItems):
         :returns:   list of dictionaries containing summary job information
         """
         state = kwd.get('state', None)
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         user_details = kwd.get('user_details', False)
 
         if is_admin:
@@ -130,7 +130,7 @@ class JobController(BaseAPIController, UsesLibraryMixinItems):
         :returns:   dictionary containing full description of job data
         """
         job = self.__get_job(trans, id)
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         job_dict = self.encode_all_ids(trans, job.to_dict('element', system_details=is_admin), True)
         full_output = util.asbool(kwd.get('full', 'false'))
         if full_output:
@@ -279,7 +279,7 @@ class JobController(BaseAPIController, UsesLibraryMixinItems):
         if job is None:
             raise exceptions.ObjectNotFound()
         belongs_to_user = (job.user == trans.user) if job.user else (job.session_id == trans.get_galaxy_session().id)
-        if not trans.user_is_admin() and not belongs_to_user:
+        if not trans.user_is_admin and not belongs_to_user:
             # Check access granted via output datasets.
             if not job.output_datasets:
                 raise exceptions.ItemAccessibilityException("Job has no output datasets.")

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -208,7 +208,7 @@ class LibrariesController(BaseAPIController):
         :raises: InsufficientPermissionsException
         """
         current_user_roles = trans.get_current_user_roles()
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         library = self.library_manager.get(trans, self.__decode_id(trans, encoded_library_id, 'library'))
         if not (is_admin or trans.app.security_agent.can_manage_library_item(current_user_roles, library)):
             raise exceptions.InsufficientPermissionsException('You do not have proper permission to access permissions of this library.')
@@ -274,7 +274,7 @@ class LibrariesController(BaseAPIController):
         """
         if payload:
             kwd.update(payload)
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
         library = self.library_manager.get(trans, self.__decode_id(trans, encoded_library_id, 'library'))
 

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -67,7 +67,7 @@ class LibraryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
         current_user_roles = trans.get_current_user_roles()
 
         def traverse(folder):
-            admin = trans.user_is_admin()
+            admin = trans.user_is_admin
             rval = []
             for subfolder in folder.active_folders:
                 if not admin:
@@ -100,7 +100,7 @@ class LibraryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
             raise exceptions.RequestParameterInvalidException('No library found with the id provided.')
         except Exception as e:
             raise exceptions.InternalServerError('Error loading from the database.' + str(e))
-        if not (trans.user_is_admin() or trans.app.security_agent.can_access_library(current_user_roles, library)):
+        if not (trans.user_is_admin or trans.app.security_agent.can_access_library(current_user_roles, library)):
             raise exceptions.RequestParameterInvalidException('No library found with the id provided.')
         encoded_id = 'F' + trans.security.encode_id(library.root_folder.id)
         # appending root folder
@@ -294,7 +294,7 @@ class LibraryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
         else:
             last_used_build = dbkey
         roles = kwd.get('roles', '')
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
         if replace_id not in ['', None, 'None']:
             replace_dataset = trans.sa_session.query(trans.app.model.LibraryDataset).get(trans.security.decode_id(replace_id))
@@ -436,7 +436,7 @@ class LibraryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
         rval = {'id': id}
         try:
             ld = self.get_library_dataset(trans, id, check_ownership=False, check_accessible=True)
-            user_is_admin = trans.user_is_admin()
+            user_is_admin = trans.user_is_admin
             can_modify = trans.app.security_agent.can_modify_library_item(trans.user.all_roles(), ld)
             log.debug('is_admin: %s, can_modify: %s', user_is_admin, can_modify)
             if not (user_is_admin or can_modify):

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -117,7 +117,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
         library_dataset = self.ld_manager.get(trans, managers_base.decode_id(self.app, encoded_dataset_id))
         dataset = library_dataset.library_dataset_dataset_association.dataset
         # User has to have manage permissions permission in order to see the roles.
-        can_manage = trans.app.security_agent.can_manage_dataset(current_user_roles, dataset) or trans.user_is_admin()
+        can_manage = trans.app.security_agent.can_manage_dataset(current_user_roles, dataset) or trans.user_is_admin
         if not can_manage:
             raise exceptions.InsufficientPermissionsException('You do not have proper permission to access permissions.')
         scope = kwd.get('scope', None)
@@ -221,7 +221,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
         # Some permissions are attached directly to the underlying dataset.
         dataset = library_dataset.library_dataset_dataset_association.dataset
         current_user_roles = trans.get_current_user_roles()
-        can_manage = trans.app.security_agent.can_manage_dataset(current_user_roles, dataset) or trans.user_is_admin()
+        can_manage = trans.app.security_agent.can_manage_dataset(current_user_roles, dataset) or trans.user_is_admin
         if not can_manage:
             raise exceptions.InsufficientPermissionsException('You do not have proper permissions to manage permissions on this dataset.')
         new_access_roles_ids = util.listify(kwd.get('access_ids[]', None))
@@ -310,7 +310,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
         library_dataset = self.ld_manager.get(trans, managers_base.decode_id(self.app, encoded_dataset_id))
         current_user_roles = trans.get_current_user_roles()
         allowed = trans.app.security_agent.can_modify_library_item(current_user_roles, library_dataset)
-        if (not allowed) and (not trans.user_is_admin()):
+        if (not allowed) and (not trans.user_is_admin):
             raise exceptions.InsufficientPermissionsException('You do not have proper permissions to delete this dataset.')
 
         if undelete:
@@ -390,7 +390,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
         if source not in ['userdir_file', 'userdir_folder', 'importdir_file', 'importdir_folder', 'admin_path']:
             raise exceptions.RequestParameterMissingException('You have to specify "source" parameter. Possible values are "userdir_file", "userdir_folder", "admin_path", "importdir_file" and "importdir_folder". ')
         elif source in ['importdir_file', 'importdir_folder']:
-            if not trans.user_is_admin():
+            if not trans.user_is_admin:
                 raise exceptions.AdminRequiredException('Only admins can import from importdir.')
             if not trans.app.config.library_import_dir:
                 raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to import into library from importdir.')
@@ -437,7 +437,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
         elif source == 'admin_path':
             if not trans.app.config.allow_library_path_paste:
                 raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to import into library from path.')
-            if not trans.user_is_admin():
+            if not trans.user_is_admin:
                 raise exceptions.AdminRequiredException('Only admins can import from path.')
 
         # Set up the traditional tool state/params
@@ -544,7 +544,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
             current_user_roles = trans.get_current_user_roles()
 
             def traverse(folder):
-                admin = trans.user_is_admin()
+                admin = trans.user_is_admin
                 rval = []
                 for subfolder in folder.active_folders:
                     if not admin:

--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -44,7 +44,7 @@ class PagesController(BaseAPIController, SharableItemSecurityMixin, UsesAnnotati
         """
         out = []
 
-        if trans.user_is_admin():
+        if trans.user_is_admin:
             r = trans.sa_session.query(trans.app.model.Page)
             if not deleted:
                 r = r.filter_by(deleted=False)
@@ -162,7 +162,7 @@ class PagesController(BaseAPIController, SharableItemSecurityMixin, UsesAnnotati
         if not page:
             raise exceptions.ObjectNotFound()
 
-        if page.user != trans.user and not trans.user_is_admin():
+        if page.user != trans.user and not trans.user_is_admin:
             raise exceptions.ItemOwnershipException()
 
         return page

--- a/lib/galaxy/webapps/galaxy/api/roles.py
+++ b/lib/galaxy/webapps/galaxy/api/roles.py
@@ -21,7 +21,7 @@ class RoleAPIController(BaseAPIController):
         """
         rval = []
         for role in trans.sa_session.query(trans.app.model.Role).filter(trans.app.model.Role.table.c.deleted == false()):
-            if trans.user_is_admin() or trans.app.security_agent.ok_to_display(trans.user, role):
+            if trans.user_is_admin or trans.app.security_agent.ok_to_display(trans.user, role):
                 item = role.to_dict(value_mapper={'id': trans.security.encode_id})
                 encoded_id = trans.security.encode_id(role.id)
                 item['url'] = url_for('role', id=encoded_id)
@@ -44,7 +44,7 @@ class RoleAPIController(BaseAPIController):
             role = trans.sa_session.query(trans.app.model.Role).get(decoded_role_id)
         except Exception:
             role = None
-        if not role or not (trans.user_is_admin() or trans.app.security_agent.ok_to_display(trans.user, role)):
+        if not role or not (trans.user_is_admin or trans.app.security_agent.ok_to_display(trans.user, role)):
             trans.response.status = 400
             return "Invalid role id ( %s ) specified." % str(role_id)
         item = role.to_dict(view='element', value_mapper={'id': trans.security.encode_id})
@@ -57,7 +57,7 @@ class RoleAPIController(BaseAPIController):
         POST /api/roles
         Creates a new role.
         """
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             trans.response.status = 403
             return "You are not authorized to create a new role."
         name = payload.get('name', None)

--- a/lib/galaxy/webapps/galaxy/api/search.py
+++ b/lib/galaxy/webapps/galaxy/api/search.py
@@ -39,14 +39,14 @@ class SearchController(BaseAPIController, SharableItemSecurityMixin):
                     return {'error': str(e)}
                 for item in results:
                     append = False
-                    if trans.user_is_admin():
+                    if trans.user_is_admin:
                         append = True
                     if not append:
                         if type(item) in [trans.app.model.LibraryFolder, trans.app.model.LibraryDatasetDatasetAssociation, trans.app.model.LibraryDataset]:
                             if (trans.app.security_agent.can_access_library_item(trans.get_current_user_roles(), item, trans.user)):
                                 append = True
                         elif type(item) in [trans.app.model.Job]:
-                            if item.used_id == trans.user or trans.user_is_admin():
+                            if item.used_id == trans.user or trans.user_is_admin:
                                 append = True
                         elif type(item) in [trans.app.model.Page, trans.app.model.StoredWorkflow]:
                             try:

--- a/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
@@ -53,7 +53,7 @@ class ToolShedRepositoriesController(BaseAPIController):
             log.debug(message)
             return dict(status='error', error=message)
         # Make sure the current user's API key proves he is an admin user in this Galaxy instance.
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             raise exceptions.AdminRequiredException('You are not authorized to request the latest installable revision for a repository in this Galaxy instance.')
 
     def __flatten_repository_dependency_list(self, trans, tool_shed_repository):
@@ -178,7 +178,7 @@ class ToolShedRepositoriesController(BaseAPIController):
         # Get the information about the repository to be installed from the payload.
         tool_shed_url, name, owner = self.__parse_repository_from_payload(payload)
         # Make sure the current user's API key proves he is an admin user in this Galaxy instance.
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             raise exceptions.AdminRequiredException('You are not authorized to request the latest installable revision for a repository in this Galaxy instance.')
         params = dict(name=name, owner=owner)
         pathspec = ['api', 'repositories', 'get_ordered_installable_revisions']
@@ -739,7 +739,7 @@ class ToolShedRepositoriesController(BaseAPIController):
                        unsuccessful_count=0,
                        repository_status=[])
         # Make sure the current user's API key proves he is an admin user in this Galaxy instance.
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             raise HTTPForbidden(detail='You are not authorized to reset metadata on repositories installed into this Galaxy instance.')
         irmm = InstalledRepositoryMetadataManager(self.app)
         query = irmm.get_query_for_setting_metadata_on_repositories(order=False)

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -458,7 +458,7 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         for k, v in inputs.items():
             if isinstance(v, dict) and v.get('src', '') == 'ldda' and 'id' in v:
                 ldda = trans.sa_session.query(trans.app.model.LibraryDatasetDatasetAssociation).get(self.decode_id(v['id']))
-                if trans.user_is_admin() or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), ldda.dataset):
+                if trans.user_is_admin or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), ldda.dataset):
                     input_patch[k] = ldda.to_history_dataset_association(target_history, add_to_history=True)
 
         for k, v in input_patch.items():

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -97,14 +97,14 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesUsersMixin, Cre
         query = trans.sa_session.query(trans.app.model.User)
         deleted = util.string_as_bool(deleted)
 
-        if f_email and (trans.user_is_admin() or trans.app.config.expose_user_email):
+        if f_email and (trans.user_is_admin or trans.app.config.expose_user_email):
             query = query.filter(trans.app.model.User.email.like("%%%s%%" % f_email))
 
-        if f_name and (trans.user_is_admin() or trans.app.config.expose_user_name):
+        if f_name and (trans.user_is_admin or trans.app.config.expose_user_name):
             query = query.filter(trans.app.model.User.username.like("%%%s%%" % f_name))
 
         if f_any:
-            if trans.user_is_admin():
+            if trans.user_is_admin:
                 query = query.filter(or_(
                     trans.app.model.User.email.like("%%%s%%" % f_any),
                     trans.app.model.User.username.like("%%%s%%" % f_any)
@@ -123,21 +123,21 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesUsersMixin, Cre
         if deleted:
             query = query.filter(trans.app.model.User.table.c.deleted == true())
             # only admins can see deleted users
-            if not trans.user_is_admin():
+            if not trans.user_is_admin:
                 return []
         else:
             query = query.filter(trans.app.model.User.table.c.deleted == false())
             # special case: user can see only their own user
             # special case2: if the galaxy admin has specified that other user email/names are
             #   exposed, we don't want special case #1
-            if not trans.user_is_admin() and not trans.app.config.expose_user_name and not trans.app.config.expose_user_email:
+            if not trans.user_is_admin and not trans.app.config.expose_user_name and not trans.app.config.expose_user_email:
                 item = trans.user.to_dict(value_mapper={'id': trans.security.encode_id})
                 return [item]
         for user in query:
             item = user.to_dict(value_mapper={'id': trans.security.encode_id})
             # If NOT configured to expose_email, do not expose email UNLESS the user is self, or
             # the user is an admin
-            if user is not trans.user and not trans.user_is_admin():
+            if user is not trans.user and not trans.user_is_admin:
                 expose_keys = ["id"]
                 if trans.app.config.expose_user_name:
                     expose_keys.append("username")
@@ -176,7 +176,7 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesUsersMixin, Cre
             else:
                 user = self.get_user(trans, id, deleted=deleted)
             # check that the user is requesting themselves (and they aren't del'd) unless admin
-            if not trans.user_is_admin():
+            if not trans.user_is_admin:
                 assert trans.user == user
                 assert not user.deleted
         except Exception:
@@ -189,11 +189,11 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesUsersMixin, Cre
         POST /api/users
         Creates a new Galaxy user.
         """
-        if not trans.app.config.allow_user_creation and not trans.user_is_admin():
+        if not trans.app.config.allow_user_creation and not trans.user_is_admin:
             raise exceptions.ConfigDoesNotAllowException('User creation is not allowed in this Galaxy instance')
-        if trans.app.config.use_remote_user and trans.user_is_admin():
+        if trans.app.config.use_remote_user and trans.user_is_admin:
             user = trans.get_or_create_remote_user(remote_user_email=payload['remote_user_email'])
-        elif trans.user_is_admin():
+        elif trans.user_is_admin:
             username = payload['username']
             email = payload['email']
             password = payload['password']
@@ -940,6 +940,6 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesUsersMixin, Cre
         user = self.get_user(trans, id)
         if not user:
             raise MessageException('Invalid user (%s).' % id)
-        if user != trans.user and not trans.user_is_admin():
+        if user != trans.user and not trans.user_is_admin:
             raise MessageException('Access denied.')
         return user

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -205,7 +205,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         Displays information needed to run a workflow from the command line.
         """
         stored_workflow = self.__get_stored_workflow(trans, id)
-        if stored_workflow.importable is False and stored_workflow.user != trans.user and not trans.user_is_admin():
+        if stored_workflow.importable is False and stored_workflow.user != trans.user and not trans.user_is_admin:
             if trans.sa_session.query(trans.app.model.StoredWorkflowUserShareAssociation).filter_by(user=trans.user, stored_workflow=stored_workflow).count() == 0:
                 message = "Workflow is neither importable, nor owned by or shared with current user"
                 raise exceptions.ItemAccessibilityException(message)
@@ -437,7 +437,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             return ("Workflow with ID='%s' can not be found\n Exception: %s") % (workflow_id, str(e))
 
         # check to see if user has permissions to selected workflow
-        if stored_workflow.user != trans.user and not trans.user_is_admin():
+        if stored_workflow.user != trans.user and not trans.user_is_admin:
             trans.response.status = 403
             return("Workflow is not owned by current user")
 
@@ -585,7 +585,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
     def __api_import_new_workflow(self, trans, payload, **kwd):
         data = payload['workflow']
         import_tools = util.string_as_bool(payload.get("import_tools", False))
-        if import_tools and not trans.user_is_admin():
+        if import_tools and not trans.user_is_admin:
             raise exceptions.AdminRequiredException()
 
         from_dict_kwds = self.__import_or_update_kwds(payload)

--- a/lib/galaxy/webapps/galaxy/controllers/data_manager.py
+++ b/lib/galaxy/webapps/galaxy/controllers/data_manager.py
@@ -16,7 +16,7 @@ class DataManager(BaseUIController):
 
     @web.expose
     def index(self, trans, **kwd):
-        not_is_admin = not trans.user_is_admin()
+        not_is_admin = not trans.user_is_admin
         if not_is_admin and not trans.app.config.enable_data_manager_user_view:
             raise paste.httpexceptions.HTTPUnauthorized("This Galaxy instance is not configured to allow non-admins to view the data manager.")
         message = escape(kwd.get('message', ''))
@@ -25,7 +25,7 @@ class DataManager(BaseUIController):
 
     @web.expose
     def manage_data_manager(self, trans, **kwd):
-        not_is_admin = not trans.user_is_admin()
+        not_is_admin = not trans.user_is_admin
         if not_is_admin and not trans.app.config.enable_data_manager_user_view:
             raise paste.httpexceptions.HTTPUnauthorized("This Galaxy instance is not configured to allow non-admins to view the data manager.")
         message = escape(kwd.get('message', ''))
@@ -39,7 +39,7 @@ class DataManager(BaseUIController):
 
     @web.expose
     def view_job(self, trans, **kwd):
-        not_is_admin = not trans.user_is_admin()
+        not_is_admin = not trans.user_is_admin
         if not_is_admin and not trans.app.config.enable_data_manager_user_view:
             raise paste.httpexceptions.HTTPUnauthorized("This Galaxy instance is not configured to allow non-admins to view the data manager.")
         message = escape(kwd.get('message', ''))
@@ -72,7 +72,7 @@ class DataManager(BaseUIController):
 
     @web.expose
     def manage_data_table(self, trans, **kwd):
-        not_is_admin = not trans.user_is_admin()
+        not_is_admin = not trans.user_is_admin
         if not_is_admin and not trans.app.config.enable_data_manager_user_view:
             raise paste.httpexceptions.HTTPUnauthorized("This Galaxy instance is not configured to allow non-admins to view the data manager.")
         message = escape(kwd.get('message', ''))

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -124,7 +124,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         roles = trans.get_current_user_roles()
         if additional_roles:
             roles = roles + additional_roles
-        return (allow_admin and trans.user_is_admin()) or trans.app.security_agent.can_access_dataset(roles, dataset_association.dataset)
+        return (allow_admin and trans.user_is_admin) or trans.app.security_agent.can_access_dataset(roles, dataset_association.dataset)
 
     @web.expose
     def errors(self, trans, id):
@@ -203,7 +203,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             return trans.show_error_message("You are not allowed to access this dataset")
         if data.purged:
             return trans.show_error_message("The dataset you are attempting to view has been purged.")
-        if data.deleted and not (trans.user_is_admin() or (data.history and trans.get_user() == data.history.user)):
+        if data.deleted and not (trans.user_is_admin or (data.history and trans.get_user() == data.history.user)):
             return trans.show_error_message("The dataset you are attempting to view has been deleted.")
         if data.state == trans.model.Dataset.states.UPLOAD:
             return trans.show_error_message("Please wait until this dataset finishes uploading before attempting to view it.")

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -491,7 +491,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         ).get(id)
         if not (history and ((history.user and trans.user and history.user.id == trans.user.id) or
                              (trans.history and history.id == trans.history.id) or
-                             trans.user_is_admin())):
+                             trans.user_is_admin)):
             return trans.show_error_message("Cannot display history structure.")
         # Resolve jobs and workflow invocations for the datasets in the history
         # items is filled with items (hdas, jobs, or workflows) that go at the

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -103,7 +103,7 @@ class ToolRunner(BaseUIController):
             # Get the dataset object
             data = trans.sa_session.query(trans.app.model.HistoryDatasetAssociation).get(id)
             # only allow rerunning if user is allowed access to the dataset.
-            if not (trans.user_is_admin() or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), data.dataset)):
+            if not (trans.user_is_admin or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), data.dataset)):
                 error("You are not allowed to access this dataset")
             # Get the associated job, if any.
             job = data.creating_job

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -276,7 +276,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Create
         username = kwd.get('username', '')
         redirect = kwd.get('redirect', '').strip()
         params = util.Params(kwd)
-        is_admin = cntrller == 'admin' and trans.user_is_admin()
+        is_admin = cntrller == 'admin' and trans.user_is_admin
         openids = trans.galaxy_session.openids
         user = None
         if not openids:
@@ -320,7 +320,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Create
             subscribe = params.get('subscribe', '')
             subscribe_checked = CheckboxField.is_checked(subscribe)
             error = ''
-            if not trans.app.config.allow_user_creation and not trans.user_is_admin():
+            if not trans.app.config.allow_user_creation and not trans.user_is_admin:
                 error = 'User registration is disabled.  Please contact your local Galaxy administrator for an account.'
             else:
                 # Check email and password validity
@@ -525,7 +525,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Create
         """
         Does the autoregistration if enabled. Returns a message
         """
-        skip_login_handling = cntrller == 'admin' and trans.user_is_admin()
+        skip_login_handling = cntrller == 'admin' and trans.user_is_admin
         autoreg = trans.app.auth_manager.check_auto_registration(trans, login, password, no_password_check=no_password_check)
         user = None
         success = False
@@ -723,9 +723,9 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Create
         subscribe_checked = CheckboxField.is_checked(subscribe)
         referer = trans.request.referer or ''
         redirect = kwd.get('redirect', referer).strip()
-        is_admin = cntrller == 'admin' and trans.user_is_admin()
+        is_admin = cntrller == 'admin' and trans.user_is_admin
         show_user_prepopulate_form = is_admin and trans.app.config.show_user_prepopulate_form
-        if not trans.app.config.allow_user_creation and not trans.user_is_admin():
+        if not trans.app.config.allow_user_creation and not trans.user_is_admin:
             message = 'User registration is disabled.  Please contact your local Galaxy administrator for an account.'
             if trans.app.config.error_email_to is not None:
                 message += ' Contact: %s' % trans.app.config.error_email_to
@@ -813,7 +813,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesUsersMixin, Create
         username = util.restore_text(kwd.get('username', ''))
         message = escape(kwd.get('message', ''))
         status = kwd.get('status', 'done')
-        is_admin = cntrller == 'admin' and trans.user_is_admin()
+        is_admin = cntrller == 'admin' and trans.user_is_admin
         user = self.create_user(trans=trans, email=email, username=username, password=password)
         error = ''
         success = True

--- a/lib/galaxy/webapps/tool_shed/api/categories.py
+++ b/lib/galaxy/webapps/tool_shed/api/categories.py
@@ -103,7 +103,7 @@ class CategoriesController(BaseAPIController):
         """
         category_dicts = []
         deleted = util.asbool(deleted)
-        if deleted and not trans.user_is_admin():
+        if deleted and not trans.user_is_admin:
             raise exceptions.AdminRequiredException('Only administrators can query deleted categories.')
         for category in trans.sa_session.query(self.app.model.Category) \
                                         .filter(self.app.model.Category.table.c.deleted == deleted) \

--- a/lib/galaxy/webapps/tool_shed/api/groups.py
+++ b/lib/galaxy/webapps/tool_shed/api/groups.py
@@ -44,7 +44,7 @@ class GroupsController(BaseAPIController):
         """
         group_dicts = []
         deleted = util.asbool(deleted)
-        if deleted and not trans.user_is_admin():
+        if deleted and not trans.user_is_admin:
             raise AdminRequiredException('Only administrators can query deleted groups.')
         for group in self.group_manager.list(trans, deleted):
             group_dicts.append(self._populate(trans, group))

--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -68,7 +68,7 @@ class RepositoriesController(BaseAPIController):
         :param owner (required): the owner of the Repository
         """
         response_dict = {}
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             response_dict['status'] = 'error'
             response_dict['message'] = "You are not authorized to add entries to this Tool Shed's repository registry."
             return response_dict
@@ -317,7 +317,7 @@ class RepositoriesController(BaseAPIController):
         irm = capsule_manager.ImportRepositoryManager(self.app,
                                                       trans.request.host,
                                                       trans.user,
-                                                      trans.user_is_admin())
+                                                      trans.user_is_admin)
         capsule_dict['tar_archive'] = tar_archive
         capsule_dict['capsule_file_name'] = capsule_file_name
         capsule_dict = irm.extract_capsule_files(**capsule_dict)
@@ -532,7 +532,7 @@ class RepositoriesController(BaseAPIController):
         :param owner (required): the owner of the Repository
         """
         response_dict = {}
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             response_dict['status'] = 'error'
             response_dict['message'] = "You are not authorized to remove entries from this Tool Shed's repository registry."
             return response_dict
@@ -573,7 +573,7 @@ class RepositoriesController(BaseAPIController):
                                        in addition to those repositories of type tool_dependency_definition.  This param is ignored
                                        if the current user is not an admin user, in which case this same restriction is automatic.
         """
-        if trans.user_is_admin():
+        if trans.user_is_admin:
             my_writable = util.asbool(my_writable)
         else:
             my_writable = True
@@ -660,7 +660,7 @@ class RepositoriesController(BaseAPIController):
                     # Skip comments.
                     continue
                 encoded_ids_to_skip.append(line.rstrip('\n'))
-        if trans.user_is_admin():
+        if trans.user_is_admin:
             my_writable = util.asbool(payload.get('my_writable', False))
         else:
             my_writable = True
@@ -1056,7 +1056,7 @@ class RepositoriesController(BaseAPIController):
 
         repository = repository_util.get_repository_in_tool_shed(self.app, id)
 
-        if not (trans.user_is_admin() or
+        if not (trans.user_is_admin or
                 self.app.security_agent.user_can_administer_repository(trans.user, repository) or
                 self.app.security_agent.can_push(self.app, trans.user, repository)):
             trans.response.status = 400

--- a/lib/galaxy/webapps/tool_shed/controllers/repository.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/repository.py
@@ -1024,7 +1024,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
             item_id = kwd.get('id', '')
             if item_id:
                 operation = kwd['operation'].lower()
-                is_admin = trans.user_is_admin()
+                is_admin = trans.user_is_admin
                 if operation == "view_or_manage_repository":
                     # The received id is a RepositoryMetadata id, so we have to get the repository id.
                     repository_metadata = metadata_util.get_repository_metadata_by_id(trans.app, item_id)
@@ -1115,7 +1115,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
             item_id = kwd.get('id', '')
             if item_id:
                 operation = kwd['operation'].lower()
-                is_admin = trans.user_is_admin()
+                is_admin = trans.user_is_admin
                 if operation == "view_or_manage_repository":
                     # The received id is a RepositoryMetadata id, so we have to get the repository id.
                     repository_metadata = metadata_util.get_repository_metadata_by_id(trans.app, item_id)
@@ -1339,7 +1339,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
         # Avoid caching
         trans.response.headers['Pragma'] = 'no-cache'
         trans.response.headers['Expires'] = '0'
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         return suc.get_repository_file_contents(trans.app, file_path, repository_id, is_admin)
 
     @web.json
@@ -1652,7 +1652,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
         irm = capsule_manager.ImportRepositoryManager(trans.app,
                                                       trans.request.host,
                                                       trans.user,
-                                                      trans.user_is_admin())
+                                                      trans.user_is_admin)
         export_info_dict = irm.get_export_info_dict(export_info_file_path)
         manifest_file_path = os.path.join(file_path, 'manifest.xml')
         # The manifest.xml file has already been validated, so no error_message should be returned here.
@@ -1708,7 +1708,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                     has_deprecated_repositories = True
                     break
             # See if the current user can administer any repositories, but only if not an admin user.
-            if not trans.user_is_admin():
+            if not trans.user_is_admin:
                 if current_user.active_repositories:
                     can_administer_repositories = True
                 else:
@@ -2159,7 +2159,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
         # Avoid caching
         trans.response.headers['Pragma'] = 'no-cache'
         trans.response.headers['Expires'] = '0'
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         return suc.open_repository_files_folder(trans.app, folder_path, repository_id, is_admin)
 
     @web.expose
@@ -2646,7 +2646,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
             irm = capsule_manager.ImportRepositoryManager(trans.app,
                                                           trans.request.host,
                                                           trans.user,
-                                                          trans.user_is_admin())
+                                                          trans.user_is_admin)
             capsule_dict = irm.upload_capsule(**kwd)
             status = capsule_dict.get('status', 'error')
             if status == 'error':
@@ -2782,7 +2782,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
             repository = repository_util.get_repository_in_tool_shed(trans.app, repository_id)
             user = trans.user
             if repository:
-                if user is not None and (trans.user_is_admin() or
+                if user is not None and (trans.user_is_admin or
                                          trans.app.security_agent.user_can_administer_repository(user, repository)):
                     return trans.response.send_redirect(web.url_for(controller='repository',
                                                                     action='manage_repository',

--- a/lib/galaxy/webapps/tool_shed/controllers/repository_review.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/repository_review.py
@@ -612,7 +612,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
     @web.require_login("view or manage repository")
     def view_or_manage_repository(self, trans, **kwd):
         repository = repository_util.get_repository_in_tool_shed(trans.app, kwd['id'])
-        if trans.user_is_admin() or repository.user == trans.user:
+        if trans.user_is_admin or repository.user == trans.user:
             return trans.response.send_redirect(web.url_for(controller='repository',
                                                             action='manage_repository',
                                                             **kwd))

--- a/lib/galaxy/webapps/tool_shed/controllers/user.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/user.py
@@ -67,7 +67,7 @@ class User(BaseUser):
     @web.require_login("to manage the public name")
     def edit_username(self, trans, cntrller, **kwd):
         params = util.Params(kwd)
-        is_admin = cntrller == 'admin' and trans.user_is_admin()
+        is_admin = cntrller == 'admin' and trans.user_is_admin
         message = util.restore_text(params.get('message', ''))
         status = params.get('status', 'done')
         user_id = params.get('user_id', None)
@@ -99,7 +99,7 @@ class User(BaseUser):
         Edit user information = username, email or password.
         """
         params = util.Params(kwd)
-        is_admin = cntrller == 'admin' and trans.user_is_admin()
+        is_admin = cntrller == 'admin' and trans.user_is_admin
         message = util.restore_text(params.get('message', ''))
         status = params.get('status', 'done')
         user_id = params.get('user_id', None)

--- a/lib/galaxy/workflow/resources/example.py.sample
+++ b/lib/galaxy/workflow/resources/example.py.sample
@@ -11,7 +11,7 @@ def admin_mapping(trans, stored_workflow, **kwds):
     ``workflow_resource_params_mapper`` to ``galaxy.workflow.resources.example:admin_mapping``.
     """
     workflow_resource_params = kwds["workflow_resource_params"]
-    if trans.user_is_admin():
+    if trans.user_is_admin:
         priority_attrib = workflow_resource_params.get("priority").attrib
         priority_attrib['data'] = []
         for child in workflow_resource_params.get('priority').getchildren():

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -282,23 +282,23 @@ def build_workflow_run_configs(trans, workflow, payload):
             try:
                 if input_source == 'ldda':
                     ldda = trans.sa_session.query(app.model.LibraryDatasetDatasetAssociation).get(trans.security.decode_id(input_id))
-                    assert trans.user_is_admin() or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), ldda.dataset)
+                    assert trans.user_is_admin or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), ldda.dataset)
                     content = ldda.to_history_dataset_association(history, add_to_history=add_to_history)
                 elif input_source == 'ld':
                     ldda = trans.sa_session.query(app.model.LibraryDataset).get(trans.security.decode_id(input_id)).library_dataset_dataset_association
-                    assert trans.user_is_admin() or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), ldda.dataset)
+                    assert trans.user_is_admin or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), ldda.dataset)
                     content = ldda.to_history_dataset_association(history, add_to_history=add_to_history)
                 elif input_source == 'hda':
                     # Get dataset handle, add to dict and history if necessary
                     content = trans.sa_session.query(app.model.HistoryDatasetAssociation).get(trans.security.decode_id(input_id))
-                    assert trans.user_is_admin() or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), content.dataset)
+                    assert trans.user_is_admin or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), content.dataset)
                 elif input_source == 'uuid':
                     dataset = trans.sa_session.query(app.model.Dataset).filter(app.model.Dataset.uuid == input_id).first()
                     if dataset is None:
                         # this will need to be changed later. If federation code is avalible, then a missing UUID
                         # could be found amoung fereration partners
                         raise exceptions.RequestParameterInvalidException("Input cannot find UUID: %s." % input_id)
-                    assert trans.user_is_admin() or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), dataset)
+                    assert trans.user_is_admin or trans.app.security_agent.can_access_dataset(trans.get_current_user_roles(), dataset)
                     content = history.add_dataset(dataset)
                 elif input_source == 'hdca':
                     content = app.dataset_collections_service.get_dataset_collection_instance(trans, 'history', input_id)

--- a/lib/tool_shed/managers/groups.py
+++ b/lib/tool_shed/managers/groups.py
@@ -56,7 +56,7 @@ class GroupManager(object):
         """
         Create a new group.
         """
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             raise ItemAccessibilityException('Only administrators can create groups.')
         else:
             if self.get(trans, name=name):
@@ -72,7 +72,7 @@ class GroupManager(object):
         Update the given group
         """
         changed = False
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             raise ItemAccessibilityException('Only administrators can update groups.')
         if group.deleted:
             raise RequestParameterInvalidException('You cannot modify a deleted group. Undelete it first.')
@@ -91,7 +91,7 @@ class GroupManager(object):
         """
         Mark given group deleted/undeleted based on the flag.
         """
-        if not trans.user_is_admin():
+        if not trans.user_is_admin:
             raise ItemAccessibilityException('Only administrators can delete and undelete groups.')
         if undelete:
             group.deleted = False
@@ -108,7 +108,7 @@ class GroupManager(object):
         :returns: query that will emit all groups
         :rtype:   sqlalchemy query
         """
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
         query = trans.sa_session.query(trans.app.model.Group)
         if is_admin:
             if deleted is None:

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -956,7 +956,7 @@ def update_repository(app, trans, id, **kwds):
     if repository is None:
         return None, "Unknown repository ID"
 
-    if not (trans.user_is_admin() or
+    if not (trans.user_is_admin or
             trans.app.security_agent.user_can_administer_repository(trans.user, repository)):
         message = "You are not the owner of this repository, so you cannot administer it."
         return None, message

--- a/templates/galaxy_client_app.mako
+++ b/templates/galaxy_client_app.mako
@@ -46,7 +46,7 @@ ${ h.dumps( dictionary, indent=( 2 if trans.debug else 0 ) ) }
         try:
             controller = trans.webapp.api_controllers.get( 'configuration', None )
             if controller:
-                config_dict = controller.get_config_dict( trans, trans.user_is_admin() )
+                config_dict = controller.get_config_dict( trans, trans.user_is_admin )
         except Exception as exc:
             pass
         return config_dict
@@ -71,7 +71,7 @@ ${ h.dumps( get_config_dict() )}
                 user_dict = trans.user.to_dict( view='element',
                     value_mapper={ 'id': trans.security.encode_id, 'total_disk_usage': float, 'email': escape, 'username': escape } )
                 user_dict[ 'quota_percent' ] = trans.app.quota_agent.get_percent( trans=trans )
-                user_dict[ 'is_admin' ] = trans.user_is_admin()
+                user_dict[ 'is_admin' ] = trans.user_is_admin
 
                 # tags used
                 users_api_controller = trans.webapp.api_controllers[ 'users' ]

--- a/templates/ind_share_base.mako
+++ b/templates/ind_share_base.mako
@@ -93,7 +93,7 @@
                             Email address of user to share with
                         </label>
                         <div style="float: left; width: 100%;  margin-right: 10px;">
-                            %if trans.app.config.expose_user_email or trans.app.config.expose_user_name or trans.user_is_admin():
+                            %if trans.app.config.expose_user_email or trans.app.config.expose_user_name or trans.user_is_admin:
                             <input type="hidden" id="email_select" name="email" >
                             </input>
                             %else:

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -176,28 +176,28 @@
         %endif
         <tr><td>History Content API ID:</td>
         <td>${encoded_hda_id}
-            %if trans.user_is_admin():
+            %if trans.user_is_admin:
                 (${hda.id})
             %endif
         </td></tr>
         %if job:
             <tr><td>Job API ID:</td>
             <td>${trans.security.encode_id( job.id )}
-                %if trans.user_is_admin():
+                %if trans.user_is_admin:
                     (${job.id})
                 %endif
             </td></tr>
         %endif
         <tr><td>History API ID:</td>
         <td>${encoded_history_id}
-            %if trans.user_is_admin():
+            %if trans.user_is_admin:
                 (${hda.history_id})
             %endif
         </td></tr>
         %if hda.dataset.uuid:
         <tr><td>UUID:</td><td>${hda.dataset.uuid}</td></tr>
         %endif
-        %if trans.user_is_admin() or trans.app.config.expose_dataset_path:
+        %if trans.user_is_admin or trans.app.config.expose_dataset_path:
             %if not hda.purged:
                 <tr><td>Full Path:</td><td>${hda.file_name | h}</td></tr>
             %endif
@@ -242,18 +242,18 @@
 
 
 
-%if job and job.command_line and (trans.user_is_admin() or trans.app.config.expose_dataset_path):
+%if job and job.command_line and (trans.user_is_admin or trans.app.config.expose_dataset_path):
 <h3>Command Line</h3>
 <pre class="code">
 ${ job.command_line | h }</pre>
 %endif
 
-%if job and (trans.user_is_admin() or trans.app.config.expose_potentially_sensitive_job_metrics):
+%if job and (trans.user_is_admin or trans.app.config.expose_potentially_sensitive_job_metrics):
 <h3>Job Metrics</h3>
 <% job_metrics = trans.app.job_metrics %>
 <% plugins = set([metric.plugin for metric in job.metrics]) %>
     %for plugin in sorted(plugins):
-    %if trans.user_is_admin() or plugin != 'env':
+    %if trans.user_is_admin or plugin != 'env':
     <h4>${ plugin | h }</h4>
     <table class="tabletip info_data_table">
         <tbody>
@@ -271,7 +271,7 @@ ${ job.command_line | h }</pre>
     %endfor
 %endif
 
-%if trans.user_is_admin():
+%if trans.user_is_admin:
 <h3>Destination Parameters</h3>
     <table class="tabletip">
         <tbody>
@@ -303,7 +303,7 @@ ${ job.command_line | h }</pre>
             <th>Dependency</th>
             <th>Dependency Type</th>
             <th>Version</th>
-            %if trans.user_is_admin():
+            %if trans.user_is_admin:
             <th>Path</th>
             %endif
         </tr>
@@ -314,7 +314,7 @@ ${ job.command_line | h }</pre>
                 <tr><td>${ dependency['name'] | h }</td>
                     <td>${ dependency['dependency_type'] | h }</td>
                     <td>${ dependency['version'] | h }</td>
-                    %if trans.user_is_admin():
+                    %if trans.user_is_admin:
                         %if 'environment_path' in dependency:
                         <td>${ dependency['environment_path'] | h }</td>
                         %elif 'path' in dependency:

--- a/templates/user/info.mako
+++ b/templates/user/info.mako
@@ -1,6 +1,6 @@
 <%inherit file="/base.mako"/>
 
-<% is_admin = cntrller == 'admin' and trans.user_is_admin() %>
+<% is_admin = cntrller == 'admin' and trans.user_is_admin %>
 
 <%def name="render_user_info()">
 

--- a/templates/user/register.mako
+++ b/templates/user/register.mako
@@ -41,7 +41,7 @@ def inherit(context):
 
         ## An admin user may be creating a new user account, in which case we want to display the registration form.
         ## But if the current user is not an admin user, then don't display the registration form.
-        %if ( cntrller=='admin' and trans.user_is_admin() ) or not trans.user:
+        %if ( cntrller=='admin' and trans.user_is_admin ) or not trans.user:
             ${render_registration_form()}
 
             %if trans.app.config.get( 'terms_url', None ) is not None:

--- a/templates/webapps/galaxy/galaxy.masthead.mako
+++ b/templates/webapps/galaxy/galaxy.masthead.mako
@@ -26,7 +26,7 @@
             'allow_user_creation'       : app.config.allow_user_creation,
             'logo_url'                  : h.url_for(app.config.get( 'logo_url', '/')),
             'logo_src'                  : h.url_for( app.config.get( 'logo_src', '/static/images/galaxyIcon_noText.png' ) ),
-            'is_admin_user'             : trans.user_is_admin(),
+            'is_admin_user'             : trans.user_is_admin,
             'active_view'               : active_view,
             'ftp_upload_dir'            : app.config.get("ftp_upload_dir",  None),
             'ftp_upload_site'           : app.config.get("ftp_upload_site",  None),

--- a/templates/webapps/galaxy/history/share.mako
+++ b/templates/webapps/galaxy/history/share.mako
@@ -38,7 +38,7 @@
                 <div class="form-row">
                     <% existing_emails = ','.join([ d.user.email for d in history.users_shared_with ]) %>
                     <label>Galaxy user emails with which to share histories</label>
-                    %if trans.app.config.expose_user_email or trans.app.config.expose_user_name or trans.user_is_admin():
+                    %if trans.app.config.expose_user_email or trans.app.config.expose_user_name or trans.user_is_admin:
                     <input type="hidden" id="email_select" name="email" value="${ existing_emails }" style="float: left; width: 250px; margin-right: 10px;">
                     </input>
                     %else:

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -319,7 +319,7 @@
                         </div>
                     %endfor
                     ## Data Manager Tools
-                    %if trans.user_is_admin() and trans.app.data_managers.data_managers:
+                    %if trans.user_is_admin and trans.app.data_managers.data_managers:
                        <div>&nbsp;</div>
                        <div class="toolSectionWrapper">
                            <div class="toolSectionTitle" id="title___DATA_MANAGER_TOOLS__">

--- a/templates/webapps/tool_shed/common/repository_actions_menu.mako
+++ b/templates/webapps/tool_shed/common/repository_actions_menu.mako
@@ -10,7 +10,7 @@
         else:
             has_metadata = False
 
-        is_admin = trans.user_is_admin()
+        is_admin = trans.user_is_admin
 
         if is_admin or trans.app.security_agent.user_can_administer_repository( trans.user, repository ):
             can_administer = True

--- a/templates/webapps/tool_shed/common/reset_metadata_on_selected_repositories.mako
+++ b/templates/webapps/tool_shed/common/reset_metadata_on_selected_repositories.mako
@@ -34,7 +34,7 @@
 <div class="toolForm">
     <div class="toolFormTitle">Reset all metadata on each selected repository</div>
         <%
-            if trans.user_is_admin():
+            if trans.user_is_admin:
                 controller = 'admin'
                 action = 'reset_metadata_on_selected_repositories_in_tool_shed'
             else:

--- a/templates/webapps/tool_shed/repository/manage_repository.mako
+++ b/templates/webapps/tool_shed/repository/manage_repository.mako
@@ -15,7 +15,7 @@
     else:
         has_metadata = False
 
-    is_admin = trans.user_is_admin()
+    is_admin = trans.user_is_admin
     is_new = repository.is_new( trans.app )
 
     if repository.deprecated:

--- a/templates/webapps/tool_shed/repository/view_repository.mako
+++ b/templates/webapps/tool_shed/repository/view_repository.mako
@@ -167,7 +167,7 @@
             <b>Times cloned / installed:</b>
             ${repository.times_downloaded}
         </div>
-        %if trans.user_is_admin():
+        %if trans.user_is_admin:
             <div class="form-row">
                 <b>Location:</b>
                 ${repository.repo_path( trans.app ) | h}

--- a/templates/webapps/tool_shed/role/role.mako
+++ b/templates/webapps/tool_shed/role/role.mako
@@ -54,7 +54,7 @@ $().ready(function() {
 </script>
 
 <%
-    if trans.user_is_admin() and in_admin_controller:
+    if trans.user_is_admin and in_admin_controller:
         render_for_admin = True
     else:
         render_for_admin = False

--- a/templates/webapps/tool_shed/user/username.mako
+++ b/templates/webapps/tool_shed/user/username.mako
@@ -5,7 +5,7 @@
     ${render_msg( message, status )}
 %endif
 
-<% is_admin = cntrller == 'admin' and trans.user_is_admin() %>
+<% is_admin = cntrller == 'admin' and trans.user_is_admin %>
 
 <h2>Manage Public Name</h2>
 <div class="toolForm">


### PR DESCRIPTION
This was noted during a previous security audit in which we found a few cases where it was being used as a property in error, and in such cases it always evaluates to `True`. Making it a property prevents this sort of error, and any future code that attempts to call it will raise an exception.