### PR TITLE
[19.05] Add local namespaced resolver to default container resolvers

### DIFF
--- a/lib/galaxy/tools/deps/containers.py
+++ b/lib/galaxy/tools/deps/containers.py
@@ -206,7 +206,9 @@ class ContainerRegistry(object):
         if self.enable_beta_mulled_containers:
             default_resolvers.extend([
                 CachedMulledDockerContainerResolver(self.app_info, namespace="biocontainers"),
+                CachedMulledDockerContainerResolver(self.app_info, namespace="local"),
                 CachedMulledSingularityContainerResolver(self.app_info, namespace="biocontainers"),
+                CachedMulledSingularityContainerResolver(self.app_info, namespace="local"),
                 MulledDockerContainerResolver(self.app_info, namespace="biocontainers"),
                 MulledSingularityContainerResolver(self.app_info, namespace="biocontainers"),
                 BuildMulledDockerContainerResolver(self.app_info),


### PR DESCRIPTION
The mulled container resolvers are building containers that are
namespaced to "local", so I think it makes a lot of sense to
include local in the defaults. This prevents planemo from
building the same image over and over again when run with
`--mulled_containers` / `--biocontainers`.