### PR TITLE
Configurable job/workflow handler assignment methods 

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1563,9 +1563,8 @@ galaxy:
   # failing jobs are just failed outright.
   #default_job_resubmission_condition: null
 
-  # In multiprocess configurations, notification between processes about
-  # new jobs must be done via the database.  In single process
-  # configurations, this can be done in memory, which is a bit quicker.
+  # This option is deprecated, use the `mem-self` handler assignment
+  # option in the job configuration instead.
   #track_jobs_in_database: true
 
   # This enables splitting of jobs into tasks, if specified by the

--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -332,24 +332,76 @@
              used by Galaxy is no environment variable of the specified name is found.
         -->
     </plugins>
-    <handlers default="handlers">
-        <!-- Additional job handlers - the id should match the name of a
-             [server:<id>] in galaxy.ini.
+    <handlers>
+        <!-- Job handler processes - for a full discussion of job handlers, see the documentation at:
+             https://docs.galaxyproject.org/en/latest/admin/scaling.html
+
+             The <handlers> container tag takes two optional attributes:
+
+               <handlers assign_with="method" default="id_or_tag"/>
+
+               - `assign_with` - How jobs should be assigned to handlers. The value can be a single method or a
+                 comma-separated list that will be tried in order. The default depends on whether any handlers and a job
+                 handler "pool" (such as uWSGI mules in a `job-handlers` farm) are configured. Valid methods are:
+
+                   - `mem-self` - Jobs are assigned to the web worker that received the tool execution request from the
+                     user via an internal in-memory queue. If a tool is configured to use a specific handler, that
+                     configuration is ignored; the process that creates the job *always* handles it. This can be
+                     slightly faster than `db-self` but only makes sense in single process environments without
+                     dedicated job handlers. This option replaces the former `track_jobs_in_database` option in
+                     galaxy.yml.
+
+                   - `db-self` - Like `mem-self` but assignment occurs by setting a new job's 'handler' column in the
+                     database to the process that created the job at the time it is created. Additionally, if a tool is
+                     configured to use a specific handler (ID or tag), that handler is assigned (tags by
+                     `db-preassign`). This is the default if no handlers are defined and no `job-handlers` pool is
+                     present (the default for a completely unconfigured Galaxy).
+
+                   - `db-preassign` - Jobs are assigned a handler by selecting one at random from the configured tag or
+                      default handlers. This occurs by setting a new job's 'handler' column in the database to the
+                      chosen handler ID (hence "preassign"ment). This is the default if handlers are defined and no
+                      `job-handlers` pool is present.
+
+                   - `uwsgi-mule-message` - Jobs are assigned a handler via uWSGI mule messaging (see uWSGI
+                     documentation). A mule in the `job-handlers` (if sent to the default tag) or `job-handlers.<tag>`
+                     farm will recieve the message and assign itself. This the default if a `job-handlers` pool is
+                     present and no handlers are configured.
+
+                 In the event that both a `job-handlers` pool is present and handlers are configured, the default is
+                 `uwsgi-mule-message,db-preassign`. At present, only `uwsgi-mule-message` is capable of deferring
+                 handler assignment to a later method (which would occur in the event that a tool is configured to use
+                 a tag for which there is not a matching pool).
+
+                 In all cases, if a tool is configured to use a specific handler (by ID, not tag), configured assignment
+                 methods are ignored and that handler is directly assigned in the job's 'handler' column at job creation
+                 time.
+
+               - `default` - An ID or tag of the handler(s) that should handle any jobs not assigned to a specific
+                 handler (which is probably most of them). If unset, the default is any untagged handlers plus any
+                 handlers in the `job-handlers` (no tag) pool.
+
+                 Note that in the event such a mixed configuration environment exists (both a `job-handlers` pool (farm)
+                 and untagged handlers are configured), the default value of
+                 `assign_with="uwsgi-mule-message,db-preassign"` would prevent any of the configured handlers from being
+                 assigned since `uwsgi-mule-message` is the preferred assignment method.
+        -->
+        <!-- Explicitly defined job handlers - the id should match the handler process's `server_name`. For webless
+             handlers, this is the value of the `server-name` argument to `galaxy-main`.
          -->
-        <handler id="handler0" tags="handlers"/>
-        <handler id="handler1" tags="handlers"/>
+        <handler id="handler0"/>
+        <handler id="handler1"/>
         <!-- Handlers will load all plugins defined in the <plugins> collection
              above by default, but can be limited to a subset using <plugin>
              tags. This is useful for heterogenous environments where the DRMAA
              plugin would need to be loaded more than once with different
              configs.
-         -->
+        -->
         <handler id="sge_handler">
             <plugin id="sge"/>
         </handler>
+        <!-- Handlers are grouped by defining (comma-separated) tags -->
         <handler id="special_handler0" tags="special_handlers"/>
         <handler id="special_handler1" tags="special_handlers"/>
-        <handler id="trackster_handler"/>
     </handlers>
     <destinations default="local">
         <!-- Destinations define details about remote resources and how jobs

--- a/config/workflow_schedulers_conf.xml.sample
+++ b/config/workflow_schedulers_conf.xml.sample
@@ -13,12 +13,29 @@
 
   <!-- Handlers (Galaxy server processes that perform the scheduling work) can
        be defined here in the same format as in job_conf.xml. By default, the
-       handlers defined in job_conf.xml will be used (or `main` if there is no
-       job_conf.xml).  -->
+       handlers defined in job_conf.xml will be used (or the web process that
+       receives the workflow scheduling request if handlers are not configured
+       in job_conf.xml).
+
+       The options here are the same as is documented for <handlers> in
+       job_conf.xml.sample_advanced with two exceptions:
+
+       - If a uWSGI farm named `workflow-schedulers` is present, it will be
+         preferred, followed by `job-handlers`. If any untagged handlers are
+         defined in this configuration they are eligible to schedule workflows
+         in addition to any matching mules.
+       - If uWSGI farms are present, the default assignment method is
+         `db-preassign` rather than `uwsgi-mule-message`, because `db-preassign`
+         is deterministic. All workflows scheduled in a single history will be
+         assigned to the same handler, ensuring they are scheduled serially
+         (preventing their outputs from being interleaved in the history). You
+         can override this by explicitly setting
+         `assign_with="uwsgi-mule-message"`.
+  -->
   <!--
-  <handlers default="handlers">
-    <handler id="handler0" tags="handlers"/>
-    <handler id="handler1" tags="handlers"/>
+  <handlers>
+    <handler id="handler0"/>
+    <handler id="handler1"/>
   </handlers>
   -->
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3277,10 +3277,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    In multiprocess configurations, notification between processes
-    about new jobs must be done via the database.  In single process
-    configurations, this can be done in memory, which is a bit
-    quicker.
+    This option is deprecated, use the `mem-self` handler assignment
+    option in the job configuration instead.
 :Default: ``true``
 :Type: bool
 

--- a/doc/source/admin/jobs.md
+++ b/doc/source/admin/jobs.md
@@ -40,7 +40,7 @@ workers
 
 The `<handlers>` configuration elements defines which Galaxy server processes (when [running multiple server processes](scaling.html)) should be used for running jobs, and how to group those processes.
 
-The handlers configuration may define a ``default`` attribute. This is the the handler(s) that should be used if no explicit handler is defined for a job and is required if >1 handlers defined.
+The handlers configuration may define a ``default`` attribute. This is the the handler(s) that should be used if no explicit handler is defined for a job. If unset, any untagged handlers will be used by default.
 
 The collection contains `<handler>` elements.
 

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -94,8 +94,20 @@ Under this strategy, job handling is offloaded to dedicated non-web-serving proc
 directly by the master uWSGI process. As a benefit of using mule messaging, only job handlers that are alive will be
 selected to run jobs.
 
-This is the recommended deployment strategy for Galaxy servers that run web servers and job handlers **on the same
-host**.
+This is the recommended deployment strategy.
+
+```eval_rst
+.. important::
+
+   If using **Zerg Mode** or running more than one uWSGI *master* process, do not use **uWSGI + Mules**. Doing so can
+   can cause jobs to be executed by mutiple handlers when recovering unassigned jobs at Galaxy server startup.
+
+   Multiple master processes is a rare configuration and is typically only used in the case of load balancing the web
+   application across multiple hosts. Note that multiple master proceses is not the same thing as the ``processess``
+   uWSGI configuration option, which is perfectly safe to set when using job handler mules.
+
+   For these scenarios, **uWSGI + Webless** is the recommended deployment strategy.
+```
 
 ### uWSGI for web serving and Webless Galaxy applications as job handlers
 
@@ -110,8 +122,8 @@ Like mules, under this strategy, job handling is offloaded to dedicated non-web-
 are [managed by the administrator](#starting-and-stopping). Because the handler is randomly assigned by the web worker
 when the job is submitted via the UI/API, jobs may be assigned to dead handlers.
 
-This is the recommended deployment strategy for Galaxy servers that run web servers and job handlers **on different
-hosts**.
+This is the recommended deployment strategy when **Zerg Mode** is used, and for Galaxy servers that run web servers and
+job handlers **on different hosts**.
 
 ## Legacy Deployment Options
 

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -212,6 +212,11 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         # Must be initialized after job_config.
         self.workflow_scheduling_manager = scheduling_manager.WorkflowSchedulingManager(self)
 
+        # Must be initialized after any component that might make use of stack messaging is configured. Alternatively if
+        # it becomes more commonly needed we could create a prefork function registration method like we do with
+        # postfork functions.
+        self.application_stack.init_late_prefork()
+
         self.containers = {}
         if self.config.enable_beta_containers_interface:
             self.containers = build_container_interfaces(

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -154,7 +154,7 @@ def find_root(kwargs):
 
 
 class Configuration(object):
-    deprecated_options = ('database_file', )
+    deprecated_options = ('database_file', 'track_jobs_in_database')
 
     def __init__(self, **kwargs):
         self.config_dict = kwargs

--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -185,6 +185,15 @@ class InternalServerError(MessageException):
     err_code = error_codes.INTERNAL_SERVER_ERROR
 
 
+class ToolExecutionError(MessageException):
+    status_code = 500
+    err_code = error_codes.TOOL_EXECUTION_ERROR
+
+    def __init__(self, err_msg, type="error", job=None):
+        super(ToolExecutionError, self).__init__(err_msg, type)
+        self.job = job
+
+
 class NotImplemented(MessageException):
     status_code = 501
     err_code = error_codes.NOT_IMPLEMENTED
@@ -221,3 +230,9 @@ class ContainerRunError(Exception):
         super(ContainerRunError, self).__init__(msg, **kwargs)
         self.image = image
         self.command = command
+
+
+class HandlerAssignmentError(Exception):
+    def __init__(self, msg=None, obj=None, **kwargs):
+        super(HandlerAssignmentError, self).__init__(msg, **kwargs)
+        self.obj = obj

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -145,6 +145,11 @@
     "message": "Error in a configuration file."
    },
    {
+    "name": "TOOL_EXECUTION_ERROR",
+    "code": 500004,
+    "message": "Tool execution failed due to an internal server error."
+   },
+   {
     "name": "NOT_IMPLEMENTED",
     "code": 501001,
     "message": "Method is not implemented."

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -217,7 +217,10 @@ class JobConfiguration(ConfiguresHandlers):
         handlers_conf = root.find('handlers')
         self._init_handler_assignment_methods(handlers_conf)
         self._init_handlers(handlers_conf)
-        self._set_default_handler_assignment_methods()
+        if not self.handler_assignment_methods_configured:
+            self._set_default_handler_assignment_methods()
+        else:
+            self.app.application_stack.init_job_handling(self)
         log.info("Job handler assignment methods set to: %s", ', '.join(self.handler_assignment_methods))
         for tag, handlers in [(t, h) for t, h in self.handlers.items() if isinstance(h, list)]:
             log.info("Tag [%s] handlers: %s", tag, ', '.join(handlers))
@@ -341,7 +344,10 @@ class JobConfiguration(ConfiguresHandlers):
         # Set the handlers
         self._init_handler_assignment_methods()
         self._init_handlers()
-        self._set_default_handler_assignment_methods()
+        if not self.handler_assignment_methods_configured:
+            self._set_default_handler_assignment_methods()
+        else:
+            self.app.application_stack.init_job_handling(self)
         # Set the destination
         self.default_destination_id = 'local'
         self.destinations['local'] = [JobDestination(id='local', runner='local')]

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -173,8 +173,7 @@ class JobConfiguration(ConfiguresHandlers):
             tree = load(job_config_file)
             self.__parse_job_conf_xml(tree)
         except IOError:
-            log.warning('Job configuration "%s" does not exist, using default'
-                        ' job configuration (this server will run jobs)',
+            log.warning('Job configuration "%s" does not exist, using default job configuration',
                         self.app.config.job_config_file)
             self.__set_default_job_conf()
         except Exception as e:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -343,7 +343,6 @@ class JobConfiguration(ConfiguresHandlers):
             self.runner_plugins.append(dict(id='tasks', load='tasks', workers=DEFAULT_LOCAL_WORKERS))
         # Set the handlers
         self._init_handler_assignment_methods()
-        self._init_handlers()
         if not self.handler_assignment_methods_configured:
             self._set_default_handler_assignment_methods()
         else:

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -743,14 +743,6 @@ class JobHandlerQueue(Monitors):
         if not self.track_jobs_in_database:
             self.queue.put((job_id, tool_id))
             self.sleeper.wake()
-        else:
-            # Workflow invocations farmed out to workers will submit jobs through here. If a handler is unassigned, we
-            # will submit for one, or else claim it ourself. TODO: This should be moved to a higher level as it's now
-            # implemented here and in MessageJobQueue
-            job = self.sa_session.query(model.Job).get(job_id)
-            if job.handler is None and self.app.application_stack.has_pool(self.app.application_stack.pools.JOB_HANDLERS):
-                msg = JobHandlerMessage(task='setup', job_id=job_id)
-                self.app.application_stack.send_message(self.app.application_stack.pools.JOB_HANDLERS, msg)
 
     def shutdown(self):
         """Attempts to gracefully shut down the worker thread"""

--- a/lib/galaxy/jobs/manager.py
+++ b/lib/galaxy/jobs/manager.py
@@ -26,15 +26,9 @@ class JobManager(object):
             self.job_handler = handler.JobHandler(app)
         else:
             self.job_handler = NoopHandler()
-        self.__check_jobs_at_startup()
+            self.__check_jobs_at_startup()
 
     def __check_jobs_at_startup(self):
-        """
-        TODO: It should be documented that starting two Galaxy uWSGI master processes simultaneously would result in a race condition that *could* cause two handlers to pick up the same job.
-
-        The recommended config for now will be webless handlers if running more than one uWSGI (master) process
-        """
-        # FIXME: test
         if self.app.job_config.use_messaging:
             jobs_at_startup = self.app.model.context.query(Job).enable_eagerloads(False) \
                 .filter((Job.state == Job.states.NEW) & (Job.handler == null())).all()

--- a/lib/galaxy/jobs/manager.py
+++ b/lib/galaxy/jobs/manager.py
@@ -50,6 +50,20 @@ class JobManager(object):
         return JobHandlerMessage(task='setup', job_id=job.id)
 
     def enqueue(self, job, tool=None):
+        """Queue a job for execution.
+
+        Due to the nature of some handler assignment methods which are wholly DB-based, the enqueue method will flush
+        the job. Callers who create the job typically should not flush the job before handing it off to ``enqueue()``.
+        If a job handler cannot be assigned, :exception:`ToolExecutionError` is raised.
+
+        :param job:     Job to enqueue.
+        :type job:      Instance of :class:`galaxy.model.Job`.
+        :param tool:    Tool that the job will execute.
+        :type tool:     Instance of :class:`galaxy.tools.Tool`.
+
+        :raises ToolExecutionError: if a handler was unable to be assigned.
+        returns: str or None -- Handler ID, tag, or pool assigned to the job.
+        """
         tool_id = None
         configured_handler = None
         if tool:
@@ -67,6 +81,15 @@ class JobManager(object):
             raise ToolExecutionError(exc.args[0], job=exc.obj)
 
     def stop(self, job, message=None):
+        """Stop a job that is currently executing.
+
+        This can be safely called on jobs that have already terminated.
+
+        :param job:     Job to stop.
+        :type job:      Instance of :class:`galaxy.model.Job`.
+        :param message: Message (if any) to be set on the job and output dataset(s) to explain the reason for stopping.
+        :type message:  str
+        """
         self.job_handler.job_stop_queue.put(job.id, error_msg=message)
 
     def shutdown(self):

--- a/lib/galaxy/jobs/manager.py
+++ b/lib/galaxy/jobs/manager.py
@@ -1,11 +1,12 @@
 """
 Top-level Galaxy job manager, moves jobs to handler(s)
 """
-
 import logging
+from functools import partial
 
 from sqlalchemy.sql.expression import null
 
+from galaxy.exceptions import HandlerAssignmentError, ToolExecutionError
 from galaxy.jobs import handler, NoopQueue
 from galaxy.model import Job
 from galaxy.web.stack.message import JobHandlerMessage
@@ -16,35 +17,86 @@ log = logging.getLogger(__name__)
 class JobManager(object):
     """
     Highest level interface to job management.
-
-    TODO: Currently the app accesses "job_queue" and "job_stop_queue" directly.
-          This should be decoupled.
     """
-
     def __init__(self, app):
         self.app = app
         self.job_lock = False
         if self.app.is_job_handler:
             log.debug("Initializing job handler")
             self.job_handler = handler.JobHandler(app)
-            self.job_stop_queue = self.job_handler.job_stop_queue
-        elif app.application_stack.has_pool(app.application_stack.pools.JOB_HANDLERS):
-            log.debug("Initializing job handler messaging interface")
-            self.job_handler = MessageJobHandler(app)
-            self.job_stop_queue = NoopQueue()
         else:
             self.job_handler = NoopHandler()
-            self.job_stop_queue = NoopQueue()
-        self.job_queue = self.job_handler.job_queue
+        self.__check_jobs_at_startup()
+
+    def __check_jobs_at_startup(self):
+        """
+        TODO: It should be documented that starting two Galaxy uWSGI master processes simultaneously would result in a race condition that *could* cause two handlers to pick up the same job.
+
+        The recommended config for now will be webless handlers if running more than one uWSGI (master) process
+        """
+        # FIXME: test
+        if self.app.job_config.use_messaging:
+            jobs_at_startup = self.app.model.context.query(Job).enable_eagerloads(False) \
+                .filter((Job.state == Job.states.NEW) & (Job.handler == null())).all()
+            if jobs_at_startup:
+                log.info(
+                    'No handler assigned at startup for the following jobs, will dispatch via message: %s',
+                    ', '.join([str(j.id) for j in jobs_at_startup]))
+            for job in jobs_at_startup:
+                tool = self.app.toolbox.get_tool(job.tool_id, job.tool_version, exact=True)
+                self.enqueue(job, tool)
 
     def start(self):
         self.job_handler.start()
+
+    def _queue_callback(self, job, tool_id):
+        self.job_handler.job_queue.put(job.id, tool_id)
+
+    def _message_callback(self, job):
+        return JobHandlerMessage(task='setup', job_id=job.id)
+
+    def enqueue(self, job, tool=None):
+        tool_id = None
+        configured_handler = None
+        if tool:
+            tool_id = tool.id
+            configured_handler = tool.get_configured_job_handler(job.params)
+            if configured_handler is not None:
+                p = " (with job params: %s)" % str(job.params) if job.params else ""
+                log.debug("(%s) Configured job handler for tool '%s'%s is: %s", job.log_str(), tool_id, p, configured_handler)
+        queue_callback = partial(self._queue_callback, job, tool_id)
+        message_callback = partial(self._message_callback, job)
+        try:
+            return self.app.job_config.assign_handler(
+                job, configured=configured_handler, queue_callback=queue_callback, message_callback=message_callback)
+        except HandlerAssignmentError as exc:
+            raise ToolExecutionError(exc.args[0], job=exc.obj)
+
+    def stop(self, job, message=None):
+        self.job_handler.job_stop_queue.put(job.id, error_msg=message)
 
     def shutdown(self):
         self.job_handler.shutdown()
 
 
+class NoopManager(object):
+    """
+    Implements the JobManager interface but does nothing
+    """
+    def __init__(self, *args, **kwargs):
+        self.job_handler = NoopHandler()
+
+    def enqueue(self, *args, **kwargs):
+        pass
+
+    def stop(self, *args, **kwargs):
+        pass
+
+
 class NoopHandler(object):
+    """
+    Implements the JobHandler interface but does nothing
+    """
     def __init__(self, *args, **kwargs):
         self.job_queue = NoopQueue()
         self.job_stop_queue = NoopQueue()
@@ -54,36 +106,3 @@ class NoopHandler(object):
 
     def shutdown(self, *args):
         pass
-
-
-class MessageJobHandler(NoopHandler):
-    """
-    Implements the JobHandler interface but just to send setup messages on startup
-
-    TODO: It should be documented that starting two Galaxy uWSGI master processes simultaneously would result in a race condition that *could* cause two handlers to pick up the same job.
-
-    The recommended config for now will be webless handlers if running more than one uWSGI (master) process
-    """
-    def __init__(self, app):
-        # This runs in the web (main) process pre-fork
-        self.app = app
-        self.job_queue = MessageJobQueue(app)
-        self.job_stop_queue = NoopQueue()
-        jobs_at_startup = self.app.model.context.query(Job).enable_eagerloads(False) \
-            .filter((Job.state == Job.states.NEW) & (Job.handler == null())).all()
-        if jobs_at_startup:
-            log.info('No handler assigned at startup for the following jobs, will dispatch via message: %s', ', '.join([str(j.id) for j in jobs_at_startup]))
-        for job in jobs_at_startup:
-            self.job_queue.put(job.id, job.tool_id)
-
-
-class MessageJobQueue(NoopQueue):
-    """
-    Implements the JobQueue / JobStopQueue interface but only sends messages to the actual job queue
-    """
-    def __init__(self, app):
-        self.app = app
-
-    def put(self, job_id, tool_id):
-        msg = JobHandlerMessage(task='setup', job_id=job_id)
-        self.app.application_stack.send_message(self.app.application_stack.pools.JOB_HANDLERS, msg)

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -296,7 +296,7 @@ class DatasetAssociationManager(base.ModelManager,
                 # Are *all* of the job's other output datasets deleted?
                 if job.check_if_output_datasets_deleted():
                     job.mark_deleted(self.app.config.track_jobs_in_database)
-                    self.app.job_manager.job_stop_queue.put(job.id)
+                    self.app.job_manager.stop(job)
                     return True
         return False
 

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -517,7 +517,6 @@ class DefaultToolAction(object):
         job.object_store_id = object_store_populator.object_store_id
         if job_params:
             job.params = dumps(job_params)
-        job.set_handler(tool.get_job_handler(job_params))
         if completed_job:
             job.set_copied_from_job_id(completed_job.id)
         trans.sa_session.add(job)
@@ -529,11 +528,8 @@ class DefaultToolAction(object):
                                      rerun_remap_job_id=rerun_remap_job_id,
                                      current_job=job,
                                      out_data=out_data)
-        log.info("Setup for job %s complete, ready to flush %s" % (job.log_str(), job_setup_timer))
+        log.info("Setup for job %s complete, ready to be enqueued %s" % (job.log_str(), job_setup_timer))
 
-        job_flush_timer = ExecutionTimer()
-        trans.sa_session.flush()
-        log.info("Flushed transaction for job %s %s" % (job.log_str(), job_flush_timer))
         # Some tools are not really executable, but jobs are still created for them ( for record keeping ).
         # Examples include tools that redirect to other applications ( epigraph ).  These special tools must
         # include something that can be retrieved from the params ( e.g., REDIRECT_URL ) to keep the job
@@ -555,8 +551,8 @@ class DefaultToolAction(object):
             trans.sa_session.flush()
             trans.response.send_redirect(url_for(controller='tool_runner', action='redirect', redirect_url=redirect_url))
         else:
-            # Put the job in the queue if tracking in memory
-            app.job_manager.job_queue.put(job.id, job.tool_id)
+            # Dispatch to a job handler. enqueue() is responsible for flushing the job
+            app.job_manager.enqueue(job, tool=tool)
             trans.log_event("Added job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id)
             return job, out_data
 

--- a/lib/galaxy/tools/actions/history_imp_exp.py
+++ b/lib/galaxy/tools/actions/history_imp_exp.py
@@ -56,11 +56,9 @@ class ImportHistoryToolAction(ToolAction):
             job.add_parameter(name, value)
 
         job.state = start_job_state  # job inputs have been configured, restore initial job state
-        job.set_handler(tool.get_job_handler(None))
-        trans.sa_session.flush()
 
         # Queue the job for execution
-        trans.app.job_manager.job_queue.put(job.id, tool.id)
+        trans.app.job_manager.enqueue(job, tool=tool)
         trans.log_event("Added import history job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id)
 
         return job, odict()
@@ -136,11 +134,9 @@ class ExportHistoryToolAction(ToolAction):
             job.add_parameter(name, value)
 
         job.state = start_job_state  # job inputs have been configured, restore initial job state
-        job.set_handler(tool.get_job_handler(None))
-        trans.sa_session.flush()
 
         # Queue the job for execution
-        trans.app.job_manager.job_queue.put(job.id, tool.id)
+        trans.app.job_manager.enqueue(job, tool=tool)
         trans.log_event("Added export history job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id)
 
         return job, odict()

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -63,7 +63,6 @@ class SetMetadataToolAction(ToolAction):
         except AttributeError:
             job.tool_version = "1.0.1"
         job.state = job.states.WAITING  # we need to set job state to something other than NEW, or else when tracking jobs in db it will be picked up before we have added input / output parameters
-        job.set_handler(tool.get_job_handler(job_params))
         sa_session.add(job)
         sa_session.flush()  # ensure job.id is available
 
@@ -104,7 +103,7 @@ class SetMetadataToolAction(ToolAction):
         sa_session.flush()
 
         # Queue the job for execution
-        app.job_manager.job_queue.put(job.id, tool.id)
+        app.job_manager.enqueue(job, tool=tool)
         # FIXME: need to add event logging to app and log events there rather than trans.
         # trans.log_event( "Added set external metadata job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id )
 

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -432,15 +432,13 @@ def create_job(trans, params, tool, json_file_path, outputs, folder=None, histor
 
     job.object_store_id = object_store_id
     job.set_state(job.states.NEW)
-    job.set_handler(tool.get_job_handler(None))
     if job_params:
         for name, value in job_params.items():
             job.add_parameter(name, value)
     trans.sa_session.add(job)
-    trans.sa_session.flush()
 
     # Queue the job for execution
-    trans.app.job_manager.job_queue.put(job.id, job.tool_id)
+    trans.app.job_manager.enqueue(job, tool=tool)
     trans.log_event("Added job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id)
     output = odict()
     for i, v in enumerate(outputs):

--- a/lib/galaxy/util/facts.py
+++ b/lib/galaxy/util/facts.py
@@ -10,6 +10,7 @@ class Facts(MutableMapping):
     """A dict-like object that evaluates values at access time."""
 
     def __init__(self, config=None, **kwargs):
+        config = config or {}
         self.__dict__ = {}
         self.__set_defaults(config)
         self.__set_config(config)

--- a/lib/galaxy/util/handlers.py
+++ b/lib/galaxy/util/handlers.py
@@ -92,11 +92,6 @@ class ConfiguresHandlers(object):
             if not self.app.config.track_jobs_in_database and \
                     HANDLER_ASSIGNMENT_METHODS.MEM_SELF not in self.UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS:
                 # DEPRECATED: You should just set mem_self as the only method if you want this
-                # FIXME: does setting MEM_SELF still disable track_jobs_in_database like it used to?
-                # FIXME: test MEM_SELF via all config routes:
-                #  1. no assign config, track_jobs_in_databse = False in config
-                #  2. assign_with='mem-self', track_jobs_in_databse = False in config
-                #  2. assign_with='mem-self', track_jobs_in_databse = True in config
                 log.warning("The `track_jobs_in_database` option is deprecated, please set `%s` as the job"
                             " handler assignment method in the job handler configuration",
                             HANDLER_ASSIGNMENT_METHODS.MEM_SELF)
@@ -262,7 +257,6 @@ class ConfiguresHandlers(object):
 
         :returns: str -- A valid job handler ID.
         """
-        # FIXME: test a combo of pool handlers and defined handlers w/ DB_PREASSIGN as the only method
         handler = configured
         if handler is None:
             handler = self.default_handler_id or self.DEFAULT_HANDLER_TAG

--- a/lib/galaxy/web/stack/__init__.py
+++ b/lib/galaxy/web/stack/__init__.py
@@ -7,9 +7,8 @@ import json
 import logging
 import os
 
-# The uwsgi module is automatically injected by the parent uwsgi
-# process and only exists that way.  If anything works, this is a
-# uwsgi-managed process.
+# The uwsgi module is automatically injected by the parent uwsgi process and only exists that way.  If anything works,
+# this is a uwsgi-managed process.
 try:
     import uwsgi
 except ImportError:
@@ -348,7 +347,6 @@ class UWSGIApplicationStack(MessageApplicationStack):
             # Pools are hierarchical (so that you can have e.g. workflow schedulers use the job handlers pool if no
             # workflow schedulers pool exists), so if a pool for a given tag has already been found higher in the
             # hierarchy, don't add mules from a farm/pool lower in the hierarchy.
-            # FIXME: test
             if tag not in job_config.pool_for_tag:
                 if self.in_pool(farm):
                     job_config.is_handler = True

--- a/lib/galaxy/web/stack/transport.py
+++ b/lib/galaxy/web/stack/transport.py
@@ -29,6 +29,9 @@ class ApplicationStackTransport(object):
         self.dispatcher = dispatcher
         self.dispatcher_thread = None
 
+    def init_late_prefork(self):
+        pass
+
     def _dispatch_messages(self):
         pass
 
@@ -70,13 +73,12 @@ class UWSGIFarmMessageTransport(ApplicationStackTransport):
     # Define any static lock names here, additional locks will be appended for each configured farm's message handler
     _locks = []
 
-    def __initialize_locks(self):
+    def init_late_prefork(self):
         num = int(uwsgi.opt.get('locks', 0)) + 1
-        farms = self.stack._configured_farms.keys()
-        need = len(farms)
+        need = len(self.stack._lock_farms)
         if num < need:
             raise RuntimeError('Need %i uWSGI locks but only %i exist(s): Set `locks = %i` in uWSGI configuration' % (need, num, need - 1))
-        self._locks.extend(['RECV_MSG_FARM_' + x for x in farms])
+        self._locks.extend(['RECV_MSG_FARM_' + x for x in sorted(self.stack._lock_farms)])
         # this would be nice, but in my 2.0.15 uWSGI, the uwsgi module has no set_option function, and I don't know if it'd work even if the function existed as documented
         # if len(self.lock_map) > 1:
         #     uwsgi.set_option('locks', len(self.lock_map))
@@ -84,7 +86,6 @@ class UWSGIFarmMessageTransport(ApplicationStackTransport):
 
     def __init__(self, app, stack, dispatcher=None):
         super(UWSGIFarmMessageTransport, self).__init__(app, stack, dispatcher=dispatcher)
-        self.__initialize_locks()
 
     def __lock(self, name_or_id):
         try:

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -203,7 +203,7 @@ class JobController(BaseAPIController, UsesLibraryMixinItems):
         if not job.finished:
             job.mark_deleted(self.app.config.track_jobs_in_database)
             trans.sa_session.flush()
-            self.app.job_manager.job_stop_queue.put(job.id)
+            self.app.job_manager.stop(job)
             return True
         else:
             return False

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2437,14 +2437,12 @@ mapping:
           failing jobs are just failed outright.
 
       track_jobs_in_database:
-        # FIXME: note deprecated, superceded by job_handler_assignment_method
         type: bool
         default: true
         required: false
         desc: |
-          In multiprocess configurations, notification between processes about new jobs
-          must be done via the database.  In single process configurations, this can be
-          done in memory, which is a bit quicker.
+          This option is deprecated, use the `mem-self` handler assignment option in the
+          job configuration instead.
 
       use_tasked_jobs:
         type: bool

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2437,6 +2437,7 @@ mapping:
           failing jobs are just failed outright.
 
       track_jobs_in_database:
+        # FIXME: note deprecated, superceded by job_handler_assignment_method
         type: bool
         default: true
         required: false

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -1648,7 +1648,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                     job.set_state(trans.app.model.Job.states.DELETED_NEW)
                     trans.sa_session.add(job)
                 else:
-                    trans.app.job_manager.job_stop_queue.put(job_id, error_msg=error_msg)
+                    trans.app.job_manager.stop(job, message=error_msg)
                 deleted.append(str(job_id))
         if deleted:
             msg = 'Queued job'

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -360,7 +360,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
                         if job.history_id == history.id and not job.finished:
                             # No need to check other outputs since the job's parent history is this history
                             job.mark_deleted(trans.app.config.track_jobs_in_database)
-                            trans.app.job_manager.job_stop_queue.put(job.id)
+                            trans.app.job_manager.stop(job)
         trans.sa_session.flush()
         if n_deleted:
             part = "Deleted %d %s" % (n_deleted, iff(n_deleted != 1, "histories", "history"))

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -116,7 +116,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
     def _assign_handler(self, workflow_invocation):
         # Use random-ish integer history_id to produce a consistent index to pick
         # job handler with.
-        random_index = workflow_invocation.history_id
+        random_index = workflow_invocation.history.id
         queue_callback = partial(self._queue_callback, workflow_invocation)
         message_callback = partial(self._message_callback, workflow_invocation)
         if self.app.config.parallelize_workflow_scheduling_within_histories:
@@ -188,7 +188,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
 
         if not self.__handlers_configured and self.__stack_has_pool:
             # Stack has a pool for us so override inherited config and use the pool
-            self.__init_handler_assignment_methods()
+            self.__init_handlers()
             self.__handlers_configured = True
 
     def __init_default_scheduler(self):
@@ -225,14 +225,10 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
             else:
                 log.warning(EXCEPTION_MESSAGE_SERIALIZE)
 
-    def __init_handlers(self, config_element):
+    def __init_handlers(self, config_element=None):
         assert not self.__handlers_configured
-        self.__init_handler_assignment_methods(config_element)
-        self._init_handlers(config_element)
-        self.__handlers_configured = True
-
-    def __init_handler_assignment_methods(self, config_element=None):
         self._init_handler_assignment_methods(config_element)
+        self._init_handlers(config_element)
         if not self.handler_assignment_methods_configured:
             self._set_default_handler_assignment_methods()
         else:
@@ -240,6 +236,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
         log.info("Workflow scheduling handler assignment method(s): %s", ', '.join(self.handler_assignment_methods))
         for tag, handlers in [(t, h) for t, h in self.handlers.items() if isinstance(h, list)]:
             log.info("Tag [%s] handlers: %s", tag, ', '.join(handlers))
+        self.__handlers_configured = True
 
     def __init_plugin(self, plugin_type, workflow_scheduler_id=None, **kwds):
         workflow_scheduler_id = workflow_scheduler_id or self.default_scheduler_id

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -153,7 +153,6 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
         try:
             self._assign_handler(workflow_invocation)
         except HandlerAssignmentError:
-            # FIXME: test, raise new exception?
             raise RuntimeError("Unable to set a handler for workflow invocation '%s'" % workflow_invocation.id)
 
         return workflow_invocation
@@ -234,7 +233,10 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
 
     def __init_handler_assignment_methods(self, config_element=None):
         self._init_handler_assignment_methods(config_element)
-        self._set_default_handler_assignment_methods()
+        if not self.handler_assignment_methods_configured:
+            self._set_default_handler_assignment_methods()
+        else:
+            self.app.application_stack.init_job_handling(self)
         log.info("Workflow scheduling handler assignment method(s): %s", ', '.join(self.handler_assignment_methods))
         for tag, handlers in [(t, h) for t, h in self.handlers.items() if isinstance(h, list)]:
             log.info("Tag [%s] handlers: %s", tag, ', '.join(handlers))

--- a/test/unit/jobs/handler_template_job_conf.xml
+++ b/test/unit/jobs/handler_template_job_conf.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<job_conf>
+    <plugins>
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4"/>
+    </plugins>
+    <handlers{assign_with}>
+        {handlers}
+    </handlers>
+    <destinations>
+        <destination id="local" runner="local"/>
+    </destinations>
+</job_conf>

--- a/test/unit/jobs/handler_template_job_conf.xml
+++ b/test/unit/jobs/handler_template_job_conf.xml
@@ -3,7 +3,7 @@
     <plugins>
         <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="4"/>
     </plugins>
-    <handlers{assign_with}>
+    <handlers{assign_with}{default}>
         {handlers}
     </handlers>
     <destinations>

--- a/test/unit/jobs/test_job_configuration.py
+++ b/test/unit/jobs/test_job_configuration.py
@@ -58,11 +58,17 @@ class JobConfXmlParserTestCase(unittest.TestCase):
         assert task_runners[0]["workers"] == 5
 
     def test_explicit_handler_default(self):
-        self.__with_advanced_config()
+        self.__with_handlers_config(
+            handlers=[{'id': 'handler0', 'tags': 'handlers'}, {'id': 'handler1', 'tags': 'handlers'}],
+            default='handlers'
+        )
         assert self.job_config.default_handler_id == "handlers"
 
     def test_handler_tag_parsing(self):
-        self.__with_advanced_config()
+        self.__with_handlers_config(
+            handlers=[{'id': 'handler0', 'tags': 'handlers'}, {'id': 'handler1', 'tags': 'handlers'}],
+            default='handlers'
+        )
         assert "handler0" in self.job_config.handlers["handlers"]
         assert "handler1" in self.job_config.handlers["handlers"]
 
@@ -264,12 +270,13 @@ class JobConfXmlParserTestCase(unittest.TestCase):
     def __with_advanced_config(self):
         self.__write_config_from(ADVANCED_JOB_CONF)
 
-    def __with_handlers_config(self, assign_with=None, handlers=None, base_pools=None):
+    def __with_handlers_config(self, assign_with=None, default=None, handlers=None, base_pools=None):
         handlers = handlers or []
         template = {
             'assign_with': ' assign_with="%s"' % assign_with if assign_with is not None else '',
+            'default': ' default="%s"' % default if default is not None else '',
             'handlers': '\n'.join([
-                '<handler id="{id}"/>'.format(
+                '<handler id="{id}"{tags}/>'.format(
                     id=x['id'],
                     tags=' tags="%s"' % x['tags'] if 'tags' in x else ''
                 ) for x in handlers]),

--- a/test/unit/jobs/test_job_configuration.py
+++ b/test/unit/jobs/test_job_configuration.py
@@ -25,6 +25,7 @@ class JobConfXmlParserTestCase(unittest.TestCase):
             job_resource_params_file="/tmp/fake_absent_path",
             config_dict={},
             default_job_resubmission_condition="",
+            track_jobs_in_database=True,
             server_name="main",
         )
         self.__write_config_from(SIMPLE_JOB_CONF)
@@ -50,12 +51,10 @@ class JobConfXmlParserTestCase(unittest.TestCase):
         assert len(task_runners) == 1
         assert task_runners[0]["workers"] == 5
 
-    def test_load_simple_handler(self):
-        main_handler = self.job_config.handlers["main"]
-        assert main_handler[0] == "main"
-
-    def test_if_one_handler_implicit_default(self):
-        assert self.job_config.default_handler_id == "main"
+    def test_if_no_handlers_implict_db_self(self):
+        assert self.job_config.default_handler_id is None
+        assert self.job_config.handlers == {}
+        assert self.job_config.handler_assignment_methods == ['db-self']
 
     def test_explicit_handler_default(self):
         self.__with_advanced_config()

--- a/test/unit/tools/test_actions.py
+++ b/test/unit/tools/test_actions.py
@@ -12,8 +12,6 @@ from galaxy.tools.actions import (
 from galaxy.tools.parser.output_objects import ToolOutput
 from .. import tools_support
 
-TEST_HANDLER_NAME = "test_handler_1"
-
 
 # I cannot think of a saner way to test if data is being wrapped than use a
 # data param in the output label - though you would probably never want to do
@@ -73,7 +71,6 @@ class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesApp, tools_
         self.app.model.context.flush()
         self.action = DefaultToolAction()
         self.app.config.len_file_path = "moocow"
-        self.app.job_config["get_handler"] = lambda h: TEST_HANDLER_NAME
         self.app.object_store = MockObjectStore()
 
     def test_output_created(self):
@@ -113,10 +110,6 @@ class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesApp, tools_
         )
         # Again this is a stupid way to ensure data parameters are wrapped.
         self.assertEqual(output["out1"].name, "Output (%s)" % hda1.dataset.get_file_name())
-
-    def test_handler_set(self):
-        job, _ = self._simple_execute()
-        assert job.handler == TEST_HANDLER_NAME
 
     def test_inactive_user_job_create_failure(self):
         self.trans.user_is_active = False

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -11,7 +11,7 @@ from galaxy import (
     quota
 )
 from galaxy.datatypes import registry
-from galaxy.jobs import NoopQueue
+from galaxy.jobs.manager import NoopManager
 from galaxy.managers import tags
 from galaxy.model import mapping
 from galaxy.tools.deps.containers import NullContainerFinder
@@ -76,7 +76,7 @@ class MockApp(object):
         self.container_finder = NullContainerFinder()
         self._toolbox_lock = MockLock()
         self.genome_builds = GenomeBuilds(self)
-        self.job_manager = Bunch(job_queue=NoopQueue())
+        self.job_manager = NoopManager()
         self.application_stack = ApplicationStack()
 
     def init_datatypes(self):


### PR DESCRIPTION
What started as a quick fix to the way we assign handlers (in order to support some new assignment methods) turned in to an overhaul. It's now possible to configure them explicitly, and the logic of how to configure them implicitly is now more centralized and clear.

This work isn't super exciting on its own, but it paves the way for new assignment methods (DB-based "message queue", AMQP messaging, etc.) that will be coming next.

## Assignment methods and configuration

Assignment methods are configured via attributes on the job config's `<handlers>` tag, the attributes and methods (none of which are now) are explained below (text pulled from `job_conf.xml.sample_advanced):

- `assign_with` - How jobs should be assigned to handlers. The value can be a single method or a comma-separated list that will be tried in order. The default depends on whether any handlers and a job handler "pool" (such as uWSGI mules in a `job-handlers` farm) are configured. Valid methods are:
     - `mem-self` - Jobs are assigned to the web worker that received the tool execution request from the user via an internal in-memory queue. If a tool is configured to use a specific handler, that configuration is ignored; the process that creates the job *always* handles it. This can be slightly faster than `db-self` but only makes sense in single process environments without dedicated job handlers. This option replaces the former `track_jobs_in_database` option in galaxy.yml.
     - `db-self` - Like `mem-self` but assignment occurs by setting a new job's 'handler' column in the database to the process that created the job at the time it is created. Additionally, if a tool is configured to use a specific handler (ID or tag), that handler is assigned (tags by `db-preassign`). This is the default if no handlers are defined and no `job-handlers` pool is present (the default for a completely unconfigured Galaxy).  
     - `db-preassign` - Jobs are assigned a handler by selecting one at random from the configured tag or default handlers. This occurs by setting a new job's 'handler' column in the database to the chosen handler ID (hence "preassign"ment). This is the default if handlers are defined and no `job-handlers` pool is present.
     - `uwsgi-mule-message` - Jobs are assigned a handler via uWSGI mule messaging (see uWSGI documentation). A mule in the `job-handlers` (if sent to the default tag) or `job-handlers.<tag>` farm will recieve the message and assign itself. This the default if a `job-handlers` pool is present and no handlers are configured.

  In the event that both a `job-handlers` pool is present and handlers are configured, the default is `uwsgi-mule-message,db-preassign`. At present, only `uwsgi-mule-message` is capable of deferring handler assignment to a later method (which would occur in the event that a tool is configured to use a tag for which there is not a matching pool).

  In all cases, if a tool is configured to use a specific handler (by ID, not tag), configured assignment methods are ignored and that handler is directly assigned in the job's 'handler' column at job creation time.

 - `default` - An ID or tag of the handler(s) that should handle any jobs not assigned to a specific handler (which is probably most of them). If unset, the default is any untagged handlers plus any handlers in the `job-handlers` (no tag) pool.

   Note that in the event such a mixed configuration environment exists (both a `job-handlers` pool (farm) and untagged handlers are configured), the default value of `assign_with="uwsgi-mule-message,db-preassign"` would prevent any of the configured handlers from being assigned since `uwsgi-mule-message` is the preferred assignment method.

Comma-separated XML attribute values is not the best way to do a list, but after some discussion with @jmchilton and our combined aversion to making any significant extensions to the job_conf.xml schema since the hope is to switch to YAML anyway (#5148) and the proposed structure there didn't translate to any XML schema we liked, this was considered to be reasonable temporary compromise, especially since it matches the way we do tags in `job_conf.xml` already.

## Improvements

- `get_handler()` is replaced with `assign_handler()`. When I added uWSGI messaging, there was a lot of special casing in `get_handler()` and spread out elsewhere for handler assignment.
- The concept of a asynchronous worker "pool" is clearer and more generalized now. I have separate work that refactors stack messaging to combine it with the existing kombu messaging that should finish things up and make worker pools usable by any part of the code.
- A `default` attribute on `<handlers>` is no longer required in any case, the default is simply any untagged handlers that are configured, plus the `job-handlers` pool (farm), if it exists. This is explained fully in additions to `job_conf.xml.sample_advanced`.
- Pool members (aka mules in a farm) can now be assigned the old fashioned way (`db-preassign`) rather than being forced to use mule messaging (`uwsgi-mule-message`). This feature will be more useful for the new assignment mechanisms and allowing the mixture of static (mule) and dynamic (webless) pool members.

### Job execution improvements

- The job of assigning handlers and queuing jobs for execution is moved from the tool action to `JobManager.enqueue()`. The job queue and job stop queues are no longer directly exposed in the manager. The manager's `enqueue()` and `stop()` methods are now the high level interfaces to job execution.
- You can now create "subpools" matching handler tags to separate handlers for different tools/purposes but still use mule messaging for assignment, and this is done without any explicit `<handlers>` configuration, you simply use a `<tool>` in `job_conf.xml`:

    ```xml
    <tools>
        <tool id="foo" handler="bar"/>
    </tools>
    ```

    and then create a pool for tag `bar` with:

    ```console
    $ uwsgi ... --mule=lib/galaxy/main.py --mule=lib/galaxy/main.py --farm=job-handlers.bar:1,2
    ```

###  Workflow scheduling improvements

- You can now create a `workflow-schedulers` pool (uWSGI farm) and automatically separate workflow scheduling from job handlers. Previously scheduling would automatically occur in the `job-handlers` pool (if it existed) or in the configured default handlers (if not).
- In my initial uWSGI farm implementation for workflow schedulers I'd used assignment by mule messaging, and only recently discovered in conversation with @jmchilton that this is not correct, since it can allow for multiple workflows to be scheduled simultaneously in the same history. After lengthy discussions as to the correct implementation, I decided to simply switch workflow scheduling to use the `db-preassign` method. However, creating a `workflow-schedulers` (or if not that, `job-handlers`) pool does automatically make its member mules eligible for assignment via `db-preassign` (which was not the case before). It is still possible to use mule messages by creating a `workflow_schedulers_conf.xml` and setting `<handlers assign_with="uwsgi-mule-message">`.

----

The unit tests only test for correct parsing of the job config, additional testing of execution with the various assignment methods would be good. I will probably work on this in the next PR (which will add new assignment types) though.