### PR TITLE
added store library to exported libs in bundleEntries

### DIFF
--- a/client/galaxy/scripts/apps/extended.js
+++ b/client/galaxy/scripts/apps/extended.js
@@ -80,3 +80,6 @@ export function multiHistory(options) {
         multipanel.render(0);
     });
 }
+
+// Used in common.mako
+export { default as store } from "store";


### PR DESCRIPTION
window.bundleEntries is missing an npm resource in common.mako. This is just a localstorage wrapper, but it's used by common.mako in existing on-page scripting.