### PR TITLE
Allow import of format2 workflows by default for 19.05.

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1350,8 +1350,10 @@ galaxy:
   # of Galaxy's stable API.
   #enable_beta_workflow_modules: false
 
-  # Enable import and export of workflows as Galaxy Format 2 workflows.
-  #enable_beta_workflow_format: false
+  # Export of workflows as Galaxy Format 2 instead of GA workflows by
+  # default. The default value of this configuration variable will
+  # switch to True in 19.09.
+  #enable_beta_export_format2_default: false
 
   # Following options only apply to workflows scheduled using the legacy
   # workflow run API (running workflows via a POST to /api/workflows).

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2769,13 +2769,14 @@
 :Type: bool
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enable_beta_workflow_format``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enable_beta_export_format2_default``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Enable import and export of workflows as Galaxy Format 2
-    workflows.
+    Export of workflows as Galaxy Format 2 instead of GA workflows by
+    default. The default value of this configuration variable will
+    switch to True in 19.09.
 :Default: ``false``
 :Type: bool
 

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -381,8 +381,8 @@ class Configuration(object):
         # workflows built using these modules may not function in the
         # future.
         self.enable_beta_workflow_modules = string_as_bool(kwargs.get('enable_beta_workflow_modules', 'False'))
-        # Enable use of gxformat2 workflows.
-        self.enable_beta_workflow_format = string_as_bool(kwargs.get('enable_beta_workflow_format', 'False'))
+        # Enable default export of gxformat2 workflows.
+        self.enable_beta_export_format2_default = string_as_bool(kwargs.get('enable_beta_export_format2_default', 'False'))
         # These are not even beta - just experiments - don't use them unless
         # you want yours tools to be broken in the future.
         self.enable_beta_tool_formats = string_as_bool(kwargs.get('enable_beta_tool_formats', 'False'))

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -270,9 +270,6 @@ class WorkflowContentsManager(UsesAnnotations):
 
         workflow_class = as_dict.get("class", None)
         if workflow_class == "GalaxyWorkflow" or "$graph" in as_dict or "yaml_content" in as_dict:
-            if not self.app.config.enable_beta_workflow_format:
-                raise exceptions.ConfigDoesNotAllowException("Format2 workflows not enabled.")
-
             # Format 2 Galaxy workflow.
             galaxy_interface = Format2ConverterGalaxyInterface()
             import_options = ImportOptions()
@@ -444,8 +441,6 @@ class WorkflowContentsManager(UsesAnnotations):
         """
 
         def to_format_2(wf_dict, **kwds):
-            if not trans.app.config.enable_beta_workflow_format:
-                raise exceptions.ConfigDoesNotAllowException("Format2 workflows not enabled.")
             return from_galaxy_native(wf_dict, None, **kwds)
 
         if version == '':
@@ -453,6 +448,13 @@ class WorkflowContentsManager(UsesAnnotations):
         if version is not None:
             version = int(version)
         workflow = stored.get_internal_version(version)
+        if style == "export":
+            # Export workflows as GA format through 19.05, in 19.09 this will become format2.
+            style = "ga"
+
+            if self.app.config.enable_beta_export_format2_default:
+                style = "format2"
+
         if style == "editor":
             wf_dict = self._workflow_to_dict_editor(trans, stored, workflow)
         elif style == "legacy":
@@ -467,8 +469,10 @@ class WorkflowContentsManager(UsesAnnotations):
         elif style == "format2_wrapped_yaml":
             wf_dict = self._workflow_to_dict_export(trans, stored, workflow=workflow)
             wf_dict = to_format_2(wf_dict, json_wrapper=True)
-        else:
+        elif style == "ga":
             wf_dict = self._workflow_to_dict_export(trans, stored, workflow=workflow)
+        else:
+            raise exceptions.RequestParameterInvalidException('Unknown workflow style [%s]' % style)
         if version:
             wf_dict['version'] = version
         else:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -420,7 +420,16 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
     def workflow_dict(self, trans, workflow_id, **kwd):
         """
         GET /api/workflows/{encoded_workflow_id}/download
+
         Returns a selected workflow as a json dictionary.
+
+        :type   style:  str
+        :param  style:  Style of export. The default is 'export', which is the meant to be used
+                        with workflow import endpoints. Other formats such as 'instance', 'editor',
+                        'run' are more tied to the GUI and should not be considered stable APIs.
+                        By default the 'export' format in 19.05 is "ga" files, in 19.09 this will
+                        become 'format2'. Style can be specified as either 'ga' or 'format2' directly
+                        to be explicit about which format to download.
         """
         stored_workflow = self.__get_stored_accessible_workflow(trans, workflow_id)
 
@@ -431,7 +440,11 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         if download_format == 'json-download':
             sname = stored_workflow.name
             sname = ''.join(c in util.FILENAME_VALID_CHARS and c or '_' for c in sname)[0:150]
-            trans.response.headers["Content-Disposition"] = 'attachment; filename="Galaxy-Workflow-%s.ga"' % (sname)
+            if ret_dict.get("format-version", None) == "0.1":
+                extension = "ga"
+            else:
+                extension = "gxwf.json"
+            trans.response.headers["Content-Disposition"] = 'attachment; filename="Galaxy-Workflow-%s.%s"' % (sname, extension)
             trans.response.set_content_type('application/galaxy-archive')
         return ret_dict
 
@@ -588,7 +601,10 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         try:
             data = json.loads(archive_data)
         except Exception:
-            raise exceptions.MessageException("The data content does not appear to be a valid workflow.")
+            if "GalaxyWorkflow" in archive_data:
+                data = {"yaml_content": archive_data}
+            else:
+                raise exceptions.MessageException("The data content does not appear to be a valid workflow.")
         if not data:
             raise exceptions.MessageException("The data content is missing.")
         raw_workflow_description = self.__normalize_workflow(trans, data)

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2058,12 +2058,13 @@ mapping:
           Enable beta workflow modules that should not yet be considered part of Galaxy's
           stable API.
 
-      enable_beta_workflow_format:
+      enable_beta_export_format2_default:
         type: bool
         default: false
         required: false
         desc: |
-          Enable import and export of workflows as Galaxy Format 2 workflows.
+          Export of workflows as Galaxy Format 2 instead of GA workflows by default. The
+          default value of this configuration variable will switch to True in 19.09.
 
       force_beta_workflow_scheduled_min_steps:
         type: int

--- a/run.sh
+++ b/run.sh
@@ -38,7 +38,6 @@ if [ ! -z "$GALAXY_RUN_WITH_TEST_TOOLS" ];
 then
     export GALAXY_CONFIG_OVERRIDE_TOOL_CONFIG_FILE="test/functional/tools/samples_tool_conf.xml"
     export GALAXY_CONFIG_ENABLE_BETA_WORKFLOW_MODULES="true"
-    export GALAXY_CONFIG_ENABLE_BETA_WORKFLOW_FORMAT="true"
     export GALAXY_CONFIG_OVERRIDE_ENABLE_BETA_TOOL_FORMATS="true"
     export GALAXY_CONFIG_OVERRIDE_WEBHOOKS_DIR="test/functional/webhooks"
 fi

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -207,7 +207,6 @@ def setup_galaxy_config(
         cleanup_job='onsuccess',
         data_manager_config_file=data_manager_config_file,
         enable_beta_tool_formats=True,
-        enable_beta_workflow_format=True,
         expose_dataset_path=True,
         file_path=file_path,
         ftp_upload_purge=False,


### PR DESCRIPTION
Setup forcing export of format2 workflows by default in next release. There should be a least one release between enabling them to be imported by default and exporting them by default anyway I think - so 19.09 workflows can still be used on slightly older Galaxy instances.