### PR TITLE
Remote tool testing enhancements

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -677,7 +677,7 @@ def _verify_extra_files_content(extra_files, hda_id, dataset_fetcher, test_data_
             shutil.rmtree(path)
 
 
-def verify_tool(tool_id, galaxy_interactor, resource_parameters=None, register_job_data=None, test_index=0, tool_version=None, quiet=False):
+def verify_tool(tool_id, galaxy_interactor, resource_parameters=None, register_job_data=None, test_index=0, tool_version=None, quiet=False, test_history=None):
     if resource_parameters is None:
         resource_parameters = {}
     tool_test_dicts = galaxy_interactor.get_tool_tests(tool_id, tool_version=tool_version)
@@ -686,7 +686,8 @@ def verify_tool(tool_id, galaxy_interactor, resource_parameters=None, register_j
 
     _handle_def_errors(testdef)
 
-    test_history = galaxy_interactor.new_history()
+    if test_history is None:
+        test_history = galaxy_interactor.new_history()
 
     stage_data_in_history(galaxy_interactor, tool_id, testdef.test_data(), test_history)
 

--- a/test/api/test_galaxy_interactor.py
+++ b/test/api/test_galaxy_interactor.py
@@ -1,0 +1,13 @@
+# Test galaxy interactor
+
+from packaging.version import Version
+
+from base import api   # noqa: I100,I202
+
+
+class GalaxyInteractorBackwardCompatTestCase(api.ApiTestCase):
+
+    def test_local_test_data_download(self):
+        self.galaxy_interactor._target_galaxy_version = Version("18.09")
+        assert self.galaxy_interactor.supports_test_data_download is False
+        assert self.galaxy_interactor.test_data_download(tool_id='cat1', filename='1.bed').readline().startswith('chr1\t147962192\t147962580')


### PR DESCRIPTION
I'll collect some things as I encounter them.

- [x] Allow passing in a test history. Otherwise you'll end up with one history per test, meaning > 1000 for a decent sized server if you're testing all tools
- [x] Fall back to local test data if Galaxy version isn't compatible with remote test data fetching/uploading
~~- [ ] Hash and check if we already used the test data, avoids re-uploading same file over and over (not sure if in interactor or in ephemeris ...)~~