### PR TITLE
[19.05] Fix multi-history copying of collections.

### DIFF
--- a/client/galaxy/scripts/mvc/history/history-contents.js
+++ b/client/galaxy/scripts/mvc/history/history-contents.js
@@ -442,7 +442,8 @@ export var HistoryContents = _super.extend(BASE_MVC.LoggableMixin).extend({
                 data: JSON.stringify({
                     content: id,
                     source: contentType,
-                    type: type
+                    type: type,
+                    copy_elements: true
                 })
             })
             .done(response => {


### PR DESCRIPTION
Previously it would copy the collection but not the elements, so if the original HDAs were deleted or purged they'd be deleted in the new history as well. This was not the behavior of the "Copy Datasets" page for instance that would do a deep copy.

There are downsides of doing it this way but this is probably the most intuitive behavior for the GUI for now. Fixes #7493.