### PR TITLE
[18.09] Fix workflow loading on systems with ASCII locale

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1012,7 +1012,7 @@ class WorkflowContentsManager(UsesAnnotations):
         if not module.label and module.type in ['data_input', 'data_collection_input']:
             new_state = safe_loads(state)
             default_label = new_state.get('name')
-            if str(default_label).lower() not in ['input dataset', 'input dataset collection']:
+            if util.unicodify(default_label).lower() not in ['input dataset', 'input dataset collection']:
                 step.label = module.label = default_label
 
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/7421,
though it's very likely Galaxy won't play well when python
is falling back to ASCII as default encoding.

WorkflowStep.label is backed by a 255 character unicode string,
but tool_inputs is JSONType, which might have integer or float values
(in principle), so we play it safe by casting to unicode.