### PR TITLE
[19.01] Use . activate "$GALAXY_CONDA_ENV"` to activate conda env

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -123,7 +123,7 @@ if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 ]; then
                     $CONDA_EXE create --yes --override-channels --channel conda-forge --channel defaults --name "$GALAXY_CONDA_ENV" 'python=2.7' 'pip>=9' 'virtualenv>=16'
                     unset __CONDA_INFO
                 fi
-                conda_activate
+                . activate "$GALAXY_CONDA_ENV"
             fi
             virtualenv "$GALAXY_VIRTUAL_ENV"
         else

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -123,7 +123,7 @@ if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 ]; then
                     $CONDA_EXE create --yes --override-channels --channel conda-forge --channel defaults --name "$GALAXY_CONDA_ENV" 'python=2.7' 'pip>=9' 'virtualenv>=16'
                     unset __CONDA_INFO
                 fi
-                . activate "$GALAXY_CONDA_ENV"
+                conda_activate
             fi
             virtualenv "$GALAXY_VIRTUAL_ENV"
         else

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -81,16 +81,14 @@ conda_activate() {
     echo "Activating Conda environment: $GALAXY_CONDA_ENV"
     # Dash is actually supported by 4.4, but not with `. /path/to/activate`, only `conda activate`, which we
     # can't load unless we know the path to <conda_root>/etc/profile.d/conda.sh
-    if ! command -v source >/dev/null; then
-        echo "WARNING: Your shell is not supported with Conda, attempting to use Conda env"
-        echo "         '$GALAXY_CONDA_ENV' with manual environment setup. To avoid this"
-        echo "         message, use a supported shell or activate the environment before"
-        echo "         starting Galaxy."
+    if [ echo "$0" == "dash"  ]; then
+        echo "WARNING: dash is not supported with Conda, attempting to use Conda env"
+        echo "         '$GALAXY_CONDA_ENV' with manual environment setup."
         PATH="$(get_conda_env_path $GALAXY_CONDA_ENV)/bin:$PATH"
         CONDA_DEFAULT_ENV="$GALAXY_CONDA_ENV"
         CONDA_PREFIX="$(get_conda_root_path)"
     else
-        source activate "$GALAXY_CONDA_ENV"
+        . activate "$GALAXY_CONDA_ENV"
     fi
 }
 


### PR DESCRIPTION
Fixes
https://github.com/galaxyproject/galaxy/issues/3876#issuecomment-463635193.
~~I'm not using `conda_activate` as I have a particular dislike for
putting random functions in my shell.~~