### PR TITLE
Handling out of memory for cli-plugin runner (LSF only).

### DIFF
--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -180,6 +180,7 @@ class ShellJobRunner(AsynchronousJobRunner):
                 if state == model.Job.states.ERROR:
                     # Try to find out the reason for exiting
                     self.__handle_out_of_memory(ajs, external_job_id)
+                    self.mark_as_failed(ajs)
             if state == model.Job.states.RUNNING and not ajs.running:
                 ajs.running = True
             ajs.old_state = state

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -180,7 +180,7 @@ class ShellJobRunner(AsynchronousJobRunner):
                 if state == model.Job.states.ERROR:
                     # Try to find out the reason for exiting
                     self.__handle_out_of_memory(ajs, external_job_id)
-                    self.mark_as_failed(ajs)
+                    self.work_queue.put((self.mark_as_failed, ajs))
             if state == model.Job.states.RUNNING and not ajs.running:
                 ajs.running = True
             ajs.old_state = state

--- a/lib/galaxy/jobs/runners/util/cli/job/__init__.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/__init__.py
@@ -61,3 +61,15 @@ class BaseJobExec(object):
         """
         Parse the status of output from get_single_status command.
         """
+
+    def get_failure_reason(self, job_id):
+        """
+        Return the failure reason for the given job_id.
+        """
+        return None
+
+    @abstractmethod
+    def parse_failure_reason(self, reason, job_id):
+        """
+        Parses the failure reason, assigning it against a
+        """

--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -1,7 +1,9 @@
 # A simple CLI runner for slurm that can be used when running Galaxy from a
 # non-submit host and using a Slurm cluster.
 from logging import getLogger
+
 from galaxy.jobs import JobState
+
 try:
     from galaxy.model import Job
     job_states = Job.states

--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -2,6 +2,8 @@
 # non-submit host and using a Slurm cluster.
 from logging import getLogger
 
+from galaxy.jobs import JobState
+
 try:
     from galaxy.model import Job
     job_states = Job.states
@@ -91,6 +93,19 @@ class LSF(BaseJobExec):
             log.warning("Job id '%s' not found LSF status check" % job_id)
             return job_states.OK
         return self._get_job_state(status)
+
+    def get_failure_reason(self, job_id):
+        return "bjobs -l " + job_id
+
+    def parse_failure_reason(self, reason):
+        # LSF will produce the following in the job output file:
+        # TERM_MEMLIMIT: job killed after reaching LSF memory usage limit.
+        # Exited with exit code 143.
+        for line in reason.splitlines():
+            if "TERM_MEMLIMIT" in line:
+                return JobState.runner_states.MEMORY_LIMIT_REACHED
+        return None
+
 
     def _get_job_state(self, state):
         # based on:

--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -96,7 +96,7 @@ class LSF(BaseJobExec):
     def get_failure_reason(self, job_id):
         return "bjobs -l " + job_id
 
-    def parse_failure_reason(self, reason):
+    def parse_failure_reason(self, reason, job_id):
         # LSF will produce the following in the job output file:
         # TERM_MEMLIMIT: job killed after reaching LSF memory usage limit.
         # Exited with exit code 143.

--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -1,9 +1,7 @@
 # A simple CLI runner for slurm that can be used when running Galaxy from a
 # non-submit host and using a Slurm cluster.
 from logging import getLogger
-
 from galaxy.jobs import JobState
-
 try:
     from galaxy.model import Job
     job_states = Job.states

--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -1,6 +1,7 @@
 # A simple CLI runner for slurm that can be used when running Galaxy from a
 # non-submit host and using a Slurm cluster.
 from logging import getLogger
+
 from galaxy.jobs import JobState
 try:
     from galaxy.model import Job

--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -1,9 +1,7 @@
 # A simple CLI runner for slurm that can be used when running Galaxy from a
 # non-submit host and using a Slurm cluster.
 from logging import getLogger
-
 from galaxy.jobs import JobState
-
 try:
     from galaxy.model import Job
     job_states = Job.states
@@ -11,7 +9,6 @@ except ImportError:
     # Not in Galaxy, map Galaxy job states to Pulsar ones.
     from pulsar.util import enum
     job_states = enum(RUNNING='running', OK='complete', QUEUED='queued', ERROR="failed")
-
 from ..job import BaseJobExec
 
 log = getLogger(__name__)
@@ -105,7 +102,6 @@ class LSF(BaseJobExec):
             if "TERM_MEMLIMIT" in line:
                 return JobState.runner_states.MEMORY_LIMIT_REACHED
         return None
-
 
     def _get_job_state(self, state):
         # based on:


### PR DESCRIPTION
This PR is a first try at handling out of memory for LSF cli plugin. Aims to sort out #6864.