### PR TITLE
Add workflow step parameters to workflow editor (try 3)

### DIFF
--- a/client/galaxy/scripts/mvc/form/form-data.js
+++ b/client/galaxy/scripts/mvc/form/form-data.js
@@ -84,7 +84,9 @@ export var Manager = Backbone.Model.extend({
                             if (field && field.value) {
                                 value = field.value();
                                 if (input.ignore === undefined || input.ignore != value) {
-                                    if (field.collapsed && input.collapsible_value) {
+                                    if (field.collapsed && field.connected) {
+                                        value = { __class__: "ConnectedValue" };
+                                    } else if (field.collapsed && input.collapsible_value) {
                                         value = input.collapsible_value;
                                     }
                                     add(flat_id, input.id, value);

--- a/client/galaxy/scripts/mvc/form/form-section.js
+++ b/client/galaxy/scripts/mvc/form/form-section.js
@@ -175,6 +175,7 @@ var View = Backbone.View.extend({
             text_value: input_def.text_value,
             collapsible_value: input_def.collapsible_value,
             collapsible_preview: input_def.collapsible_preview,
+            connectable: input_def.connectable,
             help: input_def.help,
             argument: input_def.argument,
             disabled: input_def.disabled,

--- a/client/galaxy/scripts/mvc/workflow/workflow-forms.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-forms.js
@@ -90,6 +90,7 @@ var Tool = Backbone.View.extend({
         var options = form.model.attributes;
         Utils.deepeach(options.inputs, input => {
             if (input.type) {
+                input.connectable = true;
                 if (["data", "data_collection"].indexOf(input.type) != -1) {
                     input.type = "hidden";
                     input.info = `Data input '${input.name}' (${Utils.textify(input.extensions)})`;
@@ -105,6 +106,7 @@ var Tool = Backbone.View.extend({
         });
         Utils.deepeach(options.inputs, input => {
             if (input.type === "conditional") {
+                input.connectable = false;
                 input.test_param.collapsible_value = undefined;
             }
         });

--- a/client/galaxy/scripts/mvc/workflow/workflow-icons.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-icons.js
@@ -3,5 +3,6 @@ export default {
     data_input: "fa-file-o",
     data_collection_input: "fa-folder-o",
     subworkflow: "fa-sitemap fa-rotate-270",
+    parameter_input: "fa-pencil",
     pause: "fa-pause"
 };

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -208,7 +208,7 @@ var Node = Backbone.Model.extend({
     },
     add_input_parameters: function() {
         $.each(this.config_form.inputs, (i, input) => {
-            if (input.value && input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
+            if (input.value && input.value.__class__ == 'ConnectedValue' && StepParameterTypes.includes(input.type)){
                 this.nodeView.addParameterInput(input);
             }
         });

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -208,7 +208,7 @@ var Node = Backbone.Model.extend({
     },
     add_input_parameters: function() {
         $.each(this.config_form.inputs, (i, input) => {
-            if (input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
+            if (input.value && input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
                 this.nodeView.addParameterInput(input);
             }
         });

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -200,6 +200,19 @@ var Node = Backbone.Model.extend({
             this.content_id = this.config_form.id;
         }
     },
+    add_output_parameters: function(input_parameters) {
+        $.each(input_parameters, (i, input_parameter) => {
+            this.nodeView.addParameterOutput(input_parameter);
+        });
+    },
+    add_input_parameters: function() {
+        $.each(this.config_form.inputs, (i, input) => {
+            if (input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
+                this.nodeView.addParameterInput(input);
+            }
+        });
+    },
+
     init_field_data: function(data) {
         //console.debug("init_field_data: ", data);
         if (data.type) {
@@ -225,21 +238,15 @@ var Node = Backbone.Model.extend({
         $.each(data.data_inputs, (i, input) => {
             nodeView.addDataInput(input);
         });
-        $.each(node.config_form.inputs, (i, input) => {
-            if (input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
-                console.log('Adding Parameter Input');
-                nodeView.addParameterInput(input);
-            }
-        });
+
         if (data.data_inputs.length > 0 && data.data_outputs.length > 0) {
             nodeView.addRule();
         }
         $.each(data.data_outputs, (i, output) => {
             nodeView.addDataOutput(output);
         });
-        $.each(data.input_parameters, (i, input_parameter) => {
-            nodeView.addParameterOutput(input_parameter);
-        });
+        this.add_input_parameters();
+        this.add_output_parameters(data.input_parameters);
         nodeView.render();
         this.app.workflow.node_changed(this, true);
     },
@@ -330,6 +337,8 @@ var Node = Backbone.Model.extend({
             // Won't be present in response for data inputs
             this.workflow_outputs = data.workflow_outputs ? data.workflow_outputs : [];
         }
+        this.add_input_parameters();
+        this.add_output_parameters(data.input_parameters);
         // If active, reactivate with new config_form
         this.markChanged();
         this.redraw();

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -237,7 +237,9 @@ var Node = Backbone.Model.extend({
         });
         node.nodeView = nodeView;
         $.each(data.data_inputs, (i, input) => {
-            nodeView.addDataInput(input);
+            if (nodeView.node.type != 'parameter_input') {
+                nodeView.addDataInput(input);
+            }
         });
 
         if (data.data_inputs.length > 0 && data.data_outputs.length > 0) {
@@ -317,8 +319,10 @@ var Node = Backbone.Model.extend({
         var new_body = nodeView.newInputsDiv();
         var newTerminalViews = {};
         _.each(data.data_inputs, input => {
-            var terminalView = node.nodeView.addDataInput(input, new_body);
-            newTerminalViews[input.name] = terminalView;
+            if (nodeView.node.type != 'parameter_input') {
+                var terminalView = node.nodeView.addDataInput(input, new_body);
+                newTerminalViews[input.name] = terminalView;
+            }
         });
         // Cleanup any leftover terminals
         _.each(_.difference(_.values(nodeView.terminalViews), _.values(newTerminalViews)), unusedView => {

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -6,6 +6,14 @@ import NodeView from "mvc/workflow/workflow-view-node";
 /* global $ */
 /* global Galaxy */
 
+var StepParameterTypes = [
+    'text',
+    'integer',
+    'float',
+    'boolean',
+    'color',
+]
+
 var Node = Backbone.Model.extend({
     initialize: function(app, attr) {
         this.app = app;
@@ -217,11 +225,20 @@ var Node = Backbone.Model.extend({
         $.each(data.data_inputs, (i, input) => {
             nodeView.addDataInput(input);
         });
+        $.each(node.config_form.inputs, (i, input) => {
+            if (input.value.__class__ == 'RuntimeValue' && StepParameterTypes.includes(input.type)){
+                console.log('Adding Parameter Input');
+                nodeView.addParameterInput(input);
+            }
+        });
         if (data.data_inputs.length > 0 && data.data_outputs.length > 0) {
             nodeView.addRule();
         }
         $.each(data.data_outputs, (i, output) => {
             nodeView.addDataOutput(output);
+        });
+        $.each(data.input_parameters, (i, input_parameter) => {
+            nodeView.addParameterOutput(input_parameter);
         });
         nodeView.render();
         this.app.workflow.node_changed(this, true);

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -201,8 +201,9 @@ var Node = Backbone.Model.extend({
         }
     },
     add_output_parameters: function(input_parameters) {
+        var self = this;
         $.each(input_parameters, (i, input_parameter) => {
-            this.nodeView.addParameterOutput(input_parameter);
+            self.nodeView.addParameterOutput(input_parameter);
         });
     },
     add_input_parameters: function() {

--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -431,6 +431,18 @@ var InputTerminal = BaseInputTerminal.extend({
     }
 });
 
+var InputParameterTerminal = BaseInputTerminal.extend({
+    update: function(input) {
+        this.type = input.type;
+    },
+    connect: function(connector) {
+        BaseInputTerminal.prototype.connect.call(this, connector);
+    },
+    attachable: function(other) {
+        return this.type == other.attributes.type;
+    },
+});
+
 var InputCollectionTerminal = BaseInputTerminal.extend({
     update: function(input) {
         this.multiple = false;
@@ -566,9 +578,14 @@ var OutputCollectionTerminal = Terminal.extend({
     }
 });
 
+var OutputParameterTerminal = Terminal.extend({
+});
+
 export default {
     InputTerminal: InputTerminal,
+    InputParameterTerminal: InputParameterTerminal,
     OutputTerminal: OutputTerminal,
+    OutputParameterTerminal: OutputParameterTerminal,
     InputCollectionTerminal: InputCollectionTerminal,
     OutputCollectionTerminal: OutputCollectionTerminal,
     TerminalMapping: TerminalMapping,

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -9,7 +9,7 @@ var DataInputView = Backbone.View.extend({
         this.nodeView = options.nodeView;
         this.terminalElement = options.terminalElement;
 
-        this.$el.attr("name", this.input.name).html(this.input.label);
+        this.$el.attr("name", this.input.name).html(this.input.label || this.input.name);
 
         if (!options.skipResize) {
             this.$el.css({

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -90,6 +90,61 @@ var DataOutputView = Backbone.View.extend({
     }
 });
 
+var ParameterOutputView = Backbone.View.extend({
+    className: "form-row dataRow",
+
+    initialize: function(options) {
+        this.output = options.output;
+        this.terminalElement = options.terminalElement;
+        this.nodeView = options.nodeView;
+
+        var output = this.output;
+        var label = output.label || output.name;
+        var node = this.nodeView.node;
+
+        this.$el.html(label);
+        this.calloutView = null;
+        if (["tool", "subworkflow"].indexOf(node.type) >= 0) {
+            var calloutView = new OutputCalloutView({
+                label: label,
+                output: output,
+                node: node
+            });
+            this.calloutView = calloutView;
+            this.$el.append(calloutView.el);
+            this.$el.hover(
+                () => {
+                    calloutView.hoverImage();
+                },
+                () => {
+                    calloutView.resetImage();
+                }
+            );
+        }
+        this.$el.css({
+            position: "absolute",
+            left: -1000,
+            top: -1000,
+            display: "none"
+        });
+        $("body").append(this.el);
+        this.nodeView.updateMaxWidth(this.$el.outerWidth() + 17);
+        this.$el
+            .css({
+                position: "",
+                left: "",
+                top: "",
+                display: ""
+            })
+            .detach();
+    },
+    redrawWorkflowOutput: function() {
+        if (this.calloutView) {
+            this.calloutView.resetImage();
+        }
+    }
+});
+
 var OutputCalloutView = Backbone.View.extend({
     tagName: "div",
 
@@ -153,5 +208,6 @@ var OutputCalloutView = Backbone.View.extend({
 
 export default {
     DataInputView: DataInputView,
-    DataOutputView: DataOutputView
+    DataOutputView: DataOutputView,
+    ParameterOutputView: ParameterOutputView,
 };

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
@@ -48,47 +48,12 @@ export default Backbone.View.extend({
             skipResize = false;
         }
         var terminalView = this.terminalViews[input.name];
-        var terminalViewClass =
-            input.input_type == "dataset_collection"
-                ? TerminalViews.InputCollectionTerminalView
-                : TerminalViews.InputTerminalView;
-        if (terminalView && !(terminalView instanceof terminalViewClass)) {
-            terminalView.el.terminal.destroy();
-            terminalView = null;
+        var terminalViewClass = TerminalViews.InputTerminalView;
+        if (input.input_type == "dataset_collection") {
+            terminalViewClass = TerminalViews.InputCollectionTerminalView;
+        } else if (input.input_type == "parameter") {
+            terminalViewClass = TerminalViews.InputParameterTerminalView;
         }
-        if (!terminalView) {
-            terminalView = new terminalViewClass({
-                node: this.node,
-                input: input
-            });
-        } else {
-            var terminal = terminalView.el.terminal;
-            terminal.update(input);
-            terminal.destroyInvalidConnections();
-        }
-        this.terminalViews[input.name] = terminalView;
-        var terminalElement = terminalView.el;
-        var inputView = new DataViews.DataInputView({
-            terminalElement: terminalElement,
-            input: input,
-            nodeView: this,
-            skipResize: skipResize
-        });
-        var ib = inputView.$el;
-        body.append(ib.prepend(terminalView.terminalElements()));
-        return terminalView;
-    },
-
-    addParameterInput: function(input, body) {
-        var skipResize = true;
-        if (!body) {
-            body = this.$(".inputs");
-            // initial addition to node - resize input to help calculate node
-            // width.
-            skipResize = false;
-        }
-        var terminalView = this.terminalViews[input.name];
-        var terminalViewClass = TerminalViews.InputParameterTerminalView;
         if (terminalView && !(terminalView instanceof terminalViewClass)) {
             terminalView.el.terminal.destroy();
             terminalView = null;
@@ -117,35 +82,25 @@ export default Backbone.View.extend({
     },
 
     addDataOutput: function(output) {
-        var terminalViewClass = output.collection
-            ? TerminalViews.OutputCollectionTerminalView
-            : TerminalViews.OutputTerminalView;
+        var terminalViewClass = TerminalViews.OutputTerminalView;
+        var outputViewClass = DataViews.DataOutputView;
+        if (output.collection) {
+            terminalViewClass = TerminalViews.OutputCollectionTerminalView;
+        } else if (output.parameter) {
+            terminalViewClass = TerminalViews.OutputParameterTerminalView;
+            outputViewClass = DataViews.ParameterOutputView;
+        }
         var terminalView = new terminalViewClass({
             node: this.node,
             output: output
         });
-        var outputView = new DataViews.DataOutputView({
+        var outputView = new outputViewClass({
             output: output,
             terminalElement: terminalView.el,
             nodeView: this
         });
         this.outputViews[output.name] = outputView;
         this.tool_body.append(outputView.$el.append(terminalView.terminalElements()));
-    },
-
-    addParameterOutput: function(input_parameter) {
-        var terminalViewClass = TerminalViews.OutputParameterTerminalView;
-        var terminalView = new terminalViewClass({
-            node: this.node,
-            output: input_parameter,
-        });
-        var parameterView = new DataViews.ParameterOutputView({
-            output: input_parameter,
-            terminalElement: terminalView.el,
-            nodeView: this
-        });
-        this.outputViews[input_parameter.name] = parameterView;
-        this.tool_body.append(parameterView.$el.append(terminalView.terminalElements()));
     },
 
     redrawWorkflowOutputs: function() {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
@@ -79,6 +79,43 @@ export default Backbone.View.extend({
         return terminalView;
     },
 
+    addParameterInput: function(input, body) {
+        var skipResize = true;
+        if (!body) {
+            body = this.$(".inputs");
+            // initial addition to node - resize input to help calculate node
+            // width.
+            skipResize = false;
+        }
+        var terminalView = this.terminalViews[input.name];
+        var terminalViewClass = TerminalViews.InputParameterTerminalView;
+        if (terminalView && !(terminalView instanceof terminalViewClass)) {
+            terminalView.el.terminal.destroy();
+            terminalView = null;
+        }
+        if (!terminalView) {
+            terminalView = new terminalViewClass({
+                node: this.node,
+                input: input
+            });
+        } else {
+            var terminal = terminalView.el.terminal;
+            terminal.update(input);
+            terminal.destroyInvalidConnections();
+        }
+        this.terminalViews[input.name] = terminalView;
+        var terminalElement = terminalView.el;
+        var inputView = new DataViews.DataInputView({
+            terminalElement: terminalElement,
+            input: input,
+            nodeView: this,
+            skipResize: skipResize
+        });
+        var ib = inputView.$el;
+        body.append(ib.prepend(terminalView.terminalElements()));
+        return terminalView;
+    },
+
     addDataOutput: function(output) {
         var terminalViewClass = output.collection
             ? TerminalViews.OutputCollectionTerminalView
@@ -94,6 +131,21 @@ export default Backbone.View.extend({
         });
         this.outputViews[output.name] = outputView;
         this.tool_body.append(outputView.$el.append(terminalView.terminalElements()));
+    },
+
+    addParameterOutput: function(input_parameter) {
+        var terminalViewClass = TerminalViews.OutputParameterTerminalView;
+        var terminalView = new terminalViewClass({
+            node: this.node,
+            output: input_parameter,
+        });
+        var parameterView = new DataViews.ParameterOutputView({
+            output: input_parameter,
+            terminalElement: terminalView.el,
+            nodeView: this
+        });
+        this.outputViews[input_parameter.name] = parameterView;
+        this.tool_body.append(parameterView.$el.append(terminalView.terminalElements()));
     },
 
     redrawWorkflowOutputs: function() {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
@@ -161,6 +161,17 @@ var InputTerminalView = BaseInputTerminalView.extend({
     }
 });
 
+var InputParameterTerminalView = BaseInputTerminalView.extend({
+    terminalMappingClass: Terminals.TerminalMapping,
+    terminalMappingViewClass: InputTerminalMappingView,
+    terminalForInput: function(input) {
+        return new Terminals.InputParameterTerminal({
+            element: this.el,
+            input: input
+        });
+    }
+});
+
 var InputCollectionTerminalView = BaseInputTerminalView.extend({
     terminalMappingClass: Terminals.TerminalMapping,
     terminalMappingViewClass: InputTerminalMappingView,
@@ -278,9 +289,25 @@ var OutputCollectionTerminalView = BaseOutputTerminalView.extend({
     }
 });
 
+var OutputParameterTerminalView = BaseOutputTerminalView.extend({
+    terminalMappingClass: Terminals.TerminalMapping,
+    terminalMappingViewClass: TerminalMappingView,
+    terminalForOutput: function(output) {
+        var collection_type = output.collection_type;
+        var collection_type_source = output.collection_type_source;
+        var terminal = new Terminals.OutputCollectionTerminal({
+            element: this.el,
+            type: output.type,
+        });
+        return terminal;
+    }
+});
+
 export default {
     InputTerminalView: InputTerminalView,
+    InputParameterTerminalView: InputParameterTerminalView,
     OutputTerminalView: OutputTerminalView,
+    OutputParameterTerminalView: OutputParameterTerminalView,
     InputCollectionTerminalView: InputCollectionTerminalView,
     OutputCollectionTerminalView: OutputCollectionTerminalView
 };

--- a/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
+++ b/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
@@ -357,16 +357,16 @@ QUnit.module("Node unit test", {
     },
     init_field_data_simple: function(option_overrides) {
         var data = Utils.merge(option_overrides, {
-            data_inputs: [{ name: "input1", extensions: ["data"] }],
-            data_outputs: [{ name: "output1", extensions: ["data"] }],
+            inputs: [{ name: "input1", extensions: ["data"] }],
+            outputs: [{ name: "output1", extensions: ["data"] }],
             label: null
         });
         this.node.init_field_data(data);
     },
     update_field_data_with_new_input: function(option_overrides) {
         var new_data = Utils.merge(option_overrides, {
-            data_inputs: [{ name: "input1", extensions: ["data"] }, { name: "extra_0|input1", extensions: ["data"] }],
-            data_outputs: [{ name: "output1", extensions: ["data"] }],
+            inputs: [{ name: "input1", extensions: ["data"] }, { name: "extra_0|input1", extensions: ["data"] }],
+            outputs: [{ name: "output1", extensions: ["data"] }],
             post_job_actions: "{}",
             label: "New Label"
         });
@@ -401,8 +401,8 @@ QUnit.test("init_field_data properties", function(assert) {
     var node = this.node;
     this.expect_workflow_node_changed(assert, function() {
         var data = {
-            data_inputs: [],
-            data_outputs: [],
+            inputs: [],
+            outputs: [],
             type: "tool",
             name: "cat1",
             config_form: "{}",
@@ -507,8 +507,8 @@ QUnit.test("update_field_data destroys old terminals", function(assert) {
     var node = this.node;
     this.expect_workflow_node_changed(assert, function() {
         var data = {
-            data_inputs: [{ name: "input1", extensions: ["data"] }, { name: "willDisappear", extensions: ["data"] }],
-            data_outputs: [{ name: "output1", extensions: ["data"] }]
+            inputs: [{ name: "input1", extensions: ["data"] }, { name: "willDisappear", extensions: ["data"] }],
+            outputs: [{ name: "output1", extensions: ["data"] }]
         };
         node.init_field_data(data);
         var old_input_terminal = node.input_terminals.willDisappear;

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -598,9 +598,6 @@ class WorkflowContentsManager(UsesAnnotations):
                         if isinstance(input, DataCollectionToolParameter):
                             input_connections_type[input.name] = "dataset_collection"
                 visit_input_values(module.tool.inputs, module.state.inputs, callback)
-                # Filter
-                # FIXME: this removes connection without displaying a message currently!
-                input_connections = [conn for conn in input_connections if conn.input_name in data_input_names or conn.non_data_connection]
                 # post_job_actions
                 pja_dict = {}
                 for pja in step.post_job_actions:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -561,7 +561,7 @@ class WorkflowContentsManager(UsesAnnotations):
                     data['upgrade_messages'][step.order_index] = {module.tool.name: "\n".join(module.version_changes)}
             # Get user annotation.
             annotation_str = self.get_item_annotation_str(trans.sa_session, trans.user, step) or ''
-            config_form = module.get_config_form()
+            config_form = module.get_config_form(step=step)
             # Pack attributes into plain dictionary
             step_dict = {
                 'id': step.order_index,

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -601,7 +601,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 visit_input_values(module.tool.inputs, module.state.inputs, callback)
                 # Filter
                 # FIXME: this removes connection without displaying a message currently!
-                input_connections = [conn for conn in input_connections if conn.input_name in data_input_names]
+                input_connections = [conn for conn in input_connections if conn.input_name in data_input_names or conn.non_data_connection]
                 # post_job_actions
                 pja_dict = {}
                 for pja in step.post_job_actions:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -573,6 +573,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 'errors': module.get_errors(),
                 'data_inputs': module.get_data_inputs(),
                 'data_outputs': module.get_data_outputs(),
+                'input_parameters': module.get_input_parameters(),
                 'config_form': config_form,
                 'annotation': annotation_str,
                 'post_job_actions': {},

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -571,9 +571,8 @@ class WorkflowContentsManager(UsesAnnotations):
                 'name': module.get_name(),
                 'tool_state': module.get_state(),
                 'errors': module.get_errors(),
-                'data_inputs': module.get_data_inputs(),
-                'data_outputs': module.get_data_outputs(),
-                'input_parameters': module.get_input_parameters(),
+                'inputs': module.get_all_inputs(connectable_only=True),
+                'outputs': module.get_all_outputs(),
                 'config_form': config_form,
                 'annotation': annotation_str,
                 'post_job_actions': {},
@@ -654,12 +653,12 @@ class WorkflowContentsManager(UsesAnnotations):
         """
         for order_index in sorted(steps):
             step = steps[order_index]
-            for i, step_data_output in enumerate(step['data_outputs']):
+            for i, step_data_output in enumerate(step['outputs']):
                 if step_data_output.get('collection_type_source') and step_data_output['collection_type'] is None:
                     collection_type_source = step_data_output['collection_type_source']
                     for input_connection in step['input_connections'].get(collection_type_source, []):
                         input_step = steps[input_connection['id']]
-                        for input_step_data_output in input_step['data_outputs']:
+                        for input_step_data_output in input_step['outputs']:
                             if input_step_data_output['name'] == input_connection['output_name']:
                                 step_data_output['collection_type'] = input_step_data_output.get('collection_type')
         return steps

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -846,6 +846,8 @@ class WorkflowContentsManager(UsesAnnotations):
                 label = "Input Dataset"
             elif step_type == "data_collection_input":
                 label = "Input Dataset Collection"
+            elif step_type == 'parameter_input':
+                label = "Input Parameter"
             else:
                 raise ValueError("Invalid step_type %s" % step_type)
             if legacy:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -790,8 +790,6 @@ class WorkflowContentsManager(UsesAnnotations):
                     # If the tool is installed we attempt to verify input values
                     # and connections, otherwise the last known state will be dumped without modifications.
                     visit_input_values(module.tool.inputs, module.state.inputs, callback)
-                    # FIXME: this removes connection without displaying a message currently!
-                    input_connections = [conn for conn in input_connections if (conn.input_name in data_input_names or conn.non_data_connection)]
 
             # Encode input connections as dictionary
             input_conn_dict = {}

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4179,14 +4179,10 @@ class WorkflowStepConnection(object):
         self.input_step_id = None
         self.input_name = None
 
-    def set_non_data_connection(self):
-        self.output_name = WorkflowStepConnection.NON_DATA_CONNECTION
-        self.input_name = WorkflowStepConnection.NON_DATA_CONNECTION
-
     @property
     def non_data_connection(self):
-        return (self.output_name == WorkflowStepConnection.NON_DATA_CONNECTION and
-                self.input_name == WorkflowStepConnection.NON_DATA_CONNECTION)
+        return (self.output_name == self.input_name == WorkflowStepConnection.NON_DATA_CONNECTION or
+                self.output_step and self.output_step.type == 'parameter_input')
 
     def copy(self):
         # TODO: handle subworkflow ids...

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4181,8 +4181,7 @@ class WorkflowStepConnection(object):
 
     @property
     def non_data_connection(self):
-        return (self.output_name == self.input_name == WorkflowStepConnection.NON_DATA_CONNECTION or
-                self.output_step and self.output_step.type == 'parameter_input')
+        return (self.output_name == self.input_name == WorkflowStepConnection.NON_DATA_CONNECTION)
 
     def copy(self):
         # TODO: handle subworkflow ids...

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -9,7 +9,7 @@ from boltons.iterutils import remap
 
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.json import safe_loads
-from .basic import DataCollectionToolParameter, DataToolParameter, RuntimeValue, SelectToolParameter
+from .basic import DataCollectionToolParameter, DataToolParameter, is_runtime_value, runtime_to_json, SelectToolParameter
 from .grouping import Conditional, Repeat, Section, UploadDataset
 
 REPLACE_ON_TRUTHY = object()
@@ -179,11 +179,8 @@ def check_param(trans, param, incoming_value, param_values):
     error = None
     try:
         if trans.workflow_building_mode:
-            if isinstance(value, RuntimeValue):
-                return [{'__class__' : 'RuntimeValue'}, None]
-            if isinstance(value, dict):
-                if value.get('__class__') == 'RuntimeValue':
-                    return [value, None]
+            if is_runtime_value(value):
+                return [runtime_to_json(value), None]
         value = param.from_json(value, trans, param_values)
         param.validate(value, trans)
     except ValueError as e:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -558,6 +558,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             'name'              : module.get_name(),
             'tool_state'        : module.get_state(),
             'data_inputs'       : module.get_data_inputs(),
+            'input_parameters'  : module.get_input_parameters(),
             'data_outputs'      : module.get_data_outputs(),
             'config_form'       : module.get_config_form(),
             'post_job_actions'  : module.get_post_job_actions(inputs)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -557,9 +557,8 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             'annotation'        : inputs.get('__annotation', ''),
             'name'              : module.get_name(),
             'tool_state'        : module.get_state(),
-            'data_inputs'       : module.get_data_inputs(),
-            'input_parameters'  : module.get_input_parameters(),
-            'data_outputs'      : module.get_data_outputs(),
+            'inputs'            : module.get_all_inputs(connectable_only=True),
+            'outputs'           : module.get_all_outputs(),
             'config_form'       : module.get_config_form(),
             'post_job_actions'  : module.get_post_job_actions(inputs)
         }

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -607,14 +607,20 @@ class InputParameterModule(WorkflowModule):
         optional = self.state.inputs.get("optional", self.default_optional)
         input_parameter_type = SelectToolParameter(None, XML(
             '''
-            <param name="parameter_type" label="Parameter type" type="select" value="%s">
+            <param name="parameter_type" label="Parameter type" type="select">
                 <option value="text">Text</option>
                 <option value="integer">Integer</option>
                 <option value="float">Float</option>
                 <option value="boolean">Boolean (True or False)</option>
                 <option value="color">Color</option>
             </param>
-            ''' % parameter_type))
+            '''))
+        for i, option in enumerate(input_parameter_type.static_options):
+            option = list(option)
+            if option[1] == parameter_type:
+                # item 0 is option description, item 1 is value, item 2 is "selected"
+                option[2] = True
+                input_parameter_type.static_options[i] = tuple(option)
         return odict([("parameter_type", input_parameter_type),
                       ("optional", BooleanToolParameter(None, Element("param", name="optional", label="Optional", type="boolean", value=optional)))])
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -158,6 +158,9 @@ class WorkflowModule(object):
     def get_data_outputs(self):
         return []
 
+    def get_input_parameters(self):
+        return []
+
     def get_post_job_actions(self, incoming):
         return []
 
@@ -637,6 +640,9 @@ class InputParameterModule(WorkflowModule):
 
     def get_data_inputs(self):
         return []
+
+    def get_input_parameters(self):
+        return [dict(name=self.name, label=self.label, type=self.parameter_type)]
 
     def execute(self, trans, progress, invocation_step, use_cached_job=False):
         step = invocation_step.workflow_step

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -648,7 +648,7 @@ class InputParameterModule(WorkflowModule):
         return [self.state.inputs]
 
     def get_input_parameters(self):
-        return [dict(name=self.name, label=self.label, type=self.parameter_type)]
+        return [dict(name=self.name, label=self.label, type=self.state.inputs['parameter_type'], optional=self.state.inputs['optional'])]
 
     def execute(self, trans, progress, invocation_step, use_cached_job=False):
         step = invocation_step.workflow_step

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1300,6 +1300,11 @@ def load_module_sections(trans):
                 "title": "Input Dataset Collection",
                 "description": "Input dataset collection"
             },
+            {
+                "name": "parameter_input",
+                "title": "Parameter Input",
+                "description": "Simple inputs used for workflow logic"
+            },
         ],
     }
 
@@ -1312,12 +1317,7 @@ def load_module_sections(trans):
                     "name": "pause",
                     "title": "Pause Workflow for Dataset Review",
                     "description": "Pause for Review"
-                },
-                {
-                    "name": "parameter_input",
-                    "title": "Parameter Input",
-                    "description": "Simple inputs used for workflow logic"
-                },
+                }
             ],
         }
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -639,7 +639,7 @@ class InputParameterModule(WorkflowModule):
         return state
 
     def get_data_inputs(self):
-        return []
+        return [self.state.inputs]
 
     def get_input_parameters(self):
         return [dict(name=self.name, label=self.label, type=self.parameter_type)]

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -648,7 +648,7 @@ class InputParameterModule(WorkflowModule):
         return [self.state.inputs]
 
     def get_input_parameters(self):
-        return [dict(name=self.name, label=self.label, type=self.state.inputs['parameter_type'], optional=self.state.inputs['optional'])]
+        return [dict(name=self.name, label=self.label, type=self.state.inputs.get('parameter_type', self.parameter_type), optional=self.state.inputs.get('optional', self.optional))]
 
     def execute(self, trans, progress, invocation_step, use_cached_job=False):
         step = invocation_step.workflow_step

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -387,11 +387,12 @@ class WorkflowProgress(object):
 
         if self.inputs_by_step_id:
             step_id = step.id
-            if step_id not in self.inputs_by_step_id:
+            if step_id not in self.inputs_by_step_id and 'output' not in outputs:
                 template = "Step with id %s not found in inputs_step_id (%s)"
                 message = template % (step_id, self.inputs_by_step_id)
                 raise ValueError(message)
-            outputs['output'] = self.inputs_by_step_id[step_id]
+            elif step_id in self.inputs_by_step_id:
+                outputs['output'] = self.inputs_by_step_id[step_id]
 
         self.set_step_outputs(invocation_step, outputs)
 

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -352,13 +352,10 @@ class WorkflowProgress(object):
         try:
             replacement = step_outputs[output_name]
         except KeyError:
-            if is_data:
-                # Must resolve.
-                template = "Workflow evaluation problem - failed to find output_name %s in step_outputs %s"
-                message = template % (output_name, step_outputs)
-                raise Exception(message)
-            else:
-                replacement = modules.NO_REPLACEMENT
+            # Must resolve.
+            template = "Workflow evaluation problem - failed to find output_name %s in step_outputs %s"
+            message = template % (output_name, step_outputs)
+            raise Exception(message)
         if isinstance(replacement, model.HistoryDatasetCollectionAssociation):
             if not replacement.collection.populated:
                 if not replacement.collection.waiting_for_elements:

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -265,6 +265,17 @@ def build_workflow_run_configs(trans, workflow, payload):
             # inputs with referential integrity if parameters are already normalized (coming from tool form).
             normalized_inputs = {}
 
+        if param_map:
+            # disentangle raw parameter dictionaries into formal request structures if we can
+            # to setup proper WorkflowRequestToInputDatasetAssociation, WorkflowRequestToInputDatasetCollectionAssociation
+            # and WorkflowRequestInputStepParameter objects.
+            for step in workflow.steps:
+                normalized_key = step.id
+                if step.type == "parameter_input":
+                    if normalized_key in param_map:
+                        value = param_map.pop(normalized_key)
+                        normalized_inputs[normalized_key] = value["input"]
+
         steps_by_id = workflow.steps_by_id
         # Set workflow inputs.
         for key, input_dict in normalized_inputs.items():

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -468,8 +468,8 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase):
                 'name',
                 'tool_state',
                 'tooltip',
-                'data_inputs',
-                'data_outputs',
+                'inputs',
+                'outputs',
                 'config_form',
                 'annotation',
                 'post_job_actions',
@@ -494,7 +494,7 @@ steps:
         downloaded_workflow = self._download_workflow(workflow_id, style="editor")
         steps = downloaded_workflow['steps']
         assert len(steps) == 2
-        assert steps['1']['data_outputs'][0]['collection_type'] == 'list:paired'
+        assert steps['1']['outputs'][0]['collection_type'] == 'list:paired'
 
     @skip_without_tool('collection_type_source')
     def test_export_editor_subworkflow_collection_type_source(self):
@@ -525,7 +525,7 @@ steps:
         steps = downloaded_workflow['steps']
         assert len(steps) == 2
         assert steps['1']['type'] == 'subworkflow'
-        assert steps['1']['data_outputs'][0]['collection_type'] == 'list:paired'
+        assert steps['1']['outputs'][0]['collection_type'] == 'list:paired'
 
     def test_import_missing_tool(self):
         workflow = self.workflow_populator.load_workflow_from_resource(name="test_workflow_missing_tool")

--- a/test/galaxy_selenium/navigation.yml
+++ b/test/galaxy_selenium/navigation.yml
@@ -264,6 +264,9 @@ workflow_editor:
     tool_menu_section_link: '#title___workflow__${section_name}__ a span'
     tool_menu_item_link: 'a#tool-menu-${section_name}-${item_name}'
 
+    connect_icon: 'div.ui-form-element[tour_id="${name}"] .ui-form-connected-icon'
+    collapse_icon: 'div.ui-form-element[tour_id="${name}"] .ui-form-collapsible-icon'
+
     label_input: "[tour_id='__label'] input"
     annotation_input: "[tour_id='__annotation'] textarea"
 

--- a/test/galaxy_selenium/navigation.yml
+++ b/test/galaxy_selenium/navigation.yml
@@ -236,7 +236,8 @@ workflows:
 workflow_run:
 
   selectors: 
-    input_div: "[step-label='${label}'] .select2-container"
+    input_div: "[step-label='${label}']"
+    input_data_div: "[step-label='${label}'] .select2-container"
     # TODO: put step labels in the DOM ideally
     subworkflow_step_icon: ".portlet-title-icon.fa-sitemap + span"
 


### PR DESCRIPTION
An alternative to #6919, which was an alternative of #6829.

Differences from #6829:

* Keep beta workflow modules config option, just move step parameters out of beta.
* Rather than making all non-data parameters that are specified as RuntimeValue parameters - have separate states for RuntimeValue parameters and ConnectedValue parameters. I think this change is pretty isolated to 35260f2 if we want to undo it, I think on balance it is the right thing to do but I could be convinced I'm wrong I suspect.
* Rather than defining "parameters" and "inputs" separately like in #6829, this brings in work from the CWL branch (standalone as #6911) to generalize inputs/outputs in the workflow module and API layer to non-data inputs. I like the consistency of this interface better and it starts us on the road to allow for complex field parameters in the CWL branch.

Differences from #6919:

* Defines some simple workflow editor test cases.
* ~Brings in workflow API test definition improvements #6776 to define some new tests.~ (already merged into dev and this has been rebased)
* Fixes handling of manually specified workflow definitions with non-data connections that have a connection specified but not a ConnectedValue in the tool state.

![](https://jenkins.galaxyproject.org/job/docker-selenium/4060/artifact/4060-test-screenshots/workflow_editor_parameter_connection_simple.png)
![](https://jenkins.galaxyproject.org/job/docker-selenium/4060/artifact/4060-test-screenshots/workflow_editor_parameter_connection_destroyed.png)