### PR TITLE
[19.05] Fix doc building

### DIFF
--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -2107,7 +2107,7 @@ parameter being described. All the attributes for the ``param`` element are
 documented below for completeness, but here are the common ones for each
 type are as follows:
 
-$attribute_list:name,type,optional,label,help,argument,load_contents:refresh_on_change:4
+$attribute_list:name,type,optional,label,help,argument,load_contents,refresh_on_change:4
 
 ### Parameter Types
 


### PR DESCRIPTION
Fix the following error when running `make docs`:

```
python parse_gx_xsd.py schema_template.md ../lib/galaxy/tools/xsd/galaxy.xsd > source/dev/schema.md
Traceback (most recent call last):
  File "parse_gx_xsd.py", line 214, in <module>
    main()
  File "parse_gx_xsd.py", line 31, in main
    content_list.append(tag.build_help())
  File "parse_gx_xsd.py", line 84, in build_help
    tag_help.write(_build_tag(tag, self.hide_attributes))
  File "parse_gx_xsd.py", line 99, in _build_tag
    header_level = int(header_level)
ValueError: invalid literal for int() with base 10: 'refresh_on_change'
Makefile:46: recipe for target 'source/dev/schema.md' failed
make[1]: *** [source/dev/schema.md] Error 1
```

Broken in commit 780b07f50524f1be7d897c498f9197295618b00a .