### PR TITLE
Update parameter_input type when changing parameter type

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -275,6 +275,9 @@ var Node = Backbone.Model.extend({
                 // the output already exists, but the output formats may have changed.
                 // Therefore we update the datatypes and destroy invalid connections.
                 node.output_terminals[output.name].datatypes = output.extensions;
+                if (node.type == 'parameter_input') {
+                    node.output_terminals[output.name].attributes.type = output.type;
+                }
                 node.output_terminals[output.name].destroyInvalidConnections();
             }
         });


### PR DESCRIPTION
This allows connecting/disconnecting the parameter immediately (as
opposed to having to reload).
This fixes https://github.com/galaxyproject/galaxy/issues/7495 (default
values and optional value handling have their own issue).