### PR TITLE
Update ``area`` issue/PR labels

### DIFF
--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -68,7 +68,7 @@ reviewed and tagged as appropriate.
 Kind Labels
 -----------
 
-The 'kind' label set is used for classifying the type of contribution or
+The ``kind`` label set is used for classifying the type of contribution or
 request/report to separate enhancements and new features from bugs, etc.
 
 -  ``kind/bug`` - something is broken, and it needs fixing
@@ -108,46 +108,49 @@ be indicated in the closing comment by the issue closer.
 Area Labels
 -----------
 
-The 'area' label is used for tagging issues and pull requests to a
+The ``area`` label is used for tagging issues and pull requests to a
 particular focus area. This allows for easy searching within that
 particular domain, as well as more organized release notes.
 
--  ``area/admin`` - Changes to admin functionality of the Galaxy webapp.
--  ``area/API``
--  ``area/cleanup`` - General code cleanup.
--  ``area/cwl`` - changes related to supporting the common workflow language in Galaxy
--  ``area/database`` - Change requires a modification to Galaxy's database.
--  ``area/dataset-collections``
--  ``area/datatypes`` - Changes to Galaxy's datatypes
--  ``area/datatype-framework`` - Changes to Galaxy's datatype and metadata framework
--  ``area/dependencies`` - Changes related to Python or JavaScript dependencies of Galaxy itself
--  ``area/documentation``
--  ``area/framework``
--  ``area/GIEs``
--  ``area/histories``
--  ``area/i18n``
--  ``area/libraries`` - Change related to data libraries.
--  ``area/jobs``
--  ``area/objectstore``
--  ``area/performance``
--  ``area/reports``
--  ``area/security``
--  ``area/system`` - Changes to scripts used to run or manage Galaxy.
--  ``area/testing``
--  ``area/testing/api``
--  ``area/testing/integration``
--  ``area/testing/selenium``
--  ``area/tool-framework``
--  ``area/tool-dependencies`` - Changes to dependency resolution (including Conda).
--  ``area/tools`` - Changes to specific tools in Galaxy.
--  ``area/toolshed``- Changes to the tool shed client or server.
--  ``area/UI-UX``
--  ``area/upload``
--  ``area/util``
--  ``area/visualizations``
--  ``area/webhooks``
--  ``area/workflows``
--  ``area/workflows/subworkflows``
+- ``area/admin`` - Changes to admin functionality of the Galaxy webapp
+- ``area/API``
+- ``area/authentication``
+- ``area/cleanup`` - General code cleanup
+- ``area/client-build``
+- ``area/compliance``
+- ``area/cwl`` - changes related to supporting the common workflow language in Galaxy
+- ``area/database`` - Change requires a modification to Galaxy's database
+- ``area/dataset-collections``
+- ``area/datatypes`` - Changes to Galaxy's datatypes
+- ``area/datatype-framework`` - Changes to Galaxy's datatype and metadata framework
+- ``area/dependencies`` - Changes related to Python or JavaScript dependencies of Galaxy itself
+- ``area/documentation``
+- ``area/framework``
+- ``area/GIEs``
+- ``area/histories``
+- ``area/i18n`` - Internationalization and localization
+- ``area/jobs``
+- ``area/libraries`` - Change related to data libraries
+- ``area/objectstore``
+- ``area/performance``
+- ``area/reports``
+- ``area/security``
+- ``area/scripts`` - Changes to scripts used to run or manage Galaxy.
+- ``area/testing``
+- ``area/testing/api``
+- ``area/testing/integration``
+- ``area/testing/selenium``
+- ``area/tool-framework``
+- ``area/tool-dependencies`` - Changes to dependency resolution (including Conda)
+- ``area/tools`` - Changes to specific tools in Galaxy
+- ``area/toolshed``- Changes to the Tool Shed client or server
+- ``area/UI-UX``
+- ``area/upload``
+- ``area/util``
+- ``area/visualizations``
+- ``area/webhooks``
+- ``area/workflows``
+- ``area/workflows/subworkflows``
 
 New labels should be proposed by opening a pull request against this document
 in the dev branch of Galaxy.
@@ -170,11 +173,6 @@ special purpose.
    which are subcomponents and stepping stones necessary for issue
    resolution. These *can* utilize the ``area/*`` tags but are not
    required to. Status and type make little sense here.
-
--  ``roadmap`` is a reserved tag for the primary project roadmap. This
-   is a meta-issue that is not expected to be completed, but rather
-   serves as an entry point to the high level development of the
-   project.
 
 -  ``friendliness/beginner`` can be used to indicate a nice entry-level
    issue that only requires limited understanding of the larger Galaxy

--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -114,7 +114,7 @@ particular domain, as well as more organized release notes.
 
 - ``area/admin`` - Changes to admin functionality of the Galaxy webapp
 - ``area/API``
-- ``area/authentication``
+- ``area/auth`` - Authentication and authorization
 - ``area/cleanup`` - General code cleanup
 - ``area/client-build``
 - ``area/compliance``


### PR DESCRIPTION
- Add some labels that were added on GitHub, but not here:
  - authentication
  - client-build
  - compliance
- Rename `system` to `scripts`, since this was the original (I think) and `system` is too generic
- Remove unused `roadmap`, we use GitHub `Projects` now