### PR TITLE
 [19.05] Backport #7730 Fix ignored assert_command tests

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -1064,7 +1064,7 @@ class ToolTestDescription(object):
         self.exception = processed_test_dict.get("exception", None)
 
         self.output_collections = map(TestCollectionOutputDef.from_dict, processed_test_dict.get("output_collections", []))
-        self.command_line = processed_test_dict.get("command", None)
+        self.command_line = processed_test_dict.get("command_line", None)
         self.stdout = processed_test_dict.get("stdout", None)
         self.stderr = processed_test_dict.get("stderr", None)
         self.expect_exit_code = processed_test_dict.get("expect_exit_code", None)


### PR DESCRIPTION
These were swallowed because the `raw_test_dict` already lists them under `command_line`, not `command`. (https://github.com/galaxyproject/galaxy/blob/418f1220c8f6b21bcf3b4ddcf9d19f29bdb2c373/lib/galaxy/tools/test.py#L49)
