### PR TITLE
Remove unused attribute on Job class.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -634,7 +634,6 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         self.user_id = None
         self.tool_id = None
         self.tool_version = None
-        self.tool_hash = None
         self.copied_from_job_id = None
         self.command_line = None
         self.dependencies = []


### PR DESCRIPTION
Snuck in with #7545, should have been removed when concept was axed in 4a308130b332f981708eb3ade61754a7755d3c1e.