### PR TITLE
[19.05] improve upload ux

### DIFF
--- a/client/galaxy/scripts/mvc/ui/ui-modal.js
+++ b/client/galaxy/scripts/mvc/ui/ui-modal.js
@@ -55,6 +55,7 @@ export var View = Backbone.View.extend({
                 this.hide(true);
             });
         }
+        this.$el.find(".title").focus();
     },
 
     /**
@@ -195,7 +196,7 @@ export var View = Backbone.View.extend({
             '<div class="modal-dialog">' +
             '<div class="modal-content">' +
             '<div class="modal-header">' +
-            '<h4 class="title"/>' +
+            '<h4 class="title" tabindex="0"/>' +
             "</div>" +
             '<div class="modal-body"/>' +
             '<div class="modal-footer">' +

--- a/client/galaxy/scripts/mvc/ui/ui-tabs.js
+++ b/client/galaxy/scripts/mvc/ui/ui-tabs.js
@@ -161,6 +161,7 @@ export var View = Backbone.View.extend({
                 $("<a/>")
                     .addClass("nav-link")
                     .attr("id", `tab-title-link-${options.id}`)
+                    .attr("href", "javascript:void(0);")
             );
         var $href = $tmpl.find("a");
         options.icon &&


### PR DESCRIPTION
As discussed here: https://help.galaxyproject.org/t/editing-workflow-with-screen-reader/892/10 the usability of upload with screen reader is problematic. This PR does two things:

* everything using `mvc/ui/ui-tabs.js` will have focusable tabs, which should ease the non-visual navigation 
* after opening every modal based on `mvc/ui/ui-modal.js` the focus will be set to its title which will prevent user to be 'lost' in the background of the modal