### PR TITLE
[19.01] Fix installing tools via tool_id

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/toolshed.py
+++ b/lib/galaxy/webapps/galaxy/api/toolshed.py
@@ -241,11 +241,11 @@ class ToolShedController(BaseAPIController):
             if len(tool_shed_url) == 0:
                 # By design, this list should always be from the same toolshed. If
                 # this is ever not the case, this code will need to be updated.
-                tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry(self.app, tool_ids[0].split('/')[0])
+                tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry(self.app, tool_ids[0].split('/repos')[0])
             found_repository = json.loads(util.url_get(tool_shed_url, params=dict(tool_ids=','.join(tool_ids)), pathspec=['api', 'repositories']))
-            fr_first_key = next(iter(found_repository.keys()))
-            repository_id = found_repository[fr_first_key]['repository_id']
-            repository_data['current_changeset'] = found_repository['current_changeset']
+            current_changeset = found_repository['current_changeset']
+            repository_id = found_repository[current_changeset]['repository_id']
+            repository_data['current_changeset'] = current_changeset
             repository_data['repository'] = json.loads(util.url_get(tool_shed_url, pathspec=['api', 'repositories', repository_id]))
             del found_repository['current_changeset']
             repository_data['tool_shed_url'] = tool_shed_url


### PR DESCRIPTION
Noticed this when installing via the beta install (install missing tools for a workflow)