### PR TITLE
Report a couple common errors in dataset/job report.

### DIFF
--- a/client/galaxy/scripts/mvc/dataset/dataset-error.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-error.js
@@ -32,6 +32,7 @@ var View = Backbone.View.extend({
                     url: job_url,
                     success: job => {
                         this.render_error_page(dataset, job);
+                        this.find_common_problems(job);
                     },
                     error: response => {
                         var error_response = {
@@ -54,6 +55,46 @@ var View = Backbone.View.extend({
                 this.display_message(error_response, this.$(".response-message"));
             }
         });
+    },
+
+    find_common_problems: function(job) {
+        var job_url = `${getAppRoot()}api/jobs/${job.id}/common_problems`;
+        Utils.get({
+            url: job_url,
+            success: common_problems => {
+                this.render_common_problems(job, common_problems);
+            },
+            error: response => {
+                console.log("error");
+                console.log(response);
+            }
+        });
+        return;
+    },
+
+    render_common_problems: function(job, common_problems) {
+        const has_duplicate_inputs = common_problems.has_duplicate_inputs;
+        const has_empty_inputs = common_problems.has_empty_inputs;
+        if (has_duplicate_inputs || has_empty_inputs) {
+            const reportEl = this.$el.find(".common_problems");
+            reportEl.text("Detected Common Potential Problems");
+            if (has_empty_inputs) {
+                reportEl.after(`
+                    <p>
+                        The tool was executed with one or more empty input datasets, this isn't
+                        always a problem and may not have been but frequently this is a source
+                        of error.
+                    <p>`);
+            }
+            if (has_duplicate_inputs) {
+                reportEl.after(`
+                    <p>
+                        The tool was executed with one or more duplicate input datasets, this isn't
+                        always a problem and may not have been but frequently this is a source
+                        of error.
+                    <p>`);
+            }
+        }
     },
 
     /** Render the view */
@@ -88,23 +129,24 @@ var View = Backbone.View.extend({
         const job_stderr = job.job_stderr;
         const job_messages = job.job_messages;
         if (!tool_stderr && !job_stderr && !job_messages) {
-            return '';
+            return '<h3 class="common_problems"></h3>';
         }
-        var message = '<h3>Error Details</h3>';
+        var message = "<h3>Error Details</h3>";
         if (job_messages) {
-            message += '<p>Execution resulted in the following messages:</p>';
+            message += "<p>Execution resulted in the following messages:</p>";
             for (let job_message of job_messages) {
-                message += `<p><pre>${_.escape(job_message['desc'])}</pre></p>`;
+                message += `<p><pre>${_.escape(job_message["desc"])}</pre></p>`;
             }
         }
         if (tool_stderr) {
-            message += '<p>Tool generated the following standard error:</p>';
+            message += "<p>Tool generated the following standard error:</p>";
             message += `<pre class="code">${_.escape(tool_stderr)}</pre>`;
         }
         if (job_stderr) {
-            message += '<p>Galaxy job runner generated the following standard error:</p>';
+            message += "<p>Galaxy job runner generated the following standard error:</p>";
             message += `<pre class="code">${_.escape(job_stderr)}</pre>`;
         }
+        message += `<h3 class="common_problems"></h3>`;
         return message;
     },
 

--- a/client/galaxy/scripts/mvc/dataset/dataset-error.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-error.js
@@ -62,9 +62,7 @@ var View = Backbone.View.extend({
             ${this._templateHeader()}
             <h2>Dataset Error</h2>
             <p>An error occurred while running the tool <b>${job.tool_id}</b>.</p>
-            <p>Tool execution generated the following messages:</p>
-            <pre class="code">${_.escape(job.stderr)}</pre>
-
+            ${this.job_summary(job)}
             <h3>Troubleshoot This Error</h3>
             <p>
                 There are a number of help resources to self diagnose and
@@ -83,6 +81,31 @@ var View = Backbone.View.extend({
                 better able to investigate your problem and get back to you.
             </p>`);
         this.$el.append(this._getBugFormTemplate(dataset, job));
+    },
+
+    job_summary: function(job) {
+        const tool_stderr = job.tool_stderr;
+        const job_stderr = job.job_stderr;
+        const job_messages = job.job_messages;
+        if (!tool_stderr && !job_stderr && !job_messages) {
+            return '';
+        }
+        var message = '<h3>Error Details</h3>';
+        if (job_messages) {
+            message += '<p>Execution resulted in the following messages:</p>';
+            for (let job_message of job_messages) {
+                message += `<p><pre>${_.escape(job_message['desc'])}</pre></p>`;
+            }
+        }
+        if (tool_stderr) {
+            message += '<p>Tool generated the following standard error:</p>';
+            message += `<pre class="code">${_.escape(tool_stderr)}</pre>`;
+        }
+        if (job_stderr) {
+            message += '<p>Galaxy job runner generated the following standard error:</p>';
+            message += `<pre class="code">${_.escape(job_stderr)}</pre>`;
+        }
+        return message;
     },
 
     /** Display actions messages */

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -168,6 +168,30 @@ class JobController(BaseAPIController, UsesLibraryMixinItems):
         return job_dict
 
     @expose_api
+    def common_problems(self, trans, id, **kwd):
+        """
+        * GET /api/jobs/{id}/common_problems
+            check inputs and job for common potential problems to aid in error reporting
+        """
+        job = self.__get_job(trans, id)
+        seen_ids = set()
+        has_empty_inputs = False
+        has_duplicate_inputs = False
+        for job_input_assoc in job.input_datasets:
+            input_dataset_instance = job_input_assoc.dataset
+            if input_dataset_instance.get_total_size() == 0:
+                has_empty_inputs = True
+            input_instance_id = input_dataset_instance.id
+            if input_instance_id in seen_ids:
+                has_duplicate_inputs = True
+            else:
+                seen_ids.add(input_instance_id)
+        # TODO: check percent of failing jobs around a window on job.update_time for handler - report if high.
+        # TODO: check percent of failing jobs around a window on job.update_time for destination_id - report if high.
+        # TODO: sniff inputs (add flag to allow checking files?)
+        return {"has_empty_inputs": has_empty_inputs, "has_duplicate_inputs": has_duplicate_inputs}
+
+    @expose_api
     def inputs(self, trans, id, **kwd):
         """
         show( trans, id )

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -888,6 +888,7 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect('build_for_rerun', '/api/jobs/{id}/build_for_rerun', controller='jobs', action='build_for_rerun', conditions=dict(method=['GET']))
     webapp.mapper.connect('resume', '/api/jobs/{id}/resume', controller='jobs', action='resume', conditions=dict(method=['PUT']))
     webapp.mapper.connect('job_error', '/api/jobs/{id}/error', controller='jobs', action='error', conditions=dict(method=['POST']))
+    webapp.mapper.connect('common_problems', '/api/jobs/{id}/common_problems', controller='jobs', action='common_problems', conditions=dict(method=['GET']))
 
     # Job files controllers. Only for consumption by remote job runners.
     webapp.mapper.resource('file',


### PR DESCRIPTION
Report if empty inputs were used or if the same input was used more than once, these were identified as common sources of potential errors across many tools. Neither of these are definite problems, but both could be depending on the tool and both happen frequently. Outline a few more ideas as TODOs in the code.

These were identified as action items for easing Galaxy Help/Support at the Galaxy team meeting in April of 2019.

The first commit here also updates the report for more fine grain standard error reporting and job message handling added in https://github.com/galaxyproject/galaxy/pull/7095/files (regardless of the other slightly more controversial commit, this commit should be in 19.05).

<img width="665" alt="Screen Shot 2019-04-16 at 10 24 46 AM" src="https://user-images.githubusercontent.com/216771/56217979-26607e00-6032-11e9-9657-f113682421e3.png">
