### PR TITLE
[19.01] Data library: fix tag_using_filenames not properly converted to bool

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -248,7 +248,7 @@ class LibraryActions(object):
         uploaded_dataset.dbkey = params.get('dbkey', None)
         uploaded_dataset.to_posix_lines = params.get('to_posix_lines', None)
         uploaded_dataset.space_to_tab = params.get('space_to_tab', None)
-        uploaded_dataset.tag_using_filenames = params.get('tag_using_filenames', True)
+        uploaded_dataset.tag_using_filenames = params.get('tag_using_filenames', False)
         uploaded_dataset.purge_source = getattr(trans.app.config, 'ftp_upload_purge', True)
         if in_folder:
             uploaded_dataset.in_folder = in_folder

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -230,6 +230,8 @@ class LibraryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
         # The rest of the security happens in the library_common controller.
         real_folder_id = trans.security.encode_id(parent.id)
 
+        payload['tag_using_filenames'] = util.string_as_bool(payload.get('tag_using_filenames', None))
+
         # are we copying an HDA to the library folder?
         #   we'll need the id and any message to attach, then branch to that private function
         from_hda_id, from_hdca_id, ldda_message = (payload.pop('from_hda_id', None), payload.pop('from_hdca_id', None), payload.pop('ldda_message', ''))


### PR DESCRIPTION
Hi!
I was testing the `tag_using_filenames` option when uploading to data library [using bioblend](https://github.com/galaxyproject/bioblend/pull/267), and found a little bug in `/api/libraries/{library_id}/contents`.
Setting it to `False` was not working as it was not converted to bool before being tested.
I don't know if I should have targeted this PR against the dev branch? Anyway, I'd love to have it in 18.09 too if it's possible