### PR TITLE
Sanitize html in messages using galaxy.util.sanitize_html 

### DIFF
--- a/templates/message.mako
+++ b/templates/message.mako
@@ -1,5 +1,5 @@
 <%!
-    import bleach
+    from galaxy.util.sanitize_html import sanitize_html
 
     def inherit(context):
         if context.get('use_panels'):
@@ -63,5 +63,5 @@
         if status not in ("danger", "info", "success", "warning"):
             status = "info"
     %>
-    <div class="message mt-2 alert alert-${status}">${_(bleach.clean(msg))}</div>
+    <div class="message mt-2 alert alert-${status}">${_(sanitize_html(msg))}</div>
 </%def>


### PR DESCRIPTION
... instead of bleach directly.

`galaxy.util.sanitize_html` in turn calls bleach with our 'standard' configuration

Fixes stuff like: 
![image](https://user-images.githubusercontent.com/155398/56162661-8c99c200-5f9a-11e9-9bfc-1baf9410b793.png)
