### PR TITLE
[19.05] Try to fix too many workflow step output associations.

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -594,7 +594,7 @@ class InputModule(WorkflowModule):
         progress.set_outputs_for_input(invocation_step, step_outputs)
 
     def recover_mapping(self, invocation_step, progress):
-        progress.set_outputs_for_input(invocation_step)
+        progress.set_outputs_for_input(invocation_step, already_persisted=True)
 
 
 class InputDataModule(InputModule):
@@ -1304,17 +1304,6 @@ class ToolModule(WorkflowModule):
             raise Exception(message)
 
         return complete
-
-    def recover_mapping(self, invocation_step, progress):
-        outputs = {}
-
-        for output_dataset_assoc in invocation_step.output_datasets:
-            outputs[output_dataset_assoc.output_name] = output_dataset_assoc.dataset
-
-        for output_dataset_collection_assoc in invocation_step.output_dataset_collections:
-            outputs[output_dataset_collection_assoc.output_name] = output_dataset_collection_assoc.dataset_collection
-
-        progress.set_step_outputs(invocation_step, outputs)
 
     def _effective_post_job_actions(self, step):
         effective_post_job_actions = step.post_job_actions[:]

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -405,7 +405,7 @@ class WorkflowProgress(object):
         else:
             return step_outputs[output_name]
 
-    def set_outputs_for_input(self, invocation_step, outputs=None):
+    def set_outputs_for_input(self, invocation_step, outputs=None, already_persisted=False):
         step = invocation_step.workflow_step
 
         if outputs is None:
@@ -420,7 +420,7 @@ class WorkflowProgress(object):
             elif step_id in self.inputs_by_step_id:
                 outputs['output'] = self.inputs_by_step_id[step_id]
 
-        self.set_step_outputs(invocation_step, outputs)
+        self.set_step_outputs(invocation_step, outputs, already_persisted=already_persisted)
 
     def set_step_outputs(self, invocation_step, outputs, already_persisted=False):
         step = invocation_step.workflow_step


### PR DESCRIPTION
Certain entries on main have hundreds of thousands of such records because they're being created at each iteration of workflow scheduling. This leads to serious memory and runtime issues over time.

Cleanup extra rows with:

```sql
DELETE FROM workflow_invocation_step_output_dataset_association
WHERE id NOT IN (

SELECT max(w.id) FROM
workflow_invocation_step_output_dataset_association as w GROUP BY workflow_invocation_step_id, dataset_id, output_name

)
```