### PR TITLE
Fix mtx datatype sniffer configuration

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -867,7 +867,7 @@
     <sniffer type="galaxy.datatypes.tabular:ConnectivityTable"/>
     <sniffer type="galaxy.datatypes.tabular:CSV"/>
     <sniffer type="galaxy.datatypes.tabular:TSV"/>
-    <sniffer type="galaxy.datatypes.tabular:mtx"/>
+    <sniffer type="galaxy.datatypes.tabular:MatrixMarket"/>
     <sniffer type="galaxy.datatypes.msa:Hmmer2"/>
     <sniffer type="galaxy.datatypes.msa:Hmmer3"/>
     <sniffer type="galaxy.datatypes.msa:Stockholm_1_0"/>


### PR DESCRIPTION
Follow-up on https://github.com/galaxyproject/galaxy/pull/7569

Fix the following exception at Galaxy startup:
```
galaxy.datatypes.registry ERROR 2019-04-10 19:07:33,159 [p:3319,w:0,m:0] [MainThread] Error calling method mtx from class <module 'galaxy.datatypes.tabular' from 'lib/galaxy/datatypes/tabular.pyc'>
Traceback (most recent call last):
  File "lib/galaxy/datatypes/registry.py", line 485, in load_datatype_sniffers
    aclass = getattr(module, datatype_class_name)()
AttributeError: 'module' object has no attribute 'mtx'
```