### PR TITLE
[18.09] Eliminate dependency on make for automatic client build

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -241,10 +241,16 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
     fi
 
     # Build client
-    if ! make client-production-maps; then
-        echo "ERROR: Galaxy client build failed. See ./client/README.md for more information, including how to get help."
-        exit 1
+    pushd client
+    if yarn install --network-timeout 120000 --check-files; then
+        if ! yarn run build-production-maps; then
+            echo "ERROR: Galaxy client build failed. See ./client/README.md for more information, including how to get help."
+            exit 1
+        fi
+    else
+        echo "ERROR: Galaxy client dependency installation failed. See ./client/README.md for more information, including how to get help."
     fi
+    popd
 else
     echo "Regenerating static plugin directories."
     python ./scripts/plugin_staging.py

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -69,14 +69,14 @@ in_conda_env() {
 }
 
 if [ $COPY_SAMPLE_FILES -eq 1 ]; then
-	# Create any missing config/location files
-	for sample in $SAMPLES; do
-		file=${sample%.sample}
-	    if [ ! -f "$file" -a -f "$sample" ]; then
-	        echo "Initializing $file from $(basename "$sample")"
-	        cp "$sample" "$file"
-	    fi
-	done
+    # Create any missing config/location files
+    for sample in $SAMPLES; do
+        file=${sample%.sample}
+        if [ ! -f "$file" -a -f "$sample" ]; then
+            echo "Initializing $file from $(basename "$sample")"
+            cp "$sample" "$file"
+        fi
+    done
 fi
 
 # remove problematic cached files

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -241,7 +241,7 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
     fi
 
     # Build client
-    pushd client
+    cd client
     if yarn install --network-timeout 120000 --check-files; then
         if ! yarn run build-production-maps; then
             echo "ERROR: Galaxy client build failed. See ./client/README.md for more information, including how to get help."
@@ -251,7 +251,7 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
         echo "ERROR: Galaxy client dependency installation failed. See ./client/README.md for more information, including how to get help."
         exit 1
     fi
-    popd
+    cd -
 else
     echo "Regenerating static plugin directories."
     python ./scripts/plugin_staging.py

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -249,6 +249,7 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
         fi
     else
         echo "ERROR: Galaxy client dependency installation failed. See ./client/README.md for more information, including how to get help."
+        exit 1
     fi
     popd
 else


### PR DESCRIPTION
xref gitter this morning, @olisteadman mentioned that the client build blew up due to lacking make.

It's pretty historical at this point -- it was useful before because we relied on cli-based grunt/webpack, but I've since pushed all the logic into the package scripts executed via yarn, which we install automatically.  This shifts the client auto-building logic to prefer using yarn directly, eliminating the dependency on make.  I left the make targets because they're handy shortcuts for developers, but we should prefer the actual package scripts here.

Also retabs (to spaces) a block earlier in the file where I saw tabs mixed in.