### PR TITLE
Better config isolation for integration tests.

### DIFF
--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -933,6 +933,11 @@ class GalaxyTestDriver(TestDriver):
                         galaxy_db_path,
                         **setup_galaxy_config_kwds
                     )
+
+                    isolate_galaxy_config = getattr(config_object, "isolate_galaxy_config", False)
+                    if isolate_galaxy_config:
+                        galaxy_config["config_dir"] = tempdir
+
                     self._saved_galaxy_config = galaxy_config
 
             if galaxy_config is not None:

--- a/test/base/integration_util.py
+++ b/test/base/integration_util.py
@@ -60,6 +60,10 @@ class IntegrationInstance(UsesApiTestCaseMixin):
     # Subclasses can override this to force uwsgi for tests.
     require_uwsgi = False
 
+    # Don't pull in default configs for un-configured things from Galaxy's
+    # config directory and such.
+    isolate_galaxy_config = True
+
     @classmethod
     def setUpClass(cls):
         """Configure and start Galaxy for a test."""


### PR DESCRIPTION
I don't know if this is a regression or if this was always a problem, but the integration tests are meant to be run with their own Galaxy configuration so default files in ``config/`` shouldn't affect them but do without this patch. (My object store configuration was preventing Docker tests from working.) This should make the integration tests more robust.