### PR TITLE
Delegate config file watching to single handler

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -74,9 +74,9 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         self.application_stack.register_postfork_function(self.application_stack.set_postfork_server_name, self)
         self.config.reload_sanitize_whitelist(explicit='sanitize_whitelist_file' in kwargs)
         self.amqp_internal_connection_obj = galaxy.queues.connection_from_config(self.config)
-        # control_worker *can* be initialized with a queue, but here we don't
+        # queue_worker *can* be initialized with a queue, but here we don't
         # want to and we'll allow postfork to bind and start it.
-        self.control_worker = GalaxyQueueWorker(self)
+        self.queue_worker = GalaxyQueueWorker(self)
 
         self._configure_tool_shed_registry()
         self._configure_object_store(fsmon=True)
@@ -250,7 +250,7 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         log.debug('Shutting down')
         exception = None
         try:
-            self.control_worker.shutdown()
+            self.queue_worker.shutdown()
         except Exception as e:
             exception = exception or e
             log.exception("Failed to shutdown control worker cleanly")

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -231,6 +231,7 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         self.database_heartbeat = DatabaseHeartbeat(
             application_stack=self.application_stack
         )
+        self.database_heartbeat.add_change_callback(self.watchers.change_state)
         self.application_stack.register_postfork_function(self.database_heartbeat.start)
 
         # Start web stack message handling

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -250,6 +250,11 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         log.debug('Shutting down')
         exception = None
         try:
+            self.control_worker.shutdown()
+        except Exception as e:
+            exception = exception or e
+            log.exception("Failed to shutdown control worker cleanly")
+        try:
             self.watchers.shutdown()
         except Exception as e:
             exception = exception or e
@@ -285,12 +290,6 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         except Exception as e:
             exception = exception or e
             log.exception("Failed to shutdown update repository manager cleanly")
-
-        try:
-            self.control_worker.shutdown()
-        except Exception as e:
-            exception = exception or e
-            log.exception("Failed to shutdown control worker cleanly")
 
         try:
             self.model.engine.dispose()

--- a/lib/galaxy/model/database_heartbeat.py
+++ b/lib/galaxy/model/database_heartbeat.py
@@ -5,6 +5,7 @@ import threading
 
 from galaxy.model import WorkerProcess
 from galaxy.model.orm.now import now
+from galaxy.queue_worker import send_control_task
 
 log = logging.getLogger(__name__)
 
@@ -42,6 +43,11 @@ class DatabaseHeartbeat(object):
         self.exit.set()
         if self.thread:
             self.thread.join()
+        worker_process = self.worker_process
+        if worker_process:
+            self.sa_session.delete(worker_process)
+            self.sa_session.flush()
+            send_control_task(self.application_stack.app, 'reconfigure_watcher', noop_self=True)
 
     def get_active_processes(self, last_seen_seconds=None):
         """Return all processes seen in ``last_seen_seconds`` seconds."""
@@ -64,21 +70,29 @@ class DatabaseHeartbeat(object):
         for callback in self._observers:
             callback(self._is_config_watcher)
 
+    @property
+    def worker_process(self):
+        return self.sa_session.query(WorkerProcess).filter_by(
+            server_name=self.server_name,
+            hostname=self.hostname,
+        ).first()
+
+    def update_watcher_designation(self):
+        worker_process = self.worker_process
+        if not worker_process:
+            worker_process = WorkerProcess(server_name=self.server_name, hostname=self.hostname)
+        worker_process.update_time = now()
+        self.sa_session.add(worker_process)
+        self.sa_session.flush()
+        # We only want a single process watching the various config files on the file system.
+        # We just pick the max server name for simplicity
+        is_config_watcher = self.server_name == max(
+            (p.server_name for p in self.get_active_processes(self.heartbeat_interval + 1)))
+        if is_config_watcher != self.is_config_watcher:
+            self.is_config_watcher = is_config_watcher
+
     def send_database_heartbeat(self):
         if self.active:
             while not self.exit.isSet():
-                worker_process = self.sa_session.query(WorkerProcess).filter_by(
-                    server_name=self.server_name,
-                    hostname=self.hostname,
-                ).first()
-                if not worker_process:
-                    worker_process = WorkerProcess(server_name=self.server_name, hostname=self.hostname)
-                worker_process.update_time = now()
-                self.sa_session.add(worker_process)
-                self.sa_session.flush()
-                # We only want a single process watching the various config files on the file system.
-                # We just pick the max server name for simplicity
-                is_config_watcher = self.server_name == max((p.server_name for p in self.get_active_processes(self.heartbeat_interval + 1)))
-                if is_config_watcher != self.is_config_watcher:
-                    self.is_config_watcher = is_config_watcher
+                self.update_watcher_designation()
                 self.exit.wait(self.heartbeat_interval)

--- a/lib/galaxy/model/database_heartbeat.py
+++ b/lib/galaxy/model/database_heartbeat.py
@@ -5,7 +5,6 @@ import threading
 
 from galaxy.model import WorkerProcess
 from galaxy.model.orm.now import now
-from galaxy.queue_worker import send_control_task
 
 log = logging.getLogger(__name__)
 
@@ -47,7 +46,7 @@ class DatabaseHeartbeat(object):
         if worker_process:
             self.sa_session.delete(worker_process)
             self.sa_session.flush()
-            send_control_task(self.application_stack.app, 'reconfigure_watcher', noop_self=True)
+            self.application_stack.app.queue_worker.send_control_task('reconfigure_watcher', noop_self=True)
 
     def get_active_processes(self, last_seen_seconds=None):
         """Return all processes seen in ``last_seen_seconds`` seconds."""

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -331,6 +331,12 @@ class GalaxyQueueWorker(ConsumerProducerMixin, threading.Thread):
         self.direct_queue = None
         self.control_queues = []
 
+    def send_control_task(self, task, noop_self=False, get_response=False, routing_key='control.*', kwargs=None):
+        return send_control_task(app=self.app, task=task, noop_self=noop_self, get_response=get_response, routing_key=routing_key, kwargs=kwargs)
+
+    def send_local_control_task(self, task, kwargs=None):
+        return send_local_control_task(app=self.app, task=task, kwargs=kwargs)
+
     @property
     def declare_queues(self):
         # dynamically produce queues, allows addressing all known processes at a given time

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -29,11 +29,13 @@ logging.getLogger('kombu').setLevel(logging.WARNING)
 log = logging.getLogger(__name__)
 
 
-def send_local_control_task(app, task, kwargs={}):
+def send_local_control_task(app, task, kwargs=None):
     """
     This sends a message to the process-local control worker, which is useful
     for one-time asynchronous tasks like recalculating user disk usage.
     """
+    if kwargs is None:
+        kwargs = {}
     log.info("Queuing async task %s for %s." % (task, app.config.server_name))
     payload = {'task': task,
                'kwargs': kwargs}
@@ -42,7 +44,7 @@ def send_local_control_task(app, task, kwargs={}):
     control_task.send_task(payload, routing_key, local=True, get_response=False)
 
 
-def send_control_task(app, task, noop_self=False, get_response=False, routing_key='control.*', kwargs={}):
+def send_control_task(app, task, noop_self=False, get_response=False, routing_key='control.*', kwargs=None):
     """
     This sends a control task out to all processes, useful for things like
     reloading a data table, which needs to happen individually in all
@@ -51,6 +53,8 @@ def send_control_task(app, task, noop_self=False, get_response=False, routing_ke
     Set get_response to True to wait for and return the task results
     as a list.
     """
+    if kwargs is None:
+        kwargs = {}
     log.info("Sending %s control task." % task)
     payload = {'task': task,
                'kwargs': kwargs}

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -229,10 +229,12 @@ def recalculate_user_disk_usage(app, **kwargs):
 
 
 def reload_tool_data_tables(app, **kwargs):
-    params = util.Params(kwargs)
-    log.debug("Executing tool data table reload for %s" % params.get('table_names', 'all tables'))
-    table_names = app.tool_data_tables.reload_tables(table_names=params.get('table_name', None))
-    log.debug("Finished data table reload for %s" % table_names)
+    path = kwargs.get('path')
+    table_name = kwargs.get('table_name')
+    table_names = path or table_name or 'all tables'
+    log.debug("Executing tool data table reload for %s", table_names)
+    table_names = app.tool_data_tables.reload_tables(table_names=table_name, path=path)
+    log.debug("Finished data table reload for %s", table_names)
 
 
 def rebuild_toolbox_search_index(app, **kwargs):

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -6,9 +6,6 @@ import os
 from six import string_types
 
 from galaxy import util
-from galaxy.queue_worker import (
-    send_control_task
-)
 from galaxy.tools.data import TabularToolDataTable
 from galaxy.util.odict import odict
 from galaxy.util.template import fill_template
@@ -334,10 +331,11 @@ class DataManager(object):
                         self.process_move(data_table_name, name, output_ref_values[name].extra_files_path, **data_table_value)
                         data_table_value[name] = self.process_value_translation(data_table_name, name, **data_table_value)
                 data_table.add_entry(data_table_value, persist=True, entry_source=self)
-            send_control_task(self.data_managers.app,
-                              'reload_tool_data_tables',
-                              noop_self=True,
-                              kwargs={'table_name': data_table_name})
+            self.data_managers.app.queue_worker.send_control_task(
+                'reload_tool_data_tables',
+                noop_self=True,
+                kwargs={'table_name': data_table_name}
+            )
         if self.undeclared_tables and data_tables_dict:
             # We handle the data move, by just moving all the data out of the extra files path
             # moving a directory and the target already exists, we move the contents instead
@@ -356,9 +354,11 @@ class DataManager(object):
                         if name in path_column_names:
                             data_table_value[name] = os.path.abspath(os.path.join(self.data_managers.app.config.galaxy_data_manager_data_path, value))
                     data_table.add_entry(data_table_value, persist=True, entry_source=self)
-                send_control_task(self.data_managers.app, 'reload_tool_data_tables',
-                                  noop_self=True,
-                                  kwargs={'table_name': data_table_name})
+                self.data_managers.app.queue_worker.send_control_task(
+                    'reload_tool_data_tables',
+                    noop_self=True,
+                    kwargs={'table_name': data_table_name}
+                )
         else:
             for data_table_name, data_table_values in data_tables_dict.items():
                 # tool returned extra data table entries, but data table was not declared in data manager

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -75,13 +75,14 @@ class ToolConfWatcher(object):
         self._active = False
         self._lock = threading.Lock()
         self.thread = None
-        self.exit = threading.Event()
+
         self.reload_callback = reload_callback
 
     def start(self):
         if not self._active:
             self._active = True
             if self.thread is None:
+                self.exit = threading.Event()
                 self.thread = threading.Thread(target=self.check)
                 self.thread.daemon = True
                 self.thread.start()
@@ -93,6 +94,7 @@ class ToolConfWatcher(object):
                 self.exit.set()
                 self.thread.join()
             self.thread = None
+            self.exit = None
 
     def check(self):
         """Check for changes in self.paths or self.cache and call the event handler."""

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -146,13 +146,9 @@ class ToolConfWatcher(object):
             mod_time = os.path.getmtime(path)
         with self._lock:
             self.paths[path] = mod_time
-        if not self._active:
-            self.start()
 
     def watch_file(self, tool_conf_file):
         self.monitor(tool_conf_file)
-        if not self._active:
-            self.start()
 
 
 class ToolWatcher(BaseWatcher):

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -15,37 +15,12 @@ except ImportError:
     can_watch = False
 
 from galaxy.util.hash_util import md5_hash_file
-from galaxy.web_stack import register_postfork_function
+from galaxy.util.watcher import (
+    BaseWatcher,
+    get_observer_class,
+)
 
 log = logging.getLogger(__name__)
-
-
-def get_observer_class(config_value, default, monitor_what_str):
-    """
-    """
-    config_value = config_value or default
-    config_value = str(config_value).lower()
-    if config_value in ("true", "yes", "on", "auto"):
-        expect_observer = True
-        observer_class = Observer
-    elif config_value == "polling":
-        expect_observer = True
-        observer_class = PollingObserver
-    elif config_value in ('false', 'no', 'off'):
-        expect_observer = False
-        observer_class = None
-    else:
-        message = "Unrecognized value for watch_tools config option: %s" % config_value
-        raise Exception(message)
-
-    if expect_observer and observer_class is None:
-        message = "Watchdog library unavailable, cannot monitor %s." % monitor_what_str
-        if config_value == "auto":
-            log.info(message)
-        else:
-            raise Exception(message)
-
-    return observer_class
 
 
 def get_tool_conf_watcher(reload_callback, tool_cache=None):
@@ -53,22 +28,81 @@ def get_tool_conf_watcher(reload_callback, tool_cache=None):
 
 
 def get_tool_data_dir_watcher(tool_data_tables, config):
-    config_value = getattr(config, "watch_tool_data_dir", None)
-    observer_class = get_observer_class(config_value, default="False", monitor_what_str="tool-data directory")
+    config_name = "watch_tool_data_dir"
+    config_value = getattr(config, config_name, None)
+    observer_class = get_observer_class(config_name, config_value, default="False", monitor_what_str="tool-data directory")
     if observer_class is not None:
-        return ToolDataWatcher(observer_class, tool_data_tables=tool_data_tables)
+        return ToolDataWatcher(observer_class, even_handler_class=LocFileEventHandler, tool_data_tables=tool_data_tables)
     else:
         return NullWatcher()
 
 
 def get_tool_watcher(toolbox, config):
-    config_value = getattr(config, "watch_tools", None)
-    observer_class = get_observer_class(config_value, default="False", monitor_what_str="tools")
-
+    config_name = "watch_tools"
+    config_value = getattr(config, config_name, None)
+    observer_class = get_observer_class(config_name, config_value, default="False", monitor_what_str="tools")
     if observer_class is not None:
-        return ToolWatcher(toolbox, observer_class=observer_class)
+        return ToolWatcher(observer_class=observer_class, even_handler_class=ToolFileEventHandler, toolbox=toolbox)
     else:
         return NullWatcher()
+
+
+class LocFileEventHandler(FileSystemEventHandler):
+
+    def __init__(self, loc_watcher):
+        self.loc_watcher = loc_watcher
+
+    def on_any_event(self, event):
+        self._handle(event)
+
+    def _handle(self, event):
+        # modified events will only have src path, move events will
+        # have dest_path and src_path but we only care about dest. So
+        # look at dest if it exists else use src.
+        path = getattr(event, 'dest_path', None) or event.src_path
+        path = os.path.abspath(path)
+        if path.endswith(".loc"):
+            cur_hash = md5_hash_file(path)
+            if cur_hash:
+                if self.loc_watcher.path_hash.get(path) == cur_hash:
+                    return
+                else:
+                    time.sleep(0.5)
+                    if cur_hash != md5_hash_file(path):
+                        # We're still modifying the file, it'll be picked up later
+                        return
+                    self.loc_watcher.path_hash[path] = cur_hash
+                    self.loc_watcher.tool_data_tables.reload_tables(path=path)
+
+
+class ToolFileEventHandler(FileSystemEventHandler):
+
+    def __init__(self, tool_watcher):
+        self.tool_watcher = tool_watcher
+
+    def on_any_event(self, event):
+        self._handle(event)
+
+    def _handle(self, event):
+        # modified events will only have src path, move events will
+        # have dest_path and src_path but we only care about dest. So
+        # look at dest if it exists else use src.
+        path = getattr(event, 'dest_path', None) or event.src_path
+        path = os.path.abspath(path)
+        tool_id = self.tool_watcher.tool_file_ids.get(path, None)
+        if tool_id:
+            try:
+                self.tool_watcher.toolbox.reload_tool_by_id(tool_id)
+            except Exception:
+                pass
+        elif path.endswith(".xml"):
+            directory = os.path.dirname(path)
+            dir_callback = self.tool_watcher.tool_dir_callbacks.get(directory, None)
+            if dir_callback:
+                tool_file = event.src_path
+                tool_id = dir_callback(tool_file)
+                if tool_id:
+                    self.tool_watcher.tool_file_ids[tool_file] = tool_id
 
 
 class ToolConfWatcher(object):
@@ -88,7 +122,7 @@ class ToolConfWatcher(object):
             if self.thread is None:
                 self.thread = threading.Thread(target=self.check)
                 self.thread.daemon = True
-            register_postfork_function(self.thread.start)
+            self.thread.start()
 
     def shutdown(self):
         if self._active:
@@ -174,23 +208,14 @@ class NullToolConfWatcher(object):
         pass
 
 
-class ToolWatcher(object):
+class ToolWatcher(BaseWatcher):
 
-    def __init__(self, toolbox, observer_class):
+    def __init__(self, observer_class, even_handler_class, toolbox):
+        super(ToolWatcher, self).__init__(observer_class, even_handler_class)
         self.toolbox = toolbox
         self.tool_file_ids = {}
         self.tool_dir_callbacks = {}
         self.monitored_dirs = {}
-        self.observer = observer_class()
-        self.event_handler = ToolFileEventHandler(self)
-        self.start()
-
-    def start(self):
-        register_postfork_function(self.observer.start)
-
-    def shutdown(self):
-        self.observer.stop()
-        self.observer.join()
 
     def monitor(self, dir):
         self.observer.schedule(self.event_handler, dir, recursive=False)
@@ -211,22 +236,13 @@ class ToolWatcher(object):
             self.monitor(tool_dir)
 
 
-class ToolDataWatcher(object):
+class ToolDataWatcher(BaseWatcher):
 
-    def __init__(self, observer_class, tool_data_tables):
+    def __init__(self, observer_class, even_handler_class, tool_data_tables):
+        super(ToolDataWatcher, self).__init__(observer_class, even_handler_class)
         self.tool_data_tables = tool_data_tables
         self.monitored_dirs = {}
         self.path_hash = {}
-        self.observer = observer_class()
-        self.event_handler = LocFileEventHandler(self)
-        self.start()
-
-    def start(self):
-        register_postfork_function(self.observer.start)
-
-    def shutdown(self):
-        self.observer.stop()
-        self.observer.join()
 
     def monitor(self, dir):
         self.observer.schedule(self.event_handler, dir, recursive=True)
@@ -236,64 +252,6 @@ class ToolDataWatcher(object):
         if tool_data_dir not in self.monitored_dirs:
             self.monitored_dirs[tool_data_dir] = tool_data_dir
             self.monitor(tool_data_dir)
-
-
-class LocFileEventHandler(FileSystemEventHandler):
-
-    def __init__(self, loc_watcher):
-        self.loc_watcher = loc_watcher
-
-    def on_any_event(self, event):
-        self._handle(event)
-
-    def _handle(self, event):
-        # modified events will only have src path, move events will
-        # have dest_path and src_path but we only care about dest. So
-        # look at dest if it exists else use src.
-        path = getattr(event, 'dest_path', None) or event.src_path
-        path = os.path.abspath(path)
-        if path.endswith(".loc"):
-            cur_hash = md5_hash_file(path)
-            if cur_hash:
-                if self.loc_watcher.path_hash.get(path) == cur_hash:
-                    return
-                else:
-                    time.sleep(0.5)
-                    if cur_hash != md5_hash_file(path):
-                        # We're still modifying the file, it'll be picked up later
-                        return
-                    self.loc_watcher.path_hash[path] = cur_hash
-                    self.loc_watcher.tool_data_tables.reload_tables(path=path)
-
-
-class ToolFileEventHandler(FileSystemEventHandler):
-
-    def __init__(self, tool_watcher):
-        self.tool_watcher = tool_watcher
-
-    def on_any_event(self, event):
-        self._handle(event)
-
-    def _handle(self, event):
-        # modified events will only have src path, move events will
-        # have dest_path and src_path but we only care about dest. So
-        # look at dest if it exists else use src.
-        path = getattr(event, 'dest_path', None) or event.src_path
-        path = os.path.abspath(path)
-        tool_id = self.tool_watcher.tool_file_ids.get(path, None)
-        if tool_id:
-            try:
-                self.tool_watcher.toolbox.reload_tool_by_id(tool_id)
-            except Exception:
-                pass
-        elif path.endswith(".xml"):
-            directory = os.path.dirname(path)
-            dir_callback = self.tool_watcher.tool_dir_callbacks.get(directory, None)
-            if dir_callback:
-                tool_file = event.src_path
-                tool_id = dir_callback(tool_file)
-                if tool_id:
-                    self.tool_watcher.tool_file_ids[tool_file] = tool_id
 
 
 class NullWatcher(object):

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -84,7 +84,7 @@ class ToolConfWatcher(object):
             if self.thread is None:
                 self.thread = threading.Thread(target=self.check)
                 self.thread.daemon = True
-            self.thread.start()
+                self.thread.start()
 
     def shutdown(self):
         if self._active:

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -17,6 +17,7 @@ from galaxy.util.hash_util import md5_hash_file
 from galaxy.util.watcher import (
     BaseWatcher,
     get_observer_class,
+    NullWatcher,
 )
 
 log = logging.getLogger(__name__)
@@ -154,21 +155,6 @@ class ToolConfWatcher(object):
             self.start()
 
 
-class NullToolConfWatcher(object):
-
-    def start(self):
-        pass
-
-    def shutdown(self):
-        pass
-
-    def monitor(self, conf_path):
-        pass
-
-    def watch_file(self, tool_file, tool_id):
-        pass
-
-
 class ToolWatcher(BaseWatcher):
 
     def __init__(self, observer_class, even_handler_class, toolbox):
@@ -195,18 +181,3 @@ class ToolWatcher(BaseWatcher):
         if tool_dir not in self.monitored_dirs:
             self.monitored_dirs[tool_dir] = tool_dir
             self.monitor(tool_dir)
-
-
-class NullWatcher(object):
-
-    def start(self):
-        pass
-
-    def shutdown(self):
-        pass
-
-    def watch_file(self, tool_file, tool_id):
-        pass
-
-    def watch_directory(self, tool_dir, callback=None):
-        pass

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -7,7 +7,6 @@ import logging
 import os
 
 from galaxy.managers import configuration, users
-from galaxy.queue_worker import send_control_task
 from galaxy.web import (
     expose_api,
     expose_api_anonymous_and_sessionless,
@@ -132,7 +131,7 @@ class ConfigurationController(BaseAPIController):
         PUT /api/configuration/toolbox
         Reload the Galaxy toolbox (but not individual tools).
         """
-        send_control_task(self.app.toolbox.app, 'reload_toolbox')
+        self.app.queue_worker.send_control_task('reload_toolbox')
 
 
 def _tool_conf_to_dict(conf):

--- a/lib/galaxy/webapps/galaxy/api/display_applications.py
+++ b/lib/galaxy/webapps/galaxy/api/display_applications.py
@@ -3,7 +3,6 @@ API operations on annotations.
 """
 import logging
 
-from galaxy import queue_worker
 from galaxy.web import legacy_expose_api, require_admin
 from galaxy.webapps.base.controller import BaseAPIController
 
@@ -45,10 +44,11 @@ class DisplayApplicationsController(BaseAPIController):
         :type   ids:  list
         """
         ids = payload.get('ids')
-        queue_worker.send_control_task(trans.app,
+        trans.app.queue_worker.send_control_task(
             'reload_display_application',
             noop_self=True,
-            kwargs={'display_application_ids': ids})
+            kwargs={'display_application_ids': ids}
+        )
         reloaded, failed = trans.app.datatypes_registry.reload_display_applications(ids)
         if not reloaded and failed:
             message = 'Unable to reload any of the %i requested display applications ("%s").' % (len(failed), '", "'.join(failed))

--- a/lib/galaxy/webapps/galaxy/api/tool_data.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_data.py
@@ -1,6 +1,5 @@
 import os
 
-import galaxy.queue_worker
 from galaxy import (
     exceptions,
     web
@@ -42,9 +41,11 @@ class ToolData(BaseAPIController):
         decoded_tool_data_id = id
         data_table = trans.app.tool_data_tables.data_tables.get(decoded_tool_data_id)
         data_table.reload_from_files()
-        galaxy.queue_worker.send_control_task(trans.app, 'reload_tool_data_tables',
-                                              noop_self=True,
-                                              kwargs={'table_name': decoded_tool_data_id})
+        trans.app.queue_worker.send_control_task(
+            'reload_tool_data_tables',
+            noop_self=True,
+            kwargs={'table_name': decoded_tool_data_id}
+        )
         return self._data_table(decoded_tool_data_id).to_dict(view='element')
 
     @web.require_admin
@@ -87,9 +88,11 @@ class ToolData(BaseAPIController):
             return "Invalid data table item ( %s ) specified. Wrong number of columns (%s given, %s required)." % (str(values), str(len(split_values)), str(len(data_table.get_column_name_list())))
 
         data_table.remove_entry(split_values)
-        galaxy.queue_worker.send_control_task(trans.app, 'reload_tool_data_tables',
-                                              noop_self=True,
-                                              kwargs={'table_name': decoded_tool_data_id})
+        trans.app.queue_worker.send_control_task(
+            'reload_tool_data_tables',
+            noop_self=True,
+            kwargs={'table_name': decoded_tool_data_id}
+        )
         return self._data_table(decoded_tool_data_id).to_dict(view='element')
 
     @web.require_admin

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -2,7 +2,6 @@ import logging
 import os
 from json import dumps, loads
 
-import galaxy.queue_worker
 from galaxy import exceptions, managers, util, web
 from galaxy.managers.collections_util import dictify_dataset_collection_instance
 from galaxy.tools import global_tool_errors
@@ -220,7 +219,7 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         GET /api/tools/{tool_id}/reload
         Reload specified tool.
         """
-        galaxy.queue_worker.send_control_task(trans.app, 'reload_tool', noop_self=True, kwargs={'tool_id': id})
+        trans.app.queue_worker.send_control_task('reload_tool', noop_self=True, kwargs={'tool_id': id})
         message, status = trans.app.toolbox.reload_tool_by_id(id)
         if status == 'error':
             raise exceptions.MessageException(message)

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -194,7 +194,7 @@ uwsgi_app_factory = uwsgi_app
 
 def postfork_setup():
     from galaxy.app import app
-    app.control_worker.bind_and_start()
+    app.queue_worker.bind_and_start()
     app.application_stack.log_startup()
 
 

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -8,7 +8,6 @@ from string import punctuation as PUNCTUATION
 import six
 from sqlalchemy import and_, false, or_
 
-import galaxy.queue_worker
 from galaxy import (
     model,
     util,
@@ -1609,7 +1608,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
     def jobs_control(self, trans, job_lock=None, **kwd):
         if job_lock is not None:
             job_lock = True if job_lock == 'true' else False
-            galaxy.queue_worker.send_control_task(trans.app, 'admin_job_lock', kwargs={'job_lock': job_lock}, get_response=True)
+            trans.app.queue_worker.send_control_task('admin_job_lock', kwargs={'job_lock': job_lock}, get_response=True)
         job_lock = trans.app.job_manager.job_lock
         return {'job_lock': job_lock}
 
@@ -1757,7 +1756,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                 new_whitelist = sorted([tid for tid in tools_to_whitelist if tid in trans.app.toolbox.tools_by_id])
                 f.write("\n".join(new_whitelist))
             trans.app.config.sanitize_whitelist = new_whitelist
-            galaxy.queue_worker.send_control_task(trans.app, 'reload_sanitize_whitelist', noop_self=True)
+            trans.app.queue_worker.send_control_task('reload_sanitize_whitelist', noop_self=True)
             # dispatch a message to reload list for other processes
         return trans.fill_template('/webapps/galaxy/admin/sanitize_whitelist.mako',
                                    sanitize_all=trans.app.config.sanitize_all_html,

--- a/lib/galaxy/webapps/galaxy/controllers/data_manager.py
+++ b/lib/galaxy/webapps/galaxy/controllers/data_manager.py
@@ -4,7 +4,6 @@ from json import loads
 import paste.httpexceptions
 from six import string_types
 
-import galaxy.queue_worker
 from galaxy import web
 from galaxy.util import nice_size, unicodify
 from galaxy.webapps.base.controller import BaseUIController
@@ -174,9 +173,11 @@ class DataManager(BaseUIController):
             table_name = table_name.split(",")
         # Reload the tool data tables
         table_names = self.app.tool_data_tables.reload_tables(table_names=table_name)
-        galaxy.queue_worker.send_control_task(trans.app, 'reload_tool_data_tables',
-                                              noop_self=True,
-                                              kwargs={'table_name': table_name})
+        trans.app.queue_worker.send_control_task(
+            'reload_tool_data_tables',
+            noop_self=True,
+            kwargs={'table_name': table_name}
+        )
         data = None
         if table_names:
             message = "Reloaded data table%s '%s'." % ('s'[len(table_names) == 1:],

--- a/test/unit/queue_worker/test_database_heartbeat.py
+++ b/test/unit/queue_worker/test_database_heartbeat.py
@@ -8,13 +8,15 @@ import galaxy.web_stack as stack
 
 
 @pytest.fixture
-def heartbeat_app(database_app, monkeypatch):
+def heartbeat_app(database_app):
 
-    def test_send_control_task(*args, **kwargs):
-        return
+    class QueueWorker(object):
 
-    monkeypatch.setattr(heartbeat, "send_control_task", test_send_control_task)
+        def send_control_task(self, *args, **kwargs):
+            return
+
     with setup_heartbeat_app(database_app()) as heartbeat_app:
+        heartbeat_app.queue_worker = QueueWorker()
         yield heartbeat_app
 
 

--- a/test/unit/queue_worker/test_database_heartbeat.py
+++ b/test/unit/queue_worker/test_database_heartbeat.py
@@ -3,8 +3,8 @@ import time
 
 import pytest
 
+import galaxy.model.database_heartbeat as heartbeat
 import galaxy.web_stack as stack
-from galaxy.model.database_heartbeat import DatabaseHeartbeat
 
 
 @pytest.fixture
@@ -13,7 +13,7 @@ def heartbeat_app(database_app, monkeypatch):
     def test_send_control_task(*args, **kwargs):
         return
 
-    monkeypatch.setattr(stack.database_heartbeat, "send_control_task", test_send_control_task)
+    monkeypatch.setattr(heartbeat, "send_control_task", test_send_control_task)
     with setup_heartbeat_app(database_app()) as heartbeat_app:
         yield heartbeat_app
 
@@ -23,7 +23,7 @@ def setup_heartbeat_app(app):
     app.config.server_name = 'test_heartbeat'
     app.config.attach_to_pools = False
     app.application_stack = stack.application_stack_instance(app=app)
-    app.database_heartbeat = DatabaseHeartbeat(application_stack=app.application_stack, heartbeat_interval=0.1)
+    app.database_heartbeat = heartbeat.DatabaseHeartbeat(application_stack=app.application_stack, heartbeat_interval=0.1)
     yield app
     app.database_heartbeat.shutdown()
 

--- a/test/unit/queue_worker/test_database_heartbeat.py
+++ b/test/unit/queue_worker/test_database_heartbeat.py
@@ -3,8 +3,8 @@ import time
 
 import pytest
 
-from galaxy.model.database_heartbeat import DatabaseHeartbeat
 import galaxy.web_stack as stack
+from galaxy.model.database_heartbeat import DatabaseHeartbeat
 
 
 @pytest.fixture

--- a/test/unit/queue_worker/test_queue_worker.py
+++ b/test/unit/queue_worker/test_queue_worker.py
@@ -27,7 +27,7 @@ def queue_worker_factory(request, database_app):
 
     def app_factory():
         app = setup_queue_worker_test(database_app())
-        request.addfinalizer(app.control_worker.shutdown)
+        request.addfinalizer(app.queue_worker.shutdown)
         request.addfinalizer(app.database_heartbeat.shutdown)
         return app
 
@@ -46,8 +46,8 @@ def setup_queue_worker_test(app):
     app.database_heartbeat = DatabaseHeartbeat(application_stack=app.application_stack, heartbeat_interval=10)
     app.database_heartbeat.start()
     time.sleep(0.2)
-    app.control_worker = GalaxyQueueWorker(app=app, task_mapping=control_message_to_task)
-    app.control_worker.bind_and_start()
+    app.queue_worker = GalaxyQueueWorker(app=app, task_mapping=control_message_to_task)
+    app.queue_worker.bind_and_start()
     time.sleep(0.5)
     return app
 

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -64,7 +64,7 @@ class BaseToolBoxTestCase(unittest.TestCase, UsesApp, UsesTools):
         self.app.reindex_tool_search = self.__reindex
         itp_config = os.path.join(self.test_directory, "integrated_tool_panel.xml")
         self.app.config.integrated_tool_panel_config = itp_config
-        self.app.watchers = ConfigWatchers(self.app, start_thread=False)
+        self.app.watchers = ConfigWatchers(self.app)
         self._toolbox = None
         self.config_files = []
 

--- a/test/unit/tools/test_watcher.py
+++ b/test/unit/tools/test_watcher.py
@@ -37,6 +37,7 @@ def test_tool_conf_watcher():
 
     callback = CallbackRecorder()
     conf_watcher = watcher.get_tool_conf_watcher(callback.call)
+    conf_watcher.start()
 
     with __test_directory() as t:
         tool_conf_path = path.join(t, "test_conf.xml")

--- a/test/unit/tools/test_watcher.py
+++ b/test/unit/tools/test_watcher.py
@@ -20,13 +20,14 @@ def test_watcher():
         tool_watcher = watcher.get_tool_watcher(toolbox, bunch.Bunch(
             watch_tools=True
         ))
+        tool_watcher.start()
         time.sleep(1)
         tool_watcher.watch_file(tool_path, "cool_tool")
         assert not toolbox.was_reloaded("cool_tool")
         open(tool_path, "w").write("b")
         wait_for_reload(lambda: toolbox.was_reloaded("cool_tool"))
         tool_watcher.shutdown()
-        assert not tool_watcher.observer.is_alive()
+        assert tool_watcher.observer is None
 
 
 def test_tool_conf_watcher():

--- a/test/unit/tools/test_watcher.py
+++ b/test/unit/tools/test_watcher.py
@@ -45,7 +45,7 @@ def test_tool_conf_watcher():
         open(tool_conf_path, "w").write("b")
         wait_for_reload(lambda: callback.called)
         conf_watcher.shutdown()
-        assert not conf_watcher.thread.is_alive()
+        assert conf_watcher.thread is None
 
 
 def wait_for_reload(check):


### PR DESCRIPTION
This should reduce IO especially on instances that use a lot of
handlers and/or where the config files are on a remote file system.

The process that watches the config files will now
be the active process that alphabetically compares highest.
If that process goes away or is superseded by a process that
compares higher now that process will take over.
If a change has been found a control task will be sent via
the kombu messaging system.

~~Overall this works nicely, but while stopping the current
config watcher there is a small break during which changes
to the config don't trigger a reload, this could be handled
more gracefully.~~
When stopping the current config watcher the shutdown
method in the DatabaseHeartbeat class will remove itself
from the `WorkerProcess`es and trigger a reconfiguration
of the watcher processes.

This also includes some cleanup in the actual watchers,
and uses the more generally useful `get_watcher` and
`EventHandler` instead of custom factories and Event
Handler classes