### PR TITLE
unzip/zip collection: set format equal to input format

### DIFF
--- a/lib/galaxy/tools/unzip_collection.xml
+++ b/lib/galaxy/tools/unzip_collection.xml
@@ -9,8 +9,8 @@
     <param type="data_collection" collection_type="paired" name="input" label="Input Paired Dataset" />
   </inputs>
   <outputs>
-    <data name="forward" label="${on_string} (forward)" />
-    <data name="reverse" label="${on_string} (reverse)" />
+    <data name="forward" label="${on_string} (forward)" format_source="input"/>
+    <data name="reverse" label="${on_string} (reverse)" format_source="input"/>
   </outputs>
   <help><![CDATA[
 

--- a/lib/galaxy/tools/zip_collection.xml
+++ b/lib/galaxy/tools/zip_collection.xml
@@ -11,8 +11,8 @@
   </inputs>
   <outputs>
     <collection name="output" type="paired" label="${on_string} (zipped)">
-      <data name="forward" />
-      <data name="reverse" />
+      <data name="forward" format_source="input_forward" />
+      <data name="reverse" format_source="input_reverse" />
     </collection>
   </outputs>
   <help><![CDATA[


### PR DESCRIPTION
currently `unzip collection` produces data sets of the format data. 

- in the workflow editor these can't be connected to downstream tools, except if the output data type is explicitly set which limits applicability of workflows
- in interactive processing the user needs to wait until the unzip collection tool finishes 

My fix is (again) guesswork, but seems to work -- maybe there is a more elegant solution. 

Also I'm not sure if the fix for `zip collection` is the best way to do it.