### PR TITLE
Fix toolshed repository error display

### DIFF
--- a/templates/admin/tool_shed_repository/manage_repository.mako
+++ b/templates/admin/tool_shed_repository/manage_repository.mako
@@ -36,7 +36,7 @@ ${render_galaxy_repository_actions( repository )}
             </div>
             <div class="form-row">
                 <label>Description:</label>
-                %if in_error_state:
+                %if repository.in_error_state:
                     ${description|h}
                 %else:
                     <input name="description" type="textfield" value="${description|h}" size="80"/>
@@ -51,7 +51,7 @@ ${render_galaxy_repository_actions( repository )}
                 <label>Owner:</label>
                 ${repository.owner|h}
             </div>
-            %if in_error_state:
+            %if repository.in_error_state:
                 <div class="form-row">
                     <label>Repository installation error:</label>
                     ${repository.error_message|h}
@@ -66,7 +66,7 @@ ${render_galaxy_repository_actions( repository )}
                 <label>Deleted:</label>
                 ${repository.deleted|h}
             </div>
-            %if not in_error_state:
+            %if not repository.in_error_state:
                 <div class="form-row">
                     <input type="submit" name="edit_repository_button" value="Save"/>
                 </div>
@@ -76,6 +76,6 @@ ${render_galaxy_repository_actions( repository )}
 </div>
 <p/>
 ${render_resolver_dependencies(requirements_status)}
-%if not in_error_state:
+%if not repository.in_error_state:
     ${render_repository_items( repository.metadata, containers_dict, can_set_metadata=False, render_repository_actions_for='galaxy' )}
 %endif


### PR DESCRIPTION
The template display was broken in case of error. 'in_error_state' is never defined it should be 'repository.in_error_state' instead. This was leading to some wrong field type display and not displaying the details about the error. Discover during attempts to solve #7059 .

This is how the template look like before :
![galaxy _toolshed_administration_before](https://user-images.githubusercontent.com/29703119/49579574-ed5e2180-f94c-11e8-963a-b5915961afe5.png)

After the changes : 
![galaxy _toolshed_ administration_after](https://user-images.githubusercontent.com/29703119/49579600-ff3fc480-f94c-11e8-827a-c379236fc36e.png)


