### PR TITLE
[18.09] strip() text when parsing xml

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -222,6 +222,11 @@ def parse_xml(fname):
     tree = ElementTree.ElementTree()
     try:
         root = tree.parse(fname, parser=ElementTree.XMLParser(target=DoctypeSafeCallbackTarget()))
+        for elem in root.iter('*'):
+            if elem.text is not None:
+                elem.text = elem.text.strip()
+            if elem.tail is not None:
+                elem.tail = elem.tail.strip()
     except ParseError:
         log.exception("Error parsing file %s", fname)
         raise
@@ -231,11 +236,18 @@ def parse_xml(fname):
 
 def parse_xml_string(xml_string):
     tree = ElementTree.fromstring(xml_string)
+    for elem in tree.iter('*'):
+        if elem.text is not None:
+            elem.text = elem.text.strip()
+        if elem.tail is not None:
+            elem.tail = elem.tail.strip()
     return tree
 
 
 def xml_to_string(elem, pretty=False):
-    """Returns a string from an xml tree"""
+    """
+    Returns a string from an xml tree.
+    """
     try:
         if elem is not None:
             if PY2:

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,4 +1,16 @@
+from tempfile import NamedTemporaryFile
+
 from galaxy import util
+
+SECTION_XML = """<?xml version="1.0" ?>
+<section id="fasta_fastq_manipulation" name="Fasta Fastq Manipulation" version="">
+    <tool file="toolshed.g2.bx.psu.edu/repos/peterjc/seq_filter_by_id/fb1313d79396/seq_filter_by_id/tools/seq_filter_by_id/seq_filter_by_id.xml" guid="toolshed.g2.bx.psu.edu/repos/peterjc/seq_filter_by_id/seq_filter_by_id/0.2.5">
+        <tool_shed>
+            toolshed.g2.bx.psu.edu
+        </tool_shed>
+    </tool>
+</section>
+"""
 
 
 def test_strip_control_characters():
@@ -15,3 +27,45 @@ def test_strip_control_characters_nested():
     assert util.strip_control_characters_nested(l)[0] == stripped_s
     assert util.strip_control_characters_nested(t)[0] == stripped_s
     assert util.strip_control_characters_nested(d)[42] == stripped_s
+
+
+def test_parse_xml_string():
+    section = util.parse_xml_string(SECTION_XML)
+    _verify_section(section)
+
+
+def test_parse_xml_file():
+    with NamedTemporaryFile(mode='w') as tmp:
+        tmp.write(SECTION_XML)
+        tmp.flush()
+        section = util.parse_xml(tmp.name).getroot()
+    _verify_section(section)
+
+
+def _verify_section(section):
+    tool = next(iter(section))
+    assert sorted(tool.items()) == [
+        ('file',
+         'toolshed.g2.bx.psu.edu/repos/peterjc/seq_filter_by_id/fb1313d79396/seq_filter_by_id/tools/seq_filter_by_id/seq_filter_by_id.xml'),
+        ('guid',
+         'toolshed.g2.bx.psu.edu/repos/peterjc/seq_filter_by_id/seq_filter_by_id/0.2.5')
+    ]
+    assert next(iter(tool)).text == 'toolshed.g2.bx.psu.edu'
+
+
+def test_xml_to_string():
+    section = util.parse_xml_string(SECTION_XML)
+    s = util.xml_to_string(section)
+    assert len(s.split('\n')) == 1
+
+
+def test_xml_to_string_pretty():
+    section = util.parse_xml_string(SECTION_XML)
+    s = util.xml_to_string(section, pretty=True)
+    PRETTY = """<?xml version="1.0" ?>
+<section id="fasta_fastq_manipulation" name="Fasta Fastq Manipulation" version="">
+    <tool file="toolshed.g2.bx.psu.edu/repos/peterjc/seq_filter_by_id/fb1313d79396/seq_filter_by_id/tools/seq_filter_by_id/seq_filter_by_id.xml" guid="toolshed.g2.bx.psu.edu/repos/peterjc/seq_filter_by_id/seq_filter_by_id/0.2.5">
+        <tool_shed>toolshed.g2.bx.psu.edu</tool_shed>
+    </tool>
+</section>"""
+    assert s == PRETTY


### PR DESCRIPTION
This should make parsing shed_tool_conf.xml files (and others) more robust.
Should fix https://github.com/galaxyproject/galaxy/issues/7250.