### PR TITLE
Adds a tests helper type for creating RabbitMQ cluster deployed on k8s 

### DIFF
--- a/test/base/rabbitmq.py
+++ b/test/base/rabbitmq.py
@@ -203,7 +203,10 @@ class RabbitMQK8s(object):
             "apiVersion": "v1",
             "metadata": {
                 "namespace": self.namespace,
-                "name": self.objects_name["ServiceAccount"]
+                "name": self.objects_name["ServiceAccount"],
+                "labels": {
+                    "app": self.app_tag,
+                }
             }
         }
 
@@ -220,7 +223,10 @@ class RabbitMQK8s(object):
             "apiVersion": "rbac.authorization.k8s.io/v1beta1",
             "metadata": {
                 "namespace": self.namespace,
-                "name": self.objects_name["Role"]
+                "name": self.objects_name["Role"],
+                "labels": {
+                    "app": self.app_tag,
+                }
             },
             "rules": [
                 {
@@ -250,7 +256,10 @@ class RabbitMQK8s(object):
             "apiVersion": "rbac.authorization.k8s.io/v1beta1",
             "metadata": {
                 "namespace": self.namespace,
-                "name": self.objects_name["Role"]
+                "name": self.objects_name["Role"],
+                "labels": {
+                    "app": self.app_tag,
+                }
             },
             "subjects": [
                 {
@@ -350,7 +359,10 @@ class RabbitMQK8s(object):
             "apiVersion": "v1",
             "metadata": {
                 "namespace": self.namespace,
-                "name": self.objects_name["ConfigMap"]
+                "name": self.objects_name["ConfigMap"],
+                "labels": {
+                    "app": self.app_tag,
+                }
             },
             "data": {
                 # Based on: https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s/blob/45be70d977db5da1f4d06fac0d3872df4b325da5/examples/k8s_statefulsets/rabbitmq_statefulsets.yaml#L34-L55
@@ -394,7 +406,10 @@ class RabbitMQK8s(object):
             "replicas": replicas,
             "metadata": {
                 "namespace": self.namespace,
-                "name": self.objects_name["StatefulSet"]
+                "name": self.objects_name["StatefulSet"],
+                "labels": {
+                    "app": self.app_tag,
+                }
             },
             "spec": {
                 "serviceName": self.objects_name["Service"],

--- a/test/base/rabbitmq.py
+++ b/test/base/rabbitmq.py
@@ -242,8 +242,30 @@ class RabbitMQK8s(object):
                 "name": self.objects_name["ConfigMap"]
             },
             "data": {
+                # Based on: https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s/blob/45be70d977db5da1f4d06fac0d3872df4b325da5/examples/k8s_statefulsets/rabbitmq_statefulsets.yaml#L34-L55
                 "enabled_plugins": "[rabbitmq_management,rabbitmq_peer_discovery_k8s].\n",
-                "rabbitmq.conf": "## Cluster formation. See https://www.rabbitmq.com/cluster-formation.html to learn more.\ncluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s\ncluster_formation.k8s.host = kubernetes.default.svc.cluster.local\n## Should RabbitMQ node name be computed from the pod's hostname or IP address?\n## IP addresses are not stable, so using [stable] hostnames is recommended when possible.\n## Set to \"hostname\" to use pod hostnames.\n## When this value is changed, so should the variable used to set the RABBITMQ_NODENAME\n## environment variable.\ncluster_formation.k8s.address_type = ip\n## How often should node cleanup checks run?\ncluster_formation.node_cleanup.interval = 30\n## Set to false if automatic removal of unknown/absent nodes\n## is desired. This can be dangerous, see\n##  * https://www.rabbitmq.com/cluster-formation.html#node-health-checks-and-cleanup\n##  * https://groups.google.com/forum/#!msg/rabbitmq-users/wuOfzEywHXo/k8z_HWIkBgAJ\ncluster_formation.node_cleanup.only_log_warning = true\ncluster_partition_handling = autoheal\n## See https://www.rabbitmq.com/ha.html#master-migration-data-locality\nqueue_master_locator=min-masters\n## See https://www.rabbitmq.com/access-control.html#loopback-users\nloopback_users.guest = false"
+                "rabbitmq.conf":
+                    "## Cluster formation. See https://www.rabbitmq.com/cluster-formation.html to learn more.\n"
+                    "cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s\n"
+                    "cluster_formation.k8s.host = kubernetes.default.svc.cluster.local\n"
+                    "## Should RabbitMQ node name be computed from the pod's hostname or IP address?\n"
+                    "## IP addresses are not stable, so using [stable] hostnames is recommended when possible.\n"
+                    "## Set to \"hostname\" to use pod hostnames.\n"
+                    "## When this value is changed, so should the variable used to set the RABBITMQ_NODENAME\n"
+                    "## environment variable.\n"
+                    "cluster_formation.k8s.address_type = ip\n"
+                    "## How often should node cleanup checks run?\n"
+                    "cluster_formation.node_cleanup.interval = 30\n"
+                    "## Set to false if automatic removal of unknown/absent nodes\n"
+                    "## is desired. This can be dangerous, see\n"
+                    "##  * https://www.rabbitmq.com/cluster-formation.html#node-health-checks-and-cleanup\n"
+                    "##  * https://groups.google.com/forum/#!msg/rabbitmq-users/wuOfzEywHXo/k8z_HWIkBgAJ\n"
+                    "cluster_formation.node_cleanup.only_log_warning = true\n"
+                    "cluster_partition_handling = autoheal\n"
+                    "## See https://www.rabbitmq.com/ha.html#master-migration-data-locality\n"
+                    "queue_master_locator=min-masters\n"
+                    "## See https://www.rabbitmq.com/access-control.html#loopback-users\n"
+                    "loopback_users.guest = false"
             }
         }
 
@@ -392,3 +414,7 @@ class RabbitMQK8s(object):
     def delete_cluster(self, name):
         pass
 
+
+if __name__ == '__main__':
+    rabbit = RabbitMQK8s()
+    rabbit.create_cluster()

--- a/test/base/rabbitmq.py
+++ b/test/base/rabbitmq.py
@@ -44,6 +44,26 @@ class RabbitMQK8s(object):
             "StatefulSet": "rabbitmq"
         }
 
+        # This dictionary contains uniquely assigned
+        # IP address for each port deceleration of the
+        # named port group. The port numbers are
+        # determined when creating the RabbitMQ service.
+        # Port number need to be unique hence to avoid
+        # overlapping/conflicting ports when multiple
+        # RabbitMQ clusters are created (e.g., when
+        # multiple independent tests leverage RabbitMQ
+        # clusters).
+        self.ports = {
+            "http": {
+                "port": -1,
+                "nodePort": -1
+            },
+            "amqp": {
+                "port": -1,
+                "nodePort": -1
+            }
+        }
+
         # To avoid conflicting resources when this class is
         # instantiated multiple times by different tests, a
         # timestamp is appended to all the resources name.

--- a/test/base/rabbitmq.py
+++ b/test/base/rabbitmq.py
@@ -10,6 +10,12 @@ RABBITMQ_NAME = "rabbitmq"
 RABBITMQ_MT_NAME = "rabbitmq-management"
 APP_TAG = "rabbitmq"
 
+# In case the service exists (conflict), this property sets for how
+# many times it will attempt to create the service:
+# deletes for MAX_RETRIES -1 times and creates for MAX_RETRIES times.
+MAX_RETRIES = 3
+
+
 class RabbitMQK8s(object):
     def __init__(self):
         # Configs can be set in Configuration class directly or using helper
@@ -19,21 +25,19 @@ class RabbitMQK8s(object):
         self.api_instance = client.CoreV1Api()
         self.namespace = "default"
 
-    def __create_service(self, namespace, manifest):
+    def __call_api(self, method, namespace, manifest, retries=MAX_RETRIES):
         try:
-            api_response = self.api_instance.create_namespaced_service(namespace, manifest)
+            return method(namespace, manifest)
         except ApiException as e:
-            print("Exception when calling CoreV1Api->create_namespaced_endpoints: %s\n" % e)
-        return api_response
-
-    def __create_statefulset(self, namespace, manifest):
-        try:
-            # create an instance of the API class
-            api_instance = client.AppsV1beta1Api()
-            api_response = api_instance.create_namespaced_stateful_set(namespace, manifest)
-        except ApiException as e:
-            print("Exception when calling AppsV1beta1Api->create_namespaced_stateful_set: %s\n" % e)
-        return api_response
+            if (e.reason == "Conflict" or e.status == 409) and retries > 1:
+                # Do not try recalling API if it fails deleting the service.
+                try:
+                    self.delete_service(manifest["metadata"]["name"])
+                except ApiException:
+                    raise ApiException
+                else:
+                    return self.__call_api(method, namespace, manifest, retries=retries-1)
+            print("Exception when calling the method {0}; error: {1}\n".format(method, e))
 
     def create_rabbitmq(self):
         manifest = {
@@ -66,7 +70,8 @@ class RabbitMQK8s(object):
                 }
             }
         }
-        return self.__create_service(self.namespace, manifest)
+        api_response = self.__call_api(self.api_instance.create_namespaced_service, self.namespace, manifest)
+        return api_response
 
     def create_rabbitmq_management(self):
         manifest = {
@@ -91,13 +96,16 @@ class RabbitMQK8s(object):
                 "type": "NodePort"
             }
         }
-        return self.__create_service(self.namespace, manifest)
+        api_response = self.__call_api(self.api_instance.create_namespaced_service, self.namespace, manifest)
+        return api_response
 
-    def create_rabbitmq_statefulset(self):
+    def create_rabbitmq_stateful_set(self):
         manifest = {
             # TODO
         }
-        return self.__create_statefulset(self.namespace, manifest)
+        api_instance = client.AppsV1beta1Api()
+        api_response = self.__call_api(api_instance.create_namespaced_stateful_set, self.namespace, manifest)
+        return api_response
 
     def create_deployment(self):
         # TODO: authorization and cookies.
@@ -108,10 +116,23 @@ class RabbitMQK8s(object):
         # configuration.api_key_prefix['authorization'] = 'Bearer'
         self.create_rabbitmq()
         self.create_rabbitmq_management()
-        self.create_rabbitmq_statefulset()
+        self.create_rabbitmq_stateful_set()
 
     def update_deployment(self, api_instance, deployment):
         pass
 
-    def delete_deployment(self, api_instance):
+    def delete_deployment(self, name):
         pass
+
+    def delete_service(self, name):
+        try:
+            api_response = self.api_instance.delete_namespaced_service(
+                name=name,
+                namespace=self.namespace,
+                grace_period_seconds=0,
+                async_req=False
+            )
+            return api_response
+        except ApiException as e:
+            print("Exception when calling CoreV1Api->delete_namespaced_service: %s\n" % e)
+            raise

--- a/test/base/rabbitmq.py
+++ b/test/base/rabbitmq.py
@@ -5,11 +5,6 @@ import time
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
-DEPLOYMENT_NAME = "rabbitmq-deployment"
-RABBITMQ_NAME = "rabbitmq"
-RABBITMQ_MT_NAME = "rabbitmq-management"
-APP_TAG = "rabbitmq"
-
 # In case the service exists (conflict), this property sets for how
 # many times it will attempt to create the service:
 # deletes for MAX_RETRIES -1 times and creates for MAX_RETRIES times.
@@ -33,7 +28,45 @@ class RabbitMQK8s(object):
         config.load_kube_config()
         self.core_api = client.CoreV1Api()
         self.apps_api = client.AppsV1beta1Api()
-        self.namespace = "default"
+        self.rbac_api = client.RbacAuthorizationV1beta1Api()
+
+        # Please mind the following rules when naming objects:
+        # names must consist of lower case alphanumeric
+        # characters, `-`, or `.`, and must start and
+        # end with an alphanumeric character.
+        self.namespace = "gxy-tests"
+        self.app_tag = "rabbitmq"
+        self.objects_name = {
+            "ConfigMap": "rabbitmq-config",
+            "Role": "endpoint-reader",
+            "Service": "rabbitmq",
+            "ServiceAccount": "rabbitmq",
+            "StatefulSet": "rabbitmq"
+        }
+
+        # To avoid conflicting resources when this class is
+        # instantiated multiple times by different tests, a
+        # timestamp is appended to all the resources name.
+        self.timestamp = int(time.time())
+        self.app_tag = "{0}-{1}".format(self.app_tag, self.timestamp)
+        for name in self.objects_name:
+            self.objects_name[name] = "{0}-{1}".format(
+                self.objects_name[name],
+                self.timestamp)
+
+    def __create_namespace(self):
+        """
+        Will create a namespace with title self.namespace
+        if a namespace with that title does not already exist.
+        """
+        namespaces = self.core_api.list_namespace()
+        for namespace in namespaces.items:
+            if self.namespace in namespace.metadata.self_link:
+                return
+        self.core_api.create_namespace(
+            client.V1Namespace(
+                metadata=client.V1ObjectMeta(
+                    name=self.namespace)))
 
     def __create_object(self, create_method, delete_method, list_method, manifest, retries=MAX_RETRIES):
         try:
@@ -82,69 +115,117 @@ class RabbitMQK8s(object):
             print("Exception when calling the method {0}; error: {1}\n".format(delete_method, e))
             raise
 
-    def create_rabbitmq(self):
+    def __create_service_account(self):
         manifest = {
+            "kind": "ServiceAccount",
             "apiVersion": "v1",
-            "kind": "Service",
             "metadata": {
-                "name": RABBITMQ_NAME,
-                "labels": {
-                    "app": APP_TAG
-                }
-            },
-            "spec": {
-                "ports": [
-                    {
-                        "name": "amqp",
-                        "port": 5672
-                    },
-                    {
-                        "name": "epmd",
-                        "port": 4369
-                    },
-                    {
-                        "name": "rabbitmq-dist",
-                        "port": 25672
-                    }
-                ],
-                "clusterIP": "None",
-                # Determines which set of pods are targeted by this service.
-                "selector": {
-                    "app": APP_TAG
-                }
+                "namespace": self.namespace,
+                "name": self.objects_name["ServiceAccount"]
             }
         }
+
         api_response = self.__create_object(
-            self.core_api.create_namespaced_service,
-            self.core_api.delete_namespaced_service,
-            self.core_api.list_namespaced_service,
+            self.core_api.create_namespaced_service_account,
+            self.core_api.delete_namespaced_service_account,
+            self.core_api.list_namespaced_service_account,
             manifest)
         return api_response
 
-    def create_rabbitmq_management(self):
+    def __create_role(self):
+        manifest = {
+            "kind": "Role",
+            "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+            "metadata": {
+                "namespace": self.namespace,
+                "name": self.objects_name["Role"]
+            },
+            "rules": [
+                {
+                    "apiGroups": [
+                        ""
+                    ],
+                    "verbs": [
+                        "get"
+                    ],
+                    "resources": [
+                        "endpoints"
+                    ]
+                }
+            ]
+        }
+
+        api_response = self.__create_object(
+            self.rbac_api.create_namespaced_role,
+            self.rbac_api.delete_namespaced_role,
+            self.rbac_api.list_namespaced_role,
+            manifest)
+        return api_response
+
+    def __create_role_binding(self):
+        manifest = {
+            "kind": "RoleBinding",
+            "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+            "metadata": {
+                "namespace": self.namespace,
+                "name": self.objects_name["Role"]
+            },
+            "subjects": [
+                {
+                    "kind": "ServiceAccount",
+                    "name": self.objects_name["ServiceAccount"]
+                }
+            ],
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "Role",
+                "name": self.objects_name["Role"]
+            }
+        }
+
+        api_response = self.__create_object(
+            self.rbac_api.create_namespaced_role_binding,
+            self.rbac_api.delete_namespaced_role_binding,
+            self.rbac_api.list_namespaced_role_binding,
+            manifest)
+        return api_response
+
+    def __create_service(self):
         manifest = {
             "apiVersion": "v1",
             "kind": "Service",
             "metadata": {
-                "name": RABBITMQ_MT_NAME,
+                "namespace": self.namespace,
+                "name": self.objects_name["Service"],
                 "labels": {
-                    "app": APP_TAG
+                    "app": self.app_tag,
+                    "type": "LoadBalancer"
                 }
             },
             "spec": {
+                "type": "NodePort",
                 "ports": [
                     {
+                        "port": 15672,
+                        "protocol": "TCP",
+                        "targetPort": 15672,
                         "name": "http",
-                        "port": 15672
+                        "nodePort": 31672
+                    },
+                    {
+                        "port": 5672,
+                        "protocol": "TCP",
+                        "targetPort": 5672,
+                        "name": "amqp",
+                        "nodePort": 30672
                     }
                 ],
-                # Determines which set of pods are targeted by this service.
                 "selector": {
-                    "app": APP_TAG
-                },
-                "type": "NodePort"
+                    "app": self.app_tag
+                }
             }
         }
+
         api_response = self.__create_object(
             self.core_api.create_namespaced_service,
             self.core_api.delete_namespaced_service,
@@ -152,82 +233,143 @@ class RabbitMQK8s(object):
             manifest)
         return api_response
 
-    def create_rabbitmq_stateful_set(self):
-        # TODO: a post script that (1) stops rabbits, (2) restarts
-        # the cluster, (3) joins the rabbits to the cluster.
+    def __create_config_map(self):
         manifest = {
-            "apiVersion": "apps/v1beta1",
-            "kind": "StatefulSet",
+            "kind": "ConfigMap",
+            "apiVersion": "v1",
             "metadata": {
-                "name": RABBITMQ_NAME,
-                "labels": {
-                    "app": APP_TAG
-                }
+                "namespace": self.namespace,
+                "name": self.objects_name["ConfigMap"]
+            },
+            "data": {
+                "enabled_plugins": "[rabbitmq_management,rabbitmq_peer_discovery_k8s].\n",
+                "rabbitmq.conf": "## Cluster formation. See https://www.rabbitmq.com/cluster-formation.html to learn more.\ncluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s\ncluster_formation.k8s.host = kubernetes.default.svc.cluster.local\n## Should RabbitMQ node name be computed from the pod's hostname or IP address?\n## IP addresses are not stable, so using [stable] hostnames is recommended when possible.\n## Set to \"hostname\" to use pod hostnames.\n## When this value is changed, so should the variable used to set the RABBITMQ_NODENAME\n## environment variable.\ncluster_formation.k8s.address_type = ip\n## How often should node cleanup checks run?\ncluster_formation.node_cleanup.interval = 30\n## Set to false if automatic removal of unknown/absent nodes\n## is desired. This can be dangerous, see\n##  * https://www.rabbitmq.com/cluster-formation.html#node-health-checks-and-cleanup\n##  * https://groups.google.com/forum/#!msg/rabbitmq-users/wuOfzEywHXo/k8z_HWIkBgAJ\ncluster_formation.node_cleanup.only_log_warning = true\ncluster_partition_handling = autoheal\n## See https://www.rabbitmq.com/ha.html#master-migration-data-locality\nqueue_master_locator=min-masters\n## See https://www.rabbitmq.com/access-control.html#loopback-users\nloopback_users.guest = false"
+            }
+        }
+
+        api_response = self.__create_object(
+            self.core_api.create_namespaced_config_map,
+            self.core_api.delete_namespaced_config_map,
+            self.core_api.list_namespaced_config_map,
+            manifest)
+        return api_response
+
+    def __create_statefulset(self, replicas):
+        manifest = {
+            "kind": "StatefulSet",
+            "apiVersion": "apps/v1beta1",
+            "replicas": replicas,
+            "metadata": {
+                "namespace": self.namespace,
+                "name": self.objects_name["StatefulSet"]
             },
             "spec": {
-                "serviceName": RABBITMQ_MT_NAME,
-                "replicas": 5,
+                "serviceName": self.objects_name["Service"],
                 "template": {
                     "metadata": {
-                        "name": RABBITMQ_NAME,
                         "labels": {
-                            "app": APP_TAG
+                            "app": self.app_tag
                         }
                     },
                     "spec": {
+                        "terminationGracePeriodSeconds": 10,
                         "containers": [
                             {
-                                "name": "rabbitmq",
-                                "image": "rabbitmq:3.6.6-management-alpine",
-                                "env": [
+                                "livenessProbe": {
+                                    "initialDelaySeconds": 60,
+                                    "exec": {
+                                        "command": [
+                                            "rabbitmqctl",
+                                            "status"
+                                        ]
+                                    },
+                                    "timeoutSeconds": 15,
+                                    "periodSeconds": 60
+                                },
+                                "name": "rabbitmq-k8s",
+                                "image": "rabbitmq:3.7",
+                                "volumeMounts": [
                                     {
-                                        "name": "RABBITMQ_ERLANG_COOKIE",
-                                        "valueFrom": {
-                                            "secretKeyRef": {
-                                                "name": "rabbitmq-config",
-                                                "key": "erlang-cookie"
-                                            }
-                                        }
+                                        "mountPath": "/etc/rabbitmq",
+                                        "name": "config-volume"
                                     }
                                 ],
+                                "env": [
+                                    {
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "fieldPath": "status.podIP"
+                                            }
+                                        },
+                                        "name": "GXY_TEST_POD_IP"
+                                    },
+                                    {
+                                        "name": "RABBITMQ_USE_LONGNAME",
+                                        "value": "true"
+                                    },
+                                    {
+                                        "name": "RABBITMQ_NODENAME",
+                                        "value": "rabbit@$(GXY_TEST_POD_IP)"
+                                    },
+                                    {
+                                        "name": "K8S_SERVICE_NAME",
+                                        "value": self.objects_name["Service"]
+                                    },
+                                    {
+                                        "name": "RABBITMQ_ERLANG_COOKIE",
+                                        "value": "gxycookie"
+                                    }
+                                ],
+                                "imagePullPolicy": "Always",
+                                "readinessProbe": {
+                                    "initialDelaySeconds": 20,
+                                    "exec": {
+                                        "command": [
+                                            "rabbitmqctl",
+                                            "status"
+                                        ]
+                                    },
+                                    "timeoutSeconds": 10,
+                                    "periodSeconds": 60
+                                },
                                 "ports": [
                                     {
+                                        "protocol": "TCP",
+                                        "name": "http",
+                                        "containerPort": 15672
+                                    },
+                                    {
+                                        "protocol": "TCP",
                                         "name": "amqp",
                                         "containerPort": 5672
                                     }
-                                ],
-                                "volumeMounts": [
-                                    {
-                                        "name": "rabbitmq",
-                                        "mountPath": "/var/lib/rabbitmq"
-                                    }
                                 ]
+                            }
+                        ],
+                        "serviceAccountName": self.objects_name["ServiceAccount"],
+                        "volumes": [
+                            {
+                                "configMap": {
+                                    "items": [
+                                        {
+                                            "path": "rabbitmq.conf",
+                                            "key": "rabbitmq.conf"
+                                        },
+                                        {
+                                            "path": "enabled_plugins",
+                                            "key": "enabled_plugins"
+                                        }
+                                    ],
+                                    "name": self.objects_name["ConfigMap"]
+                                },
+                                "name": "config-volume"
                             }
                         ]
                     }
-                },
-                "volumeClaimTemplates": [
-                    {
-                        "metadata": {
-                            "name": "rabbitmq",
-                            "annotations": {
-                                "volume.alpha.kubernetes.io/storage-class": "anything"
-                            }
-                        },
-                        "spec": {
-                            "accessModes": [
-                                "ReadWriteOnce"
-                            ],
-                            "resources": {
-                                "requests": {
-                                    "storage": "1Gi"
-                                }
-                            }
-                        }
-                    }
-                ]
+                }
             }
         }
+
         api_response = self.__create_object(
             self.apps_api.create_namespaced_stateful_set,
             self.apps_api.delete_namespaced_stateful_set,
@@ -235,32 +377,18 @@ class RabbitMQK8s(object):
             manifest)
         return api_response
 
-    def create_deployment(self):
-        # TODO: authorization and cookies.
-        # Configure API key authorization: BearerToken
-        # configuration = client.Configuration()
-        # configuration.api_key['authorization'] = 'YOUR_API_KEY'
-        # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-        # configuration.api_key_prefix['authorization'] = 'Bearer'
+    def create_cluster(self, replicas=3):
+        self.__create_namespace()
+        self.__create_service_account()
+        self.__create_role()
+        self.__create_role_binding()
+        self.__create_service()
+        self.__create_config_map()
+        self.__create_statefulset(replicas)
 
-        # Note: the following commands define
-        # two kubernetes services for rabbitmq (rabbitmq
-        # and its management).
-        # - the rabbitmq service is defined "headless", and reachable only from within the cluster
-        # - the management rabbitmq service is defined
-
-        self.create_rabbitmq_management()
-
-        # The required headless service for StatefulSets
-        self.create_rabbitmq()
-
-        self.create_rabbitmq_stateful_set()
-
-    def update_deployment(self, api_instance, deployment):
+    def update_cluster(self, api_instance, deployment):
         pass
 
-    def delete_deployment(self, name):
+    def delete_cluster(self, name):
         pass
 
-    def delete_service(self, name):
-        return self.__delete_object(self.core_api.delete_namespaced_service, name)

--- a/test/base/rabbitmq.py
+++ b/test/base/rabbitmq.py
@@ -1,5 +1,26 @@
 """
+This module implements a class named RabbitMQK8s, which can
+create, update, and delete RabbitMQ clusters running on a
+kubernetes cluster.
 
+There are many different RabbitMQ cluster formation methods for
+different platforms; among them, some are stateless (possibly
+with manual persistence setup) and some are stateful (usually
+with out-of-box persistency). Additionally, there are also
+different configurations on how nodes (aka RabbitMQ rabbits)
+can discover each other on the cluster. See the following
+blog post for a detailed discussion:
+https://www.rabbitmq.com/cluster-formation.html
+
+This class leverage 'Statefulset' object of Kubernetes to
+deploy a stateful RabbitMQ cluster, and uses the RabbitMQ
+Peer Discovery plugin to make rabbits discover each other
+on the cluster (the current-latest peer discovery method
+of a RabbitMQ cluster).
+
+This implementation largely follows the cluster setup model
+used in the RabbitMQ peer discovery example available at:
+https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s/tree/master/examples/k8s_statefulsets
 """
 import random
 import time

--- a/test/base/rabbitmq.py
+++ b/test/base/rabbitmq.py
@@ -1,0 +1,117 @@
+"""
+
+"""
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+DEPLOYMENT_NAME = "rabbitmq-deployment"
+RABBITMQ_NAME = "rabbitmq"
+RABBITMQ_MT_NAME = "rabbitmq-management"
+APP_TAG = "rabbitmq"
+
+class RabbitMQK8s(object):
+    def __init__(self):
+        # Configs can be set in Configuration class directly or using helper
+        # utility. If no argument provided, the config will be loaded from
+        # default location.
+        config.load_kube_config()
+        self.api_instance = client.CoreV1Api()
+        self.namespace = "default"
+
+    def __create_service(self, namespace, manifest):
+        try:
+            api_response = self.api_instance.create_namespaced_service(namespace, manifest)
+        except ApiException as e:
+            print("Exception when calling CoreV1Api->create_namespaced_endpoints: %s\n" % e)
+        return api_response
+
+    def __create_statefulset(self, namespace, manifest):
+        try:
+            # create an instance of the API class
+            api_instance = client.AppsV1beta1Api()
+            api_response = api_instance.create_namespaced_stateful_set(namespace, manifest)
+        except ApiException as e:
+            print("Exception when calling AppsV1beta1Api->create_namespaced_stateful_set: %s\n" % e)
+        return api_response
+
+    def create_rabbitmq(self):
+        manifest = {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": RABBITMQ_NAME,
+                "labels": {
+                    "app": APP_TAG
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "amqp",
+                        "port": 5672
+                    },
+                    {
+                        "name": "epmd",
+                        "port": 4369
+                    },
+                    {
+                        "name": "rabbitmq-dist",
+                        "port": 25672
+                    }
+                ],
+                "clusterIP": "None",
+                "selector": {
+                    "app": APP_TAG
+                }
+            }
+        }
+        return self.__create_service(self.namespace, manifest)
+
+    def create_rabbitmq_management(self):
+        manifest = {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": RABBITMQ_MT_NAME,
+                "labels": {
+                    "app": APP_TAG
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "http",
+                        "port": 15672
+                    }
+                ],
+                "selector": {
+                    "app": APP_TAG
+                },
+                "type": "NodePort"
+            }
+        }
+        return self.__create_service(self.namespace, manifest)
+
+    def create_rabbitmq_statefulset(self):
+        manifest = {
+            # TODO
+        }
+        return self.__create_statefulset(self.namespace, manifest)
+
+    def create_deployment(self):
+        # TODO: authorization and cookies.
+        # Configure API key authorization: BearerToken
+        # configuration = client.Configuration()
+        # configuration.api_key['authorization'] = 'YOUR_API_KEY'
+        # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+        # configuration.api_key_prefix['authorization'] = 'Bearer'
+        self.create_rabbitmq()
+        self.create_rabbitmq_management()
+        self.create_rabbitmq_statefulset()
+
+    def update_deployment(self, api_instance, deployment):
+        pass
+
+    def delete_deployment(self, api_instance):
+        pass


### PR DESCRIPTION
Initiated from discussions at https://github.com/galaxyproject/galaxy/pull/7835/; this PR adds a helper class that can create, update, and delete a RabbitMQ cluster deployed on a Kubernetes cluster. This class will be mainly used for testing the two-pod job execution approach.

It is currently WIP, and all suggestions are welcome. ping @jmchilton @mvdbeek 