### PR TITLE
Use recently introduced overflow utility instead of overwriting card defaults

### DIFF
--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -24,18 +24,17 @@
     transform: rotate(45deg);
 }
 
+// utility class from: https://github.com/twbs/bootstrap/pull/27268
+.overflow-auto {
+    overflow: auto !important;
+}
+
 // default margins
 $ui-margin-vertical: $margin-v * 0.25;
 $ui-margin-vertical-large: $margin-v * 0.5;
 $ui-margin-horizontal: $margin-h;
 $ui-margin-horizontal-small: $margin-h * 0.5;
 $ui-margin-horizontal-large: $margin-v * 2;
-
-.card {
-    .card-body {
-        overflow: auto;
-    }
-}
 
 .ui-modal {
     display: none;

--- a/templates/admin/tool_shed_repository/monitor_repository_installation.mako
+++ b/templates/admin/tool_shed_repository/monitor_repository_installation.mako
@@ -38,7 +38,7 @@
 %if tool_shed_repositories:
     <div class="card">
         <div class="card-header">Monitor installing tool shed repositories</div>
-        <div class="card-body">
+        <div class="card-body overflow-auto">
             <table class="grid">
                 <tr>
                     <td>Name</td>

--- a/templates/webapps/galaxy/admin/manage_dependencies.mako
+++ b/templates/webapps/galaxy/admin/manage_dependencies.mako
@@ -149,15 +149,15 @@
     <input type="submit" name="viewkey" value="Switch to unused dependencies view"/>
     <div class="card mt-2 mb-2">
         <div class="card-header">Tool-centric dependencies</div>
-        <div class="card-body">
+        <div class="card-body overflow-auto">
             <table class="manage-table colored" border="0" cellspacing="0" cellpadding="0" width="100%">
                 ${render_tool_centric_table(tools, requirements_status)}
 %elif viewkey == "Switch to unused dependencies view":
     <input type="submit" name="viewkey" value="Switch to details view"/>
     <input type="submit" name="viewkey" value="Switch to tool-centric view"/>
-        <div class="card">
+        <div class="card mt-2 mb-2">
         <div class="card-header">Unused dependency environments</div>
-        <div class="card-body">
+        <div class="card-body overflow-auto">
             <table class="manage-table colored" border="0" cellspacing="0" cellpadding="0" width="100%">
                 ${render_unused_dependencies(unused_environments)}
 %else:
@@ -165,7 +165,7 @@
     <input type="submit" name="viewkey" value="Switch to unused dependencies view"/>
     <div class="card mt-2 mb-2">
         <div class="card-header">Dependency details</div>
-        <div class="card-body">
+        <div class="card-body overflow-auto">
             <table class="manage-table colored" border="0" cellspacing="0" cellpadding="0" width="100%">
                 ${render_dependencies_details(tools, requirements_status, tool_ids_by_requirements)}
 %endif

--- a/templates/webapps/galaxy/admin/sanitize_whitelist.mako
+++ b/templates/webapps/galaxy/admin/sanitize_whitelist.mako
@@ -25,7 +25,7 @@
     <form name="sanitize_whitelist" method="post" action="${h.url_for( controller='admin', action='sanitize_whitelist' )}">
     <div class="card mb-3">
         <div class="card-header">Tool Sanitization Whitelist</div>
-        <div class="card-body">
+        <div class="card-body overflow-auto">
             <table class="manage-table colored" border="0" cellspacing="0" cellpadding="0" width="100%">
                 <tr>
                     <th>Whitelist</th>

--- a/templates/webapps/galaxy/admin/view_display_applications.mako
+++ b/templates/webapps/galaxy/admin/view_display_applications.mako
@@ -9,7 +9,7 @@
     <div class="card-header">There are currently ${len( display_applications )} <a class="icon-btn" href="${ h.url_for( controller='admin', action='reload_display_application' ) }" title="Reload all display applications" data-placement="bottom">
                         <span class="fa fa-refresh"></span>
                     </a> display applications loaded.</div>
-    <div class="card-body">
+    <div class="card-body overflow-auto">
         <table class="manage-table colored">
             <tr>
                 <th>Reload</th>


### PR DESCRIPTION
This PR fixes admin related views e.g. Display Applications and the Whitelist by using the recently introduced BS4 overflow utility instead of overwriting card-style defaults. This is less invasive, restores the default and prevents the cropping of border shadows of elements which are placed close to the card body borders.