### PR TITLE
Allow configuration location of user preferences extra configuration

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -674,8 +674,8 @@ galaxy:
   # format string as specified by ISO 8601 international   standard).
   #pretty_datetime_format: $locale (UTC)
 
-  # Location of the user_preferences_extra_conf.yml file, if not in the
-  # standard configuration directory.
+  # Location of the configuration file containing extra user
+  # preferences.
   #user_preferences_extra_conf_path: config/user_preferences_extra_conf.yml
 
   # Default localization for Galaxy UI. Allowed values are listed at the

--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -674,6 +674,10 @@ galaxy:
   # format string as specified by ISO 8601 international   standard).
   #pretty_datetime_format: $locale (UTC)
 
+  # Location of the user_preferences_extra_conf.yml file, if not in the
+  # standard configuration directory.
+  #user_preferences_extra_conf_path: config/user_preferences_extra_conf.yml
+
   # Default localization for Galaxy UI. Allowed values are listed at the
   # end of client/galaxy/scripts/nls/locale.js. With the default value
   # (auto), the locale will be automatically adjusted to the user's

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1249,6 +1249,17 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``user_preferences_extra_conf_path``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Location of the user_preferences_extra_conf.yml file, if not in
+    the standard configuration directory.
+:Default: ``config/user_preferences_extra_conf.yml``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~
 ``default_locale``
 ~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1254,8 +1254,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Location of the user_preferences_extra_conf.yml file, if not in
-    the standard configuration directory.
+    Location of the configuration file containing extra user
+    preferences.
 :Default: ``config/user_preferences_extra_conf.yml``
 :Type: str
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 import threading
 import time
+import yaml
 from datetime import timedelta
 
 from six import string_types
@@ -642,6 +643,13 @@ class Configuration(object):
         self.biostar_never_authenticate = string_as_bool(kwargs.get('biostar_never_authenticate', False))
         self.pretty_datetime_format = expand_pretty_datetime_format(kwargs.get('pretty_datetime_format', '$locale (UTC)'))
         self.user_preferences_extra_config_file = kwargs.get('user_preferences_extra_conf_path', None)
+        try:
+            with open(self.user_preferences_extra_config_file, 'r') as stream:
+                self.user_preferences_extra = yaml.safe_load(stream)
+        except Exception:
+            log.warning('Config file (%s) could not be found or is malformed.' % self.user_preferences_extra_config_file)
+            self.user_preferences_extra = {'preferences': {}}
+
         self.default_locale = kwargs.get('default_locale', None)
         self.master_api_key = kwargs.get('master_api_key', None)
         if self.master_api_key == "changethis":  # default in sample config file

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -17,9 +17,9 @@ import sys
 import tempfile
 import threading
 import time
-import yaml
 from datetime import timedelta
 
+import yaml
 from six import string_types
 from six.moves import configparser
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -641,6 +641,7 @@ class Configuration(object):
         self.biostar_enable_bug_reports = string_as_bool(kwargs.get('biostar_enable_bug_reports', True))
         self.biostar_never_authenticate = string_as_bool(kwargs.get('biostar_never_authenticate', False))
         self.pretty_datetime_format = expand_pretty_datetime_format(kwargs.get('pretty_datetime_format', '$locale (UTC)'))
+        self.user_preferences_extra_config_file = kwargs.get('user_preferences_extra_conf_path', None)
         self.default_locale = kwargs.get('default_locale', None)
         self.master_api_key = kwargs.get('master_api_key', None)
         if self.master_api_key == "changethis":  # default in sample config file

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -641,7 +641,7 @@ class Configuration(object):
         self.biostar_enable_bug_reports = string_as_bool(kwargs.get('biostar_enable_bug_reports', True))
         self.biostar_never_authenticate = string_as_bool(kwargs.get('biostar_never_authenticate', False))
         self.pretty_datetime_format = expand_pretty_datetime_format(kwargs.get('pretty_datetime_format', '$locale (UTC)'))
-        self.user_preferences_extra_config_file = kwargs.get('user_preferences_extra_conf_path', None)
+        self.user_preferences_extra_config_file = kwargs.get('user_preferences_extra_conf_path', 'config/user_preferences_extra_conf.yml')
         try:
             with open(self.user_preferences_extra_config_file, 'r') as stream:
                 self.user_preferences_extra = yaml.safe_load(stream)

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -61,7 +61,6 @@ PATH_DEFAULTS = dict(
     workflow_schedulers_config_file=['config/workflow_schedulers_conf.xml', 'config/workflow_schedulers_conf.xml.sample'],
     modules_mapping_files=['config/environment_modules_mapping.yml', 'config/environment_modules_mapping.yml.sample'],
     local_conda_mapping_file=['config/local_conda_mapping.yml', 'config/local_conda_mapping.yml.sample'],
-    user_preferences_extra_config_file=['config/user_preferences_extra_conf.yml'],
     containers_config_file=['config/containers_conf.yml'],
 )
 

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -6,7 +6,6 @@ import logging
 import re
 
 import six
-import yaml
 from markupsafe import escape
 from sqlalchemy import (
     false,
@@ -269,15 +268,7 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesApiKeysMixin, B
         Reads the file user_preferences_extra_conf.yml to display
         admin defined user informations
         """
-        path = trans.app.config.user_preferences_extra_config_file
-        try:
-            with open(path, 'r') as stream:
-                config = yaml.safe_load(stream)
-        except Exception:
-            log.warning('Config file (%s) could not be found or is malformed.' % path)
-            return {}
-
-        return config['preferences'] if config else {}
+        return trans.app.config.user_preferences_extra['preferences']
 
     def _build_extra_user_pref_inputs(self, preferences, user):
         """

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -936,6 +936,14 @@ mapping:
           - $iso8601 (complete format string as specified by ISO 8601 international
             standard).
 
+      user_preferences_extra_conf_path:
+        type: str
+        default: 'config/user_preferences_extra_conf.yml'
+        required: false
+        desc: |
+          Location of the user_preferences_extra_conf.yml file, if not in the
+          standard configuration directory.
+
       default_locale:
         type: str
         default: auto

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -941,8 +941,7 @@ mapping:
         default: 'config/user_preferences_extra_conf.yml'
         required: false
         desc: |
-          Location of the user_preferences_extra_conf.yml file, if not in the
-          standard configuration directory.
+          Location of the configuration file containing extra user preferences.
 
       default_locale:
         type: str


### PR DESCRIPTION
Additionally moves the yaml parsing from runtime to boottime since it is not useful to re-load it every time the API is accessed.