### PR TITLE
Move model/Tool interactions out of galaxy.jobs.output_checker.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1527,7 +1527,17 @@ class JobWrapper(HasResourceParameters):
         self.cleanup(delete_files=delete_files)
 
     def check_tool_output(self, stdout, stderr, tool_exit_code, job):
-        return check_output(self.tool, stdout, stderr, tool_exit_code, job)
+        job_id_tag = "<unknown job id>"
+        if job is not None:
+            job_id_tag = job.get_id_tag()
+
+        state, trimmed_stdout, trimmer_stderr = check_output(self.tool.stdio_regexes, self.tool.stdio_exit_codes, stdout, stderr, tool_exit_code, job_id_tag)
+
+        # Store the modified stdout and stderr in the job:
+        if job is not None:
+            job.set_streams(trimmed_stdout, trimmer_stderr)
+
+        return state
 
     def cleanup(self, delete_files=True):
         # At least one of these tool cleanup actions (job import), is needed

--- a/test/unit/jobs/test_job_output_checker.py
+++ b/test/unit/jobs/test_job_output_checker.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 
 from galaxy.jobs.output_checker import check_output, DETECTED_JOB_STATE
-from galaxy.model import Job
 from galaxy.tools.parser.error_level import StdioErrorLevel
 from galaxy.tools.parser.interface import ToolStdioRegex
 from galaxy.util.bunch import Bunch
@@ -14,8 +13,6 @@ class OutputCheckerTestCase(TestCase):
             stdio_regexes=[],
             stdio_exit_codes=[],
         )
-        self.job = Job()
-        self.job.id = "test_id"
         self.stdout = ''
         self.stderr = ''
         self.tool_exit_code = None
@@ -87,10 +84,10 @@ class OutputCheckerTestCase(TestCase):
         self.tool.stdio_regexes.append(regex)
 
     def __assertSuccessful(self):
-        assert self.__check_output() == DETECTED_JOB_STATE.OK
+        assert self.__check_output()[0] == DETECTED_JOB_STATE.OK
 
     def __assertNotSuccessful(self):
-        assert self.__check_output() != DETECTED_JOB_STATE.OK
+        assert self.__check_output()[0] != DETECTED_JOB_STATE.OK
 
     def __check_output(self):
-        return check_output(self.tool, self.stdout, self.stderr, self.tool_exit_code, self.job)
+        return check_output(self.tool.stdio_regexes, self.tool.stdio_exit_codes, self.stdout, self.stderr, self.tool_exit_code, "job_id")


### PR DESCRIPTION
This means output_checker can be placed into galaxy-lib without dependency problems, and we can evaluate if a tool passed without access to a job object or a Tool object as long as we have a description of the job outputs and stdio objects (already in galaxy-lib).

This is a prelude to being able to do job output checking in Pulsar without Galaxy internals.

xref #7050 / #7058