### PR TITLE
Implement undelete and purge API for users

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -4,7 +4,9 @@ Manager and Serializer for Users.
 import logging
 import random
 import socket
+import time
 from datetime import datetime
+from galaxy.util.hash_util import new_secure_hash
 
 from markupsafe import escape
 from sqlalchemy import and_, desc, exc, func, true
@@ -36,7 +38,6 @@ you may want to notify an administrator.
 If you're having trouble using the link when clicking it from email client, you
 can also copy and paste it into your browser.
 """
-
 
 class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
     foreign_key_name = 'user'
@@ -109,7 +110,109 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         return user
 
     def delete(self, user):
+        if not self.app.config.allow_user_deletion:
+            raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to delete/undelete users.')
+        # Check first if it is already deleted. If so, say so and do nothing.
+        # Unsure if we should add username to the log.debug or if that breaks the gdrp support
+        if user.deleted:
+            log.debug("User already deleted, but setting delete flag just in case.")
+        if user.purged:
+            log.debug("Cannot delete purged user, but setting delete flag just in case.")
+
         user.deleted = True
+        log.debug("User %s deleted" % user.username)
+        self.session().add(user)
+        self.session().flush()
+
+    def undelete(self, user):
+        log.debug("Requested undelete of user %s" % user.username)
+        if not self.app.config.allow_user_deletion:
+            raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to delete/undelete users.')
+        if user.purged:
+            raise exceptions.ItemDeletionException('Purged user cannot be undeleted.')
+        if not user.deleted:
+            log.debug('User \'%s\' has not been deleted, so it cannot be undeleted.' % user.email)
+        user.deleted = False
+        self.session().add(user)
+        self.session().flush()
+
+    def purge(self, user):
+        log.debug("Requested purge of user %s" % user)
+        if not self.app.config.allow_user_deletion:
+            raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to delete/undelete users.')
+        if not user.deleted:
+            raise exceptions.MessageException('User \'%s\' has not been deleted, so it cannot be purged.' % user.email, 'error')
+        else:
+            log.debug("Purging user %s" % user)
+        private_role = self.app.security_agent.get_private_user_role(user)
+        # Delete History
+        for active_history in user.active_histories:
+            self.session().refresh(active_history)
+            for hda in active_history.active_datasets:
+                # Delete HistoryDatasetAssociation
+                hda.deleted = True
+                self.session().add(hda)
+            active_history.deleted = True
+            self.session().add(active_history)
+        # Delete UserGroupAssociations
+        for uga in user.groups:
+            self.session().delete(uga)
+        # Delete UserRoleAssociations EXCEPT FOR THE PRIVATE ROLE
+        for ura in user.roles:
+            if ura.role_id != private_role.id:
+                self.session().delete(ura)
+        # Delete UserAddresses
+        for address in user.addresses:
+            self.session().delete(address)
+        # Purge the user
+        user.purged = True
+        compliance_log = logging.getLogger('COMPLIANCE')
+        compliance_log.info('delete-user-event: %s' % user.username)
+        # Maybe there is some case in the future where an admin needs
+        # to prove that a user was using a server for some reason (e.g.
+        # a court case.) So we make this painfully hard to recover (and
+        # not immediately reversable) in line with GDPR, but still
+        # leave open the possibility to prove someone was part of the
+        # server just in case. By knowing the exact email + approximate
+        # time of deletion, one could run through hashes for every
+        # second of the surrounding days/weeks.
+        pseudorandom_value = str(int(time.time()))
+        # Replace email + username with a (theoretically) unreversable
+        # hash. If provided with the username we can probably re-hash
+        # to identify if it is needed for some reason.
+        #
+        # Deleting multiple times will re-hash the username/email
+        email_hash = new_secure_hash(user.email + pseudorandom_value)
+        uname_hash = new_secure_hash(user.username + pseudorandom_value)
+        # We must also redact username
+        for role in user.all_roles():
+            if self.app.config.redact_username_during_deletion:
+                role.name = role.name.replace(user.username, uname_hash)
+                role.description = role.description.replace(user.username, uname_hash)
+
+            if self.app.config.redact_email_during_deletion:
+                role.name = role.name.replace(user.email, email_hash)
+                role.description = role.description.replace(user.email, email_hash)
+            user.email = email_hash
+            user.username = uname_hash
+        log.debug("User credentials changed. email is now %s and name is %s" % (user.email, user.username))
+        # Redact user addresses as well
+        if self.app.config.redact_user_address_during_deletion:
+            user_addresses = self.session().query(trans.app.model.UserAddress) \
+                .filter(trans.app.model.UserAddress.user_id == user.id).all()
+
+            for addr in user_addresses:
+                addr.desc = new_secure_hash(addr.desc + pseudorandom_value)
+                addr.name = new_secure_hash(addr.name + pseudorandom_value)
+                addr.institution = new_secure_hash(addr.institution + pseudorandom_value)
+                addr.address = new_secure_hash(addr.address + pseudorandom_value)
+                addr.city = new_secure_hash(addr.city + pseudorandom_value)
+                addr.state = new_secure_hash(addr.state + pseudorandom_value)
+                addr.postal_code = new_secure_hash(addr.postal_code + pseudorandom_value)
+                addr.country = new_secure_hash(addr.country + pseudorandom_value)
+                addr.phone = new_secure_hash(addr.phone + pseudorandom_value)
+                self.session().add(addr)
+
         self.session().add(user)
         self.session().flush()
 

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -6,7 +6,6 @@ import random
 import socket
 import time
 from datetime import datetime
-from galaxy.util.hash_util import new_secure_hash
 
 from markupsafe import escape
 from sqlalchemy import and_, desc, exc, func, true
@@ -22,6 +21,7 @@ from galaxy.managers import (
     deletable
 )
 from galaxy.security.validate_user_input import validate_email, validate_password, validate_publicname
+from galaxy.util.hash_util import new_secure_hash
 from galaxy.web import url_for
 
 log = logging.getLogger(__name__)
@@ -38,6 +38,7 @@ you may want to notify an administrator.
 If you're having trouble using the link when clicking it from email client, you
 can also copy and paste it into your browser.
 """
+
 
 class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
     foreign_key_name = 'user'

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -195,7 +195,9 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                 addr.phone = new_secure_hash(addr.phone + pseudorandom_value)
                 self.session().add(addr)
         # Purge the user
-        super(UserManager, self).purge(user)
+        user.purged = True
+        self.session().add(user)
+        self.session().flush()
 
     def _error_on_duplicate_email(self, email):
         """

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -110,21 +110,21 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             self.app.security_agent.user_set_default_permissions(user, default_access_private=permissions)
         return user
 
-    def delete(self, user):
+    def delete(self, user, flush=True):
         """Mark the given user deleted."""
         if not self.app.config.allow_user_deletion:
             raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to delete users.')
-        super(UserManager, self).delete(user)
+        super(UserManager, self).delete(user, flush=flush)
 
-    def undelete(self, user):
+    def undelete(self, user, flush=True):
         """Remove the deleted flag for the given user."""
         if not self.app.config.allow_user_deletion:
             raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to undelete users.')
         if user.purged:
             raise exceptions.ItemDeletionException('Purged user cannot be undeleted.')
-        super(UserManager, self).undelete(user)
+        super(UserManager, self).undelete(user, flush=flush)
 
-    def purge(self, user):
+    def purge(self, user, flush=True):
         """Purge the given user. They must have the deleted flag already."""
         if not self.app.config.allow_user_deletion:
             raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to delete or purge users.')
@@ -195,9 +195,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                 addr.phone = new_secure_hash(addr.phone + pseudorandom_value)
                 self.session().add(addr)
         # Purge the user
-        user.purged = True
-        self.session().add(user)
-        self.session().flush()
+        super(UserManager, self).purge(user, flush=flush)
 
     def _error_on_duplicate_email(self, email):
         """

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -198,8 +198,8 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         log.debug("User credentials changed. email is now %s and name is %s" % (user.email, user.username))
         # Redact user addresses as well
         if self.app.config.redact_user_address_during_deletion:
-            user_addresses = self.session().query(trans.app.model.UserAddress) \
-                .filter(trans.app.model.UserAddress.user_id == user.id).all()
+            user_addresses = self.session().query(self.app.model.UserAddress) \
+                .filter(self.app.model.UserAddress.user_id == user.id).all()
 
             for addr in user_addresses:
                 addr.desc = new_secure_hash(addr.desc + pseudorandom_value)

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -111,8 +111,9 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         return user
 
     def delete(self, user):
+        """Mark the given user deleted."""
         if not self.app.config.allow_user_deletion:
-            raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to delete/undelete users.')
+            raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to delete users.')
         # Check first if it is already deleted. If so, say so and do nothing.
         # Unsure if we should add username to the log.debug or if that breaks the GDPR support
         if user.deleted:
@@ -124,8 +125,9 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         self.session().flush()
 
     def undelete(self, user):
+        """Remove the deleted flag for the given user."""
         if not self.app.config.allow_user_deletion:
-            raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to delete/undelete users.')
+            raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to undelete users.')
         if user.purged:
             raise exceptions.ItemDeletionException('Purged user cannot be undeleted.')
         if not user.deleted:
@@ -135,10 +137,11 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         self.session().flush()
 
     def purge(self, user):
+        """Purge the given user. They must have the deleted flag already."""
         if not self.app.config.allow_user_deletion:
-            raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to delete/undelete users.')
+            raise exceptions.ConfigDoesNotAllowException('The configuration of this Galaxy instance does not allow admins to delete or purge users.')
         if not user.deleted:
-            raise exceptions.MessageException('User \'%s\' has not been deleted, so it cannot be purged.' % user.email, 'error')
+            raise exceptions.MessageException('User \'%s\' has not been deleted, so they cannot be purged.' % user.email)
         private_role = self.app.security_agent.get_private_user_role(user)
         # Delete History
         for active_history in user.active_histories:

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -35,6 +35,7 @@ from galaxy.web import (
     expose_api,
     expose_api_anonymous
 )
+from galaxy.web.form_builder import AddressField
 from galaxy.webapps.base.controller import (
     BaseAPIController,
     BaseUIController,
@@ -42,7 +43,6 @@ from galaxy.webapps.base.controller import (
     UsesFormDefinitionsMixin,
     UsesTagsMixin
 )
-from galaxy.web.form_builder import AddressField
 
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -243,7 +243,7 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesApiKeysMixin, B
         user = self.get_user(trans, id)
         purge = util.string_as_bool(kwd.get('purge', False))
         if purge:
-            log.debug("Purging user from api %s" % user)
+            log.debug("Purging user %s" % user)
             self.user_manager.purge(user)
         else:
             self.user_manager.delete(user)
@@ -253,8 +253,8 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesApiKeysMixin, B
     @web.require_admin
     def undelete(self, trans, id, **kwd):
         """
-        UNDELETE /api/users/{id}
-        undelete the user with the given ``id``
+        POST /api/users/{id}
+        Undelete the user with the given ``id``
 
         :param id: the encoded id of the user to be undeleted
         :type  id: str

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -168,6 +168,8 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesApiKeysMixin, B
             if not trans.user_is_admin:
                 assert trans.user == user
                 assert not user.deleted
+        except exceptions.ItemDeletionException:
+            raise
         except Exception:
             raise exceptions.RequestParameterInvalidException('Invalid user id specified', id=id)
         return self.user_serializer.serialize_to_view(user, view='detailed')
@@ -253,7 +255,7 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesApiKeysMixin, B
     @web.require_admin
     def undelete(self, trans, id, **kwd):
         """
-        POST /api/users/{id}
+        POST /api/users/deleted/{id}/undelete
         Undelete the user with the given ``id``
 
         :param id: the encoded id of the user to be undeleted

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -1,7 +1,6 @@
 import imp
 import logging
 import os
-import time
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from string import punctuation as PUNCTUATION
@@ -22,7 +21,6 @@ from galaxy.util import (
     sanitize_text,
     url_get
 )
-from galaxy.util.hash_util import new_secure_hash
 from galaxy.web import url_for
 from galaxy.web.framework.helpers import grids, time_ago
 from galaxy.web.params import QuotaParamParser

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -166,7 +166,7 @@ class UserListGrid(grids.Grid):
         grids.GridColumnFilter("Deleted", args=dict(deleted=True, purged=False)),
         grids.GridColumnFilter("Purged", args=dict(purged=True)),
         grids.GridColumnFilter("All", args=dict(deleted='All'))
-        ]
+    ]
     num_rows_per_page = 50
     use_paging = True
     default_filter = dict(purged="False")

--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -78,23 +78,23 @@ class UsersApiTestCase(api.ApiTestCase):
 
     def test_delete_user(self):
         user = self._setup_user(TEST_USER_EMAIL1)
-        response = self._delete("users/%s" % user["id"], admin=True)
+        self._delete("users/%s" % user["id"], admin=True)
         updated_user = self._get("users/deleted/%s" % user['id'], admin=True).json()
         assert updated_user['deleted'] is True, updated_user
 
     def test_purge_user(self):
         user = self._setup_user(TEST_USER_EMAIL1)
-        response = self._delete("users/%s" % user["id"], purge=True, admin=True)
+        self._delete("users/%s" % user["id"], purge=True, admin=True)
         updated_user = self._get("users/deleted/%s" % user['id'], admin=True).json()
         assert updated_user['deleted'] is True, updated_user
         assert updated_user['purged'] is True, updated_user
 
     def test_undelete_user(self):
         user = self._setup_user(TEST_USER_EMAIL2)
-        response = self._delete("users/%s" % user["id"], admin=True)
+        self._delete("users/%s" % user["id"], admin=True)
         updated_user = self._get("users/deleted/%s" % user['id'], admin=True).json()
         assert updated_user['deleted'] is True, updated_user
-        response = self._put("users/%s" % user["id"], admin=True)
+        self._put("users/%s" % user["id"], admin=True)
         updated_user = self._get("users/%s" % user['id'], admin=True).json()
         assert updated_user['deleted'] is False, updated_user
 

--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -87,10 +87,10 @@ class UsersApiTestCase(api.ApiTestCase):
         """Delete user and then purge them."""
         user = self._setup_user(TEST_USER_EMAIL_PURGE)
         response = self._delete("users/%s" % user["id"], admin=True)
-        self._assert_status_code_is(response, 200)
+        self._assert_status_code_is_ok(response)
         data = dict(purge="True")
         response = self._delete("users/%s" % user["id"], data=data, admin=True)
-        self._assert_status_code_is(response, 200)
+        self._assert_status_code_is_ok(response)
         payload = {'deleted': "True"}
         purged_user = self._get("users/%s" % user['id'], payload, admin=True).json()
         assert purged_user['deleted'] is True, purged_user

--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -10,8 +10,9 @@ from base import api  # noqa: I100,I202
 from base.populators import skip_without_tool
 
 TEST_USER_EMAIL = "user_for_users_index_test@bx.psu.edu"
-TEST_USER_EMAIL1 = "user1_for_users_index_test@bx.psu.edu"
-TEST_USER_EMAIL2 = "user2_for_users_index_test@bx.psu.edu"
+TEST_USER_EMAIL_DELETE = "user_for_delete_test@bx.psu.edu"
+TEST_USER_EMAIL_PURGE = "user_for_purge_test@bx.psu.edu"
+TEST_USER_EMAIL_UNDELETE = "user_for_undelete_test@bx.psu.edu"
 
 
 class UsersApiTestCase(api.ApiTestCase):
@@ -77,26 +78,32 @@ class UsersApiTestCase(api.ApiTestCase):
         self.assertEqual(update_json['username'], new_name)
 
     def test_delete_user(self):
-        user = self._setup_user(TEST_USER_EMAIL1)
+        user = self._setup_user(TEST_USER_EMAIL_DELETE)
         self._delete("users/%s" % user["id"], admin=True)
         updated_user = self._get("users/deleted/%s" % user['id'], admin=True).json()
         assert updated_user['deleted'] is True, updated_user
 
     def test_purge_user(self):
-        user = self._setup_user(TEST_USER_EMAIL1)
-        self._delete("users/%s" % user["id"], purge=True, admin=True)
-        updated_user = self._get("users/deleted/%s" % user['id'], admin=True).json()
-        assert updated_user['deleted'] is True, updated_user
-        assert updated_user['purged'] is True, updated_user
+        """Delete user and then purge them."""
+        user = self._setup_user(TEST_USER_EMAIL_PURGE)
+        self._delete("users/%s" % user["id"], admin=True)
+        data = dict(purge="True")
+        self._delete("users/%s" % user["id"], data=data, admin=True)
+        payload = {'deleted': "True"}
+        purged_user = self._get("users/%s" % user['id'], payload, admin=True).json()
+        assert purged_user['deleted'] is True, purged_user
+        assert purged_user['purged'] is True, purged_user
 
     def test_undelete_user(self):
-        user = self._setup_user(TEST_USER_EMAIL2)
+        """Delete user and then undelete them."""
+        user = self._setup_user(TEST_USER_EMAIL_UNDELETE)
         self._delete("users/%s" % user["id"], admin=True)
-        updated_user = self._get("users/deleted/%s" % user['id'], admin=True).json()
-        assert updated_user['deleted'] is True, updated_user
-        self._put("users/%s" % user["id"], admin=True)
-        updated_user = self._get("users/%s" % user['id'], admin=True).json()
-        assert updated_user['deleted'] is False, updated_user
+        payload = {'deleted': "True"}
+        deleted_user = self._get("users/%s" % user['id'], payload, admin=True).json()
+        assert deleted_user['deleted'] is True, deleted_user
+        self._post("users/deleted/%s/undelete" % user["id"], admin=True)
+        undeleted_user = self._get("users/%s" % user['id'], admin=True).json()
+        assert undeleted_user['deleted'] is False, undeleted_user
 
     def test_information(self):
         user = self._setup_user(TEST_USER_EMAIL)

--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -74,6 +74,15 @@ class UsersApiTestCase(api.ApiTestCase):
         update_json = update_response.json()
         self.assertEqual(update_json['username'], new_name)
 
+    def test_delete_user(self):
+        user = self._setup_user(TEST_USER_EMAIL)
+        response = self._delete("users/%s" % user["id"], admin=True)
+        updated_user = self._get("users/deleted/%s" % user['id'], admin=True).json()
+        assert updated_user['deleted'] is True, updated_user
+
+    def test_purge_user():
+        pass
+
     def test_information(self):
         user = self._setup_user(TEST_USER_EMAIL)
         url = self.__url("information/inputs", user)

--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -86,9 +86,11 @@ class UsersApiTestCase(api.ApiTestCase):
     def test_purge_user(self):
         """Delete user and then purge them."""
         user = self._setup_user(TEST_USER_EMAIL_PURGE)
-        self._delete("users/%s" % user["id"], admin=True)
+        response = self._delete("users/%s" % user["id"], admin=True)
+        self._assert_status_code_is(response, 200)
         data = dict(purge="True")
-        self._delete("users/%s" % user["id"], data=data, admin=True)
+        response = self._delete("users/%s" % user["id"], data=data, admin=True)
+        self._assert_status_code_is(response, 200)
         payload = {'deleted': "True"}
         purged_user = self._get("users/%s" % user['id'], payload, admin=True).json()
         assert purged_user['deleted'] is True, purged_user

--- a/test/api/test_users.py
+++ b/test/api/test_users.py
@@ -10,6 +10,8 @@ from base import api  # noqa: I100,I202
 from base.populators import skip_without_tool
 
 TEST_USER_EMAIL = "user_for_users_index_test@bx.psu.edu"
+TEST_USER_EMAIL1 = "user1_for_users_index_test@bx.psu.edu"
+TEST_USER_EMAIL2 = "user2_for_users_index_test@bx.psu.edu"
 
 
 class UsersApiTestCase(api.ApiTestCase):
@@ -75,13 +77,26 @@ class UsersApiTestCase(api.ApiTestCase):
         self.assertEqual(update_json['username'], new_name)
 
     def test_delete_user(self):
-        user = self._setup_user(TEST_USER_EMAIL)
+        user = self._setup_user(TEST_USER_EMAIL1)
         response = self._delete("users/%s" % user["id"], admin=True)
         updated_user = self._get("users/deleted/%s" % user['id'], admin=True).json()
         assert updated_user['deleted'] is True, updated_user
 
-    def test_purge_user():
-        pass
+    def test_purge_user(self):
+        user = self._setup_user(TEST_USER_EMAIL1)
+        response = self._delete("users/%s" % user["id"], purge=True, admin=True)
+        updated_user = self._get("users/deleted/%s" % user['id'], admin=True).json()
+        assert updated_user['deleted'] is True, updated_user
+        assert updated_user['purged'] is True, updated_user
+
+    def test_undelete_user(self):
+        user = self._setup_user(TEST_USER_EMAIL2)
+        response = self._delete("users/%s" % user["id"], admin=True)
+        updated_user = self._get("users/deleted/%s" % user['id'], admin=True).json()
+        assert updated_user['deleted'] is True, updated_user
+        response = self._put("users/%s" % user["id"], admin=True)
+        updated_user = self._get("users/%s" % user['id'], admin=True).json()
+        assert updated_user['deleted'] is False, updated_user
 
     def test_information(self):
         user = self._setup_user(TEST_USER_EMAIL)


### PR DESCRIPTION
Refactored the controller vs. manager for the deletion and purge of users. Purge now wipes out the username (regardless of gdrp setting) and takes out histories. Undelete should now work.