### PR TITLE
Drop tools without installable dependencies

### DIFF
--- a/config/tool_conf.xml.sample
+++ b/config/tool_conf.xml.sample
@@ -121,10 +121,6 @@
     <tool file="phenotype_association/linkToGProfile.xml" />
     <tool file="phenotype_association/linkToDavid.xml" />
     <tool file="phenotype_association/ldtools.xml" />
-    <tool file="phenotype_association/pass.xml" />
-    <tool file="phenotype_association/gpass.xml" />
-    <tool file="phenotype_association/beam.xml" />
-    <tool file="phenotype_association/lps.xml" />
     <tool file="phenotype_association/master2pg.xml" />
   </section>
 </toolbox>


### PR DESCRIPTION
These seem to be beyond legacy, and since their not installable let's
drop them from the default config. I left them in tool_conf.xml.main,
since they appear to be installed on main.