### PR TITLE
[PROCEDURES] relax the vote requirement for fixing bugs in releases

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -133,11 +133,6 @@ The latter is the preferred method because it is integrated in GitHub, it allows
 tracking the moment when the review was submitted, and it sends a notification
 to subscribers.
 
-Pull requests modifying freezed and tagged release branches should be restricted
-to bug fixes. Pull requests modifying tagged release branches require at least 2
-*+1* binding votes from someone other than the author of the pull request with
-no *-1* binding votes.
-
 Pull requests changing or clarifying the *Procedure Documents* (listed above):
 
 - Must be made to the ``dev`` branch of this repository.
@@ -157,6 +152,9 @@ Pull requests changing or clarifying the *Procedure Documents* (listed above):
 Any other pull request requires at least 1 *+1* binding vote from someone other
 than the author of the pull request. A member of the *committers* group merging
 a pull request is considered an implicit +1.
+
+Pull requests modifying freezed and tagged release branches should be restricted
+to bug fixes.
 
 Pull requests marked *[WIP]* (i.e. work in progress) in the title by the
 author(s), or tagged WIP via GitHub tags, may *not* be merged without


### PR DESCRIPTION
The main rationale is that we want to speed up bug fixing. Allocating time of three committers each time we want to fix a bug is too much, two should be enough.

Please vote @galaxyproject/core