### PR TITLE
[19.05] Expression tool fix: Include workdir path when reading env var from file

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -4,6 +4,7 @@ $headers
 
 _galaxy_setup_environment() {
     local _use_framework_galaxy="$1"
+    _GALAXY_JOB_DIR="$working_directory"
     _GALAXY_JOB_HOME_DIR="$working_directory/home"
     _GALAXY_JOB_TMP_DIR=$tmp_dir_creation_statement
     $env_setup_commands

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -521,7 +521,8 @@ class ToolEvaluator(object):
             os.close(fd)
             self.__write_workdir_file(config_filename, environment_variable_template, param_dict)
             config_file_basename = os.path.basename(config_filename)
-            environment_variable["value"] = "`cat %s`" % config_file_basename
+            # environment setup in job file template happens before `cd $working_directory`
+            environment_variable["value"] = '`cat "$_GALAXY_JOB_DIR/%s"`' % config_file_basename
             environment_variable["raw"] = True
             environment_variables.append(environment_variable)
 


### PR DESCRIPTION
`env_setup_commands` runs before `cd $working_directory` in the job
file template, so just using the relative path fails with
```
Traceback (most recent call last):
  File "_evaluate_expression_.py", line 1, in <module>
    from galaxy_ext.expressions.handle_job import run; run()
  File "/opt/galaxy/server/lib/galaxy_ext/expressions/handle_job.py", line 31, in run
    with open(environment_path, "r") as f:
IOError: [Errno 2] No such file or directory: ''

cat: tmp6CL_1e: No such file or directory
```