### PR TITLE
Allow discovering collections for build model object script.

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -332,8 +332,10 @@ class ModelImportStore(object):
 
                             if file_list:
                                 for extra_file in file_list:
+                                    store_by = self.object_store.store_by
+                                    dir_name = 'dataset_%s_files' % getattr(dataset_instance.dataset, store_by)
                                     self.object_store.update_from_file(
-                                        dataset_instance.dataset, extra_dir='dataset_%s_files' % dataset_instance.dataset.id,
+                                        dataset_instance.dataset, extra_dir=dir_name,
                                         alt_name=extra_file, file_name=os.path.join(self.archive_dir, dataset_extra_files_path, extra_file),
                                         create=True)
                         dataset_instance.dataset.set_total_size()  # update the filesize record in the database

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -11,11 +11,11 @@ from galaxy.model.dataset_collections.structure import UninitializedTree
 from galaxy.model.dataset_collections.type_description import COLLECTION_TYPE_DESCRIPTION_FACTORY
 from galaxy.model.store.discover import (
     discover_target_directory,
-    discovered_file_for_element,
     DiscoveredFile,
     JsonCollectedDatasetMatch,
     ModelPersistenceContext,
     persist_elements_to_folder,
+    persist_elements_to_hdca,
     persist_hdas,
     RegexCollectedDatasetMatch,
     UNSET,
@@ -26,7 +26,6 @@ from galaxy.tools.parser.output_collection_def import (
     ToolProvidedMetadataDatasetCollection,
 )
 from galaxy.util import (
-    ExecutionTimer,
     odict
 )
 
@@ -83,9 +82,7 @@ def collect_dynamic_outputs(
     output_collections,
 ):
     tool = job_context.tool
-    app = job_context.app
-    sa_session = job_context.sa_session
-    job_working_directory = job_context.job_working_directory
+    app = tool.app
 
     # unmapped outputs do not correspond to explicit outputs of the tool, they were inferred entirely
     # from the tool provided metadata (e.g. galaxy.json).
@@ -114,36 +111,17 @@ def collect_dynamic_outputs(
             assert "collection_type" in unnamed_output_dict
             object_id = destination.get("object_id")
             if object_id:
-                hdca = sa_session.query(galaxy.model.HistoryDatasetCollectionAssociation).get(int(object_id))
+                hdca = job_context.sa_session.query(galaxy.model.HistoryDatasetCollectionAssociation).get(int(object_id))
             else:
                 history = job_context.job.history
                 name = unnamed_output_dict.get("name", "unnamed collection")
                 collection_type = unnamed_output_dict["collection_type"]
                 collection_type_description = COLLECTION_TYPE_DESCRIPTION_FACTORY.for_collection_type(collection_type)
                 structure = UninitializedTree(collection_type_description)
-                hdca = collections_service.precreate_dataset_collection_instance(
+                hdca = app.dataset_collections_service.precreate_dataset_collection_instance(
                     trans, history, name, structure=structure
                 )
-            filenames = odict.odict()
-
-            def add_to_discovered_files(elements, parent_identifiers=[]):
-                for element in elements:
-                    if "elements" in element:
-                        add_to_discovered_files(element["elements"], parent_identifiers + [element["name"]])
-                    else:
-                        discovered_file = discovered_file_for_element(element, job_working_directory, parent_identifiers, collector=DEFAULT_DATASET_COLLECTOR)
-                        filenames[discovered_file.path] = discovered_file
-
-            add_to_discovered_files(elements)
-
-            collection = hdca.collection
-            collection_builder = builder.BoundCollectionBuilder(collection)
-            job_context.populate_collection_elements(
-                collection,
-                collection_builder,
-                filenames,
-            )
-            collection_builder.populate()
+            persist_elements_to_hdca(job_context, elements, hdca, collector=DEFAULT_DATASET_COLLECTOR)
         elif destination_type == "hdas":
             persist_hdas(elements, job_context)
 
@@ -218,85 +196,6 @@ class JobContext(ModelPersistenceContext):
         for discovered_file in discover_files(output_name, self.tool_provided_metadata, dataset_collectors, self.job_working_directory, collection):
             filenames[discovered_file.path] = discovered_file
         return filenames
-
-    def populate_collection_elements(self, collection, root_collection_builder, filenames, name=None, metadata_source_name=None):
-        # TODO: allow configurable sorting.
-        #    <sort by="lexical" /> <!-- default -->
-        #    <sort by="reverse_lexical" />
-        #    <sort regex="example.(\d+).fastq" by="1:numerical" />
-        #    <sort regex="part_(\d+)_sample_([^_]+).fastq" by="2:lexical,1:numerical" />
-        if name is None:
-            name = "unnamed output"
-
-        element_datasets = []
-        for filename, discovered_file in filenames.items():
-            create_dataset_timer = ExecutionTimer()
-            fields_match = discovered_file.match
-            if not fields_match:
-                raise Exception("Problem parsing metadata fields for file %s" % filename)
-            element_identifiers = fields_match.element_identifiers
-            designation = fields_match.designation
-            visible = fields_match.visible
-            ext = fields_match.ext
-            dbkey = fields_match.dbkey
-            if dbkey == INPUT_DBKEY_TOKEN:
-                dbkey = self.input_dbkey
-
-            # Create new primary dataset
-            dataset_name = fields_match.name or designation
-
-            link_data = discovered_file.match.link_data
-            tag_list = discovered_file.match.tag_list
-
-            sources = discovered_file.match.sources
-            hashes = discovered_file.match.hashes
-
-            dataset = self.create_dataset(
-                ext=ext,
-                designation=designation,
-                visible=visible,
-                dbkey=dbkey,
-                name=dataset_name,
-                filename=filename,
-                metadata_source_name=metadata_source_name,
-                link_data=link_data,
-                tag_list=tag_list,
-                sources=sources,
-                hashes=hashes,
-            )
-            log.debug(
-                "(%s) Created dynamic collection dataset for path [%s] with element identifier [%s] for output [%s] %s",
-                self.job.id,
-                filename,
-                designation,
-                name,
-                create_dataset_timer,
-            )
-            element_datasets.append((element_identifiers, dataset))
-
-        add_datasets_timer = ExecutionTimer()
-        self.add_datasets_to_history([d for (ei, d) in element_datasets])
-        log.debug(
-            "(%s) Add dynamic collection datasets to history for output [%s] %s",
-            self.job.id,
-            name,
-            add_datasets_timer,
-        )
-
-        for (element_identifiers, dataset) in element_datasets:
-            current_builder = root_collection_builder
-            for element_identifier in element_identifiers[:-1]:
-                current_builder = current_builder.get_level(element_identifier)
-            current_builder.add_dataset(element_identifiers[-1], dataset)
-
-            # Associate new dataset with job
-            element_identifier_str = ":".join(element_identifiers)
-            association_name = '__new_primary_file_%s|%s__' % (name, element_identifier_str)
-            self.add_output_dataset_association(association_name, dataset)
-
-            dataset.raw_set_dataset_state('ok')
-
-        self.flush()
 
     def persist_object(self, obj):
         self.sa_session.add(obj)


### PR DESCRIPTION
Extend the script in #7684 to include HDCAs.

This also brings in a few more model store fixes in addition to those already included in #7684. This includes a commit fixing metadata files for UUID based object stores (updating model store like done in #7650 for other parts of the code). This also brings in a model store fix for nested composite files that fixes #3628.