### PR TITLE
[19.05] Update Cheetah dependency, fixes ``AssertionError``

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -36,7 +36,7 @@ cachetools==3.1.0
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4
-cheetah3==3.2.1
+cheetah3==3.2.2
 cliff==2.14.1
 cloudauthz==0.2.0
 cloudbridge==2.0.0


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/jobs/runners/pulsar.py", line 350, in __prepare_job
    job_wrapper.prepare(**prepare_kwds)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/jobs/__init__.py", line 871, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/evaluation.py", line 451, in build
    raise e
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/evaluation.py", line 447, in build
    self.__build_command_line()
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/evaluation.py", line 472, in __build_command_line
    command_line = fill_template(command, context=param_dict)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/util/template.py", line 18, in fill_template
    return unicodify(Template(source=template_text, searchList=[context]))
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/util/__init__.py", line 1018, in unicodify
    msg = "Value '%s' could not be coerced to Unicode" % value
  File "/cvmfs/test.galaxyproject.org/venv/lib/python3.6/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1555443583_0915494_96112.py", line 261, in respond
  File "/cvmfs/test.galaxyproject.org/venv/lib/python3.6/site-packages/Cheetah/NameMapper.py", line 288, in valueFromSearchList
    executeCallables=executeCallables)
  File "/cvmfs/test.galaxyproject.org/venv/lib/python3.6/site-packages/Cheetah/NameMapper.py", line 231, in _valueForName
    if executeCallables and hasattr(nextObj, '__call__') and \
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/wrappers.py", line 138, in __getattr__
    self._fields[name] = self._input.options.get_field_by_name_for_value(name, self._value, None, self._other_values)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/parameters/dynamic_options.py", line 658, in get_field_by_name_for_value
    assert field_name in self.columns, "Requested '%s' column missing from column def" % field_name
AssertionError: Requested '__call__' column missing from column def
```
reported by @natefoo and seen on test.galaxyproject.org.
This was fixed upstream in https://github.com/CheetahTemplate3/cheetah3/commit/354c885ae50c3d38b06928493ecd640c5d3bf768
by replacing `hasattr(nextObj, '__call__')` with `callable(nextObj)`.