### PR TITLE
Avoid replacing data-referenced input values with default values

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1537,7 +1537,7 @@ class Tool(Dictifiable):
             if not error:
                 value, error = check_param(request_context, input, value, context)
             if error:
-                if update_values:
+                if update_values and not hasattr(input, 'data_ref'):
                     try:
                         previous_value = value
                         value = input.get_initial_value(request_context, context)


### PR DESCRIPTION
Fixes #6068. The idea here is that invalid input values which are based on a data-reference should be highlighted as error but not be replaced by the default value when loading the run workflow form. The default value for e.g. column parameters is usually a bad guess.