### PR TITLE
[19.01] Use just the env name when checking ``CONDA_DEFAULT_ENV``

### DIFF
--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -42,11 +42,11 @@ DEFAULT_CONDARC_OVERRIDE = "_condarc"
 # https://github.com/bioconda/bioconda-recipes/blob/master/config.yml , but
 # adding `iuc` as first channel (for Galaxy-specific packages)
 DEFAULT_ENSURE_CHANNELS = "iuc,conda-forge,bioconda,defaults"
-CONDA_SOURCE_CMD = """[ "$CONDA_DEFAULT_ENV" = "%s" ] ||
+CONDA_SOURCE_CMD = """[ "$CONDA_DEFAULT_ENV" = "{conda_environment_name}" ] ||
 MAX_TRIES=3
 COUNT=0
 while [ $COUNT -lt $MAX_TRIES ]; do
-    . %s '%s' > conda_activate.log 2>&1
+    . '{activate_path}' '{environment_path}' > conda_activate.log 2>&1
     if [ $? -eq 0 ];then
         break
     else
@@ -405,10 +405,10 @@ class MergedCondaDependency(Dependency):
                 self.environment_path,
             )
         else:
-            return CONDA_SOURCE_CMD % (
-                self.environment_path,
-                self.activate,
-                self.environment_path
+            return CONDA_SOURCE_CMD.format(
+                conda_environment_name=os.path.basename(self.environment_path),
+                activate_path=self.activate,
+                environment_path=self.environment_path
             )
 
 
@@ -474,10 +474,10 @@ class CondaDependency(Dependency):
                 self.environment_path,
             )
         else:
-            return CONDA_SOURCE_CMD % (
-                self.environment_path,
-                self.activate,
-                self.environment_path
+            return CONDA_SOURCE_CMD.format(
+                conda_environment_name=os.path.basename(self.environment_path),
+                activate_path=self.activate,
+                environment_path=self.environment_path
             )
 
 

--- a/lib/galaxy/tools/deps/resolvers/conda.py
+++ b/lib/galaxy/tools/deps/resolvers/conda.py
@@ -42,7 +42,7 @@ DEFAULT_CONDARC_OVERRIDE = "_condarc"
 # https://github.com/bioconda/bioconda-recipes/blob/master/config.yml , but
 # adding `iuc` as first channel (for Galaxy-specific packages)
 DEFAULT_ENSURE_CHANNELS = "iuc,conda-forge,bioconda,defaults"
-CONDA_SOURCE_CMD = """[ "$CONDA_DEFAULT_ENV" = "{conda_environment_name}" ] ||
+CONDA_SOURCE_CMD = """[ "$(basename "$CONDA_DEFAULT_ENV")" = "$(basename '{environment_path}')" ] ||
 MAX_TRIES=3
 COUNT=0
 while [ $COUNT -lt $MAX_TRIES ]; do
@@ -406,7 +406,6 @@ class MergedCondaDependency(Dependency):
             )
         else:
             return CONDA_SOURCE_CMD.format(
-                conda_environment_name=os.path.basename(self.environment_path),
                 activate_path=self.activate,
                 environment_path=self.environment_path
             )
@@ -475,7 +474,6 @@ class CondaDependency(Dependency):
             )
         else:
             return CONDA_SOURCE_CMD.format(
-                conda_environment_name=os.path.basename(self.environment_path),
                 activate_path=self.activate,
                 environment_path=self.environment_path
             )


### PR DESCRIPTION
This will still write the conda activate part out multiple times,
but fix the check that would otherwise lead to repeated activation
of the conda env. Fixes the slowness reported in https://github.com/galaxyproject/galaxy/issues/7849