### PR TITLE
Fix dataset checksum database migration downgrade.

### DIFF
--- a/lib/galaxy/model/migrate/versions/0148_add_checksum_table.py
+++ b/lib/galaxy/model/migrate/versions/0148_add_checksum_table.py
@@ -57,8 +57,8 @@ def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
     try:
-        dataset_source_table.drop()
-        dataset_hash_table.drop()
         dataset_source_hash_table.drop()
+        dataset_hash_table.drop()
+        dataset_source_table.drop()
     except Exception:
         log.exception("Dropping dataset source and hash tables failed.")


### PR DESCRIPTION
Fixes the following error when attempting to downgrade from migration 148, from #4659 (which was also #7487)

```
yoplait@malleus:~/work/galaxy sh manage_db.sh downgrade 145                                    ± dev
Activating virtualenv at .venv
148 -> 147...
Dropping dataset source and hash tables failed.
Traceback (most recent call last):
  File "lib/galaxy/model/migrate/versions/0148_add_checksum_table.py", line 60, in downgrade
    dataset_source_table.drop()
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/sql/schema.py", line 795, in drop
    checkfirst=checkfirst)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1940, in _run_visitor
    conn._run_visitor(visitorcallable, element, **kwargs)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1549, in _run_visitor
    **kwargs).traverse_single(element)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/sql/visitors.py", line 121, in traverse_single
    return meth(obj, **kw)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/sql/ddl.py", line 951, in visit_table
    self.connection.execute(DropTable(table))
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 948, in execute
    return meth(self, multiparams, params)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/sql/ddl.py", line 68, in _execute_on_connection
    return connection._execute_ddl(self, multiparams, params)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1009, in _execute_ddl
    compiled
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1200, in _execute_context
    context)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1413, in _handle_dbapi_exception
    exc_info
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 265, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1193, in _execute_context
    context)
  File "/Volumes/work_cs/galaxy/.venv/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 509, in do_execute
    cursor.execute(statement, parameters)
InternalError: (psycopg2.InternalError) cannot drop table dataset_source because other objects depend on it
DETAIL:  constraint dataset_source_hash_dataset_source_id_fkey on table dataset_source_hash depends on table dataset_source
HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 [SQL: '\nDROP TABLE dataset_source'] (Background on this error at: http://sqlalche.me/e/2j85)
done
```