### PR TITLE
Added a metadata element to the biom1 datatype

### DIFF
--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -255,7 +255,7 @@ class Biom1(Json):
                         metadata_value = json_dict.get(b_name, None)
                         if b_name == "columns" and metadata_value:
                             mks = metadata_value[0]['metadata'].keys()
-                            keep_columns = { mk: None for mk in mks }
+                            keep_columns = {mk: None for mk in mks}
                             for column in metadata_value:
                                 for k in column['metadata']:
                                     if column['metadata'][k] is not None:

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -272,7 +272,7 @@ class Biom1(Json):
                             metadata_value = b_transform[b_name](metadata_value)
                         setattr(dataset.metadata, m_name, metadata_value)
                     except Exception:
-                        log.exception("Something in the metadata detection for biom1 went wrong: " + str(Exception))
+                        log.exception("Something in the metadata detection for biom1 went wrong")
                         pass
 
 

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -254,17 +254,12 @@ class Biom1(Json):
                     try:
                         metadata_value = json_dict.get(b_name, None)
                         if b_name == "columns" and metadata_value:
-                            mks = metadata_value[0]['metadata'].keys()
-                            keep_columns = {mk: None for mk in mks}
+                            keep_columns = set()
                             for column in metadata_value:
-                                for k in column['metadata']:
-                                    if column['metadata'][k] is not None:
-                                        keep_columns[k] = 1
-                            final_list = []
-                            for k in keep_columns:
-                                if keep_columns[k] is not None:
-                                    final_list.append(k)
-                            final_list.sort()
+                                for k, v in column['metadata'].items():
+                                    if v is not None:
+                                        keep_columns.add(k)
+                            final_list = sorted(list(keep_columns))
                             dataset.metadata.table_column_metadata_headers = final_list
                         if b_name in b_transform:
                             metadata_value = b_transform[b_name](metadata_value)

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -254,17 +254,15 @@ class Biom1(Json):
                     try:
                         metadata_value = json_dict.get(b_name, None)
                         if b_name == "columns" and metadata_value:
-                            mks = list(metadata_value[0]['metadata'].keys())
-                            keep_columns = {}
-                            for mk in mks:
-                                keep_columns[mk] = None
+                            mks = metadata_value[0]['metadata'].keys()
+                            keep_columns = { mk: None for mk in mks }
                             for column in metadata_value:
                                 for k in column['metadata']:
-                                    if not column['metadata'][k] is None:
+                                    if column['metadata'][k] is not None:
                                         keep_columns[k] = 1
                             final_list = []
                             for k in keep_columns:
-                                if not keep_columns[k] is None:
+                                if keep_columns[k] is not None:
                                     final_list.append(k)
                             final_list.sort()
                             dataset.metadata.table_column_metadata_headers = final_list
@@ -272,7 +270,7 @@ class Biom1(Json):
                             metadata_value = b_transform[b_name](metadata_value)
                         setattr(dataset.metadata, m_name, metadata_value)
                     except Exception:
-                        log.exception("Something in the metadata detection for biom1 went wrong: " + str(Exception))
+                        log.exception("Something in the metadata detection for biom1 went wrong.")
                         pass
 
 


### PR DESCRIPTION
This PR adds an element to the biom1 datatype metadata:

```python
MetadataElement(name="table_column_metadata_headers", default=[], desc="table_column_metadata_headers", param=MetadataParameter, readonly=True, visible=True, optional=True, no_value=[])
```
It populates the array with the column header labels found in the `columns` field of the biom table.

This is so we can use the column header labels in tool wrappers.

e.g. 
```xml
<param format="biom1" name="input" type="data" label="Input File"/>
<param name="subsetColumn" type="select" label="Select a column for subsetting">
    <options>
          <filter type="data_meta" ref="input" key="table_column_metadata_headers" />
    </options>
</param>
```
This is really useful for a bunch of tools we're developing for NMDS style visualisation of metagenomic data.