### PR TITLE
Prepare all packages/ for actual releases.

### DIFF
--- a/.ci/flake8_blacklist.txt
+++ b/.ci/flake8_blacklist.txt
@@ -2,6 +2,10 @@
 .tox
 .venv
 .venv3
+packages/*/.venv
+packages/*/build
+packages/*/dist
+packages/venv
 node_modules
 database
 doc/build

--- a/packages/build_scripts/commit_version.py
+++ b/packages/build_scripts/commit_version.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# Modify version...
+import datetime
+import os
+import re
+import subprocess
+import sys
+
+
+PROJECT_DIRECTORY = os.path.join(os.path.dirname(__file__), "..")
+PROJECT_DIRECTORY_NAME = os.path.basename(os.path.abspath(PROJECT_DIRECTORY))
+PROJECT_MODULE_FILENAME = "galaxy_%s.py" % PROJECT_DIRECTORY_NAME
+PROJECT_NAME = PROJECT_DIRECTORY_NAME.replace("_", "-")
+
+
+def main(argv):
+    source_dir = argv[1]
+    version = argv[2]
+    history_path = os.path.join(PROJECT_DIRECTORY, "HISTORY.rst")
+    history = open(history_path, "r").read()
+    today = datetime.datetime.today()
+    today_str = today.strftime('%Y-%m-%d')
+    history = history.replace(".dev0", " (%s)" % today_str)
+    open(history_path, "w").write(history)
+    mod_path = os.path.join(PROJECT_DIRECTORY, source_dir, PROJECT_MODULE_FILENAME)
+    mod = open(mod_path, "r").read()
+    mod = re.sub("__version__ = '[\d\.]*\.dev0'",
+                 "__version__ = '%s'" % version,
+                 mod)
+    mod = open(mod_path, "w").write(mod)
+    tag = "galaxy-%s-%s" % (PROJECT_NAME, version)
+    shell(["git", "commit", "-m", "Version %s of %s (tag %s)." % (version, PROJECT_NAME, tag),
+           "HISTORY.rst", mod_path])
+    shell(["git", "tag", tag])
+
+
+def shell(cmds, **kwds):
+    p = subprocess.Popen(cmds, **kwds)
+    return p.wait()
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/packages/build_scripts/commit_version.py
+++ b/packages/build_scripts/commit_version.py
@@ -7,27 +7,29 @@ import subprocess
 import sys
 
 
-PROJECT_DIRECTORY = os.path.join(os.path.dirname(__file__), "..")
+DEV_RELEASE = os.environ.get("DEV_RELEASE", None) == "1"
+PROJECT_DIRECTORY = os.getcwd()
 PROJECT_DIRECTORY_NAME = os.path.basename(os.path.abspath(PROJECT_DIRECTORY))
-PROJECT_MODULE_FILENAME = "galaxy_%s.py" % PROJECT_DIRECTORY_NAME
+PROJECT_MODULE_FILENAME = "project_galaxy_%s.py" % PROJECT_DIRECTORY_NAME
 PROJECT_NAME = PROJECT_DIRECTORY_NAME.replace("_", "-")
 
 
 def main(argv):
     source_dir = argv[1]
     version = argv[2]
-    history_path = os.path.join(PROJECT_DIRECTORY, "HISTORY.rst")
-    history = open(history_path, "r").read()
-    today = datetime.datetime.today()
-    today_str = today.strftime('%Y-%m-%d')
-    history = history.replace(".dev0", " (%s)" % today_str)
-    open(history_path, "w").write(history)
     mod_path = os.path.join(PROJECT_DIRECTORY, source_dir, PROJECT_MODULE_FILENAME)
-    mod = open(mod_path, "r").read()
-    mod = re.sub("__version__ = '[\d\.]*\.dev0'",
-                 "__version__ = '%s'" % version,
-                 mod)
-    mod = open(mod_path, "w").write(mod)
+    if not DEV_RELEASE:
+        history_path = os.path.join(PROJECT_DIRECTORY, "HISTORY.rst")
+        history = open(history_path, "r").read()
+        today = datetime.datetime.today()
+        today_str = today.strftime('%Y-%m-%d')
+        history = history.replace(".dev0", " (%s)" % today_str)
+        open(history_path, "w").write(history)
+        mod = open(mod_path, "r").read()
+        mod = re.sub("__version__ = '[\d\.]*\.dev0'",
+                    "__version__ = '%s'" % version,
+                    mod)
+        mod = open(mod_path, "w").write(mod)
     tag = "galaxy-%s-%s" % (PROJECT_NAME, version)
     shell(["git", "commit", "-m", "Version %s of %s (tag %s)." % (version, PROJECT_NAME, tag),
            "HISTORY.rst", mod_path])

--- a/packages/build_scripts/commit_version.py
+++ b/packages/build_scripts/commit_version.py
@@ -26,7 +26,7 @@ def main(argv):
         history = history.replace(".dev0", " (%s)" % today_str)
         open(history_path, "w").write(history)
         mod = open(mod_path, "r").read()
-        mod = re.sub("__version__ = '[\d\.]*\.dev0'",
+        mod = re.sub(r"__version__ = '[\d\.]*\.dev0'",
                     "__version__ = '%s'" % version,
                     mod)
         mod = open(mod_path, "w").write(mod)

--- a/packages/build_scripts/new_version.py
+++ b/packages/build_scripts/new_version.py
@@ -49,7 +49,7 @@ def main(argv):
     mod_path = os.path.join(PROJECT_DIRECTORY, source_dir, PROJECT_MODULE_FILENAME)
     mod = open(mod_path, "r").read()
     if not DEV_RELEASE:
-        mod = re.sub("__version__ = '[\d\.]+'",
+        mod = re.sub(r"__version__ = '[\d\.]+'",
                     "__version__ = '%s.dev0'" % new_version,
                     mod, 1)
     else:

--- a/packages/build_scripts/new_version.py
+++ b/packages/build_scripts/new_version.py
@@ -7,41 +7,55 @@ import sys
 from distutils.version import StrictVersion
 
 
-PROJECT_DIRECTORY = os.path.join(os.path.dirname(__file__), "..")
+DEV_RELEASE = os.environ.get("DEV_RELEASE", None) == "1"
+PROJECT_DIRECTORY = os.getcwd()
 PROJECT_DIRECTORY_NAME = os.path.basename(os.path.abspath(PROJECT_DIRECTORY))
-PROJECT_MODULE_FILENAME = "galaxy_%s.py" % PROJECT_DIRECTORY_NAME
+PROJECT_MODULE_FILENAME = "project_galaxy_%s.py" % PROJECT_DIRECTORY_NAME
 PROJECT_NAME = PROJECT_DIRECTORY_NAME.replace("_", "-")
 
 
 def main(argv):
     source_dir = argv[1]
-    old_version = StrictVersion(argv[2])
-    old_version_tuple = old_version.version
-    new_version_tuple = list(old_version_tuple)
-    new_version_tuple[1] = old_version_tuple[1] + 1
-    new_version_tuple[2] = 0
-    new_version = ".".join(map(str, new_version_tuple))
+    version = argv[2]
+    if not DEV_RELEASE:
+        old_version = StrictVersion(version)
+        old_version_tuple = old_version.version
+        new_version_tuple = list(old_version_tuple)
+        new_version_tuple[1] = old_version_tuple[1] + 1
+        new_version_tuple[2] = 0
+        new_version = ".".join(map(str, new_version_tuple))
+        new_dev_version = 0
+    else:
+        dev_version = re.compile(r'dev([\d]+)').search(version).group(1)
+        new_dev_version = int(dev_version) + 1
+        new_version = version.replace("dev%s" % dev_version, "dev%s" % new_dev_version)
 
     history_path = os.path.join(PROJECT_DIRECTORY, "HISTORY.rst")
-    history = open(history_path, "r").read()
+    if not DEV_RELEASE:
+        history = open(history_path, "r").read()
 
-    def extend(from_str, line):
-        from_str += "\n"
-        return history.replace(from_str, from_str + line + "\n" )
+        def extend(from_str, line):
+            from_str += "\n"
+            return history.replace(from_str, from_str + line + "\n")
 
-    history = extend(".. to_doc", """
----------------------
-%s.dev0
----------------------
+        history = extend(".. to_doc", """
+    ---------------------
+    %s.dev0
+    ---------------------
 
-    """ % new_version)
-    open(history_path, "w").write(history)
+""" % new_version)
+        open(history_path, "w").write(history)
 
     mod_path = os.path.join(PROJECT_DIRECTORY, source_dir, PROJECT_MODULE_FILENAME)
     mod = open(mod_path, "r").read()
-    mod = re.sub("__version__ = '[\d\.]+'",
-                 "__version__ = '%s.dev0'" % new_version,
-                 mod, 1)
+    if not DEV_RELEASE:
+        mod = re.sub("__version__ = '[\d\.]+'",
+                    "__version__ = '%s.dev0'" % new_version,
+                    mod, 1)
+    else:
+        mod = re.sub("dev%s" % dev_version,
+                    "dev%s" % new_dev_version,
+                    mod, 1)
     mod = open(mod_path, "w").write(mod)
     shell(["git", "commit", "-m", "Starting work on %s %s" % (PROJECT_NAME, new_version),
            "HISTORY.rst", mod_path])

--- a/packages/build_scripts/new_version.py
+++ b/packages/build_scripts/new_version.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# Modify version...
+import os
+import re
+import subprocess
+import sys
+from distutils.version import StrictVersion
+
+
+PROJECT_DIRECTORY = os.path.join(os.path.dirname(__file__), "..")
+PROJECT_DIRECTORY_NAME = os.path.basename(os.path.abspath(PROJECT_DIRECTORY))
+PROJECT_MODULE_FILENAME = "galaxy_%s.py" % PROJECT_DIRECTORY_NAME
+PROJECT_NAME = PROJECT_DIRECTORY_NAME.replace("_", "-")
+
+
+def main(argv):
+    source_dir = argv[1]
+    old_version = StrictVersion(argv[2])
+    old_version_tuple = old_version.version
+    new_version_tuple = list(old_version_tuple)
+    new_version_tuple[1] = old_version_tuple[1] + 1
+    new_version_tuple[2] = 0
+    new_version = ".".join(map(str, new_version_tuple))
+
+    history_path = os.path.join(PROJECT_DIRECTORY, "HISTORY.rst")
+    history = open(history_path, "r").read()
+
+    def extend(from_str, line):
+        from_str += "\n"
+        return history.replace(from_str, from_str + line + "\n" )
+
+    history = extend(".. to_doc", """
+---------------------
+%s.dev0
+---------------------
+
+    """ % new_version)
+    open(history_path, "w").write(history)
+
+    mod_path = os.path.join(PROJECT_DIRECTORY, source_dir, PROJECT_MODULE_FILENAME)
+    mod = open(mod_path, "r").read()
+    mod = re.sub("__version__ = '[\d\.]+'",
+                 "__version__ = '%s.dev0'" % new_version,
+                 mod, 1)
+    mod = open(mod_path, "w").write(mod)
+    shell(["git", "commit", "-m", "Starting work on %s %s" % (PROJECT_NAME, new_version),
+           "HISTORY.rst", mod_path])
+
+
+def shell(cmds, **kwds):
+    p = subprocess.Popen(cmds, **kwds)
+    return p.wait()
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/packages/build_scripts/print_version_for_release.py
+++ b/packages/build_scripts/print_version_for_release.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+
+import ast
+import re
+import os
+import sys
+from distutils.version import LooseVersion
+
+PROJECT_DIRECTORY = os.path.join(os.path.dirname(__file__), "..")
+PROJECT_DIRECTORY_NAME = os.path.basename(os.path.abspath(PROJECT_DIRECTORY))
+PROJECT_MODULE_FILENAME = "galaxy_%s.py" % PROJECT_DIRECTORY_NAME
+
+source_dir = sys.argv[1]
+PROJECT_MODULE_PATH = os.path.join(PROJECT_DIRECTORY, source_dir, PROJECT_MODULE_FILENAME)
+
+_version_re = re.compile(r'__version__\s+=\s+(.*)')
+
+with open(PROJECT_MODULE_PATH, 'rb') as f:
+    version = str(ast.literal_eval(_version_re.search(
+        f.read().decode('utf-8')).group(1)))
+
+# Strip .devN
+version_tuple = LooseVersion(version).version[0:3]
+print(".".join(map(str, version_tuple)))

--- a/packages/build_scripts/print_version_for_release.py
+++ b/packages/build_scripts/print_version_for_release.py
@@ -1,24 +1,27 @@
 from __future__ import print_function
 
 import ast
-import re
 import os
+import re
 import sys
 from distutils.version import LooseVersion
 
-PROJECT_DIRECTORY = os.path.join(os.path.dirname(__file__), "..")
+DEV_RELEASE = os.environ.get("DEV_RELEASE", None) == "1"
+PROJECT_DIRECTORY = os.getcwd()
 PROJECT_DIRECTORY_NAME = os.path.basename(os.path.abspath(PROJECT_DIRECTORY))
-PROJECT_MODULE_FILENAME = "galaxy_%s.py" % PROJECT_DIRECTORY_NAME
+PROJECT_MODULE_FILENAME = "project_galaxy_%s.py" % PROJECT_DIRECTORY_NAME
 
 source_dir = sys.argv[1]
 PROJECT_MODULE_PATH = os.path.join(PROJECT_DIRECTORY, source_dir, PROJECT_MODULE_FILENAME)
 
 _version_re = re.compile(r'__version__\s+=\s+(.*)')
-
 with open(PROJECT_MODULE_PATH, 'rb') as f:
     version = str(ast.literal_eval(_version_re.search(
         f.read().decode('utf-8')).group(1)))
 
-# Strip .devN
-version_tuple = LooseVersion(version).version[0:3]
-print(".".join(map(str, version_tuple)))
+if not DEV_RELEASE:
+    # Strip .devN
+    version_tuple = LooseVersion(version).version[0:3]
+    print(".".join(map(str, version_tuple)))
+else:
+    print(version)

--- a/packages/data/HISTORY.rst
+++ b/packages/data/HISTORY.rst
@@ -6,7 +6,7 @@ History
 .. to_doc
 
 ---------------------
-19.5.0.dev0
+19.9.0.dev0
 ---------------------
 
-* Initial import from dev branch of Galaxy during 19.05 release cycle.
+* Initial import from dev branch of Galaxy during 19.09 development cycle.

--- a/packages/data/Makefile
+++ b/packages/data/Makefile
@@ -1,0 +1,1 @@
+../package.Makefile

--- a/packages/data/dev-requirements.txt
+++ b/packages/data/dev-requirements.txt
@@ -1,0 +1,1 @@
+../package-dev-requirements.txt

--- a/packages/data/galaxy/project_galaxy_data.py
+++ b/packages/data/galaxy/project_galaxy_data.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.5.0.dev0'
+__version__ = '19.9.0.dev0'
 
 PROJECT_NAME = "galaxy-data"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"
 PROJECT_URL = "https://github.com/galaxyproject/galaxy"
 PROJECT_AUTHOR = 'Galaxy Project and Community'
+PROJECT_DESCRIPTION = 'Galaxy Datatype Framework and Datatypes'
 PROJECT_EMAIL = 'jmchilton@gmail.com'
 RAW_CONTENT_URL = "https://raw.github.com/%s/%s/master/" % (
     PROJECT_USERAME, PROJECT_NAME

--- a/packages/data/galaxy/project_galaxy_data.py
+++ b/packages/data/galaxy/project_galaxy_data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.9.0.dev0'
+__version__ = '19.9.0.dev1'
 
 PROJECT_NAME = "galaxy-data"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"

--- a/packages/data/scripts
+++ b/packages/data/scripts
@@ -1,0 +1,1 @@
+../build_scripts

--- a/packages/data/setup.py
+++ b/packages/data/setup.py
@@ -77,6 +77,7 @@ setup(
     version=version,
     description=PROJECT_DESCRIPTION,
     long_description=readme + '\n\n' + history,
+    long_description_content_type='text/x-rst',
     author=PROJECT_AUTHOR,
     author_email=PROJECT_EMAIL,
     url=PROJECT_URL,

--- a/packages/data/setup.py
+++ b/packages/data/setup.py
@@ -26,9 +26,9 @@ with open('%s/project_galaxy_data.py' % SOURCE_DIR, 'rb') as f:
     PROJECT_URL = get_var("PROJECT_URL")
     PROJECT_AUTHOR = get_var("PROJECT_AUTHOR")
     PROJECT_EMAIL = get_var("PROJECT_EMAIL")
+    PROJECT_DESCRIPTION = get_var("PROJECT_DESCRIPTION")
 
 TEST_DIR = 'tests'
-PROJECT_DESCRIPTION = 'Galaxy Datatype Framework and Datatypes'
 PACKAGES = [
     'galaxy',
     'galaxy.datatypes',
@@ -101,7 +101,6 @@ setup(
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/packages/job_metrics/HISTORY.rst
+++ b/packages/job_metrics/HISTORY.rst
@@ -9,4 +9,4 @@ History
 19.9.0.dev0
 ---------------------
 
-* Initial import from dev branch of Galaxy during 19.09 release cycle.
+* Initial import from dev branch of Galaxy during 19.09 development cycle.

--- a/packages/job_metrics/Makefile
+++ b/packages/job_metrics/Makefile
@@ -1,0 +1,1 @@
+../package.Makefile

--- a/packages/job_metrics/dev-requirements.txt
+++ b/packages/job_metrics/dev-requirements.txt
@@ -1,0 +1,1 @@
+../package-dev-requirements.txt

--- a/packages/job_metrics/galaxy/project_galaxy_job_metrics.py
+++ b/packages/job_metrics/galaxy/project_galaxy_job_metrics.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.9.0.dev0'
+__version__ = '19.9.0.dev1'
 
 PROJECT_NAME = "galaxy-job-metrics"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"

--- a/packages/job_metrics/galaxy/project_galaxy_job_metrics.py
+++ b/packages/job_metrics/galaxy/project_galaxy_job_metrics.py
@@ -6,6 +6,7 @@ PROJECT_NAME = "galaxy-job-metrics"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"
 PROJECT_URL = "https://github.com/galaxyproject/galaxy"
 PROJECT_AUTHOR = 'Galaxy Project and Community'
+PROJECT_DESCRIPTION = 'Galaxy Job Metrics'
 PROJECT_EMAIL = 'jmchilton@gmail.com'
 RAW_CONTENT_URL = "https://raw.github.com/%s/%s/master/" % (
     PROJECT_USERAME, PROJECT_NAME

--- a/packages/job_metrics/scripts
+++ b/packages/job_metrics/scripts
@@ -1,0 +1,1 @@
+../build_scripts

--- a/packages/job_metrics/setup.py
+++ b/packages/job_metrics/setup.py
@@ -26,9 +26,9 @@ with open('%s/project_galaxy_job_metrics.py' % SOURCE_DIR, 'rb') as f:
     PROJECT_URL = get_var("PROJECT_URL")
     PROJECT_AUTHOR = get_var("PROJECT_AUTHOR")
     PROJECT_EMAIL = get_var("PROJECT_EMAIL")
+    PROJECT_DESCRIPTION = get_var("PROJECT_DESCRIPTION")
 
 TEST_DIR = 'tests'
-PROJECT_DESCRIPTION = 'Galaxy Job Metrics'
 PACKAGES = [
     'galaxy',
     'galaxy.job_metrics',
@@ -91,7 +91,6 @@ setup(
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/packages/job_metrics/setup.py
+++ b/packages/job_metrics/setup.py
@@ -32,7 +32,7 @@ TEST_DIR = 'tests'
 PACKAGES = [
     'galaxy',
     'galaxy.job_metrics',
-    'galaxy.job_metrics.instrumers',
+    'galaxy.job_metrics.instrumenters',
     'galaxy.job_metrics.collectl',
 ]
 ENTRY_POINTS = '''

--- a/packages/job_metrics/setup.py
+++ b/packages/job_metrics/setup.py
@@ -67,6 +67,7 @@ setup(
     version=version,
     description=PROJECT_DESCRIPTION,
     long_description=readme + '\n\n' + history,
+    long_description_content_type='text/x-rst',
     author=PROJECT_AUTHOR,
     author_email=PROJECT_EMAIL,
     url=PROJECT_URL,

--- a/packages/objectstore/HISTORY.rst
+++ b/packages/objectstore/HISTORY.rst
@@ -6,7 +6,7 @@ History
 .. to_doc
 
 ---------------------
-19.5.0.dev0
+19.9.0.dev0
 ---------------------
 
-* Initial import from dev branch of Galaxy during 19.05 release cycle.
+* Initial import from dev branch of Galaxy during 19.09 development cycle.

--- a/packages/objectstore/Makefile
+++ b/packages/objectstore/Makefile
@@ -1,0 +1,1 @@
+../package.Makefile

--- a/packages/objectstore/dev-requirements.txt
+++ b/packages/objectstore/dev-requirements.txt
@@ -1,0 +1,1 @@
+../package-dev-requirements.txt

--- a/packages/objectstore/galaxy/project_galaxy_objectstore.py
+++ b/packages/objectstore/galaxy/project_galaxy_objectstore.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.9.0.dev0'
+__version__ = '19.9.0.dev1'
 
 PROJECT_NAME = "galaxy-objectstore"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"

--- a/packages/objectstore/galaxy/project_galaxy_objectstore.py
+++ b/packages/objectstore/galaxy/project_galaxy_objectstore.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.5.0.dev0'
+__version__ = '19.9.0.dev0'
 
 PROJECT_NAME = "galaxy-objectstore"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"
 PROJECT_URL = "https://github.com/galaxyproject/galaxy"
 PROJECT_AUTHOR = 'Galaxy Project and Community'
+PROJECT_DESCRIPTION = 'Galaxy Objectstore Framework and Plugins'
 PROJECT_EMAIL = 'jmchilton@gmail.com'
 RAW_CONTENT_URL = "https://raw.github.com/%s/%s/master/" % (
     PROJECT_USERAME, PROJECT_NAME

--- a/packages/objectstore/scripts
+++ b/packages/objectstore/scripts
@@ -1,0 +1,1 @@
+../build_scripts

--- a/packages/objectstore/setup.py
+++ b/packages/objectstore/setup.py
@@ -65,6 +65,7 @@ setup(
     version=version,
     description=PROJECT_DESCRIPTION,
     long_description=readme + '\n\n' + history,
+    long_description_content_type='text/x-rst',
     author=PROJECT_AUTHOR,
     author_email=PROJECT_EMAIL,
     url=PROJECT_URL,

--- a/packages/objectstore/setup.py
+++ b/packages/objectstore/setup.py
@@ -26,9 +26,9 @@ with open('%s/project_galaxy_objectstore.py' % SOURCE_DIR, 'rb') as f:
     PROJECT_URL = get_var("PROJECT_URL")
     PROJECT_AUTHOR = get_var("PROJECT_AUTHOR")
     PROJECT_EMAIL = get_var("PROJECT_EMAIL")
+    PROJECT_DESCRIPTION = get_var("PROJECT_DESCRIPTION")
 
 TEST_DIR = 'tests'
-PROJECT_DESCRIPTION = 'Galaxy Datatype Framework and Datatypes'
 PACKAGES = [
     'galaxy',
     'galaxy.objectstore',
@@ -89,7 +89,6 @@ setup(
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/packages/package-dev-requirements.txt
+++ b/packages/package-dev-requirements.txt
@@ -1,0 +1,9 @@
+# For testing
+pytest
+
+# For dev
+sphinx
+
+# For release
+wheel
+twine

--- a/packages/package.Makefile
+++ b/packages/package.Makefile
@@ -7,7 +7,8 @@ IN_VENV=if [ -f $(VENV)/bin/activate ]; then . $(VENV)/bin/activate; fi;
 UPSTREAM?=galaxyproject
 SOURCE_DIR?=galaxy
 BUILD_SCRIPTS_DIR=scripts
-VERSION?=$(shell python $(BUILD_SCRIPTS_DIR)/print_version_for_release.py $(SOURCE_DIR))
+DEV_RELEASE?=0
+VERSION?=$(shell DEV_RELEASE=$(DEV_RELEASE) python $(BUILD_SCRIPTS_DIR)/print_version_for_release.py $(SOURCE_DIR) $(DEV_RELEASE))
 PROJECT_NAME?="galaxy-$(shell basename $(CURDIR))"
 PROJECT_NAME:=$(subst _,-,$(PROJECT_NAME))
 TEST_DIR?=test
@@ -74,10 +75,10 @@ _release-artifacts:
 release-artifacts: release-test-artifacts _release-artifacts
 
 commit-version:
-	$(IN_VENV) python $(BUILD_SCRIPTS_DIR)/commit_version.py $(SOURCE_DIR) $(VERSION)
+	$(IN_VENV) DEV_RELEASE=$(DEV_RELEASE) python $(BUILD_SCRIPTS_DIR)/commit_version.py $(SOURCE_DIR) $(VERSION)
 
 new-version:
-	$(IN_VENV) python $(BUILD_SCRIPTS_DIR)/new_version.py $(SOURCE_DIR) $(VERSION)
+	$(IN_VENV) DEV_RELEASE=$(DEV_RELEASE) python $(BUILD_SCRIPTS_DIR)/new_version.py $(SOURCE_DIR) $(VERSION)
 
 release-local: commit-version release-artifacts new-version
 

--- a/packages/package.Makefile
+++ b/packages/package.Makefile
@@ -1,0 +1,88 @@
+# Location of virtualenv used for development.
+VENV?=.venv
+# Open resource on Mac OS X or Linux
+OPEN_RESOURCE=bash -c 'open $$0 || xdg-open $$0'
+# Source virtualenv to execute command (flake8, sphinx, twine, etc...)
+IN_VENV=if [ -f $(VENV)/bin/activate ]; then . $(VENV)/bin/activate; fi;
+UPSTREAM?=galaxyproject
+SOURCE_DIR?=galaxy
+BUILD_SCRIPTS_DIR=scripts
+VERSION?=$(shell python $(BUILD_SCRIPTS_DIR)/print_version_for_release.py $(SOURCE_DIR))
+PROJECT_NAME?="galaxy-$(shell basename $(CURDIR))"
+PROJECT_NAME:=$(subst _,-,$(PROJECT_NAME))
+TEST_DIR?=test
+TESTS?=$(SOURCE_DIR) $(TEST_DIR)
+
+.PHONY: clean-pyc clean-build docs clean
+
+help:
+	@echo "clean - remove all build, test, coverage and Python artifacts"
+	@echo "clean-build - remove build artifacts"
+	@echo "clean-pyc - remove Python file artifacts"
+	@echo "clean-test - remove test and coverage artifacts"
+	@echo "setup-venv - setup a development virutalenv in current directory."
+	@echo "lint-dist - twine check dist results, including validating README content"
+	@echo "dist - package project for PyPI distribution"
+
+clean: clean-build clean-pyc clean-tests
+
+clean-build:
+	rm -fr build/
+	rm -fr dist/
+	rm -fr galaxy_*.egg-info
+
+clean-pyc:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-tests:
+	rm -fr .tox/
+
+setup-venv:
+	if [ ! -d $(VENV) ]; then virtualenv $(VENV); exit; fi;
+	$(IN_VENV) pip install -r requirements.txt && pip install -r dev-requirements.txt
+
+test:
+	$(IN_VENV) pytest $(TESTS)
+
+develop:
+	python setup.py develop
+
+dist: clean
+	$(IN_VENV) python setup.py sdist bdist_wheel
+	ls -l dist
+
+lint-dist: dist
+	$(IN_VENV) twine check dist/*
+
+_release-test-artifacts:
+	$(IN_VENV) twine upload -r test dist/*
+	$(OPEN_RESOURCE) https://testpypi.python.org/pypi/$(PROJECT_NAME)
+
+release-test-artifacts: lint-dist _release-test-artifacts
+
+_release-artifacts:
+	@while [ -z "$$CONTINUE" ]; do \
+	  read -r -p "Have you executed release-test and reviewed results? [y/N]: " CONTINUE; \
+	done ; \
+	[ $$CONTINUE = "y" ] || [ $$CONTINUE = "Y" ] || (echo "Exiting."; exit 1;)
+	@echo "Releasing"
+	$(IN_VENV) twine upload dist/*
+
+release-artifacts: release-test-artifacts _release-artifacts
+
+commit-version:
+	$(IN_VENV) python $(BUILD_SCRIPTS_DIR)/commit_version.py $(SOURCE_DIR) $(VERSION)
+
+new-version:
+	$(IN_VENV) python $(BUILD_SCRIPTS_DIR)/new_version.py $(SOURCE_DIR) $(VERSION)
+
+release-local: commit-version release-artifacts new-version
+
+push-release:
+	git push $(UPSTREAM) dev
+	git push upstream $(UPSTREAM)/tags/galaxy-$(PROJECT_NAME)-$(VERSION)
+
+release: release-local push-release

--- a/packages/tool_util/HISTORY.rst
+++ b/packages/tool_util/HISTORY.rst
@@ -9,4 +9,4 @@ History
 19.9.0.dev0
 ---------------------
 
-* Initial import from dev branch of Galaxy during 19.09 release cycle.
+* Initial import from dev branch of Galaxy during 19.09 development cycle.

--- a/packages/tool_util/Makefile
+++ b/packages/tool_util/Makefile
@@ -1,0 +1,1 @@
+../package.Makefile

--- a/packages/tool_util/dev-requirements.txt
+++ b/packages/tool_util/dev-requirements.txt
@@ -1,0 +1,1 @@
+../package-dev-requirements.txt

--- a/packages/tool_util/galaxy/project_galaxy_tool_util.py
+++ b/packages/tool_util/galaxy/project_galaxy_tool_util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.9.0.dev0'
+__version__ = '19.9.0.dev1'
 
 PROJECT_NAME = "galaxy-tool-util"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"

--- a/packages/tool_util/galaxy/project_galaxy_tool_util.py
+++ b/packages/tool_util/galaxy/project_galaxy_tool_util.py
@@ -6,6 +6,7 @@ PROJECT_NAME = "galaxy-tool-util"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"
 PROJECT_URL = "https://github.com/galaxyproject/galaxy"
 PROJECT_AUTHOR = 'Galaxy Project and Community'
+PROJECT_DESCRIPTION = 'Galaxy Tool and Tool Dependency Utilities'
 PROJECT_EMAIL = 'jmchilton@gmail.com'
 RAW_CONTENT_URL = "https://raw.github.com/%s/%s/master/" % (
     PROJECT_USERAME, PROJECT_NAME

--- a/packages/tool_util/scripts
+++ b/packages/tool_util/scripts
@@ -1,0 +1,1 @@
+../build_scripts

--- a/packages/tool_util/setup.py
+++ b/packages/tool_util/setup.py
@@ -26,6 +26,7 @@ with open('%s/project_galaxy_tool_util.py' % SOURCE_DIR, 'rb') as f:
     PROJECT_URL = get_var("PROJECT_URL")
     PROJECT_AUTHOR = get_var("PROJECT_AUTHOR")
     PROJECT_EMAIL = get_var("PROJECT_EMAIL")
+    PROJECT_DESCRIPTION = get_var("PROJECT_DESCRIPTION")
 
 TEST_DIR = 'tests'
 PACKAGES = [
@@ -78,6 +79,7 @@ setup(
     version=version,
     description=PROJECT_DESCRIPTION,
     long_description=readme + '\n\n' + history,
+    long_description_content_type='text/x-rst',
     author=PROJECT_AUTHOR,
     author_email=PROJECT_EMAIL,
     url=PROJECT_URL,

--- a/packages/tool_util/setup.py
+++ b/packages/tool_util/setup.py
@@ -28,7 +28,6 @@ with open('%s/project_galaxy_tool_util.py' % SOURCE_DIR, 'rb') as f:
     PROJECT_EMAIL = get_var("PROJECT_EMAIL")
 
 TEST_DIR = 'tests'
-PROJECT_DESCRIPTION = 'Galaxy Tool Utilities'
 PACKAGES = [
     'galaxy',
     'galaxy.tool_util',
@@ -103,7 +102,6 @@ setup(
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/packages/util/HISTORY.rst
+++ b/packages/util/HISTORY.rst
@@ -6,7 +6,7 @@ History
 .. to_doc
 
 ---------------------
-19.5.0.dev0
+19.9.0.dev0
 ---------------------
 
-* Initial import from dev branch of Galaxy during 19.05 release cycle.
+* Initial import from dev branch of Galaxy during 19.09 development cycle.

--- a/packages/util/Makefile
+++ b/packages/util/Makefile
@@ -1,0 +1,1 @@
+../package.Makefile

--- a/packages/util/dev-requirements.txt
+++ b/packages/util/dev-requirements.txt
@@ -1,0 +1,1 @@
+../package-dev-requirements.txt

--- a/packages/util/galaxy/project_galaxy_util.py
+++ b/packages/util/galaxy/project_galaxy_util.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.5.0.dev0'
+__version__ = '19.9.0.dev0'
 
 PROJECT_NAME = "galaxy-util"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"
 PROJECT_URL = "https://github.com/galaxyproject/galaxy"
 PROJECT_AUTHOR = 'Galaxy Project and Community'
+PROJECT_DESCRIPTION = 'Galaxy Generic Utilities'
 PROJECT_EMAIL = 'jmchilton@gmail.com'
 RAW_CONTENT_URL = "https://raw.github.com/%s/%s/master/" % (
     PROJECT_USERAME, PROJECT_NAME

--- a/packages/util/galaxy/project_galaxy_util.py
+++ b/packages/util/galaxy/project_galaxy_util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '19.9.0.dev0'
+__version__ = '19.9.0.dev2'
 
 PROJECT_NAME = "galaxy-util"
 PROJECT_OWNER = PROJECT_USERAME = "galaxyproject"

--- a/packages/util/scripts
+++ b/packages/util/scripts
@@ -1,0 +1,1 @@
+../build_scripts

--- a/packages/util/setup.py
+++ b/packages/util/setup.py
@@ -26,11 +26,12 @@ with open('%s/project_galaxy_util.py' % SOURCE_DIR, 'rb') as f:
     PROJECT_URL = get_var("PROJECT_URL")
     PROJECT_AUTHOR = get_var("PROJECT_AUTHOR")
     PROJECT_EMAIL = get_var("PROJECT_EMAIL")
+    PROJECT_DESCRIPTION = get_var("PROJECT_DESCRIPTION")
 
 TEST_DIR = 'tests'
-PROJECT_DESCRIPTION = 'Galaxy Datatype Framework and Datatypes'
 PACKAGES = [
     'galaxy',
+    'galaxy.exceptions',
     'galaxy.util',
     'galaxy.util.logging',
     'galaxy.util.path',
@@ -93,7 +94,6 @@ setup(
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/packages/util/setup.py
+++ b/packages/util/setup.py
@@ -70,6 +70,7 @@ setup(
     version=version,
     description=PROJECT_DESCRIPTION,
     long_description=readme + '\n\n' + history,
+    long_description_content_type='text/x-rst',
     author=PROJECT_AUTHOR,
     author_email=PROJECT_EMAIL,
     url=PROJECT_URL,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[wheel]
+universal = 1
+
 [flake8]
 # These are exceptions allowed by Galaxy style guidelines.
 # E128 continuation line under-indented for visual indent


### PR DESCRIPTION
Pre-releases based on this PR are already available:
- https://pypi.org/project/galaxy-util/
- https://pypi.org/project/galaxy-job-metrics/
- https://pypi.org/project/galaxy-objectstore/
- https://pypi.org/project/galaxy-tool-util/
- https://pypi.org/project/galaxy-data/

Changes:

- Update setup.py to reflect Galaxy no longer supports Python 3.4.
- Move PROJECT_DESCRIPTION into a variable imported into setup.py dynamically, reducing the differences in setup.py across packages.
- Fix some project descriptions (copy-paste problems).
- Fix versions and HISTORY.rst for a release this cycle, didn't get any 19.5.0 packages out.
- Add development requirements for publishing, linting build artifacts
- Add Makefile(s) for building projects (all synchronized via symbolic links).
- Extend Makefile template from other projects to support development releases (a bit anyway).
- Fix bug job metrics package listing.
- Build universal wheels (for Python 2/3 compat.)
- Update versions to reflect pre-releases already made.

