### PR TITLE
Remove collect_outputs_from option.

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -518,14 +518,6 @@ galaxy:
   # store this information.
   #citation_cache_lock_dir: database/citations/lock
 
-  # Tools with a number of outputs not known until runtime can write
-  # these outputs to a directory for collection by Galaxy when the job
-  # is done. Previously, this directory was new_file_path, but using one
-  # global directory can cause performance problems, so using
-  # job_working_directory ('.' or cwd when a job is run) is encouraged.
-  # By default, both are checked to avoid breaking existing tools.
-  #collect_outputs_from: 'new_file_path,job_working_directory'
-
   # Configuration file for the object store If this is set and exists,
   # it overrides any other objectstore settings.
   #object_store_config_file: config/object_store_conf.xml

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -922,22 +922,6 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~
-``collect_outputs_from``
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Tools with a number of outputs not known until runtime can write
-    these outputs to a directory for collection by Galaxy when the job
-    is done. Previously, this directory was new_file_path, but using
-    one global directory can cause performance problems, so using
-    job_working_directory ('.' or cwd when a job is run) is
-    encouraged.  By default, both are checked to avoid breaking
-    existing tools.
-:Default: ``new_file_path,job_working_directory``
-:Type: str
-
-
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``object_store_config_file``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -297,7 +297,6 @@ class Configuration(object):
         self.allow_user_impersonation = string_as_bool(kwargs.get("allow_user_impersonation", "False"))
         self.show_user_prepopulate_form = string_as_bool(kwargs.get("show_user_prepopulate_form", "False"))
         self.new_user_dataset_access_role_default_private = string_as_bool(kwargs.get("new_user_dataset_access_role_default_private", "False"))
-        self.collect_outputs_from = [x.strip() for x in kwargs.get('collect_outputs_from', 'new_file_path,job_working_directory').lower().split(',')]
         self.template_path = resolve_path(kwargs.get("template_path", "templates"), self.root)
         self.template_cache = resolve_path(kwargs.get("template_cache_path", "database/compiled_templates"), self.root)
         self.job_queue_cleanup_interval = int(kwargs.get("job_queue_cleanup_interval", "5"))

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -1,6 +1,5 @@
 """ Code allowing tools to define extra files associated with an output datset.
 """
-import glob
 import json
 import logging
 import operator
@@ -538,20 +537,8 @@ def collect_primary_datasets(tool, output, tool_provided_metadata, job_working_d
         if name in tool.outputs:
             dataset_collectors = [dataset_collector(description) for description in tool.outputs[name].dataset_collector_descriptions]
         filenames = odict.odict()
-        if 'new_file_path' in app.config.collect_outputs_from:
-            if DEFAULT_DATASET_COLLECTOR in dataset_collectors:
-                # 'new_file_path' collection should be considered deprecated,
-                # only use old-style matching (glob instead of regex and only
-                # using default collector - if enabled).
-                for filename in glob.glob(os.path.join(app.config.new_file_path, "primary_%i_*" % outdata.id)):
-                    filenames[filename] = DiscoveredFile(
-                        filename,
-                        DEFAULT_DATASET_COLLECTOR,
-                        DEFAULT_DATASET_COLLECTOR.match(outdata, os.path.basename(filename))
-                    )
-        if 'job_working_directory' in app.config.collect_outputs_from:
-            for discovered_file in discover_files(name, tool_provided_metadata, dataset_collectors, job_working_directory, outdata):
-                filenames[discovered_file.path] = discovered_file
+        for discovered_file in discover_files(name, tool_provided_metadata, dataset_collectors, job_working_directory, outdata):
+            filenames[discovered_file.path] = discovered_file
         for filename_index, (filename, discovered_file) in enumerate(filenames.items()):
             extra_file_collector = discovered_file.collector
             fields_match = discovered_file.match

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -705,18 +705,6 @@ mapping:
           external sources such as https://doi.org/ by Galaxy - the following
           parameters can be used to control the caching used to store this information.
 
-      collect_outputs_from:
-        type: str
-        default: new_file_path,job_working_directory
-        required: false
-        desc: |
-          Tools with a number of outputs not known until runtime can write these
-          outputs to a directory for collection by Galaxy when the job is done.
-          Previously, this directory was new_file_path, but using one global directory
-          can cause performance problems, so using job_working_directory ('.' or cwd
-          when a job is run) is encouraged.  By default, both are checked to avoid
-          breaking existing tools.
-
       object_store_config_file:
         type: str
         default: config/object_store_conf.xml

--- a/test/functional/tools/multi_output.xml
+++ b/test/functional/tools/multi_output.xml
@@ -1,7 +1,7 @@
 <tool id="multi_output" name="Multi_Output" version="0.1.0">
   <command>
     echo "Hello" > $report;
-    echo "World Contents" > '${__new_file_path__}/primary_${report.id}_world_visible_?'
+    echo "World Contents" > 'primary_${report.id}_world_visible_?'
   </command>
   <inputs>
     <param name="input" type="integer" value="7" />

--- a/test/unit/tools/test_collect_primary_datasets.py
+++ b/test/unit/tools/test_collect_primary_datasets.py
@@ -22,7 +22,6 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesApp, t
         self.app.object_store = object_store
         self._init_tool(tools_support.SIMPLE_TOOL_CONTENTS)
         self._setup_test_output()
-        self.app.config.collect_outputs_from = "job_working_directory"
 
         self.app.model.Dataset.object_store = object_store
 
@@ -175,14 +174,6 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesApp, t
         self._append_job_json(dict(ext="txt"), output_path=path)
         created_hda = self._collect_default_extra()
         assert created_hda.ext == "txt"
-
-    def test_new_file_path_collection(self):
-        self.app.config.collect_outputs_from = "new_file_path"
-        self.app.config.new_file_path = self.test_directory
-
-        self._setup_extra_file()
-        created_hda = self._collect_default_extra(job_working_directory="/tmp")
-        assert created_hda
 
     def test_job_param(self):
         self._setup_extra_file()


### PR DESCRIPTION
And just disable dynamic discovery of outputs from new_file_path for legacy profile tools.

This is part of an ongoing effort to kill new_file_path and simplify output discovery.

This option was added by @natefoo 10 years ago and he switched main to disable new_file_path discovery and noone ever complained. So lets just do this for all Galaxies - if main hasn't run tools that require this functionality in a decade - I very much doubt any Galaxies require this.