### PR TITLE
Refactor setup_user_get_key method to return the created test user and its API key

### DIFF
--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -121,8 +121,7 @@ class UsersApiTestCase(api.ApiTestCase):
 
     @skip_without_tool("cat1")
     def test_search_favorites(self):
-        user = self._setup_user(TEST_USER_EMAIL)
-        user_key = self._setup_user_get_key(TEST_USER_EMAIL)
+        user, user_key = self._setup_user_get_key(TEST_USER_EMAIL)
         url = self._api_url("users/%s/favorites/tools" % user["id"], params=dict(key=user_key))
         fav_response = put(url, data=json.dumps({"object_id" : "cat1"}))
         self._assert_status_code_is_ok(fav_response)


### PR DESCRIPTION
- simplifies test user creating, 
- refactors the `_setup_user_get_key` to return the test user create together with its api. 

ping @jmchilton 