### PR TITLE
Topic/empty data table

### DIFF
--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -597,7 +597,6 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
                 fields.append(field_value)
         else:
             fields = entry
-        log.error("FIELDS %s"%(str(fields)))
         is_error = False
         if self.largest_index < len(fields):
             fields = self._replace_field_separators(fields)
@@ -613,7 +612,6 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
 
         if persist and (not is_error or persist_on_error):
             filename = self.get_filename_for_source(entry_source)
-            log.error("FILENAME %s"%(str(filename)))
             if filename is None:
                 # should we default to using any filename here instead?
                 log.error("Unable to determine filename for persisting data table '%s' values: '%s'.", self.name, fields)

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -597,6 +597,7 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
                 fields.append(field_value)
         else:
             fields = entry
+        log.error("FIELDS %s"%(str(fields)))
         is_error = False
         if self.largest_index < len(fields):
             fields = self._replace_field_separators(fields)
@@ -612,6 +613,7 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
 
         if persist and (not is_error or persist_on_error):
             filename = self.get_filename_for_source(entry_source)
+            log.error("FILENAME %s"%(str(filename)))
             if filename is None:
                 # should we default to using any filename here instead?
                 log.error("Unable to determine filename for persisting data table '%s' values: '%s'.", self.name, fields)
@@ -624,13 +626,13 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
                 except IOError as e:
                     log.warning('Error opening data table file (%s) with r+b, assuming file does not exist and will open as wb: %s', filename, e)
                     data_table_fh = open(filename, 'wb')
-                if os.stat(filename)[6] != 0:
+                if os.stat(filename).st_size != 0:
                     # ensure last existing line ends with new line
                     data_table_fh.seek(-1, 2)  # last char in file
                     last_char = data_table_fh.read(1)
                     if last_char not in [b'\n', b'\r']:
                         data_table_fh.write(b'\n')
-                    fields = "%s\n" % self.separator.join(fields)
+                fields = "%s\n" % self.separator.join(fields)
                 data_table_fh.write(fields.encode('utf-8'))
         return not is_error
 


### PR DESCRIPTION
For empty loc files the following happens: 

```
Traceback (most recent call last):
  File "lib/galaxy/jobs/runners/local.py", line 152, in queue_job
    self._finish_or_resubmit_job(job_state, stdout, stderr, exit_code)
  File "lib/galaxy/jobs/runners/__init__.py", line 455, in _finish_or_resubmit_job
    job_state.job_wrapper.finish(stdout, stderr, exit_code, check_output_detected_state=check_output_detected_state)
  File "lib/galaxy/jobs/__init__.py", line 1493, in finish
    self.tool.exec_after_process(self.queue.app, inp_data, out_data, param_dict, job=job)
  File "lib/galaxy/tools/__init__.py", line 2310, in exec_after_process
    data_manager.process_result(out_data)
  File "lib/galaxy/tools/data_manager/manager.py", line 319, in process_result
    data_table.add_entry(data_table_value, persist=True, entry_source=self)
  File "lib/galaxy/tools/data/__init__.py", line 264, in add_entry
    self._add_entry(entry, allow_duplicates=allow_duplicates, persist=persist, persist_on_error=persist_on_error, entry_source=entry_source, **kwd)
  File "lib/galaxy/tools/data/__init__.py", line 636, in _add_entry
    data_table_fh.write(fields.encode('utf-8'))
AttributeError: 'list' object has no attribute 'encode'
```

because the fields list needs to turned into a string also for nonempty files.

