### PR TITLE
Automatically set cookie_path using url_for()

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -98,13 +98,6 @@ uwsgi:
 
 galaxy:
 
-  # When running multiple Galaxy instances under separate URL prefixes
-  # on a single hostname, you will want to set this to the same path as
-  # the prefix set in the uWSGI "mount" configuration option above. This
-  # value becomes the "path" attribute set in the cookie so the cookies
-  # from one instance will not clobber those from another.
-  #cookie_path: ''
-
   # By default, Galaxy uses a SQLite database at
   # 'database/universe.sqlite'.  You may use a SQLAlchemy connection
   # string to specify an external database instead.  This string takes

--- a/config/reports.yml.sample
+++ b/config/reports.yml.sample
@@ -80,13 +80,6 @@ uwsgi:
 
 reports:
 
-  # When running multiple Galaxy Reports instances under separate URL
-  # prefixes on a single hostname, you will want to set this to the same
-  # path as the prefix set in the uWSGI "mount" configuration option
-  # above. This value becomes the "path" attribute set in the cookie so
-  # the cookies from one instance will not clobber those from another.
-  #cookie_path: null
-
   # Verbosity of console log messages.  Acceptable values can be found
   # here: https://docs.python.org/2/library/logging.html#logging-levels
   #log_level: DEBUG

--- a/config/tool_shed.yml.sample
+++ b/config/tool_shed.yml.sample
@@ -351,13 +351,6 @@ tool_shed:
   # store this information.
   #citation_cache_lock_dir: database/citations/lock
 
-  # When running multiple Tool Shed instances under separate URL
-  # prefixes on a single hostname, you will want to set this to the same
-  # path as the prefix set in the uWSGI "mount" configuration option
-  # above. This value becomes the "path" attribute set in the cookie so
-  # the cookies from one instance will not clobber those from another.
-  #cookie_path: null
-
   # Turn on logging of user actions to the database.  Actions currently
   # logged are grid views, tool searches, and use of "recently" used
   # tools menu.  The log_events and log_actions functionality will

--- a/doc/source/admin/apache.md
+++ b/doc/source/admin/apache.md
@@ -235,6 +235,12 @@ previous section:
         #module: galaxy.webapps.galaxy.buildapp:uwsgi_app()
     ```
 
+    ```eval_rst
+    .. note:: Older versions of Galaxy required you to set the ``cookie_path`` option. This is no longer necessary as of
+       Galaxy release 19.05 as it is now set automatically, but the (now undocumented) option still remains and
+       overrides the automatic setting. If you have this option set, unset it unless you know what you're doing.
+    ```
+
    Be sure to consult the [Scaling and Load Balancing](scaling.md) documentation, other options unrelated to proxying
    should also be set in the `uwsgi` section of the config.
 

--- a/doc/source/admin/apache.md
+++ b/doc/source/admin/apache.md
@@ -223,8 +223,7 @@ previous section:
 	```
 
 2. The Galaxy application needs to be aware that it is running with a prefix (for generating URLs in dynamic pages).
-   This is accomplished by configuring uWSGI and Galaxy (the `uwsgi` and `galaxy` sections in `config/galaxy.yml`
-   respectively) like so and restarting Galaxy:
+   This is accomplished by configuring uWSGI (the `uwsgi` section in `config/galaxy.yml`) like so and restarting Galaxy:
 
     ```yaml
     uwsgi:
@@ -234,14 +233,7 @@ previous section:
         manage-script-name: true
         # `module` MUST NOT be set when `mount` is in use
         #module: galaxy.webapps.galaxy.buildapp:uwsgi_app()
-
-    galaxy:
-        #...
-        cookie_path: /galaxy
     ```
-
-   `cookie_path` should be set to prevent Galaxy's session cookies from clobbering each other if you are running more
-   than one instance of Galaxy under different URL prefixes on the same hostname.
 
    Be sure to consult the [Scaling and Load Balancing](scaling.md) documentation, other options unrelated to proxying
    should also be set in the `uwsgi` section of the config.

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1,17 +1,3 @@
-~~~~~~~~~~~~~~~
-``cookie_path``
-~~~~~~~~~~~~~~~
-
-:Description:
-    When running multiple Galaxy instances under separate URL prefixes
-    on a single hostname, you will want to set this to the same path
-    as the prefix set in the uWSGI "mount" configuration option above.
-    This value becomes the "path" attribute set in the cookie so the
-    cookies from one instance will not clobber those from another.
-:Default: ````
-:Type: str
-
-
 ~~~~~~~~~~~~~~~~~~~~~~~
 ``database_connection``
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/nginx.md
+++ b/doc/source/admin/nginx.md
@@ -215,8 +215,7 @@ previous section:
     ```
 
 2. The Galaxy application needs to be aware that it is running with a prefix (for generating URLs in dynamic pages).
-   This is accomplished by configuring uWSGI and Galaxy (the `uwsgi` and `galaxy` sections in `config/galaxy.yml`
-   respectively) like so and restarting Galaxy:
+   This is accomplished by configuring uWSGI (the `uwsgi` section in `config/galaxy.yml`) like so and restarting Galaxy:
 
     ```yaml
     uwsgi:
@@ -226,14 +225,7 @@ previous section:
         manage-script-name: true
         # `module` MUST NOT be set when `mount` is in use
         #module: galaxy.webapps.galaxy.buildapp:uwsgi_app()
-
-    galaxy:
-        #...
-        cookie_path: /galaxy
     ```
-
-   `cookie_path` should be set to prevent Galaxy's session cookies from clobbering each other if you are running more
-   than one instance of Galaxy under different URL prefixes on the same hostname.
 
    Be sure to consult the [Scaling and Load Balancing](scaling.md) documentation, other options unrelated to proxying
    should also be set in the `uwsgi` section of the config.

--- a/doc/source/admin/nginx.md
+++ b/doc/source/admin/nginx.md
@@ -227,6 +227,12 @@ previous section:
         #module: galaxy.webapps.galaxy.buildapp:uwsgi_app()
     ```
 
+    ```eval_rst
+    .. note:: Older versions of Galaxy required you to set the ``cookie_path`` option. This is no longer necessary as of
+       Galaxy release 19.05 as it is now set automatically, but the (now undocumented) option still remains and
+       overrides the automatic setting. If you have this option set, unset it unless you know what you're doing.
+    ```
+
    Be sure to consult the [Scaling and Load Balancing](scaling.md) documentation, other options unrelated to proxying
    should also be set in the `uwsgi` section of the config.
 

--- a/doc/source/admin/reports_options.rst
+++ b/doc/source/admin/reports_options.rst
@@ -1,18 +1,3 @@
-~~~~~~~~~~~~~~~
-``cookie_path``
-~~~~~~~~~~~~~~~
-
-:Description:
-    When running multiple Galaxy Reports instances under separate URL
-    prefixes on a single hostname, you will want to set this to the
-    same path as the prefix set in the uWSGI "mount" configuration
-    option above. This value becomes the "path" attribute set in the
-    cookie so the cookies from one instance will not clobber those
-    from another.
-:Default: ``None``
-:Type: str
-
-
 ~~~~~~~~~~~~~
 ``log_level``
 ~~~~~~~~~~~~~

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -203,7 +203,7 @@ class Configuration(object):
             tempfile.tempdir = self.new_file_path
         self.shared_home_dir = kwargs.get("shared_home_dir", None)
         self.openid_consumer_cache_path = resolve_path(kwargs.get("openid_consumer_cache_path", "database/openid_consumer_cache"), self.root)
-        self.cookie_path = kwargs.get("cookie_path", "/")
+        self.cookie_path = kwargs.get("cookie_path", None)
         self.enable_quotas = string_as_bool(kwargs.get('enable_quotas', False))
         self.enable_unique_workflow_defaults = string_as_bool(kwargs.get('enable_unique_workflow_defaults', False))
         self.tool_path = resolve_path(kwargs.get("tool_path", "tools"), self.root)

--- a/lib/galaxy/visualization/plugins/interactive_environments.py
+++ b/lib/galaxy/visualization/plugins/interactive_environments.py
@@ -88,7 +88,7 @@ class InteractiveEnvironmentRequest(object):
             self.attr.proxy_prefix = '/'.join(
                 (
                     '',
-                    self.attr.galaxy_config.cookie_path.strip('/'),
+                    (self.attr.galaxy_config.cookie_path or '/').strip('/'),
                     self.attr.galaxy_config.dynamic_proxy_prefix.strip('/'),
                     self.attr.viz_id,
                 )

--- a/lib/galaxy/visualization/plugins/interactive_environments.py
+++ b/lib/galaxy/visualization/plugins/interactive_environments.py
@@ -88,7 +88,7 @@ class InteractiveEnvironmentRequest(object):
             self.attr.proxy_prefix = '/'.join(
                 (
                     '',
-                    (self.attr.galaxy_config.cookie_path or '/').strip('/'),
+                    trans.cookie_path.strip('/'),
                     self.attr.galaxy_config.dynamic_proxy_prefix.strip('/'),
                     self.attr.viz_id,
                 )

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -620,12 +620,16 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
             # self.log_event( "Automatically created account '%s'", user.email )
         return user
 
+    @property
+    def cookie_path(self):
+        return self.app.config.cookie_path or url_for('/')
+
     def __update_session_cookie(self, name='galaxysession'):
         """
         Update the session cookie to match the current session.
         """
         self.set_cookie(self.security.encode_guid(self.galaxy_session.session_key),
-                        name=name, path=self.app.config.cookie_path or url_for('/'))
+                        name=name, path=self.cookie_path)
 
     def check_user_library_import_dir(self, user):
         if getattr(self.app.config, "user_library_import_dir_auto_creation", False):

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -625,7 +625,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
         Update the session cookie to match the current session.
         """
         self.set_cookie(self.security.encode_guid(self.galaxy_session.session_key),
-                        name=name, path=self.app.config.cookie_path)
+                        name=name, path=self.app.config.cookie_path or url_for('/'))
 
     def check_user_library_import_dir(self, user):
         if getattr(self.app.config, "user_library_import_dir_auto_creation", False):

--- a/lib/galaxy/web/proxy/__init__.py
+++ b/lib/galaxy/web/proxy/__init__.py
@@ -148,7 +148,7 @@ class GolangProxyLauncher(object):
                 config.dynamic_proxy_bind_port,
             ),
             "--listenPath", "/".join((
-                config.cookie_path,
+                (config.cookie_path or '/'),
                 config.dynamic_proxy_prefix
             )),
             "--cookieName", "galaxysession",

--- a/lib/galaxy/web/proxy/__init__.py
+++ b/lib/galaxy/web/proxy/__init__.py
@@ -13,6 +13,7 @@ from galaxy.util import (
 )
 from galaxy.util.filelock import FileLock
 from galaxy.util.lazy_process import LazyProcess, NoOpLazyProcess
+from galaxy.web.framework import url_for
 
 log = logging.getLogger(__name__)
 
@@ -148,7 +149,7 @@ class GolangProxyLauncher(object):
                 config.dynamic_proxy_bind_port,
             ),
             "--listenPath", "/".join((
-                (config.cookie_path or '/'),
+                (config.cookie_path or url_for('/')),
                 config.dynamic_proxy_prefix
             )),
             "--cookieName", "galaxysession",

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -25,17 +25,6 @@ mapping:
     required: true
     mapping:
 
-      cookie_path:
-        type: str
-        default: ''
-        required: false
-        desc: |
-          When running multiple Galaxy instances under separate URL prefixes on a
-          single hostname, you will want to set this to the same path as the prefix set
-          in the uWSGI "mount" configuration option above. This value becomes the "path"
-          attribute set in the cookie so the cookies from one instance will not clobber
-          those from another.
-
       database_connection:
         type: str
         default: sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE

--- a/lib/galaxy/webapps/reports/config.py
+++ b/lib/galaxy/webapps/reports/config.py
@@ -48,7 +48,7 @@ class Configuration(object):
         self.blog_url = kwargs.get('blog_url', None)
         self.screencasts_url = kwargs.get('screencasts_url', None)
         self.log_events = False
-        self.cookie_path = kwargs.get("cookie_path", "/")
+        self.cookie_path = kwargs.get("cookie_path", None)
         # Error logging with sentry
         self.sentry_dsn = kwargs.get('sentry_dsn', None)
 

--- a/lib/galaxy/webapps/reports/config_schema.yml
+++ b/lib/galaxy/webapps/reports/config_schema.yml
@@ -7,14 +7,6 @@ mapping:
     desc: |
       Galaxy Reports configuration options.
     mapping:
-      cookie_path:
-        type: str
-        desc: |
-          When running multiple Galaxy Reports instances under separate URL prefixes on a
-          single hostname, you will want to set this to the same path as the prefix set
-          in the uWSGI "mount" configuration option above. This value becomes the "path"
-          attribute set in the cookie so the cookies from one instance will not clobber
-          those from another.
       
       log_level:
         type: str

--- a/lib/galaxy/webapps/tool_shed/config.py
+++ b/lib/galaxy/webapps/tool_shed/config.py
@@ -66,7 +66,7 @@ class Configuration(object):
         # Where dataset files are stored
         self.file_path = resolve_path(kwargs.get("file_path", "database/community_files"), self.root)
         self.new_file_path = resolve_path(kwargs.get("new_file_path", "database/tmp"), self.root)
-        self.cookie_path = kwargs.get("cookie_path", "/")
+        self.cookie_path = kwargs.get("cookie_path", None)
         self.enable_quotas = string_as_bool(kwargs.get('enable_quotas', False))
         self.id_secret = kwargs.get("id_secret", "changethisinproductiontoo")
         # Tool stuff

--- a/lib/galaxy/webapps/tool_shed/config_schema.yml
+++ b/lib/galaxy/webapps/tool_shed/config_schema.yml
@@ -516,17 +516,6 @@ mapping:
           external sources such as https://doi.org/ by Galaxy - the following
           parameters can be used to control the caching used to store this information.
 
-      cookie_path:
-        type: str
-        default: null
-        required: false
-        desc: |
-          When running multiple Tool Shed instances under separate URL prefixes on a
-          single hostname, you will want to set this to the same path as the prefix set
-          in the uWSGI "mount" configuration option above. This value becomes the "path"
-          attribute set in the cookie so the cookies from one instance will not clobber
-          those from another.
-
       log_actions:
         type: bool
         default: true


### PR DESCRIPTION
This sets it with a trailing slash, the docs previously did not suggest that but it's probably more correct.

WIP because I'll update docs once #7216 is merged forward.