### PR TITLE
Bootstrap style deprecation warning fix

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -684,7 +684,7 @@ div.form-row-input label {
 }
 
 #run-workflow {
-    @include float-right;
+    @extend .float-right;
     @extend .mt-3;
 }
 


### PR DESCRIPTION
Swap to @extend instead of relying on (recently deprecated in 4.3) bootstrap float mixin.  I'd really like to be able to use the bootstrap mixins directly but they seem to strongly steer towards just using the utility classes.  Generates a heinous stylesheet, though.