### PR TITLE
Quote *.pyc in the find/cleanup command for manage_db.sh

### DIFF
--- a/manage_db.sh
+++ b/manage_db.sh
@@ -11,5 +11,5 @@ cd `dirname $0`
 
 setup_python
 
-find lib/galaxy/model/migrate/versions -name *.pyc -delete
+find lib/galaxy/model/migrate/versions -name '*.pyc' -delete
 python ./scripts/manage_db.py $@


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/pull/7677#discussion_r272813014

@nsoranzo Both versions worked fine in my testing, but I'm using zsh.  Which shells did the unquoted version break or potentially have problems with, out of curiosity?