### PR TITLE
Swap from 'slug.js' to 'slugify.js'.  Saves 10 MB in client bundles.

### DIFF
--- a/client/galaxy/scripts/mvc/grid/grid-view.js
+++ b/client/galaxy/scripts/mvc/grid/grid-view.js
@@ -9,7 +9,7 @@ import PopupMenu from "mvc/ui/popup-menu";
 import LoadingIndicator from "ui/loading-indicator";
 import { init_refresh_on_change } from "onload/globalInits/init_refresh_on_change";
 import store from "../../store";
-import slug from "slug";
+import slugify from "slugify";
 
 // This is necessary so that, when nested arrays are used in ajax/post/get methods, square brackets ('[]') are
 // not appended to the identifier of a nested array.
@@ -698,6 +698,6 @@ export default Backbone.View.extend({
     // use for conditional styling in the various kinds of grids
     // instead of acres of if/then statements in javascript
     getRootClassName({ title = "grid" }) {
-        return slug(title).toLowerCase();
+        return slugify(title).toLowerCase();
     }
 });

--- a/client/package.json
+++ b/client/package.json
@@ -46,7 +46,7 @@
     "raven-js": "^3.27.0",
     "requirejs": "2.3.6",
     "rxjs": "^6.3.3",
-    "slug": "^0.9.3",
+    "slugify": "^1.3.4",
     "underscore": "^1.9.1",
     "vue": "^2.5.22",
     "vue-router": "^3.0.2",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -11974,12 +11974,10 @@ slide@^1.1.5:
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
-slug@^0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/slug/-/slug-0.9.3.tgz#8c9c773d79367c0188733316cf49fd2b8db40f6a"
-  integrity sha512-DddSQQnUdAofjFOKRT+zsMNrdzdte04G5DUA+NeaUJlPAqR1bWQ22qVfayRxHFiRGR3bUV0wt5VSj4849pGKSw==
-  dependencies:
-    unicode ">= 0.3.1"
+slugify@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.3.4.tgz#78d2792d7222b55cd9fc81fa018df99af779efeb"
+  integrity sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -13058,11 +13056,6 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
   integrity sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==
-
-"unicode@>= 0.3.1":
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/unicode/-/unicode-11.0.1.tgz#735bd422ec75cf28d396eb224d535d168d5f1db6"
-  integrity sha512-+cHtykLb+eF1yrSLWTwcYBrqJkTfX7Quoyg7Juhe6uylF43ZbMdxMuSHNYlnyLT8T7POAvavgBthzUF9AIaQvQ==
 
 unified@^6.0.0:
   version "6.2.0"


### PR DESCRIPTION
```
=> Found "slugify@1.3.4"
info Disk size with unique dependencies: "24KB"

vs

=> Found "slug@0.9.3"
info Disk size with unique dependencies: "10.25MB"
```