### PR TITLE
[19.05] Fix community tags showing JSON file

### DIFF
--- a/client/galaxy/scripts/components/Tags/mounts.js
+++ b/client/galaxy/scripts/components/Tags/mounts.js
@@ -43,8 +43,6 @@ const makoClickHandler = (options, vm) =>
         let { tagClickFn = "none", clickUrl } = options;
 
         switch (tagClickFn) {
-            // I made this match the existing behavior, but I am not clear on
-            // the reason why this link redirects to a raw json page
             case "community_tag_click":
                 if (undefined !== clickUrl) {
                     let suffix = tag.value ? `:${tag.value}` : "";

--- a/templates/display_common.mako
+++ b/templates/display_common.mako
@@ -114,6 +114,8 @@
             return "datasets"
         elif controller == "page":
             return "pages"
+        elif controller == "visualization":
+            return "visualizations"
         else:
             return controller
     %>

--- a/templates/tagging_common.mako
+++ b/templates/tagging_common.mako
@@ -1,4 +1,4 @@
-<%namespace file="/display_common.mako" import="get_controller_name" />
+<%namespace file="/display_common.mako" import="get_controller_name, modern_route_for_controller" />
 <%!
 from cgi import escape
 %>
@@ -32,7 +32,7 @@ from cgi import escape
     <%
         tagged_item_id = str( trans.security.encode_id ( tagged_item.id ) )
         controller_name = get_controller_name(tagged_item)
-        click_url = h.url_for( controller='/' + controller_name , action='list_published')
+        click_url = h.url_for( controller='/' + modern_route_for_controller(controller_name) , action='list_published')
         community_tags = trans.app.tag_handler.get_community_tags( item=tagged_item, limit=5 )
 
         ## Having trouble converting list of tags into a plain array, this just


### PR DESCRIPTION
Fixes #7792

The issue was that the click URL was incorrect. It was returning
```https://usegalaxy.org/page/list_published?f-tags=dna```
when it should be
```https://usegalaxy.org/pages/list_published?f-tags=dna``` 

This was happening for histories, workflows, datasets, pages, and visualizations.