### PR TITLE
Delete running jobs after each integration test

### DIFF
--- a/test/base/integration_util.py
+++ b/test/base/integration_util.py
@@ -62,6 +62,10 @@ class IntegrationInstance(UsesApiTestCaseMixin):
         cls._test_driver.tear_down()
         cls._app_available = False
 
+    def tearDown(self):
+        for job in self.galaxy_interactor.get('jobs?state=running&?user_details=true').json():
+            self._delete("jobs/%s" % job['id'])
+
     def setUp(self):
         self.test_data_resolver = TestDataResolver()
         self._configure_interactor()


### PR DESCRIPTION
Should prevent https://jenkins.galaxyproject.org/job/docker-integration-py3/159/testReport/junit/test.integration.test_upload_configuration_options/AdminsCanPasteFilePathsTestCase/test_admin_path_paste_libraries/