### PR TITLE
Copy tools_by_id before collecting dependency status

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -1713,7 +1713,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             selected_tool_ids = []
         if not selected_environments_to_uninstall:
             selected_environments_to_uninstall = []
-        tools_by_id = trans.app.toolbox.tools_by_id
+        tools_by_id = trans.app.toolbox.tools_by_id.copy()
         view = six.next(six.itervalues(trans.app.toolbox.tools_by_id))._view
         if selected_tool_ids:
             # install the dependencies for the tools in the selected_tool_ids list


### PR DESCRIPTION
Should fix https://github.com/galaxyproject/galaxy/issues/7700:
```
File "lib/galaxy/web/framework/middleware/batch.py", line 80, in __call__
    return self.application(environ, start_response)
  File "lib/galaxy/web/framework/middleware/request_id.py", line 15, in __call__
    return self.app(environ, start_response)
  File "lib/galaxy/web/framework/middleware/xforwardedhost.py", line 23, in __call__
    return self.app(environ, start_response)
  File "lib/galaxy/web/framework/middleware/translogger.py", line 71, in __call__
    return self.application(environ, replacement_start_response)
  File "lib/galaxy/web/framework/middleware/error.py", line 166, in __call__
    response = self.exception_handler(exc_info, environ)
  File "lib/galaxy/web/framework/middleware/error.py", line 181, in exception_handler
    get_vars = wsgilib.parse_querystring(environ)
  File "/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python2.7/site-packages/paste/request.py", line 107, in parse_querystring
    strict_parsing=False)
  File "/global/apps/bioinf/galaxy/bin/Python-2.7.13/lib/python2.7/urlparse.py", line 409, in parse_qsl
    pairs = [s2 for s1 in qs.split('&') for s2 in s1.split(';')]
  File "lib/galaxy/web/framework/middleware/error.py", line 154, in __call__
    app_iter = self.application(environ, sr_checker)
  File "/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python2.7/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python2.7/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "lib/galaxy/web/framework/base.py", line 143, in __call__
    return self.handle_request(environ, start_response)
  File "lib/galaxy/web/framework/base.py", line 222, in handle_request
    body = method(trans, **kwargs)
  File "lib/galaxy/web/framework/decorators.py", line 101, in decorator
    return func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/controllers/admin.py", line 1736, in manage_tool_dependencies
    viewkey=viewkey)
  File "lib/galaxy/web/framework/webapp.py", line 917, in fill_template
    return self.fill_template_mako(filename, **kwargs)
  File "lib/galaxy/web/framework/webapp.py", line 930, in fill_template_mako
    return template.render(**data)
  File "/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python2.7/site-packages/mako/template.py", line 462, in render
    return runtime._render(self, self.callable_, args, data)
  File "/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python2.7/site-packages/mako/runtime.py", line 838, in _render
    **_kwargs_for_callable(callable_, data))
  File "/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python2.7/site-packages/mako/runtime.py", line 873, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python2.7/site-packages/mako/runtime.py", line 899, in _exec_template
    callable_(context, *args, **kwargs)
  File "/gpfs1/data/galaxy_server/galaxy-dev/database/compiled_templates/base.mako.py", line 69, in render_body
    __M_writer(unicode(next.body()))
  File "/gpfs1/data/galaxy_server/galaxy-dev/database/compiled_templates/webapps/galaxy/admin/manage_dependencies.mako.py", line 80, in render_body
    __M_writer(unicode(render_dependencies_details(tools, requirements_status, tool_ids_by_requirements)))
  File "/gpfs1/data/galaxy_server/galaxy-dev/database/compiled_templates/webapps/galaxy/admin/manage_dependencies.mako.py", line 50, in render_dependencies_details
    return render_render_dependencies_details(context._locals(__M_locals),tools,requirements_status,tool_ids_by_requirements)
  File "/gpfs1/data/galaxy_server/galaxy-dev/database/compiled_templates/webapps/galaxy/admin/manage_dependencies.mako.py", line 185, in render_render_dependencies_details
    __M_writer(filters.html_escape(unicode( ", ".join([tools[tid].name for tid in tool_ids]) )))
KeyError: u'testtoolshed.g2.bx.psu.edu/repos/matthias/dada2_makesequencetable/dada2_makeSequenceTable/1.10.0+galaxy0'
```

I suppose this can happen if the toolbox reloads while gathering dependencies.