### PR TITLE
[WIP] Fix env var name GALAXY_TOOL_DEPENDENCY_DIR

### DIFF
--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -162,7 +162,7 @@ def setup_galaxy_config(
         library_import_dir = None
     job_config_file = os.environ.get('GALAXY_TEST_JOB_CONFIG_FILE', default_job_config_file)
     tool_path = os.environ.get('GALAXY_TEST_TOOL_PATH', 'tools')
-    tool_dependency_dir = os.environ.get('GALAXY_TOOL_DEPENDENCY_DIR', None)
+    tool_dependency_dir = os.environ.get('GALAXY_TEST_TOOL_DEPENDENCY_DIR', None)
     if tool_dependency_dir is None:
         tool_dependency_dir = tempfile.mkdtemp(dir=tmpdir, prefix="tool_dependencies")
     tool_data_table_config_path = _tool_data_table_config_path(default_tool_data_table_config_path)


### PR DESCRIPTION
This is an apparent bug. (unless I'm missing something obvious - in which case, sorry!)
incorrect: GALAXY_TOOL_DEPENDENCY_DIR
correct: GALAXY_TEST_TOOL_DEPENDENCY_DIR

The present code overrides the value without reading it.

See this line: https://github.com/galaxyproject/galaxy/blob/72310185d9a74b20ab1a5de7a25e6bf5cd4efd62/test/base/driver_util.py#L244

Also this: 
https://github.com/galaxyproject/galaxy/blob/72310185d9a74b20ab1a5de7a25e6bf5cd4efd62/run_tests.sh#L215