### PR TITLE
Quick 'make all datasets private' implementation.  

### DIFF
--- a/client/galaxy/scripts/apps/analysis.js
+++ b/client/galaxy/scripts/apps/analysis.js
@@ -150,10 +150,9 @@ window.app = function app(options, bootstrapped) {
                 new GridView({
                     url_base: `${Galaxy.root}workflow/list_published`,
                     active_tab: "shared",
-                    url_data:
-                        {
-                            'f-username': ( userFilter == null ) ? "" : userFilter
-                        }
+                    url_data: {
+                        "f-username": userFilter == null ? "" : userFilter
+                    }
                 })
             );
         },

--- a/client/galaxy/scripts/mvc/history/options-menu.js
+++ b/client/galaxy/scripts/mvc/history/options-menu.js
@@ -105,13 +105,9 @@ var menu = [
                     )
                 )
             ) {
-                $.post(
-                    `${Galaxy.root}history/make_private`,
-                    { history_id: "${Galaxy.currHistoryPanel.model.id}" },
-                    () => {
-                        Galaxy.currHistoryPanel.loadCurrentHistory();
-                    }
-                );
+                $.post(`${Galaxy.root}history/make_private`, { history_id: Galaxy.currHistoryPanel.model.id }, () => {
+                    Galaxy.currHistoryPanel.loadCurrentHistory();
+                });
             }
         }
     },

--- a/client/galaxy/scripts/mvc/history/options-menu.js
+++ b/client/galaxy/scripts/mvc/history/options-menu.js
@@ -101,7 +101,7 @@ var menu = [
                 Galaxy.currHistoryPanel &&
                 confirm(
                     _l(
-                        "This will make all the data in this history private, and will set permissions such that all new data is created as private.  Any datasets within that are currently shared will need to be re-shared or published.  Are you sure you want to do this?"
+                        "This will make all the data in this history private (excluding library datasets), and will set permissions such that all new data is created as private.  Any datasets within that are currently shared will need to be re-shared or published.  Are you sure you want to do this?"
                     )
                 )
             ) {

--- a/client/galaxy/scripts/mvc/history/options-menu.js
+++ b/client/galaxy/scripts/mvc/history/options-menu.js
@@ -92,7 +92,29 @@ var menu = [
             }
         }
     },
-
+    {
+        html: _l("Make Data Private"),
+        anon: true,
+        func: function() {
+            if (
+                Galaxy &&
+                Galaxy.currHistoryPanel &&
+                confirm(
+                    _l(
+                        "This will make all the data in this history private, and will set permissions such that all new data is created as private.  Any datasets within that are currently shared will need to be re-shared or published.  Are you sure you want to do this?"
+                    )
+                )
+            ) {
+                $.post(
+                    `${Galaxy.root}history/make_private`,
+                    { history_id: "${Galaxy.currHistoryPanel.model.id}" },
+                    () => {
+                        Galaxy.currHistoryPanel.loadCurrentHistory();
+                    }
+                );
+            }
+        }
+    },
     {
         html: _l("Dataset Actions"),
         header: true,

--- a/client/galaxy/scripts/mvc/user/user-preferences.js
+++ b/client/galaxy/scripts/mvc/user/user-preferences.js
@@ -62,7 +62,9 @@ var Model = Backbone.Model.extend({
                         $.post(`${Galaxy.root}history/make_private`, { all_histories: true }, () => {
                             Galaxy.modal.show({
                                 title: _l("Datasets are now private"),
-                                body: "All of your histories and datsets have been made private.",
+                                body: `All of your histories and datsets have been made private.  If you'd like to make all *future* histories private please use the <a href="${
+                                    Galaxy.root
+                                }user/permissions">User Permissions</a> interface.`,
                                 buttons: {
                                     Close: function() {
                                         Galaxy.modal.hide();

--- a/client/galaxy/scripts/mvc/user/user-preferences.js
+++ b/client/galaxy/scripts/mvc/user/user-preferences.js
@@ -49,7 +49,7 @@ var Model = Backbone.Model.extend({
                     if (
                         confirm(
                             _l(
-                                "WARNING: This will make *all* datasets for which you have " +
+                                "WARNING: This will make all datasets (excluding library datasets) for which you have " +
                                     "'management' permissions, in all of your histories " +
                                     "private, and will set permissions such that all " +
                                     "of your new data in these histories is created as private.  Any " +

--- a/client/galaxy/scripts/mvc/user/user-preferences.js
+++ b/client/galaxy/scripts/mvc/user/user-preferences.js
@@ -41,6 +41,38 @@ var Model = Backbone.Model.extend({
                 submit_title: "Save permissions",
                 redirect: "user"
             },
+            make_data_private: {
+                title: _l("Make all data private"),
+                description: _l("Click here to make all data private."),
+                icon: "fa-lock",
+                onclick: function() {
+                    if (
+                        confirm(
+                            _l(
+                                "WARNING: This will make *all* datasets for which you have " +
+                                    "'management' permissions, in all of your histories " +
+                                    "private, and will set permissions such that all " +
+                                    "of your new data in these histories is created as private.  Any " +
+                                    "datasets within that are currently shared will need " +
+                                    "to be re-shared or published.  Are you sure you " +
+                                    "want to do this?"
+                            )
+                        )
+                    ) {
+                        $.post(`${Galaxy.root}history/make_private`, { all_histories: true }, () => {
+                            Galaxy.modal.show({
+                                title: _l("Datasets are now private"),
+                                body: "All of your histories and datsets have been made private.",
+                                buttons: {
+                                    Close: function() {
+                                        Galaxy.modal.hide();
+                                    }
+                                }
+                            });
+                        });
+                    }
+                }
+            },
             api_key: {
                 title: _l("Manage API key"),
                 description: _l("Access your current API key or create a new one."),
@@ -130,6 +162,7 @@ var View = Backbone.View.extend({
             }
             self._addLink("custom_builds");
             self._addLink("permissions");
+            self._addLink("make_data_private");
             self._addLink("api_key");
             if (config.has_user_tool_filters) {
                 self._addLink("toolbox_filters");

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -721,7 +721,9 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             trans.app.security_agent.history_set_default_permissions(history, private_permissions)
             # Set private role for all datasets
             for hda in history.datasets:
-                if (not trans.app.security_agent.dataset_is_private_to_user(hda.dataset) and trans.app.security_agent.can_manage_dataset(user_roles, hda.dataset)):
+                if (not hda.dataset.library_associations
+                        and not trans.app.security_agent.dataset_is_private_to_user(hda.dataset)
+                        and trans.app.security_agent.can_manage_dataset(user_roles, hda.dataset)):
                     # If it's not private to me, and I can manage it, set fixed private permissions.
                     trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)
                     if not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset):

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -721,12 +721,11 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             trans.app.security_agent.history_set_default_permissions(history, private_permissions)
             # Set private role for all datasets
             for hda in history.datasets:
-                if trans.app.security_agent.dataset_is_public(hda.dataset):
-                    if trans.app.security_agent.can_manage_dataset(user_roles, hda.dataset):
-                        if not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset):
-                            trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)
-                        if not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset):
-                            raise exceptions.InternalServerError('An error occured and the dataset is NOT private.')
+                if (not trans.app.security_agent.dataset_is_private_to_user(hda.dataset) and trans.app.security_agent.can_manage_dataset(user_roles, hda.dataset)):
+                    # If it's not private to me, and I can manage it, set fixed private permissions.
+                    trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)
+                    if not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset):
+                        raise exceptions.InternalServerError('An error occurred and the dataset is NOT private.')
         return {'message': 'History \'%s\' dataset permissions have been changed.' % history.name}
 
     @web.expose

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -726,7 +726,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
                     trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)
                     if not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset):
                         raise exceptions.InternalServerError('An error occurred and the dataset is NOT private.')
-        return {'message': 'History \'%s\' dataset permissions have been changed.' % history.name}
+        return {'message': 'Success, requested permissions have been changed in %s.' % ("all histories" if all_histories else history.name)}
 
     @web.expose
     @web.require_login("share histories with other users")

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -705,7 +705,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         if all_histories:
             histories = trans.user.histories
         elif history_id:
-            history = [self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)]
+            history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
             if history:
                 histories.append(history)
         if not histories:
@@ -722,7 +722,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             # Set private role for all datasets
             for hda in history.datasets:
                 if (not hda.dataset.library_associations
-                        and not trans.app.security_agent.dataset_is_private_to_user(hda.dataset)
+                        and not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset)
                         and trans.app.security_agent.can_manage_dataset(user_roles, hda.dataset)):
                     # If it's not private to me, and I can manage it, set fixed private permissions.
                     trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -694,6 +694,41 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             trans.app.security_agent.history_set_default_permissions(history, permissions)
             return {'message': 'Default history \'%s\' dataset permissions have been changed.' % history.name}
 
+    @web.expose_api
+    @web.require_login("make datasets private")
+    def make_private(self, trans, history_id=None, all_histories=False, **kwd):
+        """
+        Sets the datasets within a history to private.  Also sets the default
+        permissions for the history to private, for future datasets.
+        """
+        histories = []
+        if all_histories:
+            histories = trans.user.histories
+        elif history_id:
+            history = [self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)]
+            if history:
+                histories.append(history)
+        if not histories:
+            return self.message_exception(trans, 'Invalid history or histories specified.')
+        private_role = trans.app.security_agent.get_private_user_role(trans.user)
+        user_roles = trans.user.all_roles()
+        private_permissions = {
+            trans.app.security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS: [private_role],
+            trans.app.security_agent.permitted_actions.DATASET_ACCESS: [private_role],
+        }
+        for history in histories:
+            # Set default role for history to private
+            trans.app.security_agent.history_set_default_permissions(history, private_permissions)
+            # Set private role for all datasets
+            for hda in history.datasets:
+                if trans.app.security_agent.dataset_is_public(hda.dataset):
+                    if trans.app.security_agent.can_manage_dataset(user_roles, hda.dataset):
+                        if not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset):
+                            trans.app.security_agent.set_all_dataset_permissions(hda.dataset, private_permissions)
+                        if not trans.app.security_agent.dataset_is_private_to_user(trans, hda.dataset):
+                            raise exceptions.InternalServerError('An error occured and the dataset is NOT private.')
+        return {'message': 'History \'%s\' dataset permissions have been changed.' % history.name}
+
     @web.expose
     @web.require_login("share histories with other users")
     def share(self, trans, id=None, email="", **kwd):


### PR DESCRIPTION
Takes a single history or operates on all of a user's histories, making the datasets within that the user has 'management' permissions of private.  Intentionally doesn't use an API, rather a simple webcontroller endpoint, because I think we'll want to handle this with group operations and the like down the road, and will enhance existing APIs.

@natefoo You'd mentioned library datasets, and I was thinking about collections, too, but I didn't see at first glance how those were shared/exposed via RBAC, so if someone with more knowledge wanted to take a poke, that'd be great.