### PR TITLE
[19.05] Fix UnicodeEncodeError when verifying test results

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -164,7 +164,7 @@ class LibraryActions(object):
                 if os.path.isfile(path):
                     files.append(path)
         except Exception as e:
-            message = "Unable to get file list for configured %s, error: %s" % (import_dir_desc, str(e))
+            message = "Unable to get file list for configured %s, error: %s" % (import_dir_desc, util.unicodify(e))
             response_code = 500
             return None, response_code, message
         if not files:

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -122,7 +122,7 @@ class CustosAuthnz(IdentityProvider):
             trans.sa_session.flush()
             return True, "", disconnect_redirect_url
         except Exception as e:
-            return False, "Failed to disconnect provider {}: {}".format(provider, str(e)), None
+            return False, "Failed to disconnect provider {}: {}".format(provider, util.unicodify(e)), None
 
     def _create_oauth2_session(self, state=None, scope=None):
         client_id = self.config['client_id']

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -17,6 +17,7 @@ from cloudauthz.exceptions import (
 
 from galaxy import exceptions
 from galaxy import model
+from galaxy.util import unicodify
 from .custos_authnz import CustosAuthnz
 from .psa_authnz import (
     BACKENDS_NAME,
@@ -147,7 +148,7 @@ class AuthnzManager(object):
                 return True, "", identity_provider_class(unified_provider_name, self.oidc_config, self.oidc_backends_config[unified_provider_name])
             except Exception as e:
                 log.exception('An error occurred when loading {}'.format(identity_provider_class.__name__))
-                return False, str(e), None
+                return False, unicodify(e), None
         else:
             msg = 'The requested identity provider, `{}`, is not a recognized/expected provider.'.format(provider)
             log.debug(msg)

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -26,14 +26,19 @@ from six.moves import configparser
 from galaxy.containers import parse_containers_config
 from galaxy.exceptions import ConfigurationError
 from galaxy.tools.deps.container_resolvers.mulled import DEFAULT_CHANNELS
-from galaxy.util import ExecutionTimer
-from galaxy.util import listify
-from galaxy.util import string_as_bool
-from galaxy.util import unicodify
+from galaxy.util import (
+    ExecutionTimer,
+    listify,
+    string_as_bool,
+    unicodify
+)
 from galaxy.util.dbkeys import GenomeBuilds
 from galaxy.util.logging import LOGLV_TRACE
 from galaxy.web.formatting import expand_pretty_datetime_format
-from galaxy.web.stack import get_stack_facts, register_postfork_function
+from galaxy.web.stack import (
+    get_stack_facts,
+    register_postfork_function
+)
 from .version import VERSION_MAJOR
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -838,7 +838,7 @@ class Configuration(object):
             try:
                 os.makedirs(path)
             except Exception as e:
-                raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, e))
+                raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, unicodify(e)))
 
     def check(self):
         paths_to_check = [self.root, self.tool_path, self.tool_data_path, self.template_path]
@@ -848,7 +848,7 @@ class Configuration(object):
                 try:
                     os.makedirs(path)
                 except Exception as e:
-                    raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, e))
+                    raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, unicodify(e)))
         # Create the directories that it makes sense to create
         for path in (self.new_file_path, self.template_cache, self.ftp_upload_dir,
                      self.library_import_dir, self.user_library_import_dir,

--- a/lib/galaxy/containers/docker_model.py
+++ b/lib/galaxy/containers/docker_model.py
@@ -16,7 +16,10 @@ from galaxy.containers import (
     ContainerPort,
     ContainerVolume
 )
-from galaxy.util import pretty_print_time_interval
+from galaxy.util import (
+    pretty_print_time_interval,
+    unicodify,
+)
 
 
 CPUS_LABEL = '_galaxy_cpus'
@@ -135,7 +138,7 @@ class DockerContainer(Container):
             port_mappings = self.inspect['NetworkSettings']['Ports']
         except KeyError as exc:
             log.warning("Failed to get ports for container %s from `docker inspect` output at "
-                        "['NetworkSettings']['Ports']: %s: %s", self.id, exc.__class__.__name__, str(exc))
+                        "['NetworkSettings']['Ports']: %s: %s", self.id, exc.__class__.__name__, unicodify(exc))
             return None
         for port_name in port_mappings:
             for binding in port_mappings[port_name]:
@@ -219,7 +222,7 @@ class DockerService(Container):
             port_mappings = self.inspect['Endpoint']['Ports']
         except (IndexError, KeyError) as exc:
             log.warning("Failed to get ports for container %s from `docker service inspect` output at "
-                        "['Endpoint']['Ports']: %s: %s", self.id, exc.__class__.__name__, str(exc))
+                        "['Endpoint']['Ports']: %s: %s", self.id, exc.__class__.__name__, unicodify(exc))
             return None
         for binding in port_mappings:
             rval.append(ContainerPort(
@@ -283,7 +286,7 @@ class DockerService(Container):
                     except ValueError:
                         self._env[env_str] = None
             except KeyError as exc:
-                log.debug('Cannot retrieve container environment: KeyError: %s', str(exc))
+                log.debug('Cannot retrieve container environment: KeyError: %s', unicodify(exc))
         return self._env
 
     @property

--- a/lib/galaxy/containers/docker_model.py
+++ b/lib/galaxy/containers/docker_model.py
@@ -136,9 +136,9 @@ class DockerContainer(Container):
         rval = []
         try:
             port_mappings = self.inspect['NetworkSettings']['Ports']
-        except KeyError as exc:
+        except KeyError:
             log.warning("Failed to get ports for container %s from `docker inspect` output at "
-                        "['NetworkSettings']['Ports']: %s: %s", self.id, exc.__class__.__name__, unicodify(exc))
+                        "['NetworkSettings']['Ports']: %s: %s", self.id, exc_info=True)
             return None
         for port_name in port_mappings:
             for binding in port_mappings[port_name]:
@@ -220,9 +220,9 @@ class DockerService(Container):
         rval = []
         try:
             port_mappings = self.inspect['Endpoint']['Ports']
-        except (IndexError, KeyError) as exc:
+        except (IndexError, KeyError):
             log.warning("Failed to get ports for container %s from `docker service inspect` output at "
-                        "['Endpoint']['Ports']: %s: %s", self.id, exc.__class__.__name__, unicodify(exc))
+                        "['Endpoint']['Ports']: %s: %s", self.id, exc_info=True)
             return None
         for binding in port_mappings:
             rval.append(ContainerPort(

--- a/lib/galaxy/containers/docker_swarm.py
+++ b/lib/galaxy/containers/docker_swarm.py
@@ -33,6 +33,7 @@ from galaxy.containers.docker_model import (
     IMAGE_CONSTRAINT
 )
 from galaxy.exceptions import ContainerRunError
+from galaxy.util import unicodify
 from galaxy.util.json import safe_dumps_formatted
 
 log = logging.getLogger(__name__)
@@ -124,7 +125,7 @@ class DockerSwarmInterface(DockerInterface):
                 subprocess.check_call(['python', SWARM_MANAGER_PATH, '--containers-config-file',
                                       self.containers_config_file, '--swarm', self.key])
             except subprocess.CalledProcessError as exc:
-                log.error('Failed to launch swarm manager: %s', str(exc))
+                log.error('Failed to launch swarm manager: %s', unicodify(exc))
 
     def _get_image(self, image):
         """Get the image string, either from the argument, or from the

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -699,7 +699,7 @@ class Bcf(BaseBcf):
             subprocess.check_call(cmd)
             shutil.move(dataset_symlink + '.csi', index_file.file_name)
         except Exception as e:
-            raise Exception('Error setting BCF metadata: %s' % (str(e)))
+            raise Exception('Error setting BCF metadata: %s' % util.unicodify(e))
         finally:
             # Remove temp file and symlink
             os.remove(dataset_symlink)

--- a/lib/galaxy/datatypes/converters/wiggle_to_simple_converter.py
+++ b/lib/galaxy/datatypes/converters/wiggle_to_simple_converter.py
@@ -11,6 +11,7 @@ import sys
 
 import bx.wiggle
 
+from galaxy.util import unicodify
 from galaxy.util.ucsc import (
     UCSCLimitException,
     UCSCOutWrapper
@@ -19,7 +20,7 @@ from galaxy.util.ucsc import (
 
 def stop_err(msg):
     sys.stderr.write(msg)
-    sys.exit()
+    sys.exit(1)
 
 
 def main():
@@ -40,7 +41,7 @@ def main():
         # Wiggle data was truncated, at the very least need to warn the user.
         print('Encountered message from UCSC: "Reached output limit of 100000 data values", so be aware your data was truncated.')
     except ValueError as e:
-        stop_err(str(e))
+        stop_err(unicodify(e))
     finally:
         in_file.close()
         out_file.close()

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -210,7 +210,7 @@ class Data(object):
             out.append('</table>')
             out = "".join(out)
         except Exception as exc:
-            out = "Can't create peek %s" % unicodify(exc)
+            out = "Can't create peek: %s" % unicodify(exc)
         return out
 
     def _archive_main_file(self, archive, display_name, data_filename):
@@ -910,7 +910,7 @@ class Text(Data):
                     part_file.write(a_line)
                     lines_remaining -= 1
         except Exception as e:
-            log.error('Unable to split files: %s' % unicodify(e))
+            log.error('Unable to split files: %s', unicodify(e))
             raise
         finally:
             f.close()

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -210,7 +210,7 @@ class Data(object):
             out.append('</table>')
             out = "".join(out)
         except Exception as exc:
-            out = "Can't create peek %s" % str(exc)
+            out = "Can't create peek %s" % unicodify(exc)
         return out
 
     def _archive_main_file(self, archive, display_name, data_filename):
@@ -910,7 +910,7 @@ class Text(Data):
                     part_file.write(a_line)
                     lines_remaining -= 1
         except Exception as e:
-            log.error('Unable to split files: %s' % str(e))
+            log.error('Unable to split files: %s' % unicodify(e))
             raise
         finally:
             f.close()

--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -25,7 +25,10 @@ from galaxy.datatypes.metadata import MetadataElement
 from galaxy.datatypes.sniff import build_sniff_from_prefix
 from galaxy.datatypes.tabular import Tabular
 from galaxy.datatypes.text import Html
-from galaxy.util import nice_size
+from galaxy.util import (
+    nice_size,
+    unicodify,
+)
 
 gal_Log = logging.getLogger(__name__)
 verbose = False
@@ -835,7 +838,7 @@ class RexpBase(Html):
             out.append('</table>')
             out = "\n".join(out)
         except Exception as exc:
-            out = "Can't create html table %s" % str(exc)
+            out = "Can't create html table %s" % unicodify(exc)
         return out
 
     def display_peek(self, dataset):

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -772,9 +772,8 @@ class Gff(Tabular, _RemoteCallMixin):
                         break
                 if seqid is not None:
                     return (seqid, str(start), str(stop))  # Necessary to return strings?
-            except Exception as e:
-                # unexpected error
-                log.exception(util.unicodify(e))
+            except Exception:
+                log.exception('Unexpected error')
         return (None, None, None)  # could not determine viewport
 
     def ucsc_links(self, dataset, type, app, base_url):
@@ -1141,9 +1140,8 @@ class Wiggle(Tabular, _RemoteCallMixin):
                         break
                 if chrom is not None:
                     return (chrom, str(start), str(end))  # Necessary to return strings?
-            except Exception as e:
-                # unexpected error
-                log.exception(util.unicodify(e))
+            except Exception:
+                log.exception('Unexpected error')
         return (None, None, None)  # could not determine viewport
 
     def gbrowse_links(self, dataset, type, app, base_url):
@@ -1323,9 +1321,8 @@ class CustomTrack(Tabular):
                     if not max_line_count:
                         # exceeded viewport or total line count to check
                         break
-            except Exception as e:
-                # unexpected error
-                log.exception(util.unicodify(e))
+            except Exception:
+                log.exception('Unexpected error')
         return (None, None, None)  # could not determine viewport
 
     def ucsc_links(self, dataset, type, app, base_url):

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -774,7 +774,7 @@ class Gff(Tabular, _RemoteCallMixin):
                     return (seqid, str(start), str(stop))  # Necessary to return strings?
             except Exception as e:
                 # unexpected error
-                log.exception(str(e))
+                log.exception(util.unicodify(e))
         return (None, None, None)  # could not determine viewport
 
     def ucsc_links(self, dataset, type, app, base_url):
@@ -1143,7 +1143,7 @@ class Wiggle(Tabular, _RemoteCallMixin):
                     return (chrom, str(start), str(end))  # Necessary to return strings?
             except Exception as e:
                 # unexpected error
-                log.exception(str(e))
+                log.exception(util.unicodify(e))
         return (None, None, None)  # could not determine viewport
 
     def gbrowse_links(self, dataset, type, app, base_url):
@@ -1325,7 +1325,7 @@ class CustomTrack(Tabular):
                         break
             except Exception as e:
                 # unexpected error
-                log.exception(str(e))
+                log.exception(util.unicodify(e))
         return (None, None, None)  # could not determine viewport
 
     def ucsc_links(self, dataset, type, app, base_url):

--- a/lib/galaxy/datatypes/isa.py
+++ b/lib/galaxy/datatypes/isa.py
@@ -195,7 +195,7 @@ class _Isa(data.Data):
             out.append('</table>')
             out = "".join(out)
         except Exception as exc:
-            out = "Can't create peek %s" % str(exc)
+            out = "Can't create peek %s" % util.unicodify(exc)
         return out
 
     # Generate primary file {{{2

--- a/lib/galaxy/datatypes/isa.py
+++ b/lib/galaxy/datatypes/isa.py
@@ -195,7 +195,7 @@ class _Isa(data.Data):
             out.append('</table>')
             out = "".join(out)
         except Exception as exc:
-            out = "Can't create peek %s" % util.unicodify(exc)
+            out = "Can't create peek: %s" % util.unicodify(exc)
         return out
 
     # Generate primary file {{{2

--- a/lib/galaxy/datatypes/molecules.py
+++ b/lib/galaxy/datatypes/molecules.py
@@ -168,7 +168,7 @@ class SDF(GenericMolFile):
             if sdf_lines_accumulated:
                 _write_part_sdf_file(sdf_lines_accumulated)
         except Exception as e:
-            log.error('Unable to split files: %s' % unicodify(e))
+            log.error('Unable to split files: %s', unicodify(e))
             raise
     split = classmethod(split)
 
@@ -255,7 +255,7 @@ class MOL2(GenericMolFile):
             if mol2_lines_accumulated:
                 _write_part_mol2_file(mol2_lines_accumulated)
         except Exception as e:
-            log.error('Unable to split files: %s' % unicodify(e))
+            log.error('Unable to split files: %s', unicodify(e))
             raise
     split = classmethod(split)
 
@@ -334,7 +334,7 @@ class FPS(GenericMolFile):
             if lines_accumulated:
                 _write_part_fingerprint_file(header_lines + lines_accumulated)
         except Exception as e:
-            log.error('Unable to split files: %s' % unicodify(e))
+            log.error('Unable to split files: %s', unicodify(e))
             raise
     split = classmethod(split)
 
@@ -504,7 +504,7 @@ class PDB(GenericMolFile):
                             chain_ids.add(line[21])
             dataset.metadata.chain_ids = list(chain_ids)
         except Exception as e:
-            log.error('Error finding chain_ids: %s' % unicodify(e))
+            log.error('Error finding chain_ids: %s', unicodify(e))
             raise
 
     def set_peek(self, dataset, is_multi_byte=False):
@@ -657,7 +657,7 @@ class PQR(GenericMolFile):
                         chain_ids.add(match.groups()[5])
             dataset.metadata.chain_ids = list(chain_ids)
         except Exception as e:
-            log.error('Error finding chain_ids: %s' % unicodify(e))
+            log.error('Error finding chain_ids: %s', unicodify(e))
             raise
 
     def set_peek(self, dataset, is_multi_byte=False):
@@ -899,7 +899,7 @@ class CML(GenericXml):
             if cml_lines_accumulated:
                 _write_part_cml_file(cml_lines_accumulated)
         except Exception as e:
-            log.error('Unable to split files: %s' % unicodify(e))
+            log.error('Unable to split files: %s', unicodify(e))
             raise
     split = classmethod(split)
 

--- a/lib/galaxy/datatypes/molecules.py
+++ b/lib/galaxy/datatypes/molecules.py
@@ -19,6 +19,7 @@ from galaxy.datatypes.sniff import (
 from galaxy.datatypes.tabular import Tabular
 from galaxy.datatypes.util.generic_util import count_special_lines
 from galaxy.datatypes.xml import GenericXml
+from galaxy.util import unicodify
 
 log = logging.getLogger(__name__)
 
@@ -167,7 +168,7 @@ class SDF(GenericMolFile):
             if sdf_lines_accumulated:
                 _write_part_sdf_file(sdf_lines_accumulated)
         except Exception as e:
-            log.error('Unable to split files: %s' % str(e))
+            log.error('Unable to split files: %s' % unicodify(e))
             raise
     split = classmethod(split)
 
@@ -254,7 +255,7 @@ class MOL2(GenericMolFile):
             if mol2_lines_accumulated:
                 _write_part_mol2_file(mol2_lines_accumulated)
         except Exception as e:
-            log.error('Unable to split files: %s' % str(e))
+            log.error('Unable to split files: %s' % unicodify(e))
             raise
     split = classmethod(split)
 
@@ -333,7 +334,7 @@ class FPS(GenericMolFile):
             if lines_accumulated:
                 _write_part_fingerprint_file(header_lines + lines_accumulated)
         except Exception as e:
-            log.error('Unable to split files: %s' % str(e))
+            log.error('Unable to split files: %s' % unicodify(e))
             raise
     split = classmethod(split)
 
@@ -503,7 +504,7 @@ class PDB(GenericMolFile):
                             chain_ids.add(line[21])
             dataset.metadata.chain_ids = list(chain_ids)
         except Exception as e:
-            log.error('Error finding chain_ids: %s' % str(e))
+            log.error('Error finding chain_ids: %s' % unicodify(e))
             raise
 
     def set_peek(self, dataset, is_multi_byte=False):
@@ -656,7 +657,7 @@ class PQR(GenericMolFile):
                         chain_ids.add(match.groups()[5])
             dataset.metadata.chain_ids = list(chain_ids)
         except Exception as e:
-            log.error('Error finding chain_ids: %s' % str(e))
+            log.error('Error finding chain_ids: %s' % unicodify(e))
             raise
 
     def set_peek(self, dataset, is_multi_byte=False):
@@ -898,7 +899,7 @@ class CML(GenericXml):
             if cml_lines_accumulated:
                 _write_part_cml_file(cml_lines_accumulated)
         except Exception as e:
-            log.error('Unable to split files: %s' % str(e))
+            log.error('Unable to split files: %s' % unicodify(e))
             raise
     split = classmethod(split)
 

--- a/lib/galaxy/datatypes/mothur.py
+++ b/lib/galaxy/datatypes/mothur.py
@@ -982,7 +982,7 @@ class SffFlow(Tabular):
             out += self.make_html_peek_rows(dataset, skipchars=skipchars)
             out += '</table>'
         except Exception as exc:
-            out = "Can't create peek %s" % unicodify(exc)
+            out = "Can't create peek: %s" % unicodify(exc)
         return out
 
 

--- a/lib/galaxy/datatypes/mothur.py
+++ b/lib/galaxy/datatypes/mothur.py
@@ -13,6 +13,7 @@ from galaxy.datatypes.sniff import (
     iter_headers
 )
 from galaxy.datatypes.tabular import Tabular
+from galaxy.util import unicodify
 
 log = logging.getLogger(__name__)
 
@@ -981,7 +982,7 @@ class SffFlow(Tabular):
             out += self.make_html_peek_rows(dataset, skipchars=skipchars)
             out += '</table>'
         except Exception as exc:
-            out = "Can't create peek %s" % str(exc)
+            out = "Can't create peek %s" % unicodify(exc)
         return out
 
 

--- a/lib/galaxy/datatypes/msa.py
+++ b/lib/galaxy/datatypes/msa.py
@@ -217,7 +217,7 @@ class Stockholm_1_0(Text):
             if stockholm_lines_accumulated:
                 _write_part_stockholm_file(stockholm_lines_accumulated)
         except Exception as e:
-            log.error('Unable to split files: %s' % unicodify(e))
+            log.error('Unable to split files: %s', unicodify(e))
             raise
     split = classmethod(split)
 

--- a/lib/galaxy/datatypes/msa.py
+++ b/lib/galaxy/datatypes/msa.py
@@ -8,7 +8,10 @@ from galaxy.datatypes.data import get_file_peek, Text
 from galaxy.datatypes.metadata import MetadataElement
 from galaxy.datatypes.sniff import build_sniff_from_prefix
 from galaxy.datatypes.util import generic_util
-from galaxy.util import nice_size
+from galaxy.util import (
+    nice_size,
+    unicodify,
+)
 
 log = logging.getLogger(__name__)
 
@@ -214,7 +217,7 @@ class Stockholm_1_0(Text):
             if stockholm_lines_accumulated:
                 _write_part_stockholm_file(stockholm_lines_accumulated)
         except Exception as e:
-            log.error('Unable to split files: %s' % str(e))
+            log.error('Unable to split files: %s' % unicodify(e))
             raise
     split = classmethod(split)
 

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -222,7 +222,7 @@ class Registry(object):
                                             datatype_class = getattr(imported_module, datatype_class_name)
                                     except Exception as e:
                                         full_path = os.path.join(proprietary_path, proprietary_datatype_module)
-                                        self.log.debug("Exception importing proprietary code file %s: %s" % (str(full_path), str(e)))
+                                        self.log.debug("Exception importing proprietary code file %s: %s" % (str(full_path), galaxy.util.unicodify(e)))
                                 # Either the above exception was thrown because the proprietary_datatype_module is not derived from a class
                                 # in the repository, or we are loading Galaxy's datatypes. In either case we'll look in the registry.
                                 if datatype_class is None:

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -222,7 +222,7 @@ class Registry(object):
                                             datatype_class = getattr(imported_module, datatype_class_name)
                                     except Exception as e:
                                         full_path = os.path.join(proprietary_path, proprietary_datatype_module)
-                                        self.log.debug("Exception importing proprietary code file %s: %s" % (str(full_path), galaxy.util.unicodify(e)))
+                                        self.log.debug("Exception importing proprietary code file %s: %s", full_path, galaxy.util.unicodify(e))
                                 # Either the above exception was thrown because the proprietary_datatype_module is not derived from a class
                                 # in the repository, or we are loading Galaxy's datatypes. In either case we'll look in the registry.
                                 if datatype_class is None:

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -451,7 +451,7 @@ class Fasta(Sequence):
                     start_offset = f.tell()
                 part_file.write(line)
         except Exception as e:
-            log.error('Unable to size split FASTA file: %s' % str(e))
+            log.error('Unable to size split FASTA file: %s' % util.unicodify(e))
             raise
         finally:
             f.close()
@@ -488,7 +488,7 @@ class Fasta(Sequence):
                         rec_count = 1
                 part_file.write(line)
         except Exception as e:
-            log.error('Unable to count split FASTA file: %s' % str(e))
+            log.error('Unable to count split FASTA file: %s' % util.unicodify(e))
             raise
         finally:
             f.close()

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -451,7 +451,7 @@ class Fasta(Sequence):
                     start_offset = f.tell()
                 part_file.write(line)
         except Exception as e:
-            log.error('Unable to size split FASTA file: %s' % util.unicodify(e))
+            log.error('Unable to size split FASTA file: %s', util.unicodify(e))
             raise
         finally:
             f.close()
@@ -488,7 +488,7 @@ class Fasta(Sequence):
                         rec_count = 1
                 part_file.write(line)
         except Exception as e:
-            log.error('Unable to count split FASTA file: %s' % util.unicodify(e))
+            log.error('Unable to count split FASTA file: %s', util.unicodify(e))
             raise
         finally:
             f.close()

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -679,7 +679,7 @@ def handle_compressed_file(
                 os.close(fd)
                 os.remove(uncompressed)
                 compressed_file.close()
-                raise IOError('Problem uncompressing %s data, please try retrieving the data uncompressed: %s' % (compressed_type, e))
+                raise IOError('Problem uncompressing %s data, please try retrieving the data uncompressed: %s' % (compressed_type, util.unicodify(e)))
             if not chunk:
                 break
             os.write(fd, chunk)

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -129,7 +129,7 @@ class TabularData(data.Text):
             out.append('</table>')
             out = "".join(out)
         except Exception as exc:
-            out = "Can't create peek %s" % str(exc)
+            out = "Can't create peek %s" % util.unicodify(exc)
         return out
 
     def make_html_peek_header(self, dataset, skipchars=None, column_names=None, column_number_format='%s', column_parameter_alias=None, **kwargs):
@@ -175,7 +175,7 @@ class TabularData(data.Text):
             out.append('</tr>')
         except Exception as exc:
             log.exception('make_html_peek_header failed on HDA %s', dataset.id)
-            raise Exception("Can't create peek header %s" % str(exc))
+            raise Exception("Can't create peek header %s" % util.unicodify(exc))
         return "".join(out)
 
     def make_html_peek_rows(self, dataset, skipchars=None, **kwargs):
@@ -206,7 +206,7 @@ class TabularData(data.Text):
                         out.append('</tr>')
         except Exception as exc:
             log.exception('make_html_peek_rows failed on HDA %s', dataset.id)
-            raise Exception("Can't create peek rows %s" % str(exc))
+            raise Exception("Can't create peek rows %s" % util.unicodify(exc))
         return "".join(out)
 
     def display_peek(self, dataset):
@@ -780,7 +780,7 @@ class VcfGz(BaseVcf, binary.Binary):
         try:
             pysam.tabix_index(dataset.file_name, index=index_file.file_name, preset='vcf', force=True)
         except Exception as e:
-            raise Exception('Error setting VCF.gz metadata: %s' % (str(e)))
+            raise Exception('Error setting VCF.gz metadata: %s' % (util.unicodify(e)))
         dataset.metadata.tabix_index = index_file
 
 

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -129,7 +129,7 @@ class TabularData(data.Text):
             out.append('</table>')
             out = "".join(out)
         except Exception as exc:
-            out = "Can't create peek %s" % util.unicodify(exc)
+            out = "Can't create peek: %s" % util.unicodify(exc)
         return out
 
     def make_html_peek_header(self, dataset, skipchars=None, column_names=None, column_number_format='%s', column_parameter_alias=None, **kwargs):

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -175,7 +175,7 @@ class TabularData(data.Text):
             out.append('</tr>')
         except Exception as exc:
             log.exception('make_html_peek_header failed on HDA %s', dataset.id)
-            raise Exception("Can't create peek header %s" % util.unicodify(exc))
+            raise Exception("Can't create peek header: %s" % util.unicodify(exc))
         return "".join(out)
 
     def make_html_peek_rows(self, dataset, skipchars=None, **kwargs):
@@ -206,7 +206,7 @@ class TabularData(data.Text):
                         out.append('</tr>')
         except Exception as exc:
             log.exception('make_html_peek_rows failed on HDA %s', dataset.id)
-            raise Exception("Can't create peek rows %s" % util.unicodify(exc))
+            raise Exception("Can't create peek rows: %s" % util.unicodify(exc))
         return "".join(out)
 
     def display_peek(self, dataset):

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -688,12 +688,12 @@ class SnpSiftDbNSFP(Text):
                                 headers = lines[0].split('\t')
                                 dataset.metadata.annotation = headers[4:]
                         except Exception as e:
-                            log.warning("set_meta fname: %s  %s" % (fname, unicodify(e)))
+                            log.warning("set_meta fname: %s  %s", fname, unicodify(e))
                     if fname.endswith('.tbi'):
                         dataset.metadata.index = fname
             self.regenerate_primary_file(dataset)
         except Exception as e:
-            log.warning("set_meta fname: %s  %s" % (dataset.file_name if dataset and dataset.file_name else 'Unkwown', unicodify(e)))
+            log.warning("set_meta fname: %s  %s", dataset.file_name if dataset and dataset.file_name else 'Unkwown', unicodify(e))
 
         def set_peek(self, dataset, is_multi_byte=False):
             if not dataset.dataset.purged:

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -15,7 +15,11 @@ from six.moves import shlex_quote
 from galaxy.datatypes.data import get_file_peek, Text
 from galaxy.datatypes.metadata import MetadataElement, MetadataParameter
 from galaxy.datatypes.sniff import build_sniff_from_prefix, iter_headers
-from galaxy.util import nice_size, string_as_bool
+from galaxy.util import (
+    nice_size,
+    string_as_bool,
+    unicodify,
+)
 
 log = logging.getLogger(__name__)
 
@@ -684,12 +688,12 @@ class SnpSiftDbNSFP(Text):
                                 headers = lines[0].split('\t')
                                 dataset.metadata.annotation = headers[4:]
                         except Exception as e:
-                            log.warning("set_meta fname: %s  %s" % (fname, str(e)))
+                            log.warning("set_meta fname: %s  %s" % (fname, unicodify(e)))
                     if fname.endswith('.tbi'):
                         dataset.metadata.index = fname
             self.regenerate_primary_file(dataset)
         except Exception as e:
-            log.warning("set_meta fname: %s  %s" % (dataset.file_name if dataset and dataset.file_name else 'Unkwown', str(e)))
+            log.warning("set_meta fname: %s  %s" % (dataset.file_name if dataset and dataset.file_name else 'Unkwown', unicodify(e)))
 
         def set_peek(self, dataset, is_multi_byte=False):
             if not dataset.dataset.purged:

--- a/lib/galaxy/datatypes/upload_util.py
+++ b/lib/galaxy/datatypes/upload_util.py
@@ -55,7 +55,7 @@ def handle_upload(
                 convert_spaces_to_tabs=convert_spaces_to_tabs,
             )
         except sniff.InappropriateDatasetContentError as exc:
-            raise UploadProblemException(unicodify(exc))
+            raise UploadProblemException(exc)
     elif requested_ext == 'auto':
         ext = sniff.guess_ext(path, registry.sniff_order, is_binary=is_binary)
     else:

--- a/lib/galaxy/datatypes/upload_util.py
+++ b/lib/galaxy/datatypes/upload_util.py
@@ -1,6 +1,7 @@
 import os
 
 from galaxy.datatypes import sniff
+from galaxy.util import unicodify
 from galaxy.util.checkers import (
     check_binary,
     is_single_file_zip,
@@ -54,7 +55,7 @@ def handle_upload(
                 convert_spaces_to_tabs=convert_spaces_to_tabs,
             )
         except sniff.InappropriateDatasetContentError as exc:
-            raise UploadProblemException(str(exc))
+            raise UploadProblemException(unicodify(exc))
     elif requested_ext == 'auto':
         ext = sniff.guess_ext(path, registry.sniff_order, is_binary=is_binary)
     else:

--- a/lib/galaxy/datatypes/upload_util.py
+++ b/lib/galaxy/datatypes/upload_util.py
@@ -1,7 +1,6 @@
 import os
 
 from galaxy.datatypes import sniff
-from galaxy.util import unicodify
 from galaxy.util.checkers import (
     check_binary,
     is_single_file_zip,

--- a/lib/galaxy/datatypes/util/gff_util.py
+++ b/lib/galaxy/datatypes/util/gff_util.py
@@ -6,6 +6,7 @@ import copy
 from bx.intervals.io import GenomicInterval, GenomicIntervalReader, MissingFieldError, NiceReaderWrapper, ParseError
 from bx.tabular.io import Comment, Header
 
+from galaxy.util import unicodify
 from galaxy.util.odict import odict
 
 FASTA_DIRECTIVE = '##FASTA'
@@ -171,7 +172,7 @@ class GFFReaderWrapper(NiceReaderWrapper):
             self.skipped += 1
             # no reason to stuff an entire bad file into memmory
             if self.skipped < 10:
-                self.skipped_lines.append((self.linenum, self.current_line, str(e)))
+                self.skipped_lines.append((self.linenum, self.current_line, unicodify(e)))
 
             # For debugging, uncomment this to propogate parsing exceptions up.
             # I.e. the underlying reason for an unexpected StopIteration exception

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1021,9 +1021,9 @@ class JobWrapper(HasResourceParameters):
                 for dataset_path in self.get_output_fnames():
                     try:
                         shutil.move(dataset_path.false_path, dataset_path.real_path)
-                        log.debug("fail(): Moved %s to %s" % (dataset_path.false_path, dataset_path.real_path))
+                         log.debug("fail(): Moved %s to %s", dataset_path.false_path, dataset_path.real_path)
                     except (IOError, OSError) as e:
-                        log.error("fail(): Missing output file in working directory: %s" % unicodify(e))
+                        log.error("fail(): Missing output file in working directory: %s", unicodify(e)
             for dataset_assoc in job.output_datasets + job.output_library_datasets:
                 dataset = dataset_assoc.dataset
                 self.sa_session.refresh(dataset)
@@ -1557,7 +1557,7 @@ class JobWrapper(HasResourceParameters):
                         preserve_symlinks=True
                     )
         except Exception as e:
-            log.debug("Error in collect_associated_files: %s" % unicodify(e))
+            log.debug("Error in collect_associated_files: %s", unicodify(e))
 
     def _collect_metrics(self, has_metrics, job_metrics_directory=None):
         job = has_metrics.get_job()

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1021,9 +1021,9 @@ class JobWrapper(HasResourceParameters):
                 for dataset_path in self.get_output_fnames():
                     try:
                         shutil.move(dataset_path.false_path, dataset_path.real_path)
-                         log.debug("fail(): Moved %s to %s", dataset_path.false_path, dataset_path.real_path)
+                        log.debug("fail(): Moved %s to %s", dataset_path.false_path, dataset_path.real_path)
                     except (IOError, OSError) as e:
-                        log.error("fail(): Missing output file in working directory: %s", unicodify(e)
+                        log.error("fail(): Missing output file in working directory: %s", unicodify(e))
             for dataset_assoc in job.output_datasets + job.output_library_datasets:
                 dataset = dataset_assoc.dataset
                 self.sa_session.refresh(dataset)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1002,7 +1002,7 @@ class JobWrapper(HasResourceParameters):
             self.job_destination
         except JobMappingException as exc:
             log.debug("(%s) fail(): Job destination raised JobMappingException('%s'), caching fake '__fail__' "
-                      "destination for completion of fail method", self.get_id_tag(), str(exc.failure_message))
+                      "destination for completion of fail method", self.get_id_tag(), unicodify(exc.failure_message))
             self.job_runner_mapper.cached_job_destination = JobDestination(id='__fail__')
 
         # if the job was deleted, don't fail it
@@ -1023,7 +1023,7 @@ class JobWrapper(HasResourceParameters):
                         shutil.move(dataset_path.false_path, dataset_path.real_path)
                         log.debug("fail(): Moved %s to %s" % (dataset_path.false_path, dataset_path.real_path))
                     except (IOError, OSError) as e:
-                        log.error("fail(): Missing output file in working directory: %s" % e)
+                        log.error("fail(): Missing output file in working directory: %s" % unicodify(e))
             for dataset_assoc in job.output_datasets + job.output_library_datasets:
                 dataset = dataset_assoc.dataset
                 self.sa_session.refresh(dataset)
@@ -1327,7 +1327,7 @@ class JobWrapper(HasResourceParameters):
                             trynum = self.app.config.retry_job_output_collection
                         except (OSError, ObjectNotFound) as e:
                             trynum += 1
-                            log.warning('Error accessing dataset with ID %i, will retry: %s', dataset.dataset.id, e)
+                            log.warning('Error accessing dataset with ID %i, will retry: %s', dataset.dataset.id, unicodify(e))
                             time.sleep(2)
                 if getattr(dataset, "hidden_beneath_collection_instance", None):
                     dataset.visible = False
@@ -1356,7 +1356,7 @@ class JobWrapper(HasResourceParameters):
                             self.object_store.update_from_file(dataset.dataset, file_name=temp_fh.name, create=True)
                             dataset.set_size()
                     except Exception as e:
-                        log.warning('Unable to generate primary composite file automatically for %s: %s', dataset.dataset.id, e)
+                        log.warning('Unable to generate primary composite file automatically for %s: %s', dataset.dataset.id, unicodify(e))
                 if job.states.ERROR == final_job_state:
                     dataset.blurb = "error"
                     if not implicit_collection_jobs:
@@ -1557,7 +1557,7 @@ class JobWrapper(HasResourceParameters):
                         preserve_symlinks=True
                     )
         except Exception as e:
-            log.debug("Error in collect_associated_files: %s" % (e))
+            log.debug("Error in collect_associated_files: %s" % unicodify(e))
 
     def _collect_metrics(self, has_metrics, job_metrics_directory=None):
         job = has_metrics.get_job()

--- a/lib/galaxy/jobs/actions/post.py
+++ b/lib/galaxy/jobs/actions/post.py
@@ -7,7 +7,10 @@ import socket
 
 from markupsafe import escape
 
-from galaxy.util import send_mail
+from galaxy.util import (
+    send_mail,
+    unicodify,
+)
 from galaxy.util.logging import get_logger
 
 log = get_logger(__name__)
@@ -55,7 +58,7 @@ class EmailAction(DefaultJobAction):
         try:
             send_mail(frm, to, subject, body, app.config)
         except Exception as e:
-            log.error("EmailAction PJA Failed, exception: %s" % e)
+            log.error("EmailAction PJA Failed, exception: %s" % unicodify(e))
 
     @classmethod
     def get_short_str(cls, pja):

--- a/lib/galaxy/jobs/actions/post.py
+++ b/lib/galaxy/jobs/actions/post.py
@@ -58,7 +58,7 @@ class EmailAction(DefaultJobAction):
         try:
             send_mail(frm, to, subject, body, app.config)
         except Exception as e:
-            log.error("EmailAction PJA Failed, exception: %s" % unicodify(e))
+            log.error("EmailAction PJA Failed, exception: %s", unicodify(e))
 
     @classmethod
     def get_short_str(cls, pja):

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -28,6 +28,7 @@ from galaxy.jobs import (
     TaskWrapper
 )
 from galaxy.jobs.mapper import JobNotReadyException
+from galaxy.util import unicodify
 from galaxy.util.monitors import Monitors
 from galaxy.web.stack.handlers import HANDLER_ASSIGNMENT_METHODS
 from galaxy.web.stack.message import JobHandlerMessage
@@ -269,7 +270,7 @@ class JobHandlerQueue(Monitors):
                 # If this is a serialization failure on PostgreSQL, then e.orig is a psycopg2 TransactionRollbackError
                 # and should have attribute `code`. Other engines should just report the message and move on.
                 if int(getattr(e.orig, 'pgcode', -1)) != 40001:
-                    log.debug('Grabbing job failed (serialization failures are ok): %s', str(e))
+                    log.debug('Grabbing job failed (serialization failures are ok): %s', unicodify(e))
                 trans.rollback()
 
     def __handle_waiting_jobs(self):

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -34,7 +34,8 @@ from galaxy.util import (
     ExecutionTimer,
     in_directory,
     ParamsWithSpecs,
-    shrink_stream_by_size
+    shrink_stream_by_size,
+    unicodify,
 )
 from galaxy.util.bunch import Bunch
 from galaxy.util.monitors import Monitors
@@ -231,7 +232,7 @@ class BaseJobRunner(object):
             )
         except Exception as e:
             log.exception("(%s) Failure preparing job" % job_id)
-            job_wrapper.fail(str(e), exception=True)
+            job_wrapper.fail(unicodify(e), exception=True)
             return False
 
         if not job_wrapper.runner_command_line:
@@ -589,7 +590,7 @@ class JobState(object):
                     prefix = "(%s)" % self.job_wrapper.get_id_tag()
                 else:
                     prefix = "(%s/%s)" % (self.job_wrapper.get_id_tag(), self.job_id)
-                log.debug("%s Unable to cleanup %s: %s" % (prefix, file, str(e)))
+                log.debug("%s Unable to cleanup %s: %s" % (prefix, file, unicodify(e)))
 
 
 class AsynchronousJobState(JobState):
@@ -753,7 +754,7 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors):
                 if which_try == self.app.config.retry_job_output_collection:
                     stdout = ''
                     stderr = job_state.runner_states.JOB_OUTPUT_NOT_RETURNED_FROM_CLUSTER
-                    log.error('(%s/%s) %s: %s' % (galaxy_id_tag, external_job_id, stderr, str(e)))
+                    log.error('(%s/%s) %s: %s' % (galaxy_id_tag, external_job_id, stderr, unicodify(e)))
                     collect_output_success = False
                 else:
                     time.sleep(1)

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -231,7 +231,7 @@ class BaseJobRunner(object):
                 stderr_file=stderr_file,
             )
         except Exception as e:
-             log.exception("(%s) Failure preparing job", job_id)
+            log.exception("(%s) Failure preparing job", job_id)
             job_wrapper.fail(unicodify(e), exception=True)
             return False
 

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -231,7 +231,7 @@ class BaseJobRunner(object):
                 stderr_file=stderr_file,
             )
         except Exception as e:
-            log.exception("(%s) Failure preparing job" % job_id)
+             log.exception("(%s) Failure preparing job", job_id)
             job_wrapper.fail(unicodify(e), exception=True)
             return False
 
@@ -754,7 +754,7 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors):
                 if which_try == self.app.config.retry_job_output_collection:
                     stdout = ''
                     stderr = job_state.runner_states.JOB_OUTPUT_NOT_RETURNED_FROM_CLUSTER
-                    log.error('(%s/%s) %s: %s' % (galaxy_id_tag, external_job_id, stderr, unicodify(e)))
+                    log.error('(%s/%s) %s: %s', galaxy_id_tag, external_job_id, stderr, unicodify(e))
                     collect_output_success = False
                 else:
                     time.sleep(1)

--- a/lib/galaxy/jobs/runners/chronos.py
+++ b/lib/galaxy/jobs/runners/chronos.py
@@ -5,6 +5,7 @@ import logging
 
 from galaxy import model
 from galaxy.jobs.runners import AsynchronousJobRunner, AsynchronousJobState
+from galaxy.util import unicodify
 
 CHRONOS_IMPORT_MSG = ('The Python \'chronos\' package is required to use '
                       'this feature, please install it or correct the '
@@ -20,7 +21,7 @@ try:
     )
 except ImportError as e:
     chronos = None
-    CHRONOS_IMPORT_MSG.format(msg=str(e))
+    CHRONOS_IMPORT_MSG.format(msg=unicodify(e))
 
 
 __all__ = ('ChronosJobRunner',)
@@ -40,7 +41,7 @@ def handle_exception_call(func):
         try:
             return func(*args, **kwargs)
         except chronos_exceptions as e:
-            LOGGER.error(str(e))
+            LOGGER.error(unicodify(e))
 
     return wrapper
 

--- a/lib/galaxy/jobs/runners/godocker.py
+++ b/lib/galaxy/jobs/runners/godocker.py
@@ -10,6 +10,7 @@ from galaxy.jobs.runners import (
     AsynchronousJobRunner,
     AsynchronousJobState
 )
+from galaxy.util import unicodify
 
 
 log = logging.getLogger(__name__)
@@ -297,11 +298,11 @@ class GodockerJobRunner(AsynchronousJobRunner):
                 log_file.write(out_log)
                 log_file.close()
                 f.close()
-                log.debug("CREATE OUTPUT FILE: " + str(job_state.output_file))
-                log.debug("CREATE ERROR FILE: " + str(job_state.error_file))
-                log.debug("CREATE EXIT CODE FILE: " + str(job_state.exit_code_file))
+                log.debug("CREATE OUTPUT FILE: " + job_state.output_file)
+                log.debug("CREATE ERROR FILE: " + job_state.error_file)
+                log.debug("CREATE EXIT CODE FILE: " + job_state.exit_code_file)
             except IOError as e:
-                log.error('Could not access task log file %s' % str(e))
+                log.error('Could not access task log file %s' % unicodify(e))
                 log.debug("IO Error occurred when accessing the files.")
                 return False
         return True

--- a/lib/galaxy/jobs/runners/godocker.py
+++ b/lib/galaxy/jobs/runners/godocker.py
@@ -302,7 +302,7 @@ class GodockerJobRunner(AsynchronousJobRunner):
                 log.debug("CREATE ERROR FILE: " + job_state.error_file)
                 log.debug("CREATE EXIT CODE FILE: " + job_state.exit_code_file)
             except IOError as e:
-                log.error('Could not access task log file %s' % unicodify(e))
+                log.error('Could not access task log file: %s', unicodify(e))
                 log.debug("IO Error occurred when accessing the files.")
                 return False
         return True

--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -9,6 +9,7 @@ from subprocess import (
     STDOUT
 )
 
+from galaxy.util import unicodify
 from ..external import parse_external_id
 
 DEFAULT_QUERY_CLASSAD = dict(
@@ -82,7 +83,7 @@ def condor_submit(submit_file):
         else:
             message = PROBLEM_PARSING_EXTERNAL_ID
     except Exception as e:
-        message = str(e)
+        message = unicodify(e)
     return external_id, message
 
 
@@ -97,7 +98,7 @@ def condor_stop(external_id):
     except CalledProcessError:
         failure_message = "condor_rm failed"
     except Exception as e:
-        "error encountered calling condor_rm: %s" % e
+        "error encountered calling condor_rm: %s" % unicodify(e)
     return failure_message
 
 

--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -98,7 +98,7 @@ def condor_stop(external_id):
     except CalledProcessError:
         failure_message = "condor_rm failed"
     except Exception as e:
-        "error encountered calling condor_rm: %s" % unicodify(e)
+        failure_message = "error encountered calling condor_rm: %s" % unicodify(e)
     return failure_message
 
 

--- a/lib/galaxy/jobs/splitters/multi.py
+++ b/lib/galaxy/jobs/splitters/multi.py
@@ -181,7 +181,7 @@ def do_merge(job_wrapper, task_wrappers):
     except Exception as e:
         stdout = 'Error merging files'
         log.exception(stdout)
-        stderr = str(e)
+        stderr = util.unicodify(e)
 
     for tw in task_wrappers:
         # Prevent repetitive output, e.g. "Sequence File Aligned"x20

--- a/lib/galaxy/jobs/transfer_manager.py
+++ b/lib/galaxy/jobs/transfer_manager.py
@@ -11,7 +11,11 @@ import threading
 
 from six.moves import shlex_quote
 
-from galaxy.util import listify, sleeper
+from galaxy.util import (
+    listify,
+    sleeper,
+    unicodify,
+)
 from galaxy.util.json import jsonrpc_request, validate_jsonrpc_response
 
 log = logging.getLogger(__name__)
@@ -113,7 +117,7 @@ class TransferManager(object):
                     self.sa_session.refresh(tj)
                     error = e.args
                     if type(error) != dict:
-                        error = dict(code=256, message='Error connecting to transfer daemon', data=str(e))
+                        error = dict(code=256, message='Error connecting to transfer daemon', data=unicodify(e))
                     rval.append(dict(transfer_job_id=tj.id, state=tj.state, error=error))
             else:
                 self.sa_session.refresh(tj)

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -247,14 +247,14 @@ class CloudManager(sharable.SharableModelManager):
             if bucket is None:
                 raise RequestParameterInvalidException("The bucket `{}` not found.".format(bucket_name))
         except Exception as e:
-            raise ItemAccessibilityException("Could not get the bucket `{}`: {}".format(bucket_name, str(e)))
+            raise ItemAccessibilityException("Could not get the bucket `{}`: {}".format(bucket_name, util.unicodify(e)))
 
         datasets = []
         for obj in objects:
             try:
                 key = bucket.objects.get(obj)
             except Exception as e:
-                raise MessageException("The following error occurred while getting the object {}: {}".format(obj, str(e)))
+                raise MessageException("The following error occurred while getting the object {}: {}".format(obj, util.unicodify(e)))
             if key is None:
                 log.exception(
                     "Could not get object `{}` for user `{}`. Object may not exist, or the provided credentials are "
@@ -366,7 +366,7 @@ class CloudManager(sharable.SharableModelManager):
                             "job_id": trans.app.security.encode_id(job.id)
                         }))
                 except Exception as e:
-                    err_msg = "maybe invalid or unauthorized credentials. {}".format(e.message)
+                    err_msg = "maybe invalid or unauthorized credentials. {}".format(util.unicodify(e))
                     log.debug("Failed to send the dataset `{}` per user `{}` request to cloud, {}".format(
                         object_label, trans.user.id, err_msg))
                     failed.append(json.dumps(

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -17,6 +17,7 @@ from galaxy.exceptions import (
     MalformedId,
     RequestParameterInvalidException
 )
+from galaxy.util import unicodify
 
 log = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ class FolderManager(object):
         except NoResultFound:
             raise RequestParameterInvalidException('No folder found with the id provided.')
         except Exception as e:
-            raise InternalServerError('Error loading from the database.' + str(e))
+            raise InternalServerError('Error loading from the database.' + unicodify(e))
         folder = self.secure(trans, folder, check_manageable, check_accessible)
         return folder
 

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -9,7 +9,10 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from galaxy import exceptions
 from galaxy.managers import folders
-from galaxy.util import pretty_print_time_interval
+from galaxy.util import (
+    pretty_print_time_interval,
+    unicodify,
+)
 
 log = logging.getLogger(__name__)
 
@@ -42,7 +45,7 @@ class LibraryManager(object):
         except NoResultFound:
             raise exceptions.RequestParameterInvalidException('No library found with the id provided.')
         except Exception as e:
-            raise exceptions.InternalServerError('Error loading from the database.' + str(e))
+            raise exceptions.InternalServerError('Error loading from the database.' + unicodify(e))
         library = self.secure(trans, library, check_accessible)
         return library
 

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -43,7 +43,7 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         try:
             ld = trans.sa_session.query(trans.app.model.LibraryDataset).filter(trans.app.model.LibraryDataset.table.c.id == decoded_library_dataset_id).one()
         except Exception as e:
-            raise InternalServerError('Error loading from the database.' + str(e))
+            raise InternalServerError('Error loading from the database.' + util.unicodify(e))
         ld = self.secure(trans, ld, check_accessible)
         return ld
 

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import exc as sqlalchemy_exceptions
 import galaxy.exceptions
 from galaxy import model
 from galaxy.managers import base
+from galaxy.util import unicodify
 
 log = logging.getLogger(__name__)
 
@@ -45,5 +46,5 @@ class RoleManager(base.ModelManager):
         except sqlalchemy_exceptions.NoResultFound:
             raise galaxy.exceptions.RequestParameterInvalidException('No role found with the id provided.')
         except Exception as e:
-            raise galaxy.exceptions.InternalServerError('Error loading from the database.' + str(e))
+            raise galaxy.exceptions.InternalServerError('Error loading from the database.' + unicodify(e))
         return role

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -408,7 +408,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                     trans.log_event('User reset password: %s' % email)
                 except Exception as e:
                     log.debug(body)
-                    return "Failed to submit email. Please contact the administrator: %s" % str(e)
+                    return "Failed to submit email. Please contact the administrator: %s" % util.unicodify(e)
             else:
                 return "Failed to produce password reset token. User not found."
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3670,7 +3670,7 @@ class ImplicitlyConvertedDatasetAssociation(RepresentById):
             try:
                 os.unlink(self.file_name)
             except Exception as e:
-                log.error("Failed to purge associated file (%s) from disk: %s" % (self.file_name, e))
+                log.error("Failed to purge associated file (%s) from disk: %s" % (self.file_name, unicodify(e)))
 
 
 DEFAULT_COLLECTION_NAME = "Unnamed Collection"

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -629,10 +629,10 @@ class MetadataTempFile(object):
                 if cls.is_JSONified_value(value):
                     value = cls.from_JSON(value)
                 if isinstance(value, cls) and os.path.exists(value.file_name):
-                    log.debug('Cleaning up abandoned MetadataTempFile file: %s' % value.file_name)
+                     log.debug('Cleaning up abandoned MetadataTempFile file: %s', value.file_name)
                     os.unlink(value.file_name)
         except Exception as e:
-            log.debug('Failed to cleanup MetadataTempFile temp files from %s: %s' % (filename, unicodify(e)))
+            log.debug('Failed to cleanup MetadataTempFile temp files from %s: %s', filename, unicodify(e))
 
 
 __all__ = (

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -629,7 +629,7 @@ class MetadataTempFile(object):
                 if cls.is_JSONified_value(value):
                     value = cls.from_JSON(value)
                 if isinstance(value, cls) and os.path.exists(value.file_name):
-                     log.debug('Cleaning up abandoned MetadataTempFile file: %s', value.file_name)
+                    log.debug('Cleaning up abandoned MetadataTempFile file: %s', value.file_name)
                     os.unlink(value.file_name)
         except Exception as e:
             log.debug('Failed to cleanup MetadataTempFile temp files from %s: %s', filename, unicodify(e))

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -17,8 +17,13 @@ from six import string_types
 from sqlalchemy.orm import object_session
 
 import galaxy.model
-from galaxy.util import (form_builder, listify, string_as_bool,
-                         stringify_dictionary_keys)
+from galaxy.util import (
+    form_builder,
+    listify,
+    string_as_bool,
+    stringify_dictionary_keys,
+    unicodify,
+)
 from galaxy.util.json import safe_dumps
 from galaxy.util.object_wrapper import sanitize_lists_to_string
 from galaxy.util.odict import odict
@@ -627,7 +632,7 @@ class MetadataTempFile(object):
                     log.debug('Cleaning up abandoned MetadataTempFile file: %s' % value.file_name)
                     os.unlink(value.file_name)
         except Exception as e:
-            log.debug('Failed to cleanup MetadataTempFile temp files from %s: %s' % (filename, e))
+            log.debug('Failed to cleanup MetadataTempFile temp files from %s: %s' % (filename, unicodify(e)))
 
 
 __all__ = (

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -193,7 +193,7 @@ class ToolErrorLog(object):
             "file": file,
             "time": str(datetime.now()),
             "phase": phase,
-            "error": str(exception)
+            "error": unicodify(exception)
         })
         if len(self.error_stack) > self.max_errors:
             self.error_stack.pop()
@@ -1486,7 +1486,7 @@ class Tool(Dictifiable):
             return False, e
         except Exception as e:
             log.exception('Exception caught while attempting tool execution:')
-            message = 'Error executing tool: %s' % str(e)
+            message = 'Error executing tool: %s' % unicodify(e)
             return False, message
         if isinstance(out_data, odict):
             return job, list(out_data.items())
@@ -1933,7 +1933,7 @@ class Tool(Dictifiable):
                 if history is None:
                     raise exceptions.MessageException('History unavailable. Please specify a valid history id')
             except Exception as e:
-                raise exceptions.MessageException('[history_id=%s] Failed to retrieve history. %s.' % (history_id, str(e)))
+                raise exceptions.MessageException('[history_id=%s] Failed to retrieve history. %s.' % (history_id, unicodify(e)))
 
         # build request context
         request_context = WorkRequestContext(app=trans.app, user=trans.user, history=history, workflow_building_mode=workflow_building_mode)
@@ -1949,7 +1949,7 @@ class Tool(Dictifiable):
                 tool_message = self._compare_tool_version(job)
                 params_to_incoming(kwd, self.inputs, job_params, self.app)
             except Exception as e:
-                raise exceptions.MessageException(str(e))
+                raise exceptions.MessageException(unicodify(e))
 
         # create parameter object
         params = Params(kwd, sanitize=False)
@@ -2149,7 +2149,7 @@ class Tool(Dictifiable):
             if len(self.tool_versions) > 1 and tool_version != self.tool_versions[-1]:
                 message += 'There is a newer version of this tool available.'
         except Exception as e:
-            raise exceptions.MessageException(str(e))
+            raise exceptions.MessageException(unicodify(e))
         return message
 
     def get_default_history_by_trans(self, trans, create=False):

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -308,7 +308,7 @@ def create_paramfile(trans, uploaded_datasets):
             stdout, stderr = p.communicate()
             assert p.returncode == 0, stderr
         except Exception as e:
-            log.warning('Changing ownership of uploaded file %s failed: %s' % (path, unicodify(e)))
+            log.warning('Changing ownership of uploaded file %s failed: %s', path, unicodify(e))
 
     tool_params = []
     json_file_path = None

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -308,7 +308,7 @@ def create_paramfile(trans, uploaded_datasets):
             stdout, stderr = p.communicate()
             assert p.returncode == 0, stderr
         except Exception as e:
-            log.warning('Changing ownership of uploaded file %s failed: %s' % (path, str(e)))
+            log.warning('Changing ownership of uploaded file %s failed: %s' % (path, unicodify(e)))
 
     tool_params = []
     json_file_path = None

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -8,6 +8,7 @@ from threading import (
 from sqlalchemy import inspect
 from sqlalchemy.orm.exc import DetachedInstanceError
 
+from galaxy.util import unicodify
 from galaxy.util.hash_util import md5_hash_file
 
 log = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ class ToolCache(object):
                     if tool_id in self._new_tool_ids:
                         self._new_tool_ids.remove(tool_id)
         except Exception as e:
-            log.debug("Exception while checking tools to remove from cache: %s" % e)
+            log.debug("Exception while checking tools to remove from cache: %s" % unicodify(e))
             # If by chance the file is being removed while calculating the hash or modtime
             # we don't want the thread to die.
             pass

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -57,7 +57,7 @@ class ToolCache(object):
                     if tool_id in self._new_tool_ids:
                         self._new_tool_ids.remove(tool_id)
         except Exception as e:
-            log.debug("Exception while checking tools to remove from cache: %s" % unicodify(e))
+            log.debug("Exception while checking tools to remove from cache: %s", unicodify(e))
             # If by chance the file is being removed while calculating the hash or modtime
             # we don't want the thread to die.
             pass

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -150,7 +150,7 @@ class ToolDataTableManager(object):
                                                      tool_data_path=tool_data_path,
                                                      from_shed_config=True)
         except Exception as e:
-            error_message = 'Error attempting to parse file %s: %s' % (str(os.path.split(config_filename)[1]), str(e))
+            error_message = 'Error attempting to parse file %s: %s' % (str(os.path.split(config_filename)[1]), util.unicodify(e))
             log.debug(error_message)
             table_elems = []
         if persist:

--- a/lib/galaxy/tools/error_reports/plugins/email.py
+++ b/lib/galaxy/tools/error_reports/plugins/email.py
@@ -4,7 +4,10 @@ from __future__ import absolute_import
 import logging
 
 from galaxy.tools.errors import EmailErrorReporter
-from galaxy.util import string_as_bool
+from galaxy.util import (
+    string_as_bool,
+    unicodify,
+)
 from . import ErrorPlugin
 
 log = logging.getLogger(__name__)
@@ -29,7 +32,7 @@ class EmailPlugin(ErrorPlugin):
             error_reporter.send_report(user=job.get_user(), email=kwargs.get('email', None), message=kwargs.get('message', None), redact_user_details_in_bugreport=self.redact_user_details_in_bugreport)
             return ("Your error report has been sent", "success")
         except Exception as e:
-            return ("An error occurred sending the report by email: %s" % str(e), "danger")
+            return ("An error occurred sending the report by email: %s" % unicodify(e), "danger")
 
 
 __all__ = ('EmailPlugin', )

--- a/lib/galaxy/tools/imp_exp/export_history.py
+++ b/lib/galaxy/tools/imp_exp/export_history.py
@@ -13,6 +13,7 @@ import shutil
 import sys
 
 from galaxy.model.store import tar_export_directory
+from galaxy.util import unicodify
 
 
 def create_archive(export_directory, out_file, gzip=False):
@@ -23,7 +24,7 @@ def create_archive(export_directory, out_file, gzip=False):
         print('Created history archive.')
         return 0
     except Exception as e:
-        print('Error creating history archive: %s' % str(e), file=sys.stderr)
+        print('Error creating history archive: %s' % unicodify(e), file=sys.stderr)
         return 1
 
 

--- a/lib/galaxy/tools/linters/help.py
+++ b/lib/galaxy/tools/linters/help.py
@@ -1,5 +1,8 @@
 """This module contains a linting function for a tool's help."""
-from galaxy.util import rst_to_html
+from galaxy.util import (
+    rst_to_html,
+    unicodify,
+)
 
 
 def lint_help(tool_xml, lint_ctx):
@@ -41,5 +44,5 @@ def rst_invalid(text):
     try:
         rst_to_html(text, error=True)
     except Exception as e:
-        invalid_rst = str(e)
+        invalid_rst = unicodify(e)
     return invalid_rst

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -7,6 +7,7 @@ from json import dumps
 
 from boltons.iterutils import remap
 
+from galaxy.util import unicodify
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.json import safe_loads
 from .basic import DataCollectionToolParameter, DataToolParameter, is_runtime_value, runtime_to_json, SelectToolParameter
@@ -184,7 +185,7 @@ def check_param(trans, param, incoming_value, param_values):
         value = param.from_json(value, trans, param_values)
         param.validate(value, trans)
     except ValueError as e:
-        error = str(e)
+        error = unicodify(e)
     return value, error
 
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -752,7 +752,7 @@ class BaseURLToolParameter(HiddenToolParameter):
         try:
             return url_for(self.value, qualified=True)
         except Exception as e:
-            log.debug('Url creation failed for "%s": %s', self.name, e)
+            log.debug('Url creation failed for "%s": %s', self.name, unicodify(e))
             return self.value
 
     def to_dict(self, trans, other_values={}):
@@ -842,7 +842,7 @@ class SelectToolParameter(ToolParameter):
                 call_other_values = self._get_dynamic_options_call_other_values(trans, other_values)
                 return set(v for _, v, _ in eval(self.dynamic_options, self.tool.code_namespace, call_other_values))
             except Exception as e:
-                log.debug("Determining legal values failed for '%s': %s", self.name, e)
+                log.debug("Determining legal values failed for '%s': %s", self.name, unicodify(e))
                 return set()
         else:
             return self.legal_values

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -7,7 +7,10 @@ from six import string_types
 import galaxy.tools.parameters.basic
 import galaxy.tools.parameters.grouping
 from galaxy.tools.verify.interactor import ToolTestDescription
-from galaxy.util import string_as_bool
+from galaxy.util import (
+    string_as_bool,
+    unicodify,
+)
 
 try:
     from nose.tools import nottest
@@ -63,7 +66,7 @@ def description_from_tool_object(tool, test_index, raw_test_dict):
             "test_index": test_index,
             "inputs": {},
             "error": True,
-            "exception": str(e),
+            "exception": unicodify(e),
         }
 
     return ToolTestDescription(processed_test_dict)

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -17,7 +17,8 @@ from galaxy.util import (
     ExecutionTimer,
     listify,
     parse_xml,
-    string_as_bool
+    string_as_bool,
+    unicodify,
 )
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
@@ -633,7 +634,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             if labels is not None:
                 tool.labels = labels
         except (IOError, OSError) as exc:
-            log.error("Error reading tool configuration file from path '%s': %s", path, exc)
+            log.error("Error reading tool configuration file from path '%s': %s", path, unicodify(exc))
         except Exception:
             log.exception("Error reading tool from path: %s", path)
 
@@ -1066,7 +1067,7 @@ def _filter_for_panel(item, item_type, filters, context):
                 if not filter_method(context, filter_item):
                     return False
             except Exception as e:
-                raise MessageException("Toolbox filter exception from '%s': %s." % (filter_method.__name__, e))
+                raise MessageException("Toolbox filter exception from '%s': %s." % (filter_method.__name__, unicodify(e)))
         return True
     if item_type == panel_item_types.TOOL:
         if _apply_filter(item, filters['tool']):

--- a/lib/galaxy/tools/util/galaxyops/__init__.py
+++ b/lib/galaxy/tools/util/galaxyops/__init__.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 
 import sys
 
+from galaxy.util import unicodify
+
 
 def warn(msg):
     # TODO: since everything printed to stderr results in job.state = error, we
@@ -35,7 +37,7 @@ def parse_cols_arg(cols):
 
 def default_printer(stream, exc, obj):
     print("%d: %s" % (obj.linenum, obj.current_line), file=stream)
-    print("\tError: %s" % ((exc)), file=stream)
+    print("\tError: %s" % unicodify(exc), file=stream)
 
 
 def skipped(reader, filedesc=""):

--- a/lib/galaxy/tools/util/galaxyops/__init__.py
+++ b/lib/galaxy/tools/util/galaxyops/__init__.py
@@ -35,7 +35,7 @@ def parse_cols_arg(cols):
 
 def default_printer(stream, exc, obj):
     print("%d: %s" % (obj.linenum, obj.current_line), file=stream)
-    print("\tError: %s" % (str(exc)), file=stream)
+    print("\tError: %s" % ((exc)), file=stream)
 
 
 def skipped(reader, filedesc=""):

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -59,7 +59,7 @@ def verify(
             verify_assertions(output_content, attributes["assert_list"])
         except AssertionError as err:
             errmsg = '%s different than expected\n' % (item_label)
-            errmsg += str(err)
+            errmsg += unicodify(err)
             raise AssertionError(errmsg)
 
     # Verify checksum attributes...
@@ -79,7 +79,7 @@ def verify(
             _verify_checksum(output_content, expected_checksum_type, expected_checksum)
         except AssertionError as err:
             errmsg = '%s different than expected\n' % (item_label)
-            errmsg += str(err)
+            errmsg += unicodify(err)
             raise AssertionError(errmsg)
 
     if attributes is None:
@@ -107,7 +107,7 @@ def verify(
                 shutil.copy(temp_name, ofn)
             except Exception as exc:
                 error_log_msg = 'Could not save output file %s to %s: ' % (temp_name, ofn)
-                error_log_msg += str(exc)
+                error_log_msg += unicodify(exc)
                 log.error(error_log_msg, exc_info=True)
             else:
                 log.debug('## GALAXY_TEST_SAVE=%s. saved %s' % (keep_outputs_dir, ofn))
@@ -118,7 +118,7 @@ def verify(
                     local_fh, temp_name = _bam_to_sam(local_name, temp_name)
                     local_name = local_fh.name
                 except Exception as e:
-                    log.warning("%s. Will compare BAM files" % e)
+                    log.warning("%s. Will compare BAM files" % unicodify(e))
             if compare == 'diff':
                 files_diff(local_name, temp_name, attributes=attributes)
             elif compare == 're_match':
@@ -164,12 +164,12 @@ def _bam_to_sam(local_name, temp_name):
     try:
         pysam.view('-h', '-o%s' % temp_local.name, local_name)
     except Exception as e:
-        msg = "Converting local (test-data) BAM to SAM failed: %s" % e
+        msg = "Converting local (test-data) BAM to SAM failed: %s" % unicodify(e)
         raise Exception(msg)
     try:
         pysam.view('-h', '-o%s' % temp_temp, temp_name)
     except Exception as e:
-        msg = "Converting history BAM to SAM failed: %s" % e
+        msg = "Converting history BAM to SAM failed: %s" % unicodify(e)
         raise Exception(msg)
     os.remove(temp_name)
     return temp_local, temp_temp

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -15,6 +15,7 @@ try:
     import pysam
 except ImportError:
     pysam = None
+from six import text_type
 
 from galaxy.util import unicodify
 from galaxy.util.compression_utils import get_fileobj
@@ -138,7 +139,7 @@ def verify(
         except AssertionError as err:
             errmsg = '%s different than expected, difference (using %s):\n' % (item_label, compare)
             errmsg += "( %s v. %s )\n" % (local_name, temp_name)
-            errmsg += str(err)
+            errmsg += text_type(err)
             raise AssertionError(errmsg)
         finally:
             if 'GALAXY_TEST_NO_CLEANUP' not in os.environ:

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -105,10 +105,8 @@ def verify(
             log.debug('keep_outputs_dir: %s, ofn: %s', keep_outputs_dir, ofn)
             try:
                 shutil.copy(temp_name, ofn)
-            except Exception as exc:
-                error_log_msg = 'Could not save output file %s to %s: ' % (temp_name, ofn)
-                error_log_msg += unicodify(exc)
-                log.error(error_log_msg, exc_info=True)
+            except Exception:
+                log.exception('Could not save output file %s to %s', temp_name, ofn)
             else:
                 log.debug('## GALAXY_TEST_SAVE=%s. saved %s', keep_outputs_dir, ofn)
         compare = attributes.get('compare', 'diff')

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -15,7 +15,6 @@ try:
     import pysam
 except ImportError:
     pysam = None
-from six import text_type
 
 from galaxy.util import unicodify
 from galaxy.util.compression_utils import get_fileobj
@@ -139,7 +138,7 @@ def verify(
         except AssertionError as err:
             errmsg = '%s different than expected, difference (using %s):\n' % (item_label, compare)
             errmsg += "( %s v. %s )\n" % (local_name, temp_name)
-            errmsg += text_type(err)
+            errmsg += unicodify(err)
             raise AssertionError(errmsg)
         finally:
             if 'GALAXY_TEST_NO_CLEANUP' not in os.environ:

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -118,7 +118,7 @@ def verify(
                     local_fh, temp_name = _bam_to_sam(local_name, temp_name)
                     local_name = local_fh.name
                 except Exception as e:
-                    log.warning("%s. Will compare BAM files" % unicodify(e))
+                    log.warning("%s. Will compare BAM files", unicodify(e))
             if compare == 'diff':
                 files_diff(local_name, temp_name, attributes=attributes)
             elif compare == 're_match':

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -110,7 +110,7 @@ def verify(
                 error_log_msg += unicodify(exc)
                 log.error(error_log_msg, exc_info=True)
             else:
-                 log.debug('## GALAXY_TEST_SAVE=%s. saved %s', keep_outputs_dir, ofn)
+                log.debug('## GALAXY_TEST_SAVE=%s. saved %s', keep_outputs_dir, ofn)
         compare = attributes.get('compare', 'diff')
         try:
             if attributes.get('ftype', None) in ['bam', 'qname_sorted.bam', 'qname_input_sorted.bam', 'unsorted.bam', 'cram']:

--- a/lib/galaxy/tools/verify/__init__.py
+++ b/lib/galaxy/tools/verify/__init__.py
@@ -110,7 +110,7 @@ def verify(
                 error_log_msg += unicodify(exc)
                 log.error(error_log_msg, exc_info=True)
             else:
-                log.debug('## GALAXY_TEST_SAVE=%s. saved %s' % (keep_outputs_dir, ofn))
+                 log.debug('## GALAXY_TEST_SAVE=%s. saved %s', keep_outputs_dir, ofn)
         compare = attributes.get('compare', 'diff')
         try:
             if attributes.get('ftype', None) in ['bam', 'qname_sorted.bam', 'qname_input_sorted.bam', 'unsorted.bam', 'cram']:

--- a/lib/galaxy/tools/verify/asserts/xml.py
+++ b/lib/galaxy/tools/verify/asserts/xml.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import re
 import xml.etree
 
+from galaxy.util import unicodify
+
 
 # Helper functions used to work with XML output.
 def to_xml(output):
@@ -27,7 +29,7 @@ def assert_is_valid_xml(output):
         to_xml(output)
     except Exception as e:
         # TODO: Narrow caught exception to just parsing failure
-        raise AssertionError("Expected valid XML, but could not parse output. %s" % str(e))
+        raise AssertionError("Expected valid XML, but could not parse output. %s" % unicodify(e))
 
 
 def assert_has_element_with_path(output, path):

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -691,7 +691,7 @@ def _verify_composite_datatype_file_content(file_name, hda_id, base_name=None, a
         )
     except AssertionError as err:
         errmsg = 'Composite file (%s) of %s different than expected, difference:\n' % (base_name, item_label)
-        errmsg += str(err)
+        errmsg += util.unicodify(err)
         raise AssertionError(errmsg)
 
 
@@ -806,10 +806,10 @@ def verify_tool(tool_id,
                 job_data["job"] = job_stdio
             status = "success"
             if job_output_exceptions:
-                job_data["output_problems"] = [str(_) for _ in job_output_exceptions]
+                job_data["output_problems"] = [util.unicodify(_) for _ in job_output_exceptions]
                 status = "failure"
             if tool_execution_exception:
-                job_data["execution_problem"] = str(tool_execution_exception)
+                job_data["execution_problem"] = util.unicodify(tool_execution_exception)
                 status = "error"
             job_data["status"] = status
             register_job_data(job_data)
@@ -937,7 +937,7 @@ def _verify_outputs(testdef, history, jobs, tool_id, data_list, data_collection_
                 verify_assertions(data, assertions)
             except AssertionError as err:
                 errmsg = '%s different than expected\n' % description
-                errmsg += str(err)
+                errmsg += util.unicodify(err)
                 register_exception(AssertionError(errmsg))
 
     for output_collection_def in testdef.output_collections:
@@ -1022,7 +1022,7 @@ def _format_stream(output, stream, format):
 class JobOutputsError(AssertionError):
 
     def __init__(self, output_exceptions, job_stdio):
-        big_message = "\n".join(map(str, output_exceptions))
+        big_message = "\n".join(map(util.unicodify, output_exceptions))
         super(JobOutputsError, self).__init__(big_message)
         self.job_stdio = job_stdio
         self.output_exceptions = output_exceptions

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1012,7 +1012,7 @@ def unicodify(value, encoding=DEFAULT_ENCODING, error='replace', strip_null=Fals
     >>> assert unicodify('simple string') == u'simple string'
     >>> assert unicodify(3) == u'3'
     >>> assert unicodify(bytearray([115, 116, 114, 196, 169, 195, 177, 103])) == u'strĩñg'
-    >>> assert unicodify(Exception('message')) == u'message'
+    >>> assert unicodify(Exception(u'strĩñg')) == u'strĩñg'
     >>> assert unicodify('cómplǐcḁtëd strĩñg') == u'cómplǐcḁtëd strĩñg'
     >>> s = u'cómplǐcḁtëd strĩñg'; assert unicodify(s) == s
     >>> s = u'lâtín strìñg'; assert unicodify(s.encode('latin-1'), 'latin-1') == s
@@ -1025,9 +1025,9 @@ def unicodify(value, encoding=DEFAULT_ENCODING, error='replace', strip_null=Fals
         if isinstance(value, bytearray):
             value = bytes(value)
         elif not isinstance(value, string_types) and not isinstance(value, binary_type):
-            # In Python 2, value is not an instance of basestring
+            # In Python 2, value is not an instance of basestring (i.e. str or unicode)
             # In Python 3, value is not an instance of bytes or str
-            value = str(value)
+            value = text_type(value)
         # Now in Python 2, value is an instance of basestring, but may be not unicode
         # Now in Python 3, value is an instance of bytes or str
         if not isinstance(value, text_type):

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1203,7 +1203,7 @@ def read_dbnames(filename):
         man_builds = [(build, name) for name, build in man_builds]
         db_names = DBNames(db_names + man_builds)
     except Exception as e:
-        log.error("ERROR: Unable to read builds file: %s", e)
+        log.error("ERROR: Unable to read builds file: %s", unicodify(e))
     if len(db_names) < 1:
         db_names = DBNames([(db_names.default_value, db_names.default_name)])
     return db_names
@@ -1300,7 +1300,7 @@ def umask_fix_perms(path, umask, unmasked_perms, gid=None):
                                                                                                                     path,
                                                                                                                     oct(perms),
                                                                                                                     oct(stat.S_IMODE(st.st_mode)),
-                                                                                                                    e))
+                                                                                                                    unicodify(e)))
     # fix group
     if gid is not None and st.st_gid != gid:
         try:
@@ -1315,7 +1315,7 @@ def umask_fix_perms(path, umask, unmasked_perms, gid=None):
             log.warning('Unable to honor primary group (%s) for %s, group remains %s, error was: %s' % (desired_group,
                                                                                                         path,
                                                                                                         current_group,
-                                                                                                        e))
+                                                                                                        unicodify(e)))
 
 
 def docstring_trim(docstring):
@@ -1479,26 +1479,26 @@ def send_mail(frm, to, subject, body, config, html=None):
             s.starttls()
             log.debug('Initiated SSL/TLS connection to SMTP server: %s' % config.smtp_server)
         except RuntimeError as e:
-            log.warning('SSL/TLS support is not available to your Python interpreter: %s' % e)
+            log.warning('SSL/TLS support is not available to your Python interpreter: %s' % unicodify(e))
         except smtplib.SMTPHeloError as e:
-            log.error("The server didn't reply properly to the HELO greeting: %s" % e)
+            log.error("The server didn't reply properly to the HELO greeting: %s" % unicodify(e))
             s.close()
             raise
         except smtplib.SMTPException as e:
-            log.warning('The server does not support the STARTTLS extension: %s' % e)
+            log.warning('The server does not support the STARTTLS extension: %s' % unicodify(e))
     if config.smtp_username and config.smtp_password:
         try:
             s.login(config.smtp_username, config.smtp_password)
         except smtplib.SMTPHeloError as e:
-            log.error("The server didn't reply properly to the HELO greeting: %s" % e)
+            log.error("The server didn't reply properly to the HELO greeting: %s" % unicodify(e))
             s.close()
             raise
         except smtplib.SMTPAuthenticationError as e:
-            log.error("The server didn't accept the username/password combination: %s" % e)
+            log.error("The server didn't accept the username/password combination: %s" % unicodify(e))
             s.close()
             raise
         except smtplib.SMTPException as e:
-            log.error("No suitable authentication method was found: %s" % e)
+            log.error("No suitable authentication method was found: %s" % unicodify(e))
             s.close()
             raise
     s.sendmail(frm, to, msg.as_string())

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1477,7 +1477,7 @@ def send_mail(frm, to, subject, body, config, html=None):
     if not smtp_ssl:
         try:
             s.starttls()
-             log.debug('Initiated SSL/TLS connection to SMTP server: %s', config.smtp_server)
+            log.debug('Initiated SSL/TLS connection to SMTP server: %s', config.smtp_server)
         except RuntimeError as e:
             log.warning('SSL/TLS support is not available to your Python interpreter: %s', unicodify(e))
         except smtplib.SMTPHeloError as e:

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1477,28 +1477,28 @@ def send_mail(frm, to, subject, body, config, html=None):
     if not smtp_ssl:
         try:
             s.starttls()
-            log.debug('Initiated SSL/TLS connection to SMTP server: %s' % config.smtp_server)
+             log.debug('Initiated SSL/TLS connection to SMTP server: %s', config.smtp_server)
         except RuntimeError as e:
-            log.warning('SSL/TLS support is not available to your Python interpreter: %s' % unicodify(e))
+            log.warning('SSL/TLS support is not available to your Python interpreter: %s', unicodify(e))
         except smtplib.SMTPHeloError as e:
-            log.error("The server didn't reply properly to the HELO greeting: %s" % unicodify(e))
+            log.error("The server didn't reply properly to the HELO greeting: %s", unicodify(e))
             s.close()
             raise
         except smtplib.SMTPException as e:
-            log.warning('The server does not support the STARTTLS extension: %s' % unicodify(e))
+            log.warning('The server does not support the STARTTLS extension: %s', unicodify(e))
     if config.smtp_username and config.smtp_password:
         try:
             s.login(config.smtp_username, config.smtp_password)
         except smtplib.SMTPHeloError as e:
-            log.error("The server didn't reply properly to the HELO greeting: %s" % unicodify(e))
+            log.error("The server didn't reply properly to the HELO greeting: %s", unicodify(e))
             s.close()
             raise
         except smtplib.SMTPAuthenticationError as e:
-            log.error("The server didn't accept the username/password combination: %s" % unicodify(e))
+            log.error("The server didn't accept the username/password combination: %s", unicodify(e))
             s.close()
             raise
         except smtplib.SMTPException as e:
-            log.error("No suitable authentication method was found: %s" % unicodify(e))
+            log.error("No suitable authentication method was found: %s", unicodify(e))
             s.close()
             raise
     s.sendmail(frm, to, msg.as_string())

--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -10,6 +10,8 @@ import string
 
 from six import iteritems, string_types
 
+from ..util import unicodify
+
 __all__ = ("safe_dumps", "validate_jsonrpc_request", "validate_jsonrpc_response", "jsonrpc_request", "jsonrpc_response")
 
 log = logging.getLogger(__name__)
@@ -95,7 +97,7 @@ def validate_jsonrpc_request(request, regular_methods, notification_methods):
         return False, request, jsonrpc_response(id=None,
                                                 error=dict(code=-32700,
                                                            message='Parse error',
-                                                           data=str(e)))
+                                                           data=unicodify(e)))
     try:
         assert 'jsonrpc' in request, \
             'This server requires JSON-RPC 2.0 and no "jsonrpc" member was sent with the Request object as per the JSON-RPC 2.0 Specification.'
@@ -106,7 +108,7 @@ def validate_jsonrpc_request(request, regular_methods, notification_methods):
         return False, request, jsonrpc_response(request=request,
                                                 error=dict(code=-32600,
                                                            message='Invalid Request',
-                                                           data=str(e)))
+                                                           data=unicodify(e)))
     try:
         assert request['method'] in (regular_methods + notification_methods)
     except AssertionError:
@@ -121,7 +123,7 @@ def validate_jsonrpc_request(request, regular_methods, notification_methods):
         return False, request, jsonrpc_response(request=request,
                                                 error=dict(code=-32600,
                                                            message='Invalid Request',
-                                                           data=str(e)))
+                                                           data=unicodify(e)))
     return True, request, None
 
 
@@ -129,7 +131,7 @@ def validate_jsonrpc_response(response, id=None):
     try:
         response = json.loads(response)
     except Exception as e:
-        log.error('Response was not valid JSON: %s' % str(e))
+        log.error('Response was not valid JSON: %s' % unicodify(e))
         log.debug('Response was: %s' % response)
         return False, response
     try:

--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -132,7 +132,7 @@ def validate_jsonrpc_response(response, id=None):
         response = json.loads(response)
     except Exception as e:
         log.error('Response was not valid JSON: %s', unicodify(e))
-         log.debug('Response was: %s', response)
+        log.debug('Response was: %s', response)
         return False, response
     try:
         assert 'jsonrpc' in response, \

--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -132,7 +132,7 @@ def validate_jsonrpc_response(response, id=None):
         response = json.loads(response)
     except Exception as e:
         log.error('Response was not valid JSON: %s', unicodify(e))
-        log.debug('Response was: %s' % response)
+         log.debug('Response was: %s', response)
         return False, response
     try:
         assert 'jsonrpc' in response, \

--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -131,7 +131,7 @@ def validate_jsonrpc_response(response, id=None):
     try:
         response = json.loads(response)
     except Exception as e:
-        log.error('Response was not valid JSON: %s' % unicodify(e))
+        log.error('Response was not valid JSON: %s', unicodify(e))
         log.debug('Response was: %s' % response)
         return False, response
     try:

--- a/lib/galaxy/web/base/controller.py
+++ b/lib/galaxy/web/base/controller.py
@@ -190,12 +190,12 @@ class BaseAPIController(BaseController):
                                              check_ownership=check_ownership, check_accessible=check_accessible, deleted=deleted)
 
         except exceptions.ItemDeletionException as e:
-            raise HTTPBadRequest(detail="Invalid %s id ( %s ) specified: %s" % (class_name, str(id), str(e)))
+            raise HTTPBadRequest(detail="Invalid %s id ( %s ) specified: %s" % (class_name, str(id), util.unicodify(e)))
         except exceptions.MessageException as e:
             raise HTTPBadRequest(detail=e.err_msg)
         except Exception as e:
             log.exception("Exception in get_object check for %s %s.", class_name, str(id))
-            raise HTTPInternalServerError(comment=str(e))
+            raise HTTPInternalServerError(comment=util.unicodify(e))
 
     def validate_in_users_and_groups(self, trans, payload):
         """

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -125,7 +125,7 @@ class WebApplication(base.WebApplication):
                 try:
                     module = import_module(module_name)
                 except ControllerUnavailable as exc:
-                    log.debug("%s could not be loaded: %s" % (module_name, unicodify(exc)))
+                    log.debug("%s could not be loaded: %s", module_name, unicodify(exc))
                     continue
                 # Look for a controller inside the modules
                 for key in dir(module):
@@ -150,7 +150,7 @@ class WebApplication(base.WebApplication):
                 try:
                     module = import_module(module_name)
                 except ControllerUnavailable as exc:
-                    log.debug("%s could not be loaded: %s" % (module_name, unicodify(exc)))
+                    log.debug("%s could not be loaded: %s", module_name, unicodify(exc))
                     continue
                 for key in dir(module):
                     T = getattr(module, key)

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -125,7 +125,7 @@ class WebApplication(base.WebApplication):
                 try:
                     module = import_module(module_name)
                 except ControllerUnavailable as exc:
-                    log.debug("%s could not be loaded: %s" % (module_name, str(exc)))
+                    log.debug("%s could not be loaded: %s" % (module_name, unicodify(exc)))
                     continue
                 # Look for a controller inside the modules
                 for key in dir(module):
@@ -150,7 +150,7 @@ class WebApplication(base.WebApplication):
                 try:
                     module = import_module(module_name)
                 except ControllerUnavailable as exc:
-                    log.debug("%s could not be loaded: %s" % (module_name, str(exc)))
+                    log.debug("%s could not be loaded: %s" % (module_name, unicodify(exc)))
                     continue
                 for key in dir(module):
                     T = getattr(module, key)
@@ -637,7 +637,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
             try:
                 safe_makedirs(os.path.join(self.app.config.user_library_import_dir, user.email))
             except ConfigurationError as e:
-                self.log_event(str(e))
+                self.log_event(unicodify(e))
 
     def user_checks(self, user):
         """

--- a/lib/galaxy/webapps/galaxy/api/authenticate.py
+++ b/lib/galaxy/webapps/galaxy/api/authenticate.py
@@ -87,7 +87,7 @@ class AuthenticationController(BaseAPIController):
             try:
                 email, password = unicodify(b64decode(smart_str(split[0]))).split(':')
             except Exception as e:
-                raise exceptions.ActionInputError(str(e))
+                raise exceptions.ActionInputError(unicodify(e))
 
         # If there are only two elements, check the first and ensure it says
         # 'basic' so that we know we're about to decode the right thing. If not,

--- a/lib/galaxy/webapps/galaxy/api/authenticate.py
+++ b/lib/galaxy/webapps/galaxy/api/authenticate.py
@@ -87,7 +87,7 @@ class AuthenticationController(BaseAPIController):
             try:
                 email, password = unicodify(b64decode(smart_str(split[0]))).split(':')
             except Exception as e:
-                raise exceptions.ActionInputError(unicodify(e))
+                raise exceptions.ActionInputError(e)
 
         # If there are only two elements, check the first and ensure it says
         # 'basic' so that we know we're about to decode the right thing. If not,

--- a/lib/galaxy/webapps/galaxy/api/cloudauthz.py
+++ b/lib/galaxy/webapps/galaxy/api/cloudauthz.py
@@ -18,6 +18,7 @@ from galaxy.exceptions import (
     RequestParameterMissingException
 )
 from galaxy.managers import cloudauthzs
+from galaxy.util import unicodify
 from galaxy.web import (
     expose_api
 )
@@ -151,7 +152,7 @@ class CloudAuthzController(BaseAPIController):
         except Exception as e:
             log.exception(msg_template.format("exception while creating the new cloudauthz record"))
             raise InternalServerError('An unexpected error has occurred while responding to the create request of the '
-                                      'cloudauthz API.' + str(e))
+                                      'cloudauthz API.' + unicodify(e))
 
     @expose_api
     def delete(self, trans, encoded_authz_id, **kwargs):
@@ -188,7 +189,7 @@ class CloudAuthzController(BaseAPIController):
             log.exception(msg_template.format("exception while deleting the cloudauthz record with "
                                               "ID: `{}`.".format(encoded_authz_id)))
             raise InternalServerError('An unexpected error has occurred while responding to the DELETE request of the '
-                                      'cloudauthz API.' + str(e))
+                                      'cloudauthz API.' + unicodify(e))
 
     @expose_api
     def update(self, trans, encoded_authz_id, payload, **kwargs):
@@ -249,4 +250,4 @@ class CloudAuthzController(BaseAPIController):
             log.exception(msg_template.format("exception while updating the cloudauthz record with "
                                               "ID: `{}`.".format(encoded_authz_id)))
             raise InternalServerError('An unexpected error has occurred while responding to the PUT request of the '
-                                      'cloudauthz API.' + str(e))
+                                      'cloudauthz API.' + unicodify(e))

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -154,8 +154,8 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
                     rval = dataset.to_dict()
 
         except Exception as e:
-            rval = "Error in dataset API at listing contents: " + str(e)
-            log.error(rval + ": %s" % str(e), exc_info=True)
+            rval = "Error in dataset API at listing contents: " + util.unicodify(e)
+            log.error(rval + ": %s" % util.unicodify(e), exc_info=True)
             trans.response.status = 500
         return rval
 
@@ -424,7 +424,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
             log.exception("Error getting display data for dataset (%s) from history (%s)",
                           history_content_id, history_id)
             trans.response.status = 500
-            rval = "Could not get display data for dataset: %s" % e
+            rval = "Could not get display data for dataset: %s" % util.unicodify(e)
         return rval
 
     @web.legacy_expose_api_raw_anonymous
@@ -445,7 +445,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
             log.exception("Error getting metadata_file (%s) for dataset (%s) from history (%s)",
                           metadata_file, history_content_id, history_id)
             trans.response.status = 500
-            rval = "Could not get metadata for dataset: %s" % e
+            rval = "Could not get metadata for dataset: %s" % util.unicodify(e)
         return rval
 
     @web.expose_api_anonymous

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -153,9 +153,8 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
                 else:
                     rval = dataset.to_dict()
 
-        except Exception as e:
-            rval = "Error in dataset API at listing contents: " + util.unicodify(e)
-            log.error(rval + ": %s" % util.unicodify(e), exc_info=True)
+        except Exception:
+            log.exception('Error in dataset API at listing contents')
             trans.response.status = 500
         return rval
 

--- a/lib/galaxy/webapps/galaxy/api/datatypes.py
+++ b/lib/galaxy/webapps/galaxy/api/datatypes.py
@@ -5,7 +5,10 @@ import logging
 
 from galaxy import exceptions
 from galaxy.datatypes.data import Data
-from galaxy.util import asbool
+from galaxy.util import (
+    asbool,
+    unicodify
+)
 from galaxy.web import expose_api_anonymous_and_sessionless
 from galaxy.web.base.controller import BaseAPIController
 
@@ -36,10 +39,10 @@ class DatatypesController(BaseAPIController):
                         continue
                     rval.append(datatype_info_dict)
                 return rval
-        except Exception as exception:
-            log.error('could not get datatypes: %s', str(exception), exc_info=True)
-            if not isinstance(exception, exceptions.MessageException):
-                raise exceptions.InternalServerError(str(exception))
+        except Exception as e:
+            log.exception('Could not get datatypes')
+            if not isinstance(e, exceptions.MessageException):
+                raise exceptions.InternalServerError(unicodify(e))
             else:
                 raise
 
@@ -70,10 +73,10 @@ class DatatypesController(BaseAPIController):
                 class_to_classes[n] = dict((t, True) for t in types)
             return dict(ext_to_class_name=ext_to_class_name, class_to_classes=class_to_classes)
 
-        except Exception as exception:
-            log.error('could not get datatype mapping: %s', str(exception), exc_info=True)
-            if not isinstance(exception, exceptions.MessageException):
-                raise exceptions.InternalServerError(str(exception))
+        except Exception as e:
+            log.exception('Could not get datatype mapping')
+            if not isinstance(e, exceptions.MessageException):
+                raise exceptions.InternalServerError(unicodify(e))
             else:
                 raise
 
@@ -90,10 +93,10 @@ class DatatypesController(BaseAPIController):
                 if datatype is not None:
                     rval.append(datatype)
             return rval
-        except Exception as exception:
-            log.error('could not get datatypes: %s', str(exception), exc_info=True)
-            if not isinstance(exception, exceptions.MessageException):
-                raise exceptions.InternalServerError(str(exception))
+        except Exception as e:
+            log.exception('Could not get datatypes')
+            if not isinstance(e, exceptions.MessageException):
+                raise exceptions.InternalServerError(unicodify(e))
             else:
                 raise
 

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -287,7 +287,8 @@ class FolderContentsController(BaseAPIController, UsesLibraryMixin, UsesLibraryM
                 return self._copy_hdca_to_library_folder(trans, self.hda_manager, decoded_hdca_id, encoded_folder_id_16, ldda_message)
         except Exception as exc:
             # TODO handle exceptions better within the mixins
-            if 'not accessible to the current user' in str(exc) or 'You are not allowed to access this dataset' in str(exc):
+            exc_message = util.unicodify(exc)
+            if 'not accessible to the current user' in exc_message or 'You are not allowed to access this dataset' in exc_message:
                 raise exceptions.ItemAccessibilityException('You do not have access to the requested item')
             else:
                 log.exception(exc)

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -4,6 +4,7 @@ API operations on Group objects.
 import logging
 
 from galaxy import web
+from galaxy.util import unicodify
 from galaxy.web.base.controller import BaseAPIController, url_for
 
 log = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ class GroupRolesAPIController(BaseAPIController):
                                  url=url_for('group_role', group_id=group_id, id=encoded_id, )))
         except Exception as e:
             rval = "Error in group API at listing roles"
-            log.error(rval + ": %s" % str(e))
+            log.error(rval + ": %s" % unicodify(e))
             trans.response.status = 500
         return rval
 
@@ -63,7 +64,7 @@ class GroupRolesAPIController(BaseAPIController):
                 item = "role %s not in group %s" % (role.name, group.name)
         except Exception as e:
             item = "Error in group_role API group %s role %s" % (group.name, role.name)
-            log.error(item + ": %s" % str(e))
+            log.error(item + ": %s" % unicodify(e))
         return item
 
     @web.legacy_expose_api
@@ -95,7 +96,7 @@ class GroupRolesAPIController(BaseAPIController):
                             url=url_for('group_role', group_id=group_id, id=role_id))
         except Exception as e:
             item = "Error in group_role API Adding role %s to group %s" % (role.name, group.name)
-            log.error(item + ": %s" % str(e))
+            log.error(item + ": %s" % unicodify(e))
         return item
 
     @web.legacy_expose_api
@@ -122,5 +123,5 @@ class GroupRolesAPIController(BaseAPIController):
                 item = "role %s not in group %s" % (role.name, group.name)
         except Exception as e:
             item = "Error in group_role API Removing role %s from group %s" % (role.name, group.name)
-            log.error(item + ": %s" % str(e))
+            log.error(item + ": %s" % unicodify(e))
         return item

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -37,7 +37,7 @@ class GroupRolesAPIController(BaseAPIController):
                                  url=url_for('group_role', group_id=group_id, id=encoded_id, )))
         except Exception as e:
             rval = "Error in group API at listing roles"
-            log.error(rval + ": %s" % unicodify(e))
+            log.error(rval + ": %s", unicodify(e))
             trans.response.status = 500
         return rval
 
@@ -64,7 +64,7 @@ class GroupRolesAPIController(BaseAPIController):
                 item = "role %s not in group %s" % (role.name, group.name)
         except Exception as e:
             item = "Error in group_role API group %s role %s" % (group.name, role.name)
-            log.error(item + ": %s" % unicodify(e))
+            log.error(item + ": %s", unicodify(e))
         return item
 
     @web.legacy_expose_api
@@ -96,7 +96,7 @@ class GroupRolesAPIController(BaseAPIController):
                             url=url_for('group_role', group_id=group_id, id=role_id))
         except Exception as e:
             item = "Error in group_role API Adding role %s to group %s" % (role.name, group.name)
-            log.error(item + ": %s" % unicodify(e))
+            log.error(item + ": %s", unicodify(e))
         return item
 
     @web.legacy_expose_api
@@ -123,5 +123,5 @@ class GroupRolesAPIController(BaseAPIController):
                 item = "role %s not in group %s" % (role.name, group.name)
         except Exception as e:
             item = "Error in group_role API Removing role %s from group %s" % (role.name, group.name)
-            log.error(item + ": %s" % unicodify(e))
+            log.error(item + ": %s", unicodify(e))
         return item

--- a/lib/galaxy/webapps/galaxy/api/group_users.py
+++ b/lib/galaxy/webapps/galaxy/api/group_users.py
@@ -37,7 +37,7 @@ class GroupUsersAPIController(BaseAPIController):
                                  url=url_for('group_user', group_id=group_id, id=encoded_id, )))
         except Exception as e:
             rval = "Error in group API at listing users"
-            log.error(rval + ": %s" % unicodify(e))
+            log.error(rval + ": %s", unicodify(e))
             trans.response.status = 500
         return rval
 
@@ -64,7 +64,7 @@ class GroupUsersAPIController(BaseAPIController):
                 item = "user %s not in group %s" % (user.email, group.name)
         except Exception as e:
             item = "Error in group_user API group %s user %s" % (group.name, user.email)
-            log.error(item + ": %s" % unicodify(e))
+            log.error(item + ": %s", unicodify(e))
         return item
 
     @web.legacy_expose_api
@@ -96,7 +96,7 @@ class GroupUsersAPIController(BaseAPIController):
                             url=url_for('group_user', group_id=group_id, id=user_id))
         except Exception as e:
             item = "Error in group_user API Adding user %s to group %s" % (user.email, group.name)
-            log.error(item + ": %s" % unicodify(e))
+            log.error(item + ": %s", unicodify(e))
         return item
 
     @web.legacy_expose_api
@@ -123,5 +123,5 @@ class GroupUsersAPIController(BaseAPIController):
                 item = "user %s not in group %s" % (user.email, group.name)
         except Exception as e:
             item = "Error in group_user API Removing user %s from group %s" % (user.email, group.name)
-            log.error(item + ": %s" % unicodify(e))
+            log.error(item + ": %s", unicodify(e))
         return item

--- a/lib/galaxy/webapps/galaxy/api/group_users.py
+++ b/lib/galaxy/webapps/galaxy/api/group_users.py
@@ -4,6 +4,7 @@ API operations on Group objects.
 import logging
 
 from galaxy import web
+from galaxy.util import unicodify
 from galaxy.web.base.controller import BaseAPIController, url_for
 
 log = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ class GroupUsersAPIController(BaseAPIController):
                                  url=url_for('group_user', group_id=group_id, id=encoded_id, )))
         except Exception as e:
             rval = "Error in group API at listing users"
-            log.error(rval + ": %s" % str(e))
+            log.error(rval + ": %s" % unicodify(e))
             trans.response.status = 500
         return rval
 
@@ -63,7 +64,7 @@ class GroupUsersAPIController(BaseAPIController):
                 item = "user %s not in group %s" % (user.email, group.name)
         except Exception as e:
             item = "Error in group_user API group %s user %s" % (group.name, user.email)
-            log.error(item + ": %s" % str(e))
+            log.error(item + ": %s" % unicodify(e))
         return item
 
     @web.legacy_expose_api
@@ -95,7 +96,7 @@ class GroupUsersAPIController(BaseAPIController):
                             url=url_for('group_user', group_id=group_id, id=user_id))
         except Exception as e:
             item = "Error in group_user API Adding user %s to group %s" % (user.email, group.name)
-            log.error(item + ": %s" % str(e))
+            log.error(item + ": %s" % unicodify(e))
         return item
 
     @web.legacy_expose_api
@@ -122,5 +123,5 @@ class GroupUsersAPIController(BaseAPIController):
                 item = "user %s not in group %s" % (user.email, group.name)
         except Exception as e:
             item = "Error in group_user API Removing user %s from group %s" % (user.email, group.name)
-            log.error(item + ": %s" % str(e))
+            log.error(item + ": %s" % unicodify(e))
         return item

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -295,7 +295,7 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
         except Exception as e:
             log.exception("Error in API while creating dataset collection archive")
             trans.response.status = 500
-            return {'error': str(e)}
+            return {'error': util.unicodify(e)}
 
     def __stream_dataset_collection(self, trans, dataset_collection_instance):
         archive_type_string = 'w|gz'

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -99,7 +99,7 @@ class LibraryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
         except NoResultFound:
             raise exceptions.RequestParameterInvalidException('No library found with the id provided.')
         except Exception as e:
-            raise exceptions.InternalServerError('Error loading from the database.' + str(e))
+            raise exceptions.InternalServerError('Error loading from the database.' + util.unicodify(e))
         if not (trans.user_is_admin or trans.app.security_agent.can_access_library(current_user_roles, library)):
             raise exceptions.RequestParameterInvalidException('No library found with the id provided.')
         encoded_id = 'F' + trans.security.encode_id(library.root_folder.id)
@@ -226,7 +226,7 @@ class LibraryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
             # security is checked in the downstream controller
             parent = self.get_library_folder(trans, folder_id, check_ownership=False, check_accessible=False)
         except Exception as e:
-            return str(e)
+            return util.unicodify(e)
         # The rest of the security happens in the library_common controller.
         real_folder_id = trans.security.encode_id(parent.id)
 
@@ -480,5 +480,5 @@ class LibraryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
             log.exception('library_contents API, delete: uncaught exception: %s, %s',
                           id, str(kwd))
             trans.response.status = 500
-            rval.update({'error': str(exc)})
+            rval.update({'error': util.unicodify(exc)})
         return rval

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -659,7 +659,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                             log.exception("Requested dataset %s does not exist on the host.", fpath)
                             raise exceptions.ObjectNotFound("Requested dataset not found.")
                         except Exception as e:
-                             log.exception("Unable to add %s to temporary library download archive %s", fname, outfname)
+                            log.exception("Unable to add %s to temporary library download archive %s", fname, outfname)
                             raise exceptions.InternalServerError("Unable to add dataset to temporary library download archive . " + util.unicodify(e))
                 else:
                     try:

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -659,7 +659,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                             log.exception("Requested dataset %s does not exist on the host.", fpath)
                             raise exceptions.ObjectNotFound("Requested dataset not found.")
                         except Exception as e:
-                            log.exception("Unable to add %s to temporary library download archive %s" % (fname, outfname))
+                             log.exception("Unable to add %s to temporary library download archive %s", fname, outfname)
                             raise exceptions.InternalServerError("Unable to add dataset to temporary library download archive . " + util.unicodify(e))
                 else:
                     try:

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -86,7 +86,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
         try:
             ldda = self.get_library_dataset_dataset_association(trans, id=encoded_ldda_id, check_ownership=False, check_accessible=False)
         except Exception as e:
-            raise exceptions.ObjectNotFound('Requested version of library dataset was not found.' + str(e))
+            raise exceptions.ObjectNotFound('Requested version of library dataset was not found.' + util.unicodify(e))
 
         if ldda not in library_dataset.expired_datasets:
             raise exceptions.ObjectNotFound('Given library dataset does not have the requested version.')
@@ -533,7 +533,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                 except HTTPInternalServerError:
                     raise exceptions.InternalServerError('Internal error.')
                 except Exception as e:
-                    raise exceptions.InternalServerError('Unknown error.' + str(e))
+                    raise exceptions.InternalServerError('Unknown error.' + util.unicodify(e))
 
         folders_to_download = kwd.get('folder_ids%5B%5D', None)
         if folders_to_download is None:
@@ -640,7 +640,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                         raise exceptions.ObjectNotFound("Requested dataset not found. ")
                     except Exception as e:
                         log.exception("Unable to add composite parent %s to temporary library download archive", ldda.dataset.file_name)
-                        raise exceptions.InternalServerError("Unable to add composite parent to temporary library download archive. " + str(e))
+                        raise exceptions.InternalServerError("Unable to add composite parent to temporary library download archive. " + util.unicodify(e))
 
                     flist = glob.glob(os.path.join(ldda.dataset.extra_files_path, '*.*'))  # glob returns full paths
                     for fpath in flist:
@@ -660,7 +660,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                             raise exceptions.ObjectNotFound("Requested dataset not found.")
                         except Exception as e:
                             log.exception("Unable to add %s to temporary library download archive %s" % (fname, outfname))
-                            raise exceptions.InternalServerError("Unable to add dataset to temporary library download archive . " + str(e))
+                            raise exceptions.InternalServerError("Unable to add dataset to temporary library download archive . " + util.unicodify(e))
                 else:
                     try:
                         if format == 'zip':
@@ -675,7 +675,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                         raise exceptions.ObjectNotFound("Requested dataset not found.")
                     except Exception as e:
                         log.exception("Unable to add %s to temporary library download archive %s", ldda.dataset.file_name, outfname)
-                        raise exceptions.InternalServerError("Unknown error. " + str(e))
+                        raise exceptions.InternalServerError("Unknown error. " + util.unicodify(e))
             lname = 'selected_dataset'
             fname = lname.replace(' ', '_') + '_files'
             if format == 'zip':

--- a/lib/galaxy/webapps/galaxy/api/quotas.py
+++ b/lib/galaxy/webapps/galaxy/api/quotas.py
@@ -71,12 +71,12 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
         try:
             self.validate_in_users_and_groups(trans, payload)
         except Exception as e:
-            raise HTTPBadRequest(detail=str(e))
+            raise HTTPBadRequest(detail=util.unicodify(e))
         params = self.get_quota_params(payload)
         try:
             quota, message = self._create_quota(params)
         except ActionInputError as e:
-            raise HTTPBadRequest(detail=str(e))
+            raise HTTPBadRequest(detail=util.unicodify(e))
         item = quota.to_dict(value_mapper={'id': trans.security.encode_id})
         item['url'] = url_for('quota', id=trans.security.encode_id(quota.id))
         item['message'] = message
@@ -92,7 +92,7 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
         try:
             self.validate_in_users_and_groups(trans, payload)
         except Exception as e:
-            raise HTTPBadRequest(detail=str(e))
+            raise HTTPBadRequest(detail=util.unicodify(e))
 
         quota = self.get_quota(trans, id, deleted=False)
 
@@ -116,7 +116,7 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
             try:
                 message = method(quota, params)
             except ActionInputError as e:
-                raise HTTPBadRequest(detail=str(e))
+                raise HTTPBadRequest(detail=util.unicodify(e))
             messages.append(message)
         return '; '.join(messages)
 
@@ -139,7 +139,7 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
             if util.string_as_bool(payload.get('purge', False)):
                 message += self._purge_quota(quota, params)
         except ActionInputError as e:
-            raise HTTPBadRequest(detail=str(e))
+            raise HTTPBadRequest(detail=util.unicodify(e))
         return message
 
     @web.legacy_expose_api
@@ -153,4 +153,4 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
         try:
             return self._undelete_quota(quota)
         except ActionInputError as e:
-            raise HTTPBadRequest(detail=str(e))
+            raise HTTPBadRequest(detail=util.unicodify(e))

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -10,7 +10,8 @@ from operator import itemgetter
 from galaxy import exceptions
 from galaxy.util import (
     jstree,
-    smart_str
+    smart_str,
+    unicodify
 )
 from galaxy.util.path import (
     safe_path,
@@ -58,9 +59,9 @@ class RemoteFilesAPIController(BaseAPIController):
                     try:
                         userdir_jstree = self.__create_jstree(full_import_dir, disable, whitelist=trans.app.config.user_library_import_symlink_whitelist)
                         response = userdir_jstree.jsonData()
-                    except Exception as exception:
-                        log.debug(str(exception))
-                        raise exceptions.InternalServerError('Could not create tree representation of the given folder: ' + str(full_import_dir))
+                    except Exception as e:
+                        log.debug(unicodify(e))
+                        raise exceptions.InternalServerError('Could not create tree representation of the given folder: %s' % full_import_dir)
                     if not response:
                         raise exceptions.ObjectNotFound('You do not have any files in your user directory. Use FTP to upload there.')
                 elif format == 'ajax':
@@ -68,8 +69,8 @@ class RemoteFilesAPIController(BaseAPIController):
                 else:
                     try:
                         response = self.__load_all_filenames(full_import_dir, whitelist=trans.app.config.user_library_import_symlink_whitelist)
-                    except Exception as exception:
-                        log.error('Could not get user import files: %s', str(exception), exc_info=True)
+                    except Exception:
+                        log.exception('Could not get user import files')
                         raise exceptions.InternalServerError('Could not get the files from your user directory folder.')
             else:
                 raise exceptions.InternalServerError('Could not get the files from your user directory folder.')
@@ -82,16 +83,16 @@ class RemoteFilesAPIController(BaseAPIController):
                 try:
                     importdir_jstree = self.__create_jstree(base_dir, disable, whitelist=trans.app.config.user_library_import_symlink_whitelist)
                     response = importdir_jstree.jsonData()
-                except Exception as exception:
-                    log.debug(str(exception))
-                    raise exceptions.InternalServerError('Could not create tree representation of the given folder: ' + str(base_dir))
+                except Exception as e:
+                    log.debug(unicodify(e))
+                    raise exceptions.InternalServerError('Could not create tree representation of the given folder: %s' % base_dir)
             elif format == 'ajax':
                 raise exceptions.NotImplemented('Not implemented yet. Sorry.')
             else:
                 try:
                     response = self.__load_all_filenames(base_dir, trans.app.config.user_library_import_symlink_whitelist)
-                except Exception as exception:
-                    log.error('Could not get user import files: %s', str(exception), exc_info=True)
+                except Exception:
+                    log.exception('Could not get user import files')
                     raise exceptions.InternalServerError('Could not get the files from your import directory folder.')
         else:
             user_ftp_base_dir = trans.app.config.ftp_upload_dir
@@ -104,8 +105,8 @@ class RemoteFilesAPIController(BaseAPIController):
                 else:
                     log.warning('You do not have an FTP directory named as your login at this Galaxy instance.')
                     return None
-            except Exception as exception:
-                log.warning('Could not get ftp files: %s', str(exception), exc_info=True)
+            except Exception:
+                log.warning('Could not get ftp files', exc_info=True)
                 return None
         return response
 

--- a/lib/galaxy/webapps/galaxy/api/search.py
+++ b/lib/galaxy/webapps/galaxy/api/search.py
@@ -6,6 +6,7 @@ import logging
 from galaxy import web
 from galaxy.exceptions import ItemAccessibilityException
 from galaxy.model.search import GalaxySearchEngine
+from galaxy.util import unicodify
 from galaxy.web.base.controller import (
     BaseAPIController,
     SharableItemSecurityMixin
@@ -29,14 +30,14 @@ class SearchController(BaseAPIController, SharableItemSecurityMixin):
             try:
                 query = se.query(query_txt)
             except Exception as e:
-                return {'error': str(e)}
+                return {'error': unicodify(e)}
             if query is not None:
                 query.decode_query_ids(trans)
                 current_user_roles = trans.get_current_user_roles()
                 try:
                     results = query.process(trans)
                 except Exception as e:
-                    return {'error': str(e)}
+                    return {'error': unicodify(e)}
                 for item in results:
                     append = False
                     if trans.user_is_admin:

--- a/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
@@ -186,7 +186,7 @@ class ToolShedRepositoriesController(BaseAPIController):
             raw_text = util.url_get(tool_shed_url, password_mgr=self.app.tool_shed_registry.url_auth(tool_shed_url), pathspec=pathspec, params=params)
         except Exception as e:
             message = "Error attempting to retrieve the latest installable revision from tool shed %s for repository %s owned by %s: %s" % \
-                (str(tool_shed_url), str(name), str(owner), str(e))
+                (str(tool_shed_url), str(name), str(owner), util.unicodify(e))
             log.debug(message)
             return dict(status='error', error=message)
         if raw_text:
@@ -762,7 +762,7 @@ class ToolShedRepositoriesController(BaseAPIController):
                     results['successful_count'] += 1
             except Exception as e:
                 message = "Error resetting metadata on repository %s owned by %s: %s" % \
-                    (str(repository.name), str(repository.owner), str(e))
+                    (str(repository.name), str(repository.owner), util.unicodify(e))
                 results['unsuccessful_count'] += 1
             results['repository_status'].append(message)
         stop_time = strftime("%Y-%m-%d %H:%M:%S")

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -466,7 +466,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             stored_workflow = trans.sa_session.query(self.app.model.StoredWorkflow).get(self.decode_id(workflow_id))
         except Exception as e:
             trans.response.status = 400
-            return ("Workflow with ID='%s' can not be found\n Exception: %s") % (workflow_id, str(e))
+            return ("Workflow with ID='%s' can not be found\n Exception: %s") % (workflow_id, util.unicodify(e))
 
         # check to see if user has permissions to selected workflow
         if stored_workflow.user != trans.user and not trans.user_is_admin:

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1153,7 +1153,7 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
                                           args=(conf,),
                                           kwargs=dict(templating_formatters=build_template_error_formatters()))
         except MiddlewareWrapUnsupported as exc:
-            log.warning(str(exc))
+            log.warning(util.unicodify(exc))
             import galaxy.web.framework.middleware.error
             app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
     else:

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -645,7 +645,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                 try:
                     quotas.append(get_quota(trans, quota_id))
                 except MessageException as e:
-                    return self.message_exception(trans, str(e))
+                    return self.message_exception(trans, util.unicodify(e))
             operation = kwargs.pop('operation').lower()
             try:
                 if operation == 'delete':

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -54,7 +54,7 @@ class AdminToolshed(AdminGalaxy):
             message = 'The <b>%s</b> repository has been activated.' % escape(repository.name)
             status = 'done'
         except Exception as e:
-            error_message = "Error activating repository %s: %s" % (escape(repository.name), str(e))
+            error_message = "Error activating repository %s: %s" % (escape(repository.name), unicodify(e))
             log.exception(error_message)
             message = '%s.<br/>You may be able to resolve this by uninstalling and then reinstalling the repository.  Click <a href="%s">here</a> to uninstall the repository.' \
                 % (error_message, web.url_for(controller='admin_toolshed', action='deactivate_or_uninstall_repository', id=trans.security.encode_id(repository.id)))
@@ -577,7 +577,7 @@ class AdminToolshed(AdminGalaxy):
             tsr_ids_for_monitoring = [trans.security.encode_id(tsr.id) for tsr in tool_shed_repositories]
             return json.dumps(tsr_ids_for_monitoring)
         except install_manager.RepositoriesInstalledException as e:
-            return self.message_exception(trans, str(e))
+            return self.message_exception(trans, unicodify(e))
 
     @web.expose
     @web.require_admin
@@ -880,7 +880,7 @@ class AdminToolshed(AdminGalaxy):
                     message = 'The updates available for the repository <b>%s</b> ' % escape(str(repository.name))
                     message += 'include newly defined repository or tool dependency definitions, and attempting '
                     message += 'to update the repository resulted in the following error.  Contact the Tool Shed '
-                    message += 'administrator if necessary.<br/>%s' % str(e)
+                    message += 'administrator if necessary.<br/>%s' % unicodify(e)
                     return trans.show_error_message(message)
                 changeset_revisions = updating_to_changeset_revision
             else:

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -10,7 +10,10 @@ import requests
 from six.moves.urllib.parse import urlencode
 
 from galaxy import jobs, web
-from galaxy.util import Params
+from galaxy.util import (
+    Params,
+    unicodify,
+)
 from galaxy.util.hash_util import hmac_new
 from galaxy.web.base.controller import BaseUIController
 
@@ -171,7 +174,7 @@ class ASync(BaseUIController):
                     raise Exception(text)
                 data.state = data.blurb = data.states.RUNNING
             except Exception as e:
-                data.info = str(e)
+                data.info = unicodify(e)
                 data.state = data.blurb = data.states.ERROR
 
             trans.sa_session.flush()

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -483,7 +483,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                 try:
                     message = data.datatype.convert_dataset(trans, data, target_type)
                 except Exception as e:
-                    return self.message_exception(trans, str(e))
+                    return self.message_exception(trans, util.unicodify(e))
         elif operation == 'permission':
             if not trans.user:
                 return self.message_exception(trans, 'You must be logged in if you want to change permissions.')
@@ -830,7 +830,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                             action_param = display_link.get_param_name_by_url(action_param)
                         except ValueError as e:
                             log.debug(e)
-                            return paste.httpexceptions.HTTPNotFound(str(e))
+                            return paste.httpexceptions.HTTPNotFound(util.unicodify(e))
                         value = display_link.get_param_value(action_param)
                         assert value, "An invalid parameter name was provided: %s" % action_param
                         assert value.parameter.viewable, "This parameter is not viewable."

--- a/lib/galaxy/webapps/galaxy/controllers/openid.py
+++ b/lib/galaxy/webapps/galaxy/controllers/openid.py
@@ -7,6 +7,7 @@ import logging
 from galaxy import web
 from galaxy.openid.openid_manager import OpenIDManager
 from galaxy.openid.providers import OpenIDProviders
+from galaxy.util import unicodify
 from galaxy.web import url_for
 from galaxy.web.base.controller import BaseUIController
 
@@ -41,7 +42,7 @@ class OpenID(BaseUIController):
             if request is None:
                 return trans.show_error_message("No OpenID services are available at %s." % openid_provider_obj.op_endpoint_url)
         except Exception as e:
-            return trans.show_error_message("Failed to begin OpenID authentication: %s." % str(e))
+            return trans.show_error_message("Failed to begin OpenID authentication: %s." % unicodify(e))
         if request is not None:
             self.openid_manager.add_sreg(trans, request, required=openid_provider_obj.sreg_required, optional=openid_provider_obj.sreg_optional)
             if request.shouldSendRedirect():

--- a/lib/galaxy/webapps/galaxy/controllers/root.py
+++ b/lib/galaxy/webapps/galaxy/controllers/root.py
@@ -21,7 +21,8 @@ from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.util import (
     FILENAME_VALID_CHARS,
     listify,
-    string_as_bool
+    string_as_bool,
+    unicodify,
 )
 from galaxy.web.base import controller
 
@@ -341,7 +342,7 @@ class RootController(controller.JSAppLauncher, UsesAnnotations):
             trans.log_event("Added dataset %d to history %d" % (data.id, trans.history.id))
             return trans.show_ok_message("Dataset " + str(data.hid) + " added to history " + str(history_id) + ".")
         except Exception as e:
-            msg = "Failed to add dataset to history: %s" % (e)
+            msg = "Failed to add dataset to history: %s" % unicodify(e)
             log.error(msg)
             trans.log_event(msg)
             return trans.show_error_message("Adding File to History has Failed")

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -77,7 +77,7 @@ class ToolRunner(BaseUIController):
         try:
             vars = tool.handle_input(trans, params.__dict__, history=history)
         except Exception as e:
-            error(str(e))
+            error(galaxy.util.unicodify(e))
         if len(params) > 0:
             trans.log_event('Tool params: %s' % (str(params)), tool_id=tool_id)
         return trans.fill_template('root/tool_runner.mako', **vars)

--- a/lib/galaxy/webapps/reports/buildapp.py
+++ b/lib/galaxy/webapps/reports/buildapp.py
@@ -11,7 +11,10 @@ from paste import httpexceptions
 import galaxy.model
 import galaxy.model.mapping
 import galaxy.web.framework.webapp
-from galaxy.util import asbool
+from galaxy.util import (
+    asbool,
+    unicodify,
+)
 from galaxy.util.properties import load_app_properties
 from galaxy.webapps.util import (
     build_template_error_formatters,
@@ -128,7 +131,7 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
                                           args=(conf,),
                                           kwargs=dict(templating_formatters=build_template_error_formatters()))
         except MiddlewareWrapUnsupported as exc:
-            log.warning(str(exc))
+            log.warning(unicodify(exc))
             import galaxy.web.framework.middleware.error
             app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
     else:

--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -312,7 +312,7 @@ class RepositoriesController(BaseAPIController):
             # Open for reading with transparent compression.
             tar_archive = tarfile.open(capsule_file_path, 'r:*')
         except tarfile.ReadError as e:
-            log.debug('Error opening capsule file %s: %s', str(capsule_file_name), util.unicodify(e))
+            log.debug('Error opening capsule file %s: %s', capsule_file_name, util.unicodify(e))
             return {}
         irm = capsule_manager.ImportRepositoryManager(self.app,
                                                       trans.request.host,

--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -312,7 +312,7 @@ class RepositoriesController(BaseAPIController):
             # Open for reading with transparent compression.
             tar_archive = tarfile.open(capsule_file_path, 'r:*')
         except tarfile.ReadError as e:
-            log.debug('Error opening capsule file %s: %s' % (str(capsule_file_name), str(e)))
+            log.debug('Error opening capsule file %s: %s' % (str(capsule_file_name), util.unicodify(e)))
             return {}
         irm = capsule_manager.ImportRepositoryManager(self.app,
                                                       trans.request.host,
@@ -633,7 +633,7 @@ class RepositoriesController(BaseAPIController):
                     results['successful_count'] += 1
             except Exception as e:
                 message = "Error resetting metadata on repository %s owned by %s: %s" % \
-                    (str(repository.name), str(repository.user.username), str(e))
+                    (str(repository.name), str(repository.user.username), util.unicodify(e))
                 results['unsuccessful_count'] += 1
             status = '%s : %s' % (str(repository.name), message)
             results['repository_status'].append(status)
@@ -723,7 +723,7 @@ class RepositoriesController(BaseAPIController):
                     results['status'] = 'ok'
             except Exception as e:
                 message = "Error resetting metadata on repository %s owned by %s: %s" % \
-                    (str(repository.name), str(repository.user.username), str(e))
+                    (str(repository.name), str(repository.user.username), util.unicodify(e))
                 results['status'] = 'error'
             status = '%s : %s' % (str(repository.name), message)
             results['repository_status'].append(status)

--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -312,7 +312,7 @@ class RepositoriesController(BaseAPIController):
             # Open for reading with transparent compression.
             tar_archive = tarfile.open(capsule_file_path, 'r:*')
         except tarfile.ReadError as e:
-            log.debug('Error opening capsule file %s: %s' % (str(capsule_file_name), util.unicodify(e)))
+            log.debug('Error opening capsule file %s: %s', str(capsule_file_name), util.unicodify(e))
             return {}
         irm = capsule_manager.ImportRepositoryManager(self.app,
                                                       trans.request.host,

--- a/lib/galaxy/webapps/tool_shed/buildapp.py
+++ b/lib/galaxy/webapps/tool_shed/buildapp.py
@@ -281,7 +281,7 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
                                               args=(conf,),
                                               kwargs=dict(templating_formatters=build_template_error_formatters()))
             except MiddlewareWrapUnsupported as exc:
-                log.warning(str(exc))
+                log.warning(util.unicodify(exc))
                 import galaxy.web.framework.middleware.error
                 app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
         else:

--- a/lib/galaxy/webapps/tool_shed/controllers/repository.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/repository.py
@@ -2371,8 +2371,8 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                     try:
                         hg_util.remove_file(repo_dir, selected_file, force=True)
                     except Exception as e:
-                        log.debug("Error removing the following file using the mercurial API:\n %s" % selected_file)
-                        log.debug("The error was: %s" % util.unicodify(e))
+                        log.debug("Error removing the following file using the mercurial API:\n %s", selected_file)
+                        log.debug("The error was: %s", util.unicodify(e))
                         log.debug("Attempting to remove the file using a different approach.")
                         relative_selected_file = selected_file.split('repo_%d' % repository.id)[1].lstrip('/')
                         repo.dirstate.remove(relative_selected_file)

--- a/lib/galaxy/webapps/tool_shed/controllers/repository.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/repository.py
@@ -900,7 +900,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                                        message=message,
                                        status=status)
         except Exception as e:
-            message = "Error displaying tool, probably due to a problem in the tool config.  The exception is: %s." % str(e)
+            message = "Error displaying tool, probably due to a problem in the tool config.  The exception is: %s." % util.unicodify(e)
         if trans.webapp.name == 'galaxy' or render_repository_actions_for == 'galaxy':
             return trans.response.send_redirect(web.url_for(controller='repository',
                                                             action='preview_tools_in_changeset',
@@ -1801,7 +1801,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                                        message=message,
                                        status='error')
         except Exception as e:
-            message = "Exception thrown attempting to display tool: %s." % str(e)
+            message = "Exception thrown attempting to display tool: %s." % util.unicodify(e)
         if trans.webapp.name == 'galaxy':
             return trans.response.send_redirect(web.url_for(controller='repository',
                                                             action='preview_tools_in_changeset',
@@ -2371,8 +2371,8 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                     try:
                         hg_util.remove_file(repo_dir, selected_file, force=True)
                     except Exception as e:
-                        log.debug("Error removing the following file using the mercurial API:\n %s" % str(selected_file))
-                        log.debug("The error was: %s" % str(e))
+                        log.debug("Error removing the following file using the mercurial API:\n %s" % selected_file)
+                        log.debug("The error was: %s" % util.unicodify(e))
                         log.debug("Attempting to remove the file using a different approach.")
                         relative_selected_file = selected_file.split('repo_%d' % repository.id)[1].lstrip('/')
                         repo.dirstate.remove(relative_selected_file)
@@ -2461,7 +2461,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                 message = "Your message has been sent"
                 status = "done"
             except Exception as e:
-                message = "An error occurred sending your message by email: %s" % str(e)
+                message = "An error occurred sending your message by email: %s" % util.unicodify(e)
                 status = "error"
         else:
             # Do all we can to eliminate spam.

--- a/lib/galaxy/webapps/tool_shed/controllers/upload.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/upload.py
@@ -75,7 +75,7 @@ class UploadController(BaseUIController):
                     stream = requests.get(url, stream=True)
                 except Exception as e:
                     valid_url = False
-                    message = 'Error uploading file via http: %s' % str(e)
+                    message = 'Error uploading file via http: %s' % util.unicodify(e)
                     status = 'error'
                     uploaded_file = None
                 if valid_url:

--- a/lib/galaxy/webapps/tool_shed/util/hgweb_config.py
+++ b/lib/galaxy/webapps/tool_shed/util/hgweb_config.py
@@ -6,6 +6,8 @@ from datetime import date
 
 from six.moves import configparser
 
+from galaxy.util import unicodify
+
 log = logging.getLogger(__name__)
 
 new_hgweb_config_template = """
@@ -35,7 +37,7 @@ class HgWebConfigManager(object):
             # Persist our in-memory configuration.
             self.write_config()
         except Exception as e:
-            log.debug("Exception in HgWebConfigManager.add_entry(): %s" % str(e))
+            log.debug("Exception in HgWebConfigManager.add_entry(): %s" % unicodify(e))
         finally:
             lock.release()
 
@@ -52,7 +54,7 @@ class HgWebConfigManager(object):
             # Persist our in-memory configuration.
             self.write_config()
         except Exception as e:
-            log.debug("Exception in HgWebConfigManager.change_entry(): %s" % str(e))
+            log.debug("Exception in HgWebConfigManager.change_entry(): %s" % unicodify(e))
         finally:
             lock.release()
 

--- a/lib/galaxy/webapps/tool_shed/util/hgweb_config.py
+++ b/lib/galaxy/webapps/tool_shed/util/hgweb_config.py
@@ -37,7 +37,7 @@ class HgWebConfigManager(object):
             # Persist our in-memory configuration.
             self.write_config()
         except Exception as e:
-            log.debug("Exception in HgWebConfigManager.add_entry(): %s" % unicodify(e))
+            log.debug("Exception in HgWebConfigManager.add_entry(): %s", unicodify(e))
         finally:
             lock.release()
 
@@ -54,7 +54,7 @@ class HgWebConfigManager(object):
             # Persist our in-memory configuration.
             self.write_config()
         except Exception as e:
-            log.debug("Exception in HgWebConfigManager.change_entry(): %s" % unicodify(e))
+            log.debug("Exception in HgWebConfigManager.change_entry(): %s", unicodify(e))
         finally:
             lock.release()
 

--- a/lib/galaxy/webapps/util.py
+++ b/lib/galaxy/webapps/util.py
@@ -4,6 +4,8 @@ import logging
 
 import mako.exceptions
 
+from galaxy.util import unicodify
+
 
 log = logging.getLogger(__name__)
 
@@ -71,5 +73,5 @@ def wrap_if_allowed(app, stack, wrap, name=None, args=None, kwargs=None):
     try:
         return wrap_if_allowed_or_fail(app, stack, wrap, name=name, args=args, kwargs=kwargs)
     except MiddlewareWrapUnsupported as exc:
-        log.warning(str(exc))
+        log.warning(unicodify(exc))
         return app

--- a/lib/galaxy_ext/metadata/set_metadata.py
+++ b/lib/galaxy_ext/metadata/set_metadata.py
@@ -23,7 +23,10 @@ from sqlalchemy.orm import clear_mappers
 
 import galaxy.model.mapping  # need to load this before we unpickle, in order to setup properties assigned by the mappers
 from galaxy.model.custom_types import total_size
-from galaxy.util import stringify_dictionary_keys
+from galaxy.util import (
+    stringify_dictionary_keys,
+    unicodify,
+)
 from ._provided_metadata import parse_tool_provided_metadata
 
 # ensure supported version
@@ -127,7 +130,7 @@ def set_metadata_portable():
             dataset.metadata.to_JSON_dict(filename_out)  # write out results of set_meta
             json.dump((True, 'Metadata has been set successfully'), open(filename_results_code, 'wt+'))  # setting metadata has succeeded
         except Exception as e:
-            json.dump((False, str(e)), open(filename_results_code, 'wt+'))  # setting metadata has failed somehow
+            json.dump((False, unicodify(e)), open(filename_results_code, 'wt+'))  # setting metadata has failed somehow
 
     write_job_metadata(tool_job_working_directory, job_metadata, set_meta, tool_provided_metadata)
 
@@ -183,7 +186,7 @@ def set_metadata_legacy():
             dataset.metadata.to_JSON_dict(filename_out)  # write out results of set_meta
             json.dump((True, 'Metadata has been set successfully'), open(filename_results_code, 'wt+'))  # setting metadata has succeeded
         except Exception as e:
-            json.dump((False, str(e)), open(filename_results_code, 'wt+'))  # setting metadata has failed somehow
+            json.dump((False, unicodify(e)), open(filename_results_code, 'wt+'))  # setting metadata has failed somehow
 
     write_job_metadata(tool_job_working_directory, job_metadata, set_meta, tool_provided_metadata)
 

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -104,7 +104,7 @@ def add_file(dataset, registry, output_path):
         try:
             dataset.path = sniff.stream_url_to_file(dataset.path)
         except Exception as e:
-            raise UploadProblemException('Unable to fetch %s\n%s' % (dataset.path, str(e)))
+            raise UploadProblemException('Unable to fetch %s\n%s' % (dataset.path, unicodify(e)))
 
     # See if we have an empty file
     if not os.path.exists(dataset.path):
@@ -186,7 +186,7 @@ def add_composite_file(dataset, registry, output_path, files_path):
             try:
                 temp_name = sniff.stream_to_file(urlopen(path_or_url), prefix='url_paste')
             except Exception as e:
-                raise UploadProblemException('Unable to fetch %s\n%s' % (path_or_url, str(e)))
+                raise UploadProblemException('Unable to fetch %s\n%s' % (path_or_url, unicodify(e)))
 
             return temp_name, is_url
 
@@ -318,7 +318,7 @@ def __main__():
             else:
                 metadata.append(add_file(dataset, registry, output_path))
         except UploadProblemException as e:
-            metadata.append(file_err(str(e), dataset))
+            metadata.append(file_err(unicodify(e), dataset))
     __write_job_metadata(metadata)
 
 


### PR DESCRIPTION
Fixes
```
`Traceback (most recent call last):
  File "/home/dchristiany/.venv/bin/planemo", line 10, in <module>
    sys.exit(planemo())
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/planemo/cli.py", line 195, in handle_blended_options
    return f(*args, **kwds)
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/planemo/commands/cmd_test.py", line 87, in cli
    test_data = engine.test(runnables)
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/planemo/engine/interface.py", line 82, in test
    test_case_data = test_case.structured_test_data(run_response)
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/planemo/runnable.py", line 256, in structured_test_data
    self._check_output(output_id, output_value, output_test)
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/planemo/runnable.py", line 314, in _check_output
    output_test,
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/planemo/test/_check_output.py", line 43, in check_output
    verify_extra_files=None,
  File "/home/dchristiany/.venv/local/lib/python2.7/site-packages/galaxy/tools/verify/__init__.py", line 133, in verify
    errmsg += str(err)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 848: ordinal not in range(128)`
```
which happens on python2 on ` str(u'\xa0')`.
Fixes https://github.com/galaxyproject/planemo/issues/939 (once released
as galaxy-lib)