### PR TITLE
[19.05] Fix application of history default permissions to anonymous histories carried over upon login

### DIFF
--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -650,24 +650,27 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
         Associate the user's last accessed history (if exists) with their new session
         """
         history = None
+        set_permissions = False
         try:
             users_last_session = user.galaxy_sessions[0]
-            last_accessed = True
         except Exception:
             users_last_session = None
-            last_accessed = False
         if (prev_galaxy_session and
                 prev_galaxy_session.current_history and not
                 prev_galaxy_session.current_history.deleted and
-                prev_galaxy_session.current_history.datasets):
-            if prev_galaxy_session.current_history.user is None or prev_galaxy_session.current_history.user == user:
-                # If the previous galaxy session had a history, associate it with the new
-                # session, but only if it didn't belong to a different user.
-                history = prev_galaxy_session.current_history
-                if prev_galaxy_session.user is None:
-                    # Increase the user's disk usage by the amount of the previous history's datasets if they didn't already own it.
-                    for hda in history.datasets:
-                        user.adjust_total_disk_usage(hda.quota_amount(user))
+                prev_galaxy_session.current_history.datasets and
+                (prev_galaxy_session.current_history.user is None or
+                 prev_galaxy_session.current_history.user == user)):
+            # If the previous galaxy session had a history, associate it with the new session, but only if it didn't
+            # belong to a different user.
+            history = prev_galaxy_session.current_history
+            if prev_galaxy_session.user is None:
+                # Increase the user's disk usage by the amount of the previous history's datasets if they didn't already
+                # own it.
+                for hda in history.datasets:
+                    user.adjust_total_disk_usage(hda.quota_amount(user))
+                # Only set default history permissions if the history is from the previous session and anonymous
+                set_permissions = True
         elif self.galaxy_session.current_history:
             history = self.galaxy_session.current_history
         if (not history and users_last_session and
@@ -681,8 +684,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
         if history.user is None:
             history.user = user
         self.galaxy_session.current_history = history
-        if not last_accessed:
-            # Only set default history permissions if current history is not from a previous session
+        if set_permissions:
             self.app.security_agent.history_set_default_permissions(history, dataset=True, bypass_manage_permission=True)
         self.sa_session.add_all((prev_galaxy_session, self.galaxy_session, history))
 


### PR DESCRIPTION
This was originally addressed many years ago when the behavior on login was updated in ca6ba6e01128aecb970efdefe50492dc5bc47826. I believe the intent was to ensure that permission defaults would only be set on histories that were created while anonymous but as it was, they would only be applied to users who had no previous sessions, which would only happen on registration/creation.

Histories created upon login have their permission defaults set in the new history creation method, histories that are already owned by the user are not modified.