### PR TITLE
[18.09] Backport #8023: Fix ColumnSetAction post job action

### DIFF
--- a/lib/galaxy/jobs/actions/post.py
+++ b/lib/galaxy/jobs/actions/post.py
@@ -277,9 +277,10 @@ class ColumnSetAction(DefaultJobAction):
                 for k, v in action.action_arguments.items():
                     if v:
                         # Try to use both pure integer and 'cX' format.
-                        if v[0] == 'c':
-                            v = v[1:]
-                        v = int(v)
+                        if not isinstance(v, int):
+                            if v[0] == 'c':
+                                v = v[1:]
+                            v = int(v)
                         if v != 0:
                             setattr(dataset_assoc.dataset.metadata, k, v)
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -40,6 +40,7 @@ from galaxy.tools.parameters.basic import (
     workflow_building_modes
 )
 from galaxy.tools.parameters.wrapped import make_dict_copy
+from galaxy.util import unicodify
 from galaxy.util.bunch import Bunch
 from galaxy.util.json import safe_loads
 from galaxy.util.odict import odict
@@ -1124,7 +1125,7 @@ class ToolModule(WorkflowModule):
         replacement_parameters = set()
         for pja in step.post_job_actions:
             for argument in pja.action_arguments.values():
-                for match in re.findall(r'\$\{(.+?)\}', argument):
+                for match in re.findall(r'\$\{(.+?)\}', unicodify(argument)):
                     replacement_parameters.add(match)
 
         return list(replacement_parameters)


### PR DESCRIPTION
I didn't backport the test since it requires gxformat2 and that was factored out into an external library in 19.01, I think.

If columns are specified as integers this would fail currently.
Reported by Peter Briggs on the [mailing list](https://lists.galaxyproject.org/archives/list/galaxy-dev@lists.galaxyproject.org/thread/PXLCVKIZ5LW3MLI6333PFMANYGOCDLD2/)