### PR TITLE
cellxgene GIE: use API to get datasets.

### DIFF
--- a/config/plugins/interactive_environments/cellxgene/config/allowed_images.yml.sample
+++ b/config/plugins/interactive_environments/cellxgene/config/allowed_images.yml.sample
@@ -1,5 +1,5 @@
 ---
 -
-    image: quay.io/galaxy/cellxgene-galaxy-ie:2019.01.30
+    image: quay.io/galaxy/cellxgene-galaxy-ie:2019.05.13
     description: |
         An interactive data explorer for single-cell transcriptomics datasets

--- a/config/plugins/interactive_environments/cellxgene/docker/Dockerfile
+++ b/config/plugins/interactive_environments/cellxgene/docker/Dockerfile
@@ -1,6 +1,10 @@
 FROM python:3.6.8-slim
+
+RUN apt-get update && apt-get install -y \
+    net-tools \
+ && rm -rf /var/lib/apt/lists/*
  
-RUN pip3 install cellxgene && rm -rf ~/.cache
+RUN pip3 install cellxgene galaxy-ie-helpers && rm -rf ~/.cache
 
 ADD ./run_cellxgene.sh /
 

--- a/config/plugins/interactive_environments/cellxgene/docker/run_cellxgene.sh
+++ b/config/plugins/interactive_environments/cellxgene/docker/run_cellxgene.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-cellxgene launch --host 0.0.0.0 --port 80 /input/file.*
+get -i ${DATASET_HID} \
+    && mv /import/${DATASET_HID} /import/${DATASET_HID}.h5ad \
+    && cellxgene launch --host 0.0.0.0 --port 80 /import/${DATASET_HID}.h5ad

--- a/config/plugins/interactive_environments/cellxgene/templates/cellxgene.mako
+++ b/config/plugins/interactive_environments/cellxgene/templates/cellxgene.mako
@@ -2,12 +2,11 @@
 <%
     ie_request.load_deploy_config()
 
-    # Make the dataset available inside the container
-    data_file = ie_request.volume('/input/file.' + hda.ext, hda.file_name, mode='ro')
-
     ie_request.launch(
-       image = trans.request.params.get('image_tag', None),
-       volumes = [data_file]
+        image = trans.request.params.get('image_tag', None),
+        env_override={
+            'dataset_hid': hda.hid
+        }
     )
 
     url = ie_request.url_template('${PROXY_URL}')


### PR DESCRIPTION
No longer requires volume mounts, so useable on main. Also updates to
latest version of cellxgene in container.