### PR TITLE
Lower provider name

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -107,7 +107,7 @@ class AuthnzManager(object):
         return rtv
 
     def _unify_provider_name(self, provider):
-        if provider in self.oidc_backends_config:
+        if provider.lower() in self.oidc_backends_config:
             return provider.lower()
         for k, v in BACKENDS_NAME.iteritems():
             if v == provider:


### PR DESCRIPTION
The keys of the oidc_backends_config dict are created by lowercasing the
provider names in oidc_backends_config.xml file so we need to lower the
provider name given in the request in order to find the backend config.