### PR TITLE
Large refactoring of model migrations

### DIFF
--- a/lib/galaxy/model/migrate/versions/0002_metadata_file_table.py
+++ b/lib/galaxy/model/migrate/versions/0002_metadata_file_table.py
@@ -1,7 +1,11 @@
+"""
+"""
 import datetime
 import logging
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, Table, TEXT
+
+from galaxy.model.migrate.versions.util import create_table, drop_table
 
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
@@ -21,10 +25,12 @@ MetadataFile_table = Table("metadata_file", metadata,
 def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    MetadataFile_table.create()
+
+    create_table(MetadataFile_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    MetadataFile_table.drop()
+
+    drop_table(MetadataFile_table)

--- a/lib/galaxy/model/migrate/versions/0004_indexes_and_defaults.py
+++ b/lib/galaxy/model/migrate/versions/0004_indexes_and_defaults.py
@@ -1,7 +1,11 @@
+"""
+"""
 import logging
 import sys
 
 from sqlalchemy import Index, MetaData, Table
+
+from galaxy.model.migrate.versions.util import engine_false
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -14,21 +18,12 @@ log.addHandler(handler)
 metadata = MetaData()
 
 
-def engine_false(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "FALSE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 0
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
-
-
 def upgrade(migrate_engine):
     metadata.bind = migrate_engine
+    metadata.reflect()
+
     User_table = Table("galaxy_user", metadata, autoload=True)
     HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
-    # Load existing tables
-    metadata.reflect()
     # Add 2 indexes to the galaxy_user table
     i = Index('ix_galaxy_user_deleted', User_table.c.deleted)
     try:
@@ -60,5 +55,4 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
     pass

--- a/lib/galaxy/model/migrate/versions/0008_galaxy_forms.py
+++ b/lib/galaxy/model/migrate/versions/0008_galaxy_forms.py
@@ -103,12 +103,11 @@ SampleEvent_table = Table('sample_event', metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-    # Load existing tables
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     # Add all of the new tables above
-#    metadata.create_all()
     try:
         FormDefinitionCurrent_table.create()
     except Exception:
@@ -155,8 +154,8 @@ def upgrade(migrate_engine):
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
-    # Load existing tables
     metadata.reflect()
+
     try:
         FormDefinition_table.drop()
     except Exception:

--- a/lib/galaxy/model/migrate/versions/0011_v0010_mysql_index_fix.py
+++ b/lib/galaxy/model/migrate/versions/0011_v0010_mysql_index_fix.py
@@ -35,8 +35,8 @@ HistoryDatasetAssociationDisplayAtAuthorization_table = Table("history_dataset_a
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     if migrate_engine.name == 'mysql':
         # Load existing tables
         metadata.reflect()

--- a/lib/galaxy/model/migrate/versions/0012_user_address.py
+++ b/lib/galaxy/model/migrate/versions/0012_user_address.py
@@ -13,7 +13,6 @@ import sys
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, Table, TEXT
 from sqlalchemy.exc import NoSuchTableError
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import TrimmedString
 
 now = datetime.datetime.utcnow
@@ -45,10 +44,10 @@ UserAddress_table = Table("user_address", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-    # Load existing tables
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     # Add all of the new tables above
     try:
         UserAddress_table.create()
@@ -76,8 +75,8 @@ def upgrade(migrate_engine):
         Request_table = None
         log.debug("Failed loading table request")
     if Request_table is not None:
+        # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
         if migrate_engine.name != 'sqlite':
-            # DBTODO drop from table doesn't work in sqlite w/ sqlalchemy-migrate .6+
             Request_table.c.submitted.drop()
         col = Column("state", TrimmedString(255), index=True)
         col.create(Request_table, index_name='ix_request_state')
@@ -85,5 +84,4 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
     pass

--- a/lib/galaxy/model/migrate/versions/0013_change_lib_item_templates_to_forms.py
+++ b/lib/galaxy/model/migrate/versions/0013_change_lib_item_templates_to_forms.py
@@ -52,8 +52,8 @@ LibraryDatasetDatasetInfoAssociation_table = Table('library_dataset_dataset_info
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     # Load existing tables
     metadata.reflect()
     # Drop all of the original library_item_info tables

--- a/lib/galaxy/model/migrate/versions/0015_tagging.py
+++ b/lib/galaxy/model/migrate/versions/0015_tagging.py
@@ -15,8 +15,8 @@ import logging
 from migrate import UniqueConstraint
 from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import create_table, drop_table
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -52,43 +52,21 @@ HistoryDatasetAssociationTagAssociation_table = Table("history_dataset_associati
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        Tag_table.create()
-    except Exception:
-        log.exception("Creating tag table failed.")
-    try:
-        HistoryTagAssociation_table.create()
-    except Exception:
-        log.exception("Creating history_tag_association table failed.")
-    try:
-        DatasetTagAssociation_table.create()
-    except Exception:
-        log.exception("Creating dataset_tag_association table failed.")
-    try:
-        HistoryDatasetAssociationTagAssociation_table.create()
-    except Exception:
-        log.exception("Creating history_dataset_association_tag_association table failed.")
+
+    create_table(Tag_table)
+    create_table(HistoryTagAssociation_table)
+    create_table(DatasetTagAssociation_table)
+    create_table(HistoryDatasetAssociationTagAssociation_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        Tag_table.drop()
-    except Exception:
-        log.exception("Dropping tag table failed.")
-    try:
-        HistoryTagAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping history_tag_association table failed.")
-    try:
-        DatasetTagAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping dataset_tag_association table failed.")
-    try:
-        HistoryDatasetAssociationTagAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping history_dataset_association_tag_association table failed.")
+
+    drop_table(HistoryDatasetAssociationTagAssociation_table)
+    drop_table(DatasetTagAssociation_table)
+    drop_table(HistoryTagAssociation_table)
+    drop_table(Tag_table)

--- a/lib/galaxy/model/migrate/versions/0021_user_prefs.py
+++ b/lib/galaxy/model/migrate/versions/0021_user_prefs.py
@@ -7,6 +7,8 @@ import logging
 
 from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table, Unicode
 
+from galaxy.model.migrate.versions.util import create_table, drop_table
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
@@ -19,19 +21,15 @@ UserPreference_table = Table("user_preference", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        UserPreference_table.create()
-    except Exception:
-        log.exception("Creating user_preference table failed.")
+
+    create_table(UserPreference_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        UserPreference_table.drop()
-    except Exception:
-        log.exception("Dropping user_preference table failed.")
+
+    drop_table(UserPreference_table)

--- a/lib/galaxy/model/migrate/versions/0026_cloud_tables.py
+++ b/lib/galaxy/model/migrate/versions/0026_cloud_tables.py
@@ -8,6 +8,8 @@ import logging
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, Table, TEXT
 
+from galaxy.model.migrate.versions.util import create_table, drop_table
+
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -123,32 +125,27 @@ CloudProvider_table = Table("cloud_provider", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-    # Load existing tables
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        CloudProvider_table.create()
-        CloudUserCredentials_table.create()
-        CloudImage_table.create()
-        UCI_table.create()
-        CloudInstance_table.create()
-        CloudStore_table.create()
-        CloudSnapshot_table.create()
-    except Exception:
-        log.exception("Creating cloud tables failed.")
+
+    create_table(CloudProvider_table)
+    create_table(CloudUserCredentials_table)
+    create_table(CloudImage_table)
+    create_table(UCI_table)
+    create_table(CloudInstance_table)
+    create_table(CloudStore_table)
+    create_table(CloudSnapshot_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        CloudSnapshot_table.drop()
-        CloudStore_table.drop()
-        CloudInstance_table.drop()
-        UCI_table.drop()
-        CloudImage_table.drop()
-        CloudUserCredentials_table.drop()
-        CloudProvider_table.drop()
-    except Exception:
-        log.exception("Dropping cloud tables failed.")
+
+    drop_table(CloudSnapshot_table)
+    drop_table(CloudStore_table)
+    drop_table(CloudInstance_table)
+    drop_table(UCI_table)
+    drop_table(CloudImage_table)
+    drop_table(CloudUserCredentials_table)
+    drop_table(CloudProvider_table)

--- a/lib/galaxy/model/migrate/versions/0027_request_events.py
+++ b/lib/galaxy/model/migrate/versions/0027_request_events.py
@@ -11,8 +11,8 @@ import sys
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table, TEXT
 from sqlalchemy.exc import NoSuchTableError
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import localtimestamp, nextval
 
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
@@ -34,26 +34,10 @@ RequestEvent_table = Table('request_event', metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-
-    def localtimestamp():
-        if migrate_engine.name in ['mysql', 'postgres', 'postgresql']:
-            return "LOCALTIMESTAMP"
-        elif migrate_engine.name == 'sqlite':
-            return "current_date || ' ' || current_time"
-        else:
-            raise Exception('Unable to convert data for unknown database type: %s' % migrate_engine.name)
-
-    def nextval(table, col='id'):
-        if migrate_engine.name in ['postgres', 'postgresql']:
-            return "nextval('%s_%s_seq')" % (table, col)
-        elif migrate_engine.name in ['mysql', 'sqlite']:
-            return "null"
-        else:
-            raise Exception('Unable to convert data for unknown database type: %s' % migrate_engine.name)
-    # Load existing tables
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     # Add new request_event table
     try:
         RequestEvent_table.create()
@@ -70,7 +54,7 @@ def upgrade(migrate_engine):
         "request.state AS state," + \
         "'%s' AS comment " + \
         "FROM request;"
-    cmd = cmd % (nextval('request_event'), localtimestamp(), localtimestamp(), 'Imported from request table')
+    cmd = cmd % (nextval(migrate_engine, 'request_event'), localtimestamp(migrate_engine), localtimestamp(migrate_engine), 'Imported from request table')
     migrate_engine.execute(cmd)
 
     if migrate_engine.name != 'sqlite':
@@ -88,5 +72,4 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
     pass

--- a/lib/galaxy/model/migrate/versions/0030_history_slug_column.py
+++ b/lib/galaxy/model/migrate/versions/0030_history_slug_column.py
@@ -7,14 +7,15 @@ import logging
 
 from sqlalchemy import Column, Index, MetaData, Table, TEXT
 
+from galaxy.model.migrate.versions.util import drop_column
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
-
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     History_table = Table("history", metadata, autoload=True)
@@ -36,5 +37,4 @@ def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    History_table = Table("history", metadata, autoload=True)
-    History_table.c.slug.drop()
+    drop_column('slug', 'history', metadata)

--- a/lib/galaxy/model/migrate/versions/0036_add_deleted_column_to_library_template_assoc_tables.py
+++ b/lib/galaxy/model/migrate/versions/0036_add_deleted_column_to_library_template_assoc_tables.py
@@ -8,23 +8,17 @@ import logging
 
 from sqlalchemy import Boolean, Column, MetaData, Table
 
+from galaxy.model.migrate.versions.util import engine_false
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
-def engine_false(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "FALSE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 0
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
-
-
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     try:
         LibraryInfoAssociation_table = Table("library_info_association", metadata, autoload=True)
         c = Column("deleted", Boolean, index=True, default=False)
@@ -64,5 +58,4 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
     pass

--- a/lib/galaxy/model/migrate/versions/0037_samples_library.py
+++ b/lib/galaxy/model/migrate/versions/0037_samples_library.py
@@ -28,8 +28,8 @@ metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     # Load existing tables
     metadata.reflect()
     # retuest_type table

--- a/lib/galaxy/model/migrate/versions/0038_add_inheritable_column_to_library_template_assoc_tables.py
+++ b/lib/galaxy/model/migrate/versions/0038_add_inheritable_column_to_library_template_assoc_tables.py
@@ -12,29 +12,19 @@ import logging
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, Table, TEXT
 
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import engine_false
 
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
-def engine_false(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "FALSE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 0
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
-
-
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
 
-    #
     # In case of sqlite, check if the previous migration script deleted the
     # request table and if so, restore the table.
-    #
     if migrate_engine.name == 'sqlite':
         if not migrate_engine.has_table('request'):
             # load the tables referenced in foreign keys
@@ -83,5 +73,4 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
     pass

--- a/lib/galaxy/model/migrate/versions/0040_page_annotations.py
+++ b/lib/galaxy/model/migrate/versions/0040_page_annotations.py
@@ -18,8 +18,8 @@ PageAnnotationAssociation_table = Table("page_annotation_association", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     # Create history_annotation_association table.

--- a/lib/galaxy/model/migrate/versions/0041_workflow_invocation.py
+++ b/lib/galaxy/model/migrate/versions/0041_workflow_invocation.py
@@ -8,6 +8,8 @@ import logging
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table
 
+from galaxy.model.migrate.versions.util import create_table, drop_table
+
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 now = datetime.datetime.utcnow
@@ -31,15 +33,12 @@ tables = [WorkflowInvocation_table, WorkflowInvocationStep_table]
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     for table in tables:
-        try:
-            table.create()
-        except Exception:
-            log.warning("Failed to create table '%s', ignoring (might result in wrong schema)" % table.name)
+        create_table(table)
 
 
 def downgrade(migrate_engine):
@@ -47,4 +46,4 @@ def downgrade(migrate_engine):
     metadata.reflect()
 
     for table in reversed(tables):
-        table.drop()
+        drop_table(table)

--- a/lib/galaxy/model/migrate/versions/0043_visualization_sharing_tagging_annotating.py
+++ b/lib/galaxy/model/migrate/versions/0043_visualization_sharing_tagging_annotating.py
@@ -7,6 +7,8 @@ import logging
 
 from sqlalchemy import Boolean, Column, ForeignKey, Index, Integer, MetaData, Table, TEXT, Unicode
 
+from galaxy.model.migrate.versions.util import engine_false
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
@@ -37,18 +39,9 @@ VisualizationAnnotationAssociation_table = Table("visualization_annotation_assoc
                                                  Column("annotation", TEXT, index=False))
 
 
-def engine_false(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "FALSE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 0
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
-
-
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     Visualiation_table = Table("visualization", metadata, autoload=True)

--- a/lib/galaxy/model/migrate/versions/0047_job_table_user_id_column.py
+++ b/lib/galaxy/model/migrate/versions/0047_job_table_user_id_column.py
@@ -9,6 +9,8 @@ import sys
 from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table
 from sqlalchemy.exc import NoSuchTableError
 
+from galaxy.model.migrate.versions.util import add_column, drop_column
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 handler = logging.StreamHandler(sys.stdout)
@@ -21,30 +23,22 @@ metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     try:
         Job_table = Table("job", metadata, autoload=True)
     except NoSuchTableError:
         Job_table = None
         log.debug("Failed loading table job")
     if Job_table is not None:
-
         if migrate_engine.name != 'sqlite':
-            try:
-                col = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True, nullable=True)
-                col.create(Job_table, index_name='ix_job_user_id')
-                assert col is Job_table.c.user_id
-            except Exception:
-                log.exception("Adding column 'user_id' to job table failed.")
+            col = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True, nullable=True)
+            add_column(col, Job_table, index_name='ix_job_user_id')
         else:
-            try:
-                col = Column("user_id", Integer, nullable=True)
-                col.create(Job_table)
-                assert col is Job_table.c.user_id
-            except Exception:
-                log.exception("Adding column 'user_id' to job table failed.")
+            col = Column("user_id", Integer, nullable=True)
+            add_column(col, Job_table)
         try:
             cmd = "SELECT job.id AS galaxy_job_id, " \
                 + "galaxy_session.user_id AS galaxy_user_id " \
@@ -69,9 +63,5 @@ def upgrade(migrate_engine):
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        Job_table = Table("job", metadata, autoload=True)
-        col = Job_table.c.user_id
-        col.drop()
-    except Exception:
-        log.exception("Dropping column 'user_id' from job table failed.")
+
+    drop_column('user_id', 'job', metadata)

--- a/lib/galaxy/model/migrate/versions/0048_dataset_instance_state_column.py
+++ b/lib/galaxy/model/migrate/versions/0048_dataset_instance_state_column.py
@@ -25,9 +25,10 @@ DATASET_INSTANCE_TABLE_NAMES = ['history_dataset_association', 'library_dataset_
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     dataset_instance_tables = []
     for table_name in DATASET_INSTANCE_TABLE_NAMES:
         try:

--- a/lib/galaxy/model/migrate/versions/0050_drop_cloud_tables.py
+++ b/lib/galaxy/model/migrate/versions/0050_drop_cloud_tables.py
@@ -8,6 +8,8 @@ import logging
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, Table, TEXT
 
+from galaxy.model.migrate.versions.util import create_table, drop_table
+
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -123,32 +125,27 @@ CloudProvider_table = Table("cloud_provider", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-    # Load existing tables
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        CloudSnapshot_table.drop()
-        CloudStore_table.drop()
-        CloudInstance_table.drop()
-        UCI_table.drop()
-        CloudImage_table.drop()
-        CloudUserCredentials_table.drop()
-        CloudProvider_table.drop()
-    except Exception:
-        log.exception("Dropping cloud tables failed.")
+
+    drop_table(CloudSnapshot_table)
+    drop_table(CloudStore_table)
+    drop_table(CloudInstance_table)
+    drop_table(UCI_table)
+    drop_table(CloudImage_table)
+    drop_table(CloudUserCredentials_table)
+    drop_table(CloudProvider_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        CloudProvider_table.create()
-        CloudUserCredentials_table.create()
-        CloudImage_table.create()
-        UCI_table.create()
-        CloudInstance_table.create()
-        CloudStore_table.create()
-        CloudSnapshot_table.create()
-    except Exception:
-        log.exception("Creating cloud tables failed.")
+
+    create_table(CloudProvider_table)
+    create_table(CloudUserCredentials_table)
+    create_table(CloudImage_table)
+    create_table(UCI_table)
+    create_table(CloudInstance_table)
+    create_table(CloudStore_table)
+    create_table(CloudSnapshot_table)

--- a/lib/galaxy/model/migrate/versions/0051_imported_col_for_jobs_table.py
+++ b/lib/galaxy/model/migrate/versions/0051_imported_col_for_jobs_table.py
@@ -7,44 +7,29 @@ import logging
 
 from sqlalchemy import Boolean, Column, MetaData, Table
 
+from galaxy.model.migrate.versions.util import add_column, drop_column, engine_false
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
-def engine_false(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "FALSE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 0
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
-
-
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     # Create and initialize imported column in job table.
     Jobs_table = Table("job", metadata, autoload=True)
     c = Column("imported", Boolean, default=False, index=True)
+    add_column(c, Jobs_table, index_name="ix_job_imported")
     try:
-        # Create
-        c.create(Jobs_table, index_name="ix_job_imported")
-        assert c is Jobs_table.c.imported
-
         migrate_engine.execute("UPDATE job SET imported=%s" % engine_false(migrate_engine))
     except Exception:
-        log.exception("Adding imported column to job table failed.")
+        log.exception("Updating column 'imported' of table 'job' failed.")
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    # Drop imported column from job table.
-    Jobs_table = Table("job", metadata, autoload=True)
-    try:
-        Jobs_table.c.imported.drop()
-    except Exception:
-        log.exception("Dropping column imported from job table failed.")
+    drop_column('imported', 'job', metadata)

--- a/lib/galaxy/model/migrate/versions/0052_sample_dataset_table.py
+++ b/lib/galaxy/model/migrate/versions/0052_sample_dataset_table.py
@@ -12,28 +12,11 @@ from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table, T
 from sqlalchemy.exc import NoSuchTableError
 
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import localtimestamp, nextval
 
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
 metadata = MetaData()
-
-
-def nextval(migrate_engine, table, col='id'):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "nextval('%s_%s_seq')" % (table, col)
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return "null"
-    else:
-        raise Exception('Unable to convert data for unknown database type: %s' % migrate_engine.name)
-
-
-def localtimestamp(migrate_engine):
-    if migrate_engine.name in ['mysql', 'postgres', 'postgresql']:
-        return "LOCALTIMESTAMP"
-    elif migrate_engine.name == 'sqlite':
-        return "current_date || ' ' || current_time"
-    else:
-        raise Exception('Unable to convert data for unknown database type: %s' % migrate_engine.name)
 
 
 SampleDataset_table = Table('sample_dataset', metadata,
@@ -49,9 +32,10 @@ SampleDataset_table = Table('sample_dataset', metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     try:
         SampleDataset_table.create()
     except Exception:

--- a/lib/galaxy/model/migrate/versions/0053_item_ratings.py
+++ b/lib/galaxy/model/migrate/versions/0053_item_ratings.py
@@ -7,6 +7,8 @@ import logging
 
 from sqlalchemy import Column, ForeignKey, Index, Integer, MetaData, Table
 
+from galaxy.model.migrate.versions.util import create_table, drop_table
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
@@ -44,15 +46,11 @@ VisualizationRatingAssociation_table = Table("visualization_rating_association",
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
-    # Create history_rating_association table.
-    try:
-        HistoryRatingAssociation_table.create()
-    except Exception:
-        log.exception("Creating history_rating_association table failed.")
+    create_table(HistoryRatingAssociation_table)
 
     # Create history_dataset_association_rating_association table.
     try:
@@ -69,55 +67,17 @@ def upgrade(migrate_engine):
         else:
             log.exception("Creating history_dataset_association_rating_association table failed.")
 
-    # Create stored_workflow_rating_association table.
-    try:
-        StoredWorkflowRatingAssociation_table.create()
-    except Exception:
-        log.exception("Creating stored_workflow_rating_association table failed.")
-
-    # Create page_rating_association table.
-    try:
-        PageRatingAssociation_table.create()
-    except Exception:
-        log.exception("Creating page_rating_association table failed.")
-
-    # Create visualization_rating_association table.
-    try:
-        VisualizationRatingAssociation_table.create()
-    except Exception:
-        log.exception("Creating visualization_rating_association table failed.")
+    create_table(StoredWorkflowRatingAssociation_table)
+    create_table(PageRatingAssociation_table)
+    create_table(VisualizationRatingAssociation_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    # Drop history_rating_association table.
-    try:
-        HistoryRatingAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping history_rating_association table failed.")
-
-    # Drop history_dataset_association_rating_association table.
-    try:
-        HistoryDatasetAssociationRatingAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping history_dataset_association_rating_association table failed.")
-
-    # Drop stored_workflow_rating_association table.
-    try:
-        StoredWorkflowRatingAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping stored_workflow_rating_association table failed.")
-
-    # Drop page_rating_association table.
-    try:
-        PageRatingAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping page_rating_association table failed.")
-
-    # Drop visualization_rating_association table.
-    try:
-        VisualizationRatingAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping visualization_rating_association table failed.")
+    drop_table(VisualizationRatingAssociation_table)
+    drop_table(PageRatingAssociation_table)
+    drop_table(StoredWorkflowRatingAssociation_table)
+    drop_table(HistoryDatasetAssociationRatingAssociation_table)
+    drop_table(HistoryRatingAssociation_table)

--- a/lib/galaxy/model/migrate/versions/0055_add_pja_assoc_for_jobs.py
+++ b/lib/galaxy/model/migrate/versions/0055_add_pja_assoc_for_jobs.py
@@ -7,6 +7,8 @@ import logging
 
 from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table
 
+from galaxy.model.migrate.versions.util import create_table, drop_table
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
@@ -17,20 +19,15 @@ PostJobActionAssociation_table = Table("post_job_action_association", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        PostJobActionAssociation_table.create()
-    except Exception:
-        log.exception("Creating PostJobActionAssociation table failed.")
+
+    create_table(PostJobActionAssociation_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
-    # Load existing tables
     metadata.reflect()
-    try:
-        PostJobActionAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping PostJobActionAssociation table failed.")
+
+    drop_table(PostJobActionAssociation_table)

--- a/lib/galaxy/model/migrate/versions/0060_history_archive_import.py
+++ b/lib/galaxy/model/migrate/versions/0060_history_archive_import.py
@@ -8,6 +8,8 @@ import logging
 
 from sqlalchemy import Boolean, Column, ForeignKey, Integer, MetaData, Table, TEXT
 
+from galaxy.model.migrate.versions.util import engine_false
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
@@ -25,18 +27,9 @@ JobImportHistoryArchive_table = Table("job_import_history_archive", metadata,
                                       Column("archive_dir", TEXT))
 
 
-def engine_false(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "FALSE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 0
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
-
-
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     # Add column to history table and initialize.

--- a/lib/galaxy/model/migrate/versions/0064_add_run_and_sample_run_association_tables.py
+++ b/lib/galaxy/model/migrate/versions/0064_add_run_and_sample_run_association_tables.py
@@ -8,6 +8,8 @@ import logging
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, Table
 
+from galaxy.model.migrate.versions.util import create_table, drop_table
+
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -32,36 +34,19 @@ SampleRunAssociation_table = Table("sample_run_association", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        Run_table.create()
-    except Exception:
-        log.exception("Creating Run_table table failed.")
-    try:
-        RequestTypeRunAssociation_table.create()
-    except Exception:
-        log.exception("Creating RequestTypeRunAssociation table failed.")
-    try:
-        SampleRunAssociation_table.create()
-    except Exception:
-        log.exception("Creating SampleRunAssociation table failed.")
+
+    create_table(Run_table)
+    create_table(RequestTypeRunAssociation_table)
+    create_table(SampleRunAssociation_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
-    # Load existing tables
     metadata.reflect()
-    try:
-        SampleRunAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping SampleRunAssociation table failed.")
-    try:
-        RequestTypeRunAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping RequestTypeRunAssociation table failed.")
-    try:
-        Run_table.drop()
-    except Exception:
-        log.exception("Dropping Run_table table failed.")
+
+    drop_table(SampleRunAssociation_table)
+    drop_table(RequestTypeRunAssociation_table)
+    drop_table(Run_table)

--- a/lib/galaxy/model/migrate/versions/0068_rename_sequencer_to_external_services.py
+++ b/lib/galaxy/model/migrate/versions/0068_rename_sequencer_to_external_services.py
@@ -15,28 +15,19 @@ from migrate import ForeignKeyConstraint
 from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table
 from sqlalchemy.exc import NoSuchTableError
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import nextval
 
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
-def nextval(migrate_engine, table, col='id'):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "nextval('%s_%s_seq')" % (table, col)
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return "null"
-    else:
-        raise Exception('Unable to convert data for unknown database type: %s' % migrate_engine.name)
-
-
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-    # Load existing tables
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     # create the column. Call it external_services_id as the table 'sequencer' is
     # going to be renamed to 'external_service'
     try:
@@ -137,8 +128,8 @@ def upgrade(migrate_engine):
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
-    # Load existing tables
     metadata.reflect()
+
     # load sequencer & request_type table
     try:
         RequestType_table = Table("request_type", metadata, autoload=True)

--- a/lib/galaxy/model/migrate/versions/0074_add_purged_column_to_library_dataset_table.py
+++ b/lib/galaxy/model/migrate/versions/0074_add_purged_column_to_library_dataset_table.py
@@ -5,41 +5,21 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Boolean, Column, MetaData, Table
+from sqlalchemy import Boolean, Column, MetaData
+
+from galaxy.model.migrate.versions.util import add_column, drop_column, engine_false, engine_true
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
-def engine_false(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "FALSE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 0
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
-
-
-def engine_true(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "TRUE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 1
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
-
-
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        LibraryDataset_table = Table("library_dataset", metadata, autoload=True)
-        c = Column("purged", Boolean, index=True, default=False)
-        c.create(LibraryDataset_table, index_name='ix_library_dataset_purged')
-        assert c is LibraryDataset_table.c.purged
-    except Exception:
-        log.exception("Adding purged column to library_dataset table failed.")
+
+    c = Column('purged', Boolean, index=True, default=False)
+    add_column(c, 'library_dataset', metadata, index_name='ix_library_dataset_purged')
     # Update the purged flag to the default False
     cmd = "UPDATE library_dataset SET purged = %s;" % engine_false(migrate_engine)
     try:
@@ -63,8 +43,7 @@ def upgrade(migrate_engine):
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        LibraryDataset_table = Table("library_dataset", metadata, autoload=True)
-        LibraryDataset_table.c.purged.drop()
-    except Exception:
-        log.exception("Dropping purged column from library_dataset table failed.")
+
+    # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
+    if migrate_engine.name != 'sqlite':
+        drop_column('purged', 'library_dataset', metadata)

--- a/lib/galaxy/model/migrate/versions/0078_add_columns_for_disk_usage_accounting.py
+++ b/lib/galaxy/model/migrate/versions/0078_add_columns_for_disk_usage_accounting.py
@@ -9,72 +9,44 @@ import logging
 
 from sqlalchemy import Boolean, Column, MetaData, Numeric, Table
 
+from galaxy.model.migrate.versions.util import add_column, drop_column
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        Dataset_table = Table("dataset", metadata, autoload=True)
-        c = Column('total_size', Numeric(15, 0))
-        c.create(Dataset_table)
-        assert c is Dataset_table.c.total_size
-    except Exception:
-        log.exception("Adding total_size column to dataset table failed.")
+    c = Column('total_size', Numeric(15, 0))
+    add_column(c, 'dataset', metadata)
 
+    HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
+    c = Column("purged", Boolean, index=True, default=False)
+    add_column(c, HistoryDatasetAssociation_table, index_name="ix_history_dataset_association_purged")
     try:
-        HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
-        c = Column("purged", Boolean, index=True, default=False)
-        c.create(HistoryDatasetAssociation_table, index_name="ix_history_dataset_association_purged")
-        assert c is HistoryDatasetAssociation_table.c.purged
         migrate_engine.execute(HistoryDatasetAssociation_table.update().values(purged=False))
     except Exception:
-        log.exception("Adding purged column to history_dataset_association table failed.")
+        log.exception("Updating column 'purged' of table 'history_dataset_association' failed.")
 
-    try:
-        User_table = Table("galaxy_user", metadata, autoload=True)
-        c = Column('disk_usage', Numeric(15, 0), index=True)
-        c.create(User_table, index_name="ix_galaxy_user_disk_usage")
-        assert c is User_table.c.disk_usage
-    except Exception:
-        log.exception("Adding disk_usage column to galaxy_user table failed.")
+    c = Column('disk_usage', Numeric(15, 0), index=True)
+    add_column(c, 'galaxy_user', metadata, index_name="ix_galaxy_user_disk_usage")
 
-    try:
-        GalaxySession_table = Table("galaxy_session", metadata, autoload=True)
-        c = Column('disk_usage', Numeric(15, 0), index=True)
-        c.create(GalaxySession_table, index_name="ix_galaxy_session_disk_usage")
-        assert c is GalaxySession_table.c.disk_usage
-    except Exception:
-        log.exception("Adding disk_usage column to galaxy_session table failed.")
+    c = Column('disk_usage', Numeric(15, 0), index=True)
+    add_column(c, 'galaxy_session', metadata, index_name="ix_galaxy_session_disk_usage")
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        Dataset_table = Table("dataset", metadata, autoload=True)
-        Dataset_table.c.total_size.drop()
-    except Exception:
-        log.exception("Dropping total_size column from dataset table failed.")
 
-    try:
-        HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
-        HistoryDatasetAssociation_table.c.purged.drop()
-    except Exception:
-        log.exception("Dropping purged column from history_dataset_association table failed.")
+    drop_column('disk_usage', 'galaxy_session', metadata)
+    drop_column('disk_usage', 'galaxy_user', metadata)
 
-    try:
-        User_table = Table("galaxy_user", metadata, autoload=True)
-        User_table.c.disk_usage.drop()
-    except Exception:
-        log.exception("Dropping disk_usage column from galaxy_user table failed.")
+    # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
+    if migrate_engine.name != 'sqlite':
+        drop_column('purged', 'history_dataset_association', metadata)
 
-    try:
-        GalaxySession_table = Table("galaxy_session", metadata, autoload=True)
-        GalaxySession_table.c.disk_usage.drop()
-    except Exception:
-        log.exception("Dropping disk_usage column from galaxy_session table failed.")
+    drop_column('total_size', 'dataset', metadata)

--- a/lib/galaxy/model/migrate/versions/0082_add_tool_shed_repository_table.py
+++ b/lib/galaxy/model/migrate/versions/0082_add_tool_shed_repository_table.py
@@ -37,8 +37,8 @@ ToolShedRepository_table = Table("tool_shed_repository", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
     try:
         ToolShedRepository_table.create()

--- a/lib/galaxy/model/migrate/versions/0083_add_prepare_files_to_task.py
+++ b/lib/galaxy/model/migrate/versions/0083_add_prepare_files_to_task.py
@@ -7,53 +7,35 @@ import logging
 
 from sqlalchemy import Column, MetaData, String, Table, TEXT
 
+from galaxy.model.migrate.versions.util import add_column, drop_column
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        task_table = Table("task", metadata, autoload=True)
-        c = Column("prepare_input_files_cmd", TEXT, nullable=True)
-        c.create(task_table)
-        assert c is task_table.c.prepare_input_files_cmd
-    except Exception:
-        log.exception("Adding prepare_input_files_cmd column to task table failed.")
-    try:
-        task_table = Table("task", metadata, autoload=True)
-        c = Column("working_directory", String(1024), nullable=True)
-        c.create(task_table)
-        assert c is task_table.c.working_directory
-    except Exception:
-        log.exception("Adding working_directory column to task table failed.")
+
+    task_table = Table("task", metadata, autoload=True)
+    c = Column("prepare_input_files_cmd", TEXT, nullable=True)
+    add_column(c, task_table)
+
+    c = Column("working_directory", String(1024), nullable=True)
+    add_column(c, task_table)
 
     # remove the 'part_file' column - nobody used tasks before this, so no data needs to be migrated
-    try:
-        task_table.c.part_file.drop()
-    except Exception:
-        log.exception("Deleting column 'part_file' from the 'task' table failed.")
+    drop_column('part_file', task_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        task_table = Table("task", metadata, autoload=True)
-        task_table.c.prepare_input_files_cmd.drop()
-    except Exception:
-        log.exception("Dropping prepare_input_files_cmd column from task table failed.")
-    try:
-        task_table = Table("task", metadata, autoload=True)
-        task_table.c.working_directory.drop()
-    except Exception:
-        log.exception("Dropping working_directory column from task table failed.")
-    try:
-        task_table = Table("task", metadata, autoload=True)
-        c = Column("part_file", String(1024), nullable=True)
-        c.create(task_table)
-        assert c is task_table.c.part_file
-    except Exception:
-        log.exception("Adding part_file column to task table failed.")
+
+    task_table = Table("task", metadata, autoload=True)
+    c = Column("part_file", String(1024), nullable=True)
+    add_column(c, task_table)
+
+    drop_column('working_directory', task_table)
+    drop_column('prepare_input_files_cmd', task_table)

--- a/lib/galaxy/model/migrate/versions/0086_add_tool_shed_repository_table_columns.py
+++ b/lib/galaxy/model/migrate/versions/0086_add_tool_shed_repository_table_columns.py
@@ -8,8 +8,8 @@ import sys
 
 from sqlalchemy import Boolean, Column, MetaData, Table
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import JSONType
+from galaxy.model.migrate.versions.util import add_column, drop_column, engine_false
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -22,57 +22,35 @@ log.addHandler(handler)
 metadata = MetaData()
 
 
-def engine_false(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "FALSE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 0
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
-
-
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
     c = Column("metadata", JSONType(), nullable=True)
-    try:
-        c.create(ToolShedRepository_table)
-        assert c is ToolShedRepository_table.c.metadata
-    except Exception:
-        log.exception("Adding metadata column to the tool_shed_repository table failed.")
+    add_column(c, ToolShedRepository_table)
     c = Column("includes_datatypes", Boolean, index=True, default=False)
+    add_column(c, ToolShedRepository_table, index_name="ix_tool_shed_repository_includes_datatypes")
     try:
-        c.create(ToolShedRepository_table, index_name="ix_tool_shed_repository_includes_datatypes")
-        assert c is ToolShedRepository_table.c.includes_datatypes
         migrate_engine.execute("UPDATE tool_shed_repository SET includes_datatypes=%s" % engine_false(migrate_engine))
     except Exception:
-        log.exception("Adding includes_datatypes column to the tool_shed_repository table failed.")
+        log.exception("Updating column 'includes_datatypes' of table 'tool_shed_repository' failed.")
     c = Column("update_available", Boolean, default=False)
+    add_column(c, ToolShedRepository_table)
     try:
-        c.create(ToolShedRepository_table)
-        assert c is ToolShedRepository_table.c.update_available
         migrate_engine.execute("UPDATE tool_shed_repository SET update_available=%s" % engine_false(migrate_engine))
     except Exception:
-        log.exception("Adding update_available column to the tool_shed_repository table failed.")
+        log.exception("Updating column 'update_available' of table 'tool_shed_repository' failed.")
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
+
     ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
-    try:
-        ToolShedRepository_table.c.metadata.drop()
-    except Exception:
-        log.exception("Dropping column metadata from the tool_shed_repository table failed.")
+    drop_column('metadata', ToolShedRepository_table)
     # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
     if migrate_engine.name != 'sqlite':
-        try:
-            ToolShedRepository_table.c.includes_datatypes.drop()
-        except Exception:
-            log.exception("Dropping column includes_datatypes from the tool_shed_repository table failed.")
-        try:
-            ToolShedRepository_table.c.update_available.drop()
-        except Exception:
-            log.exception("Dropping column update_available from the tool_shed_repository table failed.")
+        drop_column('includes_datatypes', ToolShedRepository_table)
+        drop_column('update_available', ToolShedRepository_table)

--- a/lib/galaxy/model/migrate/versions/0089_add_object_store_id_columns.py
+++ b/lib/galaxy/model/migrate/versions/0089_add_object_store_id_columns.py
@@ -14,9 +14,10 @@ metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     for t_name in ('dataset', 'job', 'metadata_file'):
         t = Table(t_name, metadata, autoload=True)
         c = Column("object_store_id", TrimmedString(255), index=True)
@@ -30,6 +31,7 @@ def upgrade(migrate_engine):
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
+
     for t_name in ('dataset', 'job', 'metadata_file'):
         t = Table(t_name, metadata, autoload=True)
         try:

--- a/lib/galaxy/model/migrate/versions/0090_add_tool_shed_repository_table_columns.py
+++ b/lib/galaxy/model/migrate/versions/0090_add_tool_shed_repository_table_columns.py
@@ -8,6 +8,8 @@ import sys
 
 from sqlalchemy import Boolean, Column, MetaData, Table
 
+from galaxy.model.migrate.versions.util import drop_column, engine_false
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 handler = logging.StreamHandler(sys.stdout)
@@ -19,19 +21,11 @@ log.addHandler(handler)
 metadata = MetaData()
 
 
-def engine_false(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "FALSE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 0
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
-
-
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
     c = Column("uninstalled", Boolean, default=False)
     try:
@@ -52,14 +46,9 @@ def upgrade(migrate_engine):
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
+
     ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
     # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
     if migrate_engine.name != 'sqlite':
-        try:
-            ToolShedRepository_table.c.uninstalled.drop()
-        except Exception:
-            log.exception("Dropping column uninstalled from the tool_shed_repository table failed.")
-        try:
-            ToolShedRepository_table.c.dist_to_shed.drop()
-        except Exception:
-            log.exception("Dropping column dist_to_shed from the tool_shed_repository table failed.")
+        drop_column('uninstalled', ToolShedRepository_table)
+        drop_column('dist_to_shed', ToolShedRepository_table)

--- a/lib/galaxy/model/migrate/versions/0098_genome_index_tool_data_table.py
+++ b/lib/galaxy/model/migrate/versions/0098_genome_index_tool_data_table.py
@@ -9,6 +9,8 @@ import sys
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, String, Table
 
+from galaxy.model.migrate.versions.util import create_table, drop_table
+
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -35,20 +37,15 @@ GenomeIndexToolData_table = Table("genome_index_tool_data", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        GenomeIndexToolData_table.create()
-    except Exception:
-        log.exception("Creating genome_index_tool_data table failed.")
+
+    create_table(GenomeIndexToolData_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        GenomeIndexToolData_table.drop()
-    except Exception:
-        log.exception("Dropping genome_index_tool_data table failed.")
+
+    drop_table(GenomeIndexToolData_table)

--- a/lib/galaxy/model/migrate/versions/0101_drop_installed_changeset_revision_column.py
+++ b/lib/galaxy/model/migrate/versions/0101_drop_installed_changeset_revision_column.py
@@ -9,6 +9,8 @@ import sys
 from sqlalchemy import MetaData, Table
 from sqlalchemy.exc import NoSuchTableError
 
+from galaxy.model.migrate.versions.util import drop_column
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 handler = logging.StreamHandler(sys.stdout)
@@ -21,8 +23,8 @@ metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
     try:
         ToolDependency_table = Table("tool_dependency", metadata, autoload=True)
@@ -30,11 +32,7 @@ def upgrade(migrate_engine):
         ToolDependency_table = None
         log.debug("Failed loading table tool_dependency")
     if ToolDependency_table is not None:
-        try:
-            col = ToolDependency_table.c.installed_changeset_revision
-            col.drop()
-        except Exception:
-            log.exception("Dropping column 'installed_changeset_revision' from tool_dependency table failed.")
+        drop_column('installed_changeset_revision', ToolDependency_table)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0102_add_tool_dependency_status_columns.py
+++ b/lib/galaxy/model/migrate/versions/0102_add_tool_dependency_status_columns.py
@@ -8,8 +8,8 @@ import sys
 
 from sqlalchemy import Boolean, Column, MetaData, Table, TEXT
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import add_column, drop_column
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -23,50 +23,34 @@ metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     ToolDependency_table = Table("tool_dependency", metadata, autoload=True)
     if migrate_engine.name == 'sqlite':
         col = Column("status", TrimmedString(255))
     else:
         col = Column("status", TrimmedString(255), nullable=False)
-    try:
-        col.create(ToolDependency_table)
-        assert col is ToolDependency_table.c.status
-    except Exception:
-        log.exception("Adding status column to the tool_dependency table failed.")
-    col = Column("error_message", TEXT)
-    try:
-        col.create(ToolDependency_table)
-        assert col is ToolDependency_table.c.error_message
-    except Exception:
-        log.exception("Adding error_message column to the tool_dependency table failed.")
+    add_column(col, ToolDependency_table)
 
+    col = Column("error_message", TEXT)
+    add_column(col, ToolDependency_table)
+
+    # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
+    # TODO move to alembic.
     if migrate_engine.name != 'sqlite':
-        # This breaks in sqlite due to failure to drop check constraint.
-        # TODO move to alembic.
-        try:
-            ToolDependency_table.c.uninstalled.drop()
-        except Exception:
-            log.exception("Dropping uninstalled column from the tool_dependency table failed.")
+        drop_column('uninstalled', ToolDependency_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
+
     ToolDependency_table = Table("tool_dependency", metadata, autoload=True)
-    try:
-        ToolDependency_table.c.status.drop()
-    except Exception:
-        log.exception("Dropping column status from the tool_dependency table failed.")
-    try:
-        ToolDependency_table.c.error_message.drop()
-    except Exception:
-        log.exception("Dropping column error_message from the tool_dependency table failed.")
-    col = Column("uninstalled", Boolean, default=False)
-    try:
-        col.create(ToolDependency_table)
-        assert col is ToolDependency_table.c.uninstalled
-    except Exception:
-        log.exception("Adding uninstalled column to the tool_dependency table failed.")
+    if migrate_engine.name != 'sqlite':
+        col = Column("uninstalled", Boolean, default=False)
+        add_column(col, ToolDependency_table)
+
+    drop_column('error_message', ToolDependency_table)
+    drop_column('status', ToolDependency_table)

--- a/lib/galaxy/model/migrate/versions/0116_drop_update_available_col_add_tool_shed_status_col.py
+++ b/lib/galaxy/model/migrate/versions/0116_drop_update_available_col_add_tool_shed_status_col.py
@@ -10,6 +10,7 @@ from sqlalchemy import Boolean, Column, MetaData, Table
 from sqlalchemy.exc import NoSuchTableError
 
 from galaxy.model.custom_types import JSONType
+from galaxy.model.migrate.versions.util import add_column, drop_column, engine_false
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -22,43 +23,28 @@ log.addHandler(handler)
 metadata = MetaData()
 
 
-def engine_false(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "FALSE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 0
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
-
-
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     try:
         ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
     except NoSuchTableError:
         ToolShedRepository_table = None
         log.debug("Failed loading table tool_shed_repository")
     if ToolShedRepository_table is not None:
-        # For some unknown reason it is no longer possible to drop a column in a migration script if using the sqlite database.
+        # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
         if migrate_engine.name != 'sqlite':
-            try:
-                col = ToolShedRepository_table.c.update_available
-                col.drop()
-            except Exception:
-                log.exception("Dropping column update_available from the tool_shed_repository table failed.")
+            drop_column('update_available', ToolShedRepository_table)
         c = Column("tool_shed_status", JSONType, nullable=True)
-        try:
-            c.create(ToolShedRepository_table)
-            assert c is ToolShedRepository_table.c.tool_shed_status
-        except Exception:
-            log.exception("Adding tool_shed_status column to the tool_shed_repository table failed.")
+        add_column(c, ToolShedRepository_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
+
     try:
         ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
     except NoSuchTableError:
@@ -67,15 +53,10 @@ def downgrade(migrate_engine):
     if ToolShedRepository_table is not None:
         # For some unknown reason it is no longer possible to drop a column in a migration script if using the sqlite database.
         if migrate_engine.name != 'sqlite':
-            try:
-                col = ToolShedRepository_table.c.tool_shed_status
-                col.drop()
-            except Exception:
-                log.exception("Dropping column tool_shed_status from the tool_shed_repository table failed.")
+            drop_column('tool_shed_status', ToolShedRepository_table)
             c = Column("update_available", Boolean, default=False)
+            add_column(c, ToolShedRepository_table)
             try:
-                c.create(ToolShedRepository_table)
-                assert c is ToolShedRepository_table.c.update_available
                 migrate_engine.execute("UPDATE tool_shed_repository SET update_available=%s" % engine_false(migrate_engine))
             except Exception:
-                log.exception("Adding column update_available to the tool_shed_repository table failed.")
+                log.exception("Updating column 'update_available' of table 'tool_shed_repository' failed.")

--- a/lib/galaxy/model/migrate/versions/0119_job_metrics.py
+++ b/lib/galaxy/model/migrate/versions/0119_job_metrics.py
@@ -7,6 +7,8 @@ import logging
 
 from sqlalchemy import Column, ForeignKey, Integer, MetaData, Numeric, Table, Unicode
 
+from galaxy.model.migrate.versions.util import create_table, drop_table
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
@@ -65,12 +67,12 @@ TABLES = [
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     for table in TABLES:
-        __create(table)
+        create_table(table)
 
 
 def downgrade(migrate_engine):
@@ -78,18 +80,4 @@ def downgrade(migrate_engine):
     metadata.reflect()
 
     for table in TABLES:
-        __drop(table)
-
-
-def __create(table):
-    try:
-        table.create()
-    except Exception:
-        log.exception("Creating %s table failed.", table.name)
-
-
-def __drop(table):
-    try:
-        table.drop()
-    except Exception:
-        log.exception("Dropping %s table failed.", table.name)
+        drop_table(table)

--- a/lib/galaxy/model/migrate/versions/0120_dataset_collections.py
+++ b/lib/galaxy/model/migrate/versions/0120_dataset_collections.py
@@ -9,6 +9,7 @@ import logging
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, Table, TEXT, Unicode
 
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import create_table, drop_table
 
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
@@ -129,12 +130,12 @@ TABLES = [
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     for table in TABLES:
-        __create(table)
+        create_table(table)
 
     try:
         hda_table = Table("history_dataset_association", metadata, autoload=True)
@@ -155,18 +156,4 @@ def downgrade(migrate_engine):
         log.exception("Dropping HDA column failed.")
 
     for table in reversed(TABLES):
-        __drop(table)
-
-
-def __create(table):
-    try:
-        table.create()
-    except Exception:
-        log.exception("Creating %s table failed.", table.name)
-
-
-def __drop(table):
-    try:
-        table.drop()
-    except Exception:
-        log.exception("Dropping %s table failed.", table.name)
+        drop_table(table)

--- a/lib/galaxy/model/migrate/versions/0122_grow_mysql_blobs.py
+++ b/lib/galaxy/model/migrate/versions/0122_grow_mysql_blobs.py
@@ -33,8 +33,8 @@ BLOB_COLUMNS = [
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     if migrate_engine.name != "mysql":
@@ -49,7 +49,4 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
-    metadata.reflect()
-    # Ignoring..., changed the datatype so no guarantee these columns weren't
-    # MEDIUMBLOBs before.
+    pass

--- a/lib/galaxy/model/migrate/versions/0123_add_workflow_request_tables.py
+++ b/lib/galaxy/model/migrate/versions/0123_add_workflow_request_tables.py
@@ -8,6 +8,7 @@ import logging
 from sqlalchemy import Column, ForeignKey, Integer, MetaData, String, Table, TEXT, Unicode
 
 from galaxy.model.custom_types import JSONType, TrimmedString, UUIDType
+from galaxy.model.migrate.versions.util import add_column, create_table, drop_column, drop_table
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -66,7 +67,7 @@ def upgrade(migrate_engine):
     metadata.reflect()
 
     for table in TABLES:
-        __create(table)
+        create_table(table)
 
     History_column = Column("history_id", Integer, ForeignKey("history.id"), nullable=True)
     State_column = Column("state", TrimmedString(64))
@@ -75,11 +76,11 @@ def upgrade(migrate_engine):
     SchedulerId_column = Column("scheduler", TrimmedString(255))
     HandlerId_column = Column("handler", TrimmedString(255))
     WorkflowUUID_column = Column("uuid", UUIDType, nullable=True)
-    __add_column(History_column, "workflow_invocation", metadata)
-    __add_column(State_column, "workflow_invocation", metadata)
-    __add_column(SchedulerId_column, "workflow_invocation", metadata, index_nane="id_workflow_invocation_scheduler")
-    __add_column(HandlerId_column, "workflow_invocation", metadata, index_name="id_workflow_invocation_handler")
-    __add_column(WorkflowUUID_column, "workflow_invocation", metadata)
+    add_column(History_column, "workflow_invocation", metadata)
+    add_column(State_column, "workflow_invocation", metadata)
+    add_column(SchedulerId_column, "workflow_invocation", metadata, index_nane="id_workflow_invocation_scheduler")
+    add_column(HandlerId_column, "workflow_invocation", metadata, index_name="id_workflow_invocation_handler")
+    add_column(WorkflowUUID_column, "workflow_invocation", metadata)
 
     # All previous invocations have been scheduled...
     cmd = "UPDATE workflow_invocation SET state = 'scheduled'"
@@ -89,7 +90,7 @@ def upgrade(migrate_engine):
         log.exception("failed to update past workflow invocation states.")
 
     WorkflowInvocationStepAction_column = Column("action", JSONType, nullable=True)
-    __add_column(WorkflowInvocationStepAction_column, "workflow_invocation_step", metadata)
+    add_column(WorkflowInvocationStepAction_column, "workflow_invocation_step", metadata)
 
 
 def downgrade(migrate_engine):
@@ -97,41 +98,11 @@ def downgrade(migrate_engine):
     metadata.reflect()
 
     for table in TABLES:
-        __drop(table)
+        drop_table(table)
 
-    __drop_column("state", "workflow_invocation", metadata)
-    __drop_column("scheduler", "workflow_invocation", metadata)
-    __drop_column("uuid", "workflow_invocation", metadata)
-    __drop_column("history_id", "workflow_invocation", metadata)
-    __drop_column("handler", "workflow_invocation", metadata)
-    __drop_column("action", "workflow_invocation_step", metadata)
-
-
-def __add_column(column, table_name, metadata, **kwds):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        column.create(table, **kwds)
-    except Exception:
-        log.exception("Adding column %s column failed.", column)
-
-
-def __drop_column(column_name, table_name, metadata):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        getattr(table.c, column_name).drop()
-    except Exception:
-        log.exception("Dropping column %s failed.", column_name)
-
-
-def __create(table):
-    try:
-        table.create()
-    except Exception:
-        log.exception("Creating %s table failed.", table.name)
-
-
-def __drop(table):
-    try:
-        table.drop()
-    except Exception:
-        log.exception("Dropping %s table failed.", table.name)
+    drop_column("state", "workflow_invocation", metadata)
+    drop_column("scheduler", "workflow_invocation", metadata)
+    drop_column("uuid", "workflow_invocation", metadata)
+    drop_column("history_id", "workflow_invocation", metadata)
+    drop_column("handler", "workflow_invocation", metadata)
+    drop_column("action", "workflow_invocation_step", metadata)

--- a/lib/galaxy/model/migrate/versions/0124_job_state_history.py
+++ b/lib/galaxy/model/migrate/versions/0124_job_state_history.py
@@ -9,6 +9,7 @@ import logging
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, String, Table
 
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import create_table, drop_table
 
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
@@ -24,21 +25,15 @@ JobStateHistory_table = Table("job_state_history", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        JobStateHistory_table.create()
-    except Exception:
-        log.exception("Creating %s table failed.", JobStateHistory_table.name)
+    create_table(JobStateHistory_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        JobStateHistory_table.drop()
-    except Exception:
-        log.exception("Dropping %s table failed.", JobStateHistory_table.name)
+    drop_table(JobStateHistory_table)

--- a/lib/galaxy/model/migrate/versions/0125_workflow_step_tracking.py
+++ b/lib/galaxy/model/migrate/versions/0125_workflow_step_tracking.py
@@ -5,9 +5,10 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, MetaData, Table
+from sqlalchemy import Column, MetaData
 
 from galaxy.model.custom_types import TrimmedString, UUIDType
+from galaxy.model.migrate.versions.util import add_column, drop_column
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -20,29 +21,13 @@ def upgrade(migrate_engine):
 
     StepLabel_column = Column("label", TrimmedString(255))
     StepUUID_column = Column("uuid", UUIDType, nullable=True)
-    __add_column(StepLabel_column, "workflow_step", metadata)
-    __add_column(StepUUID_column, "workflow_step", metadata)
+    add_column(StepLabel_column, "workflow_step", metadata)
+    add_column(StepUUID_column, "workflow_step", metadata)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    __drop_column("label", "workflow_step", metadata)
-    __drop_column("uuid", "workflow_step", metadata)
-
-
-def __add_column(column, table_name, metadata, **kwds):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        column.create(table, **kwds)
-    except Exception:
-        log.exception("Adding column %s failed.", column)
-
-
-def __drop_column(column_name, table_name, metadata):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        getattr(table.c, column_name).drop()
-    except Exception:
-        log.exception("Dropping column %s failed.", column_name)
+    drop_column("label", "workflow_step", metadata)
+    drop_column("uuid", "workflow_step", metadata)

--- a/lib/galaxy/model/migrate/versions/0126_password_reset.py
+++ b/lib/galaxy/model/migrate/versions/0126_password_reset.py
@@ -7,6 +7,8 @@ import logging
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, String, Table
 
+from galaxy.model.migrate.versions.util import create_table, drop_table
+
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
@@ -17,19 +19,15 @@ PasswordResetToken_table = Table("password_reset_token", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        PasswordResetToken_table.create()
-    except Exception:
-        log.exception("Creating %s table failed.", PasswordResetToken_table.name)
+
+    create_table(PasswordResetToken_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        PasswordResetToken_table.drop()
-    except Exception:
-        log.exception("Dropping %s table failed.", PasswordResetToken_table.name)
+
+    drop_table(PasswordResetToken_table)

--- a/lib/galaxy/model/migrate/versions/0127_output_collection_adjustments.py
+++ b/lib/galaxy/model/migrate/versions/0127_output_collection_adjustments.py
@@ -8,6 +8,7 @@ import logging
 from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table, TEXT, Unicode
 
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import add_column, create_table, drop_column, drop_table
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -27,23 +28,20 @@ TABLES = [
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     for table in TABLES:
-        __create(table)
+        create_table(table)
 
-    try:
-        dataset_collection_table = Table("dataset_collection", metadata, autoload=True)
-        # need server_default because column in non-null
-        populated_state_column = Column('populated_state', TrimmedString(64), default='ok', server_default="ok", nullable=False)
-        populated_state_column.create(dataset_collection_table)
+    dataset_collection_table = Table("dataset_collection", metadata, autoload=True)
+    # need server_default because column in non-null
+    populated_state_column = Column('populated_state', TrimmedString(64), default='ok', server_default="ok", nullable=False)
+    add_column(populated_state_column, dataset_collection_table)
 
-        populated_message_column = Column('populated_state_message', TEXT, nullable=True)
-        populated_message_column.create(dataset_collection_table)
-    except Exception:
-        log.exception("Creating dataset collection populated column failed.")
+    populated_message_column = Column('populated_state_message', TEXT, nullable=True)
+    add_column(populated_message_column, dataset_collection_table)
 
 
 def downgrade(migrate_engine):
@@ -51,27 +49,8 @@ def downgrade(migrate_engine):
     metadata.reflect()
 
     for table in TABLES:
-        __drop(table)
+        drop_table(table)
 
-    try:
-        dataset_collection_table = Table("dataset_collection", metadata, autoload=True)
-        populated_state_column = dataset_collection_table.c.populated_state
-        populated_state_column.drop()
-        populated_message_column = dataset_collection_table.c.populated_state_message
-        populated_message_column.drop()
-    except Exception:
-        log.exception("Dropping dataset collection populated_state/ column failed.")
-
-
-def __create(table):
-    try:
-        table.create()
-    except Exception:
-        log.exception("Creating %s table failed.", table.name)
-
-
-def __drop(table):
-    try:
-        table.drop()
-    except Exception:
-        log.exception("Dropping %s table failed.", table.name)
+    dataset_collection_table = Table("dataset_collection", metadata, autoload=True)
+    drop_column('populated_state', dataset_collection_table)
+    drop_column('populated_state_message', dataset_collection_table)

--- a/lib/galaxy/model/migrate/versions/0128_session_timeout.py
+++ b/lib/galaxy/model/migrate/versions/0128_session_timeout.py
@@ -5,39 +5,25 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, DateTime, MetaData, Table
+from sqlalchemy import Column, DateTime, MetaData
+
+from galaxy.model.migrate.versions.util import add_column, drop_column
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     lastaction_column = Column("last_action", DateTime)
-    __add_column(lastaction_column, "galaxy_session", metadata)
+    add_column(lastaction_column, "galaxy_session", metadata)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    __drop_column("last_action", "galaxy_session", metadata)
-
-
-def __add_column(column, table_name, metadata, **kwds):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        column.create(table, **kwds)
-    except Exception:
-        log.exception("Adding column %s failed.", column)
-
-
-def __drop_column(column_name, table_name, metadata):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        getattr(table.c, column_name).drop()
-    except Exception:
-        log.exception("Dropping column %s failed.", column_name)
+    drop_column("last_action", "galaxy_session", metadata)

--- a/lib/galaxy/model/migrate/versions/0129_job_external_output_metadata_validity.py
+++ b/lib/galaxy/model/migrate/versions/0129_job_external_output_metadata_validity.py
@@ -5,7 +5,9 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Boolean, Column, MetaData, Table
+from sqlalchemy import Boolean, Column, MetaData
+
+from galaxy.model.migrate.versions.util import add_column, drop_column
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -17,7 +19,7 @@ def upgrade(migrate_engine):
     metadata.reflect()
 
     isvalid_column = Column("is_valid", Boolean, default=True)
-    __add_column(isvalid_column, "job_external_output_metadata", metadata)
+    add_column(isvalid_column, "job_external_output_metadata", metadata)
 
 
 def downgrade(migrate_engine):
@@ -25,20 +27,4 @@ def downgrade(migrate_engine):
     metadata.reflect()
     # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
     if migrate_engine.name != 'sqlite':
-        __drop_column("is_valid", "job_external_output_metadata", metadata)
-
-
-def __add_column(column, table_name, metadata, **kwds):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        column.create(table, **kwds)
-    except Exception:
-        log.exception("Adding column %s failed.", column)
-
-
-def __drop_column(column_name, table_name, metadata):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        getattr(table.c, column_name).drop()
-    except Exception:
-        log.exception("Dropping column %s failed.", column_name)
+        drop_column("is_valid", "job_external_output_metadata", metadata)

--- a/lib/galaxy/model/migrate/versions/0134_hda_set_deleted_if_purged.py
+++ b/lib/galaxy/model/migrate/versions/0134_hda_set_deleted_if_purged.py
@@ -6,16 +6,9 @@ from __future__ import print_function
 
 import logging
 
+from galaxy.model.migrate.versions.util import engine_true
+
 log = logging.getLogger(__name__)
-
-
-def engine_true(migrate_engine):
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        return "TRUE"
-    elif migrate_engine.name in ['mysql', 'sqlite']:
-        return 1
-    else:
-        raise Exception('Unknown database type: %s' % migrate_engine.name)
 
 
 def upgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0136_collection_and_workflow_state.py
+++ b/lib/galaxy/model/migrate/versions/0136_collection_and_workflow_state.py
@@ -10,13 +10,12 @@ from collections import OrderedDict
 from sqlalchemy import Column, ForeignKey, Integer, MetaData, String, Table
 
 from galaxy.model.custom_types import TrimmedString
-
+from galaxy.model.migrate.versions.util import add_column, create_table, drop_column, drop_table
 
 now = datetime.datetime.utcnow
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
-
 
 workflow_invocation_output_dataset_association_table = Table(
     "workflow_invocation_output_dataset_association", metadata,
@@ -85,13 +84,13 @@ def get_new_tables():
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     tables = get_new_tables()
     for table in tables.values():
-        __create(table)
+        create_table(table)
 
     # Set default for creation to scheduled, actual mapping has new as default.
     workflow_invocation_step_state_column = Column("state", TrimmedString(64), default="scheduled")
@@ -103,13 +102,13 @@ def upgrade(migrate_engine):
         job_id_column = Column("job_id", Integer, nullable=True)
     dataset_collection_element_count_column = Column("element_count", Integer, nullable=True)
 
-    __add_column(implicit_collection_jobs_id_column, "history_dataset_collection_association", metadata)
-    __add_column(job_id_column, "history_dataset_collection_association", metadata)
-    __add_column(dataset_collection_element_count_column, "dataset_collection", metadata)
+    add_column(implicit_collection_jobs_id_column, "history_dataset_collection_association", metadata)
+    add_column(job_id_column, "history_dataset_collection_association", metadata)
+    add_column(dataset_collection_element_count_column, "dataset_collection", metadata)
 
     implicit_collection_jobs_id_column = Column("implicit_collection_jobs_id", Integer, ForeignKey("implicit_collection_jobs.id"), nullable=True)
-    __add_column(implicit_collection_jobs_id_column, "workflow_invocation_step", metadata)
-    __add_column(workflow_invocation_step_state_column, "workflow_invocation_step", metadata)
+    add_column(implicit_collection_jobs_id_column, "workflow_invocation_step", metadata)
+    add_column(workflow_invocation_step_state_column, "workflow_invocation_step", metadata)
 
     cmd = \
         "UPDATE dataset_collection SET element_count = " + \
@@ -118,46 +117,16 @@ def upgrade(migrate_engine):
     migrate_engine.execute(cmd)
 
 
-def __add_column(column, table_name, metadata, **kwds):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        column.create(table, **kwds)
-    except Exception:
-        log.exception("Adding column %s failed.", column)
-
-
-def __drop_column(column_name, table_name, metadata):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        getattr(table.c, column_name).drop()
-    except Exception:
-        log.exception("Dropping column %s failed.", column_name)
-
-
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    __drop_column("implicit_collection_jobs_id", "history_dataset_collection_association", metadata)
-    __drop_column("job_id", "history_dataset_collection_association", metadata)
-    __drop_column("implicit_collection_jobs_id", "workflow_invocation_step", metadata)
-    __drop_column("state", "workflow_invocation_step", metadata)
-    __drop_column("element_count", "dataset_collection", metadata)
+    drop_column("implicit_collection_jobs_id", "history_dataset_collection_association", metadata)
+    drop_column("job_id", "history_dataset_collection_association", metadata)
+    drop_column("implicit_collection_jobs_id", "workflow_invocation_step", metadata)
+    drop_column("state", "workflow_invocation_step", metadata)
+    drop_column("element_count", "dataset_collection", metadata)
 
     tables = get_new_tables()
     for table in reversed(list(tables.values())):
-        __drop(table)
-
-
-def __create(table):
-    try:
-        table.create()
-    except Exception:
-        log.exception("Creating %s table failed.", table.name)
-
-
-def __drop(table):
-    try:
-        table.drop()
-    except Exception:
-        log.exception("Dropping %s table failed.", table.name)
+        drop_table(table)

--- a/lib/galaxy/model/migrate/versions/0146_workflow_paths.py
+++ b/lib/galaxy/model/migrate/versions/0146_workflow_paths.py
@@ -8,9 +8,10 @@ import logging
 from sqlalchemy import (
     Column,
     MetaData,
-    Table,
     TEXT,
 )
+
+from galaxy.model.migrate.versions.util import add_column, drop_column
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -19,30 +20,14 @@ from_path_column = Column("from_path", TEXT, nullable=True)
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
-    _add_column(from_path_column, "stored_workflow", metadata)
+    add_column(from_path_column, "stored_workflow", metadata)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
 
-    _drop_column("from_path", "stored_workflow", metadata)
-
-
-def _add_column(column, table_name, metadata, **kwds):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        column.create(table, **kwds)
-    except Exception:
-        log.exception("Adding column %s failed.", column)
-
-
-def _drop_column(column_name, table_name, metadata):
-    try:
-        table = Table(table_name, metadata, autoload=True)
-        getattr(table.c, column_name).drop()
-    except Exception:
-        log.exception("Dropping column %s failed.", column_name)
+    drop_column("from_path", "stored_workflow", metadata)

--- a/lib/galaxy/model/migrate/versions/0150_add_deleted_and_create_time_fields_for_cloudauthz.py
+++ b/lib/galaxy/model/migrate/versions/0150_add_deleted_and_create_time_fields_for_cloudauthz.py
@@ -8,47 +8,31 @@ import logging
 
 from sqlalchemy import Boolean, Column, DateTime, MetaData, Table
 
+from galaxy.model.migrate.versions.util import add_column, drop_column
+
 log = logging.getLogger(__name__)
-create_time_column = Column('create_time', DateTime)
-deleted_column = Column('deleted', Boolean)
+metadata = MetaData()
 
 
 def upgrade(migrate_engine):
     print(__doc__)
-    metadata = MetaData()
     metadata.bind = migrate_engine
     metadata.reflect()
 
     cloudauthz_table = Table("cloudauthz", metadata, autoload=True)
+    create_time_column = Column('create_time', DateTime)
+    add_column(create_time_column, cloudauthz_table)
 
-    try:
-        create_time_column.create(cloudauthz_table)
-        assert create_time_column is cloudauthz_table.c.create_time
-    except Exception:
-        log.exception("Adding column 'create_time' to `cloudauthz` table failed.")
-
-    try:
-        deleted_column.create(cloudauthz_table)
-        assert deleted_column is cloudauthz_table.c.deleted
-    except Exception:
-        log.exception("Adding column 'deleted' to `cloudauthz` table failed.")
+    deleted_column = Column('deleted', Boolean)
+    add_column(deleted_column, cloudauthz_table)
 
 
 def downgrade(migrate_engine):
-    metadata = MetaData()
     metadata.bind = migrate_engine
     metadata.reflect()
 
     cloudauthz_table = Table("cloudauthz", metadata, autoload=True)
-
-    try:
-        column = cloudauthz_table.c.create_time
-        column.drop()
-    except Exception:
-        log.exception("Dropping 'create_time' column from `cloudauthz` table failed.")
-
-    try:
-        column = cloudauthz_table.c.deleted
-        column.drop()
-    except Exception:
-        log.exception("Dropping 'deleted' column from `cloudauthz` table failed.")
+    # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
+    if migrate_engine.name != 'sqlite':
+        drop_column('deleted', cloudauthz_table)
+    drop_column('create_time', cloudauthz_table)

--- a/lib/galaxy/model/migrate/versions/util.py
+++ b/lib/galaxy/model/migrate/versions/util.py
@@ -1,0 +1,109 @@
+import logging
+
+from sqlalchemy import Table
+
+log = logging.getLogger(__name__)
+
+
+def engine_false(migrate_engine):
+    if migrate_engine.name in ['postgres', 'postgresql']:
+        return "FALSE"
+    elif migrate_engine.name in ['mysql', 'sqlite']:
+        return 0
+    else:
+        raise Exception('Unknown database type: %s' % migrate_engine.name)
+
+
+def engine_true(migrate_engine):
+    if migrate_engine.name in ['postgres', 'postgresql']:
+        return "TRUE"
+    elif migrate_engine.name in ['mysql', 'sqlite']:
+        return 1
+    else:
+        raise Exception('Unknown database type: %s' % migrate_engine.name)
+
+
+def nextval(migrate_engine, table, col='id'):
+    if migrate_engine.name in ['postgres', 'postgresql']:
+        return "nextval('%s_%s_seq')" % (table, col)
+    elif migrate_engine.name in ['mysql', 'sqlite']:
+        return "null"
+    else:
+        raise Exception('Unable to convert data for unknown database type: %s' % migrate_engine.name)
+
+
+def localtimestamp(migrate_engine):
+    if migrate_engine.name in ['mysql', 'postgres', 'postgresql']:
+        return "LOCALTIMESTAMP"
+    elif migrate_engine.name == 'sqlite':
+        return "current_date || ' ' || current_time"
+    else:
+        raise Exception('Unable to convert data for unknown database type: %s' % migrate_engine.name)
+
+
+def create_table(table):
+    try:
+        table.create()
+    except Exception:
+        log.exception("Creating table '%s' failed.", table)
+
+
+def drop_table(table):
+    try:
+        table.drop()
+    except Exception:
+        log.exception("Dropping table '%s' failed.", table)
+
+
+def add_column(column, table, metadata=None, **kwds):
+    """
+    :param table: Table to add the column to
+    :type table: :class:`Table` or str
+
+    :param metadata: Needed only if ``table`` is a table name
+    :type metadata: :class:`Metadata`
+    """
+    try:
+        if not isinstance(table, Table):
+            assert metadata is not None
+            table = Table(table, metadata, autoload=True)
+        column.create(table, **kwds)
+        assert column is getattr(table.c, column.name)
+    except Exception:
+        log.exception("Adding column '%s' to table '%s' failed.", column, table)
+
+
+def alter_column(column_name, table, metadata=None, **kwds):
+    """
+    :param table: Table to drop the column from
+    :type table: :class:`Table` or str
+
+    :param metadata: Needed only if ``table`` is a table name
+    :type metadata: :class:`Metadata`
+    """
+    try:
+        if not isinstance(table, Table):
+            assert metadata is not None
+            table = Table(table, metadata, autoload=True)
+        column = getattr(table.c, column_name)
+        column.alter(**kwds)
+    except Exception:
+        log.exception("Modifying column '%s' of table '%s' failed.", column_name, table)
+
+
+def drop_column(column_name, table, metadata=None):
+    """
+    :param table: Table to drop the column from
+    :type table: :class:`Table` or str
+
+    :param metadata: Needed only if ``table`` is a table name
+    :type metadata: :class:`Metadata`
+    """
+    try:
+        if not isinstance(table, Table):
+            assert metadata is not None
+            table = Table(table, metadata, autoload=True)
+        column = getattr(table.c, column_name)
+        column.drop()
+    except Exception:
+        log.exception("Dropping column '%s' from table '%s' failed.", column_name, table)


### PR DESCRIPTION
Put common code in `lib/galaxy/model/migrate/versions/util.py` .
The refactoring is still incomplete, but already results in 600 less lines
of code.