### PR TITLE
Support loading/using tools that are not in the install database

### DIFF
--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -1,8 +1,6 @@
 import logging
 import os
 
-from six.moves.urllib.parse import urljoin
-
 from galaxy.util import asbool
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
@@ -79,13 +77,7 @@ class ToolShedRepository(object):
         return self.deleted
 
     def get_sharable_url(self, app):
-        tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry(app, self.tool_shed)
-        if tool_shed_url:
-            # Append a slash to the tool shed URL, because urlparse.urljoin will eliminate
-            # the last part of a URL if it does not end with a forward slash.
-            tool_shed_url = '%s/' % tool_shed_url
-            return urljoin(tool_shed_url, 'view/%s/%s' % (self.owner, self.name))
-        return tool_shed_url
+        return common_util.get_tool_shed_repository_url(app, self.tool_shed, self.owner, self.name)
 
     def get_shed_config_filename(self):
         shed_config_filename = None

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1237,7 +1237,7 @@ class Tool(Dictifiable):
         if help_text is not None:
             try:
                 if self.repository_id and help_text.find('.. image:: ') >= 0:
-                # Handle tool help image display for tools that are contained in repositories in the tool shed or installed into Galaxy.
+                    # Handle tool help image display for tools that are contained in repositories in the tool shed or installed into Galaxy.
                     help_text = tool_shed.util.shed_util_common.set_image_paths(
                         self.app, help_text, encoded_repository_id=self.app.security.encode_id(self.repository_id)
                     )

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -486,7 +486,9 @@ class Tool(Dictifiable):
     @property
     def tool_shed_repository(self):
         # If this tool is included in an installed tool shed repository, return it.
-        if self.tool_shed:
+        if self._tool_shed_repository:
+            return self._tool_shed_repository
+        elif self.tool_shed:
             return repository_util.get_installed_repository(self.app,
                                                             tool_shed=self.tool_shed,
                                                             name=self.repository_name,
@@ -1225,7 +1227,7 @@ class Tool(Dictifiable):
                     help_text = tool_shed.util.shed_util_common.set_image_paths(self.app, help_text, repository_id=self.repository_id)
                 elif self._tool_shed_repository and help_text.find('.. image:: ') >= 0:
                     help_text = tool_shed.util.shed_util_common.set_image_paths(
-                        self.app, help_text, tool_shed_repository=self._tool_shed_repository, version=self.version
+                        self.app, help_text, tool_shed_repository=self._tool_shed_repository, tool_id=self.old_id, tool_version=self.version
                     )
             except Exception:
                 log.exception("Exception in parse_help, so images may not be properly displayed")

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -397,7 +397,6 @@ class Tool(Dictifiable):
         self.tool_dir = os.path.dirname(config_file)
         self.app = app
         self.repository_id = repository_id
-        self._tool_shed_repository = tool_shed_repository
         self._allow_code_files = allow_code_files
         # setup initial attribute values
         self.inputs = odict()
@@ -438,7 +437,7 @@ class Tool(Dictifiable):
         self._lineage = None
         self.dependencies = []
         # populate toolshed repository info, if available
-        self.populate_tool_shed_info()
+        self.populate_tool_shed_info(tool_shed_repository)
         # add tool resource parameters
         self.populate_resource_parameters(tool_source)
         self.tool_errors = None
@@ -486,20 +485,20 @@ class Tool(Dictifiable):
     @property
     def tool_shed_repository(self):
         # If this tool is included in an installed tool shed repository, return it.
-        if self._tool_shed_repository:
-            return self._tool_shed_repository
-        elif self.tool_shed:
+        if self.tool_shed:
             return repository_util.get_installed_repository(self.app,
                                                             tool_shed=self.tool_shed,
                                                             name=self.repository_name,
                                                             owner=self.repository_owner,
-                                                            installed_changeset_revision=self.installed_changeset_revision)
-        return None
+                                                            installed_changeset_revision=self.installed_changeset_revision,
+                                                            repository_id=self.repository_id)
 
     @property
     def repository_path(self):
         if self._repository_path is None:
-            self._repository_path = self.tool_shed_repository.repo_path(self.app)
+            repository = self.tool_shed_repository
+            if repository:
+                self._repository_path = repository.repo_path(self.app)
         return self._repository_path
 
     @property
@@ -860,7 +859,7 @@ class Tool(Dictifiable):
         """If tool shed installed tool, the base directory of the repository installed."""
         repository_dir = None
 
-        if hasattr(self, 'tool_shed') and self.tool_shed:
+        if getattr(self, 'tool_shed', None):
             repository_dir = self.tool_dir
             while True:
                 repository_dir_name = os.path.basename(repository_dir)
@@ -1182,25 +1181,8 @@ class Tool(Dictifiable):
                     root.append(inputs)
                 inputs.append(resource_xml)
 
-    def populate_tool_shed_info(self):
-        tool_shed_repository = None
-        if self.repository_id is not None and self.app.name == 'galaxy':
-            repository_id = self.app.security.decode_id(self.repository_id)
-            if hasattr(self.app, 'tool_shed_repository_cache'):
-                tool_shed_repository = self.app.tool_shed_repository_cache.get_installed_repository(repository_id=repository_id)
-        elif self._tool_shed_repository is not None and self.app.name == 'galaxy':
-            if hasattr(self._tool_shed_repository, 'id') and hasattr(self.app, 'tool_shed_repository_cache'):
-                tool_shed_repository = self.app.tool_shed_repository_cache.get_installed_repository(
-                    repository_id=self._tool_shed_repository.id
-                )
-                self.repository_id = tool_shed_repository.id
-            elif not hasattr(self._tool_shed_repository, 'id'):
-                # this is a ToolConfRepository
-                tool_shed_repository = self._tool_shed_repository
-                self._repository_path = tool_shed_repository.repo_path
+    def populate_tool_shed_info(self, tool_shed_repository):
         if tool_shed_repository:
-            if not self._tool_shed_repository:
-                self._tool_shed_repository = tool_shed_repository
             self.tool_shed = tool_shed_repository.tool_shed
             self.repository_name = tool_shed_repository.name
             self.repository_owner = tool_shed_repository.owner
@@ -1231,19 +1213,13 @@ class Tool(Dictifiable):
         tool_source = self.__help_source
         self.__help = None
         self.__help_by_page = []
-        help_header = ""
         help_footer = ""
         help_text = tool_source.parse_help()
         if help_text is not None:
             try:
-                if self.repository_id and help_text.find('.. image:: ') >= 0:
-                    # Handle tool help image display for tools that are contained in repositories in the tool shed or installed into Galaxy.
+                if self.tool_shed_repository and help_text.find('.. image:: ') >= 0:
                     help_text = tool_shed.util.shed_util_common.set_image_paths(
-                        self.app, help_text, encoded_repository_id=self.app.security.encode_id(self.repository_id)
-                    )
-                elif self._tool_shed_repository and help_text.find('.. image:: ') >= 0:
-                    help_text = tool_shed.util.shed_util_common.set_image_paths(
-                        self.app, help_text, tool_shed_repository=self._tool_shed_repository, tool_id=self.old_id, tool_version=self.version
+                        self.app, help_text, tool_shed_repository=self.tool_shed_repository, tool_id=self.old_id, tool_version=self.version
                     )
             except Exception:
                 log.exception("Exception in parse_help, so images may not be properly displayed")

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1208,9 +1208,9 @@ class Tool(Dictifiable):
         help_text = tool_source.parse_help()
         if help_text is not None:
             try:
-                if self.tool_shed_repository and help_text.find('.. image:: ') >= 0:
+                if help_text.find('.. image:: ') >= 0 and (self.tool_shed_repository or self.repository_id):
                     help_text = tool_shed.util.shed_util_common.set_image_paths(
-                        self.app, help_text, tool_shed_repository=self.tool_shed_repository, tool_id=self.old_id, tool_version=self.version
+                        self.app, help_text, encoded_repository_id=self.repository_id, tool_shed_repository=self.tool_shed_repository, tool_id=self.old_id, tool_version=self.version
                     )
             except Exception:
                 log.exception("Exception in parse_help, so images may not be properly displayed")

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -422,7 +422,6 @@ class Tool(Dictifiable):
         # tool_data_table_conf.xml entries exist.
         self.input_params = []
         # Attributes of tools installed from Galaxy tool sheds.
-        self._repository_path = None
         self.tool_shed = None
         self.repository_name = None
         self.repository_owner = None
@@ -492,14 +491,6 @@ class Tool(Dictifiable):
                                                             owner=self.repository_owner,
                                                             installed_changeset_revision=self.installed_changeset_revision,
                                                             repository_id=self.repository_id)
-
-    @property
-    def repository_path(self):
-        if self._repository_path is None:
-            repository = self.tool_shed_repository
-            if repository:
-                self._repository_path = repository.repo_path(self.app)
-        return self._repository_path
 
     @property
     def produces_collections_with_unknown_structure(self):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1178,23 +1178,26 @@ class Tool(Dictifiable):
 
     def populate_tool_shed_info(self):
         if self._tool_shed_repository is not None and self.app.name == 'galaxy':
+            tool_shed_repository = None
             if hasattr(self._tool_shed_repository, 'id') and hasattr(self.app, 'tool_shed_repository_cache'):
                 tool_shed_repository = self.app.tool_shed_repository_cache.get_installed_repository(
                     repository_id=self._tool_shed_repository.id
                 )
                 self.repository_id = tool_shed_repository.id
                 self.repository_path = tool_shed_repository.repo_path(self.app)
-            else:
+            elif not hasattr(self._tool_shed_repository, 'id'):
+                # this is a ToolConfRepository
                 tool_shed_repository = self._tool_shed_repository
                 self.repository_path = tool_shed_repository.repo_path
-            self.tool_shed = tool_shed_repository.tool_shed
-            self.repository_name = tool_shed_repository.name
-            self.repository_owner = tool_shed_repository.owner
-            self.changeset_revision = tool_shed_repository.changeset_revision
-            self.installed_changeset_revision = tool_shed_repository.installed_changeset_revision
-            self.sharable_url = common_util.get_tool_shed_repository_url(
-                self.app, self.tool_shed, self.repository_owner, self.repository_name
-            )
+            if tool_shed_repository:
+                self.tool_shed = tool_shed_repository.tool_shed
+                self.repository_name = tool_shed_repository.name
+                self.repository_owner = tool_shed_repository.owner
+                self.changeset_revision = tool_shed_repository.changeset_revision
+                self.installed_changeset_revision = tool_shed_repository.installed_changeset_revision
+                self.sharable_url = common_util.get_tool_shed_repository_url(
+                    self.app, self.tool_shed, self.repository_owner, self.repository_name
+                )
 
     @property
     def help(self):

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -128,6 +128,9 @@ class ToolShedRepositoryCache(object):
         self.app = app
         self.cache = local()
 
+    def add_local_repository(self, repository):
+        self.cache.repositories.append(repository)
+
     @property
     def tool_shed_repositories(self):
         try:

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -260,12 +260,13 @@ class DataManager(object):
     def id(self):
         return self.guid or self.declared_id  # if we have a guid, we will use that as the data_manager id
 
-    def load_tool(self, tool_filename, guid=None, data_manager_id=None, tool_shed_repository_id=None):
+    def load_tool(self, tool_filename, guid=None, data_manager_id=None, tool_shed_repository_id=None, tool_shed_repository=None):
         toolbox = self.data_managers.app.toolbox
         tool = toolbox.load_hidden_tool(tool_filename,
                                         guid=guid,
                                         data_manager_id=data_manager_id,
                                         repository_id=tool_shed_repository_id,
+                                        tool_shed_repository=tool_shed_repository,
                                         use_cached=True)
         self.data_managers.app.toolbox.data_manager_tools[tool.id] = tool
         self.tool = tool

--- a/lib/galaxy/tools/repositories.py
+++ b/lib/galaxy/tools/repositories.py
@@ -30,6 +30,7 @@ class ValidationContext(object):
         self.config.tool_data_table_config = os.path.join(self.temporary_path, 'tool_data_table_conf.xml')
         self.config.shed_tool_data_table_config = os.path.join(self.temporary_path, 'shed_tool_data_table_conf.xml')
         self.tool_data_tables = tool_data_tables
+        self.tool_shed_registry = Bunch(tool_sheds={})
         self.datatypes_registry = registry
         self.hgweb_config_manager = hgweb_config_manager
         self.config.len_file_path = os.path.join(self.temporary_path, 'chromlen.txt')

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -566,7 +566,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             #        can_load_into_panel_dict = not tool_shed_repository.deleted
             #        repository_id = self.app.security.encode_id(tool_shed_repository.id)
             #        tool = self.load_tool(concrete_path, guid=guid, repository_id=repository_id, use_cached=False)
-                    tool = self.load_tool(concrete_path, guid=guid, use_cached=False)
+                    tool = self.load_tool(concrete_path, guid=guid, repository_id=tool_shed_repository, use_cached=False)
             if not tool:  # tool was not in cache and is not a tool shed tool.
                 tool = self.load_tool(concrete_path, use_cached=False)
             if string_as_bool(item.get('hidden', False)):
@@ -597,16 +597,17 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
 
     def get_tool_repository_from_xml_item(self, item, path):
         from collections import namedtuple
-        ToolShedRepository = namedtuple('ToolShedRepository', ('tool_shed', 'name', 'owner', 'installed_changeset_revision'))
+        ToolShedRepository = namedtuple('ToolShedRepository', ('tool_shed', 'name', 'owner', 'installed_changeset_revision', 'changeset_revision'))
         tool_shed = item.elem.find("tool_shed").text
         repository_name = item.elem.find("repository_name").text
         repository_owner = item.elem.find("repository_owner").text
         installed_changeset_revision_elem = item.elem.find("installed_changeset_revision")
+        changeset_revision = item.attributes['file'].split('/')[-3]    # FIXME: ugh
         if installed_changeset_revision_elem is None:
             # Backward compatibility issue - the tag used to be named 'changeset_revision'.
             installed_changeset_revision_elem = item.elem.find("changeset_revision")
         installed_changeset_revision = installed_changeset_revision_elem.text
-        repository = ToolShedRepository(tool_shed, repository_name, repository_owner, installed_changeset_revision)
+        repository = ToolShedRepository(tool_shed, repository_name, repository_owner, installed_changeset_revision, changeset_revision)
         return repository
         if "/repos/" in path:  # The only time "/repos/" should not be in path is during testing!
             try:

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -636,6 +636,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             msg = "Attempted to load tool shed tool, but the repository with name '%s' from owner '%s' was not found " \
                   "in database. Tool will be loaded without install database."
             log.warning(msg, repository_name, repository_owner)
+            # Pull the changeset_revision from the path, and determine the base repo path.
             pre = '{shed}/repos/{owner}/{name}/'.format(
                 shed=tool_shed,
                 owner=repository_owner,

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -39,7 +39,10 @@ log = logging.getLogger(__name__)
 # A fake ToolShedRepository constructed from a shed tool conf
 ToolConfRepository = namedtuple(
     'ToolConfRepository',
-    ('tool_shed', 'name', 'owner', 'installed_changeset_revision', 'changeset_revision', 'repo_path')
+    (
+        'tool_shed', 'name', 'owner', 'installed_changeset_revision', 'changeset_revision', 'repo_path',
+        'tool_dependencies_installed_or_in_error'
+    )
 )
 
 
@@ -649,7 +652,8 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             pre = '/'.join([pre.rstrip('/'), changeset_revision, name2])
             repo_path = concrete_path[:concrete_path.index(pre) + len(pre)]
             repository = ToolConfRepository(
-                tool_shed, repository_name, repository_owner, installed_changeset_revision, changeset_revision, repo_path
+                tool_shed, repository_name, repository_owner, installed_changeset_revision, changeset_revision,
+                repo_path, None
             )
         return repository
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -642,11 +642,11 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 name=repository_name
             )
             try:
-                changeset_revision, name2 = path[path.index(pre) + len(pre):].split('/')[0:1]
+                changeset_revision = path[path.index(pre) + len(pre):].split('/', 1)[0]
             except ValueError as exc:
-                raise Exception("Cannont determine changeset revision from path '%s': %s" % (path, exc))
-            pre = '/'.join([pre, changeset_revision, name2])
-            repo_path = concrete_path[concrete_path.index(pre) + len(pre):]
+                raise Exception("Cannot determine changeset revision from path '%s': %s" % (path, exc))
+            pre = '/'.join([pre.rstrip('/'), changeset_revision])
+            repo_path = concrete_path[:concrete_path.index(pre) + len(pre)]
             repository = ToolConfRepository(
                 tool_shed, repository_name, repository_owner, installed_changeset_revision, changeset_revision, repo_path
             )

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -41,7 +41,7 @@ ToolConfRepository = namedtuple(
     'ToolConfRepository',
     (
         'tool_shed', 'name', 'owner', 'installed_changeset_revision', 'changeset_revision', 'repo_path',
-        'tool_dependencies_installed_or_in_error'
+        'tool_dependencies_installed_or_in_error', 'id'
     )
 )
 
@@ -653,8 +653,9 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             repo_path = concrete_path[:concrete_path.index(pre) + len(pre)]
             repository = ToolConfRepository(
                 tool_shed, repository_name, repository_owner, installed_changeset_revision, changeset_revision,
-                repo_path, None
+                repo_path, None, None
             )
+            self.app.tool_shed_repository_cache.add_local_repository(repository)
         return repository
 
     def _get_tool_shed_repository(self, tool_shed, name, owner, installed_changeset_revision):

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -613,17 +613,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         if installed_changeset_revision_elem is None:
             # Backward compatibility issue - the tag used to be named 'changeset_revision'.
             installed_changeset_revision_elem = item.elem.find("changeset_revision")
-        installed_changeset_revision = changeset_revision = installed_changeset_revision_elem.text
-        if "/repos/" in path:  # The only time "/repos/" should not be in path is during testing!
-            pre = '{shed}/repos/{owner}/{name}/'.format(
-                shed=tool_shed,
-                owner=repository_owner,
-                name=repository_name
-            )
-            try:
-                changeset_revision, name2 = path[path.index(pre) + len(pre):].split('/')[0:2]
-            except ValueError as exc:
-                raise Exception("Cannot determine changeset revision from path '%s': %s" % (path, exc))
+        installed_changeset_revision = installed_changeset_revision_elem.text
         repository = self._get_tool_shed_repository(tool_shed=tool_shed,
                                                     name=repository_name,
                                                     owner=repository_owner,
@@ -633,7 +623,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                   "in database. Tool will be loaded without install database."
             log.warning(msg, repository_name, repository_owner)
             repository = ToolConfRepository(
-                tool_shed, repository_name, repository_owner, installed_changeset_revision, changeset_revision, None,
+                tool_shed, repository_name, repository_owner, installed_changeset_revision, installed_changeset_revision, None,
             )
             self.app.tool_shed_repository_cache.add_local_repository(repository)
         return repository

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -642,10 +642,10 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 name=repository_name
             )
             try:
-                changeset_revision = path[path.index(pre) + len(pre):].split('/', 1)[0]
+                changeset_revision, name2 = path[path.index(pre) + len(pre):].split('/')[0:2]
             except ValueError as exc:
                 raise Exception("Cannot determine changeset revision from path '%s': %s" % (path, exc))
-            pre = '/'.join([pre.rstrip('/'), changeset_revision])
+            pre = '/'.join([pre.rstrip('/'), changeset_revision, name2])
             repo_path = concrete_path[:concrete_path.index(pre) + len(pre)]
             repository = ToolConfRepository(
                 tool_shed, repository_name, repository_owner, installed_changeset_revision, changeset_revision, repo_path

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -881,6 +881,17 @@ def populate_api_routes(webapp, app):
                      repository_id=None,
                      image_file=None)
 
+    # Do the same but without a repository id
+    webapp.add_route('/shed_tool_static/{shed}/{owner}/{repo}/{tool}/{version}/{image_file:.+?}',
+                     controller='shed_tool_static',
+                     action='index',
+                     shed=None,
+                     owner=None,
+                     repo=None,
+                     tool=None,
+                     version=None,
+                     image_file=None)
+
     webapp.mapper.connect('tool_shed_contents',
                           '/api/tool_shed/contents',
                           controller='toolshed',

--- a/lib/galaxy/webapps/galaxy/controllers/shed_tool_static.py
+++ b/lib/galaxy/webapps/galaxy/controllers/shed_tool_static.py
@@ -31,7 +31,7 @@ class ShedToolStatic(BaseUIController):
         """
         guid = '/'.join([shed, 'repos', owner, repo, tool, version])
         tool = trans.app.toolbox.get_tool(guid)
-        repo_path = tool.tool_shed_repository.repo_path
+        repo_path = tool.repository_path
         path = join(repo_path, image_file)
         if not safe_contains(repo_path, path):
             raise RequestParameterInvalidException()

--- a/lib/galaxy/webapps/galaxy/controllers/shed_tool_static.py
+++ b/lib/galaxy/webapps/galaxy/controllers/shed_tool_static.py
@@ -1,5 +1,5 @@
 import logging
-from os.path import splitext
+import os
 
 from galaxy import web
 from galaxy.exceptions import RequestParameterInvalidException
@@ -26,13 +26,17 @@ class ShedToolStatic(BaseUIController):
         """
         guid = '/'.join([shed, 'repos', owner, repo, tool, version])
         tool = trans.app.toolbox.get_tool(guid)
-        repo_path = tool.repository_path
-        path = join(repo_path, image_file)
-        if not safe_contains(repo_path, path):
+        repo_path = tool._repository_dir
+        if 'static/images' not in image_file:
+            path = join(repo_path, 'static', 'images', image_file)
+        else:
+            path = join(repo_path, image_file)
+        if not safe_contains(os.path.abspath(repo_path), os.path.abspath(path)):
             raise RequestParameterInvalidException()
-        ext = splitext(image_file)[-1].lstrip('.')
+        ext = os.path.splitext(image_file)[-1].lstrip('.')
         if ext:
             mime = trans.app.datatypes_registry.get_mimetype_by_extension(ext)
             if mime:
                 trans.response.set_content_type(mime)
-        return open(path, 'rb')
+        if os.path.exists(path):
+            return open(path, 'rb')

--- a/lib/galaxy/webapps/galaxy/controllers/shed_tool_static.py
+++ b/lib/galaxy/webapps/galaxy/controllers/shed_tool_static.py
@@ -1,0 +1,51 @@
+import logging
+from json import loads
+
+import paste.httpexceptions
+from markupsafe import escape
+from six import string_types
+
+from galaxy import web
+from galaxy.web.base.controller import BaseUIController
+
+log = logging.getLogger(__name__)
+
+
+class ShedToolStatic(BaseUIController):
+
+    @web.expose
+    def index(self, trans, shed, owner, repo, tool, version, **kwd):
+        """
+        Open an image file that is contained in an installed tool shed repository or that is referenced by a URL for display.  The
+        image can be defined in either a README.rst file contained in the repository or the help section of a Galaxy tool config that
+        is contained in the repository.  The following image definitions are all supported.  The former $PATH_TO_IMAGES is no longer
+        required, and is now ignored.
+        .. image:: https://raw.github.com/galaxy/some_image.png
+        .. image:: $PATH_TO_IMAGES/some_image.png
+        .. image:: /static/images/some_image.gif
+        .. image:: some_image.jpg
+        .. image:: /deep/some_image.png
+        """
+        guid = '/'.join([shed, 'repos', owner, repo, tool, version])
+        return self.toolbox[guid].repo_path
+    '''
+        relative_path_to_image_file = kwd.get('image_file', None)
+        if repository_id and relative_path_to_image_file:
+            repository = repository_util.get_tool_shed_repository_by_id(trans.app, repository_id)
+            if repository:
+                repo_files_dir = repository.repo_files_directory(trans.app)
+                # The following line sometimes returns None.  TODO: Figure out why.
+                path_to_file = repository_util.get_absolute_path_to_file_in_repository(repo_files_dir, relative_path_to_image_file)
+                if path_to_file and os.path.exists(path_to_file):
+                    file_name = os.path.basename(relative_path_to_image_file)
+                    try:
+                        extension = file_name.split('.')[-1]
+                    except Exception:
+                        extension = None
+                    if extension:
+                        mimetype = trans.app.datatypes_registry.get_mimetype_by_extension(extension)
+                        if mimetype:
+                            trans.response.set_content_type(mimetype)
+                    return open(path_to_file, 'r')
+        return None
+        '''

--- a/lib/galaxy/webapps/galaxy/controllers/shed_tool_static.py
+++ b/lib/galaxy/webapps/galaxy/controllers/shed_tool_static.py
@@ -1,14 +1,9 @@
 import logging
-from json import loads
 from os.path import splitext
 
-import paste.httpexceptions
-from markupsafe import escape
-from six import string_types
-
+from galaxy import web
 from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.util.path import join, safe_contains
-from galaxy import web
 from galaxy.web.base.controller import BaseUIController
 
 log = logging.getLogger(__name__)

--- a/lib/tool_shed/tools/tool_validator.py
+++ b/lib/tool_shed/tools/tool_validator.py
@@ -291,16 +291,10 @@ class ToolValidator(object):
             tool = create_tool_from_source(config_file=full_path, app=self.app, tool_source=tool_source, repository_id=repository_id, allow_code_files=False)
             valid = True
             error_message = None
-        except KeyError as e:
-            tool = None
-            valid = False
-            error_message = 'This file requires an entry for "%s" in the tool_data_table_conf.xml file.  Upload a file ' % str(e)
-            error_message += 'named tool_data_table_conf.xml.sample to the repository that includes the required entry to correct '
-            error_message += 'this error.  '
-        except Exception as e:
-            tool = None
-            valid = False
-            error_message = str(e)
+        except Exception:
+            # As best I can tell, error messages will no longer get back to the UI, so raise exceptions instead so that
+            # at least something will be logged.
+            raise
         return tool, valid, error_message
 
     def load_tool_from_tmp_config(self, repo, repository_id, ctx, ctx_file, work_dir):

--- a/lib/tool_shed/tools/tool_validator.py
+++ b/lib/tool_shed/tools/tool_validator.py
@@ -291,10 +291,18 @@ class ToolValidator(object):
             tool = create_tool_from_source(config_file=full_path, app=self.app, tool_source=tool_source, repository_id=repository_id, allow_code_files=False)
             valid = True
             error_message = None
-        except Exception:
-            # As best I can tell, error messages will no longer get back to the UI, so raise exceptions instead so that
-            # at least something will be logged.
-            raise
+        except KeyError as e:
+            tool = None
+            valid = False
+            error_message = 'This file requires an entry for "%s" in the tool_data_table_conf.xml file.  Upload a file ' % str(e)
+            error_message += 'named tool_data_table_conf.xml.sample to the repository that includes the required entry to correct '
+            error_message += 'this error.  '
+            log.exception(error_message)
+        except Exception as e:
+            tool = None
+            valid = False
+            error_message = str(e)
+            log.exception('Caught exception loading tool from %s:', full_path)
         return tool, valid, error_message
 
     def load_tool_from_tmp_config(self, repo, repository_id, ctx, ctx_file, work_dir):

--- a/lib/tool_shed/util/common_util.py
+++ b/lib/tool_shed/util/common_util.py
@@ -2,6 +2,8 @@ import json
 import logging
 import os
 
+from six.moves.urllib.parse import urljoin
+
 from galaxy import util
 from galaxy.util.odict import odict
 from galaxy.web import url_for
@@ -240,6 +242,16 @@ def get_tool_shed_url_from_tool_shed_registry(app, tool_shed):
             return shed_url
     # The tool shed from which the repository was originally installed must no longer be configured in tool_sheds_conf.xml.
     return None
+
+
+def get_tool_shed_repository_url(app, tool_shed, owner, name):
+    tool_shed_url = get_tool_shed_url_from_tool_shed_registry(app, tool_shed)
+    if tool_shed_url:
+        # Append a slash to the tool shed URL, because urlparse.urljoin will eliminate
+        # the last part of a URL if it does not end with a forward slash.
+        tool_shed_url = '%s/' % tool_shed_url
+        return urljoin(tool_shed_url, 'view/%s/%s' % (owner, name))
+    return tool_shed_url
 
 
 def get_user_by_username(app, username):

--- a/lib/tool_shed/util/readme_util.py
+++ b/lib/tool_shed/util/readme_util.py
@@ -55,7 +55,7 @@ def build_readme_files_dict(app, repository, changeset_revision, metadata, tool_
                             try:
                                 text_of_reasonable_length = suc.set_image_paths(app,
                                                                                 text_of_reasonable_length,
-                                                                                repository_id=app.security.encode_id(repository.id))
+                                                                                encoded_repository_id=app.security.encode_id(repository.id))
                             except Exception:
                                 log.exception("Exception in build_readme_files_dict, so images may not be properly displayed")
                             finally:

--- a/lib/tool_shed/util/readme_util.py
+++ b/lib/tool_shed/util/readme_util.py
@@ -54,8 +54,8 @@ def build_readme_files_dict(app, repository, changeset_revision, metadata, tool_
                             lock.acquire(True)
                             try:
                                 text_of_reasonable_length = suc.set_image_paths(app,
-                                                                                app.security.encode_id(repository.id),
-                                                                                text_of_reasonable_length)
+                                                                                text_of_reasonable_length,
+                                                                                repository_id=app.security.encode_id(repository.id))
                             except Exception:
                                 log.exception("Exception in build_readme_files_dict, so images may not be properly displayed")
                             finally:

--- a/lib/tool_shed/util/readme_util.py
+++ b/lib/tool_shed/util/readme_util.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import threading
 
 from mako.template import Template
 
@@ -50,16 +49,12 @@ def build_readme_files_dict(app, repository, changeset_revision, metadata, tool_
                         text_of_reasonable_length = basic_util.size_string(text)
                         if text_of_reasonable_length.find('.. image:: ') >= 0:
                             # Handle image display for README files that are contained in repositories in the tool shed or installed into Galaxy.
-                            lock = threading.Lock()
-                            lock.acquire(True)
                             try:
                                 text_of_reasonable_length = suc.set_image_paths(app,
                                                                                 text_of_reasonable_length,
                                                                                 encoded_repository_id=app.security.encode_id(repository.id))
                             except Exception:
                                 log.exception("Exception in build_readme_files_dict, so images may not be properly displayed")
-                            finally:
-                                lock.release()
                         if readme_file_name.endswith('.rst'):
                             text_of_reasonable_length = Template(rst_to_html(text_of_reasonable_length),
                                                                  input_encoding='utf-8',

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -601,7 +601,7 @@ def open_repository_files_folder(app, folder_path, repository_id, is_admin=False
     return folder_contents
 
 
-def set_image_paths(app, text, repository_id=None, tool_shed_repository=None, tool_id=None, tool_version=None):
+def set_image_paths(app, text, encoded_repository_id=None, tool_shed_repository=None, tool_id=None, tool_version=None):
     """
     Handle tool help image display for tools that are contained in repositories in
     the tool shed or installed into Galaxy as well as image display in repository
@@ -609,11 +609,11 @@ def set_image_paths(app, text, repository_id=None, tool_shed_repository=None, to
     return the path to it that will enable the caller to open the file.
     """
     if text:
-        if repository_util.is_tool_shed_client(app) and repository_id:
-            route_to_images = 'admin_toolshed/static/images/%s' % repository_id
-        elif repository_id:
+        if repository_util.is_tool_shed_client(app) and encoded_repository_id:
+            route_to_images = 'admin_toolshed/static/images/%s' % encoded_repository_id
+        elif encoded_repository_id:
             # We're in the tool shed.
-            route_to_images = '/repository/static/images/%s' % repository_id
+            route_to_images = '/repository/static/images/%s' % encoded_repository_id
         elif tool_shed_repository and tool_id and tool_version:
             route_to_images = 'shed_tool_static/{shed}/{owner}/{repo}/{tool}/{version}'.format(
                 shed=tool_shed_repository.tool_shed,
@@ -623,7 +623,7 @@ def set_image_paths(app, text, repository_id=None, tool_shed_repository=None, to
                 version=tool_version,
             )
         else:
-            raise Exception("repository_id or tool_shed_repository and tool_id and tool_version must be provided")
+            raise Exception("encoded_repository_id or tool_shed_repository and tool_id and tool_version must be provided")
         # We used to require $PATH_TO_IMAGES and ${static_path}, but
         # we now eliminate it if it's used.
         text = text.replace('$PATH_TO_IMAGES', '')

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -601,7 +601,7 @@ def open_repository_files_folder(app, folder_path, repository_id, is_admin=False
     return folder_contents
 
 
-def set_image_paths(app, encoded_repository_id, text):
+def set_image_paths(app, text, repository_id=None, tool_shed_repository=None, tool_id=None, tool_version=None):
     """
     Handle tool help image display for tools that are contained in repositories in
     the tool shed or installed into Galaxy as well as image display in repository
@@ -609,11 +609,21 @@ def set_image_paths(app, encoded_repository_id, text):
     return the path to it that will enable the caller to open the file.
     """
     if text:
-        if repository_util.is_tool_shed_client(app):
-            route_to_images = 'admin_toolshed/static/images/%s' % encoded_repository_id
-        else:
+        if repository_util.is_tool_shed_client(app) and repository_id:
+            route_to_images = 'admin_toolshed/static/images/%s' % repository_id
+        elif repository_id:
             # We're in the tool shed.
-            route_to_images = '/repository/static/images/%s' % encoded_repository_id
+            route_to_images = '/repository/static/images/%s' % repository_id
+        elif tool_shed_repository and tool_id and tool_version:
+            route_to_images = 'shed_tool_static/{shed}/{owner}/{repo}/{tool}/{version}'.format(
+                shed=tool_shed_repository.tool_shed,
+                owner=tool_shed_repository.owner,
+                repo=tool_shed_repository.name,
+                tool=tool_id,
+                version=tool_version,
+            )
+        else:
+            raise Exception("repository_id or tool_shed_repository and tool_id and tool_version must be provided")
         # We used to require $PATH_TO_IMAGES and ${static_path}, but
         # we now eliminate it if it's used.
         text = text.replace('$PATH_TO_IMAGES', '')

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -76,6 +76,7 @@ class MockApp(object):
         self.dataset_collections_service = None
         self.container_finder = NullContainerFinder()
         self._toolbox_lock = MockLock()
+        self.tool_shed_registry = Bunch(tool_sheds={})
         self.genome_builds = GenomeBuilds(self)
         self.job_manager = NoopManager()
         self.application_stack = ApplicationStack()


### PR DESCRIPTION
Note that such tools do not appear in the admin interface, but the presumed use case is for tools that you are not managing in this particular Galaxy instance (e.g. they are in CVMFS) anyway. The only downside is you won't be able to use the admin UI to view and fix dependencies (which we also expect to be installed in CVMFS, but you could imagine wanting to resolve them locally instead), but that might be fixable.