### PR TITLE
Fix kubernetes runner on py3

### DIFF
--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -47,7 +47,7 @@ def produce_unique_k8s_job_name(app_prefix=None, instance_id=None, job_id=None):
     if app_prefix:
         job_name += "%s-" % app_prefix
 
-    if instance_id and instance_id > 0:
+    if instance_id and len(instance_id) > 0:
         job_name += "%s-" % instance_id
 
     return job_name + job_id


### PR DESCRIPTION
instance_id is a string, so this can't be compared to an integer
on python 3. Broken in ac1b25ed4c069abf1c8d810ba26d5be43717766d,
prior to that the comparison was `len(self._galaxy_instance_id) > 0:`