### PR TITLE
[WIP] Allows datamanager tools to the users.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2501,6 +2501,32 @@ class DataManagerTool(OutputParameterJSONTool):
         return False
 
 
+class UserDataManager(DataManagerTool):
+    tool_type = 'manage_data_user'
+    default_tool_action = DataManagerToolAction
+
+    def __init__(self, config_file, root, app, guid=None, data_manager_id=None, **kwds):
+        self.data_manager_id = data_manager_id
+        super(UserDataManager, self).__init__(config_file, root, app, guid=guid, **kwds)
+        if self.data_manager_id is None:
+            self.data_manager_id = self.id
+
+    def allow_user_access(self, user, attempting_access=True):
+        """
+        :param user: model object representing user.
+        :type user: galaxy.model.User
+        :param attempting_access: is the user attempting to do something with the
+                               the tool (set false for incidental checks like toolbox
+                               listing)
+        :type attempting_access:  bool
+
+        :returns: bool -- Whether the user is allowed to access the tool.
+        Data Manager tools are only accessible to admins.
+        """
+        return True
+
+
+
 class DatabaseOperationTool(Tool):
     default_tool_action = ModelOperationToolAction
     require_dataset_ok = True
@@ -3034,7 +3060,7 @@ class FilterFromFileTool(DatabaseOperationTool):
 # Populate tool_type to ToolClass mappings
 tool_types = {}
 for tool_class in [Tool, SetMetadataTool, OutputParameterJSONTool, ExpressionTool,
-                   DataManagerTool, DataSourceTool, AsyncDataSourceTool,
+                   DataManagerTool, UserDataManager, DataSourceTool, AsyncDataSourceTool,
                    UnzipCollectionTool, ZipCollectionTool, MergeCollectionTool, RelabelFromFileTool, FilterFromFileTool,
                    BuildListCollectionTool, ExtractDatasetCollectionTool,
                    DataDestinationTool]:

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -71,7 +71,7 @@ class DataManagers(object):
                 # File does not exist
                 return None
         except Exception as e:
-            log.error("Error loading data_manager '%s':\n%s" % (e, util.xml_to_string(data_manager_elem)))
+            log.error("Error loading data_manager '%s':\n%s" % (e, util.xml_to_string(data_manager_elem)), exc_info=True)
             return None
         if add_manager:
             self.add_manager(data_manager)
@@ -277,6 +277,7 @@ class DataManager(object):
                                         tool_shed_repository=tool_shed_repository,
                                         use_cached=True)
         self.data_managers.app.toolbox.data_manager_tools[tool.id] = tool
+        toolbox.add_user_data_manager_toolbox(tool)
         self.tool = tool
         return tool
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -293,6 +293,14 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             tool_path = string.Template(tool_path).safe_substitute(tool_path_vars)
         return tool_path
 
+    def add_user_data_manager_toolbox(self, tool):
+        tool.hidden = False
+
+        tool_key= "tool_%s" % tool.id
+        tool_section = self.create_section({"data_manager":"Data Managers"})
+        self._integrated_tool_panel.update_or_append(-1, tool_key, tool)
+        self.__add_tool_to_tool_panel(tool, panel_component=self._tool_panel, section=False)
+
     def __add_tool_to_tool_panel(self, tool, panel_component, section=False):
         # See if a version of this tool is already loaded into the tool panel.
         # The value of panel_component will be a ToolSection (if the value of

--- a/test/functional/tools/sample_data_manager_conf.xml
+++ b/test/functional/tools/sample_data_manager_conf.xml
@@ -3,13 +3,27 @@
     <data_table name="testbeta">
       <output>
         <column name="value" />
-        <column name="path" output_ref="out_file" >
-		  <move type="directory" relativize_symlinks="True">
-		  	<target base="${GALAXY_DATA_MANAGER_DATA_PATH}">testbeta/${value}</target>
-		  </move>
- 		  <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/testbeta/${value}/${path}</value_translation>
-		  <value_translation type="function">abspath</value_translation>
-		</column>
+        <column name="path" output_ref="out_file">
+          <move type="directory" relativize_symlinks="True">
+            <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">testbeta/${value}</target>
+          </move>
+          <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/testbeta/${value}/${path}</value_translation>
+          <value_translation type="function">abspath</value_translation>
+        </column>
+      </output>
+    </data_table>
+  </data_manager>
+  <data_manager tool_file="user_data_manager.xml" id="test_user_data_manager" version="1.0">
+    <data_table name="testbeta">
+      <output>
+        <column name="value" />
+        <column name="path" output_ref="out_file">
+          <move type="directory" relativize_symlinks="True">
+            <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">testbeta/${value}</target>
+          </move>
+          <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/testbeta/${value}/${path}</value_translation>
+          <value_translation type="function">abspath</value_translation>
+        </column>
       </output>
     </data_table>
   </data_manager>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -55,6 +55,7 @@
   <tool file="composite_shapefile.xml" />
   <tool file="is_valid_xml.xml" />
   <tool file="param_value_from_file.xml"/>
+  <tool file="user_data_manager.xml"/>
   <!--
   TODO: Figure out why this transiently fails on Jenkins.
   <tool file="maxseconds.xml" />

--- a/test/functional/tools/user_data_manager.xml
+++ b/test/functional/tools/user_data_manager.xml
@@ -1,0 +1,16 @@
+<tool id="user_data_manager" name="Test User Data Manager" tool_type="manage_data_user" version="0.0.1">
+    <configfiles>
+        <configfile name="static_test_data">{"data_tables": {"testbeta": [{"value": "newvalue", "path": "newvalue.txt"}]}}</configfile>
+    </configfiles>
+    <command>
+        mkdir $out_file.files_path ;
+        echo "A new value" > '$out_file.files_path/newvalue.txt';
+        cp '$static_test_data' '$out_file'
+    </command>
+    <inputs>
+        <param type="text" name="ignored_value" value="" label="Ignored" />
+    </inputs>
+    <outputs>
+        <data name="out_file" format="data_manager_json"/>
+    </outputs>
+</tool>


### PR DESCRIPTION
Data managers for users
Currently, reference genome can be prebuilt only by the admin. Jobs using reference genome from the history will be indexed every time when the job is run. This project will enable the users to run the data_manager_jobs as their jobs and store the indexed reference genome as a dataset in the history. After the discussion in the codefest introduction, it seems this project can also be extended further handling data tables in a different way as an alternative to current data table architecture.  


Challenges:
This project seems to be more complicated than initially thought. There are two approaches for this project. In the first approach, data_manager tool should be made available for the user to be executed. Output of these jobs have to be stored in a dynamic datamanager datatype. This dynamic datatype should store all the information in the output Json information in its metadata. Before a tool populate its  built-in-indices, it should search in user’s history and append the user specific pre-built indices. Challenges in this approach are overlapping dbkeys, specifying the dataset with indices the jobs_params etc
 In the second approach, an internal data_manager converter can be created. When the user using the reference genome from the history, indices can be cached. Later, the cached indices will be used when the same reference genome used again in the tools. Challenges here would be that user cannot customize the data_manager parameters by themself. How to map the cached indices to the dataset ??? What happens when the user change the datatype or use the reset metadata ????
