### PR TITLE
[19.05] Ensure DEFAULT_TOOL_TEST_WAIT is integer

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -42,7 +42,7 @@ log = getLogger(__name__)
 VERBOSE_ERRORS = util.asbool(os.environ.get("GALAXY_TEST_VERBOSE_ERRORS", False))
 UPLOAD_ASYNC = util.asbool(os.environ.get("GALAXY_TEST_UPLOAD_ASYNC", True))
 ERROR_MESSAGE_DATASET_SEP = "--------------------------------------"
-DEFAULT_TOOL_TEST_WAIT = os.environ.get("GALAXY_TEST_DEFAULT_WAIT", 86400)
+DEFAULT_TOOL_TEST_WAIT = int(os.environ.get("GALAXY_TEST_DEFAULT_WAIT", 86400))
 
 DEFAULT_FTYPE = 'auto'
 # This following default dbkey was traditionally hg17 before Galaxy 18.05,

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -733,15 +733,14 @@ def verify_tool(tool_id,
                 quiet=False,
                 test_history=None,
                 force_path_paste=False,
-                maxseconds=None,
+                maxseconds=DEFAULT_TOOL_TEST_WAIT,
                 tool_test_dicts=None):
     if resource_parameters is None:
         resource_parameters = {}
     tool_test_dicts = tool_test_dicts or galaxy_interactor.get_tool_tests(tool_id, tool_version=tool_version)
     tool_test_dict = tool_test_dicts[test_index]
+    tool_test_dict.setdefault('maxseconds', maxseconds)
     testdef = ToolTestDescription(tool_test_dict)
-    if maxseconds is not None:
-        testdef.maxseconds = int(maxseconds)
     _handle_def_errors(testdef)
 
     if test_history is None:
@@ -752,8 +751,7 @@ def verify_tool(tool_id,
                           testdef.test_data(),
                           history=test_history,
                           force_path_paste=force_path_paste,
-                          maxseconds=maxseconds,
-                          )
+                          maxseconds=maxseconds)
 
     # Once data is ready, run the tool and check the outputs - record API
     # input, job info, tool run exception, as well as exceptions related to

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -48,7 +48,6 @@ DEFAULT_FTYPE = 'auto'
 # This following default dbkey was traditionally hg17 before Galaxy 18.05,
 # restore this behavior by setting GALAXY_TEST_DEFAULT_DBKEY to hg17.
 DEFAULT_DBKEY = os.environ.get("GALAXY_TEST_DEFAULT_DBKEY", "?")
-DEFAULT_MAX_SECS = DEFAULT_TOOL_TEST_WAIT
 
 
 class OutputsDict(OrderedDict):
@@ -1027,7 +1026,7 @@ class ToolTestDescription(object):
     def __init__(self, processed_test_dict):
         test_index = processed_test_dict["test_index"]
         name = processed_test_dict.get('name', 'Test-%d' % (test_index + 1))
-        maxseconds = processed_test_dict.get('maxseconds', DEFAULT_MAX_SECS)
+        maxseconds = processed_test_dict.get('maxseconds', DEFAULT_TOOL_TEST_WAIT)
         if maxseconds is not None:
             maxseconds = int(maxseconds)
 

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -247,9 +247,7 @@ class GalaxyInteractorApi(object):
     def wait_for(self, func, **kwd):
         sleep_amount = 0.2
         slept = 0
-        walltime_exceeded = kwd.get("maxseconds")
-        if walltime_exceeded is None:
-            walltime_exceeded = DEFAULT_TOOL_TEST_WAIT
+        walltime_exceeded = int(kwd.get("maxseconds", DEFAULT_TOOL_TEST_WAIT))
 
         while slept <= walltime_exceeded:
             result = func()


### PR DESCRIPTION
This fixes
```
Test 'toolshed.g2.bx.psu.edu/repos/iuc/mothur_unifrac_weighted/mothur_unifrac_weighted/1.39.5.0-0' failed
Traceback (most recent call last):
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/ephemeris/shed_tools.py", line 338, in run_test
    register_job_data=register, quiet=True, test_history=test_history,
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/galaxy/tools/verify/interactor.py", line 733, in verify_tool
    stage_data_in_history(galaxy_interactor, tool_id, testdef.test_data(), history=test_history, force_path_paste=force_path_paste)
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/galaxy/tools/verify/interactor.py", line 86, in stage_data_in_history
    upload_wait()
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/galaxy/tools/verify/interactor.py", line 369, in <lambda>
    return lambda: self.wait_for_job(jobs[0]["id"], history_id, DEFAULT_TOOL_TEST_WAIT)
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/galaxy/tools/verify/interactor.py", line 238, in wait_for_job
    self.wait_for(lambda: not self.__job_ready(job_id, history_id), maxseconds=maxseconds)
  File "/var/jenkins/shiningpanda/jobs/35ce1600/virtualenvs/d41d8cd9/lib/python3.5/site-packages/galaxy/tools/verify/interactor.py", line 245, in wait_for
    while slept <= walltime_exceeded:
TypeError: unorderable types: int() <= str()
```

that we encountered when we ran tool tests using ephemeris on Python 3.