### PR TITLE
[19.01] Fix the use of JobMappingException

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -27,7 +27,7 @@ from galaxy import model, util
 from galaxy.datatypes import metadata, sniff
 from galaxy.exceptions import ObjectInvalid, ObjectNotFound
 from galaxy.jobs.actions.post import ActionBox
-from galaxy.jobs.mapper import JobRunnerMapper
+from galaxy.jobs.mapper import JobMappingException, JobRunnerMapper
 from galaxy.jobs.runners import BaseJobRunner, JobState
 from galaxy.objectstore import ObjectStorePopulator
 from galaxy.util import safe_makedirs, unicodify
@@ -993,6 +993,17 @@ class JobWrapper(HasResourceParameters):
         """
         job = self.get_job()
         self.sa_session.refresh(job)
+
+        # If this fail method is being called because a dynamic rule raised JobMappingException, the call to
+        # self.get_destination_configuration() below accesses self.job_destination and will just cause
+        # JobMappingException to be raised again.
+        try:
+            self.job_destination
+        except JobMappingException as exc:
+            log.debug("(%s) fail(): Job destination raised JobMappingException('%s'), caching fake '__fail__' "
+                      "destination for completion of fail method", self.get_id_tag(), str(exc.failure_message))
+            self.job_runner_mapper.cached_job_destination = JobDestination(id='__fail__')
+
         # if the job was deleted, don't fail it
         if not job.state == job.states.DELETED:
             # Check if the failure is due to an exception


### PR DESCRIPTION
Currently, if a dynamic rule raises `JobMappingException`, this causes the readiness loop to call the job wrapper's `fail()` method. In `fail()`, a call to `self.get_destination_configuration()` accesses `self.job_destination` which raises `JobMappingException` again, preventing the `fail()` method from completing. The exception is caught further up and logged, but the job state remains `new` and the process repeats with each loop of the job readiness check.