### PR TITLE
gops_intersect_1 imports galaxy

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -158,6 +158,7 @@ GALAXY_LIB_TOOLS_UNVERSIONED = [
     "sam_pileup",
     "find_diag_hits",
     "cufflinks",
+    "gops_intersect_1",
     # Tools improperly migrated to the tool shed (iuc)
     "tabular_to_dbnsfp",
     # Tools improperly migrated using Galaxy (from shed other)


### PR DESCRIPTION
Otherwise fails with
```
Traceback (most recent call last):
  File "/cvmfs/sandbox.galaxyproject.org/tools/toolshed.g2.bx.psu.edu/repos/devteam/intersect/33b3f3688db4/intersect/gops_intersect.py", line 23, in <module>
    from galaxy.tools.util.galaxyops import fail, parse_cols_arg, skipped
ModuleNotFoundError: No module named 'galaxy'
```
First error found by targeting test.galaxyproject.org with remote tool tests