### PR TITLE
[19.01] Fix routing when serving Galaxy at a prefix

### DIFF
--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -421,7 +421,12 @@ var Tab = Backbone.View.extend({
                 } else {
                     let Galaxy = getGalaxyInstance();
                     if (options.target == "__use_router__" && typeof Galaxy.page != "undefined") {
-                        Galaxy.page.router.push(options.url);
+                        let prefix = getAppRoot();
+                        let path = options.url;
+                        if (path.startsWith(prefix)){
+                            path = path.slice(prefix.length);
+                        }
+                        Galaxy.page.router.push(path);
                     } else {
                         try {
                             Galaxy.frame.add(options);
@@ -460,7 +465,15 @@ var Tab = Backbone.View.extend({
                 } else {
                     let Galaxy = getGalaxyInstance();
                     if (model.attributes.target == "__use_router__" && typeof Galaxy.page != "undefined") {
-                        Galaxy.page.router.push(model.attributes.url);
+                        let prefix = getAppRoot();
+                        let path = model.attributes.url;
+                        if (path.startsWith(prefix)){
+                            path = path.slice(prefix.length);
+                        }
+                        if (!path.startsWith("/")) {
+                            path = "/" + path;
+                        }
+                        Galaxy.page.router.push(path);
                     } else {
                         Galaxy.frame.add(model.attributes);
                     }

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -9,15 +9,6 @@ import { CommunicationServerView } from "layout/communication-server-view";
 import Webhooks from "mvc/webhooks";
 import Utils from "utils/utils";
 
-function executeUseRouter(url) {
-    let Galaxy = getGalaxyInstance();
-    let prefix = getAppRoot();
-    if (url.startsWith(prefix)) {
-        url = url.replace(prefix, "/");
-    }
-    Galaxy.page.router.push(url);
-}
-
 var Collection = Backbone.Collection.extend({
     model: Backbone.Model.extend({
         defaults: {
@@ -430,7 +421,7 @@ var Tab = Backbone.View.extend({
                 } else {
                     let Galaxy = getGalaxyInstance();
                     if (options.target == "__use_router__" && typeof Galaxy.page != "undefined") {
-                        executeUseRouter(options.url);
+                        Galaxy.page.router.executeUseRouter(options.url);
                     } else {
                         try {
                             Galaxy.frame.add(options);
@@ -469,7 +460,7 @@ var Tab = Backbone.View.extend({
                 } else {
                     let Galaxy = getGalaxyInstance();
                     if (model.attributes.target == "__use_router__" && typeof Galaxy.page != "undefined") {
-                        executeUseRouter(model.attributes.url);
+                        Galaxy.page.router.executeUseRouter(model.attributes.url);
                     } else {
                         Galaxy.frame.add(model.attributes);
                     }

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -9,10 +9,10 @@ import { CommunicationServerView } from "layout/communication-server-view";
 import Webhooks from "mvc/webhooks";
 import Utils from "utils/utils";
 
-function executeUseRouter(url){
+function executeUseRouter(url) {
     let Galaxy = getGalaxyInstance();
     let prefix = getAppRoot();
-    if (url.startsWith(prefix)){
+    if (url.startsWith(prefix)) {
         url = url.replace(prefix, "/");
     }
     Galaxy.page.router.push(url);

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -9,6 +9,15 @@ import { CommunicationServerView } from "layout/communication-server-view";
 import Webhooks from "mvc/webhooks";
 import Utils from "utils/utils";
 
+function executeUseRouter(url){
+    let Galaxy = getGalaxyInstance();
+    let prefix = getAppRoot();
+    if (url.startsWith(prefix)){
+        url = url.replace(prefix, "/");
+    }
+    Galaxy.page.router.push(url);
+}
+
 var Collection = Backbone.Collection.extend({
     model: Backbone.Model.extend({
         defaults: {
@@ -421,12 +430,7 @@ var Tab = Backbone.View.extend({
                 } else {
                     let Galaxy = getGalaxyInstance();
                     if (options.target == "__use_router__" && typeof Galaxy.page != "undefined") {
-                        let prefix = getAppRoot();
-                        let path = options.url;
-                        if (path.startsWith(prefix)){
-                            path = path.slice(prefix.length);
-                        }
-                        Galaxy.page.router.push(path);
+                        executeUseRouter(options.url);
                     } else {
                         try {
                             Galaxy.frame.add(options);
@@ -465,15 +469,7 @@ var Tab = Backbone.View.extend({
                 } else {
                     let Galaxy = getGalaxyInstance();
                     if (model.attributes.target == "__use_router__" && typeof Galaxy.page != "undefined") {
-                        let prefix = getAppRoot();
-                        let path = model.attributes.url;
-                        if (path.startsWith(prefix)){
-                            path = path.slice(prefix.length);
-                        }
-                        if (!path.startsWith("/")) {
-                            path = "/" + path;
-                        }
-                        Galaxy.page.router.push(path);
+                        executeUseRouter(model.attributes.url);
                     } else {
                         Galaxy.frame.add(model.attributes);
                     }

--- a/client/galaxy/scripts/layout/panel.js
+++ b/client/galaxy/scripts/layout/panel.js
@@ -231,9 +231,16 @@ var CenterPanel = Backbone.View.extend({
 
     /** Display a view in the center panel, hide iframe */
     display: function(view) {
-        var contentWindow = this.$frame[0].contentWindow || {};
-        var message = contentWindow.onbeforeunload && contentWindow.onbeforeunload();
-        var Galaxy = getGalaxyInstance();
+        let Galaxy = getGalaxyInstance();
+        let contentWindow = this.$frame[0].contentWindow || {};
+        let message;
+        try {
+            message = contentWindow.onbeforeunload && contentWindow.onbeforeunload();
+        } catch(err) {
+            // This can happen when external content is displayed in this iframe // CORS violation
+            contentWindow = {};
+            console.warn("Iframe unload exception.  This can happen when external content is displayed in the page iframe and causes a CORS violation -- likely harmless.");
+        }
         if (!message || confirm(message)) {
             contentWindow.onbeforeunload = undefined;
             this.$frame.attr("src", "about:blank").hide();

--- a/client/galaxy/scripts/layout/panel.js
+++ b/client/galaxy/scripts/layout/panel.js
@@ -236,10 +236,12 @@ var CenterPanel = Backbone.View.extend({
         let message;
         try {
             message = contentWindow.onbeforeunload && contentWindow.onbeforeunload();
-        } catch(err) {
+        } catch (err) {
             // This can happen when external content is displayed in this iframe // CORS violation
             contentWindow = {};
-            console.warn("Iframe unload exception.  This can happen when external content is displayed in the page iframe and causes a CORS violation -- likely harmless.");
+            console.warn(
+                "Iframe unload exception.  This can happen when external content is displayed in the page iframe and causes a CORS violation -- likely harmless."
+            );
         }
         if (!message || confirm(message)) {
             contentWindow.onbeforeunload = undefined;

--- a/client/galaxy/scripts/layout/router.js
+++ b/client/galaxy/scripts/layout/router.js
@@ -19,10 +19,12 @@ var Router = Backbone.Router.extend({
             .toString(36)
             .substr(2);
         url += url.indexOf("?") == -1 ? "?" : "&";
-        url += $.param(data, true);
+        let bustParam = $.param(data, true);
+        url += bustParam;
         let Galaxy = getGalaxyInstance();
         Galaxy.params = data;
         this.navigate(url, { trigger: true });
+        window.history.replaceState(window.history.state, "", window.location.pathname.replace(bustParam, ""));
     },
 
     /** override to parse query string into obj and send to each route */

--- a/client/galaxy/scripts/layout/router.js
+++ b/client/galaxy/scripts/layout/router.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import Backbone from "backbone";
+import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import QUERY_STRING from "utils/query-string-parsing";
 import Ui from "mvc/ui/ui-misc";
@@ -10,6 +11,14 @@ var Router = Backbone.Router.extend({
     initialize: function(page, options) {
         this.page = page;
         this.options = options;
+    },
+
+    executeUseRouter: function(url) {
+        let prefix = getAppRoot();
+        if (url.startsWith(prefix)) {
+            url = url.replace(prefix, "/");
+        }
+        return this.push(url);
     },
 
     /** helper to push a new navigation state */


### PR DESCRIPTION
More galaxy-at-prefix issues fixed w/ backbone router.  Fixes #7162 (and more)
Fixed a CORS issue when welcome was external.
Prettier URLs by dropping the `__identifier` cruft after navigation.  Still annoying, but this makes nicer URLs until we have the vue router infra in.