### PR TITLE
[18.09] Do not traceback when uploading a TS repo with no changes

### DIFF
--- a/lib/tool_shed/util/hg_util.py
+++ b/lib/tool_shed/util/hg_util.py
@@ -61,6 +61,8 @@ def commit_changeset(repo_path, full_path_to_changeset, username, message):
     except Exception as e:
         error_message = "Error committing '%s' to repository: %s" % (full_path_to_changeset, e)
         if isinstance(e, subprocess.CalledProcessError):
+            if e.returncode == 1 and 'nothing changed' in e.output:
+                return
             error_message += "\nOutput was:\n%s" % e.output
         raise Exception(error_message)
 


### PR DESCRIPTION
Fix the following traceback when executing `planemo shed_update`:

```
galaxy.web.framework.decorators ERROR 2018-10-15 18:07:38,736 [p:30249,w:1,m:0] [uWSGIWorker1Core1] Uncaught exception in exposed API method:
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 154, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/tool_shed/api/repositories.py", line 1116, in create_changeset_revision
    new_repo_alert
  File "lib/tool_shed/util/repository_content_util.py", line 64, in upload_tar
    undesirable_files_removed)
  File "lib/tool_shed/util/commit_util.py", line 225, in handle_directory_changes
    message=commit_message)
  File "lib/tool_shed/util/hg_util.py", line 65, in commit_changeset
    raise Exception(error_message)
Exception: Error committing '/opt/galaxy/database/community_files/000/repo_1' to repository: Command '['hg', 'commit', '-u', u'earlhaminst', '-m', u'planemo upload for repository https://github.com/TGAC/earlham-galaxytools/tree/master/tools/TreeBest commit 22231ebc4e5e990c61243a3609b3347cf63fa024', '/opt/galaxy/database/community_files/000/repo_1']' returned non-zero exit status 1
Output was:
nothing changed

127.0.0.1 - - [15/Oct/2018:18:07:38 +0100] "POST /api/repositories/adb5f5c93f827949/changeset_revision HTTP/1.1" 500 - "-" "python-requests/2.18.4"
```

Introduced in commit 6c56467641d6eea97aaefd5bf8370f06665bb03f .