### PR TITLE
[18.09] Fix toolshed error in display_tool if tool is invalid

### DIFF
--- a/lib/galaxy/webapps/tool_shed/api/tools.py
+++ b/lib/galaxy/webapps/tool_shed/api/tools.py
@@ -166,10 +166,10 @@ class ToolsController(BaseAPIController):
 
         with ValidationContext.from_app(trans.app) as validation_context:
             tv = tool_validator.ToolValidator(validation_context)
-            repository, tool, message = tv.load_tool_from_changeset_revision(tsr_id,
-                                                                             changeset,
-                                                                             found_tool.tool_config)
-        if message:
+            repository, tool, valid, message = tv.load_tool_from_changeset_revision(tsr_id,
+                                                                                    changeset,
+                                                                                    found_tool.tool_config)
+        if message or not valid:
             status = 'error'
             return dict(message=message, status=status)
         tool_help = ''

--- a/lib/galaxy/webapps/tool_shed/controllers/repository.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/repository.py
@@ -875,17 +875,16 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
 
     @web.expose
     def display_tool(self, trans, repository_id, tool_config, changeset_revision, **kwd):
-        message = escape(kwd.get('message', ''))
         status = kwd.get('status', 'done')
         render_repository_actions_for = kwd.get('render_repository_actions_for', 'tool_shed')
         with ValidationContext.from_app(trans.app) as validation_context:
             tv = tool_validator.ToolValidator(validation_context)
-            repository, tool, message = tv.load_tool_from_changeset_revision(repository_id,
+            repository, tool, valid, message = tv.load_tool_from_changeset_revision(repository_id,
                                                                              changeset_revision,
                                                                              tool_config)
-        if message:
+        if message or not valid:
             status = 'error'
-        tool_state = tool_util.new_state(trans, tool, invalid=False)
+        tool_state = tool_util.new_state(trans, tool, invalid=not valid)
         metadata = metadata_util.get_repository_metadata_by_repository_id_changeset_revision(trans.app,
                                                                                              repository_id,
                                                                                              changeset_revision,
@@ -1772,7 +1771,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
 
         with ValidationContext.from_app(trans.app) as validation_context:
             tv = tool_validator.ToolValidator(validation_context)
-            repository, tool, error_message = tv.load_tool_from_changeset_revision(repository_id,
+            repository, tool, valid, error_message = tv.load_tool_from_changeset_revision(repository_id,
                                                                                    changeset_revision,
                                                                                    tool_config)
             tool_state = tool_util.new_state(trans, tool, invalid=True)

--- a/lib/tool_shed/util/workflow_util.py
+++ b/lib/tool_shed/util/workflow_util.py
@@ -43,10 +43,10 @@ class RepoToolModule(ToolModule):
                 tv = tool_validator.ToolValidator(validation_context)
                 for tool_dict in tools_metadata:
                     if self.tool_id in [tool_dict['id'], tool_dict['guid']]:
-                        repository, self.tool, message = tv.load_tool_from_changeset_revision(repository_id,
-                                                                                              changeset_revision,
-                                                                                              tool_dict['tool_config'])
-                        if message and self.tool is None:
+                        repository, self.tool, valid, message = tv.load_tool_from_changeset_revision(repository_id,
+                                                                                                     changeset_revision,
+                                                                                                     tool_dict['tool_config'])
+                        if self.tool is None and message or not valid:
                             self.errors = 'unavailable'
                         break
         else:


### PR DESCRIPTION
Fixes the following exception:

```
AttributeError: 'NoneType' object has no attribute 'id'
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/srv/toolshed/main/venv/local/lib/python2.7/site-packages/paste/translogger.py", line 69, in __call__
    return self.application(environ, replacement_start_response)
  File "/srv/toolshed/main/venv/local/lib/python2.7/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "routes/middleware.py", line 141, in __call__
    response = self.app(environ, start_response)
  File "/srv/toolshed/main/venv/local/lib/python2.7/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 143, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 222, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/tool_shed/controllers/repository.py", line 888, in display_tool
    tool_state = tool_util.new_state(trans, tool, invalid=False)
  File "tool_shed/util/tool_util.py", line 211, in new_state
    log.debug('Failed to build tool state for tool "%s" using standard method, will try to fall back on custom method: %s', tool.id, e)
```

(from https://sentry.galaxyproject.org/sentry/toolshed/issues/279820/).

Might also fix some other issues when redering workflow svg for
workflows with invalid tools.