### PR TITLE
Unprivileged remote tool tests

### DIFF
--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -28,7 +28,7 @@ def verify(
     output_content,
     attributes,
     filename=None,
-    get_filename=None,
+    get_filecontent=None,
     keep_outputs_dir=None,
     verify_extra_files=None,
 ):
@@ -36,8 +36,8 @@ def verify(
 
     Throw an informative assertion error if any of these tests fail.
     """
-    if get_filename is None:
-        get_filename = DEFAULT_TEST_DATA_RESOLVER.get_filename
+    if get_filecontent is None:
+        get_filecontent = DEFAULT_TEST_DATA_RESOLVER.get_filecontent
 
     # Check assertions...
     assertions = attributes.get("assert_list", None)
@@ -73,7 +73,10 @@ def verify(
         attributes = {}
 
     if filename is not None:
-        local_name = get_filename(filename)
+        file_content = get_filecontent(filename)
+        local_name = make_temp_fname(fname=filename)
+        with open(local_name, 'wb') as f:
+            f.write(file_content)
         temp_name = make_temp_fname(fname=filename)
         with open(temp_name, 'wb') as f:
             f.write(output_content)

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -31,6 +31,7 @@ def verify(
     get_filecontent=None,
     keep_outputs_dir=None,
     verify_extra_files=None,
+    mode='file',
 ):
     """Verify the content of a test output using test definitions described by attributes.
 
@@ -73,10 +74,15 @@ def verify(
         attributes = {}
 
     if filename is not None:
-        file_content = get_filecontent(filename)
-        local_name = make_temp_fname(fname=filename)
-        with open(local_name, 'wb') as f:
-            f.write(file_content)
+        if mode == 'directory':
+            # if verifying a file inside a extra_files_path directory
+            # filename already point to a file that exists on disk
+            local_name = filename
+        else:
+            file_content = get_filecontent(filename)
+            local_name = make_temp_fname(fname=filename)
+            with open(local_name, 'wb') as f:
+                f.write(file_content)
         temp_name = make_temp_fname(fname=filename)
         with open(temp_name, 'wb') as f:
             f.write(output_content)

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -4,6 +4,8 @@ from __future__ import print_function
 import os
 import re
 import sys
+import tarfile
+import tempfile
 import time
 from collections import OrderedDict
 from json import dumps
@@ -18,7 +20,11 @@ try:
     import requests
 except ImportError:
     requests = None
-from six import StringIO, text_type
+from six import (
+    BytesIO,
+    StringIO,
+    text_type,
+)
 
 from galaxy import util
 from galaxy.tools.parser.interface import TestCollectionDef, TestCollectionOutputDef
@@ -155,13 +161,13 @@ class GalaxyInteractorApi(object):
 
     def verify_output_dataset(self, history_id, hda_id, outfile, attributes, tool_id):
         fetcher = self.__dataset_fetcher(history_id)
-        test_data_path_builder = self.__test_data_path_builder(tool_id)
+        test_data_downloader = self.__test_data_downloader(tool_id)
         verify_hid(
             outfile,
             hda_id=hda_id,
             attributes=attributes,
             dataset_fetcher=fetcher,
-            test_data_path_builder=test_data_path_builder,
+            test_data_downloader=test_data_downloader,
             keep_outputs_dir=self.keep_outputs_dir
         )
         self._verify_metadata(history_id, hda_id, attributes)
@@ -251,10 +257,16 @@ class GalaxyInteractorApi(object):
         return history_json['id']
 
     @nottest
-    def test_data_path(self, tool_id, filename):
-        response = self._get("tools/%s/test_data_path?filename=%s" % (tool_id, filename), admin=True)
+    def test_data_download(self, tool_id, filename, mode='file'):
+        response = self._get("tools/%s/test_data_download?filename=%s" % (tool_id, filename), admin=True)
         assert response.status_code == 200
-        return response.json()
+        if mode == 'file':
+            return response.content
+        elif mode == 'directory':
+            path = tempfile.mkdtemp(prefix=filename)
+            with tarfile.open(BytesIO(response.content)) as tar_contents:
+                tar_contents.extractall(path=path)
+            return path
 
     def __output_id(self, output_data):
         # Allow data structure coming out of tools API - {id: <id>, output_name: <name>, etc...}
@@ -281,26 +293,22 @@ class GalaxyInteractorApi(object):
         if composite_data:
             files = {}
             for i, file_name in enumerate(composite_data):
-                file_name = self.test_data_path(tool_id, file_name)
-                files["files_%s|file_data" % i] = open(file_name, 'rb')
+                file_content = self.test_data_download(tool_id, file_name)
+                files["files_%s|file_data" % i] = file_content
                 tool_input.update({
                     "files_%d|type" % i: "upload_dataset",
                 })
             name = test_data['name']
         else:
-            file_name = self.test_data_path(tool_id, fname)
-            name = test_data.get('name', None)
-            if not name:
-                name = os.path.basename(file_name)
-
+            name = fname
+            file_content = self.test_data_download(tool_id, fname)
             tool_input.update({
                 "files_0|NAME": name,
                 "files_0|type": "upload_dataset",
+
             })
-            # TODO: Option to upload by path since we are getting the paths from Galaxy now it makes more
-            # sense to move this there.
             files = {
-                "files_0|file_data": open(file_name, 'rb')
+                "files_0|file_data": file_content,
             }
         submit_response_object = self.__submit_tool(history_id, "upload1", tool_input, extra_data={"type": "upload_dataset"}, files=files)
         if submit_response_object.status_code != 200:
@@ -536,8 +544,10 @@ class GalaxyInteractorApi(object):
             test_user = self._post('users', data, key=admin_key).json()
         return test_user
 
-    def __test_data_path_builder(self, tool_id):
-        return lambda filename: self.test_data_path(tool_id, filename)
+    def __test_data_downloader(self, tool_id):
+        def test_data_download(filename, mode='file'):
+            return self.test_data_download(tool_id, filename, mode=mode)
+        return test_data_download
 
     def __dataset_fetcher(self, history_id):
         def fetcher(hda_id, base_name=None):
@@ -596,11 +606,11 @@ class RunToolException(Exception):
 
 
 # Galaxy specific methods - rest of this can be used with arbitrary files and such.
-def verify_hid(filename, hda_id, attributes, test_data_path_builder, hid="", dataset_fetcher=None, keep_outputs_dir=False):
+def verify_hid(filename, hda_id, attributes, test_data_downloader, hid="", dataset_fetcher=None, keep_outputs_dir=False):
     assert dataset_fetcher is not None
 
     def verify_extra_files(extra_files):
-        _verify_extra_files_content(extra_files, hda_id, dataset_fetcher=dataset_fetcher, test_data_path_builder=test_data_path_builder, keep_outputs_dir=keep_outputs_dir)
+        _verify_extra_files_content(extra_files, hda_id, dataset_fetcher=dataset_fetcher, test_data_downloader=test_data_downloader, keep_outputs_dir=keep_outputs_dir)
 
     data = dataset_fetcher(hda_id)
     item_label = "History item %s" % hid
@@ -609,13 +619,13 @@ def verify_hid(filename, hda_id, attributes, test_data_path_builder, hid="", dat
         data,
         attributes=attributes,
         filename=filename,
-        get_filename=test_data_path_builder,
+        get_filecontent=test_data_downloader,
         keep_outputs_dir=keep_outputs_dir,
         verify_extra_files=verify_extra_files,
     )
 
 
-def _verify_composite_datatype_file_content(file_name, hda_id, base_name=None, attributes=None, dataset_fetcher=None, test_data_path_builder=None, keep_outputs_dir=False):
+def _verify_composite_datatype_file_content(file_name, hda_id, base_name=None, attributes=None, dataset_fetcher=None, test_data_downloader=None, keep_outputs_dir=False):
     assert dataset_fetcher is not None
 
     data = dataset_fetcher(hda_id, base_name)
@@ -626,7 +636,7 @@ def _verify_composite_datatype_file_content(file_name, hda_id, base_name=None, a
             data,
             attributes=attributes,
             filename=file_name,
-            get_filename=test_data_path_builder,
+            get_filecontent=test_data_downloader,
             keep_outputs_dir=keep_outputs_dir,
         )
     except AssertionError as err:
@@ -635,7 +645,7 @@ def _verify_composite_datatype_file_content(file_name, hda_id, base_name=None, a
         raise AssertionError(errmsg)
 
 
-def _verify_extra_files_content(extra_files, hda_id, dataset_fetcher, test_data_path_builder, keep_outputs_dir):
+def _verify_extra_files_content(extra_files, hda_id, dataset_fetcher, test_data_downloader, keep_outputs_dir):
     files_list = []
     for extra_file_dict in extra_files:
         extra_file_type = extra_file_dict["type"]
@@ -646,15 +656,17 @@ def _verify_extra_files_content(extra_files, hda_id, dataset_fetcher, test_data_
         if extra_file_type == 'file':
             files_list.append((extra_file_name, extra_file_value, extra_file_attributes))
         elif extra_file_type == 'directory':
-            for filename in os.listdir(test_data_path_builder(extra_file_value)):
+            for filename in os.listdir(test_data_downloader(extra_file_value, mode='directory')):
                 files_list.append((filename, os.path.join(extra_file_value, filename), extra_file_attributes))
         else:
             raise ValueError('unknown extra_files type: %s' % extra_file_type)
     for filename, filepath, attributes in files_list:
-        _verify_composite_datatype_file_content(filepath, hda_id, base_name=filename, attributes=attributes, dataset_fetcher=dataset_fetcher, test_data_path_builder=test_data_path_builder, keep_outputs_dir=keep_outputs_dir)
+        _verify_composite_datatype_file_content(filepath, hda_id, base_name=filename, attributes=attributes, dataset_fetcher=dataset_fetcher, test_data_downloader=test_data_downloader, keep_outputs_dir=keep_outputs_dir)
 
 
-def verify_tool(tool_id, galaxy_interactor, resource_parameters={}, register_job_data=None, test_index=0, tool_version=None, quiet=False):
+def verify_tool(tool_id, galaxy_interactor, resource_parameters=None, register_job_data=None, test_index=0, tool_version=None, quiet=False):
+    if resource_parameters is None:
+        resource_parameters = {}
     tool_test_dicts = galaxy_interactor.get_tool_tests(tool_id, tool_version=tool_version)
     tool_test_dict = tool_test_dicts[test_index]
     testdef = ToolTestDescription(tool_test_dict)

--- a/lib/galaxy/tools/verify/test_data.py
+++ b/lib/galaxy/tools/verify/test_data.py
@@ -43,9 +43,15 @@ class TestDataResolver(object):
             if not resolver.exists(name):
                 continue
             filename = resolver.path(name)
-
             if filename:
                 return os.path.abspath(filename)
+
+    def get_filecontent(self, name):
+        filename = self.get_filename(name=name)
+        return open(filename, mode='rb')
+
+    def get_directory(self, name):
+        return self.get_filename(name=name)
 
 
 def build_resolver(uri, environ):

--- a/lib/galaxy/util/streamball.py
+++ b/lib/galaxy/util/streamball.py
@@ -8,6 +8,7 @@ import os
 import tarfile
 
 from galaxy.exceptions import ObjectNotFound
+from .path import safe_walk
 
 log = logging.getLogger(__name__)
 
@@ -59,3 +60,23 @@ class ZipBall(object):
         except OSError:
             log.exception("Unable to remove temporary library download archive and directory")
         return []
+
+
+def stream_archive(trans, path, upstream_gzip=False):
+    archive_type_string = 'w|gz'
+    archive_ext = 'tgz'
+    if upstream_gzip:
+        archive_type_string = 'w|'
+        archive_ext = 'tar'
+    archive = StreamBall(mode=archive_type_string)
+    for root, directories, files in safe_walk(path):
+        for filename in files:
+            p = os.path.join(root, filename)
+            relpath = os.path.relpath(p, os.path.join(path, os.pardir))
+            archive.add(file=os.path.join(path, p), relpath=relpath)
+    archive_name = "%s.%s" % (os.path.basename(path), archive_ext)
+    trans.response.set_content_type("application/x-tar")
+    trans.response.headers["Content-Disposition"] = 'attachment; filename="{}"'.format(archive_name)
+    archive.wsgi_status = trans.response.wsgi_status()
+    archive.wsgi_headeritems = trans.response.wsgi_headeritems()
+    return archive.stream

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -146,23 +146,7 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
                 trans.response.headers["Content-Disposition"] = 'attachment; filename="%s"' % filename
                 return open(path, mode='rb')
             elif os.path.isdir(path):
-                archive_type_string = 'w|gz'
-                archive_ext = 'tgz'
-                if self.app.config.upstream_gzip:
-                    archive_type_string = 'w|'
-                    archive_ext = 'tar'
-                archive = util.streamball.StreamBall(mode=archive_type_string)
-                for root, directories, files in util.path.safe_walk(path):
-                    for file in files:
-                        p = os.path.join(root, file)
-                        relpath = os.path.relpath(p, os.path.join(path, os.pardir))
-                        archive.add(file=os.path.join(path, p), relpath=relpath)
-                archive_name = "%s.%s" % (path, archive_ext)
-                trans.response.set_content_type("application/x-tar")
-                trans.response.headers["Content-Disposition"] = 'attachment; filename="{}"'.format(archive_name)
-                archive.wsgi_status = trans.response.wsgi_status()
-                archive.wsgi_headeritems = trans.response.wsgi_headeritems()
-                return archive.stream
+                return util.streamball.stream_archive(trans=trans, path=path, upstream_gzip=self.app.config.upstream_gzip)
         raise exceptions.ObjectNotFound("Specified test data path not found.")
 
     @expose_api_anonymous_and_sessionless

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from json import dumps
 
 import galaxy.queue_worker
@@ -141,10 +142,28 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
             raise exceptions.ObjectNotFound("Test data filename not specified.")
         path = tool.test_data_path(filename)
         if path:
-            trans.response.headers["Content-Disposition"] = 'attachment; filename="%s"' % filename
-            return open(path, mode='rb')
-        else:
-            raise exceptions.ObjectNotFound("Specified test data path not found.")
+            if os.path.isfile(path):
+                trans.response.headers["Content-Disposition"] = 'attachment; filename="%s"' % filename
+                return open(path, mode='rb')
+            elif os.path.isdir(path):
+                archive_type_string = 'w|gz'
+                archive_ext = 'tgz'
+                if self.app.config.upstream_gzip:
+                    archive_type_string = 'w|'
+                    archive_ext = 'tar'
+                archive = util.streamball.StreamBall(mode=archive_type_string)
+                for root, directories, files in util.path.safe_walk(path):
+                    for file in files:
+                        p = os.path.join(root, file)
+                        relpath = os.path.relpath(p, os.path.join(path, os.pardir))
+                        archive.add(file=os.path.join(path, p), relpath=relpath)
+                archive_name = "%s.%s" % (path, archive_ext)
+                trans.response.set_content_type("application/x-tar")
+                trans.response.headers["Content-Disposition"] = 'attachment; filename="{}"'.format(archive_name)
+                archive.wsgi_status = trans.response.wsgi_status()
+                archive.wsgi_headeritems = trans.response.wsgi_headeritems()
+                return archive.stream
+        raise exceptions.ObjectNotFound("Specified test data path not found.")
 
     @expose_api_anonymous_and_sessionless
     def tests_summary(self, trans, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -129,6 +129,23 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         else:
             raise exceptions.ObjectNotFound("Specified test data path not found.")
 
+    @expose_api_raw_anonymous_and_sessionless
+    def test_data_download(self, trans, id, **kwd):
+        """
+        GET /api/tools/{tool_id}/test_data_download?tool_version={tool_version}&filename={filename}
+        """
+        tool_version = kwd.get('tool_version', None)
+        tool = self._get_tool(id, tool_version=tool_version, user=trans.user)
+        filename = kwd.get("filename")
+        if filename is None:
+            raise exceptions.ObjectNotFound("Test data filename not specified.")
+        path = tool.test_data_path(filename)
+        if path:
+            trans.response.headers["Content-Disposition"] = 'attachment; filename="%s"' % filename
+            return open(path, mode='rb')
+        else:
+            raise exceptions.ObjectNotFound("Specified test data path not found.")
+
     @expose_api_anonymous_and_sessionless
     def tests_summary(self, trans, **kwd):
         """

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -324,6 +324,7 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect('/api/tools/{id:.+?}/reload', action='reload', controller="tools")
     webapp.mapper.connect('/api/tools/tests_summary', action='tests_summary', controller="tools")
     webapp.mapper.connect('/api/tools/{id:.+?}/test_data_path', action='test_data_path', controller="tools")
+    webapp.mapper.connect('/api/tools/{id:.+?}/test_data_download', action='test_data_download', controller="tools")
     webapp.mapper.connect('/api/tools/{id:.+?}/test_data', action='test_data', controller="tools")
     webapp.mapper.connect('/api/tools/{id:.+?}/diagnostics', action='diagnostics', controller="tools")
     webapp.mapper.connect('/api/tools/{id:.+?}/citations', action='citations', controller="tools")

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -2,6 +2,7 @@
 import contextlib
 import json
 import os
+import tarfile
 
 from base import api
 from base import rules_test_data
@@ -13,6 +14,7 @@ from base.populators import (
     skip_without_tool,
     uses_test_history,
 )
+from six import BytesIO
 
 
 class ToolsTestCase(api.ApiTestCase):
@@ -225,6 +227,14 @@ class ToolsTestCase(api.ApiTestCase):
     def test_test_data_download(self):
         test_data_response = self._get("tools/%s/test_data_download?filename=1.bed" % "cat1")
         assert test_data_response.status_code == 200, test_data_response.text.startswith('chr')
+
+    @skip_without_tool("composite_output")
+    def test_test_data_download_composite(self):
+        test_data_response = self._get("tools/%s/test_data_download?filename=velveth_test1" % "composite_output")
+        assert test_data_response.status_code == 200
+        with tarfile.open(fileobj=BytesIO(test_data_response.content)) as tar_contents:
+            namelist = tar_contents.getnames()
+            assert len(namelist) == 4
 
     @uses_test_history(require_new=False)
     def test_upload_composite_as_tar(self, history_id):

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -229,6 +229,11 @@ class ToolsTestCase(api.ApiTestCase):
         assert test_data_response.status_code == 200, test_data_response.text.startswith('chr')
 
     @skip_without_tool("composite_output")
+    def test_test_data_downloads_security(self):
+        test_data_response = self._get("tools/%s/test_data_download?filename=../CONTRIBUTORS.md" % "composite_output")
+        assert test_data_response.status_code == 404, test_data_response.json()
+
+    @skip_without_tool("composite_output")
     def test_test_data_download_composite(self):
         test_data_response = self._get("tools/%s/test_data_download?filename=velveth_test1" % "composite_output")
         assert test_data_response.status_code == 200

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -221,6 +221,11 @@ class ToolsTestCase(api.ApiTestCase):
         test_data = test_data_response.json()
         assert len(test_data) == 3
 
+    @skip_without_tool("cat1")
+    def test_test_data_download(self):
+        test_data_response = self._get("tools/%s/test_data_download?filename=1.bed" % "cat1")
+        assert test_data_response.status_code == 200, test_data_response.text.startswith('chr')
+
     @uses_test_history(require_new=False)
     def test_upload_composite_as_tar(self, history_id):
         tar_path = self.test_data_resolver.get_filename("testdir.tar")

--- a/test/functional/tools/composite_output_tests.xml
+++ b/test/functional/tools/composite_output_tests.xml
@@ -2,8 +2,8 @@
   <command>
     mkdir '$output.extra_files_path';
     mkdir '$output.extra_files_path/output';
-    cp $input.extra_files_path/* $output.extra_files_path;
-    echo "1 2 3" > $output.extra_files_path/md5out;
+    cp '$input.extra_files_path'/* '$output.extra_files_path';
+    echo "1 2 3" > '$output.extra_files_path/md5out';
     echo "1" > '$output.extra_files_path/output/1';
   </command>
   <inputs>

--- a/test/functional/tools/composite_output_tests.xml
+++ b/test/functional/tools/composite_output_tests.xml
@@ -1,8 +1,10 @@
 <tool id="composite_output_tests" name="composite_output_tests" version="1.0.0">
   <command>
-    mkdir $output.extra_files_path;
+    mkdir '$output.extra_files_path';
+    mkdir '$output.extra_files_path/output';
     cp $input.extra_files_path/* $output.extra_files_path;
     echo "1 2 3" > $output.extra_files_path/md5out;
+    echo "1" > '$output.extra_files_path/output/1';
   </command>
   <inputs>
     <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth."/>
@@ -23,6 +25,7 @@
         <extra_files type="file" name="Roadmaps" value="velveth_test1/Roadmaps" />
         <extra_files type="file" name="Log" value="composite_output_expected_log" />
         <extra_files type="file" name="md5out" md5="f2b33fb7b3d0eb95090a16060e6a24f9" /><!-- md5sum of "1 2 3" -->
+        <extra_files type="directory" value="velveth_test1/output"/>
       </output>
     </test>
   </tests>


### PR DESCRIPTION
This would allow users to run tool tests against a Galaxy server.
Previously admins could ask for the path to test datasets on the Galaxy server via the API,
but access was only possible if the test files were available from where the test was run.

Instead of revealing the test data path we can also allow downloading the listed files directly.
I've changed the test interactor to now download the data from Galaxy instead of reading them from the file system. (One could also think about `paste_path` or `paste_url`, but for `paste_path` that option would need to be activated, and `paste_url` by default doesn't allow requests to localhost/127.0.01).