### PR TITLE
Update JobMetrics component to use a Vuex Store + vuex-cache...

### DIFF
--- a/client/galaxy/scripts/components/JobMetrics/mount.js
+++ b/client/galaxy/scripts/components/JobMetrics/mount.js
@@ -2,18 +2,17 @@
  * Endpoint for mounting job metrics from non-Vue environment.
  */
 import $ from "jquery";
-import Vue from "vue";
 import JobMetrics from "./JobMetrics.vue";
+import { mountVueComponent } from "utils/mountVueComponent";
 
 export const mountJobMetrics = (propsData = {}) => {
     $(".job-metrics").each((index, el) => {
         const jobId = $(el).attr("job_id");
         const datasetId = $(el).attr("dataset_id");
         const datasetType = $(el).attr("dataset_type") || "hda";
-        const component = Vue.extend(JobMetrics);
         propsData.jobId = jobId;
         propsData.datasetId = datasetId;
         propsData.datasetType = datasetType;
-        return new component({ propsData: propsData }).$mount(el);
+        mountVueComponent(JobMetrics)(propsData, el);
     });
 };

--- a/client/galaxy/scripts/store/index.js
+++ b/client/galaxy/scripts/store/index.js
@@ -4,14 +4,19 @@
 
 import Vue from "vue";
 import Vuex from "vuex";
+import createCache from "vuex-cache";
+
 import { gridSearchStore } from "./gridSearchStore";
 import { tagStore } from "./tagStore";
+import { jobMetricsStore } from "./jobMetricsStore";
 
 Vue.use(Vuex);
 
 export default new Vuex.Store({
+    plugins: [createCache()],
     modules: {
         gridSearch: gridSearchStore,
-        tags: tagStore
+        tags: tagStore,
+        jobMetrics: jobMetricsStore
     }
 });

--- a/client/galaxy/scripts/store/jobMetricsStore.js
+++ b/client/galaxy/scripts/store/jobMetricsStore.js
@@ -1,0 +1,47 @@
+export const state = {
+    jobMetricsByHdaId: {},
+    jobMetricsByLddaId: {},
+    jobMetricsByJobId: {}
+};
+
+import Vue from "vue";
+import { getAppRoot } from "onload/loadConfig";
+import axios from "axios";
+
+const getters = {
+    getJobMetricsByDatasetId: state => (datasetId, datasetType = "hda") => {
+        const jobMetricsObject = datasetType == "hda" ? state.jobMetricsByHdaId : state.jobMetricsByLddaId;
+        return jobMetricsObject[datasetId] || [];
+    },
+    getJobMetricsByJobId: state => jobId => {
+        return state.jobMetricsByJobId[jobId] || [];
+    }
+};
+
+const actions = {
+    fetchJobMetricsForDatasetId: async ({ commit }, { datasetId, datasetType }) => {
+        const { data } = await axios.get(`${getAppRoot()}api/datasets/${datasetId}/metrics?hda_ldda=${datasetType}`);
+        commit("saveJobMetricsForDatasetId", { datasetId, datasetType, jobMetrics: data });
+    },
+    fetchJobMetricsForJobId: async ({ commit }, jobId) => {
+        const { data } = await axios.get(`${getAppRoot()}api/jobs/${jobId}/metrics`);
+        commit("saveJobMetricsForJobId", { jobId, jobMetrics: data });
+    }
+};
+
+const mutations = {
+    saveJobMetricsForDatasetId: (state, { datasetId, datasetType, jobMetrics }) => {
+        const jobMetricsObject = datasetType == "hda" ? state.jobMetricsByHdaId : state.jobMetricsByLddaId;
+        Vue.set(jobMetricsObject, datasetId, jobMetrics);
+    },
+    saveJobMetricsForJobId: (state, { jobId, jobMetrics }) => {
+        Vue.set(state.jobMetricsByJobId, jobId, jobMetrics);
+    }
+};
+
+export const jobMetricsStore = {
+    state,
+    getters,
+    actions,
+    mutations
+};

--- a/client/package.json
+++ b/client/package.json
@@ -47,7 +47,8 @@
     "vue": "^2.6.10",
     "vue-router": "^3.0.2",
     "vue-rx": "^6.1.0",
-    "vuex": "^3.1.0"
+    "vuex": "^3.1.0",
+    "vuex-cache": "^3.1.0"
   },
   "scripts": {
     "watch": "gulp && yarn run save-build-hash && yarn run webpack-watch",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -13067,6 +13067,11 @@ vue@^2.6.10, vue@^2.6.9:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
   integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
 
+vuex-cache@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vuex-cache/-/vuex-cache-3.1.0.tgz#aad576cfb39b325cc7a43ea9a42414e356374c4b"
+  integrity sha512-XDzQ/jddmErZVquyHhbOHc6DPhVSt5bU8433Fzsai3XydU3cxyYTUd3PH2Ww5sesB9yu5f0wKk6MFIqgjSa3Yw==
+
 vuex@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.1.0.tgz#634b81515cf0cfe976bd1ffe9601755e51f843b9"


### PR DESCRIPTION
... to cache API requests.

I'm trying to rewrite my Markdown generation of workflow reports to not pre-build data needed as part of a mammoth request. I think using a vuex store to allow various components to reuse the same data is the right approach, but I will need a way to ensure various components don't cause the same data to be fetched repeatedly from different contexts. vuex-cache seems to be a clean enough solution to this.

This may be overkill for this single component - but I'm intending to build several components over other parts of the job API and there I think having an approach agreed on in this context will be very helpful.
