### PR TITLE
[19.01] Fix for trans.redirect not setting cookies/headers. 

### DIFF
--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -433,7 +433,7 @@ class Response(object):
         Create a new Response defaulting to HTML content and "200 OK" status
         """
         self.status = "200 OK"
-        self.headers = HeaderDict({"content-type": "text/html"})
+        self.headers = HeaderDict({"content-type": "text/html; charset=UTF-8"})
         self.cookies = SimpleCookie()
 
     def set_content_type(self, type_):
@@ -451,7 +451,7 @@ class Response(object):
         """
         if "\n" in url or "\r" in url:
             raise webob.exc.HTTPInternalServerError("Invalid redirect URL encountered.")
-        raise webob.exc.HTTPFound(location=url)
+        raise webob.exc.HTTPFound(location=url, headers=self.wsgi_headeritems())
 
     def wsgi_headeritems(self):
         """

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -17,7 +17,7 @@ from galaxy.web.framework import url_for
 
 log = logging.getLogger(__name__)
 
-JSON_CONTENT_TYPE = "application/json"
+JSON_CONTENT_TYPE = "application/json; charset=UTF-8"
 JSONP_CONTENT_TYPE = "application/javascript"
 JSONP_CALLBACK_KEY = 'callback'
 


### PR DESCRIPTION
Broken in https://github.com/galaxyproject/galaxy/pull/6561

If cookies, such as a session cookie during login, were being set and then trans.send_redirect was being used, the cookies were not actually being set in the user's browsers, so the user was not actually getting logged in. 