### PR TITLE
Fix CORS issue in legacy test tool frame installation

### DIFF
--- a/client/galaxy/scripts/onload/initQueue.js
+++ b/client/galaxy/scripts/onload/initQueue.js
@@ -17,7 +17,7 @@
 import { BehaviorSubject } from "rxjs";
 import { filter } from "rxjs/operators";
 
-const queue = (window._initQueue = new BehaviorSubject([]));
+const queue = new BehaviorSubject([]);
 
 // don't emit unless there are things to initialize
 export const initializations$ = queue.pipe(filter(list => list.length > 0));

--- a/client/galaxy/scripts/onload/initQueue.js
+++ b/client/galaxy/scripts/onload/initQueue.js
@@ -17,7 +17,7 @@
 import { BehaviorSubject } from "rxjs";
 import { filter } from "rxjs/operators";
 
-const queue = (window.top._initQueue = new BehaviorSubject([]));
+const queue = (window._initQueue = new BehaviorSubject([]));
 
 // don't emit unless there are things to initialize
 export const initializations$ = queue.pipe(filter(list => list.length > 0));


### PR DESCRIPTION
Addresses
https://github.com/galaxyproject/galaxy/issues/7335

The new initQueue stores a buffer of operations in window.top. In legacy code that executes from inside an iframe (and therefore in a different domain) this will throw a CORS error.

Moving the buffer into the local window. I think it's harmless enough.