### PR TITLE
Add path safe element_identifier

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4262,6 +4262,22 @@ appropriate command line variable.
 <param name="interval_file" type="data" format="interval" label="near intervals in"/>
 ```
 
+In the command block or configfiles ``$interval_file`` will be replaced by the
+internal file name which has a ``.dat`` extension. Sometimes this is a problem, e.g. 
+if file extensions are used to distinguish file types or if the file name
+should represent a sample name.
+
+In this case typically symlink to the file are created where the name of the symlink can be
+constructed from properties of the dataset, e.g.
+``element_identifier`` (the collection identifier/dataset name), 
+``safe_element_identifier`` (same, but characters other than alphanumerical characters, '-', '_', and '.' that are harmful on commandlines are replaced by ``_``), 
+``ext`` (the Galaxy datatype of the dataset). 
+So one can for instance 
+
+```bash
+ln -s '$interval_file' '${interval_file.safe_element_identifier}.${interval_file.ext}'
+```
+
 The following demonstrates a ``param`` which may accept multiple files and
 multiple formats.
 

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -6,7 +6,10 @@ from six import string_types, text_type
 from six.moves import shlex_quote
 
 from galaxy import exceptions
-from galaxy.util import odict
+from galaxy.util import (
+    odict,
+    sanitize_for_filename
+)
 from galaxy.util.none_like import NoneDataset
 from galaxy.util.object_wrapper import wrap_with_safe_string
 
@@ -280,6 +283,15 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
                 log.warning("Datatype class not found for extension '%s', which is used as parameter of 'is_of_type()' method" % (e))
         return self.dataset.datatype.matches_any(datatypes)
 
+    @property
+    def safe_element_identifier(self):
+        """
+        creates a string from the element identifier that can be used safely as filename
+        by replacing the the only character that is forbidden in bash script (the slash)
+        with an underscore.
+        """
+        return self.element_identifier.replace("/","_")
+
     def __str__(self):
         if self.false_path is not None:
             return self.false_path
@@ -463,6 +475,14 @@ class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
     @property
     def is_input_supplied(self):
         return self.__input_supplied
+
+    def safe_element_identifier(self):
+        """
+        creates a string from the element identifier that can be used safely as filename
+        by replacing the the only character that is forbidden in bash script (the slash)
+        with an underscore.
+        """
+        return self.element_identifier.replace("/","_")
 
     def __getitem__(self, key):
         if not self.__input_supplied:

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -286,11 +286,18 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
     @property
     def safe_element_identifier(self):
         """
-        creates a string from the element identifier that can be used safely as filename
-        by replacing the the only character that is forbidden in bash script (the slash)
-        with an underscore.
+        creates a string from the element identifier that can be used safely as
+        filename (as long as it is used in single quotes). Allowed characters
+        are alpha numeric characters, space, dash, and underscore. All other
+        characters are replaced by '_'. For empty identifiers a single underscore
+        is returned.
         """
-        return self.element_identifier.replace("/","_")
+        sid = self.element_identifier
+        if len(sid) == 0:
+            return "_"
+        if sid[0] == '-':
+            sid = "_" + sid[1:]
+        return re.sub('[^\w- ]', '_', sid)
 
     def __str__(self):
         if self.false_path is not None:

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -731,7 +731,7 @@ class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
 
     @property
     def safe_element_identifier(self) -> str | None:
-        return = sanitize_for_filename(
+        return sanitize_for_filename(
                 self.name,
                 valid_filename_chars = set(string.ascii_letters + string.digits + "-_."),
             ).lstrip("-")       

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -420,6 +420,14 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
         self._element_identifier = identifier
 
     @property
+    def safe_element_identifier(self) -> str | None:
+        return = sanitize_for_filename(
+                self.element_identifier,
+                valid_filename_chars = set(string.ascii_letters + string.digits + "-_."),
+            ).lstrip("-.")
+
+
+    @property
     def element_identifier(self) -> str:
         identifier = self._element_identifier
         if identifier is None:
@@ -720,6 +728,14 @@ class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
     @property
     def is_collection(self) -> bool:
         return True
+
+    @property
+    def safe_element_identifier(self) -> str | None:
+        return = sanitize_for_filename(
+                self.name,
+                valid_filename_chars = set(string.ascii_letters + string.digits + "-_."),
+            ).lstrip("-")       
+        
 
     @property
     def element_identifier(self) -> str | None:

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -421,7 +421,7 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
 
     @property
     def safe_element_identifier(self) -> str | None:
-        return = sanitize_for_filename(
+        return sanitize_for_filename(
                 self.element_identifier,
                 valid_filename_chars = set(string.ascii_letters + string.digits + "-_."),
             ).lstrip("-.")

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -2,6 +2,7 @@ import abc
 import logging
 import os
 import shlex
+import string
 import tempfile
 from collections.abc import (
     Iterable,

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -422,10 +422,9 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
     @property
     def safe_element_identifier(self) -> str | None:
         return sanitize_for_filename(
-                self.element_identifier,
-                valid_filename_chars = set(string.ascii_letters + string.digits + "-_."),
-            ).lstrip("-.")
-
+            self.element_identifier,
+            valid_filename_chars = set(string.ascii_letters + string.digits + "-_."),
+        ).lstrip("-.")
 
     @property
     def element_identifier(self) -> str:
@@ -732,10 +731,9 @@ class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
     @property
     def safe_element_identifier(self) -> str | None:
         return sanitize_for_filename(
-                self.name,
-                valid_filename_chars = set(string.ascii_letters + string.digits + "-_."),
-            ).lstrip("-")       
-        
+            self.name,
+            valid_filename_chars = set(string.ascii_letters + string.digits + "-_."),
+        ).lstrip("-")    
 
     @property
     def element_identifier(self) -> str | None:

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -423,7 +423,7 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
     def safe_element_identifier(self) -> str | None:
         return sanitize_for_filename(
             self.element_identifier,
-            valid_filename_chars = set(string.ascii_letters + string.digits + "-_."),
+            valid_filename_chars=set(string.ascii_letters + string.digits + "-_."),
         ).lstrip("-.")
 
     @property
@@ -732,8 +732,8 @@ class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
     def safe_element_identifier(self) -> str | None:
         return sanitize_for_filename(
             self.name,
-            valid_filename_chars = set(string.ascii_letters + string.digits + "-_."),
-        ).lstrip("-")    
+            valid_filename_chars=set(string.ascii_letters + string.digits + "-_."),
+        ).lstrip("-")
 
     @property
     def element_identifier(self) -> str | None:

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -777,8 +777,8 @@ def sanitize_param(value, valid_characters=valid_chars, character_map=mapped_cha
 def sanitize_for_filename(
     text,
     default=None,
-    valid_filename_chars = set(string.ascii_letters + string.digits + "_."),
-    invalid_filenames = ["", ".", ".."]
+    valid_filename_chars=set(string.ascii_letters + string.digits + "_."),
+    invalid_filenames=["", ".", ".."]
 ):
     """
     Restricts the characters that are allowed in a filename portion; Returns default value or a unique id string if result is not a valid name.

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -778,7 +778,7 @@ def sanitize_for_filename(
     text,
     default=None,
     valid_filename_chars=set(string.ascii_letters + string.digits + "_."),
-    invalid_filenames=["", ".", ".."]
+    invalid_filenames=["", ".", ".."],
 ):
     """
     Restricts the characters that are allowed in a filename portion; Returns default value or a unique id string if result is not a valid name.

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -775,11 +775,11 @@ def sanitize_param(value, valid_characters=valid_chars, character_map=mapped_cha
 
 
 def sanitize_for_filename(
-    text,
-    default=None,
-    valid_filename_chars=set(string.ascii_letters + string.digits + "_."),
-    invalid_filenames=["", ".", ".."],
-):
+    text: str,
+    default: Optional[str] = None,
+    valid_filename_chars: set[str] = set(string.ascii_letters + string.digits + "_."),
+    invalid_filenames: list[str] = ["", ".", ".."],
+) -> str:
     """
     Restricts the characters that are allowed in a filename portion; Returns default value or a unique id string if result is not a valid name.
     Method is overly aggressive to minimize possible complications, but a maximum length is not considered.

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -774,11 +774,12 @@ def sanitize_param(value, valid_characters=valid_chars, character_map=mapped_cha
         raise Exception(f"Unknown parameter type ({type(value)})")
 
 
-valid_filename_chars = set(string.ascii_letters + string.digits + "_.")
-invalid_filenames = ["", ".", ".."]
-
-
-def sanitize_for_filename(text, default=None):
+def sanitize_for_filename(
+    text,
+    default=None,
+    valid_filename_chars = set(string.ascii_letters + string.digits + "_."),
+    invalid_filenames = ["", ".", ".."]
+):
     """
     Restricts the characters that are allowed in a filename portion; Returns default value or a unique id string if result is not a valid name.
     Method is overly aggressive to minimize possible complications, but a maximum length is not considered.

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -2965,7 +2965,8 @@ class TestToolsApi(ApiTestCase, TestsTools):
         assert len(implicit_collections) == 0
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        assert output1_content.strip() == "Plain HDA"
+        assert output1_content.strip() == "identifier Plain HDA"
+        assert output1_content.strip() == "safe_identifier Plain_HDA"
 
     @skip_without_tool("identifier_multiple")
     def test_list_selectable_in_multidata_input(self, history_id):

--- a/test/functional/tools/identifier_all_collection_types.xml
+++ b/test/functional/tools/identifier_all_collection_types.xml
@@ -1,7 +1,8 @@
 <tool id="identifier_all_collection_types" name="identifier_all_collection_types" version="0.1">
   <command>
     #for $input in $input1:
-      echo '$input.element_identifier' >> 'output1';
+      echo 'element_identifier $input.element_identifier' >> 'output1';
+      echo 'safe_element_identifier $input.safe_element_identifier' >> 'output1';
     #end for
   </command>
   <inputs>
@@ -15,7 +16,7 @@
     <test>
       <param name="input1">
         <collection type="list:paired">
-          <element name="i1">
+          <element name="i1:">
             <collection type="paired">
               <element name="forward" value="simple_line.txt" />
               <element name="reverse" value="simple_line_alternative.txt" />
@@ -25,7 +26,8 @@
       </param>
       <output name="output1">
         <assert_contents>
-          <has_line line="i1" />
+          <has_line line="element_identifier i1:" />
+          <has_line line="safe_element_identifier i1_" />
         </assert_contents>
       </output>
     </test>

--- a/test/functional/tools/identifier_collection.xml
+++ b/test/functional/tools/identifier_collection.xml
@@ -1,7 +1,8 @@
 <tool id="identifier_collection" name="identifier_collection" version="0.1">
   <command>
     #for $input in $input1:
-      echo '$input.element_identifier' >> 'output1';
+      echo 'indentifier $input.element_identifier' >> 'output1';
+      echo 'safe_indentifier $input.safe_element_identifier' >> 'output1';
     #end for
   </command>
   <inputs>
@@ -15,7 +16,7 @@
     <test>
       <param name="input1">
         <collection type="list:paired">
-          <element name="i1">
+          <element name="i1:">
             <collection type="paired">
               <element name="forward" value="simple_line.txt" />
               <element name="reverse" value="simple_line_alternative.txt" />
@@ -25,7 +26,8 @@
       </param>
       <output name="output1">
         <assert_contents>
-          <has_line line="i1" />
+          <has_line line="identifier i1:" />
+          <has_line line="safe_identifier i1_" />
         </assert_contents>
       </output>
     </test>

--- a/test/functional/tools/identifier_single.xml
+++ b/test/functional/tools/identifier_single.xml
@@ -1,6 +1,7 @@
 <tool id="identifier_single" name="identifier_single" version="1.0.0">
     <command><![CDATA[
-echo '$input1.element_identifier' > 'output1'
+echo 'identifier $input1.element_identifier' > 'output1'
+echo 'safe_identifier $input1.safe_element_identifier' >> 'output1'
     ]]></command>
     <inputs>
         <param name="input1" type="data" label="Input 1" />


### PR DESCRIPTION
As a follow up from discussions in https://github.com/galaxyproject/galaxy/pull/7372 I would like to suggest and discuss the following convenience function for tool developers.

Currently tool developers often use something like `$safe_id = re.sub('[^\w\-\s]', '_', str($element_identifier))` for creating links to input data. This is often done because the input file name is used  by programs to encode metadata, e.g. sample names. Such a replacement is only neccessary if the output of these programs (file names or file contents) contains these file names. Hence, by the replacement of the element identifiers changes the metadata that is output of the programs, which might be confusing to users or downstream tools.

So I currently implemented a function that just replaces the only character that must not be used in file names (even if quoted) .. in a bash (would be different on windows systems). In well programmed software this might be sufficient, but I guess often we can not make this assumption. Hence the replacement of `[^\w\-\s]` would be an alternative implementation or additional function.

Note that here https://github.com/galaxyproject/galaxy/blob/c82749688e06bdd3df496416e9a03c513bccdac6/lib/galaxy/util/__init__.py#L580 is already a function that implements this (besides allowing '-') and in my tests is (to my surprise) even a wee bit faster than the regular expression. 

Looking forward to comments or reviews.

TODOs: 
- [ ] tests (using this in test/functional/tools/identifier... will only be useful once its possible in tests to supply the identifier/name in test data inputs)
- [ ] documentation
