### PR TITLE
[19.05] Use node-watch instead of fs.watch to watch for db changes

### DIFF
--- a/lib/galaxy/web/proxy/js/lib/mapper.js
+++ b/lib/galaxy/web/proxy/js/lib/mapper.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var sqlite3 = require('sqlite3')
+var watch = require('node-watch');
 
 
 var endsWith = function(subjectString, searchString) {
@@ -67,7 +68,7 @@ var mapFor = function(path) {
     }
     console.log("Watching path " + path);
     loadMap();
-    fs.watch(path, loadMap);
+    watch(path, loadMap);
     return map;
 };
 

--- a/lib/galaxy/web/proxy/js/package.json
+++ b/lib/galaxy/web/proxy/js/package.json
@@ -14,6 +14,7 @@
     "commander": "~2.19.0",
     "eventemitter3": "3.1.0",
     "http-proxy": "1.17.0",
+    "node-watch": "0.6.2",
     "sqlite3": "4.0.4"
   }
 }


### PR DESCRIPTION
fs.watch doesn't trigger inside of docker.