### PR TITLE
Allow storing objects in the object store by UUID.

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -530,6 +530,11 @@ galaxy:
   # it overrides any other objectstore settings.
   #object_store_config_file: config/object_store_conf.xml
 
+  # What Dataset attribute is used to reference files in an ObjectStore
+  # implementation, default is 'id' but can also be set to 'uuid' for
+  # more de-centralized usage.
+  #object_store_store_by: id
+
   # Galaxy sends mail for various things: subscribing users to the
   # mailing list if they request it, password resets, reporting dataset
   # errors, and sending activation emails. To do this, it needs to send

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -949,6 +949,18 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~
+``object_store_store_by``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    What Dataset attribute is used to reference files in an
+    ObjectStore implementation, default is 'id' but can also be set to
+    'uuid' for more de-centralized usage.
+:Default: ``id``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~
 ``smtp_server``
 ~~~~~~~~~~~~~~~

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -537,6 +537,8 @@ class Configuration(object):
         self.object_store = kwargs.get('object_store', 'disk')
         self.object_store_check_old_style = string_as_bool(kwargs.get('object_store_check_old_style', False))
         self.object_store_cache_path = resolve_path(kwargs.get("object_store_cache_path", "database/object_store_cache"), self.root)
+        self.object_store_store_by = kwargs.get("object_store_store_by", "id")
+
         # Handle AWS-specific config options for backward compatibility
         if kwargs.get('aws_access_key', None) is not None:
             self.os_access_key = kwargs.get('aws_access_key', None)

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -90,7 +90,7 @@ class AzureBlobObjectStore(ObjectStore):
     store_type = 'azure_blob'
 
     def __init__(self, config, config_dict):
-        super(AzureBlobObjectStore, self).__init__(config)
+        super(AzureBlobObjectStore, self).__init__(config, config_dict)
 
         self.transfer_progress = 0
 
@@ -106,10 +106,6 @@ class AzureBlobObjectStore(ObjectStore):
 
         self.cache_size = cache_dict.get('size', -1)
         self.staging_path = cache_dict.get('path') or self.config.object_store_cache_path
-
-        extra_dirs = dict(
-            (e['type'], e['path']) for e in config_dict.get('extra_dirs', []))
-        self.extra_dirs.update(extra_dirs)
 
         self._initialize()
 

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -44,7 +44,7 @@ class Cloud(ObjectStore, CloudConfigMixin):
     store_type = 'cloud'
 
     def __init__(self, config, config_dict):
-        super(Cloud, self).__init__(config)
+        super(Cloud, self).__init__(config, config_dict)
         self.transfer_progress = 0
 
         auth_dict = config_dict['auth']
@@ -67,10 +67,6 @@ class Cloud(ObjectStore, CloudConfigMixin):
 
         self.cache_size = cache_dict.get('size', -1)
         self.staging_path = cache_dict.get('path') or self.config.object_store_cache_path
-
-        extra_dirs = dict(
-            (e['type'], e['path']) for e in config_dict.get('extra_dirs', []))
-        self.extra_dirs.update(extra_dirs)
 
         self._initialize()
 

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -87,16 +87,12 @@ class PithosObjectStore(ObjectStore):
     store_type = 'pithos'
 
     def __init__(self, config, config_dict):
-        super(PithosObjectStore, self).__init__(config)
+        super(PithosObjectStore, self).__init__(config, config_dict)
         self.staging_path = self.config.file_path
         log.info('Parse config_xml for pithos object store')
         self.config_dict = config_dict
         log.debug(self.config_dict)
 
-        log.info('Define extra_dirs')
-        extra_dirs = dict(
-            (e['type'], e['path']) for e in config_dict.get('extra_dirs', []))
-        self.extra_dirs.update(extra_dirs)
         self._initialize()
 
     def _initialize(self):

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -725,6 +725,14 @@ mapping:
           Configuration file for the object store
           If this is set and exists, it overrides any other objectstore settings.
 
+      object_store_store_by:
+        type: str
+        default: id
+        required: false
+        desc: |
+          What Dataset attribute is used to reference files in an ObjectStore implementation,
+          default is 'id' but can also be set to 'uuid' for more de-centralized usage.
+
       smtp_server:
         type: str
         default: ''


### PR DESCRIPTION
This is the most obvious way to allow creating new datasets during a job creation or finish context without a database available (see #7050 / #7058 for some context).

I'm working on the job completion context first here and in this context the fixed known outputs will have database IDs but other datasets such as discovered primary datasets and dynamic collection contents will not have IDs. So if the job or Pulsar or whatever is going to write these datasets to the object store they need to be keyed on something other than ID (at least initially).

This PR builds on #7110.