### PR TITLE
Collection builder: add option to strip url prefix from pair names

### DIFF
--- a/client/galaxy/scripts/mvc/collection/list-of-pairs-collection-creator.js
+++ b/client/galaxy/scripts/mvc/collection/list-of-pairs-collection-creator.js
@@ -256,9 +256,6 @@ var PairedCollectionCreator = Backbone.View.extend(baseMVC.LoggableMixin)
             this.removeExtensions = true;
             //this.removeExtensions = false;
 
-             /** remove file extensions (\.*) from created pair names? */
-            this.removeUrlPrefix = true;
-
             /** fn to call when the cancel button is clicked (scoped to this) - if falsy, no btn is displayed */
             this.oncancel = attributes.oncancel;
             /** fn to call when the collection is created (scoped to this) */
@@ -547,9 +544,8 @@ var PairedCollectionCreator = Backbone.View.extend(baseMVC.LoggableMixin)
         },
 
         /** try to find a good pair name for the given fwd and rev datasets */
-        _guessNameForPair: function(fwd, rev, removeExtensions, removeUrlPrefix) {
+        _guessNameForPair: function(fwd, rev, removeExtensions) {
             removeExtensions = removeExtensions !== undefined ? removeExtensions : this.removeExtensions;
-            removeUrlPrefix = removeUrlPrefix !== undefined ? removeUrlPrefix : this.removeUrlPrefix;
             var fwdName = fwd.name;
             var revName = rev.name;
 
@@ -558,20 +554,20 @@ var PairedCollectionCreator = Backbone.View.extend(baseMVC.LoggableMixin)
                 revName.replace(new RegExp(this.filters[1]), "")
             );
 
+            /** remove url prefix if files were uploaded by url */
+            var lastSlashIndex = lcs.lastIndexOf("/");
+            if (lastSlashIndex > 0) {
+                var urlprefix = lcs.slice(0, lastSlashIndex + 1);
+                lcs = lcs.replace(urlprefix, "");
+                fwdName = fwdName.replace(extension, "");
+                revName = revName.replace(extension, "");
+            }
+
             if (removeExtensions) {
                 var lastDotIndex = lcs.lastIndexOf(".");
                 if (lastDotIndex > 0) {
                     var extension = lcs.slice(lastDotIndex, lcs.length);
                     lcs = lcs.replace(extension, "");
-                    fwdName = fwdName.replace(extension, "");
-                    revName = revName.replace(extension, "");
-                }
-            }
-            if (removeUrlPrefix) {
-                var lastSlashIndex = lcs.lastIndexOf("/");
-                if (lastSlashIndex > 0) {
-                    var urlprefix = lcs.slice(0, lastSlashIndex + 1);
-                    lcs = lcs.replace(urlprefix, "");
                     fwdName = fwdName.replace(extension, "");
                     revName = revName.replace(extension, "");
                 }
@@ -904,8 +900,7 @@ var PairedCollectionCreator = Backbone.View.extend(baseMVC.LoggableMixin)
 
         footerSettings: {
             ".hide-originals": "hideOriginals",
-            ".remove-extensions": "removeExtensions",
-            ".remove-urlprefix": "removeUrlPrefix"
+            ".remove-extensions": "removeExtensions"
         },
 
         /** add any jQuery/bootstrap/custom plugins to elements rendered */
@@ -1095,9 +1090,6 @@ var PairedCollectionCreator = Backbone.View.extend(baseMVC.LoggableMixin)
             // footer
             "change .remove-extensions": function(ev) {
                 this.toggleExtensions();
-            },
-            "change .remove-urlprefix": function(ev) {
-                this.toggleUrlPrefix();
             },
             "change .collection-name": "_changeName",
             "keydown .collection-name": "_nameCheckForEnter",
@@ -1509,20 +1501,7 @@ var PairedCollectionCreator = Backbone.View.extend(baseMVC.LoggableMixin)
         toggleExtensions: function(force) {
             var self = this;
             self.removeExtensions = force !== undefined ? force : !self.removeExtensions;
-            _.each(self.paired, pair => {
-                // don't overwrite custom names
-                if (pair.customizedName) {
-                    return;
-                }
-                pair.name = self._guessNameForPair(pair.forward, pair.reverse);
-            });
 
-            self._renderPaired();
-            self._renderFooter();
-        },
-        toggleUrlPrefix: function(force) {
-            var self = this;
-            self.removeUrlPrefix = force !== undefined ? force : !self.removeUrlPrefix;
             _.each(self.paired, pair => {
                 // don't overwrite custom names
                 if (pair.customizedName) {
@@ -1668,11 +1647,6 @@ var PairedCollectionCreator = Backbone.View.extend(baseMVC.LoggableMixin)
                     _l("Hide original elements"),
                     "?",
                     '<input class="hide-originals float-right" type="checkbox" />',
-                    "</label>",
-                    '<label class="setting-prompt float-right">',
-                    _l("Remove url prefix from pair names"),
-                    "?",
-                    '<input class="remove-urlprefix float-right" type="checkbox" />',
                     "</label>",
                     '<label class="setting-prompt float-right">',
                     _l("Remove file extensions from pair names"),


### PR DESCRIPTION
This adds the option to remove a url prefix from pair names when building a list of pairs collection, similar to the option to remove the file extension. 

This streamlines things a lot in [one of my training manuals](https://galaxyproject.github.io/training-material/topics/metagenomics/tutorials/mothur-miseq-sop/tutorial.html), where participants upload data from Zenodo, and create a collection. Since the downstream tools use the pair names as sample names, it was necessary for participants to manually edit every pair name, but now this should happen automatically.

e.g. before:

![galaxy_strip_urlprefix_before](https://user-images.githubusercontent.com/2563865/47718499-e0ad2600-dc48-11e8-8130-24fabaede9fa.png)

after:
![galaxy_strip_urlprefix_after](https://user-images.githubusercontent.com/2563865/47718513-e99df780-dc48-11e8-9018-b1f76145e8be.png)

ping @jmchilton 