### PR TITLE
 Replace deprecated assertEquals() method 

### DIFF
--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -462,8 +462,8 @@ class UsesLibraryMixinItems(SharableItemSecurityMixin):
     def can_current_user_add_to_library_item(self, trans, item):
         if not trans.user:
             return False
-        return ((trans.user_is_admin) or
-                (trans.app.security_agent.can_add_library_item(trans.get_current_user_roles(), item)))
+        return (trans.user_is_admin or
+                trans.app.security_agent.can_add_library_item(trans.get_current_user_roles(), item))
 
     def check_user_can_add_to_library_item(self, trans, item, check_accessible=True):
         """

--- a/test/api/test_api_batch.py
+++ b/test/api/test_api_batch.py
@@ -29,7 +29,7 @@ class ApiBatchTestCase(api.ApiTestCase):
         response = self._post_batch(batch)
         response = response.json()
         self.assertIsInstance(response, list)
-        self.assertEquals(len(response), 3)
+        self.assertEqual(len(response), 3)
 
     def test_unallowed_route(self):
         batch = [
@@ -38,7 +38,7 @@ class ApiBatchTestCase(api.ApiTestCase):
         response = self._post_batch(batch)
         response = response.json()
         self.assertIsInstance(response, list)
-        self.assertEquals(response[0]['status'], 403)
+        self.assertEqual(response[0]['status'], 403)
 
     def test_404_route(self):
         # needs to be within the allowed routes
@@ -48,7 +48,7 @@ class ApiBatchTestCase(api.ApiTestCase):
         response = self._post_batch(batch)
         response = response.json()
         self.assertIsInstance(response, list)
-        self.assertEquals(response[0]['status'], 404)
+        self.assertEqual(response[0]['status'], 404)
 
     def test_errors(self):
         batch = [
@@ -58,8 +58,8 @@ class ApiBatchTestCase(api.ApiTestCase):
         response = self._post_batch(batch)
         response = response.json()
         self.assertIsInstance(response, list)
-        self.assertEquals(response[0]['status'], 400)
-        self.assertEquals(response[1]['status'], 501)
+        self.assertEqual(response[0]['status'], 400)
+        self.assertEqual(response[1]['status'], 501)
 
     def test_querystring_params(self):
         post_data = dict(name='test')
@@ -74,6 +74,6 @@ class ApiBatchTestCase(api.ApiTestCase):
         ]
         response = self._post_batch(batch)
         response = response.json()
-        self.assertEquals(len(response), 2)
-        self.assertEquals(len(response[0]['body'].keys()), 2)
-        self.assertEquals(response[1]['body'], [])
+        self.assertEqual(len(response), 2)
+        self.assertEqual(len(response[0]['body'].keys()), 2)
+        self.assertEqual(response[1]['body'], [])

--- a/test/api/test_dataset_collections.py
+++ b/test/api/test_dataset_collections.py
@@ -84,8 +84,8 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
         assert pair_1_element["element_index"] == 0, pair_1_element
         pair_1_object = pair_1_element["object"]
         self._assert_has_keys(pair_1_object, "collection_type", "elements", "element_count")
-        self.assertEquals(pair_1_object["collection_type"], "paired")
-        self.assertEquals(pair_1_object["populated"], True)
+        self.assertEqual(pair_1_object["collection_type"], "paired")
+        self.assertEqual(pair_1_object["populated"], True)
         pair_elements = pair_1_object["elements"]
         assert len(pair_elements) == 2
         pair_1_element_1 = pair_elements[0]
@@ -201,7 +201,7 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
         }
         self.dataset_populator.fetch(payload)
         hdca = self._assert_one_collection_created_in_history()
-        self.assertEquals(hdca["name"], "Test upload")
+        self.assertEqual(hdca["name"], "Test upload")
         hdca_tags = hdca["tags"]
         assert len(hdca_tags) == 1
         assert "name:collection1" in hdca_tags
@@ -228,7 +228,7 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
         }
         self.dataset_populator.fetch(payload)
         hdca = self._assert_one_collection_created_in_history()
-        self.assertEquals(hdca["name"], "Test upload")
+        self.assertEqual(hdca["name"], "Test upload")
         assert len(hdca["elements"]) == 1, hdca
         element0 = hdca["elements"][0]
         assert element0["element_identifier"] == "samp1"

--- a/test/api/test_histories.py
+++ b/test/api/test_histories.py
@@ -28,7 +28,7 @@ class HistoriesApiTestCase(api.ApiTestCase):
         # Make sure new history appears in index of user's histories.
         index_response = self._get("histories").json()
         indexed_history = [h for h in index_response if h["id"] == created_id][0]
-        self.assertEquals(indexed_history["name"], "TestHistory1")
+        self.assertEqual(indexed_history["name"], "TestHistory1")
 
     def test_show_history(self):
         history_id = self._create_history("TestHistoryForShow")["id"]
@@ -280,7 +280,7 @@ class HistoriesApiTestCase(api.ApiTestCase):
         post_data = dict(name=name)
         create_response = self._post("histories", data=post_data).json()
         self._assert_has_keys(create_response, "name", "id")
-        self.assertEquals(create_response["name"], name)
+        self.assertEqual(create_response["name"], name)
         return create_response
 
     # TODO: (CE) test_create_from_copy

--- a/test/api/test_jobs.py
+++ b/test/api/test_jobs.py
@@ -502,7 +502,7 @@ class JobsApiTestCase(api.ApiTestCase):
         search_payload = self._search_payload(history_id=history_id, tool_id=tool_id, inputs=inputs)
         empty_search_response = self._post("jobs/search", data=search_payload)
         self._assert_status_code_is(empty_search_response, 200)
-        self.assertEquals(len(empty_search_response.json()), 0)
+        self.assertEqual(len(empty_search_response.json()), 0)
         tool_response = self._post("tools", data=search_payload)
         self.dataset_populator.wait_for_tool_run(history_id, run_response=tool_response)
         self._search(search_payload, expected_search_count=1)

--- a/test/api/test_pages.py
+++ b/test/api/test_pages.py
@@ -87,9 +87,9 @@ class PageApiTestCase(BasePageApiTestCase):
         self._assert_status_code_is(show_response, 200)
         show_json = show_response.json()
         self._assert_has_keys(show_json, "slug", "title", "id")
-        self.assertEquals(show_json["slug"], "pagetoshow")
-        self.assertEquals(show_json["title"], "MY PAGE")
-        self.assertEquals(show_json["content"], "<p>Page!</p>")
+        self.assertEqual(show_json["slug"], "pagetoshow")
+        self.assertEqual(show_json["title"], "MY PAGE")
+        self.assertEqual(show_json["content"], "<p>Page!</p>")
 
     def test_403_on_unowner_show(self):
         response_json = self._create_valid_page_as("others_page_show@bx.psu.edu", "otherspageshow")

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -230,7 +230,7 @@ class ToolsTestCase(api.ApiTestCase):
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             response = self._run("__UNZIP_COLLECTION__", history_id, inputs, assert_ok=True)
             outputs = response["outputs"]
-            self.assertEquals(len(outputs), 2)
+            self.assertEqual(len(outputs), 2)
             output_forward = outputs[0]
             output_reverse = outputs[1]
             output_forward_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output_forward)
@@ -256,7 +256,7 @@ class ToolsTestCase(api.ApiTestCase):
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             response = self._run("__UNZIP_COLLECTION__", history_id, inputs, assert_ok=True)
             implicit_collections = response["implicit_collections"]
-            self.assertEquals(len(implicit_collections), 2)
+            self.assertEqual(len(implicit_collections), 2)
             unzipped_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=implicit_collections[0]["hid"])
             assert unzipped_hdca["elements"][0]["element_type"] == "hda", unzipped_hdca
 
@@ -271,7 +271,7 @@ class ToolsTestCase(api.ApiTestCase):
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             response = self._run("__ZIP_COLLECTION__", history_id, inputs, assert_ok=True)
             output_collections = response["output_collections"]
-            self.assertEquals(len(output_collections), 1)
+            self.assertEqual(len(output_collections), 1)
             self.dataset_populator.wait_for_job(response["jobs"][0]["id"], assert_ok=True)
             zipped_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=output_collections[0]["hid"])
             assert zipped_hdca["collection_type"] == "paired"
@@ -318,7 +318,7 @@ class ToolsTestCase(api.ApiTestCase):
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             response = self._run("__ZIP_COLLECTION__", history_id, inputs, assert_ok=True)
             implicit_collections = response["implicit_collections"]
-            self.assertEquals(len(implicit_collections), 1)
+            self.assertEqual(len(implicit_collections), 1)
             self.dataset_populator.wait_for_job(response["jobs"][0]["id"], assert_ok=True)
             zipped_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=implicit_collections[0]["hid"])
             assert zipped_hdca["collection_type"] == "list:paired"
@@ -330,7 +330,7 @@ class ToolsTestCase(api.ApiTestCase):
             response = self.dataset_populator.run_exit_code_from_file(history_id, ok_hdca_id)
 
             mixed_implicit_collections = response["implicit_collections"]
-            self.assertEquals(len(mixed_implicit_collections), 1)
+            self.assertEqual(len(mixed_implicit_collections), 1)
             mixed_hdca_hid = mixed_implicit_collections[0]["hid"]
             mixed_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=mixed_hdca_hid, wait=False)
 
@@ -353,7 +353,7 @@ class ToolsTestCase(api.ApiTestCase):
             response = self.dataset_populator.run_exit_code_from_file(history_id, ok_hdca_id)
 
             mixed_implicit_collections = response["implicit_collections"]
-            self.assertEquals(len(mixed_implicit_collections), 1)
+            self.assertEqual(len(mixed_implicit_collections), 1)
             mixed_hdca_hid = mixed_implicit_collections[0]["hid"]
             mixed_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=mixed_hdca_hid, wait=False)
 
@@ -390,7 +390,7 @@ class ToolsTestCase(api.ApiTestCase):
         filter_output_collections = response["output_collections"]
         if batch:
             return response['implicit_collections'][0]
-        self.assertEquals(len(filter_output_collections), 1)
+        self.assertEqual(len(filter_output_collections), 1)
         filtered_hid = filter_output_collections[0]["hid"]
         filtered_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=filtered_hid, wait=False)
         return filtered_hdca
@@ -406,7 +406,7 @@ class ToolsTestCase(api.ApiTestCase):
             self.dataset_populator.wait_for_history(history_id)
             response = self._run("__APPLY_RULES__", history_id, inputs, assert_ok=True)
             output_collections = response["output_collections"]
-            self.assertEquals(len(output_collections), 1)
+            self.assertEqual(len(output_collections), 1)
             output_hid = output_collections[0]["hid"]
             output_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=output_hid, wait=False)
             example["check"](output_hdca, self.dataset_populator)
@@ -490,7 +490,7 @@ class ToolsTestCase(api.ApiTestCase):
             input1=dataset_to_param(new_dataset),
         )
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEquals(len(outputs), 1)
+        self.assertEqual(len(outputs), 1)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         self.assertEqual(output1_content.strip(), "Cat1Test")
@@ -523,7 +523,7 @@ class ToolsTestCase(api.ApiTestCase):
             input1=[dataset_to_param(new_dataset)],
         )
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEquals(len(outputs), 1)
+        self.assertEqual(len(outputs), 1)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         self.assertEqual(output1_content.strip(), "Cat1Testlistified")
@@ -535,7 +535,7 @@ class ToolsTestCase(api.ApiTestCase):
             # Run simple non-upload tool with an input data parameter.
             inputs = dict()
             outputs = self._run_and_get_outputs(tool_id="multiple_versions", history_id=history_id, inputs=inputs, tool_version=version)
-            self.assertEquals(len(outputs), 1)
+            self.assertEqual(len(outputs), 1)
             output1 = outputs[0]
             output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
             self.assertEqual(output1_content.strip(), "Version " + version)
@@ -557,7 +557,7 @@ class ToolsTestCase(api.ApiTestCase):
             input1={'batch': False, 'values': [dataset_to_param(new_dataset)]},
         )
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEquals(len(outputs), 1)
+        self.assertEqual(len(outputs), 1)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         self.assertEqual(output1_content.strip(), "123")
@@ -586,7 +586,7 @@ class ToolsTestCase(api.ApiTestCase):
         assert_inputs(inputs, can_be_used=False)
 
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEquals(len(outputs), 1)
+        self.assertEqual(len(outputs), 1)
         output1 = outputs[0]
 
         inputs_2 = dict(
@@ -769,7 +769,7 @@ class ToolsTestCase(api.ApiTestCase):
         self._assert_has_keys(output_collection, "id", "name", "elements", "populated")
         assert not output_collection["populated"]
         assert len(output_collection["elements"]) == 0
-        self.assertEquals(output_collection["name"], "Table split on first column")
+        self.assertEqual(output_collection["name"], "Table split on first column")
         self.dataset_populator.wait_for_job(create["jobs"][0]["id"], assert_ok=True)
 
         get_collection_response = self._get("dataset_collections/%s" % output_collection["id"], data={"instance_type": "history"})
@@ -778,7 +778,7 @@ class ToolsTestCase(api.ApiTestCase):
         output_collection = get_collection_response.json()
         self._assert_has_keys(output_collection, "id", "name", "elements", "populated")
         assert output_collection["populated"]
-        self.assertEquals(output_collection["name"], "Table split on first column")
+        self.assertEqual(output_collection["name"], "Table split on first column")
 
         assert len(output_collection["elements"]) == 2
         output_element_0 = output_collection["elements"][0]
@@ -798,7 +798,7 @@ class ToolsTestCase(api.ApiTestCase):
             'queries_0|input2': dataset_to_param(new_dataset2)
         }
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEquals(len(outputs), 1)
+        self.assertEqual(len(outputs), 1)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         self.assertEqual(output1_content.strip(), "Cat1Test\nCat2Test")
@@ -819,13 +819,13 @@ class ToolsTestCase(api.ApiTestCase):
 
     def _check_cat1_multirun(self, history_id, inputs):
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEquals(len(outputs), 2)
+        self.assertEqual(len(outputs), 2)
         output1 = outputs[0]
         output2 = outputs[1]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEquals(output1_content.strip(), "123")
-        self.assertEquals(output2_content.strip(), "456")
+        self.assertEqual(output1_content.strip(), "123")
+        self.assertEqual(output2_content.strip(), "456")
 
     @skip_without_tool("random_lines1")
     @uses_test_history(require_new=False)
@@ -867,7 +867,7 @@ class ToolsTestCase(api.ApiTestCase):
             'queries_0|input2': {'batch': True, 'values': second_two},
         }
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEquals(len(outputs), 2)
+        self.assertEqual(len(outputs), 2)
         outputs_contents = [self.dataset_populator.get_history_dataset_content(history_id, dataset=o).strip() for o in outputs]
         assert "123\n789" in outputs_contents
         assert "456\n0ab" in outputs_contents
@@ -881,7 +881,7 @@ class ToolsTestCase(api.ApiTestCase):
         }
         outputs = self._cat1_outputs(history_id, inputs=inputs)
         outputs_contents = [self.dataset_populator.get_history_dataset_content(history_id, dataset=o).strip() for o in outputs]
-        self.assertEquals(len(outputs), 4)
+        self.assertEqual(len(outputs), 4)
         assert "123\n789" in outputs_contents
         assert "456\n0ab" in outputs_contents
         assert "123\n0ab" in outputs_contents
@@ -892,19 +892,19 @@ class ToolsTestCase(api.ApiTestCase):
         implicit_collections = create['implicit_collections']
         collections = create['output_collections']
 
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(implicit_collections), 0)
-        self.assertEquals(len(collections), 1)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(len(implicit_collections), 0)
+        self.assertEqual(len(collections), 1)
 
         output_collection = collections[0]
         return output_collection
 
     def _assert_elements_are(self, collection, *args):
         elements = collection["elements"]
-        self.assertEquals(len(elements), len(args))
+        self.assertEqual(len(elements), len(args))
         for index, element in enumerate(elements):
             arg = args[index]
-            self.assertEquals(arg, element["element_identifier"])
+            self.assertEqual(arg, element["element_identifier"])
         return elements
 
     def _verify_element(self, history_id, element, **props):
@@ -914,14 +914,14 @@ class ToolsTestCase(api.ApiTestCase):
             expected_contents = props["contents"]
 
             contents = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=object_id)
-            self.assertEquals(contents, expected_contents)
+            self.assertEqual(contents, expected_contents)
 
             del props["contents"]
 
         if props:
             details = self.dataset_populator.get_history_dataset_details(history_id, dataset_id=object_id)
             for key, value in props.items():
-                self.assertEquals(details[key], value)
+                self.assertEqual(details[key], value)
 
     def _setup_repeat_multirun(self):
         history_id = self.dataset_populator.new_history()
@@ -936,13 +936,13 @@ class ToolsTestCase(api.ApiTestCase):
 
     def _check_repeat_multirun(self, history_id, inputs):
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEquals(len(outputs), 2)
+        self.assertEqual(len(outputs), 2)
         output1 = outputs[0]
         output2 = outputs[1]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEquals(output1_content.strip(), "Common\n123")
-        self.assertEquals(output2_content.strip(), "Common\n456")
+        self.assertEqual(output1_content.strip(), "Common\n123")
+        self.assertEqual(output2_content.strip(), "Common\n456")
 
     def _setup_two_multiruns(self):
         history_id = self.dataset_populator.new_history()
@@ -976,9 +976,9 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 0)
-        self.assertEquals(len(outputs), 0)
-        self.assertEquals(len(implicit_collections), 1)
+        self.assertEqual(len(jobs), 0)
+        self.assertEqual(len(outputs), 0)
+        self.assertEqual(len(implicit_collections), 1)
 
         empty_output = implicit_collections[0]
         assert empty_output["name"] == "Concatenate datasets on collection 1", empty_output
@@ -996,9 +996,9 @@ class ToolsTestCase(api.ApiTestCase):
             outputs = create['outputs']
             jobs = create['jobs']
             implicit_collections = create['implicit_collections']
-            self.assertEquals(len(jobs), 2)
-            self.assertEquals(len(outputs), 2)
-            self.assertEquals(len(implicit_collections), 1)
+            self.assertEqual(len(jobs), 2)
+            self.assertEqual(len(outputs), 2)
+            self.assertEqual(len(implicit_collections), 1)
             output1 = outputs[0]
             output2 = outputs[1]
             output1_details = self.dataset_populator.get_history_dataset_details(history_id, dataset=output1)
@@ -1017,9 +1017,9 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 2)
-        self.assertEquals(len(outputs), 2)
-        self.assertEquals(len(implicit_collections), 1)
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual(len(outputs), 2)
+        self.assertEqual(len(implicit_collections), 1)
         for output in outputs:
             assert output["file_ext"] == "txt", output
 
@@ -1035,8 +1035,8 @@ class ToolsTestCase(api.ApiTestCase):
         create = self._run('output_filter_with_input', history_id, inputs).json()
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 3)
-        self.assertEquals(len(implicit_collections), 3)
+        self.assertEqual(len(jobs), 3)
+        self.assertEqual(len(implicit_collections), 3)
         self._check_implicit_collection_populated(create)
 
     @skip_without_tool("output_filter_with_input")
@@ -1051,8 +1051,8 @@ class ToolsTestCase(api.ApiTestCase):
         create = self._run('output_filter_with_input', history_id, inputs).json()
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 3)
-        self.assertEquals(len(implicit_collections), 2)
+        self.assertEqual(len(jobs), 3)
+        self.assertEqual(len(implicit_collections), 2)
         self._check_implicit_collection_populated(create)
 
     @skip_without_tool("Cut1")
@@ -1068,9 +1068,9 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 2)
-        self.assertEquals(len(outputs), 2)
-        self.assertEquals(len(implicit_collections), 1)
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual(len(outputs), 2)
+        self.assertEqual(len(implicit_collections), 1)
         output1 = outputs[0]
         output2 = outputs[1]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
@@ -1087,12 +1087,12 @@ class ToolsTestCase(api.ApiTestCase):
         }
         create = self._run('collection_creates_dynamic_list_of_pairs', history_id, inputs).json()
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(implicit_collections), 1)
-        self.assertEquals(implicit_collections[0]['collection_type'], 'list:list:paired')
-        self.assertEquals(implicit_collections[0]['elements'][0]['object']['element_count'], None)
+        self.assertEqual(len(implicit_collections), 1)
+        self.assertEqual(implicit_collections[0]['collection_type'], 'list:list:paired')
+        self.assertEqual(implicit_collections[0]['elements'][0]['object']['element_count'], None)
         self.dataset_populator.wait_for_job(create["jobs"][0]["id"], assert_ok=True)
         hdca = self._get("histories/%s/contents/dataset_collections/%s" % (history_id, implicit_collections[0]['id'])).json()
-        self.assertEquals(hdca['elements'][0]['object']['elements'][0]['object']['elements'][0]['element_identifier'], 'forward')
+        self.assertEqual(hdca['elements'][0]['object']['elements'][0]['object']['elements'][0]['element_identifier'], 'forward')
 
     def _bed_list(self, history_id):
         bed1_contents = open(self.get_filename("1.bed"), "r").read()
@@ -1106,15 +1106,15 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 2)
-        self.assertEquals(len(outputs), 2)
-        self.assertEquals(len(implicit_collections), 1)
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual(len(outputs), 2)
+        self.assertEqual(len(implicit_collections), 1)
         output1 = outputs[0]
         output2 = outputs[1]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEquals(output1_content.strip(), "123")
-        self.assertEquals(output2_content.strip(), "456")
+        self.assertEqual(output1_content.strip(), "123")
+        self.assertEqual(output2_content.strip(), "456")
 
     @skip_without_tool("identifier_single")
     @uses_test_history(require_new=False)
@@ -1129,15 +1129,15 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 2)
-        self.assertEquals(len(outputs), 2)
-        self.assertEquals(len(implicit_collections), 1)
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual(len(outputs), 2)
+        self.assertEqual(len(implicit_collections), 1)
         output1 = outputs[0]
         output2 = outputs[1]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEquals(output1_content.strip(), "forward")
-        self.assertEquals(output2_content.strip(), "reverse")
+        self.assertEqual(output1_content.strip(), "forward")
+        self.assertEqual(output2_content.strip(), "reverse")
 
     @skip_without_tool("identifier_single")
     @uses_test_history(require_new=False)
@@ -1152,12 +1152,12 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 1)
-        self.assertEquals(len(implicit_collections), 0)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(len(implicit_collections), 0)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEquals(output1_content.strip(), "Plain HDA")
+        self.assertEqual(output1_content.strip(), "Plain HDA")
 
     @skip_without_tool("identifier_multiple")
     @uses_test_history(require_new=False)
@@ -1179,12 +1179,12 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 1)
-        self.assertEquals(len(implicit_collections), 0)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(len(implicit_collections), 0)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEquals(output1_content.strip(), "forward\nreverse")
+        self.assertEqual(output1_content.strip(), "forward\nreverse")
 
     @skip_without_tool("identifier_in_conditional")
     @uses_test_history(require_new=False)
@@ -1199,12 +1199,12 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 1)
-        self.assertEquals(len(implicit_collections), 0)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(len(implicit_collections), 0)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEquals(output1_content.strip(), "forward\nreverse")
+        self.assertEqual(output1_content.strip(), "forward\nreverse")
 
     @skip_without_tool("identifier_in_conditional")
     @uses_test_history(require_new=False)
@@ -1221,15 +1221,15 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 2)
-        self.assertEquals(len(outputs), 2)
-        self.assertEquals(len(implicit_collections), 1)
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual(len(outputs), 2)
+        self.assertEqual(len(implicit_collections), 1)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEquals(output1_content.strip(), "forward")
+        self.assertEqual(output1_content.strip(), "forward")
         output2 = outputs[1]
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEquals(output2_content.strip(), "reverse")
+        self.assertEqual(output2_content.strip(), "reverse")
 
     @skip_without_tool("identifier_multiple_in_conditional")
     @uses_test_history(require_new=False)
@@ -1244,12 +1244,12 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 1)
-        self.assertEquals(len(implicit_collections), 0)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(len(implicit_collections), 0)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEquals(output1_content.strip(), "forward\nreverse")
+        self.assertEqual(output1_content.strip(), "forward\nreverse")
 
     @skip_without_tool("identifier_multiple_in_repeat")
     @uses_test_history(require_new=False)
@@ -1264,12 +1264,12 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 1)
-        self.assertEquals(len(implicit_collections), 0)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(len(implicit_collections), 0)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEquals(output1_content.strip(), "forward\nreverse")
+        self.assertEqual(output1_content.strip(), "forward\nreverse")
 
     @skip_without_tool("identifier_single_in_repeat")
     @uses_test_history(require_new=False)
@@ -1283,8 +1283,8 @@ class ToolsTestCase(api.ApiTestCase):
         create = create_response.json()
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 2)
-        self.assertEquals(len(implicit_collections), 1)
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual(len(implicit_collections), 1)
         output_collection = implicit_collections[0]
         elements = output_collection["elements"]
         assert len(elements) == 2
@@ -1305,12 +1305,12 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 1)
-        self.assertEquals(len(implicit_collections), 0)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(len(implicit_collections), 0)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEquals(output1_content.strip(), "Normal HDA1")
+        self.assertEqual(output1_content.strip(), "Normal HDA1")
 
     @skip_without_tool("identifier_multiple")
     @uses_test_history(require_new=False)
@@ -1329,12 +1329,12 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 1)
-        self.assertEquals(len(implicit_collections), 0)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(len(implicit_collections), 0)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEquals(output1_content.strip(), "Normal HDA1\nNormal HDA2")
+        self.assertEqual(output1_content.strip(), "Normal HDA1\nNormal HDA2")
 
     @skip_without_tool("identifier_collection")
     @uses_test_history(require_new=False)
@@ -1361,11 +1361,11 @@ class ToolsTestCase(api.ApiTestCase):
         create = create_response.json()
         outputs = create['outputs']
         jobs = create['jobs']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 1)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(len(outputs), 1)
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEquals(output1_content.strip(), '\n'.join([d['name'] for d in element_identifiers]))
+        self.assertEqual(output1_content.strip(), '\n'.join([d['name'] for d in element_identifiers]))
 
     @skip_without_tool("identifier_in_actions")
     @uses_test_history(require_new=False)
@@ -1416,8 +1416,8 @@ class ToolsTestCase(api.ApiTestCase):
         create = self._run("collection_paired_structured_like", history_id, inputs, assert_ok=True)
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 2)
-        self.assertEquals(len(implicit_collections), 1)
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual(len(implicit_collections), 1)
         implicit_collection = implicit_collections[0]
         assert implicit_collection["collection_type"] == "list:paired", implicit_collection["collection_type"]
         outer_elements = implicit_collection["elements"]
@@ -1435,8 +1435,8 @@ class ToolsTestCase(api.ApiTestCase):
         create = self._run("collection_paired_conditional_structured_like", history_id, inputs, assert_ok=True)
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 2)
-        self.assertEquals(len(implicit_collections), 1)
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual(len(implicit_collections), 1)
         implicit_collection = implicit_collections[0]
         assert implicit_collection["collection_type"] == "list:paired", implicit_collection["collection_type"]
         outer_elements = implicit_collection["elements"]
@@ -1447,9 +1447,9 @@ class ToolsTestCase(api.ApiTestCase):
         outputs = create['outputs']
         jobs = create['jobs']
         implicit_collections = create['implicit_collections']
-        self.assertEquals(len(jobs), 4)
-        self.assertEquals(len(outputs), 4)
-        self.assertEquals(len(implicit_collections), 1)
+        self.assertEqual(len(jobs), 4)
+        self.assertEqual(len(outputs), 4)
+        self.assertEqual(len(implicit_collections), 1)
         implicit_collection = implicit_collections[0]
         self._assert_has_keys(implicit_collection, "collection_type", "elements")
         assert implicit_collection["collection_type"] == "list:paired"
@@ -1462,7 +1462,7 @@ class ToolsTestCase(api.ApiTestCase):
         assert first_object["collection_type"] == "paired"
         assert len(first_object["elements"]) == 2
         first_object_forward_element = first_object["elements"][0]
-        self.assertEquals(outputs[0]["id"], first_object_forward_element["object"]["id"])
+        self.assertEqual(outputs[0]["id"], first_object_forward_element["object"]["id"])
 
     @skip_without_tool("cat1")
     @uses_test_history(require_new=False)
@@ -1480,17 +1480,17 @@ class ToolsTestCase(api.ApiTestCase):
         self._assert_status_code_is(response, 200)
         response_object = response.json()
         outputs = response_object['outputs']
-        self.assertEquals(len(outputs), 2)
+        self.assertEqual(len(outputs), 2)
         output1 = outputs[0]
         output2 = outputs[1]
         self.dataset_populator.wait_for_history(history_id)
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEquals(output1_content.strip(), "123\n789")
-        self.assertEquals(output2_content.strip(), "456\n0ab")
+        self.assertEqual(output1_content.strip(), "123\n789")
+        self.assertEqual(output2_content.strip(), "456\n0ab")
 
-        self.assertEquals(len(response_object['jobs']), 2)
-        self.assertEquals(len(response_object['implicit_collections']), 1)
+        self.assertEqual(len(response_object['jobs']), 2)
+        self.assertEqual(len(response_object['implicit_collections']), 1)
 
     @skip_without_tool("cat1")
     @uses_test_history(require_new=False)
@@ -1505,13 +1505,13 @@ class ToolsTestCase(api.ApiTestCase):
         self._assert_status_code_is(response, 200)
         response_object = response.json()
         outputs = response_object['outputs']
-        self.assertEquals(len(outputs), 4)
+        self.assertEqual(len(outputs), 4)
 
-        self.assertEquals(len(response_object['jobs']), 4)
+        self.assertEqual(len(response_object['jobs']), 4)
         implicit_collections = response_object['implicit_collections']
-        self.assertEquals(len(implicit_collections), 1)
+        self.assertEqual(len(implicit_collections), 1)
         implicit_collection = implicit_collections[0]
-        self.assertEquals(implicit_collection["collection_type"], "paired:paired")
+        self.assertEqual(implicit_collection["collection_type"], "paired:paired")
 
         outer_elements = implicit_collection["elements"]
         assert len(outer_elements) == 2
@@ -1542,7 +1542,7 @@ class ToolsTestCase(api.ApiTestCase):
         for (element, expected_contents) in expected_contents_list:
             dataset_id = element["object"]["id"]
             contents = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=dataset_id)
-            self.assertEquals(expected_contents, contents)
+            self.assertEqual(expected_contents, contents)
 
     @skip_without_tool("cat1")
     @uses_test_history(require_new=False)
@@ -1559,10 +1559,10 @@ class ToolsTestCase(api.ApiTestCase):
         self._assert_status_code_is(response, 200)
         response_object = response.json()
         outputs = response_object['outputs']
-        self.assertEquals(len(outputs), 2)
+        self.assertEqual(len(outputs), 2)
 
-        self.assertEquals(len(response_object['jobs']), 2)
-        self.assertEquals(len(response_object['implicit_collections']), 1)
+        self.assertEqual(len(response_object['jobs']), 2)
+        self.assertEqual(len(response_object['implicit_collections']), 1)
 
     @skip_without_tool("identifier_source")
     def test_default_identifier_source_map_over(self):
@@ -1593,8 +1593,8 @@ class ToolsTestCase(api.ApiTestCase):
             create = self._run("collection_creates_pair", history_id, inputs, assert_ok=True)
             jobs = create['jobs']
             implicit_collections = create['implicit_collections']
-            self.assertEquals(len(jobs), 2)
-            self.assertEquals(len(implicit_collections), 1)
+            self.assertEqual(len(jobs), 2)
+            self.assertEqual(len(implicit_collections), 1)
             implicit_collection = implicit_collections[0]
             assert implicit_collection["collection_type"] == "list:paired", implicit_collection
             outer_elements = implicit_collection["elements"]
@@ -1625,7 +1625,7 @@ class ToolsTestCase(api.ApiTestCase):
             ]
             for i in range(4):
                 contents = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=pair_ids[i])
-                self.assertEquals(expected_contents[i], contents)
+                self.assertEqual(expected_contents[i], contents)
 
     @skip_without_tool("cat1")
     def test_cannot_map_over_incompatible_collections(self):
@@ -1722,8 +1722,8 @@ class ToolsTestCase(api.ApiTestCase):
             create = self._run("multi_data_param", history_id, inputs, assert_ok=True)
             jobs = create['jobs']
             implicit_collections = create['implicit_collections']
-            self.assertEquals(len(jobs), 1)
-            self.assertEquals(len(implicit_collections), 2)
+            self.assertEqual(len(jobs), 1)
+            self.assertEqual(len(implicit_collections), 2)
             output_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=implicit_collections[0]["hid"])
             assert output_hdca["collection_type"] == "list"
 
@@ -1737,8 +1737,8 @@ class ToolsTestCase(api.ApiTestCase):
             create = self._run("multi_data_repeat", history_id, inputs, assert_ok=True)
             outputs = create['outputs']
             jobs = create['jobs']
-            self.assertEquals(len(jobs), 1)
-            self.assertEquals(len(outputs), 1)
+            self.assertEqual(len(jobs), 1)
+            self.assertEqual(len(outputs), 1)
             output1 = outputs[0]
             output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
             assert output1_content.strip() == "123\n456", output1_content
@@ -1753,8 +1753,8 @@ class ToolsTestCase(api.ApiTestCase):
             create = self._run("multi_data_repeat", history_id, inputs, assert_ok=True)
             outputs = create['outputs']
             jobs = create['jobs']
-            self.assertEquals(len(jobs), 1)
-            self.assertEquals(len(outputs), 1)
+            self.assertEqual(len(jobs), 1)
+            self.assertEqual(len(outputs), 1)
             output1 = outputs[0]
             output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
             assert output1_content.strip() == "123\n456", output1_content
@@ -1771,20 +1771,20 @@ class ToolsTestCase(api.ApiTestCase):
             create = self._run("multi_data_param", history_id, inputs, assert_ok=True)
             outputs = create['outputs']
             jobs = create['jobs']
-            self.assertEquals(len(jobs), 1)
-            self.assertEquals(len(outputs), 2)
+            self.assertEqual(len(jobs), 1)
+            self.assertEqual(len(outputs), 2)
             output1, output2 = outputs
             output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
             output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-            self.assertEquals(output1_content.strip(), "123\n456\nTestData123\nTestData123\nTestData123")
-            self.assertEquals(output2_content.strip(), "123\n456")
+            self.assertEqual(output1_content.strip(), "123\n456\nTestData123\nTestData123\nTestData123")
+            self.assertEqual(output2_content.strip(), "123\n456")
 
     def _check_simple_reduce_job(self, history_id, inputs):
         create = self._run("multi_data_param", history_id, inputs, assert_ok=True)
         outputs = create['outputs']
         jobs = create['jobs']
-        self.assertEquals(len(jobs), 1)
-        self.assertEquals(len(outputs), 2)
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(len(outputs), 2)
         output1, output2 = outputs
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
@@ -1910,10 +1910,10 @@ class ToolsTestCase(api.ApiTestCase):
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         response = self._run("collection_cat_group_tag", history_id, inputs, assert_ok=True)
         outputs = response["outputs"]
-        self.assertEquals(len(outputs), 1)
+        self.assertEqual(len(outputs), 1)
         output = outputs[0]
         output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output)
-        self.assertEquals(output_content.strip(), "123\n456")
+        self.assertEqual(output_content.strip(), "123\n456")
 
     @skip_without_tool("collection_cat_group_tag_multiple")
     @uses_test_history(require_new=False)
@@ -1926,10 +1926,10 @@ class ToolsTestCase(api.ApiTestCase):
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         response = self._run("collection_cat_group_tag_multiple", history_id, inputs, assert_ok=True)
         outputs = response["outputs"]
-        self.assertEquals(len(outputs), 1)
+        self.assertEqual(len(outputs), 1)
         output = outputs[0]
         output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output)
-        self.assertEquals(output_content.strip(), "123\n456\n456\n0ab")
+        self.assertEqual(output_content.strip(), "123\n456\n456\n0ab")
 
     def __build_group_list(self, history_id):
         response = self.dataset_collection_populator.upload_collection(history_id, "list", elements=[

--- a/test/api/test_tools_upload.py
+++ b/test/api/test_tools_upload.py
@@ -43,42 +43,42 @@ class ToolsUploadTestCase(api.ApiTestCase):
     def test_upload_posix_newline_fixes_by_default(self):
         windows_content = ONE_TO_SIX_ON_WINDOWS
         result_content = self._upload_and_get_content(windows_content)
-        self.assertEquals(result_content, ONE_TO_SIX_WITH_TABS)
+        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS)
 
     def test_fetch_posix_unaltered(self):
         windows_content = ONE_TO_SIX_ON_WINDOWS
         result_content = self._upload_and_get_content(windows_content, api="fetch")
-        self.assertEquals(result_content, ONE_TO_SIX_ON_WINDOWS)
+        self.assertEqual(result_content, ONE_TO_SIX_ON_WINDOWS)
 
     def test_upload_disable_posix_fix(self):
         windows_content = ONE_TO_SIX_ON_WINDOWS
         result_content = self._upload_and_get_content(windows_content, to_posix_lines=None)
-        self.assertEquals(result_content, windows_content)
+        self.assertEqual(result_content, windows_content)
 
     def test_fetch_post_lines_option(self):
         windows_content = ONE_TO_SIX_ON_WINDOWS
         result_content = self._upload_and_get_content(windows_content, api="fetch", to_posix_lines=True)
-        self.assertEquals(result_content, ONE_TO_SIX_WITH_TABS)
+        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS)
 
     def test_upload_tab_to_space_off_by_default(self):
         table = ONE_TO_SIX_WITH_SPACES
         result_content = self._upload_and_get_content(table)
-        self.assertEquals(result_content, table)
+        self.assertEqual(result_content, table)
 
     def test_fetch_tab_to_space_off_by_default(self):
         table = ONE_TO_SIX_WITH_SPACES
         result_content = self._upload_and_get_content(table, api='fetch')
-        self.assertEquals(result_content, table)
+        self.assertEqual(result_content, table)
 
     def test_upload_tab_to_space(self):
         table = ONE_TO_SIX_WITH_SPACES
         result_content = self._upload_and_get_content(table, space_to_tab="Yes")
-        self.assertEquals(result_content, ONE_TO_SIX_WITH_TABS)
+        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS)
 
     def test_fetch_tab_to_space(self):
         table = ONE_TO_SIX_WITH_SPACES
         result_content = self._upload_and_get_content(table, api="fetch", space_to_tab=True)
-        self.assertEquals(result_content, ONE_TO_SIX_WITH_TABS)
+        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS)
 
     def test_fetch_compressed_with_explicit_type(self):
         fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
@@ -158,42 +158,42 @@ class ToolsUploadTestCase(api.ApiTestCase):
         rdata_path = TestDataResolver().get_filename("1.RData")
         with open(rdata_path, "rb") as fh:
             rdata_metadata = self._upload_and_get_details(fh, file_type="auto")
-        self.assertEquals(rdata_metadata["file_ext"], "rdata")
+        self.assertEqual(rdata_metadata["file_ext"], "rdata")
 
     @skip_without_datatype("csv")
     def test_csv_upload(self):
         csv_path = TestDataResolver().get_filename("1.csv")
         with open(csv_path, "rb") as fh:
             csv_metadata = self._upload_and_get_details(fh, file_type="csv")
-        self.assertEquals(csv_metadata["file_ext"], "csv")
+        self.assertEqual(csv_metadata["file_ext"], "csv")
 
     @skip_without_datatype("csv")
     def test_csv_upload_auto(self):
         csv_path = TestDataResolver().get_filename("1.csv")
         with open(csv_path, "rb") as fh:
             csv_metadata = self._upload_and_get_details(fh, file_type="auto")
-        self.assertEquals(csv_metadata["file_ext"], "csv")
+        self.assertEqual(csv_metadata["file_ext"], "csv")
 
     @skip_without_datatype("csv")
     def test_csv_fetch(self):
         csv_path = TestDataResolver().get_filename("1.csv")
         with open(csv_path, "rb") as fh:
             csv_metadata = self._upload_and_get_details(fh, api="fetch", ext="csv", to_posix_lines=True)
-        self.assertEquals(csv_metadata["file_ext"], "csv")
+        self.assertEqual(csv_metadata["file_ext"], "csv")
 
     @skip_without_datatype("csv")
     def test_csv_sniff_fetch(self):
         csv_path = TestDataResolver().get_filename("1.csv")
         with open(csv_path, "rb") as fh:
             csv_metadata = self._upload_and_get_details(fh, api="fetch", ext="auto", to_posix_lines=True)
-        self.assertEquals(csv_metadata["file_ext"], "csv")
+        self.assertEqual(csv_metadata["file_ext"], "csv")
 
     @skip_without_datatype("tiff")
     def test_image_upload_auto(self):
         tiff_path = TestDataResolver().get_filename("1.tiff")
         with open(tiff_path, "rb") as fh:
             tiff_metadata = self._upload_and_get_details(fh, file_type="auto")
-        self.assertEquals(tiff_metadata["file_ext"], "tiff")
+        self.assertEqual(tiff_metadata["file_ext"], "tiff")
 
     @skip_without_datatype("velvet")
     def test_composite_datatype(self):

--- a/test/api/test_workflows_from_yaml.py
+++ b/test/api/test_workflows_from_yaml.py
@@ -137,7 +137,7 @@ test_data:
   input1: "hello world"
 """, history_id=history_id)
         contents1 = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEquals(contents1.strip(), "hello world\nhello world")
+        self.assertEqual(contents1.strip(), "hello world\nhello world")
 
     def test_outputs(self):
         workflow_id = self._upload_yaml_workflow("""
@@ -161,8 +161,8 @@ test_data:
   input1: "hello world"
 """)
         workflow = self._get("workflows/%s/download" % workflow_id).json()
-        self.assertEquals(workflow["steps"]["1"]["workflow_outputs"][0]["output_name"], "out_file1")
-        self.assertEquals(workflow["steps"]["1"]["workflow_outputs"][0]["label"], "wf_output_1")
+        self.assertEqual(workflow["steps"]["1"]["workflow_outputs"][0]["output_name"], "out_file1")
+        self.assertEqual(workflow["steps"]["1"]["workflow_outputs"][0]["label"], "wf_output_1")
 
     def test_runtime_inputs(self):
         workflow = self._upload_and_download(WORKFLOW_RUNTIME_PARAMETER_SIMPLE)
@@ -240,7 +240,7 @@ test_data:
         assert subworkflow_connection["input_subworkflow_step_id"] == 0
 
         # content = self.dataset_populator.get_history_dataset_content( history_id )
-        # self.assertEquals("chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n", content)
+        # self.assertEqual("chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n", content)
 
     def test_pause(self):
         workflow_id = self._upload_yaml_workflow("""

--- a/test/unit/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
+++ b/test/unit/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
@@ -163,9 +163,9 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_filesize_run(self, l):
         job = map_tool_to_destination(runJob, theApp, vanillaTool, "user@email.com", True, path, job_conf_path)
-        self.assertEquals(job, 'Destination1')
+        self.assertEqual(job, 'Destination1')
         priority_job = map_tool_to_destination(runJob, theApp, vanillaTool, "user@email.com", True, priority_path, job_conf_path)
-        self.assertEquals(priority_job, 'Destination1_high')
+        self.assertEqual(priority_job, 'Destination1_high')
 
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
@@ -186,9 +186,9 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_default_tool(self, l):
         job = map_tool_to_destination(runJob, theApp, defaultTool, "user@email.com", True, path, job_conf_path)
-        self.assertEquals(job, 'cluster_default')
+        self.assertEqual(job, 'cluster_default')
         priority_job = map_tool_to_destination(runJob, theApp, defaultTool, "user@email.com", True, priority_path, job_conf_path)
-        self.assertEquals(priority_job, 'cluster_default_high')
+        self.assertEqual(priority_job, 'cluster_default_high')
 
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
@@ -205,9 +205,9 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_arguments_tool(self, l):
         job = map_tool_to_destination(argJob, theApp, argTool, "user@email.com", True, path, job_conf_path)
-        self.assertEquals(job, 'Destination6')
+        self.assertEqual(job, 'Destination6')
         priority_job = map_tool_to_destination(argJob, theApp, argTool, "user@email.com", True, priority_path, job_conf_path)
-        self.assertEquals(priority_job, 'Destination6_med')
+        self.assertEqual(priority_job, 'Destination6_med')
 
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
@@ -222,9 +222,9 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_arguments_arg_not_found(self, l):
         job = map_tool_to_destination(argNotFoundJob, theApp, argTool, "user@email.com", True, path, job_conf_path)
-        self.assertEquals(job, 'cluster_default')
+        self.assertEqual(job, 'cluster_default')
         priority_job = map_tool_to_destination(argNotFoundJob, theApp, argTool, "user@email.com", True, priority_path, job_conf_path)
-        self.assertEquals(priority_job, 'cluster_default_high')
+        self.assertEqual(priority_job, 'cluster_default_high')
 
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
@@ -239,9 +239,9 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_tool_not_found(self, l):
         job = map_tool_to_destination(runJob, theApp, unTool, "user@email.com", True, path, job_conf_path)
-        self.assertEquals(job, 'cluster_default')
+        self.assertEqual(job, 'cluster_default')
         priority_job = map_tool_to_destination(runJob, theApp, unTool, "user@email.com", True, priority_path, job_conf_path)
-        self.assertEquals(priority_job, 'cluster_default_high')
+        self.assertEqual(priority_job, 'cluster_default_high')
 
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
@@ -258,9 +258,9 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_fasta(self, l):
         job = map_tool_to_destination(dbJob, theApp, dbTool, "user@email.com", True, path, job_conf_path)
-        self.assertEquals(job, 'Destination4')
+        self.assertEqual(job, 'Destination4')
         priority_job = map_tool_to_destination(dbJob, theApp, dbTool, "user@email.com", True, priority_path, job_conf_path)
-        self.assertEquals(priority_job, 'Destination4_high')
+        self.assertEqual(priority_job, 'Destination4_high')
 
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
@@ -279,9 +279,9 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_fasta_count(self, l):
         job = map_tool_to_destination(dbcountJob, theApp, dbTool, "user@email.com", True, path, job_conf_path)
-        self.assertEquals(job, 'Destination4')
+        self.assertEqual(job, 'Destination4')
         priority_job = map_tool_to_destination(dbcountJob, theApp, dbTool, "user@email.com", True, priority_path, job_conf_path)
-        self.assertEquals(priority_job, 'Destination4_high')
+        self.assertEqual(priority_job, 'Destination4_high')
 
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
@@ -300,7 +300,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_no_verbose(self, l):
         job = map_tool_to_destination(runJob, theApp, noVBTool, "user@email.com", True, no_verbose_path, job_conf_path)
-        self.assertEquals(job, 'Destination1')
+        self.assertEqual(job, 'Destination1')
 
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Running 'test_no_verbose' with 'Destination1'.")
@@ -309,7 +309,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_authorized_user(self, l):
         job = map_tool_to_destination(runJob, theApp, usersTool, "user@email.com", True, users_test_path, job_conf_path)
-        self.assertEquals(job, 'special_cluster')
+        self.assertEqual(job, 'special_cluster')
 
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Running 'test_users' with 'special_cluster'."),
@@ -318,7 +318,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_unauthorized_user(self, l):
         job = map_tool_to_destination(runJob, theApp, usersTool, "userblah@email.com", True, users_test_path, job_conf_path)
-        self.assertEquals(job, 'lame_cluster')
+        self.assertEqual(job, 'lame_cluster')
 
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Running 'test_users' with 'lame_cluster'.")
@@ -344,11 +344,11 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_empty_file(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest2, job_conf_path=job_conf_path, test=True), {})
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest2, job_conf_path=job_conf_path, test=True), {})
 
     @log_capture()
     def test_no_tool_name(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest3, job_conf_path=job_conf_path, test=True), yt.iv3dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest3, job_conf_path=job_conf_path, test=True), yt.iv3dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Malformed YML; expected job name, but found a list instead!'),
@@ -357,7 +357,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_no_rule_type(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest4, job_conf_path=job_conf_path, test=True), yt.ivDict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest4, job_conf_path=job_conf_path, test=True), yt.ivDict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No rule_type found for rule 1 in 'spades'."),
@@ -366,7 +366,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_no_rule_lower_bound(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest51, job_conf_path=job_conf_path, test=True), yt.ivDict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest51, job_conf_path=job_conf_path, test=True), yt.ivDict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Missing bounds for rule 1 in 'spades'. Ignoring rule."),
@@ -375,7 +375,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_no_rule_upper_bound(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest52, job_conf_path=job_conf_path, test=True), yt.ivDict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest52, job_conf_path=job_conf_path, test=True), yt.ivDict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Missing bounds for rule 1 in 'spades'. Ignoring rule."),
@@ -384,7 +384,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_no_rule_arg(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest53, job_conf_path=job_conf_path, test=True), yt.ivDict53)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest53, job_conf_path=job_conf_path, test=True), yt.ivDict53)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Found a fail_message for rule 1 in 'spades', but destination is not 'fail'! Setting destination to 'fail'."),
@@ -393,7 +393,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_bad_rule_type(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest6, job_conf_path=job_conf_path, test=True), yt.ivDict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest6, job_conf_path=job_conf_path, test=True), yt.ivDict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Unrecognized rule_type 'iencs' found in 'spades'. Ignoring..."),
@@ -402,7 +402,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_no_err_msg(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest91, job_conf_path=job_conf_path, test=True), yt.iv91dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest91, job_conf_path=job_conf_path, test=True), yt.iv91dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No nice_value found for rule 1 in 'spades'. Setting nice_value to 0."),
@@ -431,7 +431,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_arguments_no_err_msg(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest12, job_conf_path=job_conf_path, test=True), yt.iv12dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest12, job_conf_path=job_conf_path, test=True), yt.iv12dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG',
@@ -441,7 +441,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_arguments_no_args(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest131, job_conf_path=job_conf_path, test=True), yt.iv131dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest131, job_conf_path=job_conf_path, test=True), yt.iv131dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG',
@@ -451,7 +451,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_arguments_no_arg(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest132, job_conf_path=job_conf_path, test=True), yt.iv132dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest132, job_conf_path=job_conf_path, test=True), yt.iv132dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Found a fail_message for rule 1 in 'spades', but destination is not 'fail'! Setting destination to 'fail'."),
@@ -467,7 +467,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_multiple_jobs(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest133, job_conf_path=job_conf_path, test=True), yt.iv133dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest133, job_conf_path=job_conf_path, test=True), yt.iv133dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Missing a fail_message for rule 1 in 'smalt'. Adding generic fail_message."),
@@ -483,7 +483,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_no_destination(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest134, job_conf_path=job_conf_path, test=True), yt.iv134dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest134, job_conf_path=job_conf_path, test=True), yt.iv134dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "No destination specified for rule 1 in 'spades'. Ignoring..."),
@@ -492,7 +492,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_reversed_bounds(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest135, job_conf_path=job_conf_path, test=True), yt.iv135dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest135, job_conf_path=job_conf_path, test=True), yt.iv135dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "lower_bound exceeds upper_bound for rule 1 in 'spades'. Reversing bounds."),
@@ -508,7 +508,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_missing_tool_fields(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest136, job_conf_path=job_conf_path, test=True), yt.iv136dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest136, job_conf_path=job_conf_path, test=True), yt.iv136dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Tool 'spades' does not have rules nor a default_destination!"),
@@ -524,7 +524,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_blank_tool(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest137, job_conf_path=job_conf_path, test=True), yt.iv137dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest137, job_conf_path=job_conf_path, test=True), yt.iv137dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Config section for tool 'spades' is blank!"),
@@ -541,7 +541,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_malformed_users(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest138, job_conf_path=job_conf_path, test=True), yt.iv138dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest138, job_conf_path=job_conf_path, test=True), yt.iv138dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Entry '123' in users for rule 1 in tool 'spades' is in an invalid format! Ignoring entry."),
@@ -558,7 +558,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_no_users(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest139, job_conf_path=job_conf_path, test=True), yt.iv139dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest139, job_conf_path=job_conf_path, test=True), yt.iv139dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Couldn't find a list under 'users:'! Ignoring rule."),
@@ -576,7 +576,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_malformed_user_email(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest140, job_conf_path=job_conf_path, test=True), yt.iv140dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest140, job_conf_path=job_conf_path, test=True), yt.iv140dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Supplied email 'invalid.user2@com' for rule 2 in tool 'spades' is in an invalid format! Ignoring email."),
@@ -596,7 +596,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_empty_users(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest141, job_conf_path=job_conf_path, test=True), yt.iv141dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest141, job_conf_path=job_conf_path, test=True), yt.iv141dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Entry 'None' in users for rule 2 in tool 'spades' is in an invalid format! Ignoring entry."),
@@ -615,7 +615,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_bad_num_input_datasets_bound(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest142, job_conf_path=job_conf_path, test=True), yt.iv142dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest142, job_conf_path=job_conf_path, test=True), yt.iv142dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Error: lower_bound is set to Infinity, but must be lower than upper_bound! Setting lower_bound to 0!"),
@@ -631,7 +631,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_worse_num_input_datasets_bound(self, l):
-        self.assertEquals(dt.parse_yaml(path=yt.ivYMLTest143, job_conf_path=job_conf_path, test=True), yt.iv143dict)
+        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest143, job_conf_path=job_conf_path, test=True), yt.iv143dict)
         l.check_present(
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', 'Running config validation...'),
             ('galaxy.jobs.dynamic_tool_destination', 'DEBUG', "Error: lower_bound is set to Infinity, but must be lower than upper_bound! Setting lower_bound to 0!"),

--- a/test/unit/jobs/test_job_wrapper.py
+++ b/test/unit/jobs/test_job_wrapper.py
@@ -54,7 +54,7 @@ class BaseWrapperTestCase(UsesApp):
         wrapper = self._wrapper()
         version_path = wrapper.get_version_string_path()
         expected_path = os.path.join(self.test_directory, "new_files", "GALAXY_VERSION_STRING_345")
-        self.assertEquals(version_path, expected_path)
+        self.assertEqual(version_path, expected_path)
 
     def test_prepare_sets_command_line(self):
         with self._prepared_wrapper() as wrapper:

--- a/test/unit/test_galaxy_mapping.py
+++ b/test/unit/test_galaxy_mapping.py
@@ -238,7 +238,7 @@ class MappingTests(unittest.TestCase):
 
         # TODO:
         # loaded_dataset_collection = self.query( model.DatasetCollection ).filter( model.DatasetCollection.name == "LibraryCollectionTest1" ).first()
-        # self.assertEquals(len(loaded_dataset_collection.datasets), 2)
+        # self.assertEqual(len(loaded_dataset_collection.datasets), 2)
         # assert loaded_dataset_collection.collection_type == "pair"
 
     def test_default_disk_usage(self):

--- a/test/unit/tools/test_actions.py
+++ b/test/unit/tools/test_actions.py
@@ -82,7 +82,7 @@ class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesApp, tools_
 
     def test_output_label(self):
         _, output = self._simple_execute()
-        self.assertEquals(output["out1"].name, "Output (moo)")
+        self.assertEqual(output["out1"].name, "Output (moo)")
 
     def test_output_label_data(self):
         hda1 = self.__add_dataset()
@@ -97,12 +97,12 @@ class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesApp, tools_
             tools_support.SIMPLE_CAT_TOOL_CONTENTS,
             incoming,
         )
-        self.assertEquals(output["out1"].name, "Test Tool on data 2 and data 1")
+        self.assertEqual(output["out1"].name, "Test Tool on data 2 and data 1")
 
     def test_object_store_ids(self):
         _, output = self._simple_execute(contents=TWO_OUTPUTS)
-        self.assertEquals(output["out1"].name, "Output (moo)")
-        self.assertEquals(output["out2"].name, "Output 2 (moo)")
+        self.assertEqual(output["out1"].name, "Output (moo)")
+        self.assertEqual(output["out2"].name, "Output 2 (moo)")
 
     def test_params_wrapped(self):
         hda1 = self.__add_dataset()
@@ -111,7 +111,7 @@ class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesApp, tools_
             incoming=dict(repeat1=[dict(param1=hda1)]),
         )
         # Again this is a stupid way to ensure data parameters are wrapped.
-        self.assertEquals(output["out1"].name, "Output (%s)" % hda1.dataset.get_file_name())
+        self.assertEqual(output["out1"].name, "Output (%s)" % hda1.dataset.get_file_name())
 
     def test_handler_set(self):
         job, _ = self._simple_execute()

--- a/test/unit/tools/test_collect_primary_datasets.py
+++ b/test/unit/tools/test_collect_primary_datasets.py
@@ -39,7 +39,7 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesApp, t
 
         datasets = self._collect()
         assert DEFAULT_TOOL_OUTPUT in datasets
-        self.assertEquals(len(datasets[DEFAULT_TOOL_OUTPUT]), 2)
+        self.assertEqual(len(datasets[DEFAULT_TOOL_OUTPUT]), 2)
 
         # Test default order of collection.
         assert list(datasets[DEFAULT_TOOL_OUTPUT].keys()) == ["test1", "test2"]
@@ -68,7 +68,7 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesApp, t
 
         datasets = self._collect()
         assert DEFAULT_TOOL_OUTPUT in datasets
-        self.assertEquals(len(datasets[DEFAULT_TOOL_OUTPUT]), 3)
+        self.assertEqual(len(datasets[DEFAULT_TOOL_OUTPUT]), 3)
 
         # Test default order of collection.
         assert list(datasets[DEFAULT_TOOL_OUTPUT].keys()) == ["test1", "test2", "test3"]

--- a/test/unit/tools/test_data_parameters.py
+++ b/test/unit/tools/test_data_parameters.py
@@ -27,7 +27,7 @@ class DataToolParameterTestCase(BaseParameterTestCase):
         # Selection is Optional. may be selected with other stuff,
         # not sure the UI should really allow this but easy enough
         # to just filter it out.
-        self.assertEquals([hda], self.param.to_python('%s,None' % hda.id, self.app))
+        self.assertEqual([hda], self.param.to_python('%s,None' % hda.id, self.app))
 
     def test_field_filter_on_types(self):
         hda1 = MockHistoryDatasetAssociation(name="hda1", id=1)

--- a/test/unit/tools/test_evaluation.py
+++ b/test/unit/tools/test_evaluation.py
@@ -52,7 +52,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self._setup_test_bwa_job()
         self._set_compute_environment()
         command_line, extra_filenames, _ = self.evaluator.build()
-        self.assertEquals(command_line, "bwa --thresh=4 --in=/galaxy/files/dataset_1.dat --out=/galaxy/files/dataset_2.dat")
+        self.assertEqual(command_line, "bwa --thresh=4 --in=/galaxy/files/dataset_1.dat --out=/galaxy/files/dataset_2.dat")
 
     def test_repeat_evaluation(self):
         repeat = Repeat()
@@ -63,7 +63,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self.tool._command_line = "prog1 #for $r_i in $r # $r_i.thresh#end for#"
         self._set_compute_environment()
         command_line, extra_filenames, _ = self.evaluator.build()
-        self.assertEquals(command_line, "prog1  4 5")
+        self.assertEqual(command_line, "prog1  4 5")
 
     def test_conditional_evaluation(self):
         select_xml = XML('''<param name="always_true" type="select"><option value="true">True</option></param>''')
@@ -81,7 +81,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self.tool._command_line = "prog1 --thresh=${c.thresh} --test_param=${c.always_true}"
         self._set_compute_environment()
         command_line, extra_filenames, _ = self.evaluator.build()
-        self.assertEquals(command_line, "prog1 --thresh=4 --test_param=true")
+        self.assertEqual(command_line, "prog1 --thresh=4 --test_param=true")
 
     def test_evaluation_of_optional_datasets(self):
         # Make sure optional dataset don't cause evaluation to break and
@@ -93,7 +93,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self.tool._command_line = "prog1 --opt_input='${input1}'"
         self._set_compute_environment()
         command_line, extra_filenames, _ = self.evaluator.build()
-        self.assertEquals(command_line, "prog1 --opt_input='None'")
+        self.assertEqual(command_line, "prog1 --opt_input='None'")
 
     def test_evaluation_with_path_rewrites_wrapped(self):
         self.tool.check_values = True
@@ -115,21 +115,21 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
             output_paths=[DatasetPath(2, '/galaxy/files/dataset_2.dat', false_path=job_path_2)],
         )
         command_line, extra_filenames, _ = self.evaluator.build()
-        self.assertEquals(command_line, "bwa --thresh=4 --in=%s --out=%s" % (job_path_1, job_path_2))
+        self.assertEqual(command_line, "bwa --thresh=4 --in=%s --out=%s" % (job_path_1, job_path_2))
 
     def test_configfiles_evaluation(self):
         self.tool.config_files.append(("conf1", None, "$thresh"))
         self.tool._command_line = "prog1 $conf1"
         self._set_compute_environment()
         command_line, extra_filenames, _ = self.evaluator.build()
-        self.assertEquals(len(extra_filenames), 1)
+        self.assertEqual(len(extra_filenames), 1)
         config_filename = extra_filenames[0]
         config_basename = os.path.basename(config_filename)
         # Verify config file written into working directory.
-        self.assertEquals(os.path.join(self.test_directory, config_basename), config_filename)
+        self.assertEqual(os.path.join(self.test_directory, config_basename), config_filename)
         # Verify config file contents are evaluated against parameters.
         assert open(config_filename, "r").read() == "4"
-        self.assertEquals(command_line, "prog1 %s" % config_filename)
+        self.assertEqual(command_line, "prog1 %s" % config_filename)
 
     def test_arbitrary_path_rewriting_wrapped(self):
         self.tool.check_values = True
@@ -167,7 +167,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
             return v
         self._set_compute_environment(path_rewriter=test_path_rewriter)
         command_line, extra_filenames, _ = self.evaluator.build()
-        self.assertEquals(command_line, "prog1 /new/path/human")
+        self.assertEqual(command_line, "prog1 /new/path/human")
 
     def test_template_property_app(self):
         self._assert_template_property_is("$__app__.config.new_file_path", self.app.config.new_file_path)
@@ -187,7 +187,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self._set_compute_environment()
         _, extra_filenames, _ = self.evaluator.build()
         config_filename = extra_filenames[0]
-        self.assertEquals(open(config_filename, "r").read(), value)
+        self.assertEqual(open(config_filename, "r").read(), value)
 
     def _set_compute_environment(self, **kwds):
         if "working_directory" not in kwds:

--- a/test/unit/workflows/test_extract_summary.py
+++ b/test/unit/workflows/test_extract_summary.py
@@ -30,8 +30,8 @@ class TestWorkflowExtractSummary(unittest.TestCase):
         job_dict, warnings = extract.summarize(trans=self.trans)
         assert len(job_dict) == 2
         assert not warnings
-        self.assertEquals(job_dict[hda1.job], [('out1', hda1), ('out2', hda2)])
-        self.assertEquals(job_dict[hda3.job], [('out3', hda3)])
+        self.assertEqual(job_dict[hda1.job], [('out1', hda1), ('out2', hda2)])
+        self.assertEqual(job_dict[hda3.job], [('out3', hda3)])
 
     def test_finds_original_job_if_copied(self):
         hda = MockHda()
@@ -43,7 +43,7 @@ class TestWorkflowExtractSummary(unittest.TestCase):
         job_dict, warnings = extract.summarize(trans=self.trans)
         assert not warnings
         assert len(job_dict) == 1
-        self.assertEquals(job_dict[hda.job], [('out1', derived_hda_2)])
+        self.assertEqual(job_dict[hda.job], [('out1', derived_hda_2)])
 
     def test_fake_job_hda(self):
         """ Fakes job if creating_job_associations is empty.


### PR DESCRIPTION
Fix warnings during py34-unit tests like:

```
/home/travis/build/galaxyproject/galaxy/test/unit/workflows/test_extract_summary.py:46: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(job_dict[hda.job], [('out1', derived_hda_2)])
```

See e.g. https://travis-ci.org/galaxyproject/galaxy/jobs/438829277

Also remove unneeded parentheses in lib/galaxy/web/base/controller.py