### PR TITLE
[18.01] Backport Provide element_identifier attribute in DatasetCollectionWrapper

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -404,6 +404,10 @@ class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
         return True
 
     @property
+    def element_identifier(self):
+        return self.name
+
+    @property
     def is_input_supplied(self):
         return self.__input_supplied
 

--- a/test/functional/tools/identifier_collection.xml
+++ b/test/functional/tools/identifier_collection.xml
@@ -1,15 +1,33 @@
-<tool id="identifier_collection" name="identifier_collection">
+<tool id="identifier_collection" name="identifier_collection" version="0.1">
   <command>
     #for $input in $input1:
       echo '$input.element_identifier' >> 'output1';
     #end for
   </command>
   <inputs>
-    <param type="data_collection" collection_type="list" name="input1" label="Input 1" />
+    <param type="data_collection" collection_type="list,list:paired" name="input1" label="Input 1" />
   </inputs>
   <outputs>
     <data name="output1" format="tabular" from_work_dir="output1" />
   </outputs>
   <tests>
+    <!-- test getting identifier for list:pair collections -->
+    <test>
+      <param name="input1">
+        <collection type="list:paired">
+          <element name="i1">
+            <collection type="paired">
+              <element name="forward" value="simple_line.txt" />
+              <element name="reverse" value="simple_line_alternative.txt" />
+            </collection>
+          </element>
+        </collection>
+      </param>
+      <output name="output1">
+        <assert_contents>
+          <has_line line="i1" />
+        </assert_contents>
+      </output>
+    </test>
   </tests>
 </tool>


### PR DESCRIPTION
This allows accessing `$input1.element_identifier` for an `input1` of
collection_type `list:pair`.