### PR TITLE
[18.05] Fix slurm cli on secure shell

### DIFF
--- a/lib/galaxy/jobs/runners/util/cli/shell/local.py
+++ b/lib/galaxy/jobs/runners/util/cli/shell/local.py
@@ -44,7 +44,7 @@ class LocalShell(BaseShellExec):
 
     def execute(self, cmd, persist=False, timeout=DEFAULT_TIMEOUT, timeout_check_interval=DEFAULT_TIMEOUT_CHECK_INTERVAL, **kwds):
         outf = TemporaryFile()
-        p = Popen(cmd, shell=True, stdin=None, stdout=outf, stderr=PIPE)
+        p = Popen(cmd, stdin=None, stdout=outf, stderr=PIPE)
         # poll until timeout
 
         for i in range(int(timeout / timeout_check_interval)):

--- a/lib/galaxy/jobs/runners/util/cli/shell/rsh.py
+++ b/lib/galaxy/jobs/runners/util/cli/shell/rsh.py
@@ -40,8 +40,8 @@ class SecureShell(RemoteShell):
 
     def __init__(self, rsh='ssh', rcp='scp', private_key=None, port=None, strict_host_key_checking=True, **kwargs):
         strict_host_key_checking = "yes" if strict_host_key_checking else "no"
-        options = ["-oStrictHostKeyChecking=%s" % strict_host_key_checking]
-        options.append("-oConnectTimeout=60")
+        options = ["-o", "StrictHostKeyChecking=%s" % strict_host_key_checking]
+        options.extend(["-o", "ConnectTimeout=60"])
         if private_key:
             options.extend(['-i', private_key])
         if port:

--- a/test/functional/tools/job_environment_default.xml
+++ b/test/functional/tools/job_environment_default.xml
@@ -8,6 +8,7 @@
       echo `pwd` > '$pwd';
       echo "\$HOME" > '$home';
       echo "\$TMP"  > '$tmp';
+      echo "\$SOME_ENV_VAR" > '$some_env_var';
     ]]></command>
     <inputs>
     </inputs>
@@ -17,6 +18,7 @@
         <data name="pwd" format="txt" label="pwd" />
         <data name="home" format="txt" label="home" />
         <data name="tmp" format="txt" label="tmp" />
+        <data name="some_env_var" format="txt" label="env_var" />
     </outputs>
     <help>
     </help>

--- a/test/functional/tools/job_environment_default_legacy.xml
+++ b/test/functional/tools/job_environment_default_legacy.xml
@@ -8,6 +8,7 @@
       echo `pwd` > '$pwd';
       echo "\$HOME" > '$home';
       echo "\$TMP"  > '$tmp';
+      echo "\$SOME_ENV_VAR" > '$some_env_var';
     ]]></command>
     <inputs>
     </inputs>
@@ -17,6 +18,7 @@
         <data name="pwd" format="txt" label="pwd" />
         <data name="home" format="txt" label="home" />
         <data name="tmp" format="txt" label="tmp" />
+        <data name="some_env_var" format="txt" label="env_var" />
     </outputs>
     <help>
     </help>

--- a/test/functional/tools/job_environment_explicit_shared_home.xml
+++ b/test/functional/tools/job_environment_explicit_shared_home.xml
@@ -8,6 +8,7 @@
       echo `pwd` > '$pwd';
       echo "\$HOME" > '$home';
       echo "\$TMP"  > '$tmp';
+      echo "\$SOME_ENV_VAR" > '$some_env_var';
     ]]></command>
     <inputs>
     </inputs>
@@ -17,6 +18,7 @@
         <data name="pwd" format="txt" label="pwd" />
         <data name="home" format="txt" label="home" />
         <data name="tmp" format="txt" label="tmp" />
+        <data name="some_env_var" format="txt" label="env_var" />
     </outputs>
     <help>
     </help>

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -18,11 +18,11 @@ def deploy_key(key, server, username, password, port=22):
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     client.connect(server, username=username, password=password, port=port)
-    client.exec_command('rm -R ~/.ssh/')
-    client.exec_command('mkdir -p ~/.ssh/')
-    client.exec_command('echo "%s" > ~/.ssh/authorized_keys' % key)
-    client.exec_command('chmod 644 ~/.ssh/authorized_keys')
-    client.exec_command('chmod 700 ~/.ssh/')
+    client.exec_command('rm -R .ssh/')
+    client.exec_command('mkdir -p .ssh/')
+    client.exec_command('echo "%s" > .ssh/authorized_keys' % key)
+    client.exec_command('chmod 644 .ssh/authorized_keys')
+    client.exec_command('chmod 700 .ssh/')
 
 
 def generate_key(key_path):
@@ -100,7 +100,8 @@ class BaseCliIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
         cls.container_name = "%s_container" % cls.__name__
         cls.jobs_directory = tempfile.mkdtemp()
         cls.remote_connection = start_ssh_docker(container_name=cls.container_name,
-                                                 jobs_directory=cls.jobs_directory)
+                                                 jobs_directory=cls.jobs_directory,
+                                                 image=cls.image)
         super(BaseCliIntegrationTestCase, cls).setUpClass()
 
     @classmethod
@@ -112,7 +113,9 @@ class BaseCliIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
     def handle_galaxy_config_kwds(cls, config, ):
         config["jobs_directory"] = cls.jobs_directory
         config["file_path"] = cls.jobs_directory
-        config["job_config_file"] = cli_job_config(remote_connection=cls.remote_connection, shell_plugin=cls.shell_plugin)
+        config["job_config_file"] = cli_job_config(remote_connection=cls.remote_connection,
+                                                   shell_plugin=cls.shell_plugin,
+                                                   job_plugin=cls.job_plugin)
 
     @skip_without_tool("job_environment_default")
     def test_running_cli_job(self):

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -1,0 +1,154 @@
+"""Integration tests for the CLI shell plugins and runners."""
+import collections
+import shlex
+import string
+import subprocess
+import tempfile
+import time
+import unittest
+
+import paramiko
+from base import integration_util
+from base.populators import skip_without_tool
+
+from .test_job_environments import BaseJobEnvironmentIntegrationTestCase
+
+
+def deploy_key(key, server, username, password, port=22):
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.connect(server, username=username, password=password, port=port)
+    client.exec_command('rm -R ~/.ssh/')
+    client.exec_command('mkdir -p ~/.ssh/')
+    client.exec_command('echo "%s" > ~/.ssh/authorized_keys' % key)
+    client.exec_command('chmod 644 ~/.ssh/authorized_keys')
+    client.exec_command('chmod 700 ~/.ssh/')
+
+
+def generate_key(key_path):
+    CMD = 'ssh-keygen -b 2048 -t rsa -f {key_path} -q -N ""'.format(key_path=key_path)
+    subprocess.check_call(shlex.split(CMD))
+
+
+@integration_util.skip_unless_docker()
+def start_ssh_docker(container_name, jobs_directory, port=10022, image='agaveapi/slurm'):
+    START_SLURM_DOCKER = ['docker',
+                          'run',
+                          '-h',
+                          'docker.example.com',
+                          '-p',
+                          '{port}:22'.format(port=port),
+                          '-d',
+                          '--name',
+                          container_name,
+                          '--rm',
+                          '-v',
+                          "{jobs_directory}:{jobs_directory}".format(jobs_directory=jobs_directory),
+                          '--ulimit',
+                          'nofile=2048:2048',
+                          image]
+    subprocess.check_call(START_SLURM_DOCKER)
+    key_file = tempfile.NamedTemporaryFile(suffix='_slurm_integration_ssh_key', delete=True).name
+    generate_key(key_file)
+    # Wait until ssh server in container is up
+    time.sleep(5)
+    with open("%s.pub" % key_file) as fh:
+        key = fh.read()
+    deploy_key(key=key, server='localhost', username='testuser', password='testuser', port=port)
+    return collections.namedtuple('remote_connection', 'hostname username password port private_key')(
+        'localhost', 'testuser', 'testuser', port, key_file
+    )
+
+
+def stop_ssh_docker(container_name):
+    subprocess.check_call(['docker', 'rm', '-f', container_name])
+
+
+def cli_job_config(remote_connection, shell_plugin='ParamikoShell', job_plugin='Slurm'):
+    job_conf_template = string.Template("""<job_conf>
+    <plugins>
+        <plugin id="cli" type="runner" load="galaxy.jobs.runners.cli:ShellJobRunner" workers="1"/>
+    </plugins>
+    <destinations default="ssh_slurm">
+        <destination id="ssh_slurm" runner="cli">
+            <param id="shell_plugin">$shell_plugin</param>
+            <param id="job_plugin">$job_plugin</param>
+            <param id="shell_username">$username</param>
+            <param id="shell_private_key">$private_key</param>
+            <param id="shell_hostname">$hostname</param>
+            <param id="shell_port">$port</param>
+            <param id="embed_metadata_in_job">False</param>
+            <env id="SOME_ENV_VAR">42</env>
+        </destination>
+    </destinations>
+</job_conf>
+""")
+    job_conf_str = job_conf_template.substitute(shell_plugin=shell_plugin,
+                                                job_plugin=job_plugin,
+                                                **remote_connection._asdict())
+    with tempfile.NamedTemporaryFile(suffix="_slurm_integration_job_conf", delete=False) as job_conf:
+        job_conf.write(job_conf_str)
+    return job_conf.name
+
+
+class BaseCliIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if cls is BaseCliIntegrationTestCase:
+            raise unittest.SkipTest("Base class")
+        cls.container_name = "%s_container" % cls.__name__
+        cls.jobs_directory = tempfile.mkdtemp()
+        cls.remote_connection = start_ssh_docker(container_name=cls.container_name,
+                                                 jobs_directory=cls.jobs_directory)
+        super(BaseCliIntegrationTestCase, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_ssh_docker(container_name=cls.container_name)
+        super(BaseCliIntegrationTestCase, cls).tearDownClass()
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config, ):
+        config["jobs_directory"] = cls.jobs_directory
+        config["file_path"] = cls.jobs_directory
+        config["job_config_file"] = cli_job_config(remote_connection=cls.remote_connection, shell_plugin=cls.shell_plugin)
+
+    @skip_without_tool("job_environment_default")
+    def test_running_cli_job(self):
+        job_env = self._run_and_get_environment_properties()
+        assert job_env.some_env == '42'
+
+
+class TorqueSetup(object):
+    job_plugin = 'Torque'
+    image = 'mvdbeek/galaxy-integration-docker-images:torque_latest'
+
+
+class SlurmSetup(object):
+    job_plugin = 'Slurm'
+    image = 'mvdbeek/galaxy-integration-docker-images:slurm_latest'
+
+
+class ParamikoShell(object):
+    shell_plugin = 'ParamikoShell'
+
+
+class SecureShell(object):
+    shell_plugin = 'SecureShell'
+
+
+class ParamikoCliSlurmIntegrationTestCase(SlurmSetup, ParamikoShell, BaseCliIntegrationTestCase):
+    pass
+
+
+class ShellJobCliSlurmIntegrationTestCase(SlurmSetup, SecureShell, BaseCliIntegrationTestCase):
+    pass
+
+
+class ParamikoCliTorqueIntegrationTestCase(TorqueSetup, ParamikoShell, BaseCliIntegrationTestCase):
+    pass
+
+
+class ShellJobCliTorqueIntegrationTestCase(TorqueSetup, SecureShell, BaseCliIntegrationTestCase):
+    pass

--- a/test/integration/test_job_environments.py
+++ b/test/integration/test_job_environments.py
@@ -21,6 +21,7 @@ JobEnviromentProperties = collections.namedtuple("JobEnvironmentProperties", [
     "pwd",
     "home",
     "tmp",
+    "some_env",
 ])
 
 
@@ -38,8 +39,8 @@ class RunsEnvironmentJobs:
         pwd = self.dataset_populator.get_history_dataset_content(history_id, hid=3).strip()
         home = self.dataset_populator.get_history_dataset_content(history_id, hid=4).strip()
         tmp = self.dataset_populator.get_history_dataset_content(history_id, hid=5).strip()
-
-        return JobEnviromentProperties(user_id, group_id, pwd, home, tmp)
+        some_env = self.dataset_populator.get_history_dataset_content(history_id, hid=6).strip()
+        return JobEnviromentProperties(user_id, group_id, pwd, home, tmp, some_env)
 
 
 class BaseJobEnvironmentIntegrationTestCase(integration_util.IntegrationTestCase, RunsEnvironmentJobs):


### PR DESCRIPTION
Includes tests for the CLI Slurm and Torque plugins using the ParamikoShell and the SecureShell runners.

torque and slurm docker images are being built on [dockerhub](https://hub.docker.com/r/mvdbeek/galaxy-integration-docker-images/builds/)

Should fix https://github.com/galaxyproject/galaxy/issues/6831 in combination with https://github.com/galaxyproject/galaxy/pull/6836