### PR TITLE
[18.09] Unified panel style bottom padding fix

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -352,7 +352,7 @@ div.unified-panel-body-background {
 
 #left > div.unified-panel-body,
 #right > div.unified-panel-body {
-    bottom: $panel_footer_height;
+    padding-bottom: $panel_footer_height;
     overflow: auto;
 }
 

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -12691,7 +12691,7 @@ div.unified-panel-body-background {
 
 #left > div.unified-panel-body,
 #right > div.unified-panel-body {
-  bottom: 25px;
+  padding-bottom: 25px;
   overflow: auto; }
 
 #dd-helper {


### PR DESCRIPTION
This fixes the bug @jennaj noticed in the history panel, the bottom ~25px being masked.

I really wanted to generalize this with something like:
```
div.unified-panel:has(> .unified-panel-footer) {
    .unified-panel-body {
        padding-bottom: $panel_footer_height;
        overflow: auto;
    }
}
```

But I couldn't make it cooperate, if anyone cares to follow up.