### PR TITLE
Adjust minimum tag length

### DIFF
--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -30,7 +30,7 @@ class TagHandler(object):
     def __init__(self, sa_session):
         self.sa_session = sa_session
         # Minimum tag length.
-        self.min_tag_len = 2
+        self.min_tag_len = 1
         # Maximum tag length.
         self.max_tag_len = 255
         # Tag separator.


### PR DESCRIPTION
Sets minimum tag length to 1 instead of 2.  Closes https://github.com/galaxyproject/galaxy/issues/8255

Another enhancement would be to adjust the logic here to raise an exception instead of just returning `None` for scrubbed tags here (https://github.com/galaxyproject/galaxy/blob/73832b7b69bec838fb1dca65e5cc7df2d26df6f4/lib/galaxy/model/tags.py#L299) which could then bubble back up to the API endpoints (and eventually client), and would explain this constraint to users.

But this removal of an (as far as I can tell) arbitrary limit seems like a reasonable first step.