### PR TITLE
Pass a ``JobWrapper`` instead of a ``Job`` to ``stop_job()`` methods 

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1178,11 +1178,7 @@ class JobWrapper(HasResourceParameters):
         """ Get a destination parameter that can be defaulted back
         in app.config if it needs to be applied globally.
         """
-        # this is called by self._job_dataset_path_rewriter, which is called by self.job_destination(), so to access
-        # self.job_destination directly would cause infinite recursion
-        dest_params = {}
-        if hasattr(self, 'job_runner_mapper') and hasattr(self.job_runner_mapper, 'cached_job_destination'):
-            dest_params = self.job_runner_mapper.cached_job_destination.params
+        dest_params = self.job_destination.params
         return self.get_job().get_destination_configuration(
             dest_params, self.app.config, key, default
         )
@@ -1487,9 +1483,9 @@ class JobWrapper(HasResourceParameters):
         param_dict.update({'__collected_datasets__': collected_datasets})
         # Certain tools require tasks to be completed after job execution
         # ( this used to be performed in the "exec_after_process" hook, but hooks are deprecated ).
-        self.tool.exec_after_process(self.queue.app, inp_data, out_data, param_dict, job=job)
+        self.tool.exec_after_process(self.app, inp_data, out_data, param_dict, job=job)
         # Call 'exec_after_process' hook
-        self.tool.call_hook('exec_after_process', self.queue.app, inp_data=inp_data,
+        self.tool.call_hook('exec_after_process', self.app, inp_data=inp_data,
                             out_data=out_data, param_dict=param_dict,
                             tool=self.tool, stdout=job.stdout, stderr=job.stderr)
         job.command_line = unicodify(self.command_line)

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -858,7 +858,8 @@ class JobHandlerStopQueue(Monitors):
             self.sa_session.flush()
             if job.job_runner_name is not None:
                 # tell the dispatcher to stop the job
-                self.dispatcher.stop(job)
+                job_wrapper = JobWrapper(job, self, use_persisted_destination=True)
+                self.dispatcher.stop(job, job_wrapper)
 
     def put(self, job_id, error_msg=None):
         if not self.app.config.track_jobs_in_database:
@@ -922,7 +923,7 @@ class DefaultJobDispatcher(object):
             log.error('put(): (%s) Invalid job runner: %s' % (job_wrapper.job_id, runner_name))
             job_wrapper.fail(DEFAULT_JOB_PUT_FAILURE_MESSAGE)
 
-    def stop(self, job):
+    def stop(self, job, job_wrapper):
         """
         Stop the given job. The input variable job may be either a Job or a Task.
         """
@@ -931,28 +932,17 @@ class DefaultJobDispatcher(object):
         # Note that Jobs and Tasks have runner_names, which are distinct from
         # the job_runner_name and task_runner_name.
 
-        if (isinstance(job, model.Job)):
-            log.debug("Stopping job %d:", job.get_id())
-        elif(isinstance(job, model.Task)):
-            log.debug("Stopping job %d, task %d"
-                      % (job.get_job().get_id(), job.get_id()))
-        else:
-            log.debug("Unknown job to stop")
-
         # The runner name is not set until the job has started.
         # If we're stopping a task, then the runner_name may be
         # None, in which case it hasn't been scheduled.
-        if (job.get_job_runner_name() is not None):
-            runner_name = (job.get_job_runner_name().split(":", 1))[0]
-            if (isinstance(job, model.Job)):
-                log.debug("stopping job %d in %s runner" % (job.get_id(), runner_name))
-            elif (isinstance(job, model.Task)):
-                log.debug("Stopping job %d, task %d in %s runner"
-                          % (job.get_job().get_id(), job.get_id(), runner_name))
+        job_runner_name = job.get_job_runner_name()
+        if job_runner_name is not None:
+            runner_name = job_runner_name.split(":", 1)[0]
+            log.debug("Stopping job %s in %s runner" % (job_wrapper.get_id_tag(), runner_name))
             try:
-                self.job_runners[runner_name].stop_job(job)
+                self.job_runners[runner_name].stop_job(job_wrapper)
             except KeyError:
-                log.error('stop(): (%s) Invalid job runner: %s' % (job.get_id(), runner_name))
+                log.error('stop(): (%s) Invalid job runner: %s' % (job_wrapper.get_id_tag(), runner_name))
                 # Job and output dataset states have already been updated, so nothing is done here.
 
     def recover(self, job, job_wrapper):

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -947,7 +947,7 @@ class DefaultJobDispatcher(object):
 
     def recover(self, job, job_wrapper):
         runner_name = (job.job_runner_name.split(":", 1))[0]
-        log.debug("recovering job %d in %s runner" % (job.get_id(), runner_name))
+        log.debug("recovering job %d in %s runner" % (job.id, runner_name))
         try:
             self.job_runners[runner_name].recover(job, job_wrapper)
         except KeyError:

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -233,7 +233,7 @@ class BaseJobRunner(object):
     def queue_job(self, job_wrapper):
         raise NotImplementedError()
 
-    def stop_job(self, job):
+    def stop_job(self, job_wrapper):
         raise NotImplementedError()
 
     def recover(self, job, job_wrapper):
@@ -422,7 +422,7 @@ class BaseJobRunner(object):
 
     def fail_job(self, job_state, exception=False):
         if getattr(job_state, 'stop_job', True):
-            self.stop_job(self.sa_session.query(self.app.model.Job).get(job_state.job_wrapper.job_id))
+            self.stop_job(job_state.job_wrapper)
         self._handle_runner_state('failure', job_state)
         # Not convinced this is the best way to indicate this state, but
         # something necessary

--- a/lib/galaxy/jobs/runners/chronos.py
+++ b/lib/galaxy/jobs/runners/chronos.py
@@ -145,8 +145,8 @@ class ChronosJobRunner(AsynchronousJobRunner):
         return None
 
     @handle_exception_call
-    def stop_job(self, job):
-        job_id = job.get_id_tag()
+    def stop_job(self, job_wrapper):
+        job_id = job_wrapper.get_id_tag()
         job_name = self.JOB_NAME_PREFIX + job_id
         job = self._retrieve_job(job_name)
         if job:

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -207,8 +207,9 @@ class ShellJobRunner(AsynchronousJobRunner):
             job_states.update(job_interface.parse_status(cmd_out.stdout, job_ids))
         return job_states
 
-    def stop_job(self, job):
+    def stop_job(self, job_wrapper):
         """Attempts to delete a dispatched job"""
+        job = job_wrapper.get_job()
         try:
             shell_params, job_params = self.parse_destination_params(job.destination_params)
             shell, job_interface = self.get_cli_plugins(shell_params, job_params)

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -214,8 +214,9 @@ class CondorJobRunner(AsynchronousJobRunner):
         # Replace the watch list with the updated version
         self.watched = new_watched
 
-    def stop_job(self, job):
+    def stop_job(self, job_wrapper):
         """Attempts to delete a job from the DRM queue"""
+        job = job_wrapper.get_job()
         external_id = job.job_runner_external_id
         failure_message = condor_stop(external_id)
         if failure_message:

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -321,11 +321,11 @@ class DRMAAJobRunner(AsynchronousJobRunner):
                 command = shlex.split(kill_script)
                 command.extend([str(ext_id), str(self.userid)])
                 subprocess.Popen(command, shell=False)
-            log.info("(%s/%s) Removed from DRM queue at user's request" % (job.get_id(), ext_id))
+            log.info("(%s/%s) Removed from DRM queue at user's request" % (job.id, ext_id))
         except drmaa.InvalidJobException:
-            log.exception("(%s/%s) User killed running job, but it was already dead" % (job.get_id(), ext_id))
+            log.exception("(%s/%s) User killed running job, but it was already dead" % (job.id, ext_id))
         except Exception:
-            log.exception("(%s/%s) User killed running job, but error encountered removing from DRM queue" % (job.get_id(), ext_id))
+            log.exception("(%s/%s) User killed running job, but error encountered removing from DRM queue" % (job.id, ext_id))
 
     def recover(self, job, job_wrapper):
         """Recovers jobs stuck in the queued/running state when Galaxy started"""
@@ -339,12 +339,12 @@ class DRMAAJobRunner(AsynchronousJobRunner):
         ajs.job_wrapper = job_wrapper
         ajs.job_destination = job_wrapper.job_destination
         if job.state == model.Job.states.RUNNING:
-            log.debug("(%s/%s) is still in running state, adding to the DRM queue" % (job.get_id(), job.get_job_runner_external_id()))
+            log.debug("(%s/%s) is still in running state, adding to the DRM queue" % (job.id, job.get_job_runner_external_id()))
             ajs.old_state = drmaa.JobState.RUNNING
             ajs.running = True
             self.monitor_queue.put(ajs)
         elif job.get_state() == model.Job.states.QUEUED:
-            log.debug("(%s/%s) is still in DRM queued state, adding to the DRM queue" % (job.get_id(), job.get_job_runner_external_id()))
+            log.debug("(%s/%s) is still in DRM queued state, adding to the DRM queue" % (job.id, job.get_job_runner_external_id()))
             ajs.old_state = drmaa.JobState.QUEUED_ACTIVE
             ajs.running = False
             self.monitor_queue.put(ajs)

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -308,18 +308,13 @@ class DRMAAJobRunner(AsynchronousJobRunner):
         # Replace the watch list with the updated version
         self.watched = new_watched
 
-    def stop_job(self, job):
+    def stop_job(self, job_wrapper):
         """Attempts to delete a job from the DRM queue"""
-        dest_params = {}
-        try:
-            # fully dynamic destinations may not be defined in the job config
-            dest_params = self.app.job_config.get_destination(job.destination_id).params
-        except KeyError:
-            pass
+        job = job_wrapper.get_job()
         try:
             ext_id = job.get_job_runner_external_id()
             assert ext_id not in (None, 'None'), 'External job id is None'
-            kill_script = job.get_destination_configuration(dest_params, self.app.config, "drmaa_external_killjob_script", None)
+            kill_script = job_wrapper.get_destination_configuration("drmaa_external_killjob_script")
             if kill_script is None:
                 self.ds.kill(ext_id)
             else:

--- a/lib/galaxy/jobs/runners/godocker.py
+++ b/lib/galaxy/jobs/runners/godocker.py
@@ -226,18 +226,19 @@ class GodockerJobRunner(AsynchronousJobRunner):
             self.mark_as_failed(job_state)
             return None
 
-    def stop_job(self, job):
+    def stop_job(self, job_wrapper):
         """ Attempts to delete a dispatched executing Job in GoDocker """
         '''This function is called by fail_job()
            where param job = self.sa_session.query( self.app.model.Job ).get( job_state.job_wrapper.job_id )
            No Return data expected
         '''
-        log.debug("STOP JOB EXECUTION OF JOB ID: " + str(job.id))
+        job_id = job_wrapper.job_id
+        log.debug("STOP JOB EXECUTION OF JOB ID: " + str(job_id))
         # Get task status from GoDocker.
-        job_status_god = self.get_task_status(job.id)
+        job_status_god = self.get_task_status(job_id)
         if job_status_god['status']['primary'] != "over":
             # Initiate a delete call,if the job is running in GoDocker.
-            self.delete_task(job.id)
+            self.delete_task(job_id)
         return None
 
     def recover(self, job, job_wrapper):

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -521,7 +521,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             log.exception(e)
 
         if getattr(job_state, 'stop_job', True):
-            self.stop_job(self.sa_session.query(self.app.model.Job).get(job_state.job_wrapper.job_id))
+            self.stop_job(job_state.job_wrapper)
         self._handle_runner_state('failure', job_state)
         # Not convinced this is the best way to indicate this state, but
         # something necessary
@@ -558,8 +558,9 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         return logs_file_path
 
-    def stop_job(self, job):
+    def stop_job(self, job_wrapper):
         """Attempts to delete a dispatched job to the k8s cluster"""
+        job = job_wrapper.get_job()
         try:
             jobs = Job.objects(self._pykube_api).filter(selector="app=" +
                                                                  self.__produce_unique_k8s_job_name(job.get_id_tag()))

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -165,24 +165,24 @@ class LocalJobRunner(BaseJobRunner):
             # metadata internal or job not complete yet
             pid = job.get_job_runner_external_id()
         if pid in [None, '']:
-            log.warning("stop_job(): %s: no PID in database for job, unable to stop" % job.get_id())
+            log.warning("stop_job(): %s: no PID in database for job, unable to stop" % job.id)
             return
         pid = int(pid)
         if not self._check_pid(pid):
-            log.warning("stop_job(): %s: PID %d was already dead or can't be signaled" % (job.get_id(), pid))
+            log.warning("stop_job(): %s: PID %d was already dead or can't be signaled" % (job.id, pid))
             return
         for sig in [15, 9]:
             try:
                 os.killpg(pid, sig)
             except OSError as e:
-                log.warning("stop_job(): %s: Got errno %s when attempting to signal %d to PID %d: %s" % (job.get_id(), errno.errorcode[e.errno], sig, pid, e.strerror))
+                log.warning("stop_job(): %s: Got errno %s when attempting to signal %d to PID %d: %s" % (job.id, errno.errorcode[e.errno], sig, pid, e.strerror))
                 return  # give up
             sleep(2)
             if not self._check_pid(pid):
-                log.debug("stop_job(): %s: PID %d successfully killed with signal %d" % (job.get_id(), pid, sig))
+                log.debug("stop_job(): %s: PID %d successfully killed with signal %d" % (job.id, pid, sig))
                 return
         else:
-            log.warning("stop_job(): %s: PID %d refuses to die after signaling TERM/KILL" % (job.get_id(), pid))
+            log.warning("stop_job(): %s: PID %d refuses to die after signaling TERM/KILL" % (job.id, pid))
 
     def recover(self, job, job_wrapper):
         # local jobs can't be recovered

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -154,8 +154,9 @@ class LocalJobRunner(BaseJobRunner):
             log.exception("Job wrapper finish method failed")
             self._fail_job_local(job_wrapper, "Unable to finish job")
 
-    def stop_job(self, job):
+    def stop_job(self, job_wrapper):
         # if our local job has JobExternalOutputMetadata associated, then our primary job has to have already finished
+        job = job_wrapper.get_job()
         job_ext_output_metadata = job.get_external_output_metadata()
         try:
             pid = job_ext_output_metadata[0].job_runner_external_pid  # every JobExternalOutputMetadata has a pid set, we just need to take from one of them

--- a/lib/galaxy/jobs/runners/pbs.py
+++ b/lib/galaxy/jobs/runners/pbs.py
@@ -482,7 +482,7 @@ class PBSJobRunner(AsynchronousJobRunner):
         # NB: The stop_job method was modified to limit exceptions being sent up here,
         # so the wrapper's fail method will now be called in case of error:
         if pbs_job_state.stop_job:
-            self.stop_job(self.sa_session.query(self.app.model.Job).get(pbs_job_state.job_wrapper.job_id))
+            self.stop_job(pbs_job_state.job_wrapper)
         pbs_job_state.job_wrapper.fail(pbs_job_state.fail_message)
         if pbs_job_state.job_wrapper.cleanup_job == "always":
             self.cleanup((pbs_job_state.output_file, pbs_job_state.error_file, pbs_job_state.exit_code_file, pbs_job_state.job_file))
@@ -502,8 +502,9 @@ class PBSJobRunner(AsynchronousJobRunner):
                 stage += "%s@%s:%s" % (stage_name, self.app.config.pbs_dataset_server, fname)
         return stage
 
-    def stop_job(self, job):
+    def stop_job(self, job_wrapper):
         """Attempts to delete a job from the PBS queue"""
+        job = job_wrapper.get_job()
         job_id = job.get_job_runner_external_id().encode('utf-8')
         job_tag = "(%s/%s)" % (job.get_id_tag(), job_id)
         log.debug("%s Stopping PBS job" % job_tag)

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -578,7 +578,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
         job_wrapper.command_line = job.get_command_line()
         state = job.get_state()
         if state in [model.Job.states.RUNNING, model.Job.states.QUEUED]:
-            log.debug("(Pulsar/%s) is still in running state, adding to the Pulsar queue" % (job.get_id()))
+            log.debug("(Pulsar/%s) is still in running state, adding to the Pulsar queue" % (job.id))
             job_state.old_state = True
             job_state.running = state == model.Job.states.RUNNING
             self.monitor_queue.put(job_state)

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -519,7 +519,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
 
     def fail_job(self, job_state, message=GENERIC_REMOTE_ERROR, full_status=None):
         """Seperated out so we can use the worker threads for it."""
-        self.stop_job(self.sa_session.query(self.app.model.Job).get(job_state.job_wrapper.job_id))
+        self.stop_job(job_state.job_wrapper)
         stdout = ""
         stderr = ""
         if full_status:
@@ -538,7 +538,8 @@ class PulsarJobRunner(AsynchronousJobRunner):
                 log.warning("check_pid(): Got errno %s when attempting to check PID %d: %s" % (errno.errorcode[e.errno], pid, e.strerror))
             return False
 
-    def stop_job(self, job):
+    def stop_job(self, job_wrapper):
+        job = job_wrapper.get_job()
         # if our local job has JobExternalOutputMetadata associated, then our primary job has to have already finished
         client = self.get_client(job.destination_params, job.job_runner_external_id)
         job_ext_output_metadata = job.get_external_output_metadata()

--- a/lib/galaxy/jobs/runners/tasks.py
+++ b/lib/galaxy/jobs/runners/tasks.py
@@ -129,11 +129,12 @@ class TaskedJobRunner(BaseJobRunner):
             log.exception("Job wrapper finish method failed")
             job_wrapper.fail("Unable to finish job", exception=True)
 
-    def stop_job(self, job):
+    def stop_job(self, job_wrapper):
         # We need to stop all subtasks. This is going to stay in the task
         # runner because the task runner also starts all the tasks.
-        # First, get the list of tasks from job.tasks, which uses SQL
-        # alchemy to retrieve a job's list of tasks.
+        # First, get the list of tasks from job.tasks, which uses SQLAlchemy
+        # to retrieve a job's list of tasks.
+        job = job_wrapper.get_job()
         tasks = job.get_tasks()
         if (len(tasks) > 0):
             for task in tasks:
@@ -145,8 +146,9 @@ class TaskedJobRunner(BaseJobRunner):
         # parallelism.
         else:
             # if our local job has JobExternalOutputMetadata associated, then our primary job has to have already finished
-            if job.external_output_metadata:
-                pid = job.external_output_metadata[0].job_runner_external_pid  # every JobExternalOutputMetadata has a pid set, we just need to take from one of them
+            job_ext_output_metadata = job.get_external_output_metadata()
+            if job_ext_output_metadata:
+                pid = job_ext_output_metadata[0].job_runner_external_pid  # every JobExternalOutputMetadata has a pid set, we just need to take from one of them
             else:
                 pid = job.job_runner_external_id
             if pid in [None, '']:

--- a/lib/galaxy/jobs/runners/tasks.py
+++ b/lib/galaxy/jobs/runners/tasks.py
@@ -138,7 +138,7 @@ class TaskedJobRunner(BaseJobRunner):
         tasks = job.get_tasks()
         if (len(tasks) > 0):
             for task in tasks:
-                log.debug("Killing task's job " + str(task.get_id()))
+                log.debug("Killing task's job %s" % task.id)
                 self.app.job_manager.job_handler.dispatcher.stop(task)
 
         # There were no subtasks, so just kill the job. We'll touch
@@ -190,7 +190,7 @@ class TaskedJobRunner(BaseJobRunner):
             task_state = task.get_state()
             if (model.Task.states.QUEUED == task_state):
                 log.debug("_cancel_job for job %d: Task %d is not running; setting state to DELETED"
-                          % (job.get_id(), task.get_id()))
+                          % (job.id, task.id))
                 task_wrapper.change_state(task.states.DELETED)
         # If a task failed, then the caller will have waited a few seconds
         # before recognizing the failure. In that time, a queued task could
@@ -202,7 +202,7 @@ class TaskedJobRunner(BaseJobRunner):
             if (model.Task.states.RUNNING == task_wrapper.get_state()):
                 task = task_wrapper.get_task()
                 log.debug("_cancel_job for job %d: Stopping running task %d"
-                          % (job.get_id(), task.get_id()))
+                          % (job.id, task.id))
                 job_wrapper.app.job_manager.job_handler.dispatcher.stop(task)
 
     def _check_pid(self, pid):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -200,7 +200,6 @@ def cached_id(galaxy_model_object):
 
 
 class JobLike(object):
-
     MAX_NUMERIC = 10**(JOB_METRIC_PRECISION - JOB_METRIC_SCALE) - 1
 
     def _init_metrics(self):
@@ -700,10 +699,6 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         # This is defined in the SQL Alchemy mapper as a relation to the User.
         return self.user
 
-    def get_id(self):
-        # This is defined in the SQL Alchemy's Job table (and not in the model).
-        return self.id
-
     def get_tasks(self):
         # The tasks member is pert of a reference in the SQL Alchemy schema:
         return self.tasks
@@ -984,16 +979,12 @@ class Task(JobLike, RepresentById):
         param_dict = tool.params_from_strings(param_dict, app)
         return param_dict
 
-    def get_id(self):
-        # This is defined in the SQL Alchemy schema:
-        return self.id
-
     def get_id_tag(self):
         """
         Return an id tag suitable for identifying the task.
         This combines the task's job id and the task's own id.
         """
-        return "%s_%s" % (self.job.get_id(), self.get_id())
+        return "%s_%s" % (self.job.id, self.id)
 
     def get_command_line(self):
         return self.command_line

--- a/test/unit/jobs/test_runner_local.py
+++ b/test/unit/jobs/test_runner_local.py
@@ -85,13 +85,8 @@ class TestLocalJobRunner(TestCase, UsesApp, UsesTools):
         t = threading.Thread(target=queue)
         t.start()
         external_id = self.job_wrapper.wait_for_external_id()
-        mock_job = bunch.Bunch(
-            get_external_output_metadata=lambda: None,
-            get_job_runner_external_id=lambda: str(external_id),
-            get_id=lambda: 1
-        )
         assert psutil.pid_exists(external_id)
-        runner.stop_job(mock_job)
+        runner.stop_job(self.job_wrapper)
         t.join(1)
         assert not psutil.pid_exists(external_id)
 
@@ -139,8 +134,9 @@ class MockJobWrapper(object):
         self.requires_setting_metadata = True
         self.job_destination = bunch.Bunch(id="default", params={})
         self.galaxy_lib_dir = os.path.abspath("lib")
+        self.job = model.Job()
         self.job_id = 1
-        self.external_id = None
+        self.job.id = 1
         self.output_paths = ['/tmp/output1.dat']
         self.mock_metadata_path = os.path.abspath(os.path.join(test_directory, "METADATA_SET"))
         self.metadata_command = "touch %s" % self.mock_metadata_path
@@ -161,10 +157,10 @@ class MockJobWrapper(object):
         return "ok"
 
     def wait_for_external_id(self):
-        """Test method for waiting til an external id has been registered."""
+        """Test method for waiting until an external id has been registered."""
         external_id = None
         for i in range(50):
-            external_id = self.external_id
+            external_id = self.job.job_runner_external_id
             if external_id:
                 break
             time.sleep(.1)
@@ -174,7 +170,7 @@ class MockJobWrapper(object):
         self.prepare_called = True
 
     def set_job_destination(self, job_destination, external_id):
-        self.external_id = external_id
+        self.job.job_runner_external_id = external_id
 
     def get_command_line(self):
         return self.command_line
@@ -192,7 +188,7 @@ class MockJobWrapper(object):
         return []
 
     def get_job(self):
-        return model.Job()
+        return self.job
 
     def setup_external_metadata(self, **kwds):
         return self.metadata_command


### PR DESCRIPTION
See https://github.com/galaxyproject/galaxy/pull/6912#issuecomment-432381807 .

Also:
- Drop `get_id()` method of `Job` and `Task` classes
- 2 small simplifications in ``JobWrapper`` class