### PR TITLE
Default shed tool installation to database/shed_tools

### DIFF
--- a/config/migrated_tools_conf.xml.sample
+++ b/config/migrated_tools_conf.xml.sample
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
-<toolbox tool_path="../shed_tools">
+<toolbox tool_path="database/shed_tools">
 </toolbox>

--- a/config/shed_tool_conf.xml.sample
+++ b/config/shed_tool_conf.xml.sample
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
-<toolbox tool_path="../shed_tools">
+<toolbox tool_path="database/shed_tools">
 </toolbox>

--- a/doc/source/admin/tool_panel.rst
+++ b/doc/source/admin/tool_panel.rst
@@ -37,7 +37,7 @@ Sections & Labels
 .. code-block:: xml
 
     <?xml version="1.0"?>
-    <toolbox tool_path="../shed_tools">
+    <toolbox tool_path="database/shed_tools">
         <section id="mts" name="MTS" version="">
           <tool file="toolshed.g2.bx.psu.edu/repos/devteam/fastqc/a00a6402d09a/fastqc/rgFastQC.xml" guid="toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.67" labels="new">
               <tool_shed>toolshed.g2.bx.psu.edu</tool_shed>

--- a/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
@@ -38,8 +38,8 @@ def get_message_for_no_shed_tool_config():
     message = 'The tool_config_file setting in galaxy.ini must include at least one shed tool configuration file name with a <toolbox> '
     message += 'tag that includes a tool_path attribute value which is a directory relative to the Galaxy installation directory in order to '
     message += 'automatically install tools from a tool shed into Galaxy (e.g., the file name shed_tool_conf.xml whose <toolbox> tag is '
-    message += '<toolbox tool_path="../shed_tools">).  For details, see the "Installation of Galaxy tool shed repository tools into a local '
-    message += 'Galaxy instance" section of the Galaxy tool shed wiki at https://galaxyproject.org/installing-repositories-to-galaxy/'
+    message += '<toolbox tool_path="database/shed_tools">).  For details, see the "Installation of Galaxy tool shed repository tools into a '
+    message += 'local Galaxy instance" section of the Galaxy tool shed wiki at https://galaxyproject.org/installing-repositories-to-galaxy/'
     return message
 
 
@@ -517,8 +517,8 @@ class ToolShedRepositoriesController(BaseAPIController):
                                           (e.g., galaxy.ini).  At least one shed-related tool panel config file is required to be configured. Setting
                                           this parameter to a specific file enables you to choose where the specified repository will be installed because
                                           the tool_path attribute of the <toolbox> from the specified file is used as the installation location
-                                          (e.g., <toolbox tool_path="../shed_tools">).  If this parameter is not set, a shed-related tool panel configuration
-                                          file will be selected automatically.
+                                          (e.g., <toolbox tool_path="database/shed_tools">).  If this parameter is not set, a shed-related tool panel
+                                          configuration file will be selected automatically.
         """
         # Get the information about the repository to be installed from the payload.
         tool_shed_url, name, owner, changeset_revision = self.__parse_repository_from_payload(payload, include_changeset=True)
@@ -573,8 +573,8 @@ class ToolShedRepositoriesController(BaseAPIController):
                                           (e.g., galaxy.ini).  At least one shed-related tool panel config file is required to be configured. Setting
                                           this parameter to a specific file enables you to choose where the specified repository will be installed because
                                           the tool_path attribute of the <toolbox> from the specified file is used as the installation location
-                                          (e.g., <toolbox tool_path="../shed_tools">).  If this parameter is not set, a shed-related tool panel configuration
-                                          file will be selected automatically.
+                                          (e.g., <toolbox tool_path="database/shed_tools">).  If this parameter is not set, a shed-related tool panel
+                                          configuration file will be selected automatically.
         """
         self.__ensure_can_install_repos(trans)
         # Get the information about all of the repositories to be installed.

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -815,7 +815,7 @@ class AdminToolshed(AdminGalaxy):
             message += 'shed tool configuration file name with a <b>&lt;toolbox&gt;</b> tag that includes a <b>tool_path</b> '
             message += 'attribute value which is a directory relative to the Galaxy installation directory in order '
             message += 'to automatically install tools from a Galaxy Tool Shed (e.g., the file name <b>shed_tool_conf.xml</b> '
-            message += 'whose <b>&lt;toolbox&gt;</b> tag is <b>&lt;toolbox tool_path="../shed_tools"&gt;</b>).<p/>See the '
+            message += 'whose <b>&lt;toolbox&gt;</b> tag is <b>&lt;toolbox tool_path="database/shed_tools"&gt;</b>).<p/>See the '
             message += '<a href="https://galaxyproject.org/installing-repositories-to-galaxy/" target="_blank">Installation '
             message += 'of Galaxy Tool Shed repository tools into a local Galaxy instance</a> section of the Galaxy Tool '
             message += 'Shed wiki for all of the details.'

--- a/lib/tool_shed/galaxy_install/migrate/check.py
+++ b/lib/tool_shed/galaxy_install/migrate/check.py
@@ -79,8 +79,8 @@ def verify_tools(app, url, galaxy_config_file=None, engine_options={}):
                     msg += "be removed from your file%s named %s.\n\n" % (plural, tool_panel_config_file_names)
                     msg += "CRITICAL NOTE IF YOU PLAN TO INSTALL\n"
                     msg += "The location in which the tool repositories will be installed is the value of the 'tool_path' attribute in the <tool>\n"
-                    msg += 'tag of the file named ./migrated_tool_conf.xml (i.e., <toolbox tool_path="../shed_tools">).  The default location\n'
-                    msg += "setting is '../shed_tools', which may be problematic for some cluster environments, so make sure to change it before\n"
+                    msg += 'tag of the file named ./migrated_tool_conf.xml (i.e., <toolbox tool_path="database/shed_tools">).  The default location\n'
+                    msg += "setting is 'database/shed_tools', which may be problematic for some cluster environments, so make sure to change it before\n"
                     msg += "you execute the installation process if appropriate.  The configured location must be outside of the Galaxy installation\n"
                     msg += "directory or it must be in a sub-directory protected by a properly configured .hgignore file if the directory is within\n"
                     msg += "the Galaxy installation directory hierarchy.  This is because tool shed repositories will be installed using mercurial's\n"

--- a/lib/tool_shed/util/common_util.py
+++ b/lib/tool_shed/util/common_util.py
@@ -140,7 +140,7 @@ def get_non_shed_tool_panel_configs(app):
     config_filenames = []
     for config_filename in app.config.tool_configs:
         # Any config file that includes a tool_path attribute in the root tag set like the following is shed-related.
-        # <toolbox tool_path="../shed_tools">
+        # <toolbox tool_path="database/shed_tools">
         tree, error_message = xml_util.parse_xml(config_filename)
         if tree is None:
             continue


### PR DESCRIPTION
...instead of `../shed_tools`.

The old path was historical and due to tool repositories being Mercurial repositories, which could not be contained within another Mercurial repository (Galaxy itself, at the time).

This does not affect any existing installations since `shed_tool_conf.xml` is only initialized once.