### PR TITLE
Don't unhide mapped-over outputs when job fails

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1296,6 +1296,7 @@ class JobWrapper(HasResourceParameters):
                         return self.fail("Job %s's output dataset(s) could not be read" % job.id)
 
         job_context = ExpressionContext(dict(stdout=job.stdout, stderr=job.stderr))
+        implicit_collection_jobs = job.implicit_collection_jobs_association
         for dataset_assoc in job.output_datasets + job.output_library_datasets:
             context = self.get_dataset_finish_context(job_context, dataset_assoc)
             # should this also be checking library associations? - can a library item be added from a history before the job has ended? -
@@ -1345,7 +1346,9 @@ class JobWrapper(HasResourceParameters):
                         log.warning('Unable to generate primary composite file automatically for %s: %s', dataset.dataset.id, e)
                 if job.states.ERROR == final_job_state:
                     dataset.blurb = "error"
-                    dataset.mark_unhidden()
+                    if not implicit_collection_jobs:
+                        # Only unhide dataset outputs that are not part of a implicit collection
+                        dataset.mark_unhidden()
                 elif not purged:
                     # If the tool was expected to set the extension, attempt to retrieve it
                     if dataset.ext == 'auto':

--- a/test/api/test_jobs.py
+++ b/test/api/test_jobs.py
@@ -147,6 +147,49 @@ class JobsApiTestCase(api.ApiTestCase):
         show_jobs_response = self._get("jobs/%s" % job_id, admin=True)
         self._assert_has_keys(show_jobs_response.json(), "command_line", "external_id")
 
+    def _run_detect_errors(self, history_id, inputs):
+        payload = self.dataset_populator.run_tool_payload(
+            tool_id='detect_errors_aggressive',
+            inputs=inputs,
+            history_id=history_id,
+        )
+        return self._post("tools", data=payload).json()
+
+    @skip_without_tool("detect_errors_aggressive")
+    def test_unhide_on_error(self):
+        with self.dataset_populator.test_history() as history_id:
+            inputs = {'error_bool': 'true'}
+            run_response = self._run_detect_errors(history_id=history_id, inputs=inputs)
+            job_id = run_response['jobs'][0]["id"]
+            self.dataset_populator.wait_for_job(job_id)
+            job = self.dataset_populator.get_job_details(job_id).json()
+            assert job['state'] == 'error'
+            dataset = self.dataset_populator.get_history_dataset_details(history_id=history_id,
+                                                                         dataset_id=run_response['outputs'][0]['id'],
+                                                                         assert_ok=False)
+            assert dataset['visible']
+
+    @skip_without_tool("detect_errors_aggressive")
+    def test_no_unhide_on_error_if_mapped_over(self):
+        with self.dataset_populator.test_history() as history_id:
+            hdca1 = self.dataset_collection_populator.create_list_in_history(history_id, contents=[("sample1-1", "1 2 3")]).json()
+            inputs = {
+                'error_bool': 'true',
+                'dataset': {
+                    'batch': True,
+                    'values': [{'src': 'hdca', 'id': hdca1['id']}],
+                }
+            }
+            run_response = self._run_detect_errors(history_id=history_id, inputs=inputs)
+            job_id = run_response['jobs'][0]["id"]
+            self.dataset_populator.wait_for_job(job_id)
+            job = self.dataset_populator.get_job_details(job_id).json()
+            assert job['state'] == 'error'
+            dataset = self.dataset_populator.get_history_dataset_details(history_id=history_id,
+                                                                         dataset_id=run_response['outputs'][0]['id'],
+                                                                         assert_ok=False)
+            assert not dataset['visible']
+
     @skip_without_tool('detect_errors_aggressive')
     def test_report_error(self):
         with self.dataset_populator.test_history() as history_id:

--- a/test/functional/tools/detect_errors_aggressive.xml
+++ b/test/functional/tools/detect_errors_aggressive.xml
@@ -11,6 +11,7 @@
 
     </command>
     <inputs>
+        <param name="dataset" type="data" optional="true"/>
         <param name="error_bool" type="boolean" label="error bool" />
         <param name="exception_bool" type="boolean" label="exception bool" checked="false" />
         <param name="exit_code" type="integer" value="0" label="exit code"/>


### PR DESCRIPTION
The parent dataset collection now shows the failed datasets,
and that is much easier to deal with when all jobs within
a large collection have failed.
Fixes https://github.com/galaxyproject/galaxy/issues/7492

One downside here is that we don't see anything in the history right
away (except for the failed dataset count) if a hidden collection
contains failed datasets.