### PR TITLE
Fix link to requirements.txt

### DIFF
--- a/doc/source/admin/framework_dependencies.rst
+++ b/doc/source/admin/framework_dependencies.rst
@@ -12,7 +12,7 @@ In addition to framework dependencies, as of Galaxy 18.01, the client (UI) is no
 **in the development (dev) branch of the source repository**. The built client is still provided in
 ``release_YY.MM`` branches and the ``master`` branch.
 
-.. _Python module dependencies: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/dependencies/requirements.txt
+.. _Python module dependencies: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
 .. _Python packaging best practices: https://packaging.python.org
 .. _virtualenv: https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments
 .. _pip: https://packaging.python.org/tutorials/installing-packages/#use-pip-for-installing


### PR DESCRIPTION
Links was broken after dependency files were rearranged (commit 1b0ccf6, Nov. 1, 2017)
(..not sure if this goes into master, dev, or its own branch. dev?)