### PR TITLE
Determine collection_type for all workflow steps

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -451,6 +451,7 @@ var InputCollectionTerminal = BaseInputTerminal.extend({
     update: function(input) {
         this.multiple = false;
         this.collection = true;
+        this.collection_type = input.collection_type;
         this.datatypes = input.extensions;
         var collectionTypes = [];
         if (input.collection_types) {

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -581,6 +581,7 @@ class WorkflowContentsManager(UsesAnnotations):
         data['name'] = workflow.name
         data['steps'] = {}
         data['upgrade_messages'] = {}
+        input_step_types = set(workflow.input_step_types)
         # For each step, rebuild the form and encode the state
         for step in workflow.steps:
             # Load from database representation
@@ -650,12 +651,13 @@ class WorkflowContentsManager(UsesAnnotations):
             # workflow outputs
             outputs = []
             for output in step.unique_workflow_outputs:
-                output_label = output.label
-                output_name = output.output_name
-                output_uuid = str(output.uuid) if output.uuid else None
-                outputs.append({"output_name": output_name,
-                                "uuid": output_uuid,
-                                "label": output_label})
+                if output.workflow_step.type not in input_step_types:
+                    output_label = output.label
+                    output_name = output.output_name
+                    output_uuid = str(output.uuid) if output.uuid else None
+                    outputs.append({"output_name": output_name,
+                                    "uuid": output_uuid,
+                                    "label": output_label})
             step_dict['workflow_outputs'] = outputs
 
             # Encode input connections as dictionary

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -753,7 +753,7 @@ class WorkflowContentsManager(UsesAnnotations):
         """
         for order_index in sorted(steps):
             step = steps[order_index]
-            if step['type'] == 'tool':
+            if step['type'] == 'tool' and not step.get('errors'):
                 map_over = self.get_step_map_over(step, steps)
                 for step_data_output in step['outputs']:
                     if step_data_output.get('collection_type_source') and step_data_output['collection_type'] is None:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -575,7 +575,7 @@ class WorkflowContentsManager(UsesAnnotations):
         """
         return self._resource_mapper_function(trans=trans, stored_workflow=stored, workflow=workflow)
 
-    def _workflow_to_dict_editor(self, trans, stored, workflow, tooltip=True):
+    def _workflow_to_dict_editor(self, trans, stored, workflow, tooltip=True, is_subworkflow=False):
         # Pack workflow data into a dictionary and return
         data = {}
         data['name'] = workflow.name
@@ -678,7 +678,8 @@ class WorkflowContentsManager(UsesAnnotations):
             step_dict['position'] = step.position
             # Add to return value
             data['steps'][step.order_index] = step_dict
-        data['steps'] = self._resolve_collection_type(data['steps'])
+        if is_subworkflow:
+            data['steps'] = self._resolve_collection_type(data['steps'])
         return data
 
     @staticmethod

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -678,25 +678,97 @@ class WorkflowContentsManager(UsesAnnotations):
             step_dict['position'] = step.position
             # Add to return value
             data['steps'][step.order_index] = step_dict
-        data['steps'] = self._resolve_collection_type_source(data['steps'])
+        data['steps'] = self._resolve_collection_type(data['steps'])
         return data
 
-    def _resolve_collection_type_source(self, steps):
+    @staticmethod
+    def get_step_map_over(current_step, steps):
         """
-        Fill in collection type for step outputs that infer the collection type via collection_type_source.
+        Given a tool step and its input steps guess that maximum level of mapping over.
+        All data outputs of a step need to be mapped over to this level.
+        """
+        max_map_over = ''
+        for input_name, input_connections in current_step['input_connections'].items():
+            if isinstance(input_connections, dict):
+                # if input does not accept multiple inputs
+                input_connections = [input_connections]
+            for input_value in input_connections:
+                current_data_input = None
+                for current_input in current_step['inputs']:
+                    if current_input['name'] == input_name:
+                        current_data_input = current_input
+                        # we've got one of the tools' input data definitions
+                        break
+                input_step = steps[input_value['id']]
+                for input_step_data_output in input_step['outputs']:
+                    if input_step_data_output['name'] == input_value['output_name']:
+                        collection_type = input_step_data_output.get('collection_type')
+                        # This is the defined incoming collection type, in reality there may be additional
+                        # mapping over of the workflows' data input, but this should be taken care of by the workflow editor /
+                        # outer workflow.
+                        if collection_type:
+                            if current_data_input.get('input_type') == 'dataset' and current_data_input.get('multiple'):
+                                # We reduce the innermost collection
+                                if ':' in collection_type:
+                                    # more than one layer of nesting and multiple="true" input,
+                                    # we consume the innermost collection
+                                    collection_type = ":".join(collection_type.rsplit(':')[:-1])
+                                else:
+                                    # We've reduced a list or a pair
+                                    collection_type = None
+                            elif current_data_input.get('input_type') == 'dataset_collection':
+                                current_collection_types = current_data_input['collection_types']
+                                if not current_collection_types:
+                                    # Accepts any input dataset collection, no mapping
+                                    collection_type = None
+                                elif collection_type in current_collection_types:
+                                    # incoming collection type is an exact match, no mapping over
+                                    collection_type = None
+                                else:
+                                    outer_map_over = collection_type
+                                    for accepted_collection_type in current_data_input['collection_types']:
+                                        # need to find the lowest level of mapping over,
+                                        # for collection_type = 'list:list:list' and accepted_collection_type = ['list:list', 'list']
+                                        # it'd be outer_map_over == 'list'
+                                        if collection_type.endswith(accepted_collection_type):
+                                            _outer_map_over = collection_type[:-(len(accepted_collection_type) + 1)]
+                                            if len(_outer_map_over.split(':')) < len(outer_map_over.split(':')):
+                                                outer_map_over = _outer_map_over
+                                    collection_type = outer_map_over
+                            # If there is mapping over, we're going to assume it is linked, everything else is (probably)
+                            # too hard to display in the workflow editor. With this assumption we should be able to
+                            # set the maximum mapping over level to the most deeply nested map_over
+                            if collection_type and len(collection_type.split(':')) >= len(max_map_over.split(':')):
+                                max_map_over = collection_type
+        if max_map_over:
+            return max_map_over
+        return None
+
+    def _resolve_collection_type(self, steps):
+        """
+        Fill in collection type for step outputs.
+        This can either be via collection_type_source and / or "inherited" from the step's input.
 
         This information is only needed in the workflow editor.
         """
         for order_index in sorted(steps):
             step = steps[order_index]
-            for i, step_data_output in enumerate(step['outputs']):
-                if step_data_output.get('collection_type_source') and step_data_output['collection_type'] is None:
-                    collection_type_source = step_data_output['collection_type_source']
-                    for input_connection in step['input_connections'].get(collection_type_source, []):
-                        input_step = steps[input_connection['id']]
-                        for input_step_data_output in input_step['outputs']:
-                            if input_step_data_output['name'] == input_connection['output_name']:
-                                step_data_output['collection_type'] = input_step_data_output.get('collection_type')
+            if step['type'] == 'tool':
+                map_over = self.get_step_map_over(step, steps)
+                for step_data_output in step['outputs']:
+                    if step_data_output.get('collection_type_source') and step_data_output['collection_type'] is None:
+                        collection_type_source = step_data_output['collection_type_source']
+                        for input_connection in step['input_connections'].get(collection_type_source, []):
+                            input_step = steps[input_connection['id']]
+                            for input_step_data_output in input_step['outputs']:
+                                if input_step_data_output['name'] == input_connection['output_name']:
+                                    step_data_output['collection_type'] = input_step_data_output.get('collection_type')
+                    if map_over:
+                        collection_type = map_over
+                        step_data_output['collection'] = True
+                        if step_data_output.get('collection_type'):
+                            collection_type = "%s:%s" % (map_over, step_data_output['collection_type'])
+                        step_data_output['collection_type'] = collection_type
         return steps
 
     def _workflow_to_dict_export(self, trans, stored=None, workflow=None):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -412,7 +412,7 @@ class SubWorkflowModule(WorkflowModule):
                     input_type=step_to_input_type[step_type],
                 )
                 if step.type == 'data_collection_input':
-                    input['collection_type'] = step.tool_inputs['collection_type']
+                    input['collection_type'] = step.tool_inputs.get('collection_type') if step.tool_inputs else None
                 inputs.append(input)
         return inputs
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -422,7 +422,8 @@ class SubWorkflowModule(WorkflowModule):
             subworkflow_dict = workflow_contents_manager._workflow_to_dict_editor(trans=self.trans,
                                                                                   stored=self.subworkflow.stored_workflow,
                                                                                   workflow=self.subworkflow,
-                                                                                  tooltip=False)
+                                                                                  tooltip=False,
+                                                                                  is_subworkflow=True)
             for order_index in sorted(subworkflow_dict['steps']):
                 step = subworkflow_dict['steps'][order_index]
                 data_outputs = subworkflow_dict['steps'][order_index]['outputs']

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -411,6 +411,8 @@ class SubWorkflowModule(WorkflowModule):
                     extensions=["data"],
                     input_type=step_to_input_type[step_type],
                 )
+                if step.type == 'data_collection_input':
+                    input['collection_type'] = step.tool_inputs['collection_type']
                 inputs.append(input)
         return inputs
 

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -507,7 +507,9 @@ steps:
         downloaded_workflow = self._download_workflow(workflow_id, style="editor")
         steps = downloaded_workflow['steps']
         assert len(steps) == 2
-        assert steps['1']['outputs'][0]['collection_type'] == 'list:paired'
+        # Non-subworkflow collection_type_source tools will be handled by the client,
+        # so collection_type should be None here.
+        assert steps['1']['outputs'][0]['collection_type'] is None
 
     @skip_without_tool('collection_type_source')
     def test_export_editor_subworkflow_collection_type_source(self):

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -195,6 +195,20 @@ steps:
     -   output_name: "out_file1"
 """
 
+COLLECTION_TYPE_WORKLFOW_YAML = """
+steps:
+  - type: "data_collection_input"
+    label: "input1"
+    collection_type: "list:list"
+  - type: "tool"
+    tool_id: "cat1"
+    inputs:
+      input1:
+        connections:
+        - "@output_step": 0
+          output_name: "output"
+"""
+
 
 def test_subworkflow_new_inputs():
     subworkflow_module = __new_subworkflow_module()
@@ -205,6 +219,12 @@ def test_subworkflow_new_inputs():
     assert input1["name"] == "input1"
     assert input2["input_type"] == "dataset_collection"
     assert input2["name"] == "input2", input2["name"]
+
+
+def test_subworkflow_new_inputs_collection_type():
+    subworkflow_module = __new_subworkflow_module(COLLECTION_TYPE_WORKLFOW_YAML)
+    inputs = subworkflow_module.get_data_inputs()
+    assert inputs[0]['collection_type'] == 'list:list'
 
 
 def test_subworkflow_new_outputs():
@@ -363,11 +383,11 @@ def test_subworkflow_map_over_type(test_case):
     )
 
 
-def __new_subworkflow_module():
+def __new_subworkflow_module(workflow=TEST_WORKFLOW_YAML):
     trans = MockTrans()
     mock_tool = __mock_tool(id="cat1", version="1.0")
     trans.app.toolbox.tools["cat1"] = mock_tool
-    workflow = yaml_to_model(TEST_WORKFLOW_YAML)
+    workflow = yaml_to_model(workflow)
     stored_workflow = trans.save_workflow(workflow)
     workflow_id = trans.app.security.encode_id(stored_workflow.id)
     subworkflow_module = modules.module_factory.from_dict(trans, {"type": "subworkflow", "content_id": workflow_id})

--- a/test/unit/workflows/workflow_support.py
+++ b/test/unit/workflows/workflow_support.py
@@ -123,6 +123,9 @@ def yaml_to_model(has_dict, id_offset=100):
                 value = inputs
             if key == "workflow_outputs":
                 value = [partial(_dict_to_workflow_output, workflow_step)(_) for _ in value]
+            if key == 'collection_type':
+                key = 'tool_inputs'
+                value = {'collection_type': value}
             setattr(workflow_step, key, value)
         workflow.steps.append(workflow_step)
 


### PR DESCRIPTION
This allows us to get the correct collection type for subworkflows, which is a pretty major aspect if you want to use multiple subworkflows or want to link subworkflow outputs to collection inputs. This probably doesn't return the correct nesting level for unlinked, multiplied inputs (but that also doesn't work for regular workflows at this time, and I think it can't). But this already enables things like this:
![screen shot 2019-01-22 at 19 41 53](https://user-images.githubusercontent.com/6804901/51558715-75a67080-1e80-11e9-868a-e470042d113b.png)
