### PR TITLE
added option to pass in individual globs to unit test watcher

### DIFF
--- a/client/karma/karma.config.mocha.js
+++ b/client/karma/karma.config.mocha.js
@@ -1,17 +1,49 @@
 /**
  * Runs mocha tests
+ * 
+ * Individual files can be run by passing in a comma-delimited list
+ * of globs for the karma config like this:
+ * 
+ *    env KARMA_TESTS="Tags.test.js,something.js,doodads.js" npm run test-watch
  */
 
 const baseKarmaConfig = require("./karma.config.base");
 
+
+// Unless we have an environment variable picking out
+// a specified set of files, this is what's going to run
+const defaultFiles = [
+    // component/module tests
+    "**/*.test.js",
+    // pre-existing rules definition tests
+    "**/mocha/tests/*_tests.js"
+]
+
+// allows running just a set list of files
+function getTestFiles(testFiles) {
+    let patterns = testFiles ? testFiles.split(",").map(checkGlobPrefix) : defaultFiles;
+    return patterns.map(pattern => ({ pattern, watched: true}));
+}
+
+// prefixes user-supplied glob with directory wildcard
+function checkGlobPrefix(glob) {
+    if (!glob.startsWith("**/")) {
+        return `**/${glob}`;
+    }
+    return glob;
+}
+
 module.exports = function (config) {
 
+    // assemble test files, can run individuals by specifying
+    // globs on command line
+    let files = [
+        "../../node_modules/@babel/polyfill/dist/polyfill.js",
+        ...getTestFiles(process.env.KARMA_TESTS)
+    ];
+
     let settings = Object.assign({}, baseKarmaConfig, {
-        files: [
-            "../../node_modules/@babel/polyfill/dist/polyfill.js",
-            { pattern: "**/*.test.js", watched: true },
-            { pattern: "**/mocha/tests/*_tests.js" }
-        ],
+        files,
         preprocessors: {
             "**/*.js": ["webpack"]
         },


### PR DESCRIPTION
Just a little tiny addition to the client side unit-testing script.

This lets you watch individual tests as you're developing by passing them in a command line arg to the npm test-watch script.

```
npm run test-watch watch-only="Tags/*.test.js,store/tagStore.test.js"
```
... will run karma and watch your tests with the following file globs (only).

**/Tags/*.test.js
**/store/tagStore.test.js
