### PR TITLE
Changed logout behavior to automatically redirect home

### DIFF
--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -9,6 +9,18 @@ import { CommunicationServerView } from "layout/communication-server-view";
 import Webhooks from "mvc/webhooks";
 import Utils from "utils/utils";
 
+
+function logoutClick() {
+    let galaxy = getGalaxyInstance();
+    let token = galaxy.session_csrf_token || "";
+    if (galaxy.user) {
+        galaxy.user.clearSessionStorage();
+    }
+    let url = `${galaxy.root}user/logout?session_csrf_token=${token}`;
+    window.top.location.href = url;
+}
+
+
 var Collection = Backbone.Collection.extend({
     model: Backbone.Model.extend({
         defaults: {
@@ -290,9 +302,8 @@ var Collection = Backbone.Collection.extend({
                     },
                     {
                         title: _l("Logout"),
-                        url: `user/logout?session_csrf_token=${Galaxy.session_csrf_token}`,
-                        target: "_top",
-                        divider: true
+                        divider: true,
+                        onclick: logoutClick
                     },
                     {
                         title: _l("Saved Datasets"),

--- a/templates/user/logout.mako
+++ b/templates/user/logout.mako
@@ -38,11 +38,8 @@ def inherit(context):
 <%def name="javascript_app()">
     ${ parent.javascript_app() }
     <script type="text/javascript">
-        //HACK: should happen before we get to this page - _before_ logged out of session
-        config.addInitialization(function(galaxy, config) {
-            if (galaxy.user) {
-                galaxy.user.clearSessionStorage();
-            }
+        config.addInitialization(function(galaxy) {
+            window.location.href = galaxy.root;
         });
     </script>
 </%def>


### PR DESCRIPTION
Modifies logout to wipe local session data first, then redirect to home page following logout redirect.

A cleaner solution would be to implement a logout API endpoint and do a promise-based ajax request that clears the local session after the API call was successful, then redirects home, but this will fix the immediate issue.

Addresses:
https://github.com/galaxyproject/galaxy/issues/7249