### PR TITLE
Correct code error in 'build job runner' tutorial

### DIFF
--- a/doc/source/dev/build_a_job_runner.rst
+++ b/doc/source/dev/build_a_job_runner.rst
@@ -120,10 +120,7 @@ B: Update the dictionary structure in kwargs.
 
 ::
 
-    if 'runner_param_specs' in kwargs:
-        kwargs['runner_param_specs'].update(runner_param_specs)
-    else:
-        kwargs['runner_param_specs'] = runner_param_specs
+    kwargs.update({'runner_param_specs': runner_param_specs})
 
 C: Now call the parent constructor to assign the values.
 

--- a/doc/source/dev/build_a_job_runner.rst
+++ b/doc/source/dev/build_a_job_runner.rst
@@ -120,7 +120,10 @@ B: Update the dictionary structure in kwargs.
 
 ::
 
-    kwargs['runner_param_specs'].update(runner_param_specs)
+    if 'runner_param_specs' in kwargs:
+        kwargs['runner_param_specs'].update(runner_param_specs)
+    else:
+        kwargs['runner_param_specs'] = runner_param_specs
 
 C: Now call the parent constructor to assign the values.
 


### PR DESCRIPTION
When  __init__ is called, **kwargs (most likely) will not contain
the 'runner_param_specs' key. And if so, calling update() on
kwargs['runner_param_specs'] will cause an error. Check if key exists,
then update or create.