### PR TITLE
Fix doc for statsd conf for uwsgi?

### DIFF
--- a/doc/source/admin/special_topics/performance_tracking.rst
+++ b/doc/source/admin/special_topics/performance_tracking.rst
@@ -24,7 +24,22 @@ Or a StatsD server via:
       socket: ...
       stats-push: statsd:127.0.0.1:8125
 
-The `official documentation <https://uwsgi-docs.readthedocs.io/en/latest/Metrics.html#stats-pushers>`__ contains further information on uWSGI and stats servers. In the `uWSGI Stats Server <https://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html>` documentation, you can see an example of the sort of information that you will be able to collect.
+The `official documentation <https://uwsgi-docs.readthedocs.io/en/latest/Metrics.html#stats-pushers>`__ contains further information on uWSGI and stats servers. In the `uWSGI Stats Server <https://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html>`__ documentation, you can see an example of the sort of information that you will be able to collect. Note that you will need to make sure that the statsd pusher plugin is activated in your uWSGI servers.
+
+Alternatively, you can use `gxadmin <https://github.com/usegalaxy-eu/gxadmin#uwsgi-stats_influx>`__ to generate data ready to load in an InfluxDB database. In this case, you will need to add the stats option to your galaxy.yml:
+
+.. code-block:: yaml
+
+   uwsgi:
+      socket: ...
+      stats: 127.0.0.1:9191
+
+And then run gxadmin like this:
+
+
+.. code-block:: bash
+
+   gxadmin uwsgi stats_influx 127.0.0.1:9191
 
 API / Route Timing Statistics
 -----------------------------

--- a/doc/source/admin/special_topics/performance_tracking.rst
+++ b/doc/source/admin/special_topics/performance_tracking.rst
@@ -8,7 +8,7 @@ Most performance tracking requires sending metrics to a metrics collection serve
 uWSGI
 -----
 
-As you have certainly switched to uWSGI from the default paste server, there is some built-in uWSGI support for performance logging. You can send uWSGI's internal metrics to a carbon (Graphite) server by setting the carbon option in your galaxy.yml:
+There is some built-in uWSGI support for performance logging. You can send uWSGI's internal metrics to a carbon (Graphite) server by setting the carbon option in your galaxy.yml:
 
 .. code-block:: yaml
 

--- a/doc/source/admin/special_topics/performance_tracking.rst
+++ b/doc/source/admin/special_topics/performance_tracking.rst
@@ -22,7 +22,7 @@ Or a StatsD server via:
 
    wsgi:
       socket: ...
-      statsd-push: 127.0.0.1:8125
+      stats-push: statsd:127.0.0.1:8125
 
 The `official documentation <https://uwsgi-docs.readthedocs.io/en/latest/Metrics.html#stats-pushers>`__ contains further information on uWSGI and stats servers. In the `uWSGI Stats Server <https://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html>` documentation, you can see an example of the sort of information that you will be able to collect.
 

--- a/doc/source/admin/special_topics/performance_tracking.rst
+++ b/doc/source/admin/special_topics/performance_tracking.rst
@@ -20,7 +20,7 @@ Or a StatsD server via:
 
 .. code-block:: yaml
 
-   wsgi:
+   uwsgi:
       socket: ...
       stats-push: statsd:127.0.0.1:8125
 


### PR DESCRIPTION
Hi,
So I'm (finally) trying to add more monitoring to our galaxy server.
Looking at the doc, I think there is a small mistake in the uwsgi conf to push stats to statsd, so here's a little patch.
However, this doesn't work here since I get this error at startup:
`unable to find "statsd" stats_pusher`
I guess I need to do something like https://github.com/unbit/uwsgi/issues/773 but not sure what's the good way to do it with galaxy, should I manually uninstall+reinstall uwsgi weel?