### PR TITLE
Update cloud imports to adhere with cloudbridge interface changes.

### DIFF
--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -18,7 +18,7 @@ from galaxy.managers import sharable
 from galaxy.util import Params
 
 try:
-    from cloudbridge.cloud.factory import CloudProviderFactory, ProviderList
+    from cloudbridge.factory import CloudProviderFactory, ProviderList
 except ImportError:
     CloudProviderFactory = None
     ProviderList = None

--- a/tools/cloud/send.py
+++ b/tools/cloud/send.py
@@ -21,7 +21,7 @@ from galaxy.managers.cloud import CloudManager
 
 
 try:
-    from cloudbridge.cloud.factory import CloudProviderFactory, ProviderList
+    from cloudbridge.factory import CloudProviderFactory, ProviderList
 except ImportError:
     CloudProviderFactory = None
     ProviderList = None


### PR DESCRIPTION
PR https://github.com/galaxyproject/galaxy/pull/7272 updated Cloudbridge to its current latest version, which has interfaces changes. This PR updates the `cloud` manager and the `send` tool to adhere with those interface changes. 