### PR TITLE
run circleCI on merge rather than head of PR's fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,17 +32,17 @@ jobs:
       - run:
           name: Checkout code
           command: |-
-              # add github.com to known hosts
+              # Add github.com to known hosts
               mkdir -p ~/.ssh
               echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
               ' >> ~/.ssh/known_hosts
 
-              # add the user ssh key and set correct perms
+              # Add the user ssh key and set correct perms
               (umask 077; touch ~/.ssh/id_rsa)
               chmod 0600 ~/.ssh/id_rsa
               echo "$CHECKOUT_KEY" > ~/.ssh/id_rsa
 
-              # use git+ssh instead of https
+              # Use git+ssh instead of https
               git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
               git config --global gc.auto 0 || true
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,15 +49,28 @@ jobs:
               # Shallow clone
               git clone --depth=1 "${CIRCLE_REPOSITORY_URL}" .
 
-              if [ -n "$CIRCLE_TAG" ]
+              if [[ -n "${CIRCLE_PR_NUMBER}" ]]
               then
-                git fetch --depth=10 --force origin "refs/tags/${CIRCLE_TAG}"
+                  # Update PR refs for testing.
+                  FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/head:pr/${CIRCLE_PR_NUMBER}/head"
+                  FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/merge:pr/${CIRCLE_PR_NUMBER}/merge"
+
+                  # Retrieve the refs
+                  git fetch --force origin ${FETCH_REFS}
+
+                  # Checkout PR merge ref.
+                  git checkout -qf "pr/${CIRCLE_PR_NUMBER}/merge"
+
+                  # Test for *some* merge conflicts.
+                  git branch --merged | grep "pr/${CIRCLE_PR_NUMBER}/head" > /dev/null
+              elif [ -n "$CIRCLE_TAG" ]
+              then
+                git fetch --depth=1 --force origin "refs/tags/${CIRCLE_TAG}"
               elif [[ "$CIRCLE_BRANCH" =~ ^pull\/* ]]
               then
-              # For PR from Fork
-                git fetch --depth=10 --force origin "$CIRCLE_BRANCH/head:remotes/origin/$CIRCLE_BRANCH"
+                git fetch --depth=1 --force origin "$CIRCLE_BRANCH/head:remotes/origin/$CIRCLE_BRANCH"
               else
-                git fetch --depth=10 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
+                git fetch --depth=1 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
               fi
 
               if [ -n "$CIRCLE_TAG" ]


### PR DESCRIPTION
this is taking advantage of github providing refs to preliminary merges of PRs

this is a missing feature in circleci: https://circleci.com/ideas/?idea=CCI-I-431