### PR TITLE
[19.01] Fix incorrect lddas being used as collection members

### DIFF
--- a/client/galaxy/scripts/mvc/library/library-foldertoolbar-view.js
+++ b/client/galaxy/scripts/mvc/library/library-foldertoolbar-view.js
@@ -1310,6 +1310,11 @@ var FolderToolbarView = Backbone.View.extend({
         this.collectionType = collectionType;
     },
 
+    /**
+     * Note: The collection creation process expects ldda_ids as ids
+     * in the collection_elements array but we operate on ld_ids in libraries.
+     * The code below overwrites the id with ldda_id for this reason.
+     */
     showColectionBuilder: function(checked_items) {
         let Galaxy = getGalaxyInstance();
         let collection_elements = [];
@@ -1318,16 +1323,18 @@ var FolderToolbarView = Backbone.View.extend({
             for (let i = checked_items.length - 1; i >= 0; i--) {
                 let collection_item = {};
                 let dataset = Galaxy.libraries.folderListView.folder_container.get("folder").get(checked_items[i]);
-                collection_item.id = checked_items[i];
+                collection_item.id = dataset.get("ldda_id");
                 collection_item.name = dataset.get("name");
                 collection_item.deleted = dataset.get("deleted");
                 collection_item.state = dataset.get("state");
                 collection_elements.push(collection_item);
             }
         } else if (elements_source === "folder") {
-            collection_elements = new Backbone.Collection(
-                Galaxy.libraries.folderListView.folder_container.get("folder").where({ type: "file" })
-            ).toJSON();
+            let all_datasets = Galaxy.libraries.folderListView.folder_container.get("folder").where({ type: "file" })
+            collection_elements = new Backbone.Collection(all_datasets).toJSON();
+            for (var i = collection_elements.length - 1; i >= 0; i--) {
+                collection_elements[i].id = collection_elements[i].ldda_id;
+            }
         }
         let new_history_name = this.modal.$("input[name=history_name]").val();
         if (new_history_name !== "") {

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -109,14 +109,15 @@ class FolderContentsController(BaseAPIController, UsesLibraryMixin, UsesLibraryM
                 nice_size = util.nice_size(int(content_item.library_dataset_dataset_association.get_size()))
 
                 library_dataset_dict = content_item.to_dict()
-
+                encoded_ldda_id = trans.security.encode_id(content_item.library_dataset_dataset_association.id)
                 return_item.update(dict(file_ext=library_dataset_dict['file_ext'],
                                         date_uploaded=library_dataset_dict['date_uploaded'],
                                         is_unrestricted=is_unrestricted,
                                         is_private=is_private,
                                         can_manage=can_manage,
                                         state=library_dataset_dict['state'],
-                                        file_size=nice_size))
+                                        file_size=nice_size,
+                                        ldda_id=encoded_ldda_id))
                 if content_item.library_dataset_dataset_association.message:
                     return_item.update(dict(message=content_item.library_dataset_dataset_association.message))
 


### PR DESCRIPTION
Adjust library folder api to return ldda_id on ld items
and use it for the obect passed to colelction creater
instead of the ld_id.

This bug would only materialize if you have Galaxy isntance that
has a library dataset with multiple versions. Which is the reason why
it eluded us for some time. That and missing tests.