### PR TITLE
Don't check unneeded paths and such when loading datatypes for set_metadata.

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -82,7 +82,7 @@ class Registry(object):
         self.display_sites = {}
         self.legacy_build_sites = {}
 
-    def load_datatypes(self, root_dir=None, config=None, deactivate=False, override=True):
+    def load_datatypes(self, root_dir=None, config=None, deactivate=False, override=True, use_converters=True, use_display_applications=True, use_build_sites=True):
         """
         Parse a datatypes XML file located at root_dir/config (if processing the Galaxy distributed config) or contained within
         an installed Tool Shed repository.  If deactivate is True, an installed Tool Shed repository that includes custom datatypes
@@ -119,14 +119,16 @@ class Registry(object):
                 root = config
             registration = root.find('registration')
             # Set default paths defined in local datatypes_conf.xml.
-            if not self.converters_path:
-                self.converters_path_attr = registration.get('converters_path', 'lib/galaxy/datatypes/converters')
-                self.converters_path = os.path.join(root_dir, self.converters_path_attr)
-                if not os.path.isdir(self.converters_path):
-                    raise ConfigurationError("Directory does not exist: %s" % self.converters_path)
-            if not self.display_applications_path:
-                self.display_path_attr = registration.get('display_path', 'display_applications')
-                self.display_applications_path = os.path.join(root_dir, self.display_path_attr)
+            if use_converters:
+                if not self.converters_path:
+                    self.converters_path_attr = registration.get('converters_path', 'lib/galaxy/datatypes/converters')
+                    self.converters_path = os.path.join(root_dir, self.converters_path_attr)
+                    if not os.path.isdir(self.converters_path):
+                        raise ConfigurationError("Directory does not exist: %s" % self.converters_path)
+            if use_display_applications:
+                if not self.display_applications_path:
+                    self.display_path_attr = registration.get('display_path', 'display_applications')
+                    self.display_applications_path = os.path.join(root_dir, self.display_path_attr)
             # Proprietary datatype's <registration> tag may have special attributes, proprietary_converter_path and proprietary_display_path.
             proprietary_converter_path = registration.get('proprietary_converter_path', None)
             proprietary_display_path = registration.get('proprietary_display_path', None)
@@ -367,7 +369,8 @@ class Registry(object):
                                         compressed_sniffers=compressed_sniffers)
             self.upload_file_formats.sort()
             # Load build sites
-            self._load_build_sites(root)
+            if use_build_sites:
+                self._load_build_sites(root)
         self.set_default_values()
 
         def append_to_sniff_order():

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -193,7 +193,7 @@ def validate_and_load_datatypes_config(datatypes_config):
         sys.exit(1)
     import galaxy.datatypes.registry
     datatypes_registry = galaxy.datatypes.registry.Registry()
-    datatypes_registry.load_datatypes(root_dir=galaxy_root, config=datatypes_config)
+    datatypes_registry.load_datatypes(root_dir=galaxy_root, config=datatypes_config, use_build_sites=False, use_converters=False, use_display_applications=False)
     galaxy.model.set_datatypes_registry(datatypes_registry)
     return datatypes_registry
 


### PR DESCRIPTION
Display applications and such are not available in galaxy-job-execution - don't try to load them.
