### PR TITLE
Implement portable metadata generation.

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -276,6 +276,7 @@ class Configuration(object):
         self.id_secret = kwargs.get("id_secret", "USING THE DEFAULT IS NOT SECURE!")
         self.retry_metadata_internally = string_as_bool(kwargs.get("retry_metadata_internally", "True"))
         self.max_metadata_value_size = int(kwargs.get("max_metadata_value_size", 5242880))
+        self.metadata_strategy = kwargs.get("metadata_strategy", "directory")
         self.single_user = kwargs.get("single_user", None)
         self.use_remote_user = string_as_bool(kwargs.get("use_remote_user", "False")) or self.single_user
         self.normalize_remote_user_email = string_as_bool(kwargs.get("normalize_remote_user_email", "False"))

--- a/lib/galaxy/datatypes/set_metadata_tool.xml
+++ b/lib/galaxy/datatypes/set_metadata_tool.xml
@@ -5,7 +5,7 @@
     </requirements>
     <action module="galaxy.tools.actions.metadata" class="SetMetadataToolAction"/>
     <command detect_errors="exit_code">
-"\${GALAXY_PYTHON:-python}" '${set_metadata}' ${__SET_EXTERNAL_METADATA_COMMAND_LINE__}
+cd ..; "\${GALAXY_PYTHON:-python}" '${set_metadata}' ${__SET_EXTERNAL_METADATA_COMMAND_LINE__}
     </command>
     <configfiles>
         <configfile name="set_metadata">from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()</configfile>

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1356,7 +1356,8 @@ class JobWrapper(HasResourceParameters):
                     # it would be quicker to just copy the metadata from the originating output dataset,
                     # but somewhat trickier (need to recurse up the copied_from tree), for now we'll call set_meta()
                     retry_internally = util.asbool(self.get_destination_configuration("retry_metadata_internally", True))
-                    if retry_internally and not self.external_output_metadata.external_metadata_set_successfully(dataset, self.sa_session):
+                    metadata_set_successfully = self.external_output_metadata.external_metadata_set_successfully(dataset, dataset_assoc.name, self.sa_session, working_directory=self.working_directory)
+                    if retry_internally and not metadata_set_successfully:
                         # If Galaxy was expected to sniff type and didn't - do so.
                         if dataset.ext == "_sniff_":
                             extension = sniff.handle_uploaded_dataset_file(dataset.dataset.file_name, self.app.datatypes_registry)
@@ -1364,8 +1365,7 @@ class JobWrapper(HasResourceParameters):
 
                         # call datatype.set_meta directly for the initial set_meta call during dataset creation
                         dataset.datatype.set_meta(dataset, overwrite=False)
-                    elif (job.states.ERROR != final_job_state and
-                            not self.external_output_metadata.external_metadata_set_successfully(dataset, self.sa_session)):
+                    elif (job.states.ERROR != final_job_state and not metadata_set_successfully):
                         dataset._state = model.Dataset.states.FAILED_METADATA
                     else:
                         self.external_output_metadata.load_metadata(dataset, dataset_assoc.name, self.sa_session, working_directory=self.working_directory, remote_metadata_directory=remote_metadata_directory)

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -99,6 +99,7 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
                                 job_metadata=None, compute_tmp_dir=None,
                                 include_command=True, max_metadata_value_size=0,
                                 kwds=None):
+        assert job_metadata, "setup_external_metadata must be supplied with job_metadata path"
         kwds = kwds or {}
         tmp_dir = _init_tmp_dir(tmp_dir)
 

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -287,7 +287,8 @@ class JobExternalOutputMetadataWrapper(MetadataCollectionStrategy):
             # return command required to build
             fd, fp = tempfile.mkstemp(suffix='.py', dir=tmp_dir, prefix="set_metadata_")
             metadata_script_file = abspath(fp)
-            os.fdopen(fd, 'w').write(SET_METADATA_SCRIPT)
+            with os.fdopen(fd, 'w') as f:
+                f.write(SET_METADATA_SCRIPT)
             return 'python "%s" %s' % (metadata_path_on_compute(metadata_script_file), args)
         else:
             # return args to galaxy_ext.metadata.set_metadata required to build

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2273,7 +2273,7 @@ class SetMetadataTool(Tool):
         for name, dataset in inp_data.items():
             external_metadata = get_metadata_compute_strategy(app, job.id)
             sa_session = app.model.context
-            if external_metadata.external_metadata_set_successfully(dataset, sa_session):
+            if external_metadata.external_metadata_set_successfully(dataset, name, sa_session, working_directory=working_directory):
                 external_metadata.load_metadata(dataset, name, sa_session, working_directory=working_directory)
             else:
                 dataset._state = model.Dataset.states.FAILED_METADATA

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -87,7 +87,7 @@ class SetMetadataToolAction(ToolAction):
                                                                      config_root=app.config.root,
                                                                      config_file=app.config.config_file,
                                                                      datatypes_config=datatypes_config,
-                                                                     job_metadata=None,
+                                                                     job_metadata=os.path.join(job_working_dir, 'working', tool.provided_metadata_file),
                                                                      include_command=False,
                                                                      max_metadata_value_size=app.config.max_metadata_value_size,
                                                                      kwds={'overwrite': overwrite})

--- a/lib/galaxy/tools/provided_metadata.py
+++ b/lib/galaxy/tools/provided_metadata.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 
+from galaxy.util import stringify_dictionary_keys
 
 log = logging.getLogger(__name__)
 
@@ -76,6 +77,19 @@ class ToolProvidedMetadata(object):
         """
         return {}
 
+    def rewrite(self):
+        """Write metadata back to the file system.
+
+        If metadata has not changed via outputs specified as mutable, the
+        implementation class may opt to not re-write the file.
+        """
+        return None
+
+    def get_new_datasets_for_metadata_collection(self):
+        """Return all datasets tracked that are not explicit primary outputs.
+        """
+        return []
+
 
 class NullToolProvidedMetadata(ToolProvidedMetadata):
     pass
@@ -84,12 +98,13 @@ class NullToolProvidedMetadata(ToolProvidedMetadata):
 class LegacyToolProvidedMetadata(object):
 
     def __init__(self, meta_file, job_wrapper=None):
+        self.meta_file = meta_file
         self.tool_provided_job_metadata = []
 
         with open(meta_file, 'r') as f:
             for line in f:
                 try:
-                    line = json.loads(line)
+                    line = stringify_dictionary_keys(json.loads(line))
                     assert 'type' in line
                 except Exception:
                     log.exception('(%s) Got JSON data from tool, but data is improperly formatted or no "type" key in data' % job_wrapper.job_id)
@@ -109,8 +124,9 @@ class LegacyToolProvidedMetadata(object):
 
     def get_dataset_meta(self, output_name, dataset_id):
         for meta in self.tool_provided_job_metadata:
-            if meta['type'] == 'dataset' and meta['dataset_id'] == dataset_id:
+            if meta['type'] == 'dataset' and int(meta['dataset_id']) == dataset_id:
                 return meta
+        return {}
 
     def get_new_dataset_meta_by_basename(self, output_name, basename):
         for meta in self.tool_provided_job_metadata:
@@ -132,10 +148,21 @@ class LegacyToolProvidedMetadata(object):
     def get_unnamed_outputs(self):
         return []
 
+    def rewrite(self):
+        with open(self.meta_file, 'wt') as job_metadata_fh:
+            for meta in self.tool_provided_job_metadata:
+                job_metadata_fh.write("%s\n" % (json.dumps(meta)))
+
+    def get_new_datasets_for_metadata_collection(self):
+        for meta in self.tool_provided_job_metadata:
+            if meta['type'] == 'new_primary_dataset':
+                yield meta
+
 
 class ToolProvidedMetadata(object):
 
     def __init__(self, meta_file):
+        self.meta_file = meta_file
         with open(meta_file, 'r') as f:
             self.tool_provided_job_metadata = json.load(f)
 
@@ -183,3 +210,7 @@ class ToolProvidedMetadata(object):
     def get_unnamed_outputs(self):
         log.debug("unnamed outputs [%s]" % self.tool_provided_job_metadata)
         return self.tool_provided_job_metadata.get("__unnamed_outputs", [])
+
+    def rewrite(self):
+        with open(self.meta_file, 'wt') as job_metadata_fh:
+            json.dump(self.tool_provided_job_metadata, job_metadata_fh)

--- a/lib/galaxy_ext/metadata/_provided_metadata.py
+++ b/lib/galaxy_ext/metadata/_provided_metadata.py
@@ -1,0 +1,1 @@
+../../galaxy/tools/provided_metadata.py

--- a/lib/galaxy_ext/metadata/set_metadata.py
+++ b/lib/galaxy_ext/metadata/set_metadata.py
@@ -82,9 +82,11 @@ def set_metadata_portable():
     galaxy.model.metadata.MetadataTempFile.tmp_dir = tool_job_working_directory = os.path.abspath(os.getcwd())
 
     metadata_params_path = os.path.join("metadata", "params.json")
-    with open(metadata_params_path, "r") as f:
-        metadata_params = json.load(f)
-
+    try:
+        with open(metadata_params_path, "r") as f:
+            metadata_params = json.load(f)
+    except IOError:
+        raise Exception("Failed to find metadata/params.json from cwd [%s]" % tool_job_working_directory)
     datatypes_config = metadata_params["datatypes_config"]
     job_metadata = metadata_params["job_metadata"]
     max_metadata_value_size = metadata_params.get("max_metadata_value_size") or 0

--- a/test/unit/tools/test_metadata.py
+++ b/test/unit/tools/test_metadata.py
@@ -32,7 +32,15 @@ class MetadataTestCase(unittest.TestCase, tools_support.UsesApp, tools_support.U
         super(MetadataTestCase, self).tearDown()
         self.metadata_compute_strategy = None
 
-    def test_simple_output(self):
+    def test_simple_output_legacy(self):
+        self.app.config.metadata_strategy = "legacy"
+        self._test_simple_output()
+
+    def test_simple_output_directory(self):
+        self.app.config.metadata_strategy = "directory"
+        self._test_simple_output()
+
+    def _test_simple_output(self):
         source_file_name = os.path.join(os.getcwd(), "test/functional/tools/for_workflows/cat.xml")
         self._init_tool_for_path(source_file_name)
         output_dataset = self._create_output_dataset(
@@ -46,13 +54,21 @@ class MetadataTestCase(unittest.TestCase, tools_support.UsesApp, tools_support.U
         command = self.metadata_command(output_datasets)
         self._write_output_dataset_contents(output_dataset, ">seq1\nGCTGCATG\n")
         self.exec_metadata_command(command)
-        metadata_set_successfully = self.metadata_compute_strategy.external_metadata_set_successfully(output_dataset, sa_session)
+        metadata_set_successfully = self.metadata_compute_strategy.external_metadata_set_successfully(output_dataset, "out_file1", sa_session, working_directory=self.job_working_directory)
         assert metadata_set_successfully
         self.metadata_compute_strategy.load_metadata(output_dataset, "out_file1", sa_session, working_directory=self.job_working_directory)
         assert output_dataset.metadata.data_lines == 2
         assert output_dataset.metadata.sequences == 1
 
-    def test_primary_dataset_output_extension(self):
+    def test_primary_dataset_output_extension_legacy(self):
+        self.app.config.metadata_strategy = "legacy"
+        self._test_primary_dataset_output_extension()
+
+    def test_primary_dataset_output_extension_directory(self):
+        self.app.config.metadata_strategy = "directory"
+        self._test_primary_dataset_output_extension()
+
+    def _test_primary_dataset_output_extension(self):
         source_file_name = os.path.join(os.getcwd(), "test/functional/tools/for_workflows/cat.xml")
         self._init_tool_for_path(source_file_name)
         # setting extension to 'auto' here, results in the extension specified in
@@ -69,14 +85,22 @@ class MetadataTestCase(unittest.TestCase, tools_support.UsesApp, tools_support.U
         self._write_galaxy_json("""{"type": "dataset", "dataset_id": "%s", "name": "my dynamic name", "ext": "fasta", "info": "my dynamic info"}""" % output_dataset.dataset.id)
         self._write_output_dataset_contents(output_dataset, ">seq1\nGCTGCATG\n")
         self.exec_metadata_command(command)
-        metadata_set_successfully = self.metadata_compute_strategy.external_metadata_set_successfully(output_dataset, sa_session)
+        metadata_set_successfully = self.metadata_compute_strategy.external_metadata_set_successfully(output_dataset, "out_file1", sa_session, working_directory=self.job_working_directory)
         assert metadata_set_successfully
         output_dataset.extension = "fasta"  # gets done in job finish...
         self.metadata_compute_strategy.load_metadata(output_dataset, "out_file1", sa_session, working_directory=self.job_working_directory)
         assert output_dataset.metadata.data_lines == 2
         assert output_dataset.metadata.sequences == 1
 
-    def test_primary_dataset_output_metadata_override(self):
+    def test_primary_dataset_output_metadata_override_legacy(self):
+        self.app.config.metadata_strategy = "legacy"
+        self._test_primary_dataset_output_metadata_override()
+
+    def test_primary_dataset_output_metadata_override_directory(self):
+        self.app.config.metadata_strategy = "directory"
+        self._test_primary_dataset_output_metadata_override()
+
+    def _test_primary_dataset_output_metadata_override(self):
         source_file_name = os.path.join(os.getcwd(), "test/functional/tools/for_workflows/cat.xml")
         self._init_tool_for_path(source_file_name)
         output_dataset = self._create_output_dataset(
@@ -91,7 +115,7 @@ class MetadataTestCase(unittest.TestCase, tools_support.UsesApp, tools_support.U
         self._write_galaxy_json("""{"type": "dataset", "dataset_id": "%s", "name": "my dynamic name", "ext": "fasta", "info": "my dynamic info", "metadata": {"sequences": 42}}""" % output_dataset.dataset.id)
         self._write_output_dataset_contents(output_dataset, ">seq1\nGCTGCATG\n")
         self.exec_metadata_command(command)
-        metadata_set_successfully = self.metadata_compute_strategy.external_metadata_set_successfully(output_dataset, sa_session)
+        metadata_set_successfully = self.metadata_compute_strategy.external_metadata_set_successfully(output_dataset, "out_file1", sa_session, working_directory=self.job_working_directory)
         assert metadata_set_successfully
         output_dataset.extension = "fasta"  # get done in job finish...
         self.metadata_compute_strategy.load_metadata(output_dataset, "out_file1", sa_session, working_directory=self.job_working_directory)

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -113,6 +113,7 @@ class MockAppConfig(Bunch):
         self.jobs_directory = '/tmp'
         self.new_file_path = '/tmp'
         self.tool_data_path = '/tmp'
+        self.metadata_strategy = 'legacy'
 
         self.object_store_config_file = ''
         self.object_store = 'disk'


### PR DESCRIPTION
This PR starts by implementing a new metadata generation interface (in both the narrow and broad sense of this word). This variant of external metadata generation that doesn't use command-line arguments or absolute paths and simply takes operates on the current, job working directory and knows what to do.

- Uses relative paths allowing the directory to be staged elsewhere via Pulsar, Condor, or Docker for instance.
- Avoids DB objects for hard-coded paths making everything more robust.
- Avoids huge command-lines which for huge collection reduction jobs might hit system limits for command-line length.
- Uses JSON dicts to communicate parameters - meaning we can avoid awkward argument parsing as this evolves (see old ``max_metadata_value_size`` handling in ``set_metadata.py`` for instance).
- Uses output names instead of database IDs to key files - so file naming is consistent and human readable.

This builds on the new abstraction around metadata generation introduced in #7158 to create a new implementation of ``MetadataCollectionStrategy`` called ``PortableDirectoryMetadataGenerator``. This also builds on unit testing introduced in #7459.

The second commit in this PR improves the correctness of metadata generation in the context of tool provided metadata by ensuring ``set_metadata.py`` uses the ``ToolProvidedMetadata`` abstraction introduced in #4437 and enhanced for this context in #7156. There were (and still are) things in ``set_metadata.py`` that assume the old style ``galaxy.json`` but using this abstraction sets the stage for proper external metadata collection of newer style ``galaxy.json`` files.

This PR also brings in a fix for the legacy ``ToolProvidedMetadata`` implementation for behavior defined previously only in ``set_metadata.py``.

All of this work is from https://github.com/galaxyproject/galaxy/pull/7058 (tracked on board https://github.com/galaxyproject/galaxy/projects/11). In that context, this new metadata approach is extended even further to deal with job finish tasks including object store interactions as part of the Galaxy job script - setting the stage for data outputs that are truly remote from Galaxy.
