### PR TITLE
Run singularity in silent mode

### DIFF
--- a/lib/galaxy/tools/deps/singularity_util.py
+++ b/lib/galaxy/tools/deps/singularity_util.py
@@ -28,6 +28,7 @@ def build_singularity_run_command(
         sudo=sudo,
         sudo_cmd=sudo_cmd,
     )
+    command_parts.append("-s")
     command_parts.append("exec")
     for volume in volumes:
         command_parts.extend(["-B", shlex_quote(str(volume))])


### PR DESCRIPTION
The manual says:
```
-s|--silent   Only print errors
```

Without this option I'm seeing `WARNING: Not mounting /var/tmp (already
mounted in container)` on the stderr.