### PR TITLE
[19.01] Backport #7799 Skip recording workflow outputs for input parameters

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4440,6 +4440,9 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         return [wid for wid in query.all()]
 
     def add_output(self, workflow_output, step, output_object):
+        if step.type == 'parameter_input':
+            # TODO: these should be properly tracked.
+            return
         if output_object.history_content_type == "dataset":
             output_assoc = WorkflowInvocationOutputDatasetAssociation()
             output_assoc.workflow_invocation = self


### PR DESCRIPTION
These can come in as a literal parameter value, or as a dictionary like
{'id': 'encoded_id', 'src': 'hda'}, none of which is quite right.

Came up again in https://help.galaxyproject.org/t/simple-inputs-used-for-workflow-logic-cannot-connect-to-tool-input/1368/4