### PR TITLE
Remove close option from workflow gear menu

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -68,30 +68,6 @@ export default Backbone.View.extend({
         var self = (window.workflow_globals.app = this);
         this.options = options;
         this.urls = (options && options.urls) || {};
-        var close_editor = () => {
-            self.workflow.check_changes_in_active_form();
-            if (self.workflow && self.workflow.has_changes) {
-                var do_close = () => {
-                    window.onbeforeunload = undefined;
-                    window.document.location = self.urls.workflow_index;
-                };
-                show_modal(
-                    "Close workflow editor",
-                    "There are unsaved changes to your workflow which will be lost.",
-                    {
-                        Cancel: hide_modal,
-                        "Save Changes": function() {
-                            save_current_workflow(null, do_close);
-                        }
-                    },
-                    {
-                        "Don't Save": do_close
-                    }
-                );
-            } else {
-                window.document.location = self.urls.workflow_index;
-            }
-        };
         var workflow_index = self.urls.workflow_index;
         var save_current_workflow = (eventObj, success_callback) => {
             show_message("Saving workflow", "progress");
@@ -389,8 +365,7 @@ export default Backbone.View.extend({
                 Download: {
                     url: `${getAppRoot()}api/workflows/${self.options.id}/download?format=json-download`,
                     action: function() {}
-                },
-                Close: close_editor
+                }
             });
         }
 

--- a/test/galaxy_selenium/navigates_galaxy.py
+++ b/test/galaxy_selenium/navigates_galaxy.py
@@ -804,7 +804,8 @@ class NavigatesGalaxy(HasDriver):
         return self.wait_for_and_click_selector("#workflow-run-button")
 
     def workflow_editor_click_save(self):
-        return self.wait_for_and_click_selector("#workflow-save-button")
+        self.wait_for_and_click_selector("#workflow-save-button")
+        self.sleep_for(self.wait_types.DATABASE_OPERATION)
 
     def admin_open(self):
         self.components.masthead.admin.wait_for_and_click()

--- a/test/selenium_tests/test_workflow_editor.py
+++ b/test/selenium_tests/test_workflow_editor.py
@@ -63,7 +63,7 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         editor.label_input.wait_for_and_click()  # Seems to help force the save of whole annotation.
         self.sleep_for(self.wait_types.UX_RENDER)
         self.screenshot("workflow_editor_data_input_filled_in")
-        self.workflow_editor_save_and_close()
+        self.workflow_editor_click_save()
         self.workflow_index_open_with_name(name)
         data_input_node = editor.node._(label="input1")
         data_input_node.title.wait_for_and_click()
@@ -89,7 +89,7 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         editor.label_input.wait_for_and_click()  # Seems to help force the save of whole annotation.
         self.sleep_for(self.wait_types.UX_RENDER)
         self.screenshot("workflow_editor_data_collection_input_filled_in")
-        self.workflow_editor_save_and_close()
+        self.workflow_editor_click_save()
         self.workflow_index_open_with_name(name)
         data_input_node = editor.node._(label="input1")
         data_input_node.title.wait_for_and_click()
@@ -116,7 +116,7 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         editor.label_input.wait_for_and_click()  # Seems to help force the save of whole annotation.
         self.sleep_for(self.wait_types.UX_RENDER)
         self.screenshot("workflow_editor_parameter_input_filled_in")
-        self.workflow_editor_save_and_close()
+        self.workflow_editor_click_save()
         self.workflow_index_open_with_name(name)
         data_input_node = editor.node._(label="input1")
         data_input_node.title.wait_for_and_click()
@@ -333,10 +333,6 @@ steps:
         self.workflow_index_click_option("Edit")
         self.assert_modal_has_text("Tool is not installed")
         self.screenshot("workflow_editor_missing_tool")
-
-    def workflow_editor_save_and_close(self):
-        self.workflow_editor_click_save()
-        self.workflow_editor_click_option("Close")
 
     def workflow_editor_maximize_center_pane(self, collapse_left=True, collapse_right=True):
         if collapse_left:


### PR DESCRIPTION
This PR removes the 'Close' option from the workflow gear dropdown menu. This option is redundant and not-placed well, users can navigate away either way, in which case a similar warning message is shown. It would be good to follow-up and improve the generic warning message but that can be done in another PR.