### PR TITLE
Enable tagging and annotation of jobs regardless of state

### DIFF
--- a/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
@@ -120,12 +120,12 @@ var DatasetListItemEdit = _super.extend(
             var state = this.model.get("state");
 
             if (!this.model.isDeletedOrPurged()) {
-              //Enable tagging+annotation regardless of job state (see issue #6330) 
+                //Enable tagging+annotation regardless of job state (see issue #6330)
                 this._renderTags($details);
                 this._renderAnnotation($details);
 
                 if (_.contains([STATES.OK, STATES.FAILED_METADATA], state)) {
-                  this._makeDbkeyEditLink($details);
+                    this._makeDbkeyEditLink($details);
                 }
             }
 

--- a/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
@@ -83,7 +83,7 @@ var DatasetListItemEdit = _super.extend(
                 }
 
                 // disable if still uploading or new
-            } else if (_.contains([STATES.UPLOAD, STATES.NEW], this.model.get("state"))) {
+            } else if ([STATES.UPLOAD, STATES.NEW].includes(this.model.get("state"))) {
                 editBtnData.disabled = true;
                 editBtnData.title = _l("This dataset is not yet editable");
             }
@@ -123,8 +123,7 @@ var DatasetListItemEdit = _super.extend(
                 //Enable tagging+annotation regardless of job state (see issue #6330)
                 this._renderTags($details);
                 this._renderAnnotation($details);
-
-                if (_.contains([STATES.OK, STATES.FAILED_METADATA], state)) {
+                if ([STATES.OK, STATES.FAILED_METADATA].includes(state)) {
                     this._makeDbkeyEditLink($details);
                 }
             }

--- a/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
@@ -119,10 +119,14 @@ var DatasetListItemEdit = _super.extend(
 
             var state = this.model.get("state");
 
-            if (!this.model.isDeletedOrPurged() && _.contains([STATES.OK, STATES.FAILED_METADATA], state)) {
+            if (!this.model.isDeletedOrPurged()) {
+              //Enable tagging+annotation regardless of job state (see issue #6330) 
                 this._renderTags($details);
                 this._renderAnnotation($details);
-                this._makeDbkeyEditLink($details);
+
+                if (_.contains([STATES.OK, STATES.FAILED_METADATA], state)) {
+                  this._makeDbkeyEditLink($details);
+                }
             }
 
             this._setUpBehaviors($details);


### PR DESCRIPTION
See issue #6330 

As far as I can tell, as long as a model exists (and is not purged or deleted - which is checked), the model's state is inconsequential. All states (states.js) seem to have no relevance to the creation of a record in the db association tables (history_dataset_association_tag/annotation_association).

I did not add any new tests for this change, so I'll what Travis says about this...