### PR TITLE
Make tags more colourful

### DIFF
--- a/client/galaxy/scripts/mvc/history/history-item-li.js
+++ b/client/galaxy/scripts/mvc/history/history-item-li.js
@@ -1,7 +1,7 @@
 import Utils from "utils/utils";
 
 function _templateNametag(tag) {
-    return `<span style="background-color: ${Utils.generateTagColor(tag.slice(5))}; color: ${Utils.generateTagColorFg(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(tag.slice(5))}</span>`;
+    return `<span style="${Utils.generateTagStyle(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(tag.slice(5))}</span>`;
 }
 
 function nametagTemplate(historyItem) {

--- a/client/galaxy/scripts/mvc/history/history-item-li.js
+++ b/client/galaxy/scripts/mvc/history/history-item-li.js
@@ -1,7 +1,7 @@
 import Utils from "utils/utils";
 
 function _templateNametag(tag) {
-    return `<span style="background-color: ${Utils.generateTagColor(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(tag.slice(5))}</span>`;
+    return `<span style="background-color: ${Utils.generateTagColor(tag.slice(5))}; color: ${Utils.generateTagColorFg(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(tag.slice(5))}</span>`;
 }
 
 function nametagTemplate(historyItem) {

--- a/client/galaxy/scripts/mvc/history/history-item-li.js
+++ b/client/galaxy/scripts/mvc/history/history-item-li.js
@@ -1,14 +1,7 @@
+import Utils from "utils/utils";
+
 function _templateNametag(tag) {
-    return `<span style="background-color: ${generateTagColor(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(tag.slice(5))}</span>`;
-}
-
-function generateTagColor(tagValue) {
-    var hash = hashFnv32a(tagValue);
-    var r = ((hash & 0xf) % 10),
-        g = (((hash & 0xf0) >> 4) % 10),
-        b = (((hash & 0xf00) >> 8) % 10);
-
-    return `#${r}${g}${b}`;
+    return `<span style="background-color: ${Utils.generateTagColor(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(tag.slice(5))}</span>`;
 }
 
 function nametagTemplate(historyItem) {
@@ -23,23 +16,3 @@ function nametagTemplate(historyItem) {
 export default {
     nametagTemplate: nametagTemplate
 };
-
-/**
- * Calculate a 32 bit FNV-1a hash
- * Found here: https://gist.github.com/vaiorabbit/5657561
- * Ref.: http://isthe.com/chongo/tech/comp/fnv/
- *
- * @param {string} str the input value
- * @returns {integer}
- */
-function hashFnv32a(str) {
-    /*jshint bitwise:false */
-    var i, l,
-        hval = 0x811c9dc5;
-
-    for (i = 0, l = str.length; i < l; i++) {
-        hval ^= str.charCodeAt(i);
-        hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24);
-    }
-    return hval >>> 0;
-}

--- a/client/galaxy/scripts/mvc/history/history-item-li.js
+++ b/client/galaxy/scripts/mvc/history/history-item-li.js
@@ -1,5 +1,14 @@
 function _templateNametag(tag) {
-    return `<span class="badge badge-primary badge-tags">${_.escape(tag.slice(5))}</span>`;
+    return `<span style="background-color: ${generateTagColor(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(tag.slice(5))}</span>`;
+}
+
+function generateTagColor(tagValue) {
+    var hash = hashFnv32a(tagValue);
+    var r = ((hash & 0xf) % 10),
+        g = (((hash & 0xf0) >> 4) % 10),
+        b = (((hash & 0xf00) >> 8) % 10);
+
+    return `#${r}${g}${b}`;
 }
 
 function nametagTemplate(historyItem) {
@@ -14,3 +23,23 @@ function nametagTemplate(historyItem) {
 export default {
     nametagTemplate: nametagTemplate
 };
+
+/**
+ * Calculate a 32 bit FNV-1a hash
+ * Found here: https://gist.github.com/vaiorabbit/5657561
+ * Ref.: http://isthe.com/chongo/tech/comp/fnv/
+ *
+ * @param {string} str the input value
+ * @returns {integer}
+ */
+function hashFnv32a(str) {
+    /*jshint bitwise:false */
+    var i, l,
+        hval = 0x811c9dc5;
+
+    for (i = 0, l = str.length; i < l; i++) {
+        hval ^= str.charCodeAt(i);
+        hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24);
+    }
+    return hval >>> 0;
+}

--- a/client/galaxy/scripts/mvc/ui/ui-select-default.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-default.js
@@ -208,7 +208,7 @@ var View = Backbone.View.extend({
                         ${_.reduce(
                             filteredTags.slice(0, 5),
                             (memo, tag) => {
-                                return `${memo}&nbsp;<div style="background-color: ${Utils.generateTagColor(tag.slice(5))}; color: ${Utils.generateTagColorFg(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(
+                                return `${memo}&nbsp;<div style="${Utils.generateTagStyle(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(
                                     tag
                                 )}</div>`;
                             },

--- a/client/galaxy/scripts/mvc/ui/ui-select-default.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-default.js
@@ -208,7 +208,7 @@ var View = Backbone.View.extend({
                         ${_.reduce(
                             filteredTags.slice(0, 5),
                             (memo, tag) => {
-                                return `${memo}&nbsp;<div class="badge badge-primary badge-tags">${_.escape(
+                                return `${memo}&nbsp;<div style="background-color: ${Utils.generateTagColor(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(
                                     tag
                                 )}</div>`;
                             },

--- a/client/galaxy/scripts/mvc/ui/ui-select-default.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-default.js
@@ -208,7 +208,7 @@ var View = Backbone.View.extend({
                         ${_.reduce(
                             filteredTags.slice(0, 5),
                             (memo, tag) => {
-                                return `${memo}&nbsp;<div style="background-color: ${Utils.generateTagColor(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(
+                                return `${memo}&nbsp;<div style="background-color: ${Utils.generateTagColor(tag.slice(5))}; color: ${Utils.generateTagColorFg(tag.slice(5))}" class="badge badge-primary badge-tags">${_.escape(
                                     tag
                                 )}</div>`;
                             },

--- a/client/galaxy/scripts/utils/utils.js
+++ b/client/galaxy/scripts/utils/utils.js
@@ -369,17 +369,47 @@ function hashFnv32a(str) {
     return hval >>> 0;
 }
 
-export function generateTagColor(tagValue) {
-    //var r = (15 - ((hash & 0xf) % 6)).toString(16),
-        //g = (15 - (((hash & 0xf0) >> 4) % 6)).toString(16),
-        //b = (15 - (((hash & 0xf00) >> 8) % 6)).toString(16);
+function contrastingColor(r, g, b) {
+    // Expects r, g, b as floats on range [0, 1]
+    // http://www.w3.org/TR/AERT#color-contrast
+    var o = ((r * 255 * 299) +
+             (g * 255 * 587) +
+             (b * 255 * 114)) / 1000;
+    return (o > 125) ? 'black' : 'white';
+}
 
+export function hashToTagColor(tagValue) {
     var hash = hashFnv32a(tagValue);
-    var r = (((hash & 0x00f) >> 0) % 10),
-        g = (((hash & 0x0f0) >> 4) % 10),
-        b = (((hash & 0xf00) >> 8) % 10);
+    var r = ((hash & 0x00f) >> 0),
+        g = ((hash & 0x0f0) >> 4),
+        b = ((hash & 0xf00) >> 8);
 
-    return `#${r}${g}${b}`;
+    // Pastels
+    var r2 = 15 - (r % 6),
+        g2 = 15 - (g % 6),
+        b2 = 15 - (b % 6);
+
+    // All colours
+    //var r2 = r % 0xf,
+        //g2 = g % 0xf,
+        //b2 = b % 0xf;
+
+    // Not horribly dark
+    //var r2 = r % 0xa,
+        //g2 = g % 0xa,
+        //b2 = b % 0xa;
+
+    return [r2, g2, b2];
+}
+
+export function generateTagColor(tag) {
+    var [r, g, b] = hashToTagColor(tag)
+    return `#${r.toString(16)}${g.toString(16)}${b.toString(16)}`;
+}
+
+export function generateTagColorFg(tag) {
+    var [r, g, b] = hashToTagColor(tag)
+    return contrastingColor(r / 0xf, g / 0xf, b / 0xf)
 }
 
 
@@ -403,5 +433,6 @@ export default {
     appendScriptStyle: appendScriptStyle,
     getQueryString: getQueryString,
     setWindowTitle: setWindowTitle,
-    generateTagColor: generateTagColor
+    generateTagColor: generateTagColor,
+    generateTagColorFg: generateTagColorFg
 };

--- a/client/galaxy/scripts/utils/utils.js
+++ b/client/galaxy/scripts/utils/utils.js
@@ -349,6 +349,40 @@ export function setWindowTitle(title) {
     }
 }
 
+/**
+ * Calculate a 32 bit FNV-1a hash
+ * Found here: https://gist.github.com/vaiorabbit/5657561
+ * Ref.: http://isthe.com/chongo/tech/comp/fnv/
+ *
+ * @param {string} str the input value
+ * @returns {integer}
+ */
+function hashFnv32a(str) {
+    /*jshint bitwise:false */
+    var i, l,
+        hval = 0x811c9dc5;
+
+    for (i = 0, l = str.length; i < l; i++) {
+        hval ^= str.charCodeAt(i);
+        hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24);
+    }
+    return hval >>> 0;
+}
+
+export function generateTagColor(tagValue) {
+    //var r = (15 - ((hash & 0xf) % 6)).toString(16),
+        //g = (15 - (((hash & 0xf0) >> 4) % 6)).toString(16),
+        //b = (15 - (((hash & 0xf00) >> 8) % 6)).toString(16);
+
+    var hash = hashFnv32a(tagValue);
+    var r = (((hash & 0x00f) >> 0) % 10),
+        g = (((hash & 0x0f0) >> 4) % 10),
+        b = (((hash & 0xf00) >> 8) % 10);
+
+    return `#${r}${g}${b}`;
+}
+
+
 export default {
     cssLoadFile: cssLoadFile,
     cssGetAttribute: cssGetAttribute,
@@ -368,5 +402,6 @@ export default {
     linkify: linkify,
     appendScriptStyle: appendScriptStyle,
     getQueryString: getQueryString,
-    setWindowTitle: setWindowTitle
+    setWindowTitle: setWindowTitle,
+    generateTagColor: generateTagColor
 };

--- a/client/galaxy/scripts/utils/utils.js
+++ b/client/galaxy/scripts/utils/utils.js
@@ -358,7 +358,6 @@ export function setWindowTitle(title) {
  * @returns {integer}
  */
 function hashFnv32a(str) {
-    /*jshint bitwise:false */
     var i, l,
         hval = 0x811c9dc5;
 
@@ -369,9 +368,18 @@ function hashFnv32a(str) {
     return hval >>> 0;
 }
 
+/**
+ * Implement W3C contrasting color algorithm
+ * http://www.w3.org/TR/AERT#color-contrast
+ *
+ * @param   {number}  r       Red
+ * @param   {number}  g       Green
+ * @param   {number}  b       Blue
+ * @return  {string}          Either 'white' or 'black'
+ *
+ * Assumes r, g, b are in the set [0, 1]
+ */
 function contrastingColor(r, g, b) {
-    // Expects r, g, b as floats on range [0, 1]
-    // http://www.w3.org/TR/AERT#color-contrast
     var o = ((r * 255 * 299) +
              (g * 255 * 587) +
              (b * 255 * 114)) / 1000;
@@ -417,16 +425,15 @@ function hslToRgb(h, s, l){
 export function generateTagStyle(tag) {
     var hash = hashFnv32a(tag);
     var hue = (hash >> 4) & 360;
-    //var lightnessOffset = 20; // dark
-    var lightnessOffset = 75; // pastel
+    var lightnessOffset = 75;
     var lightness = lightnessOffset + (hash & 0xf);
     var bgColor = `hsl(${hue}, 100%, ${lightness}%)`;
-    var brColor = `hsl(${hue}, 100%, 30%)`; // darker
+    var brColor = `hsl(${hue}, 100%, ${lightness - 40}%)`;
 
     var [r, g, b] = hslToRgb(hue, 1.0, lightness / 100);
     var fgColor = contrastingColor(r, g, b)
 
-    return `background-color: ${bgColor}; color: ${fgColor}; border: 1px solid gray`
+    return `background-color: ${bgColor}; color: ${fgColor}; border: 1px solid ${brColor}`
 }
 
 

--- a/client/galaxy/scripts/utils/utils.js
+++ b/client/galaxy/scripts/utils/utils.js
@@ -426,7 +426,7 @@ export function generateTagStyle(tag) {
     var [r, g, b] = hslToRgb(hue, 1.0, lightness / 100);
     var fgColor = contrastingColor(r, g, b)
 
-    return `background-color: ${bgColor}; color: ${fgColor};`
+    return `background-color: ${bgColor}; color: ${fgColor}; border: 1px solid gray`
 }
 
 


### PR DESCRIPTION
**EDIT**

After much discussion we've settled on [these Options](https://github.com/galaxyproject/galaxy/pull/7072#issuecomment-444218991). 

**Original Post**


Today I was running through the peaks2genes tutorial and found that my eyes struggled to recognise if I was looking at something tagged `#peaks` or `#genes`, and this wasn't great, they just all looked the same when scanning across a history. (I've added an example at the end.) So I've implemented coloured tags. The colours are done automatically from a hash of the string so they're stateless and consistent.

![grafik](https://user-images.githubusercontent.com/458683/49456714-79ebd100-f7e1-11e8-9c09-2c3cf212d0ae.png)

Whole UI:

![grafik](https://user-images.githubusercontent.com/458683/49458479-cd135300-f7e4-11e8-9d6c-8334a620e565.png)


It just hashes the tag, and then pulls out some bits of that number. I've done a `%10` which means that the lightest colour that can theoretically be generated is which doesn't have super amazing legibility but it isn't that bad (tags are already bad due to small size for that, this isn't making it that much worse.) 

![grafik](https://user-images.githubusercontent.com/458683/49456914-c800d480-f7e1-11e8-81ba-8f74fbf336dc.png)

I chose a hash function at random by googling, if there's something more appropriate (or already in codebase) let me know. You could probably optimise the colour distributions, I think the dark colours do not have a high perceptual difference but I'm not sure what to do about this. You could probably find a better mapping.

Light colours are also an option / nice?
![grafik](https://user-images.githubusercontent.com/458683/49457441-caaff980-f7e2-11e8-9836-22872de89884.png)

Original | New
-- | --
These colours I found difficult when scanning my history | With this patch it's much easier to scan! (Faked screenshot because I'm lazy and didn't want to backport it to 18.05)
![grafik](https://user-images.githubusercontent.com/458683/49457581-f8953e00-f7e2-11e8-93bd-cbe70c73169c.png) | ![grafik](https://user-images.githubusercontent.com/458683/49458607-0e0b6780-f7e5-11e8-93b6-4150bdf60045.png)
