### PR TITLE
Implement functional dict-ifiable tool outputs and error detection.

### DIFF
--- a/lib/galaxy/tools/parser/interface.py
+++ b/lib/galaxy/tools/parser/interface.py
@@ -343,12 +343,23 @@ class ToolStdioRegex(object):
     attribute that contains "warning" or "fatal".
     """
 
-    def __init__(self):
-        self.match = ""
-        self.stdout_match = False
-        self.stderr_match = False
-        self.error_level = StdioErrorLevel.FATAL
-        self.desc = ""
+    def __init__(self, as_dict=None):
+        as_dict = as_dict or {}
+        self.match = as_dict.get("match", "")
+        self.stdout_match = as_dict.get("stdout_match", False)
+        self.stderr_match = as_dict.get("stderr_match", False)
+        self.error_level = as_dict.get("error_level", StdioErrorLevel.FATAL)
+        self.desc = as_dict.get("desc", "")
+
+    def to_dict(self):
+        return {
+            "class": "ToolStdioRegex",
+            "match": self.match,
+            "stdout_match": self.stdout_match,
+            "stderr_match": self.stderr_match,
+            "error_level": self.error_level,
+            "desc": self.desc,
+        }
 
 
 class ToolStdioExitCode(object):
@@ -357,11 +368,21 @@ class ToolStdioExitCode(object):
     The exit_code element has a range of exit codes and the error level.
     """
 
-    def __init__(self):
-        self.range_start = float("-inf")
-        self.range_end = float("inf")
-        self.error_level = StdioErrorLevel.FATAL
-        self.desc = ""
+    def __init__(self, as_dict=None):
+        as_dict = as_dict or {}
+        self.range_start = as_dict.get("range_start", float("-inf"))
+        self.range_end = as_dict.get("range_end", float("inf"))
+        self.error_level = as_dict.get("error_level", StdioErrorLevel.FATAL)
+        self.desc = as_dict.get("desc", "")
+
+    def to_dict(self):
+        return {
+            "class": "ToolStdioExitCode",
+            "range_start": self.range_start,
+            "range_end": self.range_end,
+            "error_level": self.error_level,
+            "desc": self.desc,
+        }
 
 
 class TestCollectionDef(object):

--- a/lib/galaxy/tools/parser/output_collection_def.py
+++ b/lib/galaxy/tools/parser/output_collection_def.py
@@ -58,7 +58,9 @@ def dataset_collector_descriptions_from_list(discover_datasets_dicts):
 
 
 def dataset_collection_description(**kwargs):
-    if asbool(kwargs.get("from_provided_metadata", False)):
+    from_provided_metadata = asbool(kwargs.get("from_provided_metadata", False))
+    discover_via = kwargs.get("discover_via", "tool_provided_metadata" if from_provided_metadata else "pattern")
+    if discover_via == "tool_provided_metadata":
         for key in ["pattern", "sort_by"]:
             if kwargs.get(key):
                 raise Exception("Cannot specify attribute [%s] if from_provided_metadata is True" % key)
@@ -78,6 +80,17 @@ class DatasetCollectionDescription(object):
         self.assign_primary_output = asbool(kwargs.get('assign_primary_output', False))
         self.directory = kwargs.get("directory", None)
         self.recurse = False
+
+    def to_dict(self):
+        return {
+            'discover_via': self.discover_via,
+            'dbkey': self.default_dbkey,
+            'format': self.default_ext,
+            'visible': self.default_visible,
+            'assign_primary_output': self.assign_primary_output,
+            'directory': self.directory,
+            'recurse': self.recurse,
+        }
 
 
 class ToolProvidedMetadataDatasetCollection(DatasetCollectionDescription):
@@ -115,6 +128,16 @@ class FilePatternDatasetCollectionDescription(DatasetCollectionDescription):
         ]
         self.sort_key = sort_by
         self.sort_comp = sort_comp
+
+    def to_dict(self):
+        as_dict = super(FilePatternDatasetCollectionDescription, self).to_dict()
+        as_dict.update({
+            "sort_key": self.sort_key,
+            "sort_comp": self.sort_comp,
+            "pattern": self.pattern,
+            "recurse": self.recurse,
+        })
+        return as_dict
 
 
 DEFAULT_DATASET_COLLECTOR_DESCRIPTION = FilePatternDatasetCollectionDescription(

--- a/lib/galaxy/tools/parser/output_objects.py
+++ b/lib/galaxy/tools/parser/output_objects.py
@@ -283,7 +283,7 @@ class ToolOutputCollectionStructure(object):
             'collection_type_source': self.collection_type_source,
             'collection_type_from_rules': self.collection_type_from_rules,
             'structured_like': self.structured_like,
-            'discover_datasets': list(map(lambda d: d.to_dict(), self.dataset_collector_descriptions)),
+            'discover_datasets': [d.to_dict() for d in self.dataset_collector_descriptions],
         }
 
     @staticmethod

--- a/lib/galaxy/tools/parser/output_objects.py
+++ b/lib/galaxy/tools/parser/output_objects.py
@@ -1,5 +1,7 @@
 from galaxy.util.dictifiable import Dictifiable
 from galaxy.util.odict import odict
+from .output_actions import ToolOutputActionGroup
+from .output_collection_def import dataset_collector_descriptions_from_output_dict
 
 
 class ToolOutputBase(Dictifiable):
@@ -24,7 +26,8 @@ class ToolOutput(ToolOutputBase):
       (format, metadata_source, parent)
     """
 
-    dict_collection_visible_keys = ['name', 'format', 'label', 'hidden', 'output_type']
+    dict_collection_visible_keys = ['name', 'format', 'label', 'hidden', 'output_type', 'format_source',
+                                    'default_identifier_source', 'metadata_source', 'parent', 'count', 'from_work_dir']
 
     def __init__(self, name, format=None, format_source=None, metadata_source=None,
                  parent=None, label=None, filters=None, actions=None, hidden=False,
@@ -68,7 +71,28 @@ class ToolOutput(ToolOutputBase):
             as_dict["edam_format"] = edam_format
             edam_data = app.datatypes_registry.edam_data.get(self.format)
             as_dict["edam_data"] = edam_data
+        as_dict['discover_datasets'] = list(map(lambda d: d.to_dict(), self.dataset_collector_descriptions))
         return as_dict
+
+    @staticmethod
+    def from_dict(name, output_dict, tool=None):
+        output = ToolOutput(name)
+        output.format = output_dict.get("format", "data")
+        output.change_format = []
+        output.format_source = output_dict.get("format_source", None)
+        output.default_identifier_source = output_dict.get("default_identifier_source", None)
+        output.metadata_source = output_dict.get("metadata_source", "")
+        output.parent = output_dict.get("parent", None)
+        output.label = output_dict.get("label", None)
+        output.count = output_dict.get("count", 1)
+        output.filters = []
+        output.tool = tool
+        output.from_work_dir = output_dict.get("from_work_dir", None)
+        output.hidden = output_dict.get("hidden", "")
+        # TODO: implement tool output action group fixes
+        output.actions = ToolOutputActionGroup(output, None)
+        output.dataset_collector_descriptions = dataset_collector_descriptions_from_output_dict(output_dict)
+        return output
 
 
 class ToolExpressionOutput(ToolOutputBase):
@@ -107,9 +131,8 @@ class ToolOutputCollection(ToolOutputBase):
       </collection>
     <outputs>
     """
-    dict_collection_visible_keys = ('name', 'format', 'label', 'hidden', 'output_type')
-
-    dict_collection_visible_keys = ['name', 'default_format', 'label', 'hidden', 'inherit_format', 'inherit_metadata']
+    dict_collection_visible_keys = ['name', 'format', 'label', 'hidden', 'output_type', 'default_format',
+                                    'default_format_source', 'default_metadata_source', 'inherit_format', 'inherit_metadata']
 
     def __init__(
         self,
@@ -197,6 +220,28 @@ class ToolOutputCollection(ToolOutputBase):
             raise Exception("dataset_collector_descriptions called for output collection with static structure")
         return self.structure.dataset_collector_descriptions
 
+    def to_dict(self, view='collection', value_mapper=None, app=None):
+        as_dict = super(ToolOutputCollection, self).to_dict(view=view, value_mapper=value_mapper, app=app)
+        as_dict['structure'] = self.structure.to_dict()
+        return as_dict
+
+    @staticmethod
+    def from_dict(name, output_dict, tool=None):
+        structure = ToolOutputCollectionStructure.from_dict(output_dict["structure"])
+        rval = ToolOutputCollection(
+            name,
+            structure=structure,
+            label=output_dict.get("label", None),
+            filters=None,
+            hidden=output_dict.get("hidden", False),
+            default_format=output_dict.get("default_format", "data"),
+            default_format_source=output_dict.get("default_format_source", None),
+            default_metadata_source=output_dict.get("default_metadata_source", None),
+            inherit_format=output_dict.get("inherit_format", False),
+            inherit_metadata=output_dict.get("inherit_metadata", False),
+        )
+        return rval
+
 
 class ToolOutputCollectionStructure(object):
 
@@ -212,14 +257,14 @@ class ToolOutputCollectionStructure(object):
         self.collection_type_source = collection_type_source
         self.collection_type_from_rules = collection_type_from_rules
         self.structured_like = structured_like
-        self.dataset_collector_descriptions = dataset_collector_descriptions
+        self.dataset_collector_descriptions = dataset_collector_descriptions or []
         if collection_type and collection_type_source:
             raise ValueError("Cannot set both type and type_source on collection output.")
         if collection_type is None and structured_like is None and dataset_collector_descriptions is None and collection_type_source is None and collection_type_from_rules is None:
             raise ValueError("Output collection types must specify source of collection type information (e.g. structured_like or type_source).")
         if dataset_collector_descriptions and (structured_like or collection_type_from_rules):
             raise ValueError("Cannot specify dynamic structure (discovered_datasets) and collection type attributes structured_like or collection_type_from_rules.")
-        self.dynamic = dataset_collector_descriptions is not None
+        self.dynamic = bool(dataset_collector_descriptions)
 
     def collection_prototype(self, inputs, type_registry):
         # either must have specified structured_like or something worse
@@ -231,6 +276,26 @@ class ToolOutputCollectionStructure(object):
             collection_prototype = type_registry.prototype(collection_type)
             collection_prototype.collection_type = collection_type
         return collection_prototype
+
+    def to_dict(self):
+        return {
+            'collection_type': self.collection_type,
+            'collection_type_source': self.collection_type_source,
+            'collection_type_from_rules': self.collection_type_from_rules,
+            'structured_like': self.structured_like,
+            'discover_datasets': list(map(lambda d: d.to_dict(), self.dataset_collector_descriptions)),
+        }
+
+    @staticmethod
+    def from_dict(as_dict):
+        structure = ToolOutputCollectionStructure(
+            collection_type=as_dict['collection_type'],
+            collection_type_source=as_dict['collection_type_source'],
+            collection_type_from_rules=as_dict['collection_type_from_rules'],
+            structured_like=as_dict['structured_like'],
+            dataset_collector_descriptions=dataset_collector_descriptions_from_output_dict(as_dict),
+        )
+        return structure
 
 
 class ToolOutputCollectionPart(object):

--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -4,7 +4,6 @@ from .interface import InputSource
 from .interface import PageSource
 from .interface import PagesSource
 from .interface import ToolSource
-from .output_actions import ToolOutputActionGroup
 from .output_collection_def import dataset_collector_descriptions_from_output_dict
 from .output_objects import (
     ToolOutput,
@@ -110,23 +109,7 @@ class YamlToolSource(ToolSource):
         return outputs, output_collections
 
     def _parse_output(self, tool, name, output_dict):
-        # TODO: handle filters, actions, change_format
-        output = ToolOutput(name)
-        output.format = output_dict.get("format", "data")
-        output.change_format = []
-        output.format_source = output_dict.get("format_source", None)
-        output.default_identifier_source = output_dict.get("default_identifier_source", None)
-        output.metadata_source = output_dict.get("metadata_source", "")
-        output.parent = output_dict.get("parent", None)
-        output.label = output_dict.get("label", None)
-        output.count = output_dict.get("count", 1)
-        output.filters = []
-        output.tool = tool
-        output.from_work_dir = output_dict.get("from_work_dir", None)
-        output.hidden = output_dict.get("hidden", "")
-        # TODO: implement tool output action group fixes
-        output.actions = ToolOutputActionGroup(output, None)
-        output.dataset_collector_descriptions = dataset_collector_descriptions_from_output_dict(output_dict)
+        output = ToolOutput.from_dict(name, output_dict, tool=tool)
         return output
 
     def _parse_output_collection(self, tool, name, output_dict):


### PR DESCRIPTION
These objects can be completely recovered from serialized representation now. This is needed downstream for projects#11 to serialize data needed for extended metadata collection on worker nodes.