### PR TITLE
[18.09] Fix loading workflows with steps without default label

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1012,7 +1012,7 @@ class WorkflowContentsManager(UsesAnnotations):
         if not module.label and module.type in ['data_input', 'data_collection_input']:
             new_state = safe_loads(state)
             default_label = new_state.get('name')
-            if util.unicodify(default_label).lower() not in ['input dataset', 'input dataset collection']:
+            if default_label and util.unicodify(default_label).lower() not in ['input dataset', 'input dataset collection']:
                 step.label = module.label = default_label
 
 


### PR DESCRIPTION
Broken in https://github.com/galaxyproject/galaxy/pull/7422.
Prior to https://github.com/galaxyproject/galaxy/pull/7422
we'd call str(default_label), so if `default_label` was None
we'd get 'None'. Fixes part of https://github.com/galaxyproject/galaxy/issues/7447
