### PR TITLE
[18.05] Backport other CI config changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,10 +189,6 @@ workflows:
           <<: *requires_get_code
       - py35_lint:
           <<: *requires_get_code
-      - py35_unit:
-          <<: *requires_get_code
-      - py35_first_startup:
-          <<: *requires_get_code
       - validate_test_tools:
           <<: *requires_get_code
       - check_py3_compatibility:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,43 +4,11 @@ python: 2.7
 os:
   - linux
 env:
-  - TOX_ENV=py34-lint
-  - TOX_ENV=py27-lint
-  - TOX_ENV=py27-unit
   - TOX_ENV=qunit
-  - TOX_ENV=py27-first_startup
-  - TOX_ENV=py27-lint_docstring_include_list
-  - TOX_ENV=check_python_dependencies
-
-matrix:
-  include:
-    - env: TOX_ENV=validate_test_tools
-      addons:
-        apt:
-          packages:
-            - libxml2-utils
-    - env: TOX_ENV=check_py3_compatibility
-      addons:
-        apt:
-          packages:
-            - ack-grep
-  allow_failures:
-    - env: TOX_ENV=check_python_dependencies
-
-before_install:
-  # Workaround for https://github.com/travis-ci/travis-ci/issues/7940
-  - sudo rm -f /etc/boto.cfg
 
 install:
   - set -e
   - pip install tox
-  - |
-    if [ "$TOX_ENV" == "py27-first_startup" ]; then
-        sh scripts/common_startup.sh
-        wget -q https://github.com/jmchilton/galaxy-downloads/raw/master/db_gx_rev_0127.sqlite
-        mv db_gx_rev_0127.sqlite database/universe.sqlite
-        sh manage_db.sh -c ./config/galaxy.yml.sample upgrade
-    fi
 
 script: tox -e $TOX_ENV
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,28 @@
 [tox]
 # envlist is the list of environments that are tested when `tox` is run without any option
 # hyphens in an environment name are used to delimit factors
-envlist = check_py3_compatibility, py27-first_startup, py27-lint, py27-lint_docstring_include_list, py27-unit, py34-lint, qunit, validate_test_tools
+envlist = check_py3_compatibility, py27-first_startup, py{27,35}-lint, py27-lint_docstring_include_list, py27-unit, qunit, validate_test_tools
 skipsdist = True
+
+[testenv]
+commands =
+    first_startup: bash .ci/first_startup.sh
+    lint: bash .ci/flake8_wrapper.sh
+    unit: bash run_tests.sh -u
+whitelist_externals = bash
+setenv =
+    py{35,36,37}-first_startup: GALAXY_VIRTUAL_ENV=.venv3
+    unit: GALAXY_VIRTUAL_ENV={envdir}
+    unit: GALAXY_ENABLE_BETA_COMPRESSED_GENBANK_SNIFFING=1
+deps =
+    lint,lint_docstring,lint_docstring_include_list: -rlib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
+    unit: mock
+    unit: mock-ssh-server
+    unit: nose
+    unit: NoseHTML
 
 [testenv:check_py3_compatibility]
 commands = bash .ci/check_py3_compatibility.sh
-whitelist_externals = bash
 
 [testenv:check_python_dependencies]
 commands = make list-dependency-updates # someday change exit code on this.
@@ -14,66 +30,12 @@ whitelist_externals = make
 
 [testenv:mako_count]
 commands = bash .ci/check_mako.sh
-whitelist_externals = bash
-
-[testenv:py27-first_startup]
-commands = bash .ci/first_startup.sh
-whitelist_externals = bash
-
-[testenv:py27-lint]
-commands = bash .ci/flake8_wrapper.sh
-whitelist_externals = bash
-deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
 
 [testenv:py27-lint_docstring]
 commands = bash .ci/flake8_wrapper_docstrings.sh --exclude
-whitelist_externals = bash
-deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
 
 [testenv:py27-lint_docstring_include_list]
 commands = bash .ci/flake8_wrapper_docstrings.sh --include
-whitelist_externals = bash
-deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
-
-[testenv:py27-unit]
-commands = bash run_tests.sh -u
-whitelist_externals = bash
-setenv =
-    GALAXY_VIRTUAL_ENV={envdir}
-    GALAXY_ENABLE_BETA_COMPRESSED_GENBANK_SNIFFING=1
-deps =
-    nose
-    NoseHTML
-    mock
-    mock-ssh-server
-
-[testenv:py34-first_startup]
-commands =
-    bash .ci/first_startup.sh
-setenv =
-    GALAXY_VIRTUAL_ENV=.venv3
-whitelist_externals = bash
-
-[testenv:py34-lint]
-commands = bash .ci/flake8_wrapper.sh
-whitelist_externals = bash
-deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
-
-[testenv:py34-unit]
-commands = bash run_tests.sh -u
-whitelist_externals = bash
-setenv =
-    GALAXY_VIRTUAL_ENV={envdir}
-deps =
-    nose
-    NoseHTML
-    mock
-    mock-ssh-server
-
-[testenv:py35-lint]
-commands = bash .ci/flake8_wrapper.sh
-whitelist_externals = bash
-deps = -rlib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
 
 [testenv:qunit]
 commands = make client-test
@@ -81,8 +43,6 @@ whitelist_externals = make
 
 [testenv:validate_test_tools]
 commands = bash .ci/validate_test_tools.sh
-whitelist_externals = bash
 
 [testenv:web_controller_line_count]
 commands = bash .ci/check_controller.sh
-whitelist_externals = bash


### PR DESCRIPTION
`py35-unit` and `py35-first_startup` jobs were green on CircleCI, but doing nothing.
Remove duplicated jobs from TravisCI.