### PR TITLE
[WIP] Add dynamic watching and reloading of a subset of config.py

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -172,7 +172,7 @@ galaxy:
 
   # Time to sleep between attempts if database_wait is enabled (in
   # seconds).
-  #database_wait_sleep: 1
+  #database_wait_sleep: 1.0
 
   # Where dataset files are stored. It must accessible at the same path
   # on any cluster nodes that will run Galaxy jobs, unless using Pulsar.
@@ -310,6 +310,22 @@ galaxy:
   # are found, rules are automatically reloaded. Takes the same values
   # as the 'watch_tools' option.
   #watch_job_rules: 'false'
+
+  # Set to True to enable monitoring of a subset of options in the core
+  # configuration file, galaxy.yml. The subset of options to be watched
+  # is specified in watch_config_options. If changes are found, modified
+  # options are automatically reloaded. Takes the same values as the
+  # 'watch_tools' option.
+  #watch_config: 'false'
+
+  # Options that should be watched. The watch_config option shoudl be
+  # enabled. This is a comma separated list. Allowed options include
+  # message_box_content,  welcome_url,  tool_name_boost,
+  # tool_section_boost,  tool_description_boost,  tool_label_boost,
+  # tool_stub_boost,  tool_help_boost,  tool_search_limit,
+  # tool_enable_ngram_search,  tool_ngram_minsize,  tool_ngram_maxsize,
+  # admin_users,  cleanup_job
+  #watch_config_options: null
 
   # As of 18.09, Galaxy defaults to setting up the object store
   # configuration for output datasets during the job queue step in job
@@ -1533,6 +1549,12 @@ galaxy:
   # Galaxy configuration or loaded from an additional file with the
   # job_config_file option.
   #job_config: null
+
+  # Rather than specifying a dependency_resolvers_config_file, the
+  # definition of the resolvers to enable can be embedded into Galaxy's
+  # config with this option. This has no effect if a
+  # dependency_resolvers_config_file is used.
+  #dependency_resolvers: null
 
   # When jobs fail due to job runner problems, Galaxy can be configured
   # to retry these or reroute the jobs to new destinations. Very fine

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -170,7 +170,7 @@
 :Description:
     Time to sleep between attempts if database_wait is enabled (in
     seconds).
-:Default: ``1``
+:Default: ``1.0``
 :Type: float
 
 
@@ -473,6 +473,36 @@
     are found, rules are automatically reloaded. Takes the same values
     as the 'watch_tools' option.
 :Default: ``false``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~
+``watch_config``
+~~~~~~~~~~~~~~~~
+
+:Description:
+    Set to True to enable monitoring of a subset of options in the
+    core configuration file, galaxy.yml. The subset of options to be
+    watched is specified in watch_config_options. If changes are
+    found, modified options are automatically reloaded. Takes the same
+    values as the 'watch_tools' option.
+:Default: ``false``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~
+``watch_config_options``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Options that should be watched. The watch_config option shoudl be
+    enabled. This is a comma separated list. Allowed options include
+    message_box_content,  welcome_url,  tool_name_boost,
+    tool_section_boost,  tool_description_boost,  tool_label_boost,
+    tool_stub_boost,  tool_help_boost,  tool_search_limit,
+    tool_enable_ngram_search,  tool_ngram_minsize,
+    tool_ngram_maxsize,  admin_users,  cleanup_job
+:Default: ``None``
 :Type: str
 
 
@@ -3195,6 +3225,19 @@
     job_config_file option.
 :Default: ``None``
 :Type: map
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~
+``dependency_resolvers``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Rather than specifying a dependency_resolvers_config_file, the
+    definition of the resolvers to enable can be embedded into
+    Galaxy's config with this option. This has no effect if a
+    dependency_resolvers_config_file is used.
+:Default: ``None``
+:Type: seq
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -943,7 +943,7 @@ class Configuration(object):
 
 
 def get_core_config_file():
-    return os.environ['GALAXY_CONFIG_FILE'] or 'config/galaxy.yml'
+    return os.environ.get('GALAXY_CONFIG_FILE') or 'config/galaxy.yml'
 
 
 def reload_config_options(current_config):

--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -486,6 +486,8 @@ class Configuration(object):
         self.watch_tools = kwargs.get('watch_tools', 'false')
         self.watch_tool_data_dir = kwargs.get('watch_tool_data_dir', 'false')
         self.watch_job_rules = kwargs.get('watch_job_rules', 'false')
+        self.watch_config = kwargs.get('watch_config', 'false')
+        self.watch_config_options = kwargs.get('watch_config_options', None)
         # On can mildly speed up Galaxy startup time by disabling index of help,
         # not needed on production systems but useful if running many functional tests.
         self.index_tool_help = string_as_bool(kwargs.get("index_tool_help", True))

--- a/lib/galaxy/util/watcher.py
+++ b/lib/galaxy/util/watcher.py
@@ -154,6 +154,18 @@ class EventHandler(FileSystemEventHandler):
                 callback(path=path)
 
 
+class SimpleFileModifiedEventHandler(FileSystemEventHandler):
+    """ Minimalist event handler; when all we need is callback() on file modified """
+    def __init__(self, watcher):
+        self.watcher = watcher
+
+    def on_modified(self, event):
+        path = os.path.abspath(event.src_path)
+        callback = self.watcher.file_callbacks.get(path, None)
+        if callback:
+            callback()
+
+
 class NullWatcher(object):
 
     def start(self):

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -365,6 +365,38 @@ mapping:
           found, rules are automatically reloaded. Takes the same values as the
           'watch_tools' option.
 
+      watch_config:
+        type: str
+        default: 'false'
+        required: false
+        desc: |
+          Set to True to enable monitoring of a subset of options in the core
+          configuration file, galaxy.yml. The subset of options to be watched
+          is specified in watch_config_options. If changes are found, modified
+          options are automatically reloaded. Takes the same values as the
+          'watch_tools' option.
+
+      watch_config_options:
+        type: str
+        required: false
+        desc: |
+          Options that should be watched. The watch_config option shoudl be enabled.
+          This is a comma separated list. Allowed options include
+           message_box_content,
+           welcome_url,
+           tool_name_boost,
+           tool_section_boost,
+           tool_description_boost,
+           tool_label_boost,
+           tool_stub_boost,
+           tool_help_boost,
+           tool_search_limit,
+           tool_enable_ngram_search,
+           tool_ngram_minsize,
+           tool_ngram_maxsize,
+           admin_users,
+           cleanup_job
+
       legacy_eager_objectstore_initialization:
         type: bool
         default: false

--- a/lib/galaxy/webapps/galaxy/config_watchers.py
+++ b/lib/galaxy/webapps/galaxy/config_watchers.py
@@ -1,5 +1,8 @@
 from functools import partial
+import os.path
 from os.path import dirname
+
+from ruamel.yaml import YAML
 
 from galaxy.queue_worker import (
     job_rule_modules,
@@ -15,6 +18,24 @@ from galaxy.tools.toolbox.watcher import (
 from galaxy.util.watcher import (
     get_watcher,
 )
+
+CORE_CONFIG_PATH = 'config/galaxy.yml'
+RELOADABLE_CONFIG_OPTIONS = set([
+    'message_box_content',
+    'welcome_url',
+    'tool_name_boost',
+    'tool_section_boost',
+    'tool_description_boost',
+    'tool_label_boost',
+    'tool_stub_boost',
+    'tool_help_boost',
+    'tool_search_limit',
+    'tool_enable_ngram_search',
+    'tool_ngram_minsize',
+    'tool_ngram_maxsize',
+    'admin_users',
+    'cleanup_job'
+])
 
 
 class ConfigWatchers(object):
@@ -37,6 +58,8 @@ class ConfigWatchers(object):
             self.job_rule_watcher = get_watcher(app.config, 'watch_job_rules', monitor_what_str='job rules')
         else:
             self.job_rule_watcher = get_watcher(app.config, '__invalid__')
+        # Watcher for the core config file: config/galaxy.yml
+        self.config_watcher = get_watcher(app.config, 'watch_config', monitor_what_str='core config file')
         if start_thread:
             self.start()
 
@@ -50,12 +73,14 @@ class ConfigWatchers(object):
                 callback=partial(reload_job_rules, self.app),
                 recursive=True,
                 ignore_extensions=('.pyc', '.pyo', '.pyd'))
+        self.config_watcher.watch_file(CORE_CONFIG_PATH, callback=self.reload_config_options)
 
     def shutdown(self):
         self.tool_config_watcher.shutdown()
         self.data_manager_config_watcher.shutdown()
         self.tool_data_watcher.shutdown()
         self.tool_watcher.shutdown()
+        self.config_watcher.shutdown()
 
     def update_watch_data_table_paths(self):
         if hasattr(self.tool_data_watcher, 'monitored_dirs'):
@@ -98,3 +123,28 @@ class ConfigWatchers(object):
             job_rules_dir = dirname(rules_module.__file__)
             job_rules_paths.append(job_rules_dir)
         return job_rules_paths
+
+
+    # TODO is this a good place for these?
+    def reload_config_options(self, path):
+        new_config = self.load_core_config()
+        # get list of options to reload from config file
+        selected = new_config['watch_config_options']
+
+        for option in selected:
+            # verify that option can be reloaded and its value has been set
+            if option in RELOADABLE_CONFIG_OPTIONS and option in new_config:
+                # reload value; print
+                if getattr(self.app.config, option) != new_config.get(option):
+                    setattr(self.app.config, option, new_config[option])
+                    print('Reloading %s' % option)
+
+    def load_core_config(self):
+        yaml = YAML(typ='safe')
+        yaml.allow_duplicate_keys = True
+        path = os.path.abspath(CORE_CONFIG_PATH)
+        configs = None
+        with open(path, 'r') as f:
+            configs = yaml.load(f)
+        return configs['galaxy'] # assume only galaxy section
+


### PR DESCRIPTION
This addresses this: https://github.com/galaxyproject/galaxy/issues/8072

Requesting a (brief) preliminary review.

Summary of approach:
1. Add 2 options to galaxy.yml: one turns reloading on/off; the other lists the options to be reloaded
2. We don't want users to be able to select arbitrary options for reloading. The list of options that are safe to reload is located in config.py: users may choose a subset of these options (any others will be ignored)
3. I add a watcher to config_watchers.py for galaxy.yml (leaning heavily on @natefoo 's implementation)
4. The reloading happens in config.py.

Ping @jmchilton . Is this a reasonable approach? Also, can we assume the core config is a yaml file? (if not, I'll add support for ini format). And is this a good way to get its path? https://github.com/ic4f/galaxy/blob/dev_dynamic_config/lib/galaxy/config.py#L946

If this approach is reasonable, I'll add tests before submitting final version. 
Thanks!