### PR TITLE
[19.05] Fix migration if WorkflowStepConnection index not present

### DIFF
--- a/lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py
+++ b/lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py
@@ -45,7 +45,10 @@ def upgrade(migrate_engine):
 
     OldWorkflowStepConnection_table = Table("workflow_step_connection", metadata, autoload=True)
     for index in OldWorkflowStepConnection_table.indexes:
-        index.drop()
+        try:
+            index.drop()
+        except Exception:
+            log.exception("Dropping index '%s' from table '%s' failed", index, OldWorkflowStepConnection_table)
     OldWorkflowStepConnection_table.rename("workflow_step_connection_preupgrade145")
     # Try to deregister that table to work around some caching problems it seems.
     OldWorkflowStepConnection_table.deregister()


### PR DESCRIPTION
Fixes:
```
self = <sqlalchemy.dialects.sqlite.pysqlite.SQLiteDialect_pysqlite object at 0x125f41518>, cursor = <sqlite3.Cursor object at 0x125f5d960>
statement = '\nDROP INDEX ix_workflow_step_connection_input_subworkflow_step_id', parameters = ()
context = <sqlalchemy.dialects.sqlite.base.SQLiteExecutionContext object at 0x1241b3588>

    def do_execute(self, cursor, statement, parameters, context=None):
>       cursor.execute(statement, parameters)
E       sqlite3.OperationalError: no such index: ix_workflow_step_connection_input_subworkflow_step_id

.venv3/lib/python3.6/site-packages/sqlalchemy/engine/default.py:550: OperationalError

The above exception was the direct cause of the following exception:

cls = <class 'integration.test_kubernetes_staging.KubernetesDependencyResolutionIntegrationTestCase'>

    @classmethod
    def setUpClass(cls):
        # realpath for docker deployed in a VM on Mac, also done in driver_util.
        cls.jobs_directory = os.path.realpath(tempfile.mkdtemp())
>       super(KubernetesDependencyResolutionIntegrationTestCase, cls).setUpClass()

test/integration/test_kubernetes_staging.py:147:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test/base/integration_util.py:69: in setUpClass
    cls._test_driver.setup(config_object=cls)
test/base/driver_util.py:898: in setup
    self._register_and_run_servers(config_object)
test/base/driver_util.py:953: in _register_and_run_servers
    self.app = build_galaxy_app(galaxy_config)
test/base/driver_util.py:563: in build_galaxy_app
    app = GalaxyUniverseApplication(**simple_kwargs)
lib/galaxy/app.py:88: in __init__
    self._configure_models(check_migrate_databases=self.config.check_migrate_databases, check_migrate_tools=check_migrate_tools, config_file=config_file)
lib/galaxy/config.py:1149: in _configure_models
    create_or_verify_database(db_url, config_file, self.config.database_engine_options, app=self)
lib/galaxy/model/migrate/check.py:64: in create_or_verify_database
    migrate()
lib/galaxy/model/migrate/check.py:60: in migrate
    migrate_to_current_version(engine, db_schema)
lib/galaxy/model/migrate/check.py:149: in migrate_to_current_version
    schema.runchange(ver, change, changeset.step)
.venv3/lib/python3.6/site-packages/migrate/versioning/schema.py:93: in runchange
    change.run(self.engine, step)
.venv3/lib/python3.6/site-packages/migrate/versioning/script/py.py:148: in run
    script_func(engine)
lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py:48: in upgrade
    index.drop()
.venv3/lib/python3.6/site-packages/sqlalchemy/sql/schema.py:3713: in drop
    bind._run_visitor(ddl.SchemaDropper, self)
.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py:2033: in _run_visitor
    conn._run_visitor(visitorcallable, element, **kwargs)
.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py:1607: in _run_visitor
    visitorcallable(self.dialect, self, **kwargs).traverse_single(element)
.venv3/lib/python3.6/site-packages/sqlalchemy/sql/visitors.py:131: in traverse_single
    return meth(obj, **kw)
.venv3/lib/python3.6/site-packages/sqlalchemy/sql/ddl.py:988: in visit_index
    self.connection.execute(DropIndex(index))
.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py:988: in execute
    return meth(self, multiparams, params)
.venv3/lib/python3.6/site-packages/sqlalchemy/sql/ddl.py:72: in _execute_on_connection
    return connection._execute_ddl(self, multiparams, params)
.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py:1050: in _execute_ddl
    compiled,
.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py:1248: in _execute_context
    e, statement, parameters, cursor, context
.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py:1466: in _handle_dbapi_exception
    util.raise_from_cause(sqlalchemy_exception, exc_info)
.venv3/lib/python3.6/site-packages/sqlalchemy/util/compat.py:383: in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
.venv3/lib/python3.6/site-packages/sqlalchemy/util/compat.py:128: in reraise
    raise value.with_traceback(tb)
.venv3/lib/python3.6/site-packages/sqlalchemy/engine/base.py:1244: in _execute_context
    cursor, statement, parameters, context
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <sqlalchemy.dialects.sqlite.pysqlite.SQLiteDialect_pysqlite object at 0x125f41518>, cursor = <sqlite3.Cursor object at 0x125f5d960>
statement = '\nDROP INDEX ix_workflow_step_connection_input_subworkflow_step_id', parameters = ()
context = <sqlalchemy.dialects.sqlite.base.SQLiteExecutionContext object at 0x1241b3588>

    def do_execute(self, cursor, statement, parameters, context=None):
>       cursor.execute(statement, parameters)
E       sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such index: ix_workflow_step_connection_input_subworkflow_step_id
E       [SQL:
E       DROP INDEX ix_workflow_step_connection_input_subworkflow_step_id]
E       (Background on this error at: http://sqlalche.me/e/e3q8)

.venv3/lib/python3.6/site-packages/sqlalchemy/engine/default.py:550: OperationalError
```
when running the test in https://github.com/galaxyproject/galaxy/pull/8195