### PR TITLE
[19.01] Fix trackster issue w/ constraining (overflow:non-visible) containers

### DIFF
--- a/client/galaxy/scripts/viz/trackster/tracks.js
+++ b/client/galaxy/scripts/viz/trackster/tracks.js
@@ -1000,6 +1000,9 @@ var TracksterView = Backbone.View.extend({
                 });
             });
 
+        // We break out of the parent container with nav (and potentially other
+        // things?) so we need to override any overflow settings here.
+        parent_element.css("overflow", "visible");
         // Navigation at top
         this.nav_container = $("<div/>")
             .addClass("trackster-nav-container")


### PR DESCRIPTION
The way we create the layouts here could use a lot of refactoring, but this is a minimal, safe fix for https://github.com/galaxyproject/galaxy/issues/7501

(fixes #7501)