### PR TITLE
enhance TS repo search capabilities

### DIFF
--- a/config/tool_shed.yml.sample
+++ b/config/tool_shed.yml.sample
@@ -144,6 +144,9 @@ tool_shed:
   # For searching repositories at /api/repositories:
   #repo_owner_username_boost: 0.3
 
+  # For searching repositories at /api/repositories:
+  #categories_boost: 0.5
+
   # For searching tools at /api/tools
   #tool_name_boost: 1.2
 

--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -502,12 +502,14 @@ class RepositoriesController(BaseAPIController):
                                        'repo_long_description_boost',
                                        'repo_homepage_url_boost',
                                        'repo_remote_repository_url_boost',
+                                       'categories_boost',
                                        'repo_owner_username_boost'])
         boosts = Boosts(float(conf.get('repo_name_boost', 0.9)),
                         float(conf.get('repo_description_boost', 0.6)),
                         float(conf.get('repo_long_description_boost', 0.5)),
                         float(conf.get('repo_homepage_url_boost', 0.3)),
                         float(conf.get('repo_remote_repository_url_boost', 0.2)),
+                        float(conf.get('categories_boost', 0.5)),
                         float(conf.get('repo_owner_username_boost', 0.3)))
 
         results = repo_search.search(trans,

--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -492,8 +492,8 @@ class RepositoriesController(BaseAPIController):
         if not conf.whoosh_index_dir:
             raise ConfigDoesNotAllowException('There is no directory for the search index specified. Please contact the administrator.')
         search_term = q.strip()
-        if len(search_term) < 3:
-            raise RequestParameterInvalidException('The search term has to be at least 3 characters long.')
+        if len(search_term) < 1:
+            raise RequestParameterInvalidException('The search term has to be at least one character long.')
 
         repo_search = RepoSearch()
 

--- a/lib/galaxy/webapps/tool_shed/api/tools.py
+++ b/lib/galaxy/webapps/tool_shed/api/tools.py
@@ -90,8 +90,8 @@ class ToolsController(BaseAPIController):
         if not conf.whoosh_index_dir:
             raise exceptions.ConfigDoesNotAllowException('There is no directory for the search index specified. Please contact the administrator.')
         search_term = q.strip()
-        if len(search_term) < 3:
-            raise exceptions.RequestParameterInvalidException('The search term has to be at least 3 characters long.')
+        if len(search_term) < 1:
+            raise exceptions.RequestParameterInvalidException('The search term has to be at least one character long.')
 
         tool_search = ToolSearch()
 

--- a/lib/galaxy/webapps/tool_shed/config_schema.yml
+++ b/lib/galaxy/webapps/tool_shed/config_schema.yml
@@ -14,7 +14,7 @@ mapping:
         desc: |
           Verbosity of console log messages.  Acceptable values can be found here:
           https://docs.python.org/library/logging.html#logging-levels
-      
+
       database_connection:
         type: str
         default: sqlite:///./database/community.sqlite?isolation_level=IMMEDIATE
@@ -24,35 +24,35 @@ mapping:
           may use a SQLAlchemy connection string to specify an external database
           instead.  This string takes many options which are explained in detail in the
           config file documentation.
-      
+
       hgweb_config_dir:
         type: str
         required: false
         desc: |
           Where the hgweb.config file is stored.
           The default is the Galaxy installation directory.
-      
+
       file_path:
         type: str
         default: database/community_files
         required: false
         desc: |
           Where Tool Shed repositories are stored.
-      
+
       new_file_path:
         type: str
         default: database/tmp
         required: false
         desc: |
           Where temporary files are stored.
-      
+
       builds_file_path:
         type: str
         default: tool-data/shared/ucsc/builds.txt
         required: false
         desc: |
           File containing old-style genome builds
-      
+
       pretty_datetime_format:
         type: str
         default: $locale (UTC)
@@ -65,7 +65,7 @@ mapping:
           - $locale (complete format string for the server locale),
           - $iso8601 (complete format string as specified by ISO 8601 international
             standard).
-      
+
       toolshed_search_on:
         type: bool
         default: true
@@ -76,7 +76,7 @@ mapping:
           you can generate search index and allow full text API searching over
           the repositories and tools within the Tool Shed given that you specify
           the following two config options.
-      
+
       whoosh_index_dir:
         type: str
         default: database/toolshed_whoosh_indexes
@@ -87,84 +87,91 @@ mapping:
           you can generate search index and allow full text API searching over
           the repositories and tools within the Tool Shed given that you specify
           the following two config options.
-      
+
       repo_name_boost:
         type: float
         default: 0.9
         required: false
         desc: |
           For searching repositories at /api/repositories:
-      
+
       repo_description_boost:
         type: float
         default: 0.6
         required: false
         desc: |
           For searching repositories at /api/repositories:
-      
+
       repo_long_description_boost:
         type: float
         default: 0.5
         required: false
         desc: |
           For searching repositories at /api/repositories:
-      
+
       repo_homepage_url_boost:
         type: float
         default: 0.3
         required: false
         desc: |
           For searching repositories at /api/repositories:
-      
+
       repo_remote_repository_url_boost:
         type: float
         default: 0.2
         required: false
         desc: |
           For searching repositories at /api/repositories:
-      
+
       repo_owner_username_boost:
         type: float
         default: 0.3
         required: false
         desc: |
           For searching repositories at /api/repositories:
-      
+
+      categories_boost:
+        type: float
+        default: 0.5
+        required: false
+        desc: |
+          For searching repositories at /api/repositories:
+
       tool_name_boost:
         type: float
         default: 1.2
         required: false
         desc: |
           For searching tools at /api/tools
-      
+
       tool_description_boost:
         type: float
         default: 0.6
         required: false
         desc: |
           For searching tools at /api/tools
-      
+
       tool_help_boost:
         type: float
         default: 0.4
         required: false
         desc: |
           For searching tools at /api/tools
-      
+
       tool_repo_owner_username:
         type: float
         default: 0.3
         required: false
         desc: |
           For searching tools at /api/tools
-      
+
       ga_code:
         type: str
         required: false
         desc: |
           You can enter tracking code here to track visitor's behavior
           through your Google Analytics account. Example: UA-XXXXXXXX-Y
-      
+
       id_secret:
         type: str
         default: changethisinproductiontoo
@@ -177,7 +184,7 @@ mapping:
           them access to others' sessions.
           One simple way to generate a value for this is with the shell command:
             python -c 'from __future__ import print_function; import time; print(time.time())' | md5sum | cut -f 1 -d ' '
-      
+
       use_remote_user:
         type: bool
         default: false
@@ -187,7 +194,7 @@ mapping:
           Apache).  The upstream proxy should set a REMOTE_USER header in the request.
           Enabling remote user disables regular logins.  For more information, see:
           https://galaxyproject.org/admin/config/apache-external-user-auth/
-      
+
       remote_user_secret:
         type: str
         default: changethisinproductiontoo
@@ -226,35 +233,35 @@ mapping:
         desc: |
           If use_remote_user is enabled, you can set this to a URL that will log your
           users out.
-      
+
       debug:
         type: bool
         default: false
         required: false
         desc: |
           Configuration for debugging middleware
-      
+
       use_lint:
         type: bool
         default: false
         required: false
         desc: |
           Check for WSGI compliance.
-      
+
       use_printdebug:
         type: bool
         default: true
         required: false
         desc: |
           Intercept print statements and show them on the returned page.
-      
+
       use_interactive:
         type: bool
         default: false
         required: false
         desc: |
           NEVER enable this on a public site (even test or QA)
-      
+
       admin_users:
         type: str
         required: false
@@ -263,7 +270,7 @@ mapping:
           users (email addresses).  These users will have access to the Admin section
           of the server, and will have access to create users, groups, roles,
           libraries, and more.
-      
+
       require_login:
         type: bool
         default: false
@@ -286,21 +293,21 @@ mapping:
         desc: |
           Allow administrators to delete accounts.
 
-      
+
       smtp_server:
         type: str
         default: smtp.your_tool_shed_server
         required: false
         desc: |
           For use by email messages sent from the Tool Shed.
-      
+
       email_from:
         type: str
         default: your_tool_shed_email@server
         required: false
         desc: |
           For use by email messages sent from the Tool Shed.
-      
+
       smtp_username:
         type: str
         required: false
@@ -308,7 +315,7 @@ mapping:
           If your SMTP server requires a username and password, you can provide them
           here (password in cleartext here, but if your server supports STARTTLS it
           will be sent over the network encrypted).
-      
+
       smtp_password:
         type: str
         required: false
@@ -316,28 +323,28 @@ mapping:
           If your SMTP server requires a username and password, you can provide them
           here (password in cleartext here, but if your server supports STARTTLS it
           will be sent over the network encrypted).
-      
+
       smtp_ssl:
         type: bool
         default: false
         required: false
         desc: |
           If your SMTP server requires SSL from the beginning of the connection
-      
+
       support_url:
         type: str
         default: https://galaxyproject.org/support/
         required: false
         desc: |
           The URL linked by the "Support" link in the "Help" menu.
-      
+
       mailing_join_addr:
         type: str
         default: galaxy-announce-join@bx.psu.edu
         required: false
         desc: |
           Address to join mailing list
-      
+
       use_heartbeat:
         type: bool
         default: true
@@ -345,34 +352,34 @@ mapping:
         desc: |
           Write thread status periodically to 'heartbeat.log' (careful, uses disk
            space rapidly!)
-      
+
       use_profile:
         type: bool
         default: true
         required: false
         desc: |
           Profiling middleware (cProfile based)
-      
+
       enable_galaxy_flavor_docker_image:
         type: bool
         default: false
         required: false
         desc: |
           Enable creation of Galaxy flavor Docker Image
-      
+
       message_box_visible:
         type: bool
         default: false
         required: false
         desc: |
           Show a message box under the masthead.
-      
+
       message_box_content:
         type: str
         required: false
         desc: |
           Show a message box under the masthead.
-      
+
       message_box_class:
         type: str
         default: info
@@ -380,49 +387,49 @@ mapping:
         desc: |
           Class of the message box under the masthead. Possible values are:
           'info' (the default), 'warning', 'error', 'done'.
-      
+
       static_enabled:
         type: bool
         default: true
         required: false
         desc: |
           Serving static files (needed if running standalone)
-      
+
       static_cache_time:
         type: int
         default: 360
         required: false
         desc: |
           Serving static files (needed if running standalone)
-      
+
       static_dir:
         type: str
         default: static/
         required: false
         desc: |
           Serving static files (needed if running standalone)
-      
+
       static_images_dir:
         type: str
         default: static/images
         required: false
         desc: |
           Serving static files (needed if running standalone)
-      
+
       static_favicon_dir:
         type: str
         default: static/favicon.ico
         required: false
         desc: |
           Serving static files (needed if running standalone)
-      
+
       static_scripts_dir:
         type: str
         default: static/scripts/
         required: false
         desc: |
           Serving static files (needed if running standalone)
-      
+
       static_style_dir:
         type: str
         default: static/style/blue

--- a/lib/galaxy/webapps/tool_shed/search/repo_search.py
+++ b/lib/galaxy/webapps/tool_shed/search/repo_search.py
@@ -26,6 +26,7 @@ schema = Schema(
     times_downloaded=STORED,
     approved=STORED,
     last_updated=STORED,
+    repo_lineage=STORED,
     full_last_updated=STORED)
 
 
@@ -121,6 +122,7 @@ class RepoSearch(object):
                     hit_dict['description'] = hit.get('description')
                     hit_dict['last_updated'] = hit.get('last_updated')
                     hit_dict['full_last_updated'] = hit.get('full_last_updated')
+                    hit_dict['repo_lineage'] = hit.get('repo_lineage')
                     hit_dict['approved'] = hit.get('approved')
                     hit_dict['times_downloaded'] = hit.get('times_downloaded')
                     results['hits'].append({'repository': hit_dict, 'matched_terms': hit.matched_terms(), 'score': hit.score})

--- a/lib/galaxy/webapps/tool_shed/search/repo_search.py
+++ b/lib/galaxy/webapps/tool_shed/search/repo_search.py
@@ -176,12 +176,12 @@ class RepoSearch(object):
         allow_terms = []
         search_term_chunks = search_term.split()
         reserved_terms = []
-        for term in search_term_chunks:
-            if ":" in term:
-                reserved_filter = term.split(":")[0]
-                reserved_filter_value = term.split(":")[1]
+        for term_chunk in search_term_chunks:
+            if ":" in term_chunk:
+                reserved_filter = term_chunk.split(":")[0]
+                reserved_filter_value = term_chunk.split(":")[1]
                 if reserved_filter in RESERVED_SEARCH_TERMS:
-                    reserved_terms.append(reserved_filter + ":" + reserved_filter_value)
+                    reserved_terms.append(term_chunk)
                     if reserved_filter == "category":
                         allow_terms.append(Term('categories', reserved_filter_value))
                     elif reserved_filter == "owner":

--- a/lib/galaxy/webapps/tool_shed/search/repo_search.py
+++ b/lib/galaxy/webapps/tool_shed/search/repo_search.py
@@ -4,7 +4,7 @@ import sys
 
 import whoosh.index
 from whoosh import scoring
-from whoosh.fields import Schema, STORED, TEXT, KEYWORD
+from whoosh.fields import KEYWORD, Schema, STORED, TEXT
 from whoosh.qparser import MultifieldParser
 from whoosh.query import And, Term
 

--- a/lib/galaxy/webapps/tool_shed/search/tool_search.py
+++ b/lib/galaxy/webapps/tool_shed/search/tool_search.py
@@ -16,7 +16,7 @@ from galaxy.exceptions import ObjectNotFound
 
 log = logging.getLogger(__name__)
 
-tool_schema = Schema(
+schema = Schema(
     name=TEXT(stored=True),
     description=TEXT(stored=True),
     owner=TEXT(stored=True),
@@ -58,7 +58,7 @@ class ToolSearch(object):
                     'name',
                     'description',
                     'help',
-                    'repo_owner_username'], schema=tool_schema)
+                    'repo_owner_username'], schema=schema)
 
                 user_query = parser.parse('*' + search_term + '*')
 

--- a/scripts/tool_shed/build_ts_whoosh_index.py
+++ b/scripts/tool_shed/build_ts_whoosh_index.py
@@ -164,8 +164,8 @@ def get_repos(sa_session, path_to_repositories, hgweb_config_dir):
         hg_repo = hg.repository(ui.ui(), repo_path)
         lineage = []
         for changeset in hg_repo.changelog:
-            lineage.append(str(hg_repo.changectx(changeset)))
-        repo_lineage = ",".join(lineage)
+            lineage.append(str(changeset) + ":" + str(hg_repo.changectx(changeset)))
+        repo_lineage = str(lineage)
 
         #  Parse all the tools within repo for separate index.
         tools_list = []

--- a/scripts/tool_shed/build_ts_whoosh_index.py
+++ b/scripts/tool_shed/build_ts_whoosh_index.py
@@ -18,9 +18,9 @@ import sys
 from optparse import OptionParser
 
 from six.moves import configparser
+from mercurial import hg, ui
 from whoosh.fields import Schema, STORED, TEXT
 from whoosh.filedb.filestore import FileStorage
-from mercurial import hg, ui
 
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, 'lib')))
 


### PR DESCRIPTION
* adds `repo_lineage` to the index and results - this should allow us to quickly identify what repo needs updating and bring utility to our tool installation interface. 
* Includes changes to API to return the new attribute. 
* Also lowers the search limit for repos and tools to 1 character.
* include categories as keywords for repository index
* allow filtering on category/owner using github-like wildards "category:name"
* only log metadtaa like matched terms, do not return in http response
* refactoring

cc @guerler 