### PR TITLE
Add ImgtJson datatype for IMGT immune system libraries

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -97,6 +97,7 @@
     <datatype extension="data" type="galaxy.datatypes.data:Data" mimetype="application/octet-stream" max_optional_metadata_filesize="1048576"/>
     <datatype extension="binary" type="galaxy.datatypes.binary:Binary" mimetype="application/octet-stream" max_optional_metadata_filesize="1048576"/>
     <datatype extension="d3_hierarchy" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="true"/>
+    <datatype extension="imgt.json" type="galaxy.datatypes.text:ImgtJson" mimetype="application/json" display_in_upload="True"/>
     <datatype extension="data_manager_json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="false"/>
     <datatype extension="dbn" type="galaxy.datatypes.sequence:DotBracket" display_in_upload="true" description="Dot-Bracket format is a text-based format for storing both an RNA sequence and its corresponding 2D structure." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Dbn"/>
     <datatype extension="fai" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" subclass="true" description="A Fasta Index File is a text file consisting of lines each with five TAB-delimited columns : Name, Length, offset, linebases, Linewidth" description_url="http://www.htslib.org/doc/faidx.html"/>
@@ -852,6 +853,7 @@
     <sniffer type="galaxy.datatypes.text:Arff"/>
     <sniffer type="galaxy.datatypes.text:Ipynb"/>
     <sniffer type="galaxy.datatypes.text:Biom1"/>
+    <sniffer type="galaxy.datatypes.text:ImgtJson"/>
     <sniffer type="galaxy.datatypes.text:Json"/>
     <sniffer type="galaxy.datatypes.genetics:GenotypeMatrix"/>
     <sniffer type="galaxy.datatypes.genetics:DataIn"/>

--- a/lib/galaxy/datatypes/test/imgt.json
+++ b/lib/galaxy/datatypes/test/imgt.json
@@ -1,0 +1,8833 @@
+[ {
+  "taxonId": 9615,
+  "speciesNames": [ "conis_lupus", "dog" ],
+  "genes": [ {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV1-15*01",
+    "name": "IGHV1-15*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV1-15*01|Canis lupus familiaris|P|V-REGION|976750..977043|294 nt|1| | | | |294+24=318| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 294
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV1-30*01",
+    "name": "IGHV1-30*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV1-30*01|Canis lupus familiaris|F|V-REGION|714117..714410|294 nt|1| | | | |294+24=318| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 294
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-2*01",
+    "name": "IGHV3-2*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-2*01|Canis lupus familiaris|F|V-REGION|1233843..1234138|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-3*01",
+    "name": "IGHV3-3*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-3*01|Canis lupus familiaris|F|V-REGION|1215699..1215994|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-5*01",
+    "name": "IGHV3-5*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-5*01|Canis lupus familiaris|F|V-REGION|1163008..1163303|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-6*01",
+    "name": "IGHV3-6*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-6*01|Canis lupus familiaris|F|V-REGION|1135209..1135501|293 nt|1| | | | |293+24=317| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-7*01",
+    "name": "IGHV3-7*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-7*01|Canis lupus familiaris|F|V-REGION|1118779..1119074|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-8*01",
+    "name": "IGHV3-8*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-8*01|Canis lupus familiaris|F|V-REGION|1112259..1112554|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-9*01",
+    "name": "IGHV3-9*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-9*01|Canis lupus familiaris|F|V-REGION|1087006..1087301|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-10*01",
+    "name": "IGHV3-10*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-10*01|Canis lupus familiaris|F|V-REGION|1077081..1077376|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-13*01",
+    "name": "IGHV3-13*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-13*01|Canis lupus familiaris|F|V-REGION|1005163..1005458|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-14*01",
+    "name": "IGHV3-14*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-14*01|Canis lupus familiaris|P|V-REGION|999692..999987|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-16*01",
+    "name": "IGHV3-16*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-16*01|Canis lupus familiaris|F|V-REGION|965853..966148|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-18*01",
+    "name": "IGHV3-18*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-18*01|Canis lupus familiaris|F|V-REGION|906835..907130|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-19*01",
+    "name": "IGHV3-19*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-19*01|Canis lupus familiaris|F|V-REGION|884529..884824|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-21*01",
+    "name": "IGHV3-21*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-21*01|Canis lupus familiaris|P|V-REGION|841592..841887|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-21-1*01",
+    "name": "IGHV3-21-1*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-21-1*01|Canis lupus familiaris|P|V-REGION|829178..829461|284 nt|1| | | | |284+36=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 273,
+      "VEnd": 284
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-23*01",
+    "name": "IGHV3-23*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-23*01|Canis lupus familiaris|F|V-REGION|805772..806067|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-24*01",
+    "name": "IGHV3-24*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-24*01|Canis lupus familiaris|F|V-REGION|794014..794309|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-25*01",
+    "name": "IGHV3-25*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-25*01|Canis lupus familiaris|P|V-REGION|785012..785307|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-26*01",
+    "name": "IGHV3-26*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-26*01|Canis lupus familiaris|P|V-REGION|762762..763057|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-31*01",
+    "name": "IGHV3-31*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-31*01|Canis lupus familiaris|P|V-REGION|706521..706816|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-32*01",
+    "name": "IGHV3-32*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-32*01|Canis lupus familiaris|ORF|V-REGION|695678..695973|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-33*01",
+    "name": "IGHV3-33*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-33*01|Canis lupus familiaris|P|V-REGION|692222..692515|294 nt|1| | | | |294+24=318| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 294
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-34*01",
+    "name": "IGHV3-34*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-34*01|Canis lupus familiaris|F|V-REGION|685238..685352|115 nt|1| | || |115+205=320|partial in 5'| |"
+    },
+    "anchorPoints": {
+      "CDR3Begin": 104,
+      "VEnd": 115
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-35*01",
+    "name": "IGHV3-35*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-35*01|Canis lupus familiaris|F|V-REGION|676291..676586|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-36*01",
+    "name": "IGHV3-36*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-36*01|Canis lupus familiaris|P|V-REGION|671952..672247|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-37*01",
+    "name": "IGHV3-37*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-37*01|Canis lupus familiaris|F|V-REGION|652203..652495|293 nt|1| | | | |293+24=317| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-38*01",
+    "name": "IGHV3-38*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-38*01|Canis lupus familiaris|F|V-REGION|632668..632963|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-39*01",
+    "name": "IGHV3-39*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-39*01|Canis lupus familiaris|F|V-REGION|616746..617041|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-41*01",
+    "name": "IGHV3-41*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-41*01|Canis lupus familiaris|F|V-REGION|586047..586342|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-43*01",
+    "name": "IGHV3-43*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-43*01|Canis lupus familiaris|P|V-REGION|558635..558930|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-44*01",
+    "name": "IGHV3-44*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-44*01|Canis lupus familiaris|ORF|V-REGION|542441..542736|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-45*01",
+    "name": "IGHV3-45*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-45*01|Canis lupus familiaris|P|V-REGION|536792..537086|295 nt|1| | | | |295+24=319| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 295
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-46*01",
+    "name": "IGHV3-46*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-46*01|Canis lupus familiaris|F|V-REGION|527739..528031|293 nt|1| | | | |293+24=317| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-47*01",
+    "name": "IGHV3-47*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-47*01|Canis lupus familiaris|F|V-REGION|520717..521009|293 nt|1| | | | |293+24=317| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-47-1*01",
+    "name": "IGHV3-47-1*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-47-1*01|Canis lupus familiaris|P|V-REGION|497588..497880|293 nt|1| | | | |293+24=317| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-50*01",
+    "name": "IGHV3-50*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-50*01|Canis lupus familiaris|F|V-REGION|434142..434437|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-52*01",
+    "name": "IGHV3-52*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-52*01|Canis lupus familiaris|P|V-REGION|420977..421272|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-54*01",
+    "name": "IGHV3-54*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-54*01|Canis lupus familiaris|F|V-REGION|385679..385975|297 nt|1| | | | |297+24=321| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 297
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-58*01",
+    "name": "IGHV3-58*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-58*01|Canis lupus familiaris|F|V-REGION|315906..316201|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-60*01",
+    "name": "IGHV3-60*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-60*01|Canis lupus familiaris|P|V-REGION|297702..297985|284 nt|1| | | | |284+36=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 273,
+      "VEnd": 284
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-61*01",
+    "name": "IGHV3-61*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-61*01|Canis lupus familiaris|F|V-REGION|291231..291526|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-67*01",
+    "name": "IGHV3-67*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-67*01|Canis lupus familiaris|F|V-REGION|219729..220024|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-69*01",
+    "name": "IGHV3-69*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-69*01|Canis lupus familiaris|F|V-REGION|203949..204244|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-70*01",
+    "name": "IGHV3-70*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-70*01|Canis lupus familiaris|F|V-REGION|192208..192503|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-72*01",
+    "name": "IGHV3-72*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-72*01|Canis lupus familiaris|P|V-REGION|170231..170526|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-75*01",
+    "name": "IGHV3-75*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-75*01|Canis lupus familiaris|F|V-REGION|127588..127880|293 nt|1| | | | |293+24=317| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-76*01",
+    "name": "IGHV3-76*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-76*01|Canis lupus familiaris|F|V-REGION|105886..106178|293 nt|1| | | | |293+24=317| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-78*01",
+    "name": "IGHV3-78*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-78*01|Canis lupus familiaris|P|V-REGION|59377..59672|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-80*01",
+    "name": "IGHV3-80*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-80*01|Canis lupus familiaris|F|V-REGION|47828..48123|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-81*01",
+    "name": "IGHV3-81*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-81*01|Canis lupus familiaris|F|V-REGION|29307..29602|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-82*01",
+    "name": "IGHV3-82*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-82*01|Canis lupus familiaris|F|V-REGION|24021..24316|296 nt|1| | | | |296+24=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV3-83*01",
+    "name": "IGHV3-83*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV3-83*01|Canis lupus familiaris|P|V-REGION|1011..1307|297 nt|1| | | | |297+24=321| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 285,
+      "VEnd": 297
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGH.fasta#IGHV4-1*01",
+    "name": "IGHV4-1*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHV4-1*01|Canis lupus familiaris|F|V-REGION|1243371..1243660|290 nt|1| | | | |290+30=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 102,
+      "CDR2Begin": 153,
+      "FR3Begin": 168,
+      "CDR3Begin": 279,
+      "VEnd": 290
+    }
+  }, {
+    "baseSequence": "file://dog_D_IGH.fasta#IGHD1*01",
+    "name": "IGHD1*01",
+    "geneType": "D",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHD1*01|Canis lupus familiaris|F|D-REGION|1247360..1247390|31 nt|1| | | | |31+0=31| | |"
+    },
+    "anchorPoints": {
+      "DBegin": 0,
+      "DEnd": 31
+    }
+  }, {
+    "baseSequence": "file://dog_D_IGH.fasta#IGHD2*01",
+    "name": "IGHD2*01",
+    "geneType": "D",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHD2*01|Canis lupus familiaris|F|D-REGION|1247950..1247968|19 nt|1| | | | |19+0=19| | |"
+    },
+    "anchorPoints": {
+      "DBegin": 0,
+      "DEnd": 19
+    }
+  }, {
+    "baseSequence": "file://dog_D_IGH.fasta#IGHD3*01",
+    "name": "IGHD3*01",
+    "geneType": "D",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHD3*01|Canis lupus familiaris|F|D-REGION|1249343..1249359|17 nt|1| | | | |17+0=17| | |"
+    },
+    "anchorPoints": {
+      "DBegin": 0,
+      "DEnd": 17
+    }
+  }, {
+    "baseSequence": "file://dog_D_IGH.fasta#IGHD4*01",
+    "name": "IGHD4*01",
+    "geneType": "D",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHD4*01|Canis lupus familiaris|F|D-REGION|1251017..1251035|19 nt|1| | | | |19+0=19| | |"
+    },
+    "anchorPoints": {
+      "DBegin": 0,
+      "DEnd": 19
+    }
+  }, {
+    "baseSequence": "file://dog_D_IGH.fasta#IGHD5*01",
+    "name": "IGHD5*01",
+    "geneType": "D",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHD5*01|Canis lupus familiaris|ORF|D-REGION|1251280..1251298|19 nt|1| | | | |19+0=19| | |"
+    },
+    "anchorPoints": {
+      "DBegin": 0,
+      "DEnd": 19
+    }
+  }, {
+    "baseSequence": "file://dog_D_IGH.fasta#IGHD6*01",
+    "name": "IGHD6*01",
+    "geneType": "D",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHD6*01|Canis lupus familiaris|F|D-REGION|1280507..1280517|11 nt|1| | | | |11+0=11| | |"
+    },
+    "anchorPoints": {
+      "DBegin": 0,
+      "DEnd": 11
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGH.fasta#IGHJ1*01",
+    "name": "IGHJ1*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHJ1*01|Canis lupus familiaris|ORF|J-REGION|1281009..1281061|53 nt|2| | || |53+0=53| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 22,
+      "FR4End": 53
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGH.fasta#IGHJ2*01",
+    "name": "IGHJ2*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHJ2*01|Canis lupus familiaris|F|J-REGION|1281345..1281398|54 nt|3| | || |54+0=54| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 23,
+      "FR4End": 54
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGH.fasta#IGHJ3*01",
+    "name": "IGHJ3*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHJ3*01|Canis lupus familiaris|F|J-REGION|1281557..1281606|50 nt|2| | || |50+0=50| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 19,
+      "FR4End": 50
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGH.fasta#IGHJ4*01",
+    "name": "IGHJ4*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHJ4*01|Canis lupus familiaris|F|J-REGION|1281909..1281956|48 nt|3| | || |48+0=48| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 17,
+      "FR4End": 48
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGH.fasta#IGHJ5*01",
+    "name": "IGHJ5*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHJ5*01|Canis lupus familiaris|F|J-REGION|1282219..1282269|51 nt|3| | || |51+0=51| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 20,
+      "FR4End": 51
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGH.fasta#IGHJ6*01",
+    "name": "IGHJ6*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGH" ],
+    "meta": {
+      "comments": "IMGT000001|IGHJ6*01|Canis lupus familiaris|F|J-REGION|1282783..1282836|54 nt|3| | || |54+0=54| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 23,
+      "FR4End": 54
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2-4*01",
+    "name": "IGKV2-4*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2-4*01|Canis lupus familiaris_boxer|F|V-REGION|87583..87884|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2-5*01",
+    "name": "IGKV2-5*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2-5*01|Canis lupus familiaris_boxer|F|V-REGION|76296..76597|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2-6*01",
+    "name": "IGKV2-6*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2-6*01|Canis lupus familiaris_boxer|F|V-REGION|69194..69495|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2-7*01",
+    "name": "IGKV2-7*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2-7*01|Canis lupus familiaris_boxer|F|V-REGION|56253..56554|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2-8*01",
+    "name": "IGKV2-8*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2-8*01|Canis lupus familiaris_boxer|F|V-REGION|37622..37923|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2-9*01",
+    "name": "IGKV2-9*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2-9*01|Canis lupus familiaris_boxer|F|V-REGION|23078..23379|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2-10*01",
+    "name": "IGKV2-10*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2-10*01|Canis lupus familiaris_boxer|F|V-REGION|13334..13635|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2-11*01",
+    "name": "IGKV2-11*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2-11*01|Canis lupus familiaris_boxer|F|V-REGION|1012..1313|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2S13*01",
+    "name": "IGKV2S13*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2S13*01|Canis lupus familiaris_boxer|F|V-REGION|342391..342692|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2S14*01",
+    "name": "IGKV2S14*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2S14*01|Canis lupus familiaris_boxer|P|V-REGION|328480..328781|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2S16*01",
+    "name": "IGKV2S16*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2S16*01|Canis lupus familiaris_boxer|F|V-REGION|290540..290841|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2S18*01",
+    "name": "IGKV2S18*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2S18*01|Canis lupus familiaris_boxer|P|V-REGION|232719..233020|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV2S19*01",
+    "name": "IGKV2S19*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV2S19*01|Canis lupus familiaris_boxer|F|V-REGION|216751..217052|302 nt|1| | | | |302+33=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 111,
+      "CDR2Begin": 162,
+      "FR3Begin": 171,
+      "CDR3Begin": 276,
+      "VEnd": 302
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV3S1*01",
+    "name": "IGKV3S1*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV3S1*01|Canis lupus familiaris_boxer|F|V-REGION|307021..307306|286 nt|1| | | | |286+48=334| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 156,
+      "CDR3Begin": 261,
+      "VEnd": 286
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV4-1*01",
+    "name": "IGKV4-1*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV4-1*01|Canis lupus familiaris_boxer|ORF|V-REGION|112219..112505|287 nt|1| | | | |287+48=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 156,
+      "CDR3Begin": 261,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGK.fasta#IGKV4S1*01",
+    "name": "IGKV4S1*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKV4S1*01|Canis lupus familiaris_boxer|F|V-REGION|283808..284112|305 nt|1| | | | |305+30=335| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 114,
+      "CDR2Begin": 165,
+      "FR3Begin": 174,
+      "CDR3Begin": 279,
+      "VEnd": 305
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGK.fasta#IGKJ1*01",
+    "name": "IGKJ1*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKJ1*01|Canis lupus familiaris_boxer|F|J-REGION|134511..134548|38 nt|2| | | | |38+0=38| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGK.fasta#IGKJ2*01",
+    "name": "IGKJ2*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKJ2*01|Canis lupus familiaris_boxer|ORF|J-REGION|134863..134901|39 nt|3| | || |39+0=39| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 12,
+      "FR4End": 39
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGK.fasta#IGKJ3*01",
+    "name": "IGKJ3*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKJ3*01|Canis lupus familiaris_boxer|F|J-REGION|135172..135209|38 nt|2| | | | |38+0=38| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGK.fasta#IGKJ4*01",
+    "name": "IGKJ4*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKJ4*01|Canis lupus familiaris_boxer|F|J-REGION|135504..135541|38 nt|2| | | | |38+0=38| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGK.fasta#IGKJ5*01",
+    "name": "IGKJ5*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGK" ],
+    "meta": {
+      "comments": "IMGT000002|IGKJ5*01|Canis lupus familiaris_boxer|F|J-REGION|135820..135857|38 nt|2| | | | |38+0=38| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-41*01",
+    "name": "Canlupfam_IGLV1-41*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-41*01|Canis lupus familiaris|IGLV1|ORF|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-44*01",
+    "name": "Canlupfam_IGLV1-44*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-44*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-45*01",
+    "name": "Canlupfam_IGLV1-45*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-45*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 294
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-46*01",
+    "name": "Canlupfam_IGLV1-46*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-46*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-48*01",
+    "name": "Canlupfam_IGLV1-48*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-48*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-49*01",
+    "name": "Canlupfam_IGLV1-49*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-49*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-50*01",
+    "name": "Canlupfam_IGLV1-50*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-50*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-52*01",
+    "name": "Canlupfam_IGLV1-52*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-52*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-54*01",
+    "name": "Canlupfam_IGLV1-54*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-54*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-55*01",
+    "name": "Canlupfam_IGLV1-55*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-55*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-56*01",
+    "name": "Canlupfam_IGLV1-56*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-56*01|Canis lupus familiaris|IGLV1|ORF|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-57*01",
+    "name": "Canlupfam_IGLV1-57*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-57*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-58*01",
+    "name": "Canlupfam_IGLV1-58*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-58*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-66*01",
+    "name": "Canlupfam_IGLV1-66*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-66*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-67*01",
+    "name": "Canlupfam_IGLV1-67*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-67*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-69*01",
+    "name": "Canlupfam_IGLV1-69*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-69*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 292
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-70*01",
+    "name": "Canlupfam_IGLV1-70*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-70*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-72*01",
+    "name": "Canlupfam_IGLV1-72*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-72*01|Canis lupus familiaris|IGLV1|ORF|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 72,
+      "FR2Begin": 90,
+      "CDR2Begin": 138,
+      "CDR3Begin": 252,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-73*01",
+    "name": "Canlupfam_IGLV1-73*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-73*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-75*01",
+    "name": "Canlupfam_IGLV1-75*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-75*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-78*01",
+    "name": "Canlupfam_IGLV1-78*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-78*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-80*01",
+    "name": "Canlupfam_IGLV1-80*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-80*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-82*01",
+    "name": "Canlupfam_IGLV1-82*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-82*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 90,
+      "CDR2Begin": 138,
+      "CDR3Begin": 252,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-84*01",
+    "name": "Canlupfam_IGLV1-84*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-84*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-84-1*01",
+    "name": "Canlupfam_IGLV1-84-1*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-84-1*01|Canis lupus familiaris|IGLV1|ORF|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 294
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-86*01",
+    "name": "Canlupfam_IGLV1-86*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-86*01|Canis lupus familiaris|IGLV1|ORF|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 111,
+      "CDR2Begin": 159,
+      "CDR3Begin": 273,
+      "VEnd": 314
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-87*01",
+    "name": "Canlupfam_IGLV1-87*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-87*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-89*01",
+    "name": "Canlupfam_IGLV1-89*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-89*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-92*01",
+    "name": "Canlupfam_IGLV1-92*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-92*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-94*01",
+    "name": "Canlupfam_IGLV1-94*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-94*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-96*01",
+    "name": "Canlupfam_IGLV1-96*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-96*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-97-1*01",
+    "name": "Canlupfam_IGLV1-97-1*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-97-1*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-98*01",
+    "name": "Canlupfam_IGLV1-98*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-98*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-100*01",
+    "name": "Canlupfam_IGLV1-100*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-100*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-103*01",
+    "name": "Canlupfam_IGLV1-103*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-103*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-104*01",
+    "name": "Canlupfam_IGLV1-104*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-104*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 138,
+      "CDR3Begin": 252,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-106*01",
+    "name": "Canlupfam_IGLV1-106*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-106*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-111*01",
+    "name": "Canlupfam_IGLV1-111*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-111*01|Canis lupus familiaris|IGLV1|ORF|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-112*01",
+    "name": "Canlupfam_IGLV1-112*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-112*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-114*01",
+    "name": "Canlupfam_IGLV1-114*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-114*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-115*01",
+    "name": "Canlupfam_IGLV1-115*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-115*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-116*01",
+    "name": "Canlupfam_IGLV1-116*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-116*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-118*01",
+    "name": "Canlupfam_IGLV1-118*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-118*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-125*01",
+    "name": "Canlupfam_IGLV1-125*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-125*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-129*01",
+    "name": "Canlupfam_IGLV1-129*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-129*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-130*01",
+    "name": "Canlupfam_IGLV1-130*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-130*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-135*01",
+    "name": "Canlupfam_IGLV1-135*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-135*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-136*01",
+    "name": "Canlupfam_IGLV1-136*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-136*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-138*01",
+    "name": "Canlupfam_IGLV1-138*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-138*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-139*01",
+    "name": "Canlupfam_IGLV1-139*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-139*01|Canis lupus familiaris|IGLV1|ORF|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 297
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-141*01",
+    "name": "Canlupfam_IGLV1-141*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-141*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-143*01",
+    "name": "Canlupfam_IGLV1-143*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-143*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-144*01",
+    "name": "Canlupfam_IGLV1-144*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-144*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-146*01",
+    "name": "Canlupfam_IGLV1-146*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-146*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-147*01",
+    "name": "Canlupfam_IGLV1-147*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-147*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-149*01",
+    "name": "Canlupfam_IGLV1-149*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-149*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-150*01",
+    "name": "Canlupfam_IGLV1-150*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-150*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-151*01",
+    "name": "Canlupfam_IGLV1-151*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-151*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-152*01",
+    "name": "Canlupfam_IGLV1-152*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-152*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-155*01",
+    "name": "Canlupfam_IGLV1-155*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-155*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-157*01",
+    "name": "Canlupfam_IGLV1-157*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-157*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-158*01",
+    "name": "Canlupfam_IGLV1-158*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-158*01|Canis lupus familiaris|IGLV1|ORF|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-159*01",
+    "name": "Canlupfam_IGLV1-159*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-159*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-160*01",
+    "name": "Canlupfam_IGLV1-160*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-160*01|Canis lupus familiaris|IGLV1|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-162*01",
+    "name": "Canlupfam_IGLV1-162*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV1-162*01|Canis lupus familiaris|IGLV1|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 141,
+      "CDR3Begin": 255,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV2-31*01",
+    "name": "Canlupfam_IGLV2-31*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV2-31*01|Canis lupus familiaris|IGLV2|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 297
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV2-32*01",
+    "name": "Canlupfam_IGLV2-32*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV2-32*01|Canis lupus familiaris|IGLV2|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-2*01",
+    "name": "Canlupfam_IGLV3-2*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-2*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-3*01",
+    "name": "Canlupfam_IGLV3-3*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-3*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-4*01",
+    "name": "Canlupfam_IGLV3-4*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-4*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-7*01",
+    "name": "Canlupfam_IGLV3-7*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-7*01|Canis lupus familiaris|IGLV3|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-8*01",
+    "name": "Canlupfam_IGLV3-8*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-8*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-11*01",
+    "name": "Canlupfam_IGLV3-11*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-11*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-13*01",
+    "name": "Canlupfam_IGLV3-13*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-13*01|Canis lupus familiaris|IGLV3|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-14*01",
+    "name": "Canlupfam_IGLV3-14*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-14*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-15*01",
+    "name": "Canlupfam_IGLV3-15*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-15*01|Canis lupus familiaris|IGLV3|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-19*01",
+    "name": "Canlupfam_IGLV3-19*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-19*01|Canis lupus familiaris|IGLV3|ORF|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-21*01",
+    "name": "Canlupfam_IGLV3-21*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-21*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-23*01",
+    "name": "Canlupfam_IGLV3-23*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-23*01|Canis lupus familiaris|IGLV3|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-24*01",
+    "name": "Canlupfam_IGLV3-24*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-24*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-25*01",
+    "name": "Canlupfam_IGLV3-25*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-25*01|Canis lupus familiaris|IGLV3|ORF|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-26*01",
+    "name": "Canlupfam_IGLV3-26*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-26*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-27*01",
+    "name": "Canlupfam_IGLV3-27*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-27*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-28*01",
+    "name": "Canlupfam_IGLV3-28*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-28*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-29*01",
+    "name": "Canlupfam_IGLV3-29*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-29*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-30*01",
+    "name": "Canlupfam_IGLV3-30*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV3-30*01|Canis lupus familiaris|IGLV3|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 87,
+      "CDR2Begin": 135,
+      "CDR3Begin": 249,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-5*01",
+    "name": "Canlupfam_IGLV4-5*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV4-5*01|Canis lupus familiaris|IGLV4|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 90,
+      "CDR2Begin": 138,
+      "FR3Begin": 159,
+      "CDR3Begin": 264,
+      "VEnd": 317
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-6*01",
+    "name": "Canlupfam_IGLV4-6*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV4-6*01|Canis lupus familiaris|IGLV4|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 90,
+      "CDR2Begin": 141,
+      "FR3Begin": 162,
+      "CDR3Begin": 267,
+      "VEnd": 303
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-10*01",
+    "name": "Canlupfam_IGLV4-10*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV4-10*01|Canis lupus familiaris|IGLV4|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 90,
+      "CDR2Begin": 138,
+      "FR3Begin": 159,
+      "CDR3Begin": 264,
+      "VEnd": 317
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-16*01",
+    "name": "Canlupfam_IGLV4-16*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV4-16*01|Canis lupus familiaris|IGLV4|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 90,
+      "CDR2Begin": 138,
+      "FR3Begin": 159,
+      "CDR3Begin": 264,
+      "VEnd": 317
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-20*01",
+    "name": "Canlupfam_IGLV4-20*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV4-20*01|Canis lupus familiaris|IGLV4|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 90,
+      "CDR2Begin": 138,
+      "FR3Begin": 159,
+      "CDR3Begin": 264,
+      "VEnd": 317
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-22*01",
+    "name": "Canlupfam_IGLV4-22*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV4-22*01|Canis lupus familiaris|IGLV4|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 90,
+      "CDR2Begin": 141,
+      "FR3Begin": 162,
+      "CDR3Begin": 267,
+      "VEnd": 303
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV5-64*01",
+    "name": "Canlupfam_IGLV5-64*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV5-64*01|Canis lupus familiaris|IGLV5|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "FR3Begin": 165,
+      "CDR3Begin": 276,
+      "VEnd": 325
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV5-85*01",
+    "name": "Canlupfam_IGLV5-85*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV5-85*01|Canis lupus familiaris|IGLV5|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "FR3Begin": 165,
+      "CDR3Begin": 276,
+      "VEnd": 325
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV5-109*01",
+    "name": "Canlupfam_IGLV5-109*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV5-109*01|Canis lupus familiaris|IGLV5|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 270,
+      "VEnd": 319
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV5-131*01",
+    "name": "Canlupfam_IGLV5-131*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV5-131*01|Canis lupus familiaris|IGLV5|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "FR3Begin": 165,
+      "CDR3Begin": 276,
+      "VEnd": 325
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-36*01",
+    "name": "Canlupfam_IGLV8-36*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-36*01|Canis lupus familiaris|IGLV8|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 299
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-39*01",
+    "name": "Canlupfam_IGLV8-39*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-39*01|Canis lupus familiaris|IGLV8|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-43*01",
+    "name": "Canlupfam_IGLV8-43*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-43*01|Canis lupus familiaris|IGLV8|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-93*01",
+    "name": "Canlupfam_IGLV8-93*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-93*01|Canis lupus familiaris|IGLV8|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-99*01",
+    "name": "Canlupfam_IGLV8-99*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-99*01|Canis lupus familiaris|IGLV8|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-102*01",
+    "name": "Canlupfam_IGLV8-102*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-102*01|Canis lupus familiaris|IGLV8|ORF|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 69,
+      "FR2Begin": 90,
+      "CDR2Begin": 138,
+      "CDR3Begin": 252,
+      "VEnd": 300
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-108*01",
+    "name": "Canlupfam_IGLV8-108*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-108*01|Canis lupus familiaris|IGLV8|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 307
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-113*01",
+    "name": "Canlupfam_IGLV8-113*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-113*01|Canis lupus familiaris|IGLV8|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-119*01",
+    "name": "Canlupfam_IGLV8-119*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-119*01|Canis lupus familiaris|IGLV8|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-121*01",
+    "name": "Canlupfam_IGLV8-121*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-121*01|Canis lupus familiaris|IGLV8|P|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 307
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-128*01",
+    "name": "Canlupfam_IGLV8-128*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-128*01|Canis lupus familiaris|IGLV8|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-142*01",
+    "name": "Canlupfam_IGLV8-142*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-142*01|Canis lupus familiaris|IGLV8|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-153*01",
+    "name": "Canlupfam_IGLV8-153*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-153*01|Canis lupus familiaris|IGLV8|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-161*01",
+    "name": "Canlupfam_IGLV8-161*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLV8-161*01|Canis lupus familiaris|IGLV8|F|V-REGION"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 144,
+      "CDR3Begin": 258,
+      "VEnd": 296
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGL.fasta#Canlupfam_IGLJ1*01",
+    "name": "Canlupfam_IGLJ1*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLJ1*01|Canis lupus familiaris|F|J-REGION"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGL.fasta#Canlupfam_IGLJ2*01",
+    "name": "Canlupfam_IGLJ2*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLJ2*01|Canis lupus familiaris|F|J-REGION"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGL.fasta#Canlupfam_IGLJ3*01",
+    "name": "Canlupfam_IGLJ3*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLJ3*01|Canis lupus familiaris|F|J-REGION"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGL.fasta#Canlupfam_IGLJ4*01",
+    "name": "Canlupfam_IGLJ4*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLJ4*01|Canis lupus familiaris|F|J-REGION"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGL.fasta#Canlupfam_IGLJ5*01",
+    "name": "Canlupfam_IGLJ5*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLJ5*01|Canis lupus familiaris|F|J-REGION"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGL.fasta#Canlupfam_IGLJ6*01",
+    "name": "Canlupfam_IGLJ6*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLJ6*01|Canis lupus familiaris|F|J-REGION"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGL.fasta#Canlupfam_IGLJ7*01",
+    "name": "Canlupfam_IGLJ7*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLJ7*01|Canis lupus familiaris|F|J-REGION"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGL.fasta#Canlupfam_IGLJ8*01",
+    "name": "Canlupfam_IGLJ8*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLJ8*01|Canis lupus familiaris|F|J-REGION"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_J_IGL.fasta#Canlupfam_IGLJ9*01",
+    "name": "Canlupfam_IGLJ9*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "IGL" ],
+    "meta": {
+      "comments": "IMGT000003|Canlupfam_IGLJ9*01|Canis lupus familiaris|F|J-REGION"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 10,
+      "FR4End": 38
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV8-1*01",
+    "name": "TRAV8-1*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV8-1*01|Canis lupus familiaris_boxer|F|V-REGION|245069..245352|284 nt|1| | | | |284+39=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 171,
+      "CDR3Begin": 270,
+      "VEnd": 284
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV8-2*01",
+    "name": "TRAV8-2*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV8-2*01|Canis lupus familiaris_boxer|F|V-REGION|301190..301467|278 nt|1| | | | |278+45=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 165,
+      "CDR3Begin": 264,
+      "VEnd": 278
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-1*01",
+    "name": "TRAV9-1*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-1*01|Canis lupus familiaris_boxer|F|V-REGION|10534..10814|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-3*01",
+    "name": "TRAV9-3*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-3*01|Canis lupus familiaris_boxer|F|V-REGION|55186..55466|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-4*01",
+    "name": "TRAV9-4*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-4*01|Canis lupus familiaris_boxer|F|V-REGION|63912..64192|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-5*01",
+    "name": "TRAV9-5*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-5*01|Canis lupus familiaris_boxer|F|V-REGION|86037..86317|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-6*01",
+    "name": "TRAV9-6*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-6*01|Canis lupus familiaris_boxer|F|V-REGION|102097..102377|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-7*01",
+    "name": "TRAV9-7*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-7*01|Canis lupus familiaris_boxer|F|V-REGION|124679..124959|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-8*01",
+    "name": "TRAV9-8*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-8*01|Canis lupus familiaris_boxer|F|V-REGION|140347..140627|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-9*01",
+    "name": "TRAV9-9*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-9*01|Canis lupus familiaris_boxer|F|V-REGION|147510..147790|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-10*01",
+    "name": "TRAV9-10*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-10*01|Canis lupus familiaris_boxer|F|V-REGION|170231..170511|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-11*01",
+    "name": "TRAV9-11*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-11*01|Canis lupus familiaris_boxer|F|V-REGION|188356..188636|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-12*01",
+    "name": "TRAV9-12*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-12*01|Canis lupus familiaris_boxer|F|V-REGION|191471..191751|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV9-13*01",
+    "name": "TRAV9-13*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV9-13*01|Canis lupus familiaris_boxer|F|V-REGION|208760..209040|281 nt|1| | | | |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV10*01",
+    "name": "TRAV10*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV10*01|Canis lupus familiaris_boxer|F|V-REGION|225402..225681|280 nt|1| | | | |280+42=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 280
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV12*01",
+    "name": "TRAV12*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV12*01|Canis lupus familiaris_boxer|F|V-REGION|240874..241151|278 nt|1| | | | |278+45=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 165,
+      "CDR3Begin": 264,
+      "VEnd": 278
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV17*01",
+    "name": "TRAV17*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV17*01|Canis lupus familiaris_boxer|P|V-REGION|251351..251627|277 nt|1| | || |277+45=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 165,
+      "CDR3Begin": 264,
+      "VEnd": 277
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV19*01",
+    "name": "TRAV19*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV19*01|Canis lupus familiaris_boxer|F|V-REGION|262891..263175|285 nt|1| | | | |285+36=321| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 273,
+      "VEnd": 285
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV21*01",
+    "name": "TRAV21*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV21*01|Canis lupus familiaris_boxer|F|V-REGION|287088..287366|279 nt|1| | | | |279+42=321| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 279
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV22*01",
+    "name": "TRAV22*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV22*01|Canis lupus familiaris_boxer|F|V-REGION|306248..306518|271 nt|1| | | | |271+51=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 159,
+      "CDR3Begin": 258,
+      "VEnd": 271
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV23*01",
+    "name": "TRAV23*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV23*01|Canis lupus familiaris_boxer|F|V-REGION|308547..308826|280 nt|1| | | | |280+42=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 280
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV24*01",
+    "name": "TRAV24*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV24*01|Canis lupus familiaris_boxer|F|V-REGION|330101..330377|277 nt|1| | | | |277+42=319| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 277
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV25*01",
+    "name": "TRAV25*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV25*01|Canis lupus familiaris_boxer|P|V-REGION|344760..345028|269 nt|1| | | | |269+51=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 159,
+      "CDR3Begin": 258,
+      "VEnd": 269
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV26*01",
+    "name": "TRAV26*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV26*01|Canis lupus familiaris_boxer|P|V-REGION|403592..403868|277 nt|1| | || |277+48=325| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 162,
+      "CDR3Begin": 261,
+      "VEnd": 277
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV27*01",
+    "name": "TRAV27*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV27*01|Canis lupus familiaris_boxer|P|V-REGION|362324..362597|274 nt|1| | || |274+45=319| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 165,
+      "CDR3Begin": 264,
+      "VEnd": 274
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV28*01",
+    "name": "TRAV28*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV28*01|Canis lupus familiaris_boxer|F|V-REGION|368424..368694|271 nt|1| | | | |271+51=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 159,
+      "CDR3Begin": 258,
+      "VEnd": 271
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV29*01",
+    "name": "TRAV29*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV29*01|Canis lupus familiaris_boxer|F|V-REGION|376447..376726|280 nt|1| | | | |280+42=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 280
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV34*01",
+    "name": "TRAV34*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV34*01|Canis lupus familiaris_boxer|F|V-REGION|418160..418431|272 nt|1| | | | |272+48=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 261,
+      "VEnd": 272
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV35*01",
+    "name": "TRAV35*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV35*01|Canis lupus familiaris_boxer|F|V-REGION|430697..430971|275 nt|1| | | | |275+45=320| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 165,
+      "CDR3Begin": 264,
+      "VEnd": 275
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV37*01",
+    "name": "TRAV37*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV37*01|Canis lupus familiaris_boxer|P|V-REGION|459335..459615|281 nt|1| | || |281+42=323| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 267,
+      "VEnd": 281
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV38-1*01",
+    "name": "TRAV38-1*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV38-1*01|Canis lupus familiaris_boxer|F|V-REGION|463518..463803|286 nt|1| | | | |286+39=325| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 171,
+      "CDR3Begin": 270,
+      "VEnd": 286
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV38-2*01",
+    "name": "TRAV38-2*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV38-2*01|Canis lupus familiaris_boxer|F|V-REGION|471255..471543|289 nt|1| | | | |289+36=325| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 174,
+      "CDR3Begin": 273,
+      "VEnd": 289
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV40*01",
+    "name": "TRAV40*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV40*01|Canis lupus familiaris_boxer|F|V-REGION|502015..502281|267 nt|1| | | | |267+60=327| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 156,
+      "CDR3Begin": 249,
+      "VEnd": 267
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV43-1*01",
+    "name": "TRAV43-1*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV43-1*01|Canis lupus familiaris_boxer|F|V-REGION|1003..1276|274 nt|1| | | | |274+48=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 261,
+      "VEnd": 274
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV43-2*01",
+    "name": "TRAV43-2*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV43-2*01|Canis lupus familiaris_boxer|F|V-REGION|24019..24292|274 nt|1| | | | |274+48=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 261,
+      "VEnd": 274
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV43-3*01",
+    "name": "TRAV43-3*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV43-3*01|Canis lupus familiaris_boxer|F|V-REGION|73210..73483|274 nt|1| | | | |274+48=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 261,
+      "VEnd": 274
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV43-4*01",
+    "name": "TRAV43-4*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV43-4*01|Canis lupus familiaris_boxer|F|V-REGION|113363..113636|274 nt|1| | | | |274+48=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 261,
+      "VEnd": 274
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV43-5*01",
+    "name": "TRAV43-5*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV43-5*01|Canis lupus familiaris_boxer|F|V-REGION|155886..156159|274 nt|1| | | | |274+48=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 261,
+      "VEnd": 274
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRA.fasta#TRAV43-6*01",
+    "name": "TRAV43-6*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAV43-6*01|Canis lupus familiaris_boxer|F|V-REGION|196421..196694|274 nt|1| | | | |274+48=322| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 261,
+      "VEnd": 274
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ2*01",
+    "name": "TRAJ2*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ2*01|Canis lupus familiaris_boxer|F|J-REGION|733789..733840|52 nt|1| | | | |52+0=52| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 21,
+      "FR4End": 52
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ3*01",
+    "name": "TRAJ3*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ3*01|Canis lupus familiaris_boxer|F|J-REGION|733246..733303|58 nt|1| | || |58+0=58| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 27,
+      "FR4End": 58
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ4*01",
+    "name": "TRAJ4*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ4*01|Canis lupus familiaris_boxer|F|J-REGION|732271..732333|63 nt|3| | || |63+0=63| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 32,
+      "FR4End": 63
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ5*01",
+    "name": "TRAJ5*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ5*01|Canis lupus familiaris_boxer|F|J-REGION|729430..729489|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 29,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ6*01",
+    "name": "TRAJ6*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ6*01|Canis lupus familiaris_boxer|F|J-REGION|728024..728085|62 nt|2| | || |62+0=62| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 62
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ7*01",
+    "name": "TRAJ7*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ7*01|Canis lupus familiaris_boxer|ORF|J-REGION|726290..726348|59 nt|2| | || |59+0=59| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 28,
+      "FR4End": 59
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ8*01",
+    "name": "TRAJ8*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ8*01|Canis lupus familiaris_boxer|F|J-REGION|724717..724776|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 29,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ9*01",
+    "name": "TRAJ9*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ9*01|Canis lupus familiaris_boxer|F|J-REGION|724134..724188|55 nt|1| | | | |55+0=55| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 24,
+      "FR4End": 55
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ10*01",
+    "name": "TRAJ10*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ10*01|Canis lupus familiaris_boxer|ORF|J-REGION|722220..722283|64 nt|1| | | | |64+0=64| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 33,
+      "FR4End": 64
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ11*01",
+    "name": "TRAJ11*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ11*01|Canis lupus familiaris_boxer|ORF|J-REGION|721214..721273|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 29,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ12*01",
+    "name": "TRAJ12*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ12*01|Canis lupus familiaris_boxer|F|J-REGION|720636..720695|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 29,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ13*01",
+    "name": "TRAJ13*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ13*01|Canis lupus familiaris_boxer|F|J-REGION|719795..719855|61 nt|1| | | | |61+0=61| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 30,
+      "FR4End": 61
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ14*01",
+    "name": "TRAJ14*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ14*01|Canis lupus familiaris_boxer|P|J-REGION|718595..718651|57 nt|3| | || |57+0=57| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 26,
+      "FR4End": 57
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ15*01",
+    "name": "TRAJ15*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ15*01|Canis lupus familiaris_boxer|F|J-REGION|717846..717905|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 29,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ16*01",
+    "name": "TRAJ16*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ16*01|Canis lupus familiaris_boxer|F|J-REGION|716697..716756|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 29,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ18*01",
+    "name": "TRAJ18*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ18*01|Canis lupus familiaris_boxer|F|J-REGION|714171..714236|66 nt|3| | || |66+0=66| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 35,
+      "FR4End": 66
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ19*01",
+    "name": "TRAJ19*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ19*01|Canis lupus familiaris_boxer|ORF|J-REGION|713778..713835|58 nt|1| | | | |58+0=58| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 27,
+      "FR4End": 58
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ20*01",
+    "name": "TRAJ20*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ20*01|Canis lupus familiaris_boxer|F|J-REGION|712800..712856|57 nt|3| | || |57+0=57| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 26,
+      "FR4End": 57
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ21*01",
+    "name": "TRAJ21*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ21*01|Canis lupus familiaris_boxer|F|J-REGION|712069..712123|55 nt|1| | | | |55+0=55| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 24,
+      "FR4End": 55
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ22*01",
+    "name": "TRAJ22*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ22*01|Canis lupus familiaris_boxer|ORF|J-REGION|710308..710368|61 nt|1| | | | |61+0=61| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 61
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ23*01",
+    "name": "TRAJ23*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ23*01|Canis lupus familiaris_boxer|F|J-REGION|708681..708743|63 nt|3| | || |63+0=63| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 32,
+      "FR4End": 63
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ24*01",
+    "name": "TRAJ24*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ24*01|Canis lupus familiaris_boxer|ORF|J-REGION|708249..708309|61 nt|1| | | | |61+0=61| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 61
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ25*01",
+    "name": "TRAJ25*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ25*01|Canis lupus familiaris_boxer|F|J-REGION|707385..707444|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 29,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ26*01",
+    "name": "TRAJ26*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ26*01|Canis lupus familiaris_boxer|F|J-REGION|707047..707106|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 29,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ27*01",
+    "name": "TRAJ27*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ27*01|Canis lupus familiaris_boxer|F|J-REGION|704884..704942|59 nt|2| | || |59+0=59| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 28,
+      "FR4End": 59
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ28*01",
+    "name": "TRAJ28*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ28*01|Canis lupus familiaris_boxer|F|J-REGION|704241..704303|63 nt|3| | || |63+0=63| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 32,
+      "FR4End": 63
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ30*01",
+    "name": "TRAJ30*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ30*01|Canis lupus familiaris_boxer|F|J-REGION|702156..702214|59 nt|2| | || |59+0=59| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 28,
+      "FR4End": 59
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ31*01",
+    "name": "TRAJ31*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ31*01|Canis lupus familiaris_boxer|F|J-REGION|700140..700196|57 nt|3| | || |57+0=57| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 26,
+      "FR4End": 57
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ32*01",
+    "name": "TRAJ32*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ32*01|Canis lupus familiaris_boxer|F|J-REGION|698613..698676|64 nt|1| | | | |64+0=64| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 33,
+      "FR4End": 64
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ33*01",
+    "name": "TRAJ33*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ33*01|Canis lupus familiaris_boxer|F|J-REGION|697858..697914|57 nt|3| | || |57+0=57| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 26,
+      "FR4End": 57
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ34*01",
+    "name": "TRAJ34*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ34*01|Canis lupus familiaris_boxer|F|J-REGION|697163..697220|58 nt|1| | | | |58+0=58| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 27,
+      "FR4End": 58
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ35*01",
+    "name": "TRAJ35*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ35*01|Canis lupus familiaris_boxer|ORF|J-REGION|696232..696293|62 nt|2| | || |62+0=62| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 32,
+      "FR4End": 62
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ37*01",
+    "name": "TRAJ37*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ37*01|Canis lupus familiaris_boxer|F|J-REGION|693936..693997|62 nt|2| | || |62+0=62| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 62
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ38*01",
+    "name": "TRAJ38*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ38*01|Canis lupus familiaris_boxer|F|J-REGION|692419..692480|62 nt|2| | || |62+0=62| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 62
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ39*01",
+    "name": "TRAJ39*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ39*01|Canis lupus familiaris_boxer|F|J-REGION|691773..691835|63 nt|3| | || |63+0=63| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 32,
+      "FR4End": 63
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ40*01",
+    "name": "TRAJ40*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ40*01|Canis lupus familiaris_boxer|F|J-REGION|689660..689720|61 nt|1| | | | |61+0=61| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 30,
+      "FR4End": 61
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ41*01",
+    "name": "TRAJ41*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ41*01|Canis lupus familiaris_boxer|F|J-REGION|687619..687680|62 nt|2| | || |62+0=62| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 62
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ42*01",
+    "name": "TRAJ42*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ42*01|Canis lupus familiaris_boxer|F|J-REGION|687109..687174|66 nt|3| | || |66+0=66| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 35,
+      "FR4End": 66
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ43*01",
+    "name": "TRAJ43*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ43*01|Canis lupus familiaris_boxer|F|J-REGION|686281..686337|57 nt|3| | || |57+0=57| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 26,
+      "FR4End": 57
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ44*01",
+    "name": "TRAJ44*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ44*01|Canis lupus familiaris_boxer|F|J-REGION|685186..685248|63 nt|3| | || |63+0=63| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 32,
+      "FR4End": 63
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ45*01",
+    "name": "TRAJ45*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ45*01|Canis lupus familiaris_boxer|F|J-REGION|684074..684136|63 nt|3| | || |63+0=63| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 32,
+      "FR4End": 63
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ46*01",
+    "name": "TRAJ46*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ46*01|Canis lupus familiaris_boxer|ORF|J-REGION|683561..683623|63 nt|3| | || |63+0=63| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 33,
+      "FR4End": 63
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ48*01",
+    "name": "TRAJ48*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ48*01|Canis lupus familiaris_boxer|F|J-REGION|680985..681047|63 nt|3| | || |63+0=63| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 32,
+      "FR4End": 63
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ49*01",
+    "name": "TRAJ49*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ49*01|Canis lupus familiaris_boxer|F|J-REGION|680179..680237|59 nt|2| | || |59+0=59| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 28,
+      "FR4End": 59
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ50*01",
+    "name": "TRAJ50*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ50*01|Canis lupus familiaris_boxer|F|J-REGION|679341..679400|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 29,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ52*01",
+    "name": "TRAJ52*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ52*01|Canis lupus familiaris_boxer|ORF|J-REGION|676953..677021|69 nt|3| | || |69+0=69| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 38,
+      "FR4End": 69
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ53*01",
+    "name": "TRAJ53*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ53*01|Canis lupus familiaris_boxer|ORF|J-REGION|673986..674044|59 nt|2| | || |59+0=59| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 28,
+      "FR4End": 59
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ54*01",
+    "name": "TRAJ54*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ54*01|Canis lupus familiaris_boxer|F|J-REGION|673338..673402|65 nt|2| | || |65+0=65| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 34,
+      "FR4End": 65
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ56*01",
+    "name": "TRAJ56*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ56*01|Canis lupus familiaris_boxer|F|J-REGION|670564..670625|62 nt|2| | || |62+0=62| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 62
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ57*01",
+    "name": "TRAJ57*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ57*01|Canis lupus familiaris_boxer|ORF|J-REGION|669917..669979|63 nt|3| | || |63+0=63| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 33,
+      "FR4End": 63
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ58*01",
+    "name": "TRAJ58*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ58*01|Canis lupus familiaris_boxer|F|J-REGION|668697..668759|63 nt|3| | || |63+0=63| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 32,
+      "FR4End": 63
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ59*01",
+    "name": "TRAJ59*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ59*01|Canis lupus familiaris_boxer|ORF|J-REGION|667549..667608|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 30,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRA.fasta#TRAJ60*01",
+    "name": "TRAJ60*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRA" ],
+    "meta": {
+      "comments": "IMGT000004|TRAJ60*01|Canis lupus familiaris_boxer|F|J-REGION|667306..667361|56 nt|2| | || |56+0=56| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 25,
+      "FR4End": 56
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV1*01",
+    "name": "TRBV1*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV1*01|Canis lupus familiaris_boxer|F|V-REGION|990..1276|287 nt|1| | | | |287+45=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 165,
+      "CDR3Begin": 264,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV3-1*01",
+    "name": "TRBV3-1*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV3-1*01|Canis lupus familiaris_boxer|F|V-REGION|56373..56659|287 nt|1| | | | |287+45=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV3-2*01",
+    "name": "TRBV3-2*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV3-2*01|Canis lupus familiaris_boxer|F|V-REGION|67006..67292|287 nt|1| | | | |287+45=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV3-3*01",
+    "name": "TRBV3-3*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV3-3*01|Canis lupus familiaris_boxer|P|V-REGION|75352..75638|287 nt|1| | | | |287+45=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV4-1*01",
+    "name": "TRBV4-1*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV4-1*01|Canis lupus familiaris_boxer|F|V-REGION|52473..52759|287 nt|1| | | | |287+45=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV4-2*01",
+    "name": "TRBV4-2*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV4-2*01|Canis lupus familiaris_boxer|F|V-REGION|59857..60143|287 nt|1| | | | |287+45=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV4-3*01",
+    "name": "TRBV4-3*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV4-3*01|Canis lupus familiaris_boxer|F|V-REGION|70529..70815|287 nt|1| | | | |287+45=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV4-4*01",
+    "name": "TRBV4-4*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV4-4*01|Canis lupus familiaris_boxer|F|V-REGION|78755..79040|286 nt|1| | | | |286+45=331| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 286
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV5-2*01",
+    "name": "TRBV5-2*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV5-2*01|Canis lupus familiaris_boxer|F|V-REGION|91246..91531|286 nt|1| | | | |286+45=331| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 286
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV5-4*01",
+    "name": "TRBV5-4*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV5-4*01|Canis lupus familiaris_boxer|F|V-REGION|115468..115753|286 nt|1| | | | |286+45=331| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 286
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV7*01",
+    "name": "TRBV7*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV7*01|Canis lupus familiaris_boxer|F|V-REGION|100057..100346|290 nt|1| | | | |290+42=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 267,
+      "VEnd": 290
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV10*01",
+    "name": "TRBV10*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV10*01|Canis lupus familiaris_boxer|F|V-REGION|120266..120552|287 nt|1| | | | |287+45=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV12-1*01",
+    "name": "TRBV12-1*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV12-1*01|Canis lupus familiaris_boxer|P|V-REGION|134606..134895|290 nt|1| | | | |290+42=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 267,
+      "VEnd": 290
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV12-2*01",
+    "name": "TRBV12-2*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV12-2*01|Canis lupus familiaris_boxer|F|V-REGION|141963..142252|290 nt|1| | | | |290+42=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 267,
+      "VEnd": 290
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV15*01",
+    "name": "TRBV15*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV15*01|Canis lupus familiaris_boxer|ORF|V-REGION|147095..147381|287 nt|1| | | | |287+45=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV16*01",
+    "name": "TRBV16*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV16*01|Canis lupus familiaris_boxer|F|V-REGION|150689..150978|290 nt|1| | | | |290+42=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 267,
+      "VEnd": 290
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV18*01",
+    "name": "TRBV18*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV18*01|Canis lupus familiaris_boxer|F|V-REGION|161290..161579|290 nt|1| | | | |290+42=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 267,
+      "VEnd": 290
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV19*01",
+    "name": "TRBV19*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV19*01|Canis lupus familiaris_boxer|P|V-REGION|164573..164859|287 nt|1| | | | |287+45=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV20*01",
+    "name": "TRBV20*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV20*01|Canis lupus familiaris_boxer|F|V-REGION|169715..170007|293 nt|1| | | | |293+36=329| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 168,
+      "CDR3Begin": 273,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV21*01",
+    "name": "TRBV21*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV21*01|Canis lupus familiaris_boxer|P|V-REGION|176916..177205|290 nt|1| | | | |290+42=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 267,
+      "VEnd": 290
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV22*01",
+    "name": "TRBV22*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV22*01|Canis lupus familiaris_boxer|F|V-REGION|181387..181669|283 nt|1| | | | |283+48=331| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 75,
+      "FR2Begin": 90,
+      "CDR2Begin": 141,
+      "FR3Begin": 159,
+      "CDR3Begin": 261,
+      "VEnd": 283
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV24*01",
+    "name": "TRBV24*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV24*01|Canis lupus familiaris_boxer|F|V-REGION|190306..190593|288 nt|1| | | | |288+45=333| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV25*01",
+    "name": "TRBV25*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV25*01|Canis lupus familiaris_boxer|F|V-REGION|195581..195867|287 nt|1| | | | |287+45=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 287
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV26*01",
+    "name": "TRBV26*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV26*01|Canis lupus familiaris_boxer|F|V-REGION|202445..202730|286 nt|1| | | | |286+45=331| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 286
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV27*01",
+    "name": "TRBV27*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV27*01|Canis lupus familiaris_boxer|P|V-REGION|211739..212031|293 nt|1| | | | |293+39=332| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 270,
+      "VEnd": 293
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV28*01",
+    "name": "TRBV28*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV28*01|Canis lupus familiaris_boxer|F|V-REGION|221043..221328|286 nt|1| | | | |286+45=331| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 286
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV29*01",
+    "name": "TRBV29*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV29*01|Canis lupus familiaris_boxer|F|V-REGION|227582..227871|290 nt|1| | | | |290+39=329| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 165,
+      "CDR3Begin": 270,
+      "VEnd": 290
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRB.fasta#TRBV30*01",
+    "name": "TRBV30*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBV30*01|Canis lupus familiaris_boxer|F|V-REGION|261226..261509|284 nt|1| | | | |284+45=329| |rev-compl|"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 96,
+      "CDR2Begin": 147,
+      "FR3Begin": 162,
+      "CDR3Begin": 264,
+      "VEnd": 284
+    }
+  }, {
+    "baseSequence": "file://dog_D_TRB.fasta#TRBD1*01",
+    "name": "TRBD1*01",
+    "geneType": "D",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBD1*01|Canis lupus familiaris_boxer|F|D-REGION|243804..243815|12 nt|1| | | | |12+0=12| | |"
+    },
+    "anchorPoints": {
+      "DBegin": 0,
+      "DEnd": 12
+    }
+  }, {
+    "baseSequence": "file://dog_D_TRB.fasta#TRBD2*01",
+    "name": "TRBD2*01",
+    "geneType": "D",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "HE653929|TRBD2*01|Canis lupus familiaris|F|D-REGION|6658..6671|14 nt|1| | | | |14+0=14| | |"
+    },
+    "anchorPoints": {
+      "DBegin": 0,
+      "DEnd": 14
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ1-1*01",
+    "name": "TRBJ1-1*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBJ1-1*01|Canis lupus familiaris_boxer|F|J-REGION|244453..244500|48 nt|3| | | | |48+0=48| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 20,
+      "FR4End": 48
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ1-2*01",
+    "name": "TRBJ1-2*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBJ1-2*01|Canis lupus familiaris_boxer|F|J-REGION|244588..244631|44 nt|2| | | | |44+0=44| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 16,
+      "FR4End": 44
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ1-3*01",
+    "name": "TRBJ1-3*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBJ1-3*01|Canis lupus familiaris_boxer|P|J-REGION|245190..245239|50 nt|2| | | | |50+0=50| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 22,
+      "FR4End": 50
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ1-4*01",
+    "name": "TRBJ1-4*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBJ1-4*01|Canis lupus familiaris_boxer|ORF|J-REGION|245772..245821|50 nt|2| | | | |50+0=50| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 23,
+      "FR4End": 50
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ1-5*01",
+    "name": "TRBJ1-5*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBJ1-5*01|Canis lupus familiaris_boxer|F|J-REGION|246026..246075|50 nt|2| | | | |50+0=50| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 22,
+      "FR4End": 50
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ1-6*01",
+    "name": "TRBJ1-6*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "IMGT000005|TRBJ1-6*01|Canis lupus familiaris_boxer|F|J-REGION|246487..246539|53 nt|2| | | | |53+0=53| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 25,
+      "FR4End": 53
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ2-1*01",
+    "name": "TRBJ2-1*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "HE653929|TRBJ2-1*01|Canis lupus familiaris|F|J-REGION|7330..7379|50 nt|2| | | | |50+0=50| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 22,
+      "FR4End": 50
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ2-2*01",
+    "name": "TRBJ2-2*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "HE653929|TRBJ2-2*01|Canis lupus familiaris|F|J-REGION|7510..7560|51 nt|3| | | | |51+0=51| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 23,
+      "FR4End": 51
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ2-3*01",
+    "name": "TRBJ2-3*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "HE653929|TRBJ2-3*01|Canis lupus familiaris|F|J-REGION|7761..7809|49 nt|1| | | | |49+0=49| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 21,
+      "FR4End": 49
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ2-4*01",
+    "name": "TRBJ2-4*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "HE653929|TRBJ2-4*01|Canis lupus familiaris|ORF|J-REGION|7913..7961|49 nt|1| | | | |49+0=49| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 21,
+      "FR4End": 49
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ2-5*01",
+    "name": "TRBJ2-5*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "HE653929|TRBJ2-5*01|Canis lupus familiaris|F|J-REGION|8052..8100|49 nt|1| | | | |49+0=49| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 21,
+      "FR4End": 49
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRB.fasta#TRBJ2-6*01",
+    "name": "TRBJ2-6*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRB" ],
+    "meta": {
+      "comments": "HE653929|TRBJ2-6*01|Canis lupus familiaris|F|J-REGION|8568..8613|46 nt|1| | | | |46+0=46| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 18,
+      "FR4End": 46
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRD.fasta#TRDV2*01",
+    "name": "TRDV2*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRD" ],
+    "meta": {
+      "comments": "IMGT000004|TRDV2*01|Canis lupus familiaris_boxer|ORF|V-REGION|392191..392480|290 nt|1| | | | |290+36=326| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 102,
+      "CDR2Begin": 153,
+      "FR3Begin": 162,
+      "CDR3Begin": 273,
+      "VEnd": 290
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRD.fasta#TRDV3*01",
+    "name": "TRDV3*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRD" ],
+    "meta": {
+      "comments": "IMGT000004|TRDV3*01|Canis lupus familiaris_boxer|F|V-REGION|659399..659692|294 nt|1| | | | |294+30=324| |rev-compl|"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 168,
+      "CDR3Begin": 279,
+      "VEnd": 294
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRD.fasta#TRDV4*01",
+    "name": "TRDV4*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRD" ],
+    "meta": {
+      "comments": "IMGT000004|TRDV4*01|Canis lupus familiaris_boxer|F|V-REGION|582240..582527|288 nt|1| | | | |288+36=324| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 102,
+      "CDR2Begin": 153,
+      "FR3Begin": 162,
+      "CDR3Begin": 273,
+      "VEnd": 288
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRD.fasta#TRDV5*01",
+    "name": "TRDV5*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRD" ],
+    "meta": {
+      "comments": "IMGT000004|TRDV5*01|Canis lupus familiaris_boxer|F|V-REGION|543895..544183|289 nt|1| | | | |289+39=328| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 99,
+      "CDR2Begin": 150,
+      "FR3Begin": 159,
+      "CDR3Begin": 270,
+      "VEnd": 289
+    }
+  }, {
+    "baseSequence": "file://dog_D_TRD.fasta#TRDD1*01",
+    "name": "TRDD1*01",
+    "geneType": "D",
+    "isFunctional": true,
+    "chains": [ "TRD" ],
+    "meta": {
+      "comments": "IMGT000004|TRDD1*01|Canis lupus familiaris_boxer|F|D-REGION|626229..626237|9 nt|1| | | | |9+0=9| | |"
+    },
+    "anchorPoints": {
+      "DBegin": 0,
+      "DEnd": 9
+    }
+  }, {
+    "baseSequence": "file://dog_D_TRD.fasta#TRDD2*01",
+    "name": "TRDD2*01",
+    "geneType": "D",
+    "isFunctional": true,
+    "chains": [ "TRD" ],
+    "meta": {
+      "comments": "IMGT000004|TRDD2*01|Canis lupus familiaris_boxer|F|D-REGION|638570..638583|14 nt|1| | | | |14+0=14| | |"
+    },
+    "anchorPoints": {
+      "DBegin": 0,
+      "DEnd": 14
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRD.fasta#TRDJ1*01",
+    "name": "TRDJ1*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRD" ],
+    "meta": {
+      "comments": "IMGT000004|TRDJ1*01|Canis lupus familiaris_boxer|F|J-REGION|639557..639607|51 nt|3| | || |51+0=51| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 20,
+      "FR4End": 51
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRD.fasta#TRDJ2*01",
+    "name": "TRDJ2*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRD" ],
+    "meta": {
+      "comments": "IMGT000004|TRDJ2*01|Canis lupus familiaris_boxer|F|J-REGION|645679..645726|48 nt|3| | || |48+0=48| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 17,
+      "FR4End": 48
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRD.fasta#TRDJ3*01",
+    "name": "TRDJ3*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRD" ],
+    "meta": {
+      "comments": "IMGT000004|TRDJ3*01|Canis lupus familiaris_boxer|ORF|J-REGION|647775..647846|72 nt|3| | || |72+0=72| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 42,
+      "FR4End": 72
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRD.fasta#TRDJ4*01",
+    "name": "TRDJ4*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRD" ],
+    "meta": {
+      "comments": "IMGT000004|TRDJ4*01|Canis lupus familiaris_boxer|F|J-REGION|649884..649942|59 nt|2| | || |59+0=59| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 28,
+      "FR4End": 59
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRG.fasta#TRGV2-1*01",
+    "name": "TRGV2-1*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGV2-1*01|Canis lupus familiaris_boxer|F|V-REGION|50307..50606|300 nt|1| | || |300+27=327| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 168,
+      "CDR3Begin": 282,
+      "VEnd": 300
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRG.fasta#TRGV2-2*01",
+    "name": "TRGV2-2*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGV2-2*01|Canis lupus familiaris_boxer|F|V-REGION|104826..105125|300 nt|1| | || |300+27=327| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 168,
+      "CDR3Begin": 282,
+      "VEnd": 300
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRG.fasta#TRGV2-3*01",
+    "name": "TRGV2-3*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGV2-3*01|Canis lupus familiaris_boxer|F|V-REGION|163801..164100|300 nt|1| | || |300+27=327| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 168,
+      "CDR3Begin": 282,
+      "VEnd": 300
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRG.fasta#TRGV2-4*01",
+    "name": "TRGV2-4*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGV2-4*01|Canis lupus familiaris_boxer|F|V-REGION|219524..219823|300 nt|1| | || |300+27=327| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 168,
+      "CDR3Begin": 282,
+      "VEnd": 300
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRG.fasta#TRGV4-1*01",
+    "name": "TRGV4-1*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGV4-1*01|Canis lupus familiaris_boxer|ORF|V-REGION|238986..239285|300 nt|1| | || |300+27=327| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 168,
+      "CDR3Begin": 282,
+      "VEnd": 300
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRG.fasta#TRGV5-2*01",
+    "name": "TRGV5-2*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGV5-2*01|Canis lupus familiaris_boxer|F|V-REGION|321673..321979|307 nt|1| | || |307+18=325| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 105,
+      "CDR2Begin": 156,
+      "FR3Begin": 177,
+      "CDR3Begin": 291,
+      "VEnd": 307
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRG.fasta#TRGV6-1*01",
+    "name": "TRGV6-1*01",
+    "geneType": "V",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGV6-1*01|Canis lupus familiaris_boxer|P|V-REGION|300914..301213|300 nt|1| | || |300+27=327| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 93,
+      "CDR2Begin": 144,
+      "FR3Begin": 168,
+      "CDR3Begin": 282,
+      "VEnd": 300
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRG.fasta#TRGV7-2*01",
+    "name": "TRGV7-2*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGV7-2*01|Canis lupus familiaris_boxer|F|V-REGION|383828..384132|305 nt|1| | || |305+24=329| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 102,
+      "CDR2Begin": 153,
+      "FR3Begin": 171,
+      "CDR3Begin": 285,
+      "VEnd": 305
+    }
+  }, {
+    "baseSequence": "file://dog_V_TRG.fasta#TRGV7-3*01",
+    "name": "TRGV7-3*01",
+    "geneType": "V",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGV7-3*01|Canis lupus familiaris_boxer|F|V-REGION|396401..396709|309 nt|1| | || |309+21=330| | |"
+    },
+    "anchorPoints": {
+      "FR1Begin": 0,
+      "CDR1Begin": 78,
+      "FR2Begin": 102,
+      "CDR2Begin": 153,
+      "FR3Begin": 174,
+      "CDR3Begin": 288,
+      "VEnd": 309
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ1-1*01",
+    "name": "TRGJ1-1*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ1-1*01|Canis lupus familiaris_boxer|P|J-REGION|11246..11311|66 nt|3| | || |66+0=66| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 33,
+      "FR4End": 66
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ1-2*01",
+    "name": "TRGJ1-2*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ1-2*01|Canis lupus familiaris_boxer|ORF|J-REGION|13619..13677|59 nt|2| | || |59+0=59| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 59
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ2-1*01",
+    "name": "TRGJ2-1*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ2-1*01|Canis lupus familiaris_boxer|P|J-REGION|68516..68581|66 nt|3| | || |66+0=66| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 33,
+      "FR4End": 66
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ2-2*01",
+    "name": "TRGJ2-2*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ2-2*01|Canis lupus familiaris_boxer|F|J-REGION|71313..71371|59 nt|2| | || |59+0=59| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 59
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ3-1*01",
+    "name": "TRGJ3-1*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ3-1*01|Canis lupus familiaris_boxer|P|J-REGION|123476..123541|66 nt|3| | || |66+0=66| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 33,
+      "FR4End": 66
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ3-2*01",
+    "name": "TRGJ3-2*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ3-2*01|Canis lupus familiaris_boxer|ORF|J-REGION|125831..125889|59 nt|2| | || |59+0=59| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 59
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ4-1*01",
+    "name": "TRGJ4-1*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ4-1*01|Canis lupus familiaris_boxer|P|J-REGION|180992..181057|66 nt|3| | || |66+0=66| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 33,
+      "FR4End": 66
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ4-2*01",
+    "name": "TRGJ4-2*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ4-2*01|Canis lupus familiaris_boxer|F|J-REGION|183242..183300|59 nt|2| | || |59+0=59| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 59
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ5-1*01",
+    "name": "TRGJ5-1*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ5-1*01|Canis lupus familiaris_boxer|ORF|J-REGION|266070..266130|61 nt|1| | || |61+0=61| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 28,
+      "FR4End": 61
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ5-2*01",
+    "name": "TRGJ5-2*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ5-2*01|Canis lupus familiaris_boxer|F|J-REGION|268525..268583|59 nt|2| | || |59+0=59| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 31,
+      "FR4End": 59
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ6-1*01",
+    "name": "TRGJ6-1*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ6-1*01|Canis lupus familiaris_boxer|F|J-REGION|324844..324903|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 26,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ6-2*01",
+    "name": "TRGJ6-2*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ6-2*01|Canis lupus familiaris_boxer|ORF|J-REGION|327874..327934|61 nt|1| | || |61+0=61| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 28,
+      "FR4End": 61
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ7-1*01",
+    "name": "TRGJ7-1*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ7-1*01|Canis lupus familiaris_boxer|P|J-REGION|406077..406139|63 nt|3| | || |63+0=63| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 38,
+      "FR4End": 63
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ7-2*01",
+    "name": "TRGJ7-2*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ7-2*01|Canis lupus familiaris_boxer|F|J-REGION|407727..407786|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 32,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ8-1*01",
+    "name": "TRGJ8-1*01",
+    "geneType": "J",
+    "isFunctional": true,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ8-1*01|Canis lupus familiaris_boxer|F|J-REGION|433098..433157|60 nt|3| | || |60+0=60| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 26,
+      "FR4End": 60
+    }
+  }, {
+    "baseSequence": "file://dog_J_TRG.fasta#TRGJ8-2*01",
+    "name": "TRGJ8-2*01",
+    "geneType": "J",
+    "isFunctional": false,
+    "chains": [ "TRG" ],
+    "meta": {
+      "comments": "IMGT000006|TRGJ8-2*01|Canis lupus familiaris_boxer|P|J-REGION|437858..437915|58 nt|1| | || |58+0=58| | |"
+    },
+    "anchorPoints": {
+      "JBegin": 0,
+      "FR4Begin": 30,
+      "FR4End": 58
+    }
+  } ],
+  "meta": {
+    "comments": [ "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_D_IGH.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_D_TRB.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_D_TRD.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_J_IGH.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_J_IGK.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_J_IGL.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_J_TRA.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_J_TRB.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_J_TRD.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_J_TRG.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_V_IGH.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_V_IGK.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_V_IGL.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_V_TRA.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_V_TRB.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_V_TRD.p.fasta", "Imported from: /Volumes/Data/Projects/repseqio/library-imgt/cache/dog_V_TRG.p.fasta" ]
+  },
+  "sequenceFragments": [ {
+    "uri": "file://dog_D_IGH.fasta#IGHD1*01",
+    "range": {
+      "from": 0,
+      "to": 31
+    },
+    "sequence": "GTACTACTGTACTGATGATTACTGTTTCAAC"
+  }, {
+    "uri": "file://dog_D_IGH.fasta#IGHD2*01",
+    "range": {
+      "from": 0,
+      "to": 19
+    },
+    "sequence": "CTACTACGGTAGCTACTAC"
+  }, {
+    "uri": "file://dog_D_IGH.fasta#IGHD3*01",
+    "range": {
+      "from": 0,
+      "to": 17
+    },
+    "sequence": "TATATATATATGGATAC"
+  }, {
+    "uri": "file://dog_D_IGH.fasta#IGHD4*01",
+    "range": {
+      "from": 0,
+      "to": 19
+    },
+    "sequence": "GTATAGTAGCAGCTGGTAC"
+  }, {
+    "uri": "file://dog_D_IGH.fasta#IGHD5*01",
+    "range": {
+      "from": 0,
+      "to": 19
+    },
+    "sequence": "AGTTCTAGTAGTTGGGGCT"
+  }, {
+    "uri": "file://dog_D_IGH.fasta#IGHD6*01",
+    "range": {
+      "from": 0,
+      "to": 11
+    },
+    "sequence": "CTAACTGGGGC"
+  }, {
+    "uri": "file://dog_D_TRB.fasta#TRBD1*01",
+    "range": {
+      "from": 0,
+      "to": 12
+    },
+    "sequence": "GGTACAGGGGGC"
+  }, {
+    "uri": "file://dog_D_TRB.fasta#TRBD2*01",
+    "range": {
+      "from": 0,
+      "to": 14
+    },
+    "sequence": "GGAACTGGGGGACT"
+  }, {
+    "uri": "file://dog_D_TRD.fasta#TRDD1*01",
+    "range": {
+      "from": 0,
+      "to": 9
+    },
+    "sequence": "GTGGGCTAC"
+  }, {
+    "uri": "file://dog_D_TRD.fasta#TRDD2*01",
+    "range": {
+      "from": 0,
+      "to": 14
+    },
+    "sequence": "ATTGGAGGGATACC"
+  }, {
+    "uri": "file://dog_J_IGH.fasta#IGHJ1*01",
+    "range": {
+      "from": 0,
+      "to": 53
+    },
+    "sequence": "TGACATTTACTTTGACCTCTGGGGCCCGGGCACCCTGGTCACCATCTCCTCAG"
+  }, {
+    "uri": "file://dog_J_IGH.fasta#IGHJ2*01",
+    "range": {
+      "from": 0,
+      "to": 54
+    },
+    "sequence": "AACATGATTACTTAGACCTCTGGGGCCAGGGCACCCTGGTCACCGTCTCCTCAG"
+  }, {
+    "uri": "file://dog_J_IGH.fasta#IGHJ3*01",
+    "range": {
+      "from": 0,
+      "to": 50
+    },
+    "sequence": "CAATGCTTTTGGTTACTGGGGCCAGGGCACCCTGGTCACTGTCTCCTCAG"
+  }, {
+    "uri": "file://dog_J_IGH.fasta#IGHJ4*01",
+    "range": {
+      "from": 0,
+      "to": 48
+    },
+    "sequence": "ATAATTTTGACTACTGGGGCCAGGGAACCCTGGTCACCGTCTCCTCAG"
+  }, {
+    "uri": "file://dog_J_IGH.fasta#IGHJ5*01",
+    "range": {
+      "from": 0,
+      "to": 51
+    },
+    "sequence": "ACAACTGGTTCTACTACTGGGGCCAAGGGACCCTGGTCACTGTGTCCTCAG"
+  }, {
+    "uri": "file://dog_J_IGH.fasta#IGHJ6*01",
+    "range": {
+      "from": 0,
+      "to": 54
+    },
+    "sequence": "ATTACTATGGTATGGACTACTGGGGCCATGGCACCTCACTCTTCGTGTCCTCAG"
+  }, {
+    "uri": "file://dog_J_IGK.fasta#IGKJ1*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "GTGGACGTTCGGAGCAGGAACCAAGGTGGAGCTCAAAC"
+  }, {
+    "uri": "file://dog_J_IGK.fasta#IGKJ2*01",
+    "range": {
+      "from": 0,
+      "to": 39
+    },
+    "sequence": "TTTATACTTTCAGCCAGGGAACCAAGCTGGAGATAAAAC"
+  }, {
+    "uri": "file://dog_J_IGK.fasta#IGKJ3*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "GTTCACTTTTGGCCAAGGGACCAAACTGGAGATCAAAC"
+  }, {
+    "uri": "file://dog_J_IGK.fasta#IGKJ4*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "GCTTACGTTCGGCCAAGGGACCAAGGTGGAGATCAAAC"
+  }, {
+    "uri": "file://dog_J_IGK.fasta#IGKJ5*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "GATCACCTTTGGCAAAGGGACACATCTGGAGATTAAAC"
+  }, {
+    "uri": "file://dog_J_IGL.fasta#Canlupfam_IGLJ1*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "TTGGGTATTCGGTGAAGGGACCCAGCTGACCGTCCTCG"
+  }, {
+    "uri": "file://dog_J_IGL.fasta#Canlupfam_IGLJ2*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "TATGGTATTCGGCAGAGGGACCCAGCTGACCATCCTCG"
+  }, {
+    "uri": "file://dog_J_IGL.fasta#Canlupfam_IGLJ3*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "TAGTGTGTTCGGCGGAGGCACCCATCTGACCGTCCTCG"
+  }, {
+    "uri": "file://dog_J_IGL.fasta#Canlupfam_IGLJ4*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "TTACGTGTTCGGCTCAGGAACCCAACTGACCGTCCTTG"
+  }, {
+    "uri": "file://dog_J_IGL.fasta#Canlupfam_IGLJ5*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "TATTGTGTTCGGCGGAGGCACCCATCTGACCGTCCTCG"
+  }, {
+    "uri": "file://dog_J_IGL.fasta#Canlupfam_IGLJ6*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "TGGTGTGTTCGGCGGAGGCACCCACCTGACCGTCCTCG"
+  }, {
+    "uri": "file://dog_J_IGL.fasta#Canlupfam_IGLJ7*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "TGCTGTGTTCGGCGGAGGCACCCACCTGACCGTCCTCG"
+  }, {
+    "uri": "file://dog_J_IGL.fasta#Canlupfam_IGLJ8*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "TGCTGTGTTCGGCGGAGGCACCCACCTGACCGTCCTCG"
+  }, {
+    "uri": "file://dog_J_IGL.fasta#Canlupfam_IGLJ9*01",
+    "range": {
+      "from": 0,
+      "to": 38
+    },
+    "sequence": "TTACGTGTTCGGCTCAGGAACCCAACTGACCGTCCTTG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ10*01",
+    "range": {
+      "from": 0,
+      "to": 64
+    },
+    "sequence": "GAACTGACTGTGAGAAACAACAAACTCACCTTTGGGACAGGTGCCTGGCTGAAGGTGGAGCTGG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ11*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "CAGAGGTAGGATACAGAAGGTTGACCTTTGGAGAGGGCACCATGCTTCTAGTCTCTCCAG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ12*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "GGAAGGACACAGGCTATAGATGGATCTTTGGGAGTGGGACTCAACTGCTGGTCGGGCCCG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ13*01",
+    "range": {
+      "from": 0,
+      "to": 61
+    },
+    "sequence": "AATTCTGGGGGTAACCAAAAGTTTACCTTTGGAACTGGAACACAGCTCCAAGTCACCTCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ14*01",
+    "range": {
+      "from": 0,
+      "to": 57
+    },
+    "sequence": "CTGTGGTTTAGAACACATTCATCTTTGGGAGTGGGACATGATTATCAGTAAAACCCA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ15*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "CCTACGGGGCAGGAAATGCGTTGACTTTTGGGAAGGGAACCACAATATCAGTGAGCCCCA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ16*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "GTGTATCAAGCACCAATAATCTGGTGTTCGGAAGGGGGACCATGGTAAAAGTGGATCTTA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ18*01",
+    "range": {
+      "from": 0,
+      "to": 66
+    },
+    "sequence": "TCGACAGAGCCTCAGCCTTAGGGAAACTGCACTTCGGAAAAGGAACTCAGCTAACTGTATGGCCTG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ19*01",
+    "range": {
+      "from": 0,
+      "to": 58
+    },
+    "sequence": "TATCAAAGTTTTCACGAGTTCAGCTTTGGAAAGGGTTCCAAACACAATGTCAATCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ2*01",
+    "range": {
+      "from": 0,
+      "to": 52
+    },
+    "sequence": "GAACTGGGCAAACTCACATTTGGAAAAGGAACCCATCTGTCTGTCATATCTG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ20*01",
+    "range": {
+      "from": 0,
+      "to": 57
+    },
+    "sequence": "GTGATAGTAGTTACAACTACATTTTTGGAGCAGGAACCACAGTAACCGTAAGAGCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ21*01",
+    "range": {
+      "from": 0,
+      "to": 55
+    },
+    "sequence": "TACAACTATAACAGACTTTACTTTGGATCTGGAACCAAGCTCAGTGTAAAGCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ22*01",
+    "range": {
+      "from": 0,
+      "to": 61
+    },
+    "sequence": "TTTCTTGGTTCAGGCCAGCAACTGATCTTTGGATCCAGGACCCAGATGACTGTTGTACCTG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ23*01",
+    "range": {
+      "from": 0,
+      "to": 63
+    },
+    "sequence": "TGAATTATAACCAGGGAGGAAAGCTTATCTTCGGACAAGGAACCGAGTTATCTGTGAAGCCCA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ24*01",
+    "range": {
+      "from": 0,
+      "to": 61
+    },
+    "sequence": "ACAACTGATGGCTGGTGGAAATTGAATTCTGGAGCAGGAACCCAGGCTGTGGTCATTGCAG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ25*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "TGCAAGGACAAGGCTTCTCTTTTATATTTGGAAAGGGGACAAGGTTGCTTGTCAAGCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ26*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "GGACTAACTCTGGCAGGGATTTGATCTTCGGTCAGGGAACCAGCTTGTCTGTGCTGCCCT"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ27*01",
+    "range": {
+      "from": 0,
+      "to": 59
+    },
+    "sequence": "TAACACCAACACAGGCAAATTAACCTTTGGGGACGGGACCATGCTCACTGTGAAGCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ28*01",
+    "range": {
+      "from": 0,
+      "to": 63
+    },
+    "sequence": "TGTACTCTGGGGTTGGTAGCCAGCTCACATTCGGGAAGGGCACCAAACTCCTGGTCACACCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ3*01",
+    "range": {
+      "from": 0,
+      "to": 58
+    },
+    "sequence": "GGGATACAGCAGGGCATGCTAATCTTTGGAGCAGGGACCAGACTGAGTGTCCAGCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ30*01",
+    "range": {
+      "from": 0,
+      "to": 59
+    },
+    "sequence": "TGTACAAAGTTCGGAAAAAATCATCTTTGGAAAGGGGACTCAACTTCATGTTCTCCCCA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ31*01",
+    "range": {
+      "from": 0,
+      "to": 57
+    },
+    "sequence": "GCAATAACAACGCCAGAATCTTCTTTGGAACAGGAACGCAGCTGGTGGTAAAGCCCA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ32*01",
+    "range": {
+      "from": 0,
+      "to": 64
+    },
+    "sequence": "AACTCTGGGAGTGCTACAAATAAGCTCATCTTTGGGACTGGAACTGTGCTTTCGGTGAAGCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ33*01",
+    "range": {
+      "from": 0,
+      "to": 57
+    },
+    "sequence": "TGGATAGCAACAATCGGTTGATCTGGGGCTCTGGGACCAAGCTAATTATAAAGCCAG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ34*01",
+    "range": {
+      "from": 0,
+      "to": 58
+    },
+    "sequence": "TTCAGCAACAATGACAGACTCTTCTTTGGGGCTGGAACCAGATTACAAGTGTTTCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ35*01",
+    "range": {
+      "from": 0,
+      "to": 62
+    },
+    "sequence": "GACAGACAGGCTTGGCGAGGGTGCTGCATTTTGGGTCCTCCTCAAAGTGATTGTCACACCAC"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ37*01",
+    "range": {
+      "from": 0,
+      "to": 62
+    },
+    "sequence": "TGGCTCTAGCGACATAGGAAAACTCATCTTTGGGCAGGGGACCACTTTACGAGTCAAACCAG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ38*01",
+    "range": {
+      "from": 0,
+      "to": 62
+    },
+    "sequence": "TAATATTGGCAACAACCGTAAGCTGATTTGGGGATTGGGAACAAGGCTGGCAGTAAATCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ39*01",
+    "range": {
+      "from": 0,
+      "to": 63
+    },
+    "sequence": "TGAATAATAATGCAGGCAACAGGCTCACATTTGGAGGGGGAACAAGGTTAATGGTCAAACCCA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ4*01",
+    "range": {
+      "from": 0,
+      "to": 63
+    },
+    "sequence": "TGTCATCTGGTAGCTACAGTCAGCTGACCTTTGGAGCTGGGACCAGGCTGGTTGTGCACCCAT"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ40*01",
+    "range": {
+      "from": 0,
+      "to": 61
+    },
+    "sequence": "ACTACCTCAGGAAACTACAAATACACCTTTGGAAAAGGCACTAAGCTGAAGGTTTTACCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ41*01",
+    "range": {
+      "from": 0,
+      "to": 62
+    },
+    "sequence": "GAACTCAGACAACAGGTATAGCCTCAATTTTGGCAAAGGCACCTCGCTGCTGGTCATACCCG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ42*01",
+    "range": {
+      "from": 0,
+      "to": 66
+    },
+    "sequence": "TGAATTATGGAGGCAGCCAAGGACGACTCATCTTTGGAAAAGGCACTCAACTCTCCGTTAAACCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ43*01",
+    "range": {
+      "from": 0,
+      "to": 57
+    },
+    "sequence": "GCAATAATAACTATGGCCTTCACTTTGGAGCAGGTACCAGACTGACTGTAAAGCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ44*01",
+    "range": {
+      "from": 0,
+      "to": 63
+    },
+    "sequence": "TGACCACTGGTGGTGCCAGGAAATTCATCTTTGGGACTGGAACGAGGCTTCAGGTCACCCTGG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ45*01",
+    "range": {
+      "from": 0,
+      "to": 63
+    },
+    "sequence": "TCACTGTAGGAACAGCTAACAAACTCATCTTTGGGAAAGGGACCCAACTCATCATCAAGCCCT"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ46*01",
+    "range": {
+      "from": 0,
+      "to": 63
+    },
+    "sequence": "AGAAGACTGGCAGCAGGGACAAGCTCACTTTTGGGACCAGGACTCGTTTAACAGTCAGGCCCA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ48*01",
+    "range": {
+      "from": 0,
+      "to": 63
+    },
+    "sequence": "TGTCTAACTATGGAAGCAACAACTTAATCTTTGGGACAGGAACTAGAGTCACTGTTACACCCA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ49*01",
+    "range": {
+      "from": 0,
+      "to": 59
+    },
+    "sequence": "GAACACCGGTAACCAGAACTTCTATTTTGGGAGAGGGACAAGTTTGACTGTCATTCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ5*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "TAGACACAGGTGCCAGAGCACTCACTTTTGGGAGTGGAACAAGACTCCAAGTGCATCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ50*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "TGACAACCTCTTCCAACAAGTTGACATTTGGGCAGGGGACAAGCTTATCAGTCATTCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ52*01",
+    "range": {
+      "from": 0,
+      "to": 69
+    },
+    "sequence": "CTAATACTGGTGGCTCCAGCTATGGAAAGCTGACATTTGGACAAGGGACCTTCTTGACCGTCCATCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ53*01",
+    "range": {
+      "from": 0,
+      "to": 59
+    },
+    "sequence": "AACAGTAGATTACTACAAATTCACATTTGGAAAAGGAACTCCCTTAACTGTAAATCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ54*01",
+    "range": {
+      "from": 0,
+      "to": 65
+    },
+    "sequence": "TGACTCAGGGAGTGGCAGCCAAAAGTTGGTGTTTGGGCAAGGAACCAGGCTGACTGTCAATCCTG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ56*01",
+    "range": {
+      "from": 0,
+      "to": 62
+    },
+    "sequence": "TGATATGGGAGGCAATAATAAGCTGACATTTGGCAAAGGAACGACTGTGAGTGTTCGATCAG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ57*01",
+    "range": {
+      "from": 0,
+      "to": 63
+    },
+    "sequence": "TTCCTCAAGGTGGATCTGAACAACTCTTCTTTGGAAAAGAAATAAAACTGACAGTAAAGCCAT"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ58*01",
+    "range": {
+      "from": 0,
+      "to": 63
+    },
+    "sequence": "TCCAACAAGCCAGTGGTTTTCAAATGACATTTGGGAAAGGAACTCTGCTCACGGTGAATCTTG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ59*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "GGAAGGAAGGAAACAGGAAATTTACATCTGGAACCAGGACTCCAGTGAGAGTGAAACTTA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ6*01",
+    "range": {
+      "from": 0,
+      "to": 62
+    },
+    "sequence": "TGTATCAGGAGGAAACTACAGACTTACATTTGGAACAGGGACCAGGCTTGTTGTTCATCCAT"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ60*01",
+    "range": {
+      "from": 0,
+      "to": 56
+    },
+    "sequence": "TGAAGACCCTAAGAAACCCCACTTCGGGAAGGGGGTTCAGTTCTTTGTAGGCTTGG"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ7*01",
+    "range": {
+      "from": 0,
+      "to": 59
+    },
+    "sequence": "TGGCTGTGGGAACAACAGACTCACTTTTGGGAAGGGGATCCAAGTGATGGTCATACCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ8*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "TGAACACAGGCTATCAGAACCTTGCATTTGGAAGTGGCACCCGACTTCTGATCAGCCCAA"
+  }, {
+    "uri": "file://dog_J_TRA.fasta#TRAJ9*01",
+    "range": {
+      "from": 0,
+      "to": 55
+    },
+    "sequence": "GGAAATAATGTGGGCTTCAAATTTGGGACAGGAACAAGACTATTTGTTAAAGCAA"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ1-1*01",
+    "range": {
+      "from": 0,
+      "to": 48
+    },
+    "sequence": "TGAACACTGAAGTGTTCTTCGGAAAAGGCACCAGGCTCACAGTTATAG"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ1-2*01",
+    "range": {
+      "from": 0,
+      "to": 44
+    },
+    "sequence": "TTATGATTTTAACTTTGGCCCAGGGACCAAGCTGACAGTTGTAG"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ1-3*01",
+    "range": {
+      "from": 0,
+      "to": 50
+    },
+    "sequence": "CTTTTGAAACACCTTGCACTTTGGGGACGGGAGCCGGCTCACTGTTGTAG"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ1-4*01",
+    "range": {
+      "from": 0,
+      "to": 50
+    },
+    "sequence": "TAACAATGAAAAATTGTATTTTGCAAGTGGAACCAAGCTTTCTGTCTTGG"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ1-5*01",
+    "range": {
+      "from": 0,
+      "to": 50
+    },
+    "sequence": "GAACAACCAGGCACAGCACTTTGGAGACGGGACTCGACTCTCTGTCCTGG"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ1-6*01",
+    "range": {
+      "from": 0,
+      "to": 53
+    },
+    "sequence": "TTTCTATAACTCGCCCCTCTACTTTGGAACAGGCACCAGGCTCACCGTGACAG"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ2-1*01",
+    "range": {
+      "from": 0,
+      "to": 50
+    },
+    "sequence": "CTAATATGGGGAGCAGCACTTTGGGCCAGGGACCCGGCTCACCGTCCTAG"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ2-2*01",
+    "range": {
+      "from": 0,
+      "to": 51
+    },
+    "sequence": "CCAACACGGGGCAGCTGTACTTCGGGGCCGGTTCCAAGCTGGCCGTGCTGG"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ2-3*01",
+    "range": {
+      "from": 0,
+      "to": 49
+    },
+    "sequence": "AGCACAGAAACTCAGTATTTCGGCGGGGGCACCCGGCTGACCGTGCTCG"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ2-4*01",
+    "range": {
+      "from": 0,
+      "to": 49
+    },
+    "sequence": "AGCCTGGACACCCAGTACTTCGGGGCGGGCACCCGGCTGACCGTGCTCG"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ2-5*01",
+    "range": {
+      "from": 0,
+      "to": 49
+    },
+    "sequence": "AGCCAAAATACCCAGTACTTCGGGGCGGGCACCCGGCTGACCGTGCTAG"
+  }, {
+    "uri": "file://dog_J_TRB.fasta#TRBJ2-6*01",
+    "range": {
+      "from": 0,
+      "to": 46
+    },
+    "sequence": "CGCTACGAGCAGTATTTCGGCGCCGGCACCAGGCTCACGGTCCTCG"
+  }, {
+    "uri": "file://dog_J_TRD.fasta#TRDJ1*01",
+    "range": {
+      "from": 0,
+      "to": 51
+    },
+    "sequence": "TTACAAATAAGCTCTTCTTTGGAAAAGGAACTCACCTGGTTGTAGAAGCAA"
+  }, {
+    "uri": "file://dog_J_TRD.fasta#TRDJ2*01",
+    "range": {
+      "from": 0,
+      "to": 48
+    },
+    "sequence": "CAGTATCCATGATCTTTGGCAAAGGAGCCTATCTGGTGGTAGAACCAT"
+  }, {
+    "uri": "file://dog_J_TRD.fasta#TRDJ3*01",
+    "range": {
+      "from": 0,
+      "to": 72
+    },
+    "sequence": "GCCTGAAGAAAGCCGTTAGTCAGGCTTTTGGTCCTCTTCTTCGTCAGAGATTGCGACCAGGGAAAAAGGCAA"
+  }, {
+    "uri": "file://dog_J_TRD.fasta#TRDJ4*01",
+    "range": {
+      "from": 0,
+      "to": 59
+    },
+    "sequence": "CTCTTGGGATACTCGACAGATGTTTTTTGGAGCTGGCACCAGACTCTTCGTGGAGCCAC"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ1-1*01",
+    "range": {
+      "from": 0,
+      "to": 66
+    },
+    "sequence": "ATAACTTCCTATGATGCTGGATCAAGAGATTAACAGAAGGAATTAGGCTCTTAGTAATTCCTCCTG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ1-2*01",
+    "range": {
+      "from": 0,
+      "to": 59
+    },
+    "sequence": "GGTTCAGTATGGCTGGAGTACCAAAGTGTTTGGTCCTGGCAAAAAGCTTAGGGTCACAA"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ2-1*01",
+    "range": {
+      "from": 0,
+      "to": 66
+    },
+    "sequence": "GTAACATCTGACCAGGTTGGATCAAGAAATTTACAGAAGTTAACAGGTTTATAGTAACTCCTCATG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ2-2*01",
+    "range": {
+      "from": 0,
+      "to": 59
+    },
+    "sequence": "TTACTGGAATAGTTGGAGCAACAAAGTGTTTGGTCCTGGCACAATTCTCAGGGTTACAG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ3-1*01",
+    "range": {
+      "from": 0,
+      "to": 66
+    },
+    "sequence": "ATAACCTCTAACCGGGCTGGATCAAGATATTTACAGAAGGTACTAGGCTTATAGTAACTCCTCCTT"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ3-2*01",
+    "range": {
+      "from": 0,
+      "to": 59
+    },
+    "sequence": "CAGCTGGTCTGGCTGGTACAACAAAGTGCTTGGTCCTGGCACAATTCTCAGGGTTACAG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ4-1*01",
+    "range": {
+      "from": 0,
+      "to": 66
+    },
+    "sequence": "ATAACCTCTAACCAGGCTGGGTCAAGATATTTGCAGAAGGTACTAAGCTTATAGTAACTCCTCCTG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ4-2*01",
+    "range": {
+      "from": 0,
+      "to": 59
+    },
+    "sequence": "TTCCTGGAATAGTTGGAGGAACAAAGTGTTTGGTCCCGGCACAACGCTCAGGGTTACAG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ5-1*01",
+    "range": {
+      "from": 0,
+      "to": 61
+    },
+    "sequence": "AAAACTCCGGCTGGATCAAGATTATTTGCAGAAGGAACTAATCTCATAGTAACTCCCCCTG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ5-2*01",
+    "range": {
+      "from": 0,
+      "to": 59
+    },
+    "sequence": "GTATTTGTATAGCAGGTACAACAAAGTATTTGGTCCTGGCACAGTGCTCAGGGTTACAG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ6-1*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "ATAACTCAGGCTGGATCAAGATATTTGGAGAAGGAACTAAGCTCATAGTAACACCCTCAG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ6-2*01",
+    "range": {
+      "from": 0,
+      "to": 61
+    },
+    "sequence": "AGTGGGTATGGCTGGAACAGCAACAAAGTGATGGGTCCTGACACACAGCTCAGGGTTACAG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ7-1*01",
+    "range": {
+      "from": 0,
+      "to": 63
+    },
+    "sequence": "TCTCTTATTGCATTTCACAGACAGTGAAACTGAGGTTTGGAGAAGGTCAGTTATTTGCCTAAA"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ7-2*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "GGTTGTTTGACTGGAGCAGAATCAAAGTGTTTGGTCCTGGCACAAAGCTCATGGTTACAG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ8-1*01",
+    "range": {
+      "from": 0,
+      "to": 60
+    },
+    "sequence": "ATAACTCAGTCTGGATCAAGATATTTGGACAAGGAACTAAGGTCATAGTAACTCCTCCAG"
+  }, {
+    "uri": "file://dog_J_TRG.fasta#TRGJ8-2*01",
+    "range": {
+      "from": 0,
+      "to": 58
+    },
+    "sequence": "TAGTATGGCTAGAGCAAAATCAAAGCATTTGGTTGTGGCACAAAGCTCAGGGTTACAG"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV1-15*01",
+    "range": {
+      "from": 0,
+      "to": 294
+    },
+    "sequence": "GAGGTCCAGCTGGTGCAGTCTGGGGCTGAGGTGAAGAAGCCAGGTACATCCGTGAAGGTCTCATGCAAGACATCTGGATACACCTTCACTGACTACTATATGTACTGGGTACGACAGGCTTCAGGAGCAGGGCTTGATTGGATGGGACAGATTGGTCCCTAAGATGGTGCCACAAGGTATGCACAGAAGTTTCAGGGCAGAGTCACCCTGTCAACAGACACATCCACAAGCACAGCCTACATGGAGCTGAGCAGTCTGAGAGCTGAGGACACAGCCATGTACTACTCTGTGAGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV1-30*01",
+    "range": {
+      "from": 0,
+      "to": 294
+    },
+    "sequence": "GAGGTCCAGCTGGTGCAGTCTGGGGCTGAGGTGAAGAAGCCAGGGGCATCTGTGAAGGTCTCCTGCAAGACATCTGGATACACCTTCATTAACTACTATATGATCTGGGTACGACAGGCTCCAGGAGCAGGGCTTGATTGGATGGGACAGATTGATCCTGAAGATGGTGCCACAAGTTATGCACAGAAGTTCCAGGGCAGAGTCACCCTGACAGCAGACACATCCACAAGCACAGCCTACATGGAGCTGAGCAGTCTGAGAGCTGGGGACATAGCTGTGTACTACTGTGCGAGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-10*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGACTGAGGGAGACCTGGTGAAGCCTGGGGGATCCCTGAGACTTTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTACGACATGGACTGGGTCTACCAGGCTCCAGGGAAAGGGTTACAGTGGGTCACATACATTAGCAATGGTGGAAGTAGCACAAGGTATGCAGACGCTGTGAAGGGCCAATTCACCATCTCCAGAGACAACGCCAGGAACACGCTCTATCTGCAGATGAACAGCCTGAGAGACAAGGACATGGCCGTGTATTACTGTGTGAGTGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-13*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGAGCAACTGGTGGAGTTTGGAGGACACATGGTGAATCCTGGGGGTTCCCTGGGTCTCTCCTGTCAGGCCTCTGGATTCACCTTCAGTAGCTATGGCATGAGCTGGGTCCGCCAGGCTCAAAAGAAGGGGCTGCAGTGGGTCGGACATATTAGCTATGATGGAAGTAGCACATACTACACAGACACTGTGAGGGACAGATTCACCATCTCCAGAGACAACACCAAGAACATGCTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACAGCCGTGTATTACTGCATGAGGAA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-14*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGATGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGATCCCTGAGACTCTCCTGTGTGGCCTCTGGATTCACCTTCAGTAACTACAAAATGTACTGGGTCCACCAGGCTCCAGGGAAAGGGCTGGAGTGGGTCGCAAGGATTTATGAGAGTGGAAGTACCACATACTACGCAGAAGCTGTAAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACATGGTGTATCTGCAGATGAACAGCCTGAGAGCCTAGGACACGGCCGTGTATTACTGTGTGAGTGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-16*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTACAGCTGGTGGAGTCTGGAGGAGACCTGGTGAAGCCTGGGGGGTCCCTGAGACTCTCCTGTGTGGCCTCTGGATTCACCTTTAGTAGTTACTACATGTTTTGGATCCGCCAGGCACCAGGGAAGGGCAATCAGTGGGTCGGATATATTAACAAAGATGGAAGTAGCACATACTACCCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACACACTGTATCTGCAGATGAACAGCCTGACAGTGGAGGACACAGCCCTTTATTACTGTGCGAGAGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-18*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTTGTGAAACCTGAGGGGTCCCTGAGACTCTCCTGTGTGGTCTCTGGCTTCACCTTCAGTAGCTACGACATGAGCTGGGTCCGCCAGGCTCCAGGGAAGGGGCTGCAGTGGGTCGCATACATTAGCAGTGATGGAAGGAGCACAAGTTACACAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAACTGAGGACACAGCCGTGTATTACTGTGCGAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-19*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGCGGGGTCCCTGAGACTGTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTACAGCATGAGCTGGGTCCGCCAGGCTCCTGAGAAGGGGCTGCAGTTGGTCGCAGGTATTAACAGCGGTGGAAGTAGCACATACTACACAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACACAGTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCCATGTATTACTGTGCAAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-2*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGTCCCTGAGACTCTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCAACTACATGAGCTGGATCCGCCAGGCTCCAGGGAAGGGGCTGCAGTGGGTCTCACAAATTAGCAGTGATGGAAGTAGCACAAGCTACGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGATGAGGACACGGCAGTGTATTACTGTGCAAGGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-21*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGTTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGTCCCTGAGACTGTCCTGTGTGGTCTCTGGATTCACCTTCAGTAAGTATGGCATGAGCTGGGTCTGCCAGGCTTTGGGGAAGGGGCTACAGTTGGTCGCAGCTATTAGCTAAGATGGAAGGAGCACATACTACACAGACACTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTACCTGCAGATGAACAGCTTGAGAGCTGAGGACACGGCCGTGTATTACTGTGAGAGTGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-21-1*01",
+    "range": {
+      "from": 0,
+      "to": 284
+    },
+    "sequence": "GAGGTGAAGCTAGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGATCAATTAGACTCTCCTATGTGACCTCTGGATTCACCTTCAGGAGCTACTGGATGAGCTGGGTCAGCCAGGCTCCAGGGAAGGGGCTGCAGTGGGTCATATGGGTTAATACTGGTGGAAGCAGAAAAAGCTATGCAGATGCTGTGAAGGGGTGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCATATGAACAGCCTGAGAGCCCTGTATTATTATGTGAGTGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-23*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGAGAAGCCTGGGGGATCCCTGAGACTGTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTACGGCATGAGCTGGGTCCGCCAGGCTCCAGGGAAGGGGCTGCAGGGGGTCTCATTGATTAGGTATGATGGAAGTAGCACAAGGTATGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACAGCCGTGTATTCCTGTGCGAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-24*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTTGTGAAGCCTGAGGGGTCCCTGAGACTCTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTTCTACATGAGCTGGTTCTGCCAGGCTCCAAGGAAGGGGCTACAGTGGGTTGCAGAAATTAGCAGTAGTGGAAGTAGCACAAGCTACGCAGACATTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACATGCTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACATGGCCGTATATTATTGTGCAAGGTA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-25*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGCCTGGGGGAGAACTGGTGAAGCCTGGGGCGTCCCTGAGACTCTCCTGTGTGGTCCCTGGATTCACCTTCAGTAGCTACAACATGGGCTGGGCTCACCAGCCTCCAGGGAAGGGGATGCAGTGGGTCGCAGGTTTTAACAGCGGTGGAAGTAGCACAAGCTACACAGATGCTGTGAAGGGTGAATTCACCATCTCCAGAGACAATGTCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGATCCGAGGACACGGCCGTGTATTACTGTGTGAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-26*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGTAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGTCCCTGAGACTCTCCTGTGTGGGCTCTGGATTCACCTTCAGTAGCTACTGGATGAGCTGGGTCCGCCAGGCTCCAGGGAAGGGGCTACAGTGGGTTGCAGAAATTAGCGGTAGTGGAAGTAGCACAAACTATGCAGACGCTGTGAAGGGCCGATTCATCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCCATGTATTACTGTGCAAGGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-3*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACATGGTGAAGCCTGGGGGGTCCCTGAGACTCTCCTGTGTGGCCTCTGGATTTACCTTCAGTAGTTACTACATGTATTGGGCCCGCCAGGCTCCAGGGAAGGGGCTTCAGTGGGTCTCACACATTAACAAAGATGGAAGTAGCACAAGCTATGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCAAAGAATACGCTGTATCTGCAGATGAACAGCCTGAGAGCTGAGGACACAGCGGTGTATTACTGTGCAAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-31*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGAACTGGTGAAGCCTGGGGGGTCCCTGAGACTCTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTACTACATGAGCTGGATCCGCCAGGCTCCTGGGAAGGGGCTGCAGTGGGTCGCAGATATTAGTGACAGTGGAGGTAGCACATACTACACTGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGTCAAGAACTCGCTGTATTTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCCGTGTATTACTGTGCGAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-32*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GGGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGTCCCTGACACTCTCCTGTGTGGCCTATGGATTCACCTTCAGTAGCTACAGCATGCAATGGGTCTGTCAGGCTCCAGGGAAGGGGGTGCAGTGGGTCGCATACATTAACAGTGGTGGAAGTAGCACAAGCTCCGCAGATGCTGTGAAGGGTCGATTCATCATCTCCAGAGACAACGTCAAGAACACGCTATATCTGCAGATGAACAGCCTGAGAGCCGAGGACACCGCCGTGTATTACTGTGCGGGTGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-33*01",
+    "range": {
+      "from": 0,
+      "to": 294
+    },
+    "sequence": "GAGATGCAGCTGGTGGAGGCTGGGGGAGACCTGGTGAAGCTTGGGGGGTCCCTGAGACTCTTCTGTGTGGCCTCTGGATTTACCTTCAGTAGCTATTGGATGAGCTGGGTCGGCCAGGCTCCAGGGAAAGGGTTGCAGTGGGTTGCATACATTAACAGTGGTGGAAGTAGCACATACTATGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACTGCCTGAGAGCCGAGGACACGGCCGTATATTACTGTGTGGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-34*01",
+    "range": {
+      "from": 74,
+      "to": 115
+    },
+    "sequence": "CTGAGAGCTGAGGACACGGCCGTGTATTACTGTGCGAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-35*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGTGGGATCCCTGAGACTCTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTATGACATGAACTGGGTCCGCCAGGCTCCAGGGAAGGGGCTGCAGTGGGTCGCATACATTAGCAGTGGTGGAAGTAGCACATACTATGCAGATGCTGTGAAGGGCCGGTTCACCATCTCCAGAGACAACGCCAAGAACACGCTGTATCTTCAGATGAACAGCCTGAGAGCCGAGGACACGGCCATGTATTACTGTGCGGGTGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-36*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGGGCAGCTGGCGGAGTCTGGGGGAGACCTGGTGAAGCCTGAGAGGTCCCTGAGACTCGCCCGTGTGGCCTCTGGATTCACCTTCATTTCCTATACCATGAGCTGGGTCCACAAGGCTCCTGGGAAGGGGCTGCCGTGAGTCGCATGAATTTATTCTAGTGGAAGTAACATGAGCTATGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACATGCTGTATCTGCAGATGAACAGCCTGAGAGCTGAGGACATGGCCATGTATTACTGTGTGAATGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-37*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "GAGGTACAGCTGGTGGAGTCTGGGGAAGATTTGGTGAAGCCTGGAGGGTCCCTGAGACTCTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCAGTGAAATGAGCTGGGTCCACCAGGCTCCAGGGCAGGGGCTGCAGTGGGTCTCATGGATTAGGTATGATGGAAGTATCTCAAGGTATGCAGACACTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGTCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCCATATATTACTGTGCAGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-38*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGACCTTGAGACTGTCCTGTGTGGCCTCTGGATTCACCTTTAGTAGCTATGACATGAGCTGGGTCCGTCAGTCTCCAGGGAAGGGGCTGCAGTGGGTCGCAGTTATTTGGAATGATGGAAGTAGCACATACTACGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCCGTGTATTACTGTGCGAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-39*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTACAGCTGGTGGAATCTGGGGGAGACCTCGTGAAGCCTGGGGGTTCCCTGAGACTCTCCTGTGTGGCCTCGGGATTCACCTTCAGTAGCTACTACATGAGCTGGATCCGCCAGGCTCCTGGGAAGGGGCTGCAGTGGGTCGCAGATATTAGTGATAGTGGAGGTAGCACAGGCTACGCAGACGCTGTGAAGGGCCGGTTCACCATCTCCAGAGAGAACGCCAAGAACAAGCTGTATCTTCAGATGAACAGCCTGAGAGCCGAGGACACAGCCGTGTATTACTGTGCGAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-41*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGTCCCTGAGACTCTCCTGTGTAGCCTCTGGATTCACCTTCAGTAACTACGACATGAGCTGGGTCCGCCAGGCTCCTGGGAAGGGGCTGCAGTGGGTCGCAGCTATTAGCTATGATGGAAGTAGCACATACTACACTGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAGGAACACAGTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCTGTGTATTACTGTGCGAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-43*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "AAGGTGTAGCTGGTGGAGTCTGGGGGAGACCTGATGAAGCCTGGGGGTTCCCTGAGACTGTCCTGTGTGGCCTCTGGATTCACCTTCAGGAGCTATGGCATGAGCTGGGTCTGCCAGGCTTCAGGGAAGGGGCTGCAGTGGGTCGCAGCTATTAGCTATGATGGAAGGAGCACATACTACACAGACACTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGGCAAGAACACGCTGTACCTGCAGATGAACAGCTTGAGAGCTGAGGACACGGCCGTGTATTACTGTGCGAGTGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-44*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGTTCCCTGAGACTCTCATGTGTGACTTCTGGATTCACCTTCAGTAGCTATTGGATGAGCTGTGTCCGCCAGGCTCCAGGGAAGGAGCTGCAGTGGGTCGCGTACATTAACAGTGGTGGAAGTAGCACATGGTACACAGACGCTGTGAAGGGTCGATTCACCATCTCCAGAGACAACGCCAAGAACACGCTGTATCTGCAGATGAACAACCTGAGAGCCGAAGACACGGCCGTGTATTACTGTGCGAGGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-45*01",
+    "range": {
+      "from": 0,
+      "to": 295
+    },
+    "sequence": "GAAGTACAGCTGCTGGAGTCTGGGGGAGACCGAGTGAAACCTGGGGGGTCCCAGAGACTCTCCTGTGTGGCCTCAAGGTTCACCTTCAGTAGCTACAGCATGCATTGTCTCCGTCAGTCTCCTGGGATGGGGCTACAGTGGGTCACATACATTAGCAGTAATGGAAGCAGCACATACTATGCAGACGCTGTGAAGGGTCGATTCACCATCTCCAGAGACAAAGCCAAGAACATGCTTTATCTACAGATGAACAGCCTGAGAGCTCAGGACATAGCCCTGTATTACTGTGCAGATG"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-46*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "GAGGTACAGCTGGTGGAGTCTGGGGAAGATTTGGTGAAGCCTGGAGGGTCCCTGAGACTCTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCAGTGAAATGAGCTGGGTCCACCAGGCTCCAGGGCAGGGGCTGCAGTGGGTCTCATGGATTAGGTATGATGGAAGTAGCTCAAGGTATGCAGACACTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCCATATATTACTGTGCAGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-47*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGCGAAGCCTGGGGGGTCCCTGAGACTCTCCTGTGTGGCCTCTGGATTAACCTTCAGTAGCTACAGCATGAGCTGGGTCCGCCAGGCTCCTGGGAAGGGGCTGCAGTGGGTCACAGCTATTAGCTATGATGGAAGTAGCACATACTACACTGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAGGAACACAGTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACAGCTGTGTATTACTGTGTGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-47-1*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "GAGGTGCCACTGGTGGAATCTGGGGGAGAGCTGGTGAAGCCTGGGGGGTCCCTGAGACTCTCCTTTGTAGCCTCTGCATTCACTTTCAGTAGTTACTGGATAAGCTGGGTCCGCCAAGCTCCAGGGAAAGGGCTGCACTGAGTCTCAGTAATTAACAAAGATGGAAGTACCACATACCACGCAGATGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCTGAGGACACGGCTGTGTATTACTGTGCACA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-5*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGTCCCTGAGACTTTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTACCACATGAGCTGGGTCCGCCAGGCTCCAGGGAAGGGGCTTCAGTGGGTCGCATACATTAACAGTGGTGGAAGTAGCACAAGCTATGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACACGCTGTATCTTCAGATGAACAGCCTGAGAGCCGAGGACACGGCCGTGTATTACTGTGCGAGTGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-50*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGTCCTTGAGACTCTCCTGTGTGGCCTCTGGTTTCACCTTCAGTAGCAACGACATGGACTGGGTCCGCCAGGCTCCAGGGAAGGGGCTGCAGTGGCTCACACGGATTAGCAATGATGGAAGGAGCACAGGCTACGCAGATGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCTGAGGACACAGCCGTGTATTACTGTGCGAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-52*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAAGTGCAGCTGGTGGAGTATGGGGGAGAGCTGGTGAAGCCTGGGGGGTCCCTGAGACTGTCCTGTGTGGCCTCCGGATTCACCTTCAGTATCTACTACATGCACTGGGTCCACCAGGCTCCAGGGAAGGGGCTGCAGTGGTTCGCATGAATTAGGAGTGATGGAAGTAGCACATACTACACTGATGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAATTCCAAGAACACTCTGTATCTGCAGATGACCAGCCTGAGAGCCGAGGACACGGCCCTATATTACTGTGCGATGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-54*01",
+    "range": {
+      "from": 0,
+      "to": 297
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGATGAAGCCTGGGGGGTCCCTGAGACTCTCCTGTGTGGCCTCCGGATTCACTATCAGTAGCAACTACATGAACTGGGTCCGCCAGGCTCCAGGGAAGGGGCTGCAGTGGGTCGGATACATTAGCAGTGATGGAAGTAGCACAAGCTATGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCCGTGTATTACTGTGTGAAGGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-58*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGATCCCTGAGACTCTCTTGTGTGGCCTCCGGATTCACCTTCAGTAGCCATGCCAAGAGCTGGGTCCGCCAGGCTCCAGGGAAGGGGCTGAAGTGGGTAGCAGTTATTAGCAGTAGTGGAAGTAGCACAGGCTCCGCAGACACTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCTGAGGACACAGCCGTGTATTACTGTGCGAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-6*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGTCCCTGAGACTCTCCTGTGTAGCCTCTGGATTCACCTTCAGTAGCTCCGACATGAGCTGGATCCGCCAGGCTCCAGGAAAGGGGCTTCAGTGGGTCGCATACATTAGCAATGATGGAAGTAGCACAAGCTACGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACACGCTCTATCTGCAGATGAACAGCCTCAGAGCCGAGGACACGGCCGTGTATTACTGTGCAGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-60*01",
+    "range": {
+      "from": 0,
+      "to": 284
+    },
+    "sequence": "GAGGTGAAGCTGGTGGAGTCTGGGGGAGACCTGTTGAAGCCTGGGGGATCAATTAAACTCTCCTATGTGACCTCTGGATTCACCTTCAGGAGCTACTGGATGAGCTGGGTCAGCCAGGCTCCAGGGAAGGGGCTGCAGTGGGTCACATGGGTTAATACTGGTGGAAGCAGCAAAAGCTATGCAGATGCTGTGAAGGGGCAATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCATATGAACAGCCTGATAGCCCTGTATTATTGTGTGAGTGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-61*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGTGGAAACCTGGTGAAGCCTGGGGGTTCCCTGAGACTGTCCTGTGTGGCCTCTGGATTAACCTTCTATAGCTATGCCATTTACTGGGTCCACGAGGCTCCTGGGAAGGGGCTGCAGTGGGTCGCAGCTATTACCACTGATGGAAGTAGCACATACTACACTGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCTGAGGACATGCCCGTGTATTACTGTGCGAGGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-67*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGTCCCTGAGACTGTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTACTACATGTACTGGGTCCGCCAGGCTCCAGGGAAGGGGCTTCAGTGGGTCGCACGGATTAGCAGTGATGGAAGTAGCACATACTACGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCTATGTATTACTGTGCAAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-69*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTACAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGATCCCTGAGACTGTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTATGCCATGAGCTGGGTCCGCCAGGCTCCAGGGAAGGGGCTGCAGTGGGTCGCATACATTAACAGTGGTGGAAGTAGCACATACTACGCAGATGCTGTGAAGGGCCGGTTCACCATCTCCAGAGACAATGCCAGGAACACACTGTATCTGCAGATGAACAGCCTGAGATCCGAGGACACAGCCGTGTATTACTGTCCGAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-7*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGAGCAACTGGTGGAGTTTGGAGGACACATGGTGAATCCTGGGGGTTCCCTGGGTCTCTCCTGTCAGGCCTCTGGATTCACCTTCAGTAGCTATGGCATGAGCTGGGTCCGCCAGGCTCAAAAGAAGGGGCTGCAGTGGGTCGGACATATTAGCTATGATGGAAGTAGTACATACTACGCAGACACTTTGAGGGACAGATTCACCATCTCCAGAGACAACACCAAGAACATGCTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACAGCCGTGTATTACTGCATGAGGAA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-70*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGAGGAGACCTTGTGAAGCCTGAGCGGTCCCTGAGACTCTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTTCTACATGAGCTGGTTCTGCCAGGCTCCAGGGAAGGGGCTACAGTGTGTTGCAGAAATTAGCAGTAGTGGAAATAGCACAAGCTACGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACACGCTGTATCTACGGATGCACAGCCTGAGAGCCGAGGACACGGCTGTATATTACTGTGCAAGGTA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-72*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGCGGAGACCTGGTGAAGCCTGGGGATTCCCTGAGACTGTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTATGCCATGAGCTGGGTCCGCCAGGCTCCTAGGAAGGGGCTGCAGTGGGTCGGATACATTAGCAGTGATGGAAGTAGCACATAATACGCAGACGCTGTGAAGGGCCGATTCACCATTTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCTGAGGATACGGCCCTGTATAACTGTGCAAGGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-75*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "GAATTGCAGCTGGTGGAGCTTGGGGGAGATCTGGTGAAGCCAGGGGGGTCCCTGAGACTCTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTATGCCATGAGTTGGGTCTGCCAGGCTCCAGGGAAGGGGCTGCAGTGGGTTGCAGCTATTAGCAGTAGTGGAAGTAGCACATACCATGTAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACACAGTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCCGTGTATTACTGTGCAGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-76*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "GAGGTGCCACTGGTGGAATCTGGGGGAGAGCTGGTGAAGCCTGAGGGGTCCCTGAGATTCTCCTGTGTAGCCTCTGGATTCACTTTCAGTAGTTACTGGATAAGCTGGGTCCGCCAAGCTCCAGGGAAAGGGCTGCACTGGGTCTCAGTAATTAACAAAGATGGAAGTACCACATACCACGCAGATGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCTGAGGGCACGACTGTGTATTACTGTGCACA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-78*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTTGTGAAGCCGGAGGGGTCCCTGAGACTCTCCTGTGTGGCCGCTGGATTCACCTTTAGTAGCTACAGCATGAGCTGGGTCCGCCAGGCTCCCGGGAAGGGGGTGCAGTGGGTCACATAGATTTATGCTAGTGGAAGTAGCACAAGCTACACAGATGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACACAGTGTTTCTGCAGATGAACAGCCTGAGAGCTGAGAACACGGCCATGTATTCCTGTGCAAGGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-8*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGTCCCTGAGACTCTCCTGTGTGGCCTCTGGATTCACCTTCAGTAACTACGAAATGTACTGGGTCCGCCAGGCTCCAGGGAAAGGGCTGGAGTGGGTCGCAAGGATTTATGAGAGTGGAAGTACCACATACTATGCAGAAGCTGTAAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACATGGCGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCCGTGTATTACTGTGCGAGTGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-80*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGGGGAGATCTGGTGAAGCCTGGGGGATCCCTGAGACTCTCTTGTGTGGCCTCTGGATTCACCTTCAGTAGCTACTACATGGAATGGGTCCGCCAGGCTCCAGGGAAGGGGCTGCAGTGGGTCGCACAGATTAGCAGTGATGGAAGTAGCACATACTACCCAGACGCTGTGAAGGGTCAATTCACCATCTCCAGAGACAATGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGGGAGCCGAGGACACGGCCGTGTATTACTGTGCAAAGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-81*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGAGGAAACCTGGTGAAGCCTGGGGGGTCCCTGAGACTCTCTTGTGTGGCCTCTGGATTCACCTTCAGTAGCTACTACATGGACTGGGTCCGCCAGGCTCCAGGGAAGAGGCTGCAGTGGGTCGCAGGGATTAGCAGTGATGGAAGTAGCACATACTACCCACAGGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACACGCTCTATCTGCAGATGAACAGCCTGAGAGCCGAGGACTCTGCTGTGTATTACTGTGCGATGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-82*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGAGGAGACCTGGTGAAGTCTGGGGGGTCCCTGAGACTCTCTTGTGTGGCCTCTGGATTCACCTTCAGTAGCTACTACATGCACTGGGTCCGCCAGGCTACAGGGAAGGGGCTGCAGTGGGTCACAAGGATTAGCAATGATGGAAGTAGCACAAGGTACGCAGACGCCATGAAGGGCCAATTTACCATCTCCAGAGACAATTCCAAGAATACGCTGTATCTGCAGATGAACAGCCAGAGAGCCGAGGACATGGCCCTATATTACTGTGCAAGGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-83*01",
+    "range": {
+      "from": 0,
+      "to": 297
+    },
+    "sequence": "GAGTTGCAGCTGGTAGAGTCTGGGGGAGACCTGGTGAAGCCTGGGGGGTCTCTGAGACTTTCTTGTGTGTCCTCTGGATTCACCTTCAGTAGCTACTGGATGCACTGGGTCCTCCAGGCTCCAGGGAAAGGGCTGGAGTGGGTCGCAATTATTAACAGTGGTGGAGGTAGCATATACTACGCAGACACAGTGAAGGGCCGATTCACCATCTCCAGAGAAAACGCCAAGAACACGCTCTATCTGCAGATGAACAGCCTGAGAGCTGAGGACAGGGCCATGCATTACTGTGCGAAGGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV3-9*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "GAGGTGCAGCTGGTGGAGTCTGGAGGAGACCTGGTGAAGCCTGGGGGGTCCCTGAGACTTTCCTGTGTGGCCTCTGGATTCACCTTCAGTAGCTATGACATGGACTGGGTCCGCCAGGCTCCAGGGAAGGGGCTGCAGTGGCTCTCAGAAATTAGCAGTAGTGGAAGTAGCACATACTACGCAGACGCTGTGAAGGGCCGATTCACCATCTCCAGAGACAACGCCAAGAACACGCTGTATCTGCAGATGAACAGCCTGAGAGCCGAGGACACGGCCGTGTATTACTGTGCAAGGGA"
+  }, {
+    "uri": "file://dog_V_IGH.fasta#IGHV4-1*01",
+    "range": {
+      "from": 0,
+      "to": 290
+    },
+    "sequence": "GAACTCACACTGCAGGAGTCAGGGCCAGGACTGGTGAAGCCCTCACAGACCCTCTCTCTCACCTGTGTTGTGTCCGGAGGCTCCGTCACCAGCAGTTACTACTGGAACTGGATCCGCCAGCGCCCTGGGAGGGGACTGGAATGGATGGGGTACTGGACAGGTAGCACAAACTACAACCCGGCATTCCAGGGACGCATCTCCATCACTGCTGACACGGCCAAGAACCAGTTCTCCCTGCAGCTGAGCTCCATGACCACCGAGGACACGGCCGTGTATTACTGTGCAAGAGA"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2-10*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GATATTGTCATGACACAGACCCCACTGTCCCTGTCCGTCAGCCCTGGAGAGACTGCCTCCATCTCCTGCAAGGCCAGTCAGAGCCTCCTGCACAGTGATGGAAACACGTATTTGAATTGGTTCCGACAGAAGCCAGGCCAGTCTCCACAGCGTTTGATCTATAAGGTCTCCAACAGAGACCCTGGGGTCCCAGACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTGAGAATCAGCAGAGTGGAGGCTGACGATACTGGAGTTTATTACTGCATGCAAGGTACACAGTTTCCTCG"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2-11*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GATATCGTCATGACACAGACCCCACTGTCCCTGTCCGTCAGCCCTGGAGAGACTGCCTCCATCTCCTGCAAGGCCAGTCAGAGCCTCCTGCACAGTAACGGGAACACCTATTTGTTTTGGTTCCGACAGAAGCCAGGCCAGTCTCCACAGCGCCTGATCAACTTGGTTTCCAACAGAGACCCTGGGGTCCCACACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTGAGAATCAGCAGAGTGGAGGCTGACGATGCTGGAGTTTATTACTGCGGGCAAGGTATACAAGCTCCTCC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2-4*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GATATTGTCATGACACAGACGCCACCGTCCCTGTCTGTCAGCCCTAGAGAGACGGCCTCCATCTCCTGCAAGGCCAGTCAGAGCCTCCTGCACAGTGATGGAAACACCTATTTGGATTGGTACCTGCAAAAGCCAGGCCAGTCTCCACAGCTTCTGATCTACTTGGTTTCCAACCGCTTCACTGGCGTGTCAGACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTGAGAATCAGCAGAGTGGAGGCTAACGATACTGGAGTTTATTACTGCGGGCAAGGTACACAGCTTCCTCC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2-5*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GATATTGTCATGACACAGACCCCACTGTCCCTGTCCGTCAGCCCTGGAGAGCCGGCCTCCATCTCCTGCAAGGCCAGTCAGAGCCTCCTGCACAGTAATGGGAACACCTATTTGTATTGGTTCCGACAGAAGCCAGGCCAGTCTCCACAGCGTTTGATCTATAAGGTCTCCAACAGAGACCCTGGGGTCCCAGACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTGAGAATCAGCAGAGTGGAGGCTGATGATGCTGGAGTTTATTACTGCGGGCAAGGTATACAAGATCCTCC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2-6*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GATATTGTCATGACACAGACCCCACTGTCCCTGTCTGTCAGCCCTGGAGAGACTGCCTCCATCTCCTGCAAGGCCAGTCAGAGCCTCCTGCACAGTGATGGAAACACGTATTTGAACTGGTTCCGACAGAAGCCAGGCCAGTCTCCACAGCGTTTAATCTATAAGGTCTCCAACAGAGACCCTGGGGTCCCAGACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTGAGAATCAGCAGAGTGGAGGCTGACGATACTGGAGTTTATTACTGCGGGCAAGGTATACAAGATCCTCC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2-7*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GATATTGTCATGACACAGAACCCACTGTCCCTGTCCGTCAGCCCTGGAGAGACGGCCTCCATCTCCTGCAAGGCCAGTCAGAGCCTCCTGCACAGTAACGGGAACACCTATTTGAATTGGTTCCGACAGAAGCCAGGCCAGTCTCCACAGGGCCTGATCTATAAGGTCTCCAACAGAGACCCTGGGGTCCCAGACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTGAGAATCAGCAGAGTGGAGGCTGACGATGCTGGAGTTTATTACTGCATGCAAGGTATACAAGCTCCTCC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2-8*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GATATTGTCATGACACAGACCCCACCGTCCCTGTCCGTCAGCCCTGGAGAGCCGGCCTCCATCTCCTGCAAGGCCAGTCAGAGCCTCCTGCACAGTAACGGGAACACCTATTTGAATTGGTTCCGACAGAAGCCAGGCCAGTCTCCACAGGGCCTGATCTATAGGGTGTCCAACCGCTCCACTGGCGTGTCAGACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTGAGAATCAGCAGAGTGGAGGCTGACGATGCTGGAGTTTATTACTGCGGGCAAGGTATACAAGATCCTCC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2-9*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GATATTGTCATGACACAGACCCCACTGTCCCTGTCTGTCAGCCCTGGAGAGACTGCCTCCATCTCTTGCAAGGCCAGTCAGAGCCTCCTGCACAGTGATGGAAACACGTATTTGAATTGGTTCCGACAGAAGCCAGGCCAGTCTCCACAGCGTTTGATCTATAAGGTCTCCAACAGAGACCCTGGGGTCCCAGACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTGAGAATCAGCAGAGTGGAGGCTGACGATACTGGAGTTTATTACTGCGGGCAAGTTATACAAGATCCTCC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2S13*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GATATCGTCATGACGCAGACCCCACTGTCCCTGTCTGTCAGCCCTGGAGAGCCGGCCTCCATCTCCTGCAGGGCCAGTCAGAGCCTCCTGCACAGTAATGGGAACACCTATTTGTATTGGTTCCGACAGAAGCCAGGCCAGTCTCCACAGGGCCTGATCTACTTGGTTTCCAACCGTTTCTCTTGGGTCCCAGACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTGAGAATCAGCAGAGTGGAGGCTGACGATGCTGGAGTTTATTACTGCGGGCAAAATTTACAGTTTCCTTC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2S14*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GAGGTTGTGATGATACAGACCCCACTGTCCCTGTCTGTCAGCCCTGGAGAGCCGGCCTCCATCTCCTGCAGGGCCAGTCAGAGTCTCCGGCACAGTAATGGAAACACCTATTTGTATTGGTACCTGCAAAAGCCAGGCCAGTCTCCACAGCTTCTGATCGACTTGGTTTCCAACCATTTCACTGGGGTGTCAGACAGGTTCAGTGGCAGCGGGTCTGGCACAGATTTTACCCTGAGGATCAGCAGGGTGGAGGCTGAGGATGTTGGAGTTTATTACTGCATGCAAAGTACACATGATCCTCC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2S16*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GAGGCCGTGATGACGCAGACCCCACTGTCCCTGGCCGTCACCCCTGGAGAGCTGGCCACTATCTCCTGCAGGGCCAGTCAGAGTCTCCTGCGCAGTGATGGAAAATCCTATTTGAATTGGTACCTGCAGAAGCCAGGCCAGACTCCTCGGCCGCTGATTTATGAGGCTTCCAAGCGTTTCTCTGGGGTCTCAGACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTTAAAATCAGCAGGGTGGAGGCTGAGGATGTTGGAGTTTATTACTGCCAGCAAAGTCTACATTTTCCTCC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2S18*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GATATCGTCATGACACAGACCCCACTGTCCGTGTCTGTCAGCCCTGGAGAGACGGCCTCCATCTCCTGCAGGGCCAGTCAGAGCCTCCTGCACAGTGATGGAAACACCTATTTGGATTGGTACCTGCAGAAGCCAGGCCAGATTCCAAAGGACCTGATCTATAGGGTGTCCAACTGCTTCACTGGGGTGTCAGACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTGAGAATCAGCAGAGTGGAGGCTGACAACGCTGGAGTTTATTACTGCATGCAAGGTATACAAGATCCTCC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV2S19*01",
+    "range": {
+      "from": 0,
+      "to": 302
+    },
+    "sequence": "GATATCGTCATGACACAGACTCCACTGTCCCTGTCTGTCAGCCCTGGAGAGACGGCCTCCATCTCCTGCAGGGCCAATCAGAGCCTCCTGCACAGTAATGGGAACACCTATTTGGATTGGTACATGCAGAAGCCAGGCCAGTCTCCACAGGGCCTGATCTATAGGGTGTCCAACCACTTCACTGGCGTGTCAGACAGGTTCAGTGGCAGCGGGTCAGGGACAGATTTCACCCTGAAGATCAGCAGAGTGGAGGCTGACGATGCTGGAGTTTATTACTGCGGGCAAGGTACACACTCTCCTCC"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV3S1*01",
+    "range": {
+      "from": 0,
+      "to": 286
+    },
+    "sequence": "GAAATCGTGATGACACAGTCTCCAGCCTCCCTCTCCTTGTCTCAGGAGGAAAAAGTCACCATCACCTGCCGGGCCAGTCAGAGTGTTAGCAGCTACTTAGCCTGGTACCAGCAAAAACCTGGGCAGGCTCCCAAGCTCCTCATCTATGGTACATCCAACAGGGCCACTGGTGTCCCATCCCGGTTCAGTGGCAGTGGGTCTGGGACAGACTTCAGCTTCACCATCAGCAGCCTGGAGCCTGAAGATGTTGCAGTTTATTACTGTCAGCAGTATAATAGCGGATATA"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV4-1*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "GACATCACGATGACTCAGTGTCCAGGCTCCCTGGCTGTGTCTCCAGGTCAGCAGGTCACCACGAACTGCAGGGCCAGTCAAAGCGTTAGTGGCTACTTAGCCTGGTACCTGCAGAAACCAGGACAGCGTCCTAAGCTGCTCATCTACTTAGCCTCCAGCTGGGCATCTGGGGTCCCTGCCCGATTCAGCAGCAGTGGATCTGGGACAGATTTCACCCTCACCGTCAACAACCTCGAGGCTGAAGATGTGAGGGATTATTACTGTCAGCAGCATTATAGTTCTCCTCT"
+  }, {
+    "uri": "file://dog_V_IGK.fasta#IGKV4S1*01",
+    "range": {
+      "from": 0,
+      "to": 305
+    },
+    "sequence": "GAAATCGTGATGACCCAGTCTCCAGGCTCTCTGGCTGGGTCTGCAGGAGAGAGCGTCTCCATCAACTGCAAGTCCAGCCAGAGTCTTCTGTACAGCTTCAACCAGAAGAACTACTTAGCCTGGTACCAGCAGAAACCAGGAGAGCGTCCTAAGCTGCTCATCTACTTAGCCTCCAGCTGGGCATCTGGGGTCCCTGCCCGATTCAGCAGCAGTGGATCTGGGACAGATTTCACCCTCACCATCAACAACCTCCAGGCTGAAGATGTGGGGGATTATTACTGTCAGCAGCATTATAGTTCTCCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-100*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGACCTCAGTGTCGGGGTCCCTTGGCCAGAGGGTCACCATCTCCTGCTCTGGAAGCACGAACAACATCGGTATTGTTGGTGCGAGCTGGTACCAACAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTGGACAGTGATGGGGATCGACCGTCAGGGGTCCCTGACCGGTTTTCCGGCTCCAAGTCTGGCAACTCAGCCACCCTGACCATCACTGGGCTTCAGGCTGAGGACGAGGCTGATTATTACTGCCAGTCCTTTGATACCACGCTTGATGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-103*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGGCTGTGCTGACTCAGCCACCCTCTGTGTCTGCAGCCCTGGGGCAGAGGGTCACCATCTCCTGCACTGGAAGTAACACCAACATCGGCAGTGGTTATGATGTACAATGGTACCAGCAGCTCCCAGGAAAGTCCCCTAAAACTATCATTTATGGTAATAGCAATCGACCCTCGGGGGTCCCGGTTCGATTCTCTGGCTCCAAGTCAGGCAGCACAGCCACCCTGACCATCACTGGGATCCAGGCTGAGGATGAGGCTGATTATTACTGCCAGTCCTATGATGACAACCTCGATGGTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-104*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCAGCTTCAGTGTCTGGGTCCCTGGGCCAGAGGATCACCATCTCCTGCACTAAAAGCAGCTCCAACATCGGTAGGTATTATGTGAGCTGACAACAGCTCCCAGGAACAGGCCCCAGAACCGTCATCTATGATAATAATAACTGACCCTCGGGGGTCCCTGATCAATTTTCTGGCTCTAAATCAGGCAGCACAGCCACCCTGACCATCTCTAGGCTCCAGGCTGAGGACGATGCTGATTATTACTGCTCGCCATATGCCAGCAGTCTCAGTGCTGG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-106*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGTTGACTCAACCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCATCATCTCCTGCACTGGAAGCAGCTCCAGCATTGGCAGAGGTTATGTGGGCTGGTACCAACAGCTCCCAGGAACAGGCCCCAGAACCCTCATCTATGGTATTAGTAACCTACCCCCGGGAGTCCCCAATAGATTCTCTGGTTCGAGGTCAGGCAGCACAGCCACCCTGACCATCGCTGAGCTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCATCGTGGGACAGAAGTCTCAGTGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-111*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCTGAGGGTCACCATCTGCTGCACTGGAAGCAGCTCCAACATCAGTAGTTATTATGTGGGCTGGTACCAACCACTCGCGGGAACAGGCCCCAGAACTGTCATCTATGATAATAGTAACCGTCCCTCGGGGGTCCCTGATCAATTCTCTGGCTCCAAGTCAGGCAGCACAGCCACCCTGACCATCTCTCGGCTCCAGGCTGAGGACGAGGCTGATTATTACGGCTCATCATATGACAGCAGTCTCAATGCTGG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-112*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCAGCCTCAGTGTCTCAGTCCCTGGGTCAGAGGGTCACCATCTCCTGTACTGGAAGCAGCTCCAATGTTGGTTATAACAGTTATGTGAGCTGGTACCAGCAGCTCCCAGGAACAGTCCCCAGAACCATCATCTATTATACCAATACTCGACCCTATGGGGTTCCTGATCGATTCTCTGGCTCCAAATCAGGCAACTCAGCCACCCTGACCATTGCTGGACTCCAGGCTGAGGACGAGGCTGATTATTATTGCTCAACATATGACAGCAGTCTCAGTGGTGC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-114*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "CAGGCTTTGCTGACTCAGCCACCCTCAGTGTCTGAGGCCCTGGGACAGAGGGTCACCATCTCCTGCACTGGAAGCAGCACCAACATCGGCAGTGGTTATGATGTACAATGGTACCAGCAGCTCCCAGGAAAGTCCCCTCAAACTATCGTATACGGTAATAGCAATTGACCCTCGGGGGTCCCAGATCAATTCTCTGGCTCCAAGTCTCACAATTCAGCCACCCTGACCATCACTGGGCTCCAGACTGAGGACGAGGCTGATTATTACTGCCAGTCCTCTGATGACAACCTCGA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-115*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCAGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGGTAGATATAGTGTAGGCTGATACCAGCAGCTCCCGGGAACAGGCCCCAGAACTGTCATCTATGGTAGTAGTAGCCGACCCTCGGGGGTCCCCGATCGATTCTCTGGCTCCAAGTCAGGCAGCACAGCCACCCTGACCATCTCAGGGCTCCAGGCTGAGGACGAGGCTGATTATTACTGTTCAACATACGACAGCAGTCTCAAAGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-116*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGCCTGTGCTCACTCAGCCGCCCTCAGTGTCTGGGTTCCTGGGACAGAGGGTCACTATCTCCTGCACTGGAAGCAGCTCCAACATCCTTGGTAATTCTGTGAACTGGTACCAGCAGCTCACAGGAAGAGGCCCCAGAACCGTCATCTATTATGATAACAACCGACCCTCTGGGGTCCCTGATCAATTCTCTGGCTCCAAGTCAGGCAACTCAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAGACTGATTATTACTGCTCAACGTGGGACAGCAGGCTCAGAGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-118*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGAAAGCAGCTCCAACATCGGTGGATATTATGTGGGCTGGTACCAACAGCTCCCAGGAACAGGCCCCAGAACCATCATCTATAGTAGTAGTAACCGACCCTCAGGGGTCCCTGATTGATTCTCTGGCTCCAGGTCAGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCTACATGGGACAGCAGTCTCAAAGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-125*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCCGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGGTAGAGGTTATGTGGGCTGGTACCAACAGCTCCCGGGAACAGGCCCCAGAACCCTCATCTATGGTAATAGTAACCGACCCTCAGGGGTCCCCGATCGGTTCTCTGGCTCCAGGTCAGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGATGAGGCTGATTATTACTGCTCATCGTGGGACAGCAGTCTCAGTGCTCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-129*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGTGCTGACTCAACCAGTCTCAGTGTCTGGGGCCCTGTGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATTGGTTATAGCAGCTGTGTGAGCTGATATCAGCAGCTCCCAGGAACAGGCCCCAGAACCATCATCTATAGTATGAATACTCTACCCTCTGGGGTTCCTGATCGATTGTCTGGCTCCAGGTCAGGCAACTCAGCCACCCTAACCATCTCTGGGCTCCAGGCTGAGGACAAGGCTGACTATTACTGCTCAACATATGACAGCAGTCTCAATGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-130*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACCCAGCTGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCACCTGCACTGGAAGCAGCTCCAACATTGGTAGTGATTATGTGGGCTGGTTCCAACAGCTCCCAGGAACAGGCCCTAGAACCCTCATCTAAGGCAATAGTAACCGACCCTCGGGGGTCCCTGATCAATTCTCTGGCTCCAAGTCTGGCAGTACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGATGATGCTGATTATTACTGCACATCATGGGATAGCAGTCTCAAGGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-135*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGAATCAGCTGCCTTCAGTGTTAGGATCCCTGGGCCAGAGAATCACCATCTCCTGCTCTGGAAGCACGAATGACATCGGTATGCTTGGTGTGAACTGGTACCAAGAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTAGATGGTACTGGGAATCGACCCTCAGGGGTCCCTGACCGATTTTCTGGCTCCAAATCTGGCAACTCAGGCACTCTGACCATCACTGGGCTCCAGGCTGAGGACGAGGCTGATTATTATTGTCAGTCCACTGATCTCACGCTTGGTGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-136*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGGTAGAGGTTATGTGGGCTGGTACCAGCAGCTCCCAGGAACAGGCCCCAGAACCCTCATCTATGATAGTAGTAGCCGACCCTCGGGGGTCCCTGATCGATTCTCTGGCTCCAGGTCAGGCAGCACAGCAACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCAGCATATGACAGCAGTCTCAGTGGTGG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-138*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAATGTTGGTTATGGCAATTATGTGGGCTGGTACCAGCAGCTCCCAGGAACAAGCCCCAGAACCCTCATCTATGATAGTAGTAGCCGACCCTCGGGGGTCCCTGATCGATTCTCTGGCTCCAGGTCAGGCAGCACAGCAACCCTGACCATCTCTGGGCTCCAGGCTGAGGATGAAGCCGATTATTACTGCTCATCCTATGACAGCAGTCTCAGTGGTGG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-139*01",
+    "range": {
+      "from": 0,
+      "to": 297
+    },
+    "sequence": "CAGGCTGTGCTGACTCCGCTGCCCTCAGTGTCTGCGGCCCTGGGACAGACGGTCACCATCTCTTGTACTGGAAATAGCACCCAAATCAGCAGTGGTTATGCTGTACAATGGTACCAGCAGCTCCCAGGAAAGTCCCCTGAAACTATCATCTATGGTGATAGCAATCGACCCTCGGGGGTCCCAGATCGATTCTCTGGCTTCAGCTCTGGCAATTCAGCCACACTGGCCATCACTGGGCTCCAGGATGAGGACGAGGCTGATTATTACTGCCAGTCCTTAGATGACAACCTCAATGGT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-141*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGACCTCAGTGTCGGGGTCCCTTGGCCAGAGGGTCACCATCTCCTGCTCTGGAAGCACGAACAACATCGGTATTGTTGGTGCGAGCTGGTACCAACAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTGTACAGTGTTGGGGATCGACCGTCAGGGGTCCCTGACCGGTTTTCCGGCTCCAACTCTGGCAACTCAGCCACCCTGACCATCACTGGGCTTCAGGCTGAGGACGAGGCTGATTATTACTGCCAGTCCTTTGATACCACGCTTGGTGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-143*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGTGCTGACTCAACCAGTCTCAGTGTCTGGGGCCCTGTGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATTGGTTATAGCAGCTGTGTGAGCTGATATCAGCAGCTCCCAGGAACAGGCCCCAGAACCATCATCTATAGTATGAATACTCTACCCTCTGGGGTTCCTGATCGATTGTCTGGCTCCAGGTCAGGCAACTCAGCCACCCTAACCATCTCTGGGCTCCAGGCTGAGGACAAGGCTGACTATTACTGCTCAACATATGACAGCAGTCTCAATGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-144*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCTCCCTCAGTGTTCAGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTGCAACGTCGGTAGAGGTTATGTGATCTGGTACCAACAGCTCCTGGGAACACGCCCAAGAACCCTCATATATGGTAGTAGTAACCAACCCTCAGGGGTCCCCAATCGATTCTCTGGCTCCAGGTCAGGCAGCACAGCCACTCTGACAATCTCTGGGTTCCAGGCTGAGGATGAGGCTGATTATTACTGCTCATCCTGGGACAGCAGTCTCAGTGCTCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-146*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGAATCAGCTGCCTTCAGTGTTAGGATCCCTGGGCCAGAGAATCACCATCTCCTGCTCTGGAAGCACGAATGACATCGGTATGCTTGGTGTGAACTGGTACCAAGAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTAGATGGTACTGGGAATCGACCCTCAGGGGTCCCTGACTGATTTTCTGGCTCCAAATCTGGCAACTCAGGCACTCTGACCATCACTGGGCTCCAGGCTGAGGACGAGGCTGATTATTATTGTCAGTCCACTGATCTCACGCTTGGTGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-147*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGGTAGAGGTTATGTGGGCTGGTACCAGCAGCTCCCAGGAACAGGCCCCAGAACCCTCATCTATGATAATAGTAACCGACCCTCGGGGGTCCCTGATCGATTCTCTGGCTCCAAGTCAGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCAACATACGACAGCAGTCTCAGTGGTGG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-149*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAATGTTGGTTATGGCAATTATGTGGGCTGGTACCAGCAGCTCCCAGGAACAGGCCCCAGAACCCTCATCTATCGTAGTAGTAGCCGACCCTCGGGGGTCCCTGATCGATTCTCTGGCTCCAGGTCAGGCAGCACAGCAACCCTGACCATCTCTGGGCTCCAGGCTGAGGATGAAGCCGATTATTACTGCTCATCCTATGACAGCAGTCTCAGTGGTGG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-150*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGGCTGTGCTGACTCCGCTGCCCTCAGTGTCTGCGGCCCTGGGACAGACGGTCACCATCTCTTGTACTGGAAATAGCACCCAAATCGGCAGTGGTTATGCTGTACAATGGTACCAGCAGCTCCCAGGAAAGTCCCCTGAAACTATCATCTATGGTGATAGCAATCGACCCTCGGGGGTCCCAGATCGATTCTCTGGCTTCAGCTCTGGCAATTCAGCCACACTGGCCATCACTGGGCTCCAGGATGAGGACGAGGCTGATTATTACTGCCAGTCCTTAGATGACAACCTCGATGGTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-151*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGCGCTGACTCAAACGGCCTCCATGTCTGGGTCTCTGGGCCAGAGGGTCACCGTCTCCTGCACTGGAAGCAGTTCCAACGTTGGTTATAGAAGTTATGTGGGCTGGTACCAGCAGCTCCCAGGAACAGGCCCCAGAACCATCATCTATAATACCAATACTCGACCCTCTGGGGTTCCTGATCGATTCTCTGGCTCCATATCAGGCAGCACAGCCACCCTGACTATTGCTGGACTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCATCCTATGACAGCAGTCTCAAAGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-152*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAATCTGTGCTGATCCAGCCGGCCTCAGTGTCGGGATCCCTGGGCCAGAGAGTCACCATCTCCTGCTCTGGAAGGACAAACAACATCGGTAGGTTTGGTGCGAGCTGGTACCAACAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTGGACAGTGATGGGGATTGACCGTCAGGGGTCCCTGACCGGTTTTCCGGCTCCAGGTCTGGCAGCTCAGCCACCCTGACCATCACTGGGGTCCAGGCTGAGGATGAGGCTGATTATTACTGCCAGTCCTTTGATCCCACGCTTGGTGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-155*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCTCCCTCAGTGTCCGGGTTCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGGTAGAGGTTATGTGCACTGGTACCAACAGCTCCCAGGAACAGGCCCCAGAACCCTCATCTATGGTATTAGTAACCGACCCTCAGGGGTCCCCGATCGATTCTCTGGCTCCAGGTCAGGCAGCACAGCCACTCTGACAATCTCTGGGCTCCAGGCTGAGGATGAGGCTGATTATTACTGCTCATCCTGGGACAGCAGTCTCAGTGCTCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-157*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGGTAGAGGTTATGTGGGCTGGTACCAGCAGCTCCCAGGAACAGGCCCCAGAACCCTCATCTATGATAATAGTAACCGACCCTCGGGGGTCCCTGATCGATTCTCTGGCTCCAAGTCAGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCAACATACGACAGCAGTCTCAGTGGTGG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-158*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGAATCAGCTGCCTTCAGTGTTAGGATCCCTGGGCCAGAGAATCACCATCTCCTGCTCTGGAAGCACGAATGACATCGGTATGCTTGGTGTGAACTGGTACCAAGAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTAGATGGTACTGGGAATCGACCCTCAGGGGTCCCTGACCGATTTTCTGGCTCCAAATCTGGCAACTCAGGCACTCTGACCATCACTGGGCTCCAGGCTGAGGACGAGGCTGATTATTATTGTCAGTCCACTGATCTCACGCTTGGTGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-159*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCTCCCTCAGTGTTCAGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTGCAACGTCGGTAGAGGTTATGTGATCTGGTACCAACAGCTCCTGGGAACACGCCCAAGAACCCTCATATATGGTAGTAGTAACCAACCCTCAGGGGTCCCCAATCGATTCTCTGGCTCCAGGTCAGGCAGCACAGCCACTCTGACAATCTCTGGGTTCCAGGCTGAGGATGAGGCTGATTATTACTGCTCATCCTGGGACAGCAGTCTCAGTGCTCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-160*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGTGCTGACTCAACCAGTCTCAGTGTCTGGGGCCCTGTGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATTGGTTATAGCAGCTGTGTGAGCTGATATCAGCAGCTCCCAGGAACAGGCCCCAGAACCATCATCTATAGTATGAATACTCTACCCTCTGGGGTTCCTGATCGATTGTCTGGCTCCAGGTCAGGCAACTCAGCCACCCTAACCATCTCTGGGCTCCAGGCTGAGGACAAGGCTGACTATTACTGCTCAACATATGACAGCAGTCTCAATGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-162*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGACCTCAGTGTCGGGGTCCCTTGGCCAGAGGGTCACCATCTCCTGCTCTGGAAGCACGAACAACATCGGTATTGTTGGTGCGAGCTGGTACCAACAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTGTACAGTGATGGGGATCGACCGTCAGGGGTCCCTGACCGGTTTTCCGGCTCCAACTCTGGCAACTCAGACACCCTGACCATCACTGGGCTTCAGGCTGAGGACGAGGCTGATTATTACTGCCAGTCCTTTGATACCACGCTTGATGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-41*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCAGCCTCCGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATTTCCTGCACTGGAAGCAGCTCCAACGTTGGTTATAGCAGTAGTGTGGGCTGGTACCAGCAGTTCCCAGGAACAGGCCCCAGAACCATCATCTATTATGATAGTAGCCGACCCTCGGGGGTCCCCGATCGATTCTCTGGCTCCAAGTCTGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGATGAGGCTGATTATTACTGCTCATCTTGGGACAACAGTCTCAAAGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-44*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGGCTGTGCTGAATCAGCCGGCCTCAGTGTCTGGGGCCCTGGGCCAGAAGGTCACCATCTCCTGCTCTGGAAGCACAAATGACATTGATATATTTGGTGTGAGCTGGTACCAACAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTGGACAGTGATGGGGATCGACCCTCAGGGGTCCCTGACAGATTTTCTGGCTCCAGCTCTGGCAACTCAGGCACCCTGACCATCACTGGGCTCCAGGCTGAGGACGAGGCTGATTATTACTGTCAGTCTGTTGATTCCACGCTTGGTGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-45*01",
+    "range": {
+      "from": 0,
+      "to": 294
+    },
+    "sequence": "CAGTCTGTACTGACTCAATCAGCCTCAGCGTCTGGGTCCTTGGGCCAGAGGGTCTCCGTCTCCTGCTCTAGCAGCACAAACAACATTGGTATTATTGGTGTGAAGTGGTACCAGCAGATCCCAAGAAAGGCCCCTAAACTCCTCATATATGATAATGAGAAGAGACCCTCAGGTGTCCCCAATTGATTCTCTGGCTCCAAGTCTGGCAACTTAGGCACCCTAACCATCAATGGGCTTCAGGCTGAGGGCGAGGCTGATTATTACTGCCAGTCCATGGATTTCAGCCTCGGTGGT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-46*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAACCAGCCTCAGTGTCCGGGTCTCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATTGGTAGAGATTATGTGGGCTGGTACCAACAGCTCCCGGGAACACGCCCCAGAACCCTCATCTATGGTAATAGTAACCGACCCTCGGGGGTCCCCGATCGATTCTCTGGCTCCAAGTCAGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCTACATGGGACAACAGTCTCACTGTTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-48*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTATGCTGACTCAGCCAGCCTCAGTGTCTGGGTCCCTGGGCCAGAAGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGGTGGTAATTATGTGGGCTGGTACCAACAGCTCCCAGGAATAGGCCCTAGAACCGTCATCTATGGTAATAATTACCGACCTTCAGGGGTCCCCGATCGATTCTCTGGCTCCAAGTCAGGCAGTTCAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAGGCTGAGTATTACTGCTCATCATGGGATGATAGTCTCAGAGGTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-49*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGGCTGTGCTGACTCAGCCGCCCTCAGTGTCTGCGGTCCTGGGACAGAGGGTCACCATCTCCTGCACTGGAAGCAGCACCAACATTGGCAGTGGTTATGATGTACAATGGTACCAGCAGCTCCCAGGAAAGTCCCCTAAAACTATCATCTATGGTAATAGCAATCGACCCTCAGGGGTCCCGGATCGCTTCTCTGGCTCCAAGTCAGGCAGCACAGCCTCTCTGACCATCACTGGGCTCCAGGCTGAGGACGAGGCTGATTATTACTGCCAGTCCTCTGATGACAACCTCGATGATCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-50*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCCGGGTCTCTGGGCCAGAGAGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGATAGAAAATATGTTGGCTGGTACCAACAGCTCCCGGGAACAGGCCCCAGAACCGTCATCTATGATAATAGTAACCGACCCTCGGGGGTCCCTGATCGATTCTCTGGCTCCAAGTCAGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCAACATACGACAGCAGTCTCAGTAGTGG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-52*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCAGTAGATATAATGTGAACTGGTACCAACAGCTCCTGGGAACAGGCCCCAGAACCCTCATCTATGGTAGTAGTAACCGACCCTCGGGGGTCCCCGATTGATTCTCTGGCTCCAAGTCAGGCAGCCCAGCTACCCTGACCATCTCTGGGCTCCAGGCTGAGGATGAGGCTGATTATTACTGCTCAACATACGACAGGGGTCTCAGTGCTCG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-54*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGCCTGTGCTGACTCAGCCGCCCTCAGGGTCTGGGGGCCTGGGCCAGAGGTTCAGCATCTCCTGTTCTGGAAGCACAAACAACATCAGTGATTATTATGTGAACTGGTACTAACAGCTCCCAGGGACAGCCCCTAAAACCATTATCTATTTGGATGATACCAGACCCCCTGGGGTCCCGGATTGATTCTCTGTCTCCAAGTCTAGCAGCTCAGCTACCCTGACCATCTCTGGGCTCCAGGCTGAGGATGAAGCTGATTATTACTGCTCATCCTGGGGTGATAGTCTCAATGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-55*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGATCACCATCTCCTGCACTGGAAGCAGCTCCAACATTGGAGGTAATAATGTGGGTTGGTACCAGCAGCTCCCAGGAAGAGGCCCCAGAACTGTCATCTATAGTACAAATAGTCGACCCTCGGGGGTGCCCGATCGATTCTCTGGCTCCAAGTCTGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGATGAGGCTGATTATTACTGCTCAACGTGGGATGATAGTCTCAGTGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-56*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CGGTCTGTGCTGACTCAGCCGCCCTCAGTGTCGGGATCTGTGGGCCAGAGAATCACCATCTCCCGCTCTGGAAGCACAAACAGCATTGGTATACTTGGTGTGAACTGGTACCAAGAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTAGATGGTACTGGGAATAGACCCTCAGGGGTCCCTGACCGATTTTCTGGCTCCAAATCTGGCAACTCAGGCACTCTGACCATCACTGGGCTTCAGCCTGAGGACGAGGCTGATTATTATTGTCAGTCCATTGAACCCATGCTTGGTGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-57*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGGCTGTGCTGACTCCGCTGCCCTCAGTGTCTGCGGCCCTGGGACAGACGGTCACCATCTCTTGTACTGGAAATAGCACCCAAATCAGCAGTGGTTATGCTGTACAATGGTACCAGCAGCTCCCAGGAAAGTCCCCTGAAACTATCATCTATGGTGATAGCAATCGACCCTCGGGGGTCCCAGATCGATTCTCTGGCTTCAGCTCTGGCAATTCAGCCACACTGGCCATCACTGGGCTCCAGGATGAGGACGAGGCTGATTATTACTGCCAGTCCTTAGATGACAACCTCAATGGTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-58*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGGTAGATATAGTGTTGGCTGGTTCCAGCAGCTCCCGGGAAAAGGCCCCAGAACCGTCATCTATAGTAGTAGTAACCGACCCTCAGGGGTCCCTGATCGATTCTCTGGCTCCAAGTCAGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCAACATACGACAGCAGTCTCAGTAGTAG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-66*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGCCCTCAGTGTCAGGATCTGTGGGCCAGAGAATCACCATCTCCTGCTCTGGAAGCACAAACAGCATTGGTATACTTGGTGTGAACTGGTACCAACTGCTCTCAGGAAAGGCCCCTAAACTCCTCGTAGATGGTACTGGAAATCGACCCTCAGGGGTCCCTGACCGATTTTCTGGCTCCAAATCTGGCAACTCAGGCACTCTGACCATCACTGGGCTTCAGCCTGAGGACGAGGCTGATTATTATTGTCAGTCCATTGAACCCATGCTTGGTGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-67*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTCCTGACTCAGCCGGCCTCAGTGTCTGGGGTTCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATTGGTGGAAATTATGTGAGCTGGCACCAGCAGGTCCCAGAAACAGGCCCCAGAAACATCATCTATGCTGATAACTACCGAGCCTCGGGGGTCCCTGATCGATTCTCTGGCTCCAAGTCAGGCAGCACAGCCACCCTGACCATCTCTGTGCTCCAGGCTGAGGATGAGGCTGATTATTACTGCTCAGTGGGGGATGATAGTCTCAAAGCACC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-69*01",
+    "range": {
+      "from": 0,
+      "to": 292
+    },
+    "sequence": "CAGTCTGTGCTAACTCAGCCACCCTCAGTGTCGGGGTCGCTGGGCCAGAGGGTCACCATCTCCTGCTCTGGAAGCACAAACAACATCAGTATTGTTGGTGCGAGCTGGTACCAACAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTGGACAGTGATGGGGATCGACCGTCAGGGGTCCCTGACCGATTTTCTGGCTCTAAGTCTGGCAAATCAGCCACCCTGACCATCACTGGGCTTCAGGCTGAGGACGAGGCTGATTATTACTGTATATTGGTCCCACGCTTTGTGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-70*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGTGCTGACTCAACCGGCCTCCGTGTCTGGGTCCCTGGGCCAGAGAGTCACCATCTCTTGCACTAGAAGCAGCTCGAACGTTGGCTATGGCAATGATGTGGGATGGTACCAGCAGCTCCCAGGAACAGGCCCCAGAACCATCATCTATAATACCAATACTCGACCCTCTGGGGTTCCTGATCGATTCTCTGGCTCCAAATCAGGCAGCACAGCCACCCTGACCATCTCTGGACTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCTTCCTATGACAGCAGTCTCAATGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-72*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "CAGTCTGTGCTAACTCAGCCGGCCTCAGTGTCTGGTTCCCTGGGTCAGAGGGTCACCATCTGCACTGGAAGCAGCTCCAACATTGGTACATATAGTGTAGGCTGGTACCAACAGCTCCCAGGATCAGGCCCCAGAACCATCATCTATGGTAGTAGTAACCGACCGTTGGGGGTCCCTGATCGATTCTCTGGCTCCAGGTCAGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAAGCTGATTATTACTGCTTCACATACGACAGTAGTCTCAAAGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-73*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGAATCAGCCACCTTCAGTGTCTGGATCCCTGGGCCAGAGAATCACCATCTCCTGCTCTGGAAGCACGAATGACATCGGTATGCTTGGTGTGAACTGGTACCAACAGCTCCCAGGAAATGCCCCTAAACTCCTTGTAGATGGTACTGGGAATCGACCCTCAGGGGTCCCTGACCAATTTTCTGGCTCCAAATCTGGCAATTCAGGCACTCTGACCATCACTGGGCTCCAGGCTGAGGACGAGGCTGATTATTATTGTCAGTCCTATGATCTCACGCTTGGTGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-75*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCAGTGACTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGGTGGATATAATGTTGGCTGGTTCCAGCAGCTCCCGGGAACAGGCCCCAGAACCGTCATCTATAGTAGTAGTAACCGACCCTCGGGGGTCCCGGATCGATTCTCTGGCTCCAGGTCAGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAGGCTGAGTATTACTGCTCAACATGGGACAGCAGTCTCAAAGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-78*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAACCGGCCTCAGTGTCCAGGTCCCTGGGCCAGATAGTCACCATCTCTTGCGCTGGAAGCAGCTCCAACATCCGTACAAAATATGTGGGCTGGTACTAACAGCTCCCGAGAACAGGCCCCAGAACCGTCATCTATGGTAATAGTAACTGACCCTCGGGGGTCCTCGATCAATTCTCTGGCTCCAAGTCAGGCAGCATAGCCACCCTGACCATCTCTGTGCTCCAGGCTGAGGACGAGGCTTATTATTACTGCTCAACATATGACAGCAGTCTCAGTGCTCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-80*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGACCTCAGTGTCGTGGTCCCTGGGCCAGAGGGTCACAATCTCATGCTCTAGAAGCACGAATAACATCGGTATTGTCGGGGCGAGCTGGTACCAACAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTGGACAGTGATGGGGATCAACTGTCAGGGGTCCCTGACCGATTTTCTGGCTCCAAGTCTGGCAACTCAGCCAACCTGACCATCACTGGGCTCCAGGCTGAGGACAAGGCTGATTATTACTGCCAGTCCTTTGATCACACGCTTGGTGCTCG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-82*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCAGCCTCAGTGTCGGGGTCCCTGGGCCAGAGAGTCACCATCTCCTGCTCTGGAAGGACAAACATCGGTAGGTTTGGTGCTAGCTGGTACCAACAGCTCCCAGGAAAGGCCCCTAAACTCCTCGTGGACAGTGATGGGGATCGACCGTCAGGGGTCCCTGACCGATTTTCCGGCTCCAAGTCTGGCAACTCGGCCACTCTGACCATCACTGGTCTCCATGCTGAGGACGAGGCTGATTATTACTGTCTGTCTATTGGTCCCACGCTTGGTGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-84*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGGCTGTGCTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAATGTTGGTTATGGCAATTATGTGGGCTGGTACCAGCAGCTCCCAGGAACAGGCCCCAGAACCCTCATCTATGGTAGTAGTTACCGACCCTCGGGGGTCCCTGATCGATTCTCTGGCTCCAGTTCAGGCAGCTCAGCCACACTGACCATCTCTGGGCTCCAGGCTGAGGATGAAGCTGATTATTACTGCTCATCCTATGACAGCAGTCTCAGTGGTGG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-84-1*01",
+    "range": {
+      "from": 0,
+      "to": 294
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCAGCCTCAGCGTCTGGGTCCTTGGGCCAGAGGGTCACTGTCTCCTGCTCTAGCAGCACAAACAACATCGGTATTATTGGTGTGAAGTGGTACCAGCAGATCCCAGGAAAGGCCCATAAACTCCTCATATATGATAATGAGAAGCGACCCTCAGGTGTCCCCAATCGATTCTCTGGCTCCAAGTCTGGCGACTTAAGCACCCTGACCATCAATGGGCTTCAGGGTGAGGACGAGGCTGATTATTATTGCCAGTCCATGGATTTCAGCCTCGGTGGT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-86*01",
+    "range": {
+      "from": 0,
+      "to": 314
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCAGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAATCCCCAGCAACACAGATTTTGATGGAATAGAATTTGATACTTCTGTGAGCTGGTACCAACAGCTCCCAGAAAAGCCCCCTAAAACCATCATCTATGGTAGTACTCTTTCATTCTCGGGGGTCCCCGATCGATTCTCTGGCTCCAGGTCTGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCATCCTGGGATGATAGTCTCAAATCATA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-87*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCAGCCTCAGTGTCTGGATCCCTGGGCCAAAGGGTCACCATCTCCTGCACTGGAAGCACAAACAACATCGGTGGTGATAATTATGTGCACTGGTACCAACAGCTCCCAGGAAAGGCACCCAGTCTCCTCATCTATGGTGATGATAACAGAGAATCTGGGGTCCCTGAACGATTCTCTGGCTCCAAGTCAGGCAGCTCAGCCACTCTGACCATCACTGGGCTCCAGGCTGAGGACGAGGCTGATTATTATTGCCAGTCCTACGATGACAGCCTCAATACTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-89*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTACTGACTCAGCCGGCCTCAGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGGTGGATATTATGTGAGCTGGCTCTAGCAGCTCCCGGGAACAGGCCCCAGAACCATCATCTATAGTAGTAGTAACCGACCTTCAGGGGTCCCTGATCGATTCTCTGGCTCCAGGTCAGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAGGATGAGGCTGATTATTACTGTTCAACATACGACAGCAGTCTCAAAGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-92*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCGGCCTCGGTGTCTGGGTCCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAATGTTGGTTATGGCAATTATGTGGGCTGGTACCAGCAGCTTCCAGGAACAGGCCCCAGAACCATTATCTGTTATACCAATACTCGACCCTCTGGGGTTCCTGATCGATACTCTGGCTCCAAGTCAGGCAGCACAGCCACCCTGACCATCTCTGGGCTCCAGGCTGAAGACGAGACTGATTATTACTGTACTACGTGTGACAGCAGTCTCAATGCTAG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-94*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCTCCCTCAGTGTCCGGGTTCCTGGGCCAGAGGGTCACCATCTCCTGCACTGGAAGCAGCTCCAACATCGGTAGAGGTTATGTGCACTGGTACCAACAGCTCCCAGGAACAGGCCCCAGAACCCTCATCTATGGTATTAGTAACCGACCCTCAGGGGTCCCCGATCGATTCTCTGGCTCCAGGTCAGGCAGCACAGCCACTCTGACAATCTCTGGGCTCCAGGCTGAGGATGAGGCTGATTATTACTGCTCATCCTGGGACAGCAGTCTCAGTGCTCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-96*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGCGCTGACTCAAACGGCCTCCATGTCTGGGTCTCTGGGCCAGAGGGTCACCGTCTCCTGCACTGGAAGCAGTTCCAACGTTGGTTATAGAAGTTATGTGGGCTGGTACCAGCAGCTCCCAGGAACAGGCCCCAGAACCATCATCTATAATACCAATACTCGACCCTCTGGGGTTCCTGATCGATTCTCTGGCTCCATATCAGGCAGCACAGCCACCCTGACTATTGCTGGACTCCAGGCTGAGGACGAGGCTGATTATTACTGCTCATCCTATGACAGCAGTCTCAAAGCTCC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-97-1*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGTGCTGACTCAGCCTCCCTCAGTGTTCAGGTCCCTGGGCCAGAGGGTCACTATATCCTGCACTGGAAGCAGCTCCAACGTCGGTAGAGGTTATGTGATCTGGTACCAACAGCTCCTGGGAACACGCCCAAGAACCCTCATATATGGTAGTAGTAACCAACCCTCAGGGGTCCCCAATCAATTCTCTGGCTCCAGGTCAGGCAGCACAGACACTCTGACAATCTCTGGGTTCCAGGCTGAGGATGAGGCTGATTATTACTGCTCATCCTGGGACAGCAGTCTCAGTGCTCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV1-98*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGTCTGTGCTGACTCAACCAGTCTCAGTGTCTGGGGCCCTGTGCCAGAGGGTCACCATCTCCTGCACTGGAAACAGCTCCAACATTGGTTATAGCAGTTGTGTGAGCTGATATCAGCAGCTCCCAGGAACAGGCCCCAGAACCATCATCTATAGTATGAATACTCAACCCTCTGGGGTTCCTGATCGATTCTCTGGCTCCAGGTCAGGCAACTCAGCCACCCTAACCATCTCTGGGCTCCAGGCTGAGGACAAGGCTGACTATTACTGCTCAACATATGACAGCAGTCTCAGTGCTCA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV2-31*01",
+    "range": {
+      "from": 0,
+      "to": 297
+    },
+    "sequence": "CAGTCTGCCCTGACTCAACCTTCCTCGGTGTCTGGGACTTTGGGCCAGACTGTCACCATCTCCTGTGATGGAAGCAGCAGTAACATTGGCAGTAGTAATTATATCGAATGGTACCAACAGTTCCCAGGCACCTCCCCCAAACTCCTGATTTACTATACCAATAATCGGCCATCAGGGATCCCTGCTCGCTTCTCTGGCTCCAAGTCTGGGAACACGGCCTCCTTGACCATCTCTGGGCTCCAGGCTGAAGATGAGGCTGATTATTACTGCAGCGCATATACTGGTAGTAATACTTTC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV2-32*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGTCTGCCCTGACTCAGCCTCCCTCGATGTCTGGGACACTGGGACAGACCATCATCATTTCCTGTACTGGAAGCGGCAGTGACATTGGGAGGTATAGTTATGTCTCCTGGTACCAAGAGCTCCCAAGCACGTCCCCCACACTCCTGATTTATGGTACCAATAATCGGCCATTAGAGATCCCTGCTCGCTTCTCTGGCTCCAAGTCTGGAAACACAGCCCCCATGACCATCTCTGGGCTTCAGGCTGAAGATGAGGCTAATTATTACTGTTGCTCATATACAACCAGTGGCACACA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-11*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGTGCTGTCTCAGCCGCCATCAGCGACTGTGACTCTGAGGCAGACGGCCCGCCTCACCTGTGGGGGAGACAGCATTGGAAGTAAAAGTGTTGAATGGTACCAGCAGAAGCCGGGCCAGCCCCCCGTGCTCATTATCTATGGTGATAGCAGCAGGCCGTCAGGGATCCCTGAGCGATTCTCCGGCGCCAACTCGGGGAACACGGCCACCCTGACCATCAGCGGGGCCCTGGCCGAGGACGAGGCTGACTATTACTGCCAGGTGTGGGACAGCAGTACTAAGGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-13*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGTACTGACTCAGCTGCCATCAGTGACTGTGAACCTGGGACAGACCACCAGCATCACCTGTGGTGGAGACAGCATTGGAGGGAGAACTGTTTACTGGTACCAGCAGAAGCCTGGCCAGCGCCCCCTGCTGATTATCTATAATGATAGCAATTGGCCCTCAGAGATCCCTGCCTGATTCTCTGGCTCCAACTCAGGGAACAGGGCCTCCCTAACCATCATTGGGGCCTGGGCCTAAGATGAGTCTGAGTATTACGGAGAGGTGTGGGACAGCAGTGCTAAGGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-14*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGTGCTGACACAGCTGCCATCCATGAGTGTGACCCTGAGGCAGACGGCCCGCATCACCTGTGAGGGAGACAGCATTGGAAGTAAAAGAGTTTACTGGTACCAGCAGAAGCTGGGCCAGGTCCCTGTACTGATTATCTATGATGATAGCAGCAGGCCGTCAGGGATCCCTGAGCGATTCTCCGGCGCCAACTCGGGGAACACAGCCACCCTGACCATCAGCGGGGCCCTGGCCGAGGACGAGGCTGACTATTACTGCCAGGTGTGGGACAGCAGTACTAAGGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-15*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCACTGGGTTGAATCAGGCTCCCTCCGTGTTGGTGGCCCTGGGACAGATGGAAACAATCACCTGCTCGAGAGATGTCTTAGGGAAAAGATATGCATATAGGTACCAGCATAAGCCAAGCCAAGCCCCTGTGCTCCTAATCAATAAAAATAATGAGCAGGATTCTGGGATCCCTGACCGGTTCTCTGGCTCCAACTCGGGCAACACGGCCACCCTGACCATCAGTGGGGCCCGGGCTGAGGACGAGGCTGAGTATTACTGCCAGTCCTATGACAGCAGTGGAAATGTT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-19*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCCCTGGGCTGAATCAGCCTCCCTCCGTGTTGGTGGCCCTGGGACAGATGGCAACAAACACCTGCTCCGGAGATGTCTTAGGGAAAAGATATGCATATTGGTACCAGCATAAGCCAAGCCAAGCCCCTGTGCTCCTAATCAATAAAAATAATGAGCTGGGTTCTGGGATCCCTGACCGATTCTCTGGCTCCAACTCGGGCAACACGGCCACCCTGACCATCAGTGGGGCCCGGGCCGAGGACGAGGCTGACTATTACTGCCAGTCCTATGACAGCAGTGGAAATGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-2*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGTGCTGACTCAGTCACCCTCAGTGTCAGTGACCCTGGGACAGACGGCCAGCATCACCTGTAGGGGAAACAGCATTGGAAGGAAAGATGTTCATTGGTACCAGCAGAAGCCGGGCCAAGCCCCCCTGCTGATTATCTATAATGATAACAGCCAGCCCTCAGGGATCCCTGAGCGATTCTCTGGGACCAACTCAGGGAGCACGGCCACCCTGACCATCAGTGAGGCCCAAACCAACGATGAGGCTGACTATTACTGCCAGGTGTGGGAAAGTAGCGCTGATGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-21*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGAGCTGACTCAGCCACCATCCGTGAATGTGACCCTGAGGGAGACGGCCCACATCACCTGTGGGGGAGACAGCATTGGAAGTAAATATGTTCAATGGATCCAGCAGAATCCAGGCCAGGCCCCCGTGGTGATTATCTATAAAGATAGCAACAGGCCGACAGGGATCCCTGAGCGATTCTCTGGCGCCAACTCAGGGAACACGGCTACCCTGACCATCAGTGGGGCCCTGGCCGAAGACGAGGCTGACTATTACTGCCAGGTGGGGGACAGTGGTACTAAGGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-23*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGTACTGACTCAGCTGCCATCAGTGACTGTGAACCTGGGACAGACCACCAGCATCACCTGTGGTGGAGACAGCATTGGAGGGAGAACTGTTTACTGGTACCAGCAGAAGCCTGGCCAGCGCCCCCTGCTGATTATCTATAATGATAGCAATTGGCCCTCAGAGATCCCTGCCTGATTCTCTGGCTCCAACTCAGGGAACAGGGCCTCCCTAACCATCATTGGGGCCTGGGCCTAAGACGAGTCTGAGTATTACGGAGAGGTGTGGGACAGCAGTGCTAAGGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-24*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGTGCTGACACAGCTGCCATCCGTGAGTGTGACCCTGAGGCAGACGGCCCGCATCACCTGTGGGGGAGACAGCATTGGAAGTAAAAATGTTTACTGGTACCAGCAGAAGCTGGGCCAGGCCCCTGTACTGATTATCTATGATGATAGCAGCAGGCCGTCAGGGATCCCTGAGCGATTCTCCGGCGCCAACTCGGGGAACACGGCCACCCTGACCATCAGCGGGGCCCTGGCCGAGGATGAGGCTGACTATTACTGCCAGGTGTGGGACAGCAGTACTAAGCCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-25*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCACTGGGTTGAATCAGGCTTCCTCCGTGTTGGTGGCCCTGGGACAGATGGAAACAATCACCTGCTCGAGAGATGTCTTAGGGAAAAGATATGCATATAGGTACCAGCATAAGCCAAGCCAAGCCCCTGTGCTCCTAATCAATAAAAATAATGAGCAGGATTCTGGGATCCCTGACCGGTTCTCTGGCTCCAACTCGGGCAACACGGCCACCCTGACCATCAGTGGGGCCCGGGCTGAGGACGAGGCTGAGTATTACTGCCAGTCCTATGACAGCAGTGGAAATGTT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-26*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGTGCTGACACAGCTGCCATCCGTGAATGTGACCCTGAGGCAGCCGGCCCACATCACCTGTGGGGGAGACAGCATTGGAAGTAAAAGTGTTCACTGGTACCAACAGAAGCTGGGCCAGGCCCCTGTACTGATTATCTATGGTGATAGCAACAGGCCGTCAGGGATCCCTGAGCGATTCTCTGGTGACAACTCGGGGAACACGGCCACCCTGACCATCAGTGGGGCCCTGGCCGAGGACGAGGCTTACTATTACTGCCAGGTGTGGGACAGCAGTGCTCAGGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-27*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCAGTGTGCTGACTCAGCCTCCTTCAGTATCAGTGTCTCTGGGACAGACAGCAACCATCTCCTGCTCTGGAGAGAGTCTGAGTAAATATTATGCACAATGGTTCCAGCAGAAGGCAGGCCAAGTCCCTGTGTTGGTCATATATAAGGACACTGAGCGGCCCTCTGGGATCCCTGACCGATTCTCCGGCTCCAGTTCAGGGAACACACACACCCTGACCATCAGCGGGGCTCGGGCCGAGGACGAGGCTGACTATTACTGCGAGTCAGAAGTCAGTACTGGTACTGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-28*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGTGTTGACTCAGCTGCCTTCAGTGTCAGTGAACCTGGGAAAGACAGCCAGCATCACCTGTGAGGGAAATAACATAGGAGATAAATATGCTTATTGGTACCAGCAGAAGCCTGGCCAGGCCCCCGTGCTGATTATTTATGAGGATAGCAAGCGGCCCTCAGGGATCCCTGAGCGATTCTCTGGCTCCAACTCGGGGAACACGGCCACCCTGACCATCAGCGGGGCCAGGGCCGAGGATGAGGCTGACTATTACTGTCAGGTGTGGGACAACAGTGCTAAGGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-29*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCAGTGTGCTGACTCAGCCTCCCTCGGTGTCAGTGTCCCTGGGACAGACGGCGACCATCACCTGCTCTGGAGAGAGTCTGAGCAGATACTATGCACAATGGTATCAGCAGAAGCCAGGCCAAGCCCCCATGACAGTCATATATGGGGACAGAGAGCGACCCTCAGGGATCCCTGACCGATTCTCCAGCTCCAGTTCAGAGAACACACACACCTTGACAATCAGTGGAGCCCAGGCTGAGGATGAGGCTGAATATTACTGTGAGATATGGGACGCCAGTGCTGATGAT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-3*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGTGCTGACACAGCTGCCATCCAAAAATGTGACCCTGAAGCAGCCGGCCCACATCACCTGTGGGGGAGACAACATTGGAAGTAAAAGTGTTCACTGGTACCAGCAGAAGCTGGGCCAGGCCCCTGTACTGATTATCTATTATGATAGCAGCAGGCCGACAGGGATCCCTGAGCGATTCTCCGGCGCCAACTCGGGGAACACGGCCACCCTGACCATCAGCGGGGCCCTGGCCGAGGACGAGGCTGACTATTACTGCCAGGTGTGGGACAGCAGTGCTAAGGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-30*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTACGTGGTGACCCAGCCACCCTCAGTGTCAGTGAACCTGGGACAGACGGCCAGCATCACCTGTGGGGGAGACAACATTGCAAGCACATATGTTTCCTGGCAGCAGCAGAAGTCGGGTCAAGCCCCTGTGACGATTATCTATCGTGATAGCAACCGGCCCTCAGGGATCCCTGAGCGATTCTCTGGCTCCAACTCGGGGAACACGGCCACCCTGACCATCAGCAGGGCCCAGGCCGAGGATGAGGCTGACTATTACTGCCAGGTGTGGAAGAGTGGTAATAAGGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-4*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCACTGGGTTGAATCAGGCTCCCTCCATGTTGGTGGCCCTGGGACAGATGGAAACAATCACCTGCTCCGGAGATATCTTAGGGAAAAGATATGCATATTGGTACCAGCATAAGCCAAGCCAAGCCCCTGTGCTCCTAATCAATAAAAATAATGAGCGGGCTTCTGGGATCCCTCACTGGTTCTCTGGTTCCAACTCGGGCAACATGGCCACCCTGACCATCAGTGGGGCCCGGGCTGAGGACGAGGCTGACTATTACTGCCAGTCCTATGACAGCAGTGGAAATGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-7*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGTGCTGACTCTGCTGCTATCAGTGACCGTGAACCTGGGACAGACCACCAGCATCACCTGTGGTGGAGACAGCATTGGAGGGAGAACTGTTTACTGGTACCAGCAGAAGCCTGGCCAGCGCCCCCTGCTGATTATCTATAATGATAGCAATTGACCCTCAGGGATCCCTGCCTGATTCTCTGGCTCCAACTCAGGGAACAGGGCCTCCCTAACCATCATTGGGGCCTGGGCCTAAGACGAGTCTGAGTATTACGGAGAGGTGTGGGACAGCAGTGCTAAGGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV3-8*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "TCCTATGTGCTGACACAGCTGCCATCCGTGAGTGTGACCCTGAGGCAGACGGCCCGCATCACCTGTGGGGGAGACAGCATTGGAAGTAAAAGTGTTTACTGGTACCAGCAGAAGCTGGGCCAGGCCCCTGTACTGATTATCTATAGAGATAGCAACAGGCCGACAGGGATCCCTGAGCGATTCTCTGGCGCCAACTCGGGGAACACGGCCACCCTGACCATCAGCGGGGCCCTGGCCGAGGACGAGGCTGACTATTACTGCCAGGTGTGGGACAGCAGTACTAAGGCT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-10*01",
+    "range": {
+      "from": 0,
+      "to": 317
+    },
+    "sequence": "TTGCCCGTGCTGACCCAGCCTACAAATGCATCTGCCTCCCTGGAAGAGTCGGTCAAGCTGACCTGCACTTTGAGCAGTGAGCACAGCAATTACATTGTTCATTGGTATCAACAACAACCAGGGAAGGCCCCTCGGTATCTGATGTATGTCAGGAGTGATGGAAGCTACAAAAGGGGGGACGGGATCCCCAGTCGCTTCTCAGGCTCCAGCTCTGGGGCTGACCGCTATTTAACCATCTCCAACATCAAGTCTGAAGATGAGGATGACTATTATTACTGTGGTGCAGACTATACAATCAGTGGCCAATACGGTTAAGC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-16*01",
+    "range": {
+      "from": 0,
+      "to": 317
+    },
+    "sequence": "TTGCCCATGCTGACCCAGCCTACAAATGCATCTGCCTCCCTGGAAGAGTCGGTCAAGCTCACATGCACTTTGAGCAGTGAGCACAGCAATTACATTGTTCAATGGTATCAACAACAACCAGGGAAGGCCCCTCGGTATCTGATGCATGTCAGGAGTGATGGAAGCTACAACAGGGGGGACGGGATCCCCAGTCGCTTCTCAGGCTCCAGCTCTGGGGCTGACCGCTATTTAACCATCTCCAACATCAAGTCTGAAGATGAGGATGACTATTATTACAGTGGTGCATACTATACAATCAGTGGCCAATACGGTTAAGC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-20*01",
+    "range": {
+      "from": 0,
+      "to": 317
+    },
+    "sequence": "TTGCCCATGCTGACCGAGCCTACAAATGCATCTGCCTCCCTGGAAGAGTCAGTCAAGCTCACCTGCACTTTGAGCAGTGAGCACAGCAATTACATTGTTCGATGGTATCAACAACAACCAGGGAAGGCCCCTCGGTATCTGATGTATGTCAGGAGTGATGGAAGCTACAACAGGGGGGACGGGATCCCCAGTCGCTTTTCAGGCTCCAGCTCTGGGGCTGACCGCTATTTAACCATCTCCAACATCAAGTCTGAAGATGAGGCTGAGTATTATTACGGTGGTGCAGACTATAAAATCAGTGACCAATATGGTTAAGA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-22*01",
+    "range": {
+      "from": 0,
+      "to": 303
+    },
+    "sequence": "TTGCCCGTGCTGACCCAGCCTCCAAGTGCATCTGCCTGCCTGGAAACCTCGGTCAAGCTCACATGCACTCTGAGCAGTGAGCACAGCAGTTACTATATTTACTGGTATCAACAACAACAACCAGGGAAGGCCCCTCGGTATCTGATGAAGGTTAACAGTGATGGAAGCCACAGCAGGGGGGACGGGATCCCCAGTCGCTTCTCAGGCTCCAGCTCTGGGGCTGACCGCTATTTAACCATCTCCAACATCCAGTCTGAAGATGAGGCAGATTATTACTGTGGTGTACCCGCTGGTAGCAGTAGC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-5*01",
+    "range": {
+      "from": 0,
+      "to": 317
+    },
+    "sequence": "TTGCCCGTGCTGACCCAGCCTACAAATGCATCTGCCTCCCTGGAAGAGTCGGTCAAGCTGACCTGCACTTTGAGCAGTGAGCACAGCAATTACATTGTTCAGTGGTATCAACAACAACCAGGGAAGGCCCCTCGGTATCTGATGTATGTCAGGAGTGATGGAAGCTACAAAAGGGGGGACGGGATCCCCAGTCGCTTCTCAGGCTCCAGCTCTGGGGCTGACCGCTATTTAACCATCTCCAACATCAAGTCTGAAGATGAGGATGACTATTATTACTGTGGTGCAGACTATACAATCAGTGGCCAATACGGTTAAGC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV4-6*01",
+    "range": {
+      "from": 0,
+      "to": 303
+    },
+    "sequence": "TTGCCCGTGCTGACCCAGCCTCCAAGTGCATCTGCCTCCCTGGAAGCCTCGGTCAAGCTCACATGCACTCTGAGCAGTGAGCACAGCAGTTACTATATTTACTGGTATGAACAACAACAACCAGGGAAGGCCCCTCGGTATCTGATGAGGGTTAACAGTGATGGAAGCCACAGCAGGGGGGACGGGATCCCCAGTCGCTTCTCAGGCTCCAGCTCTGGGGCTGACCGCTATTTAACCATCTCCAACATCCAGTCTGAGGATGAGGCAGATTATTACTGTGGTGCACCCGCTGGTAGCAGTAGC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV5-109*01",
+    "range": {
+      "from": 0,
+      "to": 319
+    },
+    "sequence": "CAGCTTGTGCTGACCCAGCCGCCCTCCCTCTCTGCATCCCTGGGATCAACAACCAGACTCACCTGCACCCTGAGCAGTGGCTTCAGTGTTGGTGGCTATAGCATATACTGGCACCAGCAGAAGCCAGGGAGCACTCCCTGGTACCTCCTGTACTACTACTCAAGTACAGAGTTGGGACCTGGGGTCCCCAGCTGCTTCTCTGGATCCAAAGACACCTCAGCCAATGTAGGGCTCCTGCTCATCTCAGGGCTGCAGCCTGAGGATGAGACTGACTACTACTGTGCTATAGGTCACGGCAGTGGGAGCAGCTACACTTACC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV5-131*01",
+    "range": {
+      "from": 0,
+      "to": 325
+    },
+    "sequence": "CAGCCTGTGCTGACCCAGCCACCCTCCCTCTCTGCATCCCTGGGAACAACAGCCAGACTCACCTGCACCCTGAGCAGTGGCTTCAGTGTTGGTGACTATGACATGTACTGGTACCAGCAGAAGCCAGGGAGCCCTCCCCGGGATCTCCTGTACTACTACTCGGACTCATATAAAAACCAGGGCTCTGGGGTCTCCAAAAGCTTCTCTGGATCCAAGGATACCTCAGCCAATGCAGGGCTCCTGCTCATCTCTGGGCTGCAGCCTGAGGACGAGGCTGACTACTACTGTGCTACAGATCATGGCAGTGAGAGCAGCTACTCTTACC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV5-64*01",
+    "range": {
+      "from": 0,
+      "to": 325
+    },
+    "sequence": "CAGCTTGTGGTGACCCAGCCGCCCTCCCTCTCTGCATCCCTGGGATCATCCGCCAGACTCACCTGCACCCTGAGCAGTGGCTTCAGTGTTGGCAGTTATTCTGTAACTTGGTTCCAGCAGAAGCCAGGGAGCCCTCTCTGGTACCTCCTGTACTACCACTCAGACTCAGATAAGCACCAGGGCTCCAGGGTCCCCAGCCGCTTCTCTGGATCCAAGGACACCTCGGCCAATGCAGGGCTCCTGCTCATCTCTGGGCTGCAGCCTGAGGATGAGGCTGACTACTACTGTGCCTCCGCTCATGGCAGTGGGAGCAACTACCATTACT"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV5-85*01",
+    "range": {
+      "from": 0,
+      "to": 325
+    },
+    "sequence": "CAGCCTGTGCTGACCCAGCCACCCTCCCTCTCTGCATCCCTGGGATCAACAGCCAGACCCACCTGCACCCTGAGCAGTGGCTTCAGTGTTGGAAGCTACCATATACTCTGGTTCCAGCAGAAGTCAGAGAGCCCTCCCCGGTATCTCCTGAGGTTCTACTCAGATTCTAATGAACACCAGGGTCCCGGGGTCCCCAGCCGCTTCTCTGGATCCAAGGACACCTCAACCTATGCAGGGCTCTTGCTCATCTCTGGGCTGCAGCCTGAGGACGAGGCTGACTACTACTGTGCTACAGACCATGGCAGTGGGAGCAGCTACACTTACC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-102*01",
+    "range": {
+      "from": 0,
+      "to": 300
+    },
+    "sequence": "CAGATTGTAGTGACCCAGGAACCATCACTGTCTCCAGGAGGGACAGTCCTACTCACTTGTGGCCTCAGCTCTGGGTCAGTCACTACAAGTAACTACTCCAGCTGGTACCAGCAGACCCCAGGGCGGGCTCCTCGCACGATTATCTACAACACTAACAGCCACCCCTCTGGAGTCCCTGATCGCTTCTCTGGATCCATCTCTGGGAACAAAGCGGCGCTCACCATCACAGGAGCCCAGCCTGAGGACGAGGCTGACTACTACTGTGTTACAGAACATGGTAGTGGGAGCAGCTTCACTTAC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-108*01",
+    "range": {
+      "from": 0,
+      "to": 307
+    },
+    "sequence": "CAGACTGTGGTGACTCAGGAGTCATCAGTCTCAGTGTCTCCAGGAGGGACAGTCACACTCACGTGTGACCTCAGCTCTGGGTCAGTGACTACAAGTAACAACCCCAGCTGGTACCAGCAGACCCAAGGCCGATCTCCTCGCATGCTTATCTATGACACAAGCAGCTGTCCCTCGGAGGTCCCTGATCGCTTCTCTGGATCCATTTCTGGGAACACAGCTGCCCTCACCATCACAGGAGCCCAGCCTGAGGACAAGGCTGACTACTACTGTAGTATGCATGATGTCAGTGGGAGCAGCTACAATTACC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-113*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGACTGTGGTCACCCAGGAGCCATCACTCTCAGTGTCTCCAGGAGGGACAGTCACACTCACATGTGGCCTCAGTTCTGGGTCAGTCACTATAAGTAACTACCCCAGCTGGTCCCAGCAGACCCCAGGGCAGGCTCCTCACACAATAATCTACAGGACAAACAGCTGACCCTCTGGGGTCCCTGATCGCTTCTCTGGATCCATCTCTGGGAACAACGCCGCCCTCAGCATCACAGTCGCCCAGCCTGAGGACGAGGCTGACTATTACTGTTCATTGTATATGGGTAGTAACATTTA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-119*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGACTGTGGTAACCCAGGAGCCATCACTCTCAGTGTCTCCAGGAGGGACAGTCACACTCACTTGTGGCCTCAGCTCTGGGTCAGTCTCTACAGGTAACAAACCTGGCTGGTACCAGCACACCCCAGGCCAGGCTCCTCGCAGGATTATCTATGACACAAGCAGCCGCCCTTCTGGGGTCCCTGATCGCTTCTCTGGATCCATCTCTGAGAACAAAGCTGCCCTCACCATCACAGAAGCCCAGCCTGAGGATGAGGCTGCCTACCACTGTTCGCTGTATATGAGTGGTGGTGCTTA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-121*01",
+    "range": {
+      "from": 0,
+      "to": 307
+    },
+    "sequence": "CAGACTGTGGTGACCCAGGAGTCATCAGTCTCAGTGTCTCCAGTCGGAACAGTCACACTCACTTGTGGCCTCAGCTCTGGGTCACTGACTACAAGTAACTACACCAGCTGGTACCAGCAGACCCAAGGCCAGTCTCCTCGCATGCTTGTCTATGACACAAGCAGCTGTCCCTCTGAAGTTCCTGATCACTTCTCTGGATCCATTTCTGGGAACAAAGCCGCCCTCACCATCACAGGAGCCCAGCCTGAGGACGAGGCTGACTACTACTGTGGTATGCATGATGTCAGTGGGAGCAGCTAAAATTACC"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-128*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGACTGTGGTAACCCAGGAGCCATCACTCTCAGTGTCTCCAGGAGGGACAGTCACACTCACATGTGGCCTCAGCTCTGGGTCAGTCTCTACAAGTAATTACCCTGGCTGGTACCAGCAGACCCTAGGCCGGGCTCCTCGCACGATTATCTACAGAACAAGCAGCCGCCCCTCTGGGGTCCCTAATCGCTTCTCTGGATCCATCTCTGGGAACAAAGCCGCCCTCACCATCACAGGAGCCCAGCCTGAGGACGAGGCTGACTATTACTGTTCCTTGTATATGGGTAGTTACACTGA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-142*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGACTGTGGTCACCCAGAAGCCATCACTCTCAGTGTCTCCAGGAGGGACAGTCACACTCATATGTGGCCTCAGCTCTGGGTCAGTCTCTACAAGTAATTACCCTGGCTGGTACCAGCAGACCCAAGGCCGGGCTTCTCGCACAATTATCTACAGCACAAGCAGCCGCCCCTCTGGGGTCCCTAATCGCTTCACTGGATCCATCTCTGGGAACAAAGCCGCCCTCACCATCACAGGAGCCCAGCCTGAGGACGAGGCTGACTATTACTGTTCCTTGTATATGGGTAGTTACACTGA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-153*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGACTGTGGTAACCCAGGAGCCATCACTCTCAGTGTCTCCAGGAGGGACAGTCACACTCACATGTGGCCTCAGCTCTGGGTCAGTCTCTACAAGTAATTACCCTGGCTGGTACCAGCAGACCCAAGGCCGGGCTCCTCGCACGATTATCTACAACACAAGCAGCCGCCCCTCTGGGGTCCCTAATCGCTTCTCTGGATCCATCTCTGGAAACAAAGCCGCCCTCACCATCACAGGAGCCCAGCCCGAGGATGAGGCTGACTATTACTGTTCCTTGTATACGGGTAGTTACACTGA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-161*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGACTGTGGTCACCCAGAAGCCATCACTCTCAGTGTCTCCAGGAGGGACAGTCACACTCATATGTGGCCTCAGCTCTGGGTCAGTCTCTACAAGTAATTACCCTGGCTGGTACCAGCAGACCCAAGGCCGGGCTTCTCGCACAATTATCTACAGCACAAGCAGCCGCCCCTCTGGGGTCCCTAATCGCTTCCCTGGATCCATCTCTGGGAACAAAGCCGCCCTCATCATCACAGGAGCCCAGCCTGAGGACGAGGCTGACTATTACTGTTCCTTGTATATGGGTAGTTACACTGA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-36*01",
+    "range": {
+      "from": 0,
+      "to": 299
+    },
+    "sequence": "CAGACTGTGGTGACCCAGGAGCCATCACTCTCAGTGTCTCTGGGAGGGACAGTCACCCTCACATGTGGCCTCAGCTCCGGGTCAGTCTCTACAAGTAACTACCCCAACTGGTCCCAGCAGACCCCAGGGCAGGCTCCTCGCACGATTATCTACAACACAAACAGCCGCCCCTCTGGGGTCCCTAATCGCTTCACTGGATCCATCTCTGGGAACAAAGCCGCCCTCACCATCACAGGAGCCCAGCCTGAGGACGAGGCTGACTACTACTGTGCTCTGGGATTAAGTAGTAGTAGTAGTTA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-39*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGACTGTGGTAACCCAGGAGCCATCACTCTCAGTGTCTCCAGGAGGGACAGTCACACTCACATGTGGCCTCAGCTCTGGGTCAGTCTCTACAAGTAACCACCCTAGCTGGTACCAGCAGACCCAAGGGAAGGCTCCTCGCATGCTTATCTACAACACAAACAACCGCCCCTCTGGGATCCCTAATTGCTTCTCTGGATCCATCTCTGGGAACAAAGCCTCCCTCACCATCACAGGAGCCCAGCCTGAGGACGAGACTGACTATTACTGTTTATTGTATATGGGTAGTAACATTTA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-43*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGACTGTGGTAACCCAGGAACCATCACTCTCAGTGTCTCCATGAGGGACAGTCACACTCACATGTGGCCTCAGCTCTGGGTCAGTCTCTACAAGTAACTACCCCAACTGGTACCAGCAGACCCAAGGCCGGGCTCCTCACAGGGTTATCTACAACACAAACAACCGCCCCTCTGGGGTCCCTGATCGCTTCTCTGGATCCATCTCTGGGAACAAAGCCGCCCTCACCATCACAGCTGCCCAGCCTGAGGACGAGGCTGACTATTACTGTTCATTGTATATGGGTAGTAACATTTG"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-93*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGACTGTGGTAACCCAGGAGCCATCACTCTCAGTGTCTCCAGGAGGGACAGTCACACTCACATGTGGCCTCAGCTCTGGGTCAGTCTCTACAAGTAATTACCCTGGCTGGTACCAGCAGACCCAAGGCCGGGCTCCTCGCACGATTATCTACAACACAAGCAGCCGCCCCTCTGGGGTCCCTAATCGCTTCTCTGGATCCATCTCTGGAAACAAAGCCGCCCTCACCATCACAGGAGCCCAGCCCGAGGATGAGGCTGACTATTACTGTTCCTTGTATACGGGTAGTTACACTGA"
+  }, {
+    "uri": "file://dog_V_IGL.fasta#Canlupfam_IGLV8-99*01",
+    "range": {
+      "from": 0,
+      "to": 296
+    },
+    "sequence": "CAGACTGTGGTCACCCAGAAGCCATCACTCTCAGTGTCTCCAGGAGGGACAGTCACACTCATATGTGGCTTCAGCTCTGGGTCAGTCTCTACAAGTAATTACCCTGGCTGGTACCAGCAGACCCAAGGCCGGGCTTCTCGCACAATTATCTACAGCACAAGCAGCCGCCCCTCTGGGGTCCCTAATCGCTTCCCTGGATCCATCTCTGGGAACAAAGCCGCCCTCACCATCACAGGAGCCCAGCCTGAGGACGAGGCTGACTATTACTGTTCCTTGTATATGGGTAGTTACACTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV10*01",
+    "range": {
+      "from": 0,
+      "to": 280
+    },
+    "sequence": "AAAAACCAAGTGGAACAGAATCCTCCATCTCTGATCACCCTGGAGGGGAAGAACTACACAATTCAATGCAACTATACAGTGAACCCCTTTGGCAGCTTAAGGTGGTACAAGCACAGCACGGGGACAGGTCCTGCTTCTCTGATAGGCATGACTTACAGTGACAGCAAAAAGTCATATGGAAGCTACACAGTGACTCTGGATGCAAACTCCAAGCAGAGCTCCTTGCACATCACAGCTGCCCAGCTTAGTGATTCAGCCTCCTACATCTGTGTGGTGAGCG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV12*01",
+    "range": {
+      "from": 0,
+      "to": 278
+    },
+    "sequence": "CAGAAGGGAGTGGAGCAGAGTCCTGGATCTCTGAGCACTCCGGAGGGAACCACTGCCTCTCTCAACTGCAATTATAGTGACAGTGCTTCCCAGTACTTCATGTGGTACAGACAGTATTCTGGGAAGGGCCCTGAGTTGCTGATGAACATATACTCCAAAGGTGAAAAAGAAGAAGGAAGATTTGCAGTGCAGGTCGATAGAGCAAAACAGTATGTCTCCTTGCTCATCAGAGATTCCCAGCCCAGTGACTCAGCCACCTACCTCTGTGCAGTGAGCCG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV17*01",
+    "range": {
+      "from": 0,
+      "to": 277
+    },
+    "sequence": "AACAGCCAGCAAGAACAGAATCATCAGGTCCTGAGCATCCAGGAGGGTGAAAATGCCACCATGAACTGCAGTTATAAGACTTCTATTGACAACTTACAGTGGTATAGACAAGACTCAGTCAGAGTCTTTGTCCAATTGATTTTAGTATGTTCAAACCAGAGAGAGAAACACAGTAGAAGACTACAAGTCACACTGAACACCAGCATCAAAAGCAGTTCTTTGTCTATCGTGGCTTCCCAGGCTGCAGACACTGCTACTTATATCTGTGCTATGGATA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV19*01",
+    "range": {
+      "from": 0,
+      "to": 285
+    },
+    "sequence": "TCTCAGAAGGTAACTCAAGCCCAGCCTTCCATTTCTACTCTGGAGAAGGAGGCTGTGACCCTGGATTGTGTATATGAAGTTAGTGGTTATAGTTATTATTTATTCTGGTACAAACATCCACCAAGTGTGGAAATTATTTTCCTCATTTGTCAGGACTCATACTGGGAGCAGATTGCAACAGAGGGTCGGTATTCTCTGATCTTTCAGAAATCAGACCATTCCAGCAGCCTCACCATCACAGCATTACAGCCTGCAGACTCTGCAGTGTGTTTCTGTGCTCTGAGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV21*01",
+    "range": {
+      "from": 0,
+      "to": 279
+    },
+    "sequence": "AAACAGGAGGTGAAGCAGAGTCCTGAAGCTCTGAGCGTCCGTGAGCGGGACAGCGTGGTTCTCAGCTGCAATTTCACAGATAGTGCCATTTATTCCCTTCAGTGGTTTAGGCAGGACCCAGGGAAAGGGCTCACACTCCTGTTGTTAATGCAGTCAAATCAAAAAGAACAAACAAGTGGAAGAATTAAAGTCTGGTTGGATATGTCATCAAGACAGAGCACTTTATACATTGCAGCTTCTCAGCCCAGCGACTCGGCCACCTATCTCTGTGCAGTAAGG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV22*01",
+    "range": {
+      "from": 0,
+      "to": 271
+    },
+    "sequence": "GGCATGGAGGTGGAGCAGAGGCCCCTCGTTGAGAGTGTGCTGGAGGGAGCCAGTCCCACGCTGCAGTGCAATTTTTCTACCTCTGCGACCAGCGTGCAGTGGTTTCGCCAAGATCCTGGAGGCCACCTCGTCCACCTGTTTTACATTCCTTCGGGGACAAAGCACAATGGAAGATTAAACTCTACGACAGTCACTAAAGAGCGCCGCAGCTCATTGTACATTTTTTCTTCCCAGACCACAGACTCAGCCATTTACTTCTGTGCGGTGAAGC"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV23*01",
+    "range": {
+      "from": 0,
+      "to": 280
+    },
+    "sequence": "CAGCAGCAGGTGATACAGGGCCCTCAATCTCTGGCAGTCTGGGAAAGAGAGATTTCTACTCTGAACTGTACTTATGAGAACAGTGCTTTTGACTACTTTCTATGGTACTGGCAATACCCTAGTAAAGGCCTTGAATGCTTGCTAACCATGCTCTTGGTTGAGAGTACAAAGGAAAATGGAAGATTCACAGTTTCCCTCAATGTAAGTGCCAAAAAATTCCTATTGCACATCAGAGCTTCCCAGCCTGGAGACTCAACCACCTACCTCTGTGCAACAAGAG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV24*01",
+    "range": {
+      "from": 0,
+      "to": 277
+    },
+    "sequence": "GTATTGAATGTGGAACAGAATCCTCCATGGCTTCATGTTCAGGAAGGAGAGAATACCAATTTCACCTGCCATTTTCCTTCCAGCAATTTCTATTCTTTACAGTGGTACAGACAGGAACCTGCAAAAAGTCTCAAATTCCTATTTACAATTGCTCTAAATGGGGATGAAAAGGAAGAAGGACGAGTAAGAGCCACTCTTAATACTCGGGAAGGCTATAGCTCCCTGTACATCAAAAGATCCCAGCCTGAAGATGCAGCTGTATACCTCTGTGCCTCCA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV25*01",
+    "range": {
+      "from": 0,
+      "to": 269
+    },
+    "sequence": "GGACAAGAGATAAAGCAAAATCCTCAATTCCTGCTTTTACAAGAAGTAGAGGATTTCACCATTTATTGCAATTCCTCAAGTACTTTAAATGGCTTACAGTGGTATAAGCAGAGGCCTGGAGATGGTCCTGTTCTGATCAAATTATTTAAGGGTGGAGAAGTGAAGCAGAAAAGACGGACAGCTCAGCTTGGAGAGACTAGAAAGGACAGTTCCCTGCACAAGGCGGCCTCCCAGACTGCAGATGCAGGAACCTATTTCTGCGCAGGGAG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV26*01",
+    "range": {
+      "from": 0,
+      "to": 277
+    },
+    "sequence": "GAAACTAAGACCACACAGCCAAATGTAATGGAGAGTACTGAAGAAGAACCTGTACACCTGCCCTGTAACCACTCCACAATCAGTGGAAATGAGTACATATATTGGTATCGACAGATTCCCCAACAGAGTCCAGAGTACATGATTCATGGTCTAAAGGACAATGTGACTAATGGAATGGCCACTCTGATCATCGCAGTAGATAGAAAGTCCAGTACCTTGATTCTGCCCTGGATTACCCTCAGAGATGCTGCTGTGTACTATTGCATCGTGAAAGAGG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV27*01",
+    "range": {
+      "from": 0,
+      "to": 274
+    },
+    "sequence": "ACCCAGCTGCTGCAGCAGAGTCCTCGCTCTCTAAGCATCCAGGAGGGAGAAAATTTTACTACGTACTGCAACTTCACGAGCACTTTCCCCAGCTTTCAGTGGTACAGACAGAAGCCTGGGGCAGGTCCAGTCCACTTGATGACATTATCTAAGCGAGGAGAAGTGAAGAAGCAGAAGAGTCTAACAGCTCTGTTTGGTGAGGCAAGAAAAGACAGCTCCCTGCTTATCATTGCAGCCCAGCCTGGAGATGCTGCCATCTACTTCTGCGCAGGGT"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV28*01",
+    "range": {
+      "from": 0,
+      "to": 271
+    },
+    "sequence": "CAGATGAAGGTGGAACAGAGTCCTGGTGTCCTGATCCTCCAAGAGGGGAGAAATGCCTCTATGATGTGTAATTACTCTATTGCCGTTACCAGTGTGCAGTGGTTCCAACAAAACCATGAAGGACACCTCACGTCCTTGTTGTACATCGTTTCTGGAATGAAGCAAAAAGGAAGACTAAAATTCACAGTTGATACCAAGGAGCGTAACAGCCATCTGTATATCACAGACTCCCAGCCTGGGGACTCAGTCACTTATTTCTGTGCTGTGGAGG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV29*01",
+    "range": {
+      "from": 0,
+      "to": 280
+    },
+    "sequence": "GACCAGCAGCAGATCAAACAAACTCCATCCTTGAATGTGCAAGAAGGAAAGATTTCTATTCTGAACTGTGACTACAATAGTAATATATTTGATTACTTCCCATGGTACAAAAAATATCCTGCTAAAAGTCCCAAATTCCTAATATCAATACGTTCAGTTGTGGATAAAAATGAAGATGGAAGATTCACAGTCTTCCTCAACAAAAGTGTCAAACGCCTTTCTCTGCACATCAAAGATTCACAGCCCAGAGACTCAGCCCTGTACCTCTGCGGAGCAAGTG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV34*01",
+    "range": {
+      "from": 0,
+      "to": 272
+    },
+    "sequence": "AGCCAAGAACTGGAGCAGAGTCCACAGTCTCTGATCATCCAAGAAGGAGAAAATTTCACCATAAACTGCCATTCATCAAAGCCTGTGTATGCCCTACACTGGTACAGGCAAAAAAATAGTGAAGGTCTAATATCCTTGATGATATTATGGGAGAATGGGGAAAAGAGTCATGAAAAAACCACTGCCACGTTAAATGAGAAGAAGCAGCAAAGTTCCCTGCATATCACAGCCTCCCAGTCCAGCGACTCAGGCATCTACTTCTGTGCAGCAGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV35*01",
+    "range": {
+      "from": 0,
+      "to": 275
+    },
+    "sequence": "GGCCAGCAGCTGAATCAGAATCCTAGGTCTGTGTCCATTCAGGAAGGAGAGGATGTCTCCATGAGCTGCAATTCCTCGAGTACACTCAACACTTTTCAATGGTTCAAGCAGGATCCTGTGGAGGGCCTTGTCCTCGTGATAGCCTTATATAAGGCTGGGGAATTGACCCGAGATGGAAAACTGACTGCTCAGTTCAGTGGAACAAGAACGGACAGCTTCTTGACCATTTCAGCCTCTGAGACTGAACATTCAGGCACCTACTTCTGCAGTGGCAA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV37*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "CAACCACTAATGGAATAGAGCCCTCTCTACCTGAAAGTCCAAGAAGGCAAGAGCTTCACAATGAACTGCAGTTACAGAGGCAACACTTCAGCTTTCTTCCAATGGTTTAGGCAGGGTCCTGGGGAAAGCCTCCACGTTTTGATGCAAATGCAATCAAACAAGAAAGAGAAGATCAGTGGAAGATTCACAGCCAGTCTTAACAGGGAGGATCAGTACTTTTCCCTGCACATGGAAGATTCTCACCTCCATGACTCAACCACATTCCTGTGTGCAGCGAACAG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV38-1*01",
+    "range": {
+      "from": 0,
+      "to": 286
+    },
+    "sequence": "GCCCAGAAAGTCACTCAGACTCAACCAGACATATCTGTGCGGGACACAGAGACTGTGACCCTGAACTGCATGTATGACACTAGTGACAGTAATTATTTGTTCTGGTACAAACAGCCTCCCAGCAGGGAGATGATTCTCATTATTCGCCAAGAAGCTTATAGACAAGAGAATGCAACAAATAATCGCTTCTCTGTGAACTTCCAAAAAGGAAATAAATCCTTCAGTCTCAGGATCTCAGACTCTCGGCTGGAGGATGCTGCAATGTATTTCTGTGCTCTCATGGAGG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV38-2*01",
+    "range": {
+      "from": 0,
+      "to": 289
+    },
+    "sequence": "GCCCAGAAGGTCACTCAGACTCAACCAGAAATGTTTGTTCGGGAGACAGATACTGTGATCCTGCACTGCACGTATGACACTAGCGACAGTGATTATTATTTGTTCTGGTACAAACAGCCTCCCAGCAGGGAGATGATTCTCATTATTCGCCAAGAAGTTTATAGACAAGATAATGCAACAAATAATCGCTTCTCTGTGAACTTCCAGAAAGGAAATAAATCCTTCAGTCTCAAGATCTCAGACTCTCGGCTGGAGGATGCTGCAATGTATTTCTGTGTTCTTGCAGGAG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV40*01",
+    "range": {
+      "from": 0,
+      "to": 267
+    },
+    "sequence": "GGCAATTCAGTCAAACAGACAGACCAAATTACTGTCTTGGAAGGAACATCTGTGACTATGAGCTGCATATACACATTCACACAGAACCCTACTCTTTTCTGGTATGTCCAATACCCCAACAAAGCTCTGCAACTTCTTCATAAAGAGACGATGGAAAACAGCAAGAACTTTGGAGCCAGAAATATTAAAGACAAAAACTCCCCTATTACGAAGTCGTCAGTCCAGGTATCAAATTCGGCCATGTACTACTGTCTTCTGAGAGATACA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV43-1*01",
+    "range": {
+      "from": 0,
+      "to": 274
+    },
+    "sequence": "GGGATGAAGGTGGAGCAGAGCCCTTCAGCCCTGAGCCTGCAGGAGGGAGCCAGCTCTATCCTCAAGTGCAATTACTCTAGCGCAGTGAACAGTGTGCAGTGGTTCCGACAGAATCCCGGGGGCGGCAGGCTCACCAGGCTGTTTTACATAGCTTCAGGGATGAAGCAGAGCGGGAGGCTAAACTGCACACTGAATGCTAAGGAACGGTTCAGCACCCTCCACGTCGCGGCCTCTCAGCTGGAAGACTCAGCCACCTACCTGTGTGCGGTGGAGG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV43-2*01",
+    "range": {
+      "from": 0,
+      "to": 274
+    },
+    "sequence": "GGGATGAAGGTGGAGCAGAGCCCTTCAGCCCTGAGCCTGCAGGAGGGAGCCAGCTGTACTCTGAAGTGCAATTATTCTAGTACTCCGTACAATGTGCAGTGGTTCCGACAGAATCCCAGGGGCGGCAGCCTTACCAGGCTGTTTTACATAGCTTCAGGGATGATGCAGAGCGGAAGGCTAAACTGCACACTGAATGCTAAGGAACGGTTCAGCACCCTCCACGTCGCGGCCTCTCAGCTGGAAGACTCAGCCACCTACCTGTGTGCGGTGGAGG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV43-3*01",
+    "range": {
+      "from": 0,
+      "to": 274
+    },
+    "sequence": "GGGATGAAGGTGGAGCAGAGCCCTTCAGCCCTGAGCCTGCAGGAGGGAGCCAGCTCTATCCTCAAGTGCAATTACTCTAGCGCAGTGAACAGTGTGCAGTGGTTCCGACAGAATCCCGGGGGCGGCAGGCTCACCAGGCTGTTTTACATAGCTTCAGGGATGAAGCAGAGCGGAAGGCTAAACTGCACACTGAATGCTAAGGAACGGTTCAGCACCCTCCACGTCGCGGCCTCTCAGCTGGAAGACTCAGCCACCTACCTGTGTGCGGTGGAGG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV43-4*01",
+    "range": {
+      "from": 0,
+      "to": 274
+    },
+    "sequence": "GGGATGAAGGTGGAGCAGAGCCCTTCAGCCCTGAGCCTGCAGGAGGGAGCCAGCTCTATCCTCAAGTGCAATTACTCTAGCGCAGTGAACAGTGTGCAGTGGTTCCGACAGAATCCCGGGGGCGGCAGGCTCACCAGGCTGTTTTACATAGCTTCAGGGATGAAGCAGAGCGGAAGGCTAAACTGCACACTGAATGCTAAGGAACGGTTCAGCACCCTCCACGTCGCGGCCTCTCAGCTGGAAGACTCAGCCACCTACCTGTGTGCGGTGGAGG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV43-5*01",
+    "range": {
+      "from": 0,
+      "to": 274
+    },
+    "sequence": "GGGATGAAGGTGGAGCAGAGCCCTTCAGCCCTGAGCCTGCAGGAGGGAGCCAGCTCTATTCTCAAGTGCAATTACTCTAGCGCAGTGAGAAGTGTGCAGTGGTTCCGACAGAATCCCAGGGGCGGCAGCCTCACCAGGCTGTTTTACATAGCTTCAGGGATGAAGCAGAGCGGAAGGCTAAACTGCACACTGAATGCTAAGGAACTGTTCAGCACCCTCCACGTCGCGGCCTCTCAGCTGGAAGACTCAGCCACCTACCTGTGTGCGGTGGAGG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV43-6*01",
+    "range": {
+      "from": 0,
+      "to": 274
+    },
+    "sequence": "GGGATGAAGGTGGAGCAGAGCCCTTCAGCCCTGAGCCTGCAGGAGGGAGCCAGCTCTATCCTCAAGTGCAATTACTCTAGCGCAGTGAACAGTGTGCAGTGGTTCCGACAGAATCCCGAGGGCGGCAGCCTCACCAGGCTGTTTTACATAGCTTCAGGGATGAAGCAGAGCGGGAGGCTAAACTGCACACTGAATGCTAAGGAACTGTTCAGCACCCTCCACGTTGCGGCCTCTCAGCTGGAAGACTCAGCCACCTACTTGTGTGCGGTGGAGG"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV8-1*01",
+    "range": {
+      "from": 0,
+      "to": 284
+    },
+    "sequence": "GCCCAGTCAGTAACCCAACCGGATGCCTATGTTACTGTCTCGGAAGAAGCCCCTCTGGAGCTGAGGTGCAGCTACTCATCTTCTATTCAGCCGTATCTCTACTGGTTCGTGCAGTACCCCAACCAAGGCCCCCAGCTTCTCCTCCAGTACACATTAAAGGGAGCACTGGTTAAAGGCATCAAAGGTTTTGAGGCTGAATTTAAGAGGAATGAAACCTCCTTCCACCTGAGGAAACCCTCAGCCCATGGGAGTGACACAGCCAAGTACTTCTGTGCTCTTAGTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV8-2*01",
+    "range": {
+      "from": 0,
+      "to": 278
+    },
+    "sequence": "GCCCAATCTGTGACCCAGCCTGATGCCCACATCACTGTCCCTGAAGAATCCCCTCTGGAGCTGAGATGCAACTATTCCTATGGTGCAACTCCATATCTCTACTGGTACGTGCAGTACCCCAACCAAGGCCTCAAGCTTCTCCTCAGGTACTTTTCAGGGGATACCGTGGTTCAAGGCATCAAAGGTTTCAAGGCTGAATTTAGTAAAACCTCCTTCCACCTGAAGAAACCCTCAGCCCATTGGAGCGACTCAGCCAAGTACTTCTGTGCTGCGAGTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-1*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "AGAGACTTAGTGACCCAGAAGGACGGCCAGGTGACCCTTTCAGAAGAGGCTTTCCTGACTGTGAACTGTAATTATTCAGCATCAGGGTACCTTGCCCTTTTCTGGTATGTCCAGTATCTGAGAGAAGGTCCACAACTCCTCCTGAAAGCATCAAGAGACAAGGAGAAGGGAAGTAACAAAGGTCTCGAAGCCACCAATGACAGATCATCCAGATCCTTCCACTTGAAGAAAAGCTCAGTGCAAATGTCAGACTCAGCTGTGTACTACTGTGCCCTGAGAGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-10*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "GGAGACTCAGTGAAACAGATGGAAGGCCAAGTGACCCTCTCAGAAGAGGCTTCGTTGACTATAAATTGTACTTTCTCAACATCAGTGACACCCACTCTCTTCTGGTATGTCCAGTATCTGGGAGAAGGTCCACAGATCCTCCTGAAAGCATTAAGAGACAAGGAAAAGGGAAGCAACAAAGGATTTGAAGCAACCTTGGACAGTTCATCCAAATCCTTCCACTTGAAGAAAGGCTCAGTGCAAATGTCAGACTCAGCTGTGTACTACTGTGTCATGAGTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-11*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "GGAGACTCAGTGAACCAGACGGAAGGCCAAGTGATCCTCTCAGAAGAGGCCTTCCTGACTATAAACTGTACCTACTCGACAACATGGCCCCCCACTCTTTTCTGGTATGTCCAGTATCTGGGAGAAGGTCCACAGCTCCTCCTGAAAGCAGTGACAGACAAGGAAAAGGGAAGCAACAAAGGTTTTGAAGCCACCTTGGACAAAACATCCAGATCCTTCCACTTGAAGAAAGGCTCGGTGCAACTGTCAGACTCAGCTGTGTACTACTGTGCCTTGAGTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-12*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "GGAGACTCAGTGAACCAGACGGAAGGCCAAGTGACCCTCTCAGAAGAGGCCTTCCTAACTATAAACTGTACCTACTCGACAACAAGATCCCCCACTCTTTTCTGGTATGTCCAGTATCTGGGAGAAGGTCCAAAGCTCCTCCTGAAAGCATTAAGAGACAAGGAAAAAGGAAGCAACAAAGGTTTTGAAGCCACCTTGGACAAAACATCCAGATCCTTCCACTTGAAGAAAGGCTCGGTGCAACTGTCAGACTCAGCTGTGTACTACTGTGCCCTGAGTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-13*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "GGATACTCAGTGAAACAGATGGAAGGCCAAGTGACCCTCTCAGAAGAGGCTTCGTTGACTATAAACTGTACTTTCTCAACATCAACGACACCCACTCTCTTCTGGTATGTCCAGTATCTGGGAGAAGGTCCACAGATCCTCCTGAAAGCATTAAGAGACAAGGAAAAGGGAAGCAACAAAGGATTTGAAGCAACCTTGGACAGTTCATCCAAATCCTTCCACTTGAAGAAAGGTTCAGTGAAAATGTCAGACTCAGCTGTGTACTACTGTGCCCTGAGTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-3*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "GGAGACTCAGTGAACCAGACGGAAGGCCAAGTGACCCTCTCAGAAGAGGCCTTCCTGACTATGAACTGTACTTTCTCAACATCATGGACACCCAGTCTATTCTGGTATGTCCAGTATCTGGGAGAAGGTCCAAAGCTTCTCCTGAAAGCCTTGACAAACAAGGCAAAGGGAAGCAACAAAGGTTTTGAAGCCACCTTGGACAGTTCATCCAAATCCTTCCACTTGAAGAAAGGCTCAGTGGAAATGTCAGACTCAGCTGTGTACTACTGTGCCATGAGTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-4*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "GGAGACTCAGTGAACCAGACGGAAGGCCAAGTGATCCTCTCAGAAGAGGCCTTCCTGACTATAAACTGTACCTACTCGACAACATGGCTCCCCACTCTTTTCTGGTATGTCCAGTATCTGGGAGAAGGTCCACAGCTCTTCCTGAAAGCTGTGACAGACAAGGAAAAGGGAAGCAACAAAGGTTTTGAAGCCACCTTGGACAAAACATCCAGATCCTTCCACTTGAAGAAAGGCTCGGTGCAACTGTCAGACTCAGCTGTGTACTACTGTGCCCTGAGTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-5*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "GGAGACTCAGTGAAACAGATGGAAGGCCAAGTGACCCTCTCAGAAGAGGCTTCGTTGACTATAAACTGTACTTTCTCAACATCAACGACACCCACCCTCTTCTGGTATGTCCAGTATCTGGGAGAAGGTCCACAGATCCTCCTGAAAGCATTAAGAGACAAGGAAAAGGGAAGCAACAAAGGATTTGAAGCAACCTTGGACAGTTCATCCAAATCCTTCCACTTGAAGAAAGGCTCAGTGCAAATGTCAGACTCAGCTGTGTACTACTGTGCCCTGAGTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-6*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "GGAGACTCAGTGAACCAGACGGAAGGCCAAGTGACCCTCTCAGAAGAGGCCTTCCTGACTATGAACTGTACCTACTCAGCAACAGGATCCCTCATTCTATTCTGGTATGTCCAGTATCTGGGAGAAGGGCCACAGCTCCTCCTGAAAGCATTAAGAGACAAGGAAAAAGGAAGCAGCAAAGGTTTTGAAGCCACCTTGGACAAAACATCCAGATCCTTCCACTTGAAGAAAGGCTCGGTGCAACTGTCAGACTCAGCTGTGTACTACTGTGCCCTGAGAGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-7*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "GGAGACTCAGTGAAACAGATGGAAGGCCAAGTGACCCTCTCAGAAGAGGCTTCGTTGACTATAAACTGTACTTTCTCAACATCAACGACACCCACTCTCTTCTGGTATGTCCAGTATCTGGGAGAAGGTCCACAGATCCTCCTGAAAGCATTAAGAGACAAGGAAAAGGGAAGCAACAAAGGATTTGAAGCAACCTTGGACAGTTCATCCAAATCCTTCCACTTGAAGAAAGGCTCAGTGGAAATGTCAGACTCAGCTGTGTACTACTGTGCCCTGAGTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-8*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "GGAGACTCAGTGAACCAGACGGAAGGCCAAGTGACCCTCTCAGAAGAGGCCTTCCTGACTATGAACTGTACTTTCTCAACATCATGGTCACCCAGTCTATTCTGGTATGTCCAGTATCTGGGAGAAGGTCCAAAGCTTCTCCTGAAAGCCTTGACAAACAAGGCAAAGGGAAGCAACAAAGGTTTTGAAGCCACCTTGGACAGTTCATCCAAATCCTTCCACTTGAAGAAAGGCTCAGTGGAAATGTCAGACTCAGCTGTGTACTACTGTGCCATGAGTGA"
+  }, {
+    "uri": "file://dog_V_TRA.fasta#TRAV9-9*01",
+    "range": {
+      "from": 0,
+      "to": 281
+    },
+    "sequence": "GGAGACTCAGTGAACCAGACGGAAGGCCAAGTGATCCTCTCAGAAGAGGCTTTCCTATCTATAAACTGTACCTACTCAACAACAGGATCCCCCACTCTATTCTGGTATGTCCAGTATCTGGGAGAAGGTCCACAGCTCCTCCTGAAAGCATTAAGAGACAAGGAAAAGGGAAGCAGCAAAGGTTTTGAAGCCACCTTGGACAAAACATCCAGATCCTTCCACTTGAAGAAAGGCTCGGTGCAACTGTCAGACTCAGCTGTGTACTACTGTGCCCTGAGTGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV1*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "GCAAGCCTGGTGGAGCAAAGGCCCCGCTGGGTCCTGGTAGCTCGTGGGCAGGCTGAAACCCTGCACTGCATCCTGAGAGATTCCCAGTACCCTTGGATGAGCTGGTACCAACAGGATCTCCAGGGGCAACTGCAGGTGCTGGCCACTCTGCGGAGCCCCGGGGACGAGGAGCTCGTATCCCGTCCTGGAGCAGATTACCGGGTCACGAGGGTCAACAGCACGGAGCTGAGGCTGCACGTGGCCAATGTGACCCAGAGCAGAACCCTGTACTGCACCTGCAGTAAAGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV10*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "GATGCTGGAATTATCCAGAGCCCAAGATACAAGGTCACAGGGACAGGAAAGAGGGTGACTCTGAGATGTCACCAGACAGACAACTATGACTATATGTACTGGTATCGACATGACCTGGGACATGGGCCGAGGCTGATCTATTATTCAAATGGTATTAACAGCACTGAAAAAGGAGACCTCTCCAATGGATACACAGTCTCTAGATCAAACAAGATGGATTTCCCCCTCCTACTGGACTCTGTTACCTCCTCCCAGACATCTGTGTACTTCTGTGCCGACAGTTACTC"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV12-1*01",
+    "range": {
+      "from": 0,
+      "to": 290
+    },
+    "sequence": "AATACTGAAGTCATCCAGACACCCAGGCGCAAGGTGACAACGATGGGACAAGAAGTAACTCTGGGATGAGAGCTTACTTCTGGCCATTATACCCTTTTCTGGTACAGACAGACCTCAGGGAAGGAACCAAAGCTGCTGATTTACTTCAGCAATAAAGCTCTTATGGATGACTCGGGGATGCCCAAGGAACGGTTCTCAGCAGAGATGCCTGATGATTCATTCTCCATCCTGAAGATCCAGCCAACAGAACCCAGGGACTCAGCCACGTACCTATGTGGCAGCAGGGTAGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV12-2*01",
+    "range": {
+      "from": 0,
+      "to": 290
+    },
+    "sequence": "GACGCTGGAGTCATCCAGATACCCATGCACAAGGTGACAACGATGGGACAAGGAGTAACTCTGGGATGTGAGCCTATTTCTGGTCATGTGGTCCTCTTCTGGCACAGACAGACTTCAGGGCAGGGATGGAAGCTGCTGATTTACTTCAACAATCAATCTCCTGTGGATTACTCGGGGATGCCCAAGGAACGGTTCTCAGCAGAGATGCCTGACAAATTATTCTCCATCCTGAAGATCCAGCCAATAGAACCTGGGGACTCAGCCACGTACCTGTGTGCCAGCAGTGTAGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV15*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "GGTGCCATGGTCATCCAGAGCCCAAGATACCAGGTTACTAAGGTGGGAAAACCAGTGACTCTGAACTGTTCTCAGAACCTGAATCATGATACCATGTACTGGTACCAACAGAAGCTGAGACAAGCACCAAAGCTGCTGCTCTACTACTATGATACAGAGCTTACCAAAGAAACAGACACCTCTGATAACTTCCAACCCAGCCGGCTCAGCAATTCTCTCTGTTCTCTTAGCATCCGCTCACCAGGCTTGGGGGACTCAGCAGTGTACCTCTGTGCCAGCAGTAAAGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV16*01",
+    "range": {
+      "from": 0,
+      "to": 290
+    },
+    "sequence": "AATGCAAAAGTCATGCAGACTCCAGGACATCTGGTCAAAGGGAAAGGACAAAAAGCAAAAATGGAATGTGTCCCAATAAAAGGACATAGTTATGTTTTCTGGTATCAGCAGATCCCAGCAAAAGAGTTCAAGTTCTTGATTTCTTTCCAGGATAACGCTGTCTTTGATAAAACAGGGATGCCCACGCAGAGATTTTTAGCCTTCTGTCCAAAAAACTCACCCTGTAGCCTAGAGATCGAGCGTACAGAGCTGCAGGATTCAGCCGTGTATTTTTGTGCCAGCAGTGAATC"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV18*01",
+    "range": {
+      "from": 0,
+      "to": 290
+    },
+    "sequence": "AATGCTGGCGTCACCCAGAATCCGAGACACCTGGTGAGAAGGACAGGACAAGAGGCAATACTGACATGCAGCCCCGAGAAAGGACACAGTTATTTTTATTGGTATCAGCAGTTCCTGGGGGAAGGTCTGAAATTCATGATTTACCTCCAGAAAGAAACTATCTTAGACCAGTCAGGAATGCCAAAGAAACGCTTTTCTACTGAATTTTCCGAAGACGGACTTAGCATCTTAAAGATCCAGCCGGCAGAGTTGGGAGACTCTGCAGTGTACTTCTGTGCCAGCACCGAAGC"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV19*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "AGTGGTGGAATCACTCAGACCCCCAAATATTTGTTCAGAGAGGAAGGACGAGGTGTGACTCTGGAATGTGAACAGGATTTTAATCATGACTCTATGTACTGGTACCGACAAGACCCAGGGCAAGGGCTGAGACTGATCTACTACTCGCTGGTAGAAAATGATGCTCAGAAAGGAGACATACCTGAAGGCTACAGTGCCTCTCGGATGAAGAAGGCATTCTTCTCTCTCACCATGACATCGGTGCAAAAGAACTAGACAGCTCTATATCTCTGTGCCAGTGGTAGAGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV20*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "GGTGCCCTCGTCTTCCAGGCGCCCAGCACAATGATCTGTAAGAGCGGAGCCACCGTGCAGATCCAGTGTCAAACAGTGGACCTTCAAGCCACAACCGTGTTTTGGTATCGCCAGCTCCCGAAGCAGGGCCTTACCCTTATGGTGACCTCTAACGTGGGCAACAGTGCTACACACGAGCAGGGGTTCCCTGCAGCCAAGTTCCCTGTTAACCACCCAAACCTCACGTTTTCCTCCCTGATGGTGACGAGTTCAGGTCCTGGAGACAGCGGCCTCTACTTCTGTGGTGCTAGTCA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV21*01",
+    "range": {
+      "from": 0,
+      "to": 290
+    },
+    "sequence": "GACACTGAGGTCACCCAGAGTCCCGGACACCTGGTCAAAGGGAAGGAACAGGGAGCAAAGTTGCATTGTGTCCCTGTAAAAGGACATAATTGTGTGTATTGGTATCACCAAAAGCTGGGAGAAGAGTTCAAGTTTCTGGCTTACTTACAGAATGAAGAGATTGTTGATAAGGGAGAAATGTTCAATCGCTGATTTTCAGCTACATGCCCCAAGAACTTGCCCTGCAGCCTAGAAATCAACTCCACGGAGCCAGGGGACTGGGCCCTGTATTTCTGTGCCAGCAGCCAATG"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV22*01",
+    "range": {
+      "from": 0,
+      "to": 283
+    },
+    "sequence": "TATGCTGAAATCTGCCAGAGGCCAGCATTCCTGCTCACTAAGGCTGGACAGGAGTCCCTGGAGTGCAAACAGAACTTGAAATACCATGCCATGTACTGGTACCGGCAGGACCCAGGACAAGGTCTGCGGCTGATTTACCTCTCAACTTTTGAAAAAGATGTTCAGAGAGGACATATAACTGAAGGCTACAATGCTTCCCGAGAGGAGAAGGGGCTGTTTCCTCTCACTGTGAGGTTGGTGCACACCAACCAGACAGGTGCCTACCTCTGTTCTGGTAGCGCTC"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV24*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "GATGCTGGCATTACCCAGACCCCCCGGAATGGGATTATAAAGAAAGGAAAGAACATTTCACTGGAGTGTTCTCAGATTAAGAGTCATAACTATATGTACTGGTATCGACAAGATCCGGGAATGGGGCTACGGCTGATCTCCTACTCCTTTGGTGTCAATTATATTAATGAAGGAGAGGTCTCCAATGGGTACAGTGCTTCTCGAACGGACCTGGAGAAATTCTCCCTGTCTGTAGGGACTGCCATTCCCAACCAGACAGCTCTCTACTTCTGTGCCAGCAGCGATTCA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV25*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "GATGGTAGTGTCTCCCAGACCCCAAGACACTGTATTTCAGGGACAGGAAAGAAGATTACCCTGGAATGTTCTCAAACTATGGGCTATGACAACATGTACTGGTATCGACAAGACCCAGGAAAGGCACTACAGCTGCTCCATTATTCATATGGTGTTAATACCACAGAGAAAGCAGAGCTCTCCTCTGGATCAACTGTCTCCAGATTAAGGAAAGAGCTTTTCTCCCTAACCCTAGAGTCTACCAGCCTCTCACAGACATCCCTGTACCTCTGTGCCAGCAGTGAATA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV26*01",
+    "range": {
+      "from": 0,
+      "to": 286
+    },
+    "sequence": "GATGCTCTGGTCAATCAGTTCCCAAGACATAGGATCTTGGGGACAGGAAAGAAATTAACCCTACAGTGTTTGCAGGATATGAATCATGTTTCAATGTTCTGGTATCGCCAAGACCCAGGATTTGGGCTACAGCTGATCTACTACTCAACTGGTACTGACAACTTTGAAAAAGGAGATGCCCCTGAGGGGTATGATGTCTCTCGAAATGAGCTGAAATCTTTTCCCCTGACCCTGGTCTCTGCCAGCACCAACCAGACATCTGTGTACCTCTGTGCCAGCAGTTAGC"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV27*01",
+    "range": {
+      "from": 0,
+      "to": 293
+    },
+    "sequence": "GAAGCCGGAGTGACCCAGACCCTGAGATACCTCATCACAGGGACCAGGAGGCAGTTGACACTGCTTTGTTCTCAGGATATGAACCGCGACGCTATGTACTGGTACGGACAAGACCCAGGGCTGGGTCTAAAGCTGATCTACTCTTCAAGGAACGTTCAGTTTACTGAAAAGGGAGATGTCCCTGATGGGTACTGGGTCTCTCGGAAAGAGAAGAGAAATTCCCCCCTGGCCCCGACCCTGGAGTCGGCAGGCACCAACCACACCTCGCTGCACCTCTGCGCCAGCGGTTTATC"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV28*01",
+    "range": {
+      "from": 0,
+      "to": 286
+    },
+    "sequence": "AACGCACAAGTGACTCAAACCCCGAGACAACTCATCAAAAAAGTGGGAGCGAAAGTTTTGTTGAAATGTTCACAGAATATGGACCATGAAAGAATGTTCTGGTATCGACAAGACCCAGGTCTGGGGTTGCGGCTGCTCTACTGGTCCTATAATATTGACAGTGTTGAGACAGGAGACATCCCTTATGGGTACAGTGTCTCGAGGAAGAAGAAGGATGCCTTCCCCTTGATTCTGGAGTCTGCTCGCATCAACCAGACATCTGTGTACTTCTGCGCCAGTAGTTAGC"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV29*01",
+    "range": {
+      "from": 0,
+      "to": 290
+    },
+    "sequence": "GGAGCTCTTGTCTCTCAAAAGCCGCGCAGGGACATCTGTCAACGTGGGACCTCCATTACCATCCACTGTGAGGTCGATACCCAAGTCACCTTGATGTTCTGGTACCGTCAGCTCCCAGGACAGAGCTTGATACTGATTGCAACCGCAAACCAGGGTGCAGAGGCCACCTACGAAAGTGGATTTACCAGGGAGAAGTTTCCCATCAGCCGCCGAACCCTAATGTTCTCCACTCTGACTGTGAGCAACCTGAGCCTCGAAGACACCAGCTCTTACTTCTGCAGCGCTAGAGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV3-1*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "GACACAACAGTTTCCCAGACTCCAAGATACCTCATCGCGCACGTGGGATCGAAGAAGTTACTAAAATGTGAGCAAAATCTGGGCCATAATGCTATGTACTGGTATAAGCAAGACCTCAAGCAACTGCTGAAGATCATGTTTATCTACTTTAATCAGGGACTCAATCTAAATGAATCAGTTCCAGGTCGTTTCTCACCTGAGACATCTGACAAAGCTCATTTAAACCTTCATGTCGACTCCCTGGAGACAGGTGACTCTGCTGTGTATTTCTGTGCCAGCAGCCTAGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV3-2*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "GACACAACAGTTTCCCAGACTCCAAGATACCTCATCGCGCACGTGGGATCGAAGAAGTTACTAAAATGTGAGCAAAATCTGGGCCATAATGCTATGTACTGGTATAAGCAAGACCTCAAGCAACTGCTGAACGTTATGTTTATCTACAACAATAAGGAACTCATTCTAAATGAATCAGTTCCAGGTCGTTTCTCACCTGAGACATCTGACAAATCTCATTTAAACCTTCATGTCGACTCCCTGGAGACAGGTGACTCTGCTGTGTATTTCTGTGCCAGCAGCCAAGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV3-3*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "GACCAGTCAGTCCCTGTGACATCCTACAAGCTTCTCACACCTCAGTCTTCTCTTGCTTTTTAGCAATGTGAACAAAATCTGGGCCATGATGCTATGTACTGGTATTAGCAAGACCTCAAGCAACTGCTGAACGTTATGTTTATCTACAACAATAAGGAACTCATTCTAAATGAATCAGTTTCAGGTCGTTTCTCACCTGAGACATCTGACAAAGCTCATTTAAACCTTCATGTCAACTCTCTGGAGACAGGAGACTCTGCTGTGTATTTCTGTGCCAGCAGCCAAGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV30*01",
+    "range": {
+      "from": 0,
+      "to": 284
+    },
+    "sequence": "GCTCAGACTATCCACCAAAGGCCGCTTGCCAGGGTGCAGCTTGTGGGCAGCCTGCTCTCCCTGGAATGTACCGTGCAGGGGGCATCGAGCCCTTATCTCTACTGGTACCGGCAGTCCCTGGGAGGTGCGCCCCAGCTACTCTTCTCCTCATTAAGTGTTACCCAGATAGTCCCTGAGACACCGCACAACTTCACAGCCTCCAGGCCCCAGAACGGCCAGTTCATCCTGAGTTCTAAGAAGCTCCTTCTCAGTGACTCTGGCTTCTACCTCTGCGCCTGGAGTCT"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV4-1*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "GACACTGGAATTACCCAGACCCCCAAACACCTGGTAACAGGGCCTGGGAGGAGAGTGACCCTCAACTGTGAACAACATCTGGGACATGATGCTGTGTACTGGTATCAGCAGAGGGCTCAGAAGCCACCGAAGCTCATGTTTGCCTACAGATATAAGGAACTCATTGAGAATGAGCCTGCCTCCGGTCGCTTCTCACCTGAGTGCCCAGACAGCTCCAGGCTCTACCTTCACGTGGACGCCCTGGAGCCTGATGACTCTGCCTTGTATCTCTGTGCTAGCAGCAGGGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV4-2*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "GACACTGGAATTGCCCAGACCCCCAAACACCTGGTAACAGGGCCTGGGAGGAGAGTGACCCTCAACTGTGAACAACATCTGGGACATGATGAGGTGTACTGGTATCAGCAGAGCGGTCAGAAGCCACCGAAGCTCAAGTTTGCCTACAGATATAAGGAACTCATTGAGAATGAGACTGCCTCCGGTCGCTTCTCACCTGAGTGCCCAGACAGCTCCAGGCTCTACCTTCACGTGGACGCCCTGGAGCCCAATGACTCTGCCTTGTATCTCTGTGCTAGCAGCAGGGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV4-3*01",
+    "range": {
+      "from": 0,
+      "to": 287
+    },
+    "sequence": "GACACTGGAATTACCCAGACCCCCAAACACCTGGTAACAGGGCCTGGGAGGAGAGTGACCCTCAACTGTGAACAACATCTGGGACATGATGCTGTGTACTGGTATCAGCAGAGCGGTCAGAAGCCACCGAAGCTTATGTTTGCCTACAGATATAAGGAACTCATTGAGAATGAGACTGCCTCCGGTCGCTTCTCACCTGAGTGCCCAGACAGCTCCAGGCTCTACCTTCACGTGGACGCCCTGGAGCCTGATGACTCTGCCTTGTATCTCTGTGCTAGCAGCAGGGA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV4-4*01",
+    "range": {
+      "from": 0,
+      "to": 286
+    },
+    "sequence": "GACACTGGAATTACCCAGACCCCCAAACACCTGTTAACAGAGACAGGGAGGAGAGTGACCCTCAAGTGTGAACAACATCTGGGACATAATGCTGTGTACTGGTATCAACAGAGCACTCAGAAGCCACCAAAGCTCATGTTTGCCTACAGTTACAAGGTACTCGTTGAAAATGAGACTGCTTCTGGTCGCTTCTCACCTGAGTGCCCAGACAGCTCCAGGTTCTACCTTCACATGGATGCCCTGGAGCCCAATGACTCTGCCTTGTATCTCTGTGCTAGCAAAGAAA"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV5-2*01",
+    "range": {
+      "from": 0,
+      "to": 286
+    },
+    "sequence": "GAGTCTGAGGTCATCCAAACTCCAAGACACATGATCAAAGCAAGAGGACAGACAGTGACCCTGAGATGTTCCCTTATCTCTGGACACCTATCTGTGTACTGGTACCAACAGGCCCTGGGCCAGGGTCCCCGGTTTCTCATTCAGTATTACAATAGGGAAGAGAGAGACAAAGGAGACATCCCGGCAAGATTCTCAGTGCAGCAGTTCAGTAACTACAGCTCCCAGCTGGAGATGAACTCCCTGGAGCCAGGAGACTCAGCCCTATATCTCTGTGCCAGCAGCTTGG"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV5-4*01",
+    "range": {
+      "from": 0,
+      "to": 286
+    },
+    "sequence": "GGTGCTGGAGTCATCCAGACCCCCAGACACCTAATCAAAGGCAGCGGGGGGAAGGCTCTTCTGGAATGCCATCTCGTCTCTGGACACAACACTGTGCGCTGGTACAAGCAGGCCCCGGGACAGGGCCCCCAGTTCCTCTTTGAGTATTATAGACAGGAGCAGAGAGACAAAGGAGACGTCTCCGCACGATTCTCAGCACAGCAGTTCAGTGACGCCAGCTCCCAGCTGGAGATGAACCCCCTGGAGCTGGGAGACTCAGCCCTGTATCTCTGTGCCAGCAGCTTGG"
+  }, {
+    "uri": "file://dog_V_TRB.fasta#TRBV7*01",
+    "range": {
+      "from": 0,
+      "to": 290
+    },
+    "sequence": "GAACCCGGAGTCTCCCAATCCCCCAGGCACAGGGTCACGAAGAGGGGCCAGAATGTATCTTTCACCTGTGATCCCATTTCTGGGCATGTTGTCCTTTACTGGTACCGACAGACCATGGGGCAGGGCCCGGAGTTTCTGGTTTACTTCCAAAACGAAGAGGCAATGGACGAGTCAGGGCTGGACAAGACTCGGTTCTCTGCCAAGAGGCCCAAGGGGACCAGATCCACTCTGCAGATCCAGCGTGCAGAGCAGAGGGACTCGGCTGTGTACCTCTGTGCCAGCAGTCTCAC"
+  }, {
+    "uri": "file://dog_V_TRD.fasta#TRDV2*01",
+    "range": {
+      "from": 0,
+      "to": 290
+    },
+    "sequence": "GCTGAGAAAGTCATCCAAACTCAAAATACAGTAACAAAGCAGGAAGGAGAAGCTGCCACCTTTAACTGCAATTATGAAACCACCTGGAGTGATTACTATACTTCGTATCGGTATAAACAGCCTCCTGGCGGAGAGATGATTTTCCTCATATACCAGGATGAAAACAAGCCAAAGGAAAAACAGGGTCGCCTCTCTATAAATTTTCAAAAGGCAGCAAAATCCATCATCCTCACCATCTCTTCCTTACAACTGACAGACTCTGCAACCTATTTCTGTGCTCTTGGTAAGCC"
+  }, {
+    "uri": "file://dog_V_TRD.fasta#TRDV3*01",
+    "range": {
+      "from": 0,
+      "to": 294
+    },
+    "sequence": "TGTGAGCAAGTGATCCAGAGCTCCCTGGAACAGATGGTGGCAAGTGGCAGTAAGGTGACACTGCTCTGCACTTACGACACTTCATATTCAAACCCAGATTTGTACTGGTACCGAATAAGGTCAGATCATTCCTTTCAGTTTATCCTTTACAGGGATAACACTCAATCCAGAAATGCAGATTTTACTCAGGGTCGATTTTCTGTACTACATAATCCGTCCCAGAAAACCTTCCACTTGGTGATCTCCCAGGTGGAGCCTGAAGACAGTGCCACTTACTACTGTGCCATAGATACC"
+  }, {
+    "uri": "file://dog_V_TRD.fasta#TRDV4*01",
+    "range": {
+      "from": 0,
+      "to": 288
+    },
+    "sequence": "GATATCATTTTGGAACCAGAAACCAAAACCCTGACTGTTCTAGTTGGAGAGCCTGCCACCTTCCGCTGCAACGTAACAGGAGGGGACTTGAAGAACTATCAGGTGAGCTGGTATAGGAAGAATGAAGATAACTCCCTGACTTTAATATACAGACAGAGCAACAATACCAATGACAATTTAAGGAGTAATTTCAAAGGAAATACCGATGCTTCAAAGAGTCAATGTATACTCGACATTGAAAAAGCAACAACAGCAAACGCCGGTACCTATTACTGCGCAGCAGATATC"
+  }, {
+    "uri": "file://dog_V_TRD.fasta#TRDV5*01",
+    "range": {
+      "from": 0,
+      "to": 289
+    },
+    "sequence": "TCAGAGACGGTCCGTCAATCTCAGAATAAAGTGTATAAACAAGAGGGAGAATCTGTGACCTTGGACTGCAGCTTCACCCTCAGCTTTAACTACTATGTGATGAACTGGTATCAACAGCCTTTCGGTGAGAGGATGACTGAAGTCATGAGTATTTATTCTGATAGCACCAGCTCTTCGAAAGGACGATATTCTGTGTCATTTCAGAAAGGAAACAAAATTCTAACGCTCACCATCACAGGCTTAACGCTTACAGACTCAGGCGTCTATTTCTGTGCTGTTGGAGAAGTTC"
+  }, {
+    "uri": "file://dog_V_TRG.fasta#TRGV2-1*01",
+    "range": {
+      "from": 0,
+      "to": 300
+    },
+    "sequence": "GCGGGGCTCAAGCTGGAGCAGACTCCTGTGGTCGTGGGGCGCTTGGGCACCTTGGCCACCCTGCCGTGCACAGTGGATACCTCGGTGAGCTACATCCACTGGTACTTCCACAAGGAGGATACAGCCCCCAAGAGGCTCCTCTACCTAGACATGTCCAGGTCGTATGTGCAGAGGGATATATTCGTGAAAGCAGACAAAGTCAACGCCAAGAAAGGCAGGAACAGTTACAGCTGTAACCTGTTGTTGCAGAAACTGGAGAAGAATGATGAGGGCGTGTACTACTGCGCTGCCTGGGAAGCG"
+  }, {
+    "uri": "file://dog_V_TRG.fasta#TRGV2-2*01",
+    "range": {
+      "from": 0,
+      "to": 300
+    },
+    "sequence": "GCAGGGCTCAAGCTTGAGCAGACTCCTGTGGTCGTGGGGCGCTTGGGCACCTCGGCCACCCTGCTGTGCACAGTGGATAGCTCAGTCTACTACATCCACTGGTACTTCCACAAGAAGTTTGCAGCCCCCAAGAGGCTCCTCTATCTAGACATGTCCAGCTCAAGTGTGCAGAGGGATACATCTGTGAAAGCACACAAAGTCAATGCCAAGAAAGGCAAAGACAGTTACAGCTGTAACCTGTTGGTGCAGAAGCTGGAGAAGAGCGACGAAGGCGTGTACTACTGCGCTGCCTGGGAAGAG"
+  }, {
+    "uri": "file://dog_V_TRG.fasta#TRGV2-3*01",
+    "range": {
+      "from": 0,
+      "to": 300
+    },
+    "sequence": "GCAGGGCTCAACCTGGAGCAGAATCCTGTGGCTGTGGAGCGCTTGGACACTTTGGCCATCCTAAAATGTCAAGTGGATACCTGGGTCTGGTATATCAACTGGTACTTCCATCAGGAGGGTACAGCCCCCAAGTGGCTCCTCTACCTAGACATGTCCACCGGGAAAGTGCAGAGGGATGCATTTGTGAATGCAGACAAAGTCAGTGCCCAAAAGGGCAAGGACAGTTACAGCTGCGCCTTGTTGGTACAGAGGCTGAGGAAGAGCGACGAGGGCGTGTACTACTGTGCTGCCTGGGAACCG"
+  }, {
+    "uri": "file://dog_V_TRG.fasta#TRGV2-4*01",
+    "range": {
+      "from": 0,
+      "to": 300
+    },
+    "sequence": "GCAGGACTCAAGCTTGAGCAGACTCCTGTGGTCGTGGTGCACTTGGGCACCTCGGCCACCCTACCGTGCACAGTGGATAGCTCAGTCAACTACATCCACTGGTACTTCCACAGGGAGGGTATTGCCCCTAAGAGACTCCTTTACATACACACATACAGCTCATCTGTGCAGAGGGATGCATCTGTGAACATGGGCAAAGTCAATGCCAAGATGGACAAGAACAATTACAGCTGTAAACTGTTGGTGCAGAAGCTGGAGAAGAGCGACGAAGGCGTGTACTACTGCGCTGCCTGGGAAGAG"
+  }, {
+    "uri": "file://dog_V_TRG.fasta#TRGV4-1*01",
+    "range": {
+      "from": 0,
+      "to": 300
+    },
+    "sequence": "GTGGCATTCAGCCTGGAGCAGCCATCCGTGGTTGTGGTGCGCATGGACACCTTGGCCATTATGCCTTGCAAAGCCAGCGCCAAGATCAGCCATATCCACTGGTACCATCACCAGGAGCATACGGCCCCCCAGAGGATCCTCAGACTGGAAGTGTCTGGATCTTCTGTGAACAAGGATTCAGTCCTGAAAGCAGATAAAATCATTGCCATAAAAGATAAAGATGTCACCAGCTATAGTCTGTTGGTGCTGAAGCTGAAGAAGAACGATGAAGCTGTGTACTACTGTGCTACCTGGGAAGTG"
+  }, {
+    "uri": "file://dog_V_TRG.fasta#TRGV5-2*01",
+    "range": {
+      "from": 0,
+      "to": 307
+    },
+    "sequence": "GACACTTTAATAACCCAACTCATGCCATCCGTTATCAAGAAGCAAGGCAACACAGCATTTTTAGAATGCCAAATAAAAACAGGTGCCTTTAAGAAGAATGTATATATACACTGGTACCGACAGAAGCCAGACCAGCCTCTACAACGAATTCTGTATATTTCCTCGAATGAAAATGTGGTCCACGAACAAGGTGTTAGTGAGGAAAGATATGAAGCCAGGAAATGGAAGCAGGATTTGCCTGCGAGTCTCAGGATACACCGAGTTAATGAGGCAGATGCTGGGCTGTATTACTGTGCCTGCTGGGATA"
+  }, {
+    "uri": "file://dog_V_TRG.fasta#TRGV6-1*01",
+    "range": {
+      "from": 0,
+      "to": 300
+    },
+    "sequence": "GCGGAGACCAGGCTGGAGCAGCCTGCTGTAGTCGTGGCACGTGAGAAAAGCTCAGCCTCCCTGCTGTGCACAGCCAATGTCAAGGCCAGCTATATCCACTGGTACCGCTACCAGGAAGGAAAAGGGCTCCAGAGGCTCCTCCACCTGGCCATGTTCCAATCAAATGTGCAGTGGGATTCGGTCCTGGAAGCAGACAAAGTCACCGCCATAGAGACCAAGGATGGCTACAGCTGTACCCTGTTGGTGCTGAAGCTGGAGAAGAGCGATGAGGGCATGTACTACTGTGCTGCCTGGAGAGCA"
+  }, {
+    "uri": "file://dog_V_TRG.fasta#TRGV7-2*01",
+    "range": {
+      "from": 0,
+      "to": 305
+    },
+    "sequence": "CAGGTGAAGTTAGAACAACATGAAATATCAGTTTCCAGAGCAAGAGATAAGAGTGCCCACATATCATGCAAGGTAGTCACTGAGGATTTTAACAGTGAAGTTATACACTGGTACCGACACAAACCAGATCAGGAGATAGAACATCTAATAATGGTCCAAACAAGCTCTACTCAAGCTTCTTTAGATGGGAGGAAAAACAAACTTGAGGCAAGTAAAAATGCCGTTACTTCCACATCAACTTTGAGTATAAATTTCTTACAAGAAGAAGACGAAGCCATGTACTACTGTGCCTGCTGGAAAGGATC"
+  }, {
+    "uri": "file://dog_V_TRG.fasta#TRGV7-3*01",
+    "range": {
+      "from": 0,
+      "to": 309
+    },
+    "sequence": "CAGGTGAGGTTGGAACAACCTCAAATATCAATTTCTGGAACAAAATATAAGAGCATTAACATATTATGCAAGTTGCATGCTCAAAACTTTAACACTAAAGTGATACACTGGTACCGACAGAAACCAGAGCAGGACATAGAACATCTAACATGGGTCCAAACAAGCGCTAGCAAAGTCCCATCTTTAGATGGGAGGAAAAACAAACTTGAGGCAAGTAAAAATGCTCTTACTTCCACTTCAACTTTGAAAATAAATTTCTTACAAGAAGAAGATGAGGCCATGTACTACTGTTCCTGCTGGAGTAGGATC"
+  } ]
+} ]

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -13,7 +13,7 @@ import tempfile
 from six.moves import shlex_quote
 
 from galaxy.datatypes.data import get_file_peek, Text
-from galaxy.datatypes.metadata import DictParameter, MetadataElement, MetadataParameter
+from galaxy.datatypes.metadata import MetadataElement, MetadataParameter
 from galaxy.datatypes.sniff import build_sniff_from_prefix, iter_headers
 from galaxy.util import nice_size, string_as_bool
 

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -299,9 +299,9 @@ class ImgtJson(Json):
     MetadataElement(name="taxon_names", default=[], desc="taxonID: names", readonly=True, visible=True, no_value=[])
     """
         https://github.com/repseqio/library-imgt/releases
-        Data coming from IMGT server may be used for academic research only, 
+        Data coming from IMGT server may be used for academic research only,
         provided that it is referred to IMGT®, and cited as:
-        "IMGT®, the international ImMunoGeneTics information system® 
+        "IMGT®, the international ImMunoGeneTics information system®
         http://www.imgt.org (founder and director: Marie-Paule Lefranc, Montpellier, France)."
     """
 
@@ -336,7 +336,6 @@ class ImgtJson(Json):
         is_imgt = False
         try:
             with open(file_prefix.filename, "r") as fh:
-                prev_str = ""
                 segment_str = fh.read(load_size)
                 if segment_str.strip().startswith('['):
                     if '"taxonId"' in segment_str and '"anchorPoints"' in segment_str:
@@ -356,7 +355,7 @@ class ImgtJson(Json):
                     tax_names = []
                     for i, entry in enumerate(json_dict):
                         if 'taxonId' in entry:
-                            names = "%d: %s" % (entry['taxonId'],','.join(entry['speciesNames']))
+                            names = "%d: %s" % (entry['taxonId'], ','.join(entry['speciesNames']))
                             tax_names.append(names)
                     dataset.metadata.taxon_names = tax_names
                 except Exception:

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -13,7 +13,7 @@ import tempfile
 from six.moves import shlex_quote
 
 from galaxy.datatypes.data import get_file_peek, Text
-from galaxy.datatypes.metadata import MetadataElement, MetadataParameter
+from galaxy.datatypes.metadata import DictParameter, MetadataElement, MetadataParameter
 from galaxy.datatypes.sniff import build_sniff_from_prefix, iter_headers
 from galaxy.util import nice_size, string_as_bool
 
@@ -291,6 +291,76 @@ class Biom1(Json):
                     except Exception:
                         log.exception("Something in the metadata detection for biom1 went wrong.")
                         pass
+
+
+@build_sniff_from_prefix
+class ImgtJson(Json):
+    file_ext = "imgt.json"
+    MetadataElement(name="taxon_names", default=[], desc="taxonID: names", readonly=True, visible=True, no_value=[])
+    """
+        https://github.com/repseqio/library-imgt/releases
+        Data coming from IMGT server may be used for academic research only, 
+        provided that it is referred to IMGT®, and cited as:
+        "IMGT®, the international ImMunoGeneTics information system® 
+        http://www.imgt.org (founder and director: Marie-Paule Lefranc, Montpellier, France)."
+    """
+
+    def set_peek(self, dataset, is_multi_byte=False):
+        super(ImgtJson, self).set_peek(dataset)
+        if not dataset.dataset.purged:
+            dataset.blurb = "IMGT Library"
+
+    def sniff_prefix(self, file_prefix):
+        """
+        Determines whether the file is in json format with imgt elements
+
+        >>> from galaxy.datatypes.sniff import get_test_fname
+        >>> fname = get_test_fname( '1.json' )
+        >>> ImgtJson().sniff( fname )
+        False
+        >>> fname = get_test_fname( 'imgt.json' )
+        >>> ImgtJson().sniff( fname )
+        True
+        """
+        is_imgt = False
+        if self._looks_like_json(file_prefix):
+            is_imgt = self._looks_like_imgt(file_prefix)
+        return is_imgt
+
+    def _looks_like_imgt(self, file_prefix, load_size=5000):
+        """
+        @param filepath: [str] The path to the evaluated file.
+        @param load_size: [int] The size of the file block load in RAM (in
+                          bytes).
+        """
+        is_imgt = False
+        try:
+            with open(file_prefix.filename, "r") as fh:
+                prev_str = ""
+                segment_str = fh.read(load_size)
+                if segment_str.strip().startswith('['):
+                    if '"taxonId"' in segment_str and '"anchorPoints"' in segment_str:
+                        is_imgt = True
+        except Exception:
+            pass
+        return is_imgt
+
+    def set_meta(self, dataset, **kwd):
+        """
+            Store metadata information from the imgt file.
+        """
+        if dataset.has_data():
+            with open(dataset.file_name) as fh:
+                try:
+                    json_dict = json.load(fh)
+                    tax_names = []
+                    for i, entry in enumerate(json_dict):
+                        if 'taxonId' in entry:
+                            names = "%d: %s" % (entry['taxonId'],','.join(entry['speciesNames']))
+                            tax_names.append(names)
+                    dataset.metadata.taxon_names = tax_names
+                except Exception:
+                    return
 
 
 @build_sniff_from_prefix


### PR DESCRIPTION
Immunogenetics libraries are used as a reference for aligning immunome
sequence data.  The mixcr application uses these as references.
https://milaboratory.com/software/mixcr/
IMGT libraries are available at:
https://github.com/repseqio/library-imgt/releases
The ImgtJson datatype stores the available taxonIDs in the IMGT library
so that a taxonID can be selected from a galaxy tool from a select
parameter.