### PR TITLE
[18.01] Fix display_in_tool_panel status for shared workflows

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3756,6 +3756,13 @@ class StoredWorkflow(HasTags, Dictifiable):
         self.latest_workflow_id = None
         self.workflows = []
 
+    def show_in_tool_panel(self, user_id):
+        sa_session = object_session(self)
+        return bool(sa_session.query(StoredWorkflowMenuEntry).filter(
+            StoredWorkflowMenuEntry.stored_workflow_id == self.id,
+            StoredWorkflowMenuEntry.user_id == user_id,
+        ).count())
+
     def copy_tags_from(self, target_user, source_workflow):
         # Override to only copy owner tags.
         for src_swta in source_workflow.owner_tags:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -137,11 +137,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             item['url'] = url_for('workflow', id=encoded_id)
             item['owner'] = wf.user.username
             item['number_of_steps'] = wf.latest_workflow.step_count
-            item['show_in_tool_panel'] = False
-            for x in user.stored_workflow_menu_entries:
-                if x.stored_workflow_id == wf.id:
-                    item['show_in_tool_panel'] = True
-                    break
+            item['show_in_tool_panel'] = wf.show_in_tool_panel(user_id=user.id)
             rval.append(item)
         for wf_sa in trans.sa_session.query(model.StoredWorkflowUserShareAssociation).join(
                 model.StoredWorkflowUserShareAssociation.stored_workflow).options(
@@ -156,11 +152,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             item['slug'] = wf_sa.stored_workflow.slug
             item['owner'] = wf_sa.stored_workflow.user.username
             item['number_of_steps'] = wf_sa.stored_workflow.latest_workflow.step_count
-            item['show_in_tool_panel'] = False
-            for x in user.stored_workflow_menu_entries:
-                if x.stored_workflow_id == wf_sa.id:
-                    item['show_in_tool_panel'] = True
-                    break
+            item['show_in_tool_panel'] = wf_sa.stored_workflow.show_in_tool_panel(user_id=user.id)
             rval.append(item)
         if missing_tools:
             workflows_missing_tools = []


### PR DESCRIPTION
This is more DRY and fixes
https://github.com/galaxyproject/galaxy/issues/6889#issuecomment-438991091.

The bug itself was due to comparing
the id of a StoredWorkflowUserShareAssociation instead of StoredWorkflow
when checking if a stored workflow should be in the tool panel.