### PR TITLE
Don't show the pip progress bar when installing under CI

### DIFF
--- a/packages/test.sh
+++ b/packages/test.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+# Don't display the pip progress bar when running under CI
+PIP_PROGRESS_BAR=
+[ "$CI" = "true" ] && PIP_PROGRESS_BAR='--progress-bar off'
+
 # Change to packages directory.
 cd "$(dirname "$0")"
 
@@ -11,7 +15,7 @@ TEST_ENV_DIR=${TEST_ENV_DIR:-$(mktemp -d -t gxpkgtestenvXXXXXX)}
 
 virtualenv -p "$TEST_PYTHON" "$TEST_ENV_DIR"
 . "${TEST_ENV_DIR}/bin/activate"
-pip install pytest
+pip install ${PIP_PROGRESS_BAR} pytest
 
 # ensure ordered by dependency dag
 PACKAGE_DIRS=(
@@ -35,9 +39,9 @@ for ((i=0; i<${#PACKAGE_DIRS[@]}; i++)); do
     run_tests=${RUN_TESTS[$i]}
 
     cd "$package_dir"
-    pip install -e .
+    pip install ${PIP_PROGRESS_BAR} -e .
     if [ "$package_dir" = "util" ]; then
-        pip install -e '.[template,jstree]'
+        pip install ${PIP_PROGRESS_BAR} -e '.[template,jstree]'
     fi
 
     if [[ "$run_tests" == "1" ]]; then

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -191,15 +191,18 @@ if [ $DEV_WHEELS -eq 1 ]; then
     requirement_args="$requirement_args -r ${GALAXY_DEV_REQUIREMENTS}"
 fi
 
+PIP_PROGRESS_BAR=
+[ "$CI" = "true" ] && PIP_PROGRESS_BAR='--progress-bar off'
+
 if [ $FETCH_WHEELS -eq 1 ]; then
-    pip install $requirement_args --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
+    pip install $requirement_args --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}" ${PIP_PROGRESS_BAR}
     GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "from __future__ import print_function; import galaxy.dependencies; print('\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE')))")
     if [ -n "$GALAXY_CONDITIONAL_DEPENDENCIES" ]; then
         if pip list --format=columns | grep "psycopg2[\(\ ]*2.7.3" > /dev/null; then
             echo "An older version of psycopg2 (non-binary, version 2.7.3) has been detected.  Galaxy now uses psycopg2-binary, which will be installed after removing psycopg2."
             pip uninstall -y psycopg2 psycopg2-binary
         fi
-        echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
+        echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}" ${PIP_PROGRESS_BAR}
     fi
 fi
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ commands =
     lint: bash .ci/flake8_wrapper.sh
     unit: bash run_tests.sh -u
 whitelist_externals = bash
+passenv = CI
 setenv =
     py{35,36,37}-first_startup: GALAXY_VIRTUAL_ENV=.venv3
     unit: GALAXY_VIRTUAL_ENV={envdir}


### PR DESCRIPTION
The CircleCI output is currently full of pip progress bars, this should greatly reduce the output.