### PR TITLE
make job script actually return tool exit code

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -15,7 +15,6 @@ from galaxy.jobs.runners.util.job_script import (
 log = getLogger(__name__)
 
 CAPTURE_RETURN_CODE = "return_code=$?"
-YIELD_CAPTURED_CODE = 'sh -c "exit $return_code"'
 SETUP_GALAXY_FOR_METADATA = """
 [ "$GALAXY_VIRTUAL_ENV" = "None" ] && GALAXY_VIRTUAL_ENV="$_GALAXY_VIRTUAL_ENV"; _galaxy_setup_environment True
 """
@@ -253,8 +252,6 @@ class CommandsBuilder(object):
             self.append_command(CAPTURE_RETURN_CODE)
 
     def build(self):
-        if self.return_code_captured:
-            self.append_command(YIELD_CAPTURED_CODE)
         return self.commands
 
 

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -37,5 +37,7 @@ cd $working_directory
 $memory_statement
 $instrument_pre_commands
 $command
-echo $? > $exit_code_path
+echo $return_code > $exit_code_path
 $instrument_post_commands
+# exit with the exit code captured for the tool_script
+sh -c "exit $return_code"

--- a/lib/galaxy/jobs/runners/util/job_script/__init__.py
+++ b/lib/galaxy/jobs/runners/util/job_script/__init__.py
@@ -67,7 +67,7 @@ def job_script(template=DEFAULT_JOB_FILE_TEMPLATE, **kwds):
     >>> script = job_script(working_directory='wd', command='uptime', exit_code_path='ec')
     >>> '\\nuptime\\n' in script
     True
-    >>> 'echo $? > ec' in script
+    >>> 'echo $return_code > ec' in script
     True
     >>> 'GALAXY_LIB="None"' in script
     True

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -32,49 +32,49 @@ class TestCommandFactory(TestCase):
 
     def test_simplest_command(self):
         self.include_work_dir_outputs = False
-        self.__assert_command_is(_surrond_command(MOCK_COMMAND_LINE + "; return_code=$?"))
+        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"))
 
     def test_shell_commands(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surrond_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)))
+        self.__assert_command_is(_surround_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)))
 
     def test_shell_commands_external(self):
         self.job_wrapper.commands_in_new_shell = True
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surrond_command("%s/tool_script.sh; return_code=$?" % self.job_wrapper.working_directory))
+        self.__assert_command_is(_surround_command("%s/tool_script.sh; return_code=$?" % self.job_wrapper.working_directory))
         self.__assert_tool_script_is("#!/bin/sh\n%s; %s" % (dep_commands[0], MOCK_COMMAND_LINE))
 
     def test_remote_dependency_resolution(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surrond_command(MOCK_COMMAND_LINE + "; return_code=$?"), remote_command_params=dict(dependency_resolution="remote"))
+        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"), remote_command_params=dict(dependency_resolution="remote"))
 
     def test_explicit_local_dependency_resolution(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surrond_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)),
+        self.__assert_command_is(_surround_command("%s; %s; return_code=$?" % (dep_commands[0], MOCK_COMMAND_LINE)),
                                  remote_command_params=dict(dependency_resolution="local"))
 
     def test_task_prepare_inputs(self):
         self.include_work_dir_outputs = False
         self.job_wrapper.prepare_input_files_cmds = ["/opt/split1", "/opt/split2"]
-        self.__assert_command_is(_surrond_command("/opt/split1; /opt/split2; %s; return_code=$?") % MOCK_COMMAND_LINE)
+        self.__assert_command_is(_surround_command("/opt/split1; /opt/split2; %s; return_code=$?") % MOCK_COMMAND_LINE)
 
     def test_workdir_outputs(self):
         self.include_work_dir_outputs = True
         self.workdir_outputs = [("foo", "bar")]
-        self.__assert_command_is(_surrond_command('%s; return_code=$?; if [ -f foo ] ; then cp foo bar ; fi' % MOCK_COMMAND_LINE))
+        self.__assert_command_is(_surround_command('%s; return_code=$?; if [ -f foo ] ; then cp foo bar ; fi' % MOCK_COMMAND_LINE))
 
     def test_set_metadata_skipped_if_unneeded(self):
         self.include_metadata = True
         self.include_work_dir_outputs = False
-        self.__assert_command_is(_surrond_command(MOCK_COMMAND_LINE + "; return_code=$?"))
+        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"))
 
     def test_set_metadata(self):
         self._test_set_metadata()
@@ -87,7 +87,7 @@ class TestCommandFactory(TestCase):
         self.include_metadata = True
         self.include_work_dir_outputs = False
         self.job_wrapper.metadata_line = TEST_METADATA_LINE
-        expected_command = _surrond_command("%s; return_code=$?; cd '%s'; %s%s" % (MOCK_COMMAND_LINE, self.job_dir, SETUP_GALAXY_FOR_METADATA, TEST_METADATA_LINE))
+        expected_command = _surround_command("%s; return_code=$?; cd '%s'; %s%s" % (MOCK_COMMAND_LINE, self.job_dir, SETUP_GALAXY_FOR_METADATA, TEST_METADATA_LINE))
         self.__assert_command_is(expected_command)
 
     def test_empty_metadata(self):
@@ -98,7 +98,7 @@ class TestCommandFactory(TestCase):
         self.include_work_dir_outputs = False
         self.job_wrapper.metadata_line = ' '
         # Empty metadata command do not touch command line.
-        expected_command = _surrond_command("%s; return_code=$?; cd '%s'" % (MOCK_COMMAND_LINE, self.job_dir))
+        expected_command = _surround_command("%s; return_code=$?; cd '%s'" % (MOCK_COMMAND_LINE, self.job_dir))
         self.__assert_command_is(expected_command)
 
     def test_metadata_kwd_defaults(self):
@@ -152,8 +152,8 @@ class TestCommandFactory(TestCase):
         return build_command(**kwds)
 
 
-def _surrond_command(command):
-    return '''rm -rf working; mkdir -p working; cd working; %s; sh -c "exit $return_code"''' % command
+def _surround_command(command):
+    return '''rm -rf working; mkdir -p working; cd working; %s''' % command
 
 
 class MockJobWrapper(object):


### PR DESCRIPTION
Problem: Galaxy job scripts currently look like this:

```
...
JOB_WORKING_DIR/tool_script.sh; 
return_code=$?; 
...
sh -c "exit $return_code"
echo $? > JOB_WORKING_DIR/galaxy_JOBID.ec
date +"%s" > JOB_WORKING_DIR/__instrument_core_epoch_end
```

Since the `sh -c "exit $return_code"` is not the last command it has no effect (on the exit code of the job script) and the job_script returns the exit code of `date` (ie 0). More precisely the part 

```
sh -c "exit $return_code"
echo $? > JOB_WORKING_DIR/galaxy_6831.ec
```

has the same effect as `echo $return_code > JOB_WORKING_DIR/galaxy_JOBID.ec`

The problem then is that the job runner can not detect the potentially non-zero exit code of the tool script from the exit code of the job script. Job runners that get the exit code from galaxy_JOBID.ec are not affected, all others are, currently this is the univa job runner and it also seems that some cli runners are affected. So all features of those runners that depend of the runners ability to obtain the tool exit code don't work at the moment. 

My solution idea is to record the tool exit code always (should not hurt) and exit with the tool exit code... 

TODOs: 
- [ ] some code comments may need updates
