### PR TITLE
[19.01] Fix _.escape typo in toolshed group detail view

### DIFF
--- a/client/galaxy/scripts/toolshed/groups/group-detail-view.js
+++ b/client/galaxy/scripts/toolshed/groups/group-detail-view.js
@@ -95,7 +95,7 @@ const GroupDetailView = Backbone.View.extend({
                 '<% _.each(group.get("repositories"), function(repo) { %>',
                 "<tr>",
                 "<td>",
-                '<a data-toggle="tooltip" data-placement="top" title="Details of <%= _.escape(repo.name) %>" href="/view/<%= _.escape(repo.owner) %>/<%= _escape(repo.name) %>" id="<%= repo.id %>"><%= _.escape(repo.name) %></a>',
+                '<a data-toggle="tooltip" data-placement="top" title="Details of <%= _.escape(repo.name) %>" href="/view/<%= _.escape(repo.owner) %>/<%= _.escape(repo.name) %>" id="<%= repo.id %>"><%= _.escape(repo.name) %></a>',
                 "</td>",
                 "<td>",
                 "<%= _.escape(repo.description) %>",


### PR DESCRIPTION
fixes #7259 
(the new linting would catch things like this, but not embedded in string templates like this unfortunately -- the good news is that we're phasing this kind of thing out and using template literals)