### PR TITLE
[19.01] Correct db-self handler assignment method

### DIFF
--- a/lib/galaxy/util/handlers.py
+++ b/lib/galaxy/util/handlers.py
@@ -287,7 +287,7 @@ class ConfiguresHandlers(object):
         :returns: str -- The assigned handler ID.
         """
         if configured:
-            return self.handler_assignment_method_methods[HANDLER_ASSIGNMENT_METHODS.DB_PREASSIGN](
+            return self._handler_assignment_method_methods[HANDLER_ASSIGNMENT_METHODS.DB_PREASSIGN](
                 obj, method, configured, **kwargs
             )
         obj.set_handler(self.app.config.server_name)


### PR DESCRIPTION
When testing this, I saw some crashes due to no such attribute, it looks like an underscore was dropped here.