### PR TITLE
[19.01] Use a relative output.publicPath to avoid 404 errors when serving with a url prefix

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -97,7 +97,7 @@ let buildconfig = {
                     loader: "file-loader",
                     options: {
                         outputPath: "assets",
-                        publicPath: "/static/scripts/bundled/assets/"
+                        publicPath: "../scripts/bundled/assets/"
                     }
                 }
             },

--- a/templates/webapps/galaxy/galaxy.panels.mako
+++ b/templates/webapps/galaxy/galaxy.panels.mako
@@ -140,6 +140,8 @@
             | ${self.galaxy_config['title']}
             %endif
         </title>
+        ## relative href for site root
+        <link rel="index" href="${ h.url_for( '/' ) }"/>
 
         ${self.stylesheets()}
         ${self.javascripts()}


### PR DESCRIPTION
This should fix the first problem from #7474
The changelog is smaller than I thought, but it seems to be enough :)
ping @dannon 