### PR TITLE
Refactor output_collect.py toward a database session-less modality.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1696,6 +1696,7 @@ class Tool(Dictifiable):
             permission_provider,
             metadata_source_provider,
             input_dbkey,
+            object_store=tool.app.object_store,
         )
         collected = output_collect.collect_primary_datasets(
             job_context,

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1694,12 +1694,15 @@ class Tool(Dictifiable):
             input_ext,
             input_dbkey=input_dbkey,
         )
+        permission_provider = output_collect.PermissionProvider(inp_data, tool.app.security_agent, job)
+        metadata_source_provider = output_collect.MetadataSourceProvider(inp_data)
         output_collect.collect_dynamic_outputs(
             tool,
             out_collections,
             tool_provided_metadata,
             job_working_directory=tool_working_directory,
-            inp_data=inp_data,
+            permission_provider=permission_provider,
+            metadata_source_provider=metadata_source_provider,
             job=job,
             input_dbkey=input_dbkey,
         )

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1686,26 +1686,25 @@ class Tool(Dictifiable):
         cases where number of outputs is not known in advance).
         """
         tool = self
-        collected = output_collect.collect_primary_datasets(
-            tool,
-            out_data,
-            tool_provided_metadata,
-            tool_working_directory,
-            input_ext,
-            job=job,
-            input_dbkey=input_dbkey,
-        )
         permission_provider = output_collect.PermissionProvider(inp_data, tool.app.security_agent, job)
         metadata_source_provider = output_collect.MetadataSourceProvider(inp_data)
-        output_collect.collect_dynamic_outputs(
+        job_context = output_collect.JobContext(
             tool,
-            out_collections,
             tool_provided_metadata,
-            job_working_directory=tool_working_directory,
-            permission_provider=permission_provider,
-            metadata_source_provider=metadata_source_provider,
-            job=job,
-            input_dbkey=input_dbkey,
+            job,
+            tool_working_directory,
+            permission_provider,
+            metadata_source_provider,
+            input_dbkey,
+        )
+        collected = output_collect.collect_primary_datasets(
+            job_context,
+            out_data,
+            input_ext,
+        )
+        output_collect.collect_dynamic_outputs(
+            job_context,
+            out_collections,
         )
         # Return value only used in unit tests. Probably should be returning number of collected
         # bytes instead?

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1692,6 +1692,7 @@ class Tool(Dictifiable):
             tool_provided_metadata,
             tool_working_directory,
             input_ext,
+            job=job,
             input_dbkey=input_dbkey,
         )
         permission_provider = output_collect.PermissionProvider(inp_data, tool.app.security_agent, job)

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -32,6 +32,7 @@ class PermissionProvider(object):
         self._job = job
         self._security_agent = security_agent
         self._inp_data = inp_data
+        self._user = job.user
         self._permissions = None
 
     @property
@@ -48,12 +49,26 @@ class PermissionProvider(object):
 
         return self._permissions
 
+    def set_default_hda_permissions(self, primary_data):
+        permissions = self.permissions
+        if permissions is not UNSET:
+            self._security_agent.set_all_dataset_permissions(primary_data.dataset, permissions, new=True, flush=False)
+
+    def copy_dataset_permissions(self, init_from, primary_data):
+        self._security_agent.copy_dataset_permissions(init_from.dataset, primary_data.dataset)
+
 
 class UnusedPermissionProvider(object):
 
     @property
     def permissions(self):
         return UNSET
+
+    def set_default_hda_permissions(self, primary_data):
+        return
+
+    def copy_dataset_permissions(self, init_from, primary_data):
+        raise NotImplementedError()
 
 
 class MetadataSourceProvider(object):
@@ -267,7 +282,145 @@ def collect_dynamic_outputs(
             collection.handle_population_failed("Problem building datasets for collection.")
 
 
-class JobContext(object):
+class ModelPersistenceContext(object):
+
+    def create_dataset(
+        self,
+        ext,
+        designation,
+        visible,
+        dbkey,
+        name,
+        filename,
+        metadata_source_name=None,
+        info=None,
+        library_folder=None,
+        link_data=False,
+        primary_data=None,
+        init_from=None,
+        dataset_attributes=None,
+        tag_list=[],
+        sources=[],
+        hashes=[],
+    ):
+        sa_session = self.sa_session
+
+        # You can initialize a dataset or initialize from a dataset but not both.
+        if init_from:
+            assert primary_data is None
+        if primary_data:
+            assert init_from is None
+
+        if metadata_source_name:
+            assert init_from is None
+        if init_from:
+            assert metadata_source_name is None
+
+        if primary_data is not None:
+            primary_data.extension = ext
+            primary_data.visible = visible
+            primary_data.dbkey = dbkey
+        else:
+            if not library_folder:
+                primary_data = galaxy.model.HistoryDatasetAssociation(extension=ext,
+                                                                      designation=designation,
+                                                                      visible=visible,
+                                                                      dbkey=dbkey,
+                                                                      create_dataset=True,
+                                                                      flush=False,
+                                                                      sa_session=sa_session)
+
+                self.persist_object(primary_data)
+                if init_from:
+                    self.permission_provider.copy_dataset_permissions(init_from, primary_data)
+                    primary_data.state = init_from.state
+                else:
+                    self.permission_provider.set_default_hda_permissions(primary_data)
+            else:
+                ld = galaxy.model.LibraryDataset(folder=library_folder, name=name)
+                ldda = galaxy.model.LibraryDatasetDatasetAssociation(name=name,
+                                                                     extension=ext,
+                                                                     dbkey=dbkey,
+                                                                     library_dataset=ld,
+                                                                     user=self.user,
+                                                                     create_dataset=True,
+                                                                     flush=False,
+                                                                     sa_session=sa_session)
+                ld.library_dataset_dataset_association = ldda
+                ldda.state = ldda.states.OK
+
+                self.add_library_dataset_to_folder(library_folder, ld)
+                primary_data = ldda
+
+        for source_dict in sources:
+            source = galaxy.model.DatasetSource()
+            source.source_uri = source_dict["source_uri"]
+            primary_data.dataset.sources.append(source)
+
+        for hash_dict in hashes:
+            hash_object = galaxy.model.DatasetHash()
+            hash_object.hash_function = hash_dict["hash_function"]
+            hash_object.hash_value = hash_dict["hash_value"]
+            primary_data.dataset.hashes.append(hash_object)
+
+        self.flush()
+
+        if tag_list:
+            self.tag_handler.add_tags_from_list(self.job.user, primary_data, tag_list)
+
+        # Move data from temp location to dataset location
+        if not link_data:
+            self.object_store.update_from_file(primary_data.dataset, file_name=filename, create=True)
+        else:
+            primary_data.link_to(filename)
+
+        # We are sure there are no extra files, so optimize things that follow by settting total size also.
+        primary_data.set_size(no_extra_files=True)
+        # If match specified a name use otherwise generate one from
+        # designation.
+        primary_data.name = name
+
+        # Copy metadata from one of the inputs if requested.
+        if metadata_source_name:
+            metadata_source = self.metadata_source_provider.get_metadata_source(metadata_source_name)
+            primary_data.init_meta(copy_from=metadata_source)
+        elif init_from:
+            metadata_source = init_from
+            primary_data.init_meta(copy_from=init_from)
+            # when coming from primary dataset - respect pattern of output - this makes sense
+            primary_data.dbkey = dbkey
+        else:
+            primary_data.init_meta()
+
+        if info is not None:
+            primary_data.info = info
+
+        # add tool/metadata provided information
+        dataset_attributes = dataset_attributes or {}
+        if dataset_attributes:
+            # TODO: discover_files should produce a match that encorporates this -
+            # would simplify ToolProvidedMetadata interface and eliminate this
+            # crap path.
+            dataset_att_by_name = dict(ext='extension')
+            for att_set in ['name', 'info', 'ext', 'dbkey']:
+                dataset_att_name = dataset_att_by_name.get(att_set, att_set)
+                setattr(primary_data, dataset_att_name, dataset_attributes.get(att_set, getattr(primary_data, dataset_att_name)))
+
+        metadata_dict = dataset_attributes.get('metadata', None)
+        if metadata_dict:
+            if "dbkey" in dataset_attributes:
+                metadata_dict["dbkey"] = dataset_attributes["dbkey"]
+            # branch tested with tool_provided_metadata_3 / tool_provided_metadata_10
+            primary_data.metadata.from_JSON_dict(json_dict=metadata_dict)
+        else:
+            primary_data.set_meta()
+
+        primary_data.set_peek()
+
+        return primary_data
+
+
+class JobContext(ModelPersistenceContext):
 
     def __init__(self, tool, tool_provided_metadata, job, job_working_directory, permission_provider, metadata_source_provider, input_dbkey, object_store):
         self.tool = tool
@@ -280,20 +433,23 @@ class JobContext(object):
         self.job_working_directory = job_working_directory
         self.tool_provided_metadata = tool_provided_metadata
         self.object_store = object_store
-        self._permissions = None
 
     @property
     def work_context(self):
         from galaxy.work.context import WorkRequestContext
+        return WorkRequestContext(self.app, user=self.user)
+
+    @property
+    def user(self):
         if self.job:
             user = self.job.user
         else:
             user = None
-        return WorkRequestContext(self.app, user=user)
+        return user
 
     @property
-    def permissions(self):
-        return self.permission_provider.permissions
+    def tag_handler(self):
+        return self.app.tag_handler
 
     def find_files(self, output_name, collection, dataset_collectors):
         filenames = odict.odict()
@@ -382,137 +538,35 @@ class JobContext(object):
 
         sa_session.flush()
 
-    def create_dataset(
-        self,
-        ext,
-        designation,
-        visible,
-        dbkey,
-        name,
-        filename,
-        metadata_source_name=None,
-        info=None,
-        library_folder=None,
-        link_data=False,
-        primary_data=None,
-        init_from=None,
-        dataset_attributes=None,
-        tag_list=[],
-        sources=[],
-        hashes=[],
-    ):
-        app = self.app
-        sa_session = self.sa_session
+    def persist_object(self, obj):
+        self.sa_session.add(obj)
 
-        # You can initialize a dataset or initialize from a dataset but not both.
-        if init_from:
-            assert primary_data is None
-        if primary_data:
-            assert init_from is None
-
-        if metadata_source_name:
-            assert init_from is None
-        if init_from:
-            assert metadata_source_name is None
-
-        if primary_data is not None:
-            primary_data.extension = ext
-            primary_data.visible = visible
-            primary_data.dbkey = dbkey
-        else:
-            if not library_folder:
-                if init_from:
-                    permissions = UNSET
-                else:
-                    permissions = self.permissions
-                primary_data = galaxy.model.HistoryDatasetAssociation(extension=ext,
-                                                                      designation=designation,
-                                                                      visible=visible,
-                                                                      dbkey=dbkey,
-                                                                      create_dataset=True,
-                                                                      flush=False,
-                                                                      sa_session=sa_session)
-                if permissions is not UNSET:
-                    app.security_agent.set_all_dataset_permissions(primary_data.dataset, permissions, new=True, flush=False)
-                sa_session.add(primary_data)
-            else:
-                primary_data = _new_ldda(self.work_context, name, ext, visible, dbkey, library_folder)
-
-            if init_from:
-                app.security_agent.copy_dataset_permissions(init_from.dataset, primary_data.dataset)
-                primary_data.state = init_from.state
-
-        for source_dict in sources:
-            source = galaxy.model.DatasetSource()
-            source.source_uri = source_dict["source_uri"]
-            primary_data.dataset.sources.append(source)
-
-        for hash_dict in hashes:
-            hash_object = galaxy.model.DatasetHash()
-            hash_object.hash_function = hash_dict["hash_function"]
-            hash_object.hash_value = hash_dict["hash_value"]
-            primary_data.dataset.hashes.append(hash_object)
-
-        sa_session.flush()
-
-        if tag_list:
-            app.tag_handler.add_tags_from_list(self.job.user, primary_data, tag_list)
-
-        # Move data from temp location to dataset location
-        if not link_data:
-            self.object_store.update_from_file(primary_data.dataset, file_name=filename, create=True)
-        else:
-            primary_data.link_to(filename)
-
-        # We are sure there are no extra files, so optimize things that follow by settting total size also.
-        primary_data.set_size(no_extra_files=True)
-        # If match specified a name use otherwise generate one from
-        # designation.
-        primary_data.name = name
-
-        # Copy metadata from one of the inputs if requested.
-        if metadata_source_name:
-            metadata_source = self.metadata_source_provider.get_metadata_source(metadata_source_name)
-            primary_data.init_meta(copy_from=metadata_source)
-        elif init_from:
-            metadata_source = init_from
-            primary_data.init_meta(copy_from=init_from)
-            # when coming from primary dataset - respect pattern of output - this makes sense
-            primary_data.dbkey = dbkey
-        else:
-            primary_data.init_meta()
-
-        if info is not None:
-            primary_data.info = info
-
-        # add tool/metadata provided information
-        dataset_attributes = dataset_attributes or {}
-        if dataset_attributes:
-            # TODO: discover_files should produce a match that encorporates this -
-            # would simplify ToolProvidedMetadata interface and eliminate this
-            # crap path.
-            dataset_att_by_name = dict(ext='extension')
-            for att_set in ['name', 'info', 'ext', 'dbkey']:
-                dataset_att_name = dataset_att_by_name.get(att_set, att_set)
-                setattr(primary_data, dataset_att_name, dataset_attributes.get(att_set, getattr(primary_data, dataset_att_name)))
-
-        metadata_dict = dataset_attributes.get('metadata', None)
-        if metadata_dict:
-            if "dbkey" in dataset_attributes:
-                metadata_dict["dbkey"] = dataset_attributes["dbkey"]
-            # branch tested with tool_provided_metadata_3 / tool_provided_metadata_10
-            primary_data.metadata.from_JSON_dict(json_dict=metadata_dict)
-        else:
-            primary_data.set_meta()
-
-        primary_data.set_peek()
-
-        return primary_data
+    def flush(self):
+        self.sa_session.flush()
 
     def add_output_dataset_association(self, name, dataset):
         assoc = galaxy.model.JobToOutputDatasetAssociation(name, dataset)
         assoc.job = self.job
         self.sa_session.add(assoc)
+
+    def add_library_dataset_to_folder(self, library_folder, ld):
+        trans.sa_session.add(ld.ldda)
+
+        trans = self.work_context
+        trans.app.security_agent.copy_library_permissions(trans, library_folder, ld)
+        trans.sa_session.add(ld)
+        trans.sa_session.flush()
+
+        # Permissions must be the same on the LibraryDatasetDatasetAssociation and the associated LibraryDataset
+        trans.app.security_agent.copy_library_permissions(trans, ld, ldda)
+        # Copy the current user's DefaultUserPermissions to the new LibraryDatasetDatasetAssociation.dataset
+        trans.app.security_agent.set_all_dataset_permissions(ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user))
+        library_folder.add_library_dataset(ld, genome_build=dbkey)
+        trans.sa_session.add(library_folder)
+        trans.sa_session.flush()
+
+        trans.sa_session.add(ld)
+        trans.sa_session.flush()
 
     def add_datasets_to_history(self, datasets, for_output_dataset=None):
         sa_session = self.sa_session
@@ -858,43 +912,6 @@ class RegexCollectedDatasetMatch(JsonCollectedDatasetMatch):
 
 
 UNSET = object()
-
-
-def _new_ldda(
-    trans,
-    name,
-    ext,
-    visible,
-    dbkey,
-    library_folder,
-):
-    ld = galaxy.model.LibraryDataset(folder=library_folder, name=name)
-    trans.sa_session.add(ld)
-    trans.sa_session.flush()
-    trans.app.security_agent.copy_library_permissions(trans, library_folder, ld)
-
-    ldda = galaxy.model.LibraryDatasetDatasetAssociation(name=name,
-                                                         extension=ext,
-                                                         dbkey=dbkey,
-                                                         library_dataset=ld,
-                                                         user=trans.user,
-                                                         create_dataset=True,
-                                                         sa_session=trans.sa_session)
-    trans.sa_session.add(ldda)
-    ldda.state = ldda.states.OK
-    # Permissions must be the same on the LibraryDatasetDatasetAssociation and the associated LibraryDataset
-    trans.app.security_agent.copy_library_permissions(trans, ld, ldda)
-    # Copy the current user's DefaultUserPermissions to the new LibraryDatasetDatasetAssociation.dataset
-    trans.app.security_agent.set_all_dataset_permissions(ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user))
-    library_folder.add_library_dataset(ld, genome_build=dbkey)
-    trans.sa_session.add(library_folder)
-    trans.sa_session.flush()
-
-    ld.library_dataset_dataset_association_id = ldda.id
-    trans.sa_session.add(ld)
-    trans.sa_session.flush()
-    return ldda
-
 
 DEFAULT_DATASET_COLLECTOR = DatasetCollector(DEFAULT_DATASET_COLLECTOR_DESCRIPTION)
 DEFAULT_TOOL_PROVIDED_DATASET_COLLECTOR = ToolMetadataDatasetCollector(ToolProvidedMetadataDatasetCollection())

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -270,7 +270,7 @@ def collect_dynamic_outputs(
 
 class JobContext(object):
 
-    def __init__(self, tool, tool_provided_metadata, job, job_working_directory, permission_provider, metadata_source_provider, input_dbkey):
+    def __init__(self, tool, tool_provided_metadata, job, job_working_directory, permission_provider, metadata_source_provider, input_dbkey, object_store):
         self.tool = tool
         self.metadata_source_provider = metadata_source_provider
         self.permission_provider = permission_provider
@@ -280,6 +280,7 @@ class JobContext(object):
         self.job = job
         self.job_working_directory = job_working_directory
         self.tool_provided_metadata = tool_provided_metadata
+        self.object_store = object_store
         self._permissions = None
 
     @property
@@ -460,7 +461,7 @@ class JobContext(object):
 
         # Move data from temp location to dataset location
         if not link_data:
-            app.object_store.update_from_file(primary_data.dataset, file_name=filename, create=True)
+            self.object_store.update_from_file(primary_data.dataset, file_name=filename, create=True)
         else:
             primary_data.link_to(filename)
 
@@ -558,7 +559,7 @@ def collect_primary_datasets(job_context, output, input_ext):
             if filename_index == 0 and extra_file_collector.assign_primary_output and output_index == 0:
                 new_outdata_name = fields_match.name or "%s (%s)" % (outdata.name, designation)
                 # Move data from temp location to dataset location
-                app.object_store.update_from_file(outdata.dataset, file_name=filename, create=True)
+                job_context.object_store.update_from_file(outdata.dataset, file_name=filename, create=True)
                 primary_output_assigned = True
                 continue
             if name not in primary_datasets:
@@ -600,7 +601,7 @@ def collect_primary_datasets(job_context, output, input_ext):
                         extra_dir = os.path.join(primary_data.extra_files_path, root.replace(extra_files_path_joined, '', 1).lstrip(os.path.sep))
                         extra_dir = os.path.normpath(extra_dir)
                         for f in files:
-                            app.object_store.update_from_file(
+                            job_context.object_store.update_from_file(
                                 primary_data.dataset,
                                 extra_dir=extra_dir,
                                 alt_name=f,

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -76,7 +76,8 @@ def collect_dynamic_outputs(
     output_collections,
 ):
     tool = job_context.tool
-    app = tool.app
+    app = job_context.app
+    sa_session = job_context.sa_session
     collections_service = app.dataset_collections_service
     job_working_directory = job_context.job_working_directory
 
@@ -147,7 +148,6 @@ def collect_dynamic_outputs(
             assert "collection_type" in unnamed_output_dict
             object_id = destination.get("object_id")
             if object_id:
-                sa_session = tool.app.model.context
                 hdca = sa_session.query(galaxy.model.HistoryDatasetCollectionAssociation).get(int(object_id))
             else:
                 name = unnamed_output_dict.get("name", "unnamed collection")
@@ -204,7 +204,6 @@ def collect_dynamic_outputs(
                         hda_id = discovered_file.match.object_id
                         primary_dataset = None
                         if hda_id:
-                            sa_session = tool.app.model.context
                             primary_dataset = sa_session.query(galaxy.model.HistoryDatasetAssociation).get(hda_id)
 
                         sources = fields_match.sources
@@ -533,9 +532,8 @@ class JobContext(object):
 
 def collect_primary_datasets(job_context, output, input_ext):
     tool = job_context.tool
-    app = tool.app
     job_working_directory = job_context.job_working_directory
-    sa_session = tool.sa_session
+    sa_session = job_context.sa_session
 
     # Loop through output file names, looking for generated primary
     # datasets in form specified by discover dataset patterns or in tool provided metadata.

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -370,15 +370,14 @@ class JobContext(object):
         sa_session = self.sa_session
         job = self.job
 
-        if job:
-            add_datasets_timer = ExecutionTimer()
-            job.history.add_datasets(sa_session, [d for (ei, d) in element_datasets])
-            log.debug(
-                "(%s) Add dynamic collection datasets to history for output [%s] %s",
-                self.job.id,
-                name,
-                add_datasets_timer,
-            )
+        add_datasets_timer = ExecutionTimer()
+        job.history.add_datasets(sa_session, [d for (ei, d) in element_datasets])
+        log.debug(
+            "(%s) Add dynamic collection datasets to history for output [%s] %s",
+            self.job.id,
+            name,
+            add_datasets_timer,
+        )
 
         for (element_identifiers, dataset) in element_datasets:
             current_builder = root_collection_builder
@@ -387,11 +386,10 @@ class JobContext(object):
             current_builder.add_dataset(element_identifiers[-1], dataset)
 
             # Associate new dataset with job
-            if job:
-                element_identifier_str = ":".join(element_identifiers)
-                # Below was changed from '__new_primary_file_%s|%s__' % (name, designation )
-                assoc = galaxy.model.JobToOutputDatasetAssociation('__new_primary_file_%s|%s__' % (name, element_identifier_str), dataset)
-                assoc.job = self.job
+            element_identifier_str = ":".join(element_identifiers)
+            # Below was changed from '__new_primary_file_%s|%s__' % (name, designation )
+            assoc = galaxy.model.JobToOutputDatasetAssociation('__new_primary_file_%s|%s__' % (name, element_identifier_str), dataset)
+            assoc.job = job
             sa_session.add(assoc)
 
             dataset.raw_set_dataset_state('ok')
@@ -583,10 +581,9 @@ def collect_primary_datasets(tool, output, tool_provided_metadata, job_working_d
                 dataset_attributes=new_primary_datasets_attributes,
             )
             # Associate new dataset with job
-            if job:
-                assoc = galaxy.model.JobToOutputDatasetAssociation('__new_primary_file_%s|%s__' % (name, designation), primary_data)
-                assoc.job = job
-                sa_session.add(assoc)
+            assoc = galaxy.model.JobToOutputDatasetAssociation('__new_primary_file_%s|%s__' % (name, designation), primary_data)
+            assoc.job = job
+            sa_session.add(assoc)
 
             if new_primary_datasets_attributes:
                 extra_files_path = new_primary_datasets_attributes.get('extra_files', None)

--- a/test/unit/tools/test_collect_primary_datasets.py
+++ b/test/unit/tools/test_collect_primary_datasets.py
@@ -331,7 +331,7 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesApp, t
         else:
             tool_provided_metadata = LegacyToolProvidedMetadata(meta_file)
 
-        return self.tool.discover_outputs(self.outputs, {}, tool_provided_metadata, job_working_directory, job=None, input_ext="txt", input_dbkey="btau")
+        return self.tool.discover_outputs(self.outputs, {}, tool_provided_metadata, job_working_directory, job=self.job, input_ext="txt", input_dbkey="btau")
 
     def _replace_output_collectors(self, xml_str):
         # Rewrite tool as if it had been created with output containing
@@ -383,6 +383,7 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesApp, t
         self.app.model.context.add(job)
         self.job = job
         self.history = self._new_history(hdas=[self.hda])
+        self.job.history = self.history
         self.outputs = {DEFAULT_TOOL_OUTPUT: self.hda}
 
     def _new_history(self, hdas=[], flush=True):


### PR DESCRIPTION
Dynamic output discovery/collection (output_collect.py) happens in the job finish code on the Galaxy server, but we'd like the option to run this code and publish results to the object store as part of the job script on the worker node. On the worker node, no database session would be configured - so we need a modality of this logic that works even if a database session is unavailable. This PR does not do that but it contains a series of atomic refactorings that isolate all the session requiring code nicely - allowing downstream functionality to be added that allows this cleanly.

The huge change downstream that builds on this PR looks something like (https://github.com/galaxyproject/galaxy/pull/7058/commits/21ed487153b6b61d4412c2f4078c079a74bb0ab3) currently. It reuses the abstractions here for discovering datasets and library folders but plugs in an alternative implementation for "persisting" the resulting model objects. A model export store will back that implementation but needs to be introduced as part of the history import/export work (https://github.com/galaxyproject/galaxy/pull/7058/commits/a88ecb291b3b315b1be00097e8b62ddd680179f9).