### PR TITLE
Allow dynamic runner rules to return None to indicate that mapping should be retried on the next iteration of the job readiness check

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -481,6 +481,8 @@ class JobHandlerQueue(Monitors):
                 log.debug("Intentionally failing job with message (%s)" % failure_message)
             job_wrapper.fail(failure_message)
             return JOB_ERROR, job_destination
+        if job_destination is None:
+            return JOB_WAIT, None
         # job is ready to run, check limits
         # TODO: these checks should be refactored to minimize duplication and made more modular/pluggable
         state = self.__check_destination_jobs(job, job_wrapper)

--- a/lib/galaxy/jobs/mapper.py
+++ b/lib/galaxy/jobs/mapper.py
@@ -209,7 +209,7 @@ class JobRunnerMapper(object):
 
     def __handle_rule(self, rule_function, destination):
         job_destination = self.__invoke_expand_function(rule_function, destination.params)
-        if not isinstance(job_destination, galaxy.jobs.JobDestination):
+        if job_destination is not None and not isinstance(job_destination, galaxy.jobs.JobDestination):
             job_destination_rep = str(job_destination)  # Should be either id or url
             if '://' in job_destination_rep:
                 job_destination = self.__convert_url_to_destination(job_destination_rep)
@@ -224,14 +224,15 @@ class JobRunnerMapper(object):
             job_destination = self.__handle_dynamic_job_destination(raw_job_destination)
         else:
             job_destination = raw_job_destination
-        log.debug("(%s) Mapped job to destination id: %s", self.job_wrapper.job_id, job_destination.id)
+        if job_destination is not None:
+            log.debug("(%s) Mapped job to destination id: %s", self.job_wrapper.job_id, job_destination.id)
         self.cached_job_destination = job_destination
 
     def get_job_destination(self, params):
         """
         Cache the job_destination to avoid recalculation.
         """
-        if not hasattr(self, 'cached_job_destination'):
+        if not hasattr(self, 'cached_job_destination') or self.cached_job_destination is None:
             self.__cache_job_destination(params)
         return self.cached_job_destination
 


### PR DESCRIPTION
This makes it possible to do some very basic metascheduling since it can defer the decision on where to route jobs into the future (i.e. check multiple destinations and only assign one once it doesn't have waiting jobs).

The performance could be quite poor depending on what your rule does since it will run once for every ready job on every iteration. Some sort of caching in the rule would be recommended.

xref #6139 