### PR TITLE
[18.09] Stop tool migrations checking by default...

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -181,12 +181,11 @@ galaxy:
 
   # Enable / disable checking if any tools defined in the above non-shed
   # tool_config_files (i.e., tool_conf.xml) have been migrated from the
-  # Galaxy code distribution to the Tool Shed.  This setting should
-  # generally be set to False only for development Galaxy environments
-  # that are often rebuilt from scratch where migrated tools do not need
-  # to be available in the Galaxy tool panel.  If the following setting
-  # remains commented, the default setting will be True.
-  #check_migrate_tools: true
+  # Galaxy code distribution to the Tool Shed. This functionality is
+  # largely untested in modern Galaxy releases and has serious issues
+  # such as #7273 and the possibility of slowing down Galaxy startup, so
+  # the default and recommended value is False.
+  #check_migrate_tools: false
 
   # Tool config maintained by tool migration scripts.  If you use the
   # migration scripts to install tools that have been migrated to the

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -208,13 +208,12 @@
 :Description:
     Enable / disable checking if any tools defined in the above non-
     shed tool_config_files (i.e., tool_conf.xml) have been migrated
-    from the Galaxy code distribution to the Tool Shed.  This setting
-    should generally be set to False only for development Galaxy
-    environments that are often rebuilt from scratch where migrated
-    tools do not need to be available in the Galaxy tool panel.  If
-    the following setting remains commented, the default setting will
-    be True.
-:Default: ``true``
+    from the Galaxy code distribution to the Tool Shed. This
+    functionality is largely untested in modern Galaxy releases and
+    has serious issues such as #7273 and the possibility of slowing
+    down Galaxy startup, so the default and recommended value is
+    False.
+:Default: ``false``
 :Type: bool
 
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -240,7 +240,7 @@ class Configuration(object):
 
         # Check for tools defined in the above non-shed tool configs (i.e., tool_conf.xml) tht have
         # been migrated from the Galaxy code distribution to the Tool Shed.
-        self.check_migrate_tools = string_as_bool(kwargs.get('check_migrate_tools', True))
+        self.check_migrate_tools = string_as_bool(kwargs.get('check_migrate_tools', False))
         self.shed_tool_data_path = kwargs.get("shed_tool_data_path", None)
         self.x_frame_options = kwargs.get("x_frame_options", "SAMEORIGIN")
         if self.shed_tool_data_path:

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -182,16 +182,14 @@ mapping:
 
       check_migrate_tools:
         type: bool
-        default: true
+        default: false
         required: false
         desc: |
           Enable / disable checking if any tools defined in the above non-shed
           tool_config_files (i.e., tool_conf.xml) have been migrated from the Galaxy
-          code distribution to the Tool Shed.  This setting should generally be set to
-          False only for development Galaxy environments that are often rebuilt from
-          scratch where migrated tools do not need to be available in the Galaxy tool
-          panel.  If the following setting remains commented, the default setting will
-          be True.
+          code distribution to the Tool Shed. This functionality is largely untested
+          in modern Galaxy releases and has serious issues such as #7273 and the possibility
+          of slowing down Galaxy startup, so the default and recommended value is False.
 
       migrated_tools_config:
         type: str


### PR DESCRIPTION
They are not needed in modern Galaxies and even problematic in some ways (e.g. #7273 and having the possibility of slowing Galaxy down at startup).