### PR TITLE
[19.01] Do not require a default attrib on the workflow scheduler config's handlers tag

### DIFF
--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -207,7 +207,8 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
                 self.__init_handlers(config_element)
 
                 # Determine the default handler(s)
-                self.default_handler_id = self._get_default(self.app.config, config_element, list(self.handlers.keys()))
+                self.default_handler_id = self._get_default(
+                    self.app.config, config_element, list(self.handlers.keys()), required=False)
             else:
                 plugin_type = config_element_tag
                 plugin_element = config_element


### PR DESCRIPTION
@nuwang @afgane this should fix the issue you were encountering with db-skip-locked schedulers.