### PR TITLE
Apply metadata setter for default to conditionals

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -743,10 +743,25 @@ class DefaultToolAction(object):
                 <action name="column_names" type="metadata" default="${','.join([input.name for input in $individual_inputs ])}" />
             </actions>
         </data>
+
+        or
+        
+        <actions>
+            <conditional name="format">
+                <when value="something_good">
+                    <action type="metadata" name="column_names" default="one,two,three" />
+                </when>
+            </conditional>
+        </actions>
         """
         if output.actions:
+            action_list = output.actions.actions
             for action in output.actions.actions:
-                if action.tag == "metadata" and action.default:
+                if action.tag == "conditional":
+                    for case in action.cases:
+                        action_list.extend(case.actions)
+            for action in action_list:
+                if action.tag == "metadata" and hasattr(action, "default") and action.default:
                     metadata_new_value = fill_template(action.default, context=params).split(",")
                     dataset.metadata.__setattr__(str(action.name), metadata_new_value)
 

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -745,7 +745,7 @@ class DefaultToolAction(object):
         </data>
 
         or
-        
+
         <actions>
             <conditional name="format">
                 <when value="something_good">

--- a/test/functional/tools/metadata_column_names_conditional.xml
+++ b/test/functional/tools/metadata_column_names_conditional.xml
@@ -1,0 +1,30 @@
+<tool id="metadata_columns_conditional" name="metadata_columns_conditional" version="1.0.0">
+    <description>Tests whether metadata is being set correctly.</description>
+    <command><![CDATA[
+        cp '$input' '$output'
+    ]]></command>
+    <inputs>
+        <param name="input" type="data" multiple="false" />
+	<param name="variable" type="integer" value="1" size="1" />
+    </inputs>
+    <outputs>
+        <data format="tabular" name="output">
+            <actions>
+       	        <conditional name="variable">
+		    <when value="1">
+			    <action name="column_names" type="metadata" default="First,${input.name}" />
+		    </when>
+	        </conditional>
+            </actions>
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="2.tabular" />
+	    <param name="variable" value="1" />
+            <output name="output">
+                <metadata name="column_names" value="First,2.tabular"/>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/metadata_column_names_conditional.xml
+++ b/test/functional/tools/metadata_column_names_conditional.xml
@@ -5,25 +5,25 @@
     ]]></command>
     <inputs>
         <param name="input" type="data" multiple="false" />
-	<param name="variable" type="integer" value="1" size="1" />
+        <param name="variable" type="integer" value="1" size="1" />
     </inputs>
     <outputs>
         <data format="tabular" name="output">
             <actions>
-       	        <conditional name="variable">
-		    <when value="1">
-			    <action name="column_names" type="metadata" default="First,${input.name}" />
-		    </when>
-	        </conditional>
+                <conditional name="variable">
+                    <when value="1">
+                        <action name="column_names" type="metadata" default="First,${input.name}" />
+                    </when>     
+                </conditional>
             </actions>
         </data>
     </outputs>
     <tests>
         <test>
             <param name="input" value="2.tabular" />
-	    <param name="variable" value="1" />
+            <param name="variable" value="1" />
             <output name="output">
-                <metadata name="column_names" value="First,2.tabular"/>
+              <metadata name="column_names" value="First,2.tabular"/>
             </output>
         </test>
     </tests>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -46,6 +46,7 @@
   <tool file="metadata_bcf.xml" />
   <tool file="metadata_biom1.xml" />
   <tool file="metadata_column_names.xml" />
+  <tool file="metadata_column_names_conditional.xml" />
   <tool file="strict_shell.xml" />
   <tool file="strict_shell_default_off.xml" />
   <tool file="detect_errors_aggressive.xml" />


### PR DESCRIPTION
The existing code only expects the case like:

```
<actions>
                <action name="column_names" type="metadata" default="Geneid,${alignment.element_identifier}" />
</actions>
```

whereas a conditional can be inserted within `<actions>` yielding a case like:

```
        <actions>
            <conditional name="format">
                <when value="something_good">
                    <action type="metadata" name="column_names" default="one,two,three" />
                </when>
            </conditional>
        </actions>
```

The fact that this is not handled causes the display logic to fail when `column_names` is set for a tabular dataset inside such a conditional. This patch provides a solution for that case.