### PR TITLE
Fix lazy object store initialization for distribute object stores.

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -310,7 +310,7 @@ class HasDatasets(object):
 
     def _dataset_wrapper(self, dataset, dataset_paths, **kwargs):
         wrapper_kwds = kwargs.copy()
-        if dataset:
+        if dataset and dataset_paths:
             real_path = dataset.file_name
             if real_path in dataset_paths:
                 wrapper_kwds["dataset_path"] = dataset_paths[real_path]

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -362,6 +362,8 @@ do
           fi
           ;;
       -a|-api|--api)
+          GALAXY_TEST_USE_HIERARCHICAL_OBJECT_STORE="True"  # Run these tests with a non-trivial object store.
+          export GALAXY_TEST_USE_HIERARCHICAL_OBJECT_STORE
           GALAXY_TEST_TOOL_CONF="config/tool_conf.xml.sample,test/functional/tools/samples_tool_conf.xml"
           test_script="pytest"
           report_file="./run_api_tests.html"

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -238,6 +238,36 @@ def setup_galaxy_config(
     )
     config.update(database_conf(tmpdir, prefer_template_database=prefer_template_database))
     config.update(install_database_conf(tmpdir, default_merged=default_install_db_merged))
+    if asbool(os.environ.get("GALAXY_TEST_USE_HIERARCHICAL_OBJECT_STORE")):
+        object_store_config = os.path.join(tmpdir, "object_store_conf.yml")
+        with open(object_store_config, "w") as f:
+            contents = """
+type: hierarchical
+backends:
+   - id: files1
+     type: disk
+     weight: 1
+     files_dir: "${temp_directory}/files1"
+     extra_dirs:
+     - type: temp
+       path: "${temp_directory}/tmp1"
+     - type: job_work
+       path: "${temp_directory}/job_working_directory1"
+   - id: files2
+     type: disk
+     weight: 1
+     files_dir: "${temp_directory}/files2"
+     extra_dirs:
+     - type: temp
+       path: "${temp_directory}/tmp2"
+     - type: job_work
+       path: "${temp_directory}/job_working_directory2"
+"""
+            contents_template = string.Template(contents)
+            expanded_contents = contents_template.safe_substitute(temp_directory=tmpdir)
+            f.write(expanded_contents)
+        config["object_store_config_file"] = object_store_config
+
     if datatypes_conf is not None:
         config['datatypes_config_file'] = datatypes_conf
     if enable_tool_shed_check:


### PR DESCRIPTION
Broken I guess with collection parameters and not really anything to do with collections - probably why we sometimes see it in the tool submission form also.

This fix should also speed up tool submission on main since the whole point was to avoid was to avoid disk access in web and scheduler threads, and this disk access snuck as part of the tool action code.

Fix #7368