### PR TITLE
More structured Pulsar path handling.

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -121,7 +121,7 @@ pbr==5.4.2
 prettytable==0.7.2
 prov==1.5.1
 psutil==5.6.3
-pulsar-galaxy-lib==0.13.0
+pulsar-galaxy-lib==0.14.0.dev0
 pyasn1-modules==0.2.6
 pyasn1==0.4.6
 pycparser==2.19

--- a/lib/galaxy/job_execution/datasets.py
+++ b/lib/galaxy/job_execution/datasets.py
@@ -23,12 +23,18 @@ class DatasetPath(object):
         real_path,
         false_path=None,
         false_extra_files_path=None,
-        mutable=True
+        false_metadata_path=None,
+        mutable=True,
+        dataset_uuid=None,
+        object_store_id=None,
     ):
         self.dataset_id = dataset_id
+        self.dataset_uuid = dataset_uuid
+        self.object_store_id = object_store_id
         self.real_path = real_path
         self.false_path = false_path
         self.false_extra_files_path = false_extra_files_path
+        self.false_metadata_path = false_metadata_path
         self.mutable = mutable
 
     def __str__(self):
@@ -37,7 +43,7 @@ class DatasetPath(object):
         else:
             return self.false_path
 
-    def with_path_for_job(self, false_path, false_extra_files_path=None):
+    def with_path_for_job(self, false_path, false_extra_files_path=None, false_metadata_path=None):
         """
         Clone the dataset path but with a new false_path.
         """
@@ -48,6 +54,7 @@ class DatasetPath(object):
                 real_path=self.real_path,
                 false_path=false_path,
                 false_extra_files_path=false_extra_files_path,
+                false_metadata_path=false_metadata_path,
                 mutable=self.mutable,
             )
         return dataset_path

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1802,11 +1802,20 @@ class JobWrapper(HasResourceParameters):
         paths = []
         for da in job.input_datasets + job.input_library_datasets:  # da is JobToInputDatasetAssociation object
             if da.dataset:
-                filenames = self.get_input_dataset_fnames(da.dataset)
-                for real_path in filenames:
-                    false_path = self.dataset_path_rewriter.rewrite_dataset_path(da.dataset, 'input')
-                    paths.append(DatasetPath(da.id, real_path=real_path, false_path=false_path, mutable=False))
+                paths.append(self.get_input_path(da.dataset))
         return paths
+
+    def get_input_path(self, dataset):
+        real_path = dataset.file_name
+        false_path = self.dataset_path_rewriter.rewrite_dataset_path(dataset, 'input')
+        return DatasetPath(
+            dataset.dataset.id,
+            real_path=real_path,
+            false_path=false_path,
+            mutable=False,
+            dataset_uuid=dataset.dataset.uuid,
+            object_store_id=dataset.dataset.object_store_id,
+        )
 
     def get_output_basenames(self):
         return [os.path.basename(str(fname)) for fname in self.get_output_fnames()]
@@ -1815,6 +1824,16 @@ class JobWrapper(HasResourceParameters):
         if self.output_paths is None:
             self.compute_outputs()
         return self.output_paths
+
+    def get_output_path(self, dataset):
+        if self.output_paths is None:
+            self.compute_outputs()
+        for (hda, dataset_path) in self.output_hdas_and_paths.values():
+            if hda == dataset:
+                return dataset_path
+        if getattr(dataset, "fake_dataset_association", False):
+            return dataset.file_name
+        raise KeyError("Couldn't find job output for [%s] in [%s]" % (dataset, self.output_hdas_and_paths.values()))
 
     def get_mutable_output_fnames(self):
         if self.output_paths is None:
@@ -2344,12 +2363,28 @@ class ComputeEnvironment(object):
         """ Output unqualified filenames defined by job. """
 
     @abstractmethod
-    def output_paths(self):
-        """ Output DatasetPaths defined by job. """
+    def input_path_rewrite(self, dataset):
+        """Input path for specified dataset."""
 
     @abstractmethod
-    def input_paths(self):
-        """ Input DatasetPaths defined by job. """
+    def output_path_rewrite(self, dataset):
+        """Output path for specified dataset."""
+
+    @abstractmethod
+    def input_extra_files_rewrite(self, dataset):
+        """Input extra files path rewrite for specified dataset."""
+
+    @abstractmethod
+    def output_extra_files_rewrite(self, dataset):
+        """Output extra files path rewrite for specified dataset."""
+
+    @abstractmethod
+    def input_metadata_rewrite(self, dataset, metadata_value):
+        """Input metadata path rewrite for specified dataset."""
+
+    @abstractmethod
+    def unstructured_path_rewrite(self, path):
+        """Rewrite loc file paths, etc.."""
 
     @abstractmethod
     def working_directory(self):
@@ -2377,14 +2412,6 @@ class ComputeEnvironment(object):
         """ Location of the version file for the underlying tool. """
 
     @abstractmethod
-    def unstructured_path_rewriter(self):
-        """ Return a function that takes in a value, determines if it is path
-        to be rewritten (will be passed non-path values as well - onus is on
-        this function to determine both if its input is a path and if it should
-        be rewritten.)
-        """
-
-    @abstractmethod
     def home_directory(self):
         """Home directory of target job - none if HOME should not be set."""
 
@@ -2400,9 +2427,6 @@ class SimpleComputeEnvironment(object):
 
     def sep(self):
         return os.path.sep
-
-    def unstructured_path_rewriter(self):
-        return lambda v: v
 
 
 class SharedComputeEnvironment(SimpleComputeEnvironment):
@@ -2422,8 +2446,27 @@ class SharedComputeEnvironment(SimpleComputeEnvironment):
     def output_paths(self):
         return self.job_wrapper.get_output_fnames()
 
-    def input_paths(self):
-        return self.job_wrapper.get_input_paths(self.job)
+    def input_path_rewrite(self, dataset):
+        return self.job_wrapper.get_input_path(dataset).false_path
+
+    def output_path_rewrite(self, dataset):
+        dataset_path = self.job_wrapper.get_output_path(dataset)
+        if hasattr(dataset_path, "false_path"):
+            return dataset_path.false_path
+        else:
+            return dataset_path
+
+    def input_extra_files_rewrite(self, dataset):
+        return None
+
+    def output_extra_files_rewrite(self, dataset):
+        return None
+
+    def input_metadata_rewrite(self, dataset, metadata_value):
+        return None
+
+    def unstructured_path_rewrite(self, path):
+        return None
 
     def working_directory(self):
         return self.job_wrapper.working_directory

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -16,6 +16,9 @@ import six
 import yaml
 from pulsar.client import (
     build_client_manager,
+    CLIENT_INPUT_PATH_TYPES,
+    ClientInput,
+    ClientInputs,
     ClientJobDescription,
     ClientOutputs,
     finish_job as pulsar_finish_job,
@@ -286,11 +289,36 @@ class PulsarJobRunner(AsynchronousJobRunner):
         try:
             dependencies_description = PulsarJobRunner.__dependencies_description(client, job_wrapper)
             rewrite_paths = not PulsarJobRunner.__rewrite_parameters(client)
-            unstructured_path_rewrites = {}
+            path_rewrites_unstructured = {}
             output_names = []
             if compute_environment:
-                unstructured_path_rewrites = compute_environment.unstructured_path_rewrites
+                path_rewrites_unstructured = compute_environment.path_rewrites_unstructured
                 output_names = compute_environment.output_names()
+
+                client_inputs_list = []
+                for input_dataset_wrapper in job_wrapper.get_input_paths():
+                    # str here to resolve false_path if set on a DatasetPath object.
+                    path = str(input_dataset_wrapper)
+                    object_store_ref = {
+                        "dataset_id": input_dataset_wrapper.dataset_id,
+                        "dataset_uuid": str(input_dataset_wrapper.dataset_uuid),
+                        "object_store_id": input_dataset_wrapper.object_store_id,
+                    }
+                    client_inputs_list.append(ClientInput(path, CLIENT_INPUT_PATH_TYPES.INPUT_PATH, object_store_ref=object_store_ref))
+
+                for input_extra_path in compute_environment.path_rewrites_input_extra.keys():
+                    # TODO: track dataset for object_Store_ref...
+                    client_inputs_list.append(ClientInput(input_extra_path, CLIENT_INPUT_PATH_TYPES.INPUT_EXTRA_FILES_PATH))
+
+                for input_metadata_path in compute_environment.path_rewrites_input_metadata.keys():
+                    # TODO: track dataset for object_Store_ref...
+                    client_inputs_list.append(ClientInput(input_metadata_path, CLIENT_INPUT_PATH_TYPES.INPUT_METADATA_PATH))
+
+                input_files = None
+                client_inputs = ClientInputs(client_inputs_list)
+            else:
+                input_files = self.get_input_files(job_wrapper)
+                client_inputs = None
 
             if self.app.config.metadata_strategy == "legacy":
                 # Drop this branch in 19.09.
@@ -306,7 +334,8 @@ class PulsarJobRunner(AsynchronousJobRunner):
                 config_files.append(tool_script)
             client_job_description = ClientJobDescription(
                 command_line=command_line,
-                input_files=self.get_input_files(job_wrapper),
+                input_files=input_files,
+                client_inputs=client_inputs,  # Only one of these input defs should be non-None
                 client_outputs=self.__client_outputs(client, job_wrapper),
                 working_directory=job_wrapper.tool_working_directory,
                 metadata_directory=metadata_directory,
@@ -315,7 +344,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
                 dependencies_description=dependencies_description,
                 env=client.env,
                 rewrite_paths=rewrite_paths,
-                arbitrary_files=unstructured_path_rewrites,
+                arbitrary_files=path_rewrites_unstructured,
                 touch_outputs=output_names,
                 remote_pulsar_app_config=remote_pulsar_app_config,
                 container=None if not remote_container else remote_container.container_id,
@@ -880,11 +909,13 @@ class PulsarComputeEnvironment(ComputeEnvironment):
         self.pulsar_client = pulsar_client
         self.job_wrapper = job_wrapper
         self.local_path_config = job_wrapper.default_compute_environment()
-        self.unstructured_path_rewrites = {}
+
+        self.path_rewrites_unstructured = {}
+        self.path_rewrites_input_extra = {}
+        self.path_rewrites_input_metadata = {}
+
         # job_wrapper.prepare is going to expunge the job backing the following
         # computations, so precalculate these paths.
-        self._wrapper_input_paths = self.local_path_config.input_paths()
-        self._wrapper_output_paths = self.local_path_config.output_paths()
         self.path_mapper = PathMapper(pulsar_client, remote_job_config, self.local_path_config.working_directory())
         self._config_directory = remote_job_config["configs_directory"]
         self._working_directory = remote_job_config["working_directory"]
@@ -900,34 +931,62 @@ class PulsarComputeEnvironment(ComputeEnvironment):
         # Maybe this should use the path mapper, but the path mapper just uses basenames
         return self.job_wrapper.get_output_basenames()
 
-    def output_paths(self):
-        local_output_paths = self._wrapper_output_paths
+    def input_path_rewrite(self, dataset):
+        local_input_path_rewrite = self.local_path_config.input_path_rewrite(dataset)
+        if local_input_path_rewrite is not None:
+            local_input_path = local_input_path_rewrite
+        else:
+            local_input_path = dataset.file_name
+        remote_path = self.path_mapper.remote_input_path_rewrite(local_input_path)
+        return remote_path
 
-        results = []
-        for local_output_path in local_output_paths:
-            wrapper_path = str(local_output_path)
-            remote_path = self.path_mapper.remote_output_path_rewrite(wrapper_path)
-            results.append(self._dataset_path(local_output_path, remote_path))
-        return results
+    def output_path_rewrite(self, dataset):
+        local_output_path_rewrite = self.local_path_config.output_path_rewrite(dataset)
+        if local_output_path_rewrite is not None:
+            local_output_path = local_output_path_rewrite
+        else:
+            local_output_path = dataset.file_name
+        remote_path = self.path_mapper.remote_output_path_rewrite(local_output_path)
+        return remote_path
 
-    def input_paths(self):
-        local_input_paths = self._wrapper_input_paths
+    def input_extra_files_rewrite(self, dataset):
+        input_path_rewrite = self.input_path_rewrite(dataset)
+        base_input_path = input_path_rewrite[0:-len(".dat")]
+        remote_extra_files_path_rewrite = "%s_files" % base_input_path
+        self.path_rewrites_input_extra[dataset.extra_files_path] = remote_extra_files_path_rewrite
+        return remote_extra_files_path_rewrite
 
-        results = []
-        for local_input_path in local_input_paths:
-            wrapper_path = str(local_input_path)
-            # This will over-copy in some cases. For instance in the case of task
-            # splitting, this input will be copied even though only the work dir
-            # input will actually be used.
-            remote_path = self.path_mapper.remote_input_path_rewrite(wrapper_path)
-            results.append(self._dataset_path(local_input_path, remote_path))
-        return results
+    def output_extra_files_rewrite(self, dataset):
+        output_path_rewrite = self.output_path_rewrite(dataset)
+        base_output_path = output_path_rewrite[0:-len(".dat")]
+        remote_extra_files_path_rewrite = "%s_files" % base_output_path
+        return remote_extra_files_path_rewrite
 
-    def _dataset_path(self, local_dataset_path, remote_path):
-        remote_extra_files_path = None
-        if remote_path:
-            remote_extra_files_path = "%s_files" % remote_path[0:-len(".dat")]
-        return local_dataset_path.with_path_for_job(remote_path, remote_extra_files_path)
+    def input_metadata_rewrite(self, dataset, metadata_val):
+        # May technically be incorrect to not pass through local_path_config.input_metadata_rewrite
+        # first but that adds untested logic that wouln't ever be used.
+        remote_input_path = self.path_mapper.remote_input_path_rewrite(metadata_val, client_input_path_type=CLIENT_INPUT_PATH_TYPES.INPUT_METADATA_PATH)
+        if remote_input_path:
+            log.info("input_metadata_rewrite is %s from %s" % (remote_input_path, metadata_val))
+            self.path_rewrites_input_metadata[metadata_val] = remote_input_path
+            return remote_input_path
+
+        # No rewrite...
+        return None
+
+    def unstructured_path_rewrite(self, parameter_value):
+        path_rewrites_unstructured = self.path_rewrites_unstructured
+        if parameter_value in path_rewrites_unstructured:
+            # Path previously mapped, use previous mapping.
+            return path_rewrites_unstructured[parameter_value]
+
+        rewrite, new_unstructured_path_rewrites = self.path_mapper.check_for_arbitrary_rewrite(parameter_value)
+        if rewrite:
+            path_rewrites_unstructured.update(new_unstructured_path_rewrites)
+            return rewrite
+        else:
+            # Did not need to rewrite, use original path or value.
+            return None
 
     def working_directory(self):
         return self._working_directory
@@ -943,27 +1002,6 @@ class PulsarComputeEnvironment(ComputeEnvironment):
 
     def version_path(self):
         return self._version_path
-
-    def rewriter(self, parameter_value):
-        unstructured_path_rewrites = self.unstructured_path_rewrites
-        if parameter_value in unstructured_path_rewrites:
-            # Path previously mapped, use previous mapping.
-            return unstructured_path_rewrites[parameter_value]
-        if parameter_value in unstructured_path_rewrites.values():
-            # Path is a rewritten remote path (this might never occur,
-            # consider dropping check...)
-            return parameter_value
-
-        rewrite, new_unstructured_path_rewrites = self.path_mapper.check_for_arbitrary_rewrite(parameter_value)
-        if rewrite:
-            unstructured_path_rewrites.update(new_unstructured_path_rewrites)
-            return rewrite
-        else:
-            # Did need to rewrite, use original path or value.
-            return parameter_value
-
-    def unstructured_path_rewriter(self):
-        return self.rewriter
 
     def tool_directory(self):
         return self._tool_dir

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -7,7 +7,6 @@ import tempfile
 from six import string_types
 
 from galaxy import model
-from galaxy.job_execution.datasets import dataset_path_rewrites
 from galaxy.model.none_like import NoneDataset
 from galaxy.tools import global_tool_errors
 from galaxy.tools.parameters import (
@@ -63,7 +62,6 @@ class ToolEvaluator(object):
         for evaluating command and config cheetah templates.
         """
         self.compute_environment = compute_environment
-        self.unstructured_path_rewriter = compute_environment.unstructured_path_rewriter()
 
         job = self.job
         incoming = dict([(p.name, p.value) for p in job.parameters])
@@ -87,6 +85,8 @@ class ToolEvaluator(object):
             # fake dataset association that provides the needed attributes for
             # preparing a job.
             class FakeDatasetAssociation (object):
+                fake_dataset_association = True
+
                 def __init__(self, dataset=None):
                     self.dataset = dataset
                     self.file_name = dataset.file_name
@@ -105,9 +105,6 @@ class ToolEvaluator(object):
             inp_data,
             out_data,
             output_collections=out_collections,
-            output_paths=compute_environment.output_paths(),
-            job_working_directory=compute_environment.working_directory(),
-            input_paths=compute_environment.input_paths()
         )
 
         # Certain tools require tasks to be completed prior to job execution
@@ -119,7 +116,7 @@ class ToolEvaluator(object):
 
         self.param_dict = param_dict
 
-    def build_param_dict(self, incoming, input_datasets, output_datasets, output_collections, output_paths, job_working_directory, input_paths=[]):
+    def build_param_dict(self, incoming, input_datasets, output_datasets, output_collections):
         """
         Build the dictionary of parameters for substituting into the command
         line. Each value is wrapped in a `InputValueWrapper`, which allows
@@ -127,6 +124,9 @@ class ToolEvaluator(object):
         when the __str__ method is called it actually calls the
         `to_param_dict_string` method of the associated input.
         """
+        compute_environment = self.compute_environment
+        job_working_directory = compute_environment.working_directory()
+
         param_dict = dict()
 
         def input():
@@ -139,11 +139,10 @@ class ToolEvaluator(object):
         # All parameters go into the param_dict
         param_dict.update(incoming)
 
-        input_dataset_paths = dataset_path_rewrites(input_paths)
-        self.__populate_wrappers(param_dict, input_datasets, input_dataset_paths, job_working_directory)
-        self.__populate_input_dataset_wrappers(param_dict, input_datasets, input_dataset_paths)
-        self.__populate_output_dataset_wrappers(param_dict, output_datasets, output_paths, job_working_directory)
-        self.__populate_output_collection_wrappers(param_dict, output_collections, output_paths, job_working_directory)
+        self.__populate_wrappers(param_dict, input_datasets, job_working_directory)
+        self.__populate_input_dataset_wrappers(param_dict, input_datasets)
+        self.__populate_output_dataset_wrappers(param_dict, output_datasets, job_working_directory)
+        self.__populate_output_collection_wrappers(param_dict, output_collections, job_working_directory)
         self.__populate_unstructured_path_rewrites(param_dict)
         # Call param dict sanitizer, before non-job params are added, as we don't want to sanitize filenames.
         self.__sanitize_param_dict(param_dict)
@@ -178,7 +177,7 @@ class ToolEvaluator(object):
 
         do_walk(inputs, input_values)
 
-    def __populate_wrappers(self, param_dict, input_datasets, input_dataset_paths, job_working_directory):
+    def __populate_wrappers(self, param_dict, input_datasets, job_working_directory):
 
         def wrap_input(input_values, input):
             value = input_values[input.name]
@@ -187,7 +186,7 @@ class ToolEvaluator(object):
                 input_values[input.name] = \
                     DatasetListWrapper(job_working_directory,
                                        dataset_instances,
-                                       dataset_paths=input_dataset_paths,
+                                       compute_environment=self.compute_environment,
                                        datatypes_registry=self.app.datatypes_registry,
                                        tool=self.tool,
                                        name=input.name)
@@ -228,13 +227,9 @@ class ToolEvaluator(object):
                 wrapper_kwds = dict(
                     datatypes_registry=self.app.datatypes_registry,
                     tool=self,
-                    name=input.name
+                    name=input.name,
+                    compute_environment=self.compute_environment
                 )
-                if dataset:
-                    # A None dataset does not have a filename
-                    real_path = dataset.file_name
-                    if real_path in input_dataset_paths:
-                        wrapper_kwds["dataset_path"] = input_dataset_paths[real_path]
                 element_identifier = element_identifier_mapper.identifier(dataset, param_dict)
                 if element_identifier:
                     wrapper_kwds["identifier"] = element_identifier
@@ -244,7 +239,7 @@ class ToolEvaluator(object):
                 dataset_collection = value
                 wrapper_kwds = dict(
                     datatypes_registry=self.app.datatypes_registry,
-                    dataset_paths=input_dataset_paths,
+                    compute_environment=self.compute_environment,
                     tool=self,
                     name=input.name
                 )
@@ -256,7 +251,7 @@ class ToolEvaluator(object):
                 input_values[input.name] = wrapper
             elif isinstance(input, SelectToolParameter):
                 input_values[input.name] = SelectToolParameterWrapper(
-                    input, value, other_values=param_dict, path_rewriter=self.unstructured_path_rewriter)
+                    input, value, other_values=param_dict, compute_environment=self.compute_environment)
             else:
                 input_values[input.name] = InputValueWrapper(
                     input, value, param_dict)
@@ -268,7 +263,7 @@ class ToolEvaluator(object):
             element_identifier_mapper = ElementIdentifierMapper(input_datasets)
             self.__walk_inputs(self.tool.inputs, param_dict, wrap_input)
 
-    def __populate_input_dataset_wrappers(self, param_dict, input_datasets, input_dataset_paths):
+    def __populate_input_dataset_wrappers(self, param_dict, input_datasets):
         # TODO: Update this method for dataset collections? Need to test. -John.
 
         # FIXME: when self.check_values==True, input datasets are being wrapped
@@ -298,16 +293,11 @@ class ToolEvaluator(object):
                     datatypes_registry=self.app.datatypes_registry,
                     tool=self,
                     name=name,
+                    compute_environment=self.compute_environment,
                 )
-                if data:
-                    real_path = data.file_name
-                    if real_path in input_dataset_paths:
-                        dataset_path = input_dataset_paths[real_path]
-                        wrapper_kwds['dataset_path'] = dataset_path
                 param_dict[name] = DatasetFilenameWrapper(data, **wrapper_kwds)
 
-    def __populate_output_collection_wrappers(self, param_dict, output_collections, output_paths, job_working_directory):
-        output_dataset_paths = dataset_path_rewrites(output_paths)
+    def __populate_output_collection_wrappers(self, param_dict, output_collections, job_working_directory):
         tool = self.tool
         for name, out_collection in output_collections.items():
             if name not in tool.output_collections:
@@ -318,7 +308,7 @@ class ToolEvaluator(object):
 
             wrapper_kwds = dict(
                 datatypes_registry=self.app.datatypes_registry,
-                dataset_paths=output_dataset_paths,
+                compute_environment=self.compute_environment,
                 tool=tool,
                 name=name
             )
@@ -336,23 +326,20 @@ class ToolEvaluator(object):
                     param_dict[output_def.name] = dataset_wrapper
                     log.info("Updating param_dict for %s with %s" % (output_def.name, dataset_wrapper))
 
-    def __populate_output_dataset_wrappers(self, param_dict, output_datasets, output_paths, job_working_directory):
-        output_dataset_paths = dataset_path_rewrites(output_paths)
+    def __populate_output_dataset_wrappers(self, param_dict, output_datasets, job_working_directory):
         for name, hda in output_datasets.items():
             # Write outputs to the working directory (for security purposes)
             # if desired.
-            real_path = hda.file_name
-            if real_path in output_dataset_paths:
-                dataset_path = output_dataset_paths[real_path]
-                param_dict[name] = DatasetFilenameWrapper(hda, dataset_path=dataset_path)
-                try:
-                    open(dataset_path.false_path, 'w').close()
-                except EnvironmentError:
-                    pass  # May well not exist - e.g. Pulsar.
-            else:
-                param_dict[name] = DatasetFilenameWrapper(hda)
+            param_dict[name] = DatasetFilenameWrapper(hda, compute_environment=self.compute_environment, io_type="output")
+            try:
+                open(str(param_dict[name]), 'w').close()
+            except EnvironmentError:
+                pass  # May well not exist - e.g. Pulsar.
+
             # Provide access to a path to store additional files
-            # TODO: path munging for cluster/dataset server relocatability
+            # TODO: move compute path logic into compute environment, move setting files_path
+            # logic into DatasetFilenameWrapper. Currently this sits in the middle and glues
+            # stuff together inconsistently with the way the rest of path rewriting works.
             store_by = getattr(hda.dataset.object_store, "store_by", "id")
             file_name = "dataset_%s_files" % getattr(hda.dataset, store_by)
             param_dict[name].files_path = os.path.abspath(os.path.join(job_working_directory, file_name))
@@ -399,9 +386,9 @@ class ToolEvaluator(object):
         def rewrite_unstructured_paths(input_values, input):
             if isinstance(input, SelectToolParameter):
                 input_values[input.name] = SelectToolParameterWrapper(
-                    input, input_values[input.name], other_values=param_dict, path_rewriter=self.unstructured_path_rewriter)
+                    input, input_values[input.name], other_values=param_dict, compute_environment=self.compute_environment)
 
-        if not self.tool.check_values and self.unstructured_path_rewriter:
+        if not self.tool.check_values and self.compute_environment:
             # The tools weren't "wrapped" yet, but need to be in order to get
             # the paths rewritten.
             self.__walk_inputs(self.tool.inputs, param_dict, rewrite_unstructured_paths)

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -19,12 +19,6 @@ log = logging.getLogger(__name__)
 PATH_ATTRIBUTES = ["path"]
 
 
-# ... by default though - don't rewrite anything (if no ComputeEnviornment
-# defined or ComputeEnvironment doesn't supply a rewriter).
-def DEFAULT_PATH_REWRITER(x):
-    return x
-
-
 class ToolParameterValueWrapper(object):
     """
     Base class for object that Wraps a Tool Parameter and Value.
@@ -138,29 +132,38 @@ class SelectToolParameterWrapper(ToolParameterValueWrapper):
         Only applicable for dynamic_options selects, which have more than simple 'options' defined (name, value, selected).
         """
 
-        def __init__(self, input, value, other_values, path_rewriter):
+        def __init__(self, input, value, other_values, compute_environment):
             self._input = input
             self._value = value
             self._other_values = other_values
             self._fields = {}
-            self._path_rewriter = path_rewriter
+            self._compute_environment = compute_environment
 
         def __getattr__(self, name):
             if name not in self._fields:
                 self._fields[name] = self._input.options.get_field_by_name_for_value(name, self._value, None, self._other_values)
             values = map(str, self._fields[name])
-            if name in PATH_ATTRIBUTES:
+            if name in PATH_ATTRIBUTES and self._compute_environment:
                 # If we infer this is a path, rewrite it if needed.
-                values = map(self._path_rewriter, values)
+                new_values = []
+                for value in values:
+                    rewrite_value = self._compute_environment.unstructured_path_rewrite(value)
+                    if rewrite_value:
+                        new_values.append(rewrite_value)
+                    else:
+                        new_values.append(value)
+
+                values = new_values
+
             return self._input.separator.join(values)
 
-    def __init__(self, input, value, other_values={}, path_rewriter=None):
+    def __init__(self, input, value, other_values={}, compute_environment=None):
         self.input = input
         self.value = value
         self.input.value_label = input.value_to_display_text(value)
         self._other_values = other_values
-        self._path_rewriter = path_rewriter or DEFAULT_PATH_REWRITER
-        self.fields = self.SelectToolParameterFieldWrapper(input, value, other_values, self._path_rewriter)
+        self.compute_environment = compute_environment
+        self.fields = self.SelectToolParameterFieldWrapper(input, value, other_values, self.compute_environment)
 
     def __eq__(self, other):
         if isinstance(other, string_types):
@@ -201,15 +204,24 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
         of a Metadata Collection.
         """
 
-        def __init__(self, metadata):
-            self.metadata = metadata
+        def __init__(self, dataset, compute_environment=None):
+            self.dataset = dataset
+            self.metadata = dataset.metadata
+            self.compute_environment = compute_environment
 
         def __getattr__(self, name):
             rval = self.metadata.get(name, None)
             if name in self.metadata.spec:
                 if rval is None:
                     rval = self.metadata.spec[name].no_value
-                rval = self.metadata.spec[name].param.to_safe_string(rval)
+                metadata_param = self.metadata.spec[name].param
+                from galaxy.model.metadata import FileParameter
+                rval = metadata_param.to_safe_string(rval)
+                if isinstance(metadata_param, FileParameter) and self.compute_environment:
+                    rewrite = self.compute_environment.input_metadata_rewrite(self.dataset, rval)
+                    if rewrite is not None:
+                        rval = rewrite
+
                 # Store this value, so we don't need to recalculate if needed
                 # again
                 setattr(self, name, rval)
@@ -234,7 +246,7 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
         def items(self):
             return iter((k, self.get(k)) for k, v in self.metadata.items())
 
-    def __init__(self, dataset, datatypes_registry=None, tool=None, name=None, dataset_path=None, identifier=None):
+    def __init__(self, dataset, datatypes_registry=None, tool=None, name=None, compute_environment=None, identifier=None, io_type="input"):
         if not dataset:
             try:
                 # TODO: allow this to work when working with grouping
@@ -248,15 +260,28 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
             # Should we name this .value to maintain consistency with most other ToolParameterValueWrapper?
             self.unsanitized = dataset
             self.dataset = wrap_with_safe_string(dataset, no_wrap_classes=ToolParameterValueWrapper)
-            self.metadata = self.MetadataWrapper(dataset.metadata)
+            self.metadata = self.MetadataWrapper(dataset, compute_environment)
             if hasattr(dataset, 'tags'):
                 self.groups = {tag.user_value.lower() for tag in dataset.tags if tag.user_tname == 'group'}
             else:
                 # May be a 'FakeDatasetAssociation'
                 self.groups = set()
+        self.compute_environment = compute_environment
+        # TODO: lazy initialize this...
+        self.__io_type = io_type
+        if self.__io_type == "input":
+            path_rewrite = compute_environment and dataset and compute_environment.input_path_rewrite(dataset)
+            if path_rewrite:
+                self.false_path = path_rewrite
+            else:
+                self.false_path = None
+        else:
+            path_rewrite = compute_environment and compute_environment.output_path_rewrite(dataset)
+            if path_rewrite:
+                self.false_path = path_rewrite
+            else:
+                self.false_path = None
         self.datatypes_registry = datatypes_registry
-        self.false_path = getattr(dataset_path, "false_path", None)
-        self.false_extra_files_path = getattr(dataset_path, "false_extra_files_path", None)
         self._element_identifier = identifier
 
     @property
@@ -290,26 +315,30 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
         if self.false_path is not None and key == 'file_name':
             # Path to dataset was rewritten for this job.
             return self.false_path
-        elif self.false_extra_files_path is not None and key == 'extra_files_path':
-            # Path to extra files was rewritten for this job.
-            return self.false_extra_files_path
         elif key == 'extra_files_path':
-            try:
-                # Assume it is an output and that this wrapper
-                # will be set with correct "files_path" for this
-                # job.
-                return self.files_path
-            except AttributeError:
-                # Otherwise, we have an input - delegate to model and
-                # object store to find the static location of this
-                # directory.
+            if self.__io_type == "input":
+                path_rewrite = self.compute_environment and self.compute_environment.input_extra_files_rewrite(self.unsanitized)
+            else:
+                path_rewrite = self.compute_environment and self.compute_environment.output_extra_files_rewrite(self.unsanitized)
+            if path_rewrite:
+                return path_rewrite
+            else:
                 try:
-                    return self.unsanitized.extra_files_path
-                except exceptions.ObjectNotFound:
-                    # NestedObjectstore raises an error here
-                    # instead of just returning a non-existent
-                    # path like DiskObjectStore.
-                    raise
+                    # Assume it is an output and that this wrapper
+                    # will be set with correct "files_path" for this
+                    # job.
+                    return self.files_path
+                except AttributeError:
+                    # Otherwise, we have an input - delegate to model and
+                    # object store to find the static location of this
+                    # directory.
+                    try:
+                        return self.unsanitized.extra_files_path
+                    except exceptions.ObjectNotFound:
+                        # NestedObjectstore raises an error here
+                        # instead of just returning a non-existent
+                        # path like DiskObjectStore.
+                        raise
         else:
             return getattr(self.dataset, key)
 
@@ -320,13 +349,8 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
 
 class HasDatasets(object):
 
-    def _dataset_wrapper(self, dataset, dataset_paths, **kwargs):
-        wrapper_kwds = kwargs.copy()
-        if dataset and dataset_paths:
-            real_path = dataset.file_name
-            if real_path in dataset_paths:
-                wrapper_kwds["dataset_path"] = dataset_paths[real_path]
-        return DatasetFilenameWrapper(dataset, **wrapper_kwds)
+    def _dataset_wrapper(self, dataset, **kwargs):
+        return DatasetFilenameWrapper(dataset, **kwargs)
 
     def paths_as_file(self, sep="\n"):
         contents = sep.join(map(str, self))
@@ -340,7 +364,7 @@ class DatasetListWrapper(list, ToolParameterValueWrapper, HasDatasets):
     """
     """
 
-    def __init__(self, job_working_directory, datasets, dataset_paths=[], **kwargs):
+    def __init__(self, job_working_directory, datasets, **kwargs):
         self._dataset_elements_cache = {}
         if not isinstance(datasets, list):
             datasets = [datasets]
@@ -350,7 +374,7 @@ class DatasetListWrapper(list, ToolParameterValueWrapper, HasDatasets):
                 element = dataset
                 dataset = element.dataset_instance
                 kwargs["identifier"] = element.element_identifier
-            return self._dataset_wrapper(dataset, dataset_paths, **kwargs)
+            return self._dataset_wrapper(dataset, **kwargs)
 
         list.__init__(self, map(to_wrapper, datasets))
         self.job_working_directory = job_working_directory
@@ -392,11 +416,10 @@ class DatasetListWrapper(list, ToolParameterValueWrapper, HasDatasets):
 
 class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
 
-    def __init__(self, job_working_directory, has_collection, dataset_paths=[], **kwargs):
+    def __init__(self, job_working_directory, has_collection, **kwargs):
         super(DatasetCollectionWrapper, self).__init__()
         self.job_working_directory = job_working_directory
         self._dataset_elements_cache = {}
-        self.dataset_paths = dataset_paths
         self.kwargs = kwargs
 
         if has_collection is None:
@@ -427,9 +450,9 @@ class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
             element_identifier = dataset_collection_element.element_identifier
 
             if dataset_collection_element.is_collection:
-                element_wrapper = DatasetCollectionWrapper(job_working_directory, dataset_collection_element, dataset_paths, **kwargs)
+                element_wrapper = DatasetCollectionWrapper(job_working_directory, dataset_collection_element, **kwargs)
             else:
-                element_wrapper = self._dataset_wrapper(element_object, dataset_paths, identifier=element_identifier, **kwargs)
+                element_wrapper = self._dataset_wrapper(element_object, identifier=element_identifier, **kwargs)
 
             element_instances[element_identifier] = element_wrapper
             element_instance_list.append(element_wrapper)
@@ -443,7 +466,7 @@ class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
             wrappers = []
             for element in self.collection.dataset_elements:
                 if any([t for t in element.dataset_instance.tags if t.user_tname.lower() == 'group' and t.value.lower() == group]):
-                    wrappers.append(self._dataset_wrapper(element.element_object, self.dataset_paths, identifier=element.element_identifier, **self.kwargs))
+                    wrappers.append(self._dataset_wrapper(element.element_object, identifier=element.element_identifier, **self.kwargs))
             self._dataset_elements_cache[group] = wrappers
         return self._dataset_elements_cache[group]
 

--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -20,4 +20,9 @@ class EmbeddedPulsarIntegrationInstance(integration_util.IntegrationInstance):
 
 instance = integration_util.integration_module_instance(EmbeddedPulsarIntegrationInstance)
 
-test_tools = integration_util.integration_tool_runner(["simple_constructs", "multi_data_param", "output_filter"])
+test_tools = integration_util.integration_tool_runner([
+    "simple_constructs",
+    "multi_data_param",
+    "output_filter",
+    "vcf_bgzip_test",
+])

--- a/test/unit/tools/test_evaluation.py
+++ b/test/unit/tools/test_evaluation.py
@@ -160,12 +160,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
             "index_path": parameter
         })
         self.tool._command_line = "prog1 $index_path.fields.path"
-
-        def test_path_rewriter(v):
-            if v:
-                v = v.replace("/old", "/new")
-            return v
-        self._set_compute_environment(path_rewriter=test_path_rewriter)
+        self._set_compute_environment(unstructured_path_rewrites={"/old": "/new"})
         command_line, extra_filenames, _ = self.evaluator.build()
         self.assertEqual(command_line, "prog1 /new/path/human")
 
@@ -226,16 +221,24 @@ class TestComputeEnvironment(SimpleComputeEnvironment):
         working_directory,
         input_paths=['/galaxy/files/dataset_1.dat'],
         output_paths=['/galaxy/files/dataset_2.dat'],
-        path_rewriter=None
+        unstructured_path_rewrites=None
     ):
         self._new_file_path = new_file_path
         self._working_directory = working_directory
         self._input_paths = input_paths
         self._output_paths = output_paths
-        self._path_rewriter = path_rewriter
+        self._unstructured_path_rewrites = unstructured_path_rewrites or {}
 
     def input_paths(self):
         return self._input_paths
+
+    def input_path_rewrite(self, dataset):
+        path = self._input_paths[0]
+        return path.false_path if hasattr(path, "false_path") else path
+
+    def output_path_rewrite(self, dataset):
+        path = self._output_paths[0]
+        return path.false_path if hasattr(path, "false_path") else path
 
     def output_paths(self):
         return self._output_paths
@@ -252,11 +255,11 @@ class TestComputeEnvironment(SimpleComputeEnvironment):
     def new_file_path(self):
         return self._new_file_path
 
-    def unstructured_path_rewriter(self):
-        if self._path_rewriter:
-            return self._path_rewriter
-        else:
-            return super(TestComputeEnvironment, self).unstructured_path_rewriter()
+    def unstructured_path_rewrite(self, path):
+        for key, val in self._unstructured_path_rewrites.items():
+            if path.startswith(key):
+                return path.replace(key, val)
+        return None
 
     def tool_directory(self):
         return TEST_TOOL_DIRECTORY
@@ -284,6 +287,10 @@ class MockTool(object):
         return params_from_strings(self.inputs, params, app, ignore_errors)
 
     @property
+    def config_file(self):
+        return "<fake tool>"
+
+    @property
     def template_macro_params(self):
         return {}
 
@@ -299,10 +306,6 @@ class MockTool(object):
         return dict(
             output1=ToolOutput("output1"),
         )
-
-    @property
-    def config_file(self):
-        return self._config_files[0]
 
     @property
     def tmp_directory_vars(self):

--- a/test/unit/tools/test_wrappers.py
+++ b/test/unit/tools/test_wrappers.py
@@ -69,7 +69,8 @@ def test_select_wrapper_multiple(tool):
 @with_mock_tool
 def test_select_wrapper_with_path_rewritting(tool):
     parameter = _setup_blast_tool(tool, multiple=True)
-    wrapper = SelectToolParameterWrapper(parameter, ["val1", "val2"], other_values={}, path_rewriter=lambda v: "Rewrite<%s>" % v)
+    compute_environment = MockComputeEnvironment(None)
+    wrapper = SelectToolParameterWrapper(parameter, ["val1", "val2"], other_values={}, compute_environment=compute_environment)
     assert wrapper.fields.path == "Rewrite<path1>,Rewrite<path2>"
 
 
@@ -108,9 +109,25 @@ def test_dataset_wrapper():
 def test_dataset_wrapper_false_path():
     dataset = MockDataset()
     new_path = "/new/path/dataset_123.dat"
-    wrapper = DatasetFilenameWrapper(dataset, dataset_path=Bunch(false_path=new_path))
+    wrapper = DatasetFilenameWrapper(dataset, compute_environment=MockComputeEnvironment(false_path=new_path))
     assert str(wrapper) == new_path
     assert wrapper.file_name == new_path
+
+
+class MockComputeEnvironment(object):
+
+    def __init__(self, false_path, false_extra_files_path=None):
+        self.false_path = false_path
+        self.false_extra_files_path = false_extra_files_path
+
+    def input_path_rewrite(self, dataset):
+        return self.false_path
+
+    def input_extra_files_rewrite(self, dataset):
+        return self.false_extra_files_path
+
+    def unstructured_path_rewrite(self, path):
+        return "Rewrite<%s>" % path
 
 
 def test_dataset_false_extra_files_path():
@@ -121,13 +138,12 @@ def test_dataset_false_extra_files_path():
 
     new_path = "/new/path/dataset_123.dat"
     dataset_path = DatasetPath(123, MOCK_DATASET_PATH, false_path=new_path)
-    wrapper = DatasetFilenameWrapper(dataset, dataset_path=dataset_path)
+    wrapper = DatasetFilenameWrapper(dataset, compute_environment=MockComputeEnvironment(dataset_path))
     # Setting false_path is not enough to override
     assert wrapper.extra_files_path == MOCK_DATASET_EXTRA_FILES_PATH
 
     new_files_path = "/new/path/dataset_123_files"
-    dataset_path = DatasetPath(123, MOCK_DATASET_PATH, false_path=new_path, false_extra_files_path=new_files_path)
-    wrapper = DatasetFilenameWrapper(dataset, dataset_path=dataset_path)
+    wrapper = DatasetFilenameWrapper(dataset, compute_environment=MockComputeEnvironment(false_path=new_path, false_extra_files_path=new_files_path))
     assert wrapper.extra_files_path == new_files_path
 
 


### PR DESCRIPTION
- Track metadata files and transfer them properly (fixing  https://github.com/galaxyproject/pulsar/issues/169 along the way hopefully).
- For metadata inputs and extra files inputs, only transfer them if they are referenced in the tool command block. (Track actual references the way we do for "unstructured" - i.e. loc file - paths.)

In addition to more optimized, correct, and structured file staging this also enables loading files directly from object stores from Pulsar. The newer file actions on the Pulsar to target these kinds of files and to utilize the object store can be found here at least https://github.com/galaxyproject/pulsar/commit/d130b11b095f8354e9b0e81d488e63355d58d57a.

