### PR TITLE
Rename _future_expose_api to expose_api, expose_api to legacy_expose_api

### DIFF
--- a/lib/galaxy/web/__init__.py
+++ b/lib/galaxy/web/__init__.py
@@ -4,31 +4,30 @@ The Galaxy web application framework
 
 from .framework import url_for
 from .framework.base import httpexceptions
-# TODO: Make _future_* the default.
 from .framework.decorators import (
-    _future_expose_api,
-    _future_expose_api_anonymous,
-    _future_expose_api_anonymous_and_sessionless,
-    _future_expose_api_raw,
-    _future_expose_api_raw_anonymous,
-    _future_expose_api_raw_anonymous_and_sessionless,
     error,
     expose,
     expose_api,
     expose_api_anonymous,
+    expose_api_anonymous_and_sessionless,
     expose_api_raw,
     expose_api_raw_anonymous,
+    expose_api_raw_anonymous_and_sessionless,
     json,
     json_pretty,
+    legacy_expose_api,
+    legacy_expose_api_anonymous,
+    legacy_expose_api_raw,
+    legacy_expose_api_raw_anonymous,
     require_admin,
-    require_login
+    require_login,
 )
 
 __all__ = ('url_for', 'error', 'expose', 'json', 'json_pretty',
-           'require_admin', 'require_login', 'expose_api', 'expose_api_anonymous',
-           'expose_api_raw', 'expose_api_raw_anonymous', '_future_expose_api',
-           '_future_expose_api_anonymous', '_future_expose_api_raw',
-           '_future_expose_api_raw_anonymous',
-           '_future_expose_api_anonymous_and_sessionless',
-           '_future_expose_api_raw_anonymous_and_sessionless', 'form',
+           'require_admin', 'require_login', 'legacy_expose_api', 'legacy_expose_api_anonymous',
+           'legacy_expose_api_raw', 'legacy_expose_api_raw_anonymous', 'expose_api',
+           'expose_api_anonymous', 'expose_api_raw',
+           'expose_api_raw_anonymous',
+           'expose_api_anonymous_and_sessionless',
+           'expose_api_raw_anonymous_and_sessionless', 'form',
            'FormBuilder', 'httpexceptions')

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -1410,7 +1410,7 @@ class SharableMixin(object):
         item.slug = new_slug
         return item.slug == cur_slug
 
-    @web.expose_api
+    @web.legacy_expose_api
     def sharing(self, trans, id, payload=None, **kwd):
         skipped = False
         class_name = self.manager.model_class.__name__

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -103,7 +103,7 @@ def require_admin(func):
 
 
 # ----------------------------------------------------------------------------- (original) api decorators
-def expose_api(func, to_json=True, user_required=True):
+def legacy_expose_api(func, to_json=True, user_required=True):
     """
     Expose this function via the API.
     """
@@ -197,32 +197,31 @@ def __extract_payload_from_request(trans, func, kwargs):
     return payload
 
 
-def expose_api_raw(func):
+def legacy_expose_api_raw(func):
     """
     Expose this function via the API but don't dump the results
     to JSON.
     """
-    return expose_api(func, to_json=False)
+    return legacy_expose_api(func, to_json=False)
 
 
-def expose_api_raw_anonymous(func):
+def legacy_expose_api_raw_anonymous(func):
     """
     Expose this function via the API but don't dump the results
     to JSON.
     """
-    return expose_api(func, to_json=False, user_required=False)
+    return legacy_expose_api(func, to_json=False, user_required=False)
 
 
-def expose_api_anonymous(func, to_json=True):
+def legacy_expose_api_anonymous(func, to_json=True):
     """
     Expose this function via the API but don't require a set user.
     """
-    return expose_api(func, to_json=to_json, user_required=False)
+    return legacy_expose_api(func, to_json=to_json, user_required=False)
 
 
 # ----------------------------------------------------------------------------- (new) api decorators
-# TODO: rename as expose_api and make default.
-def _future_expose_api(func, to_json=True, user_required=True, user_or_session_required=True, handle_jsonp=True):
+def expose_api(func, to_json=True, user_required=True, user_or_session_required=True, handle_jsonp=True):
     """
     Expose this function via the API.
     """
@@ -372,31 +371,31 @@ def __api_error_response(trans, **kwds):
     return safe_dumps(error_dict)
 
 
-def _future_expose_api_anonymous(func, to_json=True):
+def expose_api_anonymous(func, to_json=True):
     """
     Expose this function via the API but don't require a set user.
     """
-    return _future_expose_api(func, to_json=to_json, user_required=False)
+    return expose_api(func, to_json=to_json, user_required=False)
 
 
-def _future_expose_api_anonymous_and_sessionless(func, to_json=True):
+def expose_api_anonymous_and_sessionless(func, to_json=True):
     """
     Expose this function via the API but don't require a user or a galaxy_session.
     """
-    return _future_expose_api(func, to_json=to_json, user_required=False, user_or_session_required=False)
+    return expose_api(func, to_json=to_json, user_required=False, user_or_session_required=False)
 
 
-def _future_expose_api_raw(func):
-    return _future_expose_api(func, to_json=False, user_required=True)
+def expose_api_raw(func):
+    return expose_api(func, to_json=False, user_required=True)
 
 
-def _future_expose_api_raw_anonymous(func):
-    return _future_expose_api(func, to_json=False, user_required=False)
+def expose_api_raw_anonymous(func):
+    return expose_api(func, to_json=False, user_required=False)
 
 
-def _future_expose_api_raw_anonymous_and_sessionless(func):
+def expose_api_raw_anonymous_and_sessionless(func):
     # TODO: tool_shed api implemented JSONP first on a method-by-method basis, don't overwrite that for now
-    return _future_expose_api(
+    return expose_api(
         func,
         to_json=False,
         user_required=False,

--- a/lib/galaxy/webapps/galaxy/api/annotations.py
+++ b/lib/galaxy/webapps/galaxy/api/annotations.py
@@ -9,7 +9,7 @@ from galaxy import (
 )
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.util.sanitize_html import sanitize_html
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import (
     BaseAPIController,
     UsesStoredWorkflowMixin

--- a/lib/galaxy/webapps/galaxy/api/authenticate.py
+++ b/lib/galaxy/webapps/galaxy/api/authenticate.py
@@ -21,7 +21,7 @@ from galaxy.util import (
     smart_str,
     unicodify
 )
-from galaxy.web import expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
+from galaxy.web import expose_api_anonymous_and_sessionless
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/authenticate.py
+++ b/lib/galaxy/webapps/galaxy/api/authenticate.py
@@ -21,7 +21,7 @@ from galaxy.util import (
     smart_str,
     unicodify
 )
-from galaxy.web import _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
+from galaxy.web import expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -10,7 +10,7 @@ from galaxy.managers import (
     cloud,
     datasets
 )
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/cloudauthz.py
+++ b/lib/galaxy/webapps/galaxy/api/cloudauthz.py
@@ -19,7 +19,7 @@ from galaxy.exceptions import (
 )
 from galaxy.managers import cloudauthzs
 from galaxy.web import (
-    _future_expose_api as expose_api
+    expose_api
 )
 from galaxy.web.base.controller import BaseAPIController
 

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -9,8 +9,8 @@ import os
 from galaxy.managers import configuration, users
 from galaxy.queue_worker import send_control_task
 from galaxy.web import (
-    _future_expose_api as expose_api,
-    _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
+    expose_api,
+    expose_api_anonymous_and_sessionless,
     require_admin
 )
 from galaxy.web.base.controller import BaseAPIController

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 from galaxy import managers
 from galaxy.managers.collections_util import api_payload_to_create_params, dictify_dataset_collection_instance
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import (
     BaseAPIController,
     UsesLibraryMixinItems

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -55,7 +55,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
         trans.response.status = 501
         return 'not implemented'
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def show(self, trans, id, hda_ldda='hda', data_type=None, provider=None, **kwd):
         """
         GET /api/datasets/{encoded_dataset_id}
@@ -98,7 +98,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
             trans.response.status = 500
         return rval
 
-    @web._future_expose_api
+    @web.expose_api
     def update_permissions(self, trans, dataset_id, payload, **kwd):
         """
         PUT /api/datasets/{encoded_dataset_id}/permissions
@@ -306,7 +306,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
 
         return data
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def extra_files(self, trans, history_content_id, history_id, **kwd):
         """
         GET /api/histories/{encoded_history_id}/contents/{encoded_content_id}/extra_files
@@ -325,7 +325,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
 
         return rval
 
-    @web.expose_api_raw_anonymous
+    @web.legacy_expose_api_raw_anonymous
     def display(self, trans, history_content_id, history_id,
                 preview=False, filename=None, to_ext=None, raw=False, **kwd):
         """
@@ -366,7 +366,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
             rval = "Could not get display data for dataset: %s" % e
         return rval
 
-    @web.expose_api_raw_anonymous
+    @web.legacy_expose_api_raw_anonymous
     def get_metadata_file(self, trans, history_content_id, history_id, metadata_file=None, **kwd):
         """
         GET /api/histories/{history_id}/contents/{history_content_id}/metadata_file
@@ -387,7 +387,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
             rval = "Could not get metadata for dataset: %s" % e
         return rval
 
-    @web._future_expose_api_anonymous
+    @web.expose_api_anonymous
     def converted(self, trans, dataset_id, ext, **kwargs):
         """
         converted( self, trans, dataset_id, ext, **kwargs )

--- a/lib/galaxy/webapps/galaxy/api/datatypes.py
+++ b/lib/galaxy/webapps/galaxy/api/datatypes.py
@@ -6,7 +6,7 @@ import logging
 from galaxy import exceptions
 from galaxy.datatypes.data import Data
 from galaxy.util import asbool
-from galaxy.web import expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
+from galaxy.web import expose_api_anonymous_and_sessionless
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/datatypes.py
+++ b/lib/galaxy/webapps/galaxy/api/datatypes.py
@@ -6,7 +6,7 @@ import logging
 from galaxy import exceptions
 from galaxy.datatypes.data import Data
 from galaxy.util import asbool
-from galaxy.web import _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
+from galaxy.web import expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/display_applications.py
+++ b/lib/galaxy/webapps/galaxy/api/display_applications.py
@@ -4,7 +4,7 @@ API operations on annotations.
 import logging
 
 from galaxy import queue_worker
-from galaxy.web import expose_api, require_admin
+from galaxy.web import legacy_expose_api, require_admin
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 class DisplayApplicationsController(BaseAPIController):
 
-    @expose_api
+    @legacy_expose_api
     def index(self, trans, **kwd):
         """
         GET /api/display_applications/
@@ -33,7 +33,7 @@ class DisplayApplicationsController(BaseAPIController):
             })
         return response
 
-    @expose_api
+    @legacy_expose_api
     @require_admin
     def reload(self, trans, payload={}, **kwd):
         """

--- a/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
+++ b/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
@@ -3,7 +3,7 @@ import logging
 from galaxy import util, web
 from galaxy.exceptions import ObjectNotFound
 from galaxy.web import expose_api
-from galaxy.web import expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
+from galaxy.web import expose_api_anonymous_and_sessionless
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
+++ b/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
@@ -2,8 +2,8 @@ import logging
 
 from galaxy import util, web
 from galaxy.exceptions import ObjectNotFound
-from galaxy.web import _future_expose_api as expose_api
-from galaxy.web import _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
+from galaxy.web import expose_api
+from galaxy.web import expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/extended_metadata.py
+++ b/lib/galaxy/webapps/galaxy/api/extended_metadata.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 
 class BaseExtendedMetadataController(BaseAPIController, UsesExtendedMetadataMixin, UsesLibraryMixinItems, UsesStoredWorkflowMixin):
 
-    @web.expose_api
+    @web.legacy_expose_api
     def index(self, trans, **kwd):
         idnum = kwd[self.exmeta_item_id]
         item = self._get_item_from_id(trans, idnum, check_writable=False)
@@ -29,7 +29,7 @@ class BaseExtendedMetadataController(BaseAPIController, UsesExtendedMetadataMixi
             if ex_meta is not None:
                 return ex_meta.data
 
-    @web.expose_api
+    @web.legacy_expose_api
     def create(self, trans, payload, **kwd):
         idnum = kwd[self.exmeta_item_id]
         item = self._get_item_from_id(trans, idnum, check_writable=True)
@@ -41,7 +41,7 @@ class BaseExtendedMetadataController(BaseAPIController, UsesExtendedMetadataMixi
             ex_obj = self.create_extended_metadata(trans, payload)
             self.set_item_extended_metadata_obj(trans, item, ex_obj)
 
-    @web.expose_api
+    @web.legacy_expose_api
     def delete(self, trans, **kwd):
         idnum = kwd[self.tagged_item_id]
         item = self._get_item_from_id(trans, idnum, check_writable=True)
@@ -51,7 +51,7 @@ class BaseExtendedMetadataController(BaseAPIController, UsesExtendedMetadataMixi
                 self.unset_item_extended_metadata_obj(trans, item)
                 self.delete_extended_metadata(trans, ex_obj)
 
-    @web.expose_api
+    @web.legacy_expose_api
     def undelete(self, trans, **kwd):
         raise HTTPNotImplemented()
 

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -10,8 +10,8 @@ from galaxy import (
 )
 from galaxy.managers import folders
 from galaxy.web import (
-    _future_expose_api as expose_api,
-    _future_expose_api_anonymous as expose_api_anonymous
+    expose_api,
+    expose_api_anonymous as expose_api_anonymous
 )
 from galaxy.web.base.controller import BaseAPIController, UsesLibraryMixin, UsesLibraryMixinItems
 

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -11,7 +11,7 @@ from galaxy import (
 from galaxy.managers import folders
 from galaxy.web import (
     expose_api,
-    expose_api_anonymous as expose_api_anonymous
+    expose_api_anonymous
 )
 from galaxy.web.base.controller import BaseAPIController, UsesLibraryMixin, UsesLibraryMixinItems
 

--- a/lib/galaxy/webapps/galaxy/api/folders.py
+++ b/lib/galaxy/webapps/galaxy/api/folders.py
@@ -8,7 +8,7 @@ from galaxy import (
     util
 )
 from galaxy.managers import folders, roles
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import BaseAPIController, UsesLibraryMixin, UsesLibraryMixinItems
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/forms.py
+++ b/lib/galaxy/webapps/galaxy/api/forms.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 class FormDefinitionAPIController(BaseAPIController):
 
-    @web.expose_api
+    @web.legacy_expose_api
     def index(self, trans, **kwd):
         """
         GET /api/forms
@@ -30,7 +30,7 @@ class FormDefinitionAPIController(BaseAPIController):
             rval.append(item)
         return rval
 
-    @web.expose_api
+    @web.legacy_expose_api
     def show(self, trans, id, **kwd):
         """
         GET /api/forms/{encoded_form_id}
@@ -53,7 +53,7 @@ class FormDefinitionAPIController(BaseAPIController):
         item['url'] = url_for('form', id=form_definition_id)
         return item
 
-    @web.expose_api
+    @web.legacy_expose_api
     def create(self, trans, payload, **kwd):
         """
         POST /api/forms

--- a/lib/galaxy/webapps/galaxy/api/genomes.py
+++ b/lib/galaxy/webapps/galaxy/api/genomes.py
@@ -15,7 +15,7 @@ class GenomesController(BaseAPIController):
     RESTful controller for interactions with genome data.
     """
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def index(self, trans, **kwd):
         """
         GET /api/genomes: returns a list of installed genomes
@@ -44,7 +44,7 @@ class GenomesController(BaseAPIController):
             rval = self.app.genomes.chroms(trans, dbkey=id, num=num, chrom=chrom, low=low)
         return rval
 
-    @web.expose_api_raw_anonymous
+    @web.legacy_expose_api_raw_anonymous
     def indexes(self, trans, id, **kwd):
         """
         GET /api/genomes/{id}/indexes?type={table name}
@@ -62,7 +62,7 @@ class GenomesController(BaseAPIController):
         if_open = open(index_file_name + index_extensions[index_type], mode='r')
         return if_open.read()
 
-    @web.expose_api_raw_anonymous
+    @web.legacy_expose_api_raw_anonymous
     def sequences(self, trans, id, num=None, chrom=None, low=None, high=None, **kwd):
         """
         GET /api/genomes/{id}/sequences

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class GroupRolesAPIController(BaseAPIController):
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def index(self, trans, group_id, **kwd):
         """
@@ -40,7 +40,7 @@ class GroupRolesAPIController(BaseAPIController):
             trans.response.status = 500
         return rval
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def show(self, trans, id, group_id, **kwd):
         """
@@ -66,7 +66,7 @@ class GroupRolesAPIController(BaseAPIController):
             log.error(item + ": %s" % str(e))
         return item
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def update(self, trans, id, group_id, **kwd):
         """
@@ -98,7 +98,7 @@ class GroupRolesAPIController(BaseAPIController):
             log.error(item + ": %s" % str(e))
         return item
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def delete(self, trans, id, group_id, **kwd):
         """

--- a/lib/galaxy/webapps/galaxy/api/group_users.py
+++ b/lib/galaxy/webapps/galaxy/api/group_users.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class GroupUsersAPIController(BaseAPIController):
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def index(self, trans, group_id, **kwd):
         """
@@ -40,7 +40,7 @@ class GroupUsersAPIController(BaseAPIController):
             trans.response.status = 500
         return rval
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def show(self, trans, id, group_id, **kwd):
         """
@@ -66,7 +66,7 @@ class GroupUsersAPIController(BaseAPIController):
             log.error(item + ": %s" % str(e))
         return item
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def update(self, trans, id, group_id, **kwd):
         """
@@ -98,7 +98,7 @@ class GroupUsersAPIController(BaseAPIController):
             log.error(item + ": %s" % str(e))
         return item
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def delete(self, trans, id, group_id, **kwd):
         """

--- a/lib/galaxy/webapps/galaxy/api/groups.py
+++ b/lib/galaxy/webapps/galaxy/api/groups.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 class GroupAPIController(BaseAPIController):
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def index(self, trans, **kwd):
         """
@@ -29,7 +29,7 @@ class GroupAPIController(BaseAPIController):
                 rval.append(item)
         return rval
 
-    @web.expose_api
+    @web.legacy_expose_api
     def create(self, trans, payload, **kwd):
         """
         POST /api/groups
@@ -71,7 +71,7 @@ class GroupAPIController(BaseAPIController):
         item['url'] = url_for('group', id=encoded_id)
         return [item]
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def show(self, trans, id, **kwd):
         """
@@ -97,7 +97,7 @@ class GroupAPIController(BaseAPIController):
         item['roles_url'] = url_for('group_roles', group_id=group_id)
         return item
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def update(self, trans, id, payload, **kwd):
         """

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -29,8 +29,8 @@ from galaxy.util import (
 )
 from galaxy.web import (
     expose_api,
-    expose_api_anonymous as expose_api_anonymous,
-    expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
+    expose_api_anonymous,
+    expose_api_anonymous_and_sessionless,
     expose_api_raw,
     url_for
 )

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -28,10 +28,10 @@ from galaxy.util import (
     string_as_bool
 )
 from galaxy.web import (
-    _future_expose_api as expose_api,
-    _future_expose_api_anonymous as expose_api_anonymous,
-    _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
-    _future_expose_api_raw as expose_api_raw,
+    expose_api,
+    expose_api_anonymous as expose_api_anonymous,
+    expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
+    expose_api_raw,
     url_for
 )
 from galaxy.web.base.controller import (

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -25,10 +25,10 @@ from galaxy.managers.jobs import fetch_job_states, summarize_jobs_to_dict
 from galaxy.util.json import safe_dumps
 from galaxy.util.streamball import StreamBall
 from galaxy.web import (
-    _future_expose_api as expose_api,
-    _future_expose_api_anonymous as expose_api_anonymous,
-    _future_expose_api_raw as expose_api_raw,
-    _future_expose_api_raw_anonymous as expose_api_raw_anonymous
+    expose_api,
+    expose_api_anonymous as expose_api_anonymous,
+    expose_api_raw,
+    expose_api_raw_anonymous as expose_api_raw_anonymous
 )
 from galaxy.web.base.controller import (
     BaseAPIController,

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -26,9 +26,9 @@ from galaxy.util.json import safe_dumps
 from galaxy.util.streamball import StreamBall
 from galaxy.web import (
     expose_api,
-    expose_api_anonymous as expose_api_anonymous,
+    expose_api_anonymous,
     expose_api_raw,
-    expose_api_raw_anonymous as expose_api_raw_anonymous
+    expose_api_raw_anonymous
 )
 from galaxy.web.base.controller import (
     BaseAPIController,

--- a/lib/galaxy/webapps/galaxy/api/item_tags.py
+++ b/lib/galaxy/webapps/galaxy/api/item_tags.py
@@ -4,7 +4,7 @@ API operations related to tagging items.
 import logging
 
 from galaxy import exceptions
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import (
     BaseAPIController,
     UsesTagsMixin

--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -11,8 +11,8 @@ from galaxy import (
     util
 )
 from galaxy.web import (
-    _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
-    _future_expose_api_raw_anonymous_and_sessionless as expose_api_raw_anonymous_and_sessionless
+    expose_api_anonymous_and_sessionless,
+    expose_api_raw_anonymous_and_sessionless,
 )
 from galaxy.web.base.controller import BaseAPIController
 

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -14,8 +14,10 @@ from galaxy import model
 from galaxy import util
 from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.jobs import JobSearch
-from galaxy.web import _future_expose_api as expose_api
-from galaxy.web import _future_expose_api_anonymous as expose_api_anonymous
+from galaxy.web import (
+    expose_api,
+    expose_api_anonymous,
+)
 from galaxy.web.base.controller import BaseAPIController
 from galaxy.web.base.controller import UsesLibraryMixinItems
 from galaxy.work.context import WorkRequestContext

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -13,8 +13,8 @@ from galaxy.managers import (
     roles
 )
 from galaxy.web import (
-    _future_expose_api as expose_api,
-    _future_expose_api_anonymous as expose_api_anonymous
+    expose_api,
+    expose_api_anonymous,
 )
 from galaxy.web.base.controller import BaseAPIController
 

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -22,7 +22,7 @@ from galaxy.model import (
     ExtendedMetadata,
     ExtendedMetadataIndex
 )
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import (
     BaseAPIController,
     HTTPBadRequest,

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -29,8 +29,8 @@ from galaxy.tools.parameters import populate_state
 from galaxy.util.path import full_path_permission_for_user, safe_contains, safe_relpath, unsafe_walk
 from galaxy.util.streamball import StreamBall
 from galaxy.web import (
-    _future_expose_api as expose_api,
-    _future_expose_api_anonymous as expose_api_anonymous
+    expose_api,
+    expose_api_anonymous,
 )
 from galaxy.web.base.controller import BaseAPIController, UsesVisualizationMixin
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/metrics.py
+++ b/lib/galaxy/webapps/galaxy/api/metrics.py
@@ -7,7 +7,7 @@ API operations for for querying and recording user metrics from some client
 import datetime
 import logging
 
-from galaxy.web import _future_expose_api_anonymous as expose_api_anonymous
+from galaxy.web import expose_api_anonymous
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/page_revisions.py
+++ b/lib/galaxy/webapps/galaxy/api/page_revisions.py
@@ -6,7 +6,7 @@ import logging
 from galaxy import exceptions
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.util.sanitize_html import sanitize_html
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import (
     BaseAPIController,
     SharableItemSecurityMixin,

--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -10,7 +10,7 @@ from galaxy.managers.pages import (
 )
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.util.sanitize_html import sanitize_html
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import (
     BaseAPIController,
     SharableItemSecurityMixin,

--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -5,7 +5,7 @@ import logging
 
 from galaxy import exceptions
 from galaxy.managers import hdas, histories
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/provenance.py
+++ b/lib/galaxy/webapps/galaxy/api/provenance.py
@@ -25,24 +25,24 @@ class BaseProvenanceController(BaseAPIController):
         super(BaseProvenanceController, self).__init__(app)
         self.hda_manager = managers.hdas.HDAManager(app)
 
-    @web.expose_api
+    @web.legacy_expose_api
     def index(self, trans, **kwd):
         follow = kwd.get('follow', False)
         value = self._get_provenance(trans, self.provenance_item_class, kwd[self.provenance_item_id], follow)
         return value
 
-    @web.expose_api
+    @web.legacy_expose_api
     def show(self, trans, elem_name, **kwd):
         follow = kwd.get('follow', False)
         value = self._get_provenance(trans, self.provenance_item_class, kwd[self.provenance_item_id], follow)
         return value
 
-    @web.expose_api
+    @web.legacy_expose_api
     def create(self, trans, tag_name, payload=None, **kwd):
         payload = payload or {}
         raise HTTPNotImplemented()
 
-    @web.expose_api
+    @web.legacy_expose_api
     def delete(self, trans, tag_name, **kwd):
         raise HTTPBadRequest("Cannot Delete Provenance")
 

--- a/lib/galaxy/webapps/galaxy/api/quotas.py
+++ b/lib/galaxy/webapps/galaxy/api/quotas.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 
 class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaParamParser):
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def index(self, trans, deleted='False', **kwd):
         """
@@ -50,7 +50,7 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
             rval.append(item)
         return rval
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def show(self, trans, id, deleted='False', **kwd):
         """
@@ -61,7 +61,7 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
         quota = self.get_quota(trans, id, deleted=util.string_as_bool(deleted))
         return quota.to_dict(view='element', value_mapper={'id': trans.security.encode_id, 'total_disk_usage': float})
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def create(self, trans, payload, **kwd):
         """
@@ -82,7 +82,7 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
         item['message'] = message
         return item
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def update(self, trans, id, payload, **kwd):
         """
@@ -120,7 +120,7 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
             messages.append(message)
         return '; '.join(messages)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def delete(self, trans, id, **kwd):
         """
@@ -142,7 +142,7 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
             raise HTTPBadRequest(detail=str(e))
         return message
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def undelete(self, trans, id, **kwd):
         """

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -16,7 +16,7 @@ from galaxy.util.path import (
     safe_path,
     safe_walk
 )
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/roles.py
+++ b/lib/galaxy/webapps/galaxy/api/roles.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 class RoleAPIController(BaseAPIController):
 
-    @web.expose_api
+    @web.legacy_expose_api
     def index(self, trans, **kwd):
         """
         GET /api/roles
@@ -28,7 +28,7 @@ class RoleAPIController(BaseAPIController):
                 rval.append(item)
         return rval
 
-    @web.expose_api
+    @web.legacy_expose_api
     def show(self, trans, id, **kwd):
         """
         GET /api/roles/{encoded_role_id}
@@ -51,7 +51,7 @@ class RoleAPIController(BaseAPIController):
         item['url'] = url_for('role', id=role_id)
         return item
 
-    @web.expose_api
+    @web.legacy_expose_api
     def create(self, trans, payload, **kwd):
         """
         POST /api/roles

--- a/lib/galaxy/webapps/galaxy/api/search.py
+++ b/lib/galaxy/webapps/galaxy/api/search.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 class SearchController(BaseAPIController, SharableItemSecurityMixin):
 
-    @web.expose_api
+    @web.legacy_expose_api
     def create(self, trans, payload, **kwd):
         """
         POST /api/search

--- a/lib/galaxy/webapps/galaxy/api/tool_data.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_data.py
@@ -6,8 +6,8 @@ from galaxy import (
     web
 )
 from galaxy.web import (
-    _future_expose_api as expose_api,
-    _future_expose_api_raw as expose_api_raw
+    expose_api,
+    expose_api_raw
 )
 from galaxy.web.base.controller import BaseAPIController
 

--- a/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
@@ -5,7 +5,7 @@ import logging
 
 from galaxy.tools.deps import views
 from galaxy.web import (
-    _future_expose_api as expose_api,
+    expose_api,
     require_admin
 )
 from galaxy.web.base.controller import BaseAPIController

--- a/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
@@ -15,7 +15,7 @@ from galaxy import (
     util,
     web
 )
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import BaseAPIController
 from tool_shed.galaxy_install.install_manager import InstallRepositoryManager
 from tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -8,10 +8,12 @@ from galaxy.managers.collections_util import dictify_dataset_collection_instance
 from galaxy.tools import global_tool_errors
 from galaxy.util.json import safe_dumps
 from galaxy.util.odict import odict
-from galaxy.web import _future_expose_api as expose_api
-from galaxy.web import _future_expose_api_anonymous as expose_api_anonymous
-from galaxy.web import _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
-from galaxy.web import _future_expose_api_raw_anonymous_and_sessionless as expose_api_raw_anonymous_and_sessionless
+from galaxy.web import (
+    expose_api,
+    expose_api_anonymous,
+    expose_api_anonymous_and_sessionless,
+    expose_api_raw_anonymous_and_sessionless,
+)
 from galaxy.web.base.controller import BaseAPIController
 from galaxy.web.base.controller import UsesVisualizationMixin
 from ._fetch_util import validate_and_normalize_targets
@@ -401,7 +403,7 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
             rval.append(citation.to_dict('bibtex'))
         return rval
 
-    @web.expose_api_raw
+    @web.legacy_expose_api_raw
     @web.require_admin
     def download(self, trans, id, **kwds):
         tool_tarball = trans.app.toolbox.package_tool(trans, id)

--- a/lib/galaxy/webapps/galaxy/api/toolshed.py
+++ b/lib/galaxy/webapps/galaxy/api/toolshed.py
@@ -11,7 +11,7 @@ from galaxy import (
     util,
     web
 )
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import BaseAPIController
 from tool_shed.util import (
     common_util,

--- a/lib/galaxy/webapps/galaxy/api/tours.py
+++ b/lib/galaxy/webapps/galaxy/api/tours.py
@@ -4,8 +4,8 @@ API Controller providing Galaxy Tours
 import logging
 
 from galaxy.web import (
-    _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
-    expose_api,
+    expose_api_anonymous_and_sessionless,
+    legacy_expose_api,
     require_admin
 )
 from galaxy.web.base.controller import BaseAPIController
@@ -38,7 +38,7 @@ class ToursController(BaseAPIController):
         """
         return self.app.tour_registry.tour_contents(tour_id)
 
-    @expose_api
+    @legacy_expose_api
     @require_admin
     def update_tour(self, trans, tour_id, **kwd):
         """

--- a/lib/galaxy/webapps/galaxy/api/uploads.py
+++ b/lib/galaxy/webapps/galaxy/api/uploads.py
@@ -6,7 +6,7 @@ import os
 import re
 
 from galaxy import exceptions
-from galaxy.web import expose_api_anonymous
+from galaxy.web import legacy_expose_api_anonymous
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)
@@ -16,11 +16,11 @@ class UploadsAPIController(BaseAPIController):
 
     READ_CHUNK_SIZE = 2 ** 16
 
-    @expose_api_anonymous
+    @legacy_expose_api_anonymous
     def index(self, trans, **kwd):
         raise exceptions.NotImplemented("Listing uploads is not implemented.")
 
-    @expose_api_anonymous
+    @legacy_expose_api_anonymous
     def create(self, trans, payload, **kwd):
         """
         POST /api/uploads/

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -32,8 +32,8 @@ from galaxy.util import (
 )
 from galaxy.util.odict import odict
 from galaxy.web import (
-    _future_expose_api as expose_api,
-    _future_expose_api_anonymous as expose_api_anonymous
+    expose_api,
+    expose_api_anonymous
 )
 from galaxy.web.base.controller import (
     BaseAPIController,

--- a/lib/galaxy/webapps/galaxy/api/visualizations.py
+++ b/lib/galaxy/webapps/galaxy/api/visualizations.py
@@ -19,7 +19,7 @@ from galaxy.managers.visualizations import (
     VisualizationSerializer
 )
 from galaxy.model.item_attrs import UsesAnnotations
-from galaxy.web import _future_expose_api as expose_api
+from galaxy.web import expose_api
 from galaxy.web.base.controller import (
     BaseAPIController,
     SharableMixin,

--- a/lib/galaxy/webapps/galaxy/api/webhooks.py
+++ b/lib/galaxy/webapps/galaxy/api/webhooks.py
@@ -4,8 +4,7 @@ API Controller providing Galaxy Webhooks
 import imp
 import logging
 
-from galaxy.web import _future_expose_api_anonymous_and_sessionless as \
-    expose_api_anonymous_and_sessionless
+from galaxy.web import expose_api_anonymous_and_sessionless
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -26,8 +26,10 @@ from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.tools.parameters import populate_state
 from galaxy.tools.parameters.basic import workflow_building_modes
 from galaxy.util.sanitize_html import sanitize_html
-from galaxy.web import _future_expose_api as expose_api
-from galaxy.web import _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
+from galaxy.web import (
+    expose_api,
+    expose_api_anonymous_and_sessionless,
+)
 from galaxy.web.base.controller import (
     BaseAPIController,
     SharableMixin,

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -631,7 +631,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             kwd['status'] = status
         return self.user_list_grid(trans, **kwd)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def quotas_list(self, trans, payload=None, **kwargs):
         message = kwargs.get('message', '')
@@ -663,7 +663,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             kwargs['status'] = status or 'done'
         return self.quota_list_grid(trans, **kwargs)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def create_quota(self, trans, payload=None, **kwd):
         if trans.request.method == 'GET':
@@ -711,7 +711,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             except ActionInputError as e:
                 return self.message_exception(trans, e.err_msg)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def rename_quota(self, trans, payload=None, **kwd):
         id = kwd.get('id')
@@ -737,7 +737,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             except ActionInputError as e:
                 return self.message_exception(trans, e.err_msg)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def manage_users_and_groups_for_quota(self, trans, payload=None, **kwd):
         quota_id = kwd.get('id')
@@ -773,7 +773,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             except ActionInputError as e:
                 return self.message_exception(trans, e.err_msg)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def edit_quota(self, trans, payload=None, **kwd):
         id = kwd.get('id')
@@ -801,7 +801,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             except ActionInputError as e:
                 return self.message_exception(trans, e.err_msg)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def set_quota_default(self, trans, payload=None, **kwd):
         id = kwd.get('id')
@@ -923,7 +923,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                                    message=message,
                                    status=status)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def tool_versions_list(self, trans, **kwd):
         return self.tool_version_list_grid(trans, **kwd)
@@ -951,7 +951,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             kwargs['status'] = status
         return self.role_list_grid(trans, **kwargs)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def create_role(self, trans, payload=None, **kwd):
         if trans.request.method == 'GET':
@@ -1023,7 +1023,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                     message += 'One of the groups associated with this role is the newly created group with the same name.'
                 return {'message' : message}
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def rename_role(self, trans, payload=None, **kwd):
         id = kwd.get('id')
@@ -1061,7 +1061,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                         trans.sa_session.flush()
             return {'message': 'Role \'%s\' has been renamed to \'%s\'.' % (old_name, new_name)}
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def manage_users_and_groups_for_role(self, trans, payload=None, **kwd):
         role_id = kwd.get('id')
@@ -1173,7 +1173,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             message += " %s " % role.name
         return (message, "done")
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def groups_list(self, trans, **kwargs):
         message = kwargs.get('message')
@@ -1195,7 +1195,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             kwargs['status'] = status
         return self.group_list_grid(trans, **kwargs)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def rename_group(self, trans, payload=None, **kwd):
         id = kwd.get('id')
@@ -1227,7 +1227,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                         trans.sa_session.flush()
             return {'message': 'Group \'%s\' has been renamed to \'%s\'.' % (old_name, new_name)}
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def manage_users_and_roles_for_group(self, trans, payload=None, **kwd):
         group_id = kwd.get('id')
@@ -1266,7 +1266,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             trans.sa_session.refresh(group)
             return {'message' : 'Group \'%s\' has been updated with %d associated users and %d associated roles.' % (group.name, len(in_users), len(in_roles))}
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def create_group(self, trans, payload=None, **kwd):
         if trans.request.method == 'GET':
@@ -1383,7 +1383,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                                                         action='create',
                                                         cntrller='admin'))
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def reset_user_password(self, trans, payload=None, **kwd):
         users = {user_id: get_user(trans, user_id) for user_id in util.listify(kwd.get('id'))}
@@ -1557,7 +1557,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
         trans.sa_session.flush()
         return ("New key '%s' generated for requested user '%s'." % (new_key.key, user.email), "done")
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def manage_roles_and_groups_for_user(self, trans, payload=None, **kwd):
         user_id = kwd.get('id')

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -76,7 +76,7 @@ class AdminToolshed(AdminGalaxy):
                                    message=message,
                                    status=status)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def browse_repositories(self, trans, **kwd):
         message = kwd.get('message', '')

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -250,7 +250,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             ck_size = int(ck_size)
         return data.datatype.display_data(trans, data, preview, filename, to_ext, offset=offset, ck_size=ck_size, **kwd)
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def get_edit(self, trans, dataset_id=None, **kwd):
         """Produces the input definitions available to modify dataset attributes"""
         status = None
@@ -389,7 +389,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         else:
             return self.message_exception(trans, 'You do not have permission to edit this dataset\'s ( id: %s ) information.' % str(dataset_id))
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def set_edit(self, trans, payload=None, **kwd):
         """Allows user to modify parameters of an HDA."""
         def __ok_to_edit_metadata(dataset_id):

--- a/lib/galaxy/webapps/galaxy/controllers/forms.py
+++ b/lib/galaxy/webapps/galaxy/controllers/forms.py
@@ -80,7 +80,7 @@ class FormsGrid(grids.Grid):
 class Forms(BaseUIController):
     forms_grid = FormsGrid()
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def forms_list(self, trans, payload=None, **kwd):
         message = kwd.get('message', '')
@@ -100,7 +100,7 @@ class Forms(BaseUIController):
             kwd['status'] = status
         return self.forms_grid(trans, **kwd)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def create_form(self, trans, payload=None, **kwd):
         if trans.request.method == 'GET':
@@ -151,7 +151,7 @@ class Forms(BaseUIController):
             message = 'The form \'%s\' has been created%s.' % (payload.get('name'), imported)
             return {'message': util.sanitize_text(message)}
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def edit_form(self, trans, payload=None, **kwd):
         id = kwd.get('id')

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -246,7 +246,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
     def list_published(self, trans, **kwargs):
         return self.published_list_grid(trans, **kwargs)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_login("work with multiple histories")
     def list(self, trans, **kwargs):
         """List all available histories"""
@@ -658,7 +658,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             user_is_owner=user_is_owner, history_dict=history_dictionary,
             user_item_rating=user_item_rating, ave_item_rating=ave_item_rating, num_ratings=num_ratings)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_login("changing default permissions")
     def permissions(self, trans, payload=None, **kwd):
         """
@@ -696,7 +696,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             trans.app.security_agent.history_set_default_permissions(history, permissions)
             return {'message': 'Default history \'%s\' dataset permissions have been changed.' % history.name}
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_login("make datasets private")
     def make_private(self, trans, history_id=None, all_histories=False, **kwd):
         """
@@ -1210,7 +1210,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         return
         # TODO: used in page/editor.mako
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_login("rename histories")
     def rename(self, trans, payload=None, **kwd):
         id = kwd.get('id')

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -518,7 +518,7 @@ class PageController(BaseUIController, SharableMixin,
                  'slug'     : p.page.slug,
                  'title'    : p.page.title} for p in shared_by_others]
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_login("create pages")
     def create(self, trans, payload=None, **kwd):
         """
@@ -573,7 +573,7 @@ class PageController(BaseUIController, SharableMixin,
                 trans.sa_session.flush()
             return {'message': 'Page \'%s\' successfully created.' % p.title, 'status': 'success'}
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_login("edit pages")
     def edit(self, trans, payload=None, **kwd):
         """

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -21,7 +21,7 @@ from galaxy.security.validate_user_input import (
     validate_password,
     validate_publicname
 )
-from galaxy.web import _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
+from galaxy.web import expose_api_anonymous_and_sessionless
 from galaxy.web import url_for
 from galaxy.web.base.controller import (
     BaseUIController,

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -270,7 +270,7 @@ class VisualizationController(BaseUIController, SharableMixin, UsesVisualization
         grid['shared_by_others'] = self._get_shared(trans)
         return grid
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_login("use Galaxy visualizations", use_panels=True)
     def list(self, trans, **kwargs):
         message = kwargs.get('message')
@@ -527,7 +527,7 @@ class VisualizationController(BaseUIController, SharableMixin, UsesVisualization
         vis_annotation = annotation or vis_config.get('annotation', None)
         return self.save_visualization(trans, vis_config, vis_type, vis_id, vis_title, vis_dbkey, vis_annotation)
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_login("edit visualizations")
     def edit(self, trans, payload=None, **kwd):
         """

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -535,7 +535,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         return_url = url_for('/') + 'workflow?status=done&message=%s' % escape(message)
         trans.response.send_redirect(return_url)
 
-    @web.expose_api
+    @web.legacy_expose_api
     def create(self, trans, payload=None, **kwd):
         if trans.request.method == 'GET':
             return {

--- a/lib/galaxy/webapps/tool_shed/api/authenticate.py
+++ b/lib/galaxy/webapps/tool_shed/api/authenticate.py
@@ -11,7 +11,7 @@ Returns:
 """
 import logging
 
-from galaxy.web import _future_expose_api_raw_anonymous_and_sessionless as expose_api_raw_anonymous_and_sessionless
+from galaxy.web import expose_api_raw_anonymous_and_sessionless
 from galaxy.webapps.galaxy.api.authenticate import AuthenticationController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/tool_shed/api/categories.py
+++ b/lib/galaxy/webapps/tool_shed/api/categories.py
@@ -8,7 +8,7 @@ from galaxy import (
 )
 from galaxy.web import (
     expose_api,
-    expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
+    expose_api_anonymous_and_sessionless,
     require_admin as require_admin
 )
 from galaxy.web.base.controller import BaseAPIController

--- a/lib/galaxy/webapps/tool_shed/api/categories.py
+++ b/lib/galaxy/webapps/tool_shed/api/categories.py
@@ -7,8 +7,8 @@ from galaxy import (
     web
 )
 from galaxy.web import (
-    _future_expose_api as expose_api,
-    _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
+    expose_api,
+    expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
     require_admin as require_admin
 )
 from galaxy.web.base.controller import BaseAPIController

--- a/lib/galaxy/webapps/tool_shed/api/configuration.py
+++ b/lib/galaxy/webapps/tool_shed/api/configuration.py
@@ -4,7 +4,7 @@ capabilities and configuration settings.
 """
 import logging
 
-from galaxy.web import _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless
+from galaxy.web import expose_api_anonymous_and_sessionless
 from galaxy.web.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/tool_shed/api/groups.py
+++ b/lib/galaxy/webapps/tool_shed/api/groups.py
@@ -11,8 +11,8 @@ from galaxy.exceptions import (
 )
 from galaxy.util import pretty_print_time_interval
 from galaxy.web import (
-    _future_expose_api as expose_api,
-    _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
+    expose_api,
+    expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
     require_admin as require_admin
 )
 from galaxy.web.base.controller import BaseAPIController

--- a/lib/galaxy/webapps/tool_shed/api/groups.py
+++ b/lib/galaxy/webapps/tool_shed/api/groups.py
@@ -12,7 +12,7 @@ from galaxy.exceptions import (
 from galaxy.util import pretty_print_time_interval
 from galaxy.web import (
     expose_api,
-    expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
+    expose_api_anonymous_and_sessionless,
     require_admin as require_admin
 )
 from galaxy.web.base.controller import BaseAPIController

--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -24,9 +24,9 @@ from galaxy.exceptions import (
 )
 from galaxy.util import checkers
 from galaxy.web import (
-    _future_expose_api as expose_api,
-    _future_expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
-    _future_expose_api_raw_anonymous_and_sessionless as expose_api_raw_anonymous_and_sessionless
+    expose_api,
+    expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
+    expose_api_raw_anonymous_and_sessionless
 )
 from galaxy.web.base.controller import (
     BaseAPIController,
@@ -54,7 +54,7 @@ log = logging.getLogger(__name__)
 class RepositoriesController(BaseAPIController):
     """RESTful controller for interactions with repositories in the Tool Shed."""
 
-    @web.expose_api
+    @web.legacy_expose_api
     def add_repository_registry_entry(self, trans, payload, **kwd):
         """
         POST /api/repositories/add_repository_registry_entry
@@ -96,7 +96,7 @@ class RepositoriesController(BaseAPIController):
             % (name, owner)
         return response_dict
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def get_ordered_installable_revisions(self, trans, name=None, owner=None, **kwd):
         """
         GET /api/repositories/get_ordered_installable_revisions
@@ -128,7 +128,7 @@ class RepositoriesController(BaseAPIController):
             return []
         return [revision[1] for revision in repository.installable_revisions(self.app, sort_revisions=True)]
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def get_repository_revision_install_info(self, trans, name, owner, changeset_revision, **kwd):
         """
         GET /api/repositories/get_repository_revision_install_info
@@ -253,7 +253,7 @@ class RepositoriesController(BaseAPIController):
             log.debug(debug_msg)
             return {}, {}, {}
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def get_installable_revisions(self, trans, **kwd):
         """
         GET /api/repositories/get_installable_revisions
@@ -279,7 +279,7 @@ class RepositoriesController(BaseAPIController):
                         'user_id': trans.security.encode_id}
         return value_mapper
 
-    @web.expose_api
+    @web.legacy_expose_api
     def import_capsule(self, trans, payload, **kwd):
         """
         POST /api/repositories/new/import_capsule
@@ -518,7 +518,7 @@ class RepositoriesController(BaseAPIController):
         results['hostname'] = web.url_for('/', qualified=True)
         return results
 
-    @web.expose_api
+    @web.legacy_expose_api
     def remove_repository_registry_entry(self, trans, payload, **kwd):
         """
         POST /api/repositories/remove_repository_registry_entry
@@ -560,7 +560,7 @@ class RepositoriesController(BaseAPIController):
             % (name, owner)
         return response_dict
 
-    @web.expose_api
+    @web.legacy_expose_api
     def repository_ids_for_setting_metadata(self, trans, my_writable=False, **kwd):
         """
         GET /api/repository_ids_for_setting_metadata
@@ -591,7 +591,7 @@ class RepositoriesController(BaseAPIController):
                 repository_ids.append(trans.security.encode_id(repository.id))
         return repository_ids
 
-    @web.expose_api
+    @web.legacy_expose_api
     def reset_metadata_on_repositories(self, trans, payload, **kwd):
         """
         PUT /api/repositories/reset_metadata_on_repositories
@@ -685,7 +685,7 @@ class RepositoriesController(BaseAPIController):
         results['stop_time'] = stop_time
         return json.dumps(results, sort_keys=True, indent=4)
 
-    @web.expose_api
+    @web.legacy_expose_api
     def reset_metadata_on_repository(self, trans, payload, **kwd):
         """
         PUT /api/repositories/reset_metadata_on_repository
@@ -1034,7 +1034,7 @@ class RepositoriesController(BaseAPIController):
             [trans.security.encode_id(x.category.id) for x in repo.categories]
         return repository_dict
 
-    @web.expose_api
+    @web.legacy_expose_api
     def create_changeset_revision(self, trans, id, payload, **kwd):
         """
         POST /api/repositories/{encoded_repository_id}/changeset_revision

--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -25,7 +25,7 @@ from galaxy.exceptions import (
 from galaxy.util import checkers
 from galaxy.web import (
     expose_api,
-    expose_api_anonymous_and_sessionless as expose_api_anonymous_and_sessionless,
+    expose_api_anonymous_and_sessionless,
     expose_api_raw_anonymous_and_sessionless
 )
 from galaxy.web.base.controller import (

--- a/lib/galaxy/webapps/tool_shed/api/repository_revisions.py
+++ b/lib/galaxy/webapps/tool_shed/api/repository_revisions.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class RepositoryRevisionsController(BaseAPIController):
     """RESTful controller for interactions with tool shed repository revisions."""
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def export(self, trans, payload, **kwd):
         """
         POST /api/repository_revisions/export
@@ -66,7 +66,7 @@ class RepositoryRevisionsController(BaseAPIController):
                         'user_id' : trans.security.encode_id}
         return value_mapper
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def index(self, trans, **kwd):
         """
         GET /api/repository_revisions
@@ -103,7 +103,7 @@ class RepositoryRevisionsController(BaseAPIController):
             repository_metadata_dicts.append(repository_metadata_dict)
         return repository_metadata_dicts
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def repository_dependencies(self, trans, id, **kwd):
         """
         GET /api/repository_revisions/{encoded repository_metadata id}/repository_dependencies
@@ -175,7 +175,7 @@ class RepositoryRevisionsController(BaseAPIController):
                 repository_dependencies_dicts.append(repository_dependency_metadata_dict)
         return repository_dependencies_dicts
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def show(self, trans, id, **kwd):
         """
         GET /api/repository_revisions/{encoded_repository_metadata_id}
@@ -196,7 +196,7 @@ class RepositoryRevisionsController(BaseAPIController):
                                                       id=encoded_repository_id)
         return repository_metadata_dict
 
-    @web.expose_api
+    @web.legacy_expose_api
     def update(self, trans, payload, **kwd):
         """
         PUT /api/repository_revisions/{encoded_repository_metadata_id}/{payload}

--- a/lib/galaxy/webapps/tool_shed/api/tools.py
+++ b/lib/galaxy/webapps/tool_shed/api/tools.py
@@ -9,7 +9,7 @@ from galaxy import (
 )
 from galaxy.tools.parameters import params_to_strings
 from galaxy.tools.repositories import ValidationContext
-from galaxy.web import _future_expose_api_raw_anonymous_and_sessionless as expose_api_raw_anonymous_and_sessionless
+from galaxy.web import expose_api_raw_anonymous_and_sessionless
 from galaxy.web.base.controller import BaseAPIController
 from galaxy.webapps.tool_shed.search.tool_search import ToolSearch
 from tool_shed.dependencies.repository import relation_builder

--- a/lib/galaxy/webapps/tool_shed/api/users.py
+++ b/lib/galaxy/webapps/tool_shed/api/users.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class UsersController(BaseAPIController):
     """RESTful controller for interactions with users in the Tool Shed."""
 
-    @web.expose_api
+    @web.legacy_expose_api
     @web.require_admin
     def create(self, trans, payload, **kwd):
         """
@@ -75,7 +75,7 @@ class UsersController(BaseAPIController):
         value_mapper = {'id' : trans.security.encode_id}
         return value_mapper
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def index(self, trans, deleted=False, **kwd):
         """
         GET /api/users
@@ -95,7 +95,7 @@ class UsersController(BaseAPIController):
             user_dicts.append(user_dict)
         return user_dicts
 
-    @web.expose_api_anonymous
+    @web.legacy_expose_api_anonymous
     def show(self, trans, id, **kwd):
         """
         GET /api/users/{encoded_user_id}


### PR DESCRIPTION
Should make it clearer that you probably want to avoid the old decorator, since it doesn't properly treat `MessageException`s for instance.