### PR TITLE
Make url_get return unicode

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1641,7 +1641,7 @@ def url_get(base_url, password_mgr=None, pathspec=None, params=None):
     response = urlopener.open(full_url)
     content = response.read()
     response.close()
-    return content
+    return unicodify(content)
 
 
 def download_to_file(url, dest_file_path, timeout=30, chunk_size=2 ** 20):


### PR DESCRIPTION
We almost always consume this using `json.loads()`,
so this would fail on python 3.
Where we don't do this it should still be fine.
Fixes https://github.com/galaxyproject/galaxy/issues/7769