### PR TITLE
Delete cloudauthz record from database instead of marking it as deleted

### DIFF
--- a/lib/galaxy/managers/cloudauthzs.py
+++ b/lib/galaxy/managers/cloudauthzs.py
@@ -6,13 +6,12 @@ import logging
 
 from galaxy import model
 from galaxy.managers import base
-from galaxy.managers import deletable
 from galaxy.managers import sharable
 
 log = logging.getLogger(__name__)
 
 
-class CloudAuthzManager(sharable.SharableModelManager, deletable.PurgableManagerMixin):
+class CloudAuthzManager(sharable.SharableModelManager):
 
     model_class = model.CloudAuthz
     foreign_key_name = 'cloudauthz'
@@ -21,7 +20,7 @@ class CloudAuthzManager(sharable.SharableModelManager, deletable.PurgableManager
         super(CloudAuthzManager, self).__init__(app, *args, **kwargs)
 
 
-class CloudAuthzsSerializer(base.ModelSerializer, deletable.PurgableSerializerMixin):
+class CloudAuthzsSerializer(base.ModelSerializer):
     """
     Interface/service object for serializing cloud authorizations (cloudauthzs) into dictionaries.
     """
@@ -41,13 +40,11 @@ class CloudAuthzsSerializer(base.ModelSerializer, deletable.PurgableSerializerMi
             'authn_id',
             'last_update',
             'last_activity',
-            'create_time',
-            'deleted'
+            'create_time'
         ])
 
     def add_serializers(self):
         super(CloudAuthzsSerializer, self).add_serializers()
-        deletable.PurgableSerializerMixin.add_serializers(self)
 
         # Arguments of the following lambda functions:
         # i  : an instance of galaxy.model.CloudAuthz.
@@ -62,6 +59,5 @@ class CloudAuthzsSerializer(base.ModelSerializer, deletable.PurgableSerializerMi
             'authn_id'     : lambda i, k, **c: self.app.security.encode_id(i.authn_id),
             'last_update'  : lambda i, k, **c: str(i.last_update),
             'last_activity': lambda i, k, **c: str(i.last_activity),
-            'create_time'  : lambda i, k, **c: str(i.create_time),
-            'deleted'      : lambda i, k, **c: str(i.deleted)
+            'create_time'  : lambda i, k, **c: str(i.create_time)
         })

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -134,8 +134,7 @@ model.CloudAuthz.table = Table(
     Column('last_update', DateTime),
     Column('last_activity', DateTime),
     Column('description', TEXT),
-    Column('create_time', DateTime, default=now),
-    Column('deleted', Boolean, default=False))
+    Column('create_time', DateTime, default=now))
 
 model.PasswordResetToken.table = Table(
     "password_reset_token", metadata,

--- a/lib/galaxy/model/migrate/versions/0150_add_create_time_field_for_cloudauthz.py
+++ b/lib/galaxy/model/migrate/versions/0150_add_create_time_field_for_cloudauthz.py
@@ -1,5 +1,5 @@
 """
-Adds `deleted` and `create_time` columns to cloudauthz table.
+Adds `create_time` columns to cloudauthz table.
 """
 
 from __future__ import print_function
@@ -23,16 +23,10 @@ def upgrade(migrate_engine):
     create_time_column = Column('create_time', DateTime)
     add_column(create_time_column, cloudauthz_table)
 
-    deleted_column = Column('deleted', Boolean)
-    add_column(deleted_column, cloudauthz_table)
-
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
     cloudauthz_table = Table("cloudauthz", metadata, autoload=True)
-    # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
-    if migrate_engine.name != 'sqlite':
-        drop_column('deleted', cloudauthz_table)
     drop_column('create_time', cloudauthz_table)

--- a/lib/galaxy/model/migrate/versions/0150_add_create_time_field_for_cloudauthz.py
+++ b/lib/galaxy/model/migrate/versions/0150_add_create_time_field_for_cloudauthz.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Boolean, Column, DateTime, MetaData, Table
+from sqlalchemy import Column, DateTime, MetaData, Table
 
 from galaxy.model.migrate.versions.util import add_column, drop_column
 

--- a/lib/galaxy/webapps/galaxy/api/cloudauthz.py
+++ b/lib/galaxy/webapps/galaxy/api/cloudauthz.py
@@ -172,7 +172,8 @@ class CloudAuthzController(BaseAPIController):
 
         try:
             cloudauthz = trans.app.authnz_manager.try_get_authz_config(trans.sa_session, trans.user.id, authz_id)
-            self.cloudauthz_manager.delete(cloudauthz)
+            trans.sa_session.delete(cloudauthz)
+            trans.sa_session.flush()
             log.debug('Deleted a cloudauthz record with id `{}` for the user id `{}` '.format(authz_id, str(trans.user.id)))
             view = self.cloudauthz_serializer.serialize_to_view(cloudauthz, trans=trans, **self._parse_serialization_params(kwargs, 'summary'))
             trans.response.status = '200'

--- a/lib/galaxy/webapps/galaxy/api/cloudauthz.py
+++ b/lib/galaxy/webapps/galaxy/api/cloudauthz.py
@@ -151,10 +151,7 @@ class CloudAuthzController(BaseAPIController):
     def delete(self, trans, encoded_authz_id, **kwargs):
         """
         * DELETE /api/cloud/authz/{encoded_authz_id}
-            Marks the CloudAuthz record with the given ``encoded_authz_id`` as deleted.
-            This API does NOT remove the specified CloudAuthz record from Galaxy's database,
-            instead it will just set its deleted attribute to True, making it inaccessible to
-            cloud APIs and managers leveraging user's CloudAuthz records.
+            Deletes the CloudAuthz record with the given ``encoded_authz_id`` from database.
 
         :type  trans: galaxy.web.framework.webapp.GalaxyWebTransaction
         :param trans: Galaxy web transaction


### PR DESCRIPTION
@martenson can we modify this migration script? I guess no newer script exists, and previous script was not included in 19.01 release. 