### PR TITLE
working elixir-aai support , psa version set to 3.1.0

### DIFF
--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -27,6 +27,10 @@
                 <b-button v-if="enable_oidc" class="mt-3" @click="submitOIDCLogin()">
                     <icon class="fa fa-google" /> Sign in with Google
                 </b-button>
+		        <b-button v-if="enable_oidc" class="mt-3" @click="submitElixirLogin()">
+                    <icon class="fa fa-sign-in" /> Sign in with Elixir-AAI
+                </b-button>
+
             </div>
             <div v-if="show_welcome_with_login" class="col">
                 <b-embed type="iframe" :src="welcome_url" aspect="1by1" />
@@ -105,6 +109,22 @@ export default {
             let rootUrl = getAppRoot();
             axios
                 .post(`${rootUrl}authnz/google/login`)
+                .then(response => {
+                    if (response.data.redirect_uri) {
+                        window.location = encodeURI(response.data.redirect_uri);
+                    }
+                    // Else do something intelligent or maybe throw an error -- what else does this endpoint possibly return?
+                })
+                .catch(error => {
+                    this.messageVariant = "danger";
+                    let message = error.response.data && error.response.data.err_msg;
+                    this.messageText = message || "Login failed for an unknown reason.";
+                });
+        },
+	    submitElixirLogin: function(method) {
+            let rootUrl = getAppRoot();
+            axios
+                .post(`${rootUrl}authnz/elixir/login`)
                 .then(response => {
                     if (response.data.redirect_uri) {
                         window.location = encodeURI(response.data.redirect_uri);

--- a/config/oidc_backends_config.xml.sample
+++ b/config/oidc_backends_config.xml.sample
@@ -22,4 +22,14 @@
          login to Galaxy using their Google account.
         -->
     </provider>
+    <provider name="Elixir">
+            <!--
+             Details on Elixir-AAI: https://www.elixir-europe.org/services/compute/aai-documentation
+            -->
+            <client_id>...</client_id>
+            <client_secret>...</client_secret>
+            <redirect_uri>http://localhost:8080/authnz/elixir/callback</redirect_uri>
+            <prompt>consent</prompt>
+
+    </provider>
 </OIDC>

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -88,8 +88,8 @@ class AuthnzManager(object):
                     log.error("Could not find a node attribute 'name'; skipping the node '{}'.".format(child.tag))
                     continue
                 idp = child.get('name').lower()
-                if idp == 'google':
-                    self.oidc_backends_config[idp] = self._parse_google_config(child)
+                if idp in BACKENDS_NAME:
+                    self.oidc_backends_config[idp] = self._parse_idp_config(child)
             if len(self.oidc_backends_config) == 0:
                 raise ParseError("No valid provider configuration parsed.")
         except ImportError:
@@ -97,7 +97,7 @@ class AuthnzManager(object):
         except ParseError as e:
             raise ParseError("Invalid configuration at `{}`: {} -- unable to continue.".format(config_file, e))
 
-    def _parse_google_config(self, config_xml):
+    def _parse_idp_config(self, config_xml):
         rtv = {
             'client_id': config_xml.find('client_id').text,
             'client_secret': config_xml.find('client_secret').text,
@@ -212,6 +212,7 @@ class AuthnzManager(object):
             success, message, backend = self._get_authnz_backend(provider)
             if success is False:
                 return False, message, (None, None)
+
             return True, message, backend.callback(state_token, authz_code, trans, login_redirect_url)
         except Exception:
             msg = 'An error occurred when handling callback from `{}` identity provider'.format(provider)

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -139,7 +139,7 @@ routes==2.4.1
 s3transfer==0.1.13
 simplejson==3.16.0
 six==1.11.0
-social-auth-core[openidconnect]==1.5.0
+social-auth-core[openidconnect]==3.1.0
 sqlalchemy-migrate==0.12.0
 sqlalchemy-utils==0.33.11
 sqlalchemy==1.2.18


### PR DESCRIPTION
The following changes have been made.

1. psa social auth library version bumped to 3.1.0 
2. "Sign in with Elixir-AAI" button added to login front end component
3. "Elixir" provider added to oidc_backends_config.xml.sample
4.  oidc providers parsing generalized in "managers"
5. "Elixir" oidc provider specific configs set in psa_authnz

This pull request is the basic minimal changes needed to get Elixir-AAI integration working. The following things can be done to enhance the solution:

1. Login buttons could be generated based on oidc provided configs instead of being hard-coded as it is now. Button icons could also be provided style classes reflecting logo if idp.
2. Provider specific configuration options could be pushed towards oidc provider config files and parsed in a more more generic manner than the hardwired elixir settings applied here
