### PR TITLE
Data set and file name fixes

### DIFF
--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -354,7 +354,7 @@ def create_paramfile(trans, uploaded_datasets):
                 uploaded_dataset.type = 'ftp_import'
             params = dict(file_type=uploaded_dataset.file_type,
                           ext=uploaded_dataset.ext,
-                          name=uploaded_dataset.name,
+                          name=os.path.basename(uploaded_dataset.name),
                           dataset_id=data.dataset.id,
                           dbkey=uploaded_dataset.dbkey,
                           type=uploaded_dataset.type,

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -91,10 +91,9 @@ def verify(
         # if the server's env has GALAXY_TEST_SAVE, save the output file to that dir
         if keep_outputs_dir:
             ofn = os.path.join(keep_outputs_dir, filename)
-            try:
-                os.makedirs(os.path.dirname(ofn))
-            except OSError:
-                pass
+            ofd = os.path.dirname(ofn)
+            if not os.path.isdir(ofd):
+                os.makedirs(os.path.dirname(ofd))
             log.debug('keep_outputs_dir: %s, ofn: %s', keep_outputs_dir, ofn)
             try:
                 shutil.copy(temp_name, ofn)

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -93,7 +93,7 @@ def verify(
             ofn = os.path.join(keep_outputs_dir, filename)
             ofd = os.path.dirname(ofn)
             if not os.path.isdir(ofd):
-                os.makedirs(os.path.dirname(ofd))
+                os.makedirs(ofd)
             log.debug('keep_outputs_dir: %s, ofn: %s', keep_outputs_dir, ofn)
             try:
                 shutil.copy(temp_name, ofn)

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -91,6 +91,10 @@ def verify(
         # if the server's env has GALAXY_TEST_SAVE, save the output file to that dir
         if keep_outputs_dir:
             ofn = os.path.join(keep_outputs_dir, filename)
+            try:
+                os.makedirs(os.path.dirname(ofn))
+            except OSError:
+                pass
             log.debug('keep_outputs_dir: %s, ofn: %s', keep_outputs_dir, ofn)
             try:
                 shutil.copy(temp_name, ofn)


### PR DESCRIPTION
- when uploading a file the data set name should not contain a path component. this happens for instance if planemo is used and the input data is in subfolders within test-data
- when testing https://github.com/galaxyproject/galaxy/pull/7352 i realised that this breaks for test-data with subfolders since these don't exist (I guess this is how the call to basename ended up there). hence is is now recursively created

second part solves https://github.com/galaxyproject/planemo/issues/901

lets see what CI says about this .. I have no idea about possible side effects

I guess these need backporting (at least to the Galaxy version now used in planemo by default)