### PR TITLE
OIDC login buttons based on configuration

### DIFF
--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -24,8 +24,8 @@
                         </b-card-footer>
                     </b-card>
                 </b-form>
-                <b-button v-if="enable_oidc" class="mt-3" @click="submitOIDCLogin()">
-                    <icon class="fa fa-google" /> Sign in with Google
+                <b-button v-for="idp in oidc_idps" :key="idp" class="d-block mt-3" @click="submitOIDCLogin(idp)">
+                    <icon v-bind:class="oidc_idps_icons[idp]" /> Sign in with {{ idp.charAt(0).toUpperCase() + idp.slice(1) }}
                 </b-button>
             </div>
             <div v-if="show_welcome_with_login" class="col">
@@ -56,6 +56,13 @@ export default {
     },
     data() {
         let galaxy = getGalaxyInstance();
+        let oidc_idps = Object.keys(galaxy.config.oidc).filter(function(key) { return galaxy.config.oidc[key]; });
+        // Icons to use for each IdP
+        let oidc_idps_icons = {'google': 'fa fa-google'};
+        // Add default icons to IdPs without icons
+        oidc_idps.filter(function(key) { return oidc_idps_icons[key] === undefined; }).forEach(function(idp) {
+             oidc_idps_icons[idp] = 'fa fa-id-card'
+        });
         return {
             login: null,
             password: null,
@@ -65,7 +72,10 @@ export default {
             messageVariant: null,
             redirect: galaxy.params.redirect,
             session_csrf_token: galaxy.session_csrf_token,
-            enable_oidc: galaxy.config.enable_oidc
+            enable_oidc: galaxy.config.enable_oidc,
+            oidc_idps: oidc_idps,
+            oidc_idps_icons: oidc_idps_icons
+
         };
     },
     computed: {
@@ -101,10 +111,10 @@ export default {
                     this.messageText = message || "Login failed for an unknown reason.";
                 });
         },
-        submitOIDCLogin: function(method) {
+        submitOIDCLogin: function(idp) {
             let rootUrl = getAppRoot();
             axios
-                .post(`${rootUrl}authnz/google/login`)
+                .post(`${rootUrl}authnz/${idp}/login`)
                 .then(response => {
                     if (response.data.redirect_uri) {
                         window.location = encodeURI(response.data.redirect_uri);

--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -117,7 +117,7 @@ export default {
                 .post(`${rootUrl}authnz/${idp}/login`)
                 .then(response => {
                     if (response.data.redirect_uri) {
-                        window.location = encodeURI(response.data.redirect_uri);
+                        window.location = response.data.redirect_uri;
                     }
                     // Else do something intelligent or maybe throw an error -- what else does this endpoint possibly return?
                 })

--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -56,7 +56,7 @@ export default {
     },
     data() {
         let galaxy = getGalaxyInstance();
-        let oidc_idps = Object.keys(galaxy.config.oidc).filter(function(key) { return galaxy.config.oidc[key]; });
+        let oidc_idps = galaxy.config.oidc;
         // Icons to use for each IdP
         let oidc_idps_icons = {'google': 'fa fa-google'};
         // Add default icons to IdPs without icons

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -94,11 +94,11 @@ class AuthnzManager(object):
                 if idp in BACKENDS_NAME:
                     self.oidc_backends_config[idp] = self._parse_idp_config(child)
                     self.oidc_backends_implementation[idp] = 'psa'
-                    self.app.config.oidc[idp] = True
+                    self.app.config.oidc.append(idp)
                 elif idp == 'custos':
                     self.oidc_backends_config[idp] = self._parse_custos_config(child)
                     self.oidc_backends_implementation[idp] = 'custos'
-                    self.app.config.oidc[idp] = True
+                    self.app.config.oidc.append(idp)
             if len(self.oidc_backends_config) == 0:
                 raise ParseError("No valid provider configuration parsed.")
         except ImportError:

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -40,6 +40,7 @@ class AuthnzManager(object):
         :param config: sets the path for OIDC configuration
             file (e.g., oidc_backends_config.xml).
         """
+        self.app = app
         self._parse_oidc_config(oidc_config_file)
         self._parse_oidc_backends_config(oidc_backends_config_file)
 
@@ -93,9 +94,11 @@ class AuthnzManager(object):
                 if idp in BACKENDS_NAME:
                     self.oidc_backends_config[idp] = self._parse_idp_config(child)
                     self.oidc_backends_implementation[idp] = 'psa'
+                    self.app.config.oidc[idp] = True
                 elif idp == 'custos':
                     self.oidc_backends_config[idp] = self._parse_custos_config(child)
                     self.oidc_backends_implementation[idp] = 'custos'
+                    self.app.config.oidc[idp] = True
             if len(self.oidc_backends_config) == 0:
                 raise ParseError("No valid provider configuration parsed.")
         except ImportError:

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -214,7 +214,7 @@ class Configuration(object):
         self.enable_oidc = kwargs.get("enable_oidc", False)
         self.oidc_config = kwargs.get("oidc_config_file", self.oidc_config_file)
         self.oidc_backends_config = kwargs.get("oidc_backends_config_file", self.oidc_backends_config_file)
-        self.oidc = {}
+        self.oidc = []
         # The value of migrated_tools_config is the file reserved for containing only those tools that have been eliminated from the distribution
         # and moved to the tool shed.
         self.integrated_tool_panel_config = resolve_path(kwargs.get('integrated_tool_panel_config', 'integrated_tool_panel.xml'), self.root)

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -214,6 +214,7 @@ class Configuration(object):
         self.enable_oidc = kwargs.get("enable_oidc", False)
         self.oidc_config = kwargs.get("oidc_config_file", self.oidc_config_file)
         self.oidc_backends_config = kwargs.get("oidc_backends_config_file", self.oidc_backends_config_file)
+        self.oidc = {}
         # The value of migrated_tools_config is the file reserved for containing only those tools that have been eliminated from the distribution
         # and moved to the tool shed.
         self.integrated_tool_panel_config = resolve_path(kwargs.get('integrated_tool_panel_config', 'integrated_tool_panel.xml'), self.root)

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -61,6 +61,7 @@ class ConfigSerializer(base.ModelSerializer):
             'allow_user_creation'               : _defaults_to(False),
             'use_remote_user'                   : _defaults_to(None),
             'enable_oidc'                       : _defaults_to(False),
+            'oidc'                              : _defaults_to(self.app.config.oidc),
             'enable_quotas'                     : _defaults_to(False),
             'remote_user_logout_href'           : _defaults_to(''),
             'datatypes_disable_auto'            : _defaults_to(False),


### PR DESCRIPTION
Instead of a hardcoded Google login button, display a login button for each OIDC backend based on the configured OIDC backends.

The approach of adding the OIDC backends to the Galaxy config object and then displaying a login button for each was taken from PR #7497. One difference is that I changed the value of the `oidc` field of the config object to be a list instead of a dictionary, since a list would preserve the order of the backends in oidc_backends_config.xml and give the admin control over the order of the login buttons.