### PR TITLE
[19.01] Fix dependency installation in UI

### DIFF
--- a/lib/galaxy/tools/deps/views.py
+++ b/lib/galaxy/tools/deps/views.py
@@ -104,6 +104,7 @@ class DependencyResolversView(object):
         return list(removed_environments)
 
     def install_dependencies(self, requirements, **kwds):
+        kwds['install'] = True
         return self._dependency_manager._requirements_to_dependencies_dict(requirements, **kwds)
 
     def install_dependency(self, index=None, **payload):


### PR DESCRIPTION
We need to pass the install kwarg here.
Broken in https://github.com/galaxyproject/galaxy/commit/2d3ab4ce1205aec24664225d74b2a851cb94b2b0