### PR TITLE
Refactor galaxy.util.handlers -> galaxy.web.stack.handlers.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -34,8 +34,8 @@ from galaxy.objectstore import ObjectStorePopulator
 from galaxy.util import safe_makedirs, unicodify
 from galaxy.util.bunch import Bunch
 from galaxy.util.expressions import ExpressionContext
-from galaxy.util.handlers import ConfiguresHandlers
 from galaxy.util.xml_macros import load
+from galaxy.web.stack.handlers import ConfiguresHandlers
 from .datasets import (DatasetPath, NullDatasetPathRewriter,
     OutputsToWorkingDirectoryPathRewriter, TaskPathRewriter)
 from .output_checker import check_output, DETECTED_JOB_STATE

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -28,8 +28,8 @@ from galaxy.jobs import (
     TaskWrapper
 )
 from galaxy.jobs.mapper import JobNotReadyException
-from galaxy.util.handlers import HANDLER_ASSIGNMENT_METHODS
 from galaxy.util.monitors import Monitors
+from galaxy.web.stack.handlers import HANDLER_ASSIGNMENT_METHODS
 from galaxy.web.stack.message import JobHandlerMessage
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/web/stack/__init__.py
+++ b/lib/galaxy/web/stack/__init__.py
@@ -19,9 +19,9 @@ from six import string_types
 
 from galaxy.util import unicodify
 from galaxy.util.facts import get_facts
-from galaxy.util.handlers import HANDLER_ASSIGNMENT_METHODS
 from galaxy.util.path import has_ext
 from galaxy.util.properties import nice_config_parser
+from .handlers import HANDLER_ASSIGNMENT_METHODS
 from .message import ApplicationStackMessage, ApplicationStackMessageDispatcher
 from .transport import ApplicationStackTransport, UWSGIFarmMessageTransport
 

--- a/lib/galaxy/web/stack/handlers.py
+++ b/lib/galaxy/web/stack/handlers.py
@@ -12,11 +12,11 @@ from collections import namedtuple
 
 from sqlalchemy.orm import object_session
 
-from . import (
+from galaxy.exceptions import HandlerAssignmentError
+from galaxy.util import (
     ExecutionTimer,
     listify
 )
-from ..exceptions import HandlerAssignmentError
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -7,8 +7,8 @@ import galaxy.workflow.schedulers
 from galaxy import model
 from galaxy.exceptions import HandlerAssignmentError
 from galaxy.util import plugin_config
-from galaxy.util.handlers import ConfiguresHandlers, HANDLER_ASSIGNMENT_METHODS
 from galaxy.util.monitors import Monitors
+from galaxy.web.stack.handlers import ConfiguresHandlers, HANDLER_ASSIGNMENT_METHODS
 from galaxy.web.stack.message import WorkflowSchedulingMessage
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Nothing in galaxy.util should import sqlalchemy stuff and this package does after #7129.