### PR TITLE
Replace ``enable_beta_export_format2_default`` with ``default_workflow_export_format``

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -1350,10 +1350,9 @@ galaxy:
   # of Galaxy's stable API.
   #enable_beta_workflow_modules: false
 
-  # Export of workflows as Galaxy Format 2 instead of GA workflows by
-  # default. The default value of this configuration variable will
-  # switch to True in 19.09.
-  #enable_beta_export_format2_default: false
+  # Default format for the export of workflows. Possible values are 'ga'
+  # or 'format2'.
+  #default_workflow_export_format: ga
 
   # Following options only apply to workflows scheduled using the legacy
   # workflow run API (running workflows via a POST to /api/workflows).

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2769,16 +2769,15 @@
 :Type: bool
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enable_beta_export_format2_default``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``default_workflow_export_format``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Export of workflows as Galaxy Format 2 instead of GA workflows by
-    default. The default value of this configuration variable will
-    switch to True in 19.09.
-:Default: ``false``
-:Type: bool
+    Default format for the export of workflows. Possible values are
+    'ga' or 'format2'.
+:Default: ``ga``
+:Type: str
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -384,8 +384,8 @@ class Configuration(object):
         # workflows built using these modules may not function in the
         # future.
         self.enable_beta_workflow_modules = string_as_bool(kwargs.get('enable_beta_workflow_modules', 'False'))
-        # Enable default export of gxformat2 workflows.
-        self.enable_beta_export_format2_default = string_as_bool(kwargs.get('enable_beta_export_format2_default', 'False'))
+        # Default format for the export of workflows.
+        self.default_workflow_export_format = kwargs.get('default_workflow_export_format', 'ga')
         # These are not even beta - just experiments - don't use them unless
         # you want yours tools to be broken in the future.
         self.enable_beta_tool_formats = string_as_bool(kwargs.get('enable_beta_tool_formats', 'False'))

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -449,12 +449,7 @@ class WorkflowContentsManager(UsesAnnotations):
             version = int(version)
         workflow = stored.get_internal_version(version)
         if style == "export":
-            # Export workflows as GA format through 19.05, in 19.09 this will become format2.
-            style = "ga"
-
-            if self.app.config.enable_beta_export_format2_default:
-                style = "format2"
-
+            style = self.app.config.default_workflow_export_format
         if style == "editor":
             wf_dict = self._workflow_to_dict_editor(trans, stored, workflow)
         elif style == "legacy":

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -421,14 +421,15 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         """
         GET /api/workflows/{encoded_workflow_id}/download
 
-        Returns a selected workflow as a json dictionary.
+        Returns a selected workflow.
 
         :type   style:  str
         :param  style:  Style of export. The default is 'export', which is the meant to be used
                         with workflow import endpoints. Other formats such as 'instance', 'editor',
                         'run' are more tied to the GUI and should not be considered stable APIs.
-                        By default the 'export' format in 19.05 is "ga" files, in 19.09 this will
-                        become 'format2'. Style can be specified as either 'ga' or 'format2' directly
+                        The default format for 'export' is specified by the
+                        admin with the `default_workflow_export_format` config
+                        option. Style can be specified as either 'ga' or 'format2' directly
                         to be explicit about which format to download.
         """
         stored_workflow = self.__get_stored_accessible_workflow(trans, workflow_id)

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2058,13 +2058,13 @@ mapping:
           Enable beta workflow modules that should not yet be considered part of Galaxy's
           stable API.
 
-      enable_beta_export_format2_default:
-        type: bool
-        default: false
+      default_workflow_export_format:
+        type: str
+        default: ga
         required: false
         desc: |
-          Export of workflows as Galaxy Format 2 instead of GA workflows by default. The
-          default value of this configuration variable will switch to True in 19.09.
+          Default format for the export of workflows. Possible values are 'ga'
+          or 'format2'.
 
       force_beta_workflow_scheduled_min_steps:
         type: int


### PR DESCRIPTION
This allows future different formats to be included.

Also remove promises about next release.

Follow-up on https://github.com/galaxyproject/galaxy/pull/7659 .