### PR TITLE
correct virtualenv download with no wget/curl

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -154,7 +154,7 @@ if [ $SET_VENV -eq 1 -a $CREATE_VENV -eq 1 ]; then
     from urllib import urlretrieve
 except:
     from urllib.request import urlretrieve
-urllib.urlretrieve('$vurl', '$vsrc')"
+urlretrieve('$vurl', '$vsrc')"
                 fi
                 echo "Verifying $vsrc checksum is $vsha"
                 python -c "import hashlib; assert hashlib.sha256(open('$vsrc', 'rb').read()).hexdigest() == '$vsha', '$vsrc: invalid checksum'"


### PR DESCRIPTION
This is a small correction to the embedded python code in a startup script that downloads virtualenv. This code could not work in the no curl/wget available case, because of a smallish python error.
Obviously, to test it you need to try installing it with a very bare bones installation (no wget nor curl)...