### PR TITLE
Update node for selenium tests

### DIFF
--- a/.ci/jenkins/selenium-py3/run_tests.sh
+++ b/.ci/jenkins/selenium-py3/run_tests.sh
@@ -2,7 +2,7 @@
 
 # Enable retries on tests to reduce chances of transient failures.
 : ${GALAXY_TEST_SELENIUM_RETRIES:=1}
-: ${GALAXY_TEST_CLIENT_BUILD_IMAGE:='node:9.4.0'}
+: ${GALAXY_TEST_CLIENT_BUILD_IMAGE:='node:11'}
 
 # If in Jenkins environment, use it for artifacts.
 if [ -n "$BUILD_NUMBER" ];

--- a/.ci/jenkins/selenium/run_tests.sh
+++ b/.ci/jenkins/selenium/run_tests.sh
@@ -2,7 +2,7 @@
 
 # Enable retries on tests to reduce chances of transient failures.
 : ${GALAXY_TEST_SELENIUM_RETRIES:=1}
-: ${GALAXY_TEST_CLIENT_BUILD_IMAGE:='node:9.4.0'}
+: ${GALAXY_TEST_CLIENT_BUILD_IMAGE:='node:11'}
 
 # If in Jenkins environment, use it for artifacts.
 if [ -n "$BUILD_NUMBER" ];


### PR DESCRIPTION
AFAICT this is at least part of the problem:
```
yarn install v1.3.2
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.4: The platform "linux" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
error eslint@5.12.0: The engine "node" is incompatible with this module. Expected version "^6.14.0 || ^8.10.0 || >=9.10.0".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Makefile:144: recipe for target 'node-deps' failed
make: *** [node-deps] Error 1
```