### PR TITLE
Update shed_tool_conf.xml.sample

### DIFF
--- a/config/shed_tool_conf.xml.sample
+++ b/config/shed_tool_conf.xml.sample
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
-<toolbox tool_path="../shed_tools">
+<toolbox tool_path="shed_tools">
 </toolbox>


### PR DESCRIPTION
With the current default tools are installed to:

`GALAXY_ROOT/../shed_tools/`

I'm not sure in how far this interferes with `shed_tool_data_path` in galaxy.yml (which defaults to `tool-data`).

Also, I guess the same should be applied to `migrated_tools_conf.xml`