### PR TITLE
Make paired check more defensive

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -426,7 +426,7 @@ var InputTerminal = BaseInputTerminal.extend({
                         "Cannot attach collections to data parameters with individual data inputs already attached."
                     );
                 }
-                if (otherCollectionType.collectionType.endsWith("paired")) {
+                if (otherCollectionType.collectionType && otherCollectionType.collectionType.endsWith("paired")) {
                     return new ConnectionAcceptable(
                         false,
                         "Cannot attach paired inputs to multiple data parameters, only lists may be treated this way."


### PR DESCRIPTION
This was erroring out if the collectionType wasn't set. This was causing
some weird dragging of the parameter (with the exception in the browser
console).