### PR TITLE
Allow for missing trailing \t in GFF records.

### DIFF
--- a/lib/galaxy/datatypes/util/gff_util.py
+++ b/lib/galaxy/datatypes/util/gff_util.py
@@ -42,7 +42,7 @@ class GFFInterval(GenomicInterval):
         self.score = self.fields[self.score_col]
 
         # GFF attributes.
-        self.attributes = parse_gff_attributes(fields[8])
+        self.attributes = parse_gff_attributes(fields[8] if 8 < self.nfields else "")
 
     def copy(self):
         return GFFInterval(self.reader, list(self.fields), self.chrom_col, self.feature_col, self.start_col,


### PR DESCRIPTION
Some tools do not output a trailing \t when writing a GFF record with an empty group.
The current code assumes .split("\t") will create an array of size 9, this fixes that.