### PR TITLE
Extend dataset search and add search API endpoint

### DIFF
--- a/lib/galaxy/managers/annotatable.py
+++ b/lib/galaxy/managers/annotatable.py
@@ -104,5 +104,6 @@ class AnnotatableFilterMixin(object):
 
     def _add_parsers(self):
         self.fn_filter_parsers.update({
-            'annotation'    : {'op': {'has': self.filter_annotation_contains, }},
+            'annotation'    : {'op': {'has': self.filter_annotation_contains,
+                                      'contains': self.filter_annotation_contains}},
         })

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -1012,6 +1012,8 @@ class ModelFilterParser(HasAModelManager):
         if not column_map:
             # no column mapping (not whitelisted)
             return None
+        if callable(column_map):
+            return column_map(attr, op, val)
         # attr must be a whitelisted column by attr name or by key passed in column_map
         # note: column_map[ 'column' ] takes precedence
         if 'column' in column_map:
@@ -1120,3 +1122,6 @@ class ModelFilterParser(HasAModelManager):
             date_string = ' '.join([group for group in match.groups() if group])
             return date_string
         raise ValueError('datetime strings must be in the ISO 8601 format and in the UTC')
+
+    def raise_filter_err(attr, op, val, msg):
+        raise exceptions.RequestParameterInvalidException(msg, column=attr, operation=op, val=val)

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -1123,5 +1123,5 @@ class ModelFilterParser(HasAModelManager):
             return date_string
         raise ValueError('datetime strings must be in the ISO 8601 format and in the UTC')
 
-    def raise_filter_err(attr, op, val, msg):
+    def raise_filter_err(self, attr, op, val, msg):
         raise exceptions.RequestParameterInvalidException(msg, column=attr, operation=op, val=val)

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -931,6 +931,7 @@ class ModelFilterParser(HasAModelManager):
             'id'            : {'op': ('in')},
             'encoded_id'    : {'column' : 'id', 'op': ('in'), 'val': self.parse_id_list},
             # dates can be directly passed through the orm into a filter (no need to parse into datetime object)
+            'extension'     : {'op': ('eq', 'like', 'in')},
             'create_time'   : {'op': ('le', 'ge'), 'val': self.parse_date},
             'update_time'   : {'op': ('le', 'ge'), 'val': self.parse_date},
         })

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -485,6 +485,19 @@ class HistoryContentsFilters(base.ModelFilterParser,
                 return sql.column('state').in_(states)
             raise_filter_err(attr, op, val, 'bad op in filter')
 
+        if attr == 'tool_id':
+            if op == 'eq':
+                cond = model.Job.table.c.tool_id == val
+            elif op == 'contains':
+                cond = model.Job.table.c.tool_id.contains(val, autoescape=True)
+            else:
+                raise_filter_err(attr, op, val, 'bad op in filter')
+            return sql.expression.and_(
+                model.Job.table.c.id == model.JobToOutputDatasetAssociation.table.c.job_id,
+                model.HistoryDatasetAssociation.table.c.id == model.JobToOutputDatasetAssociation.table.c.dataset_id,
+                cond
+            )
+
         return super(HistoryContentsFilters, self)._parse_orm_filter(attr, op, val)
 
     def decode_type_id(self, type_id):
@@ -511,6 +524,7 @@ class HistoryContentsFilters(base.ModelFilterParser,
             # 'hid-in'        : { 'op': ( 'in' ), 'val': self.parse_int_list },
             'name'          : {'op': ('eq', 'contains', 'like')},
             'state'         : {'op': ('eq', 'in')},
+            'tool_id'       : {'op': ('eq', 'contains')},
             'visible'       : {'op': ('eq'), 'val': self.parse_bool},
             'create_time'   : {'op': ('le', 'ge'), 'val': self.parse_date},
             'update_time'   : {'op': ('le', 'ge'), 'val': self.parse_date},

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -23,6 +23,7 @@ from galaxy import (
     model
 )
 from galaxy.managers import (
+    annotatable,
     base,
     containers,
     deletable,
@@ -431,7 +432,10 @@ class HistoryContentsSerializer(base.ModelSerializer, deletable.PurgableSerializ
         return self.serialize_id(content, key, **context)
 
 
-class HistoryContentsFilters(base.ModelFilterParser, deletable.PurgableFiltersMixin, taggable.TaggableFilterMixin):
+class HistoryContentsFilters(base.ModelFilterParser,
+                             annotatable.AnnotatableFilterMixin,
+                             deletable.PurgableFiltersMixin,
+                             taggable.TaggableFilterMixin):
     # surprisingly (but ominously), this works for both content classes in the union that's filtered
     model_class = model.HistoryDatasetAssociation
 
@@ -496,6 +500,7 @@ class HistoryContentsFilters(base.ModelFilterParser, deletable.PurgableFiltersMi
 
     def _add_parsers(self):
         super(HistoryContentsFilters, self)._add_parsers()
+        annotatable.AnnotatableFilterMixin._add_parsers(self)
         deletable.PurgableFiltersMixin._add_parsers(self)
         taggable.TaggableFilterMixin._add_parsers(self)
         self.orm_filter_parsers.update({

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -57,6 +57,7 @@ class HistoryContentsManager(containers.ContainerManagerMixin):
         "type_id",
         "hid",
         # joining columns
+        "extension",
         "dataset_id",
         "collection_id",
         "name",
@@ -326,6 +327,7 @@ class HistoryContentsManager(containers.ContainerManagerMixin):
             state=model.DatasetCollection.populated_state,
             # TODO: should be purgable? fix
             purged=literal(False),
+            extension=literal(None),
             # these are attached instead to the inner collection joined below
             create_time=model.DatasetCollection.create_time,
             update_time=model.DatasetCollection.update_time

--- a/lib/galaxy/managers/taggable.py
+++ b/lib/galaxy/managers/taggable.py
@@ -115,8 +115,9 @@ class TaggableFilterMixin(object):
         self.fn_filter_parsers.update({
             'tag': {
                 'op': {
-                    'eq'    : self.filter_has_tag,
-                    'has'   : self.filter_has_partial_tag,
+                    'eq' : self.filter_has_tag,
+                    'contains': self.filter_has_partial_tag,
+                    'has': self.filter_has_partial_tag,
                 }
             }
         })

--- a/lib/galaxy/managers/taggable.py
+++ b/lib/galaxy/managers/taggable.py
@@ -96,7 +96,7 @@ class TaggableDeserializerMixin(object):
 
 class TaggableFilterMixin(object):
 
-    def create_expression(self, attr, op, val):
+    def create_tag_filter(self, attr, op, val):
         target_model = getattr(model, "%sTagAssociation" % self.model_class.__name__)
         id_column = "%s_id" % target_model.table.name.rsplit('_tag_association')[0]
         if ':' not in val and op == 'eq':
@@ -119,5 +119,5 @@ class TaggableFilterMixin(object):
 
     def _add_parsers(self):
         self.orm_filter_parsers.update({
-            'tag': self.create_expression
+            'tag': self.create_tag_filter
         })

--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -95,7 +95,7 @@ class DynamicToolManager(ModelManager):
 
 class ToolFilterMixin(object):
 
-    def create_expression(self, attr, op, val):
+    def create_tool_filter(self, attr, op, val):
         if op == 'eq':
             cond = model.Job.table.c.tool_id == val
         elif op == 'contains':
@@ -110,5 +110,5 @@ class ToolFilterMixin(object):
 
     def _add_parsers(self):
         self.orm_filter_parsers.update({
-            'tool_id': self.create_expression,
+            'tool_id': self.create_tool_filter,
         })

--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -96,17 +96,30 @@ class DynamicToolManager(ModelManager):
 class ToolFilterMixin(object):
 
     def create_tool_filter(self, attr, op, val):
-        if op == 'eq':
-            cond = model.Job.table.c.tool_id == val
-        elif op == 'contains':
-            cond = model.Job.table.c.tool_id.contains(val, autoescape=True)
-        else:
-            self.raise_filter_err(attr, op, val, 'bad op in filter')
-        return sql.expression.and_(
-            model.Job.table.c.id == model.JobToOutputDatasetAssociation.table.c.job_id,
-            model.HistoryDatasetAssociation.table.c.id == model.JobToOutputDatasetAssociation.table.c.dataset_id,
-            cond
-        )
+
+        def _create_tool_filter(model_class=None):
+            if op == 'eq':
+                cond = model.Job.table.c.tool_id == val
+            elif op == 'contains':
+                cond = model.Job.table.c.tool_id.contains(val, autoescape=True)
+            else:
+                self.raise_filter_err(attr, op, val, 'bad op in filter')
+            if model_class is model.HistoryDatasetAssociation:
+                return sql.expression.and_(
+                    model.Job.table.c.id == model.JobToOutputDatasetAssociation.table.c.job_id,
+                    model.HistoryDatasetAssociation.table.c.id == model.JobToOutputDatasetAssociation.table.c.dataset_id,
+                    cond
+                )
+            elif model_class is model.HistoryDatasetCollectionAssociation:
+                return sql.expression.and_(
+                    model.Job.id == model.JobToOutputDatasetAssociation.job_id,
+                    model.JobToOutputDatasetAssociation.dataset_id == model.DatasetCollectionElement.hda_id,
+                    model.DatasetCollectionElement.dataset_collection_id == model.HistoryDatasetCollectionAssociation.collection_id,
+                    cond,
+                )
+            else:
+                return True
+        return _create_tool_filter
 
     def _add_parsers(self):
         self.orm_filter_parsers.update({

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -63,6 +63,8 @@ inflector = Inflector(English)
 log = get_logger(__name__)
 _lock = threading.RLock()
 
+namedtuple = collections.namedtuple
+
 CHUNK_SIZE = 65536  # 64k
 
 DATABASE_MAX_STRING_SIZE = 32768

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -238,6 +238,12 @@ class BaseAPIController(BaseController):
             keys = keys.split(',')
         return dict(view=view, keys=keys, default_view=default_view)
 
+    def _parse_order_by(self, manager, order_by_string):
+        ORDER_BY_SEP_CHAR = ','
+        if ORDER_BY_SEP_CHAR in order_by_string:
+            return [manager.parse_order_by(o) for o in order_by_string.split(ORDER_BY_SEP_CHAR)]
+        return manager.parse_order_by(order_by_string)
+
 
 class JSAppLauncher(BaseUIController):
     """

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -66,7 +66,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
         filters = self.history_contents_filters.parse_filters(filter_params)
         order_by = self._parse_order_by(manager=self.history_contents_manager, order_by_string=kwd.get('order', 'create_time-dsc'))
         contents = self.history_contents_manager.contents(
-            history=None, filters=filters, limit=limit, offset=offset, order_by=order_by
+            container=None, filters=filters, limit=limit, offset=offset, order_by=order_by
         )
         return [self.serializer_by_type[content.history_content_type].serialize_to_view(content, user=trans.user, trans=trans, view='summary') for content in contents]
 

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -59,9 +59,53 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
         """
         GET /api/datasets/
 
-        Search datasets or collections.
-        """
+        Search datasets or collections using a query system
 
+        :rtype:     list
+        :returns:   dictionaries containing summary of dataset or dataset_collection information
+
+        The list returned can be filtered by using two optional parameters:
+            q:      string, generally a property name to filter by followed
+                    by an (often optional) hyphen and operator string.
+            qv:     string, the value to filter by
+
+        ..example:
+            To filter the list to only those created after 2015-01-29,
+            the query string would look like:
+                '?q=create_time-gt&qv=2015-01-29'
+
+            Multiple filters can be sent in using multiple q/qv pairs:
+                '?q=create_time-gt&qv=2015-01-29&q=name-contains&qv=experiment-1'
+
+        The list returned can be paginated using two optional parameters:
+            limit:  integer, defaults to no value and no limit (return all)
+                    how many items to return
+            offset: integer, defaults to 0 and starts at the beginning
+                    skip the first ( offset - 1 ) items and begin returning
+                    at the Nth item
+
+        ..example:
+            limit and offset can be combined. Skip the first two and return five:
+                '?limit=5&offset=3'
+
+        The list returned can be ordered using the optional parameter:
+            order:  string containing one of the valid ordering attributes followed
+                    (optionally) by '-asc' or '-dsc' for ascending and descending
+                    order respectively. Orders can be stacked as a comma-
+                    separated list of values.
+
+        ..example:
+            To sort by name descending then create time descending:
+                '?order=name-dsc,create_time'
+
+        The ordering attributes and their default orders are:
+            hid defaults to 'hid-asc'
+            create_time defaults to 'create_time-dsc'
+            update_time defaults to 'update_time-dsc'
+            name    defaults to 'name-asc'
+
+        'order' defaults to 'create_time'
+        """
         filter_params = self.parse_filter_params(kwd)
         filters = self.history_contents_filters.parse_filters(filter_params)
         order_by = self._parse_order_by(manager=self.history_contents_manager, order_by_string=kwd.get('order', 'create_time-dsc'))

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -149,7 +149,7 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
         # and any sent in from the query string
         filters += self.filters.parse_filters(filter_params)
 
-        order_by = self._parse_order_by(kwd.get('order', 'create_time-dsc'))
+        order_by = self._parse_order_by(manager=self.manager, order_by_string=kwd.get('order', 'create_time-dsc'))
         histories = self.manager.list(filters=filters, order_by=order_by, limit=limit, offset=offset)
 
         rval = []
@@ -181,13 +181,6 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
 
         # otherwise, do the default filter of removing the deleted histories
         return [self.app.model.History.deleted == false()]
-
-    def _parse_order_by(self, order_by_string):
-        ORDER_BY_SEP_CHAR = ','
-        manager = self.manager
-        if ORDER_BY_SEP_CHAR in order_by_string:
-            return [manager.parse_order_by(o) for o in order_by_string.split(ORDER_BY_SEP_CHAR)]
-        return manager.parse_order_by(order_by_string)
 
     @expose_api_anonymous
     def show(self, trans, id, deleted='False', **kwd):
@@ -254,7 +247,7 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
         limit, offset = self.parse_limit_offset(kwd)
         filter_params = self.parse_filter_params(kwd)
         filters = self.filters.parse_filters(filter_params)
-        order_by = self._parse_order_by(kwd.get('order', 'create_time-dsc'))
+        order_by = self._parse_order_by(manager=self.manager, order_by_string=kwd.get('order', 'create_time-dsc'))
         histories = self.manager.list_published(filters=filters, order_by=order_by, limit=limit, offset=offset)
         rval = []
         for history in histories:
@@ -280,7 +273,7 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
         limit, offset = self.parse_limit_offset(kwd)
         filter_params = self.parse_filter_params(kwd)
         filters = self.filters.parse_filters(filter_params)
-        order_by = self._parse_order_by(kwd.get('order', 'create_time-dsc'))
+        order_by = self._parse_order_by(manager=self.manager, order_by_string=kwd.get('order', 'create_time-dsc'))
         histories = self.manager.list_shared_with(current_user,
             filters=filters, order_by=order_by, limit=limit, offset=offset)
         rval = []

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -866,7 +866,7 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
         filter_params = self.parse_filter_params(kwd)
         filters = self.history_contents_filters.parse_filters(filter_params)
         limit, offset = self.parse_limit_offset(kwd)
-        order_by = self._parse_order_by(kwd.get('order', 'hid-asc'))
+        order_by = self._parse_order_by(manager=self.history_contents_manager, order_by_string=kwd.get('order', 'hid-asc'))
         serialization_params = self._parse_serialization_params(kwd, 'summary')
         # TODO: > 16.04: remove these
         # TODO: remove 'dataset_details' and the following section when the UI doesn't need it
@@ -904,13 +904,6 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
         TYPE_ID_SEP = '-'
         split = type_id.split(TYPE_ID_SEP, 1)
         return TYPE_ID_SEP.join([split[0], self.app.security.encode_id(split[1])])
-
-    def _parse_order_by(self, order_by_string):
-        ORDER_BY_SEP_CHAR = ','
-        manager = self.history_contents_manager
-        if ORDER_BY_SEP_CHAR in order_by_string:
-            return [manager.parse_order_by(o) for o in order_by_string.split(ORDER_BY_SEP_CHAR)]
-        return manager.parse_order_by(order_by_string)
 
     @expose_api_raw
     def archive(self, trans, history_id, filename='', format='tgz', dry_run=True, **kwd):

--- a/test/api/test_datasets.py
+++ b/test/api/test_datasets.py
@@ -86,7 +86,7 @@ class DatasetsApiTestCase(api.ApiTestCase):
         payload = {'limit': 10, 'offset': 0, 'q': ['history_content_type', 'tag-invalid_op'], 'qv': ['dataset', 'notag']}
         index_response = self._get("datasets", payload)
         self._assert_status_code_is(index_response, 400)
-        assert index_response.json()['err_msg'] == 'bad filter'
+        assert index_response.json()['err_msg'] == 'bad op in filter'
 
     def test_show(self):
         hda1 = self.dataset_populator.new_dataset(self.history_id)

--- a/test/api/test_datasets.py
+++ b/test/api/test_datasets.py
@@ -71,12 +71,12 @@ class DatasetsApiTestCase(api.ApiTestCase):
         assert len(self._get("datasets", payload).json()) == 1
         self.dataset_collection_populator.create_list_in_history(self.history_id,
                                                                  name="search by tool id",
-                                                                 contents=["1\n2\n3"])
-        payload = {'limit': 1, 'offset': 0, 'q': ['history_content_type', 'tool_id'],
-                   'qv': ['dataset_collection', 'upload1']}
+                                                                 contents=["1\n2\n3"]).json()
+        self.dataset_populator.wait_for_history(self.history_id)
+        payload = {'limit': 10, 'offset': 0, 'history_id': self.history_id, 'q': ['name', 'tool_id'],
+                   'qv': ['search by tool id', 'upload1']}
         result = self._get("datasets", payload).json()
-        assert len(result) == 1
-        assert result[0]['name'] == 'search by tool id'
+        assert result[0]['name'] == 'search by tool id', result
         payload = {'limit': 1, 'offset': 0, 'q': ['history_content_type', 'tool_id'],
                    'qv': ['dataset_collection', 'uploadX']}
         result = self._get("datasets", payload).json()

--- a/test/api/test_datasets.py
+++ b/test/api/test_datasets.py
@@ -3,21 +3,22 @@ from __future__ import print_function
 import textwrap
 
 from base import api
-from base.populators import TestsDatasets
+from base.populators import DatasetPopulator
 
 
-class DatasetsApiTestCase(api.ApiTestCase, TestsDatasets):
+class DatasetsApiTestCase(api.ApiTestCase):
 
     def setUp(self):
         super(DatasetsApiTestCase, self).setUp()
-        self.history_id = self._new_history()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.history_id = self.dataset_populator.new_history()
 
     def test_index(self):
         index_response = self._get("datasets")
-        self._assert_status_code_is(index_response, 501)
+        self._assert_status_code_is(index_response, 200)
 
     def test_show(self):
-        hda1 = self._new_dataset(self.history_id)
+        hda1 = self.dataset_populator.new_dataset(self.history_id)
         show_response = self._get("datasets/%s" % (hda1["id"]))
         self._assert_status_code_is(show_response, 200)
         self.__assert_matches_hda(hda1, show_response.json())
@@ -33,8 +34,8 @@ class DatasetsApiTestCase(api.ApiTestCase, TestsDatasets):
         A   B   C   D
         10  20  30  40
         """)
-        hda1 = self._new_dataset(self.history_id, content=contents)
-        self._wait_for_history(self.history_id)
+        hda1 = self.dataset_populator.new_dataset(self.history_id, content=contents)
+        self.dataset_populator.wait_for_history(self.history_id)
         display_response = self._get("histories/%s/contents/%s/display" % (self.history_id, hda1["id"]), {
             'raw': 'True'
         })

--- a/test/unit/managers/base.py
+++ b/test/unit/managers/base.py
@@ -100,14 +100,18 @@ class BaseTestCase(unittest.TestCase):
         self.assertTrue(True, 'is uuid: ' + item)
 
     def assertORMFilter(self, item, msg=None):
-        if not isinstance(item, (sqlalchemy.sql.elements.BinaryExpression, sqlalchemy.sql.elements.BooleanClauseList)):
-            self.fail('Not an orm filter: ' + str(type(item)))
-        self.assertTrue(True, msg or ('is an orm filter: ' + str(item)))
+        if not isinstance(item.filter, (sqlalchemy.sql.elements.BinaryExpression, sqlalchemy.sql.elements.BooleanClauseList)):
+            self.fail('Not an orm filter: ' + str(type(item.filter)))
+        self.assertTrue(True, msg or ('is an orm filter: ' + str(item.filter)))
+
+    def assertORMFunctionFilter(self, item, msg=None):
+        assert item.filter_type == 'orm_function'
+        assert callable(item.filter)
 
     def assertFnFilter(self, item, msg=None):
-        if not item or not callable(item):
-            self.fail('Not a fn filter: ' + str(type(item)))
-        self.assertTrue(True, msg or ('is a fn filter: ' + str(item)))
+        if not item.filter or not callable(item.filter):
+            self.fail('Not a fn filter: ' + str(type(item.filter)))
+        self.assertTrue(True, msg or ('is a fn filter: ' + str(item.filter)))
 
     def assertIsJsonifyable(self, item):
         # TODO: use galaxy's override

--- a/test/unit/managers/base.py
+++ b/test/unit/managers/base.py
@@ -100,7 +100,7 @@ class BaseTestCase(unittest.TestCase):
         self.assertTrue(True, 'is uuid: ' + item)
 
     def assertORMFilter(self, item, msg=None):
-        if not isinstance(item, sqlalchemy.sql.elements.BinaryExpression):
+        if not isinstance(item, (sqlalchemy.sql.elements.BinaryExpression, sqlalchemy.sql.elements.BooleanClauseList)):
             self.fail('Not an orm filter: ' + str(type(item)))
         self.assertTrue(True, msg or ('is an orm filter: ' + str(item)))
 

--- a/test/unit/managers/test_HDAManager.py
+++ b/test/unit/managers/test_HDAManager.py
@@ -654,13 +654,15 @@ class HDAFilterParserTestCase(HDATestCase):
         self.assertORMFilter(self.filter_parser.parse_filter('state', 'eq', 'ok'))
         self.assertORMFilter(self.filter_parser.parse_filter('state', 'in', ['queued', 'running']))
         self.assertORMFilter(self.filter_parser.parse_filter('visible', 'eq', True))
+        # taggable
+        self.assertORMFilter(self.filter_parser.parse_filter('tag', 'eq', 'wot'))
+        self.assertORMFilter(self.filter_parser.parse_filter('tag', 'has', 'wot'))
+        # genomebuild
         self.assertFnFilter(self.filter_parser.parse_filter('genome_build', 'eq', 'wot'))
         self.assertFnFilter(self.filter_parser.parse_filter('genome_build', 'contains', 'wot'))
+        # data_type
         self.assertFnFilter(self.filter_parser.parse_filter('data_type', 'eq', 'wot'))
         self.assertFnFilter(self.filter_parser.parse_filter('data_type', 'isinstance', 'wot'))
-        # taggable
-        self.assertFnFilter(self.filter_parser.parse_filter('tag', 'eq', 'wot'))
-        self.assertFnFilter(self.filter_parser.parse_filter('tag', 'has', 'wot'))
         # annotatable
         self.assertFnFilter(self.filter_parser.parse_filter('annotation', 'has', 'wot'))
 

--- a/test/unit/managers/test_HDAManager.py
+++ b/test/unit/managers/test_HDAManager.py
@@ -655,8 +655,8 @@ class HDAFilterParserTestCase(HDATestCase):
         self.assertORMFilter(self.filter_parser.parse_filter('state', 'in', ['queued', 'running']))
         self.assertORMFilter(self.filter_parser.parse_filter('visible', 'eq', True))
         # taggable
-        self.assertORMFilter(self.filter_parser.parse_filter('tag', 'eq', 'wot'))
-        self.assertORMFilter(self.filter_parser.parse_filter('tag', 'has', 'wot'))
+        self.assertORMFunctionFilter(self.filter_parser.parse_filter('tag', 'eq', 'wot'))
+        self.assertORMFunctionFilter(self.filter_parser.parse_filter('tag', 'has', 'wot'))
         # genomebuild
         self.assertFnFilter(self.filter_parser.parse_filter('genome_build', 'eq', 'wot'))
         self.assertFnFilter(self.filter_parser.parse_filter('genome_build', 'contains', 'wot'))

--- a/test/unit/managers/test_HistoryManager.py
+++ b/test/unit/managers/test_HistoryManager.py
@@ -29,6 +29,7 @@ default_password = '123456'
 user2_data = dict(email='user2@user2.user2', username='user2', password=default_password)
 user3_data = dict(email='user3@user3.user3', username='user3', password=default_password)
 user4_data = dict(email='user4@user4.user4', username='user4', password=default_password)
+parsed_filter = base.ModelFilterParser.parsed_filter
 
 
 class HistoryManagerTestCase(BaseTestCase):
@@ -697,7 +698,7 @@ class HistoryFiltersTestCase(BaseTestCase):
         self.assertEqual(len(filters), 3)
 
         self.log('values should be parsed')
-        self.assertIsInstance(filters[1].right, sqlalchemy.sql.elements.True_)
+        self.assertIsInstance(filters[1].filter.right, sqlalchemy.sql.elements.True_)
 
     def test_parse_filters_invalid_filters(self):
         self.log('should error on non-column attr')
@@ -763,7 +764,7 @@ class HistoryFiltersTestCase(BaseTestCase):
         history3 = self.history_manager.create(name='history3', user=user2)
 
         filters = self.filter_parser.parse_filters([('annotation', 'has', 'no play'), ])
-        anno_filter = filters[0]
+        anno_filter = filters[0].filter
 
         history3.add_item_annotation(self.trans.sa_session, user2, history3, "All work and no play")
         self.trans.sa_session.flush()
@@ -797,7 +798,7 @@ class HistoryFiltersTestCase(BaseTestCase):
         self.log('should have parsed out a single filter')
         self.assertEqual(len(filters), 1)
 
-        filter_ = filters[0]
+        filter_ = filters[0].filter
         fake = galaxy_mock.OpenObject()
         fake.name = '123'
         self.log('123 should return true through the filter')


### PR DESCRIPTION
The goal is to be able to search for datasets and dataset collections via the API, without knowing which history a dataset is in. This also extends the `HistoryContentsFilters` in a way that allows searching for datasets or collections with a given tag or annotation.