### PR TITLE
Allow ``remove_value`` filter on data tables

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -388,7 +388,7 @@ class RemoveValueFilter(Filter):
         self.ref_name = elem.get("ref", None)
         self.meta_ref = elem.get("meta_ref", None)
         self.metadata_key = elem.get("key", None)
-        assert self.value is not None or ((self.ref_name is not None or self.meta_ref is not None) and self.metadata_key is not None), ValueError("Required 'value' or 'ref' and 'key' attributes missing from filter")
+        assert self.value is not None or self.ref_name is not None or (self.meta_ref is not None and self.metadata_key is not None), ValueError("Required 'value', or 'ref', or 'meta_ref' and 'key' attributes missing from filter")
         self.multiple = string_as_bool(elem.get("multiple", "False"))
         self.separator = elem.get("separator", ",")
 

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -388,7 +388,7 @@ class RemoveValueFilter(Filter):
         self.ref_name = elem.get("ref", None)
         self.meta_ref = elem.get("meta_ref", None)
         self.metadata_key = elem.get("key", None)
-        assert self.value is not None or ((self.ref_name is not None or self.meta_ref is not None)and self.metadata_key is not None), ValueError("Required 'value' or 'ref' and 'key' attributes missing from filter")
+        assert self.value is not None or ((self.ref_name is not None or self.meta_ref is not None) and self.metadata_key is not None), ValueError("Required 'value' or 'ref' and 'key' attributes missing from filter")
         self.multiple = string_as_bool(elem.get("multiple", "False"))
         self.separator = elem.get("separator", ",")
 
@@ -401,13 +401,14 @@ class RemoveValueFilter(Filter):
                 if self.multiple:
                     option_value = option_value.split(self.separator)
                     for value in filter_value:
-                        if value not in filter_value:
+                        if value not in option_value:
                             return False
                     return True
                 return option_value in filter_value
             if self.multiple:
                 return filter_value in option_value.split(self.separator)
             return option_value == filter_value
+
         value = self.value
         if value is None:
             if self.ref_name is not None:
@@ -419,7 +420,9 @@ class RemoveValueFilter(Filter):
                 if not isinstance(data_ref, HistoryDatasetAssociation) and not isinstance(data_ref, galaxy.tools.wrappers.DatasetFilenameWrapper):
                     return options  # cannot modify options
                 value = data_ref.metadata.get(self.metadata_key, None)
-        return [(disp_name, optval, selected) for disp_name, optval, selected in options if not compare_value(optval, value)]
+        # Default to the second column (i.e. 1) since this used to work only on options produced by the data_meta filter
+        value_col = self.dynamic_option.columns.get('value', 1)
+        return [option for option in options if not compare_value(option[value_col], value)]
 
 
 class SortByColumnFilter(Filter):
@@ -615,11 +618,13 @@ class DynamicOptions(object):
             # Ensure parsing dynamic options does not consume more than a megabyte worth memory.
             path = dataset.file_name
             if os.path.getsize(path) < 1048576:
-                options = self.parse_file_fields(open(path))
+                with open(path) as fh:
+                    options = self.parse_file_fields(fh)
             else:
                 # Pass just the first megabyte to parse_file_fields.
                 log.warning("Attempting to load options from large file, reading just first megabyte")
-                contents = open(path, 'r').read(1048576)
+                with open(path, 'r') as fh:
+                    contents = fh.read(1048576)
                 options = self.parse_file_fields(StringIO(contents))
         elif self.tool_data_table:
             options = self.tool_data_table.get_fields()

--- a/test/functional/tools/remove_value.xml
+++ b/test/functional/tools/remove_value.xml
@@ -1,12 +1,13 @@
-<tool id="add_remove_value" name="Add and remove values" version="0.1.0">
+<tool id="remove_value" name="Remove values from dynamic options" version="0.1.0">
     <command detect_errors="exit_code"><![CDATA[
-echo $select_value > '$out_file'
+echo $choose_value > '$out_file'
     ]]></command>
     <inputs>
-        <param name="select_value" type="select">
+        <param name="choose_value" type="select">
             <options from_data_table="test_fasta_indexes">
                 <!-- contains hg18 and hg19 -->
                 <filter type="remove_value" value="hg18"/>
+                <filter type="remove_value" value="hg20"/>
                 <!-- This doesn't work as we don't have the remaining values like name and path
                 <filter type="add_value" value="hg20"/>
                 -->
@@ -25,7 +26,7 @@ echo $select_value > '$out_file'
             </output>
         </test>
         <test expect_failure="true">
-            <param select_value="hg18"/>
+            <param name="choose_value" value="hg18"/>
         </test>
     </tests>
 </tool>

--- a/test/functional/tools/remove_value.xml
+++ b/test/functional/tools/remove_value.xml
@@ -1,0 +1,31 @@
+<tool id="add_remove_value" name="Add and remove values" version="0.1.0">
+    <command detect_errors="exit_code"><![CDATA[
+echo $select_value > '$out_file'
+    ]]></command>
+    <inputs>
+        <param name="select_value" type="select">
+            <options from_data_table="test_fasta_indexes">
+                <!-- contains hg18 and hg19 -->
+                <filter type="remove_value" value="hg18"/>
+                <!-- This doesn't work as we don't have the remaining values like name and path
+                <filter type="add_value" value="hg20"/>
+                -->
+            </options>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="out_file"/>
+    </outputs>
+    <tests>
+        <test>
+            <output name="out_file">
+                <assert_contents>
+                    <has_line line="hg19" />
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_failure="true">
+            <param select_value="hg18"/>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -12,6 +12,7 @@
   <tool file="disambiguate_cond.xml" />
   <tool file="multi_repeats.xml"/>
   <tool file="library_data.xml"/>
+  <tool file="remove_value.xml"/>
   <tool file="bibtex.xml"/>
   <tool file="multi_select.xml" />
   <tool file="multi_output.xml" />


### PR DESCRIPTION
The `RemoveValueFilter.filter_options()` method was expecting `options` to be a list of lists, where each inner list contains exactly 3-elements (name, value, selected), which is the format returned by the `data_meta` filter. In fact, the only known use of the `remove_falue` filter is in the tool `tools/maf/maf_to_interval.xml`, to filter dataset metadata.

This commit generalises the filter to look for a column of the dynamic options named `value`, and use it during the filtering.

Fix https://github.com/galaxyproject/tools-iuc/issues/2151