### PR TITLE
Simplify history import to fix extra files and ObjectStore interactions.

### DIFF
--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -101,16 +101,6 @@ class JobImportHistoryArchiveWrapper(UsesAnnotations):
                     provenance_attrs = load(open(provenance_file_name))
                     datasets_attrs += provenance_attrs
 
-                # Get counts of how often each dataset file is used; a file can
-                # be linked to multiple dataset objects (HDAs).
-                datasets_usage_counts = {}
-                for dataset_attrs in datasets_attrs:
-                    temp_dataset_file_name = \
-                        os.path.realpath(os.path.join(archive_dir, dataset_attrs['file_name']))
-                    if (temp_dataset_file_name not in datasets_usage_counts):
-                        datasets_usage_counts[temp_dataset_file_name] = 0
-                    datasets_usage_counts[temp_dataset_file_name] += 1
-
                 # Create datasets.
                 for dataset_attrs in datasets_attrs:
                     metadata = dataset_attrs['metadata']
@@ -150,26 +140,22 @@ class JobImportHistoryArchiveWrapper(UsesAnnotations):
                             os.path.realpath(os.path.abspath(os.path.join(archive_dir, dataset_attrs['file_name'])))
                         if not file_in_dir(temp_dataset_file_name, os.path.join(archive_dir, "datasets")):
                             raise MalformedContents("Invalid dataset path: %s" % temp_dataset_file_name)
-                        if datasets_usage_counts[temp_dataset_file_name] == 1:
-                            self.app.object_store.update_from_file(hda.dataset, file_name=temp_dataset_file_name, create=True)
+                        self.app.object_store.update_from_file(hda.dataset, file_name=temp_dataset_file_name, create=True)
 
-                            # Import additional files if present. Histories exported previously might not have this attribute set.
-                            dataset_extra_files_path = dataset_attrs.get('extra_files_path', None)
-                            if dataset_extra_files_path:
-                                try:
-                                    file_list = os.listdir(os.path.join(archive_dir, dataset_extra_files_path))
-                                except OSError:
-                                    file_list = []
+                        # Import additional files if present. Histories exported previously might not have this attribute set.
+                        dataset_extra_files_path = dataset_attrs.get('extra_files_path', None)
+                        if dataset_extra_files_path:
+                            try:
+                                file_list = os.listdir(os.path.join(archive_dir, dataset_extra_files_path))
+                            except OSError:
+                                file_list = []
 
-                                if file_list:
-                                    for extra_file in file_list:
-                                        self.app.object_store.update_from_file(
-                                            hda.dataset, extra_dir='dataset_%s_files' % hda.dataset.id,
-                                            alt_name=extra_file, file_name=os.path.join(archive_dir, dataset_extra_files_path, extra_file),
-                                            create=True)
-                        else:
-                            datasets_usage_counts[temp_dataset_file_name] -= 1
-                            shutil.copyfile(temp_dataset_file_name, hda.file_name)
+                            if file_list:
+                                for extra_file in file_list:
+                                    self.app.object_store.update_from_file(
+                                        hda.dataset, extra_dir='dataset_%s_files' % hda.dataset.id,
+                                        alt_name=extra_file, file_name=os.path.join(archive_dir, dataset_extra_files_path, extra_file),
+                                        create=True)
                         hda.dataset.set_total_size()  # update the filesize record in the database
 
                     # Set tags, annotations.


### PR DESCRIPTION
This usage counting that I am eliminating here made sense in (a94bf20abfd15f21c3cc380ee92896d0f107bb23) but it was broken with the transition to ObjectStore compatibility (ea89dd8f149778b6c2f0f3f4a34c8b21f7033af7) and it is broken with extra files handling (9ea0fee48aa57361147e9145be8deaaafb2a0960).
