### PR TITLE
Fix history options menu href navigation

### DIFF
--- a/client/galaxy/scripts/mvc/history/options-menu.js
+++ b/client/galaxy/scripts/mvc/history/options-menu.js
@@ -251,7 +251,7 @@ function buildMenu(isAnon, purgeAllowed, urlRoot) {
 
         if (menuOption.confirm) {
             menuOption.func = () => {
-                const galaxy_main = document.getElementById("galaxy_main");
+                const galaxy_main = window.parent.document.getElementById("galaxy_main");
                 if (confirm(menuOption.confirm) && galaxy_main){
                     galaxy_main.src = menuOption.href;
                 }

--- a/client/galaxy/scripts/mvc/history/options-menu.js
+++ b/client/galaxy/scripts/mvc/history/options-menu.js
@@ -251,8 +251,9 @@ function buildMenu(isAnon, purgeAllowed, urlRoot) {
 
         if (menuOption.confirm) {
             menuOption.func = () => {
-                if (confirm(menuOption.confirm) && window.parent.frames && window.parent.frames.galaxy_main) {
-                    window.parent.frames.galaxy_main = menuOption.href;
+                const galaxy_main = document.getElementById("galaxy_main");
+                if (confirm(menuOption.confirm) && galaxy_main){
+                    galaxy_main.src = menuOption.href;
                 }
             };
         }
@@ -265,7 +266,6 @@ var create = ($button, options) => {
     var isAnon = options.anonymous === undefined ? true : options.anonymous;
     var purgeAllowed = options.purgeAllowed || false;
     var menu = buildMenu(isAnon, purgeAllowed, getAppRoot());
-    //console.debug( 'menu:', menu );
     return new PopupMenu($button, menu);
 };
 


### PR DESCRIPTION
~Leaving this wip for a sec while I try to understand what exactly changed here, why 'galay_main' is ending up as a string hanging off the parent object instead of being the frame target, but this simplifies the logic a little (and works, for me).~

I still don't quite get what happened here, but this works well in my testing, so I'm moving on.

fixes #7608