### PR TITLE
Follow-up on handling connectable and collapsible parameters in workflows

### DIFF
--- a/client/galaxy/scripts/mvc/form/form-data.js
+++ b/client/galaxy/scripts/mvc/form/form-data.js
@@ -12,7 +12,7 @@ export var Manager = Backbone.Model.extend({
             var id = $(this).attr("id");
             var field = self.app.field_list[id];
             if (field) {
-                sum += `${id}:${JSON.stringify(field.value && field.value())}:${field.collapsed};`;
+                sum += `${id}:${JSON.stringify(field.value && field.value())}:${field.collapsed}:${field.connected};`;
             }
         });
         return sum;
@@ -84,7 +84,7 @@ export var Manager = Backbone.Model.extend({
                             if (field && field.value) {
                                 value = field.value();
                                 if (input.ignore === undefined || input.ignore != value) {
-                                    if (field.collapsed && field.connected) {
+                                    if (field.connected) {
                                         value = { __class__: "ConnectedValue" };
                                     } else if (field.collapsed && input.collapsible_value) {
                                         value = input.collapsible_value;

--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -13,7 +13,7 @@ export default Backbone.View.extend({
                 text_enable: this.app_options.text_enable || "Enable",
                 text_disable: this.app_options.text_disable || "Disable",
                 text_connected_enable: this.app_options.text_connected_enable || "Add connection to module",
-                text_connected_disable: this.app_options.text_connected_disable || "Remove connection from model",
+                text_connected_disable: this.app_options.text_connected_disable || "Remove connection from module",
                 cls_enable: this.app_options.cls_enable || "fa fa-caret-square-o-down",
                 cls_disable: this.app_options.cls_disable || "fa fa-caret-square-o-up",
                 always_refresh: this.app_options.always_refresh

--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -141,8 +141,7 @@ export default Backbone.View.extend({
                     .tooltip("dispose")
                     .attr("data-original-title", this.model.get(`text_${collapsible_state}`))
                     .tooltip({ placement: "bottom" })
-                    .show()
-                    .tooltip("show");
+                    .show();
             } else {
                 this.$collapsible_icon.hide();
             }
@@ -158,8 +157,7 @@ export default Backbone.View.extend({
                     .tooltip("dispose")
                     .attr("data-original-title", this.model.get(`text_connected_${connected_collapsible_state}`))
                     .tooltip({ placement: "bottom" })
-                    .show()
-                    .tooltip("show");
+                    .show();
             } else {
                 this.$connected_icon.hide();
             }

--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -40,8 +40,7 @@ export default Backbone.View.extend({
         // decide wether to expand or collapse fields
         var collapsible_value = this.model.get("collapsible_value");
         var value = JSON.stringify(this.model.get("value"));
-        var connected = value == JSON.stringify({ __class__: "ConnectedValue" });
-        this.field.connected = !!connected;
+        this.field.connected = value == JSON.stringify({ __class__: "ConnectedValue" });
         this.field.collapsed =
             this.field.connected ||
             (collapsible_value !== undefined &&

--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -139,8 +139,10 @@ export default Backbone.View.extend({
                     .removeClass()
                     .addClass("icon ui-form-collapsible-icon")
                     .addClass(this.model.get(`cls_${collapsible_state}`))
+                    .tooltip("dispose")
                     .attr("data-original-title", this.model.get(`text_${collapsible_state}`))
                     .tooltip({ placement: "bottom" })
+                    .tooltip("show")
                     .show();
             } else {
                 this.$collapsible_icon.hide();
@@ -154,8 +156,10 @@ export default Backbone.View.extend({
                     .addClass("icon ui-form-connected-icon")
                     .addClass(connected_icon_style)
                     .addClass(connected_icon_margin)
+                    .tooltip("dispose")
                     .attr("data-original-title", this.model.get(`text_connected_${connected_collapsible_state}`))
                     .tooltip({ placement: "bottom" })
+                    .tooltip("show")
                     .show();
             } else {
                 this.$connected_icon.hide();

--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -124,11 +124,10 @@ export default Backbone.View.extend({
         // render collapsible options
         const connected = this.field.connected;
         const collapsible =
-            !connected &&
             !this.field.collapsible_disabled &&
             !this.model.get("disabled") &&
             this.model.get("collapsible_value") !== undefined;
-        const connectable = this.model.get("connectable");
+        const connectable = collapsible && this.model.get("connectable");
         if (collapsible || connectable) {
             var collapsible_state = this.field.collapsed ? "enable" : "disable";
             this.$title_text.hide();
@@ -142,14 +141,14 @@ export default Backbone.View.extend({
                     .tooltip("dispose")
                     .attr("data-original-title", this.model.get(`text_${collapsible_state}`))
                     .tooltip({ placement: "bottom" })
-                    .tooltip("show")
-                    .show();
+                    .show()
+                    .tooltip("show");
             } else {
                 this.$collapsible_icon.hide();
             }
             if (connectable) {
                 const connected_icon_style = this.field.connected ? "fa fa-times" : "fa fa-arrows-h";
-                const connected_icon_margin = collapsible ? "ml-1" : "";
+                const connected_icon_margin = !connected && collapsible ? "ml-1" : "";
                 const connected_collapsible_state = this.field.connected ? "disable" : "enable";
                 this.$connected_icon
                     .removeClass()
@@ -159,8 +158,8 @@ export default Backbone.View.extend({
                     .tooltip("dispose")
                     .attr("data-original-title", this.model.get(`text_connected_${connected_collapsible_state}`))
                     .tooltip({ placement: "bottom" })
-                    .tooltip("show")
-                    .show();
+                    .show()
+                    .tooltip("show");
             } else {
                 this.$connected_icon.hide();
             }

--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -12,6 +12,8 @@ export default Backbone.View.extend({
             new Backbone.Model({
                 text_enable: this.app_options.text_enable || "Enable",
                 text_disable: this.app_options.text_disable || "Disable",
+                text_connected_enable: this.app_options.text_connected_enable || "Add connection to module",
+                text_connected_disable: this.app_options.text_connected_disable || "Remove connection from model",
                 cls_enable: this.app_options.cls_enable || "fa fa-caret-square-o-down",
                 cls_disable: this.app_options.cls_disable || "fa fa-caret-square-o-up",
                 always_refresh: this.app_options.always_refresh
@@ -39,7 +41,7 @@ export default Backbone.View.extend({
         var collapsible_value = this.model.get("collapsible_value");
         var value = JSON.stringify(this.model.get("value"));
         var connected = value == JSON.stringify({ __class__: "ConnectedValue" });
-        this.field.connected = connected;
+        this.field.connected = !!connected;
         this.field.collapsed =
             this.field.connected ||
             (collapsible_value !== undefined &&
@@ -50,22 +52,14 @@ export default Backbone.View.extend({
         // add click handler
         var self = this;
         this.$collapsible_icon.on("click", () => {
-            if (self.field.connected) {
-                return;
-            }
             self.field.collapsed = !self.field.collapsed;
-            if (self.field.collapsed) {
-                self.field.connected = false;
-            }
+            self.field.connected = false;
             app.trigger && app.trigger("change");
             self.render();
         });
         this.$connected_icon.on("click", () => {
             self.field.connected = !self.field.connected;
             self.field.collapsed = self.field.connected;
-            if (!self.field.connected) {
-                this.model.set("value", null);
-            }
             app.trigger && app.trigger("change");
             self.render();
         });
@@ -152,12 +146,15 @@ export default Backbone.View.extend({
                 this.$collapsible_icon.hide();
             }
             if (connectable) {
-                const connectedIconStyle = this.field.connected ? "fa fa-times" : "fa fa-arrows-h";
+                const connected_icon_style = this.field.connected ? "fa fa-times" : "fa fa-arrows-h";
+                const connected_icon_margin = collapsible ? "ml-1" : "";
+                const connected_collapsible_state = this.field.connected ? "disable" : "enable";
                 this.$connected_icon
                     .removeClass()
                     .addClass("icon ui-form-connected-icon")
-                    .addClass(connectedIconStyle)
-                    .attr("data-original-title", this.model.get(`text_${collapsible_state}`))
+                    .addClass(connected_icon_style)
+                    .addClass(connected_icon_margin)
+                    .attr("data-original-title", this.model.get(`text_connected_${connected_collapsible_state}`))
                     .tooltip({ placement: "bottom" })
                     .show();
             } else {
@@ -186,7 +183,7 @@ export default Backbone.View.extend({
                             .addClass("ui-form-collapsible")
                             .append($("<i/>").addClass("ui-form-collapsible-icon"))
                             .append($("<i/>").addClass("ui-form-connected-icon"))
-                            .append($("<span/>").addClass("ui-form-collapsible-text"))
+                            .append($("<span/>").addClass("ui-form-collapsible-text ml-1"))
                     )
                     .append($("<span/>").addClass("ui-form-title-text"))
             )

--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -134,7 +134,6 @@ $ui-margin-horizontal-large: $margin-v * 2;
             .icon {
                 cursor: pointer;
                 font-size: 1.2em;
-                width: 20px;
                 position: relative;
                 top: 1px;
             }

--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -131,8 +131,8 @@ $ui-margin-horizontal-large: $margin-v * 2;
         word-wrap: break-word;
         font-weight: bold;
         .ui-form-collapsible {
-            cursor: pointer;
             .icon {
+                cursor: pointer;
                 font-size: 1.2em;
                 width: 20px;
                 position: relative;


### PR DESCRIPTION
Connecting basic input parameters in the workflow editor is an awesome feature. Thanks a lot for adding it @jmchilton. This PR fixes a few remaining issues with the handling of connected and collapsible value options in the workflow editor. Currently connected values are not always updated after a click i.e. the terminal is not added to the module if the value was collapsed before. This required to re-click the option, to uncollapse and then re-trigger the connection request. This PR resolves this by fixing the refresh trigger and yielding priority to the connected option over the collapsible option i.e. if a parameter is connected it is connected regardless of it's prior collapsible state. Another addition ensures that only collapsible values can be connected. This avoids that e.g. data parameters are shown with a connectable option although they are always connected. Additionally, this PR fixes the tooltips which currently have two issues. They do not contain the correct text and they disappear after an option is selected. The latter being an issue of the BS4 update. Finally the pointer cursor is removed from the title text since it is not clickable anymore and margins are added between the option icons.