### PR TITLE
Be more precise with the job runner worker thread join timeout and improve documentation

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1019,9 +1019,14 @@ galaxy:
 
   # When stopping Galaxy cleanly, how much time to give various
   # monitoring/polling threads to finish before giving up on joining
-  # them. Set to 0 to disable this and restore the pre-18.01 default
-  # behavior.
-  #monitor_thread_join_timeout: 5
+  # them. Set to 0 to disable this and terminate without waiting. Among
+  # others, these threads include the job handler workers, which are
+  # responsible for preparing/submitting and collecting/finishing jobs,
+  # and which can cause job errors if not shut down cleanly. If using
+  # supervisord, consider also increasing the value of `stopwaitsecs`.
+  # If using job handler mules, consider also setting the `mule-reload-
+  # mercy` uWSGI option.
+  #monitor_thread_join_timeout: 30
 
   # Write thread status periodically to 'heartbeat.log',  (careful, uses
   # disk space rapidly!).  Useful to determine why your processes may be

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1025,7 +1025,7 @@ galaxy:
   # and which can cause job errors if not shut down cleanly. If using
   # supervisord, consider also increasing the value of `stopwaitsecs`.
   # If using job handler mules, consider also setting the `mule-reload-
-  # mercy` uWSGI option.
+  # mercy` uWSGI option. See the Galaxy Admin Documentation for more.
   #monitor_thread_join_timeout: 30
 
   # Write thread status periodically to 'heartbeat.log',  (careful, uses

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2097,9 +2097,14 @@
 :Description:
     When stopping Galaxy cleanly, how much time to give various
     monitoring/polling threads to finish before giving up on joining
-    them. Set to 0 to disable this and restore the pre-18.01 default
-    behavior.
-:Default: ``5``
+    them. Set to 0 to disable this and terminate without waiting.
+    Among others, these threads include the job handler workers, which
+    are responsible for preparing/submitting and collecting/finishing
+    jobs, and which can cause job errors if not shut down cleanly. If
+    using supervisord, consider also increasing the value of
+    `stopwaitsecs`. If using job handler mules, consider also setting
+    the `mule-reload-mercy` uWSGI option.
+:Default: ``30``
 :Type: int
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2103,7 +2103,8 @@
     jobs, and which can cause job errors if not shut down cleanly. If
     using supervisord, consider also increasing the value of
     `stopwaitsecs`. If using job handler mules, consider also setting
-    the `mule-reload-mercy` uWSGI option.
+    the `mule-reload-mercy` uWSGI option. See the Galaxy Admin
+    Documentation for more.
 :Default: ``30``
 :Type: int
 

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -407,6 +407,18 @@ option, `enable-threads` is set implicitly. This option enables the Python GIL a
 by Galaxy itself for various non-web tasks), which Galaxy uses extensively. Setting it explicitly, however, is harmless
 and can prevent strange difficult-to-debug situations if `threads` is accidentally unset.
 
+**Worker/Mule shutdown/reload mercy**
+
+By default, uWSGI will wait up to 60 seconds for web workers and mules to terminate. This is generally safe for
+servicing web requests, but some parts of Galaxy's job preparation/submission and collection/finishing operations can
+take quite a bit of time to complete and are not entirely reentrant: job errors or state inconsistencies can occur if
+interrupted (although every effort has been made to minimize such possibilities).  By default, Galaxy will wait up to 30
+seconds for the threads allocated for these operations to terminate after instructing them to shut down.  You can change
+this behavior by increasing the value of `monitor_thread_join_timeout` in the `galaxy` section of `galaxy.yml`.  If you
+increase this near to or above 60, you should set the appropriate uWSGI `*-restart-mercy` option to a higher value. If
+using **uWSGI all-in-one**, set `worker-reload-mercy`, and if using **uWSGI + Mule job handling**, set
+`mule-reload-mercy` (both in the `uwsgi` section of `galaxy.yml`).
+
 **Signals**
 
 The signal handling options (`die-on-term` and `hook-master-start` with `unix_signal` values) are not required but, if
@@ -494,6 +506,7 @@ umask           = 022
 autostart       = true
 autorestart     = true
 startsecs       = 10
+stopwaitsecs    = 65
 user            = galaxy
 numprocs        = 1
 stopsignal      = INT
@@ -505,6 +518,9 @@ process should `autostart` on boot, and `autorestart` if it ever crashes. We spe
 must stay up for this long before we consider it OK. If the process crashes sooner than that (e.g. bad changes you've
 made to your local installation) supervisord will try again a couple of times to restart the process before giving up
 and marking it as failed. This is one of the many ways supervisord is much friendly for managing these sorts of tasks. 
+
+The value of `stopwaitsecs` should be at least as large as the smallest value of uWSGI's `reload-mercy`,
+`worker-reload-mercy`, and `mule-reload-mercy` options, all of which default to `60`.
 
 If using the **uWSGI + Webless** scenario, you'll need to addtionally define job handlers to start. There's no simple
 way to activate a virtualenv when using supervisor, but you can simulate the effects by setting `$PATH` and
@@ -520,6 +536,7 @@ umask           = 022
 autostart       = true
 autorestart     = true
 startsecs       = 15
+stopwaitsecs    = 35
 user            = galaxy
 environment     = VIRTUAL_ENV="/srv/galaxy/venv",PATH="/srv/galaxy/venv/bin:%(ENV_PATH)s"
 ```
@@ -528,6 +545,9 @@ This is similar to the "web" definition above, however, you'll notice that we us
 substitution in the `command` and `process_name` fields. We've set `numprocs = 3`, which says to launch three handler
 processes. Supervisord will loop over `0..numprocs` and launch `handler0`, `handler1`, and `handler2` processes
 automatically for us, templating out the command string so each handler receives a different log file and name.
+
+The value of `stopwaitsecs` should be at least as large as the `monitor_thread_join_timeout` Galaxy option, which
+defaults to `30`.
 
 Lastly, collect the tasks defined above into a single group. If you are not using webless handlers this is as simple as:
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -423,7 +423,7 @@ class Configuration(object):
         self.use_heartbeat = string_as_bool(kwargs.get('use_heartbeat', 'False'))
         self.heartbeat_interval = int(kwargs.get('heartbeat_interval', 20))
         self.heartbeat_log = kwargs.get('heartbeat_log', None)
-        self.monitor_thread_join_timeout = int(kwargs.get("monitor_thread_join_timeout", 5))
+        self.monitor_thread_join_timeout = int(kwargs.get("monitor_thread_join_timeout", 30))
         self.log_actions = string_as_bool(kwargs.get('log_actions', 'False'))
         self.log_events = string_as_bool(kwargs.get('log_events', 'False'))
         self.sanitize_all_html = string_as_bool(kwargs.get('sanitize_all_html', True))

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -965,5 +965,12 @@ class DefaultJobDispatcher(object):
             job_wrapper.fail(DEFAULT_JOB_PUT_FAILURE_MESSAGE)
 
     def shutdown(self):
-        for runner in self.job_runners.values():
-            runner.shutdown()
+        for name, runner in self.job_runners.items():
+            failures = []
+            try:
+                runner.shutdown()
+            except Exception:
+                failures.append(name)
+                log.exception("Failed to shutdown runner %s", name)
+            if failures:
+                raise Exception("Failed to shutdown runners: %s" % ', '.join(failures))

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -966,7 +966,4 @@ class DefaultJobDispatcher(object):
 
     def shutdown(self):
         for runner in self.job_runners.values():
-            try:
-                runner.shutdown()
-            except Exception:
-                raise Exception("Failed to shutdown runner %s" % runner)
+            runner.shutdown()

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -965,12 +965,12 @@ class DefaultJobDispatcher(object):
             job_wrapper.fail(DEFAULT_JOB_PUT_FAILURE_MESSAGE)
 
     def shutdown(self):
+        failures = []
         for name, runner in self.job_runners.items():
-            failures = []
             try:
                 runner.shutdown()
             except Exception:
                 failures.append(name)
                 log.exception("Failed to shutdown runner %s", name)
-            if failures:
-                raise Exception("Failed to shutdown runners: %s" % ', '.join(failures))
+        if failures:
+            raise Exception("Failed to shutdown runners: %s" % ', '.join(failures))

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1572,7 +1572,8 @@ mapping:
           workers, which are responsible for preparing/submitting and collecting/finishing
           jobs, and which can cause job errors if not shut down cleanly. If using
           supervisord, consider also increasing the value of `stopwaitsecs`. If using job
-          handler mules, consider also setting the `mule-reload-mercy` uWSGI option.
+          handler mules, consider also setting the `mule-reload-mercy` uWSGI option. See
+          the Galaxy Admin Documentation for more.
 
       use_heartbeat:
         type: bool

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1563,12 +1563,16 @@ mapping:
 
       monitor_thread_join_timeout:
         type: int
-        default: 5
+        default: 30
         required: false
         desc: |
           When stopping Galaxy cleanly, how much time to give various monitoring/polling
           threads to finish before giving up on joining them. Set to 0 to disable this and
-          restore the pre-18.01 default behavior.
+          terminate without waiting. Among others, these threads include the job handler
+          workers, which are responsible for preparing/submitting and collecting/finishing
+          jobs, and which can cause job errors if not shut down cleanly. If using
+          supervisord, consider also increasing the value of `stopwaitsecs`. If using job
+          handler mules, consider also setting the `mule-reload-mercy` uWSGI option.
 
       use_heartbeat:
         type: bool

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -227,6 +227,7 @@ def setup_galaxy_config(
         user_library_import_dir=user_library_import_dir,
         webhooks_dir=TEST_WEBHOOKS_DIR,
         logging=LOGGING_CONFIG_DEFAULT,
+        monitor_thread_join_timeout=5,
     )
     config.update(database_conf(tmpdir, prefer_template_database=prefer_template_database))
     config.update(install_database_conf(tmpdir, default_merged=default_install_db_merged))


### PR DESCRIPTION
**Before:** Wait at most `monitor_thread_join_timeout` seconds on each work thread. Unlucky threads would only get ~5 seconds to complete their work, lucky ones would get `5 * nworkers`.

**After:** Wait at most `monitor_thread_join_timeout` seconds for *all* work threads. All threads get 30 seconds.

This makes the timing more consistent.

@erasche @Slugger70 probably relevant to your interests (but you don't have to wait for this PR, you should be able to increase `monitor_thread_join_timeout` and set the relevant supervisor/uWSGI options and see some improvement today on handler restart safety).

EDIT: [The change to lib/galaxy/jobs/handler.py](https://github.com/galaxyproject/galaxy/pull/6924/files#diff-bab4b69cf3ddd83cc0cc83f123692e0a) is probably worth backporting to 18.09 since that's a bug.