### PR TITLE
nmrML data type.

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -753,6 +753,7 @@
     <sniffer type="galaxy.datatypes.xml:Owl"/>
     <sniffer type="galaxy.datatypes.xml:Sbml"/>
     <sniffer type="galaxy.datatypes.proteomics:MzML"/>
+    <sniffer type="galaxy.datatypes.proteomics:NmrML"/>
     <sniffer type="galaxy.datatypes.proteomics:TandemXML"/>
     <sniffer type="galaxy.datatypes.proteomics:PepXml"/>
     <sniffer type="galaxy.datatypes.proteomics:Mgf"/>

--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -214,6 +214,7 @@
     <datatype extension="tandem" type="galaxy.datatypes.proteomics:TandemXML" mimetype="application/xml" display_in_upload="true"/>
     <datatype extension="thermo.raw" type="galaxy.datatypes.proteomics:ThermoRAW" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="mzml" type="galaxy.datatypes.proteomics:MzML" mimetype="application/xml" display_in_upload="true"/>
+    <datatype extension="nmrml" type="galaxy.datatypes.proteomics:NmrML" mimetype="application/xml" display_in_upload="true" description="nmrML is an open mark-up language for NMR data." description_url="http://nmrml.org/schema/"/>
     <datatype extension="mgf" type="galaxy.datatypes.proteomics:Mgf" display_in_upload="true"/>
     <datatype extension="wiff" type="galaxy.datatypes.proteomics:Wiff" display_in_upload="true"/>
     <datatype extension="mzxml" type="galaxy.datatypes.proteomics:MzXML" mimetype="application/xml" display_in_upload="true"/>

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -134,6 +134,12 @@ class MzML(ProteomicsXml):
     blurb = 'mzML Mass Spectrometry data'
     root = "(mzML|indexedmzML)"
 
+class NmrML(ProteomicsXml):
+    """nmrML data"""
+    # No edam format number yet.
+    file_ext = "nmrml"
+    blurb = 'nmrML NMR data'
+    root = "nmrML"
 
 class ProtXML(ProteomicsXml):
     """protXML data"""

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -134,12 +134,14 @@ class MzML(ProteomicsXml):
     blurb = 'mzML Mass Spectrometry data'
     root = "(mzML|indexedmzML)"
 
+
 class NmrML(ProteomicsXml):
     """nmrML data"""
     # No edam format number yet.
     file_ext = "nmrml"
     blurb = 'nmrML NMR data'
     root = "nmrML"
+
 
 class ProtXML(ProteomicsXml):
     """protXML data"""


### PR DESCRIPTION
Create a new data type for NMR data: nmrML.
This data type is already used in [PhenoMeNal](https://github.com/phnmnl) project, and will soon be used by [Worfklow4Metabolomics](https://github.com/workflow4metabolomics) in Galaxy tool [ISA extractor](https://github.com/workflow4metabolomics/isa-extractor).
It should be integrated in release 19.01, along with ISA data type.

Cc: @djcomlab, @fgiacomoni