### PR TITLE
Fix typo in cluster documentation

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1012,7 +1012,7 @@ class WorkflowContentsManager(UsesAnnotations):
         if not module.label and module.type in ['data_input', 'data_collection_input']:
             new_state = safe_loads(state)
             default_label = new_state.get('name')
-            if str(default_label).lower() not in ['input dataset', 'input dataset collection']:
+            if util.unicodify(default_label).lower() not in ['input dataset', 'input dataset collection']:
                 step.label = module.label = default_label
 
 


### PR DESCRIPTION
```
<plugins>
    <plugin id="cli" type="runner" load="galaxy.jobs.runners.cli:CLIJobRunner"/>
</plugins>
```
Should match what is in job_conf.xml.sample_advanced
```
<plugins>
    <plugin id="cli" type="runner" load="galaxy.jobs.runners.cli:ShellJobRunner"/>
</plugins>
```