### PR TITLE
Raise detailed exception for broken citation

### DIFF
--- a/lib/galaxy/managers/citations.py
+++ b/lib/galaxy/managers/citations.py
@@ -65,7 +65,11 @@ def parse_citation(elem, directory, citation_manager):
     if not citation_class:
         log.warning("Unknown or unspecified citation type: %s" % citation_type)
         return None
-    return citation_class(elem, directory, citation_manager)
+    try:
+        citation = citation_class(elem, directory, citation_manager)
+    except Exception as e:
+        raise Exception("Invalid citation of type '%s' with content '%s': %s" % (citation_type, elem.text, e))
+    return citation
 
 
 class CitationCollection(object):


### PR DESCRIPTION
For an empty citation, this will result in logging:
```
Exception: Invalid citation of type 'doi' with content 'None': 'NoneType' object has no attribute 'strip'
```

instead of:
```
AttributeError: 'NoneType' object has no attribute 'strip'
```

xref https://github.com/galaxyproject/planemo/issues/929