### PR TITLE
[19.05] Include type in subworkflow parameter input module

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -425,6 +425,8 @@ class SubWorkflowModule(WorkflowModule):
                 )
                 if step.type == 'data_collection_input':
                     input['collection_type'] = step.tool_inputs.get('collection_type') if step.tool_inputs else None
+                if step_type == 'parameter_input':
+                    input['type'] = step.tool_inputs['parameter_type']
                 inputs.append(input)
         return inputs
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/7964, thanks for the report @innovate-invent.

This is needed in so that workflow parameters can be connected properly.