### PR TITLE
Refactor workflow editor styles and move from mako to css

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -616,6 +616,8 @@ div.toolFormRow {
 }
 
 .toolForm.toolFormInCanvas {
+    z-index: 100;
+    position: absolute;
     border: solid $form-border 1px;
     @include border-radius(2px);
     background: $white;
@@ -672,6 +674,7 @@ div.form-body {
 }
 
 div.form-row {
+    position: relative;
     padding: 5px 10px;
 }
 

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -613,6 +613,12 @@ div.toolFormRow {
 .callout {
     position: absolute;
     z-index: 10000;
+    div.buttons img {
+        border: none;
+        width: 16px;
+        height: 16px;
+        cursor: pointer;
+    }
 }
 
 .toolForm.toolFormInCanvas {

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -607,6 +607,16 @@ div.toolTitleDisabled {
     color: gray;
 }
 
+div.toolTitleNoSectionDisabled {
+      padding-bottom: 0px;
+      font-style: italic;
+      color: gray;
+}
+
+div.toolFormRow {
+    position: relative;
+}
+
 .toolForm.toolFormInCanvas {
     border: solid $form-border 1px;
     @include border-radius(2px);

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -610,6 +610,11 @@ div.toolFormRow {
     position: relative;
 }
 
+.callout {
+    position: absolute;
+    z-index: 10000;
+}
+
 .toolForm.toolFormInCanvas {
     border: solid $form-border 1px;
     @include border-radius(2px);
@@ -635,13 +640,9 @@ div.toolFormRow {
             border-bottom: dotted black 1px;
             margin: 0 5px;
         }
-        .callout {
-            position: absolute;
-            z-index: 10000;
-        }
     }
-
 }
+
 .toolForm.toolFormInCanvas.tool-node-error {
     border-color: #AA6666;
     .toolFormTitle {

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -637,8 +637,15 @@ div.toolFormRow {
             z-index: 10000;
         }
     }
-}
 
+}
+.toolForm.toolFormInCanvas.tool-node-error {
+    border-color: #AA6666;
+    .toolFormTitle {
+        background: #FFCCCC;
+        border-color: #AA6666;
+    }
+}
 div.form,
 div.toolForm {
     border: solid $form-border 1px;

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -630,6 +630,14 @@ div.toolFormRow {
         font-size: $font-size-base;
         line-height: $line-height-base;
     }
+    .toolFormBody {
+        .rule {
+            height: 0;
+            border: none;
+            border-bottom: dotted black 1px;
+            margin: 0 5px;
+        }
+    }
 }
 
 div.form,

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -626,6 +626,9 @@ div.toolFormRow {
         min-height: 16px;
     }
     .toolFormBody {
+        padding: 0;
+        margin-left: 6px;
+        margin-right: 6px;
         .rule {
             height: 0;
             border: none;

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -560,13 +560,6 @@ div.metadataHelpBody {
     overflow: auto;
 }
 
-div.titleRow {
-    font-weight: bold;
-    border-bottom: dotted gray 1px;
-    margin-bottom: 0.5em;
-    padding-bottom: 0.25em;
-}
-
 // Forms
 
 div.toolFormBody div.toolFormTitle {

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -629,6 +629,8 @@ div.toolFormRow {
     .toolFormTitle {
         font-size: $font-size-base;
         line-height: $line-height-base;
+        cursor: move;
+        min-height: 16px;
     }
     .toolFormBody {
         .rule {

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -621,6 +621,7 @@ div.toolFormRow {
     background: $white;
     margin: 0px;
     &.toolForm-active {
+        z-index: 1001;
         box-shadow: 0 0 0 3px $brand-primary;
         @include border-radius(1px);
     }

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -596,6 +596,16 @@ div.toolHelpBody {
 }
 
 // In workflow
+div.toolTitleDisabled {
+    padding-top: 5px;
+    padding-bottom: 5px;
+    margin-left: 16px;
+    margin-right: 10px;
+    display: list-item;
+    list-style: square outside;
+    font-style: italic;
+    color: gray;
+}
 
 .toolForm.toolFormInCanvas {
     border: solid $form-border 1px;

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -637,6 +637,10 @@ div.toolFormRow {
             border-bottom: dotted black 1px;
             margin: 0 5px;
         }
+        .callout {
+            position: absolute;
+            z-index: 10000;
+        }
     }
 }
 

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -718,6 +718,10 @@ div.form-row-error-message {
     background: white;
 }
 
+.workflow-right .right-content {
+    margin: 3px;
+}
+
 .workflow-right .right-content .section-row {
     margin-bottom: 10px;
 }

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -84,14 +84,6 @@
       position: relative;
     }
 
-    div.tool-node-error div.toolFormTitle {
-        background: #FFCCCC;
-        border-color: #AA6666;
-    }
-    div.tool-node-error {
-        border-color: #AA6666;
-    }
-
     #canvas-area {
         position: absolute;
         top: 0; left: 305px; bottom: 0; right: 0;

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -56,12 +56,6 @@
     <style type="text/css">
     canvas { position: absolute; z-index: 10; }
     canvas.dragging { position: absolute; z-index: 1000; }
-    #canvas-area {
-        position: absolute;
-        top: 0; left: 305px; bottom: 0; right: 0;
-        border: solid red 1px;
-        overflow: none;
-    }
     </style>
 </%def>
 

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -65,19 +65,6 @@
     cursor: pointer;
     }
 
-    ## Extra styles for the representation of a tool on the canvas (looks like
-    ## a tiny tool form)
-    div.toolFormInCanvas {
-        z-index: 100;
-        position: absolute;
-        ## min-width: 130px;
-        margin: 6px;
-    }
-
-    div.form-row {
-      position: relative;
-    }
-
     #canvas-area {
         position: absolute;
         top: 0; left: 305px; bottom: 0; right: 0;

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -119,11 +119,6 @@
         clear: both;
     }
 
-    .callout {
-        position: absolute;
-        z-index: 10000;
-    }
-
     .panel-header-button-group {
         margin-right: 5px;
         padding-right: 5px;

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -54,8 +54,6 @@
     ${parent.stylesheets()}
 
     <style type="text/css">
-    body { margin: 0; padding: 0; overflow: hidden; }
-
     canvas { position: absolute; z-index: 10; }
     canvas.dragging { position: absolute; z-index: 1000; }
     ## .input-terminal-hover { background: yellow; border: solid black 1px; }

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -56,10 +56,6 @@
     <style type="text/css">
     body { margin: 0; padding: 0; overflow: hidden; }
 
-    .right-content {
-        margin: 3px;
-    }
-
     canvas { position: absolute; z-index: 10; }
     canvas.dragging { position: absolute; z-index: 1000; }
     ## .input-terminal-hover { background: yellow; border: solid black 1px; }

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -91,12 +91,6 @@
         overflow: none;
     }
 
-    div.toolFormInCanvas div.toolFormBody {
-        padding: 0;
-        margin-left: 6px;
-        margin-right: 6px;
-    }
-
     .panel-header-button-group {
         margin-right: 5px;
         padding-right: 5px;

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -56,15 +56,6 @@
     <style type="text/css">
     body { margin: 0; padding: 0; overflow: hidden; }
 
-    div.toolTitleNoSectionDisabled {
-      padding-bottom: 0px;
-      font-style: italic;
-      color: gray;
-    }
-    div.toolFormRow {
-        position: relative;
-    }
-
     .right-content {
         margin: 3px;
     }

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -56,16 +56,6 @@
     <style type="text/css">
     body { margin: 0; padding: 0; overflow: hidden; }
 
-    div.toolTitleDisabled {
-        padding-top: 5px;
-        padding-bottom: 5px;
-        margin-left: 16px;
-        margin-right: 10px;
-        display: list-item;
-        list-style: square outside;
-        font-style: italic;
-        color: gray;
-    }
     div.toolTitleNoSectionDisabled {
       padding-bottom: 0px;
       font-style: italic;

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -80,11 +80,6 @@
         margin: 3px;
     }
 
-    div.toolFormTitle {
-        cursor: move;
-        min-height: 16px;
-    }
-
     div.titleRow {
         font-weight: bold;
         border-bottom: dotted gray 1px;

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -125,9 +125,6 @@
         overflow: none;
     }
 
-    .form-row {
-    }
-
     div.toolFormInCanvas div.toolFormBody {
         padding: 0;
         margin-left: 6px;
@@ -147,18 +144,6 @@
     .callout {
         position: absolute;
         z-index: 10000;
-    }
-
-    .pjaForm {
-        margin-bottom:10px;
-    }
-
-    .pjaForm .toolFormBody{
-        padding:10px;
-    }
-
-    .pjaForm .toolParamHelp{
-        padding:5px;
     }
 
     .panel-header-button-group {

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -80,12 +80,6 @@
         margin: 3px;
     }
 
-    div.titleRow {
-        font-weight: bold;
-        border-bottom: dotted gray 1px;
-        margin-bottom: 0.5em;
-        padding-bottom: 0.25em;
-    }
     div.form-row {
       position: relative;
     }

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -119,13 +119,6 @@
         clear: both;
     }
 
-    div.rule {
-        height: 0;
-        border: none;
-        border-bottom: dotted black 1px;
-        margin: 0 5px;
-    }
-
     .callout {
         position: absolute;
         z-index: 10000;

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -72,12 +72,6 @@
         overflow: none;
     }
 
-    .panel-header-button-group {
-        margin-right: 5px;
-        padding-right: 5px;
-        border-right: solid gray 1px;
-    }
-
     </style>
 </%def>
 

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -74,12 +74,6 @@
         margin: 6px;
     }
 
-    div.toolForm-active {
-        z-index: 1001;
-        border: solid #8080FF 4px;
-        margin: 3px;
-    }
-
     div.form-row {
       position: relative;
     }

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -56,22 +56,12 @@
     <style type="text/css">
     canvas { position: absolute; z-index: 10; }
     canvas.dragging { position: absolute; z-index: 1000; }
-    ## .input-terminal-hover { background: yellow; border: solid black 1px; }
-    .unselectable { -moz-user-select: none; -khtml-user-select: none; user-select: none; }
-    img { border: 0; }
-
-    div.buttons img {
-    width: 16px; height: 16px;
-    cursor: pointer;
-    }
-
     #canvas-area {
         position: absolute;
         top: 0; left: 305px; bottom: 0; right: 0;
         border: solid red 1px;
         overflow: none;
     }
-
     </style>
 </%def>
 

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -110,9 +110,6 @@
         margin-left: 6px;
         margin-right: 6px;
     }
-    .form-row-clear {
-        clear: both;
-    }
 
     .panel-header-button-group {
         margin-right: 5px;


### PR DESCRIPTION
This PR moves workflow editor styles from the mako template to the scss style sheet. It also removes redundant, unused or conflicting style definitions and improves the specificity of css selectors. This PR prepares the adaption of the new style theme for the workflow editor.