### PR TITLE
[18.09] Fix set_peek method for copied datasets

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1399,10 +1399,10 @@ class JobWrapper(HasResourceParameters):
                     line_count = context.get('line_count', None)
                     try:
                         # Certain datatype's set_peek methods contain a line_count argument
-                        dataset_assoc.dataset.set_peek(line_count=line_count)
+                        dataset.set_peek(line_count=line_count)
                     except TypeError:
                         # ... and others don't
-                        dataset_assoc.dataset.set_peek()
+                        dataset.set_peek()
                 else:
                     # Handle purged datasets.
                     dataset.blurb = "empty"


### PR DESCRIPTION
dataset_assoc is the job to ouptut dataset association that references
the HDA created by a job. If the HDA is copied the copies need to be
updated as well, so here we need to call `set_peek` on dataset, `not`
`dataset_assoc.dataset`.

Broken in f4343d876f13e55e92ca228582b4430dcd01e4aa

Thanks for tracking this down @jmchilton!