### PR TITLE
Refactor collection mapping workflows toward independence from tools.

### DIFF
--- a/lib/galaxy/tools/parameters/history_query.py
+++ b/lib/galaxy/tools/parameters/history_query.py
@@ -16,10 +16,7 @@ class HistoryQuery(object):
         return HistoryQuery(**kwargs)
 
     @staticmethod
-    def from_parameter(param, collection_type_descriptions):
-        """ Take in a tool parameter element.
-        """
-        collection_types = param.collection_types
+    def from_collection_types(collection_types, collection_type_descriptions):
         if collection_types:
             collection_type_descriptions = [collection_type_descriptions.for_collection_type(t) for t in collection_types]
             # Place higher dimension descriptions first so subcollection mapping
@@ -29,9 +26,15 @@ class HistoryQuery(object):
             collection_type_descriptions = sorted(collection_type_descriptions, key=lambda t: t.dimension, reverse=True)
         else:
             collection_type_descriptions = None
-
         kwargs = dict(collection_type_descriptions=collection_type_descriptions)
         return HistoryQuery(**kwargs)
+
+    @staticmethod
+    def from_parameter(param, collection_type_descriptions):
+        """ Take in a tool parameter element.
+        """
+        collection_types = param.collection_types
+        return HistoryQuery.from_collection_types(collection_types, collection_type_descriptions)
 
     def direct_match(self, hdca):
         collection_type_descriptions = self.collection_type_descriptions

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -39,6 +39,7 @@ from galaxy.tools.parameters.basic import (
     TextToolParameter,
     workflow_building_modes
 )
+from galaxy.tools.parameters.history_query import HistoryQuery
 from galaxy.tools.parameters.wrapped import make_dict_copy
 from galaxy.util.bunch import Bunch
 from galaxy.util.json import safe_loads
@@ -267,6 +268,64 @@ class WorkflowModule(object):
 
         return []
 
+    def compute_collection_info(self, progress, step, all_inputs):
+        """Use get_all_inputs (if implemented) to determine collection mapping for execution.
+
+        Hopefully this can be reused for Tool and Subworkflow modules.
+        """
+
+        collections_to_match = self._find_collections_to_match(
+            progress, step, all_inputs
+        )
+        # Have implicit collections...
+        if collections_to_match.has_collections():
+            collection_info = self.trans.app.dataset_collections_service.match_collections(
+                collections_to_match
+            )
+        else:
+            collection_info = None
+
+        return collection_info
+
+    def _find_collections_to_match(self, progress, step, all_inputs):
+        collections_to_match = matching.CollectionsToMatch()
+
+        for input_dict in all_inputs:
+            name = input_dict["name"]
+            multiple = input_dict["multiple"]
+            if multiple:
+                continue
+
+            data = progress.replacement_for_input(step, input_dict)
+            can_map_over = hasattr(data, "collection")  # and data.collection.allow_implicit_mapping
+
+            if not can_map_over:
+                continue
+
+            is_data_param = input_dict["input_type"] == "dataset"
+            if is_data_param:
+                collections_to_match.add(name, data)
+                continue
+
+            is_data_collection_param = input_dict["input_type"] == "dataset_collection"
+            if is_data_collection_param:
+                dataset_collection_type_descriptions = self.trans.app.dataset_collections_service.collection_type_descriptions
+
+                history_query = HistoryQuery.from_collection_types(
+                    input_dict.get("collection_types", None),
+                    dataset_collection_type_descriptions,
+                )
+                subcollection_type_description = history_query.can_map_over(data)
+                if subcollection_type_description:
+                    collections_to_match.add(name, data, subcollection_type=subcollection_type_description.collection_type)
+                continue
+
+            if data is not NO_REPLACEMENT:
+                collections_to_match.add(name, data)
+                continue
+
+        return collections_to_match
+
 
 class SubWorkflowModule(WorkflowModule):
     # Two step improvements to build runtime inputs for subworkflow modules
@@ -302,12 +361,13 @@ class SubWorkflowModule(WorkflowModule):
             return self.subworkflow.name
         return self.name
 
-    def get_data_inputs(self):
+    def get_all_inputs(self, data_only=False):
         """ Get configure time data input descriptions. """
         # Filter subworkflow steps and get inputs
         step_to_input_type = {
             "data_input": "dataset",
             "data_collection_input": "dataset_collection",
+            "parameter_input": "parameter",
         }
         inputs = []
         if hasattr(self.subworkflow, 'input_steps'):
@@ -328,6 +388,9 @@ class SubWorkflowModule(WorkflowModule):
                 )
                 inputs.append(input)
         return inputs
+
+    def get_data_inputs(self):
+        return self.get_all_inputs(data_only=True)
 
     def get_data_outputs(self):
         outputs = []
@@ -740,21 +803,24 @@ class ToolModule(WorkflowModule):
     def get_inputs(self):
         return self.tool.inputs if self.tool else {}
 
-    def get_data_inputs(self):
-        data_inputs = []
+    def get_all_inputs(self, data_only=False):
+        inputs = []
         if self.tool:
 
             def callback(input, prefixed_name, prefixed_label, **kwargs):
-                if not hasattr(input, 'hidden') or not input.hidden:
+                visible = not hasattr(input, 'hidden') or not input.hidden
+                is_data = isinstance(input, DataToolParameter) or isinstance(input, DataCollectionToolParameter)
+                skip = data_only and (not visible or not is_data)
+                if not skip:
                     if isinstance(input, DataToolParameter):
-                        data_inputs.append(dict(
+                        inputs.append(dict(
                             name=prefixed_name,
                             label=prefixed_label,
                             multiple=input.multiple,
                             extensions=input.extensions,
                             input_type="dataset", ))
                     elif isinstance(input, DataCollectionToolParameter):
-                        data_inputs.append(dict(
+                        inputs.append(dict(
                             name=prefixed_name,
                             label=prefixed_label,
                             multiple=input.multiple,
@@ -762,9 +828,21 @@ class ToolModule(WorkflowModule):
                             collection_types=input.collection_types,
                             extensions=input.extensions,
                         ))
+                    else:
+                        inputs.append(
+                            dict(
+                                name=prefixed_name,
+                                label=prefixed_label,
+                                multiple=False,
+                                input_type="parameter",
+                            )
+                        )
 
             visit_input_values(self.tool.inputs, self.state.inputs, callback)
-        return data_inputs
+        return inputs
+
+    def get_data_inputs(self):
+        return self.get_all_inputs(data_only=True)
 
     def get_data_outputs(self):
         data_outputs = []
@@ -977,12 +1055,12 @@ class ToolModule(WorkflowModule):
         # metadata parameters from it.
         if RUNTIME_STEP_META_STATE_KEY in tool_state.inputs:
             del tool_state.inputs[RUNTIME_STEP_META_STATE_KEY]
-        collections_to_match = self._find_collections_to_match(tool, progress, step)
-        # Have implicit collections...
-        if collections_to_match.has_collections():
-            collection_info = self.trans.app.dataset_collections_service.match_collections(collections_to_match)
-        else:
-            collection_info = None
+
+        all_inputs = self.get_all_inputs()
+        all_inputs_by_name = {}
+        for input_dict in all_inputs:
+            all_inputs_by_name[input_dict["name"]] = input_dict
+        collection_info = self.compute_collection_info(progress, step, all_inputs)
 
         param_combinations = []
         if collection_info:
@@ -1001,21 +1079,20 @@ class ToolModule(WorkflowModule):
 
             # Connect up
             def callback(input, prefixed_name, **kwargs):
+                input_dict = all_inputs_by_name[prefixed_name]
+
                 replacement = NO_REPLACEMENT
-                if isinstance(input, DataToolParameter) or isinstance(input, DataCollectionToolParameter):
-                    if iteration_elements and prefixed_name in iteration_elements:
-                        if isinstance(input, DataToolParameter):
-                            # Pull out dataset instance from element.
-                            replacement = iteration_elements[prefixed_name].dataset_instance
-                            if hasattr(iteration_elements[prefixed_name], u'element_identifier') and iteration_elements[prefixed_name].element_identifier:
-                                replacement.element_identifier = iteration_elements[prefixed_name].element_identifier
-                        else:
-                            # If collection - just use element model object.
-                            replacement = iteration_elements[prefixed_name]
+                if iteration_elements and prefixed_name in iteration_elements:
+                    if isinstance(input, DataToolParameter):
+                        # Pull out dataset instance from element.
+                        replacement = iteration_elements[prefixed_name].dataset_instance
+                        if hasattr(iteration_elements[prefixed_name], u'element_identifier') and iteration_elements[prefixed_name].element_identifier:
+                            replacement.element_identifier = iteration_elements[prefixed_name].element_identifier
                     else:
-                        replacement = progress.replacement_for_tool_input(step, input, prefixed_name)
+                        # If collection - just use element model object.
+                        replacement = iteration_elements[prefixed_name]
                 else:
-                    replacement = progress.replacement_for_tool_input(step, input, prefixed_name)
+                    replacement = progress.replacement_for_input(step, input_dict)
 
                 if replacement is not NO_REPLACEMENT:
                     found_replacement_keys.add(prefixed_name)
@@ -1103,27 +1180,6 @@ class ToolModule(WorkflowModule):
             outputs[output_dataset_collection_assoc.output_name] = output_dataset_collection_assoc.dataset_collection
 
         progress.set_step_outputs(invocation_step, outputs)
-
-    def _find_collections_to_match(self, tool, progress, step):
-        collections_to_match = matching.CollectionsToMatch()
-
-        def callback(input, prefixed_name, **kwargs):
-            is_data_param = isinstance(input, DataToolParameter)
-            if is_data_param and not input.multiple:
-                data = progress.replacement_for_tool_input(step, input, prefixed_name)
-                if isinstance(data, model.HistoryDatasetCollectionAssociation):
-                    collections_to_match.add(prefixed_name, data)
-
-            is_data_collection_param = isinstance(input, DataCollectionToolParameter)
-            if is_data_collection_param and not input.multiple:
-                data = progress.replacement_for_tool_input(step, input, prefixed_name)
-                history_query = input._history_query(self.trans)
-                subcollection_type_description = history_query.can_map_over(data)
-                if subcollection_type_description:
-                    collections_to_match.add(prefixed_name, data, subcollection_type=subcollection_type_description.collection_type)
-
-        visit_input_values(tool.inputs, step.state.inputs, callback)
-        return collections_to_match
 
     def _effective_post_job_actions(self, step):
         effective_post_job_actions = step.post_job_actions[:]

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -318,24 +318,24 @@ class WorkflowProgress(object):
                 remaining_steps.append((step, invocation_step))
         return remaining_steps
 
-    def replacement_for_tool_input(self, step, input, prefixed_name):
-        """ For given workflow 'step' that has had input_connections_by_name
-        populated fetch the actual runtime input for the given tool 'input'.
-        """
+    def replacement_for_input(self, step, input_dict):
         replacement = modules.NO_REPLACEMENT
+        prefixed_name = input_dict["name"]
+        multiple = input_dict["multiple"]
         if prefixed_name in step.input_connections_by_name:
             connection = step.input_connections_by_name[prefixed_name]
-            if input.type == "data" and input.multiple:
+            if input_dict["input_type"] == "dataset" and multiple:
                 replacement = [self.replacement_for_connection(c) for c in connection]
                 # If replacement is just one dataset collection, replace tool
-                # input with dataset collection - tool framework will extract
+                # input_dict with dataset collection - tool framework will extract
                 # datasets properly.
                 if len(replacement) == 1:
                     if isinstance(replacement[0], model.HistoryDatasetCollectionAssociation):
                         replacement = replacement[0]
             else:
-                is_data = input.type in ["data", "data_collection"]
+                is_data = input_dict["input_type"] in ["dataset", "dataset_collection"]
                 replacement = self.replacement_for_connection(connection[0], is_data=is_data)
+
         return replacement
 
     def replacement_for_connection(self, connection, is_data=True):

--- a/test/unit/workflows/test_workflow_progress.py
+++ b/test/unit/workflows/test_workflow_progress.py
@@ -121,8 +121,12 @@ class WorkflowProgressTestCase(unittest.TestCase):
         self.inputs_by_step_id = {100: hda}
         progress = self._new_workflow_progress()
         progress.set_outputs_for_input(self._invocation_step(0))
-
-        replacement = progress.replacement_for_tool_input(self._step(2), MockInput(), "input1")
+        step_dict = {
+            "name": "input1",
+            "input_type": "dataset",
+            "multiple": False,
+        }
+        replacement = progress.replacement_for_input(self._step(2), step_dict)
         assert replacement is hda
 
     def test_connect_tool_output(self):
@@ -152,8 +156,12 @@ class WorkflowProgressTestCase(unittest.TestCase):
         assert len(steps) == 1, steps
         step, invocation_step = steps[0]
         assert step is self.invocation.workflow.steps[4]
-
-        replacement = progress.replacement_for_tool_input(self._step(4), MockInput(), "input1")
+        step_dict = {
+            "name": "input1",
+            "input_type": "dataset",
+            "multiple": False,
+        }
+        replacement = progress.replacement_for_input(self._step(4), step_dict)
         assert replacement is hda3
 
     # TODO: Replace multiple true HDA with HDCA
@@ -188,19 +196,15 @@ class WorkflowProgressTestCase(unittest.TestCase):
         subworkflow_progress.set_outputs_for_input(subworkflow_invocation_step)
 
         subworkflow_cat_step = subworkflow.step_by_index(1)
-
-        assert hda is subworkflow_progress.replacement_for_tool_input(
+        step_dict = {
+            "name": "input1",
+            "input_type": "dataset",
+            "multiple": False,
+        }
+        assert hda is subworkflow_progress.replacement_for_input(
             subworkflow_cat_step,
-            MockInput(),
-            "input1",
+            step_dict,
         )
-
-
-class MockInput(object):
-
-    def __init__(self, type="data", multiple=False):
-        self.multiple = multiple
-        self.type = type
 
 
 class MockModuleInjector(object):


### PR DESCRIPTION
Refactor workflow module method ``get_data_inputs`` into ``get_all_inputs`` and use the resulting dictionaries to reason about if collection mapping should occur during invocation of tools. Using these dictionaries instead of explicit tool input objects should allow reuse within other module types since they may produce the same interface.