### PR TITLE
Don't clean up jobs when running tests if `$GALAXY_TEST_NO_CLEANUP` is set

### DIFF
--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -172,6 +172,8 @@ def setup_galaxy_config(
             default_data_manager_config = data_manager_config
     data_manager_config_file = "%s,test/functional/tools/sample_data_manager_conf.xml" % default_data_manager_config
     master_api_key = get_master_api_key()
+    cleanup_job = 'never' if ("GALAXY_TEST_NO_CLEANUP" in os.environ or
+                              "TOOL_SHED_TEST_NO_CLEANUP" in os.environ) else 'onsuccess'
 
     # Data Manager testing temp path
     # For storing Data Manager outputs and .loc files so that real ones don't get clobbered
@@ -204,7 +206,7 @@ def setup_galaxy_config(
         conda_prefix=conda_prefix,
         conda_auto_init=conda_auto_init,
         conda_auto_install=conda_auto_install,
-        cleanup_job='onsuccess',
+        cleanup_job=cleanup_job,
         data_manager_config_file=data_manager_config_file,
         enable_beta_tool_formats=True,
         expose_dataset_path=True,


### PR DESCRIPTION
`$GALAXY_CONFIG_OVERRIDE_CLEANUP_JOB` can be used to override this behavior.