### PR TITLE
Record Galaxy version job was created with.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -654,8 +654,8 @@ class TaskMetricNumeric(BaseJobMetric, RepresentById):
 
 
 class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
-    dict_collection_visible_keys = ['id', 'state', 'exit_code', 'update_time', 'create_time']
-    dict_element_visible_keys = ['id', 'state', 'exit_code', 'update_time', 'create_time']
+    dict_collection_visible_keys = ['id', 'state', 'exit_code', 'update_time', 'create_time', 'galaxy_version']
+    dict_element_visible_keys = ['id', 'state', 'exit_code', 'update_time', 'create_time', 'galaxy_version']
 
     """
     A job represents a request to run a tool given input datasets, tool
@@ -1018,6 +1018,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         serialization_options.attach_identifier(id_encoder, self, job_attrs)
         job_attrs['tool_id'] = self.tool_id
         job_attrs['tool_version'] = self.tool_version
+        job_attrs['galaxy_version'] = self.galaxy_version
         job_attrs['state'] = self.state
         job_attrs['info'] = self.info
         job_attrs['traceback'] = self.traceback

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -593,6 +593,7 @@ model.Job.table = Table(
     Column("library_folder_id", Integer, ForeignKey("library_folder.id"), index=True),
     Column("tool_id", String(255)),
     Column("tool_version", TEXT, default="1.0.0"),
+    Column("galaxy_version", String(64), default=None),
     Column("dynamic_tool_id", Integer, ForeignKey("dynamic_tool.id"), index=True, nullable=True),
     Column("state", String(64), index=True),
     Column("info", TrimmedString(255)),

--- a/lib/galaxy/model/migrate/versions/0155_job_galaxy_version.py
+++ b/lib/galaxy/model/migrate/versions/0155_job_galaxy_version.py
@@ -1,0 +1,29 @@
+"""
+Add 'galaxy_version' attribute to Job table.
+"""
+import datetime
+import logging
+
+from sqlalchemy import Column, MetaData, String
+
+from galaxy.model.migrate.versions.util import add_column, drop_column
+
+now = datetime.datetime.utcnow
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+
+def upgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    print(__doc__)
+    metadata.reflect()
+
+    created_from_basename_column = Column("galaxy_version", String(64), default=None)
+    add_column(created_from_basename_column, 'job', metadata)
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    drop_column('galaxy_version', 'job', metadata)

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -668,6 +668,7 @@ class DefaultToolAction(object):
 
     def _new_job_for_session(self, trans, tool, history):
         job = trans.app.model.Job()
+        job.galaxy_version = trans.app.config.version_major
         galaxy_session = None
 
         if hasattr(trans, "get_galaxy_session"):
@@ -677,7 +678,8 @@ class DefaultToolAction(object):
                 job.session_id = model.cached_id(galaxy_session)
         if trans.user is not None:
             job.user_id = model.cached_id(trans.user)
-        job.history_id = model.cached_id(history)
+        if history:
+            job.history_id = model.cached_id(history)
         job.tool_id = tool.id
         try:
             # For backward compatibility, some tools may not have versions yet.

--- a/lib/galaxy/tools/actions/history_imp_exp.py
+++ b/lib/galaxy/tools/actions/history_imp_exp.py
@@ -18,6 +18,7 @@ class ImportHistoryToolAction(ToolAction):
         #
         trans.check_user_activation()
         job = trans.app.model.Job()
+        job.galaxy_version = trans.app.config.version_major
         session = trans.get_galaxy_session()
         job.session_id = session and session.id
         if history:
@@ -87,6 +88,7 @@ class ExportHistoryToolAction(ToolAction):
         # Create the job and output dataset objects
         #
         job = trans.app.model.Job()
+        job.galaxy_version = trans.app.config.version_major
         session = trans.get_galaxy_session()
         job.session_id = session and session.id
         if history:

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -52,6 +52,7 @@ class SetMetadataToolAction(ToolAction):
 
         # Create the job object
         job = app.model.Job()
+        job.galaxy_version = app.config.version_major
         job.session_id = session_id
         job.history_id = history_id
         job.tool_id = tool.id

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -385,6 +385,7 @@ def create_job(trans, params, tool, json_file_path, outputs, folder=None, histor
     Create the upload job.
     """
     job = trans.app.model.Job()
+    job.galaxy_version = trans.app.config.version_major
     galaxy_session = trans.get_galaxy_session()
     if type(galaxy_session) == trans.model.GalaxySession:
         job.session_id = galaxy_session.id

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -149,6 +149,8 @@ class MockAppConfig(Bunch):
         self.enable_beta_gdpr = False
         self.legacy_eager_objectstore_initialization = True
 
+        self.version_major = "19.09"
+
         # set by MockDir
         self.root = root
 


### PR DESCRIPTION
We have so much job code dependent on what version of Galaxy created a job. This should help keep track of that without having to hit the job directory to guess how Galaxy behaved at job creation. Also good to track in general for traceability/reproducibility and such.
