### PR TITLE
Fix k8s runasuser

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -54,8 +54,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_job_api_version=dict(map=str, default="batch/v1"),
             k8s_supplemental_group_id=dict(map=str),
             k8s_pull_policy=dict(map=str, default="Default"),
-            k8s_run_as_user_id=dict(map=int, default=os.getuid()),
-            k8s_run_as_group_id=dict(map=int, default=app.config.gid),
+            k8s_run_as_user_id=dict(map=str, valid=lambda s: s == "$uid" or s.isdigit()),
+            k8s_run_as_group_id=dict(map=str, valid=lambda s: s == "$gid" or s.isdigit()),
             k8s_fs_group_id=dict(map=int),
             k8s_default_requests_cpu=dict(map=str, default=None),
             k8s_default_requests_memory=dict(map=str, default=None),
@@ -77,6 +77,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         self._galaxy_instance_id = self.__get_galaxy_instance_id()
 
+        self._run_as_user_id = self.__get_run_as_user_id()
+        self._run_as_group_id = self.__get_run_as_group_id()
         self._supplemental_group = self.__get_supplemental_group()
         self._fs_group = self.__get_fs_group()
         self._default_pull_policy = self.__get_pull_policy()
@@ -170,6 +172,24 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 return self.runner_params['k8s_pull_policy']
         return None
 
+    def __get_run_as_user_id(self):
+        if "k8s_run_as_user_id" in self.runner_params:
+            run_as_user = self.runner_params["k8s_run_as_user_id"]
+            if run_as_user == "$uid":
+                return os.getuid()
+            else:
+                return int(self.runner_params["k8s_run_as_user_id"]),
+        return None
+
+    def __get_run_as_group_id(self):
+        if "k8s_run_as_group_id" in self.runner_params:
+            run_as_group = self.runner_params["k8s_run_as_group_id"]
+            if run_as_group == "$gid":
+                return self.app.config.gid
+            else:
+                return int(self.runner_params["k8s_run_as_group_id"]),
+        return None
+
     def __get_supplemental_group(self):
         if "k8s_supplemental_group_id" in self.runner_params:
             try:
@@ -243,10 +263,11 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         return k8s_spec_template
 
     def __get_k8s_security_context(self):
-        security_context = {
-            "runAsUser": int(self.runner_params["k8s_run_as_user_id"]),
-            "runAsGroup": int(self.runner_params["k8s_run_as_group_id"])
-        }
+        security_context = {}
+        if self._run_as_user_id:
+            security_context["runAsUser"] = self._run_as_user_id
+        if self._run_as_group_id:
+            security_context["runAsGroup"] = self._run_as_group_id
         if self._supplemental_group and self._supplemental_group > 0:
             security_context["supplementalGroups"] = [self._supplemental_group]
         if self._fs_group and self._fs_group > 0:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -54,6 +54,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_job_api_version=dict(map=str, default="batch/v1"),
             k8s_supplemental_group_id=dict(map=str),
             k8s_pull_policy=dict(map=str, default="Default"),
+            k8s_run_as_user_id=dict(map=int, default=os.getuid()),
+            k8s_run_as_group_id=dict(map=int, default=app.config.gid),
             k8s_fs_group_id=dict(map=int),
             k8s_default_requests_cpu=dict(map=str, default=None),
             k8s_default_requests_memory=dict(map=str, default=None),
@@ -237,16 +239,19 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         }
         # TODO include other relevant elements that people might want to use from
         # TODO http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_podspec
-
-        if self._supplemental_group and self._supplemental_group > 0:
-            k8s_spec_template["spec"]["securityContext"] = dict(supplementalGroups=[self._supplemental_group])
-        if self._fs_group and self._fs_group > 0:
-            if "securityContext" in k8s_spec_template["spec"]:
-                k8s_spec_template["spec"]["securityContext"]["fsGroup"] = self._fs_group
-            else:
-                k8s_spec_template["spec"]["securityContext"] = dict(fsGroup=self._fs_group)
-
+        k8s_spec_template["spec"]["securityContext"] = self.__get_k8s_security_context()
         return k8s_spec_template
+
+    def __get_k8s_security_context(self):
+        security_context = {
+            "runAsUser": int(self.runner_params["k8s_run_as_user_id"]),
+            "runAsGroup": int(self.runner_params["k8s_run_as_group_id"])
+        }
+        if self._supplemental_group and self._supplemental_group > 0:
+            security_context["supplementalGroups"] = [self._supplemental_group]
+        if self._fs_group and self._fs_group > 0:
+            security_context["fsGroup"] = self._fs_group
+        return security_context
 
     def __get_k8s_restart_policy(self, job_wrapper):
         """The default Kubernetes restart policy for Jobs"""


### PR DESCRIPTION
Based on the discussion here: https://github.com/galaxyproject/galaxy/pull/8089, I'm reopening this as a bug fix, as the k8srunner's job pods run as the default container user, which may be root, and therefore,  incorrectly sets file ownership on the shared filesystem.

This PR allows for specifying the docker user and group when running the job pod, so that file ownership propagates as expected. The integer values for the uid and gid can be specified, and it also allows for the special values $uid and $gid that will be replaced by the job handler's uid and gid respectively.