### PR TITLE
Allow type_source to reference a collection input in a repeat 

### DIFF
--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -192,9 +192,17 @@ class ExecutionTracker(object):
             for key, value in input_dict.items():
                 if key == input_name:
                     return value
+                if isinstance(value, list):
+                    prefix, rest_input_name = input_name.split("|", 1)
+                    if '_' in prefix:
+                        prefix, index = prefix.split('_')
+                        index = int(index)
+                        value = value[index]
                 if isinstance(value, dict):
                     if "|" in input_name:
                         prefix, rest_input_name = input_name.split("|", 1)
+                        if '_' in prefix:
+                            prefix = prefix.split('_')[0]
                         if key == prefix:
                             return find_collection(value, rest_input_name)
                     elif unqualified_recurse:


### PR DESCRIPTION
I was reviewing the local-only commits I had on our prod server, this one allows `type_source="inputs_0|input"` for 
```
    <repeat name="inputs" title="Input Collections" min="2">
        <param name="input" type="data_collection" label="Input Collection" />
    </repeat>
```
The current workaround would be to create one static input, but that seems unnecessary. 

WIP while I add a test.