### PR TITLE
Make sure ``temp_output_dir`` path is absolute

### DIFF
--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -338,7 +338,9 @@ class JobExportHistoryArchiveWrapper:
         #
         # Create attributes/metadata files for export.
         #
-        temp_output_dir = tempfile.mkdtemp()
+        # Use abspath because mkdtemp() does not, contrary to the documentation,
+        # always return an absolute path.
+        temp_output_dir = os.path.abspath(tempfile.mkdtemp())
 
         # Write history attributes to file.
         history = jeha.history


### PR DESCRIPTION
Fix `test_download_history` test during BioBlend Travis builds, see:

https://github.com/galaxyproject/galaxy/pull/7214#issuecomment-471558460

https://travis-ci.org/galaxyproject/bioblend/jobs/505250097

Note that we already do the same in other 3 places in the codebase.