### PR TITLE
Git providers error reporting plugins

### DIFF
--- a/config/error_report.yml.sample
+++ b/config/error_report.yml.sample
@@ -59,6 +59,8 @@
 # version and include all of the information the normal emailed bug reports
 # include. If you use a private Github Enterprise deployment, you can set
 # github_base_url='https://...' and github_api_url='https://api.....' as shown below.
+# The 'github_default_repo_only' flag restores the previous behaviour. When this is set
+# to true it will automatically only submit to the default git repository.
 # - type: github
 #   verbose: false
 #   user_submission: true
@@ -67,6 +69,7 @@
 #   github_api_url: https://api.github.com
 #   github_default_repo_owner: galaxyproject
 #   github_default_repo_name: galaxy
+#   github_default_repo_only: true
 
 # GitLab error reporting backend. You will need to `pip install python-gitlab`
 # in the galaxy virtualenv. This will create a new issue if none exists, and
@@ -76,7 +79,8 @@
 # gitlab_base_url='https://...'. It supports creating an issue on the git
 # repository of the tool by querying the ToolShed where the tool comes from
 # (if applicable). Set verbose to true if you want the message to be displayed
-# to the user.
+# to the user. The 'gitlab_default_repo_only' flags ensures all errors are
+# submitted to the default repository only.
 # - type: gitlab
 #   verbose: false
 #   user_submission: true
@@ -84,3 +88,4 @@
 #   gitlab_private_token: 00000000000
 #   gitlab_default_repo_owner: galaxyproject
 #   gitlab_default_repo_name: galaxy
+#   gitlab_default_repo_only: true

--- a/config/error_report.yml.sample
+++ b/config/error_report.yml.sample
@@ -64,3 +64,18 @@
 #   github_oauth_token: 00000000000
 #   github_repo_owner: galaxyproject
 #   github_repo_name: galaxy
+
+# GitLab error reporting backend. You will need to `pip install python-gitlab`
+# in the galaxy virtualenv. This will create a new issue if none exists, and
+# comment on existing, open issues. The issues are labelled based on tool ID /
+# version and include all of the information the normal emailed bug reports
+# include. If you use a private GitLab deployment, you can set
+# gitlab_base_url='https://...'. This is based off of the Github error
+# reporting backend. It supports creating an issue on the git repository of
+# the tool by querying the ToolShed where the tool comes from (if applicable).
+# - type: gitlab
+#   user_submission: true
+#   gitlab_base_url: https://gitlab.com
+#   gitlab_private_token: 00000000000
+#   gitlab_default_repo_owner: galaxyproject
+#   gitlab_default_repo_name: galaxy

--- a/config/error_report.yml.sample
+++ b/config/error_report.yml.sample
@@ -73,7 +73,9 @@
 # gitlab_base_url='https://...'. This is based off of the Github error
 # reporting backend. It supports creating an issue on the git repository of
 # the tool by querying the ToolShed where the tool comes from (if applicable).
+# Set verbose to true if you want the message to be displayed to the user.
 # - type: gitlab
+#   verbose: false
 #   user_submission: true
 #   gitlab_base_url: https://gitlab.com
 #   gitlab_private_token: 00000000000

--- a/config/error_report.yml.sample
+++ b/config/error_report.yml.sample
@@ -58,12 +58,15 @@
 # comment on existing, open issues. The issues are labelled based on tool ID /
 # version and include all of the information the normal emailed bug reports
 # include. If you use a private Github Enterprise deployment, you can set
-# github_base_url='https://...'
+# github_base_url='https://...' and github_api_url='https://api.....' as shown below.
 # - type: github
+#   verbose: false
 #   user_submission: true
 #   github_oauth_token: 00000000000
-#   github_repo_owner: galaxyproject
-#   github_repo_name: galaxy
+#   github_base_url: https://github.com
+#   github_api_url: https://api.github.com
+#   github_default_repo_owner: galaxyproject
+#   github_default_repo_name: galaxy
 
 # GitLab error reporting backend. You will need to `pip install python-gitlab`
 # in the galaxy virtualenv. This will create a new issue if none exists, and

--- a/config/error_report.yml.sample
+++ b/config/error_report.yml.sample
@@ -73,10 +73,10 @@
 # comment on existing, open issues. The issues are labelled based on tool ID /
 # version and include all of the information the normal emailed bug reports
 # include. If you use a private GitLab deployment, you can set
-# gitlab_base_url='https://...'. This is based off of the Github error
-# reporting backend. It supports creating an issue on the git repository of
-# the tool by querying the ToolShed where the tool comes from (if applicable).
-# Set verbose to true if you want the message to be displayed to the user.
+# gitlab_base_url='https://...'. It supports creating an issue on the git
+# repository of the tool by querying the ToolShed where the tool comes from
+# (if applicable). Set verbose to true if you want the message to be displayed
+# to the user.
 # - type: gitlab
 #   verbose: false
 #   user_submission: true

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -6,9 +6,9 @@ from __future__ import print_function
 import sys
 from os.path import dirname, join
 from xml.etree import ElementTree
-import yaml
 
 import pkg_resources
+import yaml
 
 from galaxy.containers import parse_containers_config
 from galaxy.util import asbool
@@ -167,9 +167,6 @@ class ConditionalDependencies(object):
 
     def check_influxdb(self):
         return 'influxdb' in self.error_report_modules
-
-
-
 
 
 def optional(config_file=None):

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -24,3 +24,8 @@ pykube==0.15.0
 kamaki
 
 watchdog
+
+# Error reporters optional modules
+python-gitlab
+pygithub
+influxdb

--- a/lib/galaxy/tools/error_reports/plugins/base_git.py
+++ b/lib/galaxy/tools/error_reports/plugins/base_git.py
@@ -36,8 +36,13 @@ class BaseGitPlugin(ErrorPlugin):
     git_project_cache = {}
     label_cache = {}
 
+    # Git variables
+    git_default_repo_owner = False
+    git_default_repo_name = False
+    git_default_repo_only = True
+
     def _determine_ts_url(self, tool):
-        if not tool.tool_shed:
+        if not tool.tool_shed or self.git_default_repo_only:
             return None
         if tool.tool_shed not in self.ts_urls:
             ts_url_request = requests.get('http://' + str(tool.tool_shed))
@@ -45,7 +50,7 @@ class BaseGitPlugin(ErrorPlugin):
         return self.ts_urls[tool.tool_shed]
 
     def _get_gitrepo_from_ts(self, job, ts_url):
-        if not ts_url:
+        if not ts_url or self.git_default_repo_only:
             return None
         if job.tool_id not in self.ts_repo_cache:
             ts_repo_request_data = requests.get(ts_url + "/api/repositories?tool_ids=" + str(job.tool_id)).json()

--- a/lib/galaxy/tools/error_reports/plugins/base_git.py
+++ b/lib/galaxy/tools/error_reports/plugins/base_git.py
@@ -5,6 +5,11 @@ from __future__ import absolute_import
 
 import logging
 import sys
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
 import requests
 import six
 if sys.version_info[0] < 3:
@@ -13,16 +18,13 @@ if sys.version_info[0] < 3:
 else:
     import urllib.parse as urllib
     urlparse = urllib
-from abc import (
-    ABCMeta,
-    abstractmethod
-)
 
 from galaxy.tools.errors import EmailErrorReporter
-from galaxy.util import string_as_bool, unicodify
+from galaxy.util import unicodify
 from . import ErrorPlugin
 
 log = logging.getLogger(__name__)
+
 
 @six.add_metaclass(ABCMeta)
 class BaseGitPlugin(ErrorPlugin):

--- a/lib/galaxy/tools/error_reports/plugins/base_git.py
+++ b/lib/galaxy/tools/error_reports/plugins/base_git.py
@@ -72,11 +72,11 @@ class BaseGitPlugin(ErrorPlugin):
         return u"""Galaxy Job Error: {tool_id} v{tool_version}""".format(**tool_kw)
 
     @abstractmethod
-    def _create_issue(self, **kwargs):
+    def _create_issue(self, issue_cache_key, error_title, error_mesage, project, **kwargs):
         raise NotImplementedError("Method _create_issue is required")
 
     @abstractmethod
-    def _append_issue(self, **kwargs):
+    def _append_issue(self, issue_cache_key, error_title, error_message, **kwargs):
         raise NotImplementedError("Method _append_issue is required")
 
     @abstractmethod

--- a/lib/galaxy/tools/error_reports/plugins/base_git.py
+++ b/lib/galaxy/tools/error_reports/plugins/base_git.py
@@ -32,14 +32,19 @@ class BaseGitPlugin(ErrorPlugin):
     ts_urls = {}
     ts_repo_cache = {}
     git_project_cache = {}
+    label_cache = {}
 
     def _determine_ts_url(self, tool):
+        if not tool.tool_shed:
+            return None
         if tool.tool_shed not in self.ts_urls:
             ts_url_request = requests.get('http://' + str(tool.tool_shed))
             self.ts_urls[tool.tool_shed] = ts_url_request.url
         return self.ts_urls[tool.tool_shed]
 
     def _get_gitrepo_from_ts(self, job, ts_url):
+        if not ts_url:
+            return None
         if job.tool_id not in self.ts_repo_cache:
             ts_repo_request_data = requests.get(ts_url + "/api/repositories?tool_ids=" + str(job.tool_id)).json()
 
@@ -65,11 +70,11 @@ class BaseGitPlugin(ErrorPlugin):
         return u"""Galaxy Job Error: {tool_id} v{tool_version}""".format(**tool_kw)
 
     @abstractmethod
-    def _create_issue(self, error_message, error_title, gl_project, issue_cache_key):
+    def _create_issue(self, **kwargs):
         raise NotImplementedError("Method _create_issue is required")
 
     @abstractmethod
-    def _append_issue(self, error_message, error_title, gitlab_urlencodedpath, issue_cache_key):
+    def _append_issue(self, **kwargs):
         raise NotImplementedError("Method _append_issue is required")
 
     @abstractmethod

--- a/lib/galaxy/tools/error_reports/plugins/base_git.py
+++ b/lib/galaxy/tools/error_reports/plugins/base_git.py
@@ -1,0 +1,77 @@
+"""This module defines the common functions for error reporting for Galaxy jobs towards Git applications (e.g. Github/GitLab).
+"""
+
+from __future__ import absolute_import
+
+import logging
+import sys
+import requests
+import six
+if sys.version_info[0] < 3:
+    import urllib as urllib
+    import urlparse as urlparse
+else:
+    import urllib.parse as urllib
+    urlparse = urllib
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
+from galaxy.tools.errors import EmailErrorReporter
+from galaxy.util import string_as_bool, unicodify
+from . import ErrorPlugin
+
+log = logging.getLogger(__name__)
+
+@six.add_metaclass(ABCMeta)
+class BaseGitPlugin(ErrorPlugin):
+    """Base definition to send error reports to a Git repository provider
+    """
+    issue_cache = {}
+    ts_urls = {}
+    ts_repo_cache = {}
+    git_project_cache = {}
+
+    def _determine_ts_url(self, tool):
+        if tool.tool_shed not in self.ts_urls:
+            ts_url_request = requests.get('http://' + str(tool.tool_shed))
+            self.ts_urls[tool.tool_shed] = ts_url_request.url
+        return self.ts_urls[tool.tool_shed]
+
+    def _get_gitrepo_from_ts(self, job, ts_url):
+        if job.tool_id not in self.ts_repo_cache:
+            ts_repo_request_data = requests.get(ts_url + "/api/repositories?tool_ids=" + str(job.tool_id)).json()
+
+            for changeset, repoinfo in ts_repo_request_data.items():
+                if isinstance(repoinfo, dict):
+                    self.ts_repo_cache[job.tool_id] = repoinfo.get('repository', {}).get('remote_repository_url', None)
+        return self.ts_repo_cache[job.tool_id]
+
+    def _get_issue_cache_key(self, job, ts_repourl):
+        return job.tool_id if ts_repourl else "default"
+
+    def _generate_error_message(self, dataset, job, kwargs):
+        # We'll re-use the email error reporter's template since most Git providers supports HTML
+        error_reporter = EmailErrorReporter(dataset.id, self.app)
+        error_reporter.create_report(job.get_user(), email=kwargs.get('email', None),
+                                     message=kwargs.get('message', None),
+                                     redact_user_details_in_bugreport=self.redact_user_details_in_bugreport)
+        # Return the HTML report
+        return error_reporter.html_report
+
+    def _generate_error_title(self, job):
+        tool_kw = {'tool_id': unicodify(job.tool_id), 'tool_version': unicodify(job.tool_version)}
+        return u"""Galaxy Job Error: {tool_id} v{tool_version}""".format(**tool_kw)
+
+    @abstractmethod
+    def _create_issue(self, error_message, error_title, gl_project, issue_cache_key):
+        raise NotImplementedError("Method _create_issue is required")
+
+    @abstractmethod
+    def _append_issue(self, error_message, error_title, gitlab_urlencodedpath, issue_cache_key):
+        raise NotImplementedError("Method _append_issue is required")
+
+    @abstractmethod
+    def _fill_issue_cache(self, git_project, issue_cache_key):
+        raise NotImplementedError("Method _fill_issue_cache is required")

--- a/lib/galaxy/tools/error_reports/plugins/github.py
+++ b/lib/galaxy/tools/error_reports/plugins/github.py
@@ -32,6 +32,7 @@ class GithubPlugin(BaseGitPlugin):
         self.github_api_url = kwargs.get('github_api_url', 'https://api.github.com')
         self.git_default_repo_owner = kwargs.get('github_default_repo_owner', False)
         self.git_default_repo_name = kwargs.get('github_default_repo_name', False)
+        self.git_default_repo_only = string_as_bool(kwargs.get('github_default_repo_only', True))
 
         try:
             import github
@@ -70,8 +71,8 @@ class GithubPlugin(BaseGitPlugin):
             ts_repourl = self._get_gitrepo_from_ts(job, ts_url)
 
             # Determine the GitLab project URL and the issue cache key
-            github_projecturl = urlparse.urlparse(ts_repourl).path[1:] if ts_repourl else \
-                "/".join([self.git_default_repo_owner, self.git_default_repo_name])
+            github_projecturl = urlparse.urlparse(ts_repourl).path[1:] if (ts_repourl and not self.git_default_repo_only) \
+                else "/".join([self.git_default_repo_owner, self.git_default_repo_name])
             issue_cache_key = self._get_issue_cache_key(job, ts_repourl)
 
             # Connect to the repo

--- a/lib/galaxy/tools/error_reports/plugins/github.py
+++ b/lib/galaxy/tools/error_reports/plugins/github.py
@@ -96,10 +96,9 @@ class GithubPlugin(BaseGitPlugin):
             log.info(error_title in self.issue_cache[issue_cache_key])
             if error_title not in self.issue_cache[issue_cache_key]:
                 # Create a new issue.
-                self._create_issue(error_message=error_message, error_title=error_title, gh_project=gh_project,
-                                   issue_cache_key=issue_cache_key, label=label)
+                self._create_issue(issue_cache_key, error_title, error_message, gh_project, label=label)
             else:
-                self._append_issue(issue_cache_key=issue_cache_key, error_title=error_title, error_message=error_message)
+                self._append_issue(issue_cache_key, error_title, error_message)
             return ('Submitted error report to Github. Your issue number is <a href="%s/%s/issues/%s" '
                     'target="_blank">#%s</a>.' % (self.github_base_url, github_projecturl,
                                                   self.issue_cache[issue_cache_key][error_title].number,

--- a/lib/galaxy/tools/error_reports/plugins/github.py
+++ b/lib/galaxy/tools/error_reports/plugins/github.py
@@ -104,19 +104,18 @@ class GithubPlugin(BaseGitPlugin):
                                                   self.issue_cache[issue_cache_key][error_title].number,
                                                   self.issue_cache[issue_cache_key][error_title].number), 'success')
 
-    def _create_issue(self, **kwargs):
+    def _create_issue(self, issue_cache_key, error_title, error_mesage, project, **kwargs):
         # Create a new issue.
-        self.issue_cache[kwargs.get('issue_cache_key')][kwargs.get('error_title')] = kwargs.get('gh_project').create_issue(
-            title=kwargs.get('error_title'),
-            body=kwargs.get('error_message'),
+        self.issue_cache[issue_cache_key][error_title] = project.create_issue(
+            title=error_title,
+            body=error_mesage,
             # Label it with a tag: tool_id/tool_version
             labels=[kwargs.get('label')]
         )
 
-    def _append_issue(self, **kwargs):
+    def _append_issue(self, issue_cache_key, error_title, error_message, **kwargs):
         # Create comment on an issue
-        self.issue_cache[kwargs.get('issue_cache_key')][kwargs.get('error_title')]\
-            .create_comment(kwargs.get('error_message'))
+        self.issue_cache[issue_cache_key][error_title].create_comment(error_message)
 
     def _fill_issue_cache(self, git_project, issue_cache_key):
         # We want to ensure that we don't generate a thousand issues when

--- a/lib/galaxy/tools/error_reports/plugins/github.py
+++ b/lib/galaxy/tools/error_reports/plugins/github.py
@@ -100,9 +100,9 @@ class GithubPlugin(BaseGitPlugin):
             else:
                 self._append_issue(issue_cache_key=issue_cache_key, error_title=error_title, error_message=error_message)
             return ('Submitted error report to Github. Your issue number is <a href="%s/%s/issues/%s" '
-                        'target="_blank">#%s</a>.' % (self.github_base_url, github_projecturl,
-                                                      self.issue_cache[issue_cache_key][error_title].number,
-                                                      self.issue_cache[issue_cache_key][error_title].number), 'success')
+                    'target="_blank">#%s</a>.' % (self.github_base_url, github_projecturl,
+                                                  self.issue_cache[issue_cache_key][error_title].number,
+                                                  self.issue_cache[issue_cache_key][error_title].number), 'success')
 
     def _create_issue(self, **kwargs):
         # Create a new issue.

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -34,6 +34,7 @@ class GitLabPlugin(BaseGitPlugin):
         self.gitlab_base_url = kwargs.get('gitlab_base_url', 'https://gitlab.com')
         self.git_default_repo_owner = kwargs.get('gitlab_default_repo_owner', False)
         self.git_default_repo_name = kwargs.get('gitlab_default_repo_name', False)
+        self.git_default_repo_only = string_as_bool(kwargs.get('gitlab_default_repo_only', True))
 
         try:
             import gitlab
@@ -90,8 +91,8 @@ class GitLabPlugin(BaseGitPlugin):
                 log.info("GitLab error reporting - Determine ToolShed Repository URL: %s", ts_repourl)
 
                 # Determine the GitLab project URL and the issue cache key
-                gitlab_projecturl = urlparse.urlparse(ts_repourl).path[1:] if ts_repourl else \
-                    "/".join([self.git_default_repo_owner, self.git_default_repo_name])
+                gitlab_projecturl = urlparse.urlparse(ts_repourl).path[1:] if (ts_repourl and not self.git_default_repo_only)\
+                    else "/".join([self.git_default_repo_owner, self.git_default_repo_name])
                 issue_cache_key = self._get_issue_cache_key(job, ts_repourl)
 
                 gitlab_urlencodedpath = urllib.quote_plus(gitlab_projecturl)

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -12,6 +12,7 @@ if sys.version_info[0] < 3:
 else:
     import urllib.parse as urllib
     urlparse = urllib
+
 from galaxy.tools.errors import EmailErrorReporter
 from galaxy.util import string_as_bool, unicodify
 from . import ErrorPlugin

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -116,10 +116,10 @@ class GitLabPlugin(BaseGitPlugin):
                 log.info(error_title in self.issue_cache[issue_cache_key])
                 if error_title not in self.issue_cache[issue_cache_key]:
                     # Create a new issue.
-                    self._create_issue(error_message=error_message, error_title=error_title, gl_project=gl_project, issue_cache_key=issue_cache_key)
+                    self._create_issue(issue_cache_key, error_title, error_message, gl_project)
                 else:
                     # Add a comment to an issue...
-                    self._append_issue(error_message=error_message, error_title=error_title, gitlab_urlencodedpath=gitlab_urlencodedpath, issue_cache_key=issue_cache_key)
+                    self._append_issue(issue_cache_key, error_title, error_message, gitlab_urlencodedpath=gitlab_urlencodedpath)
 
                 return ('Submitted error report to GitLab. Your issue number is <a href="%s/%s/issues/%s" '
                         'target="_blank">#%s</a>.' % (self.gitlab_base_url, gitlab_projecturl,

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -138,7 +138,7 @@ class GitLabPlugin(ErrorPlugin):
                     "notes"
                 ])
                 self.gitlab.http_post(gl_url, post_data={'body': error_message})
-            return ('Submitted error report to GitLab. Your issue number is %s. You can view the issue on <a href="%s/%s/issues/%s">GitLab</a>.' % (issue_cache[error_title], self.gitlab_base_url, gitlab_projecturl, issue_cache[error_title]), 'success')
+            return ('Submitted error report to GitLab. Your issue number is %s. You can view the issue on <a href="%s/%s/issues/%s" target="_blank">GitLab</a>.' % (issue_cache[error_title], self.gitlab_base_url, gitlab_projecturl, issue_cache[error_title]), 'success')
 
 
 __all__ = ('GitLabPlugin', )

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -138,7 +138,7 @@ class GitLabPlugin(ErrorPlugin):
                     "notes"
                 ])
                 self.gitlab.http_post(gl_url, post_data={'body': error_message})
-            return ('Submitted error report to GitLab. Your issue number is %s. You can view the issue on <a href="%s/%s/issues/%s" target="_blank">GitLab</a>.' % (issue_cache[error_title], self.gitlab_base_url, gitlab_projecturl, issue_cache[error_title]), 'success')
+            return ('Submitted error report to GitLab. Your issue number is <a href="%s/%s/issues/%s" target="_blank">#%s</a>.' % (self.gitlab_base_url, gitlab_projecturl, issue_cache[error_title], issue_cache[error_title]), 'success')
 
 
 __all__ = ('GitLabPlugin', )

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import logging
 import os
 import sys
+
 import requests
 if sys.version_info[0] < 3:
     import urllib as urllib
@@ -11,7 +12,6 @@ if sys.version_info[0] < 3:
 else:
     import urllib.parse as urllib
     urlparse = urllib
-
 from galaxy.tools.errors import EmailErrorReporter
 from galaxy.util import string_as_bool, unicodify
 from . import ErrorPlugin

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -1,0 +1,144 @@
+"""The module describes the ``gitlab`` error plugin plugin."""
+from __future__ import absolute_import
+
+import logging
+
+from galaxy.tools.errors import EmailErrorReporter
+from galaxy.util import string_as_bool, unicodify
+from . import ErrorPlugin
+
+log = logging.getLogger(__name__)
+
+
+class GitLabPlugin(ErrorPlugin):
+    """Send error report to GitLab.
+    """
+    plugin_type = "gitlab"
+
+    def __init__(self, **kwargs):
+        self.app = kwargs['app']
+        self.redact_user_details_in_bugreport = self.app.config.redact_user_details_in_bugreport
+        self.verbose = string_as_bool(kwargs.get('verbose', False))
+        self.user_submission = string_as_bool(kwargs.get('user_submission', False))
+
+        # GitLab settings
+        self.gitlab_base_url = kwargs.get('gitlab_base_url', 'https://gitlab.com')
+        self.gitlab_default_repo_owner = kwargs.get('gitlab_default_repo_owner', False)
+        self.gitlab_default_repo_name = kwargs.get('gitlab_default_repo_name', False)
+
+        try:
+            import gitlab
+            import requests
+            import os
+
+            session = requests.Session()
+            session.proxies = {
+                'https': os.environ.get('https_proxy'),
+                'http': os.environ.get('http_proxy'),
+            }
+            self.gitlab = gitlab.Gitlab(
+                # Allow running against GL enterprise deployments
+                kwargs.get('gitlab_base_url', 'https://gitlab.com'),
+                private_token=kwargs['gitlab_private_token'],
+                session=session
+            )
+            self.gitlab.auth()
+
+        except ImportError:
+            log.error("Please install python-gitlab to submit bug reports to gitlab")
+            self.gitlab = None
+
+    def submit_report(self, dataset, job, tool, **kwargs):
+        """Submit the error report to GitLab
+        """
+        log.info(self.gitlab)
+
+        if self.gitlab:
+            # Import the necessary libraries
+            import sys
+            import requests
+            if sys.version_info[0] < 3:
+                import urllib as urllib
+                import urlparse as urlparse
+            else:
+                import urllib.parse as urllib
+                urlparse = urllib
+
+            log.info(job.tool_id)
+            log.info(job.tool_version)
+            log.info(tool.tool_shed)
+
+            # Determine the ToolShed
+            ts_url_request = requests.get('http://'+str(tool.tool_shed))
+            ts_url = ts_url_request.url
+            log.info("Determined ToolShed is "+ts_url)
+
+            # Find the repo inside the ToolShed
+            ts_repo_request = requests.get(ts_url + "/api/repositories?tool_ids=" + str(job.tool_id))
+            ts_repo_request_data = ts_repo_request.json()
+            ts_repourl = None
+
+            for changeset, repoinfo in ts_repo_request_data.items():
+                if isinstance(repoinfo, dict):
+                    if 'repository' in repoinfo.keys():
+                        if 'remote_repository_url' in repoinfo['repository'].keys():
+                            ts_repourl = repoinfo['repository']['remote_repository_url']
+
+            log.info("Determine ToolShed Repository URL: "+ts_repourl)
+
+            if ts_repourl:
+                gitlab_projecturl = urlparse.urlparse(ts_repourl).path[1:]
+            else:
+                gitlab_projecturl = "/".join([self.gitlab_default_repo_owner,
+                                              self.gitlab_default_repo_name])
+
+            gitlab_urlencodedpath = urllib.quote_plus(gitlab_projecturl)
+
+            # Make sure we are always logged in, then retrieve the GitLab project
+            self.gitlab.auth()
+            gl_project = self.gitlab.projects.get(gitlab_urlencodedpath)
+
+            # Get a list of all the issues, parse them for de-duplication later
+            log.info(gl_project.issues.list())
+
+            issue_cache = {}
+            for issue in gl_project.issues.list():
+                if issue.state != 'closed':
+                    issue_cache[issue.title] = issue.iid
+
+            # Generate information for the tool
+            tool_kw = {'tool_id': unicodify(job.tool_id), 'tool_version': unicodify(job.tool_version)}
+            error_title = u"""Galaxy Job Error: {tool_id} v{tool_version}""".format(**tool_kw)
+
+            # We'll re-use the email error reporter's template since GitLab supports HTML
+            error_reporter = EmailErrorReporter(dataset.id, self.app)
+            error_reporter.create_report(job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None), redact_user_details_in_bugreport=self.redact_user_details_in_bugreport)
+
+            # The HTML report
+            error_message = error_reporter.html_report
+
+            log.info(error_title in issue_cache)
+            if error_title not in issue_cache:
+                # Create a new issue.
+                issue = gl_project.issues.create({
+                    'title': error_title,
+                    'description': error_message
+                })
+                issue_cache[error_title] = issue.iid
+            else:
+                # Add a comment to an issue...
+                gl_url = "/".join([
+                    self.gitlab_base_url,
+                    "api",
+                    "v4",
+                    "projects",
+                    gitlab_urlencodedpath,
+                    "issues",
+                    str(issue_cache[error_title]),
+                    "notes"
+                ])
+                self.gitlab.http_post(gl_url, post_data={'body': error_message})
+            return ('Submitted error report to GitLab. Your issue number is %s. You can view the issue on <a href="%s/%s/issues/%s">GitLab</a>.' % (issue_cache[error_title], self.gitlab_base_url, gitlab_projecturl, issue_cache[error_title]), 'success')
+
+
+__all__ = ('GitLabPlugin', )

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -160,15 +160,15 @@ class GitLabPlugin(BaseGitPlugin):
             log.error("GitLab error reporting - No connection to GitLab. Cannot report error to GitLab.")
             return ('Internal Error.', 'danger')
 
-    def _create_issue(self, **kwargs):
+    def _create_issue(self, issue_cache_key, error_title, error_mesage, project, **kwargs):
         # Create the issue on GitLab
-        issue = kwargs.get('gl_project').issues.create({
-            'title': kwargs.get('error_title'),
-            'description': kwargs.get('error_message')
+        issue = project.issues.create({
+            'title': error_title,
+            'description': error_mesage
         })
-        self.issue_cache[kwargs.get('issue_cache_key')][kwargs.get('error_title')] = issue.iid
+        self.issue_cache[issue_cache_key][error_title] = issue.iid
 
-    def _append_issue(self, **kwargs):
+    def _append_issue(self, issue_cache_key, error_title, error_message, **kwargs):
         # Add a comment to an existing issue
         gl_url = "/".join([
             self.gitlab_base_url,
@@ -177,10 +177,10 @@ class GitLabPlugin(BaseGitPlugin):
             "projects",
             kwargs.get('gitlab_urlencodedpath'),
             "issues",
-            str(self.issue_cache[kwargs.get('issue_cache_key')][kwargs.get('error_title')]),
+            str(self.issue_cache[issue_cache_key][error_title]),
             "notes"
         ])
-        self.gitlab.http_post(gl_url, post_data={'body': kwargs.get('error_message')})
+        self.gitlab.http_post(gl_url, post_data={'body': error_message})
 
     def _fill_issue_cache(self, git_project, issue_cache_key):
         self.issue_cache[issue_cache_key] = {}

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -114,10 +114,10 @@ class GitLabPlugin(BaseGitPlugin):
                 log.info(error_title in self.issue_cache[issue_cache_key])
                 if error_title not in self.issue_cache[issue_cache_key]:
                     # Create a new issue.
-                    self._create_issue(error_message, error_title, gl_project, issue_cache_key)
+                    self._create_issue(error_message=error_message, error_title=error_title, gl_project=gl_project, issue_cache_key=issue_cache_key)
                 else:
                     # Add a comment to an issue...
-                    self._append_issue(error_message, error_title, gitlab_urlencodedpath, issue_cache_key)
+                    self._append_issue(error_message=error_message, error_title=error_title, gitlab_urlencodedpath=gitlab_urlencodedpath, issue_cache_key=issue_cache_key)
 
                 return ('Submitted error report to GitLab. Your issue number is <a href="%s/%s/issues/%s" '
                         'target="_blank">#%s</a>.' % (self.gitlab_base_url, gitlab_projecturl,
@@ -159,27 +159,27 @@ class GitLabPlugin(BaseGitPlugin):
             log.error("GitLab error reporting - No connection to GitLab. Cannot report error to GitLab.")
             return ('Internal Error.', 'danger')
 
-    def _create_issue(self, error_message, error_title, gl_project, issue_cache_key):
+    def _create_issue(self, **kwargs):
         # Create the issue on GitLab
-        issue = gl_project.issues.create({
-            'title': error_title,
-            'description': error_message
+        issue = kwargs.get('gl_project').issues.create({
+            'title': kwargs.get('error_title'),
+            'description': kwargs.get('error_message')
         })
-        self.issue_cache[issue_cache_key][error_title] = issue.iid
+        self.issue_cache[kwargs.get('issue_cache_key')][kwargs.get('error_title')] = issue.iid
 
-    def _append_issue(self, error_message, error_title, gitlab_urlencodedpath, issue_cache_key):
+    def _append_issue(self, **kwargs):
         # Add a comment to an existing issue
         gl_url = "/".join([
             self.gitlab_base_url,
             "api",
             "v4",
             "projects",
-            gitlab_urlencodedpath,
+            kwargs.get('gitlab_urlencodedpath'),
             "issues",
-            str(self.issue_cache[issue_cache_key][error_title]),
+            str(self.issue_cache[kwargs.get('issue_cache_key')][kwargs.get('error_title')]),
             "notes"
         ])
-        self.gitlab.http_post(gl_url, post_data={'body': error_message})
+        self.gitlab.http_post(gl_url, post_data={'body': kwargs.get('error_message')})
 
     def _fill_issue_cache(self, git_project, issue_cache_key):
         self.issue_cache[issue_cache_key] = {}

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -66,91 +66,105 @@ class GitLabPlugin(ErrorPlugin):
         log.info(self.gitlab)
 
         if self.gitlab:
-            # Import the necessary libraries
-            import sys
-            import requests
-            if sys.version_info[0] < 3:
-                import urllib as urllib
-                import urlparse as urlparse
-            else:
-                import urllib.parse as urllib
-                urlparse = urllib
+            try:
+                # Import the necessary libraries
+                import sys
+                import requests
+                if sys.version_info[0] < 3:
+                    import urllib as urllib
+                    import urlparse as urlparse
+                else:
+                    import urllib.parse as urllib
+                    urlparse = urllib
 
-            log.info(job.tool_id)
-            log.info(job.tool_version)
-            log.info(tool.tool_shed)
+                log.info(job.tool_id)
+                log.info(job.tool_version)
+                log.info(tool.tool_shed)
 
-            # Determine the ToolShed
-            ts_url_request = requests.get('http://' + str(tool.tool_shed))
-            ts_url = ts_url_request.url
-            log.info("Determined ToolShed is " + ts_url)
+                # Determine the ToolShed url, initially we connect with HTTP and if redirect to HTTPS is set up,
+                # this will be detected by requests and used further down the line.
+                ts_url_request = requests.get('http://' + str(tool.tool_shed))
+                ts_url = ts_url_request.url
+                log.info("Determined ToolShed is " + ts_url)
 
-            # Find the repo inside the ToolShed
-            ts_repo_request = requests.get(ts_url + "/api/repositories?tool_ids=" + str(job.tool_id))
-            ts_repo_request_data = ts_repo_request.json()
-            ts_repourl = None
+                # Find the repo inside the ToolShed
+                ts_repo_request = requests.get(ts_url + "/api/repositories?tool_ids=" + str(job.tool_id))
+                ts_repo_request_data = ts_repo_request.json()
+                ts_repourl = None
 
-            for changeset, repoinfo in ts_repo_request_data.items():
-                if isinstance(repoinfo, dict):
-                    if 'repository' in repoinfo.keys():
-                        if 'remote_repository_url' in repoinfo['repository'].keys():
-                            ts_repourl = repoinfo['repository']['remote_repository_url']
+                for changeset, repoinfo in ts_repo_request_data.items():
+                    if isinstance(repoinfo, dict):
+                        if 'repository' in repoinfo.keys():
+                            if 'remote_repository_url' in repoinfo['repository'].keys():
+                                ts_repourl = repoinfo['repository']['remote_repository_url']
 
-            log.info("Determine ToolShed Repository URL: " + ts_repourl)
+                log.info("Determine ToolShed Repository URL: " + ts_repourl)
 
-            if ts_repourl:
-                gitlab_projecturl = urlparse.urlparse(ts_repourl).path[1:]
-            else:
-                gitlab_projecturl = "/".join([self.gitlab_default_repo_owner,
-                                              self.gitlab_default_repo_name])
+                if ts_repourl:
+                    gitlab_projecturl = urlparse.urlparse(ts_repourl).path[1:]
+                else:
+                    gitlab_projecturl = "/".join([self.gitlab_default_repo_owner,
+                                                  self.gitlab_default_repo_name])
 
-            gitlab_urlencodedpath = urllib.quote_plus(gitlab_projecturl)
+                gitlab_urlencodedpath = urllib.quote_plus(gitlab_projecturl)
 
-            # Make sure we are always logged in, then retrieve the GitLab project
-            self.gitlab.auth()
-            gl_project = self.gitlab.projects.get(gitlab_urlencodedpath)
+                # Make sure we are always logged in, then retrieve the GitLab project
+                self.gitlab.auth()
+                gl_project = self.gitlab.projects.get(gitlab_urlencodedpath)
 
-            # Get a list of all the issues, parse them for de-duplication later
-            log.info(gl_project.issues.list())
+                # Get a list of all the issues, parse them for de-duplication later
+                log.info(gl_project.issues.list())
 
-            issue_cache = {}
-            for issue in gl_project.issues.list():
-                if issue.state != 'closed':
-                    issue_cache[issue.title] = issue.iid
+                issue_cache = {}
+                for issue in gl_project.issues.list():
+                    if issue.state != 'closed':
+                        issue_cache[issue.title] = issue.iid
 
-            # Generate information for the tool
-            tool_kw = {'tool_id': unicodify(job.tool_id), 'tool_version': unicodify(job.tool_version)}
-            error_title = u"""Galaxy Job Error: {tool_id} v{tool_version}""".format(**tool_kw)
+                # Generate information for the tool
+                tool_kw = {'tool_id': unicodify(job.tool_id), 'tool_version': unicodify(job.tool_version)}
+                error_title = u"""Galaxy Job Error: {tool_id} v{tool_version}""".format(**tool_kw)
 
-            # We'll re-use the email error reporter's template since GitLab supports HTML
-            error_reporter = EmailErrorReporter(dataset.id, self.app)
-            error_reporter.create_report(job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None), redact_user_details_in_bugreport=self.redact_user_details_in_bugreport)
+                # We'll re-use the email error reporter's template since GitLab supports HTML
+                error_reporter = EmailErrorReporter(dataset.id, self.app)
+                error_reporter.create_report(job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None), redact_user_details_in_bugreport=self.redact_user_details_in_bugreport)
 
-            # The HTML report
-            error_message = error_reporter.html_report
+                # The HTML report
+                error_message = error_reporter.html_report
 
-            log.info(error_title in issue_cache)
-            if error_title not in issue_cache:
-                # Create a new issue.
-                issue = gl_project.issues.create({
-                    'title': error_title,
-                    'description': error_message
-                })
-                issue_cache[error_title] = issue.iid
-            else:
-                # Add a comment to an issue...
-                gl_url = "/".join([
-                    self.gitlab_base_url,
-                    "api",
-                    "v4",
-                    "projects",
-                    gitlab_urlencodedpath,
-                    "issues",
-                    str(issue_cache[error_title]),
-                    "notes"
-                ])
-                self.gitlab.http_post(gl_url, post_data={'body': error_message})
-            return ('Submitted error report to GitLab. Your issue number is %s. You can view the issue on <a href="%s/%s/issues/%s" target="_blank">GitLab</a>.' % (issue_cache[error_title], self.gitlab_base_url, gitlab_projecturl, issue_cache[error_title]), 'success')
+                log.info(error_title in issue_cache)
+                if error_title not in issue_cache:
+                    # Create a new issue.
+                    issue = gl_project.issues.create({
+                        'title': error_title,
+                        'description': error_message
+                    })
+                    issue_cache[error_title] = issue.iid
+                else:
+                    # Add a comment to an issue...
+                    gl_url = "/".join([
+                        self.gitlab_base_url,
+                        "api",
+                        "v4",
+                        "projects",
+                        gitlab_urlencodedpath,
+                        "issues",
+                        str(issue_cache[error_title]),
+                        "notes"
+                    ])
+                    self.gitlab.http_post(gl_url, post_data={'body': error_message})
+                return ('Submitted error report to GitLab. Your issue number is %s. You can view the issue on <a href="%s/%s/issues/%s" target="_blank">GitLab</a>.' % (issue_cache[error_title], self.gitlab_base_url, gitlab_projecturl, issue_cache[error_title]), 'success')
+            except ImportError:
+                log.error("Please ensure that requests, urllib and urlparse are available.")
+                return ('Error occured while submitting error report to GitLab. Report could not be submitted due to python import issues.', 'danger')
+            except Exception as e:
+                log.error("Error reporting to GitLab had an exception that could not be determined. Exception information: " + e)
+                return ('Error occured while submitting error report to GitLab. Could not determine the cause.', 'danger')
+
+
+class GitLabPluginException(Exception):
+    pass
+
+
 
 
 __all__ = ('GitLabPlugin', )

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -47,6 +47,18 @@ class GitLabPlugin(ErrorPlugin):
         except ImportError:
             log.error("Please install python-gitlab to submit bug reports to gitlab")
             self.gitlab = None
+        except gitlab.GitlabAuthenticationError:
+            log.error("Could not authenticate with GitLab.")
+            self.gitlab = None
+        except gitlab.GitlabParsingError:
+            log.error("Could not parse GitLab message.")
+            self.gitlab = None
+        except (gitlab.GitlabConnectionError, gitlab.GitlabHttpError):
+            log.error("Could not connect to GitLab.")
+            self.gitlab = None
+        except gitlab.GitlabError:
+            log.error("General error communicating with GitLab.")
+            self.gitlab = None
 
     def submit_report(self, dataset, job, tool, **kwargs):
         """Submit the error report to GitLab

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -69,9 +69,9 @@ class GitLabPlugin(ErrorPlugin):
             log.info(tool.tool_shed)
 
             # Determine the ToolShed
-            ts_url_request = requests.get('http://'+str(tool.tool_shed))
+            ts_url_request = requests.get('http://' + str(tool.tool_shed))
             ts_url = ts_url_request.url
-            log.info("Determined ToolShed is "+ts_url)
+            log.info("Determined ToolShed is " + ts_url)
 
             # Find the repo inside the ToolShed
             ts_repo_request = requests.get(ts_url + "/api/repositories?tool_ids=" + str(job.tool_id))
@@ -84,7 +84,7 @@ class GitLabPlugin(ErrorPlugin):
                         if 'remote_repository_url' in repoinfo['repository'].keys():
                             ts_repourl = repoinfo['repository']['remote_repository_url']
 
-            log.info("Determine ToolShed Repository URL: "+ts_repourl)
+            log.info("Determine ToolShed Repository URL: " + ts_repourl)
 
             if ts_repourl:
                 gitlab_projecturl = urlparse.urlparse(ts_repourl).path[1:]


### PR DESCRIPTION
The GitLab error reporter looks up the Git repository by using the ToolShed (if applicable, it otherwise defaults to another project) and uses this information to submit an issue to the selected project (default or tool specific). It's based off of the GitHubPlugin.