### PR TITLE
Fix popupmenu creation

### DIFF
--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -9,7 +9,6 @@ import { CommunicationServerView } from "layout/communication-server-view";
 import Webhooks from "mvc/webhooks";
 import Utils from "utils/utils";
 
-
 function logoutClick() {
     let galaxy = getGalaxyInstance();
     let token = galaxy.session_csrf_token || "";
@@ -19,7 +18,6 @@ function logoutClick() {
     let url = `${galaxy.root}user/logout?session_csrf_token=${token}`;
     window.top.location.href = url;
 }
-
 
 var Collection = Backbone.Collection.extend({
     model: Backbone.Model.extend({

--- a/client/galaxy/scripts/mvc/upload/collection/collection-view.js
+++ b/client/galaxy/scripts/mvc/upload/collection/collection-view.js
@@ -464,8 +464,7 @@ export default Backbone.View.extend({
 
     /** Template */
     _template: function() {
-        return (
-            `<div class="upload-view-default">
+        return `<div class="upload-view-default">
                 <div class="upload-top">
                     <div class="upload-top-info"/>
                 </div>
@@ -495,7 +494,6 @@ export default Backbone.View.extend({
                     <span class="upload-footer-genome"/>
                 </div>
                 <div class="upload-buttons"/>
-            </div>`
-        );
+            </div>`;
     }
 });

--- a/client/galaxy/scripts/mvc/upload/composite/composite-row.js
+++ b/client/galaxy/scripts/mvc/upload/composite/composite-row.js
@@ -285,8 +285,7 @@ export default Backbone.View.extend({
 
     /** Template */
     _template: function() {
-        return (
-            `<tr class="upload-row">
+        return `<tr class="upload-row">
                 <td>
                     <div class="upload-source"/>
                     <div class="upload-text-column">
@@ -320,7 +319,6 @@ export default Backbone.View.extend({
                         </div>
                     </div>
                 </td>
-            </tr>`
-        );
+            </tr>`;
     }
 });

--- a/client/galaxy/scripts/mvc/upload/composite/composite-view.js
+++ b/client/galaxy/scripts/mvc/upload/composite/composite-view.js
@@ -176,8 +176,7 @@ export default Backbone.View.extend({
 
     /** Load html template */
     _template: function() {
-        return (
-            `<div class="upload-view-composite">
+        return `<div class="upload-view-composite">
                 <div class="upload-top">
                     <div class="upload-top-info">&nbsp;</div>
                 </div>
@@ -205,7 +204,6 @@ export default Backbone.View.extend({
                     <span class="upload-footer-genome"/>
                 </div>
                 <div class="upload-buttons"/>
-            </div>`
-        );
+            </div>`;
     }
 });

--- a/client/galaxy/scripts/ui/popupmenu.js
+++ b/client/galaxy/scripts/ui/popupmenu.js
@@ -98,67 +98,59 @@ export function make_popupmenu(button_element, initial_options) {
  *  - div 2 becomes the 'face' of the popupmenu
  *
  *  NOTE: make_popup_menus finds and operates on all divs with a popupmenu attr (no need to point it at something)
- *          but (since that selector searches the dom on the page), you can send a parent in
  *  NOTE: make_popup_menus, and make_popupmenu are horrible names
  */
-export function make_popup_menus(parent) {
-    console.log("make_popup_menus");
+export function make_popup_menus() {
+    $("div[popupmenu]").each(function() {
+        var options = {};
+        var menu = $(this);
 
-    // find all popupmenu menu divs (divs that contains anchors to be converted to menu options)
-    //  either in the parent or the document if no parent passed
-    parent = parent || document;
-    $(parent)
-        .find("div[popupmenu]")
-        .each(function() {
-            var options = {};
-            var menu = $(this);
+        // find each anchor in the menu, convert them into an options map: { a.text : click_function }
+        menu.find("a").each(function() {
+            var link = $(this);
+            var link_dom = link.get(0);
+            var confirmtext = link_dom.getAttribute("confirm");
+            var href = link_dom.getAttribute("href");
+            var target = link_dom.getAttribute("target");
 
-            // find each anchor in the menu, convert them into an options map: { a.text : click_function }
-            menu.find("a").each(function() {
-                var link = $(this);
-                var link_dom = link.get(0);
-                var confirmtext = link_dom.getAttribute("confirm");
-                var href = link_dom.getAttribute("href");
-                var target = link_dom.getAttribute("target");
-
-                // no href - no function (gen. a label)
-                if (!href) {
-                    options[link.text()] = null;
-                } else {
-                    options[link.text()] = {
-                        url: href,
-                        action: function(event) {
-                            // if theres confirm text, send the dialog
-                            if (!confirmtext || confirm(confirmtext)) {
-                                // link.click() doesn't use target for some reason,
-                                // so manually do it here.
-                                if (target) {
-                                    window.open(href, target);
-                                    return false;
-                                } else {
-                                    // For all other links, do the default action.
-                                    link.click();
-                                }
+            // no href - no function (gen. a label)
+            if (!href) {
+                options[link.text()] = null;
+            } else {
+                options[link.text()] = {
+                    url: href,
+                    action: function(event) {
+                        // if theres confirm text, send the dialog
+                        if (!confirmtext || confirm(confirmtext)) {
+                            // link.click() doesn't use target for some reason,
+                            // so manually do it here.
+                            if (target) {
+                                window.open(href, target);
+                                return false;
                             } else {
-                                event.preventDefault();
+                                // For all other links, do the default action.
+                                link.click();
                             }
+                        } else {
+                            event.preventDefault();
                         }
-                    };
-                }
-            });
-            // locate the element with the id corresponding to the menu's popupmenu attr
-            var box = $(parent).find(`#${menu.attr("popupmenu")}`);
-
-            // For menus with clickable link text, make clicking on the link go through instead
-            // of activating the popup menu
-            box.find("a").bind("click", e => {
-                e.stopPropagation(); // Stop bubbling so clicking on the link goes through
-                return true;
-            });
-
-            // attach the click events and menu box building to the box element
-            make_popupmenu(box, options);
-            box.addClass("popup");
-            menu.remove();
+                    }
+                };
+            }
         });
+        // locate the element with the id corresponding to the menu's popupmenu attr
+        var box = $(`#${menu.attr("popupmenu")}`);
+
+        // For menus with clickable link text, make clicking on the link go through instead
+        // of activating the popup menu
+        box.find("a").bind("click", e => {
+            e.stopPropagation(); // Stop bubbling so clicking on the link goes through
+            return true;
+        });
+
+        // attach the click events and menu box building to the box element
+        make_popupmenu(box, options);
+        box.addClass("popup");
+        menu.remove();
+    });
 }


### PR DESCRIPTION
fixes #7314 

With the init queue changes, make_popupmenus was receiving new, unexpected arguments and attempting scope the popupmenu-setting-queries on them, resulting in no matches (and the repo menus not being stitched together, as observed).

(we probably want to just convert all these to the standard bootstrap4 equivalents, but that's more involved)