### PR TITLE
Rework and Generalize History Import and Export

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 from string import Template
 from uuid import UUID, uuid4
 
+from boltons.iterutils import remap
 from six import string_types
 from social_core.storage import AssociationMixin, CodeMixin, NonceMixin, PartialMixin, UserMixin
 from sqlalchemy import (
@@ -46,17 +47,18 @@ import galaxy.model.orm.now
 import galaxy.model.tags
 import galaxy.security.passwords
 import galaxy.util
-from galaxy.model.item_attrs import UsesAnnotations
+from galaxy.model.item_attrs import get_item_annotation_str, UsesAnnotations
 from galaxy.model.util import pgcalc
 from galaxy.security import get_permitted_actions
 from galaxy.util import (directory_hash_id, ready_name_for_url,
                          unicodify, unique_id)
 from galaxy.util.bunch import Bunch
-from galaxy.util.dictifiable import Dictifiable
+from galaxy.util.dictifiable import dict_for, Dictifiable
 from galaxy.util.form_builder import (AddressField, CheckboxField, HistoryField,
                                       PasswordField, SelectField, TextArea, TextField, WorkflowField,
                                       WorkflowMappingField)
 from galaxy.util.hash_util import new_secure_hash
+from galaxy.util.json import safe_loads
 from galaxy.util.sanitize_html import sanitize_html
 
 log = logging.getLogger(__name__)
@@ -146,6 +148,48 @@ class HasTags(object):
     @property
     def auto_propagated_tags(self):
         return [t for t in self.tags if t.user_tname in AUTO_PROPAGATED_TAGS]
+
+
+class SerializationOptions(object):
+
+    def __init__(self, for_edit, serialize_dataset_objects=None, serialize_files_handler=None):
+        self.for_edit = for_edit
+        if serialize_dataset_objects is None:
+            serialize_dataset_objects = for_edit
+        self.serialize_dataset_objects = serialize_dataset_objects
+        self.serialize_files_handler = serialize_files_handler
+
+    def attach_identifier(self, id_encoder, obj, ret_val):
+        if self.for_edit and obj.id:
+            ret_val["id"] = obj.id
+        elif obj.id:
+            ret_val["encoded_id"] = id_encoder.encode_id(obj.id, kind='model_export')
+        else:
+            if not hasattr(obj, "temp_id"):
+                obj.temp_id = uuid4().hex
+            ret_val["encoded_id"] = obj.temp_id
+
+    def get_identifier(self, id_encoder, obj):
+        if self.for_edit and obj.id:
+            return obj.id
+        elif obj.id:
+            return id_encoder.encode_id(obj.id, kind='model_export')
+        else:
+            if not hasattr(obj, "temp_id"):
+                obj.temp_id = uuid4().hex
+            return obj.temp_id
+
+    def get_identifier_for_id(self, id_encoder, obj_id):
+        if self.for_edit and obj_id:
+            return obj_id
+        elif obj_id:
+            return id_encoder.encode_id(obj_id, kind='model_export')
+        else:
+            raise NotImplementedError()
+
+    def serialize_files(self, dataset, as_dict):
+        if self.serialize_files_handler is not None:
+            self.serialize_files_handler.serialize_files(dataset, as_dict)
 
 
 class HasName(object):
@@ -939,6 +983,45 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
             if flush:
                 object_session(self).flush()
 
+    def serialize(self, id_encoder, serialization_options):
+        job_attrs = dict_for(self)
+        serialization_options.attach_identifier(id_encoder, self, job_attrs)
+        job_attrs['tool_id'] = self.tool_id
+        job_attrs['tool_version'] = self.tool_version
+        job_attrs['state'] = self.state
+        job_attrs['info'] = self.info
+        job_attrs['traceback'] = self.traceback
+        job_attrs['command_line'] = self.command_line
+        job_attrs['tool_stderr'] = self.tool_stderr
+        job_attrs['job_stderr'] = self.job_stderr
+        job_attrs['tool_stdout'] = self.tool_stdout
+        job_attrs['job_stdout'] = self.job_stdout
+        job_attrs['exit_code'] = self.exit_code
+        job_attrs['create_time'] = self.create_time.isoformat()
+        job_attrs['update_time'] = self.update_time.isoformat()
+
+        # Get the job's parameters
+        param_dict = self.raw_param_dict()
+        params_objects = {}
+        for key in param_dict:
+            params_objects[key] = safe_loads(param_dict[key])
+
+        def remap_objects(p, k, obj):
+            if isinstance(obj, dict) and "src" in obj and obj["src"] in ["hda", "hdca"]:
+                new_id = serialization_options.get_identifier_for_id(id_encoder, obj["id"])
+                new_obj = obj.copy()
+                new_obj["id"] = new_id
+                return (k, new_obj)
+            return (k, obj)
+
+        params_objects = remap(params_objects, remap_objects)
+
+        params_dict = {}
+        for name, value in params_objects.items():
+            params_dict[name] = value
+        job_attrs['params'] = params_dict
+        return job_attrs
+
     def to_dict(self, view='collection', system_details=False):
         rval = super(Job, self).to_dict(view=view)
         rval['tool_id'] = self.tool_id
@@ -1246,6 +1329,15 @@ class ImplicitCollectionJobs(RepresentById):
     @property
     def job_list(self):
         return [icjja.job for icjja in self.jobs]
+
+    def serialize(self, id_encoder, serialization_options):
+        rval = dict_for(
+            self,
+            populated_state=self.populated_state,
+            jobs=[serialization_options.get_identifier(id_encoder, j_a.job) for j_a in self.jobs]
+        )
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
 
 
 class ImplicitCollectionJobsJobAssociation(RepresentById):
@@ -1597,6 +1689,21 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):
     def activatable_datasets(self):
         # This needs to be a list
         return [hda for hda in self.datasets if not hda.dataset.deleted]
+
+    def serialize(self, id_encoder, serialization_options):
+
+        history_attrs = dict_for(
+            self,
+            create_time=self.create_time.__str__(),
+            update_time=self.update_time.__str__(),
+            name=unicodify(self.name),
+            hid_counter=self.hid_counter,
+            genome_build=self.genome_build,
+            annotation=unicodify(get_item_annotation_str(object_session(self), self.user, self)),
+            tags=self.make_tag_string_list(),
+        )
+        serialization_options.attach_identifier(id_encoder, self, history_attrs)
+        return history_attrs
 
     def to_dict(self, view='collection', value_mapper=None):
 
@@ -2163,6 +2270,25 @@ class Dataset(StorableObject, RepresentById):
                 return True
         return False
 
+    def serialize(self, id_encoder, serialization_options):
+        # serialize Dataset objects only for jobs that can actually modify these models.
+        assert serialization_options.serialize_dataset_objects
+        rval = dict_for(
+            self,
+            state=self.state,
+            deleted=self.deleted,
+            purged=self.purged,
+            external_filename=self.external_filename,
+            _extra_files_path=self._extra_files_path,
+            file_size=self.file_size,
+            object_store_id=self.object_store_id,
+            total_size=self.total_size,
+            uuid=str(self.uuid or '') or None,
+            hashes=list(map(lambda h: h.serialize(id_encoder, serialization_options), self.hashes))
+        )
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
+
 
 class DatasetSource(RepresentById):
     """ """
@@ -2174,6 +2300,16 @@ class DatasetSourceHash(RepresentById):
 
 class DatasetHash(RepresentById):
     """ """
+    def serialize(self, id_encoder, serialization_options):
+        # serialize Dataset objects only for jobs that can actually modify these models.
+        rval = dict_for(
+            self,
+            hash_function=self.hash_function,
+            hash_value=self.hash_value,
+            extra_files_path=self.extra_files_path,
+        )
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
 
 
 def datatype_for_extension(extension, datatypes_registry=None):
@@ -2632,6 +2768,39 @@ class DatasetInstance(object):
 
         return msg
 
+    def serialize(self, id_encoder, serialization_options, for_link=False):
+        if for_link:
+            rval = dict_for(
+                self
+            )
+            serialization_options.attach_identifier(id_encoder, self, rval)
+            return rval
+
+        rval = dict_for(
+            self,
+            create_time=self.create_time.__str__(),
+            update_time=self.update_time.__str__(),
+            name=unicodify(self.name),
+            info=unicodify(self.info),
+            blurb=self.blurb,
+            peek=self.peek,
+            extension=self.extension,
+            metadata=_prepare_metadata_for_serialization(dict(self.metadata.items())),
+            designation=self.designation,
+            deleted=self.deleted,
+            visible=self.visible,
+            dataset_uuid=(lambda uuid: str(uuid) if uuid else None)(self.dataset.uuid),
+        )
+
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
+
+    def _handle_serialize_files(self, id_encoder, serialization_options, rval):
+        if serialization_options.serialize_dataset_objects:
+            rval["dataset"] = self.dataset.serialize(id_encoder, serialization_options)
+        else:
+            serialization_options.serialize_files(self, rval)
+
 
 class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnotations,
                                 HasName, RepresentById):
@@ -2838,6 +3007,31 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
                 rval += self.get_total_size()
         return rval
 
+    def serialize(self, id_encoder, serialization_options, for_link=False):
+        if for_link:
+            rval = dict_for(
+                self
+            )
+            serialization_options.attach_identifier(id_encoder, self, rval)
+            return rval
+
+        rval = super(HistoryDatasetAssociation, self).serialize(id_encoder, serialization_options)
+        rval["hid"] = self.hid
+        rval["annotation"] = unicodify(getattr(self, 'annotation', ''))
+        rval["tags"] = self.make_tag_string_list()
+        if self.history:
+            rval["history_encoded_id"] = serialization_options.get_identifier(id_encoder, self.history)
+
+        # Handle copied_from_history_dataset_association information...
+        copied_from_history_dataset_association_chain = []
+        src_hda = self
+        while src_hda.copied_from_history_dataset_association:
+            src_hda = src_hda.copied_from_history_dataset_association
+            copied_from_history_dataset_association_chain.append(serialization_options.get_identifier(id_encoder, src_hda))
+        rval["copied_from_history_dataset_association_id_chain"] = copied_from_history_dataset_association_chain
+        self._handle_serialize_files(id_encoder, serialization_options, rval)
+        return rval
+
     def to_dict(self, view='collection', expose_dataset_path=False):
         """
         Return attributes of this HDA that are exposed using the API.
@@ -2955,6 +3149,19 @@ class Library(Dictifiable, HasName, RepresentById):
         self.synopsis = synopsis
         self.root_folder = root_folder
 
+    def serialize(self, id_encoder, serialization_options):
+        rval = dict_for(
+            self,
+            name=self.name,
+            description=self.description,
+            synopsis=self.synopsis,
+        )
+        if self.root_folder:
+            rval["root_folder"] = self.root_folder.serialize(id_encoder, serialization_options)
+
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
+
     def to_dict(self, view='collection', value_mapper=None):
         """
         We prepend an F to folders.
@@ -2998,12 +3205,14 @@ class Library(Dictifiable, HasName, RepresentById):
 class LibraryFolder(Dictifiable, HasName, RepresentById):
     dict_element_visible_keys = ['id', 'parent_id', 'name', 'description', 'item_count', 'genome_build', 'update_time', 'deleted']
 
-    def __init__(self, name=None, description=None, item_count=0, order_id=None):
+    def __init__(self, name=None, description=None, item_count=0, order_id=None, genome_build=None):
         self.name = name or "Unnamed folder"
         self.description = description
         self.item_count = item_count
         self.order_id = order_id
-        self.genome_build = None
+        self.genome_build = genome_build
+        self.folders = []
+        self.datasets = []
 
     def add_library_dataset(self, library_dataset, genome_build=None):
         library_dataset.folder_id = self.id
@@ -3021,6 +3230,28 @@ class LibraryFolder(Dictifiable, HasName, RepresentById):
     def activatable_library_datasets(self):
         # This needs to be a list
         return [ld for ld in self.datasets if ld.library_dataset_dataset_association and not ld.library_dataset_dataset_association.dataset.deleted]
+
+    def serialize(self, id_encoder, serialization_options):
+        rval = dict_for(
+            self,
+            name=self.name,
+            description=self.description,
+            genome_build=self.genome_build,
+            item_count=self.item_count,
+            order_id=self.order_id,
+            # update_time=self.update_time,
+            deleted=self.deleted,
+        )
+        folders = []
+        for folder in self.folders:
+            folders.append(folder.serialize(id_encoder, serialization_options))
+        rval["folders"] = folders
+        datasets = []
+        for dataset in self.datasets:
+            datasets.append(dataset.serialize(id_encoder, serialization_options))
+        rval['datasets'] = datasets
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
 
     def to_dict(self, view='collection', value_mapper=None):
         rval = super(LibraryFolder, self).to_dict(view=view, value_mapper=value_mapper)
@@ -3091,6 +3322,17 @@ class LibraryDataset(RepresentById):
 
     def display_name(self):
         self.library_dataset_dataset_association.display_name()
+
+    def serialize(self, id_encoder, serialization_options):
+        rval = dict_for(
+            self,
+            name=self.name,
+            info=self.info,
+            order_id=self.order_id,
+            ldda=self.library_dataset_dataset_association.serialize(id_encoder, serialization_options, for_link=True),
+        )
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
 
     def to_dict(self, view='collection'):
         # Since this class is a proxy to rather complex attributes we want to
@@ -3218,6 +3460,18 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, RepresentById):
 
     def has_manage_permissions_roles(self, trans):
         return self.dataset.has_manage_permissions_roles(trans)
+
+    def serialize(self, id_encoder, serialization_options, for_link=False):
+        if for_link:
+            rval = dict_for(
+                self
+            )
+            serialization_options.attach_identifier(id_encoder, self, rval)
+            return rval
+
+        rval = super(LibraryDatasetDatasetAssociation, self).serialize(id_encoder, serialization_options)
+        self._handle_serialize_files(id_encoder, serialization_options, rval)
+        return rval
 
     def to_dict(self, view='collection'):
         # Since this class is a proxy to rather complex attributes we want to
@@ -3600,6 +3854,16 @@ class DatasetCollection(Dictifiable, UsesAnnotations, RepresentById):
     def has_subcollections(self):
         return ":" in self.collection_type
 
+    def serialize(self, id_encoder, serialization_options):
+        rval = dict_for(
+            self,
+            type=self.collection_type,
+            populated_state=self.populated_state,
+            elements=list(map(lambda e: e.serialize(id_encoder, serialization_options), self.elements))
+        )
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
+
 
 class DatasetCollectionInstance(HasName):
     """
@@ -3738,6 +4002,45 @@ class HistoryDatasetCollectionAssociation(DatasetCollectionInstance,
                 break
         if len(rval) > 0:
             return rval if multiple else rval[0]
+
+    def serialize(self, id_encoder, serialization_options, for_link=False):
+        if for_link:
+            rval = dict_for(
+                self
+            )
+            serialization_options.attach_identifier(id_encoder, self, rval)
+            return rval
+
+        rval = dict_for(
+            self,
+            display_name=self.display_name(),
+            state=self.state,
+            hid=self.hid,
+            collection=self.collection.serialize(id_encoder, serialization_options),
+            implicit_output_name=self.implicit_output_name,
+        )
+        if self.history:
+            rval["history_encoded_id"] = serialization_options.get_identifier(id_encoder, self.history)
+
+        implicit_input_collections = []
+        for implicit_input_collection in self.implicit_input_collections:
+            input_hdca = implicit_input_collection.input_dataset_collection
+            implicit_input_collections.append({
+                "name": implicit_input_collection.name,
+                "input_dataset_collection": serialization_options.get_identifier(id_encoder, input_hdca)
+            })
+        if implicit_input_collections:
+            rval["implicit_input_collections"] = implicit_input_collections
+
+        # Handle copied_from_history_dataset_association information...
+        copied_from_history_dataset_collection_association_chain = []
+        src_hdca = self
+        while src_hdca.copied_from_history_dataset_collection_association:
+            src_hdca = src_hdca.copied_from_history_dataset_collection_association
+            copied_from_history_dataset_collection_association_chain.append(serialization_options.get_identifier(id_encoder, src_hdca))
+        rval["copied_from_history_dataset_collection_association_id_chain"] = copied_from_history_dataset_collection_association_chain
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
 
     def to_dict(self, view='collection'):
         original_dict_value = super(HistoryDatasetCollectionAssociation, self).to_dict(view=view)
@@ -3931,6 +4234,21 @@ class DatasetCollectionElement(Dictifiable, RepresentById):
             element_identifier=self.element_identifier,
         )
         return new_element
+
+    def serialize(self, id_encoder, serialization_options):
+        rval = dict_for(
+            self,
+            element_type=self.element_type,
+            element_index=self.element_index,
+            element_identifier=self.element_identifier
+        )
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        element_obj = self.element_object
+        if isinstance(element_obj, HistoryDatasetAssociation):
+            rval["hda"] = element_obj.serialize(id_encoder, serialization_options, for_link=True)
+        else:
+            rval["child_collection"] = element_obj.serialize(id_encoder, serialization_options)
+        return rval
 
 
 class Event(RepresentById):
@@ -5490,3 +5808,13 @@ def copy_list(lst, *args, **kwds):
         return lst
     else:
         return [el.copy(*args, **kwds) for el in lst]
+
+
+def _prepare_metadata_for_serialization(metadata):
+    """ Prepare metatdata for exporting. """
+    for name, value in list(metadata.items()):
+        # Metadata files are not needed for export because they can be
+        # regenerated.
+        if isinstance(value, MetadataFile):
+            del metadata[name]
+    return metadata

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2127,7 +2127,7 @@ mapper(model.Job, model.Job.table, properties=dict(
     # user=relation( model.User.mapper ),
     user=relation(model.User),
     galaxy_session=relation(model.GalaxySession),
-    history=relation(model.History),
+    history=relation(model.History, backref="jobs"),
     library_folder=relation(model.LibraryFolder, lazy=True),
     parameters=relation(model.JobParameter, lazy=True),
     input_datasets=relation(model.JobToInputDatasetAssociation),

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1,0 +1,1321 @@
+import abc
+import contextlib
+import datetime
+import os
+import shutil
+import tarfile
+import tempfile
+from json import dump, dumps, load
+
+import six
+from bdbag import bdbag_api as bdb
+from boltons.iterutils import remap
+from sqlalchemy.orm import eagerload_all
+from sqlalchemy.sql import expression
+
+from galaxy.exceptions import MalformedContents, ObjectNotFound
+from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.util import FILENAME_VALID_CHARS
+from galaxy.util import in_directory
+from galaxy.util.bunch import Bunch
+from galaxy.version import VERSION_MAJOR
+from ..item_attrs import add_item_annotation, get_item_annotation_str
+from ... import model
+
+ATTRS_FILENAME_HISTORY = 'history_attrs.txt'
+ATTRS_FILENAME_DATASETS = 'datasets_attrs.txt'
+ATTRS_FILENAME_JOBS = 'jobs_attrs.txt'
+ATTRS_FILENAME_IMPLICIT_COLLECTION_JOBS = 'implicit_collection_jobs_attrs.txt'
+ATTRS_FILENAME_COLLECTIONS = 'collections_attrs.txt'
+ATTRS_FILENAME_EXPORT = 'export_attrs.txt'
+ATTRS_FILENAME_LIBRARIES = 'libraries_attrs.txt'
+
+
+class ImportOptions(object):
+
+    def __init__(self, allow_edit=False, allow_library_creation=False, allow_dataset_object_edit=None):
+        self.allow_edit = allow_edit
+        self.allow_library_creation = allow_library_creation
+        if allow_dataset_object_edit is None:
+            allow_dataset_object_edit = allow_edit
+        self.allow_dataset_object_edit = allow_dataset_object_edit
+
+
+class SessionlessContext(object):
+
+    def __init__(self):
+        self.objects = []
+
+    def flush(self):
+        pass
+
+    def add(self, obj):
+        self.objects.append(obj)
+
+    def query(self, model_class):
+
+        def find(obj_id):
+            for obj in self.objects:
+                if isinstance(obj, model_class) and obj.id == obj_id:
+                    return obj
+            return None
+
+        return Bunch(find=find)
+
+
+@six.add_metaclass(abc.ABCMeta)
+class ModelImportStore(object):
+
+    def __init__(self, import_options=None, app=None, user=None, object_store=None):
+        if object_store is None:
+            if app is not None:
+                object_store = app.object_store
+        self.object_store = object_store
+        self.app = app
+        if app is not None:
+            self.sa_session = app.model.context.current
+            self.sessionless = False
+        else:
+            self.sa_session = SessionlessContext()
+            self.sessionless = True
+        self.user = user
+        self.import_options = import_options or ImportOptions()
+
+    @abc.abstractmethod
+    def defines_new_history(self):
+        """Does this store define a new history to create."""
+
+    @abc.abstractmethod
+    def new_history_properties(self):
+        """Dict of history properties if defines_new_history() is truthy."""
+
+    @abc.abstractmethod
+    def datasets_properties(self):
+        """Return a list of HDA properties."""
+
+    def library_properties(self):
+        """Return a list of library properties."""
+        return []
+
+    @abc.abstractmethod
+    def collections_properties(self):
+        """Return a list of HDCA properties."""
+
+    @abc.abstractmethod
+    def jobs_properties(self):
+        """Return a list of jobs properties."""
+
+    @abc.abstractproperty
+    def object_key(self):
+        """Key used to connect objects in metadata.
+
+        Legacy exports used 'hid' but associated objects may not be from the same history
+        and a history may contain multiple objects with the same 'hid'.
+        """
+
+    @abc.abstractproperty
+    def trust_hid(self, obj_attrs):
+        """Trust HID when importing objects into a new History."""
+
+    @contextlib.contextmanager
+    def target_history(self, default_history=None):
+        new_history = None
+
+        if self.defines_new_history():
+            history_properties = self.new_history_properties()
+            history_name = history_properties.get('name')
+            if history_name:
+                history_name = 'imported from archive: %s' % history_name
+            else:
+                history_name = 'unnamed imported history'
+
+            # Create history.
+            new_history = model.History(name=history_name,
+                                        user=self.user)
+            new_history.importing = True
+            hid_counter = history_properties.get('hid_counter')
+            genome_build = history_properties.get('genome_build')
+
+            # TODO: This seems like it shouldn't be imported, try to test and verify we can calculate this
+            # and get away without it. -John
+            if hid_counter:
+                new_history.hid_counter = hid_counter
+            if genome_build:
+                new_history.genome_build = genome_build
+
+            self._session_add(new_history)
+            self._flush()
+
+            if self.user:
+                add_item_annotation(self.sa_session, self.user, new_history, history_properties.get('annotation'))
+
+            history = new_history
+        else:
+            history = default_history
+
+        yield history
+
+        if new_history is not None:
+            # Done importing.
+            new_history.importing = False
+            self._flush()
+
+    def perform_import(self, history=None, new_history=False, job=None):
+        object_import_tracker = ObjectImportTracker()
+
+        datasets_attrs = self.datasets_properties()
+        collections_attrs = self.collections_properties()
+
+        self._import_datasets(object_import_tracker, datasets_attrs, history, new_history, job)
+        self._import_dataset_copied_associations(object_import_tracker, datasets_attrs)
+        self._import_libraries(object_import_tracker)
+        self._import_collection_instances(object_import_tracker, collections_attrs, history, new_history)
+        self._import_collection_implicit_input_associations(object_import_tracker, collections_attrs)
+        self._import_collection_copied_associations(object_import_tracker, collections_attrs)
+        self._reassign_hids(object_import_tracker, history)
+        self._import_jobs(object_import_tracker, history)
+        self._import_implicit_collection_jobs(object_import_tracker)
+        self._flush()
+
+    def _import_datasets(self, object_import_tracker, datasets_attrs, history, new_history, job):
+        object_key = self.object_key
+
+        for dataset_attrs in datasets_attrs:
+            def handle_dataset_object_edit(dataset_instance):
+                if "dataset" in dataset_attrs:
+                    assert self.import_options.allow_dataset_object_edit
+                    dataset_attributes = [
+                        "state",
+                        "deleted",
+                        "purged",
+                        "external_filename",
+                        "_extra_files_path",
+                        "file_size",
+                        "object_store_id",
+                        "total_size",
+                        "uuid"
+                    ]
+
+                    for attribute in dataset_attributes:
+                        if attribute in dataset_attrs["dataset"]:
+                            setattr(dataset_instance.dataset, attribute, dataset_attrs["dataset"][attribute])
+                    if "hashes" in dataset_attrs["dataset"]:
+                        for hash_attrs in dataset_attrs["dataset"]["hashes"]:
+                            hash_obj = model.DatasetHash()
+                            hash_obj.hash_value = hash_attrs["hash_value"]
+                            hash_obj.hash_function = hash_attrs["hash_function"]
+                            hash_obj.extra_files_path = hash_attrs["extra_files_path"]
+                            dataset_instance.dataset.hashes.append(hash_obj)
+
+                    if 'id' in dataset_attrs["dataset"] and self.import_options.allow_edit:
+                        dataset_instance.dataset.id = dataset_attrs["dataset"]['id']
+
+            if 'id' in dataset_attrs and self.import_options.allow_edit and not self.sessionless:
+                hda = self.sa_session.query(model.HistoryDatasetAssociation).get(dataset_attrs["id"])
+                attributes = [
+                    "name",
+                    "extension",
+                    "info",
+                    "blurb",
+                    "peek",
+                    "designation",
+                    "visible",
+                    "metadata",
+                ]
+                for attribute in attributes:
+                    if attribute in dataset_attrs:
+                        setattr(hda, attribute, dataset_attrs[attribute])
+
+                handle_dataset_object_edit(hda)
+                self._flush()
+            else:
+                metadata = dataset_attrs['metadata']
+
+                model_class = dataset_attrs.get("model_class", "HistoryDatasetAssociation")
+                if model_class == "HistoryDatasetAssociation":
+                    # Create dataset and HDA.
+                    dataset_instance = model.HistoryDatasetAssociation(name=dataset_attrs['name'],
+                                                                       extension=dataset_attrs['extension'],
+                                                                       info=dataset_attrs['info'],
+                                                                       blurb=dataset_attrs['blurb'],
+                                                                       peek=dataset_attrs['peek'],
+                                                                       designation=dataset_attrs['designation'],
+                                                                       visible=dataset_attrs['visible'],
+                                                                       deleted=dataset_attrs.get('deleted', False),
+                                                                       dbkey=metadata['dbkey'],
+                                                                       metadata=metadata,
+                                                                       history=history,
+                                                                       create_dataset=True,
+                                                                       flush=False,
+                                                                       sa_session=self.sa_session)
+                    if 'id' in dataset_attrs and self.import_options.allow_edit:
+                        dataset_instance.id = dataset_attrs['id']
+                elif model_class == "LibraryDatasetDatasetAssociation":
+                    # Create dataset and HDA.
+                    dataset_instance = model.LibraryDatasetDatasetAssociation(name=dataset_attrs['name'],
+                                                                              extension=dataset_attrs['extension'],
+                                                                              info=dataset_attrs['info'],
+                                                                              blurb=dataset_attrs['blurb'],
+                                                                              peek=dataset_attrs['peek'],
+                                                                              designation=dataset_attrs['designation'],
+                                                                              visible=dataset_attrs['visible'],
+                                                                              deleted=dataset_attrs.get('deleted', False),
+                                                                              dbkey=metadata['dbkey'],
+                                                                              metadata=metadata,
+                                                                              create_dataset=True,
+                                                                              sa_session=self.sa_session)
+                else:
+                    raise Exception("Unknown dataset instance type encountered")
+
+                # Older style...
+                if 'uuid' in dataset_attrs:
+                    dataset_instance.dataset.uuid = dataset_attrs["uuid"]
+                if 'dataset_uuid' in dataset_attrs:
+                    dataset_instance.dataset.uuid = dataset_attrs["dataset_uuid"]
+
+                self._session_add(dataset_instance)
+                self._flush()
+
+                if model_class == "HistoryDatasetAssociation":
+                    # don't use add_history to manage HID handling across full import to try to preserve
+                    # HID structure.
+                    dataset_instance.history = history
+                    if new_history and self.trust_hid(dataset_attrs):
+                        dataset_instance.hid = dataset_attrs['hid']
+                    else:
+                        object_import_tracker.requires_hid.append(dataset_instance)
+
+                self._flush()
+                if 'dataset' in dataset_attrs:
+                    handle_dataset_object_edit(dataset_instance)
+                else:
+                    file_name = dataset_attrs.get('file_name')
+                    if file_name:
+                        # Do security check and move/copy dataset data.
+                        archive_path = os.path.abspath(os.path.join(self.archive_dir, file_name))
+                        if os.path.islink(archive_path):
+                            raise MalformedContents("Invalid dataset path: %s" % archive_path)
+
+                        temp_dataset_file_name = \
+                            os.path.realpath(archive_path)
+
+                        if not in_directory(temp_dataset_file_name, self.archive_dir):
+                            raise MalformedContents("Invalid dataset path: %s" % temp_dataset_file_name)
+
+                    if not file_name or not os.path.exists(temp_dataset_file_name):
+                        dataset_instance.state = dataset_instance.states.DISCARDED
+                        dataset_instance.deleted = True
+                        dataset_instance.purged = True
+                        dataset_instance.dataset.deleted = True
+                        dataset_instance.dataset.purged = True
+                    else:
+                        dataset_instance.state = dataset_instance.states.OK
+                        self.object_store.update_from_file(dataset_instance.dataset, file_name=temp_dataset_file_name, create=True)
+
+                        # Import additional files if present. Histories exported previously might not have this attribute set.
+                        dataset_extra_files_path = dataset_attrs.get('extra_files_path', None)
+                        if dataset_extra_files_path:
+                            try:
+                                file_list = os.listdir(os.path.join(self.archive_dir, dataset_extra_files_path))
+                            except OSError:
+                                file_list = []
+
+                            if file_list:
+                                for extra_file in file_list:
+                                    self.object_store.update_from_file(
+                                        dataset_instance.dataset, extra_dir='dataset_%s_files' % dataset_instance.dataset.id,
+                                        alt_name=extra_file, file_name=os.path.join(self.archive_dir, dataset_extra_files_path, extra_file),
+                                        create=True)
+                        dataset_instance.dataset.set_total_size()  # update the filesize record in the database
+
+                    if dataset_instance.deleted:
+                        dataset_instance.dataset.deleted = True
+
+                if model_class == "HistoryDatasetAssociation" and self.user:
+                    add_item_annotation(self.sa_session, self.user, dataset_instance, dataset_attrs['annotation'])
+                    # TODO: Set tags.
+
+                if self.app:
+                    self.app.datatypes_registry.set_external_metadata_tool.regenerate_imported_metadata_if_needed(
+                        dataset_instance, history, job
+                    )
+
+                if model_class == "HistoryDatasetAssociation":
+                    if object_key in dataset_attrs:
+                        object_import_tracker.hdas_by_key[dataset_attrs[object_key]] = dataset_instance
+                    else:
+                        assert 'id' in dataset_attrs
+                        object_import_tracker.hdas_by_id[dataset_attrs['id']] = dataset_instance
+                else:
+                    object_import_tracker.lddas_by_key[dataset_attrs[object_key]] = dataset_instance
+
+    def _import_libraries(self, object_import_tracker):
+        object_key = self.object_key
+
+        libraries_attrs = self.library_properties()
+        for library_attrs in libraries_attrs:
+            assert self.import_options.allow_library_creation
+            name = library_attrs['name']
+            description = library_attrs['description']
+            synopsis = library_attrs['synopsis']
+            library = model.Library(name=name, description=description, synopsis=synopsis)
+            self._session_add(library)
+
+            def import_folder(folder_attrs):
+                name = folder_attrs['name']
+                description = folder_attrs['description']
+                genome_build = folder_attrs['genome_build']
+                deleted = folder_attrs['deleted']
+                library_folder = model.LibraryFolder(
+                    name=name,
+                    description=description,
+                    genome_build=genome_build
+                )
+                library_folder.deleted = deleted
+
+                self._session_add(library_folder)
+                self._flush()
+
+                for sub_folder_attrs in folder_attrs.get("folders", []):
+                    sub_folder = import_folder(sub_folder_attrs)
+                    library_folder.add_folder(sub_folder)
+
+                for ld_attrs in folder_attrs.get("datasets", []):
+                    ld = model.LibraryDataset(
+                        folder=library_folder,
+                        name=ld_attrs['name'],
+                        info=ld_attrs['info'],
+                        order_id=ld_attrs['order_id']
+                    )
+                    if 'ldda' in ld_attrs:
+                        ldda = object_import_tracker.lddas_by_key[ld_attrs["ldda"][object_key]]
+                        ld.library_dataset_dataset_association = ldda
+                    self._session_add(ld)
+
+                self._flush()
+
+                return library_folder
+
+            if 'root_folder' in library_attrs:
+                library.root_folder = import_folder(library_attrs['root_folder'])
+
+            object_import_tracker.libraries_by_key[library_attrs[object_key]] = library
+
+    def _import_collection_instances(self, object_import_tracker, collections_attrs, history, new_history):
+        object_key = self.object_key
+
+        def import_collection(collection_attrs):
+            def materialize_elements(dc):
+                if "elements" not in collection_attrs:
+                    return
+
+                elements_attrs = collection_attrs['elements']
+                for element_attrs in elements_attrs:
+                    dce = model.DatasetCollectionElement(collection=dc,
+                                                         element=model.DatasetCollectionElement.UNINITIALIZED_ELEMENT,
+                                                         element_index=element_attrs['element_index'],
+                                                         element_identifier=element_attrs['element_identifier'])
+                    if 'hda' in element_attrs:
+                        hda_attrs = element_attrs['hda']
+                        hda_key = hda_attrs[object_key]
+                        hda = object_import_tracker.hdas_by_key[hda_key]
+                        dce.hda = hda
+                    elif 'child_collection' in element_attrs:
+                        dce.child_collection = import_collection(element_attrs['child_collection'])
+                    else:
+                        raise Exception("Unknown collection element type encountered.")
+
+                    self._session_add(dce)
+
+            if "id" in collection_attrs and self.import_options.allow_edit and not self.sessionless:
+                dc = self.sa_session.query(model.DatasetCollection).get(collection_attrs["id"])
+                attributes = [
+                    "collection_type",
+                    "populated_state",
+                    "element_count",
+                ]
+                for attribute in attributes:
+                    if attribute in collection_attrs:
+                        setattr(dc, attribute, collection_attrs[attribute])
+                materialize_elements(dc)
+            else:
+                # create collection
+                dc = model.DatasetCollection(collection_type=collection_attrs['type'])
+                dc.populated_state = collection_attrs["populated_state"]
+                # TODO: element_count...
+                materialize_elements(dc)
+
+            self._session_add(dc)
+            return dc
+
+        for collection_attrs in collections_attrs:
+            dc = import_collection(collection_attrs["collection"])
+            if 'id' in collection_attrs and self.import_options.allow_edit and not self.sessionless:
+                hdca = self.sa_session.query(model.HistoryDatasetCollectionAssociation).get(collection_attrs["id"])
+                # TODO: edit attributes...
+            else:
+                hdca = model.HistoryDatasetCollectionAssociation(collection=dc,
+                                                                 visible=True,
+                                                                 name=collection_attrs['display_name'],
+                                                                 implicit_output_name=collection_attrs.get("implicit_output_name"))
+                if 'id' in collection_attrs and self.import_options.allow_edit:
+                    hdca.id = collection_attrs['id']
+
+                hdca.history = history
+                if new_history and self.trust_hid(collection_attrs):
+                    hdca.hid = collection_attrs['hid']
+                else:
+                    object_import_tracker.requires_hid.append(hdca)
+
+            self._session_add(hdca)
+            if object_key in collection_attrs:
+                object_import_tracker.hdcas_by_key[collection_attrs[object_key]] = hdca
+            else:
+                assert 'id' in collection_attrs
+                object_import_tracker.hdcas_by_id[collection_attrs['id']] = hdca
+
+    def _import_collection_implicit_input_associations(self, object_import_tracker, collections_attrs):
+        object_key = self.object_key
+
+        for collection_attrs in collections_attrs:
+            if "id" in collection_attrs:
+                # Existing object, not a new one, this property is immutable via model stores currently.
+                continue
+
+            hdca = object_import_tracker.hdcas_by_key[collection_attrs[object_key]]
+            if "implicit_input_collections" in collection_attrs:
+                implicit_input_collections = collection_attrs["implicit_input_collections"]
+                for implicit_input_collection in implicit_input_collections:
+                    name = implicit_input_collection["name"]
+                    input_collection_identifier = implicit_input_collection["input_dataset_collection"]
+                    if input_collection_identifier in object_import_tracker.hdcas_by_key:
+                        input_dataset_collection = object_import_tracker.hdcas_by_key[input_collection_identifier]
+                        hdca.add_implicit_input_collection(name, input_dataset_collection)
+
+    def _import_dataset_copied_associations(self, object_import_tracker, datasets_attrs):
+        object_key = self.object_key
+
+        # Re-establish copied_from_history_dataset_association relationships so history extraction
+        # has a greater chance of working in this history, for reproducibility.
+        for dataset_attrs in datasets_attrs:
+            if "id" in dataset_attrs:
+                # Existing object, not a new one, this property is not immutable via model stores currently.
+                continue
+
+            dataset_key = dataset_attrs[object_key]
+            if dataset_key not in object_import_tracker.hdas_by_key:
+                continue
+
+            hda = object_import_tracker.hdas_by_key[dataset_key]
+            copied_from_chain = dataset_attrs.get("copied_from_history_dataset_association_id_chain", [])
+            copied_from_object_key = _copied_from_object_key(copied_from_chain, object_import_tracker.hdas_by_key)
+            if not copied_from_object_key:
+                continue
+
+            # Re-establish the chain if we can.
+            if copied_from_object_key in object_import_tracker.hdas_by_key:
+                hda.copied_from_history_dataset_association = object_import_tracker.hdas_by_key[copied_from_object_key]
+            else:
+                # We're at the end of the chain and this HDA was copied from an HDA
+                # outside the history. So when we find this job and are looking for inputs/outputs
+                # attach to this node... unless we've already encountered another dataset
+                # copied from that jobs output... in that case we are going to cheat and
+                # say this dataset was copied from that one. It wasn't in the original Galaxy
+                # instance but I think it is find to pretend in order to create a DAG here.
+                hda_copied_from_sinks = object_import_tracker.hda_copied_from_sinks
+                if copied_from_object_key in hda_copied_from_sinks:
+                    hda.copied_from_history_dataset_association = object_import_tracker.hdas_by_key[hda_copied_from_sinks[copied_from_object_key]]
+                else:
+                    hda_copied_from_sinks[copied_from_object_key] = dataset_key
+
+    def _import_collection_copied_associations(self, object_import_tracker, collections_attrs):
+        object_key = self.object_key
+
+        # Re-establish copied_from_history_dataset_collection_association relationships so history extraction
+        # has a greater chance of working in this history, for reproducibility. Very similar to HDA code above
+        # see comments there.
+        for collection_attrs in collections_attrs:
+            if "id" in collection_attrs:
+                # Existing object, not a new one, this property is immutable via model stores currently.
+                continue
+
+            dataset_collection_key = collection_attrs[object_key]
+            if dataset_collection_key not in object_import_tracker.hdcas_by_key:
+                continue
+
+            hdca = object_import_tracker.hdcas_by_key[dataset_collection_key]
+            copied_from_chain = collection_attrs.get("copied_from_history_dataset_collection_association_id_chain", [])
+            copied_from_object_key = _copied_from_object_key(copied_from_chain, object_import_tracker.hdcas_by_key)
+            if not copied_from_object_key:
+                continue
+
+            # Re-establish the chain if we can, again see comments for hdas above for this to make more
+            # sense.
+            hdca_copied_from_sinks = object_import_tracker.hdca_copied_from_sinks
+            if copied_from_object_key in object_import_tracker.hdcas_by_key:
+                hdca.copied_from_history_dataset_collection_association = object_import_tracker.hdcas_by_key[copied_from_object_key]
+            else:
+                if copied_from_object_key in hdca_copied_from_sinks:
+                    hdca.copied_from_history_dataset_association = object_import_tracker.hdcas_by_key[hdca_copied_from_sinks[copied_from_object_key]]
+                else:
+                    hdca_copied_from_sinks[copied_from_object_key] = dataset_collection_key
+
+    def _reassign_hids(self, object_import_tracker, history):
+        # assign HIDs for newly created objects that didn't match original history
+        requires_hid = object_import_tracker.requires_hid
+        requires_hid_len = len(requires_hid)
+        if requires_hid_len > 0 and not self.sessionless:
+            base = history._next_hid(n=requires_hid_len)
+            for i, obj in enumerate(requires_hid):
+                obj.hid = base + i
+        self._flush()
+
+    def _import_jobs(self, object_import_tracker, history):
+        object_key = self.object_key
+        #
+        # Create jobs.
+        #
+        jobs_attrs = self.jobs_properties()
+
+        # Create each job.
+        for job_attrs in jobs_attrs:
+            imported_job = model.Job()
+            imported_job.user = self.user
+            imported_job.history = history
+            imported_job.imported = True
+            imported_job.tool_id = job_attrs['tool_id']
+            imported_job.tool_version = job_attrs['tool_version']
+            raw_state = job_attrs['state']
+            if raw_state not in model.Job.terminal_states:
+                raw_state = model.Job.states.ERROR
+            imported_job.set_state(raw_state)
+            imported_job.info = job_attrs.get('info', None)
+            imported_job.exit_code = job_attrs.get('exit_code', None)
+            imported_job.traceback = job_attrs.get('traceback', None)
+            if 'stdout' in job_attrs:
+                # Pre 19.05 export.
+                imported_job.tool_stdout = job_attrs.get('stdout', None)
+                imported_job.tool_stderr = job_attrs.get('stderr', None)
+            else:
+                # Post 19.05 export with separated I/O
+                imported_job.tool_stdout = job_attrs.get('tool_stdout', None)
+                imported_job.job_stdout = job_attrs.get('job_stdout', None)
+                imported_job.tool_stderr = job_attrs.get('tool_stderr', None)
+                imported_job.job_stderr = job_attrs.get('job_stderr', None)
+
+            imported_job.command_line = job_attrs.get('command_line', None)
+            try:
+                imported_job.create_time = datetime.datetime.strptime(job_attrs["create_time"], "%Y-%m-%dT%H:%M:%S.%f")
+                imported_job.update_time = datetime.datetime.strptime(job_attrs["update_time"], "%Y-%m-%dT%H:%M:%S.%f")
+            except Exception:
+                pass
+            self._session_add(imported_job)
+            self._flush()
+
+            def _find_hda(input_key):
+                hda = None
+                if input_key in object_import_tracker.hdas_by_key:
+                    hda = object_import_tracker.hdas_by_key[input_key]
+                if input_key in object_import_tracker.hda_copied_from_sinks:
+                    hda = object_import_tracker.hdas_by_key[object_import_tracker.hda_copied_from_sinks[input_key]]
+                return hda
+
+            def _find_hdca(input_key):
+                hdca = None
+                if input_key in object_import_tracker.hdcas_by_key:
+                    hdca = object_import_tracker.hdcas_by_key[input_key]
+                if input_key in object_import_tracker.hdca_copied_from_sinks:
+                    hdca = object_import_tracker.hdca_copied_from_sinks[input_key]
+                return hdca
+
+            # Connect jobs to input and output datasets.
+            params = self._normalize_job_parameters(imported_job, job_attrs, _find_hda, _find_hdca)
+            for name, value in params.items():
+                # Transform parameter values when necessary.
+                imported_job.add_parameter(name, dumps(value))
+
+            self._connect_job_io(imported_job, job_attrs, _find_hda, _find_hdca)
+            self._flush()
+
+            if object_key in job_attrs:
+                object_import_tracker.jobs_by_key[job_attrs[object_key]] = imported_job
+
+    def _import_implicit_collection_jobs(self, object_import_tracker):
+        implicit_collection_jobs_attrs = self.implicit_collection_jobs_properties()
+        for icj_attrs in implicit_collection_jobs_attrs:
+            icj = model.ImplicitCollectionJobs()
+            icj.populated_state = icj_attrs["populated_state"]
+
+            icj.jobs = []
+            for order_index, job in enumerate(icj_attrs["jobs"]):
+                icja = model.ImplicitCollectionJobsJobAssociation()
+                icja.implicit_collection_jobs = icj
+                icja.job = object_import_tracker.jobs_by_key[job]
+                icja.order_index = order_index
+                icj.jobs.append(icja)
+                self._session_add(icja)
+
+            self._session_add(icj)
+            self._flush()
+
+    def _session_add(self, obj):
+        self.sa_session.add(obj)
+
+    def _flush(self):
+        self.sa_session.flush()
+
+
+def _copied_from_object_key(copied_from_chain, objects_by_key):
+    if len(copied_from_chain) == 0:
+        return None
+
+    # Okay this gets fun, we need the last thing in the chain to reconnect jobs
+    # from outside the history to inputs/outputs in this history but there may
+    # be cycles in the chain that lead outside the original history, so just eliminate
+    # all IDs not from this history except the last one.
+    filtered_copied_from_chain = []
+    for i, copied_from_key in enumerate(copied_from_chain):
+        filter_id = (i != len(copied_from_chain) - 1) and (copied_from_key not in objects_by_key)
+        if not filter_id:
+            filtered_copied_from_chain.append(copied_from_key)
+
+    copied_from_chain = filtered_copied_from_chain
+    if len(copied_from_chain) == 0:
+        return None
+
+    copied_from_object_key = copied_from_chain[0]
+    return copied_from_object_key
+
+
+class ObjectImportTracker(object):
+    """Keep track or new and existing imported objects.
+
+    Needed to re-establish connections and such in multiple passes.
+    """
+
+    def __init__(self):
+        self.libraries_by_key = {}
+        self.hdas_by_key = {}
+        self.hdas_by_id = {}
+        self.hdcas_by_key = {}
+        self.hdcas_by_id = {}
+        self.lddas_by_key = {}
+        self.hda_copied_from_sinks = {}
+        self.hdca_copied_from_sinks = {}
+        self.jobs_by_key = {}
+        self.requires_hid = []
+
+
+def get_import_model_store_for_directory(archive_dir, **kwd):
+    assert os.path.isdir(archive_dir)
+    if os.path.exists(os.path.join(archive_dir, ATTRS_FILENAME_EXPORT)):
+        return DirectoryImportModelStoreLatest(archive_dir, **kwd)
+    else:
+        return DirectoryImportModelStore1901(archive_dir, **kwd)
+
+
+class BaseDirectoryImportModelStore(ModelImportStore):
+
+    def defines_new_history(self):
+        new_history_attributes = os.path.join(self.archive_dir, ATTRS_FILENAME_HISTORY)
+        return os.path.exists(new_history_attributes)
+
+    def new_history_properties(self):
+        new_history_attributes = os.path.join(self.archive_dir, ATTRS_FILENAME_HISTORY)
+        history_properties = load(open(new_history_attributes))
+        return history_properties
+
+    def datasets_properties(self):
+        datasets_attrs_file_name = os.path.join(self.archive_dir, ATTRS_FILENAME_DATASETS)
+        datasets_attrs = load(open(datasets_attrs_file_name))
+        provenance_file_name = datasets_attrs_file_name + ".provenance"
+
+        if os.path.exists(provenance_file_name):
+            provenance_attrs = load(open(provenance_file_name))
+            datasets_attrs += provenance_attrs
+
+        return datasets_attrs
+
+    def collections_properties(self):
+        collections_attrs_file_name = os.path.join(self.archive_dir, ATTRS_FILENAME_COLLECTIONS)
+        if os.path.exists(collections_attrs_file_name):
+            collections_attrs = load(open(collections_attrs_file_name))
+        else:
+            collections_attrs = []
+        return collections_attrs
+
+    def library_properties(self):
+        libraries_attrs_file_name = os.path.join(self.archive_dir, ATTRS_FILENAME_LIBRARIES)
+        if os.path.exists(libraries_attrs_file_name):
+            libraries_attrs = load(open(libraries_attrs_file_name))
+        else:
+            libraries_attrs = []
+        return libraries_attrs
+
+    def jobs_properties(self):
+        jobs_attr_file_name = os.path.join(self.archive_dir, ATTRS_FILENAME_JOBS)
+        jobs_attrs = load(open(jobs_attr_file_name))
+        return jobs_attrs
+
+    def implicit_collection_jobs_properties(self):
+        implicit_collection_jobs_attrs_file_name = os.path.join(self.archive_dir, ATTRS_FILENAME_IMPLICIT_COLLECTION_JOBS)
+        if os.path.exists(implicit_collection_jobs_attrs_file_name):
+            implicit_collection_jobs_attrs = load(open(implicit_collection_jobs_attrs_file_name))
+        else:
+            implicit_collection_jobs_attrs = []
+        return implicit_collection_jobs_attrs
+
+
+class DirectoryImportModelStore1901(BaseDirectoryImportModelStore):
+    object_key = 'hid'
+
+    def __init__(self, archive_dir, **kwd):
+        super(DirectoryImportModelStore1901, self).__init__(**kwd)
+        archive_dir = os.path.realpath(archive_dir)
+
+        # Bioblend previous to 17.01 exported histories with an extra subdir.
+        if not os.path.exists(os.path.join(archive_dir, ATTRS_FILENAME_HISTORY)):
+            for d in os.listdir(archive_dir):
+                if os.path.isdir(os.path.join(archive_dir, d)):
+                    archive_dir = os.path.join(archive_dir, d)
+                    break
+
+        self.archive_dir = archive_dir
+
+    def _connect_job_io(self, imported_job, job_attrs, _find_hda, _find_hdca):
+        for output_key in job_attrs['output_datasets']:
+            output_hda = _find_hda(output_key)
+            if output_hda:
+                imported_job.add_output_dataset(output_hda.name, output_hda)
+
+        if 'input_mapping' in job_attrs:
+            for input_name, input_key in job_attrs['input_mapping'].items():
+                input_hda = _find_hda(input_key)
+                if input_hda:
+                    imported_job.add_input_dataset(input_name, input_hda)
+
+    def _normalize_job_parameters(self, imported_job, job_attrs, _find_hda, _find_hdca):
+        def remap_objects(p, k, obj):
+            if isinstance(obj, dict) and obj.get('__HistoryDatasetAssociation__', False):
+                imported_hda = _find_hda(obj[self.object_key])
+                if imported_hda:
+                    return (k, {"src": "hda", "id": imported_hda.id})
+            return (k, obj)
+
+        params = job_attrs['params']
+        params = remap(params, remap_objects)
+        return params
+
+    def trust_hid(self, obj_attrs):
+        # We didn't do object tracking so we pretty much have to trust the HID and accept
+        # that it will be wrong a lot.
+        return True
+
+
+class DirectoryImportModelStoreLatest(BaseDirectoryImportModelStore):
+    object_key = 'encoded_id'
+
+    def __init__(self, archive_dir, **kwd):
+        super(DirectoryImportModelStoreLatest, self).__init__(**kwd)
+        archive_dir = os.path.realpath(archive_dir)
+        self.archive_dir = archive_dir
+        if self.defines_new_history():
+            self.import_history_encoded_id = self.new_history_properties().get("encoded_id")
+        else:
+            self.import_history_encoded_id = None
+
+    def _connect_job_io(self, imported_job, job_attrs, _find_hda, _find_hdca):
+
+        if 'input_dataset_mapping' in job_attrs:
+            for input_name, input_keys in job_attrs['input_dataset_mapping'].items():
+                input_keys = input_keys or []
+                for input_key in input_keys:
+                    input_hda = _find_hda(input_key)
+                    if input_hda:
+                        imported_job.add_input_dataset(input_name, input_hda)
+
+        if 'input_dataset_collection_mapping' in job_attrs:
+            for input_name, input_keys in job_attrs['input_dataset_collection_mapping'].items():
+                input_keys = input_keys or []
+                for input_key in input_keys:
+                    input_hdca = _find_hdca(input_key)
+                    if input_hdca:
+                        imported_job.add_input_dataset_collection(input_name, input_hdca)
+
+        if 'output_dataset_mapping' in job_attrs:
+            for output_name, output_keys in job_attrs['output_dataset_mapping'].items():
+                output_keys = output_keys or []
+                for output_key in output_keys:
+                    output_hda = _find_hda(output_key)
+                    if output_hda:
+                        imported_job.add_output_dataset(output_name, output_hda)
+
+        if 'output_dataset_collection_mapping' in job_attrs:
+            for output_name, output_keys in job_attrs['output_dataset_collection_mapping'].items():
+                output_keys = output_keys or []
+                for output_key in output_keys:
+                    output_hdca = _find_hdca(output_key)
+                    if output_hdca:
+                        imported_job.add_output_dataset_collection(output_name, output_hdca)
+
+    def trust_hid(self, obj_attrs):
+        return self.import_history_encoded_id and obj_attrs.get("history_encoded_id") == self.import_history_encoded_id
+
+    def _normalize_job_parameters(self, imported_job, job_attrs, _find_hda, _find_hdca):
+        def remap_objects(p, k, obj):
+            if isinstance(obj, dict) and "src" in obj and obj["src"] in ["hda", "hdca"]:
+                if obj["src"] == "hda":
+                    imported_hda = _find_hda(obj["id"])
+                    if imported_hda:
+                        new_id = imported_hda.id
+                    else:
+                        new_id = None
+                elif obj["src"] == "hdca":
+                    imported_hdca = _find_hdca(obj["id"])
+                    if imported_hdca:
+                        new_id = imported_hdca.id
+                    else:
+                        new_id = None
+                else:
+                    raise NotImplementedError()
+                new_obj = obj.copy()
+                new_obj["id"] = new_id
+                return (k, new_obj)
+
+            return (k, obj)
+
+        params = job_attrs['params']
+        params = remap(params, remap_objects)
+        return params
+
+
+class BagArchiveImportModelStore(DirectoryImportModelStoreLatest):
+
+    def __init__(self, bag_archive, **kwd):
+        archive_dir = tempfile.mkdtemp()
+        bdb.extract_bag(bag_archive, output_path=archive_dir)
+        # Why this line though...?
+        archive_dir = os.path.join(archive_dir, os.listdir(archive_dir)[0])
+        bdb.revert_bag(archive_dir)
+        super(BagArchiveImportModelStore, self).__init__(archive_dir, **kwd)
+
+
+@six.add_metaclass(abc.ABCMeta)
+class ModelExportStore(object):
+
+    @abc.abstractmethod
+    def export_history(self, history, include_hidden=False, include_deleted=False):
+        """Export history to store."""
+
+    @abc.abstractmethod
+    def add_dataset_collection(self, collection):
+        """Add HDCA to export store."""
+
+    @abc.abstractmethod
+    def add_dataset(self, dataset, include_files=True):
+        """Add HDA to export store."""
+
+    @abc.abstractmethod
+    def __enter__(self):
+        """Export store should be used as context manager."""
+
+    @abc.abstractmethod
+    def __exit__(self):
+        """Export store should be used as context manager."""
+
+
+class DirectoryModelExportStore(ModelExportStore):
+
+    def __init__(self, export_directory, app=None, for_edit=False, serialize_dataset_objects=None, export_files=None):
+        if not os.path.exists(export_directory):
+            os.makedirs(export_directory)
+
+        if app is not None:
+            self.app = app
+            self.security = app.security
+        else:
+            self.security = IdEncodingHelper(id_secret="randomdoesntmatter")
+
+        self.export_directory = export_directory
+        self.serialization_options = model.SerializationOptions(
+            for_edit=for_edit,
+            serialize_dataset_objects=serialize_dataset_objects,
+            serialize_files_handler=self,
+        )
+        self.export_files = export_files
+        self.included_datasets = {}
+        self.included_collections = []
+        self.included_libraries = []
+        self.included_library_folders = []
+        self.collection_datasets = {}
+        self.collections_attrs = []
+        self.dataset_id_to_path = {}
+
+    def serialize_files(self, dataset, as_dict):
+        if self.export_files is None:
+            return None
+        elif self.export_files == "symlink":
+            add = os.symlink
+        elif self.export_files == "copy":
+            def add(src, dest):
+                if os.path.isdir(src):
+                    shutil.copytree(src, dest)
+                else:
+                    shutil.copyfile(src, dest)
+
+        export_directory = self.export_directory
+        if dataset.id in self.included_datasets:
+            _, include_files = self.included_datasets[dataset.id]
+            if not include_files:
+                return
+
+            file_name, extra_files_path = None, None
+            try:
+                _file_name = dataset.file_name
+                if os.path.exists(_file_name):
+                    file_name = _file_name
+            except ObjectNotFound:
+                pass
+
+            if dataset.extra_files_path_exists():
+                extra_files_path = dataset.extra_files_path
+            else:
+                pass
+
+        dir_name = 'datasets'
+        dir_path = os.path.join(export_directory, dir_name)
+        dataset_hid = as_dict['hid']
+        assert dataset_hid, as_dict
+
+        if dataset.dataset.id in self.dataset_id_to_path:
+            file_name, extra_files_path = self.dataset_id_to_path[dataset.dataset.id]
+            if file_name is not None:
+                as_dict['file_name'] = file_name
+            if extra_files_path is not None:
+                as_dict['extra_files_path'] = extra_files_path
+            return
+
+        if file_name:
+            if not os.path.exists(dir_path):
+                os.makedirs(dir_path)
+
+            target_filename = get_export_dataset_filename(as_dict['name'], as_dict['extension'], dataset_hid)
+            arcname = os.path.join(dir_name, target_filename)
+
+            src = file_name
+            dest = os.path.join(export_directory, arcname)
+            add(src, dest)
+            as_dict['file_name'] = arcname
+
+        if extra_files_path:
+            try:
+                file_list = os.listdir(extra_files_path)
+            except OSError:
+                file_list = []
+
+            if len(file_list):
+                arcname = os.path.join(dir_name, 'extra_files_path_%s' % dataset_hid)
+                add(extra_files_path, os.path.join(export_directory, arcname))
+                as_dict['extra_files_path'] = arcname
+            else:
+                as_dict['extra_files_path'] = ''
+
+        self.dataset_id_to_path[dataset.dataset.id] = (as_dict.get("file_name"), as_dict.get("extra_files_path"))
+
+    def exported_key(self, obj):
+        return self.security.encode_id(obj.id, kind='model_export')
+
+    def __enter__(self):
+        return self
+
+    def export_history(self, history, include_hidden=False, include_deleted=False):
+        app = self.app
+        export_directory = self.export_directory
+
+        history_attrs = history.serialize(app.security, self.serialization_options)
+        history_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_HISTORY)
+        with open(history_attrs_filename, 'w') as history_attrs_out:
+            dump(history_attrs, history_attrs_out)
+
+        sa_session = app.model.context.current
+
+        # Write collections' attributes (including datasets list) to file.
+        query = (sa_session.query(model.HistoryDatasetCollectionAssociation)
+                 .filter(model.HistoryDatasetCollectionAssociation.history == history)
+                 .filter(model.HistoryDatasetCollectionAssociation.deleted == expression.false()))
+        collections = query.all()
+
+        for collection in collections:
+            # filter this ?
+            if not collection.populated:
+                break
+            if collection.state != 'ok':
+                break
+
+            self.add_dataset_collection(collection)
+
+            # export jobs for these datasets
+            for collection_dataset in collection.dataset_instances:
+                if collection_dataset.deleted and not include_deleted:
+                    include_files = False
+                else:
+                    include_files = True
+
+                self.add_dataset(collection_dataset, include_files=include_files)
+                self.collection_datasets[collection_dataset.id] = True
+
+        # Write datasets' attributes to file.
+        query = (sa_session.query(model.HistoryDatasetAssociation)
+                 .filter(model.HistoryDatasetAssociation.history == history)
+                 .join("dataset")
+                 .options(eagerload_all("dataset.actions"))
+                 .order_by(model.HistoryDatasetAssociation.hid)
+                 .filter(model.Dataset.purged == expression.false()))
+        datasets = query.all()
+        for dataset in datasets:
+            dataset.annotation = get_item_annotation_str(sa_session, history.user, dataset)
+            add_dataset = (not dataset.visible or not include_hidden) and (not dataset.deleted or include_deleted)
+            if dataset.id in self.collection_datasets:
+                add_dataset = True
+
+            if dataset.id not in self.included_datasets:
+                self.add_dataset(dataset, include_files=add_dataset)
+
+    def export_library(self, library, include_hidden=False, include_deleted=False):
+        self.included_libraries.append(library)
+        self.included_library_folders.append(library.root_folder)
+
+        def collect_datasets(library_folder):
+            for library_dataset in library_folder.datasets:
+                ldda = library_dataset.library_dataset_dataset_association
+                add_dataset = (not ldda.visible or not include_hidden) and (not ldda.deleted or include_deleted)
+                # TODO: competing IDs here between ldda and hdas - fix this!
+                self.included_datasets[ldda.id] = (ldda, add_dataset)
+            for folder in library_folder.folders:
+                collect_datasets(folder)
+
+        collect_datasets(library.root_folder)
+
+    def add_dataset_collection(self, collection):
+        self.collections_attrs.append(collection)
+        self.included_collections.append(collection)
+
+    def add_dataset(self, dataset, include_files=True):
+        self.included_datasets[dataset.id] = (dataset, include_files)
+
+    def _finalize(self):
+        export_directory = self.export_directory
+
+        datasets_attrs = []
+        provenance_attrs = []
+        for dataset_id, (dataset, include_files) in self.included_datasets.items():
+            if include_files:
+                datasets_attrs.append(dataset)
+            else:
+                provenance_attrs.append(dataset)
+
+        datasets_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_DATASETS)
+        with open(datasets_attrs_filename, 'w') as datasets_attrs_out:
+            dump(list(map(lambda d: d.serialize(self.security, self.serialization_options), datasets_attrs)), datasets_attrs_out)
+
+        with open(datasets_attrs_filename + ".provenance", 'w') as provenance_attrs_out:
+            dump(list(map(lambda d: d.serialize(self.security, self.serialization_options), provenance_attrs)), provenance_attrs_out)
+
+        libraries_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_LIBRARIES)
+        with open(libraries_attrs_filename, 'w') as librariess_attrs_out:
+            dump(list(map(lambda d: d.serialize(self.security, self.serialization_options), self.included_libraries)), librariess_attrs_out)
+
+        collections_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_COLLECTIONS)
+        with open(collections_attrs_filename, 'w') as collections_attrs_out:
+            dump(list(map(lambda d: d.serialize(self.security, self.serialization_options), self.collections_attrs)), collections_attrs_out)
+
+        #
+        # Write jobs attributes file.
+        #
+
+        # Get all jobs associated with included HDAs.
+        jobs_dict = {}
+        implicit_collection_jobs_dict = {}
+
+        def record_associated_jobs(obj):
+            # Get the job object.
+            job = None
+            for assoc in obj.creating_job_associations:
+                job = assoc.job
+                break
+            if not job:
+                # No viable job.
+                return
+
+            jobs_dict[job.id] = job
+            icja = job.implicit_collection_jobs_association
+            if icja:
+                implicit_collection_jobs = icja.implicit_collection_jobs
+                implicit_collection_jobs_dict[implicit_collection_jobs.id] = implicit_collection_jobs
+
+        for hda_id, (hda, include_files) in self.included_datasets.items():
+            # Get the associated job, if any. If this hda was copied from another,
+            # we need to find the job that created the origial hda
+            job_hda = hda
+            while job_hda.copied_from_history_dataset_association:  # should this check library datasets as well?
+                job_hda = job_hda.copied_from_history_dataset_association
+            if not job_hda.creating_job_associations:
+                # No viable HDA found.
+                continue
+
+            record_associated_jobs(job_hda)
+
+        for hdca in self.included_collections:
+            record_associated_jobs(hdca)
+
+        # Get jobs' attributes.
+        jobs_attrs = []
+        for id, job in jobs_dict.items():
+            # Don't attempt to serialize jobs for editing... yet at least.
+            if self.serialization_options.for_edit:
+                continue
+
+            job_attrs = job.serialize(self.security, self.serialization_options)
+
+            # -- Get input, output datasets. --
+
+            input_dataset_mapping = {}
+            output_dataset_mapping = {}
+            input_dataset_collection_mapping = {}
+            output_dataset_collection_mapping = {}
+            implicit_output_dataset_collection_mapping = {}
+
+            for assoc in job.input_datasets:
+                # Optional data inputs will not have a dataset.
+                if assoc.dataset:
+                    name = assoc.name
+                    if name not in input_dataset_mapping:
+                        input_dataset_mapping[name] = []
+
+                    input_dataset_mapping[name].append(self.exported_key(assoc.dataset))
+
+            for assoc in job.output_datasets:
+                # Optional data inputs will not have a dataset.
+                if assoc.dataset:
+                    name = assoc.name
+                    if name not in output_dataset_mapping:
+                        output_dataset_mapping[name] = []
+
+                    output_dataset_mapping[name].append(self.exported_key(assoc.dataset))
+
+            for assoc in job.input_dataset_collections:
+                # Optional data inputs will not have a dataset.
+                if assoc.dataset_collection:
+                    name = assoc.name
+                    if name not in input_dataset_collection_mapping:
+                        input_dataset_collection_mapping[name] = []
+
+                    input_dataset_collection_mapping[name].append(self.exported_key(assoc.dataset_collection))
+
+            for assoc in job.output_dataset_collection_instances:
+                # Optional data outputs will not have a dataset.
+                if assoc.dataset_collection_instance:
+                    name = assoc.name
+                    if name not in output_dataset_collection_mapping:
+                        output_dataset_collection_mapping[name] = []
+
+                    output_dataset_collection_mapping[name].append(self.exported_key(assoc.dataset_collection_instance))
+
+            for assoc in job.output_dataset_collections:
+                if assoc.dataset_collection:
+                    name = assoc.name
+
+                    if name not in implicit_output_dataset_collection_mapping:
+                        implicit_output_dataset_collection_mapping[name] = []
+
+                    implicit_output_dataset_collection_mapping[name].append(self.exported_key(assoc.dataset_collection))
+
+            job_attrs['input_dataset_mapping'] = input_dataset_mapping
+            job_attrs['input_dataset_collection_mapping'] = input_dataset_collection_mapping
+            job_attrs['output_dataset_mapping'] = output_dataset_mapping
+            job_attrs['output_dataset_collection_mapping'] = output_dataset_collection_mapping
+            job_attrs['implicit_output_dataset_collection_mapping'] = implicit_output_dataset_collection_mapping
+
+            jobs_attrs.append(job_attrs)
+
+        icjs_attrs = []
+        for icj_id, icj in implicit_collection_jobs_dict.items():
+            icj_attrs = icj.serialize(self.security, self.serialization_options)
+            icjs_attrs.append(icj_attrs)
+
+        jobs_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_JOBS)
+        with open(jobs_attrs_filename, 'w') as jobs_attrs_out:
+            dump(jobs_attrs, jobs_attrs_out)
+
+        icjs_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_IMPLICIT_COLLECTION_JOBS)
+        with open(icjs_attrs_filename, 'w') as icjs_attrs_out:
+            dump(icjs_attrs, icjs_attrs_out)
+
+        export_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_EXPORT)
+        with open(export_attrs_filename, 'w') as export_attrs_out:
+            dump({"galaxy_version": VERSION_MAJOR}, export_attrs_out)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self._finalize()
+        # http://effbot.org/zone/python-with-statement.htm
+        return isinstance(exc_val, TypeError)
+
+
+class TarModelExportStore(DirectoryModelExportStore):
+
+    def __init__(self, out_file, gzip=True, **kwds):
+        self.gzip = gzip
+        self.out_file = out_file
+        temp_output_dir = tempfile.mkdtemp()
+        super(TarModelExportStore, self).__init__(temp_output_dir, **kwds)
+
+    def _finalize(self):
+        super(TarModelExportStore, self)._finalize()
+        tar_export_directory(self.export_directory, self.out_file, self.gzip)
+        shutil.rmtree(self.export_directory)
+
+
+class BagDirectoryModelExportStore(DirectoryModelExportStore):
+
+    def __init__(self, out_directory, **kwds):
+        self.out_directory = out_directory
+        super(BagDirectoryModelExportStore, self).__init__(out_directory, **kwds)
+
+    def _finalize(self):
+        super(BagDirectoryModelExportStore, self)._finalize()
+        bdb.make_bag(self.out_directory)
+
+
+class BagArchiveModelExportStore(BagDirectoryModelExportStore):
+
+    def __init__(self, out_file, bag_archiver="tgz", **kwds):
+        # bag_archiver in tgz, zip, tar
+        self.bag_archiver = bag_archiver
+        self.out_file = out_file
+        temp_output_dir = tempfile.mkdtemp()
+        super(BagArchiveModelExportStore, self).__init__(temp_output_dir, **kwds)
+
+    def _finalize(self):
+        super(BagArchiveModelExportStore, self)._finalize()
+        rval = bdb.archive_bag(self.export_directory, self.bag_archiver)
+        shutil.move(rval, self.out_file)
+        shutil.rmtree(self.export_directory)
+
+
+def tar_export_directory(export_directory, out_file, gzip):
+    tarfile_mode = "w"
+    if gzip:
+        tarfile_mode += ":gz"
+
+    with tarfile.open(out_file, tarfile_mode, dereference=True) as history_archive:
+        for export_path in os.listdir(export_directory):
+            history_archive.add(os.path.join(export_directory, export_path), arcname=export_path)
+
+
+def get_export_dataset_filename(name, ext, hid):
+    """
+    Builds a filename for a dataset using its name an extension.
+    """
+    base = ''.join(c in FILENAME_VALID_CHARS and c or '_' for c in name)
+    return base + "_%s.%s" % (hid, ext)

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -1,27 +1,15 @@
-import datetime
-import json
 import logging
 import os
 import shutil
 import tempfile
-from json import dump, dumps, load
-
-from boltons.iterutils import remap
-from sqlalchemy.orm import eagerload_all
-from sqlalchemy.sql import expression
 
 from galaxy import model
-from galaxy.exceptions import MalformedContents
-from galaxy.exceptions import ObjectNotFound
-from galaxy.model.item_attrs import add_item_annotation, get_item_annotation_str
-from galaxy.util import in_directory, unicodify
+from galaxy.model import store
 from galaxy.version import VERSION_MAJOR
 
 log = logging.getLogger(__name__)
 
 ATTRS_FILENAME_HISTORY = 'history_attrs.txt'
-ATTRS_FILENAME_DATASETS = 'datasets_attrs.txt'
-ATTRS_FILENAME_JOBS = 'jobs_attrs.txt'
 
 
 class JobImportHistoryArchiveWrapper:
@@ -36,214 +24,39 @@ class JobImportHistoryArchiveWrapper:
         self.sa_session = self.app.model.context
 
     def cleanup_after_job(self):
-        """ Set history, datasets, and jobs' attributes and clean up archive directory. """
+        """ Set history, datasets, collections and jobs' attributes
+            and clean up archive directory.
+        """
 
         #
         # Import history.
         #
 
-        new_history = None
-
         jiha = self.sa_session.query(model.JobImportHistoryArchive).filter_by(job_id=self.job_id).first()
-        if jiha:
-            try:
-                archive_dir = jiha.archive_dir
-                archive_dir = os.path.realpath(archive_dir)
-                user = jiha.job.user
+        if not jiha:
+            return None
+        user = jiha.job.user
 
-                # Bioblend previous to 17.01 exported histories with an extra subdir.
-                if not os.path.exists(os.path.join(archive_dir, ATTRS_FILENAME_HISTORY)):
-                    for d in os.listdir(archive_dir):
-                        if os.path.isdir(os.path.join(archive_dir, d)):
-                            archive_dir = os.path.join(archive_dir, d)
-                            break
+        new_history = None
+        try:
+            archive_dir = jiha.archive_dir
+            model_store = store.get_import_model_store_for_directory(archive_dir, app=self.app, user=user)
+            job = jiha.job
+            with model_store.target_history(default_history=job.history) as new_history:
 
-                #
-                # Create history.
-                #
-                history_attr_file_name = os.path.join(archive_dir, ATTRS_FILENAME_HISTORY)
-                history_attrs = load(open(history_attr_file_name))
-
-                # Create history.
-                new_history = model.History(name='imported from archive: %s' % history_attrs['name'],
-                                            user=user)
-                new_history.importing = True
-                new_history.hid_counter = history_attrs['hid_counter']
-                new_history.genome_build = history_attrs['genome_build']
-                self.sa_session.add(new_history)
                 jiha.history = new_history
                 self.sa_session.flush()
 
-                # Add annotation, tags.
-                if user:
-                    add_item_annotation(self.sa_session, user, new_history, history_attrs['annotation'])
-                    """
-                    TODO: figure out to how add tags to item.
-                    for tag, value in history_attrs[ 'tags' ].items():
-                        trans.app.tag_handler.apply_item_tags( trans, trans.user, new_history, get_tag_str( tag, value ) )
-                    """
-
-                #
-                # Create datasets.
-                #
-                datasets_attrs_file_name = os.path.join(archive_dir, ATTRS_FILENAME_DATASETS)
-                datasets_attrs = load(open(datasets_attrs_file_name))
-                provenance_file_name = datasets_attrs_file_name + ".provenance"
-
-                if os.path.exists(provenance_file_name):
-                    provenance_attrs = load(open(provenance_file_name))
-                    datasets_attrs += provenance_attrs
-
-                object_key = 'hid'
-                hdas_by_key = {}
-
-                # Create datasets.
-                for dataset_attrs in datasets_attrs:
-                    metadata = dataset_attrs['metadata']
-
-                    # Create dataset and HDA.
-                    hda = model.HistoryDatasetAssociation(name=dataset_attrs['name'],
-                                                          extension=dataset_attrs['extension'],
-                                                          info=dataset_attrs['info'],
-                                                          blurb=dataset_attrs['blurb'],
-                                                          peek=dataset_attrs['peek'],
-                                                          designation=dataset_attrs['designation'],
-                                                          visible=dataset_attrs['visible'],
-                                                          deleted=dataset_attrs.get('deleted', False),
-                                                          dbkey=metadata['dbkey'],
-                                                          metadata=metadata,
-                                                          history=new_history,
-                                                          create_dataset=True,
-                                                          sa_session=self.sa_session)
-                    if 'uuid' in dataset_attrs:
-                        hda.dataset.uuid = dataset_attrs["uuid"]
-                    self.sa_session.add(hda)
-                    self.sa_session.flush()
-                    new_history.add_dataset(hda, genome_build=None)
-                    hda.hid = dataset_attrs['hid']  # Overwrite default hid set when HDA added to history.
-                    self.sa_session.flush()
-
-                    file_name = dataset_attrs.get('file_name')
-                    if file_name:
-                        # Do security check and move/copy dataset data.
-                        archive_path = os.path.abspath(os.path.join(archive_dir, file_name))
-                        if os.path.islink(archive_path):
-                            raise MalformedContents("Invalid dataset path: %s" % archive_path)
-
-                        temp_dataset_file_name = \
-                            os.path.realpath(archive_path)
-
-                        if not in_directory(temp_dataset_file_name, archive_dir):
-                            raise MalformedContents("Invalid dataset path: %s" % temp_dataset_file_name)
-
-                    if not file_name or not os.path.exists(temp_dataset_file_name):
-                        hda.state = hda.states.DISCARDED
-                        hda.deleted = True
-                        hda.purged = True
-                        hda.dataset.deleted = True
-                        hda.dataset.purged = True
-                    else:
-                        hda.state = hda.states.OK
-                        self.app.object_store.update_from_file(hda.dataset, file_name=temp_dataset_file_name, create=True)
-
-                        # Import additional files if present. Histories exported previously might not have this attribute set.
-                        dataset_extra_files_path = dataset_attrs.get('extra_files_path', None)
-                        if dataset_extra_files_path:
-                            try:
-                                file_list = os.listdir(os.path.join(archive_dir, dataset_extra_files_path))
-                            except OSError:
-                                file_list = []
-
-                            if file_list:
-                                for extra_file in file_list:
-                                    self.app.object_store.update_from_file(
-                                        hda.dataset, extra_dir='dataset_%s_files' % hda.dataset.id,
-                                        alt_name=extra_file, file_name=os.path.join(archive_dir, dataset_extra_files_path, extra_file),
-                                        create=True)
-                        hda.dataset.set_total_size()  # update the filesize record in the database
-
-                        if hda.deleted:
-                            hda.dataset.deleted = True
-
-                    if user:
-                        add_item_annotation(self.sa_session, user, hda, dataset_attrs['annotation'])
-                        # TODO: Set tags.
-
-                    self.app.datatypes_registry.set_external_metadata_tool.regenerate_imported_metadata_if_needed(
-                        hda, new_history, jiha.job
-                    )
-
-                    hdas_by_key[dataset_attrs[object_key]] = hda
-
-                #
-                # Create jobs.
-                #
-                jobs_attr_file_name = os.path.join(archive_dir, ATTRS_FILENAME_JOBS)
-                jobs_attrs = load(open(jobs_attr_file_name))
-
-                # Create each job.
-                for job_attrs in jobs_attrs:
-                    imported_job = model.Job()
-                    imported_job.user = user
-                    # TODO: set session?
-                    # imported_job.session = trans.get_galaxy_session().id
-                    imported_job.history = new_history
-                    imported_job.imported = True
-                    imported_job.tool_id = job_attrs['tool_id']
-                    imported_job.tool_version = job_attrs['tool_version']
-                    imported_job.set_state(job_attrs['state'])
-                    imported_job.info = job_attrs.get('info', None)
-                    imported_job.exit_code = job_attrs.get('exit_code', None)
-                    imported_job.traceback = job_attrs.get('traceback', None)
-                    imported_job.tool_stdout = job_attrs.get('stdout', None)
-                    imported_job.tool_stderr = job_attrs.get('stderr', None)
-                    imported_job.command_line = job_attrs.get('command_line', None)
-                    try:
-                        imported_job.create_time = datetime.datetime.strptime(job_attrs["create_time"], "%Y-%m-%dT%H:%M:%S.%f")
-                        imported_job.update_time = datetime.datetime.strptime(job_attrs["update_time"], "%Y-%m-%dT%H:%M:%S.%f")
-                    except Exception:
-                        pass
-                    self.sa_session.add(imported_job)
-                    self.sa_session.flush()
-
-                    def remap_objects(p, k, obj):
-                        if isinstance(obj, dict) and obj.get('__HistoryDatasetAssociation__', False):
-                            return (k, hdas_by_key[obj[object_key]].id)
-                        return (k, obj)
-
-                    params = job_attrs['params']
-                    params = remap(params, remap_objects)
-
-                    for name, value in params.items():
-                        # Transform parameter values when necessary.
-                        imported_job.add_parameter(name, dumps(value))
-
-                    # Connect jobs to output datasets.
-                    for output_key in job_attrs['output_datasets']:
-                        output_hda = hdas_by_key[output_key]
-                        if output_hda:
-                            imported_job.add_output_dataset(output_hda.name, output_hda)
-
-                    # Connect jobs to input datasets.
-                    if 'input_mapping' in job_attrs:
-                        for input_name, input_key in job_attrs['input_mapping'].items():
-                            input_hda = hdas_by_key[input_key]
-                            if input_hda:
-                                imported_job.add_input_dataset(input_name, input_hda)
-
-                    self.sa_session.flush()
-
-                # Done importing.
-                new_history.importing = False
-                self.sa_session.flush()
+                model_store.perform_import(new_history, job=job, new_history=True)
 
                 # Cleanup.
                 if os.path.exists(archive_dir):
                     shutil.rmtree(archive_dir)
-            except Exception as e:
-                jiha.job.tool_stderr += "Error cleaning up history import job: %s" % e
-                self.sa_session.flush()
-                raise
+
+        except Exception as e:
+            jiha.job.tool_stderr += "Error cleaning up history import job: %s" % e
+            self.sa_session.flush()
+            raise
 
         return new_history
 
@@ -259,18 +72,6 @@ class JobExportHistoryArchiveWrapper:
         self.job_id = job_id
         self.sa_session = self.app.model.context
 
-    def get_history_datasets(self, history):
-        """
-        Returns history's datasets.
-        """
-        query = (self.sa_session.query(model.HistoryDatasetAssociation)
-                 .filter(model.HistoryDatasetAssociation.history == history)
-                 .join("dataset")
-                 .options(eagerload_all("dataset.actions"))
-                 .order_by(model.HistoryDatasetAssociation.hid)
-                 .filter(model.Dataset.purged == expression.false()))
-        return query.all()
-
     def setup_job(self, jeha, include_hidden=False, include_deleted=False):
         """ Perform setup for job to export a history into an archive. Method generates
             attribute files for export, sets the corresponding attributes in the jeha
@@ -278,62 +79,7 @@ class JobExportHistoryArchiveWrapper:
             includes the command, inputs, and options; it does not include the output
             file because it must be set at runtime. """
 
-        #
-        # Helper methods/classes.
-        #
-
-        def prepare_metadata(metadata):
-            """ Prepare metatdata for exporting. """
-            for name, value in list(metadata.items()):
-                # Metadata files are not needed for export because they can be
-                # regenerated.
-                if isinstance(value, model.MetadataFile):
-                    del metadata[name]
-            return metadata
-
-        class HistoryDatasetAssociationEncoder(json.JSONEncoder):
-            """ Custom JSONEncoder for a HistoryDatasetAssociation. """
-
-            include_files = True
-
-            def default(self, obj):
-                """ Encode an HDA, default encoding for everything else. """
-                if isinstance(obj, model.HistoryDatasetAssociation):
-                    rval = {
-                        "__HistoryDatasetAssociation__": True,
-                        "create_time": obj.create_time.__str__(),
-                        "update_time": obj.update_time.__str__(),
-                        "hid": obj.hid,
-                        "name": unicodify(obj.name),
-                        "info": unicodify(obj.info),
-                        "blurb": obj.blurb,
-                        "peek": obj.peek,
-                        "extension": obj.extension,
-                        "metadata": prepare_metadata(dict(obj.metadata.items())),
-                        "parent_id": obj.parent_id,
-                        "designation": obj.designation,
-                        "deleted": obj.deleted,
-                        "visible": obj.visible,
-                        "uuid": (lambda uuid: str(uuid) if uuid else None)(obj.dataset.uuid),
-                        "annotation": unicodify(getattr(obj, 'annotation', '')),
-                        "tags": obj.make_tag_string_list()
-                    }
-                    if self.include_files:
-                        try:
-                            rval['file_name'] = obj.file_name
-                        except ObjectNotFound:
-                            rval['file_name'] = None
-
-                        if obj.extra_files_path_exists():
-                            rval['extra_files_path'] = obj.extra_files_path
-                        else:
-                            rval['extra_files_path'] = None
-
-                    return rval
-                return json.JSONEncoder.default(self, obj)
-
-        class NoFilesHistoryDatasetAssociationEncoder(HistoryDatasetAssociationEncoder):
-            include_files = False
+        app = self.app
 
         #
         # Create attributes/metadata files for export.
@@ -342,115 +88,13 @@ class JobExportHistoryArchiveWrapper:
         # always return an absolute path.
         temp_output_dir = os.path.abspath(tempfile.mkdtemp())
 
-        # Write history attributes to file.
         history = jeha.history
-        history_attrs = {
-            "create_time": history.create_time.__str__(),
-            "update_time": history.update_time.__str__(),
-            "name": unicodify(history.name),
-            "hid_counter": history.hid_counter,
-            "genome_build": history.genome_build,
-            "annotation": unicodify(get_item_annotation_str(self.sa_session, history.user, history)),
-            "tags": history.make_tag_string_list()
-        }
         history_attrs_filename = os.path.join(temp_output_dir, ATTRS_FILENAME_HISTORY)
-        with open(history_attrs_filename, 'w') as history_attrs_out:
-            dump(history_attrs, history_attrs_out)
-
         jeha.history_attrs_filename = history_attrs_filename
 
-        # Write datasets' attributes to file.
-        datasets = self.get_history_datasets(history)
-        included_datasets = []
-        datasets_attrs = []
-        provenance_attrs = []
-
-        for dataset in datasets:
-            dataset.annotation = get_item_annotation_str(self.sa_session, history.user, dataset)
-            if (not dataset.visible and not include_hidden) or (dataset.deleted and not include_deleted):
-                provenance_attrs.append(dataset)
-            else:
-                datasets_attrs.append(dataset)
-                included_datasets.append(dataset)
-
-        datasets_attrs_filename = os.path.join(temp_output_dir, ATTRS_FILENAME_DATASETS)
-        with open(datasets_attrs_filename, 'w') as datasets_attrs_out:
-            dump(datasets_attrs, datasets_attrs_out, cls=HistoryDatasetAssociationEncoder)
-
-        with open(datasets_attrs_filename + ".provenance", 'w') as provenance_attrs_out:
-            dump(provenance_attrs, provenance_attrs_out, cls=NoFilesHistoryDatasetAssociationEncoder)
-
-        #
-        # Write jobs attributes file.
-        #
-
-        # Get all jobs associated with included HDAs.
-        jobs_dict = {}
-        for hda in (included_datasets + provenance_attrs):
-            # Get the associated job, if any. If this hda was copied from another,
-            # we need to find the job that created the origial hda
-            job_hda = hda
-            while job_hda.copied_from_history_dataset_association:  # should this check library datasets as well?
-                job_hda = job_hda.copied_from_history_dataset_association
-            if not job_hda.creating_job_associations:
-                # No viable HDA found.
-                continue
-
-            # Get the job object.
-            job = None
-            for assoc in job_hda.creating_job_associations:
-                job = assoc.job
-                break
-            if not job:
-                # No viable job.
-                continue
-
-            jobs_dict[job.id] = job
-
-        # Get jobs' attributes.
-        jobs_attrs = []
-        for id, job in jobs_dict.items():
-            job_attrs = {}
-            job_attrs['tool_id'] = job.tool_id
-            job_attrs['tool_version'] = job.tool_version
-            job_attrs['state'] = job.state
-            job_attrs['info'] = job.info
-            job_attrs['traceback'] = job.traceback
-            job_attrs['command_line'] = job.command_line
-            job_attrs['stderr'] = job.stderr
-            job_attrs['stdout'] = job.stdout
-            job_attrs['exit_code'] = job.exit_code
-            job_attrs['create_time'] = job.create_time.isoformat()
-            job_attrs['update_time'] = job.update_time.isoformat()
-
-            # Get the job's parameters
-            params_dict = {}
-            try:
-                params_objects = job.get_param_values(self.app)
-                for name, value in params_objects.items():
-                    params_dict[name] = value
-            except Exception:
-                # Could not get job params.
-                pass
-
-            job_attrs['params'] = params_dict
-
-            # -- Get input, output datasets. --
-
-            input_mapping = {}
-            for assoc in job.input_datasets:
-                # Optional data inputs will not have a dataset.
-                if assoc.dataset:
-                    input_mapping[assoc.name] = assoc.dataset.hid
-            job_attrs['input_mapping'] = input_mapping
-            output_datasets = [assoc.dataset.hid for assoc in job.output_datasets]
-            job_attrs['output_datasets'] = output_datasets
-
-            jobs_attrs.append(job_attrs)
-
-        jobs_attrs_filename = os.path.join(temp_output_dir, ATTRS_FILENAME_JOBS)
-        with open(jobs_attrs_filename, 'w') as jobs_attrs_out:
-            dump(jobs_attrs, jobs_attrs_out, cls=HistoryDatasetAssociationEncoder)
+        # symlink files on export, on worker files will tarred up in a dereferenced manner.
+        with store.DirectoryModelExportStore(temp_output_dir, app=app, export_files="symlink") as export_store:
+            export_store.export_history(history, include_hidden=include_hidden, include_deleted=include_deleted)
 
         #
         # Create and return command line for running tool.

--- a/lib/galaxy/tools/imp_exp/export_history.py
+++ b/lib/galaxy/tools/imp_exp/export_history.py
@@ -9,84 +9,16 @@ from __future__ import print_function
 
 import optparse
 import os
+import shutil
 import sys
-import tarfile
-from json import dumps, loads
 
-from galaxy.util import FILENAME_VALID_CHARS
+from galaxy.model.store import tar_export_directory
 
 
-def get_dataset_filename(name, ext, hid):
-    """
-    Builds a filename for a dataset using its name an extension.
-    """
-    base = ''.join(c in FILENAME_VALID_CHARS and c or '_' for c in name)
-    return base + "_%s.%s" % (hid, ext)
-
-
-def create_archive(history_attrs_file, datasets_attrs_file, jobs_attrs_file, out_file, gzip=False):
+def create_archive(export_directory, out_file, gzip=False):
     """Create archive from the given attribute/metadata files and save it to out_file."""
-    tarfile_mode = "w"
-    if gzip:
-        tarfile_mode += ":gz"
     try:
-
-        history_archive = tarfile.open(out_file, tarfile_mode)
-
-        # Read datasets attributes from file.
-        with open(datasets_attrs_file) as datasets_attr_in:
-            datasets_attr_str = ''
-            buffsize = 1048576
-            try:
-                while True:
-                    datasets_attr_str += datasets_attr_in.read(buffsize)
-                    if not datasets_attr_str or len(datasets_attr_str) % buffsize != 0:
-                        break
-            except OverflowError:
-                pass
-        datasets_attrs = loads(datasets_attr_str)
-
-        # Add datasets to archive and update dataset attributes.
-        # TODO: security check to ensure that files added are in Galaxy dataset directory?
-        for dataset_attrs in datasets_attrs:
-            dataset_file_name = dataset_attrs['file_name']  # Full file name.
-            dataset_hid = dataset_attrs['hid']
-            dataset_archive_name = os.path.join('datasets',
-                                                get_dataset_filename(dataset_attrs['name'], dataset_attrs['extension'], dataset_hid))
-            history_archive.add(dataset_file_name, arcname=dataset_archive_name)
-
-            # Include additional files for example, files/images included in HTML output.
-            extra_files_path = dataset_attrs['extra_files_path']
-            if extra_files_path:
-                try:
-                    file_list = os.listdir(extra_files_path)
-                except OSError:
-                    file_list = []
-
-                if len(file_list):
-                    dataset_extra_files_path = 'datasets/extra_files_path_%s' % dataset_hid
-                    for fname in file_list:
-                        history_archive.add(os.path.join(extra_files_path, fname),
-                                            arcname=(os.path.join(dataset_extra_files_path, fname)))
-                    dataset_attrs['extra_files_path'] = dataset_extra_files_path
-                else:
-                    dataset_attrs['extra_files_path'] = ''
-
-            # Update dataset filename to be archive name.
-            dataset_attrs['file_name'] = dataset_archive_name
-
-        # Rewrite dataset attributes file.
-        with open(datasets_attrs_file, 'w') as datasets_attrs_out:
-            datasets_attrs_out.write(dumps(datasets_attrs))
-
-        # Finish archive.
-        history_archive.add(history_attrs_file, arcname="history_attrs.txt")
-        history_archive.add(datasets_attrs_file, arcname="datasets_attrs.txt")
-        if os.path.exists(datasets_attrs_file + ".provenance"):
-            history_archive.add(datasets_attrs_file + ".provenance", arcname="datasets_attrs.txt.provenance")
-        history_archive.add(jobs_attrs_file, arcname="jobs_attrs.txt")
-        history_archive.close()
-
+        tar_export_directory(export_directory, out_file, gzip)
         # Status.
         print('Created history archive.')
         return 0
@@ -108,18 +40,28 @@ def main(argv=None):
     gzip = bool(options.gzip)
     if galaxy_version == "19.01":
         # This job was created pre 18.0X with old argument style.
-        history_attrs, dataset_attrs, job_attrs, out_file = args
+        out_file = args[3]
+        temp_directory = os.path.dirname(args[0])
     else:
         assert len(args) >= 2
         # We have a 19.0X directory argument instead of individual arguments.
         temp_directory = args[0]
         out_file = args[1]
+
+    if galaxy_version == "19.01":
         history_attrs = os.path.join(temp_directory, 'history_attrs.txt')
         dataset_attrs = os.path.join(temp_directory, 'datasets_attrs.txt')
         job_attrs = os.path.join(temp_directory, 'jobs_attrs.txt')
 
+        shutil.move(args[0], history_attrs)
+        shutil.move(args[1], dataset_attrs)
+        provenance_path = args[1] + ".provenance"
+        if os.path.exists(provenance_path):
+            shutil.move(provenance_path, dataset_attrs + ".provenance")
+        shutil.move(args[2], job_attrs)
+
     # Create archive.
-    return create_archive(history_attrs, dataset_attrs, job_attrs, out_file, gzip)
+    return create_archive(temp_directory, out_file, gzip=gzip)
 
 
 if __name__ == "__main__":

--- a/lib/galaxy/util/dictifiable.py
+++ b/lib/galaxy/util/dictifiable.py
@@ -2,6 +2,14 @@ import datetime
 import uuid
 
 
+def dict_for(obj, **kwds):
+    # Create dict to represent item.
+    return dict(
+        model_class=obj.__class__.__name__,
+        **kwds
+    )
+
+
 class Dictifiable(object):
     """ Mixin that enables objects to be converted to dictionaries. This is useful
         when for sharing objects across boundaries, such as the API, tool scripts,
@@ -38,9 +46,7 @@ class Dictifiable(object):
                 return item
 
         # Create dict to represent item.
-        rval = dict(
-            model_class=self.__class__.__name__
-        )
+        rval = dict_for(self)
 
         # Fill item dict with visible keys.
         try:

--- a/test/api/test_histories.py
+++ b/test/api/test_histories.py
@@ -262,9 +262,6 @@ class HistoriesApiTestCase(api.ApiTestCase):
         assert len(bai_response.content) > 4
 
     def test_import_export_collection(self):
-        from nose.plugins.skip import SkipTest
-        raise SkipTest("Collection import/export not yet implemented")
-
         history_name = "for_export_with_collections"
         history_id = self.dataset_populator.new_history(name=history_name)
         self.dataset_collection_populator.create_list_in_history(history_id, contents=["Hello", "World"], direct_upload=True)
@@ -285,6 +282,26 @@ class HistoriesApiTestCase(api.ApiTestCase):
             assert element1["hid"] == 3
 
         self._check_imported_collection(imported_history_id, hid=1, collection_type="list", elements_checker=check_elements)
+
+    def test_import_export_nested_collection(self):
+        history_name = "for_export_with_nested_collections"
+        history_id = self.dataset_populator.new_history(name=history_name)
+        self.dataset_collection_populator.create_list_of_pairs_in_history(history_id)
+
+        imported_history_id = self._reimport_history(history_id, history_name, wait_on_history_length=3)
+        self._assert_history_length(imported_history_id, 3)
+
+        def check_elements(elements):
+            assert len(elements) == 1
+            element0 = elements[0]["object"]
+            self._assert_has_keys(element0, "elements", "collection_type")
+
+            child_elements = element0["elements"]
+
+            assert len(child_elements) == 2
+            assert element0["collection_type"] == "paired"
+
+        self._check_imported_collection(imported_history_id, hid=1, collection_type="list:paired", elements_checker=check_elements)
 
     def _reimport_history(self, history_id, history_name, wait_on_history_length=None, export_kwds={}):
         # Ensure the history is ready to go...

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -568,6 +568,11 @@ class BaseDatasetPopulator(object):
         self.wait_for_history(imported_history_id)
         return imported_history_id
 
+    def rename_history(self, history_id, new_name):
+        update_url = "histories/%s" % history_id
+        put_response = self._put(update_url, {"name": new_name})
+        return put_response
+
     def get_histories(self):
         history_index_response = self._get("histories")
         api_asserts.assert_status_code_is(history_index_response, 200)
@@ -576,12 +581,16 @@ class BaseDatasetPopulator(object):
     def wait_on_history_length(self, history_id, wait_on_history_length):
 
         def history_has_length():
-            contents_response = self._get("histories/%s/contents" % history_id)
-            api_asserts.assert_status_code_is(contents_response, 200)
-            contents = contents_response.json()
-            return None if len(contents) != wait_on_history_length else True
+            history_length = self.history_length(history_id)
+            return None if history_length != wait_on_history_length else True
 
         wait_on(history_has_length, desc="import history population")
+
+    def history_length(self, history_id):
+        contents_response = self._get("histories/%s/contents" % history_id)
+        api_asserts.assert_status_code_is(contents_response, 200)
+        contents = contents_response.json()
+        return len(contents)
 
     def reimport_history(self, history_id, history_name, wait_on_history_length, export_kwds, url, api_key):
         # Export the history.

--- a/test/unit/test_model_store.py
+++ b/test/unit/test_model_store.py
@@ -1,0 +1,399 @@
+import json
+import os
+from tempfile import mkdtemp
+
+from galaxy import model
+from galaxy.model import store
+from galaxy.tools.imp_exp import unpack_tar_gz_archive
+from .tools.test_history_imp_exp import _create_datasets, _mock_app, Dummy
+
+
+def test_import_export_history():
+    """Test a simple job import/export after decompressing an archive (like history import/export tool)."""
+    app = _mock_app()
+
+    u, h, d1, d2, j = _setup_simple_cat_job(app)
+
+    imported_history = _import_export_history(app, h, export_files="copy")
+
+    _assert_simple_cat_job_imported(imported_history)
+
+
+def test_import_export_bag_archive():
+    """Test a simple job import/export using a BagIt archive."""
+    dest_parent = mkdtemp()
+    dest_export = os.path.join(dest_parent, "moo.tgz")
+
+    app = _mock_app()
+
+    u, h, d1, d2, j = _setup_simple_cat_job(app)
+
+    with store.BagArchiveModelExportStore(dest_export, app=app, bag_archiver="tgz", export_files="copy") as export_store:
+        export_store.export_history(h)
+
+    model_store = store.BagArchiveImportModelStore(dest_export, app=app, user=u)
+    with model_store.target_history(default_history=None) as imported_history:
+        model_store.perform_import(imported_history)
+
+    _assert_simple_cat_job_imported(imported_history)
+
+
+def test_import_export_datasets():
+    """Test a simple job import/export using a directory."""
+    app, h, temp_directory, import_history = _setup_simple_export({"for_edit": False})
+    u = h.user
+
+    _perform_import_from_directory(temp_directory, app, u, import_history)
+
+    datasets = import_history.datasets
+    assert len(datasets) == 2
+    imported_job = datasets[1].creating_job
+    assert imported_job
+    assert imported_job.output_datasets
+    assert imported_job.output_datasets[0].dataset == datasets[1]
+
+    assert imported_job.input_datasets
+    assert imported_job.input_datasets[0].dataset == datasets[0]
+
+
+def test_import_library_require_permissions():
+    """Verify library creation (import) is off by default."""
+    app = _mock_app()
+    sa_session = app.model.context
+
+    u = model.User(email="collection@example.com", password="password")
+
+    library = model.Library(name="my library 1", description="my library description", synopsis="my synopsis")
+    root_folder = model.LibraryFolder(name="my library 1", description='folder description')
+    library.root_folder = root_folder
+    sa_session.add_all((library, root_folder))
+    sa_session.flush()
+
+    temp_directory = mkdtemp()
+    with store.DirectoryModelExportStore(temp_directory, app=app) as export_store:
+        export_store.export_library(library)
+
+    error_caught = False
+    try:
+        import_model_store = store.get_import_model_store_for_directory(temp_directory, app=app, user=u)
+        import_model_store.perform_import()
+    except AssertionError:
+        # TODO: throw and catch a better exception...
+        error_caught = True
+
+    assert error_caught
+
+
+def test_import_export_library():
+    """Test basics of library, library folder, and library dataset import/export."""
+    app = _mock_app()
+    sa_session = app.model.context
+
+    u = model.User(email="collection@example.com", password="password")
+
+    library = model.Library(name="my library 1", description="my library description", synopsis="my synopsis")
+    root_folder = model.LibraryFolder(name="my library 1", description='folder description')
+    library.root_folder = root_folder
+    sa_session.add_all((library, root_folder))
+    sa_session.flush()
+
+    subfolder = model.LibraryFolder(name="sub folder 1", description="sub folder")
+    root_folder.add_folder(subfolder)
+    sa_session.add(subfolder)
+
+    ld = model.LibraryDataset(folder=root_folder, name="my name", info="my library dataset")
+    ldda = model.LibraryDatasetDatasetAssociation(
+        create_dataset=True, flush=False
+    )
+    ld.library_dataset_dataset_association = ldda
+    root_folder.add_library_dataset(ld)
+
+    sa_session.add(ld)
+    sa_session.add(ldda)
+
+    sa_session.flush()
+    assert len(root_folder.datasets) == 1
+    assert len(root_folder.folders) == 1
+
+    temp_directory = mkdtemp()
+    with store.DirectoryModelExportStore(temp_directory, app=app) as export_store:
+        export_store.export_library(library)
+
+    import_model_store = store.get_import_model_store_for_directory(temp_directory, app=app, user=u, import_options=store.ImportOptions(allow_library_creation=True))
+    import_model_store.perform_import()
+
+    all_libraries = sa_session.query(model.Library).all()
+    assert len(all_libraries) == 2, len(all_libraries)
+    all_lddas = sa_session.query(model.LibraryDatasetDatasetAssociation).all()
+    assert len(all_lddas) == 2, len(all_lddas)
+
+    new_library = [l for l in all_libraries if l.id != library.id][0]
+    assert new_library.name == "my library 1"
+    assert new_library.description == "my library description"
+    assert new_library.synopsis == "my synopsis"
+
+    new_root = new_library.root_folder
+    assert new_root
+    assert new_root.name == "my library 1"
+
+    assert len(new_root.folders) == 1
+    assert len(new_root.datasets) == 1
+
+
+def test_finalize_job_state():
+    """Verify jobs are given finalized states on import."""
+    app, h, temp_directory, import_history = _setup_simple_export({"for_edit": False})
+    u = h.user
+
+    with open(os.path.join(temp_directory, store.ATTRS_FILENAME_JOBS), "r") as f:
+        job_attrs = json.load(f)
+
+    for job in job_attrs:
+        job["state"] = "queued"
+
+    with open(os.path.join(temp_directory, store.ATTRS_FILENAME_JOBS), "w") as f:
+        json.dump(job_attrs, f)
+
+    _perform_import_from_directory(temp_directory, app, u, import_history)
+
+    datasets = import_history.datasets
+    assert len(datasets) == 2
+    imported_job = datasets[1].creating_job
+    assert imported_job
+    assert imported_job.state == model.Job.states.ERROR
+
+
+def test_import_export_edit_datasets():
+    """Test modifying existing HDA and dataset metadata with import."""
+    app, h, temp_directory, import_history = _setup_simple_export({"for_edit": True})
+    u = h.user
+
+    # Fabric editing metadata...
+    datasets_metadata_path = os.path.join(temp_directory, store.ATTRS_FILENAME_DATASETS)
+    with open(datasets_metadata_path, "r") as f:
+        datasets_metadata = json.load(f)
+
+    datasets_metadata[0]["name"] = "my new name 0"
+    datasets_metadata[1]["name"] = "my new name 1"
+
+    assert "dataset" in datasets_metadata[0]
+    datasets_metadata[0]["dataset"]["object_store_id"] = "foo1"
+
+    with open(datasets_metadata_path, "w") as f:
+        json.dump(datasets_metadata, f)
+
+    _perform_import_from_directory(temp_directory, app, u, import_history, store.ImportOptions(allow_edit=True))
+
+    datasets = import_history.datasets
+    assert len(datasets) == 0
+
+    d1 = h.datasets[0]
+    d2 = h.datasets[1]
+
+    assert d1.name == "my new name 0", d1.name
+    assert d2.name == "my new name 1", d2.name
+    assert d1.dataset.object_store_id == "foo1", d1.dataset.object_store_id
+
+
+def test_import_export_edit_collection():
+    """Test modifying existing collections with imports."""
+    app = _mock_app()
+    sa_session = app.model.context
+
+    u = model.User(email="collection@example.com", password="password")
+    h = model.History(name="Test History", user=u)
+
+    c1 = model.DatasetCollection(collection_type="list", populated=False)
+    hc1 = model.HistoryDatasetCollectionAssociation(history=h, hid=1, collection=c1, name="HistoryCollectionTest1")
+
+    sa_session.add(hc1)
+    sa_session.add(h)
+    sa_session.flush()
+
+    import_history = model.History(name="Test History for Import", user=u)
+    sa_session.add(import_history)
+
+    temp_directory = mkdtemp()
+    with store.DirectoryModelExportStore(temp_directory, app=app, for_edit=True) as export_store:
+        export_store.add_dataset_collection(hc1)
+
+    # Fabric editing metadata for collection...
+    collections_metadata_path = os.path.join(temp_directory, store.ATTRS_FILENAME_COLLECTIONS)
+    datasets_metadata_path = os.path.join(temp_directory, store.ATTRS_FILENAME_DATASETS)
+    with open(collections_metadata_path, "r") as f:
+        hdcas_metadata = json.load(f)
+
+    assert len(hdcas_metadata) == 1
+    hdca_metadata = hdcas_metadata[0]
+    assert hdca_metadata
+    assert "id" in hdca_metadata
+    assert "collection" in hdca_metadata
+    collection_metadata = hdca_metadata["collection"]
+    assert "populated_state" in collection_metadata
+    assert collection_metadata["populated_state"] == model.DatasetCollection.populated_states.NEW
+
+    collection_metadata["populated_state"] = model.DatasetCollection.populated_states.OK
+
+    d1 = model.HistoryDatasetAssociation(extension="txt", create_dataset=True, flush=False)
+    d1.hid = 1
+    d2 = model.HistoryDatasetAssociation(extension="txt", create_dataset=True, flush=False)
+    d2.hid = 2
+    serialization_options = model.SerializationOptions(for_edit=True)
+    dataset_list = [d1.serialize(app.security, serialization_options),
+                    d2.serialize(app.security, serialization_options)]
+
+    dc = model.DatasetCollection(
+        id=collection_metadata["id"],
+        collection_type="list",
+        element_count=2,
+    )
+    dc.populated_state = model.DatasetCollection.populated_states.OK
+    dce1 = model.DatasetCollectionElement(
+        element=d1,
+        element_index=0,
+        element_identifier="first",
+    )
+    dce2 = model.DatasetCollectionElement(
+        element=d2,
+        element_index=1,
+        element_identifier="second",
+    )
+    dc.elements = [dce1, dce2]
+    with open(datasets_metadata_path, "w") as datasets_f:
+        json.dump(dataset_list, datasets_f)
+
+    hdca_metadata["collection"] = dc.serialize(app.security, serialization_options)
+    with open(collections_metadata_path, "w") as collections_f:
+        json.dump(hdcas_metadata, collections_f)
+
+    _perform_import_from_directory(temp_directory, app, u, import_history, store.ImportOptions(allow_edit=True))
+
+    sa_session.refresh(c1)
+    assert c1.populated_state == model.DatasetCollection.populated_states.OK, c1.populated_state
+    assert len(c1.elements) == 2
+
+
+def test_sessionless_import_edit_datasets():
+    app, h, temp_directory, import_history = _setup_simple_export({"for_edit": True})
+    # Create a model store without a session and import it.
+    import_model_store = store.get_import_model_store_for_directory(temp_directory, import_options=store.ImportOptions(allow_dataset_object_edit=True, allow_edit=True))
+    import_model_store.perform_import()
+    # Not using app.sa_session but a session mock that has a query/find pattern emulating usage
+    # of real sa_session.
+    d1 = import_model_store.sa_session.query(model.HistoryDatasetAssociation).find(h.datasets[0].id)
+    d2 = import_model_store.sa_session.query(model.HistoryDatasetAssociation).find(h.datasets[1].id)
+    assert d1 is not None
+    assert d2 is not None
+
+
+def test_import_datasets_with_ids_fails_if_not_editing_models():
+    app, h, temp_directory, import_history = _setup_simple_export({"for_edit": True})
+    u = h.user
+
+    caught = None
+    try:
+        _perform_import_from_directory(temp_directory, app, u, import_history, store.ImportOptions(allow_edit=False))
+    except AssertionError as e:
+        # TODO: catch a better exception
+        caught = e
+    assert caught
+
+
+def _setup_simple_export(export_kwds):
+    app = _mock_app()
+
+    u, h, d1, d2, j = _setup_simple_cat_job(app)
+
+    sa_session = app.model.context
+
+    import_history = model.History(name="Test History for Import", user=u)
+    sa_session.add(import_history)
+
+    temp_directory = mkdtemp()
+    with store.DirectoryModelExportStore(temp_directory, app=app, **export_kwds) as export_store:
+        export_store.add_dataset(d1)
+        export_store.add_dataset(d2)
+
+    return app, h, temp_directory, import_history
+
+
+def _assert_simple_cat_job_imported(imported_history):
+    assert imported_history.name == "imported from archive: Test History"
+
+    datasets = imported_history.datasets
+    assert len(datasets) == 2
+    imported_job = datasets[1].creating_job
+    assert imported_job
+    assert imported_job.output_datasets
+    assert imported_job.output_datasets[0].dataset == datasets[1]
+
+    assert imported_job.input_datasets
+    assert imported_job.input_datasets[0].dataset == datasets[0]
+
+    with open(datasets[0].file_name, "r") as f:
+        assert f.read().startswith("chr1    4225    19670")
+    with open(datasets[1].file_name, "r") as f:
+        assert f.read().startswith("chr1\t147962192\t147962580\tNM_005997_cds_0_0_chr1_147962193_r\t0\t-")
+
+
+def _setup_simple_cat_job(app):
+    sa_session = app.model.context
+
+    u = model.User(email="collection@example.com", password="password")
+    h = model.History(name="Test History", user=u)
+
+    d1, d2 = _create_datasets(sa_session, h, 2)
+
+    j = model.Job()
+    j.user = u
+    j.tool_id = "cat1"
+
+    j.add_input_dataset("input1", d1)
+    j.add_output_dataset("out_file1", d2)
+
+    sa_session.add_all((d1, d2, h, j))
+    sa_session.flush()
+
+    app.object_store.update_from_file(d1, file_name="test-data/1.txt", create=True)
+    app.object_store.update_from_file(d2, file_name="test-data/2.bed", create=True)
+
+    return u, h, d1, d2, j
+
+
+def _import_export_history(app, h, dest_export=None, export_files=None):
+    if dest_export is None:
+        dest_parent = mkdtemp()
+        dest_export = os.path.join(dest_parent, "moo.tgz")
+
+    with store.TarModelExportStore(dest_export, app=app, export_files=export_files) as export_store:
+        export_store.export_history(h)
+
+    imported_history = import_archive(dest_export, app, h.user)
+    assert imported_history
+    return imported_history
+
+
+def _perform_import_from_directory(directory, app, user, import_history, import_options=None):
+    import_model_store = store.get_import_model_store_for_directory(directory, app=app, user=user, import_options=import_options)
+    with import_model_store.target_history(default_history=import_history):
+        import_model_store.perform_import(import_history)
+
+
+def import_archive(archive_path, app, user):
+    dest_parent = mkdtemp()
+    dest_dir = os.path.join(dest_parent, 'dest')
+
+    options = Dummy()
+    options.is_url = False
+    options.is_file = True
+    options.is_b64encoded = False
+
+    args = (archive_path, dest_dir)
+    unpack_tar_gz_archive.main(options, args)
+
+    new_history = None
+    model_store = store.get_import_model_store_for_directory(dest_dir, app=app, user=user)
+    with model_store.target_history(default_history=None) as new_history:
+        model_store.perform_import(new_history)
+
+    return new_history

--- a/test/unit/tools/test_history_imp_exp.py
+++ b/test/unit/tools/test_history_imp_exp.py
@@ -15,6 +15,7 @@ from ..unittest_utils.galaxy_mock import MockApp
 
 # good enough for the very specific tests we're writing as of now...
 DATASETS_ATTRS = '''[{{"info": "\\nuploaded txt file", "peek": "foo\\n\\n\\n\\n\\n\\n", "update_time": "2016-02-08 18:39:22.937474", "name": "Pasted Entry", "extension": "txt", "tags": {{}}, "__HistoryDatasetAssociation__": true, "file_name": "{file_name}", "deleted": false, "designation": null, "visible": true, "create_time": "2016-02-08 18:38:38.682087", "hid": 1, "parent_id": null, "extra_files_path": "", "uuid": "406d913e-925d-4ccd-800d-06c9b32df309", "metadata": {{"dbkey": "?", "data_lines": 1}}, "annotation": null, "blurb": "1 line", "exported": true}}]'''
+DATASETS_ATTRS_EXPORT = '''[{{"info": "\\nuploaded txt file", "peek": "foo\\n\\n\\n\\n\\n\\n", "update_time": "2016-02-08 18:39:22.937474", "name": "Pasted Entry", "extension": "txt", "tags": {{}}, "__HistoryDatasetAssociation__": true, "file_name": "{file_name}", "deleted": false, "designation": null, "visible": true, "create_time": "2016-02-08 18:38:38.682087", "hid": 1, "parent_id": null, "_extra_files_path": "", "uuid": "406d913e-925d-4ccd-800d-06c9b32df309", "metadata": {{"dbkey": "?", "data_lines": 1}}, "annotation": null, "blurb": "1 line"}}]'''
 DATASETS_ATTRS_PROVENANCE = '''[]'''
 HISTORY_ATTRS = '''{"hid_counter": 2, "update_time": "2016-02-08 18:38:38.705058", "create_time": "2016-02-08 18:38:20.790057", "name": "paste", "tags": {}, "genome_build": "?", "annotation": null}'''
 JOBS_ATTRS = '''[{"info": null, "tool_id": "upload1", "update_time": "2016-02-08T18:39:23.356482", "stdout": "", "input_mapping": {}, "tool_version": "1.1.4", "traceback": null, "command_line": "python /galaxy/tools/data_source/upload.py /galaxy /scratch/tmppwU9rD /scratch/tmpP4_45Y 1:/scratch/jobs/000/dataset_1_files:/data/000/dataset_1.dat", "exit_code": 0, "output_datasets": [1], "state": "ok", "create_time": "2016-02-08T18:38:39.153873", "params": {"files": [{"to_posix_lines": "Yes", "NAME": "None", "file_data": null, "space_to_tab": null, "url_paste": "/scratch/strio_url_paste_o6nrv8", "__index__": 0, "ftp_files": "", "uuid": "None"}], "paramfile": "/scratch/tmpP4_45Y", "file_type": "auto", "files_metadata": {"file_type": "auto", "__current_case__": 41}, "async_datasets": "None", "dbkey": "?"}, "stderr": ""}]'''
@@ -57,23 +58,24 @@ def _run_jihaw_cleanup_check_secure(history_archive, msg):
 
 def test_create_archive():
     tempdir = mkdtemp()
-    dataset = os.path.join(tempdir, 'dataset_1.dat')
-    history_attrs_file = os.path.join(tempdir, 'history_attrs_file.txt')
-    datasets_attrs_file = os.path.join(tempdir, 'dataset_attrs_file.txt')
-    jobs_attrs_file = os.path.join(tempdir, 'jobs_attrs_file.txt')
+    dataset = os.path.join(tempdir, 'datasets/Pasted_Entry_1.txt')
+    history_attrs_file = os.path.join(tempdir, 'history_attrs.txt')
+    datasets_attrs_file = os.path.join(tempdir, 'datasets_attrs.txt')
+    jobs_attrs_file = os.path.join(tempdir, 'jobs_attrs.txt')
     out_file = os.path.join(tempdir, 'out.tar.gz')
+    os.makedirs(os.path.join(tempdir, 'datasets'))
     with open(dataset, 'w') as out:
         out.write('Hello\n')
     with open(history_attrs_file, 'w') as out:
         out.write(HISTORY_ATTRS)
     with open(datasets_attrs_file, 'w') as out:
-        out.write(DATASETS_ATTRS.format(file_name=dataset))
+        out.write(DATASETS_ATTRS_EXPORT.format(file_name=dataset))
     with open(jobs_attrs_file, 'w') as out:
         out.write(JOBS_ATTRS)
     try:
-        create_archive(history_attrs_file, datasets_attrs_file, jobs_attrs_file, out_file, gzip=True)
+        create_archive(tempdir, out_file, gzip=True)
         with tarfile.open(out_file) as t:
-            assert t.getnames() == ['datasets/Pasted_Entry_1.txt', 'history_attrs.txt', 'datasets_attrs.txt', 'jobs_attrs.txt']
+            assert sorted(t.getnames()) == sorted(['datasets', 'datasets/Pasted_Entry_1.txt', 'history_attrs.txt', 'datasets_attrs.txt', 'jobs_attrs.txt']), t.getnames()
     finally:
         shutil.rmtree(tempdir)
 
@@ -168,11 +170,13 @@ def test_export_dataset_with_deleted_and_purged():
     j1 = model.Job()
     j1.user = h.user
     j1.tool_id = "cat1"
+
     j1.add_output_dataset("out_file1", d1)
 
     j2 = model.Job()
     j2.user = h.user
     j2.tool_id = "cat1"
+
     j2.add_output_dataset("out_file1", d2)
 
     sa_session.add(d1)
@@ -196,6 +200,352 @@ def test_export_dataset_with_deleted_and_purged():
     assert datasets[0].deleted
     assert datasets[0].dataset.deleted
     assert datasets[0].creating_job
+
+
+def test_multi_inputs():
+    app, sa_session, h = _setup_history_for_export("Datasets History")
+
+    d1, d2, d3 = _create_datasets(sa_session, h, 3)
+
+    j = model.Job()
+    j.user = h.user
+    j.tool_id = "cat_multi"
+
+    # Emulate multiple data inputs into multi data input parameter...
+    j.add_input_dataset("input1", d1)
+    j.add_input_dataset("input11", d1)
+    j.add_input_dataset("input12", d2)
+    j.add_output_dataset("out_file1", d3)
+
+    sa_session.add(d1)
+    sa_session.add(d2)
+    sa_session.add(d3)
+    sa_session.add(h)
+    sa_session.add(j)
+    sa_session.flush()
+
+    app.object_store.update_from_file(d1, file_name="test-data/1.txt", create=True)
+    app.object_store.update_from_file(d2, file_name="test-data/2.bed", create=True)
+    app.object_store.update_from_file(d3, file_name="test-data/4.bed", create=True)
+
+    imported_history = _import_export(app, h)
+
+    datasets = list(imported_history.contents_iter(types=["dataset"]))
+    assert len(datasets) == 3
+    imported_job = datasets[2].creating_job
+    assert imported_job
+    assert imported_job.output_datasets
+    assert imported_job.output_datasets[0].dataset.hid == 3
+    assert imported_job.output_datasets[0].dataset == datasets[2]
+
+    assert imported_job.input_datasets
+    assert len(imported_job.input_datasets) == 3
+    names = [d.name for d in imported_job.input_datasets]
+    hids = [d.dataset.hid for d in imported_job.input_datasets]
+    _assert_distinct(names)
+    for name in ["input1", "input11", "input12"]:
+        assert name in names
+    for hid in [1, 2]:
+        assert hid in hids
+
+    with open(datasets[0].file_name, "r") as f:
+        assert f.read().startswith("chr1    4225    19670")
+    with open(datasets[1].file_name, "r") as f:
+        assert f.read().startswith("chr1\t147962192\t147962580\tNM_005997_cds_0_0_chr1_147962193_r\t0\t-")
+
+
+def test_export_collection_history():
+    app, sa_session, h = _setup_history_for_export("Collection History")
+
+    d1, d2, d3, d4 = _create_datasets(sa_session, h, 4)
+
+    c1 = model.DatasetCollection(collection_type="paired")
+    hc1 = model.HistoryDatasetCollectionAssociation(history=h, hid=1, collection=c1, name="HistoryCollectionTest1")
+
+    dce1 = model.DatasetCollectionElement(collection=c1, element=d1, element_identifier="forward", element_index=0)
+    dce2 = model.DatasetCollectionElement(collection=c1, element=d2, element_identifier="reverse", element_index=1)
+
+    c2 = model.DatasetCollection(collection_type="list:paired")
+    hc2 = model.HistoryDatasetCollectionAssociation(history=h, hid=2, collection=c2, name="HistoryCollectionTest2")
+
+    cleaf = model.DatasetCollection(collection_type="paired")
+    dce2leaf1 = model.DatasetCollectionElement(collection=cleaf, element=d3, element_identifier="forward", element_index=0)
+    dce2leaf2 = model.DatasetCollectionElement(collection=cleaf, element=d4, element_identifier="reverse", element_index=1)
+
+    dce21 = model.DatasetCollectionElement(collection=c2, element=cleaf, element_identifier="listel", element_index=0)
+
+    j = model.Job()
+    j.user = h.user
+    j.tool_id = "cat1"
+    j.add_input_dataset_collection("input1_collect", hc1)
+    j.add_output_dataset_collection("output_collect", hc2)
+
+    sa_session.add(dce1)
+    sa_session.add(dce2)
+    sa_session.add(dce21)
+    sa_session.add(dce2leaf1)
+    sa_session.add(dce2leaf2)
+    sa_session.add(hc1)
+    sa_session.add(hc2)
+    sa_session.add(j)
+    sa_session.flush()
+
+    imported_history = _import_export(app, h)
+
+    datasets = imported_history.datasets
+    assert len(datasets) == 4
+
+    dataset_collections = list(imported_history.contents_iter(types=["dataset_collection"]))
+    assert len(dataset_collections) == 2
+
+    imported_hdca1 = dataset_collections[0]
+    imported_hdca2 = dataset_collections[1]
+
+    imported_collection_2 = imported_hdca2.collection
+    assert imported_hdca1.collection.collection_type == "paired"
+    assert imported_collection_2.collection_type == "list:paired"
+
+    assert len(imported_collection_2.elements) == 1
+    imported_top_level_element = imported_collection_2.elements[0]
+    assert imported_top_level_element.element_identifier == "listel", imported_top_level_element.element_identifier
+    assert imported_top_level_element.element_index == 0, imported_top_level_element.element_index
+    imported_nested_collection = imported_top_level_element.child_collection
+    assert len(imported_nested_collection.elements) == 2
+    assert imported_nested_collection.collection_type == "paired", imported_nested_collection.collection_type
+
+    assert len(imported_history.jobs) == 1
+    imported_job = imported_history.jobs[0]
+    assert imported_job
+    assert len(imported_job.input_dataset_collections) == 1, len(imported_job.input_dataset_collections)
+    assert len(imported_job.output_dataset_collection_instances) == 1
+    assert imported_job.id != j.id
+
+
+def test_export_collection_with_mapping_history():
+    app, sa_session, h = _setup_history_for_export("Collection Mapping History")
+
+    d1, d2, d3, d4 = _create_datasets(sa_session, h, 4)
+
+    c1 = model.DatasetCollection(collection_type="list")
+    hc1 = model.HistoryDatasetCollectionAssociation(history=h, hid=1, collection=c1, name="HistoryCollectionTest1")
+    dce1 = model.DatasetCollectionElement(collection=c1, element=d1, element_identifier="el1", element_index=0)
+    dce2 = model.DatasetCollectionElement(collection=c1, element=d2, element_identifier="el2", element_index=1)
+
+    c2 = model.DatasetCollection(collection_type="list")
+    hc2 = model.HistoryDatasetCollectionAssociation(history=h, hid=2, collection=c2, name="HistoryCollectionTest2")
+    dce3 = model.DatasetCollectionElement(collection=c2, element=d3, element_identifier="el1", element_index=0)
+    dce4 = model.DatasetCollectionElement(collection=c2, element=d4, element_identifier="el2", element_index=1)
+
+    hc2.add_implicit_input_collection("input1", hc1)
+
+    j1 = model.Job()
+    j1.user = h.user
+    j1.tool_id = "cat1"
+    j1.add_input_dataset("input1", d1)
+    j1.add_output_dataset("out_file1", d3)
+
+    j2 = model.Job()
+    j2.user = h.user
+    j2.tool_id = "cat1"
+    j2.add_input_dataset("input1", d2)
+    j2.add_output_dataset("out_file1", d4)
+
+    sa_session.add(dce1)
+    sa_session.add(dce2)
+    sa_session.add(dce3)
+    sa_session.add(dce4)
+    sa_session.add(hc1)
+    sa_session.add(hc2)
+    sa_session.add(j1)
+    sa_session.add(j2)
+    sa_session.flush()
+
+    implicit_collection_jobs = model.ImplicitCollectionJobs()
+    j1.add_output_dataset_collection("out_file1", hc2)  # really?
+    ija1 = model.ImplicitCollectionJobsJobAssociation()
+    ija1.order_index = 0
+    ija1.implicit_collection_jobs = implicit_collection_jobs
+    ija1.job = j1
+
+    j2.add_output_dataset_collection("out_file1", hc2)  # really?
+    ija2 = model.ImplicitCollectionJobsJobAssociation()
+    ija2.order_index = 1
+    ija2.implicit_collection_jobs = implicit_collection_jobs
+    ija2.job = j2
+
+    sa_session.add(implicit_collection_jobs)
+    sa_session.add(ija1)
+    sa_session.add(ija2)
+    sa_session.flush()
+
+    imported_history = _import_export(app, h)
+    assert len(imported_history.jobs) == 2
+    imported_job0 = imported_history.jobs[0]
+
+    imported_icj = imported_job0.implicit_collection_jobs_association.implicit_collection_jobs
+    assert imported_icj
+    assert len(imported_icj.jobs) == 2, len(imported_icj.jobs)
+
+
+def test_export_collection_with_datasets_from_other_history():
+    app, sa_session, h = _setup_history_for_export("Collection History with dataset from other history")
+
+    dataset_history = model.History(name="Dataset History", user=h.user)
+
+    d1, d2 = _create_datasets(sa_session, dataset_history, 2)
+
+    c1 = model.DatasetCollection(collection_type="paired")
+    hc1 = model.HistoryDatasetCollectionAssociation(history=h, hid=1, collection=c1, name="HistoryCollectionTest1")
+    h.hid_counter = 2
+    dce1 = model.DatasetCollectionElement(collection=c1, element=d1, element_identifier="forward", element_index=0)
+    dce2 = model.DatasetCollectionElement(collection=c1, element=d2, element_identifier="reverse", element_index=1)
+
+    sa_session.add(dce1)
+    sa_session.add(dce2)
+    sa_session.add(d1)
+    sa_session.add(d2)
+    sa_session.add(hc1)
+    sa_session.flush()
+
+    imported_history = _import_export(app, h)
+
+    assert imported_history.hid_counter == 4, imported_history.hid_counter
+    assert len(imported_history.dataset_collections) == 1
+    assert len(imported_history.datasets) == 2
+    for hdca in imported_history.dataset_collections:
+        assert hdca.hid == 1, hdca.hid
+    for hda in imported_history.datasets:
+        assert hda.hid in [2, 3]
+    _assert_distinct_hids(imported_history)
+
+
+def test_export_collection_with_copied_datasets_and_overlapping_hids():
+    app, sa_session, h = _setup_history_for_export("Collection History with dataset from other history")
+
+    dataset_history = model.History(name="Dataset History", user=h.user)
+
+    d1, d2 = _create_datasets(sa_session, dataset_history, 2)
+
+    sa_session.add(d1)
+    sa_session.add(d2)
+    sa_session.add(dataset_history)
+    sa_session.flush()
+
+    app.object_store.update_from_file(d1, file_name="test-data/1.txt", create=True)
+    app.object_store.update_from_file(d2, file_name="test-data/2.bed", create=True)
+
+    d1_copy = d1.copy()
+    d2_copy = d2.copy()
+
+    d1_copy.history = h
+    d2_copy.history = h
+
+    c1 = model.DatasetCollection(collection_type="paired")
+    hc1 = model.HistoryDatasetCollectionAssociation(history=h, hid=3, collection=c1, name="HistoryCollectionTest1")
+    h.hid_counter = 5
+    dce1 = model.DatasetCollectionElement(collection=c1, element=d1, element_identifier="forward", element_index=0)
+    dce2 = model.DatasetCollectionElement(collection=c1, element=d2, element_identifier="reverse", element_index=1)
+
+    sa_session.add(dce1)
+    sa_session.add(dce2)
+    sa_session.add(d1_copy)
+    sa_session.add(d2_copy)
+    sa_session.add(hc1)
+    sa_session.flush()
+
+    _import_export(app, h)
+    # Currently d1 and d1_copy would have conflicting paths in the tar file... this test verifies at least
+    # this doesn't prevent the tar ball creation. A lot more work could be done here - such as making sure
+    # they map to the same dataset on import and making sure the resulting datasets all look good in the
+    # imported history.
+
+
+def test_export_copied_collection():
+    app, sa_session, h = _setup_history_for_export("Collection History with dataset from other history")
+
+    d1, d2 = _create_datasets(sa_session, h, 2)
+
+    c1 = model.DatasetCollection(collection_type="paired")
+    hc1 = model.HistoryDatasetCollectionAssociation(history=h, hid=3, collection=c1, name="HistoryCollectionTest1")
+    h.hid_counter = 4
+    dce1 = model.DatasetCollectionElement(collection=c1, element=d1, element_identifier="forward", element_index=0)
+    dce2 = model.DatasetCollectionElement(collection=c1, element=d2, element_identifier="reverse", element_index=1)
+
+    sa_session.add_all((dce1, dce2, d1, d2, hc1))
+    sa_session.flush()
+
+    hc2 = hc1.copy(element_destination=h)
+    h.add_dataset_collection(hc2)
+    assert h.hid_counter == 7
+
+    sa_session.add(hc2)
+    sa_session.flush()
+
+    assert hc2.copied_from_history_dataset_collection_association == hc1
+
+    imported_history = _import_export(app, h)
+    assert imported_history.hid_counter == 7
+
+    assert len(imported_history.dataset_collections) == 2
+    assert len(imported_history.datasets) == 4
+
+    _assert_distinct_hids(imported_history)
+    imported_by_hid = _hid_dict(imported_history)
+    assert imported_by_hid[4].copied_from_history_dataset_association == imported_by_hid[1]
+    assert imported_by_hid[5].copied_from_history_dataset_association == imported_by_hid[2]
+    assert imported_by_hid[6].copied_from_history_dataset_collection_association == imported_by_hid[3]
+
+
+def test_export_collection_hids():
+    app, sa_session, h = _setup_history_for_export("Collection History with dataset from this history")
+
+    d1, d2 = _create_datasets(sa_session, h, 2)
+
+    c1 = model.DatasetCollection(collection_type="paired")
+    hc1 = model.HistoryDatasetCollectionAssociation(history=h, hid=3, collection=c1, name="HistoryCollectionTest1")
+    h.hid_counter = 4
+    dce1 = model.DatasetCollectionElement(collection=c1, element=d1, element_identifier="forward", element_index=0)
+    dce2 = model.DatasetCollectionElement(collection=c1, element=d2, element_identifier="reverse", element_index=1)
+
+    sa_session.add(dce1)
+    sa_session.add(dce2)
+    sa_session.add(d1)
+    sa_session.add(d2)
+    sa_session.add(hc1)
+    sa_session.flush()
+
+    imported_history = _import_export(app, h)
+
+    assert imported_history.hid_counter == 4, imported_history.hid_counter
+    assert len(imported_history.dataset_collections) == 1
+    assert len(imported_history.datasets) == 2
+    for hdca in imported_history.dataset_collections:
+        assert hdca.hid == 3, hdca.hid
+    for hda in imported_history.datasets:
+        assert hda.hid in [1, 2], hda.hid
+    _assert_distinct_hids(imported_history)
+
+
+def _assert_distinct_hids(history):
+    hids = []
+    for hdca in history.dataset_collections:
+        hids.append(hdca.hid)
+    for hda in history.datasets:
+        hids.append(hda.hid)
+    _assert_distinct(hids)
+
+
+def _hid_dict(history):
+    hids = {}
+    for hdca in history.dataset_collections:
+        hids[hdca.hid] = hdca
+    for hda in history.datasets:
+        hids[hda.hid] = hda
+    return hids
+
+
+def _assert_distinct(l):
+    assert len(l) == len(set(l))
 
 
 def _create_datasets(sa_session, history, n):
@@ -226,10 +576,9 @@ def _import_export(app, h, dest_export=None):
 
     from galaxy.tools.imp_exp import export_history
     ret = export_history.main(["--gzip", jeha.temp_directory, dest_export])
-    assert ret == 0
+    assert ret == 0, ret
 
     _, imported_history = import_archive(dest_export, app=app)
-    print(_)
     assert imported_history
     return imported_history
 
@@ -262,8 +611,16 @@ def test_import_1901_default():
     assert cat_job.output_datasets[0].dataset == dataset1
 
     param_dict = cat_job.raw_param_dict()
-    assert json.loads(param_dict['input1']) == dataset0.id, param_dict['input1']
-    assert json.loads(param_dict['queries'])[0]['input2'] == dataset0.id
+    # Not sure these shouldn't be {"values": [{"src": "hda", "id": dataset0.id}]}
+    # but parameter processing for pre-19.05 exports/imports didn't work anyway so
+    # perhaps not a problem?
+    input1_param = json.loads(param_dict['input1'])
+    assert input1_param["src"] == "hda"
+    assert input1_param["id"] == dataset0.id
+
+    input2_param = json.loads(param_dict['queries'])[0]['input2']
+    assert input2_param["src"] == "hda"
+    assert input2_param["id"] == dataset0.id
 
 
 def import_archive(archive_path, app=None):


### PR DESCRIPTION
The tracking PR for remote execution work (https://github.com/galaxyproject/galaxy/pull/7058) bumped into the problem of needing to serialize/deserialize Galaxy models to/from workers. Pickling was okay initially but doesn't solve a lot of the merging things back problem. In this standing branch I'm building up a library for dealing with model object serialization and deserialization effectively. Rather than write this from scratch - I'm re-worked history import/export to be a natural first use case of this framework.

Currently this branch includes the following:

- Allow import and export collections.
- Fix job I/O for separated tool and job script streams (merged in #7095 during 19.05)
- Fix job state handling so that all imported jobs have terminal state.
- Imported job parameters were not usable I think (based on workflow extraction testing), they now work and no longer require the toolbox on import or export (so if tools get added later after the import or removed before the export - I believe everything should still work).
- Fixes to eliminate HID handling for associations (objects were previously tracked by HID but inputs/outputs in history may not be in history - so HID is not at all appropriate, problem was amplified by collections).
- Fix job output mapping - was using the HDA name instead of job output name during import (old exports don't have this info - only new ones do).
- Fixes assigning HIDs to datasets during import and fixes to hid_counter - in many ways this was very broken for imported histories.
- Introduce cohesive model object import/export abstractions including a lot of new, well tested functionality.
  - Allow import/export of datasets and collections stand-alone regardless of history.
  - Allow export and re-import of datasets and collections (so for instance datasets can be created for a job and read in at the end of a job and merged back into the database). This is needed for extended metadata collection.
  - Separate implementation for import abstraction that allow import of legacy archives without complicating logic for current archive format.
  - Implementation of import and export abstraction for [BagIt](https://datatracker.ietf.org/doc/rfc8493/) using [bdbag](https://github.com/fair-research/bdbag).
  - Context manager support and clean APIs for all of this including import and export of directories, archives, and bags.
- A lot more integration testing - in particular most of our workflow extraction tests now export and reimport the history to ensure reproducibility survives history import/export.
- A lot more unit testing.
