### PR TITLE
Fixes toolshed and reports styling that was previously applied at the…

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -2080,3 +2080,25 @@ div.toolTitleNoSection {
 [v-cloak] {
     display: none;
 }
+
+/* Toolshed, reports custom styles from mako templates */
+body.toolshed {
+    margin: 0; padding: 0; overflow: hidden;
+    #left {
+        background: #C1C9E5 url(../../images/menu_bg.png) top repeat-x;
+    }
+    .unified-panel-body {
+        overflow: auto;
+    }
+    .toolMenu {
+        margin-left: 10px;
+    }
+}
+
+
+body.reports {
+    margin: 0; padding: 0; overflow: hidden;
+    #left {
+        background: #C1C9E5 url(../../images/menu_bg.png) top repeat-x;
+    }
+}

--- a/templates/base/base_panels.mako
+++ b/templates/base/base_panels.mako
@@ -164,6 +164,7 @@
         body_class += " has-inactivity-box"
     %>
 
+
     <body scroll="no" class="full-content ${body_class}">
         %if self.require_javascript:
             <noscript>

--- a/templates/webapps/reports/base_panels.mako
+++ b/templates/webapps/reports/base_panels.mako
@@ -5,6 +5,12 @@
     ${h.css( "reports" )}
 </%def>
 
+<%def name="init()">
+    ${parent.init()}
+    <%
+        self.body_class = "reports"
+    %>
+</%def>
 
 ## Default title
 <%def name="title()">Reports</%def>

--- a/templates/webapps/reports/index.mako
+++ b/templates/webapps/reports/index.mako
@@ -1,6 +1,7 @@
 <%inherit file="/webapps/reports/base_panels.mako"/>
 
 <%def name="init()">
+    ${parent.init()}
     <%
         self.has_left_panel=True
         self.has_right_panel=False
@@ -16,12 +17,6 @@
     ## But make sure styles for the layout take precedence
     ${parent.stylesheets()}
 
-    <style type="text/css">
-        body { margin: 0; padding: 0; overflow: hidden; }
-        #left {
-            background: #C1C9E5 url("${h.url_for('/static/style/menu_bg.png')}") top repeat-x;
-        }
-    </style>
 </%def>
 
 <%def name="javascripts()">

--- a/templates/webapps/tool_shed/admin/index.mako
+++ b/templates/webapps/tool_shed/admin/index.mako
@@ -8,18 +8,6 @@
     ## But make sure styles for the layout take precedence
     ${parent.stylesheets()}
 
-    <style type="text/css">
-        body { margin: 0; padding: 0; overflow: hidden; }
-        #left {
-            background: #C1C9E5 url(${h.url_for('/static/style/menu_bg.png')}) top repeat-x;
-        }
-        .unified-panel-body {
-            overflow: auto;
-        }
-        .toolMenu {
-            margin-left: 10px;
-        }
-    </style>
 </%def>
 
 <%def name="javascripts()">
@@ -27,6 +15,7 @@
 </%def>
 
 <%def name="init()">
+    ${parent.init()}
     <%
         self.has_left_panel=True
         self.has_right_panel=False

--- a/templates/webapps/tool_shed/base_panels.mako
+++ b/templates/webapps/tool_shed/base_panels.mako
@@ -3,6 +3,13 @@
 ## Default title
 <%def name="title()">Tool Shed</%def>
 
+<%def name="init()">
+    ${parent.init()}
+    <%
+        self.body_class = "toolshed"
+    %>
+</%def>
+
 <%def name="javascripts()">
     ${parent.javascripts()}
     <script type="text/javascript">

--- a/templates/webapps/tool_shed/group/index.mako
+++ b/templates/webapps/tool_shed/group/index.mako
@@ -7,19 +7,6 @@
 
     ## But make sure styles for the layout take precedence
     ${parent.stylesheets()}
-
-    <style type="text/css">
-        body { margin: 0; padding: 0; overflow: hidden; }
-        #left {
-            background: #C1C9E5 url(${h.url_for('/static/style/menu_bg.png')}) top repeat-x;
-        }
-        .unified-panel-body {
-            overflow: auto;
-        }
-        .toolMenu {
-            margin-left: 10px;
-        }
-    </style>
 </%def>
 
 
@@ -28,6 +15,7 @@
 </%def>
 
 <%def name="init()">
+    ${parent.init()}
     %if trans.app.config.require_login and not trans.user:
         <script type="text/javascript">
             if ( window != top ) {

--- a/templates/webapps/tool_shed/index.mako
+++ b/templates/webapps/tool_shed/index.mako
@@ -8,18 +8,6 @@
     ## But make sure styles for the layout take precedence
     ${parent.stylesheets()}
 
-    <style type="text/css">
-        body { margin: 0; padding: 0; overflow: hidden; }
-        #left {
-            background: #C1C9E5 url(${h.url_for('/static/style/menu_bg.png')}) top repeat-x;
-        }
-        .unified-panel-body {
-            overflow: auto;
-        }
-        .toolMenu {
-            margin-left: 10px;
-        }
-    </style>
 </%def>
 
 <%def name="javascripts()">
@@ -27,6 +15,7 @@
 </%def>
 
 <%def name="init()">
+    ${parent.init()}
     <%
         self.has_left_panel=True
         self.has_right_panel=False


### PR DESCRIPTION
… mako template level.  We'll want to update the look here, I think, but this is an incremental step that correctly uses the background image, bundled via webpack.

Fixes image loading issue mentioned https://github.com/galaxyproject/galaxy/issues/7132#issuecomment-448660187.

Anywhere else in the application we're relying on raw strings to image urls that isn't in *webpacked CSS* will need similar treatment -- all images need to either go through webpack via styles, or be manually symlinked into the right spot in static (which is not preferred).