### PR TITLE
[19.05] Allow looking up tool section using label

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -254,6 +254,9 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             # Appending a tool to an existing section in toolbox._tool_panel
             tool_section = self._tool_panel[tool_panel_section_key]
             log.debug("Appending to tool panel section: %s" % str(tool_section.name))
+        elif new_label and self._tool_panel.get_label(new_label):
+            tool_section = self._tool_panel.get_label(new_label)
+            tool_panel_section_key = tool_section.id
         elif create_if_needed:
             # Appending a new section to toolbox._tool_panel
             if new_label is None:

--- a/lib/galaxy/tools/toolbox/panel.py
+++ b/lib/galaxy/tools/toolbox/panel.py
@@ -123,6 +123,11 @@ class ToolPanelElements(odict, HasPanelItems):
         else:
             self.insert(index, key, value)
 
+    def get_label(self, label):
+        for element in self.values():
+            if isinstance(element, ToolSection) and element.name == label:
+                return element
+
     def has_tool_with_id(self, tool_id):
         key = 'tool_%s' % tool_id
         return key in self

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -374,6 +374,15 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         # Assert tools merged in tool panel.
         assert len(self.toolbox._tool_panel) == 1
 
+    def test_get_section_by_label(self):
+        self._add_config(
+            """<toolbox><section id="tid" name="Completely unrelated"><label id="lab1" text="Label 1" /><label id="lab2" text="Label 2" /></section></toolbox>""")
+        assert len(self.toolbox._tool_panel) == 1
+        section = self.toolbox._tool_panel['tid']
+        tool_panel_section_key, section_by_label = self.toolbox.get_section(section_id='nope', new_label='Completely unrelated', create_if_needed=True)
+        assert section_by_label is section
+        assert tool_panel_section_key == 'tid'
+
     def test_get_tool_id(self):
         self._init_tool()
         self._setup_two_versions_in_config()


### PR DESCRIPTION
This is a long-standing bug.

This is the expected behavior if attempting to install
into a tool panel section that has been defined with a
custom tool_panel_id.
Fixes the issue diagnosed by @natefoo in https://github.com/galaxyproject/usegalaxy-tools/issues/9#issue-452608678