### PR TITLE
Replace trans with session and request in psa Storage

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -228,7 +228,7 @@ class AuthnzManager(object):
             log.exception(msg)
             return False, msg, None
 
-    def get_cloud_access_credentials(self, cloudauthz, request, sa_session, user_id):
+    def get_cloud_access_credentials(self, cloudauthz, sa_session, user_id, request=None):
         """
         This method leverages CloudAuthz (https://github.com/galaxyproject/cloudauthz)
         to request a cloud-based resource provider (e.g., Amazon AWS, Microsoft Azure)

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -128,7 +128,7 @@ class AuthnzManager(object):
         config = copy.deepcopy(cloudauthz.config)
         if cloudauthz.provider == "aws":
             success, message, backend = self._get_authnz_backend(cloudauthz.authn.provider)
-            strategy = Strategy(trans, Storage, backend.config)
+            strategy = Strategy(trans.request, trans, Storage, backend.config)
             on_the_fly_config(trans.sa_session)
             try:
                 config['id_token'] = cloudauthz.authn.get_id_token(strategy)

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -228,7 +228,7 @@ class AuthnzManager(object):
             log.exception(msg)
             return False, msg, None
 
-    def get_cloud_access_credentials(self, trans, cloudauthz):
+    def get_cloud_access_credentials(self, cloudauthz, request, session, sa_session, user_id):
         """
         This method leverages CloudAuthz (https://github.com/galaxyproject/cloudauthz)
         to request a cloud-based resource provider (e.g., Amazon AWS, Microsoft Azure)
@@ -254,7 +254,7 @@ class AuthnzManager(object):
                             resource provider. See CloudAuthz (https://github.com/galaxyproject/cloudauthz)
                             for details on the content of this dictionary.
         """
-        config = self._extend_cloudauthz_config(cloudauthz, trans.request, trans.session, trans.sa_session, trans.user.id)
+        config = self._extend_cloudauthz_config(cloudauthz, request, session, sa_session, user_id)
         try:
             ca = CloudAuthz()
             return ca.authorize(cloudauthz.provider, config)

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -128,7 +128,7 @@ class AuthnzManager(object):
         config = copy.deepcopy(cloudauthz.config)
         if cloudauthz.provider == "aws":
             success, message, backend = self._get_authnz_backend(cloudauthz.authn.provider)
-            strategy = Strategy(trans.request, trans, Storage, backend.config)
+            strategy = Strategy(trans.request, trans.session, trans, Storage, backend.config)
             on_the_fly_config(trans.sa_session)
             try:
                 config['id_token'] = cloudauthz.authn.get_id_token(strategy)

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -124,11 +124,11 @@ class AuthnzManager(object):
             log.debug(msg)
             return False, msg, None
 
-    def _extend_cloudauthz_config(self, cloudauthz, request, session, sa_session, user_id):
+    def _extend_cloudauthz_config(self, cloudauthz, request, sa_session, user_id):
         config = copy.deepcopy(cloudauthz.config)
         if cloudauthz.provider == "aws":
             success, message, backend = self._get_authnz_backend(cloudauthz.authn.provider)
-            strategy = Strategy(request, session, Storage, backend.config)
+            strategy = Strategy(request, None, Storage, backend.config)
             on_the_fly_config(sa_session)
             try:
                 config['id_token'] = cloudauthz.authn.get_id_token(strategy)
@@ -228,7 +228,7 @@ class AuthnzManager(object):
             log.exception(msg)
             return False, msg, None
 
-    def get_cloud_access_credentials(self, cloudauthz, request, session, sa_session, user_id):
+    def get_cloud_access_credentials(self, cloudauthz, request, sa_session, user_id):
         """
         This method leverages CloudAuthz (https://github.com/galaxyproject/cloudauthz)
         to request a cloud-based resource provider (e.g., Amazon AWS, Microsoft Azure)
@@ -260,7 +260,7 @@ class AuthnzManager(object):
                             resource provider. See CloudAuthz (https://github.com/galaxyproject/cloudauthz)
                             for details on the content of this dictionary.
         """
-        config = self._extend_cloudauthz_config(cloudauthz, request, session, sa_session, user_id)
+        config = self._extend_cloudauthz_config(cloudauthz, request, sa_session, user_id)
         try:
             ca = CloudAuthz()
             return ca.authorize(cloudauthz.provider, config)

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -128,7 +128,7 @@ class AuthnzManager(object):
         config = copy.deepcopy(cloudauthz.config)
         if cloudauthz.provider == "aws":
             success, message, backend = self._get_authnz_backend(cloudauthz.authn.provider)
-            strategy = Strategy(trans.request, trans.session, trans, Storage, backend.config)
+            strategy = Strategy(trans.request, trans.session, Storage, backend.config)
             on_the_fly_config(trans.sa_session)
             try:
                 config['id_token'] = cloudauthz.authn.get_id_token(strategy)

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -242,12 +242,18 @@ class AuthnzManager(object):
         identity token, as required by CloudAuthz for AWS. Then requests temporary
         credentials from the CloudAuthz library using the updated configuration.
 
-        :type  trans:       galaxy.web.framework.webapp.GalaxyWebTransaction
-        :param trans:       Galaxy web transaction
-
         :type  cloudauthz:  CloudAuthz
         :param cloudauthz:  an instance of CloudAuthz to be used for getting temporary
                             credentials.
+
+        :type   request:    galaxy.web.framework.base.Request
+        :param  request:    Encapsulated HTTP(S) request.
+
+        :type   sa_session: sqlalchemy.orm.scoping.scoped_session
+        :param  sa_session: SQLAlchemy database handle.
+
+        :type   user_id:    int
+        :param  user_id:    Decoded Galaxy user ID.
 
         :rtype:             dict
         :return:            a dictionary containing credentials to access a cloud-based

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -124,14 +124,14 @@ class PSAAuthnz(IdentityProvider):
 
     def authenticate(self, trans):
         on_the_fly_config(trans.sa_session)
-        strategy = Strategy(trans.request, trans.session, trans, Storage, self.config)
+        strategy = Strategy(trans.request, trans.session, Storage, self.config)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
         return do_auth(backend)
 
     def callback(self, state_token, authz_code, trans, login_redirect_url):
         on_the_fly_config(trans.sa_session)
         self.config[setting_name('LOGIN_REDIRECT_URL')] = login_redirect_url
-        strategy = Strategy(trans.request, trans.session, trans, Storage, self.config)
+        strategy = Strategy(trans.request, trans.session, Storage, self.config)
         strategy.session_set(BACKENDS_NAME[self.config['provider']] + '_state', state_token)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
         redirect_url = do_complete(
@@ -145,7 +145,7 @@ class PSAAuthnz(IdentityProvider):
         on_the_fly_config(trans.sa_session)
         self.config[setting_name('DISCONNECT_REDIRECT_URL')] =\
             disconnect_redirect_url if disconnect_redirect_url is not None else ()
-        strategy = Strategy(trans.request, trans.session, trans, Storage, self.config)
+        strategy = Strategy(trans.request, trans.session, Storage, self.config)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
         response = do_disconnect(backend, self._get_current_user(trans), association_id)
         if isinstance(response, six.string_types):
@@ -155,8 +155,7 @@ class PSAAuthnz(IdentityProvider):
 
 class Strategy(BaseStrategy):
 
-    def __init__(self, request, session, trans, storage, config, tpl=None):
-        self.trans = trans
+    def __init__(self, request, session, storage, config, tpl=None):
         self.request = request
         self.session = session if session else {}
         self.config = config

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -124,14 +124,14 @@ class PSAAuthnz(IdentityProvider):
 
     def authenticate(self, trans):
         on_the_fly_config(trans.sa_session)
-        strategy = Strategy(trans.request, trans, Storage, self.config)
+        strategy = Strategy(trans.request, trans.session, trans, Storage, self.config)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
         return do_auth(backend)
 
     def callback(self, state_token, authz_code, trans, login_redirect_url):
         on_the_fly_config(trans.sa_session)
         self.config[setting_name('LOGIN_REDIRECT_URL')] = login_redirect_url
-        strategy = Strategy(trans.request, trans, Storage, self.config)
+        strategy = Strategy(trans.request, trans.session, trans, Storage, self.config)
         strategy.session_set(BACKENDS_NAME[self.config['provider']] + '_state', state_token)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
         redirect_url = do_complete(
@@ -145,7 +145,7 @@ class PSAAuthnz(IdentityProvider):
         on_the_fly_config(trans.sa_session)
         self.config[setting_name('DISCONNECT_REDIRECT_URL')] =\
             disconnect_redirect_url if disconnect_redirect_url is not None else ()
-        strategy = Strategy(trans.request, trans, Storage, self.config)
+        strategy = Strategy(trans.request, trans.session, trans, Storage, self.config)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
         response = do_disconnect(backend, self._get_current_user(trans), association_id)
         if isinstance(response, six.string_types):
@@ -155,10 +155,10 @@ class PSAAuthnz(IdentityProvider):
 
 class Strategy(BaseStrategy):
 
-    def __init__(self, request, trans, storage, config, tpl=None):
+    def __init__(self, request, session, trans, storage, config, tpl=None):
         self.trans = trans
         self.request = request
-        self.session = trans.session if trans.session else {}
+        self.session = session if session else {}
         self.config = config
         self.config['SOCIAL_AUTH_REDIRECT_IS_HTTPS'] = True if self.request.host.startswith('https:') else False
         self.config['SOCIAL_AUTH_GOOGLE_OPENIDCONNECT_EXTRA_DATA'] = ['id_token']

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -195,9 +195,11 @@ class Strategy(BaseStrategy):
         path = path or ''
         if path.startswith('http://') or path.startswith('https://'):
             return path
-        return \
-            self.request.host +\
-            '/authn' + ('/' + self.config.get('provider')) if self.config.get('provider', None) is not None else ''
+        if self.request:
+            return \
+                self.request.host +\
+                '/authn' + ('/' + self.config.get('provider')) if self.config.get('provider', None) is not None else ''
+        return path
 
     def redirect(self, url):
         return url

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -124,14 +124,14 @@ class PSAAuthnz(IdentityProvider):
 
     def authenticate(self, trans):
         on_the_fly_config(trans.sa_session)
-        strategy = Strategy(trans, Storage, self.config)
+        strategy = Strategy(trans.request, trans, Storage, self.config)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
         return do_auth(backend)
 
     def callback(self, state_token, authz_code, trans, login_redirect_url):
         on_the_fly_config(trans.sa_session)
         self.config[setting_name('LOGIN_REDIRECT_URL')] = login_redirect_url
-        strategy = Strategy(trans, Storage, self.config)
+        strategy = Strategy(trans.request, trans, Storage, self.config)
         strategy.session_set(BACKENDS_NAME[self.config['provider']] + '_state', state_token)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
         redirect_url = do_complete(
@@ -145,7 +145,7 @@ class PSAAuthnz(IdentityProvider):
         on_the_fly_config(trans.sa_session)
         self.config[setting_name('DISCONNECT_REDIRECT_URL')] =\
             disconnect_redirect_url if disconnect_redirect_url is not None else ()
-        strategy = Strategy(trans, Storage, self.config)
+        strategy = Strategy(trans.request, trans, Storage, self.config)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
         response = do_disconnect(backend, self._get_current_user(trans), association_id)
         if isinstance(response, six.string_types):
@@ -155,12 +155,12 @@ class PSAAuthnz(IdentityProvider):
 
 class Strategy(BaseStrategy):
 
-    def __init__(self, trans, storage, config, tpl=None):
+    def __init__(self, request, trans, storage, config, tpl=None):
         self.trans = trans
-        self.request = trans.request
+        self.request = request
         self.session = trans.session if trans.session else {}
         self.config = config
-        self.config['SOCIAL_AUTH_REDIRECT_IS_HTTPS'] = True if self.trans.request.host.startswith('https:') else False
+        self.config['SOCIAL_AUTH_REDIRECT_IS_HTTPS'] = True if self.request.host.startswith('https:') else False
         self.config['SOCIAL_AUTH_GOOGLE_OPENIDCONNECT_EXTRA_DATA'] = ['id_token']
         super(Strategy, self).__init__(storage, tpl)
 
@@ -197,7 +197,7 @@ class Strategy(BaseStrategy):
         if path.startswith('http://') or path.startswith('https://'):
             return path
         return \
-            self.trans.request.host +\
+            self.request.host +\
             '/authn' + ('/' + self.config.get('provider')) if self.config.get('provider', None) is not None else ''
 
     def redirect(self, url):

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -198,7 +198,7 @@ class Strategy(BaseStrategy):
         if self.request:
             return \
                 self.request.host +\
-                '/authn' + ('/' + self.config.get('provider')) if self.config.get('provider', None) is not None else ''
+                '/authnz' + ('/' + self.config.get('provider')) if self.config.get('provider', None) is not None else ''
         return path
 
     def redirect(self, url):

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -159,7 +159,7 @@ class Strategy(BaseStrategy):
         self.request = request
         self.session = session if session else {}
         self.config = config
-        self.config['SOCIAL_AUTH_REDIRECT_IS_HTTPS'] = True if self.request.host.startswith('https:') else False
+        self.config['SOCIAL_AUTH_REDIRECT_IS_HTTPS'] = True if self.request and self.request.host.startswith('https:') else False
         self.config['SOCIAL_AUTH_GOOGLE_OPENIDCONNECT_EXTRA_DATA'] = ['id_token']
         super(Strategy, self).__init__(storage, tpl)
 

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -214,7 +214,7 @@ class CloudManager(sharable.SharableModelManager):
             input_args = {}
 
         cloudauthz = trans.app.authnz_manager.try_get_authz_config(trans, authz_id)
-        credentials = trans.app.authnz_manager.get_cloud_access_credentials(trans, cloudauthz)
+        credentials = trans.app.authnz_manager.get_cloud_access_credentials(cloudauthz, trans.request, trans.session, trans.sa_session, trans.user.id)
         connection = self._configure_provider(cloudauthz.provider, credentials)
         try:
             bucket = connection.storage.buckets.get(bucket_name)

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -214,7 +214,7 @@ class CloudManager(sharable.SharableModelManager):
             input_args = {}
 
         cloudauthz = trans.app.authnz_manager.try_get_authz_config(trans, authz_id)
-        credentials = trans.app.authnz_manager.get_cloud_access_credentials(cloudauthz, trans.request, trans.session, trans.sa_session, trans.user.id)
+        credentials = trans.app.authnz_manager.get_cloud_access_credentials(cloudauthz, trans.request, trans.sa_session, trans.user.id)
         connection = self._configure_provider(cloudauthz.provider, credentials)
         try:
             bucket = connection.storage.buckets.get(bucket_name)

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -214,7 +214,7 @@ class CloudManager(sharable.SharableModelManager):
             input_args = {}
 
         cloudauthz = trans.app.authnz_manager.try_get_authz_config(trans, authz_id)
-        credentials = trans.app.authnz_manager.get_cloud_access_credentials(cloudauthz, trans.request, trans.sa_session, trans.user.id)
+        credentials = trans.app.authnz_manager.get_cloud_access_credentials(cloudauthz, trans.sa_session, trans.user.id, trans.request)
         connection = self._configure_provider(cloudauthz.provider, credentials)
         try:
             bucket = connection.storage.buckets.get(bucket_name)


### PR DESCRIPTION
This PR replaces `trans` in the `Strategy` constructor with `request` and `session`. This change makes it possible to instantiate a `Strategy` when `trans` is not available/exposed; e.g., from within a tool wrapper. 

ping @jmchilton 