### PR TITLE
Localize version strings to the working directory w/predictable path.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -20,6 +20,7 @@ from tempfile import NamedTemporaryFile
 from xml.etree import ElementTree
 
 import six
+from pulsar.client.staging import COMMAND_VERSION_FILENAME
 
 import galaxy
 from galaxy import model, util
@@ -830,6 +831,10 @@ class JobWrapper(HasResourceParameters):
         return param_dict
 
     def get_version_string_path(self):
+        return os.path.abspath(os.path.join(self.working_directory, COMMAND_VERSION_FILENAME))
+
+    # TODO: Remove in Galaxy 20.XX, for running jobs at GX upgrade
+    def get_version_string_path_legacy(self):
         return os.path.abspath(os.path.join(self.app.config.new_file_path, "GALAXY_VERSION_STRING_%s" % self.job_id))
 
     def __prepare_upload_paramfile(self, tool_evaluator):
@@ -1274,6 +1279,9 @@ class JobWrapper(HasResourceParameters):
 
         if self.tool.version_string_cmd:
             version_filename = self.get_version_string_path()
+            # TODO: Remove in Galaxy 20.XX, for running jobs at GX upgrade
+            if not os.path.exists(version_filename):
+                version_filename = self.get_version_string_path_legacy()
             if os.path.exists(version_filename):
                 self.version_string = open(version_filename).read()
                 os.unlink(version_filename)

--- a/test/unit/jobs/test_job_wrapper.py
+++ b/test/unit/jobs/test_job_wrapper.py
@@ -52,7 +52,7 @@ class BaseWrapperTestCase(UsesApp):
 
     def test_version_path(self):
         wrapper = self._wrapper()
-        version_path = wrapper.get_version_string_path()
+        version_path = wrapper.get_version_string_path_legacy()
         expected_path = os.path.join(self.test_directory, "new_files", "GALAXY_VERSION_STRING_345")
         self.assertEqual(version_path, expected_path)
 


### PR DESCRIPTION
``new_file_path`` is awful and we shouldn't be using it. Making the job directory more self contained should make remote execution more plausible, simple.

xref #7050 / #7058