### PR TITLE
Pin python version for fiona package

### DIFF
--- a/test/functional/tools/composite_shapefile.xml
+++ b/test/functional/tools/composite_shapefile.xml
@@ -1,6 +1,7 @@
 <tool id="shapefile_composite" name="composite shapefile tool" version="1.0.0">
     <requirements>
         <requirement type="package" version="1.8.6">fiona</requirement>
+        <requirement type="package" version="3.6">python</requirement>
     </requirements>
     <command><![CDATA[
         mkdir '$output_shapefile.extra_files_path' &&


### PR DESCRIPTION
This currently causes our framework tests to fail.
This happened at the same time as the switch to
python 3.7, so I'm hoping this will fix the tests.