### PR TITLE
Add datatype for Mash Sketch files.

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -538,6 +538,7 @@
     <datatype extension="biom2" type="galaxy.datatypes.binary:Biom2" mimetype="application/octet-stream" display_in_upload="true">
       <converter file="biom2_to_biom1.xml" target_datatype="biom1"/>
     </datatype>
+    <datatype extension="msh" type="galaxy.datatypes.binary:MashSketch" display_in_upload="True" />
     <!-- Strand-specific Coordinate Count Datatype used by the Center for Eukaryotic Gene Regulation labs at Penn State -->
     <datatype extension="scidx" type="galaxy.datatypes.interval:ScIdx" display_in_upload="true"/>
     <!--Cheminformatics Datatypes -->

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -126,6 +126,18 @@ class Cel(Binary):
             return False
 
 
+class MashSketch(Binary):
+    """
+        Mash Sketch file.
+        Sketches are used by the MinHash algorithm to allow fast distance estimations 
+        with low storage and memory requirements. To make a sketch, each k-mer in a sequence 
+        is hashed, which creates a pseudo-random identifier. By sorting these identifiers (hashes), 
+        a small subset from the top of the sorted list can represent the entire sequence (these are min-hashes). 
+        The more similar another sequence is, the more min-hashes it is likely to share.
+    """
+    file_ext = "msh"
+    
+    
 class CompressedArchive(Binary):
     """
         Class describing an compressed binary file

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -129,10 +129,10 @@ class Cel(Binary):
 class MashSketch(Binary):
     """
         Mash Sketch file.
-        Sketches are used by the MinHash algorithm to allow fast distance estimations 
-        with low storage and memory requirements. To make a sketch, each k-mer in a sequence 
-        is hashed, which creates a pseudo-random identifier. By sorting these identifiers (hashes), 
-        a small subset from the top of the sorted list can represent the entire sequence (these are min-hashes). 
+        Sketches are used by the MinHash algorithm to allow fast distance estimations
+        with low storage and memory requirements. To make a sketch, each k-mer in a sequence
+        is hashed, which creates a pseudo-random identifier. By sorting these identifiers (hashes),
+        a small subset from the top of the sorted list can represent the entire sequence (these are min-hashes).
         The more similar another sequence is, the more min-hashes it is likely to share.
     """
     file_ext = "msh"

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -136,8 +136,8 @@ class MashSketch(Binary):
         The more similar another sequence is, the more min-hashes it is likely to share.
     """
     file_ext = "msh"
-    
-    
+
+
 class CompressedArchive(Binary):
     """
         Class describing an compressed binary file


### PR DESCRIPTION
https://mash.readthedocs.io/en/latest/sketches.html

I'm working on adding a `mash screen` tool to the tools-iuc repo:

https://github.com/galaxyproject/tools-iuc/pull/2205

This pull request adds a datatype for mash sketch files.