### PR TITLE
Make galaxy.model.dataset_collections more usable outside manager context.

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -15,8 +15,8 @@ from galaxy.managers.collections_util import validate_input_element_identifiers
 from galaxy.model import tags
 from galaxy.model.dataset_collections import builder
 from galaxy.model.dataset_collections.matching import MatchingCollections
-from galaxy.model.dataset_collections.registry import DatasetCollectionTypesRegistry
-from galaxy.model.dataset_collections.type_description import CollectionTypeDescriptionFactory
+from galaxy.model.dataset_collections.registry import DATASET_COLLECTION_TYPES_REGISTRY
+from galaxy.model.dataset_collections.type_description import COLLECTION_TYPE_DESCRIPTION_FACTORY
 from galaxy.util import (
     odict,
     validation
@@ -36,8 +36,8 @@ class DatasetCollectionManager(object):
     ELEMENTS_UNINITIALIZED = object()
 
     def __init__(self, app):
-        self.type_registry = DatasetCollectionTypesRegistry(app)
-        self.collection_type_descriptions = CollectionTypeDescriptionFactory(self.type_registry)
+        self.type_registry = DATASET_COLLECTION_TYPES_REGISTRY
+        self.collection_type_descriptions = COLLECTION_TYPE_DESCRIPTION_FACTORY
         self.model = app.model
         self.security = app.security
 
@@ -239,9 +239,7 @@ class DatasetCollectionManager(object):
         return dataset_collection
 
     def collection_builder_for(self, dataset_collection):
-        collection_type = dataset_collection.collection_type
-        collection_type_description = self.collection_type_descriptions.for_collection_type(collection_type)
-        return builder.BoundCollectionBuilder(dataset_collection, collection_type_description)
+        return builder.BoundCollectionBuilder(dataset_collection)
 
     def delete(self, trans, instance_type, id, recursive=False, purge=False):
         dataset_collection_instance = self.get_dataset_collection_instance(trans, instance_type, id, check_ownership=True)

--- a/lib/galaxy/model/dataset_collections/builder.py
+++ b/lib/galaxy/model/dataset_collections/builder.py
@@ -1,5 +1,6 @@
 from galaxy import model
 from galaxy.util.odict import odict
+from .type_description import COLLECTION_TYPE_DESCRIPTION_FACTORY
 
 
 def build_collection(type, dataset_instances):
@@ -78,10 +79,12 @@ class CollectionBuilder(object):
 class BoundCollectionBuilder(CollectionBuilder):
     """ More stateful builder that is bound to a particular model object. """
 
-    def __init__(self, dataset_collection, collection_type_description):
+    def __init__(self, dataset_collection):
         self.dataset_collection = dataset_collection
         if dataset_collection.populated:
             raise Exception("Cannot reset elements of an already populated dataset collection.")
+        collection_type = dataset_collection.collection_type
+        collection_type_description = COLLECTION_TYPE_DESCRIPTION_FACTORY.for_collection_type(collection_type)
         super(BoundCollectionBuilder, self).__init__(collection_type_description)
 
     def populate(self):

--- a/lib/galaxy/model/dataset_collections/registry.py
+++ b/lib/galaxy/model/dataset_collections/registry.py
@@ -9,7 +9,7 @@ PLUGIN_CLASSES = [list.ListDatasetCollectionType, paired.PairedDatasetCollection
 
 class DatasetCollectionTypesRegistry(object):
 
-    def __init__(self, app):
+    def __init__(self):
         self.__plugins = dict([(p.collection_type, p()) for p in PLUGIN_CLASSES])
 
     def get(self, plugin_type):
@@ -24,3 +24,6 @@ class DatasetCollectionTypesRegistry(object):
         elements = [e for e in plugin_type_object.prototype_elements()]
         dataset_collection.elements = elements
         return dataset_collection
+
+
+DATASET_COLLECTION_TYPES_REGISTRY = DatasetCollectionTypesRegistry()

--- a/lib/galaxy/model/dataset_collections/type_description.py
+++ b/lib/galaxy/model/dataset_collections/type_description.py
@@ -1,8 +1,9 @@
+from .registry import DATASET_COLLECTION_TYPES_REGISTRY
 
 
 class CollectionTypeDescriptionFactory(object):
 
-    def __init__(self, type_registry):
+    def __init__(self, type_registry=DATASET_COLLECTION_TYPES_REGISTRY):
         # taking in type_registry though not using it, because we will someday
         # I think.
         self.type_registry = type_registry
@@ -136,3 +137,6 @@ def map_over_collection_type(mapped_over_collection_type, target_collection_type
             target_collection_type = target_collection_type.collection_type
 
         return "%s:%s" % (mapped_over_collection_type, target_collection_type)
+
+
+COLLECTION_TYPE_DESCRIPTION_FACTORY = CollectionTypeDescriptionFactory()

--- a/test/unit/dataset_collections/test_matching.py
+++ b/test/unit/dataset_collections/test_matching.py
@@ -4,7 +4,7 @@ from galaxy.model.dataset_collections import (
     type_description,
 )
 
-TYPE_REGISTRY = registry.DatasetCollectionTypesRegistry(None)
+TYPE_REGISTRY = registry.DatasetCollectionTypesRegistry()
 TYPE_DESCRIPTION_FACTORY = type_description.CollectionTypeDescriptionFactory(TYPE_REGISTRY)
 
 


### PR DESCRIPTION
Follow up to #7588 in some ways.

Need these collection builders outside the context of an available ``app`` for #7058 so ``DatasetCollectionTypesRegistry`` shouldn't consume ``app`` and never used it. Sent ``app`` to the method five years ago imaging a real configurable plugin infrastructure for collection types. That was classic-@jmchilton-speculative-complexity and has never proven needed.
