### PR TITLE
Fix spacing in tool panel labels

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1522,7 +1522,8 @@ div.toolSectionTitle {
 }
 
 div.toolPanelLabel {
-    @extend .m-2;
+    @extend .mt-3;
+    @extend .mb-2;
     font-weight: bold;
     color: $gray-600;
     text-transform: uppercase;


### PR DESCRIPTION
Currently tool panel labels have a right margin which they should not have, this PR fixes this issue and restores top/bottom margins as previously defined.