### PR TITLE
Add tool directory to dynamic_options global namespace

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -820,6 +820,8 @@ class SelectToolParameter(ToolParameter):
             return self.options.get_options(trans, other_values)
         elif self.dynamic_options:
             call_other_values = self._get_dynamic_options_call_other_values(trans, other_values)
+            # add __tool_directory__ to dynamic options global namespace
+            self.tool.code_namespace['__tool_directory__'] = self.tool.tool_dir
             try:
                 return eval(self.dynamic_options, self.tool.code_namespace, call_other_values)
             except Exception as e:


### PR DESCRIPTION
Maybe this is not good idea.
Basically, I want to the `code` tag file able to access the tool directory. Because of the current implementation of `code` file , it seems impossible to take advantage of the `__file__` attribute from inside of the `code` file. In the other hand, it's also not easy to pass the `__tool_directory__` to dynamic_options as an argument in tool wrapper. Instead, this PR pushes the `__tool_directory__` to the global namespace. Then `code` function can directly call the variable without passing it as an argument.
If there is a better solution, please let me know. 
Thanks. 