### PR TITLE
[19.01] Communication Server Display Fixes

### DIFF
--- a/client/galaxy/scripts/layout/communication-server-view.js
+++ b/client/galaxy/scripts/layout/communication-server-view.js
@@ -26,7 +26,7 @@ export var CommunicationServerView = Backbone.View.extend({
         var $el_chat_modal_header = null;
         var $el_chat_modal_body = null;
 
-        var iframe_template = `<iframe class="f-iframe fade in communication-iframe" src="${src}"> </iframe>`;
+        var iframe_template = `<iframe class="f-iframe communication-iframe" src="${src}"> </iframe>`;
 
         var header_template =
             '<i class="fa fa-comment" aria-hidden="true" title="Communicate with other users"></i>' +

--- a/client/galaxy/scripts/layout/communication-server-view.js
+++ b/client/galaxy/scripts/layout/communication-server-view.js
@@ -26,7 +26,7 @@ export var CommunicationServerView = Backbone.View.extend({
         var $el_chat_modal_header = null;
         var $el_chat_modal_body = null;
 
-        var iframe_template = `<iframe class="f-iframe communication-iframe" src="${src}"> </iframe>`;
+        var iframe_template = `<iframe class="f-iframe" src="${src}"> </iframe>`;
 
         var header_template =
             '<i class="fa fa-comment" aria-hidden="true" title="Communicate with other users"></i>' +

--- a/client/galaxy/scripts/layout/communication-server-view.js
+++ b/client/galaxy/scripts/layout/communication-server-view.js
@@ -26,7 +26,7 @@ export var CommunicationServerView = Backbone.View.extend({
         var $el_chat_modal_header = null;
         var $el_chat_modal_body = null;
 
-        var iframe_template = `<iframe class="f-iframe" src="${src}"> </iframe>`;
+        var iframe_template = `<iframe class="h-100 w-100" src="${src}"> </iframe>`;
 
         var header_template =
             '<i class="fa fa-comment" aria-hidden="true" title="Communicate with other users"></i>' +

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1893,11 +1893,6 @@ div.toolTitleNoSection {
     padding: 2px;
 }
 
-.communication-iframe {
-    width: 100%;
-    height: 100%;
-}
-
 .close-modal {
     float: right;
     cursor: pointer;


### PR DESCRIPTION
xref https://help.galaxyproject.org/t/debug-communication-server/602

This fixes the display issue, but I couldn't actually get the communication server functioning.  I ran into:

```
Traceback (most recent call last):
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/engineio/server.py", line 505, in _trigger_event
    return self.handlers[event](*args)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/socketio/server.py", line 590, in _handle_eio_message
    self._handle_event(sid, pkt.namespace, pkt.id, pkt.data)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/socketio/server.py", line 526, in _handle_event
    self._handle_event_internal(self, sid, data, namespace, id)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/socketio/server.py", line 529, in _handle_event_internal
    r = server._trigger_event(data[0], namespace, sid, *data[1:])
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/socketio/server.py", line 558, in _trigger_event
    return self.handlers[namespace][event](*args)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/flask_socketio/__init__.py", line 258, in _handler
    *args)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/flask_socketio/__init__.py", line 641, in _handle_event
    ret = handler(*args)
  File "./scripts/communication/communication_server.py", line 180, in event_connect
    log.info("%s connected" % (flask_login.current_user.username,))
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/werkzeug/local.py", line 347, in __getattr__
    return getattr(self._get_current_object(), name)
AttributeError: 'AnonymousUserMixin' object has no attribute 'username'
```

Which I tracked down to being a result of the communication server attempting to read Galaxy's session cookie, but not having access.