### PR TITLE
[18.09] Backport: tests need to count data sets and collections

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -748,7 +748,7 @@ def _verify_outputs(testdef, history, jobs, tool_id, data_list, data_collection_
     maxseconds = testdef.maxseconds
     if testdef.num_outputs is not None:
         expected = testdef.num_outputs
-        actual = len(data_list)
+        actual = len(data_list) + len(data_collection_list)
         if expected != actual:
             message_template = "Incorrect number of outputs - expected %d, found %s."
             message = message_template % (expected, actual)

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -2200,7 +2200,7 @@ steps:
     state:
       produce_out_1: False
       filter_text_1: '1'
-      produce_collection: True
+      produce_collection: False
 test_data: {}
     """, history_id=history_id, wait=False)
             self.wait_for_invocation_and_jobs(history_id, run_object.workflow_id, run_object.invocation_id)

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -2200,6 +2200,7 @@ steps:
     state:
       produce_out_1: False
       filter_text_1: '1'
+      produce_collection: True
 test_data: {}
     """, history_id=history_id, wait=False)
             self.wait_for_invocation_and_jobs(history_id, run_object.workflow_id, run_object.invocation_id)

--- a/test/functional/tools/output_filter.xml
+++ b/test/functional/tools/output_filter.xml
@@ -9,6 +9,7 @@
   <inputs>
     <param name="produce_out_1" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Do Filter 1" />
     <param name="filter_text_1" type="text" value="1" />
+    <param name="produce_collection" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Collection Filter" />
   </inputs>
   <outputs>
     <data format="txt" from_work_dir="1" name="out_1">
@@ -19,8 +20,11 @@
       <!-- Must pass all filters... -->
       <filter>filter_text_1 == "foo"</filter>
     </data>
-    <data format="txt" from_work_dir="3" name="out_3">
-    </data>
+    <data format="txt" from_work_dir="3" name="out_3"/>
+    <collection name="list_output" type="list" label="List">
+      <discover_datasets pattern="(?P&lt;identifier_0&gt;[45])" ext="txt" visible="true" />
+      <filter>produce_collection is True</filter>
+    </collection>
   </outputs>
   <tests>
     <test expect_num_outputs="3">
@@ -40,6 +44,18 @@
       <param name="produce_out_1" value="false" />
       <param name="filter_text_1" value="not_foo_or_bar" />
       <output name="out_3"><assert_contents><has_line line="test" /></assert_contents></output>
+    </test>
+    <test expect_num_outputs="4">
+      <param name="produce_out_1" value="true" />
+      <param name="filter_text_1" value="foo" />
+      <param name="produce_collection" value="true" />
+      <output name="out_1"><assert_contents><has_line line="test" /></assert_contents></output>
+      <output name="out_2"><assert_contents><has_line line="test" /></assert_contents></output>
+      <output name="out_3"><assert_contents><has_line line="test" /></assert_contents></output>
+      <output_collection name="list_output" type="list">
+        <element name="4"><assert_contents><has_line line="test" /></assert_contents></element>
+        <element name="5"><assert_contents><has_line line="test" /></assert_contents></element>
+      </output_collection>
     </test>
   </tests>
 </tool>


### PR DESCRIPTION
Would like to backport this since IUC uses 18.09 in their CI tests. 