### PR TITLE
[19.01] Fix variable name for work mem in pgcleanup.py

### DIFF
--- a/scripts/cleanup_datasets/pgcleanup.py
+++ b/scripts/cleanup_datasets/pgcleanup.py
@@ -991,7 +991,7 @@ class Cleanup(object):
             # TODO: is this per session or cursor?
             if self.args.work_mem is not None:
                 log.info('Setting work_mem to %s' % self.args.work_mem)
-                self._conn.cursor().execute('SET work_mem TO %s', (self.args.work_mem,))
+                self.__conn.cursor().execute('SET work_mem TO %s', (self.args.work_mem,))
         return self.__conn
 
     def __parse_args(self):


### PR DESCRIPTION
Missed during the refactoring I did in 19.01.