### PR TITLE
[19.01] Possible fix for WSGI process issue #7758

### DIFF
--- a/lib/galaxy/objectstore/s3_multipart_upload.py
+++ b/lib/galaxy/objectstore/s3_multipart_upload.py
@@ -5,26 +5,16 @@ This parallelizes the task over available cores using multiprocessing.
 Code mostly taken form CloudBioLinux.
 """
 
-import contextlib
-import functools
 import glob
-import multiprocessing
 import os
 import subprocess
-from multiprocessing.pool import IMapIterator
+import threading
 
 try:
     import boto
     from boto.s3.connection import S3Connection
 except ImportError:
     boto = None
-
-
-def map_wrap(f):
-    @functools.wraps(f)
-    def wrapper(args):
-        return f(*args)
-    return wrapper
 
 
 def mp_from_ids(s3server, mp_id, mp_keyname, mp_bucketname):
@@ -51,7 +41,6 @@ def mp_from_ids(s3server, mp_id, mp_keyname, mp_bucketname):
     return mp
 
 
-@map_wrap
 def transfer_part(s3server, mp_id, mp_keyname, mp_bucketname, i, part):
     """Transfer a part of a multipart upload. Designed to be run in parallel.
     """
@@ -64,8 +53,6 @@ def transfer_part(s3server, mp_id, mp_keyname, mp_bucketname, i, part):
 def multipart_upload(s3server, bucket, s3_key_name, tarball, mb_size):
     """Upload large files using Amazon's multipart upload functionality.
     """
-    cores = multiprocessing.cpu_count()
-
     def split_file(in_file, mb_size, split_num=5):
         prefix = os.path.join(os.path.dirname(in_file),
                               "%sS3PART" % (os.path.basename(s3_key_name)))
@@ -80,29 +67,11 @@ def multipart_upload(s3server, bucket, s3_key_name, tarball, mb_size):
     mp = bucket.initiate_multipart_upload(s3_key_name,
                                           reduced_redundancy=s3server['use_rr'])
 
-    with multimap(cores) as pmap:
-        for _ in pmap(transfer_part, ((s3server, mp.id, mp.key_name, mp.bucket_name, i, part)
-                                      for (i, part) in
-                                      enumerate(split_file(tarball, mb_size, cores)))):
-            pass
+    for (i, part) in enumerate(split_file(tarball, mb_size)):
+        t = threading.Thread(
+            target=transfer_part, 
+            args=(s3server, mp.id, mp.key_name, mp.bucket_name, i, part))
+        t.start()
+        t.join()
+
     mp.complete_upload()
-
-
-@contextlib.contextmanager
-def multimap(cores=None):
-    """Provide multiprocessing imap like function.
-
-    The context manager handles setting up the pool, worked around interrupt issues
-    and terminating the pool on completion.
-    """
-    if cores is None:
-        cores = max(multiprocessing.cpu_count() - 1, 1)
-
-    def wrapper(func):
-        def wrap(self, timeout=None):
-            return func(self, timeout=timeout if timeout is not None else 1e100)
-        return wrap
-    IMapIterator.next = wrapper(IMapIterator.next)
-    pool = multiprocessing.Pool(cores)
-    yield pool.imap
-    pool.terminate()

--- a/lib/galaxy/objectstore/s3_multipart_upload.py
+++ b/lib/galaxy/objectstore/s3_multipart_upload.py
@@ -69,7 +69,7 @@ def multipart_upload(s3server, bucket, s3_key_name, tarball, mb_size):
 
     for (i, part) in enumerate(split_file(tarball, mb_size)):
         t = threading.Thread(
-            target=transfer_part, 
+            target=transfer_part,
             args=(s3server, mp.id, mp.key_name, mp.bucket_name, i, part))
         t.start()
         t.join()


### PR DESCRIPTION
PR originating from issue #7758 

The use of multiprocessing.Pool and creating as many WSGI processes as CPUs was crashing our server when users uploaded multiple files. Our server has 16 vCPUs, so at times hundreds of WSGI processes were created to upload files to the object store.
Since this code is executing on the hosting server and from within a WSGI process, spawning full-weight processes to write files is too much of a resource drain on the hosting server. 

I made a minimal change and moved to lighter weight threads instead of processes. I have been running this on our dev instance and it is working.

As a side note, in 18.09 the lib/galaxy/jobs/__init__.py file called the s3 multipart code twice in succession. This greatly added to the server load. Looks like this issue has been eliminated in 19.01

18.09
```
                if 'uuid' in context:
                    dataset.dataset.uuid = context['uuid']
                # Update (non-library) job output datasets through the object store
                if dataset not in job.output_library_datasets:
                    self.object_store.update_from_file(dataset.dataset, create=True)
                self.__update_output(job, dataset)
```
19.01
```
                if 'uuid' in context:
                    dataset.dataset.uuid = context['uuid']
                self.__update_output(job, dataset)
 
```
