### PR TITLE
Add a validator that ensures one metadata is between min and max values

### DIFF
--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -453,7 +453,7 @@ class MetadataInRangeValidator(Validator):
     Validator that ensures a metadata is in a specific range
     """
     requires_dataset_metadata = True
-    
+
     @classmethod
     def from_element(cls, param, elem):
         metadata_name = elem.get('metadata_name', None)
@@ -517,7 +517,7 @@ validator_types = dict(expression=ExpressionValidator,
                        dataset_metadata_in_file=MetadataInFileColumnValidator,
                        dataset_metadata_in_data_table=MetadataInDataTableColumnValidator,
                        dataset_ok_validator=DatasetOkValidator,
-		       dataset_metadata_in_range=MetadataInRangeValidator,)
+                       dataset_metadata_in_range=MetadataInRangeValidator,)
 
 
 def get_suite():

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -452,7 +452,6 @@ class MetadataInRangeValidator(Validator):
     """
     Validator that ensures a metadata is in a specific range
     """
-    requires_dataset_metadata = True
 
     @classmethod
     def from_element(cls, param, elem):

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -484,7 +484,11 @@ class MetadataInRangeValidator(Validator):
         if value:
             if not isinstance(value, model.DatasetInstance):
                 raise ValueError('A non-dataset value was provided.')
-            value_to_check = int(value.metadata.spec[self.metadata_name].param.to_string(value.metadata.get(self.metadata_name)))
+            try:
+                value_to_check = int(value.metadata.spec[self.metadata_name].param.to_string(value.metadata.get(self.metadata_name)))
+            except KeyError:
+                self.message = '{} Metadata missing'.format(self.metadata_name)
+                raise ValueError(self.message)
             try:
                 float(value_to_check)
             except ValueError:

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -3134,7 +3134,7 @@ validators is in the ``validator_types`` dictionary in
 Valid values include: ``expression``, ``regex``, ``in_range``, ``length``,
 ``metadata``, ``unspecified_build``, ``no_options``, ``empty_field``,
 ``dataset_metadata_in_file``, ``dataset_metadata_in_data_table``,
-``dataset_ok_validator``]]></xs:documentation>
+``dataset_ok_validator``, ``dataset_metadata_in_range``]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="message" type="xs:string">

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -5305,6 +5305,7 @@ and ``bibtex`` are the only supported options.</xs:documentation>
       <xs:enumeration value="empty_field"/>
       <xs:enumeration value="dataset_metadata_in_file"/>
       <xs:enumeration value="dataset_metadata_in_data_table"/>
+      <xs:enumeration value="dataset_metadata_in_range"/>
       <xs:enumeration value="dataset_ok_validator"/>
     </xs:restriction>
   </xs:simpleType>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -98,6 +98,7 @@
   <tool file="validation_default.xml" />
   <tool file="validation_sanitizer.xml" />
   <tool file="validation_repeat.xml" />
+  <tool file="validation_metadata_in_range.xml"/>
   <tool file="empty_output.xml" />
   <tool file="validation_empty_dataset.xml" />
   <tool file="implicit_conversion.xml" />

--- a/test/functional/tools/validation_metadata_in_range.xml
+++ b/test/functional/tools/validation_metadata_in_range.xml
@@ -1,0 +1,30 @@
+<tool id="validation_metadata_in_range" name="validation_metadata_in_range" profile="19.05" version="0.1">
+  <command>
+    echo "Hello World" > out1;
+  </command>
+  <inputs>
+    <param name="input1" type="data" format="fasta" label="fasta file with more than 10 sequences">
+      <validator type="dataset_metadata_in_range" metadata_name="sequences" min="2"/>
+    </param>
+  </inputs>
+  <outputs>
+    <data name="out_file1" from_work_dir="out1" format="txt"/>
+  </outputs>
+  <tests>
+    <test expect_failure="true">
+    <!-- fails because 1.fasta has just a single sequence -->
+      <param name="input1" value="1.fasta" ftype="fasta"/>
+    </test>
+    <test expect_failure="false">
+    <!-- works because 4.fasta has more than 1 sequence -->
+      <param name="input1" value="4.fasta" ftype="fasta"/>
+      <output name="out_file1">
+         <assert_contents>
+            <has_line line="Hello World" />
+         </assert_contents>
+      </output>
+    </test>
+  </tests>
+  <help>
+  </help>
+</tool>

--- a/test/functional/tools/validation_metadata_in_range.xml
+++ b/test/functional/tools/validation_metadata_in_range.xml
@@ -3,7 +3,7 @@
     echo "Hello World" > out1;
   </command>
   <inputs>
-    <param name="input1" type="data" format="fasta" label="fasta file with more than 10 sequences">
+    <param name="input1" type="data" format="fasta" label="fasta file with more than one sequence">
       <validator type="dataset_metadata_in_range" metadata_name="sequences" min="2"/>
     </param>
   </inputs>


### PR DESCRIPTION
I'm not sure if it's not already done but I have written a class to add a validator that ensures one metadata is between min and max values. Typically it can be used to ensure that a fasta file has the right number of sequences.
```
<param name="file_fasta" type="data" format="fasta"  label=">Reference (Fasta)">
    <validator type="dataset_metadata_in_range" max="1" metadata_name="sequences"/>
</param>
```