### PR TITLE
[19.01] Only check for exit code on actual sort command

### DIFF
--- a/tools/filters/sorter.py
+++ b/tools/filters/sorter.py
@@ -42,9 +42,7 @@ def main():
             # sed header
             if header_lines > 0:
                 sed_header = ['sed', '-n', "1,%dp" % header_lines, input]
-                exit_code = subprocess.call(sed_header, stdout=out)
-                if exit_code:
-                    stop_err('Capturing header lines failed')
+                subprocess.check_call(sed_header, stdout=out)
 
             # grep comments
             grep_comments = ['grep', '^#', input]

--- a/tools/filters/sorter.py
+++ b/tools/filters/sorter.py
@@ -38,21 +38,26 @@ def main():
         header_lines = options.header_lines
         key = [" -k" + k for k in options.key]
 
-        # sed header
-        if header_lines > 0:
-            sed_header = "sed -n '1,%dp' %s > %s" % (header_lines, input, output)
-            subprocess.check_call(sed_header, shell=True)
+        with open(output, 'w') as out:
+            # sed header
+            if header_lines > 0:
+                sed_header = ['sed', '-n', "1,%dp" % header_lines, input]
+                exit_code = subprocess.call(sed_header, stdout=out)
+                if exit_code:
+                    stop_err('Capturing header lines failed')
 
-        # grep comments
-        grep_comments = "(grep '^#' %s) >> %s" % (input, output)
-        subprocess.call(grep_comments, shell=True)
+            # grep comments
+            grep_comments = ['grep', '^#', input]
+            exit_code = subprocess.call(grep_comments, stdout=out)
+            if exit_code not in [0, 1]:
+                stop_err('Searching for comment lines failed')
 
-        # grep and sort columns
-        sed_header_restore = ""
-        if header_lines > 0:
-            sed_header_restore = "sed '1,%dd' | " % (header_lines)
-        sort_columns = "(cat %s | %s grep '^[^#]' | sort -f -t '\t' %s) >> %s" % (input, sed_header_restore, ' '.join(key), output)
-        subprocess.check_call(sort_columns, shell=True)
+            # grep and sort columns
+            sed_header_restore = ""
+            if header_lines > 0:
+                sed_header_restore = "sed '1,%dd' | " % (header_lines)
+            sort_columns = "(cat %s | %s grep '^[^#]' | sort -f -t '\t' %s)" % (input, sed_header_restore, ' '.join(key))
+            subprocess.check_call(sort_columns, stdout=out, shell=True)
 
     except Exception as ex:
         stop_err('Error running sorter.py\n' + str(ex))

--- a/tools/filters/sorter.py
+++ b/tools/filters/sorter.py
@@ -45,7 +45,7 @@ def main():
 
         # grep comments
         grep_comments = "(grep '^#' %s) >> %s" % (input, output)
-        subprocess.check_call(grep_comments, shell=True)
+        subprocess.call(grep_comments, shell=True)
 
         # grep and sort columns
         sed_header_restore = ""


### PR DESCRIPTION
The grep command that collects headers will exit with a non-zero exit code if there is no header, so we can't use `subprocess.check_call` there. You can see the test is actually failing here: https://jenkins.galaxyproject.org/view/All/job/docker-main-tools/218/testReport/

And you can manually test the tool with planemo:
```
All 4 test(s) executed passed.
sort1[0]: passed
sort1[1]: passed
sort1[2]: passed
sort1[3]: passed
```