### PR TITLE
[19.01] Fixes for job handler and worklflow scheduler self-assignment grab limits

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -140,7 +140,7 @@ class JobConfiguration(ConfiguresHandlers):
         self.default_handler_id = None
         self.handler_assignment_methods = None
         self.handler_assignment_methods_configured = False
-        self.handler_max_grab = 1
+        self.handler_max_grab = None
         self.destinations = {}
         self.destination_tags = {}
         self.default_destination_id = None

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -107,8 +107,9 @@ class JobHandlerQueue(Monitors):
             .where(and_(
                 model.Job.table.c.handler.in_(self.app.job_config.self_handler_tags),
                 model.Job.table.c.state == model.Job.states.NEW)) \
-            .order_by(model.Job.table.c.id) \
-            .limit(self.app.job_config.handler_max_grab)
+            .order_by(model.Job.table.c.id)
+        if self.app.job_config.handler_max_grab:
+            subq = subq.limit(self.app.job_config.handler_max_grab)
         if method == HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED:
             subq = subq.with_for_update(skip_locked=True)
         self.__grab_query = model.Job.table.update() \

--- a/lib/galaxy/util/handlers.py
+++ b/lib/galaxy/util/handlers.py
@@ -90,7 +90,9 @@ class ConfiguresHandlers(object):
                     self.handler_assignment_methods = [method]
             if self.handler_assignment_methods == [HANDLER_ASSIGNMENT_METHODS.MEM_SELF]:
                 self.app.config.track_jobs_in_database = False
-            self.handler_max_grab = int(config_element.attrib.get('max_grab', self.handler_max_grab))
+            self.handler_max_grab = config_element.attrib.get('max_grab', self.handler_max_grab)
+            if self.handler_max_grab is not None:
+                self.handler_max_grab = int(self.handler_max_grab)
 
     def _set_default_handler_assignment_methods(self):
         if not self.handler_assignment_methods_configured:

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -47,7 +47,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
         self.handlers = {}
         self.handler_assignment_methods_configured = False
         self.handler_assignment_methods = None
-        self.handler_max_grab = 1
+        self.handler_max_grab = None
         self.default_handler_id = None
 
         self.__plugin_classes = self.__plugins_dict()


### PR DESCRIPTION
Default the maximum grab limit for handler database preassignment methods to unlimited as I'd originally intended. The old default of 1 meant low throughput, as discovered on usegalaxy.eu. Also I apparently forgot to document the config param.

Fixes #8057.