### PR TITLE
Possible fix for fasta file never getting filesize

### DIFF
--- a/lib/galaxy/jobs/dynamic_tool_destination.py
+++ b/lib/galaxy/jobs/dynamic_tool_destination.py
@@ -1391,7 +1391,7 @@ def map_tool_to_destination(
                                 for line in inp_db:
                                     if line[0] == ">":
                                         records += 1
-                    elif filesize_rule_present:
+                    if filesize_rule_present:
                         query_file = str(inp_data[da].file_name)
                         file_size += os.path.getsize(query_file)
             except AttributeError:


### PR DESCRIPTION
See issue: #7373 

Changing the `elif` to an `if` for filesize_rule_present means that the size of an input fasta file will be returned correctly instead of defaulting to 0B.