### PR TITLE
[19.01] Fix displaying and editing SelectTagParameters in workflow editor

### DIFF
--- a/client/galaxy/scripts/mvc/form/form-parameters.js
+++ b/client/galaxy/scripts/mvc/form/form-parameters.js
@@ -27,6 +27,7 @@ export default Backbone.Model.extend({
         boolean: "_fieldBoolean",
         drill_down: "_fieldDrilldown",
         color: "_fieldColor",
+        group_tag: "_fieldSelect",
         hidden: "_fieldHidden",
         hidden_data: "_fieldHidden",
         baseurl: "_fieldHidden",
@@ -123,7 +124,7 @@ export default Backbone.Model.extend({
     /** Text input field */
     _fieldText: function(input_def) {
         // field replaces e.g. a select field
-        if (input_def.options && input_def.data) {
+        if (input_def.data_ref || input_def.options && input_def.data) {
             input_def.area = input_def.multiple;
             if (Utils.isEmpty(input_def.value)) {
                 input_def.value = null;

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1075,6 +1075,8 @@ class SelectTagParameter(SelectToolParameter):
         # Get the value of the associated data reference (a dataset)
         history_items = other_values.get(self.data_ref, None)
         # Check if a dataset is selected
+        if is_runtime_value(history_items):
+            return []
         if not history_items:
             return []
         tags = set()
@@ -1105,7 +1107,7 @@ class SelectTagParameter(SelectToolParameter):
         return SelectToolParameter.get_initial_value(self, trans, other_values)
 
     def get_legal_values(self, trans, other_values):
-        if self.data_ref not in other_values:
+        if self.data_ref not in other_values and not trans.workflow_building_mode:
             raise ValueError("Value for associated data reference not found (data_ref).")
         return set(self.get_tag_list(other_values))
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -564,7 +564,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         Builds module models for the workflow editor.
         """
         inputs = payload.get('inputs', {})
-        trans.workflow_build_mode = workflow_building_modes.ENABLED
+        trans.workflow_building_mode = workflow_building_modes.ENABLED
         module = module_factory.from_dict(trans, payload)
         if 'tool_state' not in payload:
             module_state = {}

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -23,6 +23,7 @@ from galaxy.managers import (
 )
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.tools.parameters import populate_state
+from galaxy.tools.parameters.basic import workflow_building_modes
 from galaxy.util.sanitize_html import sanitize_html
 from galaxy.web import _future_expose_api as expose_api
 from galaxy.web import _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
@@ -563,6 +564,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         Builds module models for the workflow editor.
         """
         inputs = payload.get('inputs', {})
+        trans.workflow_build_mode = workflow_building_modes.ENABLED
         module = module_factory.from_dict(trans, payload)
         if 'tool_state' not in payload:
             module_state = {}


### PR DESCRIPTION
@lparsons noticed that you can't see or edit group tags in the workflow editor.
Like for select lists we just fall back to displaying tags as text.
This isn't great, we should be following the normal tag rules here,
like splitting on whitespace, but I guess that's the minimum
solution here.