### PR TITLE
Don't display outputs that aren't going to be produced in workflow editor

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -24,6 +24,7 @@ from galaxy.managers import (
 )
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.tools.parameters import populate_state
+from galaxy.tools.parameters.basic import workflow_building_modes
 from galaxy.util.sanitize_html import sanitize_html
 from galaxy.web import _future_expose_api as expose_api
 from galaxy.web import _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
@@ -561,6 +562,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         Builds module models for the workflow editor.
         """
         inputs = payload.get('inputs', {})
+        trans.workflow_build_mode = workflow_building_modes.ENABLED
         module = module_factory.from_dict(trans, payload)
         if 'tool_state' not in payload:
             module_state = {}

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -22,6 +22,7 @@ from galaxy.tools import (
     DefaultToolState,
     ToolInputsNotReadyException
 )
+from galaxy.tools.actions import filter_output
 from galaxy.tools.execute import execute, MappingParameters, PartialJobExecution
 from galaxy.tools.parameters import (
     check_param,
@@ -929,6 +930,8 @@ class ToolModule(WorkflowModule):
         data_outputs = []
         if self.tool:
             for name, tool_output in self.tool.outputs.items():
+                if filter_output(tool_output, self.state.inputs):
+                    continue
                 extra_kwds = {}
                 if tool_output.collection:
                     extra_kwds["collection"] = True

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -491,6 +491,50 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase):
                 'label',
             )
 
+    @skip_without_tool('output_filter')
+    def test_export_editor_filtered_outputs(self):
+        template = """
+class: GalaxyWorkflow
+steps:
+  - tool_id: output_filter_with_input
+    state:
+      produce_out_1: {produce_out_1}
+      filter_text_1: {filter_text_1}
+      produce_collection: false
+      produce_paired_collection: false
+"""
+        workflow_id = self._upload_yaml_workflow(template.format(produce_out_1='false', filter_text_1='false'))
+        downloaded_workflow = self._download_workflow(workflow_id, style="editor")
+        outputs = downloaded_workflow['steps']['0']['outputs']
+        assert len(outputs) == 1
+        assert outputs[0]['name'] == 'out_3'
+        workflow_id = self._upload_yaml_workflow(template.format(produce_out_1='true', filter_text_1='false'))
+        downloaded_workflow = self._download_workflow(workflow_id, style="editor")
+        outputs = downloaded_workflow['steps']['0']['outputs']
+        assert len(outputs) == 2
+        assert outputs[0]['name'] == 'out_1'
+        assert outputs[1]['name'] == 'out_3'
+        workflow_id = self._upload_yaml_workflow(template.format(produce_out_1='true', filter_text_1='foo'))
+        downloaded_workflow = self._download_workflow(workflow_id, style="editor")
+        outputs = downloaded_workflow['steps']['0']['outputs']
+        assert len(outputs) == 3
+        assert outputs[0]['name'] == 'out_1'
+        assert outputs[1]['name'] == 'out_2'
+        assert outputs[2]['name'] == 'out_3'
+
+    @skip_without_tool('output_filter_with_input')
+    def test_export_editor_filtered_outputs_exception_handling(self):
+        workflow_id = self._upload_yaml_workflow("""
+class: GalaxyWorkflow
+steps:
+  - tool_id: output_filter_exception_1
+""")
+        downloaded_workflow = self._download_workflow(workflow_id, style="editor")
+        outputs = downloaded_workflow['steps']['0']['outputs']
+        assert len(outputs) == 2
+        assert outputs[0]['name'] == 'out_1'
+        assert outputs[1]['name'] == 'out_2'
+
     @skip_without_tool('collection_type_source')
     def test_export_editor_collection_type_source(self):
         workflow_id = self._upload_yaml_workflow("""

--- a/test/functional/tools/output_filter_with_input.xml
+++ b/test/functional/tools/output_filter_with_input.xml
@@ -22,6 +22,8 @@
       <filter>filter_text_1 == "foo"</filter>
     </data>
     <data format="txt" from_work_dir="3" name="out_3">
+      <!-- always produce out_3 -->
+      <filter>input_1.ext != 'xyz'</filter>
     </data>
   </outputs>
   <tests>

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -238,7 +238,7 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
 
     def _try_until_no_errors(self, f):
         e = None
-        for i in range(10):
+        for i in range(30):
             try:
                 f()
                 return

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -451,6 +451,7 @@ def __mock_tool(
                                           format='input',
                                           format_source=None,
                                           change_format=[],
+                                          filters=[],
                                           label=None)},
         params_from_strings=mock.Mock(),
         check_and_update_param_values=mock.Mock(),


### PR DESCRIPTION
This obviously doesn't work (yet) with filters that work on the input dataset, but this already removes a lot of outputs that are not going to be produced based on static options. Since exceptions default to producing the dataset this isn't much harm.

![output_filter](https://user-images.githubusercontent.com/6804901/53795351-184b1800-3f32-11e9-8d33-e337a2254566.gif)
