### PR TITLE
Continue gracefully in set_meta if unable to count number of dataset lines.

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -802,10 +802,13 @@ class Text(Data):
         """
         data_lines = 0
         with compression_utils.get_fileobj(dataset.file_name) as in_file:
-            for line in in_file:
-                line = line.strip()
-                if line and not line.startswith('#'):
-                    data_lines += 1
+            try:
+                for line in in_file:
+                    line = line.strip()
+                    if line and not line.startswith('#'):
+                        data_lines += 1
+            except Exception:
+                pass
         return data_lines
 
     def set_peek(self, dataset, line_count=None, is_multi_byte=False, WIDTH=256, skipchars=None, line_wrap=True):

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -802,6 +802,9 @@ class Text(Data):
         """
         data_lines = 0
         with compression_utils.get_fileobj(dataset.file_name) as in_file:
+            # FIXME: Potential encoding issue can prevent the ability to iterate over lines
+            # causing set_meta process to fail otherwise OK jobs. A better solution than
+            # a silent try/except is desirable.
             try:
                 for line in in_file:
                     line = line.strip()


### PR DESCRIPTION
Possibly caused by datatype inconsistency (e.g. binary set as text), which is corrected elsewhere, but would cause otherwise unnecessary job failure here. 