### PR TITLE
File-based Workflow Editor

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import json
 import logging
+import os
 import uuid
 from collections import namedtuple
 
@@ -11,6 +12,7 @@ from gxformat2 import (
     ImportOptions,
     python_to_workflow,
 )
+from gxformat2.converter import ordered_load
 from six import string_types
 from sqlalchemy import and_
 from sqlalchemy.orm import joinedload, subqueryload
@@ -241,7 +243,12 @@ class WorkflowContentsManager(UsesAnnotations):
         self.app = app
         self._resource_mapper_function = get_resource_mapper_function(app)
 
-    def normalize_workflow_format(self, as_dict):
+    def ensure_raw_description(self, dict_or_raw_description):
+        if not isinstance(dict_or_raw_description, RawWorkflowDescription):
+            dict_or_raw_description = RawWorkflowDescription(dict_or_raw_description)
+        return dict_or_raw_description
+
+    def normalize_workflow_format(self, trans, as_dict):
         """Process incoming workflow descriptions for consumption by other methods.
 
         Currently this mostly means converting format 2 workflows into standard Galaxy
@@ -250,6 +257,18 @@ class WorkflowContentsManager(UsesAnnotations):
         side the data model and apply updates in a way that largely preserves YAML structure
         so workflows can be extracted.
         """
+        workflow_directory = None
+        workflow_path = None
+
+        if as_dict.get("src", None) == "from_path":
+            if not trans.user_is_admin:
+                raise exceptions.AdminRequiredException()
+
+            workflow_path = as_dict.get("path")
+            with open(workflow_path, "r") as f:
+                as_dict = ordered_load(f)
+            workflow_directory = os.path.normpath(os.path.dirname(workflow_path))
+
         workflow_class = as_dict.get("class", None)
         if workflow_class == "GalaxyWorkflow" or "$graph" in as_dict or "yaml_content" in as_dict:
             if not self.app.config.enable_beta_workflow_format:
@@ -259,13 +278,14 @@ class WorkflowContentsManager(UsesAnnotations):
             galaxy_interface = Format2ConverterGalaxyInterface()
             import_options = ImportOptions()
             import_options.deduplicate_subworkflows = True
-            as_dict = python_to_workflow(as_dict, galaxy_interface, workflow_directory=None, import_options=import_options)
-        return as_dict
+            as_dict = python_to_workflow(as_dict, galaxy_interface, workflow_directory=workflow_directory, import_options=import_options)
 
-    def build_workflow_from_dict(
+        return RawWorkflowDescription(as_dict, workflow_path)
+
+    def build_workflow_from_raw_description(
         self,
         trans,
-        data,
+        raw_workflow_description,
         source=None,
         add_to_menu=False,
         publish=False,
@@ -273,6 +293,7 @@ class WorkflowContentsManager(UsesAnnotations):
         exact_tools=True,
         fill_defaults=False,
     ):
+        data = raw_workflow_description.as_dict
         # Put parameters in workflow mode
         trans.workflow_building_mode = workflow_building_modes.ENABLED
         # If there's a source, put it in the workflow name.
@@ -280,9 +301,9 @@ class WorkflowContentsManager(UsesAnnotations):
             name = "%s (imported from %s)" % (data['name'], source)
         else:
             name = data['name']
-        workflow, missing_tool_tups = self._workflow_from_dict(
+        workflow, missing_tool_tups = self._workflow_from_raw_description(
             trans,
-            data,
+            raw_workflow_description,
             name=name,
             exact_tools=exact_tools,
             fill_defaults=fill_defaults,
@@ -293,6 +314,7 @@ class WorkflowContentsManager(UsesAnnotations):
         if create_stored_workflow:
             # Connect up
             stored = model.StoredWorkflow()
+            stored.from_path = raw_workflow_description.workflow_path
             stored.name = workflow.name
             workflow.stored_workflow = stored
             stored.latest_workflow = workflow
@@ -327,13 +349,15 @@ class WorkflowContentsManager(UsesAnnotations):
             missing_tools=missing_tool_tups
         )
 
-    def update_workflow_from_dict(self, trans, stored_workflow, workflow_data, **kwds):
+    def update_workflow_from_raw_description(self, trans, stored_workflow, raw_workflow_description, **kwds):
+        raw_workflow_description = self.ensure_raw_description(raw_workflow_description)
+
         # Put parameters in workflow mode
         trans.workflow_building_mode = workflow_building_modes.ENABLED
 
-        workflow, missing_tool_tups = self._workflow_from_dict(
+        workflow, missing_tool_tups = self._workflow_from_raw_description(
             trans,
-            workflow_data,
+            raw_workflow_description,
             name=stored_workflow.name,
             **kwds
         )
@@ -349,6 +373,8 @@ class WorkflowContentsManager(UsesAnnotations):
         stored_workflow.latest_workflow = workflow
         # Persist
         trans.sa_session.flush()
+        if stored_workflow.from_path:
+            self._sync_stored_workflow(trans, stored_workflow)
         # Return something informative
         errors = []
         if workflow.has_errors:
@@ -357,7 +383,8 @@ class WorkflowContentsManager(UsesAnnotations):
             errors.append("This workflow contains cycles")
         return workflow, errors
 
-    def _workflow_from_dict(self, trans, data, name, **kwds):
+    def _workflow_from_raw_description(self, trans, raw_workflow_description, name, **kwds):
+        data = raw_workflow_description.as_dict
         if isinstance(data, string_types):
             data = json.loads(data)
 
@@ -448,6 +475,18 @@ class WorkflowContentsManager(UsesAnnotations):
         else:
             wf_dict['version'] = len(stored.workflows) - 1
         return wf_dict
+
+    def _sync_stored_workflow(self, trans, stored_workflow):
+        workflow_path = stored_workflow.from_path
+        workflow = stored_workflow.latest_workflow
+        with open(workflow_path, "w") as f:
+            if workflow_path.endswith(".ga"):
+                wf_dict = self._workflow_to_dict_export(trans, stored_workflow, workflow=workflow)
+                json.dump(wf_dict, f, indent=4)
+            else:
+                wf_dict = self._workflow_to_dict_export(trans, stored_workflow, workflow=workflow)
+                wf_dict = from_galaxy_native(wf_dict, None, json_wrapper=True)
+                f.write(wf_dict["yaml_content"])
 
     def _workflow_to_dict_run(self, trans, stored, workflow):
         """
@@ -821,7 +860,7 @@ class WorkflowContentsManager(UsesAnnotations):
             # newer Galaxy instances can be used with older Galaxy
             # instances if they do no include multiple input
             # tools. This should be removed at some point. Mirrored
-            # hack in _workflow_from_dict should never be removed so
+            # hack in _workflow_from_raw_description should never be removed so
             # existing workflow exports continue to function.
             for input_name, input_conn in dict(input_conn_dict).items():
                 if len(input_conn) == 1:
@@ -1041,8 +1080,9 @@ class WorkflowContentsManager(UsesAnnotations):
         return subworkflow
 
     def __build_embedded_subworkflow(self, trans, data, **kwds):
-        subworkflow = self.build_workflow_from_dict(
-            trans, data, create_stored_workflow=False, fill_defaults=kwds.get("fill_defaults", False)
+        raw_workflow_description = self.ensure_raw_description(data)
+        subworkflow = self.build_workflow_from_raw_description(
+            trans, raw_workflow_description, create_stored_workflow=False, fill_defaults=kwds.get("fill_defaults", False)
         ).workflow
         return subworkflow
 
@@ -1093,6 +1133,13 @@ class MissingToolsException(exceptions.MessageException):
     def __init__(self, workflow, errors):
         self.workflow = workflow
         self.errors = errors
+
+
+class RawWorkflowDescription(object):
+
+    def __init__(self, as_dict, workflow_path=None):
+        self.as_dict = as_dict
+        self.workflow_path = workflow_path
 
 
 class Format2ConverterGalaxyInterface(ImporterGalaxyInterface):

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -874,6 +874,7 @@ model.StoredWorkflow.table = Table(
     Column("deleted", Boolean, default=False),
     Column("importable", Boolean, default=False),
     Column("slug", TEXT, index=True),
+    Column("from_path", TEXT, index=True),
     Column("published", Boolean, index=True, default=False))
 
 model.Workflow.table = Table(

--- a/lib/galaxy/model/migrate/versions/0146_workflow_paths.py
+++ b/lib/galaxy/model/migrate/versions/0146_workflow_paths.py
@@ -1,0 +1,62 @@
+"""
+Migration script for workflow paths.
+"""
+from __future__ import print_function
+
+import logging
+
+from sqlalchemy import (
+    Column,
+    MetaData,
+    Table,
+    TEXT,
+)
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+from_path_column = Column("from_path", TEXT, nullable=True)
+
+
+def upgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    print(__doc__)
+    metadata.reflect()
+
+    __add_column(from_path_column, "stored_workflow", metadata)
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+
+    __drop_column(from_path_column, "stored_workflow", metadata)
+
+
+def __add_column(column, table_name, metadata, **kwds):
+    try:
+        table = Table(table_name, metadata, autoload=True)
+        column.create(table, **kwds)
+    except Exception:
+        log.exception("Adding column %s failed.", column)
+
+
+def __drop_column(column_name, table_name, metadata):
+    try:
+        table = Table(table_name, metadata, autoload=True)
+        getattr(table.c, column_name).drop()
+    except Exception:
+        log.exception("Dropping column %s failed.", column_name)
+
+
+def _create(table):
+    try:
+        table.create()
+    except Exception:
+        log.exception("Creating %s table failed.", table.name)
+
+
+def _drop(table):
+    try:
+        table.drop()
+    except Exception:
+        log.exception("Dropping %s table failed.", table.name)

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -1243,9 +1243,10 @@ class UsesStoredWorkflowMixin(SharableItemSecurityMixin, UsesAnnotations):
         """
         # TODO: replace this method with direct access to manager.
         workflow_contents_manager = workflows.WorkflowContentsManager(self.app)
-        created_workflow = workflow_contents_manager.build_workflow_from_dict(
+        raw_workflow_description = workflow_contents_manager.ensure_raw_description(data)
+        created_workflow = workflow_contents_manager.build_workflow_from_raw_description(
             trans,
-            data,
+            raw_workflow_description,
             source=source,
             add_to_menu=add_to_menu,
             publish=publish,

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -417,6 +417,19 @@ steps:
       inner_input: outer_input
 """
 
+WORKFLOW_ONE_STEP_DEFAULT = """
+class: GalaxyWorkflow
+inputs:
+  input: data
+steps:
+  randomlines:
+    tool_id: random_lines1
+    in:
+      input: input
+      num_lines:
+        default: 6
+"""
+
 WORKFLOW_WITH_OUTPUTS = """
 class: GalaxyWorkflow
 inputs:

--- a/test/integration/test_dockerized_jobs.py
+++ b/test/integration/test_dockerized_jobs.py
@@ -1,7 +1,6 @@
 """Integration tests for running tools in Docker containers."""
 
 import os
-import tempfile
 
 from base import integration_util
 from base.populators import (
@@ -21,7 +20,7 @@ class DockerizedJobsIntegrationTestCase(integration_util.IntegrationTestCase, Ru
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        cls.jobs_directory = tempfile.mkdtemp()
+        cls.jobs_directory = cls._test_driver.mkdtemp()
         config["jobs_directory"] = cls.jobs_directory
         config["job_config_file"] = DOCKERIZED_JOB_CONFIG_FILE
         # Disable tool dependency resolution.

--- a/test/integration/test_workflow_sync.py
+++ b/test/integration/test_workflow_sync.py
@@ -1,0 +1,53 @@
+"""Integration tests for workflow syncing."""
+
+import json
+import os
+
+import yaml
+
+from base import integration_util  # noqa: I100,I202
+from base.populators import (  # noqa: I100
+    DatasetPopulator,
+    WorkflowPopulator,
+)
+from base.workflow_fixtures import WORKFLOW_SIMPLE_CAT_TWICE  # noqa: I100
+
+
+class WorkflowSyncTestCase(integration_util.IntegrationTestCase):
+
+    framework_tool_and_types = True
+    require_admin_user = True
+
+    def setUp(self):
+        super(WorkflowSyncTestCase, self).setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        cls.workflow_directory = cls._test_driver.mkdtemp()
+
+    def test_sync_format2(self):
+        workflow_path = self._write_workflow_content("workflow.yml", WORKFLOW_SIMPLE_CAT_TWICE)
+        workflow_id = self.workflow_populator.import_workflow_from_path(workflow_path)
+        with self.workflow_populator.export_for_update(workflow_id) as workflow_object:
+            workflow_object["annotation"] = "new annotation"
+        with open(workflow_path, "r") as f:
+            data = yaml.load(f)
+            assert data["doc"] == "new annotation"
+
+    def test_sync_ga(self):
+        workflow_json = self.workflow_populator.load_workflow("synctest")
+        workflow_path = self._write_workflow_content("workflow.ga", json.dumps(workflow_json))
+        workflow_id = self.workflow_populator.import_workflow_from_path(workflow_path)
+        with self.workflow_populator.export_for_update(workflow_id) as workflow_object:
+            workflow_object["annotation"] = "new annotation"
+        with open(workflow_path, "r") as f:
+            data = json.load(f)
+            assert data["annotation"] == "new annotation"
+
+    def _write_workflow_content(self, filename, content):
+        workflow_path = os.path.join(self.workflow_directory, filename)
+        with open(workflow_path, "w") as f:
+            f.write(content)
+        return workflow_path


### PR DESCRIPTION
- Allow workflows to be uploaded via path using the GUI and and API for admins.
- Track the path of such uploads and re-sync workflows on save (both .ga and format 2 workflows) - this will allow Planemo to leverage the Galaxy workflow editor to interactively save workflows (e.g. ``planemo workflow_edit <workflow.(ga|yml)>``).

Builds on #6850 