### PR TITLE
ease the usage of galaxy.yml in ansible

### DIFF
--- a/config/galaxy.yml.sample
+++ b/config/galaxy.yml.sample
@@ -16,7 +16,7 @@
 # 
 # Config hackers are encouraged to check there before asking for help.
 # 
-uwsgi:
+uwsgi: &UWSGI
 
   # The address and port on which to listen.  By default, only listen to
   # localhost (galaxy will not be accessible over the network).  Use
@@ -96,7 +96,7 @@ uwsgi:
   # Ensure application threads will run if `threads` is unset.
   enable-threads: true
 
-galaxy:
+galaxy: &GALAXY
 
   # By default, Galaxy uses a SQLite database at
   # 'database/universe.sqlite'.  You may use a SQLAlchemy connection
@@ -1772,3 +1772,8 @@ galaxy:
   # reason to disable it.
   #use_pbkdf2: true
 
+galaxy_config:
+  "uwsgi":
+    <<: *UWSGI
+  "galaxy":
+    <<: *GALAXY


### PR DESCRIPTION
Using anchor, you just need to modify the galaxy.yml and the ansible-galaxy role will do the almost rest. Thus, it's easier to sync the galaxy.yml after an update to the instance!?

```yaml
- name: galaxy server
  hosts: galaxy
  vars_files:
    - "{{ inventory_dir }}/group_vars/galaxy/main.yml"
    - "{{ inventory_dir }}/group_vars/galaxy/galaxy.yml"
  handlers:
    - name: Restart Galaxy
      supervisorctl:
        name: galaxy
        state: restarted
  pre_tasks:
    - name: Install Dependencies
      package:
        name: ['python-psycopg2', 'git', 'python-virtualenv', 'make']
  roles:
     - role: geerlingguy.pip
     - role: usegalaxy-eu.supervisor
     - role: galaxyproject.galaxy
```