### PR TITLE
Updated documentation in admin/scaling.md

### DIFF
--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -795,7 +795,7 @@ ExecStart=/srv/galaxy/venv/bin/uwsgi --yaml /srv/galaxy/config/galaxy.yml
 WantedBy=multi-user.target
 ```
 
-For multiple handlers the service file needs to be a template unit - the filename follows the syntax 
+For multiple handlers, the service file needs to be a [template unit](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Description>) - the filename follows the syntax 
 `<service_name>@<argument>.service` and all instances of `%I` in the service file are replaced with the `<argument>`
 
 ```ini

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -770,7 +770,66 @@ galaxy:handler2: started
 
 ### Systemd
 
-TODO: write this section.
+Sample **uWSGI + Webless** strategy for systemd. While setting the PATH and VIRTUAL_ENV variables may not be strictly
+neccesary, if you have any problems might be useful to comment them out. More information of systemd.service environment
+settings can be found in the [documentation](http://0pointer.de/public/systemd-man/systemd.exec.html#Environment=)
+
+
+```ini
+[Unit]
+Description=Galaxy web handler
+After=network.target
+After=time-sync.target
+
+[Service]
+PermissionsStartOnly=true
+Type=simple
+User=galaxy
+Group=galaxy
+Restart=on-abort
+WorkingDirectory=/srv/galaxy/server
+TimeoutStartSec=10
+ExecStart=/srv/galaxy/venv/bin/uwsgi --yaml /srv/galaxy/config/galaxy.yml
+#Environment=VIRTUAL_ENV=/srv/galaxy/venv PATH=/srv/galaxy/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+[Install]
+WantedBy=multi-user.target
+```
+
+For multiple handlers the service file needs to be a template unit - the filename follows the syntax 
+`<service_name>@<argument>.service` and all instances of `%I` in the service file are replaced with the `<argument>`
+
+```ini
+[Unit]
+Description=Galaxy handlers
+After=network.target
+After=time-sync.target
+
+[Service]
+PermissionsStartOnly=true
+Type=simple
+User=galaxy
+Group=galaxy
+Restart=on-abort
+WorkingDirectory=/srv/galaxy/server
+TimeoutStartSec=10
+ExecStart=/srv/galaxy/venv/bin/python ./scripts/galaxy-main -c /srv/galaxy/config/galaxy.yml --server-name=handler%I --log-file=/srv/galaxy/log/handler%I.log
+#Environment=VIRTUAL_ENV=/srv/galaxy/venv PATH=/srv/galaxy/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+[Install]
+WantedBy=multi-user.target
+```
+
+We can now enable and start the web services with 
+```console
+# systemctl enable galaxy-web
+Created symlink from /etc/systemd/system/multi-user.target.wants/galaxy-web.service to /etc/systemd/system/galaxy-web.service.
+# systemctl enable galaxy-handler@{0..3}
+Created symlink from /etc/systemd/system/multi-user.target.wants/galaxy-handler@0.service to /etc/systemd/system/galaxy-handler@.service.
+Created symlink from /etc/systemd/system/multi-user.target.wants/galaxy-handler@1.service to /etc/systemd/system/galaxy-handler@.service.
+Created symlink from /etc/systemd/system/multi-user.target.wants/galaxy-handler@2.service to /etc/systemd/system/galaxy-handler@.service.
+Created symlink from /etc/systemd/system/multi-user.target.wants/galaxy-handler@3.service to /etc/systemd/system/galaxy-handler@.service.
+# systemctl start galaxy-handler@{0..3}
+# systemctl start galaxy-web
+```
 
 ### Transparent Restart - Zerg Mode
 

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -770,8 +770,7 @@ galaxy:handler2: started
 
 ### Systemd
 
-Sample **uWSGI + Webless** strategy for systemd. While setting the `PATH` and `VIRTUAL_ENV` variables may not be strictly
-neccesary, if you have any problems, it might be useful to comment them out. More information of systemd.service environment
+Sample **uWSGI + Webless** strategy for systemd. More information on systemd.service environment
 settings can be found in the [documentation](http://0pointer.de/public/systemd-man/systemd.exec.html#Environment=)
 
 
@@ -790,7 +789,7 @@ Restart=on-abort
 WorkingDirectory=/srv/galaxy/server
 TimeoutStartSec=10
 ExecStart=/srv/galaxy/venv/bin/uwsgi --yaml /srv/galaxy/config/galaxy.yml
-#Environment=VIRTUAL_ENV=/srv/galaxy/venv PATH=/srv/galaxy/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+Environment=VIRTUAL_ENV=/srv/galaxy/venv PATH=/srv/galaxy/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 [Install]
 WantedBy=multi-user.target
 ```

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -770,7 +770,7 @@ galaxy:handler2: started
 
 ### Systemd
 
-Sample **uWSGI + Webless** strategy for systemd. While setting the PATH and VIRTUAL_ENV variables may not be strictly
+Sample **uWSGI + Webless** strategy for systemd. While setting the `PATH` and `VIRTUAL_ENV` variables may not be strictly
 neccesary, if you have any problems might be useful to comment them out. More information of systemd.service environment
 settings can be found in the [documentation](http://0pointer.de/public/systemd-man/systemd.exec.html#Environment=)
 

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -800,7 +800,7 @@ For multiple handlers the service file needs to be a template unit - the filenam
 
 ```ini
 [Unit]
-Description=Galaxy handlers
+Description=Galaxy job handlers
 After=network.target
 After=time-sync.target
 
@@ -818,7 +818,7 @@ ExecStart=/srv/galaxy/venv/bin/python ./scripts/galaxy-main -c /srv/galaxy/confi
 WantedBy=multi-user.target
 ```
 
-We can now enable and start the web services with 
+We can now enable and start the web services with systemd 
 ```console
 # systemctl enable galaxy-web
 Created symlink from /etc/systemd/system/multi-user.target.wants/galaxy-web.service to /etc/systemd/system/galaxy-web.service.

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -771,7 +771,7 @@ galaxy:handler2: started
 ### Systemd
 
 Sample **uWSGI + Webless** strategy for systemd. While setting the `PATH` and `VIRTUAL_ENV` variables may not be strictly
-neccesary, if you have any problems might be useful to comment them out. More information of systemd.service environment
+neccesary, if you have any problems, it might be useful to comment them out. More information of systemd.service environment
 settings can be found in the [documentation](http://0pointer.de/public/systemd-man/systemd.exec.html#Environment=)
 
 


### PR DESCRIPTION
While updating to 19.01 I had some downtime rebuilding galaxy venv. Decided to move from supervisor to systemd.service files and @erasche reccomended to update the documentation aswell.