### PR TITLE
Run make config-rebuild to update config/docs

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -172,7 +172,7 @@ galaxy:
 
   # Time to sleep between attempts if database_wait is enabled (in
   # seconds).
-  #database_wait_sleep: 1
+  #database_wait_sleep: 1.0
 
   # Where dataset files are stored. It must accessible at the same path
   # on any cluster nodes that will run Galaxy jobs, unless using Pulsar.
@@ -1533,6 +1533,12 @@ galaxy:
   # Galaxy configuration or loaded from an additional file with the
   # job_config_file option.
   #job_config: null
+
+  # Rather than specifying a dependency_resolvers_config_file, the
+  # definition of the resolvers to enable can be embedded into Galaxy's
+  # config with this option. This has no effect if a
+  # dependency_resolvers_config_file is used.
+  #dependency_resolvers: null
 
   # When jobs fail due to job runner problems, Galaxy can be configured
   # to retry these or reroute the jobs to new destinations. Very fine

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -170,7 +170,7 @@
 :Description:
     Time to sleep between attempts if database_wait is enabled (in
     seconds).
-:Default: ``1``
+:Default: ``1.0``
 :Type: float
 
 
@@ -3195,6 +3195,19 @@
     job_config_file option.
 :Default: ``None``
 :Type: map
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~
+``dependency_resolvers``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Rather than specifying a dependency_resolvers_config_file, the
+    definition of the resolvers to enable can be embedded into
+    Galaxy's config with this option. This has no effect if a
+    dependency_resolvers_config_file is used.
+:Default: ``None``
+:Type: seq
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1,4 +1,5 @@
-
+# When committing this file, make sure to run make config-rebuild to rebuild
+# all sample YAML and RST files, and add those to your commit.
 type: map
 desc: |
   Galaxy is configured by default to be usable in a single-user development


### PR DESCRIPTION
This is to update galaxy.yml.sample and galaxy_options.rst to be consistent with the latest update to config_schema.yml (PRs https://github.com/galaxyproject/galaxy/pull/7897 and https://github.com/galaxyproject/galaxy/pull/8118)

(generated with `make config-rebuild`)

NOTE: I assume we run this each time we update config_schema.yml? I saw this while rebuilding with my own updates, and I didn't want to add this older update to an unrelated PR. 