### PR TITLE
Add tool hover

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1545,8 +1545,6 @@ div.toolPanelLabel {
 }
 
 div.toolTitle {
-    padding-top: 5px;
-    padding-bottom: 5px;
     margin-left: 10px;
     margin-right: 10px;
     display: block;
@@ -1559,9 +1557,15 @@ div.toolTitle {
 div a.tool-link {
     text-decoration: none;
     display: block;
+    padding-top: 5px;
+    padding-bottom: 5px;
 
     span.tool-old-link {
         text-decoration: underline;
+    }
+
+    &:hover {
+        background: darken($panel-bg-color, 5%);
     }
 }
 


### PR DESCRIPTION
Originally in https://github.com/galaxyproject/galaxy/pull/4470 I added some CSS changes to enlarge the click targets and make hovering over tools darken their backgrounds a bit. (I know it switches to a hand, but with larger click targets not always clear which tool you're hovering over.) Apparently those css changes were never included, not even in the original PR, so I'm re-proposing them now.

![image](https://user-images.githubusercontent.com/458683/53628204-4fec5400-3c02-11e9-944d-2e1fed450056.png)

the padding is moved from the tool title to the tool link to ensure there's no vertical space that doesn't lead to a tool.

![image](https://user-images.githubusercontent.com/458683/53628231-61cdf700-3c02-11e9-885c-64600fbd85ca.png)
