### PR TITLE
Fix failure in resubmitting job more than once

### DIFF
--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -181,6 +181,8 @@ class ShellJobRunner(AsynchronousJobRunner):
                     # Try to find out the reason for exiting
                     self.__handle_out_of_memory(ajs, external_job_id)
                     self.work_queue.put((self.mark_as_failed, ajs))
+                    # Don't add the job to the watched items once it fails, deals with https://github.com/galaxyproject/galaxy/issues/7820
+                    continue
             if state == model.Job.states.RUNNING and not ajs.running:
                 ajs.running = True
             ajs.old_state = state


### PR DESCRIPTION
This addresses the problem of sequential resubmissions failing as described in #7820. It does so by avoiding to add failed jobs to the watched items.