### PR TITLE
History panel header button organization, tweaks.

### DIFF
--- a/client/galaxy/scripts/entry/panels/history-panel.js
+++ b/client/galaxy/scripts/entry/panels/history-panel.js
@@ -8,8 +8,8 @@ import CurrentHistoryView from "mvc/history/history-view-edit-current";
 /** the right hand panel in the analysis page that shows the current history */
 var HistoryPanel = Backbone.View.extend({
     initialize: function(page, options) {
-        let Galaxy = getGalaxyInstance();
-        let self = this;
+        const Galaxy = getGalaxyInstance();
+        const panelHeaderButtons = [];
 
         this.userIsAnonymous = Galaxy.user.isAnonymous();
         this.allow_user_dataset_purge = options.config.allow_user_dataset_purge;
@@ -32,19 +32,24 @@ var HistoryPanel = Backbone.View.extend({
             title: _l("Refresh history"),
             cls: "panel-header-button",
             icon: "fa fa-refresh",
-            onclick: function() {
-                self.historyView.loadCurrentHistory();
+            onclick: () => {
+                this.historyView.loadCurrentHistory();
             }
         });
-        this.buttonNew = new Ui.ButtonLink({
-            id: "history-new-button",
-            title: _l("Create new history"),
-            cls: "panel-header-button",
-            icon: "fa fa-plus",
-            onclick: function() {
-                Galaxy.currHistoryPanel.createNewHistory();
-            }
-        });
+        panelHeaderButtons.push(this.buttonRefresh);
+
+        if (!this.userIsAnonymous){
+            this.buttonNew = new Ui.ButtonLink({
+                id: "history-new-button",
+                title: _l("Create new history"),
+                cls: "panel-header-button",
+                icon: "fa fa-plus",
+                onclick: function() {
+                    Galaxy.currHistoryPanel.createNewHistory();
+                }
+            });
+            panelHeaderButtons.push(this.buttonNew);
+        }
         this.buttonOptions = new Ui.ButtonLink({
             id: "history-options-button",
             title: _l("History options"),
@@ -53,6 +58,8 @@ var HistoryPanel = Backbone.View.extend({
             icon: "fa fa-cog",
             href: `${this.root}root/history_options`
         });
+        panelHeaderButtons.push(this.buttonOptions);
+
         this.buttonViewMulti = new Ui.ButtonLink({
             id: "history-view-multi-button",
             title: _l("View all histories"),
@@ -60,12 +67,13 @@ var HistoryPanel = Backbone.View.extend({
             icon: "fa fa-columns",
             href: `${this.root}history/view_multiple`
         });
+        panelHeaderButtons.push(this.buttonViewMulti);
 
         this.model = new Backbone.Model({
         // define components
             cls: "history-right-panel",
             title: _l("History"),
-            buttons: [this.buttonRefresh, this.buttonNew, this.buttonOptions, this.buttonViewMulti]
+            buttons: panelHeaderButtons
         });
 
         // build body template and connect history view

--- a/client/galaxy/scripts/entry/panels/history-panel.js
+++ b/client/galaxy/scripts/entry/panels/history-panel.js
@@ -50,15 +50,6 @@ var HistoryPanel = Backbone.View.extend({
             });
             panelHeaderButtons.push(this.buttonNew);
         }
-        this.buttonOptions = new Ui.ButtonLink({
-            id: "history-options-button",
-            title: _l("History options"),
-            cls: "panel-header-button",
-            target: "galaxy_main",
-            icon: "fa fa-cog",
-            href: `${this.root}root/history_options`
-        });
-        panelHeaderButtons.push(this.buttonOptions);
 
         this.buttonViewMulti = new Ui.ButtonLink({
             id: "history-view-multi-button",
@@ -68,6 +59,16 @@ var HistoryPanel = Backbone.View.extend({
             href: `${this.root}history/view_multiple`
         });
         panelHeaderButtons.push(this.buttonViewMulti);
+
+        this.buttonOptions = new Ui.ButtonLink({
+            id: "history-options-button",
+            title: _l("History options"),
+            cls: "panel-header-button",
+            target: "galaxy_main",
+            icon: "fa fa-cog",
+            href: `${this.root}root/history_options`
+        });
+        panelHeaderButtons.push(this.buttonOptions);
 
         this.model = new Backbone.Model({
         // define components


### PR DESCRIPTION
It'd be nice for consistency to keep the 'cog' always at the far right (last entry) in our menu button lists.  This also only presents the 'create new history' (`+`) button when it's an option for the user (i.e. -- not anons; currently if anonymous and you click it it just pops up a big red alert).  This aligns handling of this with many other options we similarly mask if the user is anonymous.