### PR TITLE
Fix workflow output rectification

### DIFF
--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -221,9 +221,9 @@ var Collection = Backbone.Collection.extend({
         }
         if (options.helpsite_url) {
             helpTab.menu.unshift({
-                    title: _l("Galaxy Help"),
-                    url: options.helpsite_url,
-                    target: "_blank"
+                title: _l("Galaxy Help"),
+                url: options.helpsite_url,
+                target: "_blank"
             });
         }
         this.add(helpTab);

--- a/client/galaxy/scripts/mvc/workflow/workflow-manager.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-manager.js
@@ -95,7 +95,7 @@ class Workflow {
             if (node.type === "tool" && node.workflow_outputs && node.workflow_outputs.length > 0) {
                 using_workflow_outputs = true;
             }
-            $.each(node.post_job_actions, (pja_using_workflow_outputsid, pja) => {
+            $.each(node.post_job_actions, (pja_id, pja) => {
                 if (pja.action_type === "HideDatasetAction") {
                     has_existing_pjas = true;
                 }

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -673,6 +673,16 @@ export default Backbone.View.extend({
             success: function(data) {
                 node.init_field_data(data);
                 node.update_field_data(data);
+                // Post init/update, for new modules we want to default to
+                // nodes being outputs
+                // TODO: Overhaul the handling of all this when we modernize
+                // the editor, replace callout image manipulation with a simple
+                // class toggle, etc.
+                $.each(node.output_terminals, (ot_id, ot) => {
+                    node.addWorkflowOutput(ot.name);
+                    var callout = $(node.element).find(`.callout.${ot.name.replace(/(?=[()])/g, "\\")}`);
+                    callout.find("img").attr("src", `${Galaxy.root}static/images/fugue/asterisk-small.png`);
+                });
                 self.workflow.activate_node(node);
             }
         });


### PR DESCRIPTION
This should fix #7055.  It cleans up the logic that determines whether a workflow is 'using workflow outputs' (via stars) to only count 'tool steps'.  It also 'cleans' PJAs inadvertently added to previous versions of the workflow by dropping the tool step constraint during that processing.

So, going forward, workflows will be correctly saved with outputs/stars.