### PR TITLE
[19.01] Restrict workflow invocation index to current user

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -781,9 +781,11 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         else:
             history_id = None
 
-        if stored_workflow_id is None and encoded_history_id is None:
+        if not trans.user_is_admin:
+            # We restrict the query to the current users' invocations
             user_id = trans.user.id
         else:
+            # Get all invocation if user is admin
             user_id = None
 
         invocations = self.workflow_manager.build_invocations_query(

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -3222,6 +3222,9 @@ input:
         with self._different_user():
             usage_details_response = self._get("workflows/%s/usage/%s" % (workflow_id, usage["id"]))
             self._assert_status_code_is(usage_details_response, 403)
+            index_response = self._get("workflows/%s/invocations" % workflow_id)
+            self._assert_status_code_is(index_response, 200)
+            assert len(index_response.json()) == 0
 
         invocation_ids = self._all_user_invocation_ids()
         assert usage["id"] in invocation_ids


### PR DESCRIPTION
If the user is not an admin.
Fixes https://github.com/galaxyproject/galaxy/issues/7710

An alternative would be to skip Accessibility / Ownership
exceptions, but given that we can just restrict the query
this seems like the better approach to me.