### PR TITLE
De-couple objectstore abstraction from XML.

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -13,6 +13,7 @@ import threading
 import time
 from xml.etree import ElementTree
 
+import yaml
 try:
     from sqlalchemy.orm import object_session
 except ImportError:
@@ -205,9 +206,22 @@ class ObjectStore(object):
         """Return the percentage indicating how full the store is."""
         raise NotImplementedError()
 
+    @classmethod
+    def parse_xml(clazz, config_xml):
+        """Parse an XML description of a configuration for this object store.
+
+        Return a configuration dictionary (such as would correspond to the YAML configuration)
+        for the object store.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def from_xml(clazz, config, config_xml, **kwd):
+        config_dict = clazz.parse_xml(config_xml)
+        return clazz(config, config_dict, **kwd)
+
 
 class DiskObjectStore(ObjectStore):
-
     """
     Standard Galaxy object store.
 
@@ -217,14 +231,14 @@ class DiskObjectStore(ObjectStore):
     >>> import tempfile
     >>> file_path=tempfile.mkdtemp()
     >>> obj = Bunch(id=1)
-    >>> s = DiskObjectStore(Bunch(umask=0o077, jobs_directory=file_path, new_file_path=file_path, object_store_check_old_style=False), file_path=file_path)
+    >>> s = DiskObjectStore(Bunch(umask=0o077, jobs_directory=file_path, new_file_path=file_path, object_store_check_old_style=False), dict(files_dir=file_path))
     >>> s.create(obj)
     >>> s.exists(obj)
     True
     >>> assert s.get_filename(obj) == file_path + '/000/dataset_1.dat'
     """
 
-    def __init__(self, config, config_xml=None, file_path=None, extra_dirs=None):
+    def __init__(self, config, config_dict):
         """
         :type config: object
         :param config: An object, most likely populated from
@@ -234,8 +248,6 @@ class DiskObjectStore(ObjectStore):
             * file_path -- Default directory to store objects to disk in.
             * umask -- the permission bits for newly created files.
 
-        :type config_xml: ElementTree
-
         :type file_path: str
         :param file_path: Override for the `config.file_path` value.
 
@@ -243,16 +255,28 @@ class DiskObjectStore(ObjectStore):
         :param extra_dirs: Keys are string, values are directory paths.
         """
         super(DiskObjectStore, self).__init__(config)
-        self.file_path = file_path or config.file_path
-        # The new config_xml overrides universe settings.
+        self.file_path = config_dict.get("files_dir") or config.file_path
+        extra_dirs = dict(
+            (e['type'], e['path']) for e in config_dict.get('extra_dirs', []))
+        self.extra_dirs.update(extra_dirs)
+
+    @classmethod
+    def parse_xml(clazz, config_xml):
+        extra_dirs = []
+        file_path = None
+
         if config_xml is not None:
             for e in config_xml:
                 if e.tag == 'files_dir':
-                    self.file_path = e.get('path')
+                    file_path = e.get('path')
                 else:
-                    self.extra_dirs[e.get('type')] = e.get('path')
-        if extra_dirs is not None:
-            self.extra_dirs.update(extra_dirs)
+                    extra_dirs.append({"type": e.get('type'), "path": e.get('path')})
+
+        config_dict = {
+            "files_dir": file_path,
+            "extra_dirs": extra_dirs,
+        }
+        return config_dict
 
     def _get_filename(self, obj, base_dir=None, dir_only=False, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False):
         """
@@ -546,7 +570,7 @@ class DistributedObjectStore(NestedObjectStore):
     with weighting.
     """
 
-    def __init__(self, config, config_xml=None, fsmon=False):
+    def __init__(self, config, config_dict, fsmon=False):
         """
         :type config: object
         :param config: An object, most likely populated from
@@ -561,21 +585,34 @@ class DistributedObjectStore(NestedObjectStore):
         :param fsmon: If True, monitor the file system for free space,
             removing backends when they get too full.
         """
-        super(DistributedObjectStore, self).__init__(config,
-                config_xml=config_xml)
-        if config_xml is None:
-            self.distributed_config = config.distributed_object_store_config_file
-            assert self.distributed_config is not None, \
-                "distributed object store ('object_store = distributed') " \
-                "requires a config file, please set one in " \
-                "'distributed_object_store_config_file')"
+        super(DistributedObjectStore, self).__init__(config)
+
         self.backends = {}
         self.weighted_backend_ids = []
         self.original_weighted_backend_ids = []
         self.max_percent_full = {}
-        self.global_max_percent_full = 0.0
+        self.global_max_percent_full = config_dict.get("global_max_percent_full", 0)
         random.seed()
-        self.__parse_distributed_config(config, config_xml)
+
+        backends_def = config_dict["backends"]
+        for backend_def in backends_def:
+            backened_id = backend_def["id"]
+            file_path = backend_def["files_dir"]
+            extra_dirs = backend_def.get("extra_dirs", [])
+            maxpctfull = backend_def.get("max_percent_full", 0)
+            weight = backend_def["weight"]
+            disk_config_dict = dict(files_dir=file_path, extra_dirs=extra_dirs)
+            self.backends[backened_id] = DiskObjectStore(config, disk_config_dict)
+            self.max_percent_full[backened_id] = maxpctfull
+            log.debug("Loaded disk backend '%s' with weight %s and file_path: %s" % (backened_id, weight, file_path))
+
+            for i in range(0, weight):
+                # The simplest way to do weighting: add backend ids to a
+                # sequence the number of times equalling weight, then randomly
+                # choose a backend from that sequence at creation
+                self.weighted_backend_ids.append(backened_id)
+        self.original_weighted_backend_ids = self.weighted_backend_ids
+
         self.sleeper = None
         if fsmon and (self.global_max_percent_full or [_ for _ in self.max_percent_full.values() if _ != 0.0]):
             self.sleeper = Sleeper()
@@ -584,40 +621,65 @@ class DistributedObjectStore(NestedObjectStore):
             self.filesystem_monitor_thread.start()
             log.info("Filesystem space monitor started")
 
-    def __parse_distributed_config(self, config, config_xml=None):
-        if config_xml is None:
-            root = ElementTree.parse(self.distributed_config).getroot()
-            log.debug('Loading backends for distributed object store from %s', self.distributed_config)
+    @classmethod
+    def parse_xml(clazz, config_xml, legacy=False):
+        if legacy:
+            backends_root = config_xml
         else:
-            root = config_xml.find('backends')
-            log.debug('Loading backends for distributed object store from %s', config_xml.get('id'))
-        self.global_max_percent_full = float(root.get('maxpctfull', 0))
-        for elem in [e for e in root if e.tag == 'backend']:
+            backends_root = config_xml.find('backends')
+
+        backends = []
+        config_dict = {
+            'global_max_percent_full': float(backends_root.get('maxpctfull', 0)),
+            'backends': backends,
+        }
+
+        for elem in [e for e in backends_root if e.tag == 'backend']:
             id = elem.get('id')
             weight = int(elem.get('weight', 1))
             maxpctfull = float(elem.get('maxpctfull', 0))
-            if elem.get('type', 'disk'):
+            elem_type = elem.get('type', 'disk')
+
+            if elem_type:
                 path = None
-                extra_dirs = {}
+                extra_dirs = []
                 for sub in elem:
                     if sub.tag == 'files_dir':
                         path = sub.get('path')
                     elif sub.tag == 'extra_dir':
                         type = sub.get('type')
-                        extra_dirs[type] = sub.get('path')
-                self.backends[id] = DiskObjectStore(config, file_path=path, extra_dirs=extra_dirs)
-                self.max_percent_full[id] = maxpctfull
-                log.debug("Loaded disk backend '%s' with weight %s and file_path: %s" % (id, weight, path))
-                if extra_dirs:
-                    log.debug("    Extra directories:")
-                    for type, dir in extra_dirs.items():
-                        log.debug("        %s: %s" % (type, dir))
-            for i in range(0, weight):
-                # The simplest way to do weighting: add backend ids to a
-                # sequence the number of times equalling weight, then randomly
-                # choose a backend from that sequence at creation
-                self.weighted_backend_ids.append(id)
-        self.original_weighted_backend_ids = self.weighted_backend_ids
+                        extra_dirs.append({"type": type, "path": sub.get('path')})
+
+                backend_dict = {
+                    'id': id,
+                    'weight': weight,
+                    'max_percent_full': maxpctfull,
+                    'files_dir': path,
+                    'extra_dirs': extra_dirs,
+                    'type': elem_type,
+                }
+                backends.append(backend_dict)
+
+        return config_dict
+
+    @classmethod
+    def from_xml(clazz, config, config_xml, fsmon=False):
+        legacy = False
+        if config_xml is None:
+            distributed_config = config.distributed_object_store_config_file
+            assert distributed_config is not None, \
+                "distributed object store ('object_store = distributed') " \
+                "requires a config file, please set one in " \
+                "'distributed_object_store_config_file')"
+
+            log.debug('Loading backends for distributed object store from %s', distributed_config)
+            config_xml = ElementTree.parse(distributed_config).getroot()
+            legacy = True
+        else:
+            log.debug('Loading backends for distributed object store from %s', config_xml.get('id'))
+
+        config_dict = clazz.parse_xml(config_xml, legacy=legacy)
+        return clazz(config, config_dict, fsmon=fsmon)
 
     def shutdown(self):
         """Shut down. Kill the free space monitor if there is one."""
@@ -693,12 +755,27 @@ class HierarchicalObjectStore(NestedObjectStore):
     When creating objects only the first store is used.
     """
 
-    def __init__(self, config, config_xml=None, fsmon=False):
+    def __init__(self, config, config_dict, fsmon=False):
         """The default contructor. Extends `NestedObjectStore`."""
-        super(HierarchicalObjectStore, self).__init__(config, config_xml=config_xml)
-        self.backends = odict()
+        super(HierarchicalObjectStore, self).__init__(config)
+
+        backends = odict()
+        for order, backend_def in enumerate(config_dict["backends"]):
+            backends[order] = build_object_store_from_config(config, config_dict=backend_def, fsmon=fsmon)
+
+        self.backends = backends
+
+    @classmethod
+    def parse_xml(clazz, config_xml):
+        backends_list = []
         for b in sorted(config_xml.find('backends'), key=lambda b: int(b.get('order'))):
-            self.backends[int(b.get('order'))] = build_object_store_from_config(config, fsmon=fsmon, config_xml=b)
+            store_type = b.get("type")
+            objectstore_class, _ = type_to_object_store_class(store_type)
+            backend_config_dict = objectstore_class.parse_xml(b)
+            backend_config_dict["type"] = store_type
+            backends_list.append(backend_config_dict)
+
+        return {"backends": backends_list}
 
     def exists(self, obj, **kwargs):
         """Check all child object stores."""
@@ -712,7 +789,44 @@ class HierarchicalObjectStore(NestedObjectStore):
         self.backends[0].create(obj, **kwargs)
 
 
-def build_object_store_from_config(config, fsmon=False, config_xml=None):
+def type_to_object_store_class(store, fsmon=False):
+    objectstore_class = None
+    objectstore_constructor_kwds = {}
+    if store == 'disk':
+        objectstore_class = DiskObjectStore
+    elif store == 's3':
+        from .s3 import S3ObjectStore
+        objectstore_class = S3ObjectStore
+    elif store == 'cloud':
+        from .cloud import Cloud
+        objectstore_class = Cloud
+    elif store == 'swift':
+        from .s3 import SwiftObjectStore
+        objectstore_class = SwiftObjectStore
+    elif store == 'distributed':
+        objectstore_class = DistributedObjectStore
+        objectstore_constructor_kwds["fsmon"] = fsmon
+    elif store == 'hierarchical':
+        objectstore_class = HierarchicalObjectStore
+        objectstore_constructor_kwds["fsmon"] = fsmon
+    elif store == 'irods':
+        from .rods import IRODSObjectStore
+        objectstore_class = IRODSObjectStore
+    elif store == 'azure_blob':
+        from .azure_blob import AzureBlobObjectStore
+        objectstore_class = AzureBlobObjectStore
+    elif store == 'pithos':
+        from .pithos import PithosObjectStore
+        objectstore_class = PithosObjectStore
+    # Disable the Pulsar object store for now until it receives some attention
+    # elif store == 'pulsar':
+    #    from .pulsar import PulsarObjectStore
+    #    return PulsarObjectStore(config=config, config_xml=config_xml)
+
+    return objectstore_class, objectstore_constructor_kwds
+
+
+def build_object_store_from_config(config, fsmon=False, config_xml=None, config_dict=None):
     """
     Invoke the appropriate object store.
 
@@ -722,51 +836,39 @@ def build_object_store_from_config(config, fsmon=False, config_xml=None):
     Or you can specify the object store type in the `object_store` attribute of
     the `config` object. Currently 'disk', 's3', 'swift', 'distributed',
     'hierarchical', 'irods', and 'pulsar' are supported values.
-
     """
-    if config_xml is None and os.path.exists(config.object_store_config_file):
-        # This is a top level invocation of build_object_store_from_config, and
-        # we have an object_store_conf.xml -- read the .xml and build
-        # accordingly
-        root = ElementTree.parse(config.object_store_config_file).getroot()
-        store = root.get('type')
-        config_xml = root
+    from_object = 'xml'
+
+    if config_xml is None and config_dict is None:
+        config_file = config.object_store_config_file
+        if os.path.exists(config_file):
+            if config_file.endswith(".xml") or config_file.endswith(".xml.sample"):
+                # This is a top level invocation of build_object_store_from_config, and
+                # we have an object_store_conf.xml -- read the .xml and build
+                # accordingly
+                config_xml = ElementTree.parse(config.object_store_config_file).getroot()
+                store = config_xml.get('type')
+            else:
+                with open(config_file, "rt") as f:
+                    config_dict = yaml.safe_load(f)
+                from_object = 'dict'
+                store = config_dict.get('type')
+        else:
+            store = config.object_store
     elif config_xml is not None:
         store = config_xml.get('type')
-    else:
-        store = config.object_store
+    elif config_dict is not None:
+        from_object = 'dict'
+        store = config_dict.get('type')
 
-    if store == 'disk':
-        return DiskObjectStore(config=config, config_xml=config_xml)
-    elif store == 's3':
-        from .s3 import S3ObjectStore
-        return S3ObjectStore(config=config, config_xml=config_xml)
-    elif store == 'cloud':
-        from .cloud import Cloud
-        return Cloud(config=config, config_xml=config_xml)
-    elif store == 'swift':
-        from .s3 import SwiftObjectStore
-        return SwiftObjectStore(config=config, config_xml=config_xml)
-    elif store == 'distributed':
-        return DistributedObjectStore(
-            config=config, fsmon=fsmon, config_xml=config_xml)
-    elif store == 'hierarchical':
-        return HierarchicalObjectStore(config=config, config_xml=config_xml)
-    elif store == 'irods':
-        from .rods import IRODSObjectStore
-        return IRODSObjectStore(config=config, config_xml=config_xml)
-    elif store == 'azure_blob':
-        from .azure_blob import AzureBlobObjectStore
-        return AzureBlobObjectStore(config=config, config_xml=config_xml)
-    elif store == 'pithos':
-        from .pithos import PithosObjectStore
-        return PithosObjectStore(config=config, config_xml=config_xml)
-    # Disable the Pulsar object store for now until it receives some attention
-    # elif store == 'pulsar':
-    #    from .pulsar import PulsarObjectStore
-    #    return PulsarObjectStore(config=config, config_xml=config_xml)
-    else:
+    objectstore_class, objectstore_constructor_kwds = type_to_object_store_class(store, fsmon=fsmon)
+    if objectstore_class is None:
         log.error("Unrecognized object store definition: {0}".format(store))
+
+    if from_object == 'xml':
+        return objectstore_class.from_xml(config=config, config_xml=config_xml, **objectstore_constructor_kwds)
+    else:
+        return objectstore_class(config=config, config_dict=config_dict, **objectstore_constructor_kwds)
 
 
 def local_extra_dirs(func):

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -38,6 +38,49 @@ NO_BLOBSERVICE_ERROR_MESSAGE = ("ObjectStore configured, but no azure.storage.bl
 log = logging.getLogger(__name__)
 
 
+def parse_config_xml(config_xml):
+    try:
+        auth_xml = config_xml.findall('auth')[0]
+
+        account_name = auth_xml.get('account_name')
+        account_key = auth_xml.get('account_key')
+
+        container_xml = config_xml.find('container')
+        container_name = container_xml.get('name')
+        max_chunk_size = int(container_xml.get('max_chunk_size', 250))  # currently unused
+
+        c_xml = config_xml.findall('cache')[0]
+        cache_size = float(c_xml.get('size', -1))
+        staging_path = c_xml.get('path', None)
+
+        tag, attrs = 'extra_dir', ('type', 'path')
+        extra_dirs = config_xml.findall(tag)
+        if not extra_dirs:
+            msg = 'No {tag} element in XML tree'.format(tag=tag)
+            log.error(msg)
+            raise Exception(msg)
+        extra_dirs = [dict(((k, e.get(k)) for k in attrs)) for e in extra_dirs]
+        return {
+            'auth': {
+                'account_name': account_name,
+                'account_key': account_key,
+            },
+            'container': {
+                'name': container_name,
+                'max_chunk_size': max_chunk_size,
+            },
+            'cache': {
+                'size': cache_size,
+                'path': staging_path,
+            },
+            'extra_dirs': extra_dirs,
+        }
+    except Exception:
+        # Toss it back up after logging, we can't continue loading at this point.
+        log.exception("Malformed ObjectStore Configuration XML -- unable to continue")
+        raise
+
+
 class AzureBlobObjectStore(ObjectStore):
     """
     Object store that stores objects as blobs in an Azure Blob Container. A local
@@ -45,14 +88,34 @@ class AzureBlobObjectStore(ObjectStore):
     Galaxy and Azure.
     """
 
-    def __init__(self, config, config_xml):
-        if BlockBlobService is None:
-            raise Exception(NO_BLOBSERVICE_ERROR_MESSAGE)
+    def __init__(self, config, config_dict):
         super(AzureBlobObjectStore, self).__init__(config)
 
-        self.staging_path = self.config.file_path
         self.transfer_progress = 0
-        self._parse_config_xml(config_xml)
+
+        auth_dict = config_dict["auth"]
+        container_dict = config_dict["container"]
+        cache_dict = config_dict["cache"]
+
+        self.account_name = auth_dict.get('account_name')
+        self.account_key = auth_dict.get('account_key')
+
+        self.container_name = container_dict.get('name')
+        self.max_chunk_size = container_dict.get('max_chunk_size', 250)  # currently unused
+
+        self.cache_size = cache_dict.get('size', -1)
+        self.staging_path = cache_dict.get('path') or self.config.object_store_cache_path
+
+        extra_dirs = dict(
+            (e['type'], e['path']) for e in config_dict.get('extra_dirs', []))
+        self.extra_dirs.update(extra_dirs)
+
+        self._initialize()
+
+    def _initialize(self):
+        if BlockBlobService is None:
+            raise Exception(NO_BLOBSERVICE_ERROR_MESSAGE)
+
         self._configure_connection()
 
         # Clean cache only if value is set in galaxy.ini
@@ -70,28 +133,9 @@ class AzureBlobObjectStore(ObjectStore):
     ###################
 
     # config_xml is an ElementTree object.
-    def _parse_config_xml(self, config_xml):
-        try:
-            auth_xml = config_xml.find('auth')
-            self.account_name = auth_xml.get('account_name')
-            self.account_key = auth_xml.get('account_key')
-            container_xml = config_xml.find('container')
-            self.container_name = container_xml.get('name')
-            self.max_chunk_size = int(container_xml.get('max_chunk_size', 250))  # currently unused
-            cache_xml = config_xml.find('cache')
-            self.cache_size = float(cache_xml.get('size', -1))
-            self.staging_path = cache_xml.get('path', self.config.object_store_cache_path)
-
-            for d_xml in config_xml.findall('extra_dir'):
-                self.extra_dirs[d_xml.get('type')] = d_xml.get('path')
-
-            log.debug("Object cache dir:    %s", self.staging_path)
-            log.debug("       job work dir: %s", self.extra_dirs['job_work'])
-
-        except Exception:
-            # Toss it back up after logging, we can't continue loading at this point.
-            log.exception("Malformed ObjectStore Configuration XML -- unable to continue")
-            raise
+    @classmethod
+    def parse_xml(clazz, config_xml):
+        return parse_config_xml(config_xml)
 
     def _configure_connection(self):
         log.debug("Configuring Connection")

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -15,12 +15,11 @@ from galaxy.exceptions import ObjectInvalid, ObjectNotFound
 from galaxy.util import (
     directory_hash_id,
     safe_relpath,
-    string_as_bool,
     umask_fix_perms,
 )
 from galaxy.util.sleeper import Sleeper
+from .s3 import parse_config_xml
 from ..objectstore import convert_bytes, ObjectStore
-
 try:
     from cloudbridge.cloud.factory import CloudProviderFactory, ProviderList
     from cloudbridge.cloud.interfaces.exceptions import InvalidNameException
@@ -42,13 +41,41 @@ class Cloud(ObjectStore):
     cache exists that is used as an intermediate location for files between
     Galaxy and the cloud storage.
     """
-    def __init__(self, config, config_xml):
+    def __init__(self, config, config_dict):
         super(Cloud, self).__init__(config)
+        self.transfer_progress = 0
+
+        auth_dict = config_dict['auth']
+        bucket_dict = config_dict['bucket']
+        connection_dict = config_dict.get('connection', {})
+        cache_dict = config_dict['cache']
+
+        self.access_key = auth_dict.get('access_key')
+        self.secret_key = auth_dict.get('secret_key')
+
+        self.bucket = bucket_dict.get('name')
+        self.use_rr = bucket_dict.get('use_reduced_redundancy', False)
+        self.max_chunk_size = bucket_dict.get('max_chunk_size', 250)
+
+        self.host = connection_dict.get('host', None)
+        self.port = connection_dict.get('port', 6000)
+        self.multipart = connection_dict.get('multipart', True)
+        self.is_secure = connection_dict.get('is_secure', True)
+        self.conn_path = connection_dict.get('conn_path', '/')
+
+        self.cache_size = cache_dict.get('size', -1)
+        self.staging_path = cache_dict.get('path') or self.config.object_store_cache_path
+
+        extra_dirs = dict(
+            (e['type'], e['path']) for e in config_dict.get('extra_dirs', []))
+        self.extra_dirs.update(extra_dirs)
+
+        self._initialize()
+
+    def _initialize(self):
         if CloudProviderFactory is None:
             raise Exception(NO_CLOUDBRIDGE_ERROR_MESSAGE)
-        self.staging_path = self.config.file_path
-        self.transfer_progress = 0
-        self._parse_config_xml(config_xml)
+
         self._configure_connection()
         self.bucket = self._get_bucket(self.bucket)
         # Clean cache only if value is set in galaxy.ini
@@ -73,38 +100,9 @@ class Cloud(ObjectStore):
                       'aws_secret_key': self.secret_key}
         self.conn = CloudProviderFactory().create_provider(ProviderList.AWS, aws_config)
 
-    def _parse_config_xml(self, config_xml):
-        try:
-            a_xml = config_xml.findall('auth')[0]
-            self.access_key = a_xml.get('access_key')
-            self.secret_key = a_xml.get('secret_key')
-            b_xml = config_xml.findall('bucket')[0]
-            self.bucket = b_xml.get('name')
-            self.max_chunk_size = int(b_xml.get('max_chunk_size', 250))
-            cn_xml = config_xml.findall('connection')
-            if not cn_xml:
-                cn_xml = {}
-            else:
-                cn_xml = cn_xml[0]
-            self.host = cn_xml.get('host', None)
-            self.port = int(cn_xml.get('port', 6000))
-            self.multipart = string_as_bool(cn_xml.get('multipart', 'True'))
-            self.is_secure = string_as_bool(cn_xml.get('is_secure', 'True'))
-            self.conn_path = cn_xml.get('conn_path', '/')
-            c_xml = config_xml.findall('cache')[0]
-            self.cache_size = float(c_xml.get('size', -1))
-            self.staging_path = c_xml.get('path', self.config.object_store_cache_path)
-
-            for d_xml in config_xml.findall('extra_dir'):
-                self.extra_dirs[d_xml.get('type')] = d_xml.get('path')
-
-            log.debug("Object cache dir:    %s", self.staging_path)
-            log.debug("       job work dir: %s", self.extra_dirs['job_work'])
-
-        except Exception:
-            # Toss it back up after logging, we can't continue loading at this point.
-            log.exception("Malformed ObjectStore Configuration XML -- unable to continue")
-            raise
+    @classmethod
+    def parse_xml(clazz, config_xml):
+        return parse_config_xml(config_xml)
 
     def __cache_monitor(self):
         time.sleep(2)  # Wait for things to load before starting the monitor

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -85,24 +85,31 @@ class PithosObjectStore(ObjectStore):
     Cache is ignored for the time being.
     """
 
-    def __init__(self, config, config_xml):
-        if KamakiClient is None:
-            raise Exception(NO_KAMAKI_ERROR_MESSAGE)
+    def __init__(self, config, config_dict):
         super(PithosObjectStore, self).__init__(config)
         self.staging_path = self.config.file_path
-        self.transfer_progress = 0
         log.info('Parse config_xml for pithos object store')
-        self.config_dict = parse_config_xml(config_xml)
+        self.config_dict = config_dict
         log.debug(self.config_dict)
+
+        log.info('Define extra_dirs')
+        extra_dirs = dict(
+            (e['type'], e['path']) for e in config_dict.get('extra_dirs', []))
+        self.extra_dirs.update(extra_dirs)
+        self._initialize()
+
+    def _initialize(self):
+        if KamakiClient is None:
+            raise Exception(NO_KAMAKI_ERROR_MESSAGE)
 
         log.info('Authenticate Synnefo account')
         self._authenticate()
         log.info('Initialize Pithos+ client')
         self._init_pithos()
 
-        log.info('Define extra_dirs')
-        self.extra_dirs = dict(
-            (e['type'], e['path']) for e in self.config_dict['extra_dirs'])
+    @classmethod
+    def parse_xml(clazz, config_xml):
+        return parse_config_xml(config_xml)
 
     def _authenticate(self):
         auth = self.config_dict['auth']

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -38,6 +38,71 @@ log = logging.getLogger(__name__)
 logging.getLogger('boto').setLevel(logging.INFO)  # Otherwise boto is quite noisy
 
 
+def parse_config_xml(config_xml):
+    try:
+        a_xml = config_xml.findall('auth')[0]
+        access_key = a_xml.get('access_key')
+        secret_key = a_xml.get('secret_key')
+
+        b_xml = config_xml.findall('bucket')[0]
+        bucket_name = b_xml.get('name')
+        use_rr = string_as_bool(b_xml.get('use_reduced_redundancy', "False"))
+        max_chunk_size = int(b_xml.get('max_chunk_size', 250))
+
+        cn_xml = config_xml.findall('connection')
+        if not cn_xml:
+            cn_xml = {}
+        else:
+            cn_xml = cn_xml[0]
+
+        host = cn_xml.get('host', None)
+        port = int(cn_xml.get('port', 6000))
+        multipart = string_as_bool(cn_xml.get('multipart', 'True'))
+        is_secure = string_as_bool(cn_xml.get('is_secure', 'True'))
+        conn_path = cn_xml.get('conn_path', '/')
+
+        c_xml = config_xml.findall('cache')[0]
+        cache_size = float(c_xml.get('size', -1))
+
+        staging_path = c_xml.get('path', None)
+
+        tag, attrs = 'extra_dir', ('type', 'path')
+        extra_dirs = config_xml.findall(tag)
+        if not extra_dirs:
+            msg = 'No {tag} element in XML tree'.format(tag=tag)
+            log.error(msg)
+            raise Exception(msg)
+        extra_dirs = [dict(((k, e.get(k)) for k in attrs)) for e in extra_dirs]
+
+        return {
+            'auth': {
+                'access_key': access_key,
+                'secret_key': secret_key,
+            },
+            'bucket': {
+                'name': bucket_name,
+                'use_reduced_redundancy': use_rr,
+                'max_chunk_size': max_chunk_size,
+            },
+            'connection': {
+                'host': host,
+                'port': port,
+                'multipart': multipart,
+                'is_secure': is_secure,
+                'conn_path': conn_path,
+            },
+            'cache': {
+                'size': cache_size,
+                'path': staging_path,
+            },
+            'extra_dirs': extra_dirs,
+        }
+    except Exception:
+        # Toss it back up after logging, we can't continue loading at this point.
+        log.exception("Malformed ObjectStore Configuration XML -- unable to continue")
+        raise
+
+
 class S3ObjectStore(ObjectStore):
     """
     Object store that stores objects as items in an AWS S3 bucket. A local
@@ -45,13 +110,55 @@ class S3ObjectStore(ObjectStore):
     Galaxy and S3.
     """
 
-    def __init__(self, config, config_xml):
+    def __init__(self, config, config_dict):
+        super(S3ObjectStore, self).__init__(config)
+
+        self.transfer_progress = 0
+
+        auth_dict = config_dict['auth']
+        bucket_dict = config_dict['bucket']
+        connection_dict = config_dict.get('connection', {})
+        cache_dict = config_dict['cache']
+
+        self.access_key = auth_dict.get('access_key')
+        self.secret_key = auth_dict.get('secret_key')
+
+        self.bucket = bucket_dict.get('name')
+        self.use_rr = bucket_dict.get('use_reduced_redundancy', False)
+        self.max_chunk_size = bucket_dict.get('max_chunk_size', 250)
+
+        self.host = connection_dict.get('host', None)
+        self.port = connection_dict.get('port', 6000)
+        self.multipart = connection_dict.get('multipart', True)
+        self.is_secure = connection_dict.get('is_secure', True)
+        self.conn_path = connection_dict.get('conn_path', '/')
+
+        self.cache_size = cache_dict.get('size', -1)
+        self.staging_path = cache_dict.get('path') or self.config.object_store_cache_path
+
+        extra_dirs = dict(
+            (e['type'], e['path']) for e in config_dict.get('extra_dirs', []))
+        self.extra_dirs.update(extra_dirs)
+
+        log.debug("Object cache dir:    %s", self.staging_path)
+        log.debug("       job work dir: %s", self.extra_dirs['job_work'])
+
+        self._initialize()
+
+    def _initialize(self):
         if boto is None:
             raise Exception(NO_BOTO_ERROR_MESSAGE)
-        super(S3ObjectStore, self).__init__(config)
-        self.staging_path = self.config.file_path
-        self.transfer_progress = 0
-        self._parse_config_xml(config_xml)
+
+        # for multipart upload
+        self.s3server = {'access_key': self.access_key,
+                         'secret_key': self.secret_key,
+                         'is_secure': self.is_secure,
+                         'max_chunk_size': self.max_chunk_size,
+                         'host': self.host,
+                         'port': self.port,
+                         'use_rr': self.use_rr,
+                         'conn_path': self.conn_path}
+
         self._configure_connection()
         self.bucket = self._get_bucket(self.bucket)
         # Clean cache only if value is set in galaxy.ini
@@ -73,48 +180,9 @@ class S3ObjectStore(ObjectStore):
         log.debug("Configuring S3 Connection")
         self.conn = S3Connection(self.access_key, self.secret_key)
 
-    def _parse_config_xml(self, config_xml):
-        try:
-            a_xml = config_xml.findall('auth')[0]
-            self.access_key = a_xml.get('access_key')
-            self.secret_key = a_xml.get('secret_key')
-            b_xml = config_xml.findall('bucket')[0]
-            self.bucket = b_xml.get('name')
-            self.use_rr = string_as_bool(b_xml.get('use_reduced_redundancy', "False"))
-            self.max_chunk_size = int(b_xml.get('max_chunk_size', 250))
-            cn_xml = config_xml.findall('connection')
-            if not cn_xml:
-                cn_xml = {}
-            else:
-                cn_xml = cn_xml[0]
-            self.host = cn_xml.get('host', None)
-            self.port = int(cn_xml.get('port', 6000))
-            self.multipart = string_as_bool(cn_xml.get('multipart', 'True'))
-            self.is_secure = string_as_bool(cn_xml.get('is_secure', 'True'))
-            self.conn_path = cn_xml.get('conn_path', '/')
-            c_xml = config_xml.findall('cache')[0]
-            self.cache_size = float(c_xml.get('size', -1))
-            self.staging_path = c_xml.get('path', self.config.object_store_cache_path)
-
-            for d_xml in config_xml.findall('extra_dir'):
-                self.extra_dirs[d_xml.get('type')] = d_xml.get('path')
-
-            log.debug("Object cache dir:    %s", self.staging_path)
-            log.debug("       job work dir: %s", self.extra_dirs['job_work'])
-
-            # for multipart upload
-            self.s3server = {'access_key': self.access_key,
-                             'secret_key': self.secret_key,
-                             'is_secure': self.is_secure,
-                             'max_chunk_size': self.max_chunk_size,
-                             'host': self.host,
-                             'port': self.port,
-                             'use_rr': self.use_rr,
-                             'conn_path': self.conn_path}
-        except Exception:
-            # Toss it back up after logging, we can't continue loading at this point.
-            log.exception("Malformed ObjectStore Configuration XML -- unable to continue")
-            raise
+    @classmethod
+    def parse_xml(clazz, config_xml):
+        return parse_config_xml(config_xml)
 
     def __cache_monitor(self):
         time.sleep(2)  # Wait for things to load before starting the monitor

--- a/test/unit/test_objectstore.py
+++ b/test/unit/test_objectstore.py
@@ -3,9 +3,18 @@ from contextlib import contextmanager
 from shutil import rmtree
 from string import Template
 from tempfile import mkdtemp
+from xml.etree import ElementTree
+
+import yaml
+from six import StringIO
 
 from galaxy import objectstore
 from galaxy.exceptions import ObjectInvalid
+from galaxy.objectstore.azure_blob import AzureBlobObjectStore
+from galaxy.objectstore.cloud import Cloud
+from galaxy.objectstore.pithos import PithosObjectStore
+from galaxy.objectstore.s3 import S3ObjectStore
+
 
 DISK_TEST_CONFIG = """<?xml version="1.0"?>
 <object_store type="disk">
@@ -16,60 +25,72 @@ DISK_TEST_CONFIG = """<?xml version="1.0"?>
 """
 
 
+DISK_TEST_CONFIG_YAML = """
+type: disk
+files_dir: "${temp_directory}/files1"
+extra_dirs:
+  - type: temp
+    path: "${temp_directory}/tmp1"
+  - type: job_work
+    path: "${temp_directory}/job_working_directory1"
+"""
+
+
 def test_disk_store():
-    with TestConfig(DISK_TEST_CONFIG) as (directory, object_store):
-        # Test no dataset with id 1 exists.
-        absent_dataset = MockDataset(1)
-        assert not object_store.exists(absent_dataset)
+    for config_str in [DISK_TEST_CONFIG, DISK_TEST_CONFIG_YAML]:
+        with TestConfig(config_str) as (directory, object_store):
+            # Test no dataset with id 1 exists.
+            absent_dataset = MockDataset(1)
+            assert not object_store.exists(absent_dataset)
 
-        # Write empty dataset 2 in second backend, ensure it is empty and
-        # exists.
-        empty_dataset = MockDataset(2)
-        directory.write("", "files1/000/dataset_2.dat")
-        assert object_store.exists(empty_dataset)
-        assert object_store.empty(empty_dataset)
+            # Write empty dataset 2 in second backend, ensure it is empty and
+            # exists.
+            empty_dataset = MockDataset(2)
+            directory.write("", "files1/000/dataset_2.dat")
+            assert object_store.exists(empty_dataset)
+            assert object_store.empty(empty_dataset)
 
-        # Write non-empty dataset in backend 1, test it is not emtpy & exists.
-        hello_world_dataset = MockDataset(3)
-        directory.write("Hello World!", "files1/000/dataset_3.dat")
-        assert object_store.exists(hello_world_dataset)
-        assert not object_store.empty(hello_world_dataset)
+            # Write non-empty dataset in backend 1, test it is not emtpy & exists.
+            hello_world_dataset = MockDataset(3)
+            directory.write("Hello World!", "files1/000/dataset_3.dat")
+            assert object_store.exists(hello_world_dataset)
+            assert not object_store.empty(hello_world_dataset)
 
-        # Test get_data
-        data = object_store.get_data(hello_world_dataset)
-        assert data == "Hello World!"
+            # Test get_data
+            data = object_store.get_data(hello_world_dataset)
+            assert data == "Hello World!"
 
-        data = object_store.get_data(hello_world_dataset, start=1, count=6)
-        assert data == "ello W"
+            data = object_store.get_data(hello_world_dataset, start=1, count=6)
+            assert data == "ello W"
 
-        # Test Size
+            # Test Size
 
-        # Test absent and empty datasets yield size of 0.
-        assert object_store.size(absent_dataset) == 0
-        assert object_store.size(empty_dataset) == 0
-        # Elsewise
-        assert object_store.size(hello_world_dataset) > 0  # Should this always be the number of bytes?
+            # Test absent and empty datasets yield size of 0.
+            assert object_store.size(absent_dataset) == 0
+            assert object_store.size(empty_dataset) == 0
+            # Elsewise
+            assert object_store.size(hello_world_dataset) > 0  # Should this always be the number of bytes?
 
-        # Test percent used (to some degree)
-        percent_store_used = object_store.get_store_usage_percent()
-        assert percent_store_used > 0.0
-        assert percent_store_used < 100.0
+            # Test percent used (to some degree)
+            percent_store_used = object_store.get_store_usage_percent()
+            assert percent_store_used > 0.0
+            assert percent_store_used < 100.0
 
-        # Test update_from_file test
-        output_dataset = MockDataset(4)
-        output_real_path = os.path.join(directory.temp_directory, "files1", "000", "dataset_4.dat")
-        assert not os.path.exists(output_real_path)
-        output_working_path = directory.write("NEW CONTENTS", "job_working_directory1/example_output")
-        object_store.update_from_file(output_dataset, file_name=output_working_path, create=True)
-        assert os.path.exists(output_real_path)
+            # Test update_from_file test
+            output_dataset = MockDataset(4)
+            output_real_path = os.path.join(directory.temp_directory, "files1", "000", "dataset_4.dat")
+            assert not os.path.exists(output_real_path)
+            output_working_path = directory.write("NEW CONTENTS", "job_working_directory1/example_output")
+            object_store.update_from_file(output_dataset, file_name=output_working_path, create=True)
+            assert os.path.exists(output_real_path)
 
-        # Test delete
-        to_delete_dataset = MockDataset(5)
-        to_delete_real_path = directory.write("content to be deleted!", "files1/000/dataset_5.dat")
-        assert object_store.exists(to_delete_dataset)
-        assert object_store.delete(to_delete_dataset)
-        assert not object_store.exists(to_delete_dataset)
-        assert not os.path.exists(to_delete_real_path)
+            # Test delete
+            to_delete_dataset = MockDataset(5)
+            to_delete_real_path = directory.write("content to be deleted!", "files1/000/dataset_5.dat")
+            assert object_store.exists(to_delete_dataset)
+            assert object_store.delete(to_delete_dataset)
+            assert not object_store.exists(to_delete_dataset)
+            assert not os.path.exists(to_delete_real_path)
 
 
 def test_disk_store_alt_name_relpath():
@@ -126,39 +147,64 @@ HIERARCHICAL_TEST_CONFIG = """<?xml version="1.0"?>
 """
 
 
+HIERARCHICAL_TEST_CONFIG_YAML = """
+type: hierarchical
+backends:
+   - id: files1
+     type: disk
+     weight: 1
+     files_dir: "${temp_directory}/files1"
+     extra_dirs:
+     - type: temp
+       path: "${temp_directory}/tmp1"
+     - type: job_work
+       path: "${temp_directory}/job_working_directory1"
+   - id: files2
+     type: disk
+     weight: 1
+     files_dir: "${temp_directory}/files2"
+     extra_dirs:
+     - type: temp
+       path: "${temp_directory}/tmp2"
+     - type: job_work
+       path: "${temp_directory}/job_working_directory2"
+"""
+
+
 def test_hierarchical_store():
-    with TestConfig(HIERARCHICAL_TEST_CONFIG) as (directory, object_store):
+    for config_str in [HIERARCHICAL_TEST_CONFIG, HIERARCHICAL_TEST_CONFIG_YAML]:
+        with TestConfig(config_str) as (directory, object_store):
 
-        # Test no dataset with id 1 exists.
-        assert not object_store.exists(MockDataset(1))
+            # Test no dataset with id 1 exists.
+            assert not object_store.exists(MockDataset(1))
 
-        # Write empty dataset 2 in second backend, ensure it is empty and
-        # exists.
-        directory.write("", "files2/000/dataset_2.dat")
-        assert object_store.exists(MockDataset(2))
-        assert object_store.empty(MockDataset(2))
+            # Write empty dataset 2 in second backend, ensure it is empty and
+            # exists.
+            directory.write("", "files2/000/dataset_2.dat")
+            assert object_store.exists(MockDataset(2))
+            assert object_store.empty(MockDataset(2))
 
-        # Write non-empty dataset in backend 1, test it is not emtpy & exists.
-        directory.write("Hello World!", "files1/000/dataset_3.dat")
-        assert object_store.exists(MockDataset(3))
-        assert not object_store.empty(MockDataset(3))
+            # Write non-empty dataset in backend 1, test it is not emtpy & exists.
+            directory.write("Hello World!", "files1/000/dataset_3.dat")
+            assert object_store.exists(MockDataset(3))
+            assert not object_store.empty(MockDataset(3))
 
-        # Assert creation always happens in first backend.
-        for i in range(100):
-            dataset = MockDataset(100 + i)
-            object_store.create(dataset)
-            assert object_store.get_filename(dataset).find("files1") > 0
+            # Assert creation always happens in first backend.
+            for i in range(100):
+                dataset = MockDataset(100 + i)
+                object_store.create(dataset)
+                assert object_store.get_filename(dataset).find("files1") > 0
 
 
 DISTRIBUTED_TEST_CONFIG = """<?xml version="1.0"?>
 <object_store type="distributed">
     <backends>
-        <backend id="files1" type="disk" weight="2" order="0">
+        <backend id="files1" type="disk" weight="2">
             <files_dir path="${temp_directory}/files1"/>
             <extra_dir type="temp" path="${temp_directory}/tmp1"/>
             <extra_dir type="job_work" path="${temp_directory}/job_working_directory1"/>
         </backend>
-        <backend id="files2" type="disk" weight="1" order="1">
+        <backend id="files2" type="disk" weight="1">
             <files_dir path="${temp_directory}/files2"/>
             <extra_dir type="temp" path="${temp_directory}/tmp2"/>
             <extra_dir type="job_work" path="${temp_directory}/job_working_directory2"/>
@@ -168,28 +214,290 @@ DISTRIBUTED_TEST_CONFIG = """<?xml version="1.0"?>
 """
 
 
+DISTRIBUTED_TEST_CONFIG_YAML = """
+type: distributed
+backends:
+   - id: files1
+     type: disk
+     weight: 2
+     files_dir: "${temp_directory}/files1"
+     extra_dirs:
+     - type: temp
+       path: "${temp_directory}/tmp1"
+     - type: job_work
+       path: "${temp_directory}/job_working_directory1"
+   - id: files2
+     type: disk
+     weight: 1
+     files_dir: "${temp_directory}/files2"
+     extra_dirs:
+     - type: temp
+       path: "${temp_directory}/tmp2"
+     - type: job_work
+       path: "${temp_directory}/job_working_directory2"
+"""
+
+
 def test_distributed_store():
-    with TestConfig(DISTRIBUTED_TEST_CONFIG) as (directory, object_store):
-        with __stubbed_persistence() as persisted_ids:
-            for i in range(100):
-                dataset = MockDataset(100 + i)
-                object_store.create(dataset)
+    for config_str in [DISTRIBUTED_TEST_CONFIG, DISTRIBUTED_TEST_CONFIG_YAML]:
+        with TestConfig(config_str) as (directory, object_store):
+            with __stubbed_persistence() as persisted_ids:
+                for i in range(100):
+                    dataset = MockDataset(100 + i)
+                    object_store.create(dataset)
 
-        # Test distributes datasets between backends according to weights
-        backend_1_count = len([v for v in persisted_ids.values() if v == "files1"])
-        backend_2_count = len([v for v in persisted_ids.values() if v == "files2"])
+            # Test distributes datasets between backends according to weights
+            backend_1_count = len([v for v in persisted_ids.values() if v == "files1"])
+            backend_2_count = len([v for v in persisted_ids.values() if v == "files2"])
 
-        assert backend_1_count > 0
-        assert backend_2_count > 0
-        assert backend_1_count > backend_2_count
+            assert backend_1_count > 0
+            assert backend_2_count > 0
+            assert backend_1_count > backend_2_count
+
+
+# Unit testing the cloud and advanced infrastructure object stores is difficult, but
+# we can at least stub out initializing and test the configuration of these things from
+# XML and dicts.
+class UnitializedPithosObjectStore(PithosObjectStore):
+
+    def _initialize(self):
+        pass
+
+
+class UnitializeS3ObjectStore(S3ObjectStore):
+
+    def _initialize(self):
+        pass
+
+
+class UnitializedAzureBlobObjectStore(AzureBlobObjectStore):
+
+    def _initialize(self):
+        pass
+
+
+class UnitializedCloudObjectStore(Cloud):
+
+    def _initialize(self):
+        pass
+
+
+PITHOS_TEST_CONFIG = """<?xml version="1.0"?>
+<object_store type="pithos">
+    <auth url="http://example.org/" token="extoken123" />
+    <container name="foo" project="cow" />
+    <extra_dir type="temp" path="database/tmp_pithos"/>
+    <extra_dir type="job_work" path="database/working_pithos"/>
+</object_store>
+"""
+
+
+PITHOS_TEST_CONFIG_YAML = """
+type: pithos
+auth:
+  url: http://example.org/
+  token: extoken123
+
+container:
+  name: foo
+  project: cow
+
+extra_dirs:
+  - type: temp
+    path: database/tmp_pithos
+  - type: job_work
+    path: database/working_pithos
+"""
+
+
+def test_config_parse_pithos():
+    for config_str in [PITHOS_TEST_CONFIG, PITHOS_TEST_CONFIG_YAML]:
+        with TestConfig(config_str, clazz=UnitializedPithosObjectStore) as (directory, object_store):
+            configured_config_dict = object_store.config_dict
+            for key in ["auth", "container", "extra_dirs"]:
+                assert key in configured_config_dict
+
+            auth_dict = configured_config_dict["auth"]
+            _assert_key_has_value(auth_dict, "url", "http://example.org/")
+            _assert_key_has_value(auth_dict, "token", "extoken123")
+
+            container_dict = configured_config_dict["container"]
+
+            _assert_key_has_value(container_dict, "name", "foo")
+            _assert_key_has_value(container_dict, "project", "cow")
+
+            assert object_store.extra_dirs["job_work"] == "database/working_pithos"
+            assert object_store.extra_dirs["temp"] == "database/tmp_pithos"
+
+
+S3_TEST_CONFIG = """<object_store type="s3">
+     <auth access_key="access_moo" secret_key="secret_cow" />
+     <bucket name="unique_bucket_name_all_lowercase" use_reduced_redundancy="False" />
+     <cache path="database/object_store_cache" size="1000" />
+     <extra_dir type="job_work" path="database/job_working_directory_s3"/>
+     <extra_dir type="temp" path="database/tmp_s3"/>
+</object_store>
+"""
+
+
+S3_TEST_CONFIG_YAML = """
+type: s3
+auth:
+  access_key: access_moo
+  secret_key: secret_cow
+
+bucket:
+  name: unique_bucket_name_all_lowercase
+  use_reduced_redundancy: false
+
+cache:
+  path: database/object_store_cache
+  size: 1000
+
+extra_dirs:
+- type: job_work
+  path: database/job_working_directory_s3
+- type: temp
+  path: database/tmp_s3
+"""
+
+
+def test_config_parse_s3():
+    for config_str in [S3_TEST_CONFIG, S3_TEST_CONFIG_YAML]:
+        with TestConfig(config_str, clazz=UnitializeS3ObjectStore) as (directory, object_store):
+            assert object_store.access_key == "access_moo"
+            assert object_store.secret_key == "secret_cow"
+
+            assert object_store.bucket == "unique_bucket_name_all_lowercase"
+            assert object_store.use_rr is False
+
+            assert object_store.host is None
+            assert object_store.port == 6000
+            assert object_store.multipart is True
+            assert object_store.is_secure is True
+            assert object_store.conn_path == "/"
+
+            assert object_store.cache_size == 1000
+            assert object_store.staging_path == "database/object_store_cache"
+            assert object_store.extra_dirs["job_work"] == "database/job_working_directory_s3"
+            assert object_store.extra_dirs["temp"] == "database/tmp_s3"
+
+
+CLOUD_TEST_CONFIG = """<object_store type="cloud">
+     <auth access_key="access_moo" secret_key="secret_cow" />
+     <bucket name="unique_bucket_name_all_lowercase" use_reduced_redundancy="False" />
+     <cache path="database/object_store_cache" size="1000" />
+     <extra_dir type="job_work" path="database/job_working_directory_cloud"/>
+     <extra_dir type="temp" path="database/tmp_cloud"/>
+</object_store>
+"""
+
+
+CLOUD_TEST_CONFIG_YAML = """
+type: s3
+auth:
+  access_key: access_moo
+  secret_key: secret_cow
+
+bucket:
+  name: unique_bucket_name_all_lowercase
+  use_reduced_redundancy: false
+
+cache:
+  path: database/object_store_cache
+  size: 1000
+
+extra_dirs:
+- type: job_work
+  path: database/job_working_directory_cloud
+- type: temp
+  path: database/tmp_cloud
+"""
+
+
+def test_config_parse_cloud():
+    for config_str in [CLOUD_TEST_CONFIG, CLOUD_TEST_CONFIG_YAML]:
+        with TestConfig(config_str, clazz=UnitializedCloudObjectStore) as (directory, object_store):
+            assert object_store.access_key == "access_moo"
+            assert object_store.secret_key == "secret_cow"
+
+            assert object_store.bucket == "unique_bucket_name_all_lowercase"
+            assert object_store.use_rr is False
+
+            assert object_store.host is None
+            assert object_store.port == 6000
+            assert object_store.multipart is True
+            assert object_store.is_secure is True
+            assert object_store.conn_path == "/"
+
+            assert object_store.cache_size == 1000
+            assert object_store.staging_path == "database/object_store_cache"
+            assert object_store.extra_dirs["job_work"] == "database/job_working_directory_cloud"
+            assert object_store.extra_dirs["temp"] == "database/tmp_cloud"
+
+
+AZURE_BLOB_TEST_CONFIG = """<object_store type="azure_blob">
+    <auth account_name="azureact" account_key="password123" />
+    <container name="unique_container_name" max_chunk_size="250"/>
+    <cache path="database/object_store_cache" size="100" />
+    <extra_dir type="job_work" path="database/job_working_directory_azure"/>
+    <extra_dir type="temp" path="database/tmp_azure"/>
+</object_store>
+"""
+
+
+AZURE_BLOB_TEST_CONFIG_YAML = """
+type: azure_blob
+auth:
+  account_name: azureact
+  account_key: password123
+
+container:
+  name: unique_container_name
+  max_chunk_size: 250
+
+cache:
+  path: database/object_store_cache
+  size: 100
+
+extra_dirs:
+- type: job_work
+  path: database/job_working_directory_azure
+- type: temp
+  path: database/tmp_azure
+"""
+
+
+def test_config_parse_azure():
+    for config_str in [AZURE_BLOB_TEST_CONFIG, AZURE_BLOB_TEST_CONFIG_YAML]:
+        with TestConfig(config_str, clazz=UnitializedAzureBlobObjectStore) as (directory, object_store):
+            assert object_store.account_name == "azureact"
+            assert object_store.account_key == "password123"
+
+            assert object_store.container_name == "unique_container_name"
+            assert object_store.max_chunk_size == 250
+
+            assert object_store.cache_size == 100
+            assert object_store.staging_path == "database/object_store_cache"
+            assert object_store.extra_dirs["job_work"] == "database/job_working_directory_azure"
+            assert object_store.extra_dirs["temp"] == "database/tmp_azure"
 
 
 class TestConfig(object):
-    def __init__(self, config_xml):
+    def __init__(self, config_str, clazz=None):
         self.temp_directory = mkdtemp()
-        self.write(config_xml, "store.xml")
-        config = MockConfig(self.temp_directory)
-        self.object_store = objectstore.build_object_store_from_config(config)
+        if config_str.startswith("<"):
+            config_file = "store.xml"
+        else:
+            config_file = "store.yaml"
+        self.write(config_str, config_file)
+        config = MockConfig(self.temp_directory, config_file)
+        if clazz is None:
+            self.object_store = objectstore.build_object_store_from_config(config)
+        elif config_file == "store.xml":
+            self.object_store = clazz.from_xml(config, ElementTree.fromstring(config_str))
+        else:
+            self.object_store = clazz(config, yaml.safe_load(StringIO(config_str)))
 
     def __enter__(self):
         return self, self.object_store
@@ -210,9 +518,9 @@ class TestConfig(object):
 
 class MockConfig(object):
 
-    def __init__(self, temp_directory):
+    def __init__(self, temp_directory, config_file):
         self.file_path = temp_directory
-        self.object_store_config_file = os.path.join(temp_directory, "store.xml")
+        self.object_store_config_file = os.path.join(temp_directory, config_file)
         self.object_store_check_old_style = False
         self.jobs_directory = temp_directory
         self.new_file_path = temp_directory
@@ -245,3 +553,8 @@ def __stubbed_persistence():
 
     finally:
         setattr(objectstore, PERSIST_METHOD_NAME, real_method)
+
+
+def _assert_key_has_value(the_dict, key, value):
+    assert key in the_dict, "dict [%s] doesn't container expected key [%s]" % key
+    assert the_dict[key] == value, "%s != %s" % (the_dict[key], value)


### PR DESCRIPTION
- Allow loading objectstores for Python dicts and YAML configurations.
- New tests for XML parsing of azure, cloud, pithos, and S3 object stores configs.
- New tests for YAML parsing of all these object stores plus the vanilla disk and nested ones.

Sets up both loading object store configs right in Galaxy's galaxy.yml or Pulsar's app.yml as well as writing per-job object store configs out for #7050 so that jobs can know how to stage and unstage their own files on the potentially remote worker.

xref #7050 / #7058