### PR TITLE
WIP: library_upload_dir: improvements

### DIFF
--- a/scripts/api/library_upload_dir.py
+++ b/scripts/api/library_upload_dir.py
@@ -34,10 +34,17 @@ class Uploader(object):
         self.gi = galaxy.GalaxyInstance(url=url, key=api)
         libs = self.gi.libraries.get_libraries(library_id=library_id,
                                         name=library_name)
+
+        # TODO libs also contains deleted libraries even if it should not
+        # https://github.com/galaxyproject/bioblend/issues/239 fixed by
+        # https://github.com/galaxyproject/bioblend/pull/273
+        # remove if bioblend>0.12 is released
+        libs = [d for d in libs if not d['deleted']]
+
         if len(libs) == 0:
             raise Exception("Unknown library [%s,%s]" % (library_id, library_name))
         elif len(libs) > 1:
-            raise Exception("Ambiguous library [%s,%s]" % (library_id, library_name))
+            raise Exception("Ambiguous libraries for [%s,%s]: %s" % (library_id, library_name, libs))
         else:
             libs = libs[0]
         self.library_id = libs['id']
@@ -48,7 +55,6 @@ class Uploader(object):
         self.folder_id = libs['root_folder_id']
         self.should_link = should_link
         self.non_local = non_local
-        self.root_folder = root_folder
         self.dbkey = dbkey
         self.preserve_dirs = preserve_dirs
         self.tag_using_filenames = tag_using_filenames

--- a/scripts/api/library_upload_dir.py
+++ b/scripts/api/library_upload_dir.py
@@ -204,15 +204,15 @@ class Uploader(object):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
         description=textwrap.dedent('''
-        Upload files or directories into a data library.
+        Takes one or more path given as positional arguments (or via stdin) and uploads |
+        the files or directories contained therein into a data library.
 
-        If PATH/TO/FILE_OR_DIR is given on stdin the contents of
-        ROOT_FOLDER/PATH/TO/FILE_OR_DIR will be uploaded to PATH/TO/FILE_OR_DIR
-        in the specified folder and libary. If ROOT_FOLDER is empty, then
-        the path should be absolute. Data sets and folders will only be
-        created in the library if they are not present yet. If --preserve_dirs
-        is set then the structure in ROOT_FOLDER/PATH/TO/FILE_OR_DIR will be
-        preserved in the libary.'''))
+        The contents of path (PATH/TO/FILE_OR_DIR) will be uploaded to
+        PATH/TO/FILE_OR_DIR in the specified folder (-f/-F) and libary (-l/-L). Note that
+        the path can be given relative to the current working directory. Data sets and
+        folders will only be created in the library if they are not present yet. If
+        --preserve_dirs is set then the structure in PATH/TO/FILE_OR_DIR will be preserved
+        in the libary.'''))
 
     parser.add_argument("-u", "--url", dest="url", required=True, help="Galaxy URL")
     parser.add_argument("-a", "--api", dest="api", required=True, help="API Key")
@@ -220,9 +220,10 @@ if __name__ == '__main__':
     libparser = parser.add_mutually_exclusive_group(required=True)
     libparser.add_argument("-l", "--lib", dest="library_id", help="Library ID")
     libparser.add_argument("-L", "--library_name", help="Library name")
-    parser.add_argument("-f", "--folder", dest="folder_id",
+    folderparser = parser.add_mutually_exclusive_group(required=False)
+    folderparser.add_argument("-f", "--folder", dest="folder_id",
                         help="Folder ID. If not specified upload to root folder of the library or the folder specified with --folder_name.")
-    parser.add_argument("-F", "--folder_name", help="Folder to upload to, can be a path")
+    folderparser.add_argument("-F", "--folder_name", help="Folder to upload to, can be a path")
 
     parser.add_argument("--nonlocal", dest="non_local", action="store_true", default=False,
                         help="Set this flag if you are NOT running this script on your Galaxy head node with access to the full filesystem")

--- a/scripts/api/library_upload_dir.py
+++ b/scripts/api/library_upload_dir.py
@@ -82,14 +82,16 @@ class Uploader(object):
         contents of the data library, and then filter out things that are
         interesting to us based on a folder prefix.
         """
-
+        print("###prepopulate_memo")
         existing = self.gi.libraries.show_library(self.library_id, contents=True)
+        print("existing %s"%existing)
 
         uploading_to = [x for x in existing if x['id'] == self.folder_id]
         if len(uploading_to) == 0:
             raise Exception("Unknown folder [%s] in library [%s]" %
                             (self.folder_id, self.library_id))
         else:
+            print("uploading_to %s"%(uploading_to))
             uploading_to = uploading_to[0]
 
         for x in existing:
@@ -101,6 +103,7 @@ class Uploader(object):
             if name_part.startswith('/'):
                 name_part = name_part[1:]
             self.memo_path[name_part] = x['id']
+        print("self.memo_path"%(self.memo_path))
 
     def memoized_path(self, path_parts, base_folder=None):
         """Get the folder ID for a given folder path specified by path_parts.
@@ -111,6 +114,7 @@ class Uploader(object):
         previously existing paths and will not respect those. TODO: handle
         existing paths.
         """
+        print("###memoized_path")
         if base_folder is None:
             base_folder = self.folder_id
         dropped_prefix = []
@@ -185,8 +189,8 @@ class Uploader(object):
             # So that we can check if it really needs to be uploaded.
             already_uploaded = memo_key in self.memo_path.keys()
             fid = self.memoized_path(basepath, base_folder=self.folder_id)
+            print("%s %s"%( memo_key, self.memo_path))
             print('[%s/%s] %s/%s uploaded=%s' % (idx + 1, len(all_files), fid, fname, already_uploaded))
-
             if not already_uploaded:
                 if self.non_local:
                     self.gi.libraries.upload_file_from_local_path(
@@ -196,6 +200,7 @@ class Uploader(object):
                         dbkey=self.dbkey
                     )
                 else:
+                    print("libid %s\npath %s\nfolderid %s\nlink %s\npreserve %s\ntag %s"%(self.library_id,path,fid,self.dbkey,'link_to_files' if self.should_link else 'copy_files',self.preserve_dirs,self.tag_using_filenames))
                     self.gi.libraries.upload_from_galaxy_filesystem(
                         library_id=self.library_id,
                         filesystem_paths=path,

--- a/scripts/api/library_upload_dir.py
+++ b/scripts/api/library_upload_dir.py
@@ -22,7 +22,7 @@ class Uploader(object):
         library_id id of the library
         library_name name of the library
         folder_id id of the folder to upload to (None: root_folder)
-        should_link link data sets instead of uploading 
+        should_link link data sets instead of uploading
         non_local set to true iff not running on Galaxy head node
         root_folder path from which files are to be uploaded
                     ie uploaded files are given relative to this path


### PR DESCRIPTION
**major improvement**: when using upload_from_galaxy_filesystem the PATH needed to be given absolute and the script generates the complete hierarchy in Galaxy library (i.e. starting from root). Now the script has an additional parameter `--root_folder ROOT` which allows to upload ROOT/PATH into the library folder PATH.

**minor improvements**:
- added `--library_name` which allows to specify the library by name
- fixed `--folder` which now works as documented, ie the root folder of the library is used if not given
- added preserve dir and tag using files names
- also started a bit with documentation

Questions: 
- maybe there is also a better way to add filesystem folders to a library folder
- maybe a mechanism like the one I implemented with --root should be in the API .. then this would also be possible with `parsec`
- should this script stay here or is it better to integrate into (e.g.) ephemeris ... ?