### PR TITLE
Fix uWSGI startup with separate ini file under Python 3

### DIFF
--- a/lib/galaxy/web/stack/__init__.py
+++ b/lib/galaxy/web/stack/__init__.py
@@ -324,7 +324,7 @@ class UWSGIApplicationStack(MessageApplicationStack):
             parser = nice_config_parser(config_file)
             if not parser.has_section(config_section) and parser.has_section('app:main'):
                 kwds['config_section'] = 'app:main'
-        kwds['config_file'] = config_file
+        kwds['config_file'] = unicodify(config_file)
         return kwds
 
     @classmethod


### PR DESCRIPTION
Ensure ``config_file`` is a Unicode string.

Fix #7714.

Alternative to #7715.