### PR TITLE
[cli-lsf] Make LSF project configurable in job

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -812,8 +812,9 @@
         <destination id="local_lsf_8cpu_16GbRam" runner="cli">
             <param id="shell_plugin">LocalShell</param>
             <param id="job_plugin">LSF</param>
-            <param id="memory">16000</param>
-            <param id="cores">8</param>
+            <param id="job_memory">16000</param>
+            <param id="job_cores">8</param>
+            <param id="job_project">BigMem</param>
         </destination>
 
         <destination id="condor" runner="condor">

--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -18,7 +18,8 @@ argmap = {
     'memory': '-M',  # There is code in job_script_kwargs relying on this name's setting
     'cores': '-n',
     'queue': '-q',
-    'working_dir': '-cwd'
+    'working_dir': '-cwd',
+    'project': '-P'
 }
 
 


### PR DESCRIPTION
This PR adds the ability to have the LSF project configurable for cli-lsf destinations.

It also updates (and correct) the example in `job_conf.xml.sample_advanced`.

I have tested this to work correctly on our LSF setup.