### PR TITLE
[19.01] Fix multipanel history search.

### DIFF
--- a/client/galaxy/scripts/mvc/history/multi-panel.js
+++ b/client/galaxy/scripts/mvc/history/multi-panel.js
@@ -473,7 +473,7 @@ var MultiPanelColumns = Backbone.View.extend(baseMVC.LoggableMixin).extend({
 
     /** create a column and its panel and set up any listeners to them */
     createColumn: function createColumn(history, options) {
-        let Galaxy = getGalaxyInstance();
+        const Galaxy = getGalaxyInstance();
         // options passed can be re-used, so extend them before adding the model to prevent pollution for the next
         options = _.extend({}, options, {
             model: history,
@@ -836,17 +836,17 @@ var MultiPanelColumns = Backbone.View.extend(baseMVC.LoggableMixin).extend({
     setUpBehaviors: function() {
         this._moreOptionsPopover();
         const searchHistories = searchFor => {
-                const multipanel = this;
-                this.historySearch = searchFor;
-                this.filters = [
-                    function() {
-                        // This is intentionally a function where 'this' gets
-                        // bound, applying the filter to the model of the
-                        // caller.
-                        return this.model.matchesAll(multipanel.historySearch);
-                    }
-                ];
-                this.renderColumns(0);
+            const multipanel = this;
+            this.historySearch = searchFor;
+            this.filters = [
+                function() {
+                    // This is intentionally a function where 'this' gets
+                    // bound, applying the filter to the model of the
+                    // caller.
+                    return this.model.matchesAll(multipanel.historySearch);
+                }
+            ];
+            this.renderColumns(0);
         };
         // input to search histories
         this.$("#search-histories").searchInput({

--- a/client/galaxy/scripts/mvc/history/multi-panel.js
+++ b/client/galaxy/scripts/mvc/history/multi-panel.js
@@ -756,7 +756,6 @@ var MultiPanelColumns = Backbone.View.extend(baseMVC.LoggableMixin).extend({
         "click .order .set-order": "_chooseOrder",
         "click #toggle-deleted": "_clickToggleDeletedDatasets",
         "click #toggle-hidden": "_clickToggleHiddenDatasets"
-        //'dragstart .list-item .title-bar'                       : function( e ){ console.debug( 'ok' ); }
     },
 
     close: function(ev) {
@@ -768,6 +767,7 @@ var MultiPanelColumns = Backbone.View.extend(baseMVC.LoggableMixin).extend({
         this.toggleDeletedHistories($(ev.currentTarget).is(":checked"));
         this.toggleOptionsPopover();
     },
+
     /** Include deleted histories in the collection */
     toggleDeletedHistories: function(show) {
         if (show) {
@@ -835,20 +835,7 @@ var MultiPanelColumns = Backbone.View.extend(baseMVC.LoggableMixin).extend({
     /** Set up any view plugins */
     setUpBehaviors: function() {
         this._moreOptionsPopover();
-        // input to search histories
-        this.$("#search-histories").searchInput({
-            name: "search-histories",
-            placeholder: _l("search histories"),
-
-            onfirstsearch: searchFor => {
-                this.$("#search-histories").searchInput("toggle-loading");
-                this.renderInfo(_l("loading all histories for search"));
-                this.collection.fetchAll().done(() => {
-                    this.$("#search-histories").searchInput("toggle-loading");
-                    this.renderInfo("");
-                });
-            },
-            onsearch: searchFor => {
+        const searchHistories = searchFor => {
                 const multipanel = this;
                 this.historySearch = searchFor;
                 this.filters = [
@@ -860,7 +847,23 @@ var MultiPanelColumns = Backbone.View.extend(baseMVC.LoggableMixin).extend({
                     }
                 ];
                 this.renderColumns(0);
+        };
+        // input to search histories
+        this.$("#search-histories").searchInput({
+            name: "search-histories",
+            placeholder: _l("search histories"),
+
+            onfirstsearch: searchFor => {
+                this.$("#search-histories").searchInput("toggle-loading");
+                this.renderInfo(_l("loading all histories for search"));
+                this.collection.fetchAll().done(() => {
+                    this.$("#search-histories").searchInput("toggle-loading");
+                    this.renderInfo("");
+                    searchHistories(searchFor);
+                });
             },
+
+            onsearch: searchHistories,
             onclear: searchFor => {
                 this.historySearch = null;
                 //TODO: remove specifically not just reset

--- a/client/galaxy/scripts/mvc/history/multi-panel.js
+++ b/client/galaxy/scripts/mvc/history/multi-panel.js
@@ -835,7 +835,6 @@ var MultiPanelColumns = Backbone.View.extend(baseMVC.LoggableMixin).extend({
     /** Set up any view plugins */
     setUpBehaviors: function() {
         this._moreOptionsPopover();
-
         // input to search histories
         this.$("#search-histories").searchInput({
             name: "search-histories",
@@ -850,10 +849,14 @@ var MultiPanelColumns = Backbone.View.extend(baseMVC.LoggableMixin).extend({
                 });
             },
             onsearch: searchFor => {
+                const multipanel = this;
                 this.historySearch = searchFor;
                 this.filters = [
-                    () => {
-                        return this.model.matchesAll(this.historySearch);
+                    function() {
+                        // This is intentionally a function where 'this' gets
+                        // bound, applying the filter to the model of the
+                        // caller.
+                        return this.model.matchesAll(multipanel.historySearch);
                     }
                 ];
                 this.renderColumns(0);


### PR DESCRIPTION
Fixes #8084 

Additionally fixes another bug found where the first search fetched the data to search but didn't, well, search it.  Now it does.