### PR TITLE
Remove view button, fix library flag in data dialog

### DIFF
--- a/client/galaxy/scripts/components/DataDialog/DataDialog.test.js
+++ b/client/galaxy/scripts/components/DataDialog/DataDialog.test.js
@@ -153,7 +153,6 @@ describe("DataDialog.vue", () => {
         emitted = wrapper.emitted();
         expect(wrapper.classes()).contain("data-dialog-modal");
         expect(wrapper.find(".fa-spinner").text()).to.equals("");
-        expect(wrapper.find(".btn-secondary").text()).to.equals("Clear");
         expect(wrapper.find(".btn-primary").text()).to.equals("Ok");
         expect(wrapper.contains(".fa-spinner")).to.equals(true);
         return Vue.nextTick().then(() => {
@@ -169,7 +168,6 @@ describe("DataDialog.vue", () => {
         emitted = wrapper.emitted();
         expect(wrapper.classes()).contain("data-dialog-modal");
         expect(wrapper.find(".fa-spinner").text()).to.equals("");
-        expect(wrapper.find(".btn-secondary").text()).to.equals("Clear");
         expect(wrapper.find(".btn-primary").text()).to.equals("Ok");
         expect(wrapper.contains(".fa-spinner")).to.equals(true);
         return Vue.nextTick().then(() => {

--- a/client/galaxy/scripts/components/DataDialog/DataDialog.test.js
+++ b/client/galaxy/scripts/components/DataDialog/DataDialog.test.js
@@ -153,10 +153,9 @@ describe("DataDialog.vue", () => {
         emitted = wrapper.emitted();
         expect(wrapper.classes()).contain("data-dialog-modal");
         expect(wrapper.find(".fa-spinner").text()).to.equals("");
-        expect(wrapper.find(".btn-primary").text()).to.equals("Ok");
         expect(wrapper.contains(".fa-spinner")).to.equals(true);
         return Vue.nextTick().then(() => {
-            expect(wrapper.findAll(".fa-copy").length).to.equals(2);
+            expect(wrapper.findAll(".fa-folder").length).to.equals(2);
             expect(wrapper.findAll(".fa-file-o").length).to.equals(2);
         });
     });
@@ -168,10 +167,9 @@ describe("DataDialog.vue", () => {
         emitted = wrapper.emitted();
         expect(wrapper.classes()).contain("data-dialog-modal");
         expect(wrapper.find(".fa-spinner").text()).to.equals("");
-        expect(wrapper.find(".btn-primary").text()).to.equals("Ok");
         expect(wrapper.contains(".fa-spinner")).to.equals(true);
         return Vue.nextTick().then(() => {
-            expect(wrapper.findAll(".fa-copy").length).to.equals(2);
+            expect(wrapper.findAll(".fa-folder").length).to.equals(2);
             expect(wrapper.findAll(".fa-file-o").length).to.equals(2);
         });
     });

--- a/client/galaxy/scripts/components/DataDialog/DataDialog.vue
+++ b/client/galaxy/scripts/components/DataDialog/DataDialog.vue
@@ -20,7 +20,7 @@
                 <div class="fa fa-caret-left mr-1" />
                 Back
             </b-btn>
-            <b-btn size="sm" class="float-right ml-1" variant="primary" @click="finalize" :disabled="!hasValue">
+            <b-btn v-if="multiple" size="sm" class="float-right ml-1" variant="primary" @click="finalize" :disabled="!hasValue">
                 Ok
             </b-btn>
             <b-btn size="sm" class="float-right" @click="modalShow = false"> Cancel </b-btn>

--- a/client/galaxy/scripts/components/DataDialog/DataDialog.vue
+++ b/client/galaxy/scripts/components/DataDialog/DataDialog.vue
@@ -20,7 +20,14 @@
                 <div class="fa fa-caret-left mr-1" />
                 Back
             </b-btn>
-            <b-btn v-if="multiple" size="sm" class="float-right ml-1" variant="primary" @click="finalize" :disabled="!hasValue">
+            <b-btn
+                v-if="multiple"
+                size="sm"
+                class="float-right ml-1"
+                variant="primary"
+                @click="finalize"
+                :disabled="!hasValue"
+            >
                 Ok
             </b-btn>
             <b-btn size="sm" class="float-right" @click="modalShow = false"> Cancel </b-btn>

--- a/client/galaxy/scripts/components/DataDialog/DataDialog.vue
+++ b/client/galaxy/scripts/components/DataDialog/DataDialog.vue
@@ -117,6 +117,8 @@ export default {
                 } else {
                     this.finalize();
                 }
+            } else {
+                this.load(record.url);
             }
         },
         /** Called when selection is complete, values are formatted and parsed to external callback **/

--- a/client/galaxy/scripts/components/DataDialog/DataDialogSearch.vue
+++ b/client/galaxy/scripts/components/DataDialog/DataDialogSearch.vue
@@ -2,7 +2,7 @@
     <b-input-group>
         <b-input v-model="filter" placeholder="Type to Search" />
         <b-input-group-append>
-            <b-btn :disabled="!filter" @click="filter = ''">Clear</b-btn>
+            <b-btn :disabled="!filter" @click="filter = ''"><i class="fa fa-times"/></b-btn>
         </b-input-group-append>
     </b-input-group>
 </template>

--- a/client/galaxy/scripts/components/DataDialog/DataDialogTable.vue
+++ b/client/galaxy/scripts/components/DataDialog/DataDialogTable.vue
@@ -12,7 +12,7 @@
             @filtered="filtered"
         >
             <template slot="label" slot-scope="data">
-                <i v-if="data.item.isDataset" class="fa fa-file-o" /> <i v-else class="fa fa-copy" />
+                <i v-if="data.item.isDataset" class="fa fa-file-o" /> <i v-else class="fa fa-folder" />
                 {{ data.value ? data.value : "-" }}
             </template>
             <template slot="details" slot-scope="data">
@@ -20,17 +20,6 @@
             </template>
             <template slot="time" slot-scope="data">
                 {{ data.value ? data.value : "-" }}
-            </template>
-            <template slot="arrow" slot-scope="data">
-                <b-button
-                    variant="link"
-                    size="sm"
-                    class="py-0"
-                    v-if="!data.item.isDataset"
-                    @click.stop="load(data.item.url)"
-                >
-                    View
-                </b-button>
             </template>
         </b-table>
         <div v-if="nItems === 0">
@@ -77,11 +66,6 @@ export default {
                 },
                 time: {
                     sortable: true
-                },
-                arrow: {
-                    label: "",
-                    sortable: false,
-                    class: "text-right"
                 }
             },
             nItems: 0,
@@ -105,10 +89,6 @@ export default {
         /** Collects selected datasets in value array **/
         clicked: function(record) {
             this.$emit("clicked", record);
-        },
-        /** Performs server request to retrieve data records **/
-        load: function(url) {
-            this.$emit("load", url);
         }
     }
 };

--- a/client/galaxy/scripts/entry/panels/tool-panel.js
+++ b/client/galaxy/scripts/entry/panels/tool-panel.js
@@ -46,7 +46,7 @@ var ToolPanel = Backbone.View.extend({
         const panel_buttons = [this.upload_button];
 
         // add favorite filter button
-        if (Galaxy.user && Galaxy.user.id){
+        if (Galaxy.user && Galaxy.user.id) {
             this.favorite_button = new Buttons.ButtonLink({
                 cls: "panel-header-button",
                 title: _l("Show favorites"),

--- a/client/galaxy/scripts/mvc/ui/ui-select-content.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-content.js
@@ -356,7 +356,7 @@ const View = Backbone.View.extend({
                     },
                     {
                         multiple: cnf.multiple,
-                        library: cnf.library,
+                        library: !!cnf.library,
                         format: null
                     }
                 );

--- a/client/galaxy/scripts/mvc/upload/composite/composite-view.js
+++ b/client/galaxy/scripts/mvc/upload/composite/composite-view.js
@@ -29,7 +29,7 @@ export default Backbone.View.extend({
             onclick: function() {
                 self._eventReset();
             }
-        })
+        });
         this.btnStart = new Ui.Button({
             title: _l("Start"),
             onclick: function() {
@@ -63,7 +63,7 @@ export default Backbone.View.extend({
                         self.collection.add({
                             id: self.collection.size(),
                             file_desc: item.description || item.name,
-                            optional: item.optional,
+                            optional: item.optional
                         });
                     });
                 }
@@ -113,7 +113,11 @@ export default Backbone.View.extend({
             this.select_genome.enable();
             this.select_extension.enable();
         }
-        if (this.collection.where({ status: "ready" }).length + this.collection.where({ optional: true }).length == this.collection.length && this.collection.length > 0) {
+        if (
+            this.collection.where({ status: "ready" }).length + this.collection.where({ optional: true }).length ==
+                this.collection.length &&
+            this.collection.length > 0
+        ) {
             this.btnStart.enable();
             this.btnStart.$el.addClass("btn-primary");
         } else {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -287,7 +287,9 @@ export default Backbone.View.extend({
                 $("#workflow-version-switch").unbind("change");
                 if (this.value != self.workflow.workflow_version) {
                     if (self.workflow && self.workflow.has_changes) {
-                        const r = window.confirm("There are unsaved changes to your workflow which will be lost. Continue ?");
+                        const r = window.confirm(
+                            "There are unsaved changes to your workflow which will be lost. Continue ?"
+                        );
                         if (r == false) {
                             // We rebuild the version select list, to reset the selected version
                             self.build_version_select();


### PR DESCRIPTION
This PR removes the current "view" button from the data dialog row and allows users to click on the entire row instead. Additionally, it fixes a bug regarding the library flag. The seach clearing label is replaced by an x-icon. xref #7879. 