### PR TITLE
output_checker: fixed wrong comparison

### DIFF
--- a/lib/galaxy/jobs/output_checker.py
+++ b/lib/galaxy/jobs/output_checker.py
@@ -77,7 +77,6 @@ def check_output(stdio_regexes, stdio_exit_codes, stdout, stderr, tool_exit_code
             max_error_level = StdioErrorLevel.NO_ERROR
             if tool_exit_code is not None:
                 for stdio_exit_code in stdio_exit_codes:
-                    log.debug("checking exit code: $d-%d" % (stdio_exit_code.range_start, stdio_exit_code.range_end))
                     if (tool_exit_code >= stdio_exit_code.range_start and
                             tool_exit_code <= stdio_exit_code.range_end):
                         # Tack on a generic description of the code
@@ -152,7 +151,7 @@ def check_output(stdio_regexes, stdio_exit_codes, stdout, stderr, tool_exit_code
                 peak = stderr[0:ERROR_PEAK]
             else:
                 peak = ""
-            log.debug("job failed, detected %s, standard error is - [%s]" % peak)
+            log.debug("job failed, detected state %s, standard error is - [%s]" % (state, peak))
     except Exception:
         log.exception("Job state check encountered unexpected exception; assuming execution successful")
 

--- a/lib/galaxy/jobs/output_checker.py
+++ b/lib/galaxy/jobs/output_checker.py
@@ -77,6 +77,7 @@ def check_output(stdio_regexes, stdio_exit_codes, stdout, stderr, tool_exit_code
             max_error_level = StdioErrorLevel.NO_ERROR
             if tool_exit_code is not None:
                 for stdio_exit_code in stdio_exit_codes:
+                    log.debug("checking exit code: $d-%d"%(stdio_exit_code.range_start,stdio_exit_code.range_end))
                     if (tool_exit_code >= stdio_exit_code.range_start and
                             tool_exit_code <= stdio_exit_code.range_end):
                         # Tack on a generic description of the code
@@ -146,10 +147,12 @@ def check_output(stdio_regexes, stdio_exit_codes, stdout, stderr, tool_exit_code
             if stderr:
                 state = DETECTED_JOB_STATE.GENERIC_ERROR
 
-        if DETECTED_JOB_STATE != DETECTED_JOB_STATE.OK and stderr:
+        if state != DETECTED_JOB_STATE.OK and stderr:
             if stderr:
                 peak = stderr[0:ERROR_PEAK]
-                log.debug("job failed, standard error is - [%s]" % peak)
+            else:
+                peak = ""
+            log.debug("job failed, detected %s, standard error is - [%s]" % peak)
     except Exception:
         log.exception("Job state check encountered unexpected exception; assuming execution successful")
 

--- a/lib/galaxy/jobs/output_checker.py
+++ b/lib/galaxy/jobs/output_checker.py
@@ -77,7 +77,7 @@ def check_output(stdio_regexes, stdio_exit_codes, stdout, stderr, tool_exit_code
             max_error_level = StdioErrorLevel.NO_ERROR
             if tool_exit_code is not None:
                 for stdio_exit_code in stdio_exit_codes:
-                    log.debug("checking exit code: $d-%d"%(stdio_exit_code.range_start,stdio_exit_code.range_end))
+                    log.debug("checking exit code: $d-%d" % (stdio_exit_code.range_start, stdio_exit_code.range_end))
                     if (tool_exit_code >= stdio_exit_code.range_start and
                             tool_exit_code <= stdio_exit_code.range_end):
                         # Tack on a generic description of the code


### PR DESCRIPTION
- fixed comparison (which was always true before -- except if my intuition on how Bunch works is wrong)
- always log state to info

@jmchilton while reviewing to code again I had the impression that the job_messages list should also be filled in the case of checking for regexes. If so I would add this to this PR as soon as possible.
