### PR TITLE
GIE Galaxy Filesystem Volume

### DIFF
--- a/config/plugins/interactive_environments/askomics/templates/askomics.mako
+++ b/config/plugins/interactive_environments/askomics/templates/askomics.mako
@@ -17,13 +17,13 @@ else:
 
 # Launch the IE. This builds and runs the docker command in the background.
 ie_request.launch(
-    additional_ids=additional_ids if ie_request.use_volumes else None,
     env_override={
         'ASKO_load_url': 'http://localhost:6543',
         'ASKOMICS_API_KEY': askomics_api_key,
         'ASKO_files_dir': '/tmp/askomics-ie',
         'VIRT_Parameters_NumberOfBuffers': 10000,  # see https://github.com/xgaia/askomics-docker-compose/tree/master/virtuoso#virtuoso for this values
-        'VIRT_Parameters_MaxDirtyBuffers': 6000
+        'VIRT_Parameters_MaxDirtyBuffers': 6000,
+        'ADDITIONAL_IDS': additional_ids,
     }
 )
 

--- a/config/plugins/interactive_environments/bam_iobio/templates/bam_iobio.mako
+++ b/config/plugins/interactive_environments/bam_iobio/templates/bam_iobio.mako
@@ -7,12 +7,8 @@ from galaxy.util import sockets
 # Sets ID and sets up a lot of other variables
 ie_request.load_deploy_config()
 ie_request.attr.docker_port = 80
-ie_request.attr.import_volume = False
 
-bam = ie_request.volume(hda.file_name, '/input/bamfile.bam', mode='ro')
-bam_index = ie_request.volume(hda.metadata.bam_index.file_name, '/input/bamfile.bam.bai', mode='ro')
-
-ie_request.launch(volumes=[bam, bam_index], env_override={
+ie_request.launch(env_override={
     'PUB_HTTP_PORT': ie_request.attr.galaxy_config.dynamic_proxy_bind_port,
     'PUB_HOSTNAME': ie_request.attr.HOST,
 })

--- a/config/plugins/interactive_environments/hicbrowser/templates/hicbrowser.mako
+++ b/config/plugins/interactive_environments/hicbrowser/templates/hicbrowser.mako
@@ -3,13 +3,7 @@
     # Sets ID and sets up a lot of other variables
     ie_request.load_deploy_config()
 
-    # Define a volume that will be mounted into the container.
-    # This is a useful way to provide access to large files in the container,
-    # if the user knows ahead of time that they will need it.
-
     import os
-    mount_path = hda.file_name
-    data_vol = ie_request.volume(mount_path, '/data/data_pack.tar.gz', mode='rw')
 
     # Add all environment variables collected from Galaxy's IE infrastructure
     # Launch the IE.
@@ -17,7 +11,6 @@
     ie_request.launch(
        image = trans.request.params.get('image_tag', None),
        additional_ids = trans.request.params.get('additional_dataset_ids', None),
-       volumes = [data_vol]
     )
 
     # Only once the container is launched can we template our URLs. The ie_request

--- a/config/plugins/interactive_environments/jupyter/templates/jupyter.mako
+++ b/config/plugins/interactive_environments/jupyter/templates/jupyter.mako
@@ -8,7 +8,6 @@ import hashlib
 # Sets ID and sets up a lot of other variables
 ie_request.load_deploy_config()
 ie_request.attr.docker_port = 8888
-ie_request.attr.import_volume = False
 
 if ie_request.attr.PASSWORD_AUTH:
     m = hashlib.sha1()
@@ -32,7 +31,6 @@ else:
 # Add all environment variables collected from Galaxy's IE infrastructure
 ie_request.launch(
     image=trans.request.params.get('image_tag', None),
-    additional_ids=additional_ids if ie_request.use_volumes else None,
     env_override={
         'notebook_password': PASSWORD,
         'dataset_hid': DATASET_HID,

--- a/config/plugins/interactive_environments/neo/templates/neo.mako
+++ b/config/plugins/interactive_environments/neo/templates/neo.mako
@@ -2,19 +2,14 @@
 <%
     # Sets ID and sets up a lot of other variables
     ie_request.load_deploy_config()
-    # Define a volume that will be mounted into the container.
-    # This is a useful way to provide access to large files in the container,
-    # if the user knows ahead of time that they will need it.
+
     import os
     mount_path = str(os.path.dirname(hda.file_name)) + '/dataset_{}_files'.format( hda.dataset.id )
-    data_vol = ie_request.volume(mount_path, '/data', mode='rw')
-    # data_vol = ie_request.volume('${HOME}/neo4j/data', '/data/', how='rw')
     # Add all environment variables collected from Galaxy's IE infrastructure
     # Launch the IE.
     ie_request.launch(
        image=trans.request.params.get('image_tag', None),
        additional_ids=trans.request.params.get('additional_dataset_ids', None),
-       volumes =[data_vol]
     )
     # Only once the container is launched can we template our URLs. The ie_request
     # doesn't have all of the information needed until the container is running.

--- a/config/plugins/interactive_environments/rstudio/templates/rstudio.mako
+++ b/config/plugins/interactive_environments/rstudio/templates/rstudio.mako
@@ -24,7 +24,6 @@ DATASET_HID = hda.hid
 # Add all environment variables collected from Galaxy's IE infrastructure
 ie_request.launch(
     image=trans.request.params.get('image_tag', None),
-    additional_ids=additional_ids if ie_request.use_volumes else None,
     env_override={
         'notebook_username': USERNAME,
         'notebook_password': PASSWORD,

--- a/lib/galaxy/visualization/plugins/interactive_environments.py
+++ b/lib/galaxy/visualization/plugins/interactive_environments.py
@@ -285,7 +285,7 @@ class InteractiveEnvironmentRequest(object):
 
         galaxy_volume_options = [
             ('type', 'volume'),
-            ('destination': '/galaxy'),
+            ('destination', '/galaxy'),
             ('volume-driver', 'galaxy'),
             ('volume-opt', 'url=%s' % env['GALAXY_URL']),
             ('volume-opt', 'apikey=%s' % env['API_KEY']),


### PR DESCRIPTION
I'm breaking *all* of the IEs :) But this is necessary for Main + EU.

This is not globally optimal. It is not optimal for small sites which don't have the requirements that we do. It is not optimal for Phinch/Bam IOBIO/HicBrowser IEs which just want a single file, and they want it mounted in (and it may be large.)

However it gives us a single way forward with a single way to access files that big sites can use and small sites can live with.

## Galaxy Filesystem

I've developed a docker volume plugin. This is a small service that responds to API requests from Docker and then mounts/unmounts FUSE volumes.

The FUSE mount is a Galaxy FUSE mount, it does the same thing as previous galaxy-fuse filesystems but actually implements the `read` operation (all prior art requires `expose_dataset_path` and just uses symlinks.) It exposes two methods, and ID-only and an ID + "human readable name". It supports dataset collections (list, paired, list:paired). The ID-only version will work well for IEs that just need a specific file (DATASET_ID, HISTORY_ID are passed, should be sufficient to find the path since it will always be `/galaxy/history/...`)

https://github.com/erasche/docker-galaxy-volume

```
$ docker run -it --user 1000:1000 --mount type=volume,destination=/galaxy,volume-driver=galaxy,volume-opt=url=http://localhost,volume-opt=apikey=76d1a621e9d80751c1475c176ae6ee12 python:3.6-alpine /bin/sh
/ $ find /galaxy/
/galaxy/
/galaxy/histories
/galaxy/histories/f597429621d6eb2b
/galaxy/histories/f597429621d6eb2b/f2db41e1fa331b3e_dc
/galaxy/histories/f597429621d6eb2b/f2db41e1fa331b3e_dc/33b43b4e7093c91f
/galaxy/histories/f597429621d6eb2b/f2db41e1fa331b3e_dc/a799d38679e985db
/galaxy/histories/f597429621d6eb2b/f2db41e1fa331b3e_dc/5969b1f7201f12ae
/galaxy/histories/f597429621d6eb2b/f2db41e1fa331b3e_dc/df7a1f0c02a5b08e
/galaxy/histories/f597429621d6eb2b/f597429621d6eb2b_dc
/galaxy/histories/f597429621d6eb2b/f597429621d6eb2b_dc/33b43b4e7093c91f_dc
/galaxy/histories/f597429621d6eb2b/f597429621d6eb2b_dc/33b43b4e7093c91f_dc/ebfb8f50c6abde6d
/galaxy/histories/f597429621d6eb2b/f597429621d6eb2b_dc/33b43b4e7093c91f_dc/1cd8e2f6b131e891
/galaxy/histories/f597429621d6eb2b/f597429621d6eb2b_dc/df7a1f0c02a5b08e_dc
/galaxy/histories/f597429621d6eb2b/f597429621d6eb2b_dc/df7a1f0c02a5b08e_dc/f597429621d6eb2b
/galaxy/histories/f597429621d6eb2b/f597429621d6eb2b_dc/df7a1f0c02a5b08e_dc/f2db41e1fa331b3e

$ docker run -it --user 1000:1000 --mount type=volume,destination=/galaxy,volume-driver=galaxy,volume-opt=url=http://localhost,volume-opt=apikey=76d1a621e9d80751c1475c176ae6ee12,volume-opt=human_readable=true python:3.6-alpine /bin/sh
/ $ find /galaxy/
/galaxy/
/galaxy/histories
/galaxy/histories/Test __f597429621d6eb2b
/galaxy/histories/Test __f597429621d6eb2b/list __f2db41e1fa331b3e_dc
/galaxy/histories/Test __f597429621d6eb2b/list __f2db41e1fa331b3e_dc/Pasted Entry __33b43b4e7093c91f
/galaxy/histories/Test __f597429621d6eb2b/list __f2db41e1fa331b3e_dc/Pasted Entry __a799d38679e985db
/galaxy/histories/Test __f597429621d6eb2b/list __f2db41e1fa331b3e_dc/Pasted Entry __5969b1f7201f12ae
/galaxy/histories/Test __f597429621d6eb2b/list __f2db41e1fa331b3e_dc/Pasted Entry __df7a1f0c02a5b08e
/galaxy/histories/Test __f597429621d6eb2b/list:paired __f597429621d6eb2b_dc
/galaxy/histories/Test __f597429621d6eb2b/list:paired __f597429621d6eb2b_dc/1 __33b43b4e7093c91f_dc
/galaxy/histories/Test __f597429621d6eb2b/list:paired __f597429621d6eb2b_dc/1 __33b43b4e7093c91f_dc/Pasted Entry __ebfb8f50c6abde6d
/galaxy/histories/Test __f597429621d6eb2b/list:paired __f597429621d6eb2b_dc/1 __33b43b4e7093c91f_dc/Pasted Entry __1cd8e2f6b131e891
/galaxy/histories/Test __f597429621d6eb2b/list:paired __f597429621d6eb2b_dc/2 __df7a1f0c02a5b08e_dc
/galaxy/histories/Test __f597429621d6eb2b/list:paired __f597429621d6eb2b_dc/2 __df7a1f0c02a5b08e_dc/Pasted Entry __f597429621d6eb2b
/galaxy/histories/Test __f597429621d6eb2b/list:paired __f597429621d6eb2b_dc/2 __df7a1f0c02a5b08e_dc/Pasted Entry __f2db41e1fa331b3e
```

## TODO

- [ ] rewrite all IEs to take advantage of this
- [ ] see if anything else can be ripped out
- [ ] easy deployment of the galaxy docker volume driver
