### PR TITLE
[18.09] Fix for workflow parameter collection in workflows view.

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -734,9 +734,11 @@ export default Backbone.View.extend({
                 $.each(node.post_job_actions, (k, pja) => {
                     if (pja.action_arguments) {
                         $.each(pja.action_arguments, (k, action_argument) => {
-                            var arg_matches = action_argument.match(parameter_re);
-                            if (arg_matches) {
-                                matches = matches.concat(arg_matches);
+                            if (typeof action_argument === "string") {
+                                var arg_matches = action_argument.match(parameter_re);
+                                if (arg_matches) {
+                                    matches = matches.concat(arg_matches);
+                                }
                             }
                         });
                     }

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -735,7 +735,7 @@ export default Backbone.View.extend({
                     if (pja.action_arguments) {
                         $.each(pja.action_arguments, (k, action_argument) => {
                             if (typeof action_argument === "string") {
-                                var arg_matches = action_argument.match(parameter_re);
+                                let arg_matches = action_argument.match(parameter_re);
                                 if (arg_matches) {
                                     matches = matches.concat(arg_matches);
                                 }


### PR DESCRIPTION
This fixes #6918.

I didn't track down when exactly this broke, but the problem was that the internal representation of columns in the data is now (?) correctly (?) an integer.  Anyway, we just skip matching for params against those.