### PR TITLE
Fix rerunning a tool via API

### DIFF
--- a/lib/galaxy/visualization/data_providers/basic.py
+++ b/lib/galaxy/visualization/data_providers/basic.py
@@ -54,6 +54,15 @@ class BaseDataProvider(object):
         """
         raise Exception("Unimplemented Function")
 
+    def get_filters(self):
+        """
+        Returns filters for provider's data. Return value is a list of
+        filters; each filter is a dictionary with the keys 'name', 'index', 'type'.
+        NOTE: This method uses the original dataset's datatype and metadata to
+        create the filters.
+        """
+        return []
+
 
 class ColumnDataProvider(BaseDataProvider):
     """ Data provider for columnar data """

--- a/lib/galaxy/visualization/data_providers/genome.py
+++ b/lib/galaxy/visualization/data_providers/genome.py
@@ -223,10 +223,7 @@ class GenomeDataProvider(BaseDataProvider):
 
     def get_filters(self):
         """
-        Returns filters for provider's data. Return value is a list of
-        filters; each filter is a dictionary with the keys 'name', 'index', 'type'.
-        NOTE: This method uses the original dataset's datatype and metadata to
-        create the filters.
+        Returns filters for provider's data.
         """
         # Get column names.
         try:
@@ -272,7 +269,9 @@ class GenomeDataProvider(BaseDataProvider):
 
 class FilterableMixin(object):
     def get_filters(self):
-        """ Returns a dataset's filters. """
+        """
+        Returns filters for provider's data.
+        """
         # Get filters.
         # TODOs:
         # (a) might be useful to move this into each datatype's set_meta method;
@@ -800,7 +799,7 @@ class RawVcfDataProvider(VcfDataProvider):
         return line_filter_iter()
 
 
-class BamDataProvider(GenomeDataProvider, FilterableMixin):
+class BamDataProvider(GenomeDataProvider):
     """
     Provides access to intervals from a sorted indexed BAM file. Coordinate
     data is reported in BED format: 0-based, half-open.
@@ -810,7 +809,7 @@ class BamDataProvider(GenomeDataProvider, FilterableMixin):
 
     def get_filters(self):
         """
-        Returns filters for dataset.
+        Returns filters for provider's data.
         """
         # HACK: first 7 fields are for drawing, so start filter column index at 7.
         filter_col = 7
@@ -1528,7 +1527,7 @@ class ENCODEPeakTabixDataProvider(TabixDataProvider, ENCODEPeakDataProvider):
 
     def get_filters(self):
         """
-        Returns filters for dataset.
+        Returns filters for provider's data.
         """
         # HACK: first 8 fields are for drawing, so start filter column index at 9.
         filter_col = 8

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -1005,8 +1005,11 @@ class UsesVisualizationMixin(UsesLibraryMixinItems):
         """
         Returns track configuration dict for a dataset.
         """
+        filters = []
         # Get data provider.
         track_data_provider = trans.app.data_provider_registry.get_data_provider(trans, original_dataset=dataset)
+        if track_data_provider:
+            filters = track_data_provider.get_filters()
 
         # Get track definition.
         return {
@@ -1014,7 +1017,7 @@ class UsesVisualizationMixin(UsesLibraryMixinItems):
             "name": dataset.name,
             "dataset": trans.security.encode_dict_ids(dataset.to_dict()),
             "prefs": {},
-            "filters": {'filters' : track_data_provider.get_filters()},
+            "filters": {'filters' : filters},
             "tool": self.get_tool_def(trans, dataset),
             "tool_state": {}
         }

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -613,9 +613,6 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         decoded_dataset_id = self.decode_id(payload.get('target_dataset_id'))
         original_dataset = self.hda_manager.get_accessible(decoded_dataset_id, user=trans.user)
         original_dataset = self.hda_manager.error_if_uploading(original_dataset)
-        msg = self.hda_manager.data_conversion_status(original_dataset)
-        if msg:
-            return msg
 
         # Set tool parameters--except non-hidden dataset parameters--using combination of
         # job's previous parameters and incoming parameters. Incoming parameters


### PR DESCRIPTION
When sending an API request `POST /api/tools` with payload:

```python
{
    'action': 'rerun',
    'history_id': history_id,
    'inputs': {},
    'target_dataset_id': target_dataset_id
    'tool_id': tool_id,
}
```

the following exception was raised:

```
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 283, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/api/tools.py", line 456, in create
    return self._create(trans, payload, **kwd)
  File "lib/galaxy/webapps/galaxy/api/tools.py", line 462, in _create
    return self._rerun_tool(trans, payload, **kwd)
  File "lib/galaxy/webapps/galaxy/api/tools.py", line 710, in _rerun_tool
    for action in tool.trackster_conf.actions:
AttributeError: 'NoneType' object has no attribute 'actions'
```

and after fixing this, another exception was raised:

```
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 283, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/api/tools.py", line 456, in create
    return self._create(trans, payload, **kwd)
  File "lib/galaxy/webapps/galaxy/api/tools.py", line 462, in _create
    return self._rerun_tool(trans, payload, **kwd)
  File "lib/galaxy/webapps/galaxy/api/tools.py", line 822, in _rerun_tool
    dataset_dict['track_config'] = self.get_new_track_config(trans, output_dataset)
  File "lib/galaxy/web/base/controller.py", line 1017, in get_new_track_config
    "filters": {'filters' : track_data_provider.get_filters()},
AttributeError: 'NoneType' object has no attribute 'get_filters'
```

Also add basic `get_filters()` method to `BaseDataProvider` class.