### PR TITLE
Refactor comments in sample object stores to remove nested comments.

### DIFF
--- a/config/object_store_conf.xml.sample
+++ b/config/object_store_conf.xml.sample
@@ -21,65 +21,80 @@
             <extra_dir type="job_work" path="database/job_working_directory3"/>
         </object_store>
 
-        <!--  Sample S3 Object Store
+        <!-- Sample S3 Object Store
+             The "size" attribute of <cache> is in gigabytes.
+        -->
+        <!--
         <object_store type="s3">
              <auth access_key="...." secret_key="....." />
              <bucket name="unique_bucket_name_all_lowercase" use_reduced_redundancy="False" />
-             <cache path="database/object_store_cache" size="1000" /> <!-- size is in gigabytes -->
+             <cache path="database/object_store_cache" size="1000" />
              <extra_dir type="job_work" path="database/job_working_directory_s3"/>
              <extra_dir type="temp" path="database/tmp_s3"/>
         </object_store>
         -->
 
-        <!--  Sample Swift Object Store
+        <!-- Sample Swift Object Store
+             The "size" attribute of <cache> is in gigabytes.
+        -->
+        <!--
         <object_store type="swift">
             <auth access_key="...." secret_key="....." />
             <bucket name="unique_bucket_name" use_reduced_redundancy="False" max_chunk_size="250"/>
             <connection host="" port="" is_secure="" conn_path="" multipart="True"/>
-            <cache path="database/object_store_cache" size="1000" />  <!-- size is in gigabytes -->
+            <cache path="database/object_store_cache" size="1000" />
             <extra_dir type="job_work" path="database/job_working_directory_swift"/>
             <extra_dir type="temp" path="database/tmp_swift"/>
         </object_store>
         -->
 
         <!-- Sample Azure Object Store
+             The "size" attribute of <cache> is in gigabytes.
+        -->
+        <!--
         <object_store type="azure_blob">
-            <auth account_name="..." account_key="...." />
+        <auth account_name="..." account_key="...." />
             <container name="unique_container_name" max_chunk_size="250"/>
-            <cache path="database/object_store_cache" size="100" /> <!-- size is in gigabytes -->
+            <cache path="database/object_store_cache" size="100" />
             <extra_dir type="job_work" path="database/job_working_directory_azure"/>
             <extra_dir type="temp" path="database/tmp_azure"/>
         </object_store>
         -->
 
-        <!-- Cloud ObjectStore: Amazon Simple Storage Service (S3) -->
+        <!-- Cloud ObjectStore: Amazon Simple Storage Service (S3)
+             The "size" attribute of <cache> is in gigabytes.
+        -->
         <!--
         <object_store type="cloud" provider="aws" order="0">
             <auth access_key="..." secret_key="..." />
             <bucket name="..." use_reduced_redundancy="False" />
-            <cache path="database/object_store_cache" size="100" /> <!-- size is in gigabytes -->
+            <cache path="database/object_store_cache" size="100" />
             <extra_dir type="job_work" path="database/job_working_directory_s3"/>
             <extra_dir type="temp" path="database/tmp_s3"/>
         </object_store>
         -->
 
-        <!-- Cloud ObjectStore: Microsoft Azure Blob Storage -->
+        <!-- Cloud ObjectStore: Microsoft Azure Blob Storage
+             The "size" attribute of <cache> is in gigabytes.
+        -->
         <!--
         <object_store type="cloud" provider="azure" order="0">
             <auth subscription_id="..." client_id="..." secret="..." tenant="..." />
             <bucket name="..." use_reduced_redundancy="False" />
-            <cache path="database/object_store_cache" size="100" /> <!-- size is in gigabytes -->
+            <cache path="database/object_store_cache" size="100" />
             <extra_dir type="job_work" path="database/job_working_directory_azure"/>
             <extra_dir type="temp" path="database/tmp_azure"/>
         </object_store>
         -->
 
-        <!-- Cloud ObjectStore: Google Compute Platform (GCP) -->
+        <!-- Cloud ObjectStore: Google Compute Platform (GCP)
+             The "size" attribute of <cache> is in gigabytes.
+        -->
         <!--
         <object_store type="cloud" provider="google" order="0">
             <auth credentials_file="..." />
             <bucket name="..." use_reduced_redundancy="False" />
-            <cache path="database/object_store_cache" size="1000" /> <!-- size is in gigabytes -->
+            <cache path="database/object_store_cache" size="1000" />
             <extra_dir type="job_work" path="database/job_working_directory_gcp"/>
             <extra_dir type="temp" path="database/tmp_gcp"/>
         </object_store>


### PR DESCRIPTION
This addresses the issue mentioned in #8014.

 ### Motivation
These changes were made because `config/object_store_conf.xml.sample` contained invalid XML that nested comments.  This meant that if you copied `config/object_store_conf.xml.sample` to `config/object_store_conf.xml` and modified it to suit your needs, Galaxy would crash because the XML parser would refuse to parse the file.

### Method

`config/object_store_conf.xml.sample`  contained nested comments advising that the "size" attribute of the `<cache>` tags for the various cloud Object Stores was specified in gigabytes.   This information has been moved to a single comment above the block of the commented out configuration code.

### Testing

Copy  `config/object_store_conf.xml.sample` to `config/object_store_conf.xml`, optionally edit it to use a particular object store, and then restart Galaxy.  You should be able to run the application and store data appropriately.
