### PR TITLE
Refactor jstree.py out of galaxy.util to simplify library dependencies.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/_jstree.py
+++ b/lib/galaxy/webapps/galaxy/api/_jstree.py
@@ -47,21 +47,19 @@ class Node(dictobj.DictionaryObject):
     For example, users may want to pass "attr" or some other valid jsTree options.
 
     Example:
-      >>> import jstree
+      >>> from . import _jstree as jstree
       >>> node = jstree.Node('a', None)
       >>> print(node)
       Node({'text': 'a', 'children': MutableDictionaryObject({})})
       >>> print(node.jsonData())
       {'text': 'a'}
 
-      >>> import jstree
       >>> node = jstree.Node('a', 1)
       >>> print(node)
       Node({'text': 'a', 'children': MutableDictionaryObject({}), 'li_attr': DictionaryObject({'id': 1}), 'id': 1})
       >>> print(node.jsonData())
       {'text': 'a', 'id': 1, 'li_attr': {'id': 1}}
 
-      >>> import jstree
       >>> node = jstree.Node('a', 5, icon="folder", state = {'opened': True})
       >>> print(node)
       Node({'text': 'a', 'id': 5, 'state': DictionaryObject({'opened': True}), 'children': MutableDictionaryObject({}), 'li_attr': DictionaryObject({'id': 5}), 'icon': 'folder'})

--- a/lib/galaxy/webapps/galaxy/api/_jstree.py
+++ b/lib/galaxy/webapps/galaxy/api/_jstree.py
@@ -45,26 +45,6 @@ class Node(dictobj.DictionaryObject):
     will later be output in jsonData().  It allows for more advanced
     configuration than the default path handling that JSTree currently allows.
     For example, users may want to pass "attr" or some other valid jsTree options.
-
-    Example:
-      >>> from . import _jstree as jstree
-      >>> node = jstree.Node('a', None)
-      >>> print(node)
-      Node({'text': 'a', 'children': MutableDictionaryObject({})})
-      >>> print(node.jsonData())
-      {'text': 'a'}
-
-      >>> node = jstree.Node('a', 1)
-      >>> print(node)
-      Node({'text': 'a', 'children': MutableDictionaryObject({}), 'li_attr': DictionaryObject({'id': 1}), 'id': 1})
-      >>> print(node.jsonData())
-      {'text': 'a', 'id': 1, 'li_attr': {'id': 1}}
-
-      >>> node = jstree.Node('a', 5, icon="folder", state = {'opened': True})
-      >>> print(node)
-      Node({'text': 'a', 'id': 5, 'state': DictionaryObject({'opened': True}), 'children': MutableDictionaryObject({}), 'li_attr': DictionaryObject({'id': 5}), 'icon': 'folder'})
-      >>> print(node.jsonData())
-      {'text': 'a', 'state': {'opened': True}, 'id': 5, 'li_attr': {'id': 5}, 'icon': 'folder'}
     """
     super(Node, self).__init__()
 

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -8,16 +8,14 @@ import time
 from operator import itemgetter
 
 from galaxy import exceptions
-from galaxy.util import (
-    jstree,
-    smart_str
-)
+from galaxy.util import smart_str
 from galaxy.util.path import (
     safe_path,
     safe_walk
 )
 from galaxy.web import expose_api
 from galaxy.web.base.controller import BaseAPIController
+from . import _jstree as jstree
 
 log = logging.getLogger(__name__)
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -515,7 +515,7 @@ do
       -u|-unit|--unit)
           report_file="run_unit_tests.html"
           test_script="pytest"
-          unit_extra='--doctest-modules --ignore lib/galaxy/web/proxy/js/node_modules/ --ignore lib/galaxy/webapps/tool_shed/controllers --ignore lib/galaxy/jobs/runners/chronos.py --ignore lib/galaxy/webapps/tool_shed/model/migrate --ignore lib/galaxy/util/jstree.py'
+          unit_extra='--doctest-modules --ignore lib/galaxy/web/proxy/js/node_modules/ --ignore lib/galaxy/webapps/tool_shed/controllers --ignore lib/galaxy/jobs/runners/chronos.py --ignore lib/galaxy/webapps/tool_shed/model/migrate'
           if [ $# -gt 1 ]; then
               unit_extra="$unit_extra $2"
               shift 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@
 # W503 is line breaks before binary operators, which has been reversed in PEP 8.
 # D** are docstring linting - which we mostly ignore except D302. (Hopefully we will solve more over time).
 ignore = E128,E203,E501,E402,E741,W503,W504,D100,D101,D102,D103,D104,D105,D106,D107,D200,D201,D202,D204,D205,D206,D207,D208,D209,D210,D211,D300,D301,D400,D401,D402,D403,D412,D413
-exclude = lib/galaxy/util/jstree.py
 # For flake8-import-order
 # https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_smarkets.py
 import-order-style = smarkets


### PR DESCRIPTION
This utility is only used in one file - remote_files.py - so just place it beside that file to keep galaxy-util dependencies simpler.

Needed for #7971.