### PR TITLE
[19.05] Update tool output datatype in workflow editor if datatype changes

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-forms.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-forms.js
@@ -278,6 +278,9 @@ function _makeSection(output_id, label, options) {
                 options: extensions,
                 help: "This action will change the datatype of the output to the indicated datatype.",
                 onchange: function(new_value) {
+                    if (new_value === '__empty__') {
+                        new_value = null;
+                    }
                     workflow.updateDatatype(node, output_id, new_value);
                 }
             },

--- a/client/galaxy/scripts/mvc/workflow/workflow-forms.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-forms.js
@@ -276,7 +276,10 @@ function _makeSection(output_id, label, options) {
                 ignore: "__empty__",
                 value: "__empty__",
                 options: extensions,
-                help: "This action will change the datatype of the output to the indicated value."
+                help: "This action will change the datatype of the output to the indicated datatype.",
+                onchange: function(new_value) {
+                    workflow.updateDatatype(node, output_id, new_value);
+                }
             },
             {
                 action: "TagDatasetAction",

--- a/client/galaxy/scripts/mvc/workflow/workflow-manager.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-manager.js
@@ -54,6 +54,10 @@ class Workflow {
             return false;
         }
     }
+    updateDatatype(node, outputName, newDatatype) {
+        node.changeOutputDatatype(outputName, newDatatype);
+        return true;
+    }
     create_node(type, title_text, content_id) {
         var node = this.app.prebuildNode(type, title_text, content_id);
         this.add_node(node);

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -60,6 +60,14 @@ var Node = Backbone.Model.extend({
         }
         return changed;
     },
+    changeOutputDatatype: function(outputName, datatype) {
+        const output_terminal = this.output_terminals[outputName];
+        const output = this.nodeView.outputViews[outputName].output;
+        output_terminal.datatypes = [datatype];
+        output.extensions = [datatype];
+        this.nodeView.updateDataOutputView(output);
+        this.markChanged();
+    },
     connectedOutputTerminals: function() {
         return this._connectedTerminals(this.output_terminals);
     },

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -63,10 +63,11 @@ var Node = Backbone.Model.extend({
     changeOutputDatatype: function(outputName, datatype) {
         const output_terminal = this.output_terminals[outputName];
         const output = this.nodeView.outputViews[outputName].output;
-        output_terminal.datatypes = [datatype];
-        output.extensions = [datatype];
+        output_terminal.force_datatype = datatype;
+        output.force_datatype = datatype;
         this.nodeView.updateDataOutputView(output);
         this.markChanged();
+        output_terminal.destroyInvalidConnections();
     },
     connectedOutputTerminals: function() {
         return this._connectedTerminals(this.output_terminals);
@@ -284,6 +285,7 @@ var Node = Backbone.Model.extend({
                 // the output already exists, but the output formats may have changed.
                 // Therefore we update the datatypes and destroy invalid connections.
                 node.output_terminals[output.name].datatypes = output.extensions;
+                node.output_terminals[output.name].force_datatype = output.force_datatype;
                 if (node.type == "parameter_input") {
                     node.output_terminals[output.name].attributes.type = output.type;
                 }

--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -212,6 +212,7 @@ var OutputTerminal = Terminal.extend({
     initialize: function(attr) {
         Terminal.prototype.initialize.call(this, attr);
         this.datatypes = attr.datatypes;
+        this.force_datatype = attr.force_datatype;
     },
 
     resetMappingIfNeeded: function() {
@@ -354,19 +355,8 @@ var BaseInputTerminal = Terminal.extend({
                 return new ConnectionAcceptable(true, null);
             }
             var cat_outputs = [];
-            cat_outputs = cat_outputs.concat(other.datatypes);
-            if (other.node.post_job_actions) {
-                for (var pja_i in other.node.post_job_actions) {
-                    var pja = other.node.post_job_actions[pja_i];
-                    if (
-                        pja.action_type == "ChangeDatatypeAction" &&
-                        (pja.output_name === "" || pja.output_name == other.name) &&
-                        pja.action_arguments
-                    ) {
-                        cat_outputs.push(pja.action_arguments.newtype);
-                    }
-                }
-            }
+            const other_datatypes = other.force_datatype ? [other.force_datatype] : other.datatypes;
+            cat_outputs = cat_outputs.concat(other_datatypes);
             // FIXME: No idea what to do about case when datatype is 'input'
             for (var other_datatype_i in cat_outputs) {
                 var other_datatype = cat_outputs[other_datatype_i];
@@ -615,6 +605,7 @@ var OutputCollectionTerminal = Terminal.extend({
     initialize: function(attr) {
         Terminal.prototype.initialize.call(this, attr);
         this.datatypes = attr.datatypes;
+        this.force_datatype = attr.force_datatype;
         if (attr.collection_type) {
             this.collectionType = new CollectionTypeDescription(attr.collection_type);
         } else {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -49,7 +49,7 @@ var DataOutputView = Backbone.View.extend({
 
         var isInput = output.extensions.indexOf("input") >= 0 || output.extensions.indexOf("input_collection") >= 0;
         if (!isInput) {
-            label = `${label} (${output.extensions.join(", ")})`;
+            label = `${label} (${output.force_datatype || output.extensions.join(", ")})`;
         }
         this.$el.html(label);
         this.calloutView = null;

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
@@ -84,26 +84,43 @@ export default Backbone.View.extend({
         return terminalView;
     },
 
-    addDataOutput: function(output) {
-        var terminalViewClass = TerminalViews.OutputTerminalView;
-        var outputViewClass = DataViews.DataOutputView;
+    terminalViewForOutput: function(output) {
+        let terminalViewClass = TerminalViews.OutputTerminalView;
         if (output.collection) {
             terminalViewClass = TerminalViews.OutputCollectionTerminalView;
         } else if (output.parameter) {
             terminalViewClass = TerminalViews.OutputParameterTerminalView;
-            outputViewClass = DataViews.ParameterOutputView;
         }
-        var terminalView = new terminalViewClass({
+        const terminalView = new terminalViewClass({
             node: this.node,
             output: output
-        });
-        var outputView = new outputViewClass({
+        })
+        return terminalView
+    },
+
+    outputViewforOutput: function(output, terminalView) {
+        const outputViewClass = output.parameter ? DataViews.ParameterOutputView : DataViews.DataOutputView;
+        const outputView = new outputViewClass({
             output: output,
             terminalElement: terminalView.el,
             nodeView: this
         });
+        return outputView
+    },
+
+    addDataOutput: function(output) {
+        const terminalView = this.terminalViewForOutput(output);
+        const outputView = this.outputViewforOutput(output, terminalView);
         this.outputViews[output.name] = outputView;
         this.tool_body.append(outputView.$el.append(terminalView.terminalElements()));
+    },
+
+    updateDataOutputView(output){
+        const terminalView = this.terminalViewForOutput(output);
+        const outputView = this.outputViews[output.name];
+        const newOutputView = this.outputViewforOutput(output, terminalView);
+        newOutputView.$el.append(terminalView.terminalElements());
+        outputView.$el.html(newOutputView.$el);
     },
 
     redrawWorkflowOutputs: function() {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
@@ -115,7 +115,7 @@ export default Backbone.View.extend({
         this.tool_body.append(outputView.$el.append(terminalView.terminalElements()));
     },
 
-    updateDataOutputView(output){
+    updateDataOutputView: function(output) {
         const terminalView = this.terminalViewForOutput(output);
         const outputView = this.outputViews[output.name];
         const newOutputView = this.outputViewforOutput(output, terminalView);

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
@@ -291,7 +291,8 @@ var OutputTerminalView = BaseOutputTerminalView.extend({
         var type = output.extensions;
         var terminal = new Terminals.OutputTerminal({
             element: this.el,
-            datatypes: type
+            datatypes: type,
+            force_datatype: output.force_datatype,
         });
         return terminal;
     }
@@ -307,7 +308,8 @@ var OutputCollectionTerminalView = BaseOutputTerminalView.extend({
             element: this.el,
             collection_type: collection_type,
             collection_type_source: collection_type_source,
-            datatypes: output.extensions
+            datatypes: output.extensions,
+            force_datatype: output.force_datatype,
         });
         return terminal;
     }

--- a/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
+++ b/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
@@ -74,15 +74,6 @@ QUnit.module("Input terminal model test", {
         }
         return this.input_terminal.canAccept(other).canAccept;
     },
-    pja_change_datatype_node: function(output_name, newtype) {
-        var pja = {
-            action_type: "ChangeDatatypeAction",
-            output_name: output_name,
-            action_arguments: { newtype: newtype }
-        };
-        var otherNode = { post_job_actions: [pja] };
-        return otherNode;
-    }
 });
 
 QUnit.test("test update", function(assert) {
@@ -130,7 +121,7 @@ QUnit.test("test destroy", function(assert) {
 });
 
 QUnit.test("can accept exact datatype", function(assert) {
-    var other = { node: {}, datatypes: ["txt"] }; // input also txt
+    var other = { node: {}, datatypes: ["txt"], force_datatype: null }; // input also txt
     assert.ok(this.test_accept(other));
 });
 
@@ -145,22 +136,12 @@ QUnit.test("cannot accept incorrect datatype", function(assert) {
 });
 
 QUnit.test("can accept incorrect datatype if converted with PJA", function(assert) {
-    var otherNode = this.pja_change_datatype_node("out1", "txt");
-    var other = { node: otherNode, datatypes: ["binary"], name: "out1" }; // Was binary but converted to txt
+    var other = { node: {}, datatypes: ["binary"], force_datatype: 'txt', name: "out1" }; // Was binary but converted to txt
     assert.ok(this.test_accept(other));
 });
 
 QUnit.test("cannot accept incorrect datatype if converted with PJA to incompatible type", function(assert) {
-    var otherNode = this.pja_change_datatype_node("out1", "bam"); // bam's are not txt
-    var other = { node: otherNode, datatypes: ["binary"], name: "out1" };
-    assert.ok(!this.test_accept(other));
-});
-
-QUnit.test("cannot accept incorrect datatype if some other output converted with PJA to compatible type", function(
-    assert
-) {
-    var otherNode = this.pja_change_datatype_node("out2", "txt");
-    var other = { node: otherNode, datatypes: ["binary"], name: "out1" };
+    var other = { node: {}, datatypes: ["binary"], force_datatype: 'bam', name: "out1" };
     assert.ok(!this.test_accept(other));
 });
 

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -645,6 +645,10 @@ class WorkflowContentsManager(UsesAnnotations):
                         output_name=pja.output_name,
                         action_arguments=pja.action_arguments
                     )
+                    if pja.action_type == 'ChangeDatatypeAction':
+                        for output in step_dict['outputs']:
+                            if output['name'] == pja.output_name:
+                                output['force_datatype'] = [pja.action_arguments['newtype']]
                 step_dict['post_job_actions'] = pja_dict
 
             # workflow outputs


### PR DESCRIPTION
This adds the `force_dataype` key value pair into the step dict on the backend, which means that subworkflows outputs and tools that have a change datatype PJA will display the correct output datatype.
The client now also sets `force_datatype` when changing the PJA and updates the node's output label to indicate the new output datatype.

fixes #7965 and #4813