### PR TITLE
Update IE proxy dependencies 

### DIFF
--- a/lib/galaxy/web/proxy/js/package.json
+++ b/lib/galaxy/web/proxy/js/package.json
@@ -11,9 +11,9 @@
     "url": "https://bitbucket.org/galaxy/galaxy-central"
   },
   "dependencies": {
-    "commander": "~2.14.1",
-    "eventemitter3": "0.1.6",
-    "http-proxy": "1.16.2",
-    "sqlite3": "3.1.13"
+    "commander": "~2.19.0",
+    "eventemitter3": "3.1.0",
+    "http-proxy": "1.17.0",
+    "sqlite3": "4.0.4"
   }
 }


### PR DESCRIPTION
I could no longer install/run the proxy (compilation fail related to sqlite3 on npm/yarn install).  I'm guessing it's related to a recent sqlite3 update (via brew on my system), but this version bump fixed it for me.

I'm hoping the versions I've updated to are backwards compatible in terms of compilation (seem to be in terms of functionality -- it's definitely all working for me now when it wasn't before), but I'd sure appreciate someone else checking with an older sqlite lib version.