### PR TITLE
Bugfix: when removing tags from a dataset, only the first tag can be removed

### DIFF
--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -198,7 +198,7 @@ class TagManager(object):
             if tag.value is not None:
                 tag_str += ":" + tag.user_value
             tags_str_list.append(tag_str)
-        return ", ".join(tags_str_list)
+        return ",".join(tags_str_list)
 
     def get_tag_by_id(self, tag_id):
         """Get a Tag object from a tag id."""

--- a/test/unit/managers/test_TagManager.py
+++ b/test/unit/managers/test_TagManager.py
@@ -82,10 +82,10 @@ class TagManagerTestCase(BaseTestCase):
 
     def test_remove_tag_from_list(self):
         hda = self._create_vanilla_hda()
-        tags = ['tag1', 'tag2']
+        tags = ['tag1', 'tag2', 'tag3']
         self.tag_manager.set_tags_from_list(self.user, hda, tags)
         self._check_tag_list(hda.tags, tags)
-        self.tag_manager.remove_tags_from_list(self.user, hda, ['tag1'])
+        self.tag_manager.remove_tags_from_list(self.user, hda, ['tag1', 'tag3'])
         self._check_tag_list(hda.tags, ['tag2'])
 
     def test_delete_item_tags(self):


### PR DESCRIPTION
When removing tags from a dataset, e.g. as part of a workflow, only the first tag in a list is currently possible to remove. The cause is that a space character is erroneously added in front of these tags.

I have added a test that fails with the current code, and then fixed the issue. This might also fix other tag-related bugs.