### PR TITLE
Unit test Galaxy packages during CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,13 @@ jobs:
       - run: sudo apt-get install -y libxml2-utils
       - *install_tox
       - run: tox -e validate_test_tools
+  test_galaxy_packages:
+    docker:
+      - image: circleci/python:2.7.15
+    <<: *set_workdir
+    steps:
+      - *restore_repo_cache
+      - run: sh packages/test.sh
   check_py3_compatibility:
     docker:
       - image: circleci/python:2.7.15
@@ -201,6 +208,8 @@ workflows:
       - py35_unit:
           <<: *requires_get_code
       - py35_first_startup:
+          <<: *requires_get_code
+      - test_galaxy_packages:
           <<: *requires_get_code
       - validate_test_tools:
           <<: *requires_get_code

--- a/lib/galaxy/model/none_like.py
+++ b/lib/galaxy/model/none_like.py
@@ -2,7 +2,6 @@
 Objects with No values
 """
 
-from galaxy.datatypes.registry import Registry
 from galaxy.model.metadata import MetadataCollection
 
 
@@ -27,10 +26,7 @@ class NoneDataset(RecursiveNone):
     def __init__(self, datatypes_registry=None, ext='data', dbkey='?'):
         self.ext = self.extension = ext
         self.dbkey = dbkey
-        if datatypes_registry is None:
-            # Default Value Required for unit tests
-            datatypes_registry = Registry()
-            datatypes_registry.load_datatypes()
+        assert datatypes_registry is not None
         self.datatype = datatypes_registry.get_datatype_by_extension(ext)
         self._metadata = None
         self.metadata = MetadataCollection(self)

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -10,12 +10,12 @@ from galaxy import model
 from galaxy.jobs.actions.post import ActionBox
 from galaxy.model import LibraryDatasetDatasetAssociation, WorkflowRequestInputParameter
 from galaxy.model.dataset_collections.builder import CollectionBuilder
+from galaxy.model.none_like import NoneDataset
 from galaxy.objectstore import ObjectStorePopulator
 from galaxy.tools.parameters import update_dataset_ids
 from galaxy.tools.parameters.basic import DataCollectionToolParameter, DataToolParameter, RuntimeValue
 from galaxy.tools.parameters.wrapped import WrappedParameters
 from galaxy.util import ExecutionTimer
-from galaxy.util.none_like import NoneDataset
 from galaxy.util.odict import odict
 from galaxy.util.template import fill_template
 from galaxy.web import url_for

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -8,6 +8,7 @@ from six import string_types
 
 from galaxy import model
 from galaxy.jobs.datasets import dataset_path_rewrites
+from galaxy.model.none_like import NoneDataset
 from galaxy.tools import global_tool_errors
 from galaxy.tools.parameters import (
     visit_input_values,
@@ -38,7 +39,6 @@ from galaxy.util import (
     unicodify,
 )
 from galaxy.util.bunch import Bunch
-from galaxy.util.none_like import NoneDataset
 from galaxy.util.object_wrapper import wrap_with_safe_string
 from galaxy.util.template import fill_template
 from galaxy.work.context import WorkRequestContext

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -6,8 +6,8 @@ from six import string_types, text_type
 from six.moves import shlex_quote
 
 from galaxy import exceptions
+from galaxy.model.none_like import NoneDataset
 from galaxy.util import odict
-from galaxy.util.none_like import NoneDataset
 from galaxy.util.object_wrapper import wrap_with_safe_string
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/util/monitors.py
+++ b/lib/galaxy/util/monitors.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 import logging
 import threading
 
-from galaxy.web.stack import register_postfork_function
 from .sleeper import Sleeper
+from .web_compat import register_postfork_function
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/util/watcher.py
+++ b/lib/galaxy/util/watcher.py
@@ -21,7 +21,7 @@ except ImportError:
     can_watch = False
 
 from galaxy.util.hash_util import md5_hash_file
-from galaxy.web.stack import register_postfork_function
+from .web_compat import register_postfork_function
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/util/web_compat.py
+++ b/lib/galaxy/util/web_compat.py
@@ -1,0 +1,10 @@
+"""Work around for gross circular dependency between galaxy.util and galaxy.web.stack.
+
+Provide a function that will delay to forking in a uwsgi environment but run immediately
+otherwise.
+"""
+try:
+    from galaxy.web.stack import register_postfork_function
+except ImportError:
+    def register_postfork_function(f, *args, **kwargs):
+        f(*args, **kwargs)

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -1,7 +1,7 @@
 galaxy-objectstore
 galaxy-util
 bdbag
-bx
+bx-python
 h5py
 isa-rwval
 numpy

--- a/packages/data/tests/unittest_utils
+++ b/packages/data/tests/unittest_utils
@@ -1,1 +1,0 @@
-../../../test/unit/unittest_utils

--- a/packages/data/tests/unittest_utils/__init__.py
+++ b/packages/data/tests/unittest_utils/__init__.py
@@ -1,0 +1,1 @@
+../../test/unit/unittest_utils/__init__.py

--- a/packages/data/tests/unittest_utils/tempfilecache.py
+++ b/packages/data/tests/unittest_utils/tempfilecache.py
@@ -1,0 +1,1 @@
+../../test/unit/unittest_utils/tempfilecache.py

--- a/packages/data/tests/unittest_utils/utility.py
+++ b/packages/data/tests/unittest_utils/utility.py
@@ -1,0 +1,1 @@
+../../test/unit/unittest_utils/utility.py

--- a/packages/job_metrics/galaxy/project_galaxy_job_metrics.py
+++ b/packages/job_metrics/galaxy/project_galaxy_job_metrics.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.9.0.dev1'
+__version__ = '19.9.0.dev2'
 
 PROJECT_NAME = "galaxy-job-metrics"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"

--- a/packages/objectstore/galaxy/project_galaxy_objectstore.py
+++ b/packages/objectstore/galaxy/project_galaxy_objectstore.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.9.0.dev1'
+__version__ = '19.9.0.dev2'
 
 PROJECT_NAME = "galaxy-objectstore"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -17,9 +17,9 @@ PACKAGE_DIRS="
     util
     objectstore
     job_metrics
-    tool_util
 "
-# 'data' package doesn't yet work.
+# tool_util seems to need containers...
+# 'data' package doesn't yet work - quota, unit test problems, tool shed install database dependencies...
 
 
 for package_dir in $PACKAGE_DIRS; do

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -16,8 +16,11 @@ pip install pytest
 PACKAGE_DIRS="
     util
     objectstore
-    data
+    job_metrics
+    tool_util
 "
+# 'data' package doesn't yet work.
+
 
 for package_dir in $PACKAGE_DIRS; do
     cd "$package_dir"

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -21,7 +21,11 @@ PACKAGE_DIRS="
 
 for package_dir in $PACKAGE_DIRS; do
     cd "$package_dir"
-    python setup.py install
+    pip install -e .
+    if [ "$package_dir" = "util" ];
+    then
+        pip install -e '.[template,jstree]'
+    fi
     pytest --doctest-modules galaxy tests
     cd ..
 done

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+# Change to packages directory.
+cd "$(dirname "$0")"
+
+TEST_PYTHON=${TEST_PYTHON:-"python"}
+TEST_ENV_DIR=${TEST_ENV_DIR:-`mktemp -d -t gxpkgtestenvXXXXXX`}
+
+virtualenv -p "$TEST_PYTHON" "$TEST_ENV_DIR"
+. "${TEST_ENV_DIR}/bin/activate"
+pip install pytest
+
+# ensure ordered by dependency dag
+PACKAGE_DIRS="
+    util
+    objectstore
+    data
+"
+
+for package_dir in $PACKAGE_DIRS; do
+    cd "$package_dir"
+    python setup.py install
+    pytest --doctest-modules galaxy tests
+    cd ..
+done

--- a/packages/tool_util/galaxy/project_galaxy_tool_util.py
+++ b/packages/tool_util/galaxy/project_galaxy_tool_util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.9.0.dev1'
+__version__ = '19.9.0.dev2'
 
 PROJECT_NAME = "galaxy-tool-util"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"

--- a/packages/util/galaxy/project_galaxy_util.py
+++ b/packages/util/galaxy/project_galaxy_util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.9.0.dev2'
+__version__ = '19.9.0.dev3'
 
 PROJECT_NAME = "galaxy-util"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"

--- a/packages/util/requirements.txt
+++ b/packages/util/requirements.txt
@@ -1,7 +1,6 @@
 bleach
 boltons
 bz2file; python_version < '3.3'
-Cheetah3
 docutils
 markupsafe
 packaging

--- a/packages/util/setup.py
+++ b/packages/util/setup.py
@@ -80,6 +80,10 @@ setup(
     package_dir=PACKAGE_DIR,
     include_package_data=True,
     install_requires=requirements,
+    extras_require={
+        'template': ['future', 'Cheetah3'],
+        'jstree': ['dictobj'],
+    },
     license="AFL",
     zip_safe=False,
     keywords='galaxy',


### PR DESCRIPTION
All the same unit tests run in the context of a full Galaxy but this will ensure the tests also run with their dependencies as would be configured via pip-installed variants. This will catch dependency problems and ensure the package dependency structure remains correct.

Update: So I redid this on top of the new job metrics and tool_util packages and on top of #8051. I can't get galaxy-data or galaxy-tool-util quite tested right but testing this other stuff has already caught dependencies so I think this PR represents a good step forward and I'm taking it out of WIP.

xref #7524 
