### PR TITLE
do not invoke tool_script.sh on a pulsar job with container execution enabled

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -75,7 +75,7 @@ def build_command(
     if (container and modify_command_for_container) or job_wrapper.commands_in_new_shell:
         if container and modify_command_for_container:
             # Many Docker containers do not have /bin/bash.
-            external_command_shell = container.shell
+            external_command_shell = container.shell if job_wrapper.commands_in_new_shell else 'none'
         else:
             external_command_shell = shell
         externalized_commands = __externalize_commands(job_wrapper, external_command_shell, commands_builder, remote_command_params)


### PR DESCRIPTION
I have pulsar setup with container execution enabled and it presents the same behavior described by @bgruening here: https://github.com/galaxyproject/pulsar/issues/188

The patch here solves the problem avoiding the invocation of the tool_script.sh on Pulsar.  
I consider this more like a workaround rather than a solution.

command line before this patch: 

```
"command_line": "SINGULARITYENV_GALAXY_SLOTS=$GALAXY_SLOTS singularity \
-s exec \
-B /data/share/staging/337:/data/share/staging/337:rw \
-B /data/share/staging/337/tool_files:/data/share/staging/337/tool_files:ro \
-B /data/share/staging/337/outputs:/data/share/staging/337/outputs:rw \
-B /data/share/staging/337/working:/data/share/staging/337/working:rw \
--pwd /data/share/staging//337/working \
/srv/galaxy/var/database/container_cache/singularity/mulled/mulled-v2-653d40ac56aa6bd9196ed18b87259e19fc7ccc68:3acae3f9a8cb5c7cb63f9701edf1e0953f81e554-0 \
/bin/bash /data/share/staging//337/metadata/tool_script.sh > ../tool_stdout 2> ../tool_stderr; return_code=$?; sh -c \"exit $return_code\""
```

command line after this patch:

```
"command_line": "SINGULARITYENV_GALAXY_SLOTS=$GALAXY_SLOTS singularity \
-s exec \
-B /data/share/staging/338:/data/share/staging/338:rw \
-B /data/share/staging/338/tool_files:/data/share/staging/338/tool_files:ro \
-B /data/share/staging/338/outputs:/data/share/staging/338/outputs:rw \
-B /data/share/staging/338/working:/data/share/staging/338/working:rw \
--pwd /data/share/staging//338/working \
/srv/galaxy/var/database/container_cache/singularity/mulled/mulled-v2-653d40ac56aa6bd9196ed18b87259e19fc7ccc68:3acae3f9a8cb5c7cb63f9701edf1e0953f81e554-0 \
samtools 2>&1 | grep Version > /data/share/staging//338/outputs/COMMAND_VERSION 2>&1; ln -s '/data/share/staging//338/inputs/dataset_346.dat' infile && ln -s '/data/_metadata_files/000/metadata_32.dat' infile.bai &&    samtools stats       infile   > '/data/share/staging//338/outputs/dataset_400.dat'; return_code=$?; sh -c \"exit $return_code\""
```