### PR TITLE
Fix handling of forgotten LSF jobs in cli

### DIFF
--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -81,8 +81,13 @@ class LSF(BaseJobExec):
         return rval
 
     def parse_single_status(self, status, job_id):
-        if "is not found" in status:
+        if not status:
             # Job not found in LSF, most probably finished and forgotten.
+            # lsf outputs: Job <num> is not found -- but that is on the stderr
+            # Note: a very old failed job job will not be shown here either,
+            # which would be badly handled here. So this only works well when Galaxy
+            # is constantly monitoring the jobs. The logic here is that DONE jobs get forgotten
+            # faster than failed jobs.
             return job_states.OK
         return self._get_job_state(status)
 

--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -88,6 +88,7 @@ class LSF(BaseJobExec):
             # which would be badly handled here. So this only works well when Galaxy
             # is constantly monitoring the jobs. The logic here is that DONE jobs get forgotten
             # faster than failed jobs.
+            log.warning("Job id '%s' not found LSF status check" % job_id)
             return job_states.OK
         return self._get_job_state(status)
 


### PR DESCRIPTION
Previous case assumed that "is not found" was part of the STDOUT when in fact is in the STDERR (and STDOUT is empty).