### PR TITLE
Allow re-populating objectstore from to_dict form.

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -25,6 +25,7 @@ from galaxy.util import (
     force_symlink,
     umask_fix_perms,
 )
+from galaxy.util.bunch import Bunch
 from galaxy.util.odict import odict
 from galaxy.util.path import (
     safe_makedirs,
@@ -891,6 +892,12 @@ def build_object_store_from_config(config, fsmon=False, config_xml=None, config_
     'hierarchical', 'irods', and 'pulsar' are supported values.
     """
     from_object = 'xml'
+
+    if config is None and config_dict is not None and 'config' in config_dict:
+        # Build a config object from to_dict of an ObjectStore.
+        config = Bunch(**config_dict["config"])
+    elif config is None:
+        raise Exception("build_object_store_from_config sent None as config parameter and one cannot be recovered from config_dict")
 
     if config_xml is None and config_dict is None:
         config_file = config.object_store_config_file


### PR DESCRIPTION
This was meant for #7110 I think, I'm not sure why I didn't land up actually including it. Needed now for extended metadata collection using galaxy-job-execution package on Pulsar.