### PR TITLE
Fix default involucro path

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -556,9 +556,10 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
         involucro_path = kwargs.get('involucro_path', None)
         if involucro_path is None:
-            target_dir = resolve_path(kwargs.get("tool_dependency_dir", "dependencies"), self.data_dir)
+            target_dir = kwargs.get("tool_dependency_dir", "dependencies")
             if target_dir == "none":
-                target_dir = "database"
+                target_dir = "dependencies"
+            target_dir = resolve_path(target_dir, self.data_dir)
             involucro_path = os.path.join(target_dir, "involucro")
         self.involucro_path = resolve_path(involucro_path, self.root)
         self.involucro_auto_init = string_as_bool(kwargs.get('involucro_auto_init', True))


### PR DESCRIPTION
BaseAppConfiguration.root is now an absolute path, and so is
BaseAppConfiguration.data_dir, so the result of
`resolve_path(kwargs.get("tool_dependency_dir", "dependencies"), self.data_dir)`
is not "none" as it used to be, but `"<galaxy_data_dir>/none"` and so
the fallback will not be used.

This can be fixed by setting the default target dir to `dependencies`
and join it to self.data_dir, which defaults to `galaxy_root/database`
on classic installations.

Fixes the issues in https://github.com/galaxyproject/galaxy/pull/8195#issuecomment-513246346