### PR TITLE
Add --force_path_paste argument to tool test verify script.

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -73,7 +73,7 @@ class OutputsDict(OrderedDict):
             return item
 
 
-def stage_data_in_history(galaxy_interactor, tool_id, all_test_data, history):
+def stage_data_in_history(galaxy_interactor, tool_id, all_test_data, history=None, force_path_paste=False):
     # Upload any needed files
     upload_waits = []
 
@@ -81,12 +81,12 @@ def stage_data_in_history(galaxy_interactor, tool_id, all_test_data, history):
 
     if UPLOAD_ASYNC:
         for test_data in all_test_data:
-            upload_waits.append(galaxy_interactor.stage_data_async(test_data, history, tool_id))
+            upload_waits.append(galaxy_interactor.stage_data_async(test_data, history, tool_id, force_path_paste=force_path_paste))
         for upload_wait in upload_waits:
             upload_wait()
     else:
         for test_data in all_test_data:
-            upload_wait = galaxy_interactor.stage_data_async(test_data, history, tool_id)
+            upload_wait = galaxy_interactor.stage_data_async(test_data, history, tool_id, force_path_paste=force_path_paste)
             upload_wait()
 
 
@@ -270,6 +270,11 @@ class GalaxyInteractorApi(object):
         return history_json['id']
 
     @nottest
+    def test_data_path(self, tool_id, filename):
+        response = self._get("tools/%s/test_data_path?filename=%s" % (tool_id, filename), admin=True)
+        return response.json()
+
+    @nottest
     def test_data_download(self, tool_id, filename, mode='file'):
         if self.supports_test_data_download:
             response = self._get("tools/%s/test_data_download?filename=%s" % (tool_id, filename), admin=True)
@@ -284,9 +289,7 @@ class GalaxyInteractorApi(object):
                 return path
         else:
             # We can only use local data
-            response = self._get("tools/%s/test_data_path?filename=%s" % (tool_id, filename), admin=True)
-            assert response.status_code == 200
-            file_name = response.json()
+            file_name = self.test_data_path(tool_id, filename)
             if mode == 'file':
                 return open(file_name, mode='rb')
             elif mode == 'directory':
@@ -304,7 +307,7 @@ class GalaxyInteractorApi(object):
             output_id = output_data
         return output_id
 
-    def stage_data_async(self, test_data, history_id, tool_id):
+    def stage_data_async(self, test_data, history_id, tool_id, force_path_paste=False):
         fname = test_data['fname']
         tool_input = {
             "file_type": test_data['ftype'],
@@ -320,28 +323,41 @@ class GalaxyInteractorApi(object):
         if composite_data:
             files = {}
             for i, file_name in enumerate(composite_data):
-                file_content = self.test_data_download(tool_id, file_name)
-                files["files_%s|file_data" % i] = file_content
+                if force_path_paste:
+                    file_path = self.test_data_path(tool_id, file_name)
+                    tool_input.update({
+                        "files_%d|url_paste" % i: "file://" + file_path
+                    })
+                else:
+                    file_content = self.test_data_download(tool_id, file_name)
+                    files["files_%s|file_data" % i] = file_content
                 tool_input.update({
                     "files_%d|type" % i: "upload_dataset",
                 })
             name = test_data['name']
         else:
             name = fname
-            file_content = self.test_data_download(tool_id, fname)
             tool_input.update({
                 "files_0|NAME": name,
                 "files_0|type": "upload_dataset",
 
             })
-            files = {
-                "files_0|file_data": file_content,
-            }
+            files = {}
+            if force_path_paste:
+                file_name = self.test_data_path(tool_id, fname)
+                tool_input.update({
+                    "files_0|url_paste": "file://" + file_name
+                })
+            else:
+                file_content = self.test_data_download(tool_id, fname)
+                files = {
+                    "files_0|file_data": file_content
+                }
         submit_response_object = self.__submit_tool(history_id, "upload1", tool_input, extra_data={"type": "upload_dataset"}, files=files)
         if submit_response_object.status_code != 200:
             raise Exception("Request to upload dataset failed [%s]" % submit_response_object.content)
         submit_response = submit_response_object.json()
-        assert "outputs" in submit_response, "Invalid response from server [%s], expecteding outputs in response." % submit_response
+        assert "outputs" in submit_response, "Invalid response from server [%s], expecting outputs in response." % submit_response
         outputs = submit_response["outputs"]
         assert len(outputs) > 0, "Invalid response from server [%s], expecting an output dataset." % submit_response
         dataset = outputs[0]
@@ -702,7 +718,7 @@ def _verify_extra_files_content(extra_files, hda_id, dataset_fetcher, test_data_
             shutil.rmtree(path)
 
 
-def verify_tool(tool_id, galaxy_interactor, resource_parameters=None, register_job_data=None, test_index=0, tool_version=None, quiet=False, test_history=None):
+def verify_tool(tool_id, galaxy_interactor, resource_parameters=None, register_job_data=None, test_index=0, tool_version=None, quiet=False, test_history=None, force_path_paste=False):
     if resource_parameters is None:
         resource_parameters = {}
     tool_test_dicts = galaxy_interactor.get_tool_tests(tool_id, tool_version=tool_version)
@@ -714,7 +730,7 @@ def verify_tool(tool_id, galaxy_interactor, resource_parameters=None, register_j
     if test_history is None:
         test_history = galaxy_interactor.new_history()
 
-    stage_data_in_history(galaxy_interactor, tool_id, testdef.test_data(), test_history)
+    stage_data_in_history(galaxy_interactor, tool_id, testdef.test_data(), history=test_history, force_path_paste=force_path_paste)
 
     # Once data is ready, run the tool and check the outputs - record API
     # input, job info, tool run exception, as well as exceptions related to

--- a/lib/galaxy/tools/verify/script.py
+++ b/lib/galaxy/tools/verify/script.py
@@ -60,7 +60,7 @@ def main(argv=None):
         try:
             verify_tool(
                 tool_id, galaxy_interactor, test_index=test_index, tool_version=tool_version,
-                register_job_data=register, quiet=not verbose
+                register_job_data=register, quiet=not verbose, force_path_paste=args.force_path_paste
             )
 
             if verbose:
@@ -93,6 +93,7 @@ def _arg_parser():
     parser.add_argument('-u', '--galaxy-url', default="http://localhost:8080", help='Galaxy URL')
     parser.add_argument('-k', '--key', default=None, help='Galaxy User API Key')
     parser.add_argument('-a', '--admin-key', default=None, help='Galaxy Admin API Key')
+    parser.add_argument('--force_path_paste', default=False, action="store_true", help='This requires Galaxy-side config option "allow_path_paste" enabled. Allows for fetching test data locally. Only for admins.')
     parser.add_argument('-t', '--tool-id', default=None, help='Tool ID')
     parser.add_argument('--tool-version', default=None, help='Tool Version')
     parser.add_argument('-i', '--test-index', default=ALL_TESTS, help='Tool Test Index (starting at 0) - by default all tests will run.')


### PR DESCRIPTION
Reverts small changes in https://github.com/galaxyproject/galaxy/pull/7160 and brings in option added in https://github.com/galaxyproject/galaxy-lib/pull/137.

Though #7160 made huge strides in usability of this stuff, I still like making progress toward pasting paths since I believe this is the long term direction this code should move in (https://github.com/galaxyproject/galaxy/pull/7160#issuecomment-450751074). Some people (@bgruening) don't even think Galaxy should have a copy of the test data - so that will even more encourage pasting URIs.