### PR TITLE
Fix exception thrown with invalid session key

### DIFF
--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -436,14 +436,14 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
             # Decode the cookie value to get the session_key
             try:
                 session_key = self.security.decode_guid(secure_id)
+                if session_key:
+                    # Retrieve the galaxy_session id via the unique session_key
+                    galaxy_session = self.sa_session.query(self.app.model.GalaxySession) \
+                                                    .filter(and_(self.app.model.GalaxySession.table.c.session_key == session_key,
+                                                                 self.app.model.GalaxySession.table.c.is_valid == true())).options(joinedload("user")).first()
             except Exception:
                 # We'll end up creating a new galaxy_session
                 session_key = None
-            if session_key:
-                # Retrieve the galaxy_session id via the unique session_key
-                galaxy_session = self.sa_session.query(self.app.model.GalaxySession) \
-                                                .filter(and_(self.app.model.GalaxySession.table.c.session_key == session_key,
-                                                             self.app.model.GalaxySession.table.c.is_valid == true())).options(joinedload("user")).first()
         # If remote user is in use it can invalidate the session and in some
         # cases won't have a cookie set above, so we need to to check some
         # things now.


### PR DESCRIPTION
Move session lookup into try/except, user will then just get a new
session. Fixes
```
127.0.0.1 - - [25/Jul/2019:13:24:23 +0200] "GET / HTTP/1.1" 500 - "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36"
Traceback (most recent call last):
  File "lib/galaxy/web/framework/middleware/error.py", line 154, in __call__
    app_iter = self.application(environ, sr_checker)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "lib/galaxy/web/framework/base.py", line 143, in __call__
    return self.handle_request(environ, start_response)
  File "lib/galaxy/web/framework/base.py", line 199, in handle_request
    trans = self.transaction_factory(environ)
  File "lib/galaxy/web/framework/webapp.py", line 82, in <lambda>
    self.set_transaction_factory(lambda e: self.transaction_chooser(e, galaxy_app, session_cookie))
  File "lib/galaxy/web/framework/webapp.py", line 115, in transaction_chooser
    return GalaxyWebTransaction(environ, galaxy_app, self, session_cookie)
  File "lib/galaxy/web/framework/webapp.py", line 219, in __init__
    self._ensure_valid_session(session_cookie)
  File "lib/galaxy/web/framework/webapp.py", line 446, in _ensure_valid_session
    self.app.model.GalaxySession.table.c.is_valid == true())).options(joinedload("user")).first()
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3222, in first
    ret = list(self[0:1])
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3012, in __getitem__
    return list(res)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3324, in __iter__
    return self._execute_and_instances(context)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3349, in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 988, in execute
    return meth(self, multiparams, params)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/sql/elements.py", line 287, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1107, in _execute_clauseelement
    distilled_params,
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
    e, statement, parameters, cursor, context
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1468, in _handle_dbapi_exception
    util.reraise(*exc_info)
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 154, in reraise
    raise value
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1244, in _execute_context
    cursor, statement, parameters, context
  File "/Users/mvandenb/src/galaxy/.venv3/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 550, in do_execute
    cursor.execute(statement, parameters)
ValueError: A string literal cannot contain NUL (0x00) characters.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "lib/galaxy/web/framework/middleware/batch.py", line 80, in __call__
    return self.application(environ, start_response)
  File "lib/galaxy/web/framework/middleware/request_id.py", line 15, in __call__
    return self.app(environ, start_response)
  File "lib/galaxy/web/framework/middleware/xforwardedhost.py", line 23, in __call__
    return self.app(environ, start_response)
  File "lib/galaxy/web/framework/middleware/translogger.py", line 71, in __call__
    return self.application(environ, replacement_start_response)
  File "lib/galaxy/web/framework/middleware/error.py", line 164, in __call__
    exc_info)
  File "lib/galaxy/web/framework/middleware/translogger.py", line 70, in replacement_start_response
    return start_response(status, headers, exc_info)
SystemError: <built-in function uwsgi_spit> returned a result with an error set
```
Which can be provoked by switching between python 3 and python 2.