### PR TITLE
Slightly improved import/export testing.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -924,6 +924,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
     def to_dict(self, view='collection', system_details=False):
         rval = super(Job, self).to_dict(view=view)
         rval['tool_id'] = self.tool_id
+        rval['history_id'] = self.history_id
         if system_details:
             # System level details that only admins should have.
             rval['external_id'] = self.job_runner_external_id

--- a/test/api/test_histories.py
+++ b/test/api/test_histories.py
@@ -180,11 +180,51 @@ class HistoriesApiTestCase(api.ApiTestCase):
         self._assert_status_code_is(create_response, 403)
 
     def test_import_export(self):
-        history_name = "for_export"
+        history_name = "for_export_default"
         history_id = self.dataset_populator.new_history(name=history_name)
         self.dataset_populator.new_dataset(history_id, content="1 2 3")
-        imported_history_id = self._reimport_history(history_id, history_name)
-        self._assert_history_length(imported_history_id, 1)
+        # deleted_hda = self.dataset_populator.new_dataset(history_id, content="1 2 3")
+        # self.dataset_populator.delete_dataset(history_id, deleted_hda["id"])
+        imported_history_id = self._reimport_history(history_id, history_name, wait_on_history_length=1)
+
+        def upload_job_check(job):
+            assert job["tool_id"] == "upload1"
+
+        # def check_discarded(hda):
+        #    assert hda["state"] == "discarded", hda
+        #    assert hda["purged"] is True
+
+        self._check_imported_dataset(history_id=imported_history_id, hid=1, job_checker=upload_job_check)
+        # self._check_imported_dataset(history_id=imported_history_id, hid=2, has_job=False, hda_checker=check_discarded, job_checker=upload_job_check)
+
+        imported_content = self.dataset_populator.get_history_dataset_content(
+            history_id=imported_history_id,
+            hid=1,
+        )
+        assert imported_content == "1 2 3\n"
+
+    def test_import_export_include_deleted(self):
+        from nose.plugins.skip import SkipTest
+        raise SkipTest("Import/export of deleted dataset logic is currently broken fixed in #7367")
+        history_name = "for_export_include_deleted"
+        history_id = self.dataset_populator.new_history(name=history_name)
+        self.dataset_populator.new_dataset(history_id, content="1 2 3")
+        deleted_hda = self.dataset_populator.new_dataset(history_id, content="1 2 3")
+        self.dataset_populator.delete_dataset(history_id, deleted_hda["id"])
+
+        imported_history_id = self._reimport_history(history_id, history_name, wait_on_history_length=2, export_kwds={"include_deleted": "True"})
+        self._assert_history_length(imported_history_id, 2)
+
+        def upload_job_check(job):
+            assert job["tool_id"] == "upload1"
+
+        def check_ok(hda):
+            assert hda["state"] == "ok", hda
+            assert hda["deleted"] is True, hda
+
+        self._check_imported_dataset(history_id=imported_history_id, hid=1, job_checker=upload_job_check)
+        self._check_imported_dataset(history_id=imported_history_id, hid=2, hda_checker=check_ok, job_checker=upload_job_check)
+
         imported_content = self.dataset_populator.get_history_dataset_content(
             history_id=imported_history_id,
             hid=1,
@@ -197,6 +237,7 @@ class HistoriesApiTestCase(api.ApiTestCase):
         self.dataset_populator.new_dataset(history_id, content=open(self.test_data_resolver.get_filename("1.bam"), 'rb'), file_type='bam', wait=True)
         imported_history_id = self._reimport_history(history_id, history_name)
         self._assert_history_length(imported_history_id, 1)
+        self._check_imported_dataset(history_id=imported_history_id, hid=1)
         import_bam_metadata = self.dataset_populator.get_history_dataset_details(
             history_id=imported_history_id,
             hid=1,
@@ -222,18 +263,31 @@ class HistoriesApiTestCase(api.ApiTestCase):
 
         history_name = "for_export_with_collections"
         history_id = self.dataset_populator.new_history(name=history_name)
-        self.dataset_collection_populator.create_list_in_history(history_id, contents=["Hello", "World"])
+        self.dataset_collection_populator.create_list_in_history(history_id, contents=["Hello", "World"], direct_upload=True)
 
-        imported_history_id = self._reimport_history(history_id, history_name)
-
+        imported_history_id = self._reimport_history(history_id, history_name, wait_on_history_length=3)
         self._assert_history_length(imported_history_id, 3)
 
-    def _reimport_history(self, history_id, history_name):
+        def check_elements(elements):
+            assert len(elements) == 2
+            element0 = elements[0]["object"]
+            element1 = elements[1]["object"]
+            for element in [element0, element1]:
+                assert not element["visible"]
+                assert not element["deleted"]
+                assert element["state"] == "ok"
+
+            assert element0["hid"] == 2
+            assert element1["hid"] == 3
+
+        self._check_imported_collection(imported_history_id, hid=1, collection_type="list", elements_checker=check_elements)
+
+    def _reimport_history(self, history_id, history_name, wait_on_history_length=None, export_kwds={}):
         # Ensure the history is ready to go...
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
 
         # Export the history.
-        download_path = self._export(history_id)
+        download_path = self._export(history_id, **export_kwds)
 
         # Create download for history
         full_download_url = "%s%s?key=%s" % (self.url, download_path, self.galaxy_interactor.api_key)
@@ -260,6 +314,16 @@ class HistoriesApiTestCase(api.ApiTestCase):
         imported_history_id = imported_history["id"]
         self.dataset_populator.wait_for_history(imported_history_id)
 
+        if wait_on_history_length:
+
+            def history_has_length():
+                contents_response = self._get("histories/%s/contents" % imported_history_id)
+                self._assert_status_code_is(contents_response, 200)
+                contents = contents_response.json()
+                return None if len(contents) != wait_on_history_length else True
+
+            wait_on(history_has_length, desc="import history population")
+
         return imported_history_id
 
     def _assert_history_length(self, history_id, n):
@@ -267,6 +331,46 @@ class HistoriesApiTestCase(api.ApiTestCase):
         self._assert_status_code_is(contents_response, 200)
         contents = contents_response.json()
         assert len(contents) == n, contents
+
+    def _check_imported_dataset(self, history_id, hid, has_job=True, hda_checker=None, job_checker=None):
+        imported_dataset_metadata = self.dataset_populator.get_history_dataset_details(
+            history_id=history_id,
+            hid=hid,
+        )
+        assert imported_dataset_metadata["history_content_type"] == "dataset"
+        assert imported_dataset_metadata["history_id"] == history_id
+
+        if hda_checker is not None:
+            hda_checker(imported_dataset_metadata)
+
+        assert "creating_job" in imported_dataset_metadata
+        job_id = imported_dataset_metadata["creating_job"]
+        if has_job:
+            assert job_id
+
+            job_details = self.dataset_populator.get_job_details(job_id, full=True)
+            assert job_details.status_code == 200, job_details.content
+            job = job_details.json()
+            assert 'history_id' in job, job
+            assert job['history_id'] == history_id, job
+
+            if job_checker is not None:
+                job_checker(job)
+
+    def _check_imported_collection(self, history_id, hid, collection_type=None, elements_checker=None):
+        imported_collection_metadata = self.dataset_populator.get_history_collection_details(
+            history_id=history_id,
+            hid=hid,
+        )
+        assert imported_collection_metadata["history_content_type"] == "dataset_collection"
+        assert imported_collection_metadata["history_id"] == history_id
+        assert "collection_type" in imported_collection_metadata
+        assert "elements" in imported_collection_metadata
+        if collection_type is not None:
+            assert imported_collection_metadata["collection_type"] == collection_type, imported_collection_metadata
+
+        if elements_checker is not None:
+            elements_checker(imported_collection_metadata["elements"])
 
     def test_create_tag(self):
         post_data = dict(name="TestHistoryForTag")
@@ -276,9 +380,9 @@ class HistoriesApiTestCase(api.ApiTestCase):
         tag_create_response = self._post(tag_url, data=tag_data)
         self._assert_status_code_is(tag_create_response, 200)
 
-    def _export(self, history_id):
+    def _export(self, history_id, **kwd):
         export_url = self._api_url("histories/%s/exports" % history_id, use_key=True)
-        put_response = put(export_url)
+        put_response = put(export_url, data=kwd)
         self._assert_status_code_is(put_response, 202)
 
         def export_ready_response():

--- a/test/base/populators.py
+++ b/test/base/populators.py
@@ -254,6 +254,10 @@ class BaseDatasetPopulator(object):
     def cancel_job(self, job_id):
         return self._delete("jobs/%s" % job_id)
 
+    def delete_dataset(self, history_id, content_id):
+        delete_response = self._delete("histories/%s/contents/%s" % (history_id, content_id))
+        return delete_response
+
     def _summarize_history(self, history_id):
         pass
 


### PR DESCRIPTION
- Wait on history length, so partially imported histories are not a problem.
- More assertions - more attribute testing, check history_id, etc...

Breaking up #7217 (part of #7441) into even smaller pieces to try to understand which of them fails on Jenkins (they all pass locally for me). Bisection by PR ☹️.
