### PR TITLE
[WIP] API Schema Generation.

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -2,6 +2,7 @@
 --extra-index-url https://pypi.python.org/simple
 adal==1.2.1
 amqp==2.5.0
+apispec==2.0.2
 appdirs==1.4.3
 asn1crypto==0.24.0
 attrs==19.1.0

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -13,6 +13,7 @@ from importlib import import_module
 
 import mako.lookup
 import mako.runtime
+from apispec import APISpec
 from babel import Locale
 from babel.support import Translations
 from Cheetah.Template import Template
@@ -84,6 +85,54 @@ class WebApplication(base.WebApplication):
         self.mako_template_lookup = self.create_mako_template_lookup(galaxy_app, name)
         # Security helper
         self.security = galaxy_app.security
+
+
+    def build_apispec(self):
+        """
+        Traverse all route paths starting with "api" and create an APISpec instance.
+        """
+        # API specification builder
+        apispec = APISpec(title=self.name,
+                          version="0.0.0-unsupported", # galaxy_app.config.version_major,
+                          openapi_version="3.0.2")
+        import re, sys
+        from apispec import yaml_utils
+        RE_URL = re.compile(r"""
+            (?::\(|{)
+                (\w*)
+                (?::.*)?
+            (?:\)|})""", re.X)
+        for rule in self.mapper.matchlist:
+            if rule.routepath.endswith(".:(format)") or not rule.routepath.startswith("api/"):
+                continue
+            # Try to replace routes various ways to encode variables with simple swagger {form}
+            swagger_path = RE_URL.sub(r'{\1}', rule.routepath)
+            controller = rule.defaults.get('controller', '')
+            action = rule.defaults.get('action', '' )
+            # Get the list of methods for the route
+            methods = []
+            if rule.conditions:
+                m = rule.conditions.get('method', [])
+                methods = type(m) is str and [m] or m
+            print >>sys.stderr, ">>>", rule.routepath, swagger_path, "|".join(methods), action
+            # Find the controller class
+            if controller not in self.api_controllers:
+                log.warning("No controller class found for '%s' while building API spec", controller)
+                continue
+            controller_class = self.api_controllers[controller]
+            if not hasattr(controller_class, action):
+                log.warning("No action found for '%s' in class '%s' while building API spec", action, controller_class )
+                continue
+            action_method = getattr(controller_class, action)
+            # First try to load method docs from docstring
+            operations = yaml_utils.load_operations_from_docstring(action_method.__doc__)
+            # Add methods that have routes but are not documents
+            for method in methods:
+                if method not in operations:
+                    operations[method.lower()] = {}
+            # Store the swagger path            
+            apispec.path(swagger_path, operations)
+        return apispec 
 
     def create_mako_template_lookup(self, galaxy_app, name):
         paths = []

--- a/lib/galaxy/webapps/galaxy/api/genomes.py
+++ b/lib/galaxy/webapps/galaxy/api/genomes.py
@@ -19,6 +19,17 @@ class GenomesController(BaseAPIController):
     def index(self, trans, **kwd):
         """
         GET /api/genomes: returns a list of installed genomes
+        ---
+        get:
+            description: returns a list of installed genomes
+            responses:
+                200:
+                    content:
+                        application/json: 
+                            schema:
+                                type: array
+                                items:
+                                    type: string
         """
 
         return self.app.genomes.get_dbkeys(trans, **kwd)

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1044,6 +1044,9 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect("create", "/api/metrics", controller="metrics",
                           action="create", conditions=dict(method=["POST"]))
 
+    # JXTX DEBUG
+    print >>sys.stderr, "APISPEC:", webapp.build_apispec().to_yaml()
+
 
 def _add_item_tags_controller(webapp, name_prefix, path_prefix, **kwd):
     # Not just using map.resources because actions should be based on name not id


### PR DESCRIPTION
This is very rudimentary at the moment, no way to access the schema
from the web, just prints it out for now.

Traverse all registered API routes, attempt to load schema information
if available in docstring, register with an `APISpec` instance, and
convert to YAML.