### PR TITLE
Add GEDA for iCn3D

### DIFF
--- a/display_applications/icn3d/icn3d_simple.xml
+++ b/display_applications/icn3d/icn3d_simple.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<display id="icn3d_simple" version="1.0.0" name="view iniCn3D at">
+    <dynamic_links from_data_table="icn3d_simple_display" skip_startswith="#" id="value" name="name">
+        <url>${ url % {  'icn3d_file_type': $icn3d_file.ext, 'icn3d_file_url_qp': $icn3d_file.qp } }</url>
+        <param type="data" name="icn3d_file" url="galaxy_${DATASET_HASH}.${dataset.ext}" />
+    </dynamic_links>
+</display>

--- a/display_applications/icn3d/icn3d_simple.xml
+++ b/display_applications/icn3d/icn3d_simple.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<display id="icn3d_simple" version="1.0.0" name="view iniCn3D at">
+<display id="icn3d_simple" version="1.0.0" name="view in iCn3D at">
     <dynamic_links from_data_table="icn3d_simple_display" skip_startswith="#" id="value" name="name">
         <url>${ url % {  'icn3d_file_type': $icn3d_file.ext, 'icn3d_file_url_qp': $icn3d_file.qp } }</url>
         <param type="data" name="icn3d_file" url="galaxy_${DATASET_HASH}.${dataset.ext}" />

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -593,6 +593,7 @@
       <converter file="sdf_to_inchi_converter.xml" target_datatype="inchi"/>
       <converter file="sdf_to_mol2_converter.xml" target_datatype="mol2"/>
       <converter file="sdf_to_cml_converter.xml" target_datatype="cml"/>
+      <display file="icn3d/icn3d_simple.xml"/>
     </datatype>
     <datatype extension="inchi" type="galaxy.datatypes.molecules:InChI" display_in_upload="true">
       <converter file="inchi_to_smi_converter.xml" target_datatype="smi"/>
@@ -613,6 +614,7 @@
       <converter file="mol2_to_inchi_converter.xml" target_datatype="inchi"/>
       <converter file="mol2_to_mol_converter.xml" target_datatype="mol"/>
       <converter file="mol2_to_cml_converter.xml" target_datatype="cml"/>
+      <display file="icn3d/icn3d_simple.xml"/>
     </datatype>
     <datatype extension="cml" type="galaxy.datatypes.molecules:CML" display_in_upload="true">
       <converter file="cml_to_smi_converter.xml" target_datatype="smi"/>

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -624,7 +624,9 @@
     <datatype extension="obfs" type="galaxy.datatypes.molecules:OBFS" mimetype="text/html" display_in_upload="true"/>
     <datatype extension="drf" type="galaxy.datatypes.molecules:DRF" display_in_upload="true"/>
     <datatype extension="phar" type="galaxy.datatypes.molecules:PHAR" display_in_upload="false"/>
-    <datatype extension="pdb" type="galaxy.datatypes.molecules:PDB" display_in_upload="true"/>
+    <datatype extension="pdb" type="galaxy.datatypes.molecules:PDB" display_in_upload="true">
+      <display file="icn3d/icn3d_simple.xml"/>
+    </datatype>
     <datatype extension="pdbqt" type="galaxy.datatypes.molecules:PDBQT" display_in_upload="true"/>
     <datatype extension="pqr" type="galaxy.datatypes.molecules:PQR" display_in_upload="true" />
     <datatype extension="trr" type="galaxy.datatypes.binary:Trr" display_in_upload="true"/>

--- a/lib/galaxy/config/sample/tool_data_table_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_data_table_conf.xml.sample
@@ -105,4 +105,9 @@
         <columns>value, name, url</columns>
         <file path="tool-data/intermine_simple_display.loc" />
     </table>
+    <!-- simple iCn3D Structure Viewer servers -->
+    <table name="icn3d_simple_display" comment_char="#" allow_duplicate_entries="False">
+        <columns>value, name, url</columns>
+        <file path="tool-data/icn3d_simple_display.loc" />
+    </table>
 </tables>

--- a/tool-data/icn3d_simple_display.loc.sample
+++ b/tool-data/icn3d_simple_display.loc.sample
@@ -1,0 +1,3 @@
+# Table used for listing simple iCn3D Structure Viewer servers
+#<unique_id>	<display_name>	<url>
+ncbi_icn3d	NCBI	https://www.ncbi.nlm.nih.gov/Structure/icn3d/full.html?type=%(icn3d_file_type)s&url=%(icn3d_file_url_qp)s


### PR DESCRIPTION
> iCn3D, a Web-based 3D Viewer for Sharing 1D/2D/3D Representations of Biomolecular Structures.
> Abstract
> MOTIVATION:
> Build a web-based 3D molecular structure viewer focusing on interactive structural analysis.
> 
> RESULTS:
> iCn3D (I-see-in-3D) can simultaneously show 3D structure, 2D molecular contacts, and 1D protein and nucleotide sequences through an integrated sequence/annotation browser. Pre-defined and arbitrary molecular features can be selected in any of the 1D/2D/3D windows as sets of residues and these selections are synchronized dynamically in all displays. Biological annotations such as protein domains, single nucleotide variations, etc. can be shown as tracks in the 1D sequence/annotation browser. These customized displays can be shared with colleagues or publishers via a simple URL. iCn3D can display structure-structure alignments obtained from NCBI's VAST+ service. It can also display the alignment of a sequence with a structure as identified by BLAST, and thus relate 3D structure to a large fraction of all known proteins. iCn3D can also display electron density maps or electron microscopy (EM) density maps, and export files for 3D printing. The following example URL exemplifies some of the 1D/2D/3D representations: https://www.ncbi.nlm.nih.gov/Structure/icn3d/full.html?mmdbid=1TUP&showanno=1&show2d=1&showsets=1.
> 
> AVAILABILITY:
> iCn3D is freely available to the public. Its source code is available at https://github.com/ncbi/icn3d.
> 
> SUPPLEMENTARY INFORMATION:
> Supplementary data are available at Bioinformatics online.
> 
> Published by Oxford University Press 2019.

https://www.ncbi.nlm.nih.gov/pubmed/31218344 / https://academic.oup.com/bioinformatics/advance-article/doi/10.1093/bioinformatics/btz502/5520951