### PR TITLE
[19.01] Fix workflow save_as functionality

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -601,7 +601,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             session.flush()
 
             try:
-                workflow, errors = workflow_contents_manager.update_workflow_from_dict(
+                workflow, errors = workflow_contents_manager.build_workflow_from_raw_description(
                     trans,
                     stored_workflow,
                     workflow_data,

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -601,7 +601,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             session.flush()
 
             try:
-                workflow, errors = workflow_contents_manager.build_workflow_from_raw_description(
+                workflow, errors = workflow_contents_manager.update_workflow_from_raw_description(
                     trans,
                     stored_workflow,
                     workflow_data,


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/7240, broken in https://github.com/galaxyproject/galaxy/pull/7019,
where it was renamed from `build_workflow_from_dict` to
~~`build_workflow_from_raw_description`~~ `update_workflow_from_raw_description `.