### PR TITLE
[18.09] Release announce codeblock formatting fix

### DIFF
--- a/doc/source/releases/18.09_announce.rst
+++ b/doc/source/releases/18.09_announce.rst
@@ -64,11 +64,9 @@ Upgrade Warning for Admins
 This release includes changes to the way that non-terminal jobs are handled that greatly improve performance and the
 user experience. As a result, when upgrading a Galaxy server with a large number of jobs in the ``new`` state, job
 handlers will block on first startup (jobs will not run) as these old ``new`` state jobs are migrated to a terminal
-state. This process will generate messages of the format:
+state. This process will generate messages of the format::
 
-    .. code-block::
-
-        galaxy.jobs DEBUG 2018-10-18 22:40:36,900 Pausing Job '995223', Execution of this dataset's job is paused because its input datasets are in an error state.
+    galaxy.jobs DEBUG 2018-10-18 22:40:36,900 Pausing Job '995223', Execution of this dataset's job is paused because its input datasets are in an error state.
 
 Once migration is complete, job handlers will resume normal operation.
 


### PR DESCRIPTION
I think this should do it, ~but I'm trying to build locally to test first~.   For a faster turnaround I tested in isolation, this fixes the code block.

Note https://docs.galaxyproject.org/en/master/releases/18.09_announce.html#upgrade-warning-for-admins, the missing block.

