### PR TITLE
[19.05] Restored google analytics inits in mako templates

### DIFF
--- a/templates/base.mako
+++ b/templates/base.mako
@@ -65,7 +65,9 @@
 
     ${ galaxy_client.load( app=self.js_app ) }
     ${ galaxy_client.config_sentry( app=self.js_app ) }
-    ${ galaxy_client.config_google_analytics( app=self.js_app ) }
+    %if self.js_app and self.js_app.config and self.js_app.config.ga_code:
+        ${ galaxy_client.config_google_analytics(self.js_app.config.ga_code) }
+    %endif
 
     %if not form_input_auto_focus is UNDEFINED and form_input_auto_focus:
         <script type="text/javascript">

--- a/templates/base/base_panels.mako
+++ b/templates/base/base_panels.mako
@@ -70,7 +70,7 @@
     </script>
 
     %if t.webapp.name == 'galaxy' and app.config.ga_code:
-        ${galaxy_client.config_google_analytics(app)}
+        ${galaxy_client.config_google_analytics(app.config.ga_code)}
     %endif
 
 </%def>

--- a/templates/galaxy_client_app.mako
+++ b/templates/galaxy_client_app.mako
@@ -39,8 +39,6 @@ ${ h.dumps( dictionary, indent=( 2 if trans.debug else 0 ) ) }
     %if app and app.config:
         <script type="text/javascript">
 
-            // TODO: make this work the same in all places, maybe 
-            // make a global func in galaxy_client_app?
             var sentry = {};
             %if app.config.sentry_dsn:
                 sentry.sentry_dsn_public = "${app.config.sentry_dsn_public}"
@@ -57,17 +55,20 @@ ${ h.dumps( dictionary, indent=( 2 if trans.debug else 0 ) ) }
     %endif
 </%def>
 
-<%def name="config_google_analytics(app)">
-    %if app and app.config and app.config.ga_code:
-        <script>
+<%def name="config_google_analytics(ga_code)">
+    <script>
+        console.log("config_google_analytics ga_code:", '${ga_code}');
+        %if ga_code:
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-            ga('create', '${app.config.ga_code}', 'auto');
+            ga('create', '${ga_code}', 'auto');
             ga('send', 'pageview');
-        </script>
-    %endif
+        %else:
+            console.warn("Missing google analytics code");
+        %endif
+    </script>
 </%def>
 
 

--- a/templates/js-app.mako
+++ b/templates/js-app.mako
@@ -74,8 +74,10 @@
     </script>
     %endif
 
-    ## ${ galaxy_client.config_sentry(app)}
-    ## ${ galaxy_client.config_google_analytics(app)}
+    ${ galaxy_client.config_sentry(app) }
+    %if app.config.ga_code:
+        ${ galaxy_client.config_google_analytics(app.config.ga_code) }
+    %endif
 
 </%def>
 

--- a/templates/webapps/galaxy/galaxy.panels.mako
+++ b/templates/webapps/galaxy/galaxy.panels.mako
@@ -225,7 +225,7 @@
     </script>
 
     ${ galaxy_client.load() }
-    ## ${ galaxy_client.config_sentry(app) }
+    ${ galaxy_client.config_sentry(app) }
 
 </%def>
 

--- a/templates/webapps/tool_shed/base_panels.mako
+++ b/templates/webapps/tool_shed/base_panels.mako
@@ -46,7 +46,7 @@
 <%def name="masthead()">
 
     %if app.config.ga_code:
-        ${galaxy_client.config_google_analytics(app)}
+        ${ galaxy_client.config_google_analytics(app.config.ga_code)}
     %endif
 
     ## start main tag


### PR DESCRIPTION
Looks like I commented out a call to the analytics and sentry inits during my reorganization of all those init scripts. Restored that, added some minor parameter checking to make sure the google analytics code is actually configured.