### PR TITLE
[19.05] Fix cancelling jobs with a message from the admin panel

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -883,7 +883,10 @@ class JobHandlerStopQueue(Monitors):
                                      .filter((model.Job.state == model.Job.states.DELETED_NEW) &
                                              (model.Job.handler == self.app.config.server_name)).all()
             for job in newly_deleted_jobs:
-                jobs_to_check.append((job, job.stderr))
+                # job.stderr is always a string (job.job_stderr + job.tool_stderr, possibly `''`),
+                # while any `not None` message returned in self.queue.get_nowait() is interpreted
+                # as an error, so here we use None if job.stderr is false-y
+                jobs_to_check.append((job, job.stderr or None))
         # Also pull from the queue (in the case of Administrative stopped jobs)
         try:
             while 1:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -322,13 +322,15 @@ class JobLike(object):
 
         return "%s[%s,tool_id=%s]" % (self.__class__.__name__, extra, self.tool_id)
 
-    def get_stdout(self):
-        stdout = self.tool_stdout
+    @property
+    def stdout(self):
+        stdout = self.tool_stdout or ''
         if self.job_stdout:
             stdout += "\n" + self.job_stdout
         return stdout
 
-    def set_stdout(self, stdout):
+    @stdout.setter
+    def stdout(self, stdout):
         raise NotImplementedError("Attempt to set stdout, must set tool_stdout or job_stdout")
 
     @property

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -331,17 +331,16 @@ class JobLike(object):
     def set_stdout(self, stdout):
         raise NotImplementedError("Attempt to set stdout, must set tool_stdout or job_stdout")
 
-    def get_stderr(self):
-        stderr = self.tool_stderr
+    @property
+    def stderr(self):
+        stderr = self.tool_stderr or ''
         if self.job_stderr:
             stderr += "\n" + self.job_stderr
         return stderr
 
-    def set_stderr(self, stderr):
+    @stderr.setter
+    def stderr(self, stderr):
         raise NotImplementedError("Attempt to set stdout, must set tool_stderr or job_stderr")
-
-    stdout = property(get_stdout, set_stdout)
-    stderr = property(get_stderr, set_stderr)
 
 
 class User(Dictifiable, RepresentById):

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -244,7 +244,7 @@ class GalaxyInteractorApi(object):
     def wait_for_job(self, job_id, history_id, maxseconds):
         self.wait_for(lambda: not self.__job_ready(job_id, history_id), maxseconds=maxseconds)
 
-    def wait_for(self, func, **kwd):
+    def wait_for(self, func, what='Tool test run', **kwd):
         sleep_amount = 0.2
         slept = 0
         walltime_exceeded = int(kwd.get("maxseconds", DEFAULT_TOOL_TEST_WAIT))
@@ -258,7 +258,7 @@ class GalaxyInteractorApi(object):
             else:
                 return
 
-        message = 'Tool test run exceeded walltime [total %s, max %s], terminating.' % (slept, walltime_exceeded)
+        message = '%s exceeded walltime [total %s, max %s], terminating.' % (what, slept, walltime_exceeded)
         log.info(message)
         raise AssertionError(message)
 

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -324,6 +324,7 @@ class JobController(BaseAPIController, UsesLibraryMixinItems):
             for data_assoc in job.output_datasets:
                 if not self.dataset_manager.is_accessible(data_assoc.dataset.dataset, trans.user):
                     raise exceptions.ItemAccessibilityException("You are not allowed to rerun this job.")
+        trans.sa_session.refresh(job)
         return job
 
     @expose_api

--- a/test/integration/test_local_job_cancellation.py
+++ b/test/integration/test_local_job_cancellation.py
@@ -37,6 +37,7 @@ class LocalJobCancellationTestCase(integration_util.IntegrationTestCase):
         with self.dataset_populator.test_history() as history_id:
             job_dict = self.setup_cat_data_and_sleep(history_id)
             self.galaxy_interactor.wait_for(lambda: self._get("jobs/%s" % job_dict['id']).json()['state'] != 'running',
+                                            what="Wait for job to start running",
                                             maxseconds=60)
             app = self._app
             sa_session = app.model.context.current
@@ -48,6 +49,7 @@ class LocalJobCancellationTestCase(integration_util.IntegrationTestCase):
             sa_session.add(job)
             sa_session.flush()
             self.galaxy_interactor.wait_for(lambda: self._get("jobs/%s" % job_dict['id']).json()['state'] != 'error',
+                                            what="Wait for job to end in error",
                                             maxseconds=60)
 
     def test_kill_process(self):

--- a/test/integration/test_local_job_cancellation.py
+++ b/test/integration/test_local_job_cancellation.py
@@ -18,29 +18,51 @@ class LocalJobCancellationTestCase(integration_util.IntegrationTestCase):
         super(LocalJobCancellationTestCase, self).setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
+    def setup_cat_data_and_sleep(self, history_id):
+        hda1 = self.dataset_populator.new_dataset(history_id, content="1 2 3")
+        running_inputs = {
+            "input1": {"src": "hda", "id": hda1["id"]},
+            "sleep_time": 240,
+        }
+        running_response = self.dataset_populator.run_tool(
+            "cat_data_and_sleep",
+            running_inputs,
+            history_id,
+            assert_ok=False,
+        ).json()
+        job_dict = running_response["jobs"][0]
+        return job_dict
+
+    def test_cancel_job_with_admin_message(self):
+        with self.dataset_populator.test_history() as history_id:
+            job_dict = self.setup_cat_data_and_sleep(history_id)
+            self.galaxy_interactor.wait_for(lambda: self._get("jobs/%s" % job_dict['id']).json()['state'] != 'running',
+                                            maxseconds=60)
+            app = self._app
+            sa_session = app.model.context.current
+            Job = app.model.Job
+            job = sa_session.query(Job).filter_by(tool_id="cat_data_and_sleep").order_by(Job.create_time.desc()).first()
+            # This is how the admin controller code cancels a job
+            job.job_stderr = 'admin cancelled job'
+            job.set_state(app.model.Job.states.DELETED_NEW)
+            sa_session.add(job)
+            sa_session.flush()
+            self.galaxy_interactor.wait_for(lambda: self._get("jobs/%s" % job_dict['id']).json()['state'] != 'error',
+                                            maxseconds=60)
+
     def test_kill_process(self):
         """
         """
         with self.dataset_populator.test_history() as history_id:
-            hda1 = self.dataset_populator.new_dataset(history_id, content="1 2 3")
-            running_inputs = {
-                "input1": {"src": "hda", "id": hda1["id"]},
-                "sleep_time": 240,
-            }
-            running_response = self.dataset_populator.run_tool(
-                "cat_data_and_sleep",
-                running_inputs,
-                history_id,
-                assert_ok=False,
-            ).json()
-            job_dict = running_response["jobs"][0]
+            job_dict = self.setup_cat_data_and_sleep(history_id)
 
             app = self._app
             sa_session = app.model.context.current
             external_id = None
             state = False
+            Job = app.model.Job
 
-            job = sa_session.query(app.model.Job).filter_by(tool_id="cat_data_and_sleep").one()
+            job = sa_session.query(Job).filter_by(tool_id="cat_data_and_sleep").order_by(Job.create_time.desc()).first()
             # Not checking the state here allows the change from queued to running to overwrite
             # the change from queued to deleted_new in the API thread - this is a problem because
             # the job will still run. See issue https://github.com/galaxyproject/galaxy/issues/4960.


### PR DESCRIPTION
Discussed this with @slugger70 and @erasche on gitter.
The traceback was:
```
galaxy.jobs.handler ERROR 2019-06-26 13:09:12,754 [p:32491,w:0,m:2] [JobHandlerStopQueue.monitor_thread] Exception in monitor_step
Traceback (most recent call last):
  File "lib/galaxy/jobs/handler.py", line 866, in monitor
    self.monitor_step()
  File "lib/galaxy/jobs/handler.py", line 886, in monitor_step
    jobs_to_check.append((job, job.stderr))
  File "lib/galaxy/model/__init__.py", line 337, in get_stderr
    stderr += "\n" + self.job_stderr
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'unicode'
```