### PR TITLE
Do not default to DEV_WHEELS=1 if no Git is found

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -100,7 +100,6 @@ if command -v git >/dev/null && [ -d .git ]; then
     esac
 else
     GIT_BRANCH=0
-    DEV_WHEELS=1
 fi
 
 : ${GALAXY_VIRTUAL_ENV:=.venv}


### PR DESCRIPTION
If there is no Git repo in a Galaxy install, DEV_WHEELS will not be
turned on by default. If they are needed, use the --dev-wheels flag.

(Current behavior: common_startup.sh will turn on the DEV_WHEELS option
if no git repo is found, making the assumption that it is dealing with a
dev install. Thus, dev dependencies are installed whenever there's no
Git repo, including the use case when Galaxy was downloaded as a tarball,
when they may or may not be desired. There is no option to override
this behavior without editing the script.)