### PR TITLE
Use markupsafe.escape instead of cgi.escape

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -8,11 +8,11 @@ import shutil
 import string
 import tempfile
 import zipfile
-from cgi import escape
 from inspect import isclass
 
 import six
 import webob.exc
+from markupsafe import escape
 
 from galaxy import util
 from galaxy.datatypes.metadata import MetadataElement  # import directly to maintain ease of use in Datatype class definitions

--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -15,8 +15,8 @@ import logging
 import os
 import re
 import sys
-from cgi import escape
 
+from markupsafe import escape
 from six.moves.urllib.parse import quote_plus
 
 from galaxy.datatypes import metadata

--- a/lib/galaxy/datatypes/isa.py
+++ b/lib/galaxy/datatypes/isa.py
@@ -14,7 +14,6 @@ import re
 import shutil
 import sys
 import tempfile
-from cgi import escape
 
 # Imports isatab after turning off warnings inside logger settings to avoid pandas warning making uploads fail.
 logging.getLogger("isatools.isatab").setLevel(logging.ERROR)
@@ -22,6 +21,7 @@ from isatools import (
     isajson,
     isatab_meta
 )
+from markupsafe import escape
 
 from galaxy import util
 from galaxy.datatypes import data

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -9,10 +9,10 @@ import re
 import string
 import subprocess
 import sys
-from cgi import escape
 from itertools import islice
 
 import bx.align.maf
+from markupsafe import escape
 
 from galaxy import util
 from galaxy.datatypes import metadata

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -12,10 +12,10 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from cgi import escape
 from json import dumps
 
 import pysam
+from markupsafe import escape
 
 from galaxy import util
 from galaxy.datatypes import binary, data, metadata

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -1,8 +1,9 @@
 """
 Functionality for dealing with tool errors.
 """
-import cgi
 import string
+
+import markupsafe
 
 from galaxy import (
     model,
@@ -219,7 +220,7 @@ class ErrorReporter(object):
         # Escape all of the content  for use in the HTML report
         for parameter in report_variables.keys():
             if report_variables[parameter] is not None:
-                report_variables[parameter] = cgi.escape(unicodify(report_variables[parameter]))
+                report_variables[parameter] = markupsafe.escape(unicodify(report_variables[parameter]))
 
         self.html_report = string.Template(error_report_template_html).safe_substitute(report_variables)
 

--- a/lib/galaxy/web/framework/middleware/error.py
+++ b/lib/galaxy/web/framework/middleware/error.py
@@ -9,10 +9,10 @@ Error handler middleware
 When an exception is thrown from the wrapper application, this logs
 the exception and displays an error page.
 """
-import cgi
 import sys
 import traceback
 
+import markupsafe
 import six
 from paste import (
     request,
@@ -449,7 +449,7 @@ def send_report(rep, exc_data, html=True):
 
             <pre>%s</pre>
             </p>""" % (
-                cgi.escape(str(rep)), output.getvalue())
+                markupsafe.escape(str(rep)), output.getvalue())
         else:
             return (
                 "Additionally an error occurred while sending the "

--- a/lib/galaxy/web/framework/middleware/profile.py
+++ b/lib/galaxy/web/framework/middleware/profile.py
@@ -2,11 +2,11 @@
 Middleware that profiles the request with cProfile and displays profiling
 information at the bottom of each page.
 """
-import cgi
 import cProfile
 import pstats
 import threading
 
+import markupsafe
 from paste import response
 
 
@@ -93,9 +93,9 @@ def pstats_as_html(stats, *sel_list):
     funcs, order_message, select_message = get_func_list(stats, sel_list)
     # Deal with any ordering or selection messages
     if order_message:
-        rval.append("<div>%s</div>" % cgi.escape(order_message))
+        rval.append("<div>%s</div>" % markupsafe.escape(order_message))
     if select_message:
-        rval.append("<div>%s</div>" % cgi.escape(select_message))
+        rval.append("<div>%s</div>" % markupsafe.escape(select_message))
     # Build a table for the functions
     if list:
         rval.append("<table>")
@@ -114,7 +114,7 @@ def pstats_as_html(stats, *sel_list):
             ncalls = str(nc)
             if nc != cc:
                 ncalls = ncalls + '/' + str(cc)
-            rval.append("<td>%s</td>" % cgi.escape(ncalls))
+            rval.append("<td>%s</td>" % markupsafe.escape(ncalls))
             # tottime
             rval.append("<td>%0.8f</td>" % tt)
             # percall
@@ -122,7 +122,7 @@ def pstats_as_html(stats, *sel_list):
                 percall = ""
             else:
                 percall = "%0.8f" % (tt / nc)
-            rval.append("<td>%s</td>" % cgi.escape(percall))
+            rval.append("<td>%s</td>" % markupsafe.escape(percall))
             # cumtime
             rval.append("<td>%0.8f</td>" % ct)
             # ctpercall
@@ -130,9 +130,9 @@ def pstats_as_html(stats, *sel_list):
                 ctpercall = ""
             else:
                 ctpercall = "%0.8f" % (ct / cc)
-            rval.append("<td>%s</td>" % cgi.escape(ctpercall))
+            rval.append("<td>%s</td>" % markupsafe.escape(ctpercall))
             # location
-            rval.append("<td>%s</td>" % cgi.escape(func_std_string(func)))
+            rval.append("<td>%s</td>" % markupsafe.escape(func_std_string(func)))
             # row complete
             rval.append("</tr>")
         rval.append("</table>")

--- a/templates/tagging_common.mako
+++ b/templates/tagging_common.mako
@@ -1,6 +1,6 @@
 <%namespace file="/display_common.mako" import="get_controller_name" />
 <%!
-from cgi import escape
+from markupsafe import escape
 %>
 
 ## Render a tagging element if there is a tagged_item.

--- a/templates/webapps/galaxy/workflow/display.mako
+++ b/templates/webapps/galaxy/workflow/display.mako
@@ -2,9 +2,9 @@
 <%namespace file="/display_common.mako" import="render_message" />
 
 <%!
+    import markupsafe
     from galaxy.tools.parameters.basic import DataCollectionToolParameter, DataToolParameter, RuntimeValue
     from galaxy.web import form_builder
-    import cgi
 %>
 
 <%def name="stylesheets()">
@@ -64,7 +64,7 @@
                     <i>select at runtime</i>
                 %endif
             %else:
-                ${cgi.escape( param.value_to_display_text( value ) or 'Unavailable.' )}
+                ${markupsafe.escape( param.value_to_display_text( value ) or 'Unavailable.' )}
             %endif
         </div>
         %if hasattr( step, 'upgrade_messages' ) and step.upgrade_messages and param.name in step.upgrade_messages:


### PR DESCRIPTION
This silences some deprecation warnings on python 3.