### PR TITLE
Update ``use_interactive`` default in docs

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1021,8 +1021,8 @@ galaxy:
   #use_printdebug: true
 
   # Enable live debugging in your browser.  This should NEVER be enabled
-  # on a public site.  Enabled in the sample config for development.
-  #use_interactive: true
+  # on a public site.
+  #use_interactive: false
 
   # When stopping Galaxy cleanly, how much time to give various
   # monitoring/polling threads to finish before giving up on joining

--- a/config/reports.yml.sample
+++ b/config/reports.yml.sample
@@ -113,7 +113,7 @@ reports:
   #use_lint: false
 
   # NEVER enable this on a public site (even test or QA)
-  #use_interactive: true
+  #use_interactive: false
 
   # Write thread status periodically to 'heartbeat.log' (careful, uses
   # disk space rapidly!)

--- a/config/tool_shed.yml.sample
+++ b/config/tool_shed.yml.sample
@@ -207,7 +207,7 @@ tool_shed:
   #use_printdebug: true
 
   # NEVER enable this on a public site (even test or QA)
-  #use_interactive: true
+  #use_interactive: false
 
   # Administrative users - set this to a comma-separated list of valid
   # Tool Shed users (email addresses).  These users will have access to

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2103,9 +2103,8 @@
 
 :Description:
     Enable live debugging in your browser.  This should NEVER be
-    enabled on a public site.  Enabled in the sample config for
-    development.
-:Default: ``true``
+    enabled on a public site.
+:Default: ``false``
 :Type: bool
 
 

--- a/doc/source/admin/reports_options.rst
+++ b/doc/source/admin/reports_options.rst
@@ -108,7 +108,7 @@
 
 :Description:
     NEVER enable this on a public site (even test or QA)
-:Default: ``true``
+:Default: ``false``
 :Type: bool
 
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1566,11 +1566,11 @@ mapping:
 
       use_interactive:
         type: bool
-        default: true
+        default: false
         required: false
         desc: |
           Enable live debugging in your browser.  This should NEVER be enabled on a
-          public site.  Enabled in the sample config for development.
+          public site.
 
       monitor_thread_join_timeout:
         type: int

--- a/lib/galaxy/webapps/reports/config_schema.yml
+++ b/lib/galaxy/webapps/reports/config_schema.yml
@@ -74,7 +74,7 @@ mapping:
       
       use_interactive:
         type: bool
-        default: true
+        default: false
         desc: |
           NEVER enable this on a public site (even test or QA)
       

--- a/lib/galaxy/webapps/tool_shed/config_schema.yml
+++ b/lib/galaxy/webapps/tool_shed/config_schema.yml
@@ -251,7 +251,7 @@ mapping:
       
       use_interactive:
         type: bool
-        default: true
+        default: false
         required: false
         desc: |
           NEVER enable this on a public site (even test or QA)


### PR DESCRIPTION
This was never enabled by default in the code, but it was explicitly set to True in `config/galaxy.ini.sample` . Since we moved to `galaxy.yml.sample`, this has defaulted to False in practice.