### PR TITLE
Fix InputValueWrapper gt/ge/lt/le comparisons

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -1,5 +1,6 @@
 import logging
 import tempfile
+from functools import total_ordering
 
 from six import string_types, text_type
 from six.moves import shlex_quote
@@ -67,6 +68,7 @@ class RawObjectWrapper(ToolParameterValueWrapper):
         return getattr(self.obj, key)
 
 
+@total_ordering
 class InputValueWrapper(ToolParameterValueWrapper):
     """
     Wraps an input so that __str__ gives the "param_dict" representation.
@@ -106,6 +108,16 @@ class InputValueWrapper(ToolParameterValueWrapper):
 
     def __getattr__(self, key):
         return getattr(self.value, key)
+
+    def __gt__(self, other):
+        if isinstance(other, string_types):
+            return str(self) > other
+        elif isinstance(other, int):
+            return int(self) > other
+        elif isinstance(other, float):
+            return float(self) > other
+        else:
+            super(InputValueWrapper, self).__gt__(other)
 
     def __int__(self):
         return int(float(self))

--- a/test/unit/tools/test_wrappers.py
+++ b/test/unit/tools/test_wrappers.py
@@ -88,6 +88,12 @@ def test_input_value_wrapper(tool):
     parameter = IntegerToolParameter(tool, XML('<param name="blah" type="integer" value="10" min="0" />'))
     wrapper = InputValueWrapper(parameter, "5")
     assert str(wrapper) == "5"
+    assert int(wrapper) == 5
+    assert wrapper == "5"
+    assert wrapper == 5
+    assert wrapper == 5.0
+    assert wrapper > 2
+    assert wrapper < 10
 
 
 def test_dataset_wrapper():


### PR DESCRIPTION
This caused meme to fail. Again I'm not 100% sure why this wasn't an issue on python 2.