### PR TITLE
[19.01] Improve error message during tool testing

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -273,7 +273,7 @@ class GalaxyInteractorApi(object):
     def test_data_download(self, tool_id, filename, mode='file'):
         if self.supports_test_data_download:
             response = self._get("tools/%s/test_data_download?filename=%s" % (tool_id, filename), admin=True)
-            assert response.status_code == 200, "Test file (%s) is missing. Try --update_test_data to generate one." % filename
+            assert response.status_code == 200, "Test file (%s) is missing. If you use planemo try --update_test_data to generate one." % filename
             if mode == 'file':
                 return response.content
             elif mode == 'directory':
@@ -285,7 +285,7 @@ class GalaxyInteractorApi(object):
         else:
             # We can only use local data
             response = self._get("tools/%s/test_data_path?filename=%s" % (tool_id, filename), admin=True)
-            assert response.status_code == 200, "Test file (%s) is missing. Try --update_test_data to generate one." % filename
+            assert response.status_code == 200, "Test file (%s) is missing. If you use planemo try --update_test_data to generate one." % filename
             file_name = response.json()
             if mode == 'file':
                 return open(file_name, mode='rb')

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -273,7 +273,7 @@ class GalaxyInteractorApi(object):
     def test_data_download(self, tool_id, filename, mode='file'):
         if self.supports_test_data_download:
             response = self._get("tools/%s/test_data_download?filename=%s" % (tool_id, filename), admin=True)
-            assert response.status_code == 200
+            assert response.status_code == 200, "Test file (%s) is missing. Try --update_test_data to generate one." % filename
             if mode == 'file':
                 return response.content
             elif mode == 'directory':
@@ -285,7 +285,7 @@ class GalaxyInteractorApi(object):
         else:
             # We can only use local data
             response = self._get("tools/%s/test_data_path?filename=%s" % (tool_id, filename), admin=True)
-            assert response.status_code == 200
+            assert response.status_code == 200, "Test file (%s) is missing. Try --update_test_data to generate one." % filename
             file_name = response.json()
             if mode == 'file':
                 return open(file_name, mode='rb')


### PR DESCRIPTION
If a test-data file is not available provide a meaningful error message. Currently, a user gets the following and my inbox is flooded with questions :)

```
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/bag/projects/code/galaxy/test/functional/test_toolbox.py", line 99, in test_tool
    self.do_it(tool_version=tool_version, test_index=test_index)
  File "/home/bag/projects/code/galaxy/test/functional/test_toolbox.py", line 36, in do_it
    verify_tool(tool_id, self.galaxy_interactor, resource_parameters=resource_parameters, test_index=test_index, tool_version=tool_version, register_job_data=register_job_data)
  File "/home/bag/projects/code/galaxy/lib/galaxy/tools/verify/interactor.py", line 763, in verify_tool
    raise e
JobOutputsError
```