### PR TITLE
Fix trackster toolbox filter for logged-in users

### DIFF
--- a/lib/galaxy/tools/toolbox/filters/__init__.py
+++ b/lib/galaxy/tools/toolbox/filters/__init__.py
@@ -46,9 +46,8 @@ class FilterFactory(object):
                     if category:
                         validate = getattr(trans.app.config, 'user_tool_%s_filters' % category, [])
                         self.__init_filters(category, user_filters, filters, validate=validate)
-        else:
-            if kwds.get("trackster", False):
-                filters["tool"].append(_has_trackster_conf)
+        if kwds.get("trackster", False):
+            filters["tool"].append(_has_trackster_conf)
 
         return filters
 

--- a/test/unit/tools/test_toolbox_filters.py
+++ b/test/unit/tools/test_toolbox_filters.py
@@ -14,16 +14,17 @@ def test_stock_filtering_requires_login_tools():
 
 
 def test_stock_filtering_hidden_tools():
-    filters = filter_factory({}).build_filters(mock_trans())['tool']
-    assert not is_filtered(filters, mock_trans(), mock_tool(hidden=False))
-    assert is_filtered(filters, mock_trans(), mock_tool(hidden=True))
+    trans = mock_trans()
+    filters = filter_factory({}).build_filters(trans)['tool']
+    assert not is_filtered(filters, trans, mock_tool(hidden=False))
+    assert is_filtered(filters, trans, mock_tool(hidden=True))
 
 
 def test_trackster_filtering():
-    filters = filter_factory({}).build_filters(mock_trans(), trackster=True)['tool']
-    # Ekkk... is trackster_conf broken? Why is it showing up.
-    # assert is_filtered( filters, mock_trans(), mock_tool( trackster_conf=False ) )
-    assert not is_filtered(filters, mock_trans(), mock_tool(trackster_conf=True))
+    trans = mock_trans()
+    filters = filter_factory({}).build_filters(trans, trackster=True)['tool']
+    assert is_filtered(filters, trans, mock_tool(trackster_conf=False))
+    assert not is_filtered(filters, trans, mock_tool(trackster_conf=True))
 
 
 def test_custom_filters():
@@ -57,7 +58,7 @@ def filter_factory(config_dict=None):
 
 def is_filtered(filters, trans, tool):
     context = Bunch(trans=trans)
-    return not all(map(lambda filter: filter(context, tool), filters))
+    return not all(_(context, tool) for _ in filters)
 
 
 def mock_tool(require_login=False, hidden=False, trackster_conf=False, allow_access=True):


### PR DESCRIPTION
Broken in commits 7a2f6cba32c5dd28d9a53329a6b3f71453cbd45d and f1ff62e82a620067a72f7705712afcc1e94ab72b .

Restore corresponding unit test.