### PR TITLE
Fix use of ``PIP_PROGRESS_BAR`` env variable

### DIFF
--- a/packages/test.sh
+++ b/packages/test.sh
@@ -3,8 +3,7 @@
 set -e
 
 # Don't display the pip progress bar when running under CI
-PIP_PROGRESS_BAR=
-[ "$CI" = "true" ] && PIP_PROGRESS_BAR='--progress-bar off'
+[ "$CI" = 'true' ] && export PIP_PROGRESS_BAR=off
 
 # Change to packages directory.
 cd "$(dirname "$0")"
@@ -15,7 +14,7 @@ TEST_ENV_DIR=${TEST_ENV_DIR:-$(mktemp -d -t gxpkgtestenvXXXXXX)}
 
 virtualenv -p "$TEST_PYTHON" "$TEST_ENV_DIR"
 . "${TEST_ENV_DIR}/bin/activate"
-pip install ${PIP_PROGRESS_BAR} pytest
+pip install pytest
 
 # ensure ordered by dependency dag
 PACKAGE_DIRS=(
@@ -41,9 +40,9 @@ for ((i=0; i<${#PACKAGE_DIRS[@]}; i++)); do
     run_tests=${RUN_TESTS[$i]}
 
     cd "$package_dir"
-    pip install ${PIP_PROGRESS_BAR} -e .
+    pip install -e .
     if [ "$package_dir" = "util" ]; then
-        pip install ${PIP_PROGRESS_BAR} -e '.[template,jstree]'
+        pip install -e '.[template,jstree]'
     fi
 
     if [[ "$run_tests" == "1" ]]; then

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -187,18 +187,17 @@ if [ $DEV_WHEELS -eq 1 ]; then
     requirement_args="$requirement_args -r ${GALAXY_DEV_REQUIREMENTS}"
 fi
 
-PIP_PROGRESS_BAR=
-[ "$CI" = "true" ] && PIP_PROGRESS_BAR='--progress-bar off'
+[ "$CI" = 'true' ] && export PIP_PROGRESS_BAR=off
 
 if [ $FETCH_WHEELS -eq 1 ]; then
-    pip install $requirement_args --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}" ${PIP_PROGRESS_BAR}
+    pip install $requirement_args --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
     GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "from __future__ import print_function; import galaxy.dependencies; print('\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE')))")
     if [ -n "$GALAXY_CONDITIONAL_DEPENDENCIES" ]; then
         if pip list --format=columns | grep "psycopg2[\(\ ]*2.7.3" > /dev/null; then
             echo "An older version of psycopg2 (non-binary, version 2.7.3) has been detected.  Galaxy now uses psycopg2-binary, which will be installed after removing psycopg2."
             pip uninstall -y psycopg2 psycopg2-binary
         fi
-        echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}" ${PIP_PROGRESS_BAR}
+        echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
     fi
 fi
 


### PR DESCRIPTION
`PIP_PROGRESS_BAR` environment variable is used by `pip` to set the value for the `--progress-bar` option. It seems that specifying it also only the command line does not override it in some configurations, e.g. on TravisCI Linux builds of BioBlend, see e.g. https://travis-ci.org/galaxyproject/bioblend/jobs/558857557

Follow-up on https://github.com/galaxyproject/galaxy/pull/8290 , fix issue reported in https://github.com/galaxyproject/galaxy/pull/8290#issuecomment-509860833 .