### PR TITLE
Eliminate import dependency of datatypes on galaxy.web (url_for).

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -35,6 +35,7 @@ from galaxy.util import (
 from galaxy.visualization.data_providers.registry import DataProviderRegistry
 from galaxy.visualization.genomes import Genomes
 from galaxy.visualization.plugins.registry import VisualizationsRegistry
+from galaxy.web import url_for
 from galaxy.web.proxy import ProxyManager
 from galaxy.web.stack import application_stack_instance
 from galaxy.webapps.galaxy.config_watchers import ConfigWatchers
@@ -226,6 +227,11 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         self.application_stack.register_postfork_function(self.application_stack.start)
 
         self.model.engine.dispose()
+
+        # Inject url_for for components to more easily optionally depend
+        # on url_for.
+        self.url_for = url_for
+
         self.server_starttime = int(time.time())  # used for cachebusting
         log.info("Galaxy app startup finished %s" % self.startup_timer)
 

--- a/lib/galaxy/datatypes/display_applications/application.py
+++ b/lib/galaxy/datatypes/display_applications/application.py
@@ -11,7 +11,6 @@ from galaxy.util import (
 )
 from galaxy.util.odict import odict
 from galaxy.util.template import fill_template
-from galaxy.web import url_for
 from .parameters import (
     DEFAULT_DATASET_NAME,
     DisplayApplicationDataParameter,
@@ -20,9 +19,6 @@ from .parameters import (
 from .util import encode_dataset_user
 
 log = logging.getLogger(__name__)
-
-# Any basic functions that we want to provide as a basic part of parameter dict should be added to this dict
-BASE_PARAMS = {'qp': quote_plus, 'url_for': url_for}
 
 
 class DisplayApplicationLink(object):
@@ -53,13 +49,13 @@ class DisplayApplicationLink(object):
 
     def get_display_url(self, data, trans):
         dataset_hash, user_hash = encode_dataset_user(trans, data, None)
-        return url_for(controller='dataset',
-                       action="display_application",
-                       dataset_id=dataset_hash,
-                       user_id=user_hash,
-                       app_name=quote_plus(self.display_application.id),
-                       link_name=quote_plus(self.id),
-                       app_action=None)
+        return trans.app.url_for(controller='dataset',
+                                 action="display_application",
+                                 dataset_id=dataset_hash,
+                                 user_id=user_hash,
+                                 app_name=quote_plus(self.display_application.id),
+                                 link_name=quote_plus(self.id),
+                                 app_action=None)
 
     def get_inital_values(self, data, trans):
         if self.other_values:
@@ -67,6 +63,7 @@ class DisplayApplicationLink(object):
         else:
             rval = odict()
         rval.update({'BASE_URL': trans.request.base, 'APP': trans.app})  # trans automatically appears as a response, need to add properties of trans that we want here
+        BASE_PARAMS = {'qp': quote_plus, 'url_for': trans.app.url_for}
         for key, value in BASE_PARAMS.items():  # add helper functions/variables
             rval[key] = value
         rval[DEFAULT_DATASET_NAME] = data  # always have the display dataset name available

--- a/lib/galaxy/datatypes/display_applications/parameters.py
+++ b/lib/galaxy/datatypes/display_applications/parameters.py
@@ -6,7 +6,6 @@ from six.moves.urllib.parse import quote_plus
 from galaxy.util import string_as_bool
 from galaxy.util.bunch import Bunch
 from galaxy.util.template import fill_template
-from galaxy.web import url_for
 
 DEFAULT_DATASET_NAME = 'dataset'
 
@@ -191,14 +190,14 @@ class DisplayParameterValueWrapper(object):
         if self.parameter.strip_https and base_url[: 5].lower() == 'https':
             base_url = "http%s" % base_url[5:]
         return "%s%s" % (base_url,
-                         url_for(controller='dataset',
-                                 action="display_application",
-                                 dataset_id=self._dataset_hash,
-                                 user_id=self._user_hash,
-                                 app_name=quote_plus(self.parameter.link.display_application.id),
-                                 link_name=quote_plus(self.parameter.link.id),
-                                 app_action=self.action_name,
-                                 action_param=self._url))
+                         self.trans.app.url_for(controller='dataset',
+                                                action="display_application",
+                                                dataset_id=self._dataset_hash,
+                                                user_id=self._user_hash,
+                                                app_name=quote_plus(self.parameter.link.display_application.id),
+                                                link_name=quote_plus(self.parameter.link.id),
+                                                app_action=self.action_name,
+                                                action_param=self._url))
 
     @property
     def action_name(self):

--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -97,7 +97,7 @@ class GenomeGraphs(Tabular):
                                                       dataset_id=dataset.id,
                                                       action='display_at',
                                                       filename='ucsc_' + site_name)
-                    display_url = "%s%s/display_as?id=%i&display_app=%s&authz_method=display_at" % (base_url, url_for(controller='root'), dataset.id, type)
+                    display_url = "%s%s/display_as?id=%i&display_app=%s&authz_method=display_at" % (base_url, app.url_for(controller='root'), dataset.id, type)
                     display_url = quote_plus(display_url)
                     # was display_url = quote_plus( "%s/display_as?id=%i&display_app=%s" % (base_url, dataset.id, type) )
                     # redirect_url = quote_plus( "%sdb=%s&position=%s:%s-%s&hgt.customText=%%s" % (site_url, dataset.dbkey, chrom, start, stop) )

--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -26,7 +26,6 @@ from galaxy.datatypes.sniff import build_sniff_from_prefix
 from galaxy.datatypes.tabular import Tabular
 from galaxy.datatypes.text import Html
 from galaxy.util import nice_size
-from galaxy.web import url_for
 
 gal_Log = logging.getLogger(__name__)
 verbose = False
@@ -94,10 +93,10 @@ class GenomeGraphs(Tabular):
             for site_name, site_url in app.datatypes_registry.get_legacy_sites_by_build('ucsc', dataset.dbkey):
                 if site_name in app.datatypes_registry.get_display_sites('ucsc'):
                     site_url = site_url.replace('/hgTracks?', '/hgGenome?')  # for genome graphs
-                    internal_url = "%s" % url_for(controller='dataset',
-                                                  dataset_id=dataset.id,
-                                                  action='display_at',
-                                                  filename='ucsc_' + site_name)
+                    internal_url = "%s" % app.url_for(controller='dataset',
+                                                      dataset_id=dataset.id,
+                                                      action='display_at',
+                                                      filename='ucsc_' + site_name)
                     display_url = "%s%s/display_as?id=%i&display_app=%s&authz_method=display_at" % (base_url, url_for(controller='root'), dataset.id, type)
                     display_url = quote_plus(display_url)
                     # was display_url = quote_plus( "%s/display_as?id=%i&display_app=%s" % (base_url, dataset.id, type) )

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -19,7 +19,6 @@ from galaxy.datatypes.sniff import (
 )
 from galaxy.datatypes.tabular import Tabular
 from galaxy.datatypes.util.gff_util import parse_gff3_attributes, parse_gff_attributes
-from galaxy.web import url_for
 from . import (
     data,
     dataproviders
@@ -260,10 +259,10 @@ class Interval(Tabular):
         # Accumulate links for valid sites
         ret_val = []
         for site_name, site_url in valid_sites:
-            internal_url = url_for(controller='dataset', dataset_id=dataset.id,
-                                   action='display_at', filename='ucsc_' + site_name)
+            internal_url = app.url_for(controller='dataset', dataset_id=dataset.id,
+                                       action='display_at', filename='ucsc_' + site_name)
             display_url = quote_plus("%s%s/display_as?id=%i&display_app=%s&authz_method=display_at" %
-                                     (base_url, url_for(controller='root'), dataset.id, type))
+                                     (base_url, app.url_for(controller='root'), dataset.id, type))
             redirect_url = quote_plus("%sdb=%s&position=%s:%s-%s&hgt.customText=%%s" %
                                       (site_url, dataset.dbkey, chrom, start, stop))
             link = '%s?redirect_url=%s&display_url=%s' % (internal_url, redirect_url, display_url)
@@ -607,10 +606,10 @@ class _RemoteCallMixin(object):
         the data available, followed by redirecting to the remote site with a
         link back to the available information.
         """
-        internal_url = "%s" % url_for(controller='dataset', dataset_id=dataset.id, action='display_at', filename='%s_%s' % (type, site_name))
+        internal_url = "%s" % app.url_for(controller='dataset', dataset_id=dataset.id, action='display_at', filename='%s_%s' % (type, site_name))
         base_url = app.config.get("display_at_callback", base_url)
         display_url = quote_plus("%s%s/display_as?id=%i&display_app=%s&authz_method=display_at" %
-                                 (base_url, url_for(controller='root'), dataset.id, type))
+                                 (base_url, app.url_for(controller='root'), dataset.id, type))
         link = '%s?redirect_url=%s&display_url=%s' % (internal_url, redirect_url, display_url)
         return link
 
@@ -1335,8 +1334,8 @@ class CustomTrack(Tabular):
         if chrom is not None:
             for site_name, site_url in app.datatypes_registry.get_legacy_sites_by_build('ucsc', dataset.dbkey):
                 if site_name in app.datatypes_registry.get_display_sites('ucsc'):
-                    internal_url = "%s" % url_for(controller='dataset', dataset_id=dataset.id, action='display_at', filename='ucsc_' + site_name)
-                    display_url = quote_plus("%s%s/display_as?id=%i&display_app=%s&authz_method=display_at" % (base_url, url_for(controller='root'), dataset.id, type))
+                    internal_url = "%s" % app.url_for(controller='dataset', dataset_id=dataset.id, action='display_at', filename='ucsc_' + site_name)
+                    display_url = quote_plus("%s%s/display_as?id=%i&display_app=%s&authz_method=display_at" % (base_url, app.url_for(controller='root'), dataset.id, type))
                     redirect_url = quote_plus("%sdb=%s&position=%s:%s-%s&hgt.customText=%%s" % (site_url, dataset.dbkey, chrom, start, stop))
                     link = '%s?redirect_url=%s&display_url=%s' % (internal_url, redirect_url, display_url)
                     ret_val.append((site_name, link))


### PR DESCRIPTION
Use app to find url_for at runtime. app objects created outside a web context can stub this out and throw an exception if display applications are used in that context (which wouldn't make sense anyway).

This is a step toward being able to break datatypes out into their own package and toward faster loading of datatype modules.