### PR TITLE
Normalized jquery bundle

### DIFF
--- a/client/galaxy/scripts/libs/jquery.custom.js
+++ b/client/galaxy/scripts/libs/jquery.custom.js
@@ -1,0 +1,24 @@
+/**
+ * jQuery and all its horrible plugins. Bundled together and repackaged into a
+ * single module, then aliased by webpack as "jquery";
+ */
+
+var jQuery = require("jqueryVendor");
+
+require("imports-loader?jQuery=jqueryVendor!libs/jquery/jquery.autocomplete");
+require("imports-loader?jQuery=jqueryVendor!libs/jquery/jquery.event.hover");
+require("imports-loader?jQuery=jqueryVendor!libs/jquery/jquery.event.drag");
+require("imports-loader?jQuery=jqueryVendor!libs/jquery/jquery.event.drop");
+require("imports-loader?jQuery=jqueryVendor,define=>false!jquery-mousewheel");
+require("imports-loader?jQuery=jqueryVendor!libs/jquery/jquery.form");
+require("imports-loader?jQuery=jqueryVendor!libs/jquery/jquery.rating");
+require("imports-loader?jQuery=jqueryVendor!libs/jquery/select2");
+require("imports-loader?jQuery=jqueryVendor!libs/jquery/jquery-ui");
+require("imports-loader?jQuery=jqueryVendor!libs/jquery/jstorage");
+require("imports-loader?jQuery=jqueryVendor!libs/farbtastic");
+require("imports-loader?jQuery=jqueryVendor,$=jqueryVendor,define=>false!jquery.cookie");
+require("imports-loader?jQuery=jqueryVendor!libs/jquery/jquery.dynatree");
+require("imports-loader?jQuery=jqueryVendor!jquery.complexify");
+require("imports-loader?jQuery=jqueryVendor!jquery-migrate");
+
+module.exports = jQuery;

--- a/client/galaxy/scripts/onload/index.js
+++ b/client/galaxy/scripts/onload/index.js
@@ -1,24 +1,5 @@
 /* global $, _, Galaxy */
-
 import "polyfills";
-
-// Jquery and all its horrible plugins
-import "jquery-migrate";
-/* we really need to get rid of these jquery plugins */
-import "libs/jquery/jquery.autocomplete";
-import "libs/jquery/jquery.event.hover";
-import "libs/jquery/jquery.event.drag";
-import "libs/jquery/jquery.event.drop";
-import "jquery-mousewheel";
-import "libs/jquery/jquery.form";
-import "libs/jquery/jquery.rating";
-import "libs/jquery/select2";
-import "libs/jquery/jquery-ui";
-import "libs/jquery/jstorage";
-import "libs/farbtastic";
-import "jquery.cookie";
-import "libs/jquery/jquery.dynatree";
-import "jquery.complexify";
 
 // Bootstrap overwrites .tooltip() method, so load it after jquery-ui
 import "bootstrap";

--- a/client/galaxy/scripts/qunit/test.js
+++ b/client/galaxy/scripts/qunit/test.js
@@ -15,6 +15,6 @@ import jd from "qunit/tests/job_dag_tests";
 import hc from "qunit/tests/history_contents_model_tests";
 import hda from "qunit/tests/hda_base_tests";
 import modal from "qunit/tests/modal_tests";
-// import page from "qunit/tests/page_tests";
+import page from "qunit/tests/page_tests";
 import utils from "qunit/tests/utils_tests";
 import ui from "qunit/tests/ui_tests";

--- a/client/galaxy/scripts/qunit/tests/page_tests.js
+++ b/client/galaxy/scripts/qunit/tests/page_tests.js
@@ -1,5 +1,7 @@
 /* global QUnit */
-
+import _ from "underscore";
+import $ from "jquery";
+import Backbone from "backbone";
 import testApp from "qunit/test-app";
 import Page from "layout/page";
 

--- a/client/galaxy/scripts/utils/installMonitor.js
+++ b/client/galaxy/scripts/utils/installMonitor.js
@@ -46,7 +46,7 @@ export function installMonitor(globalProp, fallbackValue = null) {
                 logger.groupCollapsed(`${label} write...`, newValue);
                 logger.trace();
                 logger.groupEnd();
-                return (window._monitorStorage[globalProp] = newValue);
+                window._monitorStorage[globalProp] = newValue;
             }
         });
     } catch (err) {
@@ -76,7 +76,8 @@ export function installMonitor(globalProp, fallbackValue = null) {
                 logger.log("target?", target);
                 logger.trace();
                 logger.groupEnd();
-                return (target[prop] = val);
+                target[prop] = val;
+                return true;
             }
         }
     );

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -24,7 +24,11 @@ let buildconfig = {
         chunkFilename: "[name].chunk.js"
     },
     resolve: {
-        modules: [scriptsBase, "node_modules", styleBase, imageBase]
+        modules: [scriptsBase, "node_modules", styleBase, imageBase],
+        alias: {
+            jquery$: `${libsBase}/jquery.custom.js`,
+            jqueryVendor$: `${libsBase}/jquery/jquery.js`
+        }
     },
     optimization: {
         splitChunks: {
@@ -61,7 +65,7 @@ let buildconfig = {
                 options: { babelrc: true }
             },
             {
-                test: require.resolve("jquery"),
+                test: `${libsBase}/jquery.custom.js`,
                 use: [
                     {
                         loader: "expose-loader",
@@ -149,8 +153,8 @@ let buildconfig = {
         // this plugin allows using the following keys/globals in scripts (w/o req'ing them first)
         // and webpack will automagically require them in the bundle for you
         new webpack.ProvidePlugin({
-            $: "jquery",
-            jQuery: "jquery",
+            $: `${libsBase}/jquery.custom.js`,
+            jQuery: `${libsBase}/jquery.custom.js`,
             _: "underscore",
             Backbone: "backbone",
             Galaxy: ["galaxy.monitor", "default"]

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -12876,6 +12876,7 @@ vue-loader@^15.2.4, vue-loader@^15.4.2:
 vue-router@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.0.1.tgz#d9b05ad9c7420ba0f626d6500d693e60092cc1e9"
+  integrity sha512-vLLoY452L+JBpALMP5UHum9+7nzR9PeIBCghU9ZtJ1eWm6ieUI8Zb/DI3MYxH32bxkjzYV1LRjNv4qr8d+uX/w==
 
 vue-style-loader@^3.0.1:
   version "3.1.2"


### PR DESCRIPTION
So we KIND OF had a solution for this. Previously we jammed all jquery plugins into a script that frequently gets included (onload.js) in entry points that are rendered by webpack. However, that can fail because of [webpack's tree-shaking](https://webpack.js.org/guides/tree-shaking/): explicitly when you render an entry point that does not require onload.js.

This PR modifies the webpack configs to guarantee the same version of jquery with the same attached plugins regardless of whether that particular onload.js script got included. This was something that could occasionally happen in iframe documents.

This is accomplished pretty easily with webpack's module aliasing rules. The "jQuery" module now points to a file called "jquery.custom.js" which builds on "jqueryVendor" which points at the npm or local lib version. Then we use the expose-loader to put the jquery variable on every page rendered by webpack regardless of whether or not jquery was included in the source script.

The end result is the same version of jquery with the same plugins everywhere in the site. So no more weird ".select2 is not a function" errors.