### PR TITLE
Workflow parameter via API typing issues

### DIFF
--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -3067,7 +3067,6 @@ steps:
             inputs = {
                 '0': self._ds_entry(hda),
             }
-            workflow_request = {}
             workflow_request = {"replacement_params": dumps(dict(numlines=3))}
             invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs=inputs, request=workflow_request)
 


### PR DESCRIPTION
Add simple test (that currently fails but should not), demonstrating workflow replacement parameter typing issue.

Currently this results in this error:
```
Traceback (most recent call last):
  File "/Volumes/work_cs/galaxy/lib/galaxy/jobs/runners/__init__.py", line 223, in prepare_job
    job_wrapper.prepare()
  File "/Volumes/work_cs/galaxy/lib/galaxy/jobs/__init__.py", line 863, in prepare
    tool_evaluator.set_compute_environment(compute_environment, get_special=get_special)
  File "/Volumes/work_cs/galaxy/lib/galaxy/tools/evaluation.py", line 78, in set_compute_environment
    visit_input_values(self.tool.inputs, incoming, validate_inputs)
  File "/Volumes/work_cs/galaxy/lib/galaxy/tools/parameters/__init__.py", line 167, in visit_input_values
    callback_helper(input, input_values, name_prefix, label_prefix, parent_prefix=parent_prefix, context=context)
  File "/Volumes/work_cs/galaxy/lib/galaxy/tools/parameters/__init__.py", line 130, in callback_helper
    new_value = callback(**args)
  File "/Volumes/work_cs/galaxy/lib/galaxy/tools/evaluation.py", line 76, in validate_inputs
    value = input.from_json(value, request_context, context)
  File "/Volumes/work_cs/galaxy/lib/galaxy/tools/parameters/basic.py", line 357, in from_json
    raise ValueError("An integer is required")
```

The UI works because the client actually does this parameter substitution prior to submission, even though it also sends along the dict.