### PR TITLE
[19.01] Re-enable script staging

### DIFF
--- a/client/galaxy/scripts/galaxy.interactive_environments.js
+++ b/client/galaxy/scripts/galaxy.interactive_environments.js
@@ -19,7 +19,7 @@ export function clear_main_area() {
 
 export function display_spinner() {
     $("#main").append(
-        `<img id="spinner" src="${galaxy_root}static/style/largespinner.gif" style="position:absolute;margin:auto;top:0;left:0;right:0;bottom:0;">`
+        `<div id="ie-loading-spinner"></div>`
     );
 }
 

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -2102,3 +2102,14 @@ body.reports {
         background: #C1C9E5 url(../../images/menu_bg.png) top repeat-x;
     }
 }
+
+/* Used in Galaxy IE for spinner loading TODO: Remove in IE entrypoint refactoring */
+#ie-loading-spinner {
+    position:absolute;
+    margin:auto;
+    top:0;
+    left:0;
+    right:0;
+    bottom:0;
+    background: url(../../images/largespinner.gif) no-repeat center center fixed;
+}

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -58,6 +58,8 @@ gulp.task("fonts", function() {
         .pipe(gulp.dest("../static/images/fonts"));
 });
 
+// TODO: Remove script and lib tasks (for 19.05) once we are sure there are no
+// external accessors (via require or explicit inclusion in templates)
 gulp.task("scripts", function() {
     return gulp
         .src(paths.scripts)

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -66,6 +66,7 @@ gulp.task("scripts", function() {
                 plugins: ["transform-es2015-modules-amd"]
             })
         )
+        .pipe(uglify())
         .pipe(gulp.dest("../static/scripts/"));
 });
 

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -5,6 +5,7 @@ var _ = require("underscore");
 
 var gulp = require("gulp");
 var uglify = require("gulp-uglify");
+var babel = require("gulp-babel");
 
 var paths = {
     node_modules: "./node_modules",
@@ -57,6 +58,17 @@ gulp.task("fonts", function() {
         .pipe(gulp.dest("../static/images/fonts"));
 });
 
+gulp.task("scripts", function() {
+    return gulp
+        .src(paths.scripts)
+        .pipe(
+            babel({
+                plugins: ["transform-es2015-modules-amd"]
+            })
+        )
+        .pipe(gulp.dest("../static/scripts/"));
+});
+
 gulp.task("libs", function() {
     return gulp
         .src(paths.libs)
@@ -75,4 +87,4 @@ gulp.task("clean", function() {
 
 gulp.task("staging", ["stage-libs", "fonts"]);
 
-gulp.task("default", ["libs"]);
+gulp.task("default", ["libs", "scripts"]);

--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
     "d3": "3",
     "decode-uri-component": "^0.2.0",
     "font-awesome": "^4.7.0",
+    "gulp-babel": "^8.0.0",
     "gulp-uglify": "^3.0.1",
     "handsontable": "^2.0.0",
     "imports-loader": "^0.8.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1104,6 +1104,13 @@ ansi-align@^1.0.0:
   dependencies:
     string-width "^1.0.1"
 
+ansi-colors@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-1.1.0.tgz#6374b4dd5d4718ff3ce27a671a3b1cad077132a9"
+  integrity sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==
+  dependencies:
+    ansi-wrap "^0.1.0"
+
 ansi-colors@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.1.0.tgz#dcfaacc90ef9187de413ec3ef8d5eb981a98808f"
@@ -1158,7 +1165,7 @@ ansi-styles@~1.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
   integrity sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=
 
-ansi-wrap@0.1.0:
+ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
   integrity sha1-qCJQ3bABXponyoLoLqYDu/pF768=
@@ -5829,6 +5836,16 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
+gulp-babel@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-babel/-/gulp-babel-8.0.0.tgz#e0da96f4f2ec4a88dd3a3030f476e38ab2126d87"
+  integrity sha512-oomaIqDXxFkg7lbpBou/gnUkX51/Y/M2ZfSjL2hdqXTAlSWZcgZtd2o0cOH0r/eE8LWD0+Q/PsLsr2DKOoqToQ==
+  dependencies:
+    plugin-error "^1.0.1"
+    replace-ext "^1.0.0"
+    through2 "^2.0.0"
+    vinyl-sourcemaps-apply "^0.2.0"
+
 gulp-sourcemaps@^2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/gulp-sourcemaps/-/gulp-sourcemaps-2.6.4.tgz#cbb2008450b1bcce6cd23bf98337be751bf6e30a"
@@ -9338,6 +9355,16 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
+plugin-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
+  integrity sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==
+  dependencies:
+    ansi-colors "^1.0.1"
+    arr-diff "^4.0.0"
+    arr-union "^3.1.0"
+    extend-shallow "^3.0.2"
+
 plur@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/plur/-/plur-1.0.0.tgz#db85c6814f5e5e5a3b49efc28d604fec62975156"
@@ -10899,7 +10926,7 @@ replace-ext@0.0.1:
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
   integrity sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=
 
-replace-ext@1.0.0:
+replace-ext@1.0.0, replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
   integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=

--- a/static/style/largespinner.gif
+++ b/static/style/largespinner.gif
@@ -1,0 +1,1 @@
+../../client/galaxy/images/largespinner.gif

--- a/static/style/largespinner.gif
+++ b/static/style/largespinner.gif
@@ -1,1 +1,0 @@
-../../client/galaxy/images/largespinner.gif


### PR DESCRIPTION
This PR (temporarily) re-enables independent script transpiling/staging.  We do want to drop this long term as I did in #6917, but I'd be more comfortable leaving it in for 19.01.  It shouldn't change the behavior of anything in the 'core', but it is necessary for some plugin functionality (like IEs) to work without some additional refactoring (which I'm also working on, but will target the post-freeze -dev with).

We'll want to deprecate this now, with 19.01 being the last release supporting any of this sort of access -- it'll be disabled in 19.05 completely xref #6936 