### PR TITLE
Update test/selenium_tests/test_library_contents.py

### DIFF
--- a/test/selenium_tests/test_library_contents.py
+++ b/test/selenium_tests/test_library_contents.py
@@ -1,8 +1,10 @@
 from .framework import (
     retry_assertion_during_transitions,
+    retry_during_transitions,
     selenium_test,
     SeleniumTestCase,
 )
+from selenium.webdriver.support.ui import Select
 
 
 class LibraryContentsTestCase(SeleniumTestCase):
@@ -31,6 +33,9 @@ class LibraryContentsTestCase(SeleniumTestCase):
         self.wait_for_absent_or_hidden(self.navigation.libraries.folder.selectors.import_modal)
 
         self.libraries_dataset_import_from_history()
+        # Need to select the right item on the dropdown
+        self._select_history_option("dataset_add_bulk", "Unnamed history")
+        self.sleep_for(self.wait_types.UX_RENDER)
         self.libraries_dataset_import_from_history_select(["1.txt"])
         # Add
         self.sleep_for(self.wait_types.UX_RENDER)
@@ -99,3 +104,8 @@ class LibraryContentsTestCase(SeleniumTestCase):
         self.name = self._get_random_name(prefix="testcontents")
         self.libraries_index_create(self.name)
         self.libraries_open_with_name(self.name)
+
+    @retry_during_transitions
+    def _select_history_option(self, select_id, label_text):
+        select = Select(self.driver.find_element_by_id(select_id))
+        select.select_by_visible_text(label_text)

--- a/test/selenium_tests/test_library_contents.py
+++ b/test/selenium_tests/test_library_contents.py
@@ -1,11 +1,11 @@
+from selenium.webdriver.support.ui import Select
+
 from .framework import (
     retry_assertion_during_transitions,
     retry_during_transitions,
     selenium_test,
     SeleniumTestCase,
 )
-
-from selenium.webdriver.support.ui import Select
 
 
 class LibraryContentsTestCase(SeleniumTestCase):

--- a/test/selenium_tests/test_library_contents.py
+++ b/test/selenium_tests/test_library_contents.py
@@ -4,6 +4,7 @@ from .framework import (
     selenium_test,
     SeleniumTestCase,
 )
+
 from selenium.webdriver.support.ui import Select
 
 


### PR DESCRIPTION
Fixed a minor bug in "test_import_dataset_from_history".


This test used to break when the test context had other saved histories making it very state-dependent. Now it explicitly selects the test history that was created as part of the test before moving on. 

The issue of cleaning up the other saved histories is probably worth another PR.