### PR TITLE
Remove legacy job handling hacks.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1223,7 +1223,6 @@ class JobWrapper(HasResourceParameters):
         stderr,
         tool_exit_code=None,
         check_output_detected_state=None,
-        remote_working_directory=None,
         remote_metadata_directory=None,
     ):
         """
@@ -1231,8 +1230,6 @@ class JobWrapper(HasResourceParameters):
         the output datasets based on stderr and stdout from the command, and
         the contents of the output files.
         """
-        # remote_working_directory not used with updated (7.0+ pulsar and 16.04+
-        # originated Galaxy job - keep for a few releases for older jobs)
         finish_timer = util.ExecutionTimer()
 
         # default post job setup
@@ -1382,11 +1379,8 @@ class JobWrapper(HasResourceParameters):
                         def path_rewriter(path):
                             if not path:
                                 return path
-                            normalized_remote_working_directory = remote_working_directory and os.path.normpath(remote_working_directory)
                             normalized_remote_metadata_directory = remote_metadata_directory and os.path.normpath(remote_metadata_directory)
                             normalized_path = os.path.normpath(path)
-                            if remote_working_directory and normalized_path.startswith(normalized_remote_working_directory):
-                                return normalized_path.replace(normalized_remote_working_directory, self.working_directory, 1)
                             if remote_metadata_directory and normalized_path.startswith(normalized_remote_metadata_directory):
                                 return normalized_path.replace(normalized_remote_metadata_directory, self.working_directory, 1)
                             return path
@@ -1465,10 +1459,6 @@ class JobWrapper(HasResourceParameters):
         param_dict = self.tool.params_from_strings(param_dict, self.app)
         # Create generated output children and primary datasets and add to param_dict
         tool_working_directory = self.tool_working_directory
-        # LEGACY: Remove in 17.XX
-        if not os.path.exists(tool_working_directory):
-            # Maybe this is a legacy job, use the job working directory instead
-            tool_working_directory = self.working_directory
         collected_datasets = {
             'primary': self.tool.collect_primary_datasets(out_data, self.get_tool_provided_job_metadata(), tool_working_directory, input_ext, input_dbkey)
         }

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -477,7 +477,6 @@ class PulsarJobRunner(AsynchronousJobRunner):
         try:
             client = self.get_client_from_state(job_state)
             run_results = client.full_status()
-            remote_working_directory = run_results.get("working_directory", None)
             remote_metadata_directory = run_results.get("metadata_directory", None)
             stdout = run_results.get('stdout', '')
             stderr = run_results.get('stderr', '')
@@ -510,7 +509,6 @@ class PulsarJobRunner(AsynchronousJobRunner):
                 stdout,
                 stderr,
                 exit_code,
-                remote_working_directory=remote_working_directory,
                 remote_metadata_directory=remote_metadata_directory,
             )
         except Exception:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -895,11 +895,6 @@ class Tool(Dictifiable):
 
     def tool_provided_metadata(self, job_wrapper):
         meta_file = os.path.join(job_wrapper.tool_working_directory, self.provided_metadata_file)
-        # LEGACY: Remove in 17.XX
-        if not os.path.exists(meta_file):
-            # Maybe this is a legacy job, use the job working directory instead
-            meta_file = os.path.join(job_wrapper.working_directory, self.provided_metadata_file)
-
         if not os.path.exists(meta_file):
             return output_collect.NullToolProvidedMetadata()
         if self.provided_metadata_style == "legacy":

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -531,10 +531,6 @@ def collect_primary_datasets(tool, output, tool_provided_metadata, job_working_d
     new_primary_datasets = {}
     try:
         galaxy_json_path = os.path.join(job_working_directory, "working", tool.provide_metadata_file)
-        # LEGACY: Remove in 17.XX
-        if not os.path.exists(galaxy_json_path):
-            # Maybe this is a legacy job, use the job working directory instead
-            galaxy_json_path = os.path.join(job_working_directory, tool.provide_metadata_file)
         json_file = open(galaxy_json_path, 'r')
         for line in json_file:
             line = json.loads(line)


### PR DESCRIPTION
These were left in at various times to let Galaxy jobs complete after version upgrades, but the plan was always to remove them eventually.

Modifying these bits heavily in #7058 / #7050 so it is a good time to clean things up.