### PR TITLE
[19.01] Fix emoji tags

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1058,7 +1058,7 @@ def smart_str(s, encoding=DEFAULT_ENCODING, strings_only=False, errors='strict')
 
 def strip_control_characters(s):
     """Strip unicode control characters from a string."""
-    return "".join(c for c in unicodify(s) if unicodedata.category(c)[0] != "C")
+    return "".join(c for c in unicodify(s) if unicodedata.category(c)[0] != "C" or unicodedata.category(c) == "Cn")
 
 
 def strip_control_characters_nested(item):

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1058,7 +1058,7 @@ def smart_str(s, encoding=DEFAULT_ENCODING, strings_only=False, errors='strict')
 
 def strip_control_characters(s):
     """Strip unicode control characters from a string."""
-    return "".join(c for c in unicodify(s) if unicodedata.category(c)[0] != "C" or unicodedata.category(c) == "Cn")
+    return "".join(c for c in unicodify(s) if unicodedata.category(c) != "Cc")
 
 
 def strip_control_characters_nested(item):


### PR DESCRIPTION
Hey @mvdbeek apparently #6572 caused the regression in #7075. Would this patch sit well with you?

I definitely get blocking the other `C.` classes of characters, but `Cn` includes a lot of emoji that I'd like to have, and shouldn't include any whitespace which I think are just in Cc/Cf?