### PR TITLE
[19.01] Fix entering workflow parameter in workflow run form

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1715,7 +1715,7 @@ class DataToolParameter(BaseDataToolParameter):
                 self.conversions.append((name, conv_extension, [conv_type]))
 
     def from_json(self, value, trans, other_values={}):
-        if trans.workflow_building_mode is workflow_building_modes.ENABLED:
+        if trans.workflow_building_mode is workflow_building_modes.ENABLED or is_runtime_value(value):
             return None
         if not value and not self.optional:
             raise ValueError("Specify a dataset of the required format / build for parameter %s." % self.name)


### PR DESCRIPTION
Entering old-style workflow parameters calls the tool build api endpoint,
which errors with this scary-looking message:
```
galaxy.web.framework.decorators ERROR 2019-03-15 19:05:29,801 Uncaught exception in exposed API method:
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1193, in _execute_context
    context)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/engine/default.py", line 509, in do_execute
    cursor.execute(statement, parameters)
psycopg2.DataError: invalid input syntax for integer: "__class__"
LINE 3: WHERE history_dataset_association.id = '__class__'
                                               ^

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/web/framework/decorators.py", line 283, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/api/tools.py", line 123, in build
    return tool.to_json(trans, kwd.get('inputs', kwd))
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/__init__.py", line 1914, in to_json
    populate_state(request_context, self.inputs, params.__dict__, state_inputs, state_errors)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/parameters/__init__.py", line 364, in populate_state
    value, error = check_param(request_context, input, param_value, context) if check else [param_value, None]
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/parameters/__init__.py", line 184, in check_param
    value = param.from_json(value, trans, param_values)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/parameters/basic.py", line 1783, in from_json
    rval = trans.sa_session.query(trans.app.model.HistoryDatasetAssociation).get(value)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 924, in get
    ident, loading.load_on_pk_identity)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 1007, in _get_impl
    return db_load_fn(self, primary_key_identity)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/orm/loading.py", line 250, in load_on_pk_identity
    return q.one()
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 2954, in one
    ret = self.one_or_none()
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 2924, in one_or_none
    ret = list(self)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 2995, in __iter__
    return self._execute_and_instances(context)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 3018, in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 948, in execute
    return meth(self, multiparams, params)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/sql/elements.py", line 269, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1060, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1200, in _execute_context
    context)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1413, in _handle_dbapi_exception
    exc_info
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 265, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 248, in reraise
    raise value.with_traceback(tb)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1193, in _execute_context
    context)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.6/site-packages/sqlalchemy/engine/default.py", line 509, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.DataError: (psycopg2.DataError) invalid input syntax for integer: "__class__"
LINE 3: WHERE history_dataset_association.id = '__class__'
                                               ^
 [SQL: 'SELECT history_dataset_association.id AS history_dataset_association_id, history_dataset_association.history_id AS history_dataset_association_history_id, history_dataset_association.dataset_id AS history_dataset_association_dataset_id, history_dataset_association.create_time AS history_dataset_association_create_time, history_dataset_association.update_time AS history_dataset_association_update_time, history_dataset_association.state AS history_dataset_association_state, history_dataset_association.copied_from_history_dataset_association_id AS history_dataset_association_copied_from_history_dataset_a_1, history_dataset_association.copied_from_library_dataset_dataset_association_id AS history_dataset_association_copied_from_library_dataset_d_2, history_dataset_association.name AS history_dataset_association_name, history_dataset_association.info AS history_dataset_association_info, history_dataset_association.blurb AS history_dataset_association_blurb, history_dataset_association.peek AS history_dataset_association_peek, history_dataset_association.tool_version AS history_dataset_association_tool_version, history_dataset_association.extension AS history_dataset_association_extension, history_dataset_association.parent_id AS history_dataset_association_parent_id, history_dataset_association.designation AS history_dataset_association_designation, history_dataset_association.deleted AS history_dataset_association_deleted, history_dataset_association.visible AS history_dataset_association_visible, history_dataset_association.extended_metadata_id AS history_dataset_association_extended_metadata_id, history_dataset_association.version AS history_dataset_association_version, history_dataset_association.hid AS history_dataset_association_hid, history_dataset_association.purged AS history_dataset_association_purged, history_dataset_association.hidden_beneath_collection_instance_id AS history_dataset_association_hidden_beneath_collection_ins_3, dataset_1.id AS dataset_1_id, dataset_1.create_time AS dataset_1_create_time, dataset_1.update_time AS dataset_1_update_time, dataset_1.state AS dataset_1_state, dataset_1.deleted AS dataset_1_deleted, dataset_1.purged AS dataset_1_purged, dataset_1.purgable AS dataset_1_purgable, dataset_1.object_store_id AS dataset_1_object_store_id, dataset_1.external_filename AS dataset_1_external_filename, dataset_1._extra_files_path AS dataset_1__extra_files_path, dataset_1.file_size AS dataset_1_file_size, dataset_1.total_size AS dataset_1_total_size, dataset_1.uuid AS dataset_1_uuid \nFROM history_dataset_association LEFT OUTER JOIN dataset AS dataset_1 ON dataset_1.id = history_dataset_association.dataset_id \nWHERE history_dataset_association.id = %(param_1)s'] [parameters: {'param_1': '__class__'}] (Background on this error at: http://sqlalche.me/e/9h9h)
127.0.0.1 - - [15/Mar/2019:19:05:16 +0200] "POST /api/tools/Filter1/build HTTP/1.1" 500 - "http://127.0.0.1:8080/workflows/run?id=ba03619785539f8c" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36"
galaxy.web.framework.decorators ERROR 2019-03-15 19:05:29,803 Uncaught
```

That said I don't think the workflow run form has any business
calling that tools API endpoint, it would probably be more accurate
to call api.workflows.build_module, which could/should do some advanced
validation.