### PR TITLE
[18.09] In enqueue, always set an object_store_id if one isn't set.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1198,9 +1198,6 @@ class JobWrapper(HasResourceParameters):
         self.sa_session.flush()
 
     def _set_object_store_ids(self, job):
-        if self.app.config.legacy_eager_objectstore_initialization:
-            return
-
         if job.object_store_id:
             # We aren't setting this during job creation anymore, but some existing
             # jobs may have this set. Skip this following code if that is the case.


### PR DESCRIPTION
Tool actions other than the regular tool action (such as the upload ones) might not set an object store id even in the legacy mode.