### PR TITLE
Script to populate datasets/libraries directly into an objectstore and model store.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2289,6 +2289,10 @@ class Dataset(StorableObject, RepresentById):
     def serialize(self, id_encoder, serialization_options):
         # serialize Dataset objects only for jobs that can actually modify these models.
         assert serialization_options.serialize_dataset_objects
+
+        def to_int(n):
+            return int(n) if n is not None else 0
+
         rval = dict_for(
             self,
             state=self.state,
@@ -2296,9 +2300,9 @@ class Dataset(StorableObject, RepresentById):
             purged=self.purged,
             external_filename=self.external_filename,
             _extra_files_path=self._extra_files_path,
-            file_size=self.file_size,
+            file_size=to_int(self.file_size),
             object_store_id=self.object_store_id,
-            total_size=self.total_size,
+            total_size=to_int(self.total_size),
             uuid=str(self.uuid or '') or None,
             hashes=list(map(lambda h: h.serialize(id_encoder, serialization_options), self.hashes))
         )

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2404,8 +2404,10 @@ class DatasetInstance(object):
 
     def set_dataset_state(self, state):
         if self.raw_set_dataset_state(state):
-            object_session(self).add(self.dataset)
-            object_session(self).flush()  # flush here, because hda.flush() won't flush the Dataset object
+            sa_session = object_session(self)
+            if sa_session:
+                object_session(self).add(self.dataset)
+                object_session(self).flush()  # flush here, because hda.flush() won't flush the Dataset object
     state = property(get_dataset_state, set_dataset_state)
 
     def get_file_name(self):

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1006,23 +1006,23 @@ class DirectoryModelExportStore(ModelExportStore):
                     shutil.copyfile(src, dest)
 
         export_directory = self.export_directory
-        if dataset.id in self.included_datasets:
-            _, include_files = self.included_datasets[dataset.id]
-            if not include_files:
-                return
 
-            file_name, extra_files_path = None, None
-            try:
-                _file_name = dataset.file_name
-                if os.path.exists(_file_name):
-                    file_name = _file_name
-            except ObjectNotFound:
-                pass
+        _, include_files = self.included_datasets[dataset.id]
+        if not include_files:
+            return
 
-            if dataset.extra_files_path_exists():
-                extra_files_path = dataset.extra_files_path
-            else:
-                pass
+        file_name, extra_files_path = None, None
+        try:
+            _file_name = dataset.file_name
+            if os.path.exists(_file_name):
+                file_name = _file_name
+        except ObjectNotFound:
+            pass
+
+        if dataset.extra_files_path_exists():
+            extra_files_path = dataset.extra_files_path
+        else:
+            pass
 
         dir_name = 'datasets'
         dir_path = os.path.join(export_directory, dir_name)

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -417,12 +417,19 @@ class ModelImportStore(object):
                                                          element_identifier=element_attrs['element_identifier'])
                     if 'hda' in element_attrs:
                         hda_attrs = element_attrs['hda']
-                        hda_key = hda_attrs[object_key]
-                        hdas_by_key = object_import_tracker.hdas_by_key
-                        if hda_key in hdas_by_key:
-                            hda = hdas_by_key[hda_key]
+                        if object_key in hda_attrs:
+                            hda_key = hda_attrs[object_key]
+                            hdas_by_key = object_import_tracker.hdas_by_key
+                            if hda_key in hdas_by_key:
+                                hda = hdas_by_key[hda_key]
+                            else:
+                                raise KeyError("Failed to find exported hda with key [%s] of type [%s] in [%s]" % (hda_key, object_key, hdas_by_key))
                         else:
-                            raise KeyError("Failed to find exported hda with key [%s] of type [%s] in [%s]" % (hda_key, object_key, hdas_by_key))
+                            hda_id = hda_attrs["id"]
+                            hdas_by_id = object_import_tracker.hdas_by_id
+                            if hda_id not in hdas_by_id:
+                                raise Exception("Failed to find HDA with id [%s] in [%s]" % (hda_id, hdas_by_id))
+                            hda = hdas_by_id[hda_id]
                         dce.hda = hda
                     elif 'child_collection' in element_attrs:
                         dce.child_collection = import_collection(element_attrs['child_collection'])

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -343,7 +343,10 @@ class ModelImportStore(object):
 
                 if model_class == "HistoryDatasetAssociation" and self.user:
                     add_item_annotation(self.sa_session, self.user, dataset_instance, dataset_attrs['annotation'])
-                    # TODO: Set tags.
+                    tag_list = dataset_attrs.get('tags')
+                    if tag_list:
+                        tag_handler = model.tags.GalaxyTagHandler(sa_session=self.sa_session)
+                        tag_handler.set_tags_from_list(user=self.user, item=dataset_instance, new_tags_list=tag_list)
 
                 if self.app:
                     self.app.datatypes_registry.set_external_metadata_tool.regenerate_imported_metadata_if_needed(

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -19,7 +19,6 @@ from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util import FILENAME_VALID_CHARS
 from galaxy.util import in_directory
 from galaxy.util.bunch import Bunch
-from galaxy.version import VERSION_MAJOR
 from ..item_attrs import add_item_annotation, get_item_annotation_str
 from ... import model
 
@@ -30,6 +29,7 @@ ATTRS_FILENAME_IMPLICIT_COLLECTION_JOBS = 'implicit_collection_jobs_attrs.txt'
 ATTRS_FILENAME_COLLECTIONS = 'collections_attrs.txt'
 ATTRS_FILENAME_EXPORT = 'export_attrs.txt'
 ATTRS_FILENAME_LIBRARIES = 'libraries_attrs.txt'
+GALAXY_EXPORT_VERSION = "2"
 
 
 class ImportOptions(object):
@@ -1329,7 +1329,7 @@ class DirectoryModelExportStore(ModelExportStore):
 
         export_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_EXPORT)
         with open(export_attrs_filename, 'w') as export_attrs_out:
-            dump({"galaxy_version": VERSION_MAJOR}, export_attrs_out)
+            dump({"galaxy_export_version": GALAXY_EXPORT_VERSION}, export_attrs_out)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is None:

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -725,7 +725,7 @@ def _copied_from_object_key(copied_from_chain, objects_by_key):
 
 
 class ObjectImportTracker(object):
-    """Keep track or new and existing imported objects.
+    """Keep track of new and existing imported objects.
 
     Needed to re-establish connections and such in multiple passes.
     """
@@ -957,13 +957,21 @@ class ModelExportStore(object):
         """Export store should be used as context manager."""
 
     @abc.abstractmethod
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_val, exc_tb):
         """Export store should be used as context manager."""
 
 
 class DirectoryModelExportStore(ModelExportStore):
 
     def __init__(self, export_directory, app=None, for_edit=False, serialize_dataset_objects=None, export_files=None, strip_metadata_files=True):
+        """
+        :param export_directory: path to export directory. Will be created if it does not exist.
+        :param app: Galaxy App or app-like object. Must be provided if `for_edit` and/or `serialize_dataset_objects` are True
+        :param for_edit: Allow modifying existing HDA and dataset metadata during import.
+        :param serialize_dataset_objects: If True will encode IDs using the host secret. Defaults `for_edit`.
+        :param export_files: How files should be exported, can be 'symlink', 'copy' or None, in which case files
+                             will not be serialized.
+        """
         if not os.path.exists(export_directory):
             os.makedirs(export_directory)
 
@@ -1327,6 +1335,7 @@ class DirectoryModelExportStore(ModelExportStore):
         if exc_type is None:
             self._finalize()
         # http://effbot.org/zone/python-with-statement.htm
+        # Ignores TypeError exceptions
         return isinstance(exc_val, TypeError)
 
 

--- a/lib/galaxy/model/store/build_objects.py
+++ b/lib/galaxy/model/store/build_objects.py
@@ -1,0 +1,130 @@
+import argparse
+import logging
+import os
+import sys
+
+import yaml
+
+import galaxy.model
+from galaxy.datatypes.registry import example_datatype_registry_for_sample
+from galaxy.model import store
+from galaxy.model.store.discover import persist_target_to_export_store
+from galaxy.objectstore import build_object_store_from_config
+from galaxy.util.bunch import Bunch
+
+DESCRIPTION = """Build import ready model objects from YAML description of files.
+
+The positional argument to this script should be a a YAML file containing a data
+fetch API-like YAML file describing files. This script will then import this data
+into a defined object store and populate metadata corresponding to these files as
+datasets into a "model store".
+
+The YAML file should contain a dictionary of destination+elements objects or a list
+of such dictionaries. Each such destination+elements dictionary should contain at least
+two keys - 'destination' and 'items'.
+
+Examples of destinations for creating libraries and just populating history datasets
+are as follows:
+
+```
+destination:
+  type: library
+  name: Training Material
+  description: Data for selected tutorials from https://training.galaxyproject.org.
+```
+
+```
+destination:
+  type: hdas
+````
+
+The 'items' definition should be a list of files or library folders. If library folders
+need to be setup they should each be defined with a name and recursive set of items (
+again files or folders). The following code fragment describes both a library folder
+definition and a file entry:
+
+```
+items:
+  - name: "Example Folder 1"
+    description: "Description of what is in Example Folder 1"
+    items:
+      - url: https://raw.githubusercontent.com/eteriSokhoyan/test-data/master/cliques-high-representatives.fa
+        filename: cliques-high-representatives.fa
+        ext: fasta
+        info: "A cool longer description."
+        dbkey: "hg19"
+        md5: e5d21b1ea57fc9a31f8ea0110531bf3d
+```
+
+Currently for each file a filename must be supplied, url information will be stored if
+provided but not fetched on-demand like the upload 2.0/data fetch endpoint.
+
+Differences with respect to the Upload 2.0 YAML/JSON format: currently various src tags
+such as 'url' are not supported, data cleaning options such as to_posix_lines, and
+space_to_tab are not supported, unpacking zip files and walking directoriesm etc.. are
+not supported either. The format consumed by this script should continue to evolve to
+converge with the upload 2.0 format.
+"""
+
+logging.basicConfig()
+log = logging.getLogger(__name__)
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    args = _arg_parser().parse_args(argv)
+    object_store_config = Bunch(
+        object_store_store_by="uuid",
+        object_store_config_file=args.object_store_config,
+        object_store_check_old_style=False,
+        jobs_directory=None,
+        new_file_path=None,
+        umask=os.umask(0o77),
+        gid=os.getgid(),
+    )
+    object_store = build_object_store_from_config(object_store_config)
+    galaxy.model.Dataset.object_store = object_store
+    galaxy.model.set_datatypes_registry(example_datatype_registry_for_sample())
+    from galaxy.model import mapping
+    mapping.init("/tmp", "sqlite:///:memory:", create_tables=True, object_store=object_store)
+
+    with open(args.objects, "r") as f:
+        targets = yaml.load(f)
+        if not isinstance(targets, list):
+            targets = [targets]
+
+    export_path = args.export
+    export_type = args.export_type
+
+    if export_type is None:
+        export_type = "directory" if not export_path.endswith(".tgz") else "bag_archive"
+
+    export_types = {
+        "directory": store.DirectoryModelExportStore,
+        "tar": store.TarModelExportStore,
+        "bag_directory": store.BagDirectoryModelExportStore,
+        "bag_archive": store.BagArchiveModelExportStore,
+    }
+    store_class = export_types[export_type]
+    export_kwds = {
+        "serialize_dataset_objects": True,
+    }
+
+    with store_class(export_path, **export_kwds) as export_store:
+        for target in targets:
+            persist_target_to_export_store(target, export_store, object_store, ".")
+
+
+def _arg_parser():
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument('objects', metavar='OBJECT_CONFIG', help='config file describing files to build objects for')
+    parser.add_argument('--object-store-config', help="object store configuration file")
+    parser.add_argument('-e', '--export', default="export", help='export path')
+    parser.add_argument('--export-type', default=None, help='export type (if needed)')
+    return parser
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -1,0 +1,578 @@
+"""Utilities for discovering files to add to a model store.
+
+Working with input "JSON" format used for Fetch API, galaxy.json
+imports, etc... High-level utilities in this file can be used during
+job output discovery or for persisting Galaxy model objects
+corresponding to files in other contexts.
+"""
+import abc
+import os
+from collections import namedtuple
+
+import six
+
+import galaxy.model
+from galaxy import util
+from galaxy.exceptions import (
+    RequestParameterInvalidException
+)
+from galaxy.util.hash_util import HASH_NAME_MAP
+
+
+UNSET = object()
+
+
+@six.add_metaclass(abc.ABCMeta)
+class ModelPersistenceContext(object):
+    """Class for creating datasets while finding files.
+
+    This class implement the create_dataset method that takes care of populating metadata
+    required for datasets and other potential model objects.
+    """
+
+    def create_dataset(
+        self,
+        ext,
+        designation,
+        visible,
+        dbkey,
+        name,
+        filename,
+        metadata_source_name=None,
+        info=None,
+        library_folder=None,
+        link_data=False,
+        primary_data=None,
+        init_from=None,
+        dataset_attributes=None,
+        tag_list=[],
+        sources=[],
+        hashes=[],
+    ):
+        sa_session = self.sa_session
+
+        # You can initialize a dataset or initialize from a dataset but not both.
+        if init_from:
+            assert primary_data is None
+        if primary_data:
+            assert init_from is None
+
+        if metadata_source_name:
+            assert init_from is None
+        if init_from:
+            assert metadata_source_name is None
+
+        if primary_data is not None:
+            primary_data.extension = ext
+            primary_data.visible = visible
+            primary_data.dbkey = dbkey
+        else:
+            if not library_folder:
+                primary_data = galaxy.model.HistoryDatasetAssociation(extension=ext,
+                                                                      designation=designation,
+                                                                      visible=visible,
+                                                                      dbkey=dbkey,
+                                                                      create_dataset=True,
+                                                                      flush=False,
+                                                                      sa_session=sa_session)
+
+                self.persist_object(primary_data)
+                if init_from:
+                    self.permission_provider.copy_dataset_permissions(init_from, primary_data)
+                    primary_data.state = init_from.state
+                else:
+                    self.permission_provider.set_default_hda_permissions(primary_data)
+            else:
+                ld = galaxy.model.LibraryDataset(folder=library_folder, name=name)
+                ldda = galaxy.model.LibraryDatasetDatasetAssociation(name=name,
+                                                                     extension=ext,
+                                                                     dbkey=dbkey,
+                                                                     # library_dataset=ld,
+                                                                     user=self.user,
+                                                                     create_dataset=True,
+                                                                     flush=False,
+                                                                     sa_session=sa_session)
+                ld.library_dataset_dataset_association = ldda
+                ldda.raw_set_dataset_state(ldda.states.OK)
+
+                self.add_library_dataset_to_folder(library_folder, ld)
+                primary_data = ldda
+
+        for source_dict in sources:
+            source = galaxy.model.DatasetSource()
+            source.source_uri = source_dict["source_uri"]
+            primary_data.dataset.sources.append(source)
+
+        for hash_dict in hashes:
+            hash_object = galaxy.model.DatasetHash()
+            hash_object.hash_function = hash_dict["hash_function"]
+            hash_object.hash_value = hash_dict["hash_value"]
+            primary_data.dataset.hashes.append(hash_object)
+
+        self.flush()
+
+        if tag_list:
+            self.tag_handler.add_tags_from_list(self.job.user, primary_data, tag_list)
+
+        # Move data from temp location to dataset location
+        if not link_data:
+            self.object_store.update_from_file(primary_data.dataset, file_name=filename, create=True)
+        else:
+            primary_data.link_to(filename)
+
+        # We are sure there are no extra files, so optimize things that follow by settting total size also.
+        primary_data.set_size(no_extra_files=True)
+        # If match specified a name use otherwise generate one from
+        # designation.
+        primary_data.name = name
+
+        # Copy metadata from one of the inputs if requested.
+        if metadata_source_name:
+            metadata_source = self.metadata_source_provider.get_metadata_source(metadata_source_name)
+            primary_data.init_meta(copy_from=metadata_source)
+        elif init_from:
+            metadata_source = init_from
+            primary_data.init_meta(copy_from=init_from)
+            # when coming from primary dataset - respect pattern of output - this makes sense
+            primary_data.dbkey = dbkey
+        else:
+            primary_data.init_meta()
+
+        if info is not None:
+            primary_data.info = info
+
+        # add tool/metadata provided information
+        dataset_attributes = dataset_attributes or {}
+        if dataset_attributes:
+            # TODO: discover_files should produce a match that encorporates this -
+            # would simplify ToolProvidedMetadata interface and eliminate this
+            # crap path.
+            dataset_att_by_name = dict(ext='extension')
+            for att_set in ['name', 'info', 'ext', 'dbkey']:
+                dataset_att_name = dataset_att_by_name.get(att_set, att_set)
+                setattr(primary_data, dataset_att_name, dataset_attributes.get(att_set, getattr(primary_data, dataset_att_name)))
+
+        metadata_dict = dataset_attributes.get('metadata', None)
+        if metadata_dict:
+            if "dbkey" in dataset_attributes:
+                metadata_dict["dbkey"] = dataset_attributes["dbkey"]
+            # branch tested with tool_provided_metadata_3 / tool_provided_metadata_10
+            primary_data.metadata.from_JSON_dict(json_dict=metadata_dict)
+        else:
+            primary_data.set_meta()
+
+        primary_data.set_peek()
+
+        return primary_data
+
+    @abc.abstractproperty
+    def tag_handler(self):
+        """Return a galaxy.model.tags.TagHandler-like object for persisting tags."""
+
+    @abc.abstractproperty
+    def user(self):
+        """If bound to a database, return the user the datasets should be created for.
+
+        Return None otherwise.
+        """
+
+    @abc.abstractmethod
+    def add_library_dataset_to_folder(self, library_folder, ld):
+        """Add library dataset to persisted library folder."""
+
+    @abc.abstractmethod
+    def create_library_folder(self, parent_folder, name, description):
+        """Create a library folder ready from supplied attributes for supplied parent."""
+
+    def add_datasets_to_history(self, datasets, for_output_dataset=None):
+        """Add datasets to the history this context points at."""
+
+    def persist_object(self, obj):
+        """Add the target to the persistence layer."""
+
+    def flush(self):
+        """If database bound, flush the persisted objects to ensure IDs."""
+
+
+@six.add_metaclass(abc.ABCMeta)
+class PermissionProvider(object):
+    """Interface for working with permissions while importing datasets with ModelPersistenceContext."""
+
+    @property
+    def permissions(self):
+        return UNSET
+
+    def set_default_hda_permissions(self, primary_data):
+        return
+
+    @abc.abstractmethod
+    def copy_dataset_permissions(self, init_from, primary_data):
+        """Copy dataset permissions from supplied input dataset."""
+
+
+class UnusedPermissionProvider(PermissionProvider):
+
+    def copy_dataset_permissions(self, init_from, primary_data):
+        """Throws NotImplementedError.
+
+        This should only be called as part of job output collection where
+        there should be a session available to initialize this from.
+        """
+        raise NotImplementedError()
+
+
+@six.add_metaclass(abc.ABCMeta)
+class MetadataSourceProvider(object):
+    """Interface for working with fetching input dataset metadata with ModelPersistenceContext."""
+
+    @abc.abstractmethod
+    def get_metadata_source(self, input_name):
+        """Get metadata for supplied input_name."""
+
+
+class UnusedMetadataSourceProvider(MetadataSourceProvider):
+
+    def get_metadata_source(self, input_name):
+        """Throws NotImplementedError.
+
+        This should only be called as part of job output collection where
+        one can actually collect metadata from inputs, this is unused in the
+        context of SessionlessModelPersistenceContext.
+        """
+        raise NotImplementedError()
+
+
+class SessionlessModelPersistenceContext(ModelPersistenceContext):
+    """A variant of ModelPersistenceContext that persists to an export store instead of database directly."""
+
+    def __init__(self, object_store, export_store, working_directory):
+        self.permission_provider = UnusedPermissionProvider()
+        self.metadata_source_provider = UnusedMetadataSourceProvider()
+        self.sa_session = None
+        self.object_store = object_store
+        self.export_store = export_store
+
+        self.job_working_directory = working_directory  # TODO: rename...
+
+    @property
+    def tag_handler(self):
+        raise NotImplementedError()
+
+    @property
+    def user(self):
+        return None
+
+    def add_library_dataset_to_folder(self, library_folder, ld):
+        library_folder.datasets.append(ld)
+        ld.order_id = library_folder.item_count
+        library_folder.item_count += 1
+
+    def create_library_folder(self, parent_folder, name, description):
+        nested_folder = galaxy.model.LibraryFolder(name=name, description=description, order_id=parent_folder.item_count)
+        parent_folder.item_count += 1
+        parent_folder.folders.append(nested_folder)
+        return nested_folder
+
+    def add_datasets_to_history(self, datasets, for_output_dataset=None):
+        # Consider copying these datasets to for_output_dataset copied histories
+        # somehow. Not sure it is worth the effort/complexity?
+        for dataset in datasets:
+            self.export_store.add_dataset(dataset)
+
+    def persist_object(self, obj):
+        """No-op right now for the sessionless variant of this.
+
+        This works currently because either things are added to a target history with add_datasets_to_history
+        or the parent LibraryFolder was added to the export store in persist_target_to_export_store.
+        """
+
+    def flush(self):
+        """No-op for the sessionless variant of this, no database to flush."""
+
+
+def persist_target_to_export_store(target_dict, export_store, object_store, work_directory):
+    replace_request_syntax_sugar(target_dict)
+    model_persistence_context = SessionlessModelPersistenceContext(object_store, export_store, work_directory)
+
+    assert "destination" in target_dict
+    assert "elements" in target_dict
+    destination = target_dict["destination"]
+    elements = target_dict["elements"]
+
+    assert "type" in destination
+    destination_type = destination["type"]
+
+    assert destination_type in ["library", "hdas"]
+    if destination_type == "library":
+        name = get_required_item(destination, "name", "Must specify a library name")
+        description = destination.get("description", "")
+        synopsis = destination.get("synopsis", "")
+        root_folder = galaxy.model.LibraryFolder(name=name, description='')
+        library = galaxy.model.Library(
+            name=name,
+            description=description,
+            synopsis=synopsis,
+            root_folder=root_folder,
+        )
+        persist_elements_to_folder(model_persistence_context, elements, root_folder)
+        export_store.export_library(library)
+    elif destination_type == "hdas":
+        persist_hdas(elements, model_persistence_context)
+
+
+def persist_elements_to_folder(model_persistence_context, elements, library_folder):
+    for element in elements:
+        if "elements" in element:
+            assert "name" in element
+            name = element["name"]
+            description = element.get("description")
+            nested_folder = model_persistence_context.create_library_folder(library_folder, name, description)
+            persist_elements_to_folder(model_persistence_context, element["elements"], nested_folder)
+        else:
+            discovered_file = discovered_file_for_element(element, model_persistence_context.job_working_directory)
+            fields_match = discovered_file.match
+            designation = fields_match.designation
+            visible = fields_match.visible
+            ext = fields_match.ext
+            dbkey = fields_match.dbkey
+            info = element.get("info", None)
+            link_data = discovered_file.match.link_data
+
+            # Create new primary dataset
+            name = fields_match.name or designation
+
+            sources = fields_match.sources
+            hashes = fields_match.hashes
+            model_persistence_context.create_dataset(
+                ext=ext,
+                designation=designation,
+                visible=visible,
+                dbkey=dbkey,
+                name=name,
+                filename=discovered_file.path,
+                info=info,
+                library_folder=library_folder,
+                link_data=link_data,
+                sources=sources,
+                hashes=hashes,
+            )
+
+
+def persist_hdas(elements, model_persistence_context):
+    # discover files as individual datasets for the target history
+    datasets = []
+
+    def collect_elements_for_history(elements):
+        for element in elements:
+            if "elements" in element:
+                collect_elements_for_history(element["elements"])
+            else:
+                discovered_file = discovered_file_for_element(element, model_persistence_context.job_working_directory)
+                fields_match = discovered_file.match
+                designation = fields_match.designation
+                ext = fields_match.ext
+                dbkey = fields_match.dbkey
+                info = element.get("info", None)
+                link_data = discovered_file.match.link_data
+
+                # Create new primary dataset
+                name = fields_match.name or designation
+
+                hda_id = discovered_file.match.object_id
+                primary_dataset = None
+                if hda_id:
+                    primary_dataset = model_persistence_context.sa_session.query(galaxy.model.HistoryDatasetAssociation).get(hda_id)
+
+                sources = fields_match.sources
+                hashes = fields_match.hashes
+                dataset = model_persistence_context.create_dataset(
+                    ext=ext,
+                    designation=designation,
+                    visible=True,
+                    dbkey=dbkey,
+                    name=name,
+                    filename=discovered_file.path,
+                    info=info,
+                    link_data=link_data,
+                    primary_data=primary_dataset,
+                    sources=sources,
+                    hashes=hashes,
+                )
+                dataset.raw_set_dataset_state('ok')
+                if not hda_id:
+                    datasets.append(dataset)
+
+    collect_elements_for_history(elements)
+    model_persistence_context.add_datasets_to_history(datasets)
+
+    def add_datasets_to_history(self, datasets, for_output_dataset=None):
+        if for_output_dataset is not None:
+            raise NotImplementedError()
+
+        for dataset in datasets:
+            self.export_store.add_dataset(dataset)
+
+    def persist_object(self, obj):
+        pass
+
+    def flush(self):
+        pass
+
+
+def get_required_item(from_dict, key, message):
+    if key not in from_dict:
+        raise RequestParameterInvalidException(message)
+    return from_dict[key]
+
+
+def validate_and_normalize_target(obj):
+    replace_request_syntax_sugar(obj)
+
+
+def replace_request_syntax_sugar(obj):
+    # For data libraries and hdas to make sense - allow items and items_from in place of elements
+    # and elements_from. This is destructive and modifies the supplied request.
+    if isinstance(obj, list):
+        for el in obj:
+            replace_request_syntax_sugar(el)
+    elif isinstance(obj, dict):
+        if "items" in obj:
+            obj["elements"] = obj["items"]
+            del obj["items"]
+        if "items_from" in obj:
+            obj["elements_from"] = obj["items_from"]
+            del obj["items_from"]
+        for value in obj.values():
+            replace_request_syntax_sugar(value)
+
+        if "src" in obj or "filename" in obj:
+            # item...
+            new_hashes = []
+            for key in HASH_NAME_MAP.keys():
+                if key in obj:
+                    new_hashes.append({"hash_function": key, "hash_value": obj[key]})
+                    del obj[key]
+                if key.lower() in obj:
+                    new_hashes.append({"hash_function": key, "hash_value": obj[key.lower()]})
+                    del obj[key.lower()]
+
+            if "hashes" not in obj:
+                obj["hashes"] = []
+            obj["hashes"].extend(new_hashes)
+
+
+DiscoveredFile = namedtuple('DiscoveredFile', ['path', 'collector', 'match'])
+
+
+def discovered_file_for_element(dataset, job_working_directory, parent_identifiers=[], collector=None):
+    target_directory = discover_target_directory(getattr(collector, "directory", None), job_working_directory)
+    filename = dataset["filename"]
+    # handle link_data_only here, verify filename is in directory if not linking...
+    if not dataset.get("link_data_only"):
+        path = os.path.join(target_directory, filename)
+        if not util.in_directory(path, target_directory):
+            raise Exception("Problem with tool configuration, attempting to pull in datasets from outside working directory.")
+    else:
+        path = filename
+    return DiscoveredFile(path, collector, JsonCollectedDatasetMatch(dataset, collector, filename, path=path, parent_identifiers=parent_identifiers))
+
+
+def discover_target_directory(dir_name, job_working_directory):
+    if dir_name:
+        directory = os.path.join(job_working_directory, dir_name)
+        if not util.in_directory(directory, job_working_directory):
+            raise Exception("Problem with tool configuration, attempting to pull in datasets from outside working directory.")
+        return directory
+    else:
+        return job_working_directory
+
+
+class JsonCollectedDatasetMatch(object):
+
+    def __init__(self, as_dict, collector, filename, path=None, parent_identifiers=[]):
+        self.as_dict = as_dict
+        self.collector = collector
+        self.filename = filename
+        self.path = path
+        self._parent_identifiers = parent_identifiers
+
+    @property
+    def designation(self):
+        # If collecting nested collection, grab identifier_0,
+        # identifier_1, etc... and join on : to build designation.
+        element_identifiers = self.raw_element_identifiers
+        if element_identifiers:
+            return ":".join(element_identifiers)
+        elif "designation" in self.as_dict:
+            return self.as_dict.get("designation")
+        elif "name" in self.as_dict:
+            return self.as_dict.get("name")
+        else:
+            return None
+
+    @property
+    def element_identifiers(self):
+        return self._parent_identifiers + (self.raw_element_identifiers or [self.designation])
+
+    @property
+    def raw_element_identifiers(self):
+        identifiers = []
+        i = 0
+        while True:
+            key = "identifier_%d" % i
+            if key in self.as_dict:
+                identifiers.append(self.as_dict.get(key))
+            else:
+                break
+            i += 1
+
+        return identifiers
+
+    @property
+    def name(self):
+        """ Return name or None if not defined by the discovery pattern.
+        """
+        return self.as_dict.get("name")
+
+    @property
+    def dbkey(self):
+        return self.as_dict.get("dbkey", getattr(self.collector, "default_dbkey", "?"))
+
+    @property
+    def ext(self):
+        return self.as_dict.get("ext", getattr(self.collector, "default_ext", "data"))
+
+    @property
+    def visible(self):
+        try:
+            return self.as_dict["visible"].lower() == "visible"
+        except KeyError:
+            return getattr(self.collector, "default_visible", True)
+
+    @property
+    def link_data(self):
+        return bool(self.as_dict.get("link_data_only", False))
+
+    @property
+    def tag_list(self):
+        return self.as_dict.get("tags", [])
+
+    @property
+    def object_id(self):
+        return self.as_dict.get("object_id", None)
+
+    @property
+    def sources(self):
+        return self.as_dict.get("sources", [])
+
+    @property
+    def hashes(self):
+        return self.as_dict.get("hashes", [])
+
+
+class RegexCollectedDatasetMatch(JsonCollectedDatasetMatch):
+
+    def __init__(self, re_match, collector, filename, path=None):
+        super(RegexCollectedDatasetMatch, self).__init__(
+            re_match.groupdict(), collector, filename, path=path
+        )

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -99,12 +99,11 @@ def _fetch_target(upload_config, target):
         url = item.get("url")
         if url:
             sources.append({"source_uri": url})
-        hashes = []
-        for hash_function in HASH_NAMES:
-            hash_value = item.get(hash_function)
-            if hash_value:
-                hashes.append({"hash_function": hash_function, "hash_value": hash_value})
-                _handle_hash_validation(upload_config, hash_function, hash_value, path)
+        hashes = item.get("hashes", [])
+        for hash_dict in hashes:
+            hash_function = hash_dict.get("hash_function")
+            hash_value = hash_dict.get("hash_value")
+            _handle_hash_validation(upload_config, hash_function, hash_value, path)
 
         dbkey = item.get("dbkey", "?")
         requested_ext = item.get("ext", "auto")

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -1,5 +1,6 @@
 galaxy-objectstore
 galaxy-util
+bdbag
 bx
 h5py
 isa-rwval

--- a/packages/data/setup.py
+++ b/packages/data/setup.py
@@ -39,11 +39,13 @@ PACKAGES = [
     'galaxy.model.dataset_collections',
     'galaxy.model.migrate',
     'galaxy.model.orm',
+    'galaxy.model.store',
     'galaxy.model.tool_shed_install',
     'galaxy.security',
 ]
 ENTRY_POINTS = '''
         [console_scripts]
+        gx-build-objects=galaxy.model.store.build_objects:main
 '''
 PACKAGE_DATA = {
     # Be sure to update MANIFEST.in for source dist.

--- a/test/unit/test_model_discovery.py
+++ b/test/unit/test_model_discovery.py
@@ -1,0 +1,154 @@
+import os
+from tempfile import mkdtemp
+
+from galaxy import model
+from galaxy.model import store
+from galaxy.model.store.discover import persist_target_to_export_store
+from .tools.test_history_imp_exp import _mock_app
+
+
+def test_model_create_context_persist_hdas():
+    work_directory = mkdtemp()
+    with open(os.path.join(work_directory, "file1.txt"), "w") as f:
+        f.write("hello world\nhello world line 2")
+    target = {
+        "destination": {
+            "type": "hdas",
+        },
+        "elements": [{
+            "filename": "file1.txt",
+            "ext": "txt",
+            "dbkey": "hg19",
+            "name": "my file",
+            "md5": "e5d21b1ea57fc9a31f8ea0110531bf3d",
+        }],
+    }
+    app = _mock_app(store_by="uuid")
+    temp_directory = mkdtemp()
+    with store.DirectoryModelExportStore(temp_directory, serialize_dataset_objects=True) as export_store:
+        persist_target_to_export_store(target, export_store, app.object_store, work_directory)
+
+    u = model.User(email="collection@example.com", password="password")
+    import_history = model.History(name="Test History for Import", user=u)
+
+    sa_session = app.model.context
+    sa_session.add(u)
+    sa_session.add(import_history)
+    sa_session.flush()
+
+    assert len(import_history.datasets) == 0
+
+    import_options = store.ImportOptions(allow_dataset_object_edit=True)
+    import_model_store = store.get_import_model_store_for_directory(temp_directory, app=app, user=u, import_options=import_options)
+    with import_model_store.target_history(default_history=import_history):
+        import_model_store.perform_import(import_history)
+
+    assert len(import_history.datasets) == 1
+    imported_hda = import_history.datasets[0]
+    assert imported_hda.ext == "txt"
+    assert imported_hda.name == "my file"
+    assert imported_hda.metadata.data_lines == 2
+    assert len(imported_hda.dataset.hashes) == 1
+    assert imported_hda.dataset.hashes[0].hash_value == "e5d21b1ea57fc9a31f8ea0110531bf3d"
+
+    with open(imported_hda.file_name, "r") as f:
+        assert f.read().startswith("hello world\n")
+
+
+def test_persist_target_library_dataset():
+    work_directory = mkdtemp()
+    with open(os.path.join(work_directory, "file1.txt"), "w") as f:
+        f.write("hello world\nhello world line 2")
+    target = {
+        "destination": {
+            "type": "library",
+            "name": "Example Library",
+            "description": "Example Library Description",
+            "synopsis": "Example Library Synopsis",
+        },
+        "elements": [{
+            "filename": "file1.txt",
+            "ext": "txt",
+            "dbkey": "hg19",
+            "name": "my file",
+        }],
+    }
+    sa_session = _import_library_target(target, work_directory)
+    new_library = _assert_one_library_created(sa_session)
+
+    assert new_library.name == "Example Library"
+    assert new_library.description == "Example Library Description"
+    assert new_library.synopsis == "Example Library Synopsis"
+
+    new_root = new_library.root_folder
+    assert new_root
+    assert new_root.name == "Example Library"
+
+    assert len(new_root.datasets) == 1
+    ldda = new_root.datasets[0].library_dataset_dataset_association
+    assert ldda.metadata.data_lines == 2
+    with open(ldda.file_name, "r") as f:
+        assert f.read().startswith("hello world\n")
+
+
+def test_persist_target_library_folder():
+    work_directory = mkdtemp()
+    with open(os.path.join(work_directory, "file1.txt"), "w") as f:
+        f.write("hello world\nhello world line 2")
+    target = {
+        "destination": {
+            "type": "library",
+            "name": "Example Library",
+            "description": "Example Library Description",
+            "synopsis": "Example Library Synopsis",
+        },
+        "items": [{
+            "name": "Folder 1",
+            "description": "Folder 1 Description",
+            "items": [{
+                "filename": "file1.txt",
+                "ext": "txt",
+                "dbkey": "hg19",
+                "info": "dataset info",
+                "name": "my file",
+            }]
+        }],
+    }
+    sa_session = _import_library_target(target, work_directory)
+    new_library = _assert_one_library_created(sa_session)
+    new_root = new_library.root_folder
+    assert len(new_root.datasets) == 0
+    assert len(new_root.folders) == 1
+
+    child_folder = new_root.folders[0]
+    assert child_folder.name == "Folder 1"
+    assert child_folder.description == "Folder 1 Description"
+    assert len(child_folder.folders) == 0
+    assert len(child_folder.datasets) == 1
+    ldda = child_folder.datasets[0].library_dataset_dataset_association
+    assert ldda.metadata.data_lines == 2
+    with open(ldda.file_name, "r") as f:
+        assert f.read().startswith("hello world\n")
+
+
+def _assert_one_library_created(sa_session):
+    all_libraries = sa_session.query(model.Library).all()
+    assert len(all_libraries) == 1, len(all_libraries)
+    new_library = all_libraries[0]
+    return new_library
+
+
+def _import_library_target(target, work_directory):
+    app = _mock_app(store_by="uuid")
+    temp_directory = mkdtemp()
+    with store.DirectoryModelExportStore(temp_directory, app=app, serialize_dataset_objects=True) as export_store:
+        persist_target_to_export_store(target, export_store, app.object_store, work_directory)
+
+    u = model.User(email="library@example.com", password="password")
+
+    import_options = store.ImportOptions(allow_dataset_object_edit=True, allow_library_creation=True)
+    import_model_store = store.get_import_model_store_for_directory(temp_directory, app=app, user=u, import_options=import_options)
+    import_model_store.perform_import()
+
+    sa_session = app.model.context
+    return sa_session

--- a/test/unit/test_model_store.py
+++ b/test/unit/test_model_store.py
@@ -1,3 +1,4 @@
+"""Unit tests for importing and exporting data from model stores."""
 import json
 import os
 from tempfile import mkdtemp, NamedTemporaryFile

--- a/test/unit/test_objectstore.py
+++ b/test/unit/test_objectstore.py
@@ -740,14 +740,14 @@ def test_config_parse_azure():
 
 
 class TestConfig(object):
-    def __init__(self, config_str=DISK_TEST_CONFIG, clazz=None):
+    def __init__(self, config_str=DISK_TEST_CONFIG, clazz=None, store_by="id"):
         self.temp_directory = mkdtemp()
         if config_str.startswith("<"):
             config_file = "store.xml"
         else:
             config_file = "store.yaml"
         self.write(config_str, config_file)
-        config = MockConfig(self.temp_directory, config_file)
+        config = MockConfig(self.temp_directory, config_file, store_by=store_by)
         if clazz is None:
             self.object_store = objectstore.build_object_store_from_config(config)
         elif config_file == "store.xml":
@@ -774,11 +774,12 @@ class TestConfig(object):
 
 class MockConfig(object):
 
-    def __init__(self, temp_directory, config_file):
+    def __init__(self, temp_directory, config_file, store_by="id"):
         self.file_path = temp_directory
         self.object_store_config_file = os.path.join(temp_directory, config_file)
         self.object_store_check_old_style = False
         self.object_store_cache_path = os.path.join(temp_directory, "staging")
+        self.object_store_store_by = store_by
         self.jobs_directory = temp_directory
         self.new_file_path = temp_directory
         self.umask = 0000

--- a/test/unit/tools/test_history_imp_exp.py
+++ b/test/unit/tools/test_history_imp_exp.py
@@ -38,9 +38,9 @@ def _run_jihaw_cleanup(archive_dir, app=None):
     return app, jihaw.cleanup_after_job()
 
 
-def _mock_app():
+def _mock_app(store_by="id"):
     app = MockApp()
-    test_object_store_config = TestConfig()
+    test_object_store_config = TestConfig(store_by=store_by)
     app.object_store = test_object_store_config.object_store
     app.model.Dataset.object_store = app.object_store
     app.datatypes_registry.set_external_metadata_tool = MockSetExternalTool()

--- a/test/unit/tools/test_history_imp_exp.py
+++ b/test/unit/tools/test_history_imp_exp.py
@@ -604,8 +604,8 @@ def _assert_distinct(l):
     assert len(l) == len(set(l))
 
 
-def _create_datasets(sa_session, history, n):
-    return [model.HistoryDatasetAssociation(extension="txt", history=history, create_dataset=True, sa_session=sa_session, hid=i + 1) for i in range(n)]
+def _create_datasets(sa_session, history, n, extension="txt"):
+    return [model.HistoryDatasetAssociation(extension=extension, history=history, create_dataset=True, sa_session=sa_session, hid=i + 1) for i in range(n)]
 
 
 def _setup_history_for_export(history_name):


### PR DESCRIPTION
The included script takes in an object store definition to write to, model store output target (e.g. tar file or directory or bagit file/directory format matching the new history exports added in 7367), and a bunch of files in defined via an upload-2.0-style YAML - and writes the physical files into the object store and writes persisted metadata into the model store. The supplied script describes the input format as do the new unit tests in test_model_discover.py.

Right now datasets for a history and whole libraries (including recursive folders and library datasets) can be described this way. These concepts have been extended to collections in #7058 but only in the context of discovering job outputs and writing them to an export model store current.

This script was created mostly by refactoring stuff out of output_collect.py that is used to create datasets during output discovery (i.e. parsing the same data out of galaxy.json files).

The interesting new thing here is mostly just the last commit, but this builds on:
- #7367 
- #7650 
- Various smaller fixes and enhancements to the model store concept introduced in #7367.
