### PR TITLE
Redirect to welcome page after successful handling of oidc callback.

### DIFF
--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -280,7 +280,10 @@ class JSAppLauncher(BaseUIController):
         Should not be used with url_for -- see
         (https://github.com/galaxyproject/galaxy/issues/1878) for why.
         """
-        self._check_require_login(trans)
+        if kwd.get("successful_oidc_callback", False):
+            trans.response.send_redirect(web.url_for(controller="root", action="welcome"))
+        else:
+            self._check_require_login(trans)
         return self._bootstrapped_client(trans, **kwd)
 
     def _bootstrapped_client(self, trans, app_name='analysis', **kwd):

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -79,7 +79,7 @@ class OIDC(JSAppLauncher):
                                             "identity provider. Please try again, and if the problem persists, "
                                             "contact the Galaxy instance admin.".format(provider))
         trans.handle_user_login(user)
-        return self.client(trans)
+        return self.client(trans, successful_oidc_callback=True)
 
     @web.expose
     @web.require_login("authenticate against the selected identity provider")


### PR DESCRIPTION
Fix xref: https://github.com/galaxyproject/galaxy/issues/8099

This PR implements: 
- redirect to welcome page after oidc callback is successfully handled; 
- remove callback url, hence remove the ability of resending the callback url by refreshing the page. 

One issue is that it shows welcome page without the side panels. Any thoughts?

ping @dannon @erasche 