### PR TITLE
[WIP] Implement optional and default_value for workflow input parameters.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4655,6 +4655,15 @@ class WorkflowStep(RepresentById):
     def tool_uuid(self):
         return self.dynamic_tool and self.dynamic_tool.uuid
 
+    @property
+    def input_default_value(self):
+        tool_inputs = self.tool_inputs
+        tool_state = tool_inputs
+        default_value = tool_state.get("default")
+        if default_value:
+            default_value = json.loads(default_value)["value"]
+        return default_value
+
     def get_input(self, input_name):
         for step_input in self.inputs:
             if step_input.name == input_name:

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -19,7 +19,7 @@ REPLACE_ON_TRUTHY = object()
 __all__ = ('DataCollectionToolParameter', 'DataToolParameter', 'SelectToolParameter')
 
 
-def visit_input_values(inputs, input_values, callback, name_prefix='', label_prefix='', parent_prefix='', context=None, no_replacement_value=REPLACE_ON_TRUTHY):
+def visit_input_values(inputs, input_values, callback, name_prefix='', label_prefix='', parent_prefix='', context=None, no_replacement_value=REPLACE_ON_TRUTHY, replace_optional_connections=False):
     """
     Given a tools parameter definition (`inputs`) and a specific set of
     parameter `values`, call `callback` for each non-grouping parameter,
@@ -116,10 +116,11 @@ def visit_input_values(inputs, input_values, callback, name_prefix='', label_pre
     No value found for 'b 1 > d 1 > j'.
     """
     def callback_helper(input, input_values, name_prefix, label_prefix, parent_prefix, context=None, error=None):
+        value = input_values.get(input.name)
         args = {
             'input'             : input,
             'parent'            : input_values,
-            'value'             : input_values.get(input.name),
+            'value'             : value,
             'prefixed_name'     : '%s%s' % (name_prefix, input.name),
             'prefixed_label'    : '%s%s' % (label_prefix, input.label or input.name),
             'prefix'            : parent_prefix,
@@ -135,6 +136,8 @@ def visit_input_values(inputs, input_values, callback, name_prefix='', label_pre
             replace = new_value != no_replacement_value
         if replace:
             input_values[input.name] = new_value
+        elif replace_optional_connections and is_runtime_value(value):
+            input_values[input.name] = input.value
 
     def get_current_case(input, input_values):
         try:

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1086,11 +1086,7 @@ class ToolModule(WorkflowModule):
     # ---- Run time ---------------------------------------------------------
 
     def recover_state(self, state, **kwds):
-        """ Recover state `dict` from simple dictionary describing configuration
-        state (potentially from persisted step state).
-
-        Sub-classes should supply a `default_state` method which contains the
-        initial state `dict` with key, value pairs for all available attributes.
+        """
         """
         super(ToolModule, self).recover_state(state, **kwds)
         if kwds.get("fill_defaults", False) and self.tool:

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -414,9 +414,13 @@ class WorkflowProgress(object):
         if self.inputs_by_step_id:
             step_id = step.id
             if step_id not in self.inputs_by_step_id and 'output' not in outputs:
-                template = "Step with id %s not found in inputs_step_id (%s)"
-                message = template % (step_id, self.inputs_by_step_id)
-                raise ValueError(message)
+                default_value = step.input_default_value
+                if default_value:
+                    outputs['output'] = default_value
+                else:
+                    template = "Step with id %s not found in inputs_step_id (%s)"
+                    message = template % (step.log_str(), self.inputs_by_step_id)
+                    raise ValueError(message)
             elif step_id in self.inputs_by_step_id:
                 outputs['output'] = self.inputs_by_step_id[step_id]
 

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -82,10 +82,13 @@ def _normalize_inputs(steps, inputs, inputs_by):
         for possible_input_key in possible_input_keys:
             if possible_input_key in inputs:
                 inputs_key = possible_input_key
-        if not inputs_key:
-            message = "Workflow cannot be run because an expected input step '%s' has no input dataset." % step.id
+        default_value = json.loads(step.tool_inputs.get("default") or 'null')
+        optional = json.loads(step.tool_inputs.get("optional") or 'false')
+        if not inputs_key and default_value is None and not optional:
+            message = "Workflow cannot be run because an expected input step '%s' (%s) has no input dataset." % (step.id, step.label)
             raise exceptions.MessageException(message)
-        normalized_inputs[step.id] = inputs[inputs_key]
+        if inputs_key:
+            normalized_inputs[step.id] = inputs[inputs_key]
     return normalized_inputs
 
 

--- a/test/base/workflow_fixtures.py
+++ b/test/base/workflow_fixtures.py
@@ -316,6 +316,64 @@ steps:
 """
 
 
+WORKFLOW_PARAMETER_INPUT_INTEGER_REQUIRED = """
+class: GalaxyWorkflow
+inputs:
+  data_input: data
+  int_input: integer
+steps:
+  random:
+    tool_id: random_lines1
+    in:
+      input: data_input
+      num_lines: int_input
+    state:
+      seed_source:
+        seed_source_selector: set_seed
+        seed: asdf
+"""
+
+
+WORKFLOW_PARAMETER_INPUT_INTEGER_OPTIONAL = """
+class: GalaxyWorkflow
+inputs:
+  data_input: data
+  int_input:
+    type: integer
+    optional: true
+steps:
+  random:
+    tool_id: random_lines1
+    in:
+      input: data_input
+      num_lines: int_input
+    state:
+      seed_source:
+        seed_source_selector: set_seed
+        seed: asdf
+"""
+
+
+WORKFLOW_PARAMETER_INPUT_INTEGER_DEFAULT = """
+class: GalaxyWorkflow
+inputs:
+  data_input: data
+  int_input:
+    type: integer
+    default: 3
+steps:
+  random:
+    tool_id: random_lines1
+    in:
+      input: data_input
+      num_lines: int_input
+    state:
+      seed_source:
+        seed_source_selector: set_seed
+        seed: asdf
+"""
+
+
 WORKFLOW_RUNTIME_PARAMETER_SIMPLE = """
 class: GalaxyWorkflow
 inputs:


### PR DESCRIPTION
Initial commit here from CWL branch (https://github.com/common-workflow-language/galaxy/pull/47) where it does more or less work for executing CWL workflows - but that branch depends on a ``FieldTypeToolParameter`` for capturing the structured default value and probably has no functional GUI for configuring these things.

TODO:
 - [x] Implement a gxformat2 syntax for specifying an input as optional.
 - [x] Implement a gxformat2 syntax for specifying a default value.
 - [x] Write tests for optional in vanilla Galaxy workflows.
 - [x] Write tests for default_value in vanilla Galaxy workflows.
 - [x] Establish Galaxy workflow semantics for specifying an input as optional with no default value.
 - [x] Rework this backend to work without ``FieldTypeToolParameter ``  (use of ``TextToolParameter `` in initial commit is a bootstrap).
 - [ ] Implement a GUI works for marking an input as optional.
 - [ ] Implement a GUI for specifying a default value.
