### PR TITLE
Fix genomespace exporter tool

### DIFF
--- a/tools/genomespace/genomespace_exporter.xml
+++ b/tools/genomespace/genomespace_exporter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool name="GenomeSpace Exporter" id="genomespace_exporter" require_login="True" version="0.0.6">
+<tool name="GenomeSpace Exporter" id="genomespace_exporter" require_login="True" version="0.0.7" profile="16.04">
     <description> - send data to GenomeSpace</description>
     <environment_variables>
         <environment_variable name="GS_TOKEN">
@@ -8,7 +8,7 @@
             $token
         </environment_variable>
     </environment_variables>
-    <command>python $__tool_directory__/genomespace_exporter.py
+    <command detect_errors="exit_code">python $__tool_directory__/genomespace_exporter.py
         #set $target_folder = $genomespace_browser.split('^')[0]
         #assert $target_folder, Exception('You must select a valid target folder.')
         


### PR DESCRIPTION
Specify profile and look for exit codes for genomespace tool -- warnings cause failures otherwise.

Someone more familiar with the tool -- is this going to work like I expect, or is it going to potentially fail without returning a nonzero exit code?

And, we may need to apply this to the other genomespace tools using cloudbridge as well.

xref https://github.com/galaxyproject/galaxy/pull/7647#issuecomment-481208063
