### PR TITLE
Updates interactor to not ignore numbers in user email address 

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -579,7 +579,7 @@ class GalaxyInteractorApi(object):
         try:
             test_user = [user for user in all_users if user["email"] == email][0]
         except IndexError:
-            username = re.sub('[^a-z-\d]', '--', email.lower())
+            username = re.sub(r"[^a-z-\d]", '--', email.lower())
             password = password or 'testpass'
             # If remote user middleware is enabled - this endpoint consumes
             # ``remote_user_email`` otherwise it requires ``email``, ``password``

--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -579,7 +579,7 @@ class GalaxyInteractorApi(object):
         try:
             test_user = [user for user in all_users if user["email"] == email][0]
         except IndexError:
-            username = re.sub('[^a-z-]', '--', email.lower())
+            username = re.sub('[^a-z-\d]', '--', email.lower())
             password = password or 'testpass'
             # If remote user middleware is enabled - this endpoint consumes
             # ``remote_user_email`` otherwise it requires ``email``, ``password``


### PR DESCRIPTION
All the following email addresses would resolved to a common `user--test--com` username:
- user@test.com
- user1@test.com
- user10@test.com

This PR updates the email-to-username regular expression to accept alphanumeric. 