### PR TITLE
Fix non-eager object store with nested object stores

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2184,6 +2184,10 @@ class Dataset(StorableObject, RepresentById):
         else:
             return os.path.abspath(self.external_extra_files_path)
 
+    def create_extra_files_path(self):
+        if not self.extra_files_path_exists():
+            self.object_store.create(self, dir_only=True, extra_dir=self._extra_files_rel_path)
+
     def set_extra_files_path(self, extra_files_path):
         if not extra_files_path:
             self.external_extra_files_path = None

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -467,7 +467,10 @@ class DiskObjectStore(ObjectStore):
             # construct and return hashed path
             if os.path.exists(path):
                 return path
-        return self._construct_path(obj, **kwargs)
+        path = self._construct_path(obj, **kwargs)
+        if not os.path.exists(path):
+            raise ObjectNotFound
+        return path
 
     def update_from_file(self, obj, file_name=None, create=False, **kwargs):
         """`create` parameter is not used in this implementation."""

--- a/lib/galaxy/tools/parameters/output_collect.py
+++ b/lib/galaxy/tools/parameters/output_collect.py
@@ -316,6 +316,7 @@ def collect_primary_datasets(job_context, output, input_ext):
                 extra_files_path = new_primary_datasets_attributes.get('extra_files', None)
                 if extra_files_path:
                     extra_files_path_joined = os.path.join(job_working_directory, extra_files_path)
+                    primary_data.dataset.create_extra_files_path()
                     for root, dirs, files in os.walk(extra_files_path_joined):
                         extra_dir = os.path.join(primary_data.extra_files_path, root.replace(extra_files_path_joined, '', 1).lstrip(os.path.sep))
                         extra_dir = os.path.normpath(extra_dir)

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -322,7 +322,7 @@ class HasDatasets(object):
 
     def _dataset_wrapper(self, dataset, dataset_paths, **kwargs):
         wrapper_kwds = kwargs.copy()
-        if dataset:
+        if dataset and dataset_paths:
             real_path = dataset.file_name
             if real_path in dataset_paths:
                 wrapper_kwds["dataset_path"] = dataset_paths[real_path]

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -362,6 +362,8 @@ do
           fi
           ;;
       -a|-api|--api)
+          GALAXY_TEST_USE_HIERARCHICAL_OBJECT_STORE="True"  # Run these tests with a non-trivial object store.
+          export GALAXY_TEST_USE_HIERARCHICAL_OBJECT_STORE
           GALAXY_TEST_TOOL_CONF="config/tool_conf.xml.sample,test/functional/tools/samples_tool_conf.xml"
           test_script="pytest"
           report_file="./run_api_tests.html"

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -240,6 +240,36 @@ def setup_galaxy_config(
     )
     config.update(database_conf(tmpdir, prefer_template_database=prefer_template_database))
     config.update(install_database_conf(tmpdir, default_merged=default_install_db_merged))
+    if asbool(os.environ.get("GALAXY_TEST_USE_HIERARCHICAL_OBJECT_STORE")):
+        object_store_config = os.path.join(tmpdir, "object_store_conf.yml")
+        with open(object_store_config, "w") as f:
+            contents = """
+type: hierarchical
+backends:
+   - id: files1
+     type: disk
+     weight: 1
+     files_dir: "${temp_directory}/files1"
+     extra_dirs:
+     - type: temp
+       path: "${temp_directory}/tmp1"
+     - type: job_work
+       path: "${temp_directory}/job_working_directory1"
+   - id: files2
+     type: disk
+     weight: 1
+     files_dir: "${temp_directory}/files2"
+     extra_dirs:
+     - type: temp
+       path: "${temp_directory}/tmp2"
+     - type: job_work
+       path: "${temp_directory}/job_working_directory2"
+"""
+            contents_template = string.Template(contents)
+            expanded_contents = contents_template.safe_substitute(temp_directory=tmpdir)
+            f.write(expanded_contents)
+        config["object_store_config_file"] = object_store_config
+
     if datatypes_conf is not None:
         config['datatypes_config_file'] = datatypes_conf
     if enable_tool_shed_check:

--- a/test/unit/jobs/test_job_wrapper.py
+++ b/test/unit/jobs/test_job_wrapper.py
@@ -191,6 +191,9 @@ class MockObjectStore(object):
     def create(self, *args, **kwds):
         pass
 
+    def exists(self, *args, **kwargs):
+        return True
+
     def get_filename(self, *args, **kwds):
         if kwds.get("base_dir", "") == "job_work":
             return self.working_directory

--- a/test/unit/test_model_store.py
+++ b/test/unit/test_model_store.py
@@ -283,6 +283,7 @@ def test_import_export_composite_datasets():
     h = model.History(name="Test History", user=u)
 
     d1 = _create_datasets(sa_session, h, 1, extension="html")[0]
+    app.object_store.create(d1.dataset, dir_only=True, extra_dir=d1.dataset._extra_files_rel_path)
     sa_session.add_all((h, d1))
     sa_session.flush()
 

--- a/test/unit/test_model_store.py
+++ b/test/unit/test_model_store.py
@@ -283,7 +283,7 @@ def test_import_export_composite_datasets():
     h = model.History(name="Test History", user=u)
 
     d1 = _create_datasets(sa_session, h, 1, extension="html")[0]
-    app.object_store.create(d1.dataset, dir_only=True, extra_dir=d1.dataset._extra_files_rel_path)
+    d1.dataset.create_extra_files_path()
     sa_session.add_all((h, d1))
     sa_session.flush()
 

--- a/test/unit/tools/test_actions.py
+++ b/test/unit/tools/test_actions.py
@@ -274,6 +274,9 @@ class MockObjectStore(object):
         self.first_create = True
         self.object_store_id = "mycoolid"
 
+    def exists(self, *args, **kwargs):
+        return True
+
     def create(self, dataset):
         self.created_datasets.append(dataset)
         if self.first_create:

--- a/test/unit/tools/test_collect_primary_datasets.py
+++ b/test/unit/tools/test_collect_primary_datasets.py
@@ -408,6 +408,9 @@ class MockObjectStore(object):
         path = self.created_datasets[dataset]
         return os.stat(path).st_size
 
+    def exists(self, *args, **kwargs):
+        return True
+
     def get_filename(self, dataset):
         return self.created_datasets[dataset]
 


### PR DESCRIPTION
This changes `get_filename` to not create a file in the object store and instead requires explicitly creating a file. This is how the hierarchical object store already works, and that seems like a more sane default. 
Fixes #1765 and #7368 