### PR TITLE
Refactor galaxy.web.form_builder into galaxy.util.form_builder.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -53,11 +53,11 @@ from galaxy.util import (directory_hash_id, ready_name_for_url,
                          unicodify, unique_id)
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
+from galaxy.util.form_builder import (AddressField, CheckboxField, HistoryField,
+                                      PasswordField, SelectField, TextArea, TextField, WorkflowField,
+                                      WorkflowMappingField)
 from galaxy.util.hash_util import new_secure_hash
 from galaxy.util.sanitize_html import sanitize_html
-from galaxy.web.form_builder import (AddressField, CheckboxField, HistoryField,
-                                     PasswordField, SelectField, TextArea, TextField, WorkflowField,
-                                     WorkflowMappingField)
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -17,12 +17,11 @@ from six import string_types
 from sqlalchemy.orm import object_session
 
 import galaxy.model
-from galaxy.util import (listify, string_as_bool,
+from galaxy.util import (form_builder, listify, string_as_bool,
                          stringify_dictionary_keys)
 from galaxy.util.json import safe_dumps
 from galaxy.util.object_wrapper import sanitize_lists_to_string
 from galaxy.util.odict import odict
-from galaxy.web import form_builder
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -81,13 +81,12 @@ from galaxy.util import (
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
 from galaxy.util.expressions import ExpressionContext
+from galaxy.util.form_builder import SelectField
 from galaxy.util.json import safe_loads
 from galaxy.util.odict import odict
 from galaxy.util.rules_dsl import RuleSet
 from galaxy.util.template import fill_template
 from galaxy.version import VERSION_MAJOR
-from galaxy.web import url_for
-from galaxy.web.form_builder import SelectField
 from galaxy.work.context import WorkRequestContext
 from tool_shed.util import common_util
 from .execute import (
@@ -1837,9 +1836,9 @@ class Tool(Dictifiable):
         if link_details:
             # Add details for creating a hyperlink to the tool.
             if not isinstance(self, DataSourceTool):
-                link = url_for(controller='tool_runner', tool_id=self.id)
+                link = self.app.url_for(controller='tool_runner', tool_id=self.id)
             else:
-                link = url_for(controller='tool_runner', action='data_source_redirect', tool_id=self.id)
+                link = self.app.url_for(controller='tool_runner', action='data_source_redirect', tool_id=self.id)
 
             # Basic information
             tool_dict.update({'link': link,
@@ -1923,7 +1922,7 @@ class Tool(Dictifiable):
         # create tool help
         tool_help = ''
         if self.help:
-            tool_help = self.help.render(static_path=url_for('/static'), host_url=url_for('/', qualified=True))
+            tool_help = self.help.render(static_path=self.app.url_for('/static'), host_url=self.app.url_for('/', qualified=True))
             tool_help = unicodify(tool_help, 'utf-8')
 
         # update tool model
@@ -1943,7 +1942,7 @@ class Tool(Dictifiable):
             'job_remap'     : self._get_job_remap(job),
             'history_id'    : trans.security.encode_id(history.id) if history else None,
             'display'       : self.display_interface,
-            'action'        : url_for(self.action),
+            'action'        : self.app.url_for(self.action),
             'method'        : self.method,
             'enctype'       : self.enctype
         })

--- a/lib/galaxy/util/form_builder.py
+++ b/lib/galaxy/util/form_builder.py
@@ -1,0 +1,196 @@
+"""
+Classes for generating HTML forms
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+
+import logging
+
+from galaxy.util import (
+    asbool
+)
+
+log = logging.getLogger(__name__)
+
+
+class BaseField(object):
+    def __init__(self, name, value=None, label=None, **kwds):
+        self.name = name
+        self.label = label
+        self.value = value
+        self.disabled = kwds.get('disabled', False)
+        if 'optional' in kwds:
+            self.optional = asbool(kwds.get('optional'))
+        else:
+            self.optional = kwds.get('required', 'optional') == 'optional'
+        self.help = kwds.get('helptext')
+
+    def to_dict(self):
+        return {
+            'name'      : self.name,
+            'label'     : self.label,
+            'disabled'  : self.disabled,
+            'optional'  : self.optional,
+            'value'     : self.value,
+            'help'      : self.help
+        }
+
+
+class TextField(BaseField):
+    """
+    A standard text input box.
+    """
+    def to_dict(self):
+        d = super(TextField, self).to_dict()
+        d['type'] = 'text'
+        return d
+
+
+class PasswordField(BaseField):
+    """
+    A password input box. text appears as "******"
+    """
+    def to_dict(self):
+        d = super(PasswordField, self).to_dict()
+        d['type'] = 'password'
+        return d
+
+
+class TextArea(BaseField):
+    """
+    A standard text area box.
+    """
+    def to_dict(self):
+        d = super(TextArea, self).to_dict()
+        d['type'] = 'text'
+        d['area'] = True
+        return d
+
+
+class CheckboxField(BaseField):
+    """
+    A checkbox (boolean input)
+    """
+    @staticmethod
+    def is_checked(value):
+        if value in [True, "True", "true"]:
+            return True
+        return False
+
+    def to_dict(self):
+        d = super(CheckboxField, self).to_dict()
+        d['type'] = 'boolean'
+        return d
+
+
+class SelectField(BaseField):
+    """
+    A select field.
+    """
+
+    def __init__(self, name, multiple=None, display=None, field_id=None, value=None, selectlist=None, refresh_on_change=False, **kwds):
+        super(SelectField, self).__init__(name, value, **kwds)
+        self.field_id = field_id
+        self.multiple = multiple or False
+        self.refresh_on_change = refresh_on_change
+        self.selectlist = selectlist or []
+        self.options = list()
+        if display == "checkboxes":
+            assert multiple, "Checkbox display only supported for multiple select"
+        elif display == "radio":
+            assert not(multiple), "Radio display only supported for single select"
+        elif display is not None:
+            raise Exception("Unknown display type: %s" % display)
+        self.display = display
+
+    def add_option(self, text, value, selected=False):
+        self.options.append((text, value, selected))
+
+    def to_dict(self):
+        d = super(SelectField, self).to_dict()
+        d['type'] = 'select'
+        d['display'] = self.display
+        d['multiple'] = self.multiple
+        d['data'] = []
+        for value in self.selectlist:
+            d['data'].append({'label': value, 'value': value})
+        d['options'] = [{'label': t[0], 'value': t[1]} for t in self.options]
+        return d
+
+
+class AddressField(BaseField):
+    @staticmethod
+    def fields():
+        return [("desc", "Short address description", "Required"),
+                ("name", "Name", ""),
+                ("institution", "Institution", ""),
+                ("address", "Address", ""),
+                ("city", "City", ""),
+                ("state", "State/Province/Region", ""),
+                ("postal_code", "Postal Code", ""),
+                ("country", "Country", ""),
+                ("phone", "Phone", "")]
+
+    def __init__(self, name, user=None, value=None, security=None, **kwds):
+        super(AddressField, self).__init__(name, value, **kwds)
+        self.user = user
+        self.security = security
+
+    def to_dict(self):
+        d = super(AddressField, self).to_dict()
+        d['type'] = 'select'
+        d['data'] = []
+        if self.user and self.security:
+            for a in self.user.addresses:
+                if not a.deleted:
+                    d['data'].append({'label': a.desc, 'value': self.security.encode_id(a.id)})
+        return d
+
+
+class WorkflowField(BaseField):
+    def __init__(self, name, user=None, value=None, security=None, **kwds):
+        super(WorkflowField, self).__init__(name, value, **kwds)
+        self.user = user
+        self.value = value
+        self.security = security
+
+    def to_dict(self):
+        d = super(WorkflowField, self).to_dict()
+        d['type'] = 'select'
+        d['data'] = []
+        if self.user and self.security:
+            for a in self.user.stored_workflows:
+                if not a.deleted:
+                    d['data'].append({'label': a.name, 'value': self.security.encode_id(a.id)})
+        return d
+
+
+class WorkflowMappingField(BaseField):
+    def __init__(self, name, user=None, value=None, **kwds):
+        super(WorkflowMappingField, self).__init__(name, value, **kwds)
+        self.user = user
+
+
+class HistoryField(BaseField):
+    def __init__(self, name, user=None, value=None, security=None, **kwds):
+        super(HistoryField, self).__init__(name, value, **kwds)
+        self.user = user
+        self.value = value
+        self.security = security
+
+    def to_dict(self):
+        d = super(HistoryField, self).to_dict()
+        d['type'] = 'select'
+        d['data'] = [{'label': 'New History', 'value': 'new'}]
+        if self.user and self.security:
+            for a in self.user.histories:
+                if not a.deleted:
+                    d['data'].append({'label': a.name, 'value': self.security.encode_id(a.id)})
+        return d
+
+
+def get_suite():
+    """Get unittest suite for this module"""
+    import doctest
+    import sys
+    return doctest.DocTestSuite(sys.modules[__name__])

--- a/lib/galaxy/web/form_builder.py
+++ b/lib/galaxy/web/form_builder.py
@@ -1,195 +1,25 @@
-"""
-Classes for generating HTML forms
-"""
-from __future__ import print_function
-
-import logging
-
-from galaxy.util import (
-    asbool
+from galaxy.util.form_builder import (
+    AddressField,
+    BaseField,
+    CheckboxField,
+    HistoryField,
+    PasswordField,
+    SelectField,
+    TextArea,
+    TextField,
+    WorkflowField,
+    WorkflowMappingField,
 )
 
-log = logging.getLogger(__name__)
-
-
-class BaseField(object):
-    def __init__(self, name, value=None, label=None, **kwds):
-        self.name = name
-        self.label = label
-        self.value = value
-        self.disabled = kwds.get('disabled', False)
-        if 'optional' in kwds:
-            self.optional = asbool(kwds.get('optional'))
-        else:
-            self.optional = kwds.get('required', 'optional') == 'optional'
-        self.help = kwds.get('helptext')
-
-    def to_dict(self):
-        return {
-            'name'      : self.name,
-            'label'     : self.label,
-            'disabled'  : self.disabled,
-            'optional'  : self.optional,
-            'value'     : self.value,
-            'help'      : self.help
-        }
-
-
-class TextField(BaseField):
-    """
-    A standard text input box.
-    """
-    def to_dict(self):
-        d = super(TextField, self).to_dict()
-        d['type'] = 'text'
-        return d
-
-
-class PasswordField(BaseField):
-    """
-    A password input box. text appears as "******"
-    """
-    def to_dict(self):
-        d = super(PasswordField, self).to_dict()
-        d['type'] = 'password'
-        return d
-
-
-class TextArea(BaseField):
-    """
-    A standard text area box.
-    """
-    def to_dict(self):
-        d = super(TextArea, self).to_dict()
-        d['type'] = 'text'
-        d['area'] = True
-        return d
-
-
-class CheckboxField(BaseField):
-    """
-    A checkbox (boolean input)
-    """
-    @staticmethod
-    def is_checked(value):
-        if value in [True, "True", "true"]:
-            return True
-        return False
-
-    def to_dict(self):
-        d = super(CheckboxField, self).to_dict()
-        d['type'] = 'boolean'
-        return d
-
-
-class SelectField(BaseField):
-    """
-    A select field.
-    """
-
-    def __init__(self, name, multiple=None, display=None, field_id=None, value=None, selectlist=None, refresh_on_change=False, **kwds):
-        super(SelectField, self).__init__(name, value, **kwds)
-        self.field_id = field_id
-        self.multiple = multiple or False
-        self.refresh_on_change = refresh_on_change
-        self.selectlist = selectlist or []
-        self.options = list()
-        if display == "checkboxes":
-            assert multiple, "Checkbox display only supported for multiple select"
-        elif display == "radio":
-            assert not(multiple), "Radio display only supported for single select"
-        elif display is not None:
-            raise Exception("Unknown display type: %s" % display)
-        self.display = display
-
-    def add_option(self, text, value, selected=False):
-        self.options.append((text, value, selected))
-
-    def to_dict(self):
-        d = super(SelectField, self).to_dict()
-        d['type'] = 'select'
-        d['display'] = self.display
-        d['multiple'] = self.multiple
-        d['data'] = []
-        for value in self.selectlist:
-            d['data'].append({'label': value, 'value': value})
-        d['options'] = [{'label': t[0], 'value': t[1]} for t in self.options]
-        return d
-
-
-class AddressField(BaseField):
-    @staticmethod
-    def fields():
-        return [("desc", "Short address description", "Required"),
-                ("name", "Name", ""),
-                ("institution", "Institution", ""),
-                ("address", "Address", ""),
-                ("city", "City", ""),
-                ("state", "State/Province/Region", ""),
-                ("postal_code", "Postal Code", ""),
-                ("country", "Country", ""),
-                ("phone", "Phone", "")]
-
-    def __init__(self, name, user=None, value=None, security=None, **kwds):
-        super(AddressField, self).__init__(name, value, **kwds)
-        self.user = user
-        self.security = security
-
-    def to_dict(self):
-        d = super(AddressField, self).to_dict()
-        d['type'] = 'select'
-        d['data'] = []
-        if self.user and self.security:
-            for a in self.user.addresses:
-                if not a.deleted:
-                    d['data'].append({'label': a.desc, 'value': self.security.encode_id(a.id)})
-        return d
-
-
-class WorkflowField(BaseField):
-    def __init__(self, name, user=None, value=None, security=None, **kwds):
-        super(WorkflowField, self).__init__(name, value, **kwds)
-        self.user = user
-        self.value = value
-        self.security = security
-
-    def to_dict(self):
-        d = super(WorkflowField, self).to_dict()
-        d['type'] = 'select'
-        d['data'] = []
-        if self.user and self.security:
-            for a in self.user.stored_workflows:
-                if not a.deleted:
-                    d['data'].append({'label': a.name, 'value': self.security.encode_id(a.id)})
-        return d
-
-
-class WorkflowMappingField(BaseField):
-    def __init__(self, name, user=None, value=None, **kwds):
-        super(WorkflowMappingField, self).__init__(name, value, **kwds)
-        self.user = user
-
-
-class HistoryField(BaseField):
-    def __init__(self, name, user=None, value=None, security=None, **kwds):
-        super(HistoryField, self).__init__(name, value, **kwds)
-        self.user = user
-        self.value = value
-        self.security = security
-
-    def to_dict(self):
-        d = super(HistoryField, self).to_dict()
-        d['type'] = 'select'
-        d['data'] = [{'label': 'New History', 'value': 'new'}]
-        if self.user and self.security:
-            for a in self.user.histories:
-                if not a.deleted:
-                    d['data'].append({'label': a.name, 'value': self.security.encode_id(a.id)})
-        return d
-
-
-def get_suite():
-    """Get unittest suite for this module"""
-    import doctest
-    import sys
-    return doctest.DocTestSuite(sys.modules[__name__])
+__all__ = (
+    "AddressField",
+    "BaseField",
+    "CheckboxField",
+    "HistoryField",
+    "PasswordField",
+    "SelectField",
+    "TextArea",
+    "TextField",
+    "WorkflowField",
+    "WorkflowMappingField",
+)

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -82,6 +82,10 @@ class MockApp(object):
         self.application_stack = ApplicationStack()
         self.auth_manager = AuthManager(self)
 
+        def url_for(*args, **kwds):
+            return "/mock/url"
+        self.url_for = url_for
+
     def init_datatypes(self):
         datatypes_registry = registry.Registry()
         datatypes_registry.load_datatypes()


### PR DESCRIPTION
We have other utilities for web content in galaxy.util like sanitize_html, so while I'm not eager to put web stuff in there it is not bringing any dependencies into galaxy's util package. The upshot here is that now model doesn't need to have dependencies on galaxy.web (other than implicitly through galaxy.managers.tags - fixed in https://github.com/galaxyproject/galaxy/pull/7530).

Contains some more cleanup related to url_for (see #7521 for context).