### PR TITLE
Fix migration 0146 column selection on downgrade

### DIFF
--- a/lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py
+++ b/lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py
@@ -104,7 +104,7 @@ def downgrade(migrate_engine):
         "FROM workflow_step_connection_predowngrade145 AS wsc JOIN workflow_step_input AS wsi ON wsc.input_step_input_id = wsi.id ORDER BY wsc.id"
     migrate_engine.execute(insert_step_connections_cmd)
 
-    for table in (WorkflowStepInput_table, NewWorkflowStepConnection_table):
+    for table in (NewWorkflowStepConnection_table, WorkflowStepInput_table):
         _drop(table)
 
 

--- a/lib/galaxy/model/migrate/versions/0146_workflow_paths.py
+++ b/lib/galaxy/model/migrate/versions/0146_workflow_paths.py
@@ -29,7 +29,7 @@ def upgrade(migrate_engine):
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
 
-    __drop_column(from_path_column, "stored_workflow", metadata)
+    __drop_column("from_path", "stored_workflow", metadata)
 
 
 def __add_column(column, table_name, metadata, **kwds):

--- a/lib/galaxy/model/migrate/versions/0146_workflow_paths.py
+++ b/lib/galaxy/model/migrate/versions/0146_workflow_paths.py
@@ -23,16 +23,16 @@ def upgrade(migrate_engine):
     print(__doc__)
     metadata.reflect()
 
-    __add_column(from_path_column, "stored_workflow", metadata)
+    _add_column(from_path_column, "stored_workflow", metadata)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
 
-    __drop_column("from_path", "stored_workflow", metadata)
+    _drop_column("from_path", "stored_workflow", metadata)
 
 
-def __add_column(column, table_name, metadata, **kwds):
+def _add_column(column, table_name, metadata, **kwds):
     try:
         table = Table(table_name, metadata, autoload=True)
         column.create(table, **kwds)
@@ -40,23 +40,9 @@ def __add_column(column, table_name, metadata, **kwds):
         log.exception("Adding column %s failed.", column)
 
 
-def __drop_column(column_name, table_name, metadata):
+def _drop_column(column_name, table_name, metadata):
     try:
         table = Table(table_name, metadata, autoload=True)
         getattr(table.c, column_name).drop()
     except Exception:
         log.exception("Dropping column %s failed.", column_name)
-
-
-def _create(table):
-    try:
-        table.create()
-    except Exception:
-        log.exception("Creating %s table failed.", table.name)
-
-
-def _drop(table):
-    try:
-        table.drop()
-    except Exception:
-        log.exception("Dropping %s table failed.", table.name)


### PR DESCRIPTION
This fixes migration 0146 and 0145 downgrade errors seen below.

```
yoplait@malleus:/Volumes/work_cs/galaxy dropdb galaxy; createdb galaxy; pg_dump galaxyclone | psql galaxy

<snip, it works fine, copies an old db @ 143 from a few months ago>

yoplait@malleus:/Volumes/work_cs/galaxy ./manage_db.sh upgrade                                                                                               ± dev
Activating virtualenv at .venv
143 -> 144...

Migration script to add the cleanup_event_user_association table.

Created cleanup_event_user_association table
done
144 -> 145...

Migration script for workflow step input table.

done
145 -> 146...

Migration script for workflow paths.

done


yoplait@malleus:/Volumes/work_cs/galaxy ./manage_db.sh downgrade 142                                                                                   ± dev
Activating virtualenv at .venv
146 -> 145...
Dropping column from_path failed.
Traceback (most recent call last):
  File "lib/galaxy/model/migrate/versions/0146_workflow_paths.py", line 46, in __drop_column
    getattr(table.c, column_name).drop()
TypeError: getattr(): attribute name must be string
done
145 -> 144...
Dropping workflow_step_input table failed.
Traceback (most recent call last):
  File "lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py", line 120, in _drop
    table.drop()
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/sql/schema.py", line 795, in drop
    checkfirst=checkfirst)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1940, in _run_visitor
    conn._run_visitor(visitorcallable, element, **kwargs)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1549, in _run_visitor
    **kwargs).traverse_single(element)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/sql/visitors.py", line 121, in traverse_single
    return meth(obj, **kw)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/sql/ddl.py", line 951, in visit_table
    self.connection.execute(DropTable(table))
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 948, in execute
    return meth(self, multiparams, params)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/sql/ddl.py", line 68, in _execute_on_connection
    return connection._execute_ddl(self, multiparams, params)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1009, in _execute_ddl
    compiled
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1200, in _execute_context
    context)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1413, in _handle_dbapi_exception
    exc_info
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 265, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1193, in _execute_context
    context)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 509, in do_execute
    cursor.execute(statement, parameters)
InternalError: (psycopg2.InternalError) cannot drop table workflow_step_input because other objects depend on it
DETAIL:  constraint workflow_step_connection_input_step_input_id_fkey on table workflow_step_connection_predowngrade145 depends on table workflow_step_input
HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 [SQL: '\nDROP TABLE workflow_step_input'] (Background on this error at: http://sqlalche.me/e/2j85)
done
144 -> 143...
Dropped cleanup_event_user_association table
done
143 -> 142...
done
```