### PR TITLE
Hide ExpressionTools in main analysis app

### DIFF
--- a/client/galaxy/scripts/mvc/tool/tools.js
+++ b/client/galaxy/scripts/mvc/tool/tools.js
@@ -438,14 +438,16 @@ var ToolPanel = Backbone.Model.extend({
             parse_elt = elt_dict => {
                 var type = elt_dict.model_class;
                 // There are many types of tools; for now, anything that ends in 'Tool'
-                // is treated as a generic tool.
-                if (type.indexOf("Tool") === type.length - 4) {
+                // and is not a ExpressionTool is treated as a generic tool.
+                if (type.indexOf("Tool") === type.length - 4 && type != 'ExpressionTool') {
                     return self.attributes.tools.get(elt_dict.id);
                 } else if (type === "ToolSection") {
                     // Parse elements.
-                    var elems = _.map(elt_dict.elems, parse_elt);
-                    elt_dict.elems = elems;
-                    return new ToolSection(elt_dict);
+                    var elems = _.map(elt_dict.elems, parse_elt).filter(Boolean);
+                    if (elems.length > 0) {
+                        elt_dict.elems = elems;
+                        return new ToolSection(elt_dict);
+                    }
                 } else if (type === "ToolSectionLabel") {
                     return new ToolSectionLabel(elt_dict);
                 }


### PR DESCRIPTION
This shows expression tools only via the API or the workflow editor.
Resolves https://github.com/galaxyproject/galaxy/issues/7795