### PR TITLE
[19.01] Fix workflow extraction for jobs whose JobToDatasetOutputAssociation references a discovered dataset

### DIFF
--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -141,7 +141,7 @@ def extract_steps(trans, history=None, job_ids=None, dataset_ids=None, dataset_c
                 hid = None
                 for implicit_pair in jobs[job]:
                     query_assoc_name, dataset_collection = implicit_pair
-                    if query_assoc_name == assoc_name:
+                    if query_assoc_name == assoc_name or assoc_name.startswith("__new_primary_file_%s|" % query_assoc_name):
                         hid = dataset_collection.hid
                 if hid is None:
                     template = "Failed to find matching implicit job - job id is %s, implicit pairs are %s, assoc_name is %s."


### PR DESCRIPTION
To test this run a tool that generates discovered data sets twice, with the second run taking the first output as input.