### PR TITLE
[19.01] Fix the filename of saved test-data

### DIFF
--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -89,7 +89,7 @@ def verify(
 
         # if the server's env has GALAXY_TEST_SAVE, save the output file to that dir
         if keep_outputs_dir:
-            ofn = os.path.join(keep_outputs_dir, os.path.basename(local_name))
+            ofn = os.path.join(keep_outputs_dir, filename)
             log.debug('keep_outputs_dir: %s, ofn: %s', keep_outputs_dir, ofn)
             try:
                 shutil.copy(temp_name, ofn)


### PR DESCRIPTION
Without that fix the test-data from planemo generated with `--update_test_data` looks like that:

```
insgesamt 32
-rw-r--r-- 1 bag bag 123 Feb  7  2018 intarna_query.fa
-rw-r--r-- 1 bag bag 288 Feb 12 21:07 intarna_result.tabular
-rw-r--r-- 1 bag bag 370 Feb  7  2018 intarna_target.fa
-rw------- 1 bag bag 288 Feb 12 20:37 tmp8kJrkLintarna_result.tabular
```
The tmp prefix should not be copied over.