### PR TITLE
Fix display application inclusion in galaxy-data for set-metadata.

### DIFF
--- a/packages/data/setup.py
+++ b/packages/data/setup.py
@@ -33,6 +33,7 @@ PACKAGES = [
     'galaxy',
     'galaxy.datatypes',
     'galaxy.datatypes.dataproviders',
+    'galaxy.datatypes.display_applications',
     'galaxy.datatypes.util',
     'galaxy.datatypes.test',
     'galaxy.model',


### PR DESCRIPTION
Already published as https://pypi.org/project/galaxy-data/19.9.0.dev2/.