### PR TITLE
fix for test data in sub directories

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -341,7 +341,7 @@ class GalaxyInteractorApi(object):
                 tool_input.update({
                     "files_%d|type" % i: "upload_dataset",
                 })
-            name = os.path.basename(test_data['name'])
+            name = test_data['name']
         else:
             name = os.path.basename(fname)
             tool_input.update({

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -341,9 +341,9 @@ class GalaxyInteractorApi(object):
                 tool_input.update({
                     "files_%d|type" % i: "upload_dataset",
                 })
-            name = test_data['name']
+            name = os.path.basename(test_data['name'])
         else:
-            name = fname
+            name = os.path.basename(fname)
             tool_input.update({
                 "files_0|NAME": name,
                 "files_0|type": "upload_dataset",


### PR DESCRIPTION
in order to get the data set names for test data `basename` should be applied. otherwise tests are failing 
for tools that
- organize test data is in subdirectories and
- assume that the id of the data set will be identical to the file name. 

For an example see https://github.com/galaxyproject/tools-iuc/pull/2439.

@nsoranzo suggested that this was introduced here: https://github.com/galaxyproject/galaxy/commit/6791f3b99905ac0db0a8e2c23f38a4bce8b1d3c8 (galaxy 19.01). 

I just played around a bit and this seems to work. But its not unlikely that I overlooked something. Also a test would be nice ensure this in the future.
