### PR TITLE
Improve k8s job error handling

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -456,7 +456,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             # We should not get here
             log.debug(
                 "Reaching unexpected point for Kubernetes job name %s where it is not classified as succ., active nor failed.", job.name)
-            log.debug("Here's the full job object\n========================================\n%s\n========================================", job.obj)
+            log.debug("k8s full job object:\n%s", job.obj)
             return job_state
 
         elif len(jobs.response['items']) == 0:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -544,7 +544,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 log_string += "\n\n==== Pod " + pod.name + " log end   ===="
             except Exception as detail:
                 log.info("Could not write log file for pod %s due to HTTPError %s",
-                         detail, pod_obj['metadata']['name'])
+                         pod_obj['metadata']['name'], detail)
         if isinstance(log_string, text_type):
             log_string = log_string.encode('utf8')
 

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -455,7 +455,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 return self._handle_job_failure(job, job_state)
             # We should not get here
             log.debug(
-                "Reaching unexpected point for Kubernetes job, where it is not classified as succ., active nor failed.")
+                "Reaching unexpected point for Kubernetes job name %s where it is not classified as succ., active nor failed.", job.name)
+            log.debug("Here's the full job object\n========================================\n%s\n========================================", job.obj)
             return job_state
 
         elif len(jobs.response['items']) == 0:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -524,7 +524,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             with open(job_state.output_file, 'r') as outfile:
                 stdout_content = outfile.read()
         except IOError as e:
-            stdout_content = "<Failed to recuperate log>"
+            stdout_content = "<Failed to recuperate log for job {} >".format(job_state.job_id)
             log.error("Failed to get stdout for job %s", job_state.job_id)
             log.exception(e)
 


### PR DESCRIPTION
This PR should fix cases where successful Kubernetes jobs whose logs have gone missing can't be marked as finished by Galaxy. The current implementation trips over an IOError before reaching the code where the job is marked as finished.

In addition, the PR adds logging to DEBUG of full Kubernetes job objects that are in an unexpected state.  The idea is that this debug output should help users of the k8s runner debug an issue that has been with us for a while.