### PR TITLE
Skip migrations on entirely clean new databases

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1199,7 +1199,7 @@ class ConfiguresGalaxyMixin(object):
         # TODO: Consider more aggressive check here that this is not the same
         # database file under the hood.
         combined_install_database = not(install_db_url and install_db_url != db_url)
-        install_db_url = db_url if combined_install_database else install_db_url
+        install_db_url = install_db_url or db_url
         install_database_options = self.config.database_engine_options if combined_install_database else self.config.install_database_engine_options
 
         if self.config.database_wait:
@@ -1213,8 +1213,9 @@ class ConfiguresGalaxyMixin(object):
             # Initialize database / check for appropriate schema version.  # If this
             # is a new installation, we'll restrict the tool migration messaging.
             from galaxy.model.migrate.check import create_or_verify_database
-            create_or_verify_database(db_url, config_file, self.config.database_engine_options, app=self)
-            tsi_create_or_verify_database(install_db_url, install_database_options, app=self)
+            create_or_verify_database(db_url, config_file, self.config.database_engine_options, app=self, map_install_models=combined_install_database)
+            if not combined_install_database:
+                tsi_create_or_verify_database(install_db_url, install_database_options, app=self)
 
         if check_migrate_tools:
             # Alert the Galaxy admin to tools that have been moved from the distribution to the tool shed.

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1199,7 +1199,7 @@ class ConfiguresGalaxyMixin(object):
         # TODO: Consider more aggressive check here that this is not the same
         # database file under the hood.
         combined_install_database = not(install_db_url and install_db_url != db_url)
-        install_db_url = install_db_url or db_url
+        install_db_url = db_url if combined_install_database else install_db_url
         install_database_options = self.config.database_engine_options if combined_install_database else self.config.install_database_engine_options
 
         if self.config.database_wait:

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2776,6 +2776,7 @@ def init(file_path, url, engine_options=None, create_tables=False, map_install_m
     if map_install_models:
         import galaxy.model.tool_shed_install.mapping  # noqa: F401
         from galaxy.model import tool_shed_install
+        galaxy.model.tool_shed_install.mapping.init(url=url, engine_options=engine_options, create_tables=create_tables)
         model_modules.append(tool_shed_install)
 
     result = ModelMapping(model_modules, engine=engine)

--- a/lib/galaxy/model/migrate/check.py
+++ b/lib/galaxy/model/migrate/check.py
@@ -11,6 +11,8 @@ from sqlalchemy import (
 from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy_utils import create_database, database_exists
 
+from galaxy.model import mapping
+
 log = logging.getLogger(__name__)
 
 # path relative to galaxy
@@ -60,7 +62,16 @@ def create_or_verify_database(url, galaxy_config_file, engine_options={}, app=No
         migrate_to_current_version(engine, db_schema)
 
     meta = MetaData(bind=engine)
-    if new_database or (app and getattr(app.config, 'database_auto_migrate', False)):
+    if new_database and app:
+        log.info("Creating new database from scratch, skipping migrations")
+        current_version = migrate_repository.version().version
+        mapping.init(file_path=app.config.file_path, url=url, create_tables=True)
+        schema.ControlledSchema.create(engine, migrate_repository, version=current_version)
+        db_schema = schema.ControlledSchema(engine, migrate_repository)
+        assert db_schema.version == current_version
+        migrate()
+        return
+    elif app and getattr(app.config, 'database_auto_migrate', False):
         migrate()
         return
 

--- a/lib/galaxy/model/migrate/check.py
+++ b/lib/galaxy/model/migrate/check.py
@@ -71,7 +71,7 @@ def create_or_verify_database(url, galaxy_config_file, engine_options={}, app=No
         assert db_schema.version == current_version
         migrate()
         return
-    elif app and getattr(app.config, 'database_auto_migrate', False):
+    elif getattr(app.config, 'database_auto_migrate', False):
         migrate()
         return
 

--- a/lib/galaxy/model/migrate/check.py
+++ b/lib/galaxy/model/migrate/check.py
@@ -20,7 +20,7 @@ migrate_repository_directory = os.path.abspath(os.path.dirname(__file__)).replac
 migrate_repository = repository.Repository(migrate_repository_directory)
 
 
-def create_or_verify_database(url, galaxy_config_file, engine_options={}, app=None):
+def create_or_verify_database(url, galaxy_config_file, engine_options={}, app=None, map_install_models=False):
     """
     Check that the database is use-able, possibly creating it if empty (this is
     the only time we automatically create tables, otherwise we force the
@@ -65,7 +65,7 @@ def create_or_verify_database(url, galaxy_config_file, engine_options={}, app=No
     if new_database and app:
         log.info("Creating new database from scratch, skipping migrations")
         current_version = migrate_repository.version().version
-        mapping.init(file_path=app.config.file_path, url=url, create_tables=True)
+        mapping.init(file_path=app.config.file_path, url=url, map_install_models=map_install_models, create_tables=True)
         schema.ControlledSchema.create(engine, migrate_repository, version=current_version)
         db_schema = schema.ControlledSchema(engine, migrate_repository)
         assert db_schema.version == current_version


### PR DESCRIPTION
This should be a very nice speedup for ansible tutorials, tests, planemo etc. ... and there'd be less reasons to even include a prebuilt database with docker-galaxy-stables, kubernetes etc, allowing even smaller images.