### PR TITLE
Don't let parameter_input steps be workflow outputs

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4875,6 +4875,9 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         return [wid for wid in query.all()]
 
     def add_output(self, workflow_output, step, output_object):
+        if step.type == 'parameter_input':
+            # TODO: these should be properly tracked.
+            return
         if output_object.history_content_type == "dataset":
             output_assoc = WorkflowInvocationOutputDatasetAssociation()
             output_assoc.workflow_invocation = self


### PR DESCRIPTION
~~The only step types that can create workflow outputs should be
`tool` and `subworkflow`, but not `data_input`, `data_collection_input` or `parameter_input`~~.
This fixes https://github.com/galaxyproject/galaxy/issues/7263
(and addresses some older workarounds at the root).