### PR TITLE
Add python to Count1 tool requirements

### DIFF
--- a/tools/filters/uniq.xml
+++ b/tools/filters/uniq.xml
@@ -1,7 +1,8 @@
-<tool id="Count1" name="Count" version="1.0.2">
+<tool id="Count1" name="Count" version="1.0.3">
   <description>occurrences of each record</description>
     <requirements>
         <requirement type="package" version="8.30">coreutils</requirement>
+        <requirement type="package" version="3.7">python</requirement>
     </requirements>
   <command>python '$__tool_directory__/uniq.py' -i '$input' -o '$out_file1' -c '$column' -d $delim -s $sorting</command>
   <inputs>


### PR DESCRIPTION
... the version is kind of arbitrary, but I guess we'll want to move away from 2.

Without python the tool will fail if run containerised.
There are more tools that use just python or perl, do we also want to add requirements there ?