### PR TITLE
Add nodejs dependency to parse_values_from_file

### DIFF
--- a/tools/expression_tools/parse_values_from_file.xml
+++ b/tools/expression_tools/parse_values_from_file.xml
@@ -1,5 +1,8 @@
 <tool name="Parse parameter value" id="param_value_from_file" version="0.1.0" tool_type="expression">
     <description>from dataset</description>
+    <requirements>
+        <requirement type="package" version="10.13.0">nodejs</requirement>
+    </requirements>
     <expression type="ecma5.1">{
 var output;
 if ($job.remove_newlines || $job.param_type != 'text') {


### PR DESCRIPTION
This is working nicely as we preserve the Galaxy environment for non-standard tool classes anyway. That said we could also hard code a nodejs dependency in the ExpressionTool class (might be nicer for expression tools defined within workflows ?).