### PR TITLE
[18.05] Restrict loading of JSON files on the server via the workflow API to Galaxy admins

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -278,6 +278,8 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             raise exceptions.RequestParameterInvalidException(message)
 
         if 'installed_repository_file' in payload:
+            if not trans.user_is_admin:
+                raise exceptions.AdminRequiredException()
             installed_repository_file = payload.get('installed_repository_file', '')
             if not os.path.exists(installed_repository_file):
                 raise exceptions.MessageException("Repository file '%s' not found.")


### PR DESCRIPTION
Fix https://github.com/galaxyproject/security/issues/29