### PR TITLE
Fix composite data and metadata file handling for UUID object stores

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -372,7 +372,9 @@ class Data(object):
             return smart_str(data)
         if filename and filename != "index":
             # For files in extra_files_path
-            file_path = trans.app.object_store.get_filename(data.dataset, extra_dir='dataset_%s_files' % data.dataset.id, alt_name=filename)
+            store_by = data.dataset.object_store.store_by
+            extra_dir = 'dataset_%s_files' % getattr(data.dataset, store_by)
+            file_path = trans.app.object_store.get_filename(data.dataset, extra_dir=extra_dir, alt_name=filename)
             if os.path.exists(file_path):
                 if os.path.isdir(file_path):
                     with tempfile.NamedTemporaryFile(mode='w', delete=False, dir=trans.app.config.new_file_path, prefix='gx_html_autocreate_') as tmp_fh:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1522,7 +1522,10 @@ class JobWrapper(HasResourceParameters):
             log.exception("Unable to cleanup job %d", self.job_id)
 
     def _collect_extra_files(self, dataset, job_working_directory):
-        temp_file_path = os.path.join(job_working_directory, "dataset_%s_files" % (dataset.id))
+        object_store = self.app.object_store
+        store_by = getattr(object_store, "store_by", "id")
+        file_name = "dataset_%s_files" % getattr(dataset, store_by)
+        temp_file_path = os.path.join(job_working_directory, file_name)
         extra_dir = None
         try:
             # This skips creation of directories - object store

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -133,6 +133,7 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
             "datatypes_config": datatypes_config,
             "max_metadata_value_size": max_metadata_value_size,
             "outputs": outputs,
+            "object_store_store_by": galaxy.model.Dataset.object_store.store_by,
         }
         with open(metadata_params_path, "w") as f:
             json.dump(metadata_params, f)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1966,8 +1966,12 @@ class DefaultHistoryPermissions(RepresentById):
 
 class StorableObject(object):
 
-    def __init__(self, id, **kwargs):
+    def __init__(self, id, uuid):
         self.id = id
+        if uuid is None:
+            self.uuid = uuid4()
+        else:
+            self.uuid = UUID(str(uuid))
 
 
 class Dataset(StorableObject, RepresentById):
@@ -2018,7 +2022,7 @@ class Dataset(StorableObject, RepresentById):
     engine = None
 
     def __init__(self, id=None, state=None, external_filename=None, extra_files_path=None, file_size=None, purgable=True, uuid=None):
-        super(Dataset, self).__init__(id=id)
+        super(Dataset, self).__init__(id=id, uuid=uuid)
         self.state = state
         self.deleted = False
         self.purged = False
@@ -2029,10 +2033,6 @@ class Dataset(StorableObject, RepresentById):
         self.file_size = file_size
         self.sources = []
         self.hashes = []
-        if uuid is None:
-            self.uuid = uuid4()
-        else:
-            self.uuid = UUID(str(uuid))
 
     def in_ready_state(self):
         return self.state in self.ready_states
@@ -4815,8 +4815,8 @@ class WorkflowInvocationStepOutputDatasetCollectionAssociation(Dictifiable, Repr
 
 class MetadataFile(StorableObject, RepresentById):
 
-    def __init__(self, dataset=None, name=None):
-        super(MetadataFile, self).__init__(id=None)
+    def __init__(self, dataset=None, name=None, uuid=None):
+        super(MetadataFile, self).__init__(id=None, uuid=uuid)
         if isinstance(dataset, HistoryDatasetAssociation):
             self.history_dataset = dataset
         elif isinstance(dataset, LibraryDatasetDatasetAssociation):
@@ -4825,17 +4825,21 @@ class MetadataFile(StorableObject, RepresentById):
 
     @property
     def file_name(self):
-        assert self.id is not None, "ID must be set before filename used (commit the object)"
         # Ensure the directory structure and the metadata file object exist
         try:
             da = self.history_dataset or self.library_dataset
             if self.object_store_id is None and da is not None:
                 self.object_store_id = da.dataset.object_store_id
-            if not da.dataset.object_store.exists(self, extra_dir='_metadata_files', extra_dir_at_root=True, alt_name="metadata_%d.dat" % self.id):
-                da.dataset.object_store.create(self, extra_dir='_metadata_files', extra_dir_at_root=True, alt_name="metadata_%d.dat" % self.id)
-            path = da.dataset.object_store.get_filename(self, extra_dir='_metadata_files', extra_dir_at_root=True, alt_name="metadata_%d.dat" % self.id)
+            object_store = da.dataset.object_store
+            store_by = object_store.store_by
+            identifier = getattr(self, store_by)
+            alt_name = "metadata_%s.dat" % identifier
+            if not object_store.exists(self, extra_dir='_metadata_files', extra_dir_at_root=True, alt_name=alt_name):
+                object_store.create(self, extra_dir='_metadata_files', extra_dir_at_root=True, alt_name=alt_name)
+            path = object_store.get_filename(self, extra_dir='_metadata_files', extra_dir_at_root=True, alt_name=alt_name)
             return path
         except AttributeError:
+            assert self.id is not None, "ID must be set before MetadataFile used without an HDA/LDDA (commit the object)"
             # In case we're not working with the history_dataset
             path = os.path.join(Dataset.file_path, '_metadata_files', *directory_hash_id(self.id))
             # Create directory if it does not exist

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1123,6 +1123,7 @@ model.MetadataFile.table = Table(
     Column("create_time", DateTime, default=now),
     Column("update_time", DateTime, index=True, default=now, onupdate=now),
     Column("object_store_id", TrimmedString(255), index=True),
+    Column("uuid", UUIDType(), index=True),
     Column("deleted", Boolean, index=True, default=False),
     Column("purged", Boolean, index=True, default=False))
 

--- a/lib/galaxy/model/migrate/versions/0149_dynamic_tools.py
+++ b/lib/galaxy/model/migrate/versions/0149_dynamic_tools.py
@@ -13,10 +13,6 @@ now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
-now = datetime.datetime.utcnow
-log = logging.getLogger(__name__)
-metadata = MetaData()
-
 
 DynamicTool_table = Table(
     "dynamic_tool", metadata,

--- a/lib/galaxy/model/migrate/versions/0152_add_metadata_file_uuid.py
+++ b/lib/galaxy/model/migrate/versions/0152_add_metadata_file_uuid.py
@@ -1,0 +1,43 @@
+"""
+Adds `uuid` column to MetadataFile table.
+"""
+
+from __future__ import print_function
+
+import logging
+
+from sqlalchemy import Column, MetaData, Table
+
+from galaxy.model.custom_types import UUIDType
+
+log = logging.getLogger(__name__)
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata = MetaData()
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    metadata_file_table = Table("metadata_file", metadata, autoload=True)
+
+    try:
+        uuid_column = Column('uuid', UUIDType())
+        uuid_column.create(metadata_file_table)
+        assert uuid_column is metadata_file_table.c.uuid
+    except Exception:
+        log.exception("Adding column 'uuid' to `MetadataFile` table failed.")
+
+
+def downgrade(migrate_engine):
+    metadata = MetaData()
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    metadata_file_table = Table("metadata_file", metadata, autoload=True)
+
+    try:
+        column = metadata_file_table.c.uuid
+        column.drop()
+    except Exception:
+        log.exception("Dropping 'uuid' column from `metadata_file` table failed.")

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -237,7 +237,12 @@ class ObjectStore(object):
         }
 
     def _get_object_id(self, obj):
-        return getattr(obj, self.store_by)
+        if hasattr(obj, self.store_by):
+            return getattr(obj, self.store_by)
+        else:
+            # job's don't have uuids, so always use ID in this case when creating
+            # job working directories.
+            return obj.id
 
 
 class DiskObjectStore(ObjectStore):

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -351,7 +351,9 @@ class ToolEvaluator(object):
                 param_dict[name] = DatasetFilenameWrapper(hda)
             # Provide access to a path to store additional files
             # TODO: path munging for cluster/dataset server relocatability
-            param_dict[name].files_path = os.path.abspath(os.path.join(job_working_directory, "dataset_%s_files" % (hda.dataset.id)))
+            store_by = getattr(hda.dataset.object_store, "store_by", "id")
+            file_name = "dataset_%s_files" % getattr(hda.dataset, store_by)
+            param_dict[name].files_path = os.path.abspath(os.path.join(job_working_directory, file_name))
         for out_name, output in self.tool.outputs.items():
             if out_name not in param_dict and output.filters:
                 # Assume the reason we lack this output is because a filter

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -345,9 +345,12 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
 
             if raw:
                 if filename and filename != 'index':
-                    file_path = trans.app.object_store.get_filename(hda.dataset,
-                                                                    extra_dir=('dataset_%s_files' % hda.dataset.id),
-                                                                    alt_name=filename)
+                    object_store = trans.app.object_store
+                    store_by = getattr(object_store, "store_by", "id")
+                    dir_name = 'dataset_%s_files' % getattr(hda.dataset, store_by)
+                    file_path = object_store.get_filename(hda.dataset,
+                                                          extra_dir=dir_name,
+                                                          alt_name=filename)
                 else:
                     file_path = hda.file_name
                 rval = open(file_path, 'rb')

--- a/lib/galaxy_ext/metadata/set_metadata.py
+++ b/lib/galaxy_ext/metadata/set_metadata.py
@@ -109,7 +109,9 @@ def set_metadata_portable():
         try:
             dataset = cPickle.load(open(filename_in, 'rb'))  # load DatasetInstance
             dataset.dataset.external_filename = dataset_filename_override
-            files_path = os.path.abspath(os.path.join(tool_job_working_directory, "dataset_%s_files" % (dataset.dataset.id)))
+            store_by = metadata_params.get("object_store_store_by", "id")
+            extra_files_dir_name = "dataset_%s_files" % getattr(dataset.dataset, store_by)
+            files_path = os.path.abspath(os.path.join(tool_job_working_directory, extra_files_dir_name))
             dataset.dataset.external_extra_files_path = files_path
             file_dict = tool_provided_metadata.get_dataset_meta(output_name, dataset.dataset.id)
             if 'ext' in file_dict:

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -235,6 +235,7 @@ def setup_galaxy_config(
         webhooks_dir=TEST_WEBHOOKS_DIR,
         logging=LOGGING_CONFIG_DEFAULT,
         monitor_thread_join_timeout=5,
+        object_store_store_by="uuid",
     )
     config.update(database_conf(tmpdir, prefer_template_database=prefer_template_database))
     config.update(install_database_conf(tmpdir, default_merged=default_install_db_merged))


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/7154 added the ability to store objects in an object store by UUID. This was needed for working with "discovered" datasets in the context of remote workers writing to the object store. In that case, these objects will not have an ID yet and no database should assume to be present, so the remote code would have no way of knowing where to store the data if keyed on ID. UUIDs offer a mechanism to let the remote code decide where to put the data.

#7154 enabled some very simple tests to pass on the remote data and execution branch (#7058), but running the full suite of tool framework tests - it became quickly apparent composite and metadata files need to be handled also.
