### PR TITLE
Update to PSA 3.1 and support login with Globus identity

### DIFF
--- a/config/oidc_backends_config.xml.sample
+++ b/config/oidc_backends_config.xml.sample
@@ -31,12 +31,4 @@
 
         <prompt>consent</prompt>
     </provider>
-
-    <provider name="PixelPin">
-        <client_id> ... </client_id>
-        <client_secret> ... </client_secret>
-        <redirect_uri>http://localhost:8080/authnz/pixelpin/callback</redirect_uri>
-
-        <prompt>consent</prompt>
-    </provider>
 </OIDC>

--- a/config/oidc_backends_config.xml.sample
+++ b/config/oidc_backends_config.xml.sample
@@ -22,6 +22,8 @@
          login to Galaxy using their Google account.
         -->
     </provider>
+
+    <!-- Documentation: http://globus-integration-examples.readthedocs.io -->
     <provider name="Globus">
         <client_id> ... </client_id>
         <client_secret> ... /client_secret>

--- a/config/oidc_backends_config.xml.sample
+++ b/config/oidc_backends_config.xml.sample
@@ -39,4 +39,12 @@
 
         <prompt>consent</prompt>
     </provider>
+
+    <provider name="PixelPin">
+        <client_id> ... </client_id>
+        <client_secret> ... </client_secret>
+        <redirect_uri>http://localhost:8080/authnz/pixelpin/callback</redirect_uri>
+
+        <prompt>consent</prompt>
+    </provider>
 </OIDC>

--- a/config/oidc_backends_config.xml.sample
+++ b/config/oidc_backends_config.xml.sample
@@ -31,4 +31,12 @@
 
         <prompt>consent</prompt>
     </provider>
+
+    <provider name="Elixir">
+        <client_id> ... </client_id>
+        <client_secret> ... </client_secret>
+        <redirect_uri>http://localhost:8080/authnz/elixir/callback</redirect_uri>
+
+        <prompt>consent</prompt>
+    </provider>
 </OIDC>

--- a/config/oidc_backends_config.xml.sample
+++ b/config/oidc_backends_config.xml.sample
@@ -32,14 +32,6 @@
         <prompt>consent</prompt>
     </provider>
 
-    <provider name="Elixir">
-        <client_id> ... </client_id>
-        <client_secret> ... </client_secret>
-        <redirect_uri>http://localhost:8080/authnz/elixir/callback</redirect_uri>
-
-        <prompt>consent</prompt>
-    </provider>
-
     <provider name="PixelPin">
         <client_id> ... </client_id>
         <client_secret> ... </client_secret>

--- a/config/oidc_backends_config.xml.sample
+++ b/config/oidc_backends_config.xml.sample
@@ -22,4 +22,11 @@
          login to Galaxy using their Google account.
         -->
     </provider>
+    <provider name="Globus">
+        <client_id> ... </client_id>
+        <client_secret> ... /client_secret>
+        <redirect_uri>http://localhost:8080/authnz/globus/callback</redirect_uri>
+
+        <prompt>consent</prompt>
+    </provider>
 </OIDC>

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -88,8 +88,8 @@ class AuthnzManager(object):
                     log.error("Could not find a node attribute 'name'; skipping the node '{}'.".format(child.tag))
                     continue
                 idp = child.get('name').lower()
-                if idp == 'google':
-                    self.oidc_backends_config[idp] = self._parse_google_config(child)
+                if idp in BACKENDS_NAME:
+                    self.oidc_backends_config[idp] = self._parse_idp_config(child)
             if len(self.oidc_backends_config) == 0:
                 raise ParseError("No valid provider configuration parsed.")
         except ImportError:
@@ -97,7 +97,7 @@ class AuthnzManager(object):
         except ParseError as e:
             raise ParseError("Invalid configuration at `{}`: {} -- unable to continue.".format(config_file, e))
 
-    def _parse_google_config(self, config_xml):
+    def _parse_idp_config(self, config_xml):
         rtv = {
             'client_id': config_xml.find('client_id').text,
             'client_secret': config_xml.find('client_secret').text,

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -18,11 +18,13 @@ DEFAULTS = {
 }
 
 BACKENDS = {
-    'google': 'social_core.backends.google_openidconnect.GoogleOpenIdConnect'
+    'google': 'social_core.backends.google_openidconnect.GoogleOpenIdConnect',
+    "globus": "social_core.backends.globus.GlobusOpenIdConnect"
 }
 
 BACKENDS_NAME = {
-    'google': 'google-openidconnect'
+    'google': 'google-openidconnect',
+    "globus": "globus"
 }
 
 AUTH_PIPELINE = (
@@ -98,11 +100,21 @@ class PSAAuthnz(IdentityProvider):
 
         if provider == 'google':
             self._setup_google_backend(oidc_backend_config)
+        elif provider == "globus":
+            self._setup_globus_backend(oidc_backend_config)
 
     def _setup_google_backend(self, oidc_backend_config):
         self.config[setting_name('AUTH_EXTRA_ARGUMENTS')] = {'access_type': 'offline'}
         self.config['SOCIAL_AUTH_GOOGLE_OPENIDCONNECT_KEY'] = oidc_backend_config.get('client_id')
         self.config['SOCIAL_AUTH_GOOGLE_OPENIDCONNECT_SECRET'] = oidc_backend_config.get('client_secret')
+        self.config['redirect_uri'] = oidc_backend_config.get('redirect_uri')
+        if oidc_backend_config.get('prompt') is not None:
+            self.config[setting_name('AUTH_EXTRA_ARGUMENTS')]['prompt'] = oidc_backend_config.get('prompt')
+
+    def _setup_globus_backend(self, oidc_backend_config):
+        self.config[setting_name('AUTH_EXTRA_ARGUMENTS')] = {'access_type': 'offline'}
+        self.config['KEY'] = oidc_backend_config.get('client_id')
+        self.config['SECRET'] = oidc_backend_config.get('client_secret')
         self.config['redirect_uri'] = oidc_backend_config.get('redirect_uri')
         if oidc_backend_config.get('prompt') is not None:
             self.config[setting_name('AUTH_EXTRA_ARGUMENTS')]['prompt'] = oidc_backend_config.get('prompt')

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -19,12 +19,14 @@ DEFAULTS = {
 
 BACKENDS = {
     'google': 'social_core.backends.google_openidconnect.GoogleOpenIdConnect',
-    "globus": "social_core.backends.globus.GlobusOpenIdConnect"
+    "globus": "social_core.backends.globus.GlobusOpenIdConnect",
+    "elixir": "social_core.backends.elixir.ElixirOpenIdConnect"
 }
 
 BACKENDS_NAME = {
     'google': 'google-openidconnect',
-    "globus": "globus"
+    "globus": "globus",
+    "elixir": "elixir"
 }
 
 AUTH_PIPELINE = (

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -98,20 +98,10 @@ class PSAAuthnz(IdentityProvider):
         # the just logged-in user.
         self.config[setting_name('INACTIVE_USER_LOGIN')] = True
 
-        if provider == 'google':
-            self._setup_google_backend(oidc_backend_config)
-        elif provider == "globus":
-            self._setup_globus_backend(oidc_backend_config)
+        if provider in BACKENDS_NAME:
+            self._setup_idp(oidc_backend_config)
 
-    def _setup_google_backend(self, oidc_backend_config):
-        self.config[setting_name('AUTH_EXTRA_ARGUMENTS')] = {'access_type': 'offline'}
-        self.config['SOCIAL_AUTH_GOOGLE_OPENIDCONNECT_KEY'] = oidc_backend_config.get('client_id')
-        self.config['SOCIAL_AUTH_GOOGLE_OPENIDCONNECT_SECRET'] = oidc_backend_config.get('client_secret')
-        self.config['redirect_uri'] = oidc_backend_config.get('redirect_uri')
-        if oidc_backend_config.get('prompt') is not None:
-            self.config[setting_name('AUTH_EXTRA_ARGUMENTS')]['prompt'] = oidc_backend_config.get('prompt')
-
-    def _setup_globus_backend(self, oidc_backend_config):
+    def _setup_idp(self, oidc_backend_config):
         self.config[setting_name('AUTH_EXTRA_ARGUMENTS')] = {'access_type': 'offline'}
         self.config['KEY'] = oidc_backend_config.get('client_id')
         self.config['SECRET'] = oidc_backend_config.get('client_secret')

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -19,14 +19,12 @@ DEFAULTS = {
 
 BACKENDS = {
     'google': 'social_core.backends.google_openidconnect.GoogleOpenIdConnect',
-    "globus": "social_core.backends.globus.GlobusOpenIdConnect",
-    "pixelpin": "social_core.backends.pixelpin.PixelPinOpenIDConnect"
+    "globus": "social_core.backends.globus.GlobusOpenIdConnect"
 }
 
 BACKENDS_NAME = {
     'google': 'google-openidconnect',
-    "globus": "globus",
-    "pixelpin": "pixelpin-openidconnect"
+    "globus": "globus"
 }
 
 AUTH_PIPELINE = (

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -20,13 +20,15 @@ DEFAULTS = {
 BACKENDS = {
     'google': 'social_core.backends.google_openidconnect.GoogleOpenIdConnect',
     "globus": "social_core.backends.globus.GlobusOpenIdConnect",
-    "elixir": "social_core.backends.elixir.ElixirOpenIdConnect"
+    "elixir": "social_core.backends.elixir.ElixirOpenIdConnect",
+    "pixelpin": "social_core.backends.pixelpin.PixelPinOpenIDConnect"
 }
 
 BACKENDS_NAME = {
     'google': 'google-openidconnect',
     "globus": "globus",
-    "elixir": "elixir"
+    "elixir": "elixir",
+    "pixelpin": "pixelpin-openidconnect"
 }
 
 AUTH_PIPELINE = (

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -20,14 +20,12 @@ DEFAULTS = {
 BACKENDS = {
     'google': 'social_core.backends.google_openidconnect.GoogleOpenIdConnect',
     "globus": "social_core.backends.globus.GlobusOpenIdConnect",
-    "elixir": "social_core.backends.elixir.ElixirOpenIdConnect",
     "pixelpin": "social_core.backends.pixelpin.PixelPinOpenIDConnect"
 }
 
 BACKENDS_NAME = {
     'google': 'google-openidconnect',
     "globus": "globus",
-    "elixir": "elixir",
     "pixelpin": "pixelpin-openidconnect"
 }
 

--- a/lib/galaxy/dependencies/pipfiles/default/Pipfile
+++ b/lib/galaxy/dependencies/pipfiles/default/Pipfile
@@ -73,7 +73,7 @@ pyparsing = "*"
 "Fabric3" = "*"
 paramiko = "*"
 python-genomespaceclient = "<2.0"
-social_auth_core = {version = "==1.5.0", extras = ['openidconnect']}
+social_auth_core = {version = "==3.1.0", extras = ['openidconnect']}
 cloudauthz = "<=0.2.0"
 gxformat2 = "*"
 

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -3,7 +3,7 @@
 alabaster==0.7.12
 argh==0.26.2
 atomicwrites==1.3.0
-attrs==18.2.0
+attrs==19.1.0
 babel==2.6.0
 certifi==2018.11.29
 chardet==3.0.4
@@ -15,9 +15,9 @@ gunicorn==19.9.0
 idna==2.8
 imagesize==1.1.0
 jinja2==2.10
-lxml==4.3.1
+lxml==4.3.2
 markdown==2.6.11
-markupsafe==1.1.0
+markupsafe==1.1.1
 mock==2.0.0
 more-itertools==5.0.0
 nose==1.3.7
@@ -25,9 +25,9 @@ nosehtml==0.4.5
 packaging==19.0
 pathlib2==2.3.3 ; python_version < '3.6'
 pathtools==0.1.2
-pbr==5.1.2
-pluggy==0.8.1
-py==1.7.0
+pbr==5.1.3
+pluggy==0.9.0
+py==1.8.0
 pygithub3==0.5.1 ; python_version < '3'
 pygments==2.3.1
 pyparsing==2.3.1
@@ -47,7 +47,7 @@ sphinx-markdown-tables==0.0.9
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.4
 sphinxcontrib-websupport==1.1.0
-testfixtures==6.5.2
+testfixtures==6.6.0
 twill==0.9.1 ; python_version < '3'
 typing==3.6.6 ; python_version < '3.5'
 urllib3==1.24.1

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -1,7 +1,7 @@
 -i https://wheels.galaxyproject.org/simple
 --extra-index-url https://pypi.python.org/simple
 adal==1.2.1
-amqp==2.4.1
+amqp==2.4.2
 appdirs==1.4.3
 asn1crypto==0.24.0
 azure-common==1.1.14
@@ -21,10 +21,10 @@ babel==2.6.0
 bagit==1.6.4
 bcrypt==3.1.6
 bdbag==1.4.1
-beaker==1.10.0
+beaker==1.10.1
 bioblend==0.12.0
 bleach==3.1.0
-boltons==19.0.1
+boltons==19.1.0
 boto3==1.7.84
 boto==2.49.0
 botocore==1.10.84
@@ -33,7 +33,7 @@ bx-python==0.8.2
 bz2file==0.98 ; python_version < '3.3'
 cachetools==3.1.0
 certifi==2018.11.29
-cffi==1.12.1
+cffi==1.12.2
 chardet==3.0.4
 cheetah3==3.2.0
 cliff==2.14.0
@@ -41,14 +41,15 @@ cloudauthz==0.2.0
 cloudbridge==1.0.2
 cmd2==0.8.9
 contextlib2==0.5.5 ; python_version < '3.5'
-cryptography==2.5
-debtcollector==1.20.0
+cryptography==2.6.1
+debtcollector==1.21.0
 decorator==4.3.2
 deprecation==2.0.6
 dictobj==0.4
 docopt==0.6.2
 docutils==0.14
 dogpile.cache==0.7.1
+ecdsa==0.13
 enum34==1.1.6 ; python_version < '3.4'
 fabric3==1.14.post1
 funcsigs==1.0.2 ; python_version < '3.3'
@@ -63,14 +64,14 @@ ipaddress==1.0.22 ; python_version < '3.3'
 isa-rwval==0.10.7
 iso8601==0.1.12
 isodate==0.6.0
-jmespath==0.9.3
+jmespath==0.9.4
 jsonpatch==1.23
 jsonpointer==2.0
 jsonschema==2.6.0
-keystoneauth1==3.11.2
-kombu==4.3.0
+keystoneauth1==3.13.0
+kombu==4.4.0
 mako==1.0.7
-markupsafe==1.1.0
+markupsafe==1.1.1
 mercurial==3.7.3 ; python_version < '3'
 monotonic==1.5
 msgpack==0.6.1
@@ -82,34 +83,31 @@ netifaces==0.10.9
 networkx==1.11
 nodeenv==1.3.3
 nose==1.3.7
-numpy==1.16.1
+numpy==1.16.2
 oauthlib==3.0.1
 openstacksdk==0.17.0
 os-client-config==1.31.2
-os-service-types==1.5.0
-osc-lib==1.12.0
-oslo.config==6.8.0
-oslo.context==2.22.0
-oslo.i18n==3.23.0
-oslo.log==3.42.2
-oslo.serialization==2.28.1
-oslo.utils==3.40.2
+os-service-types==1.6.0
+osc-lib==1.12.1
+oslo.config==6.8.1
+oslo.context==2.22.1
+oslo.i18n==3.23.1
+oslo.log==3.42.3
+oslo.serialization==2.28.2
+oslo.utils==3.40.3
 packaging==19.0
 paramiko==2.4.2
 parsley==1.3
-paste==3.0.6
+paste==3.0.7
 pastedeploy==2.0.1
 pastescript==3.0.0
-pbr==5.1.2
+pbr==5.1.3
 prettytable==0.7.2
 psutil==5.5.1
 pulsar-galaxy-lib==0.8.3
 pyasn1==0.4.5
 pycparser==2.19
 pycryptodome==3.7.3
-pycryptodomex==3.7.3
-pyinotify==0.9.6 ; sys_platform != 'win32' and sys_platform != 'darwin' and sys_platform != 'sunos5'
-pyjwkest==1.4.0
 pyjwt==1.7.1
 pykwalify==1.7.0
 pynacl==1.3.0
@@ -122,10 +120,11 @@ python-cinderclient==4.0.0
 python-dateutil==2.8.0
 python-genomespaceclient==1.1.0
 python-glanceclient==2.12.0
+python-jose==3.0.1
 python-keystoneclient==3.17.0
 python-neutronclient==6.9.0
 python-novaclient==11.0.0
-python-openid==2.2.5
+python-openid==2.2.5 ; python_version < '3.0'
 python-swiftclient==3.6.0
 pytz==2018.9
 pyyaml==3.13
@@ -136,15 +135,16 @@ requests==2.21.0
 requestsexceptions==1.4.0
 rfc3986==1.2.0
 routes==2.4.1
+rsa==4.0
 s3transfer==0.1.13
 simplejson==3.16.0
 six==1.11.0
-social-auth-core[openidconnect]==1.5.0
+social-auth-core[openidconnect]==3.1.0
 sqlalchemy-migrate==0.12.0
 sqlalchemy-utils==0.33.11
-sqlalchemy==1.2.18
+sqlalchemy==1.3.0
 sqlparse==0.2.4
-stevedore==1.30.0
+stevedore==1.30.1
 subprocess32==3.5.3 ; python_version < '3.0'
 svgwrite==1.2.1
 tempita==0.5.2

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -143,7 +143,7 @@ six==1.11.0
 social-auth-core[openidconnect]==3.1.0
 sqlalchemy-migrate==0.12.0
 sqlalchemy-utils==0.33.11
-sqlalchemy==1.3.0
+sqlalchemy==1.2.18
 sqlparse==0.2.4
 stevedore==1.30.1
 subprocess32==3.5.3 ; python_version < '3.0'

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -68,7 +68,7 @@ jmespath==0.9.4
 jsonpatch==1.23
 jsonpointer==2.0
 jsonschema==2.6.0
-keystoneauth1==3.13.0
+keystoneauth1==3.13.1
 kombu==4.4.0
 mako==1.0.7
 markupsafe==1.1.1
@@ -100,14 +100,15 @@ paramiko==2.4.2
 parsley==1.3
 paste==3.0.7
 pastedeploy==2.0.1
-pastescript==3.0.0
+pastescript==3.1.0
 pbr==5.1.3
 prettytable==0.7.2
-psutil==5.5.1
+psutil==5.6.0
 pulsar-galaxy-lib==0.8.3
 pyasn1==0.4.5
 pycparser==2.19
 pycryptodome==3.7.3
+pyinotify==0.9.6 ; sys_platform != 'win32' and sys_platform != 'darwin' and sys_platform != 'sunos5'
 pyjwt==1.7.1
 pykwalify==1.7.0
 pynacl==1.3.0

--- a/lib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
@@ -1,11 +1,11 @@
 -i https://pypi.python.org/simple
-configparser==3.7.1 ; python_version < '3.2'
+configparser==3.7.3 ; python_version < '3.2'
 entrypoints==0.3
 enum34==1.1.6 ; python_version < '3.4'
-flake8-import-order==0.18
-flake8==3.7.6
+flake8-import-order==0.18.1
+flake8==3.7.7
 functools32==3.2.3.post2 ; python_version < '3.2'
 mccabe==0.6.1
 pycodestyle==2.5.0
-pyflakes==2.1.0
+pyflakes==2.1.1
 typing==3.6.6 ; python_version < '3.5'


### PR DESCRIPTION
- Updates to current latest PSA version (3.1.0);
- Make some backend configuration generic;
- Support three new OIDC-based backends: Globus, Elixir, and PixelPin