### PR TITLE
Fall back to binary comparison if BAM conversion fails

### DIFF
--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -107,7 +107,7 @@ def verify(
                     local_fh, temp_name = _bam_to_sam(local_name, temp_name)
                     local_name = local_fh.name
                 except Exception as e:
-                    log.warning( "Conversion BAM to SAM failed for local or temp file. Will compare BAM files")
+                    log.warning( "%s. Will compare BAM files" %e)
             if compare == 'diff':
                 files_diff(local_name, temp_name, attributes=attributes)
             elif compare == 're_match':
@@ -153,11 +153,13 @@ def _bam_to_sam(local_name, temp_name):
     try:
         pysam.view('-h', '-o%s' % temp_local.name, local_name)
     except Exception as e:
-        raise Exception("Converting local (test-data) BAM to SAM failed: %s" % e)
+        msg = "Converting local (test-data) BAM to SAM failed: %s" % e
+        raise Exception(msg)
     try:
         pysam.view('-h', '-o%s' % temp_temp, temp_name)
     except Exception as e:
-        raise Exception("Converting history BAM to SAM failed: %s" % e)
+        msg = "Converting history BAM to SAM failed: %s" % e
+        raise Exception(msg)
     os.remove(temp_name)
     return temp_local, temp_temp
 

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -103,9 +103,11 @@ def verify(
         try:
             compare = attributes.get('compare', 'diff')
             if attributes.get('ftype', None) in ['bam', 'qname_sorted.bam', 'qname_input_sorted.bam', 'unsorted.bam']:
-                if attributes.get("decompress", None):
+                try:
                     local_fh, temp_name = _bam_to_sam(local_name, temp_name)
                     local_name = local_fh.name
+                except Exception as e:
+                    log.warning( str(e), "will compare BAM files")
             if compare == 'diff':
                 files_diff(local_name, temp_name, attributes=attributes)
             elif compare == 're_match':

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -107,7 +107,7 @@ def verify(
                     local_fh, temp_name = _bam_to_sam(local_name, temp_name)
                     local_name = local_fh.name
                 except Exception as e:
-                    log.warning( str(e), "will compare BAM files")
+                    log.warning( "Conversion BAM to SAM failed for local or temp file. Will compare BAM files")
             if compare == 'diff':
                 files_diff(local_name, temp_name, attributes=attributes)
             elif compare == 're_match':

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -103,8 +103,9 @@ def verify(
         try:
             compare = attributes.get('compare', 'diff')
             if attributes.get('ftype', None) in ['bam', 'qname_sorted.bam', 'qname_input_sorted.bam', 'unsorted.bam']:
-                local_fh, temp_name = _bam_to_sam(local_name, temp_name)
-                local_name = local_fh.name
+                if attributes.get("decompress", None):
+                    local_fh, temp_name = _bam_to_sam(local_name, temp_name)
+                    local_name = local_fh.name
             if compare == 'diff':
                 files_diff(local_name, temp_name, attributes=attributes)
             elif compare == 're_match':

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -107,7 +107,7 @@ def verify(
                     local_fh, temp_name = _bam_to_sam(local_name, temp_name)
                     local_name = local_fh.name
                 except Exception as e:
-                    log.warning("%s. Will compare BAM files" %e)
+                    log.warning("%s. Will compare BAM files" % e)
             if compare == 'diff':
                 files_diff(local_name, temp_name, attributes=attributes)
             elif compare == 're_match':

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -107,7 +107,7 @@ def verify(
                     local_fh, temp_name = _bam_to_sam(local_name, temp_name)
                     local_name = local_fh.name
                 except Exception as e:
-                    log.warning( "%s. Will compare BAM files" %e)
+                    log.warning("%s. Will compare BAM files" %e)
             if compare == 'diff':
                 files_diff(local_name, temp_name, attributes=attributes)
             elif compare == 're_match':

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -1218,8 +1218,7 @@ it may be inconvenient to upload the entiry file and this can be used instead.
     <xs:attribute name="decompress" type="PermissiveBoolean">
       <xs:annotation>
         <xs:documentation xml:lang="en"><![CDATA[
-				This flag is useful for testing BAM files and gzipped outputs that are non-deterministic despite having deterministic decompressed contents. Local and produced BAM files are converted to SAM files prior to evaluation (for any value of ``compare``). Gzipped files (local and produced) are attempted to be decompressed if needed if ``compare`` is set to ``diff``. This is available in Galaxy since release 17.05 and was introduced in [pull request #3550](https://github.com/galaxyproject/galaxy/pull/3550).
-
+This flag is useful for testing gzipped outputs that are non-deterministic despite having deterministic decompressed contents. Gzipped files (local and produced) are attempted to be decompressed if needed if ``compare`` is set to ``diff``. The default value is False. This is available in Galaxy since release 17.05 and was introduced in [pull request #3550](https://github.com/galaxyproject/galaxy/pull/3550).
 ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -1218,8 +1218,7 @@ it may be inconvenient to upload the entiry file and this can be used instead.
     <xs:attribute name="decompress" type="PermissiveBoolean">
       <xs:annotation>
         <xs:documentation xml:lang="en"><![CDATA[
-
-If ``compare`` is set to ``diff``, attempt to decompress both produced output and expected output files if needed before performing the diff. This flag is useful for testing gzipped outputs that are non-deterministic despite having deterministic decompressed contents. This is available in Galaxy since release 17.05 and was introduced in [pull request #3550](https://github.com/galaxyproject/galaxy/pull/3550).
+				This flag is useful for testing BAM files and gzipped outputs that are non-deterministic despite having deterministic decompressed contents. Local and produced BAM files are converted to SAM files prior to evaluation (for any value of ``compare``). Gzipped files (local and produced) are attempted to be decompressed if needed if ``compare`` is set to ``diff``. This is available in Galaxy since release 17.05 and was introduced in [pull request #3550](https://github.com/galaxyproject/galaxy/pull/3550).
 
 ]]></xs:documentation>
       </xs:annotation>

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -1218,7 +1218,7 @@ it may be inconvenient to upload the entiry file and this can be used instead.
     <xs:attribute name="decompress" type="PermissiveBoolean">
       <xs:annotation>
         <xs:documentation xml:lang="en"><![CDATA[
-This flag is useful for testing gzipped outputs that are non-deterministic despite having deterministic decompressed contents. Gzipped files (local and produced) are attempted to be decompressed if needed if ``compare`` is set to ``diff``. The default value is False. This is available in Galaxy since release 17.05 and was introduced in [pull request #3550](https://github.com/galaxyproject/galaxy/pull/3550).
+This flag is useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. Compressed files are attempted to be decompressed if needed if ``compare`` is set to ``diff``. The default value is False. This is available in Galaxy since release 17.05 and was introduced in [pull request #3550](https://github.com/galaxyproject/galaxy/pull/3550).
 ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -1218,7 +1218,7 @@ it may be inconvenient to upload the entiry file and this can be used instead.
     <xs:attribute name="decompress" type="PermissiveBoolean">
       <xs:annotation>
         <xs:documentation xml:lang="en"><![CDATA[
-This flag is useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. Compressed files are attempted to be decompressed if needed if ``compare`` is set to ``diff``. The default value is False. This is available in Galaxy since release 17.05 and was introduced in [pull request #3550](https://github.com/galaxyproject/galaxy/pull/3550).
+When this attribute is true and ``compare`` is set to ``diff``, try to decompress files if needed. This flag is useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. By default, only files compressed with bz2, gzip and zip will be automatically decompressed. This is available in Galaxy since release 17.05 and was introduced in [pull request #3550](https://github.com/galaxyproject/galaxy/pull/3550).
 ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>


### PR DESCRIPTION
the so far undocumented conversion of bam to sam files should be optional.\

one might think about leaving the conversion the default and skipping it if decompress==false

ping @peterjc https://github.com/galaxyproject/galaxy/issues/700

I stumbled over this since stacks produced bam files that can currently not converted https://github.com/pysam-developers/pysam -- so it should be possible to deactivate.  
