### PR TITLE
Fix nested macro/token expansion on python 3

### DIFF
--- a/test/unit/tools/test_parsing.py
+++ b/test/unit/tools/test_parsing.py
@@ -41,6 +41,26 @@ TOOL_XML_1 = """
 </tool>
 """
 
+TOOL_WITH_TOKEN = r"""
+<tool id="tool_with_token" name="Token" version="1">
+    <macros>
+        <token name="@ESCAPE_IDENTIFIER@">
+<![CDATA[
+#set identifier = re.sub('[^\s\w\-]', '_', str($file.element_identifier))
+        ]]></token>
+        <token name="@NESTED_TOKEN@">
+<![CDATA[
+    before
+    @ESCAPE_IDENTIFIER@
+    after
+        ]]></token>
+    </macros>
+    <command>
+@NESTED_TOKEN@
+    </command>
+</tool>
+"""
+
 TOOL_YAML_1 = """
 name: "Bowtie Mapper"
 class: GalaxyTool
@@ -301,6 +321,12 @@ class XmlLoaderTestCase(BaseLoaderTestCase):
 
     def test_refresh_option(self):
         assert self._tool_source.parse_refresh() is False
+
+    def test_nested_token(self):
+        tool_source = self._get_tool_source(source_contents=TOOL_WITH_TOKEN)
+        command = tool_source.parse_command()
+        assert command
+        assert '@' not in command
 
 
 class YamlLoaderTestCase(BaseLoaderTestCase):


### PR DESCRIPTION
I noticed that in multiqc `@ESCAPE_IDENTIFIER@` wasn't being replaced.
It's surprising that this didn't cause any issues on python 2, but might have to do with the iteration order changes.