### PR TITLE
Kubernetes / CLI runner integration test fixes

### DIFF
--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -76,6 +76,8 @@ def stream_to_open_named_file(stream, fd, filename, source_encoding=None, source
         else:
             # Compressed files must be encoded after they are uncompressed in the upload utility,
             # while binary files should not be encoded at all.
+            if isinstance(chunk, text_type):
+                chunk = chunk.encode(target_encoding, target_error)
             os.write(fd, chunk)
     os.close(fd)
     return filename

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -67,7 +67,7 @@ def cli_job_config(remote_connection, shell_plugin='ParamikoShell', job_plugin='
     job_conf_str = job_conf_template.substitute(shell_plugin=shell_plugin,
                                                 job_plugin=job_plugin,
                                                 **remote_connection._asdict())
-    with tempfile.NamedTemporaryFile(suffix="_slurm_integration_job_conf", mode="w", delete=False) as job_conf:
+    with tempfile.NamedTemporaryFile(suffix="_slurm_integration_job_conf.xml", mode="w", delete=False) as job_conf:
         job_conf.write(job_conf_str)
     return job_conf.name
 

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -111,7 +111,7 @@ def job_config(jobs_directory):
                                                 tool_directory=TOOL_DIR,
                                                 k8s_config_path=os.environ.get('GALAXY_TEST_KUBE_CONFIG_PATH', '~/.kube/config'),
                                                 )
-    with tempfile.NamedTemporaryFile(suffix="_kubernetes_integration_job_conf", mode="w", delete=False) as job_conf:
+    with tempfile.NamedTemporaryFile(suffix="_kubernetes_integration_job_conf.xml", mode="w", delete=False) as job_conf:
         job_conf.write(job_conf_str)
     return Config(job_conf.name)
 


### PR DESCRIPTION
These are required to run the kubernetes tests. The job config files now have to contain `.xml` (https://github.com/galaxyproject/galaxy/pull/7854). `stream_to_file` may receive StringIO objects, so chunk may be unicode. In that case we need to call `encode`.