### PR TITLE
Fix job wrapper fail for queued jobs

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -451,13 +451,15 @@ class JobHandlerQueue(Monitors):
             if hda_deleted or dataset_deleted:
                 if dataset_purged:
                     # If the dataset has been purged we can't resume the job by undeleting the input
-                    jobs_to_fail[job_id].append("Input dataset '%s' was deleted before the job started" % (hda_name))
+                    jobs_to_fail[job_id].append("Input dataset '%s' was deleted before the job started" % hda_name)
                 else:
-                    jobs_to_pause[job_id].append("Input dataset '%s' was deleted before the job started" % (hda_name))
+                    jobs_to_pause[job_id].append("Input dataset '%s' was deleted before the job started" % hda_name)
             elif hda_state == model.HistoryDatasetAssociation.states.FAILED_METADATA:
-                jobs_to_pause[job_id].append("Input dataset '%s' failed to properly set metadata" % (hda_name))
+                jobs_to_pause[job_id].append("Input dataset '%s' failed to properly set metadata" % hda_name)
             elif dataset_state == model.Dataset.states.PAUSED:
-                jobs_to_pause[job_id].append("Input dataset '%s' was paused before the job started" % (hda_name))
+                jobs_to_pause[job_id].append("Input dataset '%s' was paused before the job started" % hda_name)
+            elif dataset_state == model.Dataset.states.ERROR:
+                jobs_to_pause[job_id].append("Input dataset '%s' is in error state" % hda_name)
             elif dataset_state != model.Dataset.states.OK:
                 jobs_to_ignore[job_id].append("Input dataset '%s' is in %s state" % (hda_name, dataset_state))
         for job_id in sorted(jobs_to_pause):

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -1924,6 +1924,13 @@ input1:
 
     @skip_without_tool("cat")
     def test_pause_outputs_with_deleted_inputs(self):
+        self._deleted_inputs_workflow(purge=False)
+
+    @skip_without_tool("cat")
+    def test_error_outputs_with_purged_inputs(self):
+        self._deleted_inputs_workflow(purge=True)
+
+    def _deleted_inputs_workflow(self, purge):
         # We run a workflow on a collection with a deleted element.
         with self.dataset_populator.test_history() as history_id:
             workflow_id = self._upload_yaml_workflow("""
@@ -1948,7 +1955,8 @@ steps:
             hdca1 = self.dataset_collection_populator.create_list_in_history(history_id,
                                                                              contents=[("sample1-1", "1 2 3")]).json()
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-            r = self._delete("histories/%s/contents/%s" % (history_id, hdca1['elements'][DELETED]['object']['id']))
+            deleted_id = hdca1['elements'][DELETED]['object']['id']
+            r = self._delete("histories/%s/contents/%s?purge=%s" % (history_id, deleted_id, purge))
             label_map = {"input1": self._ds_entry(hdca1)}
             workflow_request = dict(
                 history="hist_id=%s" % history_id,
@@ -1962,7 +1970,8 @@ steps:
             self.dataset_populator.wait_for_history_jobs(history_id, assert_ok=False)
             contents = self.__history_contents(history_id)
             assert contents[DELETED]['deleted']
-            assert contents[PAUSED_1]['state'] == 'paused'
+            state = 'error' if purge else 'paused'
+            assert contents[PAUSED_1]['state'] == state
             assert contents[PAUSED_2]['state'] == 'paused'
 
     def test_run_with_implicit_connection(self):


### PR DESCRIPTION
whose input datasets are purged. The error only occurs if `outputs_to_working_directory` is set.

The new test then also revealed that we didn't properly pause jobs with inputs in error state (they'd just be ignored), which is fixed by https://github.com/galaxyproject/galaxy/pull/8179/commits/920925da162b71f63cbd6ad5482a24c7079b3139