### PR TITLE
[18.09] Fix traceback when starting under Python3 with ``galaxy.ini``

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -93,7 +93,7 @@ oslo.utils==3.37.0; python_version != '3.3.*'
 packaging==17.1
 paramiko==2.4.2
 parsley==1.3
-paste==2.0.3
+paste==3.0.4
 pastedeploy==1.5.2
 pastescript==2.0.2
 pbr==4.2.0


### PR DESCRIPTION
Update `paste` requirement to 3.0.4 to include:

https://github.com/cdent/paste/pull/14

to fix the following traceback:

```
Starting server in PID 6792.
Traceback (most recent call last):
  File "./scripts/paster.py", line 27, in <module>
    serve.run()
  File "/opt/galaxy/lib/galaxy/util/pastescript/serve.py", line 1055, in run
    invoke(command, command_name, options, args[1:])
  File "/opt/galaxy/lib/galaxy/util/pastescript/serve.py", line 1061, in invoke
    exit_code = runner.run(args)
  File "/opt/galaxy/lib/galaxy/util/pastescript/serve.py", line 226, in run
    result = self.command()
  File "/opt/galaxy/lib/galaxy/util/pastescript/serve.py", line 676, in command
    serve()
  File "/opt/galaxy/lib/galaxy/util/pastescript/serve.py", line 653, in serve
    server(app)
  File "/opt/galaxy/lib/galaxy/util/pastescript/loadwsgi.py", line 232, in server_wrapper
    **context.local_conf)
  File "/opt/galaxy/lib/galaxy/util/pastescript/loadwsgi.py", line 90, in fix_call
    val = callable(*args, **kw)
  File "/opt/galaxy/.venv3/lib/python3.5/site-packages/paste/httpserver.py", line 1358, in server_runner
    for name, value in kwargs.items():
RuntimeError: dictionary changed size during iteration
galaxy.app DEBUG 2018-11-05 13:38:00,059 Shutting down
```