### PR TITLE
Implicit conversion for input collection parameters

### DIFF
--- a/lib/galaxy/model/dataset_collections/builder.py
+++ b/lib/galaxy/model/dataset_collections/builder.py
@@ -36,6 +36,28 @@ class CollectionBuilder(object):
         self._collection_type_description = collection_type_description
         self._current_elements = odict()
 
+    def replace_elements_in_collection(self, template_collection, replacement_dict):
+        self._current_elements = self._replace_elements_in_collection(
+            template_collection=template_collection,
+            replacement_dict=replacement_dict,
+        )
+
+    def _replace_elements_in_collection(self, template_collection, replacement_dict):
+        elements = odict()
+        for element in template_collection.elements:
+            if element.is_collection:
+                collection_builder = CollectionBuilder(
+                    collection_type_description=self._collection_type_description.child_collection_type_description()
+                )
+                collection_builder.replace_elements_in_collection(
+                    template_collection=element.child_collection,
+                    replacement_dict=replacement_dict
+                )
+                elements[element.element_identifier] = collection_builder
+            else:
+                elements[element.element_identifier] = replacement_dict.get(element.element_object, element.element_object)
+        return elements
+
     def get_level(self, identifier):
         if not self._nested_collection:
             message_template = "Cannot add nested collection to collection of type [%s]"

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -8,6 +8,7 @@ from six import string_types
 from galaxy import model
 from galaxy.jobs.actions.post import ActionBox
 from galaxy.model import LibraryDatasetDatasetAssociation, WorkflowRequestInputParameter
+from galaxy.model.dataset_collections.builder import CollectionBuilder
 from galaxy.objectstore import ObjectStorePopulator
 from galaxy.tools.parameters import update_dataset_ids
 from galaxy.tools.parameters.basic import DataCollectionToolParameter, DataToolParameter, RuntimeValue
@@ -158,8 +159,10 @@ class DefaultToolAction(object):
                     return
 
                 collection = None
+                child_collection = False
                 if hasattr(value, 'child_collection'):
                     # if we are mapping a collection over a tool, we only require the child_collection
+                    child_collection = True
                     collection = value.child_collection
                 else:
                     # else the tool takes a collection as input so we need everything
@@ -171,11 +174,27 @@ class DefaultToolAction(object):
                 for action, role_id in action_tuples:
                     record_permission(action, role_id)
 
+                replace_collection = False
+                processed_dataset_dict = {}
                 for i, v in enumerate(collection.dataset_instances):
-                    # Skipping implicit conversion stuff for now, revisit at
-                    # some point and figure out if implicitly converting a
-                    # dataset collection makes senese.
-                    input_datasets[prefix + input.name + str(i + 1)] = v
+                    processed_dataset = process_dataset(v)
+                    if processed_dataset is not v:
+                        replace_collection = True
+                        processed_dataset_dict[v] = processed_dataset
+                    input_datasets[prefix + input.name + str(i + 1)] = processed_dataset
+
+                if replace_collection:
+                    collection_type_description = trans.app.dataset_collections_service.collection_type_descriptions.for_collection_type(collection.collection_type)
+                    collection_builder = CollectionBuilder(collection_type_description)
+                    collection_builder.replace_elements_in_collection(
+                        template_collection=collection,
+                        replacement_dict=processed_dataset_dict,
+                    )
+                    new_collection = collection_builder.build()
+                    if child_collection:
+                        value.child_collection = new_collection
+                    else:
+                        value.collection = new_collection
 
         tool.visit_inputs(param_values, visitor)
         return input_datasets, all_permissions
@@ -901,6 +920,16 @@ def filter_output(output, incoming):
     return False
 
 
+def get_ext_or_implicit_ext(hda):
+    if hda.implicitly_converted_parent_datasets:
+        # implicitly_converted_parent_datasets is a list of ImplicitlyConvertedDatasetAssociation
+        # objects, and their type is the target_ext, so this should be correct even if there
+        # are multiple ImplicitlyConvertedDatasetAssociation objects (meaning 2 datasets had been converted
+        # to produce a dataset with the required datatype)
+        return hda.implicitly_converted_parent_datasets[0].type
+    return hda.ext
+
+
 def determine_output_format(output, parameter_context, input_datasets, input_dataset_collections, random_input_ext):
     """ Determines the output format for a dataset based on an abstract
     description of the output (galaxy.tools.parser.ToolOutput), the parameter
@@ -918,17 +947,12 @@ def determine_output_format(output, parameter_context, input_datasets, input_dat
     if format_source is not None and format_source in input_datasets:
         try:
             input_dataset = input_datasets[output.format_source]
-            if input_dataset.implicitly_converted_parent_datasets:
-                # implicitly_converted_parent_datasets is a list of ImplicitlyConvertedDatasetAssociation
-                # objects, and their type is the target_ext, so this should be correct even if there
-                # are multiple ImplicitlyConvertedDatasetAssociation objects (meaning 2 datasets had been converted
-                # to produce a dataset with the required datatype)
-                ext = input_dataset.implicitly_converted_parent_datasets[0].type
-            else:
-                ext = input_dataset.ext
+            ext = get_ext_or_implicit_ext(input_dataset)
         except Exception:
             pass
     elif format_source is not None:
+        element_index = None
+        collection_name = format_source
         if re.match(r"^[^\[\]]*\[[^\[\]]*\]$", format_source):
             collection_name, element_index = format_source[0:-1].split("[")
             # Treat as json to interpret "forward" vs 0 with type
@@ -936,10 +960,14 @@ def determine_output_format(output, parameter_context, input_datasets, input_dat
             element_index = element_index.replace("'", '"')
             element_index = json.loads(element_index)
 
-            if collection_name in input_dataset_collections:
-                try:
-                    input_collection = input_dataset_collections[collection_name][0][0]
-                    input_collection_collection = input_collection.collection
+        if collection_name in input_dataset_collections:
+            try:
+                input_collection = input_dataset_collections[collection_name][0][0]
+                input_collection_collection = input_collection.collection
+                if element_index is None:
+                    # just pick the first HDA
+                    input_dataset = input_collection_collection.dataset_instances[0]
+                else:
                     try:
                         input_element = input_collection_collection[element_index]
                     except KeyError:
@@ -948,11 +976,10 @@ def determine_output_format(output, parameter_context, input_datasets, input_dat
                                 input_element = element
                                 break
                     input_dataset = input_element.element_object
-                    input_extension = input_dataset.ext
-                    ext = input_extension
-                except Exception as e:
-                    log.debug("Exception while trying to determine format_source: %s", e)
-                    pass
+                ext = get_ext_or_implicit_ext(input_dataset)
+            except Exception as e:
+                log.debug("Exception while trying to determine format_source: %s", e)
+                pass
 
     # process change_format tags
     if output.change_format is not None:

--- a/test/functional/tools/implicit_collection_conversion.xml
+++ b/test/functional/tools/implicit_collection_conversion.xml
@@ -1,0 +1,30 @@
+<tool id="implicit_collection_conversion" name="implicit_collection_conversion" version="0.1">
+  <command>
+    #for $key in $input1.keys()
+        cut -f 1 '$input1[key]' > '$output1[key]'
+    #end for
+  </command>
+  <inputs>
+    <param type="data_collection" collection_type="list" format="tabular" name="input1" label="Input 1" />
+  </inputs>
+  <outputs>
+    <collection name="output1" type="list" structured_like="input1" format_source="input1" />
+  </outputs>
+  <tests>
+    <!-- Test implicit conversion. -->
+    <test>
+      <param name="input1">
+        <collection type="list">
+          <element name="e1" value="1.fasta" ftype="fasta" />
+        </collection>
+      </param>
+      <output_collection name="output1" count="1">
+        <element name="e1" ftype="tabular">
+          <assert_contents>
+            <has_text text="hg17" />
+          </assert_contents>
+        </element>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/implicit_nested_list_conversion.xml
+++ b/test/functional/tools/implicit_nested_list_conversion.xml
@@ -1,0 +1,39 @@
+<tool id="implicit_nested_collection_conversion" name="implicit_nested_collection_conversion" version="0.1">
+  <command>
+    #for $outer_key in $input1.keys()
+        #for $inner_key in $input1[$outer_key].keys():
+            cut -f 1 '$input1[$outer_key][$inner_key]' > '$output1[$outer_key][$inner_key]'
+        #end for
+    #end for
+  </command>
+  <inputs>
+    <param type="data_collection" collection_type="list:list" format="tabular" name="input1" label="Input 1" />
+  </inputs>
+  <outputs>
+    <collection name="output1" type="list:list" structured_like="input1" format_source="input1">
+    </collection>
+  </outputs>
+  <tests>
+    <!-- Test implicit conversion. -->
+    <test>
+      <param name="input1">
+        <collection type="list:list">
+          <element name="o1">
+            <collection type="list">
+              <element name="i1" value="1.fasta" ftype="fasta" />
+            </collection>
+          </element>
+        </collection>
+      </param>
+      <output_collection name="output1" count="1">
+        <element name="o1">
+          <element name="i1" ftype="tabular">
+            <assert_contents>
+              <has_text text="hg17" />
+            </assert_contents>
+          </element>
+        </element>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -109,6 +109,8 @@
   <tool file="empty_output.xml" />
   <tool file="validation_empty_dataset.xml" />
   <tool file="implicit_conversion.xml" />
+  <tool file="implicit_collection_conversion.xml" />
+  <tool file="implicit_nested_list_conversion.xml" />
   <tool file="explicit_conversion.xml" />
   <tool file="identifier_source.xml" />
   <tool file="identifier_single.xml" />


### PR DESCRIPTION
The last 2 commits add implicit conversion support for input collections, while the first commits include #7682. This had never been implemented, so I think we don't need to target 19.01 for this (though it is a bug given the UI lets you do this, and if you try it'll fail ...).