### PR TITLE
Generalized Kubernetes Staging (Dependency Resolution or Containers)

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -121,7 +121,7 @@ pbr==5.4.2
 prettytable==0.7.2
 prov==1.5.1
 psutil==5.6.3
-pulsar-galaxy-lib==0.12.1
+pulsar-galaxy-lib==0.13.0
 pyasn1-modules==0.2.6
 pyasn1==0.4.6
 pycparser==2.19

--- a/test/integration/test_kubernetes_staging.py
+++ b/test/integration/test_kubernetes_staging.py
@@ -31,7 +31,7 @@ runners:
     load: galaxy.jobs.runners.local:LocalJobRunner
     workers: 1
   pulsar_k8s:
-    load: galaxy.jobs.runners.pulsar:PulsarKubernetesCoexecutionJobRunner
+    load: galaxy.jobs.runners.pulsar:PulsarKubernetesJobRunner
     galaxy_url: ${infrastructure_url}
     amqp_url: ${amqp_url}
 
@@ -62,7 +62,7 @@ runners:
     load: galaxy.jobs.runners.local:LocalJobRunner
     workers: 1
   pulsar_k8s:
-    load: galaxy.jobs.runners.pulsar:PulsarKubernetesDependencyResolvingJobRunner
+    load: galaxy.jobs.runners.pulsar:PulsarKubernetesJobRunner
     galaxy_url: ${infrastructure_url}
     amqp_url: ${amqp_url}
 
@@ -74,16 +74,6 @@ execution:
       runner: pulsar_k8s
       pulsar_app_config:
         message_queue_url: '${container_amqp_url}'
-        dependency_resolution:
-          cache: false
-          use: true
-          default_base_path: /pulsar_dependencies
-          cache_dir: /pulsar_dependencies/_cache
-          resolvers:
-          - type: conda
-            auto_init: true
-            auto_install: true
-            prefix: '/pulsar_dependencies/conda'
       env:
         - name: SOME_ENV_VAR
           value: '42'

--- a/test/integration/test_kubernetes_staging.py
+++ b/test/integration/test_kubernetes_staging.py
@@ -17,7 +17,7 @@ import tempfile
 
 from base import integration_util  # noqa: I100,I202
 from base.populators import skip_without_tool
-from .test_containerized_jobs import MulledJobTestCases  # noqa: I201
+from .test_containerized_jobs import EXTENDED_TIMEOUT, MulledJobTestCases  # noqa: I201
 from .test_job_environments import BaseJobEnvironmentIntegrationTestCase  # noqa: I201
 
 TOOL_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, 'tools'))
@@ -25,8 +25,7 @@ AMQP_URL = os.environ.get("GALAXY_TEST_AMQP_URL", "amqp://guest:guest@localhost:
 GALAXY_TEST_KUBERNETES_INFRASTRUCTURE_HOST = os.environ.get("GALAXY_TEST_KUBERNETES_INFRASTRUCTURE_HOST", "host.docker.internal")
 
 
-def job_config(jobs_directory):
-    job_conf_template = string.Template("""
+CONTAINERIZED_TEMPLATE = """
 runners:
   local:
     load: galaxy.jobs.runners.local:LocalJobRunner
@@ -54,7 +53,50 @@ execution:
 tools:
   - id: upload1
     environment: local_environment
-""")
+"""
+
+
+DEPENDENCY_RESOLUTION_TEMPLATE = """
+runners:
+  local:
+    load: galaxy.jobs.runners.local:LocalJobRunner
+    workers: 1
+  pulsar_k8s:
+    load: galaxy.jobs.runners.pulsar:PulsarKubernetesDependencyResolvingJobRunner
+    galaxy_url: ${infrastructure_url}
+    amqp_url: ${amqp_url}
+
+execution:
+  default: pulsar_k8s_environment
+  environments:
+    pulsar_k8s_environment:
+      k8s_config_path: ${k8s_config_path}
+      runner: pulsar_k8s
+      pulsar_app_config:
+        message_queue_url: '${container_amqp_url}'
+        dependency_resolution:
+          cache: false
+          use: true
+          default_base_path: /pulsar_dependencies
+          cache_dir: /pulsar_dependencies/_cache
+          resolvers:
+          - type: conda
+            auto_init: true
+            auto_install: true
+            prefix: '/pulsar_dependencies/conda'
+      env:
+        - name: SOME_ENV_VAR
+          value: '42'
+    local_environment:
+      runner: local
+tools:
+  - id: upload1
+    environment: local_environment
+"""
+
+
+def job_config(template_str, jobs_directory):
+    job_conf_template = string.Template(template_str)
     port = os.environ.get('GALAXY_TEST_PORT')
     assert port
     infrastructure_url = "http://%s:%s" % (GALAXY_TEST_KUBERNETES_INFRASTRUCTURE_HOST, port)
@@ -73,32 +115,63 @@ tools:
 
 @integration_util.skip_unless_kubernetes()
 @integration_util.skip_unless_fixed_port()
-class BaseKubernetesStagingIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
+class KubernetesStagingContainerIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
 
     def setUp(self):
-        super(BaseKubernetesStagingIntegrationTestCase, self).setUp()
+        super(KubernetesStagingContainerIntegrationTestCase, self).setUp()
         self.history_id = self.dataset_populator.new_history()
 
     @classmethod
     def setUpClass(cls):
         # realpath for docker deployed in a VM on Mac, also done in driver_util.
         cls.jobs_directory = os.path.realpath(tempfile.mkdtemp())
-        super(BaseKubernetesStagingIntegrationTestCase, cls).setUpClass()
+        super(KubernetesStagingContainerIntegrationTestCase, cls).setUpClass()
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         config["jobs_directory"] = cls.jobs_directory
         config["file_path"] = cls.jobs_directory
-        config["job_config_file"] = job_config(cls.jobs_directory)
-
+        config["job_config_file"] = job_config(CONTAINERIZED_TEMPLATE, cls.jobs_directory)
         config["default_job_shell"] = '/bin/sh'
-        # Disable tool dependency resolution.
+        # Disable local tool dependency resolution.
         config["tool_dependency_dir"] = "none"
 
     @skip_without_tool("job_environment_default")
     def test_job_environment(self):
         job_env = self._run_and_get_environment_properties()
         assert job_env.some_env == '42'
+
+
+@integration_util.skip_unless_kubernetes()
+@integration_util.skip_unless_fixed_port()
+class KubernetesDependencyResolutionIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
+
+    def setUp(self):
+        super(KubernetesDependencyResolutionIntegrationTestCase, self).setUp()
+        self.history_id = self.dataset_populator.new_history()
+
+    @classmethod
+    def setUpClass(cls):
+        # realpath for docker deployed in a VM on Mac, also done in driver_util.
+        cls.jobs_directory = os.path.realpath(tempfile.mkdtemp())
+        super(KubernetesDependencyResolutionIntegrationTestCase, cls).setUpClass()
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["jobs_directory"] = cls.jobs_directory
+        config["file_path"] = cls.jobs_directory
+        config["job_config_file"] = job_config(DEPENDENCY_RESOLUTION_TEMPLATE, cls.jobs_directory)
+
+        config["default_job_shell"] = '/bin/sh'
+        # Disable tool dependency resolution.
+        config["tool_dependency_dir"] = "none"
+        config["enable_beta_mulled_containers"] = "true"
+
+    def test_mulled_simple(self):
+        self.dataset_populator.run_tool("mulled_example_simple", {}, self.history_id)
+        self.dataset_populator.wait_for_history(self.history_id, assert_ok=True)
+        output = self.dataset_populator.get_history_dataset_content(self.history_id, timeout=EXTENDED_TIMEOUT)
+        assert "0.7.15-r1140" in output
 
 
 def to_infrastructure_uri(uri):


### PR DESCRIPTION
Renamed the Pulsar runner derivative for Kubernetes. It now works using just one container and dependency resolution if docker isn't enabled for that destination. Dependency resolution in the container can be configured using nested configuration in the job conf yaml file (``puslar_app_config: {dependency_resolution: {}}``) but a default is set by the Pulsar client library that configures a Conda environment that is configured inside the container. If a container is configured for the job destination, the two-container co-execution strategy from #7835 is still used (but this PR makes that something of an uninteresting implementation detail).

Original Description:

~Builds on #8152 (un-merged) and #7835 (merged) to implement a Kubernetes runner with Pulsar staging but that works with dependency resolution inside of the Pulsar container instead of a second co-executing container.~

~This requires a Pulsar release and a Pulsar Docker container publication (against this branch of Pulsar https://github.com/galaxyproject/pulsar/pull/195)... but it essentially works currently I think with those changes.~

~The example dependency resolution shown here uses a Conda install setup inside the Pulsar container but the goal longer term I guess would be to setup separate Conda resolvers for that and for CVMFS - so it would use CVMFS if available and would auto install locally inside the container if not.~

~The other longer term goal would be to merge the actual runner implementation between this and #7835 - so that you wouldn't need to care if one or two containers would be used. That detail would just be handled by the Pulsar client based on whether a container is configured or not.~
 
