### PR TITLE
Python dependency upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,12 @@ release-bootstrap-history: ## bootstrap history for a new release
 update-dependencies:  ## update linting + dev dependencies
 	sh lib/galaxy/dependencies/pipfiles/update.sh
 
+build-dependencies-docker: ## Builds the docker container used for dependency updates
+	$(MAKE) -C lib/galaxy/dependencies/pipfiles/docker
+
+update-dependencies-docker: build-dependencies-docker  ## update dependencies using docker container (if on OSX, you should use this)
+	sh lib/galaxy/dependencies/pipfiles/update.sh -d
+
 update-and-commit-dependencies:  ## update and commit linting + dev dependencies
 	sh lib/galaxy/dependencies/pipfiles/update.sh -c
 

--- a/Makefile
+++ b/Makefile
@@ -129,17 +129,14 @@ release-check-blocking-prs: ## Check github for release blocking PRs
 release-bootstrap-history: ## bootstrap history for a new release
 	$(IN_VENV) python scripts/bootstrap_history.py --release $(RELEASE_CURR)
 
-update-dependencies:  ## update linting + dev dependencies
-	sh lib/galaxy/dependencies/pipfiles/update.sh
-
 build-dependencies-docker: ## Builds the docker container used for dependency updates
 	$(MAKE) -C lib/galaxy/dependencies/pipfiles/docker
 
-update-dependencies-docker: build-dependencies-docker  ## update dependencies using docker container (if on OSX, you should use this)
+update-dependencies:  build-dependencies-docker ## update linting + dev dependencies
 	sh lib/galaxy/dependencies/pipfiles/update.sh -d
 
-update-and-commit-dependencies:  ## update and commit linting + dev dependencies
-	sh lib/galaxy/dependencies/pipfiles/update.sh -c
+update-and-commit-dependencies: build-dependencies-docker ## update and commit linting + dev dependencies
+	sh lib/galaxy/dependencies/pipfiles/update.sh -d -c
 
 node-deps: ## Install NodeJS dependencies.
 ifndef YARN

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -1,3 +1,5 @@
+-i https://wheels.galaxyproject.org/simple
+--extra-index-url https://pypi.python.org/simple
 alabaster==0.7.12
 argh==0.26.2
 atomicwrites==1.3.0
@@ -22,14 +24,14 @@ more-itertools==5.0.0
 nose==1.3.7
 nosehtml==0.4.5
 packaging==19.0
-pathlib2==2.3.2; python_version < '3'
+pathlib2==2.3.2 ; python_version < '3'
 pathtools==0.1.2
 pbr==5.1.3
 pluggy==0.9.0
 port-for==0.4
 psutil==5.6.1
 py==1.8.0
-pygithub3==0.5.1; python_version < '3'
+pygithub3==0.5.1 ; python_version < '3'
 pygments==2.3.1
 pyparsing==2.4.0
 pytest-html==1.20.0
@@ -41,20 +43,16 @@ pytz==2019.1
 pyyaml==5.1
 recommonmark==0.5.0
 requests==2.21.0
-scandir==1.10.0; python_version < '3.5'
+scandir==1.10.0 ; python_version < '3.5'
 selenium==3.141.0
 six==1.11.0
 snowballstemmer==1.2.1
 sphinx-markdown-tables==0.0.9
 sphinx-rtd-theme==0.4.3
-sphinx==2.0.1
-sphinxcontrib-applehelp==1.0.1
-sphinxcontrib-devhelp==1.0.1
-sphinxcontrib-htmlhelp==1.0.2
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.2
-sphinxcontrib-serializinghtml==1.1.3
+sphinx==1.8.5
+sphinxcontrib-websupport==1.1.0
 testfixtures==6.7.0
-twill==0.9.1; python_version < '3'
-urllib3==1.24.1
+twill==0.9.1 ; python_version < '3'
+typing==3.6.6 ; python_version < '3.5'
+urllib3==1.24.1 ; python_version == '2.7'
 watchdog==0.9.0

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -1,5 +1,3 @@
--i https://wheels.galaxyproject.org/simple
---extra-index-url https://pypi.python.org/simple
 alabaster==0.7.12
 argh==0.26.2
 atomicwrites==1.3.0
@@ -14,42 +12,49 @@ future==0.17.1
 gunicorn==19.9.0
 idna==2.8
 imagesize==1.1.0
-jinja2==2.10
-lxml==4.3.2
+jinja2==2.10.1
+lxml==4.3.3
 markdown==2.6.11
 markupsafe==1.1.1
+mirakuru==1.1.0
 mock==2.0.0
 more-itertools==5.0.0
 nose==1.3.7
 nosehtml==0.4.5
 packaging==19.0
-pathlib2==2.3.2 ; python_version < '3'
+pathlib2==2.3.2; python_version < '3'
 pathtools==0.1.2
 pbr==5.1.3
 pluggy==0.9.0
+port-for==0.4
+psutil==5.6.1
 py==1.8.0
-pygithub3==0.5.1 ; python_version < '3'
+pygithub3==0.5.1; python_version < '3'
 pygments==2.3.1
-pyparsing==2.3.1
+pyparsing==2.4.0
 pytest-html==1.20.0
 pytest-metadata==1.8.0
-pytest-pythonpath==0.7.3
 pytest-postgresql==1.4.0
-pytest==4.3.1
-pytz==2018.9
+pytest-pythonpath==0.7.3
+pytest==4.4.0
+pytz==2019.1
 pyyaml==5.1
 recommonmark==0.5.0
 requests==2.21.0
-scandir==1.10.0 ; python_version < '3.5'
+scandir==1.10.0; python_version < '3.5'
 selenium==3.141.0
 six==1.11.0
 snowballstemmer==1.2.1
 sphinx-markdown-tables==0.0.9
 sphinx-rtd-theme==0.4.3
-sphinx==1.8.4
-sphinxcontrib-websupport==1.1.0
-testfixtures==6.6.1
-twill==0.9.1 ; python_version < '3'
-typing==3.6.6 ; python_version < '3.5'
-urllib3==1.24.1 ; python_version == '2.7'
+sphinx==2.0.1
+sphinxcontrib-applehelp==1.0.1
+sphinxcontrib-devhelp==1.0.1
+sphinxcontrib-htmlhelp==1.0.2
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.2
+sphinxcontrib-serializinghtml==1.1.3
+testfixtures==6.7.0
+twill==0.9.1; python_version < '3'
+urllib3==1.24.1
 watchdog==0.9.0

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -1,8 +1,10 @@
+-i https://wheels.galaxyproject.org/simple
+--extra-index-url https://pypi.python.org/simple
 adal==1.2.1
 amqp==2.4.2
 appdirs==1.4.3
 asn1crypto==0.24.0
-avro==1.8.1; python_version < '3'
+avro==1.8.1 ; python_version < '3'
 azure-common==1.1.14
 azure-cosmosdb-nspkg==2.0.2
 azure-cosmosdb-table==1.0.4
@@ -28,7 +30,7 @@ boto3==1.9.114
 boto==2.49.0
 botocore==1.12.130
 bx-python==0.8.2
-bz2file==0.98; python_version < '3.3'
+bz2file==0.98 ; python_version < '3.3'
 cachecontrol==0.11.7
 cachetools==3.1.0
 certifi==2019.3.9
@@ -39,7 +41,7 @@ cliff==2.14.1
 cloudauthz==0.2.0
 cloudbridge==2.0.0
 cmd2==0.8.9
-contextlib2==0.5.5; python_version < '3.5'
+contextlib2==0.5.5 ; python_version < '3.5'
 cryptography==2.6.1
 cwltool==1.0.20180721142728
 debtcollector==1.21.0
@@ -65,7 +67,7 @@ gxformat2==0.8.2
 h5py==2.9.0
 httplib2==0.12.1
 idna==2.8
-ipaddress==1.0.22; python_version < '3.3'
+ipaddress==1.0.22 ; python_version < '3.3'
 isa-rwval==0.10.7
 iso8601==0.1.12
 isodate==0.6.0
@@ -77,9 +79,9 @@ keystoneauth1==3.13.1
 kombu==4.5.0
 lockfile==0.12.2
 lxml==4.3.3
-mako==1.0.8
+mako==1.0.9
 markupsafe==1.1.1
-mercurial==3.7.3; python_version < '3'
+mercurial==3.7.3 ; python_version < '3'
 mistune==0.8.4
 monotonic==1.5
 msgpack==0.6.1
@@ -111,7 +113,7 @@ parsley==1.3
 paste==3.0.8
 pastedeploy==2.0.1
 pastescript==3.1.0
-pathlib2==2.3.2; python_version < '3'
+pathlib2==2.3.2 ; python_version < '3'
 pbr==5.1.3
 prettytable==0.7.2
 prov==1.5.1
@@ -122,6 +124,7 @@ pyasn1==0.4.5
 pycparser==2.19
 pycryptodome==3.8.1
 pyeventsystem==0.1.0
+pyinotify==0.9.6 ; sys_platform != 'win32' and sys_platform != 'darwin' and sys_platform != 'sunos5'
 pyjwt==1.7.1
 pykwalify==1.7.0
 pynacl==1.3.0
@@ -138,7 +141,7 @@ python-jose==3.0.1
 python-keystoneclient==3.17.0
 python-neutronclient==6.9.0
 python-novaclient==11.0.0
-python-openid==2.2.5; python_version < '3.0'
+python-openid==2.2.5 ; python_version < '3.0'
 python-swiftclient==3.6.0
 pytz==2019.1
 pyyaml==5.1
@@ -152,18 +155,18 @@ requestsexceptions==1.4.0
 rfc3986==1.2.0
 routes==2.4.1
 rsa==4.0
-ruamel.ordereddict==0.4.13; platform_python_implementation == 'CPython' and python_version <= '2.7'
+ruamel.ordereddict==0.4.13 ; platform_python_implementation == 'CPython' and python_version <= '2.7'
 ruamel.yaml==0.15.91
 s3transfer==0.2.0
-scandir==1.10.0; python_version < '3.5'
+scandir==1.10.0 ; python_version < '3.5'
 schema-salad==2.7.20181126142424
 shellescape==3.4.1
 simplejson==3.16.0
 six==1.11.0
-social-auth-core==3.1.0
+social-auth-core[openidconnect]==3.1.0
 sqlalchemy-migrate==0.12.0
 sqlalchemy-utils==0.33.11
-sqlalchemy==1.3.2
+sqlalchemy==1.3.3
 sqlparse==0.3.0
 stevedore==1.30.1
 subprocess32==3.5.3 ; python_version < '3.0'
@@ -173,13 +176,13 @@ tenacity==4.12.0
 typing-extensions==3.7.2
 typing==3.6.6 ; python_version < '3.5'
 tzlocal==1.5.1
-unicodecsv==0.14.1; python_version < '3.0'
+unicodecsv==0.14.1 ; python_version < '3.0'
 uritemplate==3.0.0
-urllib3==1.24.1
+urllib3==1.24.1 ; python_version == '2.7'
 uwsgi==2.0.18
 vine==1.3.0
 warlock==1.3.0
-wcwidth==0.1.7; sys_platform != 'win32'
+wcwidth==0.1.7 ; sys_platform != 'win32'
 webencodings==0.5.1
 webob==1.8.5
 whoosh==2.7.4

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -1,10 +1,8 @@
--i https://wheels.galaxyproject.org/simple
---extra-index-url https://pypi.python.org/simple
 adal==1.2.1
 amqp==2.4.2
 appdirs==1.4.3
 asn1crypto==0.24.0
-avro==1.8.1 ; python_version < '3'
+avro==1.8.1; python_version < '3'
 azure-common==1.1.14
 azure-cosmosdb-nspkg==2.0.2
 azure-cosmosdb-table==1.0.4
@@ -28,24 +26,24 @@ bleach==3.1.0
 boltons==19.1.0
 boto3==1.9.114
 boto==2.49.0
-botocore==1.12.115
+botocore==1.12.130
 bx-python==0.8.2
-bz2file==0.98 ; python_version < '3.3'
+bz2file==0.98; python_version < '3.3'
 cachecontrol==0.11.7
 cachetools==3.1.0
 certifi==2019.3.9
 cffi==1.12.2
 chardet==3.0.4
-cheetah3==3.2.0
+cheetah3==3.2.1
 cliff==2.14.1
 cloudauthz==0.2.0
 cloudbridge==2.0.0
 cmd2==0.8.9
-contextlib2==0.5.5 ; python_version < '3.5'
+contextlib2==0.5.5; python_version < '3.5'
 cryptography==2.6.1
 cwltool==1.0.20180721142728
 debtcollector==1.21.0
-decorator==4.3.2
+decorator==4.4.0
 deprecated==1.2.5
 deprecation==2.0.6
 dictobj==0.4
@@ -67,7 +65,7 @@ gxformat2==0.8.2
 h5py==2.9.0
 httplib2==0.12.1
 idna==2.8
-ipaddress==1.0.22 ; python_version < '3.3'
+ipaddress==1.0.22; python_version < '3.3'
 isa-rwval==0.10.7
 iso8601==0.1.12
 isodate==0.6.0
@@ -76,12 +74,12 @@ jsonpatch==1.23
 jsonpointer==2.0
 jsonschema==2.6.0
 keystoneauth1==3.13.1
-kombu==4.4.0
+kombu==4.5.0
 lockfile==0.12.2
-lxml==4.3.2
-mako==1.0.7
+lxml==4.3.3
+mako==1.0.8
 markupsafe==1.1.1
-mercurial==3.7.3 ; python_version < '3'
+mercurial==3.7.3; python_version < '3'
 mistune==0.8.4
 monotonic==1.5
 msgpack==0.6.1
@@ -113,7 +111,7 @@ parsley==1.3
 paste==3.0.8
 pastedeploy==2.0.1
 pastescript==3.1.0
-pathlib2==2.3.2 ; python_version < '3'
+pathlib2==2.3.2; python_version < '3'
 pbr==5.1.3
 prettytable==0.7.2
 prov==1.5.1
@@ -122,14 +120,13 @@ pulsar-galaxy-lib==0.8.3
 pyasn1-modules==0.2.4
 pyasn1==0.4.5
 pycparser==2.19
-pycryptodome==3.7.3
+pycryptodome==3.8.1
 pyeventsystem==0.1.0
-pyinotify==0.9.6 ; sys_platform != 'win32' and sys_platform != 'darwin' and sys_platform != 'sunos5'
 pyjwt==1.7.1
 pykwalify==1.7.0
 pynacl==1.3.0
 pyopenssl==19.0.0
-pyparsing==2.3.1
+pyparsing==2.4.0
 pyperclip==1.7.0
 pysam==0.15.2
 pysftp==0.2.9
@@ -141,9 +138,9 @@ python-jose==3.0.1
 python-keystoneclient==3.17.0
 python-neutronclient==6.9.0
 python-novaclient==11.0.0
-python-openid==2.2.5 ; python_version < '3.0'
+python-openid==2.2.5; python_version < '3.0'
 python-swiftclient==3.6.0
-pytz==2018.9
+pytz==2019.1
 pyyaml==5.1
 rdflib-jsonld==0.4.0
 rdflib==4.2.2
@@ -155,18 +152,18 @@ requestsexceptions==1.4.0
 rfc3986==1.2.0
 routes==2.4.1
 rsa==4.0
-ruamel.ordereddict==0.4.13 ; platform_python_implementation == 'CPython' and python_version <= '2.7'
-ruamel.yaml==0.15.89
+ruamel.ordereddict==0.4.13; platform_python_implementation == 'CPython' and python_version <= '2.7'
+ruamel.yaml==0.15.91
 s3transfer==0.2.0
-scandir==1.10.0 ; python_version < '3.5'
+scandir==1.10.0; python_version < '3.5'
 schema-salad==2.7.20181126142424
 shellescape==3.4.1
 simplejson==3.16.0
 six==1.11.0
-social-auth-core[openidconnect]==3.1.0
+social-auth-core==3.1.0
 sqlalchemy-migrate==0.12.0
 sqlalchemy-utils==0.33.11
-sqlalchemy==1.2.18
+sqlalchemy==1.3.2
 sqlparse==0.3.0
 stevedore==1.30.1
 subprocess32==3.5.3 ; python_version < '3.0'
@@ -176,13 +173,13 @@ tenacity==4.12.0
 typing-extensions==3.7.2
 typing==3.6.6 ; python_version < '3.5'
 tzlocal==1.5.1
-unicodecsv==0.14.1 ; python_version < '3.0'
+unicodecsv==0.14.1; python_version < '3.0'
 uritemplate==3.0.0
-urllib3==1.24.1 ; python_version == '2.7'
+urllib3==1.24.1
 uwsgi==2.0.18
-vine==1.2.0
+vine==1.3.0
 warlock==1.3.0
-wcwidth==0.1.7 ; sys_platform != 'win32'
+wcwidth==0.1.7; sys_platform != 'win32'
 webencodings==0.5.1
 webob==1.8.5
 whoosh==2.7.4

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -166,7 +166,7 @@ six==1.11.0
 social-auth-core[openidconnect]==3.1.0
 sqlalchemy-migrate==0.12.0
 sqlalchemy-utils==0.33.11
-sqlalchemy==1.3.3
+sqlalchemy==1.2.18
 sqlparse==0.3.0
 stevedore==1.30.1
 subprocess32==3.5.3 ; python_version < '3.0'

--- a/lib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
@@ -1,5 +1,4 @@
--i https://pypi.python.org/simple
-configparser==3.7.3 ; python_version < '3.2'
+configparser==3.7.4 ; python_version < '3.2'
 entrypoints==0.3
 enum34==1.1.6 ; python_version < '3.4'
 flake8-import-order==0.18.1

--- a/lib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
@@ -1,3 +1,4 @@
+-i https://pypi.python.org/simple
 configparser==3.7.4 ; python_version < '3.2'
 entrypoints==0.3
 enum34==1.1.6 ; python_version < '3.4'

--- a/lib/galaxy/dependencies/pipfiles/update.sh
+++ b/lib/galaxy/dependencies/pipfiles/update.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 usage() {
 cat << EOF
@@ -43,7 +44,7 @@ export PIPENV_IGNORE_VIRTUALENVS=1
 for env in $ENVS; do
     cd "$THIS_DIRECTORY/$env"
     if [ "$docker" -eq 1 ]; then
-        docker run -v `pwd`:/working -t 'galaxy/update-python-dependencies'
+        docker run -v "$(pwd):/working" -t 'galaxy/update-python-dependencies'
     else
         pipenv lock -v
         pipenv lock -r > pinned-requirements.txt
@@ -70,6 +71,9 @@ for env in $ENVS; do
                 -e "s/^subprocess32==\([^ ;]\{1,\}\).*$/subprocess32==\1 ; python_version < '3.0'/" \
                 -e "s/^typing==\([^ ;]\{1,\}\).*$/typing==\1 ; python_version < '3.5'/" \
                 pinned-requirements.txt pinned-dev-requirements.txt
+    if ! grep '==' pinned-dev-requirements.txt ; then
+        rm -f pinned-dev-requirements.txt
+    fi
 done
 
 if [ "$commit" -eq 1 ]; then


### PR DESCRIPTION
This also swaps to docker-based dependency updating as the default Makefile target.

Sqlalchemy was intentionally held back at 1.2.18