### PR TITLE
Restrict search to items in owned histories

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -115,7 +115,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
         if history_id:
             container = self.history_manager.get_accessible(self.decode_id(history_id), trans.user)
         contents = self.history_contents_manager.contents(
-            container=container, filters=filters, limit=limit, offset=offset, order_by=order_by
+            container=container, filters=filters, limit=limit, offset=offset, order_by=order_by, user_id=trans.user.id,
         )
         return [self.serializer_by_type[content.history_content_type].serialize_to_view(content, user=trans.user, trans=trans, view='summary') for content in contents]
 

--- a/test/api/test_datasets.py
+++ b/test/api/test_datasets.py
@@ -88,6 +88,14 @@ class DatasetsApiTestCase(api.ApiTestCase):
         self._assert_status_code_is(index_response, 400)
         assert index_response.json()['err_msg'] == 'bad op in filter'
 
+    def test_search_returns_only_accessible(self):
+        hda_id = self.dataset_populator.new_dataset(self.history_id)['id']
+        with self._different_user():
+            payload = {'limit': 10, 'offset': 0, 'q': ['history_content_type'], 'qv': ['dataset']}
+            index_response = self._get("datasets", payload).json()
+            for item in index_response:
+                assert hda_id != item['id']
+
     def test_show(self):
         hda1 = self.dataset_populator.new_dataset(self.history_id)
         show_response = self._get("datasets/%s" % (hda1["id"]))


### PR DESCRIPTION
This was an oversight in https://github.com/galaxyproject/galaxy/pull/7745.
This is the quick fix, but I think it's feasible to implement the
accessible logic as a query, which means we could push this down to
a Mixin, and treat it as a regular fiter (so admins could for instance
search/sort for the largest datasets, which is already possible in the
reports app).