### PR TITLE
Use small button for editable text fields in history annotation

### DIFF
--- a/client/galaxy/scripts/ui/editable-text.js
+++ b/client/galaxy/scripts/ui/editable-text.js
@@ -64,6 +64,7 @@ $.fn.make_text_editable = function(config_dict) {
                     }
                 });
             button_elt = $("<button/>")
+                .addClass("btn-sm")
                 .text("Done")
                 .click(() => {
                     set_text(input_elt.val());

--- a/client/galaxy/scripts/ui/editable-text.js
+++ b/client/galaxy/scripts/ui/editable-text.js
@@ -64,7 +64,7 @@ $.fn.make_text_editable = function(config_dict) {
                     }
                 });
             button_elt = $("<button/>")
-                .addClass("btn-sm")
+                .addClass("btn-sm float-right")
                 .text("Done")
                 .click(() => {
                     set_text(input_elt.val());


### PR DESCRIPTION
Fixes issue listed in #6706.

![image](https://user-images.githubusercontent.com/2105447/46975619-15d84680-d095-11e8-9cd1-564c0bbd2450.png)



