### PR TITLE
Fix ObjectNotFound exception when exporting an history

### DIFF
--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -11,6 +11,7 @@ from sqlalchemy.sql import expression
 
 from galaxy import model
 from galaxy.exceptions import MalformedContents
+from galaxy.exceptions import ObjectNotFound
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.web.framework.helpers import to_unicode
 
@@ -358,12 +359,21 @@ class JobExportHistoryArchiveWrapper(UsesAnnotations):
                         "designation": obj.designation,
                         "deleted": obj.deleted,
                         "visible": obj.visible,
-                        "file_name": obj.file_name,
                         "uuid": (lambda uuid: str(uuid) if uuid else None)(obj.dataset.uuid),
                         "annotation": to_unicode(getattr(obj, 'annotation', '')),
-                        "tags": get_item_tag_dict(obj),
-                        "extra_files_path": obj.extra_files_path
+                        "tags": get_item_tag_dict(obj)
                     }
+
+                    try:
+                        rval['file_name'] = obj.file_name
+                    except ObjectNotFound:
+                        rval['file_name'] = None
+
+                    if obj.extra_files_path_exists():
+                        rval['extra_files_path'] = obj.extra_files_path
+                    else:
+                        rval['extra_files_path'] = None
+
                     if not obj.visible and not include_hidden:
                         rval['exported'] = False
                     elif obj.deleted and not include_deleted:


### PR DESCRIPTION
Hi,
Here's a fix for 2 ObjectNotFound exceptions one of our user found while trying to export an history. It is a similar error as in #1765 or #6585

Here's the first exception:
```
Traceback (most recent call last): 
File "lib/galaxy/web/framework/base.py", line 222,
 in handle_request body = method(trans, **kwargs)
File "lib/galaxy/webapps/galaxy/controllers/history.py", line 1137,
 in export_archive self.queue_history_export(trans, history, gzip=gzip, include_hidden=include_hidden, include_deleted=include_deleted) 
File "lib/galaxy/web/base/controller.py", line 418,
 in queue_history_export history_exp_tool.execute(trans, incoming=params, history=history, set_output_hid=True) 
File "lib/galaxy/tools/__init__.py", line 1517,
 in execute return self.tool_action.execute(self, trans, incoming=incoming, set_output_hid=set_output_hid, history=history, **kwargs) 
File "lib/galaxy/tools/actions/history_imp_exp.py", line 124,
 in execute include_deleted=incoming['include_deleted']) 
File "lib/galaxy/tools/imp_exp/__init__.py", line 414,
 in setup_job datasets_attrs_out.write(dumps(datasets_attrs, cls=HistoryDatasetAssociationEncoder)) 
File "/local/miniconda3/envs/python-2.7.15/lib/python2.7/json/__init__.py", line 251,
 in dumps sort_keys=sort_keys, **kw).encode(obj) 
File "/local/miniconda3/envs/python-2.7.15/lib/python2.7/json/encoder.py", line 207,
 in encode chunks = self.iterencode(o, _one_shot=True) 
File "/local/miniconda3/envs/python-2.7.15/lib/python2.7/json/encoder.py", line 270,
 in iterencode return _iterencode(o, 0) 
File "lib/galaxy/tools/imp_exp/__init__.py", line 365,
 in default "extra_files_path": obj.extra_files_path 
File "lib/galaxy/model/__init__.py", line 2195,
 in extra_files_path return self.dataset.extra_files_path 
File "lib/galaxy/model/__init__.py", line 1988,
 in get_extra_files_path return self.object_store.get_filename(self, dir_only=True, extra_dir=self._extra_files_path or "dataset_%d_files" % self.id) 
File "lib/galaxy/objectstore/__init__.py", line 506,
 in get_filename return self._call_method('get_filename', obj, ObjectNotFound, True, **kwargs) 
File "lib/galaxy/objectstore/__init__.py", line 534,
 in _call_method % (method, self._repr_object_for_exception(obj), str(kwargs)))
 ObjectNotFound: objectstore, _call_method failed: get_filename on Dataset(id=42983), kwargs: {'dir_only': True, 'extra_dir': 'dataset_42983_files'} 
```
And the second one (when the frst one was fixed):
```
 Traceback (most recent call last):
File "lib/galaxy/web/framework/base.py", line 222,
 in handle_request body = method(trans, **kwargs)
File "lib/galaxy/webapps/galaxy/controllers/history.py", line 1137,
 in export_archive self.queue_history_export(trans, history, gzip=gzip, include_hidden=include_hidden, include_deleted=include_deleted)
File "lib/galaxy/web/base/controller.py", line 418,
 in queue_history_export history_exp_tool.execute(trans, incoming=params, history=history, set_output_hid=True)
File "lib/galaxy/tools/__init__.py", line 1517,
 in execute return self.tool_action.execute(self, trans, incoming=incoming, set_output_hid=set_output_hid, history=history, **kwargs)
File "lib/galaxy/tools/actions/history_imp_exp.py", line 124,
 in execute include_deleted=incoming['include_deleted'])
File "lib/galaxy/tools/imp_exp/__init__.py", line 496,
 in setup_job jobs_attrs_out.write(dumps(jobs_attrs, cls=HistoryDatasetAssociationEncoder))
File "/local/miniconda3/envs/python-2.7.15/lib/python2.7/json/__init__.py", line 251,
 in dumps sort_keys=sort_keys, **kw).encode(obj)
File "/local/miniconda3/envs/python-2.7.15/lib/python2.7/json/encoder.py", line 207,
 in encode chunks = self.iterencode(o, _one_shot=True)
File "/local/miniconda3/envs/python-2.7.15/lib/python2.7/json/encoder.py", line 270,
 in iterencode return _iterencode(o, 0)
File "lib/galaxy/tools/imp_exp/__init__.py", line 361,
 in default "file_name": obj.file_name,
File "lib/galaxy/model/__init__.py", line 2181,
 in get_file_name return self.dataset.get_file_name()
File "lib/galaxy/model/__init__.py", line 1969,
 in get_file_name filename = self.object_store.get_filename(self)
File "lib/galaxy/objectstore/__init__.py", line 506,
 in get_filename return self._call_method('get_filename', obj, ObjectNotFound, True, **kwargs)
File "lib/galaxy/objectstore/__init__.py", line 534,
 in _call_method % (method, self._repr_object_for_exception(obj), str(kwargs)))
 ObjectNotFound: objectstore, _call_method failed: get_filename on Dataset(id=42595), kwargs: {} 
```

I tested the patch on our 18.09 instance, it seems to work