### PR TITLE
Bugfix for input selection w/ tag representation in ui-select-default

### DIFF
--- a/client/galaxy/scripts/mvc/ui/ui-select-default.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-default.js
@@ -5,6 +5,7 @@ import $ from "jquery";
 import _ from "underscore";
 import Backbone from "backbone";
 import Utils from "utils/utils";
+import { keyedColorScheme } from "utils/color";
 import Buttons from "mvc/ui/ui-buttons";
 var View = Backbone.View.extend({
     initialize: function(options) {
@@ -211,9 +212,10 @@ var View = Backbone.View.extend({
                         ${_.reduce(
                             filteredTags.slice(0, 5),
                             (memo, tag) => {
-                                return `${memo}&nbsp;<div style="${Utils.generateTagStyle(
-                                    tag.slice(5)
-                                )}" class="badge badge-primary badge-tags">${_.escape(tag)}</div>`;
+                                let tagColors = keyedColorScheme(tag.slice(5));
+                                return `${memo}&nbsp;<div style="background-color: ${tagColors.primary}; color: ${tagColors.contrasting}; border: 1px solid ${tagColors.darker}" class="badge badge-primary badge-tags">${_.escape(
+                                    tag
+                                )}</div>`;
                             },
                             ""
                         )}

--- a/client/galaxy/scripts/mvc/ui/ui-select-default.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-default.js
@@ -212,7 +212,7 @@ var View = Backbone.View.extend({
                         ${_.reduce(
                             filteredTags.slice(0, 5),
                             (memo, tag) => {
-                                let tagColors = keyedColorScheme(tag.slice(5));
+                                const tagColors = keyedColorScheme(tag.slice(5));
                                 return `${memo}&nbsp;<div style="background-color: ${tagColors.primary}; color: ${tagColors.contrasting}; border: 1px solid ${tagColors.darker}" class="badge badge-primary badge-tags">${_.escape(
                                     tag
                                 )}</div>`;


### PR DESCRIPTION
Without this, Galaxy will throw a client exception and halt if you attempted to open an input menu containing tags, like this one:  (picture is post-fix)

![image](https://user-images.githubusercontent.com/155398/55526076-94379d80-5661-11e9-9d81-fbb8ebe5360d.png)


