### PR TITLE
[19.01] Bump yarn network tolerance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ ifndef YARN
 	@echo "Could not find yarn, which is required to build the Galaxy client.\nTo install yarn, please visit \033[0;34mhttps://yarnpkg.com/en/docs/install\033[0m for instructions, and package information for all platforms.\n"
 	false;
 else
-	cd client && yarn install --network-timeout 120000 --check-files
+	cd client && yarn install --network-timeout 300000 --check-files
 endif
 	
 

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -248,7 +248,7 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
 
     # Build client
     cd client
-    if yarn install --network-timeout 120000 --check-files; then
+    if yarn install --network-timeout 300000 --check-files; then
         if ! yarn run build-production-maps; then
             echo "ERROR: Galaxy client build failed. See ./client/README.md for more information, including how to get help."
             exit 1


### PR DESCRIPTION
From 2 minutes to 5 minutes -- 2 minutes was too low for some larger dependencies as debugged with @AjitPS in gitter.