### PR TITLE
Fix unit test that uses fake trans.user_is_admin

### DIFF
--- a/test/unit/tools/test_toolbox_filters.py
+++ b/test/unit/tools/test_toolbox_filters.py
@@ -75,7 +75,7 @@ def mock_tool(require_login=False, hidden=False, trackster_conf=False, allow_acc
 
 
 def mock_trans(has_user=True, is_admin=False):
-    trans = Bunch(user_is_admin=lambda: is_admin)
+    trans = Bunch(user_is_admin=is_admin)
     if has_user:
         trans.user = Bunch(preferences={})
     else:


### PR DESCRIPTION
for the change to a property made in #6835.

The test passed but made the same error of using an uncalled function as a boolean that was to be avoided by turning it in to a property (it is a fake attribute in the test).