### PR TITLE
catch exceptions occuring in expression validators

### DIFF
--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -113,10 +113,15 @@ class ExpressionValidator(Validator):
         self.expression = compile(expression, '<string>', 'eval')
 
     def validate(self, value, trans=None):
-        if not(eval(self.expression, dict(value=value))):
-            message = self.message
-            if self.substitute_value_in_message:
-                message = message % value
+        message = self.message
+        if self.substitute_value_in_message:
+            message = message % value
+        try:
+            evalresult = eval(self.expression, dict(value=value))
+        except Exception:
+            log.error("Validator %s could not be evaluated on %s" % (self.expression, str(value)))
+            raise ValueError(message)
+        if not(evalresult):
             raise ValueError(message)
 
 

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -119,7 +119,7 @@ class ExpressionValidator(Validator):
         try:
             evalresult = eval(self.expression, dict(value=value))
         except Exception:
-            log.error("Validator %s could not be evaluated on %s" % (self.expression, str(value)))
+            log.debug("Validator %s could not be evaluated on %s" % (self.expression, str(value)), exc_info=True)
             raise ValueError(message)
         if not(evalresult):
             raise ValueError(message)


### PR DESCRIPTION
rationale: in any case the user should not be bothered with python exceptions, but they are still of interest for admins and tool developers.

Hence I suggest in case of any exception to raise a value Error with the validator's message (hence the user will see the message intended by the validator) and to write an error to the log for admins and tool
developers.

Still does not help in this use case where two validators check if the input is a list of integers within a range: 

```
<validator type="regex" message="a comma separated list of integer values is required"><![CDATA[[+-]?[0-9]+(,[+-]?[0-9]+)*]]></validator>
      <validator type="expression" message="a comma separated list of integer values in the range 0:100 is required"><![CDATA[len(value.split(',')) == len([_ for _ in value.split(',') if 0 <= int(_) <= 100])
]]></validator>
```

Maybe we should log to `debug` and maybe include the StackTrace in the log, but this might require an additional import. Opinions?
