### PR TITLE
prevent double sanitizing history name when renaming

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1207,8 +1207,8 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
                     messages.append('History \'%s\' does not appear to belong to you.' % cur_name)
                 # skip if it wouldn't be a change
                 elif new_name != cur_name:
-                    # escape, sanitize, set, and log the change
-                    h.name = sanitize_html(escape(new_name))
+                    # sanitize, set, and log the change
+                    h.name = sanitize_html(new_name)
                     trans.sa_session.add(h)
                     trans.sa_session.flush()
                     trans.log_event('History renamed: id: %s, renamed to: %s' % (str(h.id), new_name))


### PR DESCRIPTION
This is intended to fix: https://github.com/galaxyproject/usegalaxy-playbook/issues/169 / https://github.com/galaxyproject/galaxy/issues/6873

I was originally trying to "unescape" the name whenever it was displayed instead of removing the escape altogether, but given that names for workflows are only sanitized and not escaped, and that the history name is not escaped when changed from the panel on the right, I thought it might just be that it didn't need to be escaped in the first place.
If I am wrong and it does need to be escaped, let me know and I can instead try to convert it to its value whenever returned to the UI, while storing it escaped