### PR TITLE
[WIP] Add button for downloading png screenshots of the center panel

### DIFF
--- a/client/galaxy/scripts/components/Masthead/index.vue
+++ b/client/galaxy/scripts/components/Masthead/index.vue
@@ -43,6 +43,7 @@ export default {
 }
 
 .framed {
+    min-height: 100vh;
     #messagebox,
     #masthead {
         display: none;

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -106,7 +106,7 @@ const Collection = Backbone.Collection.extend({
                                 downloadImage(iFrameDoc.getElementsByTagName("body")[0]);
                         }
                         else {
-                            let centerPanel = document.getElementById("center-panel");
+                            const centerPanel = document.getElementById("center-panel");
                             const center = centerPanel ? centerPanel.firstElementChild : document.getElementById("center");
                             if (center) {
                                 downloadImage(center);

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -9,6 +9,8 @@ import _l from "utils/localization";
 import { CommunicationServerView } from "layout/communication-server-view";
 import Webhooks from "mvc/webhooks";
 import Utils from "utils/utils";
+import html2canvas from "html2canvas";
+import { saveAs } from "file-saver";
 
 function logoutClick() {
     const galaxy = getGalaxyInstance();
@@ -81,7 +83,41 @@ const Collection = Backbone.Collection.extend({
                     title: _l("Interactive Environments"),
                     url: "visualization/gie_list",
                     target: "galaxy_main"
+                },
+                {
+                    title: _l("Download png Screenshot (beta)"),
+                    onclick: () => {
+                        const downloadImage = element => {
+                            html2canvas(element).then(
+                                function (canvas) {
+                                    canvas.toBlob(function (blob) {
+                                        saveAs(blob, "galaxy_screenshot.png");
+                                    });
+                                },
+                                function (err) {
+                                    alert(`not supported on this page error: ${err} `);
+                                }
+                            );
+                        };
+
+                        const iFrame = document.getElementById("galaxy_main");
+                        if (iFrame && iFrame.style.display != "none") {
+                            const iFrameDoc = iFrame.contentDocument || iFrame.contentWindow.document;
+                                downloadImage(iFrameDoc.getElementsByTagName("body")[0]);
+                        }
+                        else {
+                            let centerPanel = document.getElementById("center-panel");
+                            const center = centerPanel ? centerPanel.firstElementChild : document.getElementById("center");
+
+                            if (center) {
+                                downloadImage(center);
+                            } else {
+                                alert("Could not find image to download on this page");
+                            }
+                        }
+                    }
                 }
+
             ]
         });
 

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -108,7 +108,6 @@ const Collection = Backbone.Collection.extend({
                         else {
                             let centerPanel = document.getElementById("center-panel");
                             const center = centerPanel ? centerPanel.firstElementChild : document.getElementById("center");
-
                             if (center) {
                                 downloadImage(center);
                             } else {

--- a/client/galaxy/scripts/layout/panel.js
+++ b/client/galaxy/scripts/layout/panel.js
@@ -257,7 +257,7 @@ const CenterPanel = Backbone.View.extend({
 
     template: function() {
         return (
-            '<div class="center-container">' +
+            '<div id="center-container">' +
             '<iframe id="galaxy_main" name="galaxy_main" frameborder="0" class="center-frame" />' +
             '<div id="center-panel" />' +
             "</div>"

--- a/client/galaxy/scripts/layout/panel.js
+++ b/client/galaxy/scripts/layout/panel.js
@@ -202,7 +202,7 @@ const CenterPanel = Backbone.View.extend({
     initialize: function(options) {
         this.setElement($(this.template()));
         this.$frame = this.$(".center-frame");
-        this.$panel = this.$(".center-panel");
+        this.$panel = this.$("#center-panel");
         this.$frame.on("load", this._iframeChangeHandler.bind(this));
     },
 
@@ -259,7 +259,7 @@ const CenterPanel = Backbone.View.extend({
         return (
             '<div class="center-container">' +
             '<iframe id="galaxy_main" name="galaxy_main" frameborder="0" class="center-frame" />' +
-            '<div class="center-panel" />' +
+            '<div id="center-panel" />' +
             "</div>"
         );
     },

--- a/client/galaxy/scripts/layout/panel.js
+++ b/client/galaxy/scripts/layout/panel.js
@@ -201,7 +201,7 @@ const RightPanel = SidePanel.extend({
 const CenterPanel = Backbone.View.extend({
     initialize: function(options) {
         this.setElement($(this.template()));
-        this.$frame = this.$(".center-frame");
+        this.$frame = this.$("#galaxy_main");
         this.$panel = this.$("#center-panel");
         this.$frame.on("load", this._iframeChangeHandler.bind(this));
     },
@@ -217,7 +217,7 @@ const CenterPanel = Backbone.View.extend({
             if (location && location.host) {
                 $(iframe).show();
                 this.$panel.empty().hide();
-                Galaxy.trigger("center-frame:load", {
+                Galaxy.trigger("galaxy_main:load", {
                     fullpath: location.pathname + location.search + location.hash,
                     pathname: location.pathname,
                     search: location.search,
@@ -258,7 +258,7 @@ const CenterPanel = Backbone.View.extend({
     template: function() {
         return (
             '<div id="center-container">' +
-            '<iframe id="galaxy_main" name="galaxy_main" frameborder="0" class="center-frame" />' +
+            '<iframe id="galaxy_main" name="galaxy_main" frameborder="0" />' +
             '<div id="center-panel" />' +
             "</div>"
         );

--- a/client/galaxy/scripts/mvc/history/history-view-edit-current.js
+++ b/client/galaxy/scripts/mvc/history/history-view-edit-current.js
@@ -361,7 +361,7 @@ var CurrentHistoryView = _super.extend(
                 // compare the url to the following list and if there's a match
                 // pull the id from url and indicate in the history view that
                 // the dataset with that id is the 'current'ly active dataset
-                "center-frame:load": function(data) {
+                "galaxy_main:load": function(data) {
                     var pathToMatch = data.fullpath;
                     var hdaId = null;
                     var useToURLRegexMap = {

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -163,7 +163,7 @@ body {
     left: $panel-width;
     right: $panel-width;
     overflow: hidden;
-    .center-container {
+    #center-container {
         position: absolute;
         width: 100%;
         height: 100%;

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -176,7 +176,7 @@ body {
             overflow: auto;
             background: $brand-white;
         }
-        .center-frame {
+        #galaxy_main {
             position: absolute;
             width: 100%;
             height: 100%;

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -167,7 +167,7 @@ body {
         position: absolute;
         width: 100%;
         height: 100%;
-        .center-panel {
+        #center-panel {
             display: none;
             position: absolute;
             width: 100%;

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "galaxy-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Galaxy client application build system",
   "keywords": [
     "galaxy"
@@ -23,9 +23,11 @@
     "bootstrap-vue": "^2.0.0-rc.16",
     "d3": "3",
     "decode-uri-component": "^0.2.0",
+    "file-saver": "^2.0.2",
     "flush-promises": "^1.0.2",
     "font-awesome": "^4.7.0",
     "handsontable": "^2.0.0",
+    "html2canvas": "^1.0.0-rc.3",
     "imask": "^4.1.5",
     "imports-loader": "^0.8.0",
     "jquery": "2",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "galaxy-client",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Galaxy client application build system",
   "keywords": [
     "galaxy"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2453,6 +2453,11 @@ base64-arraybuffer@0.1.5:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
   integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=
 
+base64-arraybuffer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz#4b944fac0191aa5907afe2d8c999ccc57ce80f45"
+  integrity sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==
+
 base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
@@ -3932,6 +3937,13 @@ css-initials@^0.2.0:
   resolved "https://registry.yarnpkg.com/css-initials/-/css-initials-0.2.0.tgz#14c225bd8656255a6baee07231ef82fa55aacaa3"
   integrity sha512-t80yjg0pi4VAIc5itIqLh6M+ZlA+cB+gUXEQkDR09+ExTDwLMGfJ8YviBsGW+DklIrb2k9fwB75Io8ooWXDxxw==
 
+css-line-break@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-1.1.1.tgz#d5e9bdd297840099eb0503c7310fd34927a026ef"
+  integrity sha512-1feNVaM4Fyzdj4mKPIQNL2n70MmuYzAXZ1aytlROFX1JsOo070OsugwGjj7nl6jnDJWHDM8zRZswkmeYVWZJQA==
+  dependencies:
+    base64-arraybuffer "^0.2.0"
+
 css-loader@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-2.1.1.tgz#d8254f72e412bb2238bb44dd674ffbef497333ea"
@@ -5356,6 +5368,11 @@ file-loader@^3.0.1:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
 
+file-saver@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.2.tgz#06d6e728a9ea2df2cce2f8d9e84dfcdc338ec17a"
+  integrity sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw==
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -6358,6 +6375,13 @@ html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
   integrity sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
+
+html2canvas@^1.0.0-rc.3:
+  version "1.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.0.0-rc.3.tgz#1de88b073f6bcaa6954ca1edfb46da13b258b038"
+  integrity sha512-nWRk34IO3QopcDYpiPAbRW6VoI10H7uxEhcSFjox0JB6wZOMd6Mak+NqHPLljSFFEOvBjPafyRgcHnuWcFpWvg==
+  dependencies:
+    css-line-break "1.1.1"
 
 htmlparser2@^3.10.0:
   version "3.10.0"

--- a/config/plugins/tours/core.galaxy_ui.yaml
+++ b/config/plugins/tours/core.galaxy_ui.yaml
@@ -89,14 +89,14 @@ steps:
         - 'a[href$="tool_runner?tool_id=Filter1"]'
 
     - title: "Filter Tool"
-      element: '.center-panel'
+      element: '#center-panel'
       intro: "Your tool is loaded into the main Galaxy page and ready for use."
       position: "right"
       #backdropContainer: 'background'
       #backdrop: true
 
     - title: "Tool parameters"
-      element: '.center-panel .ui-portlet'
+      element: '#center-panel .ui-portlet'
       intro: "Here you can choose your tool parameters. Select your input dataset from your history and specify parameters for your analysis."
       position: "right"
 


### PR DESCRIPTION
This pull request adds a menu item to the main navigation menu under the "visualizations" tab. This code has been tested and is working on most pages but there are still some issues that may need to be addressed. Please feel free to pull down this branch and test the functionality out and report any issues here. It would be nice to have some testing from people who did not work on the development of this feature (me and @astrovsky01)

**Current known issues:**

**—Galaxy Homepage—**

1. The buttons do not render properly

**—Tool Forms—**

Example: Tools -> Convert Formats -> GFF-to-BED-converter

1. Pre formatted tags with horizontal scroll get cut off in screenshot.

There are "pre" tags on this page which are preformatted and have a horizontal scroll. The screenshot only shows what is currently visible on the screen horizontally. (Should this be fixed?)


2. Some of the "button" tags are not rendered correctly in the screenshot. 

The buttons are close to the original in the screenshot but the shading is off.


**—create visualizations—**

All visualizations - Any forms on the right side with vertical scroll will only show what is visible on screen (Should this be fixed?)

Bar graphs - Y axis numbers get cut off if they are too large. This may be an issue with svg tags.

Heatmaps - no issues found yet.

Multiple sequence alignment - no issues found yet.

PV protein viewer - no issues found yet.

NGL viewer - no issues found yet.

Pie Chart (NVD3) - no issues found yet

Scatter plot (NVD3) - The vertices are drawn too large on the screenshot



