### PR TITLE
Plugin static staging fix

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -3,7 +3,6 @@ const fs = require("fs");
 const del = require("del");
 const { src, dest, series, parallel } = require("gulp");
 const uglify = require("gulp-uglify-es").default;
-const babel = require("gulp-babel");
 
 const paths = {
     node_modules: "./node_modules",
@@ -59,18 +58,17 @@ function libs() {
         .pipe(dest("../static/scripts/libs/"));
 }
 
-function plugins() {
+function stagePlugins() {
     return src(paths.plugin_dirs).pipe(dest("../static/plugins/"));
 }
 
-function clean() {
-    //Wipe out all scripts that aren't handled by webpack
-    return del(["../static/scripts/**/*.js", "!../static/scripts/bundled/**.*.js"], { force: true });
+function cleanPlugins() {
+    return del(["../static/plugins/{visualizations,interactive_environments}/*"], { force: true });
 }
 
 module.exports.fonts = fonts;
 module.exports.libs = libs;
-module.exports.clean = clean;
 module.exports.stageLibs = stageLibs;
-module.exports.plugins = plugins;
-module.exports.default = parallel(stageLibs, fonts, plugins);
+module.exports.cleanPlugins = cleanPlugins;
+module.exports.plugins = series(cleanPlugins, stagePlugins);
+module.exports.default = parallel(stageLibs, fonts, module.exports.plugins);

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -2,7 +2,6 @@ const path = require("path");
 const fs = require("fs");
 const del = require("del");
 const { src, dest, series, parallel } = require("gulp");
-const uglify = require("gulp-uglify-es").default;
 
 const paths = {
     node_modules: "./node_modules",

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -52,12 +52,6 @@ function fonts() {
     );
 }
 
-function libs() {
-    return src(paths.libs)
-        .pipe(uglify())
-        .pipe(dest("../static/scripts/libs/"));
-}
-
 function stagePlugins() {
     return src(paths.plugin_dirs).pipe(dest("../static/plugins/"));
 }
@@ -67,7 +61,6 @@ function cleanPlugins() {
 }
 
 module.exports.fonts = fonts;
-module.exports.libs = libs;
 module.exports.stageLibs = stageLibs;
 module.exports.cleanPlugins = cleanPlugins;
 module.exports.plugins = series(cleanPlugins, stagePlugins);

--- a/client/package.json
+++ b/client/package.json
@@ -91,7 +91,6 @@
     "expose-loader": "^0.7.5",
     "file-loader": "^3.0.1",
     "gulp": "^4.0.0",
-    "gulp-babel": "^8.0.0",
     "gulp-uglify-es": "^1.0.4",
     "ignore-loader": "^0.1.2",
     "json-loader": "^0.5.7",

--- a/client/package.json
+++ b/client/package.json
@@ -91,7 +91,6 @@
     "expose-loader": "^0.7.5",
     "file-loader": "^3.0.1",
     "gulp": "^4.0.0",
-    "gulp-uglify-es": "^1.0.4",
     "ignore-loader": "^0.1.2",
     "json-loader": "^0.5.7",
     "karma": "^1.7.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6105,17 +6105,6 @@ gulp-cli@^2.0.0:
     v8flags "^3.0.1"
     yargs "^7.1.0"
 
-gulp-uglify-es@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/gulp-uglify-es/-/gulp-uglify-es-1.0.4.tgz#59ee0d5ea98c1e09c6eaa58c8b018a6ad33f48d4"
-  integrity sha512-UMRufZsBmQizCYpftutaiVoLswpbzFEfY90EJLU4YlTgculeHnanb794s88TMd5tpCZVC638sAX6JrLVYTP/Wg==
-  dependencies:
-    o-stream "^0.2.2"
-    plugin-error "^1.0.1"
-    terser "^3.7.5"
-    vinyl "^2.1.0"
-    vinyl-sourcemaps-apply "^0.2.1"
-
 gulp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/gulp/-/gulp-4.0.0.tgz#95766c601dade4a77ed3e7b2b6dc03881b596366"
@@ -8706,11 +8695,6 @@ numbro@1.11.0:
   resolved "https://registry.yarnpkg.com/numbro/-/numbro-1.11.0.tgz#39aa17b358b4682aec8ca0d5755f35c5d9ce8f9e"
   integrity sha1-OaoXs1i0aCrsjKDVdV81xdnOj54=
 
-o-stream@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/o-stream/-/o-stream-0.2.2.tgz#7fe03af870b8f9537af33b312b381b3034ab410f"
-  integrity sha512-V3j76KU3g/Gyl8rpdi2z72rn5zguMvTCQgAXfBe3pxEefKqXmOUOD7mvx/mNjykdxGqDVfpSoo8r+WdrkWg/1Q==
-
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -9426,16 +9410,6 @@ pkg-up@2.0.0:
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
   dependencies:
     find-up "^2.1.0"
-
-plugin-error@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
-  integrity sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==
-  dependencies:
-    ansi-colors "^1.0.1"
-    arr-diff "^4.0.0"
-    arr-union "^3.1.0"
-    extend-shallow "^3.0.2"
 
 plur@^1.0.0:
   version "1.0.0"
@@ -11661,7 +11635,7 @@ source-map@^0.4.2:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -12143,7 +12117,7 @@ terser-webpack-plugin@^1.1.0, terser-webpack-plugin@^1.2.2:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
-terser@^3.16.1, terser@^3.7.5:
+terser@^3.16.1:
   version "3.17.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-3.17.0.tgz#f88ffbeda0deb5637f9d24b0da66f4e15ab10cb2"
   integrity sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==
@@ -12886,14 +12860,7 @@ vinyl-sourcemap@^1.1.0:
     remove-bom-buffer "^3.0.0"
     vinyl "^2.0.0"
 
-vinyl-sourcemaps-apply@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz#ab6549d61d172c2b1b87be5c508d239c8ef87705"
-  integrity sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=
-  dependencies:
-    source-map "^0.5.1"
-
-vinyl@^2.0.0, vinyl@^2.1.0:
+vinyl@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.2.0.tgz#d85b07da96e458d25b2ffe19fece9f2caa13ed86"
   integrity sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6081,16 +6081,6 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-gulp-babel@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/gulp-babel/-/gulp-babel-8.0.0.tgz#e0da96f4f2ec4a88dd3a3030f476e38ab2126d87"
-  integrity sha512-oomaIqDXxFkg7lbpBou/gnUkX51/Y/M2ZfSjL2hdqXTAlSWZcgZtd2o0cOH0r/eE8LWD0+Q/PsLsr2DKOoqToQ==
-  dependencies:
-    plugin-error "^1.0.1"
-    replace-ext "^1.0.0"
-    through2 "^2.0.0"
-    vinyl-sourcemaps-apply "^0.2.0"
-
 gulp-cli@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/gulp-cli/-/gulp-cli-2.0.1.tgz#7847e220cb3662f2be8a6d572bf14e17be5a994b"
@@ -12896,7 +12886,7 @@ vinyl-sourcemap@^1.1.0:
     remove-bom-buffer "^3.0.0"
     vinyl "^2.0.0"
 
-vinyl-sourcemaps-apply@^0.2.0, vinyl-sourcemaps-apply@^0.2.1:
+vinyl-sourcemaps-apply@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz#ab6549d61d172c2b1b87be5c508d239c8ef87705"
   integrity sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=


### PR DESCRIPTION
This fixes a bug where previously staged plugins (via symlink in the python version of this staging) would not be overwritten with the same real file contents.  This would cause 404s for plugin static under uwsgi serving due to the removal of `config/plugins/etc` from the static-safe map.

Includes minor gulpfile cleanup and dropping a few now-unused dependencies.