### PR TITLE
Define fontawesome icon in login component using 'i' and not 'icon'

### DIFF
--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -25,7 +25,7 @@
                     </b-card>
                 </b-form>
                 <b-button v-for="idp in oidc_idps" :key="idp" class="d-block mt-3" @click="submitOIDCLogin(idp)">
-                    <icon v-bind:class="oidc_idps_icons[idp]" /> Sign in with {{ idp.charAt(0).toUpperCase() + idp.slice(1) }}
+                    <i v-bind:class="oidc_idps_icons[idp]" /> Sign in with {{ idp.charAt(0).toUpperCase() + idp.slice(1) }}
                 </b-button>
             </div>
             <div v-if="show_welcome_with_login" class="col">


### PR DESCRIPTION
This fixes an issue with Vue trying to link an 'icon' element, which we're not using (though we can potentially swap to it if warranted -- vue-awesome would provide v-icon, but I'm not sure yet if that's worth it).