### PR TITLE
remove underline from history datasets

### DIFF
--- a/client/galaxy/style/scss/list-item.scss
+++ b/client/galaxy/style/scss/list-item.scss
@@ -80,7 +80,6 @@ $vertical-gap: 8px;
         .title {
             display: inline;
             font-weight: bold;
-            text-decoration: underline;
             word-wrap: break-word;
             word-break: break-all;
             line-height: 16px;

--- a/client/galaxy/style/scss/list-item.scss
+++ b/client/galaxy/style/scss/list-item.scss
@@ -84,6 +84,9 @@ $vertical-gap: 8px;
             word-break: break-all;
             line-height: 16px;
         }
+        .title:hover {
+            text-decoration: underline;
+        }
         .subtitle {
             color: #777;
             font-size: 90%;


### PR DESCRIPTION
I don't think we are losing any information with the ink used for these

![galaxy_and_galaxy](https://user-images.githubusercontent.com/1814954/51350553-71401900-1a76-11e9-8b39-b5c0776c9043.png)
