### PR TITLE
More robust task messaging

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -86,7 +86,7 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         if config_file:
             log.debug('Using "galaxy.ini" config file: %s', config_file)
         check_migrate_tools = self.config.check_migrate_tools
-        self._configure_models(check_migrate_databases=True, check_migrate_tools=check_migrate_tools, config_file=config_file)
+        self._configure_models(check_migrate_databases=self.config.check_migrate_databases, check_migrate_tools=check_migrate_tools, config_file=config_file)
 
         # Manage installed tool shed repositories.
         self.installed_repository_manager = installed_repository_manager.InstalledRepositoryManager(self)
@@ -228,7 +228,6 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         self._configure_signal_handlers(handlers)
 
         self.database_heartbeat = DatabaseHeartbeat(
-            sa_session=self.model.context,
             application_stack=self.application_stack
         )
         self.application_stack.register_postfork_function(self.database_heartbeat.start)

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -173,6 +173,7 @@ class Configuration(object):
 
         self.version_major = VERSION_MAJOR
         # Database related configuration
+        self.check_migrate_databases = kwargs.get('check_migrate_databases', True)
         self.database = resolve_path(kwargs.get("database_file", "database/universe.sqlite"), self.root)
         self.database_connection = kwargs.get("database_connection", False)
         self.database_engine_options = get_database_engine_options(kwargs)

--- a/lib/galaxy/dependencies/pipfiles/default/Pipfile
+++ b/lib/galaxy/dependencies/pipfiles/default/Pipfile
@@ -17,6 +17,7 @@ pygithub3 = {version = "*", markers = "python_version < '3'"}
 pytest = "*"
 pytest-html = "*"
 pytest-pythonpath = "*"
+pytest-postgresql = "*"
 recommonmark = "*"
 selenium = "*"
 Sphinx = "*"

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -34,7 +34,7 @@ pyparsing==2.3.1
 pytest-html==1.20.0
 pytest-metadata==1.8.0
 pytest-pythonpath==0.7.3
-pytest-pgsql==1.1.1 ; python_version > '3.3'
+pytest-postgresql==1.3.4
 pytest==4.3.1
 pytz==2018.9
 pyyaml==5.1

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -34,6 +34,7 @@ pyparsing==2.3.1
 pytest-html==1.20.0
 pytest-metadata==1.8.0
 pytest-pythonpath==0.7.3
+pytest-pgsql==1.1.1 ; python_version > '3.3'
 pytest==4.3.1
 pytz==2018.9
 pyyaml==5.1

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -173,6 +173,12 @@ class UsesCreateAndUpdateTime(object):
         return (galaxy.model.orm.now.now() - create_time).total_seconds()
 
 
+class WorkerProcess(UsesCreateAndUpdateTime):
+
+    def __init__(self, server_name):
+        self.server_name = server_name
+
+
 def cached_id(galaxy_model_object):
     """Get model object id attribute without a firing a database query.
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -47,6 +47,14 @@ log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
+model.WorkerProcess.table = Table(
+    'worker_process',
+    metadata,
+    Column('server_name', Text, primary_key=True),
+    Column("update_time", DateTime, default=now, onupdate=now),
+)
+
+
 model.User.table = Table(
     "galaxy_user", metadata,
     Column("id", Integer, primary_key=True),
@@ -1491,6 +1499,8 @@ model.APIKeys.table = Table(
 def simple_mapping(model, **kwds):
     mapper(model, model.table, properties=kwds)
 
+
+simple_mapping(model.WorkerProcess)
 
 mapper(model.FormValues, model.FormValues.table, properties=dict(
     form_definition=relation(model.FormDefinition,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1493,6 +1493,65 @@ model.APIKeys.table = Table(
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
     Column("key", TrimmedString(32), index=True, unique=True))
 
+CleanupEvent_table = Table("cleanup_event", metadata,
+                           Column("id", Integer, primary_key=True),
+                           Column("create_time", DateTime, default=now),
+                           Column("message", TrimmedString(1024)))
+
+CleanupEventDatasetAssociation_table = Table("cleanup_event_dataset_association", metadata,
+                                             Column("id", Integer, primary_key=True),
+                                             Column("create_time", DateTime, default=now),
+                                             Column("cleanup_event_id", Integer, ForeignKey("cleanup_event.id"), index=True, nullable=True),
+                                             Column("dataset_id", Integer, ForeignKey("dataset.id"), index=True))
+
+CleanupEventMetadataFileAssociation_table = Table("cleanup_event_metadata_file_association", metadata,
+                                                  Column("id", Integer, primary_key=True),
+                                                  Column("create_time", DateTime, default=now),
+                                                  Column("cleanup_event_id", Integer, ForeignKey("cleanup_event.id"), index=True, nullable=True),
+                                                  Column("metadata_file_id", Integer, ForeignKey("metadata_file.id"), index=True))
+
+CleanupEventHistoryAssociation_table = Table("cleanup_event_history_association", metadata,
+                                             Column("id", Integer, primary_key=True),
+                                             Column("create_time", DateTime, default=now),
+                                             Column("cleanup_event_id", Integer, ForeignKey("cleanup_event.id"), index=True, nullable=True),
+                                             Column("history_id", Integer, ForeignKey("history.id"), index=True))
+
+CleanupEventHistoryDatasetAssociationAssociation_table = Table("cleanup_event_hda_association", metadata,
+                                                               Column("id", Integer, primary_key=True),
+                                                               Column("create_time", DateTime, default=now),
+                                                               Column("cleanup_event_id", Integer, ForeignKey("cleanup_event.id"), index=True, nullable=True),
+                                                               Column("hda_id", Integer, ForeignKey("history_dataset_association.id"), index=True))
+
+CleanupEventLibraryAssociation_table = Table("cleanup_event_library_association", metadata,
+                                             Column("id", Integer, primary_key=True),
+                                             Column("create_time", DateTime, default=now),
+                                             Column("cleanup_event_id", Integer, ForeignKey("cleanup_event.id"), index=True, nullable=True),
+                                             Column("library_id", Integer, ForeignKey("library.id"), index=True))
+
+CleanupEventLibraryFolderAssociation_table = Table("cleanup_event_library_folder_association", metadata,
+                                                   Column("id", Integer, primary_key=True),
+                                                   Column("create_time", DateTime, default=now),
+                                                   Column("cleanup_event_id", Integer, ForeignKey("cleanup_event.id"), index=True, nullable=True),
+                                                   Column("library_folder_id", Integer, ForeignKey("library_folder.id"), index=True))
+
+CleanupEventLibraryDatasetAssociation_table = Table("cleanup_event_library_dataset_association", metadata,
+                                                    Column("id", Integer, primary_key=True),
+                                                    Column("create_time", DateTime, default=now),
+                                                    Column("cleanup_event_id", Integer, ForeignKey("cleanup_event.id"), index=True, nullable=True),
+                                                    Column("library_dataset_id", Integer, ForeignKey("library_dataset.id"), index=True))
+
+CleanupEventLibraryDatasetDatasetAssociationAssociation_table = Table("cleanup_event_ldda_association", metadata,
+                                                                      Column("id", Integer, primary_key=True),
+                                                                      Column("create_time", DateTime, default=now),
+                                                                      Column("cleanup_event_id", Integer, ForeignKey("cleanup_event.id"), index=True, nullable=True),
+                                                                      Column("ldda_id", Integer, ForeignKey("library_dataset_dataset_association.id"), index=True))
+
+CleanupEventImplicitlyConvertedDatasetAssociationAssociation_table = Table("cleanup_event_icda_association", metadata,
+                                                                           Column("id", Integer, primary_key=True),
+                                                                           Column("create_time", DateTime, default=now),
+                                                                           Column("cleanup_event_id", Integer, ForeignKey("cleanup_event.id"), index=True, nullable=True),
+                                                                           Column("icda_id", Integer, ForeignKey("implicitly_converted_dataset_association.id"), index=True))
+
 
 # With the tables defined we can define the mappers and setup the
 # relationships between the model objects.

--- a/lib/galaxy/model/migrate/versions/0151_add_worker_process.py
+++ b/lib/galaxy/model/migrate/versions/0151_add_worker_process.py
@@ -1,0 +1,53 @@
+"""
+Add table for worker processes
+"""
+from __future__ import print_function
+
+import logging
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    MetaData,
+    Table,
+    TEXT,
+)
+
+from galaxy.model.orm.now import now
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+
+WorkerProcess_table = Table(
+    'worker_process',
+    metadata,
+    Column('server_name', TEXT, primary_key=True),
+    Column("update_time", DateTime, default=now, onupdate=now),
+)
+
+
+def upgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    print(__doc__)
+    metadata.reflect()
+    _create(WorkerProcess_table)
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    _drop(WorkerProcess_table)
+
+
+def _create(table):
+    try:
+        table.create()
+    except Exception:
+        log.exception("Creating %s table failed.", table.name)
+
+
+def _drop(table):
+    try:
+        table.drop()
+    except Exception:
+        log.exception("Dropping %s table failed.", table.name)

--- a/lib/galaxy/model/migrate/versions/0151_add_worker_process.py
+++ b/lib/galaxy/model/migrate/versions/0151_add_worker_process.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     TEXT,
 )
 
+from galaxy.model.migrate.versions.util import create_table, drop_table
 from galaxy.model.orm.now import now
 
 log = logging.getLogger(__name__)
@@ -31,23 +32,9 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     print(__doc__)
     metadata.reflect()
-    _create(WorkerProcess_table)
+    create_table(WorkerProcess_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
-    _drop(WorkerProcess_table)
-
-
-def _create(table):
-    try:
-        table.create()
-    except Exception:
-        log.exception("Creating %s table failed.", table.name)
-
-
-def _drop(table):
-    try:
-        table.drop()
-    except Exception:
-        log.exception("Dropping %s table failed.", table.name)
+    drop_table(WorkerProcess_table)

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -326,6 +326,8 @@ class GalaxyQueueWorker(ConsumerProducerMixin, threading.Thread):
     def bind_and_start(self):
         log.info("Binding and starting galaxy control worker for %s", self.app.config.server_name)
         self.control_queue = galaxy.queues.control_queue_from_config(self.app.config)
+        # Delete messages for this control queue on startup
+        self.control_queue(self.connection).delete()
         self.start()
 
     def get_consumers(self, Consumer, channel):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -260,9 +260,6 @@ class GalaxyQueueWorker(ConsumerMixin, threading.Thread):
         if queue:
             # Allows assignment of a particular queue for this worker.
             self.control_queue = queue
-        else:
-            # Default to figuring out which control queue to use based on the app config.
-            queue = galaxy.queues.control_queue_from_config(app.config)
         self.task_mapping = task_mapping
         self.declare_queues = galaxy.queues.all_control_queues_for_declare(app.config, app.application_stack)
         # TODO we may want to purge the queue at the start to avoid executing

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -349,7 +349,7 @@ class GalaxyQueueWorker(ConsumerProducerMixin, threading.Thread):
                 result = 'NO_OP'
         else:
             log.warning("Received a malformed task message:\n%s" % body)
-        if message.properties['reply_to']:
+        if message.properties.get('reply_to'):
             self.producer.publish(
                 {'result': result},
                 exchange='',

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -57,6 +57,7 @@ def send_control_task(app, task, noop_self=False, kwargs={}):
             control_queues = galaxy.queues.all_control_queues_for_declare(app.config, app.application_stack)
             producer.publish(payload, exchange=galaxy.queues.galaxy_exchange,
                              declare=[galaxy.queues.galaxy_exchange] + control_queues,
+                             retry=True,
                              routing_key='control')
     except Exception:
         # This is likely connection refused.

--- a/lib/galaxy/queues.py
+++ b/lib/galaxy/queues.py
@@ -27,14 +27,14 @@ def all_control_queues_for_declare(config, application_stack):
     return [Queue("control.%s" % server_name, galaxy_exchange, routing_key='control.*') for server_name in server_names]
 
 
-def control_queue_from_config(config):
+def control_queues_from_config(config):
     """
     Returns a Queue instance with the correct name and routing key for this
     galaxy process's config
     """
-    return Queue("control.%s" % config.server_name,
-                 galaxy_exchange,
-                 routing_key='control.%s' % config.server_name)
+    exchange_queue = Queue("control.%s" % config.server_name, galaxy_exchange, routing_key='control.%s' % config.server_name)
+    non_exchange_queue = Queue("control.%s" % config.server_name, routing_key='control.%s' % config.server_name)
+    return exchange_queue, non_exchange_queue
 
 
 def connection_from_config(config):

--- a/lib/galaxy/queues.py
+++ b/lib/galaxy/queues.py
@@ -18,11 +18,13 @@ def all_control_queues_for_declare(config, application_stack):
     """
     For in-memory routing (used by sqlalchemy-based transports), we need to be able to
     build the entire routing table in producers.
-
-    Refactor later to actually persist this somewhere instead of building it repeatedly.
     """
-    possible_stack_queues = [Queue("control.%s.%s" % (config.server_name.split('.')[0], wkr['id']), galaxy_exchange, routing_key='control') for wkr in application_stack.workers()]
-    return possible_stack_queues + [Queue('control.%s' % q, galaxy_exchange, routing_key='control') for q in config.server_names]
+    # Get all active processes and construct queues for each process
+    if application_stack and application_stack.app:
+        server_names = (p.server_name for p in application_stack.app.database_heartbeat.get_active_processes())
+    else:
+        server_names = config.server_names
+    return [Queue("control.%s" % server_name, galaxy_exchange, routing_key='control.*') for server_name in server_names]
 
 
 def control_queue_from_config(config):

--- a/lib/galaxy/web/stack/database_heartbeat.py
+++ b/lib/galaxy/web/stack/database_heartbeat.py
@@ -1,0 +1,54 @@
+import datetime
+import threading
+
+from galaxy.model import WorkerProcess
+from galaxy.model.orm.now import now
+
+
+class DatabaseHeartbeat(object):
+
+    def __init__(self, sa_session, server_name=None, application_stack=None, heartbeat_interval=60):
+        self.sa_session = sa_session
+        self._server_name = server_name
+        self.application_stack = application_stack
+        self.heartbeat_interval = heartbeat_interval
+        self.exit = threading.Event()
+        self.thread = None
+        self.active = False
+
+    @property
+    def server_name(self):
+        # Application stack manipulates server name after forking
+        return self.application_stack.app.config.server_name if self.application_stack else self._server_name
+
+    def start(self):
+        if not self.active:
+            self.thread = threading.Thread(target=self.send_database_heartbeat, name="database_heartbeart_%s.thread" % self.server_name)
+            self.thread.daemon = True
+            self.active = True
+            self.thread.start()
+
+    def shutdown(self):
+        self.active = False
+        self.exit.set()
+        if self.thread:
+            self.thread.join()
+
+    def get_active_processes(self, last_seen_seconds=None):
+        """Return all processes seen in ``last_seen_seconds`` seconds."""
+        if last_seen_seconds is None:
+            last_seen_seconds = self.heartbeat_interval
+        seconds_ago = now() - datetime.timedelta(seconds=last_seen_seconds)
+        return self.sa_session.query(WorkerProcess).filter(WorkerProcess.table.c.update_time > seconds_ago).all()
+
+    def send_database_heartbeat(self):
+        if self.active:
+            while not self.exit.isSet():
+                worker_process = self.sa_session.query(WorkerProcess).filter_by(
+                    server_name=self.server_name).first()
+                if not worker_process:
+                    worker_process = WorkerProcess(server_name=self.server_name)
+                worker_process.update_time = now()
+                self.sa_session.add(worker_process)
+                self.sa_session.flush()
+                self.exit.wait(self.heartbeat_interval)

--- a/lib/galaxy/web/stack/database_heartbeat.py
+++ b/lib/galaxy/web/stack/database_heartbeat.py
@@ -7,9 +7,7 @@ from galaxy.model.orm.now import now
 
 class DatabaseHeartbeat(object):
 
-    def __init__(self, sa_session, server_name=None, application_stack=None, heartbeat_interval=60):
-        self.sa_session = sa_session
-        self._server_name = server_name
+    def __init__(self, application_stack, heartbeat_interval=60):
         self.application_stack = application_stack
         self.heartbeat_interval = heartbeat_interval
         self.exit = threading.Event()
@@ -17,9 +15,13 @@ class DatabaseHeartbeat(object):
         self.active = False
 
     @property
+    def sa_session(self):
+        return self.application_stack.app.model.context
+
+    @property
     def server_name(self):
         # Application stack manipulates server name after forking
-        return self.application_stack.app.config.server_name if self.application_stack else self._server_name
+        return self.application_stack.app.config.server_name
 
     def start(self):
         if not self.active:

--- a/scripts/galaxy-main
+++ b/scripts/galaxy-main
@@ -103,6 +103,7 @@ def load_galaxy_app(
         attach_to_pools=attach_to_pools,
         **kwds
     )
+    app.database_heartbeat.start()
     app.control_worker.bind_and_start()
     app.application_stack.log_startup()
     return app

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -25,9 +25,15 @@ from six.moves import (
     shlex_quote
 )
 from six.moves.urllib.parse import urlparse
+from sqlalchemy_utils import (
+    create_database,
+    database_exists,
+)
 
 from galaxy.app import UniverseApplication as GalaxyUniverseApplication
 from galaxy.config import LOGGING_CONFIG_DEFAULT
+from galaxy.model import mapping
+from galaxy.model.tool_shed_install import mapping as toolshed_mapping
 from galaxy.tools.verify.interactor import GalaxyInteractorApi, verify_tool
 from galaxy.util import asbool, download_to_file
 from galaxy.util.properties import load_app_properties
@@ -311,6 +317,7 @@ def copy_database_template(source, db_path):
 def database_conf(db_path, prefix="GALAXY", prefer_template_database=False):
     """Find (and populate if needed) Galaxy database connection."""
     database_auto_migrate = False
+    check_migrate_databases = True
     dburi_var = "%s_TEST_DBURI" % prefix
     template_name = None
     if dburi_var in os.environ:
@@ -323,6 +330,12 @@ def database_conf(db_path, prefix="GALAXY", prefer_template_database=False):
             actual_db = "gxtest" + ''.join(random.choice(string.ascii_uppercase) for _ in range(10))
             actual_database_parsed = database_template_parsed._replace(path="/%s" % actual_db)
             database_connection = actual_database_parsed.geturl()
+            if not database_exists(database_connection):
+                # We pass by migrations and instantiate the current table
+                create_database(database_connection)
+                mapping.init('/tmp', database_connection, create_tables=True, map_install_models=True)
+                toolshed_mapping.init(database_connection, create_tables=True)
+                check_migrate_databases = False
     else:
         default_db_filename = "%s.sqlite" % prefix.lower()
         template_var = "%s_TEST_DB_TEMPLATE" % prefix
@@ -337,6 +350,7 @@ def database_conf(db_path, prefix="GALAXY", prefer_template_database=False):
             database_auto_migrate = True
         database_connection = 'sqlite:///%s' % db_path
     config = {
+        "check_migrate_databases": check_migrate_databases,
         "database_connection": database_connection,
         "database_auto_migrate": database_auto_migrate
     }

--- a/test/unit/queue_worker/__init__.py
+++ b/test/unit/queue_worker/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for Galaxy Queue Worker
+"""

--- a/test/unit/queue_worker/conftest.py
+++ b/test/unit/queue_worker/conftest.py
@@ -27,7 +27,8 @@ def sqlite_connection(request):
 def sqlite_rabbitmq_app(sqlite_connection):
 
     def create_app():
-        return create_base_test(sqlite_connection, amqp_type='rabbitmq', amqp_connection='amqp://guest:guest@localhost:5672/')
+        amqp_connection = os.environ.get('GALAXY_TEST_AMQP_INTERNAL_CONNECTION')
+        return create_base_test(sqlite_connection, amqp_type='rabbitmq', amqp_connection=amqp_connection)
 
     return create_app
 
@@ -56,4 +57,7 @@ def database_app(request):
     if request.param == 'postgres_app':
         if not which('initdb'):
             pytest.skip("initdb must be on PATH for postgresql fixture")
+    if request.param == 'sqlite_rabbitmq_app':
+        if not os.environ.get('GALAXY_TEST_AMQP_INTERNAL_CONNECTION'):
+            pytest.skip("rabbitmq tests will be skipped if GALAXY_TEST_AMQP_INTERNAL_CONNECTION env var is unset")
     return request.getfixturevalue(request.param)

--- a/test/unit/queue_worker/conftest.py
+++ b/test/unit/queue_worker/conftest.py
@@ -15,7 +15,7 @@ def create_base_test(connection):
     yield app
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def sqlite_connection():
     fd, path = tempfile.mkstemp()
     os.close(fd)
@@ -23,20 +23,28 @@ def sqlite_connection():
     os.remove(path)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def sqlite_app(sqlite_connection):
-    with create_base_test(sqlite_connection) as app:
-        yield app
+
+    def create_app():
+        with create_base_test(sqlite_connection) as app:
+            return app
+
+    return create_app
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def postgres_app(postgresql_proc):
     connection = "postgresql://{p.user}@{p.host}:{p.port}/".format(p=postgresql_proc)
-    with create_base_test(connection) as app:
-        yield app
+
+    def create_app():
+        with create_base_test(connection) as app:
+            return app
+
+    return create_app
 
 
-@pytest.fixture(params=['postgres_app', 'sqlite_app'], scope='session')
+@pytest.fixture(params=['postgres_app', 'sqlite_app'])
 def database_app(request):
     if request.param == 'postgres_app':
         if not which('initdb'):

--- a/test/unit/queue_worker/conftest.py
+++ b/test/unit/queue_worker/conftest.py
@@ -1,0 +1,44 @@
+import contextlib
+import os
+import tempfile
+
+import pytest
+
+from galaxy.util import which
+from ..unittest_utils import galaxy_mock
+
+
+@contextlib.contextmanager
+def create_base_test(connection):
+    app = galaxy_mock.MockApp(database_connection=connection)
+    app.config.database_connection = connection
+    yield app
+
+
+@pytest.fixture(scope='session')
+def sqlite_connection():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    yield 'sqlite:////%s' % path
+    os.remove(path)
+
+
+@pytest.fixture(scope='session')
+def sqlite_app(sqlite_connection):
+    with create_base_test(sqlite_connection) as app:
+        yield app
+
+
+@pytest.fixture(scope='session')
+def postgres_app(postgresql_proc):
+    connection = "postgresql://{p.user}@{p.host}:{p.port}/".format(p=postgresql_proc)
+    with create_base_test(connection) as app:
+        yield app
+
+
+@pytest.fixture(params=['postgres_app', 'sqlite_app'], scope='session')
+def database_app(request):
+    if request.param == 'postgres_app':
+        if not which('initdb'):
+            pytest.skip("initdb must be on PATH for postgresql fixture")
+    yield request.getfixturevalue(request.param)

--- a/test/unit/queue_worker/test_database_heartbeat.py
+++ b/test/unit/queue_worker/test_database_heartbeat.py
@@ -8,7 +8,7 @@ from galaxy.web.stack.database_heartbeat import DatabaseHeartbeat
 
 @pytest.fixture
 def heartbeat_app(database_app):
-    with setup_heartbeat_app(database_app) as heartbeat_app:
+    with setup_heartbeat_app(database_app()) as heartbeat_app:
         yield heartbeat_app
 
 

--- a/test/unit/queue_worker/test_database_heartbeat.py
+++ b/test/unit/queue_worker/test_database_heartbeat.py
@@ -1,0 +1,40 @@
+import contextlib
+import time
+
+import pytest
+
+from galaxy.web.stack.database_heartbeat import DatabaseHeartbeat
+
+
+@pytest.fixture
+def heartbeat_app(database_app):
+    with setup_heartbeat_app(database_app) as heartbeat_app:
+        yield heartbeat_app
+
+
+@contextlib.contextmanager
+def setup_heartbeat_app(app):
+    app.config.server_name = 'test_queue_worker'
+    app.database_heartbeat = DatabaseHeartbeat(sa_session=app.model.context, server_name=app.config.server_name, heartbeat_interval=0.1)
+    yield app
+    app.database_heartbeat.shutdown()
+
+
+def test_database_heartbeat(heartbeat_app):
+    active_processes = heartbeat_app.database_heartbeat.get_active_processes()
+    assert len(active_processes) == 0
+    heartbeat_app.database_heartbeat.start()
+    # thread needs to start
+    time.sleep(0.2)
+    active_processes = heartbeat_app.database_heartbeat.get_active_processes()
+    assert len(active_processes) == 1
+    process = active_processes[0]
+    update_time = process.update_time
+    time.sleep(0.2)
+    heartbeat_app.model.context.refresh(process)
+    next_update_time = process.update_time
+    assert update_time < next_update_time
+    heartbeat_app.database_heartbeat.shutdown()
+    time.sleep(0.5)
+    assert len(heartbeat_app.database_heartbeat.get_active_processes(last_seen_seconds=5)) == 1
+    assert len(heartbeat_app.database_heartbeat.get_active_processes(last_seen_seconds=0.4)) == 0

--- a/test/unit/queue_worker/test_database_heartbeat.py
+++ b/test/unit/queue_worker/test_database_heartbeat.py
@@ -3,6 +3,7 @@ import time
 
 import pytest
 
+from galaxy.web.stack import application_stack_instance
 from galaxy.web.stack.database_heartbeat import DatabaseHeartbeat
 
 
@@ -14,8 +15,10 @@ def heartbeat_app(database_app):
 
 @contextlib.contextmanager
 def setup_heartbeat_app(app):
-    app.config.server_name = 'test_queue_worker'
-    app.database_heartbeat = DatabaseHeartbeat(sa_session=app.model.context, server_name=app.config.server_name, heartbeat_interval=0.1)
+    app.config.server_name = 'test_heartbeat'
+    app.config.attach_to_pools = False
+    app.application_stack = application_stack_instance(app=app)
+    app.database_heartbeat = DatabaseHeartbeat(application_stack=app.application_stack, heartbeat_interval=0.1)
     yield app
     app.database_heartbeat.shutdown()
 

--- a/test/unit/queue_worker/test_database_heartbeat.py
+++ b/test/unit/queue_worker/test_database_heartbeat.py
@@ -28,7 +28,7 @@ def test_database_heartbeat(heartbeat_app):
     assert len(active_processes) == 0
     heartbeat_app.database_heartbeat.start()
     # thread needs to start
-    time.sleep(0.2)
+    time.sleep(0.5)
     active_processes = heartbeat_app.database_heartbeat.get_active_processes()
     assert len(active_processes) == 1
     process = active_processes[0]

--- a/test/unit/queue_worker/test_queue_worker.py
+++ b/test/unit/queue_worker/test_queue_worker.py
@@ -77,6 +77,7 @@ def test_send_control_task_get_result(queue_worker_factory):
 def test_send_local_control_task_with_non_target_listeners(queue_worker_factory):
     app1 = queue_worker_factory('test_server1')
     app2 = queue_worker_factory('test_server2')
+    assert app2.some_var == 'foo'
     send_local_control_task(app=app1, task='echo')
     wait_for_var(app1, 'some_var', 'bar')
     assert app2.some_var == 'foo'
@@ -84,6 +85,7 @@ def test_send_local_control_task_with_non_target_listeners(queue_worker_factory)
 
 def test_send_control_task_noop_self(queue_worker_factory):
     app = queue_worker_factory('test_server')
+    assert app.some_var == 'foo'
     response = send_control_task(app=app, task='echo', noop_self=True, get_response=True)
     assert response == 'NO_OP'
     assert app.some_var == 'foo'

--- a/test/unit/queue_worker/test_queue_worker.py
+++ b/test/unit/queue_worker/test_queue_worker.py
@@ -1,9 +1,7 @@
 import contextlib
-import logging
 import time
 
 import pytest
-
 
 from galaxy.queue_worker import (
     GalaxyQueueWorker,
@@ -11,8 +9,8 @@ from galaxy.queue_worker import (
     send_local_control_task,
 )
 from galaxy.queues import connection_from_config
-
-log = logging.getLogger(__name__)
+from galaxy.web.stack import application_stack_instance
+from galaxy.web.stack.database_heartbeat import DatabaseHeartbeat
 
 
 def bar(app, **kwargs):
@@ -24,50 +22,77 @@ control_message_to_task = {'echo': bar}
 
 
 @pytest.fixture()
-def queue_worker_app(database_app):
-    with setup_queue_worker_test(database_app) as queue_worker_app:
-        yield queue_worker_app
+def queue_worker_factory(database_app):
+
+    def app_factory(server_name):
+        with setup_queue_worker_test(database_app(), server_name) as queue_worker_app:
+            return queue_worker_app
+
+    return app_factory
 
 
 @contextlib.contextmanager
-def setup_queue_worker_test(app):
-    app.config.server_name = 'test_queue_worker'
-    app.config.server_names = ['test_queue_worker']
+def setup_queue_worker_test(app, server_name):
+    app.some_var = 'foo'
+    app.config.server_name = server_name
+    app.config.server_names = [server_name]
+    app.config.attach_to_pools = False
     app.config.amqp_internal_connection = "sqlalchemy+" + app.config.database_connection
     app.amqp_internal_connection_obj = connection_from_config(app.config)
+    app.application_stack = application_stack_instance(app=app)
+    app.database_heartbeat = DatabaseHeartbeat(sa_session=app.model.context, application_stack=app.application_stack, heartbeat_interval=10)
+    app.database_heartbeat.start()
+    time.sleep(0.2)
     app.control_worker = GalaxyQueueWorker(app=app, task_mapping=control_message_to_task)
     app.control_worker.bind_and_start()
-    time.sleep(0.5)
+    time.sleep(0.2)
     try:
         yield app
     finally:
         app.control_worker.shutdown()
+        app.database_heartbeat.shutdown()
 
 
-def test_send_control_task(queue_worker_app):
-    queue_worker_app.some_var = 'foo'
-    send_control_task(app=queue_worker_app, task='echo')
-    wait_for_var(queue_worker_app, 'some_var', 'bar')
+def test_send_control_task(queue_worker_factory):
+    app = queue_worker_factory('test_server')
+    send_control_task(app=app, task='echo')
+    wait_for_var(app, 'some_var', 'bar')
 
 
-def test_send_control_task_get_result(queue_worker_app):
-    queue_worker_app.some_var = 'foo'
-    response = send_control_task(app=queue_worker_app, task='echo', get_response=True)
+def test_send_control_task_to_many_listeners(queue_worker_factory):
+    app1 = queue_worker_factory('test_server1')
+    app2 = queue_worker_factory('test_server2')
+    send_control_task(app=app1, task='echo')
+    for app in [app1, app2]:
+        wait_for_var(app, 'some_var', 'bar')
+
+
+def test_send_control_task_get_result(queue_worker_factory):
+    app = queue_worker_factory('test_server')
+    response = send_control_task(app=app, task='echo', get_response=True)
     assert response == 'bar'
-    assert queue_worker_app.some_var == 'bar'
+    assert app.some_var == 'bar'
 
 
-def test_send_control_task_noop_self(queue_worker_app):
-    queue_worker_app.some_var = 'foo'
-    response = send_control_task(app=queue_worker_app, task='echo', noop_self=True, get_response=True)
+def test_send_local_control_task_with_non_target_listeners(queue_worker_factory):
+    app1 = queue_worker_factory('test_server1')
+    app2 = queue_worker_factory('test_server2')
+    send_local_control_task(app=app1, task='echo')
+    wait_for_var(app1, 'some_var', 'bar')
+    assert app2.some_var == 'foo'
+
+
+def test_send_control_task_noop_self(queue_worker_factory):
+    app = queue_worker_factory('test_server')
+    response = send_control_task(app=app, task='echo', noop_self=True, get_response=True)
     assert response == 'NO_OP'
-    assert queue_worker_app.some_var == 'foo'
+    assert app.some_var == 'foo'
 
 
-def test_send_local_control_task(queue_worker_app):
-    queue_worker_app.some_var = 'foo'
-    send_local_control_task(app=queue_worker_app, task='echo')
-    wait_for_var(queue_worker_app, 'some_var', 'bar')
+def test_send_local_control_task(queue_worker_factory):
+    app = queue_worker_factory('test_server')
+    send_local_control_task(app=app, task='echo')
+    wait_for_var(app, 'some_var', 'bar')
 
 
 def wait_for_var(obj, var, value, tries=10, sleep=0.25):

--- a/test/unit/queue_worker/test_queue_worker.py
+++ b/test/unit/queue_worker/test_queue_worker.py
@@ -1,0 +1,54 @@
+import os
+import tempfile
+import time
+
+import pytest
+
+from galaxy.queue_worker import (
+    GalaxyQueueWorker,
+    send_control_task,
+)
+from galaxy.queues import connection_from_config
+from ..tools_support import UsesApp
+
+
+def foo(app, **kwargs):
+    app.some_var = 'bar'
+
+
+control_message_to_task = {'echo': foo}
+
+
+@pytest.fixture
+def sqlite_database_path():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    yield path
+    os.remove(path)
+
+
+@pytest.fixture
+def simple_app(sqlite_database_path):
+    test = UsesApp()
+    test.setup_app()
+    test.app.config.server_name = 'test_queue_worker'
+    test.app.config.server_names = ['test_server_name', 'test_queue_worker']
+    test.app.config.amqp_internal_connection = 'sqlalchemy+sqlite:////%s' % sqlite_database_path
+    test.app.amqp_internal_connection_obj = connection_from_config(test.app.config)
+    test.queue_worker = GalaxyQueueWorker(app=test.app, task_mapping=control_message_to_task)
+    test.queue_worker.bind_and_start()
+    yield test.app
+    test.queue_worker.shutdown()
+
+
+def test_queue_worker_echo(simple_app):
+    simple_app.some_var = 'foo'
+    send_control_task(app=simple_app, task='echo')
+    wait_for_var(simple_app, 'some_var', 'bar')
+
+
+def wait_for_var(obj, var, value, tries=10, sleep=0.25):
+    while getattr(obj, var) != value and tries >= 0:
+        tries -= 1
+        time.sleep(sleep)
+    assert getattr(obj, var) == value

--- a/test/unit/queue_worker/test_queue_worker.py
+++ b/test/unit/queue_worker/test_queue_worker.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 import time
 
 import pytest
@@ -7,12 +8,16 @@ import pytest
 from galaxy.queue_worker import (
     GalaxyQueueWorker,
     send_control_task,
+    send_local_control_task,
 )
 from galaxy.queues import connection_from_config
+
+log = logging.getLogger(__name__)
 
 
 def bar(app, **kwargs):
     app.some_var = 'bar'
+    return 'bar'
 
 
 control_message_to_task = {'echo': bar}
@@ -27,21 +32,41 @@ def queue_worker_app(database_app):
 @contextlib.contextmanager
 def setup_queue_worker_test(app):
     app.config.server_name = 'test_queue_worker'
-    app.config.server_names = ['test_server_name', 'test_queue_worker']
+    app.config.server_names = ['test_queue_worker']
     app.config.amqp_internal_connection = "sqlalchemy+" + app.config.database_connection
     app.amqp_internal_connection_obj = connection_from_config(app.config)
-    queue_worker = GalaxyQueueWorker(app=app, task_mapping=control_message_to_task)
-    queue_worker.bind_and_start()
+    app.control_worker = GalaxyQueueWorker(app=app, task_mapping=control_message_to_task)
+    app.control_worker.bind_and_start()
     time.sleep(0.5)
     try:
         yield app
     finally:
-        queue_worker.shutdown()
+        app.control_worker.shutdown()
 
 
-def test_queue_worker_echo(queue_worker_app):
+def test_send_control_task(queue_worker_app):
     queue_worker_app.some_var = 'foo'
     send_control_task(app=queue_worker_app, task='echo')
+    wait_for_var(queue_worker_app, 'some_var', 'bar')
+
+
+def test_send_control_task_get_result(queue_worker_app):
+    queue_worker_app.some_var = 'foo'
+    response = send_control_task(app=queue_worker_app, task='echo', get_response=True)
+    assert response == 'bar'
+    assert queue_worker_app.some_var == 'bar'
+
+
+def test_send_control_task_noop_self(queue_worker_app):
+    queue_worker_app.some_var = 'foo'
+    response = send_control_task(app=queue_worker_app, task='echo', noop_self=True, get_response=True)
+    assert response == 'NO_OP'
+    assert queue_worker_app.some_var == 'foo'
+
+
+def test_send_local_control_task(queue_worker_app):
+    queue_worker_app.some_var = 'foo'
+    send_local_control_task(app=queue_worker_app, task='echo')
     wait_for_var(queue_worker_app, 'some_var', 'bar')
 
 

--- a/test/unit/queue_worker/test_queue_worker.py
+++ b/test/unit/queue_worker/test_queue_worker.py
@@ -37,7 +37,6 @@ def setup_queue_worker_test(app, server_name):
     app.config.server_name = server_name
     app.config.server_names = [server_name]
     app.config.attach_to_pools = False
-    app.config.amqp_internal_connection = "sqlalchemy+" + app.config.database_connection
     app.amqp_internal_connection_obj = connection_from_config(app.config)
     app.application_stack = application_stack_instance(app=app)
     app.database_heartbeat = DatabaseHeartbeat(sa_session=app.model.context, application_stack=app.application_stack, heartbeat_interval=10)
@@ -45,7 +44,7 @@ def setup_queue_worker_test(app, server_name):
     time.sleep(0.2)
     app.control_worker = GalaxyQueueWorker(app=app, task_mapping=control_message_to_task)
     app.control_worker.bind_and_start()
-    time.sleep(0.2)
+    time.sleep(0.5)
     try:
         yield app
     finally:

--- a/test/unit/queue_worker/test_queue_worker.py
+++ b/test/unit/queue_worker/test_queue_worker.py
@@ -1,81 +1,48 @@
 import contextlib
-import os
-import sys
-import tempfile
 import time
 
 import pytest
+
 
 from galaxy.queue_worker import (
     GalaxyQueueWorker,
     send_control_task,
 )
 from galaxy.queues import connection_from_config
-from galaxy.util import which
-from ..tools_support import UsesApp
 
 
-def foo(app, **kwargs):
+def bar(app, **kwargs):
     app.some_var = 'bar'
 
 
-control_message_to_task = {'echo': foo}
+control_message_to_task = {'echo': bar}
 
 
-@pytest.fixture
-def sqlite_connection():
-    fd, path = tempfile.mkstemp()
-    os.close(fd)
-    yield 'sqlalchemy+sqlite:////%s' % path
-    os.remove(path)
-
-
-@pytest.fixture
-def simple_app(sqlite_connection):
-    with create_test(sqlite_connection) as test:
-        yield test.app
-
-
-@pytest.fixture
-def postgres_app(postgresql_db):
-    connection = "sqlalchemy+" + str(postgresql_db.engine.url)
-    if postgresql_db.has_table('kombu_message'):
-        raise Exception("postgresql table has kombu_message table, this shouldn't happen during tests.")
-    with create_test(connection) as test:
-        time.sleep(0.5)
-        # Wait for kombu table setup
-        yield test.app
+@pytest.fixture()
+def queue_worker_app(database_app):
+    with setup_queue_worker_test(database_app) as queue_worker_app:
+        yield queue_worker_app
 
 
 @contextlib.contextmanager
-def create_test(amqp_connection):
-    test = UsesApp()
-    test.setup_app()
-    test.app.config.server_name = 'test_queue_worker'
-    test.app.config.server_names = ['test_server_name', 'test_queue_worker']
-    test.app.config.amqp_internal_connection = amqp_connection
-    test.app.amqp_internal_connection_obj = connection_from_config(test.app.config)
-    test.queue_worker = GalaxyQueueWorker(app=test.app, task_mapping=control_message_to_task)
-    test.queue_worker.bind_and_start()
+def setup_queue_worker_test(app):
+    app.config.server_name = 'test_queue_worker'
+    app.config.server_names = ['test_server_name', 'test_queue_worker']
+    app.config.amqp_internal_connection = "sqlalchemy+" + app.config.database_connection
+    app.amqp_internal_connection_obj = connection_from_config(app.config)
+    queue_worker = GalaxyQueueWorker(app=app, task_mapping=control_message_to_task)
+    queue_worker.bind_and_start()
+    time.sleep(0.5)
     try:
-        yield test
+        yield app
     finally:
-        test.queue_worker.shutdown()
+        queue_worker.shutdown()
 
 
-@pytest.mark.skipif(sys.version_info[0] < 3,
-                    reason="postgresql_db fixture requires python 3 or higher")
-@pytest.mark.skipif(not which('initdb'), reason='reason postgresql initdb not on PATH')
-def test_queue_worker_echo_postgresql(postgres_app):
-    postgres_app.some_var = 'foo'
-    send_control_task(app=postgres_app, task='echo')
-    wait_for_var(postgres_app, 'some_var', 'bar')
-
-
-def test_queue_worker_echo(simple_app):
-    simple_app.some_var = 'foo'
-    send_control_task(app=simple_app, task='echo')
-    wait_for_var(simple_app, 'some_var', 'bar')
+def test_queue_worker_echo(queue_worker_app):
+    queue_worker_app.some_var = 'foo'
+    send_control_task(app=queue_worker_app, task='echo')
+    wait_for_var(queue_worker_app, 'some_var', 'bar')
 
 
 def wait_for_var(obj, var, value, tries=10, sleep=0.25):

--- a/test/unit/queue_worker/test_queue_worker.py
+++ b/test/unit/queue_worker/test_queue_worker.py
@@ -43,7 +43,7 @@ def setup_queue_worker_test(app):
     app.config.attach_to_pools = False
     app.amqp_internal_connection_obj = connection_from_config(app.config)
     app.application_stack = application_stack_instance(app=app)
-    app.database_heartbeat = DatabaseHeartbeat(sa_session=app.model.context, application_stack=app.application_stack, heartbeat_interval=10)
+    app.database_heartbeat = DatabaseHeartbeat(application_stack=app.application_stack, heartbeat_interval=10)
     app.database_heartbeat.start()
     time.sleep(0.2)
     app.control_worker = GalaxyQueueWorker(app=app, task_mapping=control_message_to_task)

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -61,7 +61,7 @@ class MockApp(object):
         self.security = self.config.security
         self.name = kwargs.get('name', 'galaxy')
         self.object_store = objectstore.build_object_store_from_config(self.config)
-        self.model = mapping.init("/tmp", "sqlite:///:memory:", create_tables=True, object_store=self.object_store)
+        self.model = mapping.init("/tmp", self.config.database_connection, create_tables=True, object_store=self.object_store)
         self.security_agent = self.model.security_agent
         self.visualizations_registry = MockVisualizationsRegistry()
         self.tag_handler = tags.GalaxyTagHandler(self.model.context)
@@ -111,6 +111,7 @@ class MockAppConfig(Bunch):
         Bunch.__init__(self, **kwargs)
         root = root or '/tmp'
         self.security = idencoding.IdEncodingHelper(id_secret='6e46ed6483a833c100e68cc3f1d0dd76')
+        self.database_connection = kwargs.get('database_connection', "sqlite:///:memory:")
         self.use_remote_user = kwargs.get('use_remote_user', False)
         self.file_path = '/tmp'
         self.jobs_directory = '/tmp'


### PR DESCRIPTION
This implements a database heartbeat and allows the QueueWorker to receive and send tasks to local and remote processes as long as they are connected to the database. This should immediately improve things like the data table reload that is triggered after running a data manager tool and therefore fixes https://github.com/galaxyproject/galaxy/issues/7564 and https://github.com/galaxyproject/galaxy/issues/7568

I'm also implementing a way to wait and get the results of a task, which I will use for waiting for these reloads (in a new PR). Longer term we could use this to manage tool dependencies for handlers that run remotely and scheduling the config watching to a single process (instead of every process doing that separately). 
Everything implemented here has unit tests for amqp connections via sqlite and postgresql as well as a real message broker.