### PR TITLE
Serialize the config attribute of an authnz record as a json object.

### DIFF
--- a/lib/galaxy/managers/cloudauthzs.py
+++ b/lib/galaxy/managers/cloudauthzs.py
@@ -56,7 +56,7 @@ class CloudAuthzsSerializer(base.ModelSerializer, deletable.PurgableSerializerMi
             'model_class'  : lambda *a, **c: 'CloudAuthz',
             'user_id'      : lambda i, k, **c: self.app.security.encode_id(i.user_id),
             'provider'     : lambda i, k, **c: str(i.provider),
-            'config'       : lambda i, k, **c: str(i.config),
+            'config'       : lambda i, k, **c: i.config,
             'authn_id'     : lambda i, k, **c: self.app.security.encode_id(i.authn_id),
             'last_update'  : lambda i, k, **c: str(i.last_update),
             'last_activity': lambda i, k, **c: str(i.last_activity)


### PR DESCRIPTION
The type of the config object is dictionary; hence, with `str` it will be serialized as a python dictionary rather than a proper JSON object. 

For instance with `str` it looks like: 

```
{
    “config”: “{u’role_arn’: u’xyz’}“,
}
```

however, without `str` it is serialized properly as:

```
{  
   "config": {  
      "role_arn": "xyz"
   }
}
```
