### PR TITLE
Don't create jobs for inactive users

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -145,6 +145,11 @@ class AdminRequiredException(MessageException):
     err_code = error_codes.ADMIN_REQUIRED
 
 
+class UserActivationRequiredException(MessageException):
+    status_code = 403
+    err_code = error_codes.USER_ACTIVATION_REQUIRED
+
+
 class ObjectNotFound(MessageException):
     """ Accessed object was not found """
     status_code = 404

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -115,6 +115,11 @@
     "message": "No such object found."
    },   
    {
+    "name": "USER_ACTIVATION_REQUIRED",
+    "code": 403007,
+    "message": "Action requires account activation."
+   },
+   {
     "name": "DEPRECATED_API_CALL",
     "code": 404002,
     "message": "This API method or call signature has been deprecated and is no longer available"

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -110,14 +110,14 @@
     "message": "Action requires admin account."
    },   
    {
-    "name": "USER_OBJECT_NOT_FOUND",
-    "code": 404001,
-    "message": "No such object found."
-   },   
-   {
     "name": "USER_ACTIVATION_REQUIRED",
     "code": 403007,
     "message": "Action requires account activation."
+   },
+   {
+    "name": "USER_OBJECT_NOT_FOUND",
+    "code": 404001,
+    "message": "No such object found."
    },
    {
     "name": "DEPRECATED_API_CALL",

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -134,6 +134,10 @@ class ProvidesUserContext(object):
         return can_do_run_as
 
     @property
+    def user_is_active(self):
+        return not self.app.config.user_activation_on or self.user is None or self.user.active
+
+    @property
     def user_ftp_dir(self):
         base_dir = self.app.config.ftp_upload_dir
         if base_dir is None:

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -6,6 +6,7 @@ from json import dumps
 
 from six import text_type
 
+from galaxy.exceptions import UserActivationRequiredException
 from galaxy.util import bunch
 
 
@@ -136,6 +137,11 @@ class ProvidesUserContext(object):
     @property
     def user_is_active(self):
         return not self.app.config.user_activation_on or self.user is None or self.user.active
+
+    def check_user_activation(self):
+        """If user activation is enabled and the user is not activated throw an exception."""
+        if not self.user_is_active:
+            raise UserActivationRequiredException()
 
     @property
     def user_ftp_dir(self):

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -6,6 +6,7 @@ from json import dumps
 from six import string_types
 
 from galaxy import model
+from galaxy.exceptions import UserActivationRequiredException
 from galaxy.jobs.actions.post import ActionBox
 from galaxy.model import LibraryDatasetDatasetAssociation, WorkflowRequestInputParameter
 from galaxy.objectstore import ObjectStorePopulator
@@ -261,6 +262,8 @@ class DefaultToolAction(object):
         submitting the job to the job queue. If history is not specified, use
         trans.history as destination for tool's output datasets.
         """
+        if not trans.user_is_active:
+            raise UserActivationRequiredException()
         incoming = incoming or {}
         self._check_access(tool, trans)
         app = trans.app

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -6,7 +6,6 @@ from json import dumps
 from six import string_types
 
 from galaxy import model
-from galaxy.exceptions import UserActivationRequiredException
 from galaxy.jobs.actions.post import ActionBox
 from galaxy.model import LibraryDatasetDatasetAssociation, WorkflowRequestInputParameter
 from galaxy.objectstore import ObjectStorePopulator
@@ -262,8 +261,7 @@ class DefaultToolAction(object):
         submitting the job to the job queue. If history is not specified, use
         trans.history as destination for tool's output datasets.
         """
-        if not trans.user_is_active:
-            raise UserActivationRequiredException()
+        trans.check_user_activation()
         incoming = incoming or {}
         self._check_access(tool, trans)
         app = trans.app

--- a/lib/galaxy/tools/actions/history_imp_exp.py
+++ b/lib/galaxy/tools/actions/history_imp_exp.py
@@ -2,6 +2,7 @@ import logging
 import os
 import tempfile
 
+from galaxy.exceptions import UserActivationRequiredException
 from galaxy.tools.actions import ToolAction
 from galaxy.tools.imp_exp import JobExportHistoryArchiveWrapper
 from galaxy.util.odict import odict
@@ -16,6 +17,8 @@ class ImportHistoryToolAction(ToolAction):
         #
         # Create job.
         #
+        if not trans.user_is_active:
+            raise UserActivationRequiredException()
         job = trans.app.model.Job()
         session = trans.get_galaxy_session()
         job.session_id = session and session.id
@@ -69,6 +72,8 @@ class ExportHistoryToolAction(ToolAction):
     """Tool action used for exporting a history to an archive. """
 
     def execute(self, tool, trans, incoming={}, set_output_hid=False, overwrite=True, history=None, **kwargs):
+        if not trans.user_is_active:
+            raise UserActivationRequiredException()
         #
         # Get history to export.
         #

--- a/lib/galaxy/tools/actions/history_imp_exp.py
+++ b/lib/galaxy/tools/actions/history_imp_exp.py
@@ -2,7 +2,6 @@ import logging
 import os
 import tempfile
 
-from galaxy.exceptions import UserActivationRequiredException
 from galaxy.tools.actions import ToolAction
 from galaxy.tools.imp_exp import JobExportHistoryArchiveWrapper
 from galaxy.util.odict import odict
@@ -17,8 +16,7 @@ class ImportHistoryToolAction(ToolAction):
         #
         # Create job.
         #
-        if not trans.user_is_active:
-            raise UserActivationRequiredException()
+        trans.check_user_activation()
         job = trans.app.model.Job()
         session = trans.get_galaxy_session()
         job.session_id = session and session.id
@@ -72,8 +70,7 @@ class ExportHistoryToolAction(ToolAction):
     """Tool action used for exporting a history to an archive. """
 
     def execute(self, tool, trans, incoming={}, set_output_hid=False, overwrite=True, history=None, **kwargs):
-        if not trans.user_is_active:
-            raise UserActivationRequiredException()
+        trans.check_user_activation()
         #
         # Get history to export.
         #

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -3,6 +3,7 @@ import os
 from json import dumps
 
 from galaxy.datatypes.metadata import JobExternalOutputMetadataWrapper
+from galaxy.exceptions import UserActivationRequiredException
 from galaxy.jobs.datasets import DatasetPath
 from galaxy.util.odict import odict
 from . import ToolAction
@@ -17,6 +18,8 @@ class SetMetadataToolAction(ToolAction):
         """
         Execute using a web transaction.
         """
+        if not trans.user_is_active:
+            raise UserActivationRequiredException()
         job, odict = self.execute_via_app(tool, trans.app, trans.get_galaxy_session().id,
                                           trans.history.id, trans.user, incoming, set_output_hid,
                                           overwrite, history, job_params)

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -3,7 +3,6 @@ import os
 from json import dumps
 
 from galaxy.datatypes.metadata import JobExternalOutputMetadataWrapper
-from galaxy.exceptions import UserActivationRequiredException
 from galaxy.jobs.datasets import DatasetPath
 from galaxy.util.odict import odict
 from . import ToolAction
@@ -18,8 +17,7 @@ class SetMetadataToolAction(ToolAction):
         """
         Execute using a web transaction.
         """
-        if not trans.user_is_active:
-            raise UserActivationRequiredException()
+        trans.check_user_activation()
         job, odict = self.execute_via_app(tool, trans.app, trans.get_galaxy_session().id,
                                           trans.history.id, trans.user, incoming, set_output_hid,
                                           overwrite, history, job_params)

--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -22,6 +22,8 @@ class ModelOperationToolAction(DefaultToolAction):
         tool.check_inputs_ready(inp_data, inp_dataset_collections)
 
     def execute(self, tool, trans, incoming={}, set_output_hid=False, overwrite=True, history=None, job_params=None, execution_cache=None, collection_info=None, **kwargs):
+        trans.check_user_activation()
+
         if execution_cache is None:
             execution_cache = ToolExecutionCache(trans)
 

--- a/lib/galaxy/tools/actions/upload.py
+++ b/lib/galaxy/tools/actions/upload.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from galaxy.dataset_collections.structure import UninitializedTree
-from galaxy.exceptions import RequestParameterMissingException
+from galaxy.exceptions import RequestParameterMissingException, UserActivationRequiredException
 from galaxy.tools.actions import upload_common
 from galaxy.util import ExecutionTimer
 from galaxy.util.bunch import Bunch
@@ -15,6 +15,8 @@ log = logging.getLogger(__name__)
 class BaseUploadToolAction(ToolAction):
 
     def execute(self, tool, trans, incoming={}, history=None, **kwargs):
+	if not trans.user_is_active:
+	    raise UserActivationRequiredException()
         dataset_upload_inputs = []
         for input_name, input in tool.inputs.items():
             if input.type == "upload_dataset":

--- a/lib/galaxy/tools/actions/upload.py
+++ b/lib/galaxy/tools/actions/upload.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from galaxy.dataset_collections.structure import UninitializedTree
-from galaxy.exceptions import RequestParameterMissingException, UserActivationRequiredException
+from galaxy.exceptions import RequestParameterMissingException
 from galaxy.tools.actions import upload_common
 from galaxy.util import ExecutionTimer
 from galaxy.util.bunch import Bunch
@@ -15,8 +15,7 @@ log = logging.getLogger(__name__)
 class BaseUploadToolAction(ToolAction):
 
     def execute(self, tool, trans, incoming={}, history=None, **kwargs):
-        if not trans.user_is_active:
-            raise UserActivationRequiredException()
+        trans.check_user_activation()
         dataset_upload_inputs = []
         for input_name, input in tool.inputs.items():
             if input.type == "upload_dataset":

--- a/lib/galaxy/tools/actions/upload.py
+++ b/lib/galaxy/tools/actions/upload.py
@@ -15,8 +15,8 @@ log = logging.getLogger(__name__)
 class BaseUploadToolAction(ToolAction):
 
     def execute(self, tool, trans, incoming={}, history=None, **kwargs):
-	if not trans.user_is_active:
-	    raise UserActivationRequiredException()
+        if not trans.user_is_active:
+            raise UserActivationRequiredException()
         dataset_upload_inputs = []
         for input_name, input in tool.inputs.items():
             if input.type == "upload_dataset":

--- a/test/unit/tools/test_actions.py
+++ b/test/unit/tools/test_actions.py
@@ -257,6 +257,10 @@ class MockTrans(object):
 
     user_is_active = property(get_user_is_active, set_user_is_active)
 
+    def check_user_activation(self):
+        if not self.user_is_active:
+            raise UserActivationRequiredException()
+
     def db_dataset_for(self, input_db_key):
         return None
 

--- a/test/unit/tools/test_actions.py
+++ b/test/unit/tools/test_actions.py
@@ -3,6 +3,7 @@ import unittest
 from xml.etree.ElementTree import XML
 
 from galaxy import model
+from galaxy.exceptions import UserActivationRequiredException
 from galaxy.tools.actions import (
     DefaultToolAction,
     determine_output_format,
@@ -116,6 +117,14 @@ class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesApp, tools_
     def test_handler_set(self):
         job, _ = self._simple_execute()
         assert job.handler == TEST_HANDLER_NAME
+
+    def test_inactive_user_job_create_failure(self):
+        self.trans.user_is_active = False
+        try:
+            self._simple_execute()
+        except UserActivationRequiredException:
+            return
+        assert False, "Tool execution succeeded for inactive user!"
 
     def __add_dataset(self, state='ok'):
         hda = model.HistoryDatasetAssociation()
@@ -237,6 +246,16 @@ class MockTrans(object):
         self.user = user
         self.sa_session = self.app.model.context
         self.model = app.model
+        self._user_is_active = True
+
+    def get_user_is_active(self):
+        # NOTE: the real user_is_active also checks whether activation is enabled in the config
+        return self._user_is_active
+
+    def set_user_is_active(self, active):
+        self._user_is_active = active
+
+    user_is_active = property(get_user_is_active, set_user_is_active)
 
     def db_dataset_for(self, input_db_key):
         return None


### PR DESCRIPTION
This mostly avoids the accumulation of jobs in the `new` state that will never run because the user never activates their account. It'd still be possible on servers that allow anonymous jobs because you could create a job before logging in and then log in before it gets picked up by a handler. But this should take care of nearly all such jobs.

This is the backend only, although the UI is acceptable for history import/export. Uploading yields a 400 in the upload modal with no indication as to the cause of failure and running regular jobs returns a modal and the response json, and the error message is in there but it's easy to miss:

> The server could not complete the request. Please contact the Galaxy Team if this error persists. Error executing tool: Action requires account activation.

Could a UI person take a look at making this display nicer? Also, for uploads, it'd be good if the client outright prevented uploading so that users don't waste a bunch of time uploading a file only to have the job creation fail.