### PR TITLE
Patch for metadata setting of minimal BIOM1 files

### DIFF
--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -280,9 +280,10 @@ class Biom1(Json):
                         if b_name == "columns" and metadata_value:
                             keep_columns = set()
                             for column in metadata_value:
-                                for k, v in column['metadata'].items():
-                                    if v is not None:
-                                        keep_columns.add(k)
+                                if column['metadata'] is not None:
+                                    for k, v in column['metadata'].items():
+                                        if v is not None:
+                                            keep_columns.add(k)
                             final_list = sorted(list(keep_columns))
                             dataset.metadata.table_column_metadata_headers = final_list
                         if b_name in b_transform:


### PR DESCRIPTION
Hi,

As reported in #7625, the upload and generation of BIOM file are raising errors on 19.01, not on 18.09. This issue happens only with minimal BIOM files (not rich ones).

The minimal BIOM1 files may have `column = {u'id': u'sth', u'metadata': None}`, raising then the following error:

```
ERROR:galaxy.datatypes.text:Something in the metadata detection for biom1 went wrong.
Traceback (most recent call last):
  File "/opt/galaxy/server/lib/galaxy/datatypes/text.py", line 259, in set_meta
    for k, v in column['metadata'].items():
AttributeError: 'NoneType' object has no attribute 'items'
```

This PR checks if `column['metadata']` is not None before the for loop. It should fix #7625.

@nsoranzo @Slugger70 could you check this patch? Should I add some tests? If yes, how/where?

Thanks a lot

Bérénice

---

See [BIOM1 specs](http://biom-format.org/documentation/format_versions/biom-1.0.html) for examples of minimal and rich BIOM1 files