### PR TITLE
Fix flakey history import metadata test

### DIFF
--- a/test/api/test_histories.py
+++ b/test/api/test_histories.py
@@ -192,7 +192,7 @@ class HistoriesApiTestCase(api.ApiTestCase):
     def test_import_metadata_regeneration(self):
         history_name = "for_import_metadata_regeneration"
         history_id = self.dataset_populator.new_history(name=history_name)
-        self.dataset_populator.new_dataset(history_id, content=open(self.test_data_resolver.get_filename("1.bam"), 'rb'), file_type='bam')
+        self.dataset_populator.new_dataset(history_id, content=open(self.test_data_resolver.get_filename("1.bam"), 'rb'), file_type='bam', wait=True)
         imported_history_id = self._reimport_history(history_id, history_name)
         self._assert_history_length(imported_history_id, 1)
         import_bam_metadata = self.dataset_populator.get_history_dataset_details(


### PR DESCRIPTION
We need to wait for the BAM dataset to be final before we can export.
(At least that solved it locally for me).