### PR TITLE
Cleanup, test, and fix metadata collection code.

### DIFF
--- a/lib/galaxy/datatypes/metadata.py
+++ b/lib/galaxy/datatypes/metadata.py
@@ -11,7 +11,6 @@ from galaxy.model.metadata import (
     DBKeyParameter,
     DictParameter,
     FileParameter,
-    JobExternalOutputMetadataWrapper,
     ListParameter,
     MetadataCollection,
     MetadataElement,
@@ -42,5 +41,4 @@ __all__ = (
     "PythonObjectParameter",
     "FileParameter",
     "MetadataTempFile",
-    "JobExternalOutputMetadataWrapper",
 )

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -24,11 +24,12 @@ from pulsar.client.staging import COMMAND_VERSION_FILENAME
 
 import galaxy
 from galaxy import model, util
-from galaxy.datatypes import metadata, sniff
+from galaxy.datatypes import sniff
 from galaxy.exceptions import ObjectInvalid, ObjectNotFound
 from galaxy.jobs.actions.post import ActionBox
 from galaxy.jobs.mapper import JobRunnerMapper
 from galaxy.jobs.runners import BaseJobRunner, JobState
+from galaxy.metadata import get_metadata_compute_strategy
 from galaxy.objectstore import ObjectStorePopulator
 from galaxy.util import safe_makedirs, unicodify
 from galaxy.util.bunch import Bunch
@@ -702,7 +703,7 @@ class JobWrapper(HasResourceParameters):
         self.output_hdas_and_paths = None
         self.tool_provided_job_metadata = None
         # Wrapper holding the info required to restore and clean up from files used for setting metadata externally
-        self.external_output_metadata = metadata.JobExternalOutputMetadataWrapper(job)
+        self.external_output_metadata = get_metadata_compute_strategy(self.app, job.id)
         self.job_runner_mapper = JobRunnerMapper(self, queue.dispatcher.url_to_destination, self.app.job_config)
         self.params = None
         if job.params:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1363,23 +1363,7 @@ class JobWrapper(HasResourceParameters):
                             not self.external_output_metadata.external_metadata_set_successfully(dataset, self.sa_session)):
                         dataset._state = model.Dataset.states.FAILED_METADATA
                     else:
-                        # load metadata from file
-                        # we need to no longer allow metadata to be edited while the job is still running,
-                        # since if it is edited, the metadata changed on the running output will no longer match
-                        # the metadata that was stored to disk for use via the external process,
-                        # and the changes made by the user will be lost, without warning or notice
-                        output_filename = self.external_output_metadata.get_output_filenames_by_dataset(dataset, self.sa_session).filename_out
-
-                        def path_rewriter(path):
-                            if not path:
-                                return path
-                            normalized_remote_metadata_directory = remote_metadata_directory and os.path.normpath(remote_metadata_directory)
-                            normalized_path = os.path.normpath(path)
-                            if remote_metadata_directory and normalized_path.startswith(normalized_remote_metadata_directory):
-                                return normalized_path.replace(normalized_remote_metadata_directory, self.working_directory, 1)
-                            return path
-
-                        dataset.metadata.from_JSON_dict(output_filename, path_rewriter=path_rewriter)
+                        self.external_output_metadata.load_metadata(dataset, dataset_assoc.name, self.sa_session, working_directory=self.working_directory, remote_metadata_directory=remote_metadata_directory)
                     line_count = context.get('line_count', None)
                     try:
                         # Certain datatype's set_peek methods contain a line_count argument

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1752,9 +1752,14 @@ class JobWrapper(HasResourceParameters):
         if datatypes_config is None:
             datatypes_config = os.path.join(self.working_directory, 'registry.xml')
             self.app.datatypes_registry.to_xml_file(path=datatypes_config)
-        command = self.external_output_metadata.setup_external_metadata([output_dataset_assoc.dataset for
-                                                                         output_dataset_assoc in
-                                                                         job.output_datasets + job.output_library_datasets],
+
+        output_datasets = {}
+        for output_dataset_assoc in job.output_datasets + job.output_library_datasets:
+            output_name = output_dataset_assoc.name
+            assert output_name not in output_datasets
+            output_datasets[output_dataset_assoc.name] = output_dataset_assoc.dataset
+
+        command = self.external_output_metadata.setup_external_metadata(output_datasets,
                                                                         self.sa_session,
                                                                         exec_dir=exec_dir,
                                                                         tmp_dir=tmp_dir,

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -1,0 +1,216 @@
+"""Define abstraction for capturing the metadata of job's output datasets."""
+
+import json
+import os
+import shutil
+import tempfile
+from logging import getLogger
+from os.path import abspath
+
+from six.moves import cPickle
+
+import galaxy.model
+from galaxy.model.metadata import FileParameter, MetadataTempFile
+from galaxy.util import in_directory
+
+log = getLogger(__name__)
+
+
+def get_metadata_compute_strategy(app, job_id):
+    return JobExternalOutputMetadataWrapper(job_id)
+
+
+class JobExternalOutputMetadataWrapper(object):
+    """
+    Class with methods allowing set_meta() to be called externally to the
+    Galaxy head.
+    This class allows access to external metadata filenames for all outputs
+    associated with a job.
+    We will use JSON as the medium of exchange of information, except for the
+    DatasetInstance object which will use pickle (in the future this could be
+    JSONified as well)
+    """
+
+    def __init__(self, job_id):
+        self.job_id = job_id
+
+    def get_output_filenames_by_dataset(self, dataset, sa_session):
+        if isinstance(dataset, galaxy.model.HistoryDatasetAssociation):
+            return sa_session.query(galaxy.model.JobExternalOutputMetadata) \
+                             .filter_by(job_id=self.job_id,
+                                        history_dataset_association_id=dataset.id,
+                                        is_valid=True) \
+                             .first()  # there should only be one or None
+        elif isinstance(dataset, galaxy.model.LibraryDatasetDatasetAssociation):
+            return sa_session.query(galaxy.model.JobExternalOutputMetadata) \
+                             .filter_by(job_id=self.job_id,
+                                        library_dataset_dataset_association_id=dataset.id,
+                                        is_valid=True) \
+                             .first()  # there should only be one or None
+        return None
+
+    def get_dataset_metadata_key(self, dataset):
+        # Set meta can be called on library items and history items,
+        # need to make different keys for them, since ids can overlap
+        return "%s_%d" % (dataset.__class__.__name__, dataset.id)
+
+    def invalidate_external_metadata(self, datasets, sa_session):
+        for dataset in datasets:
+            jeom = self.get_output_filenames_by_dataset(dataset, sa_session)
+            # shouldn't be more than one valid, but you never know
+            while jeom:
+                jeom.is_valid = False
+                sa_session.add(jeom)
+                sa_session.flush()
+                jeom = self.get_output_filenames_by_dataset(dataset, sa_session)
+
+    def setup_external_metadata(self, datasets, sa_session, exec_dir=None,
+                                tmp_dir=None, dataset_files_path=None,
+                                output_fnames=None, config_root=None,
+                                config_file=None, datatypes_config=None,
+                                job_metadata=None, compute_tmp_dir=None,
+                                include_command=True, max_metadata_value_size=0,
+                                kwds=None):
+        kwds = kwds or {}
+        assert tmp_dir is not None
+
+        if not os.path.exists(tmp_dir):
+            os.makedirs(tmp_dir)
+
+        # path is calculated for Galaxy, may be different on compute - rewrite
+        # for the compute server.
+        def metadata_path_on_compute(path):
+            compute_path = path
+            if compute_tmp_dir and tmp_dir and in_directory(path, tmp_dir):
+                path_relative = os.path.relpath(path, tmp_dir)
+                compute_path = os.path.join(compute_tmp_dir, path_relative)
+            return compute_path
+
+        # fill in metadata_files_dict and return the command with args required to set metadata
+        def __metadata_files_list_to_cmd_line(metadata_files):
+            def __get_filename_override():
+                if output_fnames:
+                    for dataset_path in output_fnames:
+                        if dataset_path.real_path == metadata_files.dataset.file_name:
+                            return dataset_path.false_path or dataset_path.real_path
+                return ""
+            line = '"%s,%s,%s,%s,%s,%s"' % (
+                metadata_path_on_compute(metadata_files.filename_in),
+                metadata_path_on_compute(metadata_files.filename_kwds),
+                metadata_path_on_compute(metadata_files.filename_out),
+                metadata_path_on_compute(metadata_files.filename_results_code),
+                __get_filename_override(),
+                metadata_path_on_compute(metadata_files.filename_override_metadata),
+            )
+            return line
+        if not isinstance(datasets, list):
+            datasets = [datasets]
+        if exec_dir is None:
+            exec_dir = os.path.abspath(os.getcwd())
+        if dataset_files_path is None:
+            dataset_files_path = galaxy.model.Dataset.file_path
+        if config_root is None:
+            config_root = os.path.abspath(os.getcwd())
+        if datatypes_config is None:
+            raise Exception('In setup_external_metadata, the received datatypes_config is None.')
+        metadata_files_list = []
+        for dataset in datasets:
+            key = self.get_dataset_metadata_key(dataset)
+            # future note:
+            # wonkiness in job execution causes build command line to be called more than once
+            # when setting metadata externally, via 'auto-detect' button in edit attributes, etc.,
+            # we don't want to overwrite (losing the ability to cleanup) our existing dataset keys and files,
+            # so we will only populate the dictionary once
+            metadata_files = self.get_output_filenames_by_dataset(dataset, sa_session)
+            if not metadata_files:
+                job = sa_session.query(galaxy.model.Job).get(self.job_id)
+                metadata_files = galaxy.model.JobExternalOutputMetadata(job=job, dataset=dataset)
+                # we are using tempfile to create unique filenames, tempfile always returns an absolute path
+                # we will use pathnames relative to the galaxy root, to accommodate instances where the galaxy root
+                # is located differently, i.e. on a cluster node with a different filesystem structure
+
+                # file to store existing dataset
+                metadata_files.filename_in = abspath(tempfile.NamedTemporaryFile(dir=tmp_dir, prefix="metadata_in_%s_" % key).name)
+
+                # FIXME: HACK
+                # sqlalchemy introduced 'expire_on_commit' flag for sessionmaker at version 0.5x
+                # This may be causing the dataset attribute of the dataset_association object to no-longer be loaded into memory when needed for pickling.
+                # For now, we'll simply 'touch' dataset_association.dataset to force it back into memory.
+                dataset.dataset  # force dataset_association.dataset to be loaded before pickling
+                # A better fix could be setting 'expire_on_commit=False' on the session, or modifying where commits occur, or ?
+
+                # Touch also deferred column
+                dataset._metadata
+
+                cPickle.dump(dataset, open(metadata_files.filename_in, 'wb+'))
+                # file to store metadata results of set_meta()
+                metadata_files.filename_out = abspath(tempfile.NamedTemporaryFile(dir=tmp_dir, prefix="metadata_out_%s_" % key).name)
+                open(metadata_files.filename_out, 'wt+')  # create the file on disk, so it cannot be reused by tempfile (unlikely, but possible)
+                # file to store a 'return code' indicating the results of the set_meta() call
+                # results code is like (True/False - if setting metadata was successful/failed , exception or string of reason of success/failure )
+                metadata_files.filename_results_code = abspath(tempfile.NamedTemporaryFile(dir=tmp_dir, prefix="metadata_results_%s_" % key).name)
+                # create the file on disk, so it cannot be reused by tempfile (unlikely, but possible)
+                json.dump((False, 'External set_meta() not called'), open(metadata_files.filename_results_code, 'wt+'))
+                # file to store kwds passed to set_meta()
+                metadata_files.filename_kwds = abspath(tempfile.NamedTemporaryFile(dir=tmp_dir, prefix="metadata_kwds_%s_" % key).name)
+                json.dump(kwds, open(metadata_files.filename_kwds, 'wt+'), ensure_ascii=True)
+                # existing metadata file parameters need to be overridden with cluster-writable file locations
+                metadata_files.filename_override_metadata = abspath(tempfile.NamedTemporaryFile(dir=tmp_dir, prefix="metadata_override_%s_" % key).name)
+                open(metadata_files.filename_override_metadata, 'wt+')  # create the file on disk, so it cannot be reused by tempfile (unlikely, but possible)
+                override_metadata = []
+                for meta_key, spec_value in dataset.metadata.spec.items():
+                    if isinstance(spec_value.param, FileParameter) and dataset.metadata.get(meta_key, None) is not None:
+                        metadata_temp = MetadataTempFile()
+                        metadata_temp.tmp_dir = tmp_dir
+                        shutil.copy(dataset.metadata.get(meta_key, None).file_name, metadata_temp.file_name)
+                        override_metadata.append((meta_key, metadata_temp.to_JSON()))
+                json.dump(override_metadata, open(metadata_files.filename_override_metadata, 'wt+'))
+                # add to session and flush
+                sa_session.add(metadata_files)
+                sa_session.flush()
+            metadata_files_list.append(metadata_files)
+        args = '"%s" "%s" %s %s' % (metadata_path_on_compute(datatypes_config),
+                                    job_metadata,
+                                    " ".join(map(__metadata_files_list_to_cmd_line, metadata_files_list)),
+                                    max_metadata_value_size)
+        if include_command:
+            # return command required to build
+            fd, fp = tempfile.mkstemp(suffix='.py', dir=tmp_dir, prefix="set_metadata_")
+            metadata_script_file = abspath(fp)
+            os.fdopen(fd, 'w').write('from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()')
+            return 'python "%s" %s' % (metadata_path_on_compute(metadata_script_file), args)
+        else:
+            # return args to galaxy_ext.metadata.set_metadata required to build
+            return args
+
+    def external_metadata_set_successfully(self, dataset, sa_session):
+        metadata_files = self.get_output_filenames_by_dataset(dataset, sa_session)
+        if not metadata_files:
+            return False  # this file doesn't exist
+        rval, rstring = json.load(open(metadata_files.filename_results_code))
+        if not rval:
+            log.debug('setting metadata externally failed for %s %s: %s' % (dataset.__class__.__name__, dataset.id, rstring))
+        return rval
+
+    def cleanup_external_metadata(self, sa_session):
+        log.debug('Cleaning up external metadata files')
+        for metadata_files in sa_session.query(galaxy.model.Job).get(self.job_id).external_output_metadata:
+            # we need to confirm that any MetadataTempFile files were removed, if not we need to remove them
+            # can occur if the job was stopped before completion, but a MetadataTempFile is used in the set_meta
+            MetadataTempFile.cleanup_from_JSON_dict_filename(metadata_files.filename_out)
+            dataset_key = self.get_dataset_metadata_key(metadata_files.dataset)
+            for key, fname in [('filename_in', metadata_files.filename_in),
+                               ('filename_out', metadata_files.filename_out),
+                               ('filename_results_code', metadata_files.filename_results_code),
+                               ('filename_kwds', metadata_files.filename_kwds),
+                               ('filename_override_metadata', metadata_files.filename_override_metadata)]:
+                try:
+                    os.remove(fname)
+                except Exception as e:
+                    log.debug('Failed to cleanup external metadata file (%s) for %s: %s' % (key, dataset_key, e))
+
+    def set_job_runner_external_pid(self, pid, sa_session):
+        for metadata_files in sa_session.query(galaxy.model.Job).get(self.job_id).external_output_metadata:
+            metadata_files.job_runner_external_pid = pid
+            sa_session.add(metadata_files)
+            sa_session.flush()

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -38,7 +38,7 @@ class MetadataCollectionStrategy(object):
         pass
 
     @abc.abstractmethod
-    def setup_external_metadata(self, datasets, sa_session, exec_dir=None,
+    def setup_external_metadata(self, datasets_dict, sa_session, exec_dir=None,
                                 tmp_dir=None, dataset_files_path=None,
                                 output_fnames=None, config_root=None,
                                 config_file=None, datatypes_config=None,
@@ -104,7 +104,7 @@ class JobExternalOutputMetadataWrapper(MetadataCollectionStrategy):
                 sa_session.flush()
                 jeom = self._get_output_filenames_by_dataset(dataset, sa_session)
 
-    def setup_external_metadata(self, datasets, sa_session, exec_dir=None,
+    def setup_external_metadata(self, datasets_dict, sa_session, exec_dir=None,
                                 tmp_dir=None, dataset_files_path=None,
                                 output_fnames=None, config_root=None,
                                 config_file=None, datatypes_config=None,
@@ -143,8 +143,8 @@ class JobExternalOutputMetadataWrapper(MetadataCollectionStrategy):
                 metadata_path_on_compute(metadata_files.filename_override_metadata),
             )
             return line
-        if not isinstance(datasets, list):
-            datasets = [datasets]
+
+        datasets = list(datasets_dict.values())
         if exec_dir is None:
             exec_dir = os.path.abspath(os.getcwd())
         if dataset_files_path is None:

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -49,7 +49,7 @@ class JobExternalOutputMetadataWrapper(object):
                              .first()  # there should only be one or None
         return None
 
-    def get_dataset_metadata_key(self, dataset):
+    def _get_dataset_metadata_key(self, dataset):
         # Set meta can be called on library items and history items,
         # need to make different keys for them, since ids can overlap
         return "%s_%d" % (dataset.__class__.__name__, dataset.id)
@@ -115,7 +115,7 @@ class JobExternalOutputMetadataWrapper(object):
             raise Exception('In setup_external_metadata, the received datatypes_config is None.')
         metadata_files_list = []
         for dataset in datasets:
-            key = self.get_dataset_metadata_key(dataset)
+            key = self._get_dataset_metadata_key(dataset)
             # future note:
             # wonkiness in job execution causes build command line to be called more than once
             # when setting metadata externally, via 'auto-detect' button in edit attributes, etc.,
@@ -198,7 +198,7 @@ class JobExternalOutputMetadataWrapper(object):
             # we need to confirm that any MetadataTempFile files were removed, if not we need to remove them
             # can occur if the job was stopped before completion, but a MetadataTempFile is used in the set_meta
             MetadataTempFile.cleanup_from_JSON_dict_filename(metadata_files.filename_out)
-            dataset_key = self.get_dataset_metadata_key(metadata_files.dataset)
+            dataset_key = self._get_dataset_metadata_key(metadata_files.dataset)
             for key, fname in [('filename_in', metadata_files.filename_in),
                                ('filename_out', metadata_files.filename_out),
                                ('filename_results_code', metadata_files.filename_results_code),

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -14,11 +14,10 @@ import weakref
 from os.path import abspath
 
 from six import string_types
-from six.moves import cPickle
 from sqlalchemy.orm import object_session
 
 import galaxy.model
-from galaxy.util import (in_directory, listify, string_as_bool,
+from galaxy.util import (listify, string_as_bool,
                          stringify_dictionary_keys)
 from galaxy.util.json import safe_dumps
 from galaxy.util.object_wrapper import sanitize_lists_to_string
@@ -627,202 +626,6 @@ class MetadataTempFile(object):
             log.debug('Failed to cleanup MetadataTempFile temp files from %s: %s' % (filename, e))
 
 
-class JobExternalOutputMetadataWrapper(object):
-    """
-    Class with methods allowing set_meta() to be called externally to the
-    Galaxy head.
-    This class allows access to external metadata filenames for all outputs
-    associated with a job.
-    We will use JSON as the medium of exchange of information, except for the
-    DatasetInstance object which will use pickle (in the future this could be
-    JSONified as well)
-    """
-
-    def __init__(self, job):
-        self.job_id = job.id
-
-    def get_output_filenames_by_dataset(self, dataset, sa_session):
-        if isinstance(dataset, galaxy.model.HistoryDatasetAssociation):
-            return sa_session.query(galaxy.model.JobExternalOutputMetadata) \
-                             .filter_by(job_id=self.job_id,
-                                        history_dataset_association_id=dataset.id,
-                                        is_valid=True) \
-                             .first()  # there should only be one or None
-        elif isinstance(dataset, galaxy.model.LibraryDatasetDatasetAssociation):
-            return sa_session.query(galaxy.model.JobExternalOutputMetadata) \
-                             .filter_by(job_id=self.job_id,
-                                        library_dataset_dataset_association_id=dataset.id,
-                                        is_valid=True) \
-                             .first()  # there should only be one or None
-        return None
-
-    def get_dataset_metadata_key(self, dataset):
-        # Set meta can be called on library items and history items,
-        # need to make different keys for them, since ids can overlap
-        return "%s_%d" % (dataset.__class__.__name__, dataset.id)
-
-    def invalidate_external_metadata(self, datasets, sa_session):
-        for dataset in datasets:
-            jeom = self.get_output_filenames_by_dataset(dataset, sa_session)
-            # shouldn't be more than one valid, but you never know
-            while jeom:
-                jeom.is_valid = False
-                sa_session.add(jeom)
-                sa_session.flush()
-                jeom = self.get_output_filenames_by_dataset(dataset, sa_session)
-
-    def setup_external_metadata(self, datasets, sa_session, exec_dir=None,
-                                tmp_dir=None, dataset_files_path=None,
-                                output_fnames=None, config_root=None,
-                                config_file=None, datatypes_config=None,
-                                job_metadata=None, compute_tmp_dir=None,
-                                include_command=True, max_metadata_value_size=0,
-                                kwds=None):
-        kwds = kwds or {}
-        assert tmp_dir is not None
-
-        if not os.path.exists(tmp_dir):
-            os.makedirs(tmp_dir)
-
-        # path is calculated for Galaxy, may be different on compute - rewrite
-        # for the compute server.
-        def metadata_path_on_compute(path):
-            compute_path = path
-            if compute_tmp_dir and tmp_dir and in_directory(path, tmp_dir):
-                path_relative = os.path.relpath(path, tmp_dir)
-                compute_path = os.path.join(compute_tmp_dir, path_relative)
-            return compute_path
-
-        # fill in metadata_files_dict and return the command with args required to set metadata
-        def __metadata_files_list_to_cmd_line(metadata_files):
-            def __get_filename_override():
-                if output_fnames:
-                    for dataset_path in output_fnames:
-                        if dataset_path.real_path == metadata_files.dataset.file_name:
-                            return dataset_path.false_path or dataset_path.real_path
-                return ""
-            line = '"%s,%s,%s,%s,%s,%s"' % (
-                metadata_path_on_compute(metadata_files.filename_in),
-                metadata_path_on_compute(metadata_files.filename_kwds),
-                metadata_path_on_compute(metadata_files.filename_out),
-                metadata_path_on_compute(metadata_files.filename_results_code),
-                __get_filename_override(),
-                metadata_path_on_compute(metadata_files.filename_override_metadata),
-            )
-            return line
-        if not isinstance(datasets, list):
-            datasets = [datasets]
-        if exec_dir is None:
-            exec_dir = os.path.abspath(os.getcwd())
-        if dataset_files_path is None:
-            dataset_files_path = galaxy.model.Dataset.file_path
-        if config_root is None:
-            config_root = os.path.abspath(os.getcwd())
-        if datatypes_config is None:
-            raise Exception('In setup_external_metadata, the received datatypes_config is None.')
-        metadata_files_list = []
-        for dataset in datasets:
-            key = self.get_dataset_metadata_key(dataset)
-            # future note:
-            # wonkiness in job execution causes build command line to be called more than once
-            # when setting metadata externally, via 'auto-detect' button in edit attributes, etc.,
-            # we don't want to overwrite (losing the ability to cleanup) our existing dataset keys and files,
-            # so we will only populate the dictionary once
-            metadata_files = self.get_output_filenames_by_dataset(dataset, sa_session)
-            if not metadata_files:
-                job = sa_session.query(galaxy.model.Job).get(self.job_id)
-                metadata_files = galaxy.model.JobExternalOutputMetadata(job=job, dataset=dataset)
-                # we are using tempfile to create unique filenames, tempfile always returns an absolute path
-                # we will use pathnames relative to the galaxy root, to accommodate instances where the galaxy root
-                # is located differently, i.e. on a cluster node with a different filesystem structure
-
-                # file to store existing dataset
-                metadata_files.filename_in = abspath(tempfile.NamedTemporaryFile(dir=tmp_dir, prefix="metadata_in_%s_" % key).name)
-
-                # FIXME: HACK
-                # sqlalchemy introduced 'expire_on_commit' flag for sessionmaker at version 0.5x
-                # This may be causing the dataset attribute of the dataset_association object to no-longer be loaded into memory when needed for pickling.
-                # For now, we'll simply 'touch' dataset_association.dataset to force it back into memory.
-                dataset.dataset  # force dataset_association.dataset to be loaded before pickling
-                # A better fix could be setting 'expire_on_commit=False' on the session, or modifying where commits occur, or ?
-
-                # Touch also deferred column
-                dataset._metadata
-
-                cPickle.dump(dataset, open(metadata_files.filename_in, 'wb+'))
-                # file to store metadata results of set_meta()
-                metadata_files.filename_out = abspath(tempfile.NamedTemporaryFile(dir=tmp_dir, prefix="metadata_out_%s_" % key).name)
-                open(metadata_files.filename_out, 'wt+')  # create the file on disk, so it cannot be reused by tempfile (unlikely, but possible)
-                # file to store a 'return code' indicating the results of the set_meta() call
-                # results code is like (True/False - if setting metadata was successful/failed , exception or string of reason of success/failure )
-                metadata_files.filename_results_code = abspath(tempfile.NamedTemporaryFile(dir=tmp_dir, prefix="metadata_results_%s_" % key).name)
-                # create the file on disk, so it cannot be reused by tempfile (unlikely, but possible)
-                json.dump((False, 'External set_meta() not called'), open(metadata_files.filename_results_code, 'wt+'))
-                # file to store kwds passed to set_meta()
-                metadata_files.filename_kwds = abspath(tempfile.NamedTemporaryFile(dir=tmp_dir, prefix="metadata_kwds_%s_" % key).name)
-                json.dump(kwds, open(metadata_files.filename_kwds, 'wt+'), ensure_ascii=True)
-                # existing metadata file parameters need to be overridden with cluster-writable file locations
-                metadata_files.filename_override_metadata = abspath(tempfile.NamedTemporaryFile(dir=tmp_dir, prefix="metadata_override_%s_" % key).name)
-                open(metadata_files.filename_override_metadata, 'wt+')  # create the file on disk, so it cannot be reused by tempfile (unlikely, but possible)
-                override_metadata = []
-                for meta_key, spec_value in dataset.metadata.spec.items():
-                    if isinstance(spec_value.param, FileParameter) and dataset.metadata.get(meta_key, None) is not None:
-                        metadata_temp = MetadataTempFile()
-                        metadata_temp.tmp_dir = tmp_dir
-                        shutil.copy(dataset.metadata.get(meta_key, None).file_name, metadata_temp.file_name)
-                        override_metadata.append((meta_key, metadata_temp.to_JSON()))
-                json.dump(override_metadata, open(metadata_files.filename_override_metadata, 'wt+'))
-                # add to session and flush
-                sa_session.add(metadata_files)
-                sa_session.flush()
-            metadata_files_list.append(metadata_files)
-        args = '"%s" "%s" %s %s' % (metadata_path_on_compute(datatypes_config),
-                                    job_metadata,
-                                    " ".join(map(__metadata_files_list_to_cmd_line, metadata_files_list)),
-                                    max_metadata_value_size)
-        if include_command:
-            # return command required to build
-            fd, fp = tempfile.mkstemp(suffix='.py', dir=tmp_dir, prefix="set_metadata_")
-            metadata_script_file = abspath(fp)
-            os.fdopen(fd, 'w').write('from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()')
-            return 'python "%s" %s' % (metadata_path_on_compute(metadata_script_file), args)
-        else:
-            # return args to galaxy_ext.metadata.set_metadata required to build
-            return args
-
-    def external_metadata_set_successfully(self, dataset, sa_session):
-        metadata_files = self.get_output_filenames_by_dataset(dataset, sa_session)
-        if not metadata_files:
-            return False  # this file doesn't exist
-        rval, rstring = json.load(open(metadata_files.filename_results_code))
-        if not rval:
-            log.debug('setting metadata externally failed for %s %s: %s' % (dataset.__class__.__name__, dataset.id, rstring))
-        return rval
-
-    def cleanup_external_metadata(self, sa_session):
-        log.debug('Cleaning up external metadata files')
-        for metadata_files in sa_session.query(galaxy.model.Job).get(self.job_id).external_output_metadata:
-            # we need to confirm that any MetadataTempFile files were removed, if not we need to remove them
-            # can occur if the job was stopped before completion, but a MetadataTempFile is used in the set_meta
-            MetadataTempFile.cleanup_from_JSON_dict_filename(metadata_files.filename_out)
-            dataset_key = self.get_dataset_metadata_key(metadata_files.dataset)
-            for key, fname in [('filename_in', metadata_files.filename_in),
-                               ('filename_out', metadata_files.filename_out),
-                               ('filename_results_code', metadata_files.filename_results_code),
-                               ('filename_kwds', metadata_files.filename_kwds),
-                               ('filename_override_metadata', metadata_files.filename_override_metadata)]:
-                try:
-                    os.remove(fname)
-                except Exception as e:
-                    log.debug('Failed to cleanup external metadata file (%s) for %s: %s' % (key, dataset_key, e))
-
-    def set_job_runner_external_pid(self, pid, sa_session):
-        for metadata_files in sa_session.query(galaxy.model.Job).get(self.job_id).external_output_metadata:
-            metadata_files.job_runner_external_pid = pid
-            sa_session.add(metadata_files)
-            sa_session.flush()
-
-
 __all__ = (
     "Statement",
     "MetadataElement",
@@ -840,5 +643,4 @@ __all__ = (
     "PythonObjectParameter",
     "FileParameter",
     "MetadataTempFile",
-    "JobExternalOutputMetadataWrapper",
 )

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -25,9 +25,9 @@ from galaxy import (
     exceptions,
     model
 )
-from galaxy.datatypes.metadata import JobExternalOutputMetadataWrapper
 from galaxy.managers.jobs import JobSearch
 from galaxy.managers.tags import GalaxyTagManager
+from galaxy.metadata import get_metadata_compute_strategy
 from galaxy.queue_worker import send_control_task
 from galaxy.tools.actions import DefaultToolAction
 from galaxy.tools.actions.data_manager import DataManagerToolAction
@@ -2259,7 +2259,7 @@ class SetMetadataTool(Tool):
 
     def exec_after_process(self, app, inp_data, out_data, param_dict, job=None):
         for name, dataset in inp_data.items():
-            external_metadata = JobExternalOutputMetadataWrapper(job)
+            external_metadata = get_metadata_compute_strategy(app, job.id)
             if external_metadata.external_metadata_set_successfully(dataset, app.model.context):
                 dataset.metadata.from_JSON_dict(external_metadata.get_output_filenames_by_dataset(dataset, app.model.context).filename_out)
             else:

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -75,7 +75,10 @@ class SetMetadataToolAction(ToolAction):
         datatypes_config = os.path.join(job_working_dir, 'registry.xml')
         app.datatypes_registry.to_xml_file(path=datatypes_config)
         external_metadata_wrapper = get_metadata_compute_strategy(app, job.id)
-        cmd_line = external_metadata_wrapper.setup_external_metadata(dataset,
+        output_datatasets_dict = {
+            dataset_name: dataset,
+        }
+        cmd_line = external_metadata_wrapper.setup_external_metadata(output_datatasets_dict,
                                                                      sa_session,
                                                                      exec_dir=None,
                                                                      tmp_dir=job_working_dir,

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -2,8 +2,8 @@ import logging
 import os
 from json import dumps
 
-from galaxy.datatypes.metadata import JobExternalOutputMetadataWrapper
 from galaxy.jobs.datasets import DatasetPath
+from galaxy.metadata import get_metadata_compute_strategy
 from galaxy.util.odict import odict
 from . import ToolAction
 
@@ -74,7 +74,7 @@ class SetMetadataToolAction(ToolAction):
         job_working_dir = app.object_store.get_filename(job, base_dir='job_work', dir_only=True, extra_dir=str(job.id))
         datatypes_config = os.path.join(job_working_dir, 'registry.xml')
         app.datatypes_registry.to_xml_file(path=datatypes_config)
-        external_metadata_wrapper = JobExternalOutputMetadataWrapper(job)
+        external_metadata_wrapper = get_metadata_compute_strategy(app, job.id)
         cmd_line = external_metadata_wrapper.setup_external_metadata(dataset,
                                                                      sa_session,
                                                                      exec_dir=None,

--- a/lib/galaxy_ext/metadata/set_metadata.py
+++ b/lib/galaxy_ext/metadata/set_metadata.py
@@ -123,15 +123,15 @@ def set_metadata():
             dataset.dataset.external_filename = dataset_filename_override
             files_path = os.path.abspath(os.path.join(tool_job_working_directory, "dataset_%s_files" % (dataset.dataset.id)))
             dataset.dataset.external_extra_files_path = files_path
-            if dataset.dataset.id in existing_job_metadata_dict:
-                dataset.extension = existing_job_metadata_dict[dataset.dataset.id].get('ext', dataset.extension)
+            file_dict = existing_job_metadata_dict.get(dataset.dataset.id, {})
+            if 'ext' in file_dict:
+                dataset.extension = file_dict['ext']
             # Metadata FileParameter types may not be writable on a cluster node, and are therefore temporarily substituted with MetadataTempFiles
             override_metadata = json.load(open(override_metadata))
             for metadata_name, metadata_file_override in override_metadata:
                 if galaxy.datatypes.metadata.MetadataTempFile.is_JSONified_value(metadata_file_override):
                     metadata_file_override = galaxy.datatypes.metadata.MetadataTempFile.from_JSON(metadata_file_override)
                 setattr(dataset.metadata, metadata_name, metadata_file_override)
-            file_dict = existing_job_metadata_dict.get(dataset.dataset.id, {})
             set_meta_with_tool_provided(dataset, file_dict, set_meta_kwds, datatypes_registry, max_metadata_value_size)
             dataset.metadata.to_JSON_dict(filename_out)  # write out results of set_meta
             json.dump((True, 'Metadata has been set successfully'), open(filename_results_code, 'wt+'))  # setting metadata has succeeded

--- a/lib/galaxy_ext/metadata/set_metadata.py
+++ b/lib/galaxy_ext/metadata/set_metadata.py
@@ -103,7 +103,7 @@ def set_metadata():
             try:
                 line = stringify_dictionary_keys(json.loads(line))
                 if line['type'] == 'dataset':
-                    existing_job_metadata_dict[line['dataset_id']] = line
+                    existing_job_metadata_dict[int(line['dataset_id'])] = line
                 elif line['type'] == 'new_primary_dataset':
                     new_job_metadata_dict[line['filename']] = line
             except Exception:


### PR DESCRIPTION
There are a trio of important metadata commits in #7058 for #7050. One [rearranges set_metadata.py to use ToolProvidedMetadata instead of custom parsing of galaxy.json](https://github.com/galaxyproject/galaxy/commit/e7b188f61395210775c614d47446e6a9624378d0), one [introduces a new method of metadata generation that is portable and more robust](https://github.com/galaxyproject/galaxy/commit/1a73696652ce923780e93e7f9839b3919d2744ad), and one [extends this new method to capture much more of the job finish code as part of metadata collection](https://github.com/galaxyproject/galaxy/commit/33daa6a68c0ed86d49fcc7a8a7e9f1c03370e031).

This PR is refactors, introduce extension points and unit tests, and fixes bugs that set the stage for doing all of this confidently and cleanly in the that branch. I debated whether the a unit test for metadata collection was needed because it isn't very isolated - but given that I've already caught a bug that was covered up by job finish code handling metadata errors fairly robustly - I've been convinced this testing is very valuable despite the large suite of API/framework tests we have. The API/framework tests both mask metadata collection errors but also make it hard to debug metadata problems due to all the levels of indirection with these errors propagating back up through the job finish code and pytest test reporting.