### PR TITLE
Move pykube from conditional requirements to pinned requirements.

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -143,9 +143,6 @@ class ConditionalDependencies(object):
     def check_pbs_python(self):
         return "galaxy.jobs.runners.pbs:PBSJobRunner" in self.job_runners
 
-    def check_pykube(self):
-        return "galaxy.jobs.runners.kubernetes:KubernetesJobRunner" in self.job_runners
-
     def check_chronos_python(self):
         return "galaxy.jobs.runners.chronos:ChronosJobRunner" in self.job_runners
 

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -17,9 +17,6 @@ galaxycloudrunner
 # Chronos client
 chronos-python==0.38.0
 
-# Kubernetes job runner
-pykube==0.15.0
-
 # Synnefo / Pithos+ object store client
 kamaki
 

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -126,6 +126,7 @@ pycryptodome==3.8.1
 pyeventsystem==0.1.0
 pyinotify==0.9.6 ; sys_platform != 'win32' and sys_platform != 'darwin' and sys_platform != 'sunos5'
 pyjwt==1.7.1
+pykube==0.15.0
 pykwalify==1.7.0
 pynacl==1.3.0
 pyopenssl==19.0.0


### PR DESCRIPTION
Since pykube is necessary for some tests now (e.g., https://github.com/galaxyproject/galaxy/pull/7835), and might be required for more tests in the future, hence maybe it might be easier to install it by default.

ping @jmchilton @nsoranzo 