### PR TITLE
Update cloudauthz to its latest version 

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -29,7 +29,6 @@ nosehtml==0.4.5
 packaging==19.0
 pathlib2==2.3.2 ; python_version < '3'
 pathtools==0.1.2
-pbr==5.1.3
 pluggy==0.12.0
 port-for==0.4
 psutil==5.6.2

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -4,22 +4,25 @@ alabaster==0.7.12
 argh==0.26.2
 atomicwrites==1.3.0
 attrs==19.1.0
-babel==2.6.0
+babel==2.7.0
 certifi==2019.3.9
 chardet==3.0.4
-commonmark==0.8.1
+commonmark==0.9.0
+configparser==3.7.4 ; python_version < '3.2'
+contextlib2==0.5.5 ; python_version < '3.5'
 docutils==0.14
 funcsigs==1.0.2 ; python_version < '3.3'
 future==0.17.1
 gunicorn==19.9.0
 idna==2.8
 imagesize==1.1.0
+importlib-metadata==0.17
 jinja2==2.10.1
 lxml==4.3.3
 markdown==2.6.11
 markupsafe==1.1.1
 mirakuru==1.1.0
-mock==2.0.0
+mock==3.0.5
 more-itertools==5.0.0
 nose==1.3.7
 nosehtml==0.4.5
@@ -27,22 +30,22 @@ packaging==19.0
 pathlib2==2.3.2 ; python_version < '3'
 pathtools==0.1.2
 pbr==5.1.3
-pluggy==0.9.0
+pluggy==0.12.0
 port-for==0.4
-psutil==5.6.1
+psutil==5.6.2
 py==1.8.0
 pygithub3==0.5.1 ; python_version < '3'
-pygments==2.3.1
+pygments==2.4.2
 pyparsing==2.4.0
 pytest-html==1.20.0
 pytest-metadata==1.8.0
-pytest-postgresql==1.4.0
+pytest-postgresql==1.4.1
 pytest-pythonpath==0.7.3
-pytest==4.4.1
+pytest==4.6.2
 pytz==2019.1
-pyyaml==5.1
+pyyaml==5.1.1
 recommonmark==0.5.0
-requests==2.21.0
+requests==2.22.0
 scandir==1.10.0 ; python_version < '3.5'
 selenium==3.141.0
 six==1.11.0
@@ -50,9 +53,11 @@ snowballstemmer==1.2.1
 sphinx-markdown-tables==0.0.9
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
-sphinxcontrib-websupport==1.1.0
-testfixtures==6.7.0
+sphinxcontrib-websupport==1.1.2
+testfixtures==6.8.2
 twill==0.9.1 ; python_version < '3'
 typing==3.6.6 ; python_version < '3.5'
-urllib3==1.24.2 ; python_version == '2.7'
+urllib3==1.25.3 ; python_version == '2.7'
 watchdog==0.9.0
+wcwidth==0.1.7 ; sys_platform != 'win32'
+zipp==0.5.1

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -1,9 +1,10 @@
 -i https://wheels.galaxyproject.org/simple
 --extra-index-url https://pypi.python.org/simple
 adal==1.2.1
-amqp==2.4.2
+amqp==2.5.0
 appdirs==1.4.3
 asn1crypto==0.24.0
+attrs==19.1.0
 avro==1.8.1 ; python_version < '3'
 azure-common==1.1.14
 azure-cosmosdb-nspkg==2.0.2
@@ -16,9 +17,9 @@ azure-mgmt-resource==2.0.0
 azure-mgmt-storage==2.0.0
 azure-nspkg==3.0.2
 azure-storage-blob==1.3.1
-azure-storage-common==1.4.0
+azure-storage-common==1.4.2
 azure-storage-nspkg==3.1.0
-babel==2.6.0
+babel==2.7.0
 bagit==1.6.4
 bcrypt==3.1.6
 bdbag==1.4.1
@@ -28,21 +29,21 @@ bleach==3.1.0
 boltons==19.1.0
 boto3==1.9.114
 boto==2.49.0
-botocore==1.12.133
+botocore==1.12.164
 bx-python==0.8.2
 bz2file==0.98 ; python_version < '3.3'
 cachecontrol==0.11.7
-cachetools==3.1.0
+cachetools==3.1.1
 certifi==2019.3.9
 cffi==1.12.3
 chardet==3.0.4
-cheetah3==3.2.2
+cheetah3==3.2.3
 cliff==2.14.1
-cloudauthz==0.3.0
+cloudauthz==0.2.0
 cloudbridge==2.0.0
 cmd2==0.8.9
 contextlib2==0.5.5 ; python_version < '3.5'
-cryptography==2.6.1
+cryptography==2.7
 cwltool==1.0.20180721142728
 debtcollector==1.21.0
 decorator==4.4.0
@@ -65,7 +66,7 @@ google-auth-httplib2==0.0.3
 google-auth==1.6.3
 gxformat2==0.8.3
 h5py==2.9.0
-httplib2==0.12.1
+httplib2==0.13.0
 idna==2.8
 ipaddress==1.0.22 ; python_version < '3.3'
 isa-rwval==0.10.7
@@ -74,12 +75,12 @@ isodate==0.6.0
 jmespath==0.9.4
 jsonpatch==1.23
 jsonpointer==2.0
-jsonschema==2.6.0
+jsonschema==3.0.1
 keystoneauth1==3.14.0
-kombu==4.5.0
+kombu==4.6.1
 lockfile==0.12.2
 lxml==4.3.3
-mako==1.0.9
+mako==1.0.12
 markupsafe==1.1.1
 mercurial==3.7.3 ; python_version < '3'
 mistune==0.8.4
@@ -94,35 +95,35 @@ netifaces==0.10.9
 networkx==1.11
 nodeenv==1.3.3
 nose==1.3.7
-numpy==1.16.2
+numpy==1.16.4
 oauth2client==4.1.3
 oauthlib==3.0.1
 openstacksdk==0.17.0
 os-client-config==1.32.0
-os-service-types==1.6.0
+os-service-types==1.7.0
 osc-lib==1.12.1
-oslo.config==6.8.1
+oslo.config==6.9.0
 oslo.context==2.22.1
 oslo.i18n==3.23.1
-oslo.log==3.42.3
-oslo.serialization==2.28.2
-oslo.utils==3.40.3
+oslo.log==3.44.0
+oslo.serialization==2.29.1
+oslo.utils==3.41.0
 packaging==19.0
 paramiko==2.4.2
 parsley==1.3
-paste==3.0.8
+paste==3.0.8 ; python_version == '2.7'
 pastedeploy==2.0.1
 pastescript==3.1.0
 pathlib2==2.3.2 ; python_version < '3'
-pbr==5.1.3
+pbr==5.2.1
 prettytable==0.7.2
 prov==1.5.1
-psutil==5.6.1
-pulsar-galaxy-lib==0.11.0
-pyasn1-modules==0.2.4
+psutil==5.6.2
+pulsar-galaxy-lib==0.12.1
+pyasn1-modules==0.2.5
 pyasn1==0.4.5
 pycparser==2.19
-pycryptodome==3.8.1
+pycryptodome==3.8.2
 pyeventsystem==0.1.0
 pyinotify==0.9.6 ; sys_platform != 'win32' and sys_platform != 'darwin' and sys_platform != 'sunos5'
 pyjwt==1.7.1
@@ -131,6 +132,7 @@ pynacl==1.3.0
 pyopenssl==19.0.0
 pyparsing==2.4.0
 pyperclip==1.7.0
+pyrsistent==0.15.2
 pysam==0.15.2
 pysftp==0.2.9
 python-cinderclient==4.0.0
@@ -144,32 +146,32 @@ python-novaclient==11.0.0
 python-openid==2.2.5 ; python_version < '3.0'
 python-swiftclient==3.6.0
 pytz==2019.1
-pyyaml==5.1
+pyyaml==5.1.1
 rdflib-jsonld==0.4.0
 rdflib==4.2.2
 repoze.lru==0.7
 requests-oauthlib==1.2.0
 requests-toolbelt==0.9.1
-requests==2.21.0
+requests==2.22.0
 requestsexceptions==1.4.0
-rfc3986==1.2.0
+rfc3986==1.3.2
 routes==2.4.1
 rsa==4.0
 ruamel.ordereddict==0.4.13 ; platform_python_implementation == 'CPython' and python_version <= '2.7'
-ruamel.yaml==0.15.92
-s3transfer==0.2.0
+ruamel.yaml==0.15.97
+s3transfer==0.2.1
 scandir==1.10.0 ; python_version < '3.5'
 schema-salad==2.7.20181126142424
 shellescape==3.4.1
 simplejson==3.16.0
 six==1.11.0
-social-auth-core[openidconnect]==3.1.0+gx0
+social-auth-core[openidconnect]==3.1.0
 sqlalchemy-migrate==0.12.0
 sqlalchemy-utils==0.33.11
-sqlalchemy==1.2.18
+sqlalchemy==1.3.4
 sqlparse==0.3.0
 stevedore==1.30.1
-subprocess32==3.5.3 ; python_version < '3.0'
+subprocess32==3.5.4 ; python_version < '3.0'
 svgwrite==1.2.1
 tempita==0.5.2
 tenacity==4.12.0
@@ -178,10 +180,10 @@ typing==3.6.6 ; python_version < '3.5'
 tzlocal==1.5.1
 unicodecsv==0.14.1 ; python_version < '3.0'
 uritemplate==3.0.0
-urllib3==1.24.2 ; python_version == '2.7'
+urllib3==1.25.3 ; python_version == '2.7'
 uwsgi==2.0.18
 vine==1.3.0
-warlock==1.3.0
+warlock==1.3.3
 wcwidth==0.1.7 ; sys_platform != 'win32'
 webencodings==0.5.1
 webob==1.8.5

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -38,7 +38,7 @@ cffi==1.12.3
 chardet==3.0.4
 cheetah3==3.2.2
 cliff==2.14.1
-cloudauthz==0.2.0
+cloudauthz==0.3.0
 cloudbridge==2.0.0
 cmd2==0.8.9
 contextlib2==0.5.5 ; python_version < '3.5'


### PR DESCRIPTION
This PR does: 

- increment cloudauthz to its current latest version;
- run `make update-dependencies`

ping @nsoranzo 