### PR TITLE
[18.09] Fix install operation in installed_repository_grid

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -587,6 +587,11 @@ class AdminToolshed(AdminGalaxy):
         repository_id = kwd.get('id', None)
         if repository_id is None:
             return trans.show_error_message('Missing required encoded repository id.')
+        if repository_id and isinstance(repository_id, list):
+            # FIXME: This is a hack that avoids unhandled and duplicate url parameters leaking in.
+            # This should be handled somewhere in the grids system, but given the legacy status
+            # this should be OK.
+            repository_id = [r for r in repository_id if '=' not in r][0]  # This method only work for a single repo id
         operation = kwd.get('operation', None)
         repository = repository_util.get_installed_tool_shed_repository(trans.app, repository_id)
         if repository is None:


### PR DESCRIPTION
The incoming url keywords look like this:
```
operation=install&id=ebfb8f50c6abde6d?async=false&sort=name&page=1&show_item_checkboxes=true&advanced_search=false&operation=install&id=ebfb8f50c6abde6d
```
and the id parameter gets parsed into a list:
```
['ebfb8f50c6abde6d?async=false', 'ebfb8f50c6abde6d']
```

Obviously there's something wrong in the grid or mako,
but this works fine.

Fixes https://github.com/galaxyproject/galaxy/issues/5619