### PR TITLE
[19.05] Fixed wrong example for amqp_ack_republish_time in job_conf.xml.sample_advanced 

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -66,7 +66,7 @@
           <!-- <param id="persistence_directory">/path/to/dir</param> -->
           <!-- Number of seconds to wait for an acknowledgement before
                republishing a message. -->
-          <!-- <param id="amqp_republish_time">30</param> -->
+          <!-- <param id="amqp_ack_republish_time">30</param> -->
           <!-- Pulsar job manager to communicate with (see Pulsar
                docs for information on job managers). -->
           <!-- <param id="manager">_default_</param> -->


### PR DESCRIPTION
"amqp_republish_time" should be "amqp_ack_republish_time" according to: https://github.com/galaxyproject/galaxy/blob/96d3f85372f074c71e73fea3bc822bd200f1127f/lib/galaxy/jobs/runners/pulsar.py#L110