### PR TITLE
Call tool_script.sh with shell

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -140,7 +140,7 @@ def __externalize_commands(job_wrapper, shell, commands_builder, remote_command_
         tool_commands
     )
     write_script(local_container_script, script_contents, config)
-    commands = local_container_script
+    commands = "%s %s" % (shell, local_container_script)
     if 'working_directory' in remote_command_params:
         commands = "%s %s" % (shell, join(remote_command_params['working_directory'], script_name))
     commands += " > ../tool_stdout 2> ../tool_stderr"

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -45,7 +45,11 @@ class TestCommandFactory(TestCase):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surround_command("%s/tool_script.sh > ../tool_stdout 2> ../tool_stderr; return_code=$?" % self.job_wrapper.working_directory))
+        self.__assert_command_is(_surround_command(
+            "%s %s/tool_script.sh > ../tool_stdout 2> ../tool_stderr; return_code=$?" % (
+                self.job_wrapper.shell,
+                self.job_wrapper.working_directory,
+            )))
         self.__assert_tool_script_is("#!/bin/sh\n%s; %s" % (dep_commands[0], MOCK_COMMAND_LINE))
 
     def test_remote_dependency_resolution(self):


### PR DESCRIPTION
The way we currently invoke the tool_script.sh script requires that we can set the executable bit on the script. That's not the case in our environment (i've worked around this with a terrible hack so far), and I don't think there's any harm in including the shell explicitly. The shell can be configured via the destination and the container resolver, so I think this should be fine in all situations.