### PR TITLE
[19.01] Fix bug preventing handler runner plugin handling.

### DIFF
--- a/lib/galaxy/util/handlers.py
+++ b/lib/galaxy/util/handlers.py
@@ -57,6 +57,7 @@ class ConfiguresHandlers(object):
                     log.error("Handler '%s' overlaps handler with the same name, ignoring", handler_id)
                 else:
                     log.debug("Read definition for handler '%s'", handler_id)
+                    self._parse_handler(handler_id, handler)
                     self.add_handler(
                         handler_id,
                         [x.strip() for x in handler.get('tags', self.DEFAULT_HANDLER_TAG).split(',')]

--- a/test/unit/jobs/test_job_configuration.py
+++ b/test/unit/jobs/test_job_configuration.py
@@ -230,7 +230,7 @@ class JobConfXmlParserTestCase(unittest.TestCase):
 
         assert env_dest.env[3]["execute"] == "module load javastuff/2.10"
 
-    def test_hanlder_runner_plugins(self):
+    def test_handler_runner_plugins(self):
         self.__with_advanced_config()
         assert self.job_config.handler_runner_plugins["sge_handler"] == ["sge"]
         assert "special_handler1" not in self.job_config.handler_runner_plugins

--- a/test/unit/jobs/test_job_configuration.py
+++ b/test/unit/jobs/test_job_configuration.py
@@ -230,6 +230,16 @@ class JobConfXmlParserTestCase(unittest.TestCase):
 
         assert env_dest.env[3]["execute"] == "module load javastuff/2.10"
 
+    def test_hanlder_runner_plugins(self):
+        self.__with_advanced_config()
+        assert self.job_config.handler_runner_plugins["sge_handler"] == ["sge"]
+        assert "special_handler1" not in self.job_config.handler_runner_plugins
+
+    def test_resource_groups(self):
+        self.__with_advanced_config()
+        assert self.job_config.default_resource_group == "default"
+        assert self.job_config.resource_groups["memoryonly"] == ["memory"]
+
     def test_macro_expansion(self):
         self.__with_advanced_config()
         for name in ["foo_small", "foo_medium", "foo_large", "foo_longrunning"]:


### PR DESCRIPTION
Broken in https://github.com/galaxyproject/galaxy/pull/7091 somewhere.

With some more job config test cases from https://github.com/galaxyproject/galaxy/pull/7854 that would have covered this.