### PR TITLE
Sort Collection: add missing when tags

### DIFF
--- a/lib/galaxy/tools/sort_collection_list.xml
+++ b/lib/galaxy/tools/sort_collection_list.xml
@@ -14,6 +14,8 @@
                 <option value="numeric">numerically (strips all characters except numbers)</option>
                 <option value="file">Sort collection using order of identifiers in text file</option>
             </param>
+            <when value="alpha" />
+            <when value="numeric" />
             <when value="file">
                 <param name="sort_file" type="data" format="txt" label="Select file that contains the new order of collection elements" help="Lines in text file must match collection"></param>
             </when>


### PR DESCRIPTION
which will remove warning during startup 

```
galaxy.tools WARNING 2019-07-22 10:19:12,886 [p:193674,w:0,m:0] [MainThread] Tool __SORTLIST__: a when tag has not been defined for 'sort_type (sort_type) --> alpha', assuming empty inputs.
galaxy.tools WARNING 2019-07-22 10:19:12,887 [p:193674,w:0,m:0] [MainThread] Tool __SORTLIST__: a when tag has not been defined for 'sort_type (sort_type) --> numeric', assuming empty inputs.
```