### PR TITLE
More refactoring of model migrations

### DIFF
--- a/lib/galaxy/model/migrate/versions/0004_indexes_and_defaults.py
+++ b/lib/galaxy/model/migrate/versions/0004_indexes_and_defaults.py
@@ -3,9 +3,15 @@
 import logging
 import sys
 
-from sqlalchemy import Index, MetaData, Table
+from sqlalchemy import (
+    MetaData,
+    Table
+)
 
-from galaxy.model.migrate.versions.util import engine_false
+from galaxy.model.migrate.versions.util import (
+    add_index,
+    engine_false
+)
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -23,18 +29,8 @@ def upgrade(migrate_engine):
     metadata.reflect()
 
     User_table = Table("galaxy_user", metadata, autoload=True)
-    HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
-    # Add 2 indexes to the galaxy_user table
-    i = Index('ix_galaxy_user_deleted', User_table.c.deleted)
-    try:
-        i.create()
-    except Exception:
-        log.exception("Adding index 'ix_galaxy_user_deleted' to galaxy_user table failed.")
-    i = Index('ix_galaxy_user_purged', User_table.c.purged)
-    try:
-        i.create()
-    except Exception:
-        log.exception("Adding index 'ix_galaxy_user_purged' to galaxy_user table failed.")
+    add_index('ix_galaxy_user_deleted', User_table, 'deleted')
+    add_index('ix_galaxy_user_purged', User_table, 'purged')
     # Set the default data in the galaxy_user table, but only for null values
     cmd = "UPDATE galaxy_user SET deleted = %s WHERE deleted is null" % engine_false(migrate_engine)
     try:
@@ -46,12 +42,9 @@ def upgrade(migrate_engine):
         migrate_engine.execute(cmd)
     except Exception:
         log.exception("Setting default data for galaxy_user.purged column failed.")
-    # Add 1 index to the history_dataset_association table
-    i = Index('ix_hda_copied_from_library_dataset_dataset_association_id', HistoryDatasetAssociation_table.c.copied_from_library_dataset_dataset_association_id)
-    try:
-        i.create()
-    except Exception:
-        log.exception("Adding index 'ix_hda_copied_from_library_dataset_dataset_association_id' to history_dataset_association table failed.")
+    add_index('ix_hda_copied_from_library_dataset_dataset_association_id',
+        'history_dataset_association',
+        'copied_from_library_dataset_dataset_association_id', metadata)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0025_user_info.py
+++ b/lib/galaxy/model/migrate/versions/0025_user_info.py
@@ -27,6 +27,7 @@ def upgrade(migrate_engine):
     print(__doc__)
     metadata.bind = migrate_engine
     metadata.reflect()
+
     try:
         User_table = Table("galaxy_user", metadata, autoload=True)
     except NoSuchTableError:
@@ -34,7 +35,7 @@ def upgrade(migrate_engine):
         log.debug("Failed loading table galaxy_user")
     if User_table is not None:
         col = Column("form_values_id", Integer, index=True)
-        add_column(col, User_table, index_name='ix_user_form_values_id')
+        add_column(col, User_table, index_name='ix_galaxy_user_form_values_id')
         try:
             FormValues_table = Table("form_values", metadata, autoload=True)
         except NoSuchTableError:

--- a/lib/galaxy/model/migrate/versions/0073_add_ldda_to_implicit_conversion_table.py
+++ b/lib/galaxy/model/migrate/versions/0073_add_ldda_to_implicit_conversion_table.py
@@ -5,34 +5,37 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData
+)
+
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        Implicitly_converted_table = Table("implicitly_converted_dataset_association", metadata, autoload=True)
-        if migrate_engine.name != 'sqlite':
-            c = Column("ldda_parent_id", Integer, ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True)
-        else:
-            # Can't use the ForeignKey in sqlite.
-            c = Column("ldda_parent_id", Integer, index=True, nullable=True)
-        c.create(Implicitly_converted_table, index_name="ix_implicitly_converted_dataset_assoc_ldda_parent_id")
-        assert c is Implicitly_converted_table.c.ldda_parent_id
-    except Exception:
-        log.exception("Adding ldda_parent_id column to implicitly_converted_dataset_association table failed.")
+
+    if migrate_engine.name != 'sqlite':
+        c = Column("ldda_parent_id", Integer, ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True)
+    else:
+        # Can't use the ForeignKey in SQLite.
+        c = Column("ldda_parent_id", Integer, index=True, nullable=True)
+    add_column(c, 'implicitly_converted_dataset_association', metadata, index_name='ix_implicitly_converted_dataset_assoc_ldda_parent_id')
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        Implicitly_converted_table = Table("implicitly_converted_dataset_association", metadata, autoload=True)
-        Implicitly_converted_table.c.ldda_parent_id.drop()
-    except Exception:
-        log.exception("Dropping ldda_parent_id column from implicitly_converted_dataset_association table failed.")
+
+    drop_column('ldda_parent_id', 'implicitly_converted_dataset_association', metadata)

--- a/lib/galaxy/model/migrate/versions/0084_add_ldda_id_to_implicit_conversion_table.py
+++ b/lib/galaxy/model/migrate/versions/0084_add_ldda_id_to_implicit_conversion_table.py
@@ -5,33 +5,37 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData
+)
+
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        Implicitly_converted_table = Table("implicitly_converted_dataset_association", metadata, autoload=True)
-        if migrate_engine.name != 'sqlite':
-            c = Column("ldda_id", Integer, ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True)
-        else:
-            c = Column("ldda_id", Integer, index=True, nullable=True)
-        c.create(Implicitly_converted_table, index_name="ix_implicitly_converted_ds_assoc_ldda_id")
-        assert c is Implicitly_converted_table.c.ldda_id
-    except Exception:
-        log.exception("Adding ldda_id column to implicitly_converted_dataset_association table failed.")
+
+    if migrate_engine.name != 'sqlite':
+        c = Column("ldda_id", Integer, ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True)
+    else:
+        # Can't use the ForeignKey in SQLite.
+        c = Column("ldda_id", Integer, index=True, nullable=True)
+    add_column(c, 'implicitly_converted_dataset_association', metadata, index_name='ix_implicitly_converted_ds_assoc_ldda_id')
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        Implicitly_converted_table = Table("implicitly_converted_dataset_association", metadata, autoload=True)
-        Implicitly_converted_table.c.ldda_id.drop()
-    except Exception:
-        log.exception("Dropping ldda_id column from implicitly_converted_dataset_association table failed.")
+
+    drop_column('ldda_id', 'implicitly_converted_dataset_association', metadata)

--- a/lib/galaxy/model/migrate/versions/0147_job_messages.py
+++ b/lib/galaxy/model/migrate/versions/0147_job_messages.py
@@ -8,64 +8,51 @@ import logging
 from sqlalchemy import Column, MetaData, Table, TEXT
 
 from galaxy.model.custom_types import JSONType
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    alter_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
-job_messages_column = Column("job_messages", JSONType, nullable=True)
-task_job_messages_column = Column("job_messages", JSONType, nullable=True)
-job_job_stdout_column = Column("job_stdout", TEXT, nullable=True)
-job_job_stderr_column = Column("job_stderr", TEXT, nullable=True)
-task_job_stdout_column = Column("job_stdout", TEXT, nullable=True)
-task_job_stderr_column = Column("job_stderr", TEXT, nullable=True)
+metadata = MetaData()
 
 
 def upgrade(migrate_engine):
     print(__doc__)
-    metadata = MetaData()
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        jobs_table = Table("job", metadata, autoload=True)
-        job_messages_column.create(jobs_table)
-        assert job_messages_column is jobs_table.c.job_messages
+    jobs_table = Table("job", metadata, autoload=True)
+    job_messages_column = Column("job_messages", JSONType, nullable=True)
+    add_column(job_messages_column, jobs_table)
+    job_job_stdout_column = Column("job_stdout", TEXT, nullable=True)
+    add_column(job_job_stdout_column, jobs_table)
+    job_job_stderr_column = Column("job_stderr", TEXT, nullable=True)
+    add_column(job_job_stderr_column, jobs_table)
 
-        job_job_stdout_column.create(jobs_table)
-        job_job_stderr_column.create(jobs_table)
+    tasks_table = Table("task", metadata, autoload=True)
+    task_job_messages_column = Column("job_messages", JSONType, nullable=True)
+    add_column(task_job_messages_column, tasks_table)
+    task_job_stdout_column = Column("job_stdout", TEXT, nullable=True)
+    add_column(task_job_stdout_column, tasks_table)
+    task_job_stderr_column = Column("job_stderr", TEXT, nullable=True)
+    add_column(task_job_stderr_column, tasks_table)
 
-        jobs_table.c.stdout.alter(name="tool_stdout")
-        jobs_table.c.stderr.alter(name="tool_stderr")
-
-        tasks_table = Table("task", metadata, autoload=True)
-        task_job_messages_column.create(tasks_table)
-        assert task_job_messages_column is tasks_table.c.job_messages
-
-        task_job_stdout_column.create(tasks_table)
-        task_job_stderr_column.create(tasks_table)
-
-        tasks_table.c.stdout.alter(name="tool_stdout")
-        tasks_table.c.stderr.alter(name="tool_stderr")
-    except Exception:
-        log.exception("Failed to alter jobs and/or tasks tables.")
+    for table in [jobs_table, tasks_table]:
+        alter_column('stdout', table, name='tool_stdout')
+        alter_column('stderr', table, name='tool_stderr')
 
 
 def downgrade(migrate_engine):
-    metadata = MetaData()
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        jobs_table = Table("job", metadata, autoload=True)
-        tasks_table = Table("task", metadata, autoload=True)
-
-        for colname in ["job_messages", "job_stdout", "job_stderr"]:
-            job_col = getattr(jobs_table.c, colname)
-            job_col.drop()
-            task_col = getattr(tasks_table.c, colname)
-            task_col.drop()
-
-        for table in [jobs_table, tasks_table]:
-            table.c.tool_stdout.alter(name="stdout")
-            table.c.tool_stderr.alter(name="stderr")
-
-    except Exception:
-        log.exception("Failed to alter jobs and/or tasks tables.")
+    jobs_table = Table("job", metadata, autoload=True)
+    tasks_table = Table("task", metadata, autoload=True)
+    for colname in ["job_messages", "job_stdout", "job_stderr"]:
+        drop_column(colname, jobs_table)
+        drop_column(colname, tasks_table)
+    for table in [jobs_table, tasks_table]:
+        alter_column('tool_stdout', table, name='stdout')
+        alter_column('tool_stderr', table, name='stderr')

--- a/lib/galaxy/model/migrate/versions/0151_add_worker_process.py
+++ b/lib/galaxy/model/migrate/versions/0151_add_worker_process.py
@@ -29,12 +29,15 @@ WorkerProcess_table = Table(
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     create_table(WorkerProcess_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
+    metadata.reflect()
+
     drop_table(WorkerProcess_table)


### PR DESCRIPTION
- Refactor migrations adding indexes
- Fix 4 index names in old migrations to prevent duplicated indexes
- Fix the order of dropping tables in migration 14
- More migration refactoring