### PR TITLE
Kubernetes job runner integration test and enhancements

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -135,7 +135,7 @@
                         storage: 10Gi
                       accessModes:
                         - ReadWriteMany
-                      persistentVolumeReclaimPolicy: Retained
+                      persistentVolumeReclaimPolicy: Retain
                       nfs:
                         path: /scratch1/galaxy_data
                         server: 192.168.64.1

--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -120,11 +120,6 @@
         <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
             <!-- The Kubernetes (k8s) plugin allows to send jobs to a k8s cluster which shares filesystem with Galaxy.
 
-                 This requires installing pykube. Install pykube by activating Galaxy's virtual
-                 environment and then executing the following pip command:
-
-                 pip install pykube==0.15.0
-
                  The shared file system needs to be exposed to k8s through a Persistent Volume (rw) and a Persistent
                  Volume Claim. An example of a Persistent Volume could be, in yaml (access modes, reclaim policy and
                  path are relevant) (persistent_volume.yaml):

--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -165,7 +165,7 @@
                  kubectl create -f <path/to/persistent_volume.yaml>
                  kubectl create -f <path/to/pv_claim.yaml>
 
-                 pointing of course to the same Kubernetes cluster that you intend to use.
+                 pointing to the Kubernetes cluster that you intend to use.
             -->
 
             <param id="k8s_config_path">/path/to/kubeconfig</param>
@@ -191,14 +191,12 @@
                  Kubernetes 1.2 and on. Changing this a much newer version in the future might require changes to the
                  plugin runner code. Value extensions/v1beta1 is also supported for pre 1.2 legacy installations.
                  -->
-            <param id="k8s_persistent_volume_claim_name">galaxy_pvc</param>
-            <!-- The name of the Persisten Volume Claim (PVC) to be used, details above, needs to match the PVC's
-                 metadata:name -->
+            <param id="k8s_persistent_volume_claims">galaxy_pvc1:/mount_point1,galaxy_pvc2:/mount_point2</param>
+            <!-- Comma separated list of Persistent Volume Claim (PVC) to container mount point mappings, in the format
+                 PVC:mount point
 
-            <param id="k8s_persistent_volume_claim_mount_path">/scratch1/galaxy_data</param>
-            <!-- The mount path needs to be parent directory of the "file_path" and "new_file_path" paths
-                 set in universe_wsgi.ini (or equivalent general galaxy config file). This is the mount path of the
-                 PVC within the docker container that will be actually running the tool -->
+                 Typical mount paths are the file_path, job_working_directory, all paths containing tools and scripts
+                 and all library paths set in galaxy.yml (or equivalent general galaxy config file). -->
 
             <!-- <param id="k8s_namespace">default</param> -->
             <!-- The namespace to be used on the Kubernetes cluster, if different from default, this needs to be set

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -104,6 +104,9 @@ class ConditionalDependencies(object):
     def check_pbs_python(self):
         return "galaxy.jobs.runners.pbs:PBSJobRunner" in self.job_runners
 
+    def check_pykube(self):
+        return "galaxy.jobs.runners.kubernetes:KubernetesJobRunner" in self.job_runners
+
     def check_chronos_python(self):
         return "galaxy.jobs.runners.chronos:ChronosJobRunner" in self.job_runners
 

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -17,6 +17,9 @@ galaxycloudrunner
 # Chronos client
 chronos-python==0.38.0
 
+# Kubernetes job runner
+pykube==0.15.0
+
 # Synnefo / Pithos+ object store client
 kamaki
 

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -15,6 +15,7 @@ from galaxy.jobs.runners.util.job_script import (
 log = getLogger(__name__)
 
 CAPTURE_RETURN_CODE = "return_code=$?"
+YIELD_CAPTURED_CODE = 'sh -c "exit $return_code"'
 SETUP_GALAXY_FOR_METADATA = """
 [ "$GALAXY_VIRTUAL_ENV" = "None" ] && GALAXY_VIRTUAL_ENV="$_GALAXY_VIRTUAL_ENV"; _galaxy_setup_environment True
 """
@@ -268,6 +269,8 @@ tee -a stderr.log < "$err" >&2 &""",
             self.append_command(CAPTURE_RETURN_CODE)
 
     def build(self):
+        if self.return_code_captured:
+            self.append_command(YIELD_CAPTURED_CODE)
         return self.commands
 
 

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -30,6 +30,8 @@ def build_command(
     create_tool_working_directory=True,
     remote_command_params={},
     metadata_directory=None,
+    stdout_file=None,
+    stderr_file=None,
 ):
     """
     Compose the sequence of commands necessary to execute a job. This will
@@ -103,6 +105,8 @@ def build_command(
     if include_work_dir_outputs:
         __handle_work_dir_outputs(commands_builder, job_wrapper, runner, remote_command_params)
 
+    if stdout_file and stderr_file:
+        commands_builder.capture_stdout_stderr(stdout_file, stderr_file)
     commands_builder.capture_return_code()
 
     if include_metadata and job_wrapper.requires_setting_metadata:
@@ -227,23 +231,36 @@ class CommandsBuilder(object):
         # the last thing that happens is an exit with return code.
         self.return_code_captured = False
 
-    def prepend_command(self, command):
+    def prepend_command(self, command, sep=";"):
         if command:
-            self.commands = u"%s; %s" % (command,
+            self.commands = u"%s%s %s" % (command,
+                                         sep,
                                          self.commands)
         return self
 
     def prepend_commands(self, commands):
         return self.prepend_command(u"; ".join(c for c in commands if c))
 
-    def append_command(self, command):
+    def append_command(self, command, sep=';'):
         if command:
-            self.commands = u"%s; %s" % (self.commands,
-                                         command)
+            self.commands = u"%s%s %s" % (self.commands,
+                                          sep,
+                                          command)
         return self
 
     def append_commands(self, commands):
         self.append_command(u"; ".join(c for c in commands if c))
+
+    def capture_stdout_stderr(self, stdout_file, stderr_file):
+        self.prepend_command("""out="${TMPDIR:-/tmp}/out.$$" err="${TMPDIR:-/tmp}/err.$$"
+mkfifo "$out" "$err"
+trap 'rm "$out" "$err"' EXIT
+tee -a stdout.log < "$out" &
+tee -a stderr.log < "$err" >&2 &""",
+                             sep="")
+        self.append_command("> '{stdout_file}' 2> '{stderr_file}'".format(stdout_file=stdout_file,
+                                                                          stderr_file=stderr_file),
+                            sep="")
 
     def capture_return_code(self):
         if not self.return_code_captured:

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -193,8 +193,13 @@ class BaseJobRunner(object):
         """
         raise NotImplementedError()
 
-    def prepare_job(self, job_wrapper, include_metadata=False, include_work_dir_outputs=True,
-                    modify_command_for_container=True):
+    def prepare_job(self,
+                    job_wrapper,
+                    include_metadata=False,
+                    include_work_dir_outputs=True,
+                    modify_command_for_container=True,
+                    stdout_file=None,
+                    stderr_file=None):
         """Some sanity checks that all runners' queue_job() methods are likely to want to do
         """
         job_id = job_wrapper.get_id_tag()
@@ -220,7 +225,9 @@ class BaseJobRunner(object):
                 job_wrapper,
                 include_metadata=include_metadata,
                 include_work_dir_outputs=include_work_dir_outputs,
-                modify_command_for_container=modify_command_for_container
+                modify_command_for_container=modify_command_for_container,
+                stdout_file=stdout_file,
+                stderr_file=stderr_file,
             )
         except Exception as e:
             log.exception("(%s) Failure preparing job" % job_id)
@@ -243,8 +250,13 @@ class BaseJobRunner(object):
     def recover(self, job, job_wrapper):
         raise NotImplementedError()
 
-    def build_command_line(self, job_wrapper, include_metadata=False, include_work_dir_outputs=True,
-                           modify_command_for_container=True):
+    def build_command_line(self,
+                           job_wrapper,
+                           include_metadata=False,
+                           include_work_dir_outputs=True,
+                           modify_command_for_container=True,
+                           stdout_file=None,
+                           stderr_file=None):
         container = self._find_container(job_wrapper)
         if not container and job_wrapper.requires_containerization:
             raise Exception("Failed to find a container when required, contact Galaxy admin.")
@@ -254,7 +266,9 @@ class BaseJobRunner(object):
             include_metadata=include_metadata,
             include_work_dir_outputs=include_work_dir_outputs,
             modify_command_for_container=modify_command_for_container,
-            container=container
+            container=container,
+            stdout_file=stdout_file,
+            stderr_file=stderr_file,
         )
 
     def get_work_dir_outputs(self, job_wrapper, job_working_directory=None, tool_working_directory=None):

--- a/lib/galaxy/jobs/runners/chronos.py
+++ b/lib/galaxy/jobs/runners/chronos.py
@@ -142,7 +142,6 @@ class ChronosJobRunner(AsynchronousJobRunner):
                                    job_id=job_name,
                                    job_destination=job_destination)
         self.monitor_queue.put(ajs)
-        return None
 
     @handle_exception_call
     def stop_job(self, job_wrapper):

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -76,6 +76,7 @@ class ShellJobRunner(AsynchronousJobRunner):
         script = self.get_job_file(
             job_wrapper,
             exit_code_path=ajs.exit_code_file,
+            shell=job_wrapper.shell,
             **job_file_kwargs
         )
 

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -111,6 +111,7 @@ class CondorJobRunner(AsynchronousJobRunner):
             job_wrapper,
             exit_code_path=cjs.exit_code_file,
             slots_statement=galaxy_slots_statement,
+            shell=job_wrapper.shell,
         )
         try:
             self.write_executable_script(executable, script)

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -152,7 +152,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
             jt['nativeSpecification'] = native_spec
 
         # fill in the DRM's job run template
-        script = self.get_job_file(job_wrapper, exit_code_path=ajs.exit_code_file)
+        script = self.get_job_file(job_wrapper, exit_code_path=ajs.exit_code_file, shell=job_wrapper.shell)
         try:
             self.write_executable_script(ajs.job_file, script)
         except Exception:

--- a/lib/galaxy/jobs/runners/godocker.py
+++ b/lib/galaxy/jobs/runners/godocker.py
@@ -160,7 +160,6 @@ class GodockerJobRunner(AsynchronousJobRunner):
             # Create an object of AsynchronousJobState and add it to the monitor queue.
             ajs = AsynchronousJobState(files_dir=job_wrapper.working_directory, job_wrapper=job_wrapper, job_id=job_id, job_destination=job_destination)
             self.monitor_queue.put(ajs)
-        return None
 
     def check_watched_item(self, job_state):
         """ Get the job current status from GoDocker

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -61,7 +61,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_default_requests_memory=dict(map=str, default=None),
             k8s_default_limits_cpu=dict(map=str, default=None),
             k8s_default_limits_memory=dict(map=str, default=None),
-            k8s_pod_retrials=dict(map=int, valid=lambda x: int > 0, default=3))
+            k8s_pod_retrials=dict(map=int, valid=lambda x: int >= 0, default=3))
 
         if 'runner_param_specs' not in kwargs:
             kwargs['runner_param_specs'] = dict()

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -263,14 +263,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         k8s_container = {
             "name": self.__get_k8s_container_name(ajs.job_wrapper),
             "image": self._find_container(ajs.job_wrapper).container_id,
-            "env": [{
-                "name": "GALAXY_VIRTUAL_ENV",
-                "value": "None"
-            }, {
-                "name": "GALAXY_LIB",
-                "value": "None"
-            }
-            ],
             # this form of command overrides the entrypoint and allows multi command
             # command line execution, separated by ;, which is what Galaxy does
             # to assemble the command.

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -151,10 +151,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         ajs.job_id = k8s_job_name
         self.monitor_queue.put(ajs)
 
-        # external_runJob_script can be None, in which case it's not used.
-        external_runjob_script = None
-        return external_runjob_script
-
     def __get_pull_policy(self):
         if "k8s_pull_policy" in self.runner_params:
             if self.runner_params['k8s_pull_policy'] in ["Always", "IfNotPresent", "Never"]:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -3,6 +3,7 @@ Offload jobs to a Kubernetes cluster.
 """
 
 import logging
+import math
 import os
 import re
 from time import sleep
@@ -286,7 +287,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 if 'memory' in limits:
                     envs.append({'name': 'GALAXY_MEMORY_MB', 'value': str(ByteSize(limits['memory']).to_unit('M', as_string=False))})
                 if 'cpu' in limits:
-                    envs.append({'name': 'GALAXY_SLOTS', 'value': limits['cpu']})
+                    envs.append({'name': 'GALAXY_SLOTS', 'value': str(int(math.ceil(float(limits['cpu']))))})
             k8s_container['resources'] = resources
             k8s_container['env'] = envs
 

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -263,10 +263,22 @@ class KubernetesJobRunner(AsynchronousJobRunner):
     def __get_k8s_containers(self, ajs):
         """Fills in all required for setting up the docker containers to be used, including setting a pull policy if
            this has been set.
+           $GALAXY_VIRTUAL_ENV is set to None to avoid the galaxy virtualenv inside the tool container.
+           $GALAXY_LIB is set to None to avoid changing the python path inside the container.
+           Setting these variables changes the described behaviour in the job file shell script
+           used to execute the tool inside the container.
         """
         k8s_container = {
             "name": self.__get_k8s_container_name(ajs.job_wrapper),
             "image": self._find_container(ajs.job_wrapper).container_id,
+            "env": [{
+                "name": "GALAXY_VIRTUAL_ENV",
+                "value": "None"
+            }, {
+                "name": "GALAXY_LIB",
+                "value": "None"
+            }
+            ],
             # this form of command overrides the entrypoint and allows multi command
             # command line execution, separated by ;, which is what Galaxy does
             # to assemble the command.

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -89,13 +89,16 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         # We currently don't need to include_metadata or include_work_dir_outputs, as working directory is the same
         # where galaxy will expect results.
         log.debug("Starting queue_job for job " + job_wrapper.get_id_tag())
-        if not self.prepare_job(job_wrapper, include_metadata=False, modify_command_for_container=False, yield_return_code=False):
-            return
-
         ajs = AsynchronousJobState(files_dir=job_wrapper.working_directory,
                                    job_wrapper=job_wrapper,
                                    job_destination=job_wrapper.job_destination)
 
+        if not self.prepare_job(job_wrapper,
+                                include_metadata=False,
+                                modify_command_for_container=False,
+                                stdout_file=ajs.output_file,
+                                stderr_file=ajs.error_file):
+            return
 
         script = self.get_job_file(job_wrapper, exit_code_path=ajs.exit_code_file, shell=job_wrapper.shell)
         try:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -3,8 +3,8 @@ Offload jobs to a Kubernetes cluster.
 """
 
 import logging
+import os
 import re
-from os import environ as os_environ
 from time import sleep
 
 
@@ -46,7 +46,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         # Check if pykube was importable, fail if not
         assert KubeConfig is not None, K8S_IMPORT_MESSAGE
         runner_param_specs = dict(
-            k8s_config_path=dict(map=str, default=os_environ.get('KUBECONFIG', None)),
+            k8s_config_path=dict(map=str, default=os.environ.get('KUBECONFIG', None)),
             k8s_use_service_account=dict(map=bool, default=False),
             k8s_persistent_volume_claim_name=dict(map=str),
             k8s_persistent_volume_claim_mount_path=dict(map=str),

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -67,8 +67,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         """Start the job runner parent object """
         super(KubernetesJobRunner, self).__init__(app, nworkers, **kwargs)
 
-        # self.cli_interface = CliInterface()
-
         if "k8s_use_service_account" in self.runner_params and self.runner_params["k8s_use_service_account"]:
             self._pykube_api = HTTPClient(KubeConfig.from_service_account())
         else:
@@ -280,15 +278,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         if self._default_pull_policy:
             k8s_container["imagePullPolicy"] = self._default_pull_policy
-        # if self.__requires_ports(job_wrapper):
-        #    k8s_container['ports'] = self.__get_k8s_containers_ports(job_wrapper)
 
         return [k8s_container]
-
-    # def __get_k8s_containers_ports(self, job_wrapper):
-
-    #    for k,v self.runner_params:
-    #        if k.startswith("container_port_"):
 
     def __get_resources(self, job_wrapper):
         mem_request = self.__get_memory_request(job_wrapper)

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -107,7 +107,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                                 stderr_file=ajs.error_file):
             return
 
-        script = self.get_job_file(job_wrapper, exit_code_path=ajs.exit_code_file, shell=job_wrapper.shell)
+        script = self.get_job_file(job_wrapper, exit_code_path=ajs.exit_code_file, shell=job_wrapper.shell, galaxy_virtual_env=None)
         try:
             self.write_executable_script(ajs.job_file, script)
         except Exception:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -7,9 +7,6 @@ import os
 import re
 from time import sleep
 
-
-from six import text_type
-
 from galaxy import model
 from galaxy.jobs.runners import (
     AsynchronousJobRunner,
@@ -555,8 +552,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             except Exception as detail:
                 log.info("Could not write log file for pod %s due to HTTPError %s",
                          pod_obj['metadata']['name'], detail)
-        if isinstance(log_string, text_type):
-            log_string = log_string.encode('utf8')
 
         logs_file_path = job_state.output_file
         try:
@@ -586,7 +581,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
     def recover(self, job, job_wrapper):
         """Recovers jobs stuck in the queued/running state when Galaxy started"""
-        # TODO this needs to be implemented to override unimplemented base method
         job_id = job.get_job_runner_external_id()
         log.debug("k8s trying to recover job: " + job_id)
         if job_id is None:

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -73,6 +73,7 @@ class LocalJobRunner(BaseJobRunner):
             'command': command_line,
             'exit_code_path': exit_code_path,
             'working_directory': job_wrapper.working_directory,
+            'shell': job_wrapper.shell,
         }
         job_file_contents = self.get_job_file(job_wrapper, **job_script_props)
         self.write_executable_script(job_file, job_file_contents)

--- a/lib/galaxy/jobs/runners/pbs.py
+++ b/lib/galaxy/jobs/runners/pbs.py
@@ -288,7 +288,7 @@ class PBSJobRunner(AsynchronousJobRunner):
             stage_commands = ''
 
         env_setup_commands = [stage_commands]
-        script = self.get_job_file(job_wrapper, exit_code_path=ecfile, env_setup_commands=env_setup_commands)
+        script = self.get_job_file(job_wrapper, exit_code_path=ecfile, env_setup_commands=env_setup_commands, shell=job_wrapper.shell)
         job_file = "%s/%s.sh" % (self.app.config.cluster_files_directory, job_wrapper.job_id)
         self.write_executable_script(job_file, script)
         # job was deleted while we were preparing it

--- a/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
@@ -23,6 +23,9 @@ elif [ -f "$PBS_NODEFILE" ]; then
     GALAXY_SLOTS=`wc -l < $PBS_NODEFILE`
 elif [ -n "$LSB_DJOB_NUMPROC" ]; then
     GALAXY_SLOTS="$LSB_DJOB_NUMPROC"
+elif [ -n "$GALAXY_SLOTS" ]; then
+    # kubernetes runner injects GALAXY_SLOTS into environment
+    GALAXY_SLOTS=$GALAXY_SLOTS
 else
     GALAXY_SLOTS="1"
     unset GALAXY_SLOTS_CONFIGURED

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -37,7 +37,5 @@ cd $working_directory
 $memory_statement
 $instrument_pre_commands
 $command
-echo $return_code > $exit_code_path
+echo $? > $exit_code_path
 $instrument_post_commands
-# exit with the exit code captured for the tool_script
-sh -c "exit $return_code"

--- a/lib/galaxy/jobs/runners/util/job_script/__init__.py
+++ b/lib/galaxy/jobs/runners/util/job_script/__init__.py
@@ -67,7 +67,7 @@ def job_script(template=DEFAULT_JOB_FILE_TEMPLATE, **kwds):
     >>> script = job_script(working_directory='wd', command='uptime', exit_code_path='ec')
     >>> '\\nuptime\\n' in script
     True
-    >>> 'echo $return_code > ec' in script
+    >>> 'echo $? > ec' in script
     True
     >>> 'GALAXY_LIB="None"' in script
     True

--- a/lib/galaxy/tools/deps/dependencies.py
+++ b/lib/galaxy/tools/deps/dependencies.py
@@ -36,7 +36,11 @@ class ToolInfo(object):
     # variables they can consume (e.g. JVM options, license keys, etc..)
     # and add these to env_path_through
 
-    def __init__(self, container_descriptions=[], requirements=[], requires_galaxy_python_environment=False, env_pass_through=["GALAXY_SLOTS"]):
+    def __init__(self, container_descriptions=None, requirements=None, requires_galaxy_python_environment=False, env_pass_through=["GALAXY_SLOTS"]):
+        if container_descriptions is None:
+            container_descriptions = []
+        if requirements is None:
+            requirements = []
         self.container_descriptions = container_descriptions
         self.requirements = requirements
         self.requires_galaxy_python_environment = requires_galaxy_python_environment

--- a/lib/galaxy/util/bytesize.py
+++ b/lib/galaxy/util/bytesize.py
@@ -1,0 +1,68 @@
+SUFFIX_TO_BYTES = {
+    'KI': 1024,
+    'MI': 1024**2,
+    'GI': 1024**3,
+    'TI': 1024**4,
+    'PI': 1024**5,
+    'EI': 1024**6,
+    'K': 1000,
+    'M': 1000**2,
+    'G': 1000**3,
+    'T': 1000**4,
+    'P': 1000**5,
+    'E': 1000**6,
+}
+
+
+class ByteSize(object):
+    """Convert multiples of bytes to various units."""
+
+    def __init__(self, value):
+        """
+        Represents a quantity of bytes.
+
+        `value` may be an integer, in which case it is assumed to be bytes.
+        If value is a string, it is parsed as bytes if no suffix (Mi, M, Gi, G ...)
+        is found.
+
+        >>> values = [128974848, '129e6', '129M', '123Mi' ]
+        >>> [ByteSize(v).to_unit('M') for v in values]
+        ['128M', '129M', '129M', '128M']
+        """
+        self.value = parse_bytesize(value)
+
+    def to_unit(self, unit=None, as_string=True):
+        """unit must be `None` or one of Ki,Mi,Gi,Ti,Pi,Ei,K,M,G,T,P."""
+        if unit is None:
+            if as_string:
+                return str(self.value)
+            return self.value
+        unit = unit.upper()
+        new_value = int(self.value / SUFFIX_TO_BYTES[unit])
+        if not as_string:
+            return new_value
+        return "{value}{suffix}".format(value=new_value, suffix=unit)
+
+
+def parse_bytesize(value):
+    if isinstance(value, int):
+        # Assume bytes
+        return value
+    value = value.upper()
+    found_suffix = None
+    for suffix in SUFFIX_TO_BYTES:
+        if value.endswith(suffix):
+            found_suffix = suffix
+            break
+    if found_suffix:
+        value = value[:-len(found_suffix)]
+    try:
+        value = int(value)
+    except ValueError:
+        try:
+            value = float(value)
+        except ValueError:
+            raise ValueError("{value} is not a valid integer or float value".format(value=value))
+    if found_suffix:
+        value = value * SUFFIX_TO_BYTES[found_suffix]
+    return value

--- a/test/base/integration_util.py
+++ b/test/base/integration_util.py
@@ -37,6 +37,10 @@ def skip_unless_singularity():
     return skip_unless_executable("singularity")
 
 
+def skip_unless_kubernetes():
+    return skip_unless_executable("kubectl")
+
+
 class IntegrationTestCase(TestCase, UsesApiTestCaseMixin):
     """Unit test case with utilities for spinning up Galaxy."""
 

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -60,6 +60,7 @@
   <tool file="job_environment_default.xml" />
   <tool file="job_environment_default_legacy.xml" />
   <tool file="job_environment_explicit_shared_home.xml" />
+  <tool file="galaxy_slots_and_memory.xml" />
   <tool file="version_command_plain.xml" />
   <tool file="version_command_interpreter.xml" />
   <tool file="version_command_tool_dir.xml" />

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -17,7 +17,22 @@ SINGULARITY_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "singularity_job_co
 EXTENDED_TIMEOUT = 120
 
 
-class DockerizedJobsIntegrationTestCase(integration_util.IntegrationTestCase, RunsEnvironmentJobs):
+class MulledJobTestCases(object):
+    def test_explicit(self):
+        self.dataset_populator.run_tool("mulled_example_explicit", {}, self.history_id)
+        self.dataset_populator.wait_for_history(self.history_id, assert_ok=True)
+        output = self.dataset_populator.get_history_dataset_content(self.history_id, timeout=EXTENDED_TIMEOUT)
+        assert "0.7.15-r1140" in output
+
+    def test_mulled_simple(self):
+        self.dataset_populator.run_tool("mulled_example_simple", {}, self.history_id)
+        self.dataset_populator.wait_for_history(self.history_id, assert_ok=True)
+        output = self.dataset_populator.get_history_dataset_content(self.history_id, timeout=EXTENDED_TIMEOUT)
+        assert "0.7.15-r1140" in output
+
+
+@integration_util.skip_unless_docker()
+class DockerizedJobsIntegrationTestCase(integration_util.IntegrationTestCase, RunsEnvironmentJobs, MulledJobTestCases):
 
     framework_tool_and_types = True
     job_config_file = DOCKERIZED_JOB_CONFIG_FILE
@@ -47,19 +62,7 @@ class DockerizedJobsIntegrationTestCase(integration_util.IntegrationTestCase, Ru
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.history_id = self.dataset_populator.new_history()
 
-    def test_explicit(self):
-        self.dataset_populator.run_tool("mulled_example_explicit", {}, self.history_id)
-        self.dataset_populator.wait_for_history(self.history_id, assert_ok=True)
-        output = self.dataset_populator.get_history_dataset_content(self.history_id, timeout=EXTENDED_TIMEOUT)
-        assert "0.7.15-r1140" in output
-
-    def test_mulled_simple(self):
-        self.dataset_populator.run_tool("mulled_example_simple", {}, self.history_id)
-        self.dataset_populator.wait_for_history(self.history_id, assert_ok=True)
-        output = self.dataset_populator.get_history_dataset_content(self.history_id, timeout=EXTENDED_TIMEOUT)
-        assert "0.7.15-r1140" in output
-
-    def test_container_job_enviornment(self):
+    def test_container_job_environment(self):
         job_env = self._run_and_get_environment_properties("job_environment_default")
 
         euid = os.geteuid()

--- a/test/integration/test_job_recovery.py
+++ b/test/integration/test_job_recovery.py
@@ -18,6 +18,7 @@ class JobRecoveryBeforeHandledIntegerationTestCase(integration_util.IntegrationT
     def setUp(self):
         super(JobRecoveryBeforeHandledIntegerationTestCase, self).setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.history_id = self.dataset_populator.new_history()
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -93,6 +93,8 @@ def job_config(path):
     </plugins>
     <destinations default="k8s_destination">
         <destination id="k8s_destination" runner="k8s">
+            <param id="limits_cpu">2</param>
+            <param id="limits_memory">10M</param>
             <param id="docker_enabled">true</param>
             <param id="docker_default_container_id">busybox:ubuntu-14.04</param>
             <env id="SOME_ENV_VAR">42</env>
@@ -211,3 +213,17 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
         assert details['state'] == 'error', details
         assert details['stdout'] == 'The bool is not true\n', details
         assert details['stderr'] == 'Fatal error: Exit code 127 (Failing exit code.)\nThe bool is very not true\n'
+
+    @skip_without_tool('galaxy_slots_and_memory')
+    def test_slots_and_memory(self):
+        self.dataset_populator.run_tool(
+            'galaxy_slots_and_memory',
+            {},
+            self.history_id,
+            assert_ok=True
+        )
+        dataset_content = self.dataset_populator.get_history_dataset_content(self.history_id, hid=1).strip()
+        CPU = '2'
+        MEM = '10'
+        MEM_PER_SLOT = '5'
+        assert [CPU, MEM, MEM_PER_SLOT] == dataset_content.split('\n'), dataset_content

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -1,0 +1,132 @@
+"""Integration tests for the CLI shell plugins and runners."""
+import collections
+import os
+import string
+import subprocess
+import tempfile
+
+from base import integration_util  # noqa: I100,I202
+from base.populators import skip_without_tool
+from .test_job_environments import BaseJobEnvironmentIntegrationTestCase  # noqa: I201
+
+integration_util.skip_unless_kubernetes()
+
+PERSISTENT_VOLUME_NAME = 'pv-galaxy-integration-test'
+PERSISTENT_VOLUME_CLAIM_NAME = 'galaxy-pvc-integration-test'
+Config = collections.namedtuple('ConfigTuple', 'path')
+
+
+class KubeSetupConfigTuple(Config):
+
+    def setup(self):
+        subprocess.check_call(['kubectl', 'create', '-f', self.path])
+
+    def teardown(self):
+        subprocess.check_call(['kubectl', 'delete', '-f', self.path])
+
+
+def persistent_volume(path):
+    volume_yaml = string.Template("""
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: $persistent_volume_name
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  local:
+    path: $path
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: app
+          operator: NotIn
+          values:
+            - 'i-do-not-exist'
+    """).substitute(path=path,
+                    persistent_volume_name=PERSISTENT_VOLUME_NAME)
+    with tempfile.NamedTemporaryFile(suffix="_persistent_volume.yml", mode="w", delete=False) as volume:
+        volume.write(volume_yaml)
+    return KubeSetupConfigTuple(path=volume.name)
+
+
+def persistent_volume_claim():
+    peristent_volume_claim_yaml = string.Template("""
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: $persistent_volume_claim_name
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeName: $persistent_volume_name
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: manual
+""").substitute(persistent_volume_name=PERSISTENT_VOLUME_NAME,
+                persistent_volume_claim_name=PERSISTENT_VOLUME_CLAIM_NAME)
+    with tempfile.NamedTemporaryFile(suffix="_persistent_volume_claim.yml", mode="w", delete=False) as volume_claim:
+        volume_claim.write(peristent_volume_claim_yaml)
+    return KubeSetupConfigTuple(path=volume_claim.name)
+
+
+def job_config(path):
+    job_conf_template = string.Template("""<job_conf>
+    <plugins>
+        <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
+            <param id="k8s_persistent_volume_claim_name">galaxy-pvc-integration-test</param>
+            <param id="k8s_persistent_volume_claim_mount_path">$path</param>
+            <param id="k8s_config_path">$k8s_config_path</param>
+            <param id="k8s_galaxy_instance_id">gx-short-id</param>
+        </plugin>
+    </plugins>
+    <destinations default="k8s_destination">
+        <destination id="k8s_destination" runner="k8s">
+            <param id="docker_enabled">true</param>
+            <env id="SOME_ENV_VAR">42</env>
+        </destination>
+    </destinations>
+</job_conf>
+""")
+    job_conf_str = job_conf_template.substitute(path=path, k8s_config_path=os.environ.get('GALAXY_TEST_KUBE_CONFIG_PATH', '~/.kube/config'))
+    with tempfile.NamedTemporaryFile(suffix="_kubernetes_integration_job_conf", mode="w", delete=False) as job_conf:
+        job_conf.write(job_conf_str)
+    return Config(job_conf.name)
+
+
+class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.jobs_directory = tempfile.mkdtemp()
+        cls.persistent_volume = persistent_volume(path=cls.jobs_directory)
+        cls.persistent_volume.setup()
+        cls.persistent_volume_claim = persistent_volume_claim()
+        cls.persistent_volume_claim.setup()
+        cls.job_config = job_config(path=cls.jobs_directory)
+        super(BaseKubernetesIntegrationTestCase, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.persistent_volume_claim.teardown()
+        cls.persistent_volume.teardown()
+        super(BaseKubernetesIntegrationTestCase, cls).tearDownClass()
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config, ):
+        config["jobs_directory"] = cls.jobs_directory
+        config["file_path"] = cls.jobs_directory
+        config["job_config_file"] = cls.job_config.path
+
+    @skip_without_tool("job_environment_default")
+    def test_running_cli_job(self):
+        job_env = self._run_and_get_environment_properties()
+        assert job_env.some_env == '42'

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -125,6 +125,7 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
         config["jobs_directory"] = cls.jobs_directory
         config["file_path"] = cls.jobs_directory
         config["job_config_file"] = cls.job_config.path
+        config["default_job_shell"] = '/bin/sh'
 
     @skip_without_tool("job_environment_default")
     def test_running_cli_job(self):

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -1,5 +1,7 @@
 """Integration tests for the CLI shell plugins and runners."""
+# Tested on docker for mac 18.06.1-ce-mac73 using the default kubernetes setup
 import collections
+import json
 import os
 import string
 import subprocess
@@ -7,6 +9,7 @@ import tempfile
 
 from base import integration_util  # noqa: I100,I202
 from base.populators import skip_without_tool
+from .test_dockerized_jobs import MulledJobTestCases  # noqa: I201
 from .test_job_environments import BaseJobEnvironmentIntegrationTestCase  # noqa: I201
 
 integration_util.skip_unless_kubernetes()
@@ -81,6 +84,7 @@ spec:
 def job_config(path):
     job_conf_template = string.Template("""<job_conf>
     <plugins>
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="2"/>
         <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
             <param id="k8s_persistent_volume_claim_name">galaxy-pvc-integration-test</param>
             <param id="k8s_persistent_volume_claim_mount_path">$path</param>
@@ -91,9 +95,15 @@ def job_config(path):
     <destinations default="k8s_destination">
         <destination id="k8s_destination" runner="k8s">
             <param id="docker_enabled">true</param>
+            <param id="docker_default_container_id">busybox:ubuntu-14.04</param>
             <env id="SOME_ENV_VAR">42</env>
         </destination>
+        <destination id="local_dest" runner="local">
+        </destination>
     </destinations>
+    <tools>
+        <tool id="upload1" destination="local_dest"/>
+    </tools>
 </job_conf>
 """)
     job_conf_str = job_conf_template.substitute(path=path, k8s_config_path=os.environ.get('GALAXY_TEST_KUBE_CONFIG_PATH', '~/.kube/config'))
@@ -102,7 +112,11 @@ def job_config(path):
     return Config(job_conf.name)
 
 
-class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
+
+    def setUp(self):
+        super(BaseKubernetesIntegrationTestCase, self).setUp()
+        self.history_id = self.dataset_populator.new_history()
 
     @classmethod
     def setUpClass(cls):
@@ -126,8 +140,51 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
         config["file_path"] = cls.jobs_directory
         config["job_config_file"] = cls.job_config.path
         config["default_job_shell"] = '/bin/sh'
+        # Disable tool dependency resolution.
+        config["tool_dependency_dir"] = "none"
+        config["enable_beta_mulled_containers"] = "true"
 
     @skip_without_tool("job_environment_default")
-    def test_running_cli_job(self):
+    def test_job_environment(self):
         job_env = self._run_and_get_environment_properties()
         assert job_env.some_env == '42'
+
+    @skip_without_tool('cat_data_and_sleep')
+    def test_kill_process(self):
+        with self.dataset_populator.test_history() as history_id:
+            hda1 = self.dataset_populator.new_dataset(history_id, content="1 2 3")
+            running_inputs = {
+                "input1": {"src": "hda", "id": hda1["id"]},
+                "sleep_time": 240,
+            }
+            running_response = self.dataset_populator.run_tool(
+                "cat_data_and_sleep",
+                running_inputs,
+                history_id,
+                assert_ok=False,
+            ).json()
+            job_dict = running_response["jobs"][0]
+
+            app = self._app
+            sa_session = app.model.context.current
+            external_id = None
+            state = False
+
+            job = sa_session.query(app.model.Job).filter_by(tool_id="cat_data_and_sleep").one()
+            # Not checking the state here allows the change from queued to running to overwrite
+            # the change from queued to deleted_new in the API thread - this is a problem because
+            # the job will still run. See issue https://github.com/galaxyproject/galaxy/issues/4960.
+            while external_id is None or state != app.model.Job.states.RUNNING:
+                sa_session.refresh(job)
+                assert not job.finished
+                external_id = job.job_runner_external_id
+                state = job.state
+
+            status = json.loads(subprocess.check_output(['kubectl', 'get', 'job', external_id, '-o', 'json']))
+            assert status['status']['active'] == 1
+
+            delete_response = self.dataset_populator.cancel_job(job_dict["id"])
+            assert delete_response.json() is True
+
+            status = json.loads(subprocess.check_output(['kubectl', 'get', 'job', external_id, '-o', 'json']))
+            assert 'active' not in status['status']

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -93,7 +93,7 @@ def job_config(path):
     </plugins>
     <destinations default="k8s_destination">
         <destination id="k8s_destination" runner="k8s">
-            <param id="limits_cpu">2</param>
+            <param id="limits_cpu">1.9</param>
             <param id="limits_memory">10M</param>
             <param id="docker_enabled">true</param>
             <param id="docker_default_container_id">busybox:ubuntu-14.04</param>

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -12,8 +12,6 @@ from base.populators import skip_without_tool
 from .test_dockerized_jobs import MulledJobTestCases  # noqa: I201
 from .test_job_environments import BaseJobEnvironmentIntegrationTestCase  # noqa: I201
 
-integration_util.skip_unless_kubernetes()
-
 PERSISTENT_VOLUME_NAME = 'pv-galaxy-integration-test'
 PERSISTENT_VOLUME_CLAIM_NAME = 'galaxy-pvc-integration-test'
 Config = collections.namedtuple('ConfigTuple', 'path')
@@ -112,6 +110,7 @@ def job_config(path):
     return Config(job_conf.name)
 
 
+@integration_util.skip_unless_kubernetes()
 class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
 
     def setUp(self):

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -10,7 +10,7 @@ import time
 
 from base import integration_util  # noqa: I100,I202
 from base.populators import skip_without_tool
-from .test_dockerized_jobs import MulledJobTestCases  # noqa: I201
+from .test_containerized_jobs import MulledJobTestCases  # noqa: I201
 from .test_job_environments import BaseJobEnvironmentIntegrationTestCase  # noqa: I201
 
 PERSISTENT_VOLUME_NAME = 'pv-galaxy-integration-test'

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -228,6 +228,18 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
         assert details['stdout'] == 'The bool is not true\n', details
         assert details['stderr'] == 'Fatal error: Exit code 127 (Failing exit code.)\nThe bool is very not true\n'
 
+    @skip_without_tool('Count1')
+    def test_python_dep(self):
+        with self.dataset_populator.test_history() as history_id:
+            hda1 = self.dataset_populator.new_dataset(history_id, content="1\t2\t3", file_type='tabular', wait=True)
+            self.dataset_populator.run_tool(
+                'Count1',
+                {'input': {"src": "hda", "id": hda1["id"]},
+                 'column': [1]},
+                self.history_id,
+                assert_ok=True,
+            )
+
     @skip_without_tool('galaxy_slots_and_memory')
     def test_slots_and_memory(self):
         self.dataset_populator.run_tool(

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -32,49 +32,49 @@ class TestCommandFactory(TestCase):
 
     def test_simplest_command(self):
         self.include_work_dir_outputs = False
-        self.__assert_command_is(_surrond_command(MOCK_COMMAND_LINE + "; return_code=$?"))
+        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"))
 
     def test_shell_commands(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surrond_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)))
+        self.__assert_command_is(_surround_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)))
 
     def test_shell_commands_external(self):
         self.job_wrapper.commands_in_new_shell = True
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surrond_command("%s/tool_script.sh; return_code=$?" % self.job_wrapper.working_directory))
+        self.__assert_command_is(_surround_command("%s/tool_script.sh; return_code=$?" % self.job_wrapper.working_directory))
         self.__assert_tool_script_is("#!/bin/sh\n%s; %s" % (dep_commands[0], MOCK_COMMAND_LINE))
 
     def test_remote_dependency_resolution(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surrond_command(MOCK_COMMAND_LINE + "; return_code=$?"), remote_command_params=dict(dependency_resolution="remote"))
+        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"), remote_command_params=dict(dependency_resolution="remote"))
 
     def test_explicit_local_dependency_resolution(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surrond_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)),
+        self.__assert_command_is(_surround_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)),
                                  remote_command_params=dict(dependency_resolution="local"))
 
     def test_task_prepare_inputs(self):
         self.include_work_dir_outputs = False
         self.job_wrapper.prepare_input_files_cmds = ["/opt/split1", "/opt/split2"]
-        self.__assert_command_is(_surrond_command("/opt/split1; /opt/split2; %s; return_code=$?") % MOCK_COMMAND_LINE)
+        self.__assert_command_is(_surround_command("/opt/split1; /opt/split2; %s; return_code=$?") % MOCK_COMMAND_LINE)
 
     def test_workdir_outputs(self):
         self.include_work_dir_outputs = True
         self.workdir_outputs = [("foo", "bar")]
-        self.__assert_command_is(_surrond_command('%s; return_code=$?; if [ -f foo ] ; then cp foo bar ; fi' % MOCK_COMMAND_LINE))
+        self.__assert_command_is(_surround_command('%s; return_code=$?; if [ -f foo ] ; then cp foo bar ; fi' % MOCK_COMMAND_LINE))
 
     def test_set_metadata_skipped_if_unneeded(self):
         self.include_metadata = True
         self.include_work_dir_outputs = False
-        self.__assert_command_is(_surrond_command(MOCK_COMMAND_LINE + "; return_code=$?"))
+        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"))
 
     def test_set_metadata(self):
         self._test_set_metadata()
@@ -87,7 +87,7 @@ class TestCommandFactory(TestCase):
         self.include_metadata = True
         self.include_work_dir_outputs = False
         self.job_wrapper.metadata_line = TEST_METADATA_LINE
-        expected_command = _surrond_command("%s; return_code=$?; cd '%s'; %s%s" % (MOCK_COMMAND_LINE, self.job_dir, SETUP_GALAXY_FOR_METADATA, TEST_METADATA_LINE))
+        expected_command = _surround_command("%s; return_code=$?; cd '%s'; %s%s" % (MOCK_COMMAND_LINE, self.job_dir, SETUP_GALAXY_FOR_METADATA, TEST_METADATA_LINE))
         self.__assert_command_is(expected_command)
 
     def test_empty_metadata(self):
@@ -98,7 +98,7 @@ class TestCommandFactory(TestCase):
         self.include_work_dir_outputs = False
         self.job_wrapper.metadata_line = ' '
         # Empty metadata command do not touch command line.
-        expected_command = _surrond_command("%s; return_code=$?; cd '%s'" % (MOCK_COMMAND_LINE, self.job_dir))
+        expected_command = _surround_command("%s; return_code=$?; cd '%s'" % (MOCK_COMMAND_LINE, self.job_dir))
         self.__assert_command_is(expected_command)
 
     def test_metadata_kwd_defaults(self):
@@ -152,7 +152,7 @@ class TestCommandFactory(TestCase):
         return build_command(**kwds)
 
 
-def _surrond_command(command):
+def _surround_command(command):
     return '''rm -rf working; mkdir -p working; cd working; %s; sh -c "exit $return_code"''' % command
 
 

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -32,49 +32,49 @@ class TestCommandFactory(TestCase):
 
     def test_simplest_command(self):
         self.include_work_dir_outputs = False
-        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"))
+        self.__assert_command_is(_surrond_command(MOCK_COMMAND_LINE + "; return_code=$?"))
 
     def test_shell_commands(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surround_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)))
+        self.__assert_command_is(_surrond_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)))
 
     def test_shell_commands_external(self):
         self.job_wrapper.commands_in_new_shell = True
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surround_command("%s/tool_script.sh; return_code=$?" % self.job_wrapper.working_directory))
+        self.__assert_command_is(_surrond_command("%s/tool_script.sh; return_code=$?" % self.job_wrapper.working_directory))
         self.__assert_tool_script_is("#!/bin/sh\n%s; %s" % (dep_commands[0], MOCK_COMMAND_LINE))
 
     def test_remote_dependency_resolution(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"), remote_command_params=dict(dependency_resolution="remote"))
+        self.__assert_command_is(_surrond_command(MOCK_COMMAND_LINE + "; return_code=$?"), remote_command_params=dict(dependency_resolution="remote"))
 
     def test_explicit_local_dependency_resolution(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surround_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)),
+        self.__assert_command_is(_surrond_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)),
                                  remote_command_params=dict(dependency_resolution="local"))
 
     def test_task_prepare_inputs(self):
         self.include_work_dir_outputs = False
         self.job_wrapper.prepare_input_files_cmds = ["/opt/split1", "/opt/split2"]
-        self.__assert_command_is(_surround_command("/opt/split1; /opt/split2; %s; return_code=$?") % MOCK_COMMAND_LINE)
+        self.__assert_command_is(_surrond_command("/opt/split1; /opt/split2; %s; return_code=$?") % MOCK_COMMAND_LINE)
 
     def test_workdir_outputs(self):
         self.include_work_dir_outputs = True
         self.workdir_outputs = [("foo", "bar")]
-        self.__assert_command_is(_surround_command('%s; return_code=$?; if [ -f foo ] ; then cp foo bar ; fi' % MOCK_COMMAND_LINE))
+        self.__assert_command_is(_surrond_command('%s; return_code=$?; if [ -f foo ] ; then cp foo bar ; fi' % MOCK_COMMAND_LINE))
 
     def test_set_metadata_skipped_if_unneeded(self):
         self.include_metadata = True
         self.include_work_dir_outputs = False
-        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"))
+        self.__assert_command_is(_surrond_command(MOCK_COMMAND_LINE + "; return_code=$?"))
 
     def test_set_metadata(self):
         self._test_set_metadata()
@@ -87,7 +87,7 @@ class TestCommandFactory(TestCase):
         self.include_metadata = True
         self.include_work_dir_outputs = False
         self.job_wrapper.metadata_line = TEST_METADATA_LINE
-        expected_command = _surround_command("%s; return_code=$?; cd '%s'; %s%s" % (MOCK_COMMAND_LINE, self.job_dir, SETUP_GALAXY_FOR_METADATA, TEST_METADATA_LINE))
+        expected_command = _surrond_command("%s; return_code=$?; cd '%s'; %s%s" % (MOCK_COMMAND_LINE, self.job_dir, SETUP_GALAXY_FOR_METADATA, TEST_METADATA_LINE))
         self.__assert_command_is(expected_command)
 
     def test_empty_metadata(self):
@@ -98,7 +98,7 @@ class TestCommandFactory(TestCase):
         self.include_work_dir_outputs = False
         self.job_wrapper.metadata_line = ' '
         # Empty metadata command do not touch command line.
-        expected_command = _surround_command("%s; return_code=$?; cd '%s'" % (MOCK_COMMAND_LINE, self.job_dir))
+        expected_command = _surrond_command("%s; return_code=$?; cd '%s'" % (MOCK_COMMAND_LINE, self.job_dir))
         self.__assert_command_is(expected_command)
 
     def test_metadata_kwd_defaults(self):
@@ -152,8 +152,8 @@ class TestCommandFactory(TestCase):
         return build_command(**kwds)
 
 
-def _surround_command(command):
-    return '''rm -rf working; mkdir -p working; cd working; %s''' % command
+def _surrond_command(command):
+    return '''rm -rf working; mkdir -p working; cd working; %s; sh -c "exit $return_code"''' % command
 
 
 class MockJobWrapper(object):


### PR DESCRIPTION
- pykube is now a conditional requirement and will be installed if a kubernetes runner is set up
- Submit ajs.job_file instead of tool_script.sh, which allows using standard Galaxy features, like setting env variables per destination, reading stdout/stderr from file, collecting job measurements
- Fixes state changes
- Allows selecting the shell to use for all job runners
- Python 3 fixes for container resolver
- Writes stdout and stderr to standard file locations
- Passes GALAXY_SLOTS and GALAXY_MEMORY_MB and GALAXY_MEMORY_MB_PER_SLOT to wrappers
- Includes integration tests for running jobs, cancelling jobs, executing jobs in mulled containers, detecting exit code, stdout, stderr and passing GALAXY_SLOTS and GALAXY_MEMORY_MB.