### PR TITLE
Fix portable metadata datatypes config.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1931,7 +1931,8 @@ class JobWrapper(HasResourceParameters):
         if config_file is None:
             config_file = self.app.config.config_file
         if datatypes_config is None:
-            datatypes_config = os.path.join(self.working_directory, 'registry.xml')
+            datatypes_config = os.path.join(self.working_directory, 'metadata', 'registry.xml')
+            safe_makedirs(os.path.join(self.working_directory, 'metadata'))
             self.app.datatypes_registry.to_xml_file(path=datatypes_config)
 
         output_datasets = {}

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -138,6 +138,7 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
             }
 
         metadata_params_path = os.path.join(metadata_dir, "params.json")
+        datatypes_config = os.path.relpath(datatypes_config, tmp_dir)
         metadata_params = {
             "job_metadata": job_relative_path(job_metadata),
             "datatypes_config": datatypes_config,

--- a/test/unit/tools/test_metadata.py
+++ b/test/unit/tools/test_metadata.py
@@ -6,6 +6,7 @@ from galaxy import model
 from galaxy.job_execution.datasets import DatasetPath
 from galaxy.metadata import get_metadata_compute_strategy
 from galaxy.objectstore import ObjectStorePopulator
+from galaxy.util import safe_makedirs
 from .. import tools_support
 
 
@@ -150,7 +151,8 @@ class MetadataTestCase(unittest.TestCase, tools_support.UsesApp, tools_support.U
         dataset_files_path = self.app.model.Dataset.file_path
         config_root = self.app.config.root
         config_file = None
-        datatypes_config = os.path.join(self.job_working_directory, 'registry.xml')
+        datatypes_config = os.path.join(self.job_working_directory, 'metadata', 'registry.xml')
+        safe_makedirs(os.path.join(self.job_working_directory, 'metadata'))
         self.app.datatypes_registry.to_xml_file(path=datatypes_config)
         job_metadata = os.path.join(self.tool_working_directory, self.tool.provided_metadata_file)
         output_fnames = [DatasetPath(o.dataset.id, o.dataset.file_name, None) for o in output_datasets.values()]


### PR DESCRIPTION
Absolute paths were preventing this from being re-locatable.