### PR TITLE
Fix index out of bounds exception when a dataset is empty or missing columns

### DIFF
--- a/tools/stats/filtering.py
+++ b/tools/stats/filtering.py
@@ -186,7 +186,7 @@ if not check_expression(cond_text):
 # Work out which columns are used in the filter (save using 1 based counting)
 used_cols = sorted(set(int(match.group()[1:])
                    for match in re.finditer(r'c(\d)+', cond_text)))
-largest_col_index = max(used_cols)
+largest_col_index = min(in_columns, max(used_cols))
 
 # Prepare the column variable names and wrappers for column data types. Only
 # cast columns used in the filter.


### PR DESCRIPTION
If columns are referenced but not present, logic already exists to exclude them.