### PR TITLE
[19.01] Backport workflow output rectification

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-manager.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-manager.js
@@ -90,10 +90,10 @@ class Workflow {
         var using_workflow_outputs = false;
         var has_existing_pjas = false;
         $.each(this.nodes, (k, node) => {
-            if (node.workflow_outputs && node.workflow_outputs.length > 0) {
+            if (node.type === "tool" && node.workflow_outputs && node.workflow_outputs.length > 0) {
                 using_workflow_outputs = true;
             }
-            $.each(node.post_job_actions, (pja_id, pja) => {
+            $.each(node.post_job_actions, (pja_using_workflow_outputsid, pja) => {
                 if (pja.action_type === "HideDatasetAction") {
                     has_existing_pjas = true;
                 }
@@ -102,43 +102,41 @@ class Workflow {
         if (using_workflow_outputs !== false || has_existing_pjas !== false) {
             // Using workflow outputs, or has existing pjas.  Remove all PJAs and recreate based on outputs.
             $.each(this.nodes, (k, node) => {
-                if (node.type === "tool") {
-                    var node_changed = false;
-                    if (node.post_job_actions === null) {
-                        node.post_job_actions = {};
-                        node_changed = true;
+                var node_changed = false;
+                if (node.post_job_actions === null) {
+                    node.post_job_actions = {};
+                    node_changed = true;
+                }
+                var pjas_to_rem = [];
+                $.each(node.post_job_actions, (pja_id, pja) => {
+                    if (pja.action_type == "HideDatasetAction") {
+                        pjas_to_rem.push(pja_id);
                     }
-                    var pjas_to_rem = [];
-                    $.each(node.post_job_actions, (pja_id, pja) => {
-                        if (pja.action_type == "HideDatasetAction") {
-                            pjas_to_rem.push(pja_id);
+                });
+                if (pjas_to_rem.length > 0) {
+                    $.each(pjas_to_rem, (i, pja_name) => {
+                        node_changed = true;
+                        delete node.post_job_actions[pja_name];
+                    });
+                }
+                if (using_workflow_outputs) {
+                    $.each(node.output_terminals, (ot_id, ot) => {
+                        var create_pja = !node.isWorkflowOutput(ot.name);
+                        if (create_pja === true) {
+                            node_changed = true;
+                            var pja = {
+                                action_type: "HideDatasetAction",
+                                output_name: ot.name,
+                                action_arguments: {}
+                            };
+                            node.post_job_actions[`HideDatasetAction${ot.name}`] = null;
+                            node.post_job_actions[`HideDatasetAction${ot.name}`] = pja;
                         }
                     });
-                    if (pjas_to_rem.length > 0) {
-                        $.each(pjas_to_rem, (i, pja_name) => {
-                            node_changed = true;
-                            delete node.post_job_actions[pja_name];
-                        });
-                    }
-                    if (using_workflow_outputs) {
-                        $.each(node.output_terminals, (ot_id, ot) => {
-                            var create_pja = !node.isWorkflowOutput(ot.name);
-                            if (create_pja === true) {
-                                node_changed = true;
-                                var pja = {
-                                    action_type: "HideDatasetAction",
-                                    output_name: ot.name,
-                                    action_arguments: {}
-                                };
-                                node.post_job_actions[`HideDatasetAction${ot.name}`] = null;
-                                node.post_job_actions[`HideDatasetAction${ot.name}`] = pja;
-                            }
-                        });
-                    }
-                    // lastly, if this is the active node, and we made changes, reload the display at right.
-                    if (this.active_node == node && node_changed === true) {
-                        this.reload_active_node();
-                    }
+                }
+                // lastly, if this is the active node, and we made changes, reload the display at right.
+                if (this.active_node == node && node_changed === true) {
+                    this.reload_active_node();
                 }
             });
         }

--- a/client/galaxy/scripts/mvc/workflow/workflow-manager.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-manager.js
@@ -93,7 +93,7 @@ class Workflow {
             if (node.type === "tool" && node.workflow_outputs && node.workflow_outputs.length > 0) {
                 using_workflow_outputs = true;
             }
-            $.each(node.post_job_actions, (pja_using_workflow_outputsid, pja) => {
+            $.each(node.post_job_actions, (pja_id, pja) => {
                 if (pja.action_type === "HideDatasetAction") {
                     has_existing_pjas = true;
                 }

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -647,6 +647,16 @@ export default Backbone.View.extend({
             success: function(data) {
                 node.init_field_data(data);
                 node.update_field_data(data);
+                // Post init/update, for new modules we want to default to
+                // nodes being outputs
+                // TODO: Overhaul the handling of all this when we modernize
+                // the editor, replace callout image manipulation with a simple
+                // class toggle, etc.
+                $.each(node.output_terminals, (ot_id, ot) => {
+                    node.addWorkflowOutput(ot.name);
+                    var callout = $(node.element).find(`.callout.${ot.name.replace(/(?=[()])/g, "\\")}`);
+                    callout.find("img").attr("src", `${Galaxy.root}static/images/fugue/asterisk-small.png`);
+                });
                 self.workflow.activate_node(node);
             }
         });

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -645,6 +645,7 @@ export default Backbone.View.extend({
             url: `${getAppRoot()}api/workflows/build_module`,
             data: request_data,
             success: function(data) {
+                const Galaxy = getGalaxyInstance();
                 node.init_field_data(data);
                 node.update_field_data(data);
                 // Post init/update, for new modules we want to default to


### PR DESCRIPTION
@dannon I don't need bfc0e65950978901b743070c3b9be1e58181c53f for 19.01, right ?
I didn't see any issue in testing, but I'm not sure how to know if `Galaxy` is globally available.