### PR TITLE
Round-off the time taken for CPU execution

### DIFF
--- a/lib/galaxy/job_metrics/formatting.py
+++ b/lib/galaxy/job_metrics/formatting.py
@@ -11,8 +11,8 @@ class JobMetricFormatter(object):
 def seconds_to_str(value):
     """Convert seconds to a simple simple string describing the amount of time."""
     if value < 60:
-        return "%s seconds" % value
+        return "%s seconds" % round(value, 2)
     elif value < 3600:
-        return "%s minutes" % (value / 60)
+        return "%s minutes" % round(value / 60, 2)
     else:
-        return "%s hours and %s minutes" % (value / 3600, (value % 3600) / 60)
+        return "%s hours and %s minutes" % (round(value / 3600, 2), round((value % 3600) / 60, 2))


### PR DESCRIPTION
The feature to round off the "CPU Time" under Job Metrics has been implemented.


![job_metric](https://user-images.githubusercontent.com/20727154/59364710-92f8b000-8d37-11e9-96c5-b9cb89781b53.png)
