### PR TITLE
[19.01] Backport fix saving imported subworkflows

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4035,7 +4035,7 @@ class Workflow(Dictifiable, RepresentById):
         top_level_workflow = self
         if self.stored_workflow is None:
             # TODO: enforce this at creation...
-            assert len(self.parent_workflow_steps) == 1
+            assert len(set(w.uuid for w in self.parent_workflow_steps)) == 1
             return self.parent_workflow_steps[0].workflow.top_level_workflow
         return top_level_workflow
 


### PR DESCRIPTION
whose child-workflow is included more than once.
Fixes https://github.com/galaxyproject/galaxy/issues/7261 and probably https://github.com/galaxyproject/galaxy/issues/6032