### PR TITLE
Fix failing integration test.

### DIFF
--- a/test/integration/simple_job_conf.xml
+++ b/test/integration/simple_job_conf.xml
@@ -4,6 +4,10 @@
         <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="1"/>
     </plugins>
 
+    <handlers>
+        <handler id="main"/>
+    </handlers>
+
     <destinations>
         <destination id="local_dest" runner="local">
         </destination>


### PR DESCRIPTION
https://jenkins.galaxyproject.org/job/docker-integration/9044/testReport/junit/test.integration.test_job_recovery/JobRecoveryBeforeHandledIntegerationTestCase/test_recovery/

Likely transiently broken with #7874