### PR TITLE
[18.09] Fix ``LocalShell`` doctest

### DIFF
--- a/lib/galaxy/jobs/runners/util/cli/shell/local.py
+++ b/lib/galaxy/jobs/runners/util/cli/shell/local.py
@@ -24,7 +24,7 @@ class LocalShell(BaseShellExec):
     """
 
     >>> shell = LocalShell()
-    >>> def exec_python(script, **kwds): return shell.execute('python -c "%s"' % script, **kwds)
+    >>> def exec_python(script, **kwds): return shell.execute(['python', '-c', script], **kwds)
     >>> exec_result = exec_python("from __future__ import print_function; print('Hello World')")
     >>> exec_result.stderr == u''
     True


### PR DESCRIPTION
Broken in commit 57a1f19b069597bde97852b3e0d0a3e1c0068bc4 .

Targeting 18.09 since this doctest is not run under 18.05 (see https://github.com/galaxyproject/galaxy/blob/release_18.05/run_tests.sh#L470 ), which is why this was not noticed.