### PR TITLE
Follow-up on #6850

### DIFF
--- a/lib/galaxy/model/migrate/versions/0006_change_qual_datatype.py
+++ b/lib/galaxy/model/migrate/versions/0006_change_qual_datatype.py
@@ -8,7 +8,6 @@ import logging
 import sys
 
 from sqlalchemy import Index, MetaData, Table
-from sqlalchemy.orm import scoped_session, sessionmaker
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -24,7 +23,6 @@ metadata = MetaData()
 def upgrade(migrate_engine):
     print(__doc__)
     metadata.bind = migrate_engine
-    db_session = scoped_session(sessionmaker(bind=migrate_engine, autoflush=False, autocommit=True))
     HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
     # Load existing tables
     metadata.reflect()
@@ -38,12 +36,12 @@ def upgrade(migrate_engine):
     # Set the default data in the galaxy_user table, but only for null values
     cmd = "UPDATE history_dataset_association SET extension = 'qual454' WHERE extension = 'qual' and peek like \'>%%\'"
     try:
-        db_session.execute(cmd)
+        migrate_engine.execute(cmd)
     except Exception:
         log.exception("Resetting extension qual to qual454 in history_dataset_association failed.")
     cmd = "UPDATE history_dataset_association SET extension = 'qualsolexa' WHERE extension = 'qual' and peek not like \'>%%\'"
     try:
-        db_session.execute(cmd)
+        migrate_engine.execute(cmd)
     except Exception:
         log.exception("Resetting extension qual to qualsolexa in history_dataset_association failed.")
     # Add 1 index to the history_dataset_association table

--- a/lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py
+++ b/lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py
@@ -21,7 +21,6 @@ from galaxy.model.custom_types import JSONType
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
-
 WorkflowStepInput_table = Table(
     "workflow_step_input", metadata,
     Column("id", Integer, primary_key=True),
@@ -65,7 +64,7 @@ def upgrade(migrate_engine):
 
     insert_step_inputs_cmd = \
         "INSERT INTO workflow_step_input (workflow_step_id, name) " + \
-        "SELECT input_step_id, input_name FROM workflow_step_connection_preupgrade145"
+        "SELECT DISTINCT input_step_id, input_name FROM workflow_step_connection_preupgrade145"
     migrate_engine.execute(insert_step_inputs_cmd)
 
     insert_step_connections_cmd = \


### PR DESCRIPTION
Only migrate distinct (input_step_id, input_name) pairs, otherwise the UNIQUE constraint on the `workflow_step_input` table is violated.

Reported by @mvdbeek.

Also a small simplification of SQLAlchemy session handling in 2 files (found while trying to run the migration step in a transaction and failing).