### PR TITLE
Refactor IntegrationTestCase to allow integration test functions.

### DIFF
--- a/test/base/integration_util.py
+++ b/test/base/integration_util.py
@@ -7,6 +7,8 @@ tessting configuration.
 import os
 from unittest import skip, SkipTest, TestCase
 
+import pytest
+
 from galaxy.tools.deps.commands import which
 from galaxy.tools.verify.test_data import TestDataResolver
 from .api import UsesApiTestCaseMixin
@@ -37,7 +39,7 @@ def skip_unless_kubernetes():
     return skip_unless_executable("kubectl")
 
 
-class IntegrationTestCase(TestCase, UsesApiTestCaseMixin):
+class IntegrationInstance(UsesApiTestCaseMixin):
     """Unit test case with utilities for spinning up Galaxy."""
 
     prefer_template_database = True
@@ -119,3 +121,27 @@ class IntegrationTestCase(TestCase, UsesApiTestCaseMixin):
 
     def _run_tool_test(self, *args, **kwargs):
         return self._test_driver.run_tool_test(*args, **kwargs)
+
+
+class IntegrationTestCase(IntegrationInstance, TestCase):
+    """Unit TestCase with utilities for spinning up Galaxy."""
+
+
+def integration_module_instance(clazz):
+
+    def _instance():
+        instance = clazz()
+        instance.setUpClass()
+        instance.setUp()
+        yield instance
+        instance.tearDownClass()
+
+    return pytest.fixture(scope='module')(_instance)
+
+
+def integration_tool_runner(tool_ids):
+
+    def test_tools(instance, tool_id):
+        instance._run_tool_test(tool_id)
+
+    return pytest.mark.parametrize("tool_id", tool_ids)(test_tools)

--- a/test/integration/test_datatype_upload.py
+++ b/test/integration/test_datatype_upload.py
@@ -4,9 +4,10 @@ import tempfile
 
 import pytest
 
-from galaxy.datatypes.registry import Registry
+from base import integration_util  # noqa: I100,I202
+from galaxy.datatypes.registry import Registry  # noqa: I201
 from galaxy.util.hash_util import md5_hash_file
-from .test_upload_configuration_options import BaseUploadContentConfigurationTestCase
+from .test_upload_configuration_options import BaseUploadContentConfigurationInstance
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 TEST_FILE_DIR = '%s/../../lib/galaxy/datatypes/test' % SCRIPT_DIRECTORY
@@ -36,22 +37,12 @@ def collect_test_data():
     return {os.path.basename(data.path): data for data in test_data_description}
 
 
-class UploadTestDatatypeDataTestCase(BaseUploadContentConfigurationTestCase):
+class UploadTestDatatypeDataTestCase(BaseUploadContentConfigurationInstance):
     framework_tool_and_types = False
     datatypes_conf_override = DATATYPES_CONFIG
 
-    def runTest(self):
-        # we don't want to run the standard unittest tests when we setup UploadTestDatatypeDataTestCase
-        pass
 
-
-@pytest.fixture(scope='module')
-def instance():
-    instance = UploadTestDatatypeDataTestCase()
-    instance.setUpClass()
-    instance.setUp()
-    yield instance
-    instance.tearDownClass()
+instance = integration_util.integration_module_instance(UploadTestDatatypeDataTestCase)
 
 
 @pytest.fixture

--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -8,8 +8,8 @@ SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 EMBEDDED_PULSAR_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "embedded_pulsar_job_conf.xml")
 
 
-class EmbeddedPulsarIntegrationTestCase(integration_util.IntegrationTestCase):
-    """Start a Pulsar job."""
+class EmbeddedPulsarIntegrationInstance(integration_util.IntegrationInstance):
+    """Describe a Galaxy test instance with embedded pulsar configured."""
 
     framework_tool_and_types = True
 
@@ -17,11 +17,7 @@ class EmbeddedPulsarIntegrationTestCase(integration_util.IntegrationTestCase):
     def handle_galaxy_config_kwds(cls, config):
         config["job_config_file"] = EMBEDDED_PULSAR_JOB_CONFIG_FILE
 
-    def test_tool_simple_constructs(self):
-        self._run_tool_test("simple_constructs")
 
-    def test_multi_data_param(self):
-        self._run_tool_test("multi_data_param")
+instance = integration_util.integration_module_instance(EmbeddedPulsarIntegrationInstance)
 
-    def test_work_dir_outputs(self):
-        self._run_tool_test("output_filter")
+test_tools = integration_util.integration_tool_runner(["simple_constructs", "multi_data_param", "output_filter"])

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -24,6 +24,7 @@ import os
 import re
 import shutil
 import tempfile
+import unittest
 
 from base import integration_util
 from base.api_util import (
@@ -45,12 +46,12 @@ SCRIPT_DIR = os.path.normpath(os.path.dirname(__file__))
 TEST_DATA_DIRECTORY = os.path.join(SCRIPT_DIR, os.pardir, os.pardir, "test-data")
 
 
-class BaseUploadContentConfigurationTestCase(integration_util.IntegrationTestCase):
+class BaseUploadContentConfigurationInstance(integration_util.IntegrationInstance):
 
     framework_tool_and_types = True
 
     def setUp(self):
-        super(BaseUploadContentConfigurationTestCase, self).setUp()
+        super(BaseUploadContentConfigurationInstance, self).setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.library_populator = LibraryPopulator(self.galaxy_interactor)
         self.history_id = self.dataset_populator.new_history()
@@ -82,6 +83,10 @@ class BaseUploadContentConfigurationTestCase(integration_util.IntegrationTestCas
     def _ensure_directory(self, path):
         if not os.path.exists(path):
             os.makedirs(path)
+
+
+class BaseUploadContentConfigurationTestCase(BaseUploadContentConfigurationInstance, unittest.TestCase):
+    pass
 
 
 class InvalidFetchRequestsTestCase(BaseUploadContentConfigurationTestCase):


### PR DESCRIPTION
I like what @mvdbeek did with test_datatype_upload.py in turning a test class into a fixture, but I wanted to formalize it a bit and eliminate the hackiness around re-defining ``runTest`` and instantiating a TestCase just to run a test method outside the test case.

I want to be able to make more integration tests like test_pulsar_embedded.py, where we just define a configuration and then some tool tests to run. In particular this will be useful for extended metadata testing of the most interesting tools.