### PR TITLE
[19.05] Fix workflow tags lost on save

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,9 +140,6 @@ jobs:
     steps:
       - *restore_repo_cache
       - *install_tox
-      - run: sudo apt-get update
-      # For uwsgi
-      - run: sudo apt-get install -y libpython3.5-dev
       - run: tox -e py35-first_startup
   validate_test_tools:
     docker:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -552,7 +552,8 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
                     if (trans.security.decode_id(id) in entries):
                         trans.get_user().stored_workflow_menu_entries.remove(entries[trans.security.decode_id(id)])
             # set tags
-            trans.app.tag_handler.set_tags_from_list(user=trans.user, item=stored_workflow, new_tags_list=workflow_dict.get('tags', []))
+            if 'tags' in workflow_dict:
+                trans.app.tag_handler.set_tags_from_list(user=trans.user, item=stored_workflow, new_tags_list=workflow_dict['tags'])
 
             if 'steps' in workflow_dict:
                 try:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -566,9 +566,6 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
                     )
                 except workflows.MissingToolsException:
                     raise exceptions.MessageException("This workflow contains missing tools. It cannot be saved until they have been removed from the workflow or installed.")
-            else:
-                # We only adjusted tags and menu entry
-                return payload
         else:
             message = "Updating workflow requires dictionary containing 'workflow' attribute with new JSON description."
             raise exceptions.RequestParameterInvalidException(message)

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -343,6 +343,20 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase):
         # Make sure the positions have been updated.
         map(tweak_step, updated_workflow_content['steps'].items())
 
+    def test_update_tags(self):
+        workflow_object = self.workflow_populator.load_workflow(name="test_import")
+        upload_response = self.__test_upload(workflow=workflow_object)
+        workflow = upload_response.json()
+        workflow['tags'] = ['a_tag', 'b_tag']
+        update_response = self._update_workflow(workflow['id'], workflow).json()
+        assert update_response['tags'] == ['a_tag', 'b_tag']
+        del workflow['tags']
+        update_response = self._update_workflow(workflow['id'], workflow).json()
+        assert update_response['tags'] == ['a_tag', 'b_tag']
+        workflow['tags'] = []
+        update_response = self._update_workflow(workflow['id'], workflow).json()
+        assert update_response['tags'] == []
+
     def test_update_no_tool_id(self):
         workflow_object = self.workflow_populator.load_workflow(name="test_import")
         upload_response = self.__test_upload(workflow=workflow_object)


### PR DESCRIPTION
We accept different kinds of payloads when updating workflows.
The summary payload as sent by the workflow overview page includes a tags key,
while the workflow payload sent by the workflow editor only
includes the steps (tag updates are sent through a different
endpoint), so anytime a workflow is saved in the workflow editor
we would fallback to an empty list as the new tags, effectively
removing all tags. So instead we only update tags if there is a `tags`
key in the payload

Fixes #6888