### PR TITLE
[19.01] Fix HDF5 test assert docs

### DIFF
--- a/doc/parse_gx_xsd.py
+++ b/doc/parse_gx_xsd.py
@@ -83,8 +83,9 @@ def _build_tag(tag, hide_attributes):
             assertions_buffer.write("--- | ---\n")
             elements = assertion_tag.findall("{http://www.w3.org/2001/XMLSchema}choice/{http://www.w3.org/2001/XMLSchema}element")
             for element in elements:
-                doc = _doc_or_none(element).strip()
-                assertions_buffer.write("``%s`` | %s\n" % (element.attrib["name"], doc))
+                doc = _doc_or_none(element)
+                assert doc, "Documentation for %s is empty" % element.attrib["name"]
+                assertions_buffer.write("``%s`` | %s\n" % (element.attrib["name"], doc.strip()))
             text = text.replace(line, assertions_buffer.getvalue())
     tag_help.write(text)
     best_practices = _get_bp_link(annotation_el)

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -1243,7 +1243,7 @@ $assertions
 
 ### Examples
 
-The following demonstrtes a wide variety of text-based and tabular
+The following demonstrates a wide variety of text-based and tabular
 assertion statements.
 
 ```xml
@@ -1584,8 +1584,8 @@ module.
       <xs:element name="has_text_matching" type="xs:anyType">
         <xs:annotation>
           <xs:documentation><![CDATA[Asserts text matching the specified regular expression (``expression``) appears in the output (e.g. ``<has_text_matching expression="1274\d+53" />`` ).]]>
-        </xs:documentation>
-      </xs:annotation>
+          </xs:documentation>
+        </xs:annotation>
       </xs:element>
       <xs:element name="has_line" type="xs:anyType">
         <xs:annotation>
@@ -1651,37 +1651,18 @@ module.
           <xs:documentation><![CDATA[This tag allows the developer to recurisively specify additional assertions as child elements about just the text contained in the element specified by the XPath-like ``path`` (e.g. ``<element_text path="BlastOutput_iterations/Iteration/Iteration_hits/Hit/Hit_def"><not_has_text text="EDK72998.1" /></element_text>``).]]></xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="has_h5_keys" type="AssertHasH5Keys">
+      <xs:element name="has_h5_keys" type="xs:anyType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en"><![CDATA[Asserts the HDF5 output has a set of attributes (``keys``), specified as a comma-separated list (e.g. ``<has_h5_keys keys="bins,chroms,indexes,pixels" />``).]]></xs:documentation>
+        </xs:annotation>
       </xs:element>
-      <xs:element name="has_h5_attribute" type="AssertHasH5Attribute">
+      <xs:element name="has_h5_attribute" type="xs:anyType">
+        <xs:annotation>
+          <xs:documentation xml:lang="en"><![CDATA[Asserts the HDF5 output has the specified ``value`` for an attribute (``key``) (e.g. ``<has_attr key="nchroms" value="15" />``).]]></xs:documentation>
+        </xs:annotation>
       </xs:element>
     </xs:choice>
   </xs:group>
-  <xs:complexType name="AssertHasH5Keys">
-    <xs:annotation>
-      <xs:documentation xml:lang="en"><![CDATA[Asserts HDF5 output contains the specified ``keys`` (h5py.File().keys()) (e.g. ``<has_h5_keys keys="bins, chroms,indexes,pixels" />``).]]></xs:documentation>
-    </xs:annotation>
-    <xs:attribute name="keys" type="xs:string">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">Comma separated list of keys to check for.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="AssertHasH5Attribute">
-    <xs:annotation>
-      <xs:documentation xml:lang="en"><![CDATA[Asserts HDF5 output contains the specified key-vaue pair given as ``key`` and ``value`` (e.g. ``<has_attr key="nchroms" value="15" />``).]]></xs:documentation>
-    </xs:annotation>
-    <xs:attribute name="key" type="xs:string">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">Key to check H5 attribute value of.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="value" type="xs:string">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">Expected value of H5 attribute to check.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
   <xs:complexType name="Inputs">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[Consists of all elements that define the


### PR DESCRIPTION
The content of `TestAssertions` is special and cannot contain `complexType`s.

Introduced in https://github.com/galaxyproject/galaxy/pull/7301 , they are breaking `make docs`, see for example:

https://jenkins.galaxyproject.org/job/latest-Sphinx-Docs/2223/console