### PR TITLE
Requirejs template purge

### DIFF
--- a/templates/base.mako
+++ b/templates/base.mako
@@ -51,7 +51,6 @@
 <%def name="javascripts()">
     ## TODO: remove when all libs are required directly in modules
     ${h.js(
-        'libs/require',
         'bundled/libs.chunk',
         'bundled/base.chunk'
     )}

--- a/templates/js-app.mako
+++ b/templates/js-app.mako
@@ -37,7 +37,6 @@
 
 <%def name="javascripts()">
     ${ h.js(
-        'libs/require',
         'bundled/libs.chunk',
         'bundled/base.chunk'
     )}


### PR DESCRIPTION
This drops the (now nonexistent) requirejs lib from our templates.  This has been deprecated for some time now, and I grepped around and didn't see anything, but -- does anyone know of any plugins which are still using require-based entrypoints?

(marking as a bug, since these files don't exist anymore and throw 404s when we attempt to access them)