### PR TITLE
Fix BootstrapVue component specification in Citations

### DIFF
--- a/client/galaxy/scripts/components/Citations.vue
+++ b/client/galaxy/scripts/components/Citations.vue
@@ -29,13 +29,10 @@
 </template>
 <script>
 import _ from "underscore";
-import { getAppRoot } from "onload/loadConfig";
-
 import axios from "axios";
 import Vue from 'vue';
 import BootstrapVue from 'bootstrap-vue';
-
-
+import { getAppRoot } from "onload/loadConfig";
 import * as bibtexParse from "libs/bibtexParse";
 import { convertLaTeX } from "latex-to-unicode-converter";
 import { stringifyLaTeX } from "latex-parser";

--- a/client/galaxy/scripts/components/Citations.vue
+++ b/client/galaxy/scripts/components/Citations.vue
@@ -30,10 +30,17 @@
 <script>
 import _ from "underscore";
 import { getAppRoot } from "onload/loadConfig";
+
 import axios from "axios";
+import Vue from 'vue';
+import BootstrapVue from 'bootstrap-vue';
+
+
 import * as bibtexParse from "libs/bibtexParse";
 import { convertLaTeX } from "latex-to-unicode-converter";
 import { stringifyLaTeX } from "latex-parser";
+
+Vue.use(BootstrapVue);
 
 export default {
     props: {


### PR DESCRIPTION
This worked in the normal tool view because other things register BootstrapVue components, but it'd fail in the workflow editor due to the old-style entrypoint.

Fixes #7776 