### PR TITLE
Allow rules module override and refactor submodule imports

### DIFF
--- a/lib/galaxy/containers/__init__.py
+++ b/lib/galaxy/containers/__init__.py
@@ -22,7 +22,7 @@ from six import string_types, with_metaclass
 from six.moves import shlex_quote
 
 from galaxy.exceptions import ContainerCLIError
-from galaxy.util.submodules import submodules
+from galaxy.util.submodules import import_submodules
 
 
 DEFAULT_CONTAINER_TYPE = 'docker'
@@ -380,7 +380,7 @@ def parse_containers_config(containers_config_file):
 
 def _get_interface_modules():
     interfaces = []
-    modules = submodules(sys.modules[__name__])
+    modules = import_submodules(sys.modules[__name__])
     for module in modules:
         module_names = [getattr(module, _) for _ in dir(module)]
         classes = [_ for _ in module_names if inspect.isclass(_) and

--- a/lib/galaxy/jobs/runners/state_handler_factory.py
+++ b/lib/galaxy/jobs/runners/state_handler_factory.py
@@ -1,7 +1,7 @@
 import logging
 
 import galaxy.jobs.runners.state_handlers
-from galaxy.util.submodules import submodules
+from galaxy.util.submodules import import_submodules
 
 log = logging.getLogger(__name__)
 
@@ -12,8 +12,8 @@ def build_state_handlers():
 
 def _get_state_handlers_dict():
     state_handlers = {}
-    for module in submodules(galaxy.jobs.runners.state_handlers):
-        for func in module.__all__:
+    for module in import_submodules(galaxy.jobs.runners.state_handlers, ordered=True):
+        for func in getattr(module, "__all__", []):
             if func not in state_handlers:
                 state_handlers[func] = []
             state_handlers[func].append(getattr(module, func))

--- a/lib/galaxy/tools/lint.py
+++ b/lib/galaxy/tools/lint.py
@@ -29,7 +29,7 @@ def lint_xml(tool_xml, level=LEVEL_ALL, fail_level=LEVEL_WARN, extra_modules=[],
 def lint_tool_source_with(lint_context, tool_source, extra_modules=[]):
     import galaxy.tools.linters
     tool_xml = getattr(tool_source, "xml_tree", None)
-    linter_modules = submodules.submodules(galaxy.tools.linters)
+    linter_modules = submodules.import_submodules(galaxy.tools.linters, ordered=True)
     linter_modules.extend(extra_modules)
     for module in linter_modules:
         tool_type = tool_source.parse_tool_type() or "default"

--- a/lib/galaxy/util/plugin_config.py
+++ b/lib/galaxy/util/plugin_config.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     yaml = None
 
-from galaxy.util.submodules import submodules
+from galaxy.util.submodules import import_submodules
 
 
 def plugins_dict(module, plugin_type_identifier):
@@ -15,7 +15,7 @@ def plugins_dict(module, plugin_type_identifier):
     """
     plugin_dict = {}
 
-    for plugin_module in submodules(module):
+    for plugin_module in import_submodules(module, ordered=True):
         # FIXME: this is not how one is suppose to use __all__ why did you do
         # this past John?
         for clazz in getattr(plugin_module, "__all__", []):

--- a/lib/galaxy/webapps/galaxy/config_watchers.py
+++ b/lib/galaxy/webapps/galaxy/config_watchers.py
@@ -2,10 +2,10 @@ from functools import partial
 from os.path import dirname
 
 from galaxy.queue_worker import (
+    job_rule_modules,
     reload_data_managers,
     reload_job_rules,
-    reload_toolbox,
-    job_rule_modules
+    reload_toolbox
 )
 from galaxy.tools.toolbox.watcher import (
     get_tool_conf_watcher,

--- a/lib/galaxy/webapps/galaxy/config_watchers.py
+++ b/lib/galaxy/webapps/galaxy/config_watchers.py
@@ -1,4 +1,3 @@
-import sys
 from functools import partial
 from os.path import dirname
 
@@ -6,6 +5,7 @@ from galaxy.queue_worker import (
     reload_data_managers,
     reload_job_rules,
     reload_toolbox,
+    job_rule_modules
 )
 from galaxy.tools.toolbox.watcher import (
     get_tool_conf_watcher,
@@ -93,15 +93,7 @@ class ConfigWatchers(object):
     @property
     def job_rules_paths(self):
         job_rules_paths = []
-        default = 'galaxy.jobs.rules'
-        rules_module_name = default
-        if self.app.job_config.dynamic_params is not None:
-            rules_module_name = self.app.job_config.dynamic_params.get('rules_module', default)
-        rules_module = sys.modules.get(rules_module_name, None)
-        if not rules_module:
-            # if using a non-default module, it's not imported until a JobRunnerMapper is instantiated when the first
-            # JobWrapper is created
-            rules_module = __import__(rules_module_name)
-        job_rules_dir = dirname(rules_module.__file__)
-        job_rules_paths.append(job_rules_dir)
+        for rules_module in job_rule_modules(self.app):
+            job_rules_dir = dirname(rules_module.__file__)
+            job_rules_paths.append(job_rules_dir)
         return job_rules_paths

--- a/test/unit/jobs/test_mapper.py
+++ b/test/unit/jobs/test_mapper.py
@@ -11,6 +11,7 @@ from galaxy.jobs.mapper import (
 )
 from galaxy.util import bunch
 from . import test_rules
+from . import test_rules_override
 
 WORKFLOW_UUID = uuid.uuid1().hex
 TOOL_JOB_DESTINATION = JobDestination()
@@ -87,6 +88,12 @@ def test_dynamic_mapping_missing_function():
     mapper.job_wrapper.tool.all_ids = ["no_such_function"]
     error_message = ERROR_MESSAGE_RULE_FUNCTION_NOT_FOUND % ("missing_func")
     __assert_mapper_errors_with_message(mapper, error_message)
+
+def test_dynamic_mapping_rule_module_override():
+    mapper = __mapper(__dynamic_destination(dict(function="rule_module_override",
+                                                 rules_module=test_rules_override.__name__)))
+    assert mapper.get_job_destination({}) is DYNAMICALLY_GENERATED_DESTINATION
+    assert mapper.job_config.rule_response == "new_rules_package"
 
 
 def __assert_mapper_errors_with_message(mapper, message):

--- a/test/unit/jobs/test_mapper.py
+++ b/test/unit/jobs/test_mapper.py
@@ -89,6 +89,7 @@ def test_dynamic_mapping_missing_function():
     error_message = ERROR_MESSAGE_RULE_FUNCTION_NOT_FOUND % ("missing_func")
     __assert_mapper_errors_with_message(mapper, error_message)
 
+
 def test_dynamic_mapping_rule_module_override():
     mapper = __mapper(__dynamic_destination(dict(function="rule_module_override",
                                                  rules_module=test_rules_override.__name__)))

--- a/test/unit/jobs/test_rules_override/10_rule.py
+++ b/test/unit/jobs/test_rules_override/10_rule.py
@@ -1,0 +1,4 @@
+
+def rule_module_override():
+    # Dummy rule for testing rule module overrides
+    return 'new_rules_package'

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -69,6 +69,7 @@ class MockApp(object):
         self.init_datatypes()
         self.job_config = Bunch(
             dynamic_params=None,
+            destinations={}
         )
         self.tool_data_tables = {}
         self.dataset_collections_service = None


### PR DESCRIPTION
This PR allows the rules_module to be specified per destination, instead of only at the plugin level, allowing for greater flexibility WRT to where dynamic rules can come from.
For example:
```
        <destination id="pulsar_djr" runner="dynamic">
            <param id="type">python</param>
            <param id="function">cloudlaunch_pulsar_burst</param>
            <param id="rules_module">galaxycloudrunner.rules</param>
        </destination>
```
In addition, this PR also does the following:
1. Updates filesystem watchers to also watch for per destination rules_module changes
2. Refactors `galaxy.util.submodule` import handling, preferring importlib over `__import__` statements
3. Removes some code duplication in the job mapper by using galaxy.util.submodule
4. Adds a test for rules_module overriding
