### PR TITLE
Some work on tool menu styles

### DIFF
--- a/client/galaxy/scripts/entry/panels/tool-panel.js
+++ b/client/galaxy/scripts/entry/panels/tool-panel.js
@@ -141,9 +141,9 @@ const ToolPanel = Backbone.View.extend({
                     <div class="toolSectionPad"/>
                     <div class="toolSectionPad"/>
                     <div class="toolSectionTitle" id="title_XXinternalXXworkflow">
-                        <span>
+                        <a>
                             ${_l("Workflows")}
-                        </span>
+                        </a>
                     </div>
                         <div id="internal-workflows" class="toolSectionBody">
                             <div class="toolSectionBg"/>

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1483,10 +1483,6 @@ div.permissionContainer {
     min-height: 100%;
 }
 
-div.toolSectionWrapper {
-    @extend .mb-1;
-}
-
 div.toolSectionTitle {
     font-weight: 500;
     font-size: $h4-font-size;
@@ -1496,8 +1492,7 @@ div.toolSectionTitle {
 }
 
 div.toolPanelLabel {
-    @extend .mt-3;
-    @extend .mb-2;
+    @extend .py-1;
     @extend .px-3;
     font-weight: bold;
     font-size: $h4-font-size;

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1477,11 +1477,10 @@ div.permissionContainer {
 .toolMenuContainer {
     color: $panel-text-color;
     a {
-        color: $panel-text-color;
+	color: $panel-text-color;
     }
     background: $panel-bg-color;
     min-height: 100%;
-    @extend .m-3;
 }
 
 div.toolSectionWrapper {
@@ -1491,35 +1490,46 @@ div.toolSectionWrapper {
 div.toolSectionTitle {
     font-weight: 500;
     font-size: $h4-font-size;
-}
-
-div.toolPanelLabel {
-    @extend .mt-3;
-    @extend .mb-2;
-    font-weight: bold;
-    color: $gray-600;
-    text-transform: uppercase;
-}
-
-div.toolTitle {
-    @extend .m-2;
-    display: block;
-    .labels {
-        float: right;
-    }
-}
-
-div a.tool-link {
-    text-decoration: none;
-    display: block;
-    span.tool-old-link {
-        text-decoration: underline;
-    }
     &:hover {
         background: darken($panel-bg-color, 5%);
     }
 }
 
+div.toolPanelLabel {
+    @extend .mt-3;
+    @extend .mb-2;
+    @extend .px-3;
+    font-weight: bold;
+    font-size: $h4-font-size;
+    color: $gray-600;
+    text-transform: uppercase;
+}
+
+div.toolSectionWrapper div.toolPanelLabel {
+    font-size: inherit;
+}
+
+div.toolSectionTitle, div.toolTitle {
+    display: block;
+    .labels {
+        float: right;
+    }
+
+    a {
+	@extend .px-3;
+	@extend .py-1;
+	text-decoration: none;
+	display: block;
+	span.tool-old-link {
+	    font-weight: 500;
+            // text-decoration: underline;
+	}
+	&:hover {
+            background: darken($panel-bg-color, 5%);
+	}
+    }
+}
+    
 div.toolTitleNoSection {
     @extend .pb-1;
     font-weight: bold;

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1528,6 +1528,12 @@ div.toolSectionTitle, div.toolTitle {
             background: darken($panel-bg-color, 5%);
 	}
     }
+
+    &.text-muted a {
+	&:hover {
+	    background: inherit;
+	}
+    }
 }
     
 div.toolTitleNoSection {

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1500,11 +1500,7 @@ div.toolPanelLabel {
     text-transform: uppercase;
 }
 
-div.toolSectionWrapper div.toolPanelLabel {
-    font-size: inherit;
-}
-
-div.toolSectionTitle, div.toolTitle {
+div.toolSectionTitle, div.toolTitle, div.toolTitleNoSection {
     display: block;
     .labels {
         float: right;
@@ -1515,10 +1511,6 @@ div.toolSectionTitle, div.toolTitle {
 	@extend .py-1;
 	text-decoration: none;
 	display: block;
-	span.tool-old-link {
-	    font-weight: 500;
-            // text-decoration: underline;
-	}
 	&:hover {
             background: darken($panel-bg-color, 5%);
 	}
@@ -1530,13 +1522,14 @@ div.toolSectionTitle, div.toolTitle {
 	}
     }
 }
-    
-div.toolTitleNoSection {
-    @extend .pb-1;
-    font-weight: bold;
+
+div.toolSectionWrapper {
+    div.toolTitle a, div.toolPanelLabel {
+	@extend .pl-4;
+	font-size: inherit;
+    }
 }
 
-// Dataset Display Styles
 #loading_indicator {
     position: fixed;
     right: 10px;

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -91,13 +91,15 @@
             %else:
                 <div class="toolTitleNoSection text-muted">
             %endif
-                %if "[[" in tool.description and "]]" in tool.description:
-                    ${tool.description.replace( '[[', '' % tool.id ).replace( "]]", "" )}
-                %elif tool.name:
-                    ${tool.name} ${tool.description}
-                %else:
-                    ${tool.description}
-                %endif
+	        <a>
+		    %if "[[" in tool.description and "]]" in tool.description:
+                        ${tool.description.replace( '[[', '' % tool.id ).replace( "]]", "" )}
+                    %elif tool.name:
+                        ${tool.name} ${tool.description}
+                    %else:
+                        ${tool.description}
+                    %endif
+		</a>
             </div>
         %endif
     %endif


### PR DESCRIPTION
Highlighting the background of items was added at some point, but did
not extend to fill the entire width and was not applied to the section
elements. This attempts to make things a bit more visually appealing
and consistent.

Additionally there are some debatable changes:

Removed the indent for items, I think it is clear from the size and
weight changes
Remove underlines, the background highlight is an equally good
indicator that these are clickable
Top level labels are now large like the sections, second level
returns to the default font size

(This PR previously murdered by a force push)

![tool_menu_styles](https://user-images.githubusercontent.com/79973/60765745-5eaab200-a09f-11e9-963a-bde1ab04b860.gif)
