### PR TITLE
Add workflow step parameters to workflow editor - alternative.

### DIFF
--- a/client/galaxy/scripts/mvc/form/form-data.js
+++ b/client/galaxy/scripts/mvc/form/form-data.js
@@ -84,7 +84,9 @@ export var Manager = Backbone.Model.extend({
                             if (field && field.value) {
                                 value = field.value();
                                 if (input.ignore === undefined || input.ignore != value) {
-                                    if (field.collapsed && input.collapsible_value) {
+                                    if (field.collapsed && field.connected) {
+                                        value = { __class__: "ConnectedValue" };
+                                    } else if (field.collapsed && input.collapsible_value) {
                                         value = input.collapsible_value;
                                     }
                                     add(flat_id, input.id, value);

--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -25,6 +25,7 @@ export default Backbone.View.extend({
         this.$collapsible = this.$(".ui-form-collapsible");
         this.$collapsible_text = this.$(".ui-form-collapsible-text");
         this.$collapsible_icon = this.$(".ui-form-collapsible-icon");
+        this.$connected_icon = this.$(".ui-form-connected-icon");
         this.$title = this.$(".ui-form-title");
         this.$title_text = this.$(".ui-form-title-text");
         this.$error_text = this.$(".ui-form-error-text");
@@ -36,16 +37,35 @@ export default Backbone.View.extend({
 
         // decide wether to expand or collapse fields
         var collapsible_value = this.model.get("collapsible_value");
+        var value = JSON.stringify(this.model.get("value"));
+        var connected = value == JSON.stringify({ __class__: "ConnectedValue" });
+        this.field.connected = connected;
         this.field.collapsed =
-            collapsible_value !== undefined &&
-            JSON.stringify(this.model.get("value")) == JSON.stringify(collapsible_value);
+            this.field.connected ||
+            (collapsible_value !== undefined &&
+                JSON.stringify(this.model.get("value")) == JSON.stringify(collapsible_value));
         this.listenTo(this.model, "change", this.render, this);
         this.render();
 
         // add click handler
         var self = this;
-        this.$collapsible.on("click", () => {
+        this.$collapsible_icon.on("click", () => {
+            if (self.field.connected) {
+                return;
+            }
             self.field.collapsed = !self.field.collapsed;
+            if (self.field.collapsed) {
+                self.field.connected = false;
+            }
+            app.trigger && app.trigger("change");
+            self.render();
+        });
+        this.$connected_icon.on("click", () => {
+            self.field.connected = !self.field.connected;
+            self.field.collapsed = self.field.connected;
+            if (!self.field.connected) {
+                this.model.set("value", null);
+            }
             app.trigger && app.trigger("change");
             self.render();
         });
@@ -108,21 +128,41 @@ export default Backbone.View.extend({
                 style: this.model.get("style")
             });
         // render collapsible options
-        if (
+        const connected = this.field.connected;
+        const collapsible =
+            !connected &&
             !this.field.collapsible_disabled &&
             !this.model.get("disabled") &&
-            this.model.get("collapsible_value") !== undefined
-        ) {
+            this.model.get("collapsible_value") !== undefined;
+        const connectable = this.model.get("connectable");
+        if (collapsible || connectable) {
             var collapsible_state = this.field.collapsed ? "enable" : "disable";
             this.$title_text.hide();
             this.$collapsible.show();
             this.$collapsible_text.text(this.model.get("label"));
-            this.$collapsible_icon
-                .removeClass()
-                .addClass("icon")
-                .addClass(this.model.get(`cls_${collapsible_state}`))
-                .attr("data-original-title", this.model.get(`text_${collapsible_state}`))
-                .tooltip({ placement: "bottom" });
+            if (collapsible && !connected) {
+                this.$collapsible_icon
+                    .removeClass()
+                    .addClass("icon")
+                    .addClass(this.model.get(`cls_${collapsible_state}`))
+                    .attr("data-original-title", this.model.get(`text_${collapsible_state}`))
+                    .tooltip({ placement: "bottom" })
+                    .show();
+            } else {
+                this.$collapsible_icon.hide();
+            }
+            if (connectable) {
+                const connectedIconStyle = this.field.connected ? "fa fa-times" : "fa fa-arrows-h";
+                this.$connected_icon
+                    .removeClass()
+                    .addClass("icon")
+                    .addClass(connectedIconStyle)
+                    .attr("data-original-title", this.model.get(`text_${collapsible_state}`))
+                    .tooltip({ placement: "bottom" })
+                    .show();
+            } else {
+                this.$connected_icon.hide();
+            }
         } else {
             this.$title_text.show().text(this.model.get("label"));
             this.$collapsible.hide();
@@ -145,6 +185,7 @@ export default Backbone.View.extend({
                         $("<div/>")
                             .addClass("ui-form-collapsible")
                             .append($("<i/>").addClass("ui-form-collapsible-icon"))
+                            .append($("<i/>").addClass("ui-form-connected-icon"))
                             .append($("<span/>").addClass("ui-form-collapsible-text"))
                     )
                     .append($("<span/>").addClass("ui-form-title-text"))

--- a/client/galaxy/scripts/mvc/form/form-section.js
+++ b/client/galaxy/scripts/mvc/form/form-section.js
@@ -175,6 +175,7 @@ var View = Backbone.View.extend({
             text_value: input_def.text_value,
             collapsible_value: input_def.collapsible_value,
             collapsible_preview: input_def.collapsible_preview,
+            connectable: input_def.connectable,
             help: input_def.help,
             argument: input_def.argument,
             disabled: input_def.disabled,

--- a/client/galaxy/scripts/mvc/workflow/workflow-forms.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-forms.js
@@ -90,6 +90,7 @@ var Tool = Backbone.View.extend({
         var options = form.model.attributes;
         Utils.deepeach(options.inputs, input => {
             if (input.type) {
+                input.connectable = true;
                 if (["data", "data_collection"].indexOf(input.type) != -1) {
                     input.type = "hidden";
                     input.info = `Data input '${input.name}' (${Utils.textify(input.extensions)})`;
@@ -105,6 +106,7 @@ var Tool = Backbone.View.extend({
         });
         Utils.deepeach(options.inputs, input => {
             if (input.type === "conditional") {
+                input.connectable = false;
                 input.test_param.collapsible_value = undefined;
             }
         });

--- a/client/galaxy/scripts/mvc/workflow/workflow-icons.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-icons.js
@@ -3,5 +3,6 @@ export default {
     data_input: "fa-file-o",
     data_collection_input: "fa-folder-o",
     subworkflow: "fa-sitemap fa-rotate-270",
+    parameter_input: "fa-pencil",
     pause: "fa-pause"
 };

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -208,7 +208,7 @@ var Node = Backbone.Model.extend({
     },
     add_input_parameters: function() {
         $.each(this.config_form.inputs, (i, input) => {
-            if (input.value && input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
+            if (input.value && input.value.__class__ == 'ConnectedValue' && StepParameterTypes.includes(input.type)){
                 this.nodeView.addParameterInput(input);
             }
         });

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -208,7 +208,7 @@ var Node = Backbone.Model.extend({
     },
     add_input_parameters: function() {
         $.each(this.config_form.inputs, (i, input) => {
-            if (input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
+            if (input.value && input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
                 this.nodeView.addParameterInput(input);
             }
         });

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -237,7 +237,9 @@ var Node = Backbone.Model.extend({
         });
         node.nodeView = nodeView;
         $.each(data.data_inputs, (i, input) => {
-            nodeView.addDataInput(input);
+            if (nodeView.node.type != 'parameter_input') {
+                nodeView.addDataInput(input);
+            }
         });
 
         if (data.data_inputs.length > 0 && data.data_outputs.length > 0) {
@@ -317,8 +319,10 @@ var Node = Backbone.Model.extend({
         var new_body = nodeView.newInputsDiv();
         var newTerminalViews = {};
         _.each(data.data_inputs, input => {
-            var terminalView = node.nodeView.addDataInput(input, new_body);
-            newTerminalViews[input.name] = terminalView;
+            if (nodeView.node.type != 'parameter_input') {
+                var terminalView = node.nodeView.addDataInput(input, new_body);
+                newTerminalViews[input.name] = terminalView;
+            }
         });
         // Cleanup any leftover terminals
         _.each(_.difference(_.values(nodeView.terminalViews), _.values(newTerminalViews)), unusedView => {

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -6,6 +6,14 @@ import NodeView from "mvc/workflow/workflow-view-node";
 /* global $ */
 /* global Galaxy */
 
+var StepParameterTypes = [
+    'text',
+    'integer',
+    'float',
+    'boolean',
+    'color',
+]
+
 var Node = Backbone.Model.extend({
     initialize: function(app, attr) {
         this.app = app;
@@ -217,11 +225,20 @@ var Node = Backbone.Model.extend({
         $.each(data.data_inputs, (i, input) => {
             nodeView.addDataInput(input);
         });
+        $.each(node.config_form.inputs, (i, input) => {
+            if (input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
+                console.log('Adding Parameter Input');
+                nodeView.addParameterInput(input);
+            }
+        });
         if (data.data_inputs.length > 0 && data.data_outputs.length > 0) {
             nodeView.addRule();
         }
         $.each(data.data_outputs, (i, output) => {
             nodeView.addDataOutput(output);
+        });
+        $.each(data.input_parameters, (i, input_parameter) => {
+            nodeView.addParameterOutput(input_parameter);
         });
         nodeView.render();
         this.app.workflow.node_changed(this, true);

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -201,8 +201,9 @@ var Node = Backbone.Model.extend({
         }
     },
     add_output_parameters: function(input_parameters) {
+        var self = this;
         $.each(input_parameters, (i, input_parameter) => {
-            this.nodeView.addParameterOutput(input_parameter);
+            self.nodeView.addParameterOutput(input_parameter);
         });
     },
     add_input_parameters: function() {

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -200,19 +200,6 @@ var Node = Backbone.Model.extend({
             this.content_id = this.config_form.id;
         }
     },
-    add_output_parameters: function(input_parameters) {
-        var self = this;
-        $.each(input_parameters, (i, input_parameter) => {
-            self.nodeView.addParameterOutput(input_parameter);
-        });
-    },
-    add_input_parameters: function() {
-        $.each(this.config_form.inputs, (i, input) => {
-            if (input.value && input.value.__class__ == 'ConnectedValue' && StepParameterTypes.includes(input.type)){
-                this.nodeView.addParameterInput(input);
-            }
-        });
-    },
 
     init_field_data: function(data) {
         console.debug("init_field_data: ", data);
@@ -236,27 +223,23 @@ var Node = Backbone.Model.extend({
             node: node
         });
         node.nodeView = nodeView;
-        $.each(data.data_inputs, (i, input) => {
-            if (nodeView.node.type != 'parameter_input') {
-                nodeView.addDataInput(input);
-            }
+        $.each(data.inputs, (i, input) => {
+            nodeView.addDataInput(input);
         });
 
-        if (data.data_inputs.length > 0 && data.data_outputs.length > 0) {
+        if (data.inputs.length > 0 && data.outputs.length > 0) {
             nodeView.addRule();
         }
-        $.each(data.data_outputs, (i, output) => {
+        $.each(data.outputs, (i, output) => {
             nodeView.addDataOutput(output);
         });
-        this.add_input_parameters();
-        this.add_output_parameters(data.input_parameters);
         nodeView.render();
         this.app.workflow.node_changed(this, true);
     },
     update_field_data: function(data) {
         var node = this;
         var nodeView = node.nodeView;
-        // remove unused output views and remove pre-existing output views from data.data_outputs,
+        // remove unused output views and remove pre-existing output views from data.outputs,
         // so that these are not added twice.
         var unused_outputs = [];
         // nodeView.outputViews contains pre-existing outputs,
@@ -264,7 +247,7 @@ var Node = Backbone.Model.extend({
         // Now we gather the unused outputs
         $.each(nodeView.outputViews, (i, output_view) => {
             var cur_name = output_view.output.name;
-            var data_names = data.data_outputs;
+            var data_names = data.outputs;
             var cur_name_in_data_outputs = false;
             _.each(data_names, data_name => {
                 if (data_name.name == cur_name) {
@@ -292,7 +275,7 @@ var Node = Backbone.Model.extend({
                 node.workflow_outputs.splice(i, 1); // removes output from list of workflow outputs
             }
         });
-        $.each(data.data_outputs, (i, output) => {
+        $.each(data.outputs, (i, output) => {
             if (!nodeView.outputViews[output.name]) {
                 nodeView.addDataOutput(output); // add data output if it does not yet exist
             } else {
@@ -318,11 +301,9 @@ var Node = Backbone.Model.extend({
         var old_body = nodeView.$("div.inputs");
         var new_body = nodeView.newInputsDiv();
         var newTerminalViews = {};
-        _.each(data.data_inputs, input => {
-            if (nodeView.node.type != 'parameter_input') {
-                var terminalView = node.nodeView.addDataInput(input, new_body);
-                newTerminalViews[input.name] = terminalView;
-            }
+        _.each(data.inputs, input => {
+            var terminalView = node.nodeView.addDataInput(input, new_body);
+            newTerminalViews[input.name] = terminalView;
         });
         // Cleanup any leftover terminals
         _.each(_.difference(_.values(nodeView.terminalViews), _.values(newTerminalViews)), unusedView => {
@@ -334,16 +315,15 @@ var Node = Backbone.Model.extend({
         // type (not really valid right?) but adding special logic here for
         // data collection input parameters that can have their collection
         // change.
-        if (data.data_outputs.length == 1 && "collection_type" in data.data_outputs[0]) {
-            nodeView.updateDataOutput(data.data_outputs[0]);
+        var data_outputs = data.outputs;
+        if (data_outputs.length == 1 && "collection_type" in data_outputs[0]) {
+            nodeView.updateDataOutput(data_outputs[0]);
         }
         old_body.replaceWith(new_body);
         if ("workflow_outputs" in data) {
             // Won't be present in response for data inputs
             this.workflow_outputs = data.workflow_outputs ? data.workflow_outputs : [];
         }
-        this.add_input_parameters();
-        this.add_output_parameters(data.input_parameters);
         // If active, reactivate with new config_form
         this.markChanged();
         this.redraw();

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -200,6 +200,19 @@ var Node = Backbone.Model.extend({
             this.content_id = this.config_form.id;
         }
     },
+    add_output_parameters: function(input_parameters) {
+        $.each(input_parameters, (i, input_parameter) => {
+            this.nodeView.addParameterOutput(input_parameter);
+        });
+    },
+    add_input_parameters: function() {
+        $.each(this.config_form.inputs, (i, input) => {
+            if (input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
+                this.nodeView.addParameterInput(input);
+            }
+        });
+    },
+
     init_field_data: function(data) {
         console.debug("init_field_data: ", data);
         if (data.type) {
@@ -225,21 +238,15 @@ var Node = Backbone.Model.extend({
         $.each(data.data_inputs, (i, input) => {
             nodeView.addDataInput(input);
         });
-        $.each(node.config_form.inputs, (i, input) => {
-            if (input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
-                console.log('Adding Parameter Input');
-                nodeView.addParameterInput(input);
-            }
-        });
+
         if (data.data_inputs.length > 0 && data.data_outputs.length > 0) {
             nodeView.addRule();
         }
         $.each(data.data_outputs, (i, output) => {
             nodeView.addDataOutput(output);
         });
-        $.each(data.input_parameters, (i, input_parameter) => {
-            nodeView.addParameterOutput(input_parameter);
-        });
+        this.add_input_parameters();
+        this.add_output_parameters(data.input_parameters);
         nodeView.render();
         this.app.workflow.node_changed(this, true);
     },
@@ -330,6 +337,8 @@ var Node = Backbone.Model.extend({
             // Won't be present in response for data inputs
             this.workflow_outputs = data.workflow_outputs ? data.workflow_outputs : [];
         }
+        this.add_input_parameters();
+        this.add_output_parameters(data.input_parameters);
         // If active, reactivate with new config_form
         this.markChanged();
         this.redraw();

--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -431,6 +431,18 @@ var InputTerminal = BaseInputTerminal.extend({
     }
 });
 
+var InputParameterTerminal = BaseInputTerminal.extend({
+    update: function(input) {
+        this.type = input.type;
+    },
+    connect: function(connector) {
+        BaseInputTerminal.prototype.connect.call(this, connector);
+    },
+    attachable: function(other) {
+        return this.type == other.attributes.type;
+    },
+});
+
 var InputCollectionTerminal = BaseInputTerminal.extend({
     update: function(input) {
         this.multiple = false;
@@ -566,9 +578,14 @@ var OutputCollectionTerminal = Terminal.extend({
     }
 });
 
+var OutputParameterTerminal = Terminal.extend({
+});
+
 export default {
     InputTerminal: InputTerminal,
+    InputParameterTerminal: InputParameterTerminal,
     OutputTerminal: OutputTerminal,
+    OutputParameterTerminal: OutputParameterTerminal,
     InputCollectionTerminal: InputCollectionTerminal,
     OutputCollectionTerminal: OutputCollectionTerminal,
     TerminalMapping: TerminalMapping,

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -9,7 +9,7 @@ var DataInputView = Backbone.View.extend({
         this.nodeView = options.nodeView;
         this.terminalElement = options.terminalElement;
 
-        this.$el.attr("name", this.input.name).html(this.input.label);
+        this.$el.attr("name", this.input.name).html(this.input.label || this.input.name);
 
         if (!options.skipResize) {
             this.$el.css({

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -90,6 +90,61 @@ var DataOutputView = Backbone.View.extend({
     }
 });
 
+var ParameterOutputView = Backbone.View.extend({
+    className: "form-row dataRow",
+
+    initialize: function(options) {
+        this.output = options.output;
+        this.terminalElement = options.terminalElement;
+        this.nodeView = options.nodeView;
+
+        var output = this.output;
+        var label = output.label || output.name;
+        var node = this.nodeView.node;
+
+        this.$el.html(label);
+        this.calloutView = null;
+        if (["tool", "subworkflow"].indexOf(node.type) >= 0) {
+            var calloutView = new OutputCalloutView({
+                label: label,
+                output: output,
+                node: node
+            });
+            this.calloutView = calloutView;
+            this.$el.append(calloutView.el);
+            this.$el.hover(
+                () => {
+                    calloutView.hoverImage();
+                },
+                () => {
+                    calloutView.resetImage();
+                }
+            );
+        }
+        this.$el.css({
+            position: "absolute",
+            left: -1000,
+            top: -1000,
+            display: "none"
+        });
+        $("body").append(this.el);
+        this.nodeView.updateMaxWidth(this.$el.outerWidth() + 17);
+        this.$el
+            .css({
+                position: "",
+                left: "",
+                top: "",
+                display: ""
+            })
+            .detach();
+    },
+    redrawWorkflowOutput: function() {
+        if (this.calloutView) {
+            this.calloutView.resetImage();
+        }
+    }
+});
+
 var OutputCalloutView = Backbone.View.extend({
     tagName: "div",
 
@@ -153,5 +208,6 @@ var OutputCalloutView = Backbone.View.extend({
 
 export default {
     DataInputView: DataInputView,
-    DataOutputView: DataOutputView
+    DataOutputView: DataOutputView,
+    ParameterOutputView: ParameterOutputView,
 };

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
@@ -48,47 +48,12 @@ export default Backbone.View.extend({
             skipResize = false;
         }
         var terminalView = this.terminalViews[input.name];
-        var terminalViewClass =
-            input.input_type == "dataset_collection"
-                ? TerminalViews.InputCollectionTerminalView
-                : TerminalViews.InputTerminalView;
-        if (terminalView && !(terminalView instanceof terminalViewClass)) {
-            terminalView.el.terminal.destroy();
-            terminalView = null;
+        var terminalViewClass = TerminalViews.InputTerminalView;
+        if (input.input_type == "dataset_collection") {
+            terminalViewClass = TerminalViews.InputCollectionTerminalView;
+        } else if (input.input_type == "parameter") {
+            terminalViewClass = TerminalViews.InputParameterTerminalView;
         }
-        if (!terminalView) {
-            terminalView = new terminalViewClass({
-                node: this.node,
-                input: input
-            });
-        } else {
-            var terminal = terminalView.el.terminal;
-            terminal.update(input);
-            terminal.destroyInvalidConnections();
-        }
-        this.terminalViews[input.name] = terminalView;
-        var terminalElement = terminalView.el;
-        var inputView = new DataViews.DataInputView({
-            terminalElement: terminalElement,
-            input: input,
-            nodeView: this,
-            skipResize: skipResize
-        });
-        var ib = inputView.$el;
-        body.append(ib.prepend(terminalView.terminalElements()));
-        return terminalView;
-    },
-
-    addParameterInput: function(input, body) {
-        var skipResize = true;
-        if (!body) {
-            body = this.$(".inputs");
-            // initial addition to node - resize input to help calculate node
-            // width.
-            skipResize = false;
-        }
-        var terminalView = this.terminalViews[input.name];
-        var terminalViewClass = TerminalViews.InputParameterTerminalView;
         if (terminalView && !(terminalView instanceof terminalViewClass)) {
             terminalView.el.terminal.destroy();
             terminalView = null;
@@ -117,35 +82,25 @@ export default Backbone.View.extend({
     },
 
     addDataOutput: function(output) {
-        var terminalViewClass = output.collection
-            ? TerminalViews.OutputCollectionTerminalView
-            : TerminalViews.OutputTerminalView;
+        var terminalViewClass = TerminalViews.OutputTerminalView;
+        var outputViewClass = DataViews.DataOutputView;
+        if (output.collection) {
+            terminalViewClass = TerminalViews.OutputCollectionTerminalView;
+        } else if (output.parameter) {
+            terminalViewClass = TerminalViews.OutputParameterTerminalView;
+            outputViewClass = DataViews.ParameterOutputView;
+        }
         var terminalView = new terminalViewClass({
             node: this.node,
             output: output
         });
-        var outputView = new DataViews.DataOutputView({
+        var outputView = new outputViewClass({
             output: output,
             terminalElement: terminalView.el,
             nodeView: this
         });
         this.outputViews[output.name] = outputView;
         this.tool_body.append(outputView.$el.append(terminalView.terminalElements()));
-    },
-
-    addParameterOutput: function(input_parameter) {
-        var terminalViewClass = TerminalViews.OutputParameterTerminalView;
-        var terminalView = new terminalViewClass({
-            node: this.node,
-            output: input_parameter,
-        });
-        var parameterView = new DataViews.ParameterOutputView({
-            output: input_parameter,
-            terminalElement: terminalView.el,
-            nodeView: this
-        });
-        this.outputViews[input_parameter.name] = parameterView;
-        this.tool_body.append(parameterView.$el.append(terminalView.terminalElements()));
     },
 
     redrawWorkflowOutputs: function() {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
@@ -79,6 +79,43 @@ export default Backbone.View.extend({
         return terminalView;
     },
 
+    addParameterInput: function(input, body) {
+        var skipResize = true;
+        if (!body) {
+            body = this.$(".inputs");
+            // initial addition to node - resize input to help calculate node
+            // width.
+            skipResize = false;
+        }
+        var terminalView = this.terminalViews[input.name];
+        var terminalViewClass = TerminalViews.InputParameterTerminalView;
+        if (terminalView && !(terminalView instanceof terminalViewClass)) {
+            terminalView.el.terminal.destroy();
+            terminalView = null;
+        }
+        if (!terminalView) {
+            terminalView = new terminalViewClass({
+                node: this.node,
+                input: input
+            });
+        } else {
+            var terminal = terminalView.el.terminal;
+            terminal.update(input);
+            terminal.destroyInvalidConnections();
+        }
+        this.terminalViews[input.name] = terminalView;
+        var terminalElement = terminalView.el;
+        var inputView = new DataViews.DataInputView({
+            terminalElement: terminalElement,
+            input: input,
+            nodeView: this,
+            skipResize: skipResize
+        });
+        var ib = inputView.$el;
+        body.append(ib.prepend(terminalView.terminalElements()));
+        return terminalView;
+    },
+
     addDataOutput: function(output) {
         var terminalViewClass = output.collection
             ? TerminalViews.OutputCollectionTerminalView
@@ -94,6 +131,21 @@ export default Backbone.View.extend({
         });
         this.outputViews[output.name] = outputView;
         this.tool_body.append(outputView.$el.append(terminalView.terminalElements()));
+    },
+
+    addParameterOutput: function(input_parameter) {
+        var terminalViewClass = TerminalViews.OutputParameterTerminalView;
+        var terminalView = new terminalViewClass({
+            node: this.node,
+            output: input_parameter,
+        });
+        var parameterView = new DataViews.ParameterOutputView({
+            output: input_parameter,
+            terminalElement: terminalView.el,
+            nodeView: this
+        });
+        this.outputViews[input_parameter.name] = parameterView;
+        this.tool_body.append(parameterView.$el.append(terminalView.terminalElements()));
     },
 
     redrawWorkflowOutputs: function() {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
@@ -161,6 +161,17 @@ var InputTerminalView = BaseInputTerminalView.extend({
     }
 });
 
+var InputParameterTerminalView = BaseInputTerminalView.extend({
+    terminalMappingClass: Terminals.TerminalMapping,
+    terminalMappingViewClass: InputTerminalMappingView,
+    terminalForInput: function(input) {
+        return new Terminals.InputParameterTerminal({
+            element: this.el,
+            input: input
+        });
+    }
+});
+
 var InputCollectionTerminalView = BaseInputTerminalView.extend({
     terminalMappingClass: Terminals.TerminalMapping,
     terminalMappingViewClass: InputTerminalMappingView,
@@ -278,9 +289,25 @@ var OutputCollectionTerminalView = BaseOutputTerminalView.extend({
     }
 });
 
+var OutputParameterTerminalView = BaseOutputTerminalView.extend({
+    terminalMappingClass: Terminals.TerminalMapping,
+    terminalMappingViewClass: TerminalMappingView,
+    terminalForOutput: function(output) {
+        var collection_type = output.collection_type;
+        var collection_type_source = output.collection_type_source;
+        var terminal = new Terminals.OutputCollectionTerminal({
+            element: this.el,
+            type: output.type,
+        });
+        return terminal;
+    }
+});
+
 export default {
     InputTerminalView: InputTerminalView,
+    InputParameterTerminalView: InputParameterTerminalView,
     OutputTerminalView: OutputTerminalView,
+    OutputParameterTerminalView: OutputParameterTerminalView,
     InputCollectionTerminalView: InputCollectionTerminalView,
     OutputCollectionTerminalView: OutputCollectionTerminalView
 };

--- a/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
+++ b/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
@@ -357,16 +357,16 @@ QUnit.module("Node unit test", {
     },
     init_field_data_simple: function(option_overrides) {
         var data = Utils.merge(option_overrides, {
-            data_inputs: [{ name: "input1", extensions: ["data"] }],
-            data_outputs: [{ name: "output1", extensions: ["data"] }],
+            inputs: [{ name: "input1", extensions: ["data"] }],
+            outputs: [{ name: "output1", extensions: ["data"] }],
             label: null
         });
         this.node.init_field_data(data);
     },
     update_field_data_with_new_input: function(option_overrides) {
         var new_data = Utils.merge(option_overrides, {
-            data_inputs: [{ name: "input1", extensions: ["data"] }, { name: "extra_0|input1", extensions: ["data"] }],
-            data_outputs: [{ name: "output1", extensions: ["data"] }],
+            inputs: [{ name: "input1", extensions: ["data"] }, { name: "extra_0|input1", extensions: ["data"] }],
+            outputs: [{ name: "output1", extensions: ["data"] }],
             post_job_actions: "{}",
             label: "New Label"
         });
@@ -401,8 +401,8 @@ QUnit.test("init_field_data properties", function(assert) {
     var node = this.node;
     this.expect_workflow_node_changed(assert, function() {
         var data = {
-            data_inputs: [],
-            data_outputs: [],
+            inputs: [],
+            outputs: [],
             type: "tool",
             name: "cat1",
             config_form: "{}",
@@ -507,8 +507,8 @@ QUnit.test("update_field_data destroys old terminals", function(assert) {
     var node = this.node;
     this.expect_workflow_node_changed(assert, function() {
         var data = {
-            data_inputs: [{ name: "input1", extensions: ["data"] }, { name: "willDisappear", extensions: ["data"] }],
-            data_outputs: [{ name: "output1", extensions: ["data"] }]
+            inputs: [{ name: "input1", extensions: ["data"] }, { name: "willDisappear", extensions: ["data"] }],
+            outputs: [{ name: "output1", extensions: ["data"] }]
         };
         node.init_field_data(data);
         var old_input_terminal = node.input_terminals.willDisappear;

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -553,7 +553,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 visit_input_values(module.tool.inputs, module.state.inputs, callback)
                 # Filter
                 # FIXME: this removes connection without displaying a message currently!
-                input_connections = [conn for conn in input_connections if conn.input_name in data_input_names]
+                input_connections = [conn for conn in input_connections if conn.input_name in data_input_names or conn.non_data_connection]
                 # post_job_actions
                 pja_dict = {}
                 for pja in step.post_job_actions:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -525,6 +525,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 'errors': module.get_errors(),
                 'data_inputs': module.get_data_inputs(),
                 'data_outputs': module.get_data_outputs(),
+                'input_parameters': module.get_input_parameters(),
                 'config_form': config_form,
                 'annotation': annotation_str,
                 'post_job_actions': {},

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -798,6 +798,8 @@ class WorkflowContentsManager(UsesAnnotations):
                 label = "Input Dataset"
             elif step_type == "data_collection_input":
                 label = "Input Dataset Collection"
+            elif step_type == 'parameter_input':
+                label = "Input Parameter"
             else:
                 raise ValueError("Invalid step_type %s" % step_type)
             if legacy:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -742,8 +742,6 @@ class WorkflowContentsManager(UsesAnnotations):
                     # If the tool is installed we attempt to verify input values
                     # and connections, otherwise the last known state will be dumped without modifications.
                     visit_input_values(module.tool.inputs, module.state.inputs, callback)
-                    # FIXME: this removes connection without displaying a message currently!
-                    input_connections = [conn for conn in input_connections if (conn.input_name in data_input_names or conn.non_data_connection)]
 
             # Encode input connections as dictionary
             input_conn_dict = {}

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -523,9 +523,8 @@ class WorkflowContentsManager(UsesAnnotations):
                 'name': module.get_name(),
                 'tool_state': module.get_state(),
                 'errors': module.get_errors(),
-                'data_inputs': module.get_data_inputs(),
-                'data_outputs': module.get_data_outputs(),
-                'input_parameters': module.get_input_parameters(),
+                'inputs': module.get_all_inputs(connectable_only=True),
+                'outputs': module.get_all_outputs(),
                 'config_form': config_form,
                 'annotation': annotation_str,
                 'post_job_actions': {},
@@ -606,12 +605,12 @@ class WorkflowContentsManager(UsesAnnotations):
         """
         for order_index in sorted(steps):
             step = steps[order_index]
-            for i, step_data_output in enumerate(step['data_outputs']):
+            for i, step_data_output in enumerate(step['outputs']):
                 if step_data_output.get('collection_type_source') and step_data_output['collection_type'] is None:
                     collection_type_source = step_data_output['collection_type_source']
                     for input_connection in step['input_connections'].get(collection_type_source, []):
                         input_step = steps[input_connection['id']]
-                        for input_step_data_output in input_step['data_outputs']:
+                        for input_step_data_output in input_step['outputs']:
                             if input_step_data_output['name'] == input_connection['output_name']:
                                 step_data_output['collection_type'] = input_step_data_output.get('collection_type')
         return steps

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -550,9 +550,6 @@ class WorkflowContentsManager(UsesAnnotations):
                         if isinstance(input, DataCollectionToolParameter):
                             input_connections_type[input.name] = "dataset_collection"
                 visit_input_values(module.tool.inputs, module.state.inputs, callback)
-                # Filter
-                # FIXME: this removes connection without displaying a message currently!
-                input_connections = [conn for conn in input_connections if conn.input_name in data_input_names or conn.non_data_connection]
                 # post_job_actions
                 pja_dict = {}
                 for pja in step.post_job_actions:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4179,14 +4179,10 @@ class WorkflowStepConnection(object):
         self.input_step_id = None
         self.input_name = None
 
-    def set_non_data_connection(self):
-        self.output_name = WorkflowStepConnection.NON_DATA_CONNECTION
-        self.input_name = WorkflowStepConnection.NON_DATA_CONNECTION
-
     @property
     def non_data_connection(self):
-        return (self.output_name == WorkflowStepConnection.NON_DATA_CONNECTION and
-                self.input_name == WorkflowStepConnection.NON_DATA_CONNECTION)
+        return (self.output_name == self.input_name == WorkflowStepConnection.NON_DATA_CONNECTION or
+                self.output_step and self.output_step.type == 'parameter_input')
 
     def copy(self):
         # TODO: handle subworkflow ids...

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4181,8 +4181,7 @@ class WorkflowStepConnection(object):
 
     @property
     def non_data_connection(self):
-        return (self.output_name == self.input_name == WorkflowStepConnection.NON_DATA_CONNECTION or
-                self.output_step and self.output_step.type == 'parameter_input')
+        return (self.output_name == self.input_name == WorkflowStepConnection.NON_DATA_CONNECTION)
 
     def copy(self):
         # TODO: handle subworkflow ids...

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -9,7 +9,7 @@ from boltons.iterutils import remap
 
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.json import safe_loads
-from .basic import DataCollectionToolParameter, DataToolParameter, RuntimeValue, SelectToolParameter
+from .basic import DataCollectionToolParameter, DataToolParameter, is_runtime_value, runtime_to_json, SelectToolParameter
 from .grouping import Conditional, Repeat, Section, UploadDataset
 
 REPLACE_ON_TRUTHY = object()
@@ -179,11 +179,8 @@ def check_param(trans, param, incoming_value, param_values):
     error = None
     try:
         if trans.workflow_building_mode:
-            if isinstance(value, RuntimeValue):
-                return [{'__class__' : 'RuntimeValue'}, None]
-            if isinstance(value, dict):
-                if value.get('__class__') == 'RuntimeValue':
-                    return [value, None]
+            if is_runtime_value(value):
+                return [runtime_to_json(value), None]
         value = param.from_json(value, trans, param_values)
         param.validate(value, trans)
     except ValueError as e:

--- a/lib/galaxy/tools/parameters/history_query.py
+++ b/lib/galaxy/tools/parameters/history_query.py
@@ -16,10 +16,7 @@ class HistoryQuery(object):
         return HistoryQuery(**kwargs)
 
     @staticmethod
-    def from_parameter(param, collection_type_descriptions):
-        """ Take in a tool parameter element.
-        """
-        collection_types = param.collection_types
+    def from_collection_types(collection_types, collection_type_descriptions):
         if collection_types:
             collection_type_descriptions = [collection_type_descriptions.for_collection_type(t) for t in collection_types]
             # Place higher dimension descriptions first so subcollection mapping
@@ -29,9 +26,15 @@ class HistoryQuery(object):
             collection_type_descriptions = sorted(collection_type_descriptions, key=lambda t: t.dimension, reverse=True)
         else:
             collection_type_descriptions = None
-
         kwargs = dict(collection_type_descriptions=collection_type_descriptions)
         return HistoryQuery(**kwargs)
+
+    @staticmethod
+    def from_parameter(param, collection_type_descriptions):
+        """ Take in a tool parameter element.
+        """
+        collection_types = param.collection_types
+        return HistoryQuery.from_collection_types(collection_types, collection_type_descriptions)
 
     def direct_match(self, hdca):
         collection_type_descriptions = self.collection_type_descriptions

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -557,6 +557,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             'name'              : module.get_name(),
             'tool_state'        : module.get_state(),
             'data_inputs'       : module.get_data_inputs(),
+            'input_parameters'  : module.get_input_parameters(),
             'data_outputs'      : module.get_data_outputs(),
             'config_form'       : module.get_config_form(),
             'post_job_actions'  : module.get_post_job_actions(inputs)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -556,9 +556,8 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             'annotation'        : inputs.get('__annotation', ''),
             'name'              : module.get_name(),
             'tool_state'        : module.get_state(),
-            'data_inputs'       : module.get_data_inputs(),
-            'input_parameters'  : module.get_input_parameters(),
-            'data_outputs'      : module.get_data_outputs(),
+            'inputs'            : module.get_all_inputs(connectable_only=True),
+            'outputs'           : module.get_all_outputs(),
             'config_form'       : module.get_config_form(),
             'post_job_actions'  : module.get_post_job_actions(inputs)
         }

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1244,6 +1244,11 @@ def load_module_sections(trans):
                 "title": "Input Dataset Collection",
                 "description": "Input dataset collection"
             },
+            {
+                "name": "parameter_input",
+                "title": "Parameter Input",
+                "description": "Simple inputs used for workflow logic"
+            },
         ],
     }
 
@@ -1256,12 +1261,7 @@ def load_module_sections(trans):
                     "name": "pause",
                     "title": "Pause Workflow for Dataset Review",
                     "description": "Pause for Review"
-                },
-                {
-                    "name": "parameter_input",
-                    "title": "Parameter Input",
-                    "description": "Simple inputs used for workflow logic"
-                },
+                }
             ],
         }
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -544,14 +544,20 @@ class InputParameterModule(WorkflowModule):
         optional = self.state.inputs.get("optional", self.default_optional)
         input_parameter_type = SelectToolParameter(None, XML(
             '''
-            <param name="parameter_type" label="Parameter type" type="select" value="%s">
+            <param name="parameter_type" label="Parameter type" type="select">
                 <option value="text">Text</option>
                 <option value="integer">Integer</option>
                 <option value="float">Float</option>
                 <option value="boolean">Boolean (True or False)</option>
                 <option value="color">Color</option>
             </param>
-            ''' % parameter_type))
+            '''))
+        for i, option in enumerate(input_parameter_type.static_options):
+            option = list(option)
+            if option[1] == parameter_type:
+                # item 0 is option description, item 1 is value, item 2 is "selected"
+                option[2] = True
+                input_parameter_type.static_options[i] = tuple(option)
         return odict([("parameter_type", input_parameter_type),
                       ("optional", BooleanToolParameter(None, Element("param", name="optional", label="Optional", type="boolean", value=optional)))])
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -157,6 +157,9 @@ class WorkflowModule(object):
     def get_data_outputs(self):
         return []
 
+    def get_input_parameters(self):
+        return []
+
     def get_post_job_actions(self, incoming):
         return []
 
@@ -574,6 +577,9 @@ class InputParameterModule(WorkflowModule):
 
     def get_data_inputs(self):
         return []
+
+    def get_input_parameters(self):
+        return [dict(name=self.name, label=self.label, type=self.parameter_type)]
 
     def execute(self, trans, progress, invocation_step, use_cached_job=False):
         step = invocation_step.workflow_step

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -585,7 +585,7 @@ class InputParameterModule(WorkflowModule):
         return [self.state.inputs]
 
     def get_input_parameters(self):
-        return [dict(name=self.name, label=self.label, type=self.state.inputs['parameter_type'], optional=self.state.inputs['optional'])]
+        return [dict(name=self.name, label=self.label, type=self.state.inputs.get('parameter_type', self.parameter_type), optional=self.state.inputs.get('optional', self.optional))]
 
     def execute(self, trans, progress, invocation_step, use_cached_job=False):
         step = invocation_step.workflow_step

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -585,7 +585,7 @@ class InputParameterModule(WorkflowModule):
         return [self.state.inputs]
 
     def get_input_parameters(self):
-        return [dict(name=self.name, label=self.label, type=self.parameter_type)]
+        return [dict(name=self.name, label=self.label, type=self.state.inputs['parameter_type'], optional=self.state.inputs['optional'])]
 
     def execute(self, trans, progress, invocation_step, use_cached_job=False):
         step = invocation_step.workflow_step

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -576,7 +576,7 @@ class InputParameterModule(WorkflowModule):
         return state
 
     def get_data_inputs(self):
-        return []
+        return [self.state.inputs]
 
     def get_input_parameters(self):
         return [dict(name=self.name, label=self.label, type=self.parameter_type)]

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -39,6 +39,7 @@ from galaxy.tools.parameters.basic import (
     TextToolParameter,
     workflow_building_modes
 )
+from galaxy.tools.parameters.history_query import HistoryQuery
 from galaxy.tools.parameters.wrapped import make_dict_copy
 from galaxy.util.bunch import Bunch
 from galaxy.util.json import safe_loads
@@ -270,6 +271,64 @@ class WorkflowModule(object):
 
         return []
 
+    def compute_collection_info(self, progress, step, all_inputs):
+        """Use get_all_inputs (if implemented) to determine collection mapping for execution.
+
+        Hopefully this can be reused for Tool and Subworkflow modules.
+        """
+
+        collections_to_match = self._find_collections_to_match(
+            progress, step, all_inputs
+        )
+        # Have implicit collections...
+        if collections_to_match.has_collections():
+            collection_info = self.trans.app.dataset_collections_service.match_collections(
+                collections_to_match
+            )
+        else:
+            collection_info = None
+
+        return collection_info
+
+    def _find_collections_to_match(self, progress, step, all_inputs):
+        collections_to_match = matching.CollectionsToMatch()
+
+        for input_dict in all_inputs:
+            name = input_dict["name"]
+            multiple = input_dict["multiple"]
+            if multiple:
+                continue
+
+            data = progress.replacement_for_input(step, input_dict)
+            can_map_over = hasattr(data, "collection")  # and data.collection.allow_implicit_mapping
+
+            if not can_map_over:
+                continue
+
+            is_data_param = input_dict["input_type"] == "dataset"
+            if is_data_param:
+                collections_to_match.add(name, data)
+                continue
+
+            is_data_collection_param = input_dict["input_type"] == "dataset_collection"
+            if is_data_collection_param:
+                dataset_collection_type_descriptions = self.trans.app.dataset_collections_service.collection_type_descriptions
+
+                history_query = HistoryQuery.from_collection_types(
+                    input_dict.get("collection_types", None),
+                    dataset_collection_type_descriptions,
+                )
+                subcollection_type_description = history_query.can_map_over(data)
+                if subcollection_type_description:
+                    collections_to_match.add(name, data, subcollection_type=subcollection_type_description.collection_type)
+                continue
+
+            if data is not NO_REPLACEMENT:
+                collections_to_match.add(name, data)
+                continue
+
+        return collections_to_match
+
 
 class SubWorkflowModule(WorkflowModule):
     # Two step improvements to build runtime inputs for subworkflow modules
@@ -305,12 +364,13 @@ class SubWorkflowModule(WorkflowModule):
             return self.subworkflow.name
         return self.name
 
-    def get_data_inputs(self):
+    def get_all_inputs(self, data_only=False):
         """ Get configure time data input descriptions. """
         # Filter subworkflow steps and get inputs
         step_to_input_type = {
             "data_input": "dataset",
             "data_collection_input": "dataset_collection",
+            "parameter_input": "parameter",
         }
         inputs = []
         if hasattr(self.subworkflow, 'input_steps'):
@@ -331,6 +391,9 @@ class SubWorkflowModule(WorkflowModule):
                 )
                 inputs.append(input)
         return inputs
+
+    def get_data_inputs(self):
+        return self.get_all_inputs(data_only=True)
 
     def get_data_outputs(self):
         outputs = []
@@ -752,21 +815,24 @@ class ToolModule(WorkflowModule):
     def get_inputs(self):
         return self.tool.inputs if self.tool else {}
 
-    def get_data_inputs(self):
-        data_inputs = []
+    def get_all_inputs(self, data_only=False):
+        inputs = []
         if self.tool:
 
             def callback(input, prefixed_name, prefixed_label, **kwargs):
-                if not hasattr(input, 'hidden') or not input.hidden:
+                visible = not hasattr(input, 'hidden') or not input.hidden
+                is_data = isinstance(input, DataToolParameter) or isinstance(input, DataCollectionToolParameter)
+                skip = data_only and (not visible or not is_data)
+                if not skip:
                     if isinstance(input, DataToolParameter):
-                        data_inputs.append(dict(
+                        inputs.append(dict(
                             name=prefixed_name,
                             label=prefixed_label,
                             multiple=input.multiple,
                             extensions=input.extensions,
                             input_type="dataset", ))
                     elif isinstance(input, DataCollectionToolParameter):
-                        data_inputs.append(dict(
+                        inputs.append(dict(
                             name=prefixed_name,
                             label=prefixed_label,
                             multiple=input.multiple,
@@ -774,9 +840,21 @@ class ToolModule(WorkflowModule):
                             collection_types=input.collection_types,
                             extensions=input.extensions,
                         ))
+                    else:
+                        inputs.append(
+                            dict(
+                                name=prefixed_name,
+                                label=prefixed_label,
+                                multiple=False,
+                                input_type="parameter",
+                            )
+                        )
 
             visit_input_values(self.tool.inputs, self.state.inputs, callback)
-        return data_inputs
+        return inputs
+
+    def get_data_inputs(self):
+        return self.get_all_inputs(data_only=True)
 
     def get_data_outputs(self):
         data_outputs = []
@@ -989,12 +1067,12 @@ class ToolModule(WorkflowModule):
         # metadata parameters from it.
         if RUNTIME_STEP_META_STATE_KEY in tool_state.inputs:
             del tool_state.inputs[RUNTIME_STEP_META_STATE_KEY]
-        collections_to_match = self._find_collections_to_match(tool, progress, step)
-        # Have implicit collections...
-        if collections_to_match.has_collections():
-            collection_info = self.trans.app.dataset_collections_service.match_collections(collections_to_match)
-        else:
-            collection_info = None
+
+        all_inputs = self.get_all_inputs()
+        all_inputs_by_name = {}
+        for input_dict in all_inputs:
+            all_inputs_by_name[input_dict["name"]] = input_dict
+        collection_info = self.compute_collection_info(progress, step, all_inputs)
 
         param_combinations = []
         if collection_info:
@@ -1013,21 +1091,20 @@ class ToolModule(WorkflowModule):
 
             # Connect up
             def callback(input, prefixed_name, **kwargs):
+                input_dict = all_inputs_by_name[prefixed_name]
+
                 replacement = NO_REPLACEMENT
-                if isinstance(input, DataToolParameter) or isinstance(input, DataCollectionToolParameter):
-                    if iteration_elements and prefixed_name in iteration_elements:
-                        if isinstance(input, DataToolParameter):
-                            # Pull out dataset instance from element.
-                            replacement = iteration_elements[prefixed_name].dataset_instance
-                            if hasattr(iteration_elements[prefixed_name], u'element_identifier') and iteration_elements[prefixed_name].element_identifier:
-                                replacement.element_identifier = iteration_elements[prefixed_name].element_identifier
-                        else:
-                            # If collection - just use element model object.
-                            replacement = iteration_elements[prefixed_name]
+                if iteration_elements and prefixed_name in iteration_elements:
+                    if isinstance(input, DataToolParameter):
+                        # Pull out dataset instance from element.
+                        replacement = iteration_elements[prefixed_name].dataset_instance
+                        if hasattr(iteration_elements[prefixed_name], u'element_identifier') and iteration_elements[prefixed_name].element_identifier:
+                            replacement.element_identifier = iteration_elements[prefixed_name].element_identifier
                     else:
-                        replacement = progress.replacement_for_tool_input(step, input, prefixed_name)
+                        # If collection - just use element model object.
+                        replacement = iteration_elements[prefixed_name]
                 else:
-                    replacement = progress.replacement_for_tool_input(step, input, prefixed_name)
+                    replacement = progress.replacement_for_input(step, input_dict)
 
                 if replacement is not NO_REPLACEMENT:
                     found_replacement_keys.add(prefixed_name)
@@ -1115,27 +1192,6 @@ class ToolModule(WorkflowModule):
             outputs[output_dataset_collection_assoc.output_name] = output_dataset_collection_assoc.dataset_collection
 
         progress.set_step_outputs(invocation_step, outputs)
-
-    def _find_collections_to_match(self, tool, progress, step):
-        collections_to_match = matching.CollectionsToMatch()
-
-        def callback(input, prefixed_name, **kwargs):
-            is_data_param = isinstance(input, DataToolParameter)
-            if is_data_param and not input.multiple:
-                data = progress.replacement_for_tool_input(step, input, prefixed_name)
-                if isinstance(data, model.HistoryDatasetCollectionAssociation):
-                    collections_to_match.add(prefixed_name, data)
-
-            is_data_collection_param = isinstance(input, DataCollectionToolParameter)
-            if is_data_collection_param and not input.multiple:
-                data = progress.replacement_for_tool_input(step, input, prefixed_name)
-                history_query = input._history_query(self.trans)
-                subcollection_type_description = history_query.can_map_over(data)
-                if subcollection_type_description:
-                    collections_to_match.add(prefixed_name, data, subcollection_type=subcollection_type_description.collection_type)
-
-        visit_input_values(tool.inputs, step.state.inputs, callback)
-        return collections_to_match
 
     def _effective_post_job_actions(self, step):
         effective_post_job_actions = step.post_job_actions[:]

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -34,6 +34,7 @@ from galaxy.tools.parameters.basic import (
     DataToolParameter,
     is_runtime_value,
     parameter_types,
+    runtime_to_json,
     RuntimeValue,
     SelectToolParameter,
     TextToolParameter,
@@ -151,15 +152,18 @@ class WorkflowModule(object):
         """ This returns inputs displayed in the workflow editor """
         return {}
 
+    def get_all_inputs(self, data_only=False, connectable_only=False):
+        return []
+
     def get_data_inputs(self):
         """ Get configure time data input descriptions. """
+        return self.get_all_inputs(data_only=True)
+
+    def get_all_outputs(self, data_only=False):
         return []
 
     def get_data_outputs(self):
-        return []
-
-    def get_input_parameters(self):
-        return []
+        return self.get_all_outputs(data_only=True)
 
     def get_post_job_actions(self, incoming):
         return []
@@ -364,7 +368,7 @@ class SubWorkflowModule(WorkflowModule):
             return self.subworkflow.name
         return self.name
 
-    def get_all_inputs(self, data_only=False):
+    def get_all_inputs(self, data_only=False, connectable_only=False):
         """ Get configure time data input descriptions. """
         # Filter subworkflow steps and get inputs
         step_to_input_type = {
@@ -392,10 +396,7 @@ class SubWorkflowModule(WorkflowModule):
                 inputs.append(input)
         return inputs
 
-    def get_data_inputs(self):
-        return self.get_all_inputs(data_only=True)
-
-    def get_data_outputs(self):
+    def get_all_outputs(self, data_only=False):
         outputs = []
         if hasattr(self.subworkflow, 'workflow_outputs'):
             from galaxy.managers.workflows import WorkflowContentsManager
@@ -406,7 +407,7 @@ class SubWorkflowModule(WorkflowModule):
                                                                                   tooltip=False)
             for order_index in sorted(subworkflow_dict['steps']):
                 step = subworkflow_dict['steps'][order_index]
-                data_outputs = subworkflow_dict['steps'][order_index]['data_outputs']
+                data_outputs = subworkflow_dict['steps'][order_index]['outputs']
                 for workflow_output in step['workflow_outputs']:
                     label = workflow_output['label']
                     if not label:
@@ -501,7 +502,7 @@ class InputModule(WorkflowModule):
         state.inputs = dict(input=None)
         return state
 
-    def get_data_inputs(self):
+    def get_all_inputs(self, data_only=False, connectable_only=False):
         return []
 
     def execute(self, trans, progress, invocation_step, use_cached_job=False):
@@ -541,7 +542,7 @@ class InputDataModule(InputModule):
     type = "data_input"
     name = "Input dataset"
 
-    def get_data_outputs(self):
+    def get_all_outputs(self, data_only=False):
         return [dict(name='output', extensions=['input'])]
 
     def get_filter_set(self, connections=None):
@@ -582,7 +583,7 @@ class InputDataCollectionModule(InputModule):
         input_element = Element("param", name="input", label=self.label, type="data_collection", collection_type=collection_type)
         return dict(input=DataCollectionToolParameter(None, input_element, self.trans))
 
-    def get_data_outputs(self):
+    def get_all_outputs(self, data_only=False):
         return [
             dict(
                 name='output',
@@ -644,11 +645,16 @@ class InputParameterModule(WorkflowModule):
         state.inputs = dict(input=None)
         return state
 
-    def get_data_inputs(self):
-        return [self.state.inputs]
+    def get_all_outputs(self, data_only=False):
+        if data_only:
+            return []
 
-    def get_input_parameters(self):
-        return [dict(name=self.name, label=self.label, type=self.state.inputs.get('parameter_type', self.parameter_type), optional=self.state.inputs.get('optional', self.optional))]
+        return [dict(
+            name='output',
+            label=self.label,
+            type=self.state.inputs.get('parameter_type', self.parameter_type),
+            parameter=True,
+        )]
 
     def execute(self, trans, progress, invocation_step, use_cached_job=False):
         step = invocation_step.workflow_step
@@ -663,7 +669,7 @@ class PauseModule(WorkflowModule):
     type = "pause"
     name = "Pause for dataset review"
 
-    def get_data_inputs(self):
+    def get_all_inputs(self, data_only=False, connectable_only=False):
         input = dict(
             name="input",
             label="Dataset for Review",
@@ -671,9 +677,9 @@ class PauseModule(WorkflowModule):
             extensions='input',
             input_type="dataset",
         )
-        return [input]
+        return [input] if not data_only else []
 
-    def get_data_outputs(self):
+    def get_all_outputs(self, data_only=False):
         return [dict(name="output", label="Reviewed Dataset", extensions=['input'])]
 
     def get_runtime_state(self):
@@ -815,14 +821,24 @@ class ToolModule(WorkflowModule):
     def get_inputs(self):
         return self.tool.inputs if self.tool else {}
 
-    def get_all_inputs(self, data_only=False):
+    def get_all_inputs(self, data_only=False, connectable_only=False):
+        if data_only and connectable_only:
+            raise Exception("Must specify at most one of data_only and connectable_only as True.")
+
         inputs = []
         if self.tool:
 
-            def callback(input, prefixed_name, prefixed_label, **kwargs):
+            def callback(input, prefixed_name, prefixed_label, value=None, **kwargs):
                 visible = not hasattr(input, 'hidden') or not input.hidden
+                input_type = input.type
                 is_data = isinstance(input, DataToolParameter) or isinstance(input, DataCollectionToolParameter)
-                skip = data_only and (not visible or not is_data)
+                is_connectable = is_runtime_value(value) and runtime_to_json(value)["__class__"] == "ConnectedValue"
+                if data_only:
+                    skip = not visible or not is_data
+                elif connectable_only:
+                    skip = not visible or not (is_data or is_connectable)
+                else:
+                    skip = not visible
                 if not skip:
                     if isinstance(input, DataToolParameter):
                         inputs.append(dict(
@@ -847,16 +863,14 @@ class ToolModule(WorkflowModule):
                                 label=prefixed_label,
                                 multiple=False,
                                 input_type="parameter",
+                                type=input_type,
                             )
                         )
 
             visit_input_values(self.tool.inputs, self.state.inputs, callback)
         return inputs
 
-    def get_data_inputs(self):
-        return self.get_all_inputs(data_only=True)
-
-    def get_data_outputs(self):
+    def get_all_outputs(self, data_only=False):
         data_outputs = []
         if self.tool:
             for name, tool_output in self.tool.outputs.items():

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -318,24 +318,24 @@ class WorkflowProgress(object):
                 remaining_steps.append((step, invocation_step))
         return remaining_steps
 
-    def replacement_for_tool_input(self, step, input, prefixed_name):
-        """ For given workflow 'step' that has had input_connections_by_name
-        populated fetch the actual runtime input for the given tool 'input'.
-        """
+    def replacement_for_input(self, step, input_dict):
         replacement = modules.NO_REPLACEMENT
+        prefixed_name = input_dict["name"]
+        multiple = input_dict["multiple"]
         if prefixed_name in step.input_connections_by_name:
             connection = step.input_connections_by_name[prefixed_name]
-            if input.type == "data" and input.multiple:
+            if input_dict["input_type"] == "dataset" and multiple:
                 replacement = [self.replacement_for_connection(c) for c in connection]
                 # If replacement is just one dataset collection, replace tool
-                # input with dataset collection - tool framework will extract
+                # input_dict with dataset collection - tool framework will extract
                 # datasets properly.
                 if len(replacement) == 1:
                     if isinstance(replacement[0], model.HistoryDatasetCollectionAssociation):
                         replacement = replacement[0]
             else:
-                is_data = input.type in ["data", "data_collection"]
+                is_data = input_dict["input_type"] in ["dataset", "dataset_collection"]
                 replacement = self.replacement_for_connection(connection[0], is_data=is_data)
+
         return replacement
 
     def replacement_for_connection(self, connection, is_data=True):

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -352,13 +352,10 @@ class WorkflowProgress(object):
         try:
             replacement = step_outputs[output_name]
         except KeyError:
-            if is_data:
-                # Must resolve.
-                template = "Workflow evaluation problem - failed to find output_name %s in step_outputs %s"
-                message = template % (output_name, step_outputs)
-                raise Exception(message)
-            else:
-                replacement = modules.NO_REPLACEMENT
+            # Must resolve.
+            template = "Workflow evaluation problem - failed to find output_name %s in step_outputs %s"
+            message = template % (output_name, step_outputs)
+            raise Exception(message)
         if isinstance(replacement, model.HistoryDatasetCollectionAssociation):
             if not replacement.collection.populated:
                 if not replacement.collection.waiting_for_elements:

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -265,6 +265,17 @@ def build_workflow_run_configs(trans, workflow, payload):
             # inputs with referential integrity if parameters are already normalized (coming from tool form).
             normalized_inputs = {}
 
+        if param_map:
+            # disentangle raw parameter dictionaries into formal request structures if we can
+            # to setup proper WorkflowRequestToInputDatasetAssociation, WorkflowRequestToInputDatasetCollectionAssociation
+            # and WorkflowRequestInputStepParameter objects.
+            for step in workflow.steps:
+                normalized_key = step.id
+                if step.type == "parameter_input":
+                    if normalized_key in param_map:
+                        value = param_map.pop(normalized_key)
+                        normalized_inputs[normalized_key] = value["input"]
+
         steps_by_id = workflow.steps_by_id
         # Set workflow inputs.
         for key, input_dict in normalized_inputs.items():

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -467,8 +467,8 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase):
                 'name',
                 'tool_state',
                 'tooltip',
-                'data_inputs',
-                'data_outputs',
+                'inputs',
+                'outputs',
                 'config_form',
                 'annotation',
                 'post_job_actions',
@@ -493,7 +493,7 @@ steps:
         downloaded_workflow = self._download_workflow(workflow_id, style="editor")
         steps = downloaded_workflow['steps']
         assert len(steps) == 2
-        assert steps['1']['data_outputs'][0]['collection_type'] == 'list:paired'
+        assert steps['1']['outputs'][0]['collection_type'] == 'list:paired'
 
     @skip_without_tool('collection_type_source')
     def test_export_editor_subworkflow_collection_type_source(self):
@@ -527,7 +527,7 @@ steps:
         steps = downloaded_workflow['steps']
         assert len(steps) == 2
         assert steps['1']['type'] == 'subworkflow'
-        assert steps['1']['data_outputs'][0]['collection_type'] == 'list:paired'
+        assert steps['1']['outputs'][0]['collection_type'] == 'list:paired'
 
     def test_import_missing_tool(self):
         workflow = self.workflow_populator.load_workflow_from_resource(name="test_workflow_missing_tool")

--- a/test/unit/workflows/test_workflow_progress.py
+++ b/test/unit/workflows/test_workflow_progress.py
@@ -121,8 +121,12 @@ class WorkflowProgressTestCase(unittest.TestCase):
         self.inputs_by_step_id = {100: hda}
         progress = self._new_workflow_progress()
         progress.set_outputs_for_input(self._invocation_step(0))
-
-        replacement = progress.replacement_for_tool_input(self._step(2), MockInput(), "input1")
+        step_dict = {
+            "name": "input1",
+            "input_type": "dataset",
+            "multiple": False,
+        }
+        replacement = progress.replacement_for_input(self._step(2), step_dict)
         assert replacement is hda
 
     def test_connect_tool_output(self):
@@ -152,8 +156,12 @@ class WorkflowProgressTestCase(unittest.TestCase):
         assert len(steps) == 1, steps
         step, invocation_step = steps[0]
         assert step is self.invocation.workflow.steps[4]
-
-        replacement = progress.replacement_for_tool_input(self._step(4), MockInput(), "input1")
+        step_dict = {
+            "name": "input1",
+            "input_type": "dataset",
+            "multiple": False,
+        }
+        replacement = progress.replacement_for_input(self._step(4), step_dict)
         assert replacement is hda3
 
     # TODO: Replace multiple true HDA with HDCA
@@ -188,19 +196,15 @@ class WorkflowProgressTestCase(unittest.TestCase):
         subworkflow_progress.set_outputs_for_input(subworkflow_invocation_step)
 
         subworkflow_cat_step = subworkflow.step_by_index(1)
-
-        assert hda is subworkflow_progress.replacement_for_tool_input(
+        step_dict = {
+            "name": "input1",
+            "input_type": "dataset",
+            "multiple": False,
+        }
+        assert hda is subworkflow_progress.replacement_for_input(
             subworkflow_cat_step,
-            MockInput(),
-            "input1",
+            step_dict,
         )
-
-
-class MockInput(object):
-
-    def __init__(self, type="data", multiple=False):
-        self.multiple = multiple
-        self.type = type
 
 
 class MockModuleInjector(object):


### PR DESCRIPTION
UI for workflow step parameters - built on a slightly rebased version of #6829. Differences include:

- Keep beta workflow modules config option, just move step parameters out of beta.
- Rather than making all non-data parameters that are specified as RuntimeValue parameters - have separate states for RuntimeValue parameters and ConnectedValue parameters. I think this change is pretty isolated to 82cdbf3a11ee4bbb8303a3e4cea86baf9a103a30 if we want to undo it, I think on balance it is the right thing to do but I could be convinced I'm wrong I suspect.
- Rather than defining "parameters" and "inputs" separately like in #6829, this brings in work from the CWL branch (standalone as #6911) to generalize inputs/outputs in the workflow module and API layer to non-data inputs. I like the consistency of this interface better and it starts us on the road to allow for complex field parameters in the CWL branch.
