### PR TITLE
[19.01] Backport #7466: Don't display outputs that aren't going to be produced in workflow editor

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -23,6 +23,7 @@ from galaxy.tools import (
     DefaultToolState,
     ToolInputsNotReadyException
 )
+from galaxy.tools.actions import filter_output
 from galaxy.tools.execute import execute, MappingParameters, PartialJobExecution
 from galaxy.tools.parameters import (
     check_param,
@@ -930,6 +931,8 @@ class ToolModule(WorkflowModule):
         data_outputs = []
         if self.tool:
             for name, tool_output in self.tool.outputs.items():
+                if filter_output(tool_output, self.state.inputs):
+                    continue
                 extra_kwds = {}
                 if tool_output.collection:
                     extra_kwds["collection"] = True

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -491,6 +491,50 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase):
                 'label',
             )
 
+    @skip_without_tool('output_filter')
+    def test_export_editor_filtered_outputs(self):
+        template = """
+class: GalaxyWorkflow
+steps:
+  - tool_id: output_filter_with_input
+    state:
+      produce_out_1: {produce_out_1}
+      filter_text_1: {filter_text_1}
+      produce_collection: false
+      produce_paired_collection: false
+"""
+        workflow_id = self._upload_yaml_workflow(template.format(produce_out_1='false', filter_text_1='false'))
+        downloaded_workflow = self._download_workflow(workflow_id, style="editor")
+        outputs = downloaded_workflow['steps']['0']['outputs']
+        assert len(outputs) == 1
+        assert outputs[0]['name'] == 'out_3'
+        workflow_id = self._upload_yaml_workflow(template.format(produce_out_1='true', filter_text_1='false'))
+        downloaded_workflow = self._download_workflow(workflow_id, style="editor")
+        outputs = downloaded_workflow['steps']['0']['outputs']
+        assert len(outputs) == 2
+        assert outputs[0]['name'] == 'out_1'
+        assert outputs[1]['name'] == 'out_3'
+        workflow_id = self._upload_yaml_workflow(template.format(produce_out_1='true', filter_text_1='foo'))
+        downloaded_workflow = self._download_workflow(workflow_id, style="editor")
+        outputs = downloaded_workflow['steps']['0']['outputs']
+        assert len(outputs) == 3
+        assert outputs[0]['name'] == 'out_1'
+        assert outputs[1]['name'] == 'out_2'
+        assert outputs[2]['name'] == 'out_3'
+
+    @skip_without_tool('output_filter_with_input')
+    def test_export_editor_filtered_outputs_exception_handling(self):
+        workflow_id = self._upload_yaml_workflow("""
+class: GalaxyWorkflow
+steps:
+  - tool_id: output_filter_exception_1
+""")
+        downloaded_workflow = self._download_workflow(workflow_id, style="editor")
+        outputs = downloaded_workflow['steps']['0']['outputs']
+        assert len(outputs) == 2
+        assert outputs[0]['name'] == 'out_1'
+        assert outputs[1]['name'] == 'out_2'
+
     @skip_without_tool('collection_type_source')
     def test_export_editor_collection_type_source(self):
         workflow_id = self._upload_yaml_workflow("""

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -491,7 +491,7 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase):
                 'label',
             )
 
-    @skip_without_tool('output_filter')
+    @skip_without_tool('output_filter_with_input')
     def test_export_editor_filtered_outputs(self):
         template = """
 class: GalaxyWorkflow
@@ -522,7 +522,7 @@ steps:
         assert outputs[1]['name'] == 'out_2'
         assert outputs[2]['name'] == 'out_3'
 
-    @skip_without_tool('output_filter_with_input')
+    @skip_without_tool('output_filter_exception_1')
     def test_export_editor_filtered_outputs_exception_handling(self):
         workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow

--- a/test/functional/tools/output_filter_with_input.xml
+++ b/test/functional/tools/output_filter_with_input.xml
@@ -22,6 +22,8 @@
       <filter>filter_text_1 == "foo"</filter>
     </data>
     <data format="txt" from_work_dir="3" name="out_3">
+      <!-- always produce out_3 -->
+      <filter>input_1.ext != 'xyz'</filter>
     </data>
   </outputs>
   <tests>

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -284,6 +284,7 @@ def __mock_tool(
                                           format='input',
                                           format_source=None,
                                           change_format=[],
+                                          filters=[],
                                           label=None)},
         params_from_strings=mock.Mock(),
         check_and_update_param_values=mock.Mock(),


### PR DESCRIPTION
@innovate-invent ran into this recently and I think in general people have trouble identifying the outputs that a tool actually generates. If you connect a non-existing output or make it a workflow output that workflow will stop scheduling at that step, so this makes it much harder to generate invalid or partially running workflows.