### PR TITLE
Catered for shlex.split(command_inject) and updated Neo4j IE to v3.1.9

### DIFF
--- a/config/plugins/interactive_environments/neo/config/allowed_images.yml.sample
+++ b/config/plugins/interactive_environments/neo/config/allowed_images.yml.sample
@@ -6,6 +6,6 @@
 # appropriate `apt-get/pip install` statements.
 ---
 -
-    image: quay.io/sanbi-sa/neo_ie:3.1
+    image: quay.io/sanbi-sa/neo_ie:3.1.9
     description: |
         Neo4j is a highly scalable, robust native graph database.

--- a/config/plugins/interactive_environments/neo/config/neo.ini.sample
+++ b/config/plugins/interactive_environments/neo/config/neo.ini.sample
@@ -48,8 +48,8 @@ command_inject = --sig-proxy=true -e DEBUG=false -e DEFAULT_CONTAINER_RUNTIME=12
 
 # To run containers in Docker Swarm mode on (an existing swarm), set the
 # following option to True *and*:
-# - set docker_connect_port above. For thoba/neo4j_galaxy_ie the port
-#   should most likely be 7474.
+# - set docker_connect_port above. For quay.io/sanbi-sa/neo_ie:3.1.9 the port
+#   should most likely be 80.
 # - If command_inject is uncommented and includes `--sig-proxy`, that option should
 #   be removed.
 #swarm_mode = False

--- a/config/plugins/interactive_environments/neo/templates/neo.mako
+++ b/config/plugins/interactive_environments/neo/templates/neo.mako
@@ -7,7 +7,7 @@
     # if the user knows ahead of time that they will need it.
     import os
     mount_path = str(os.path.dirname(hda.file_name)) + '/dataset_{}_files'.format( hda.dataset.id )
-    data_vol = ie_request.volume(mount_path, '/data', how='rw')
+    data_vol = ie_request.volume(mount_path, '/data', mode='rw')
     # data_vol = ie_request.volume('${HOME}/neo4j/data', '/data/', how='rw')
     # Add all environment variables collected from Galaxy's IE infrastructure
     # Launch the IE.

--- a/lib/galaxy/visualization/plugins/interactive_environments.py
+++ b/lib/galaxy/visualization/plugins/interactive_environments.py
@@ -294,7 +294,22 @@ class InteractiveEnvironmentRequest(object):
         def _flag_opts(flag, opts):
             return [arg for pair in product((flag,), opts) for arg in pair]
 
+        def _check_uid_and_gid(cmd_inject):
+            """
+            Check and replace shell uid and gid using os
+            :param cmd_inject:
+            """
+            # --user="$(id -u):$(id -g)"
+            # https://docs.docker.com/engine/reference/run/#user
+            # -e USER_UID=$(id -u) -e USER_GID=$(id -g)
+            uid_gid_subs = {"$(id -u)": "{}".format(os.geteuid()), "$(id -g)": "{}".format(os.getgid())}
+            subs = sorted(uid_gid_subs)
+            regex = re.compile('|'.join(map(re.escape, subs)))
+            return regex.sub(lambda match: uid_gid_subs[match.group(0)], cmd_inject)
+
         command_inject = self.attr.viz_config.get("docker", "command_inject")
+        command_inject = _check_uid_and_gid(command_inject)
+
         # --name should really not be set, but we'll try to honor it anyway
         name = ['--name=%s' % self._get_name_for_run()] if '--name' not in command_inject else []
         env = self._get_env_for_run(env_override)
@@ -429,7 +444,7 @@ class InteractiveEnvironmentRequest(object):
             host_port = self._find_port_mapping(port_mappings)[-1]
             log.debug("Container host/port: %s:%s", self.attr.docker_hostname, host_port)
 
-            # Now we configure our proxy_requst object and we manually specify
+            # Now we configure our proxy_request object and we manually specify
             # the port to map to and ensure the proxy is available.
             self.attr.proxy_request = self.trans.app.proxy_manager.setup_proxy(
                 self.trans,


### PR DESCRIPTION
When injecting `$(id -u)` or `$(id -g)` in `command_inject` (`viz_id.ini`), `shlex.split(command_inject)` in [#L309](https://github.com/thobalose/galaxy/blob/dev/lib/galaxy/visualization/plugins/interactive_environments.py#L309) splits the command to `'-e', 'USER_UID=$(id', '-u)', '-e', 'USER_GID=$(id', '-g)'`. 

