### PR TITLE
[19.05] Update node.post_job_actions when changing post job actions

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -66,6 +66,15 @@ var Node = Backbone.Model.extend({
         output_terminal.force_datatype = datatype;
         output.force_datatype = datatype;
         this.nodeView.updateDataOutputView(output);
+        if (datatype) {
+            this.post_job_actions['ChangeDatatypeAction' + outputName] = {
+                action_arguments: {newtype: datatype},
+                action_type: "ChangeDatatypeAction",
+                output_name: outputName,
+            };
+        } else {
+            delete this.post_job_actions['ChangeDatatypeAction' + outputName];
+        }
         this.markChanged();
         output_terminal.destroyInvalidConnections();
     },

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -65,7 +65,6 @@ var Node = Backbone.Model.extend({
         const output = this.nodeView.outputViews[outputName].output;
         output_terminal.force_datatype = datatype;
         output.force_datatype = datatype;
-        this.nodeView.updateDataOutputView(output);
         if (datatype) {
             this.post_job_actions['ChangeDatatypeAction' + outputName] = {
                 action_arguments: {newtype: datatype},

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
@@ -115,14 +115,6 @@ export default Backbone.View.extend({
         this.tool_body.append(outputView.$el.append(terminalView.terminalElements()));
     },
 
-    updateDataOutputView: function(output) {
-        const terminalView = this.terminalViewForOutput(output);
-        const outputView = this.outputViews[output.name];
-        const newOutputView = this.outputViewforOutput(output, terminalView);
-        newOutputView.$el.append(terminalView.terminalElements());
-        outputView.$el.html(newOutputView.$el);
-    },
-
     redrawWorkflowOutputs: function() {
         _.each(this.outputViews, outputView => {
             outputView.redrawWorkflowOutput();


### PR DESCRIPTION
I broke persisting post job actions in
https://github.com/galaxyproject/galaxy/pull/7989.
The onchange function prevented updating the post job action.

Also the mapOver state is being lost, so I'll also fix that ...