### PR TITLE
Fix ``size_to_bytes`` for some float values

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1359,8 +1359,15 @@ def size_to_bytes(size):
     4096
     >>> size_to_bytes('2.2 TB')
     2418925581107
+    >>> size_to_bytes('.01 TB')
+    10995116277
+    >>> size_to_bytes('1.b')
+    1
+    >>> size_to_bytes('1.2E2k')
+    122880
     """
-    size_re = re.compile(r'(?P<number>\d+(\.\d+)?)\s*(?P<multiple>[eptgmk]?(b|bytes?)?)?$')
+    # The following number regexp is based on https://stackoverflow.com/questions/385558/extract-float-double-value/385597#385597
+    size_re = re.compile(r'(?P<number>(\d+(\.\d*)?|\.\d+)(e[+-]?\d+)?)\s*(?P<multiple>[eptgmk]?(b|bytes?)?)?$')
     size_match = size_re.match(size.lower())
     if size_match is None:
         raise ValueError("Could not parse string '%s'" % size)


### PR DESCRIPTION
Values like `.01` and `1.` were broken in commit 26a6b1c83381d1c75131f330d8b8f4c23680f1dd . The new regexp allows also scientific notation like `1.2E2` .

Found while testing BioBlend on the Galaxy dev branch: https://travis-ci.org/nsoranzo/bioblend/jobs/466782730