### PR TITLE
Remove galaxy.web.buildapp legacy.

### DIFF
--- a/lib/galaxy/web/buildapp.py
+++ b/lib/galaxy/web/buildapp.py
@@ -1,5 +1,0 @@
-"""For backward compatibility only, pulls app_factor from galaxy.webapps.main"""
-
-from galaxy.webapps.galaxy.buildapp import app_factory
-
-__all__ = ('app_factory', )


### PR DESCRIPTION
I think it would take a very old ini to reference this, I think everyone is pointing at a newer entrypoint.