### PR TITLE
[19.05] Fix error in recognizing destination default container image

### DIFF
--- a/lib/galaxy/tools/deps/containers.py
+++ b/lib/galaxy/tools/deps/containers.py
@@ -148,7 +148,7 @@ class ContainerFinder(object):
             key = "%s_image" % container_type
         if key in destination_info:
             return destination_info.get(key)
-        elif "%s_image_default" in destination_info:
+        elif "%s_image_default" % container_type in destination_info:
             return self.__build_container_id_from_parts(container_type, destination_info, mode="default")
         return None
 
@@ -159,7 +159,7 @@ class ContainerFinder(object):
 
         # TODO: Right now this assumes all containers available when a
         # container type is - there should be more thought put into this.
-        # Checking which are availalbe - settings policies for what can be
+        # Checking which are available - settings policies for what can be
         # auto-fetched, etc....
         return CONTAINER_CLASSES[container_type](container_id, self.app_info, tool_info, destination_info, job_info, container_description)
 


### PR DESCRIPTION
Closes: https://github.com/galaxyproject/galaxy/issues/8115

There is a workaround available, which is to specify the full container id with: `docker_default_container_id`. Should I close the PR and make it against the dev branch instead?