### PR TITLE
Don't parse HTML for tool help search index.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1241,6 +1241,13 @@ class Tool(Dictifiable):
             self.__ensure_help()
         return self.__help_by_page
 
+    @property
+    def raw_help(self):
+        # may return rst (or Markdown in the future)
+        tool_source = self.__help_source
+        help_text = tool_source.parse_help()
+        return help_text
+
     def __ensure_help(self):
         with HELP_UNINITIALIZED:
             if self.__help is HELP_UNINITIALIZED:

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -104,15 +104,15 @@ class ToolBoxSearch(object):
             add_doc_kwds['stub'] = to_unicode(id)
         if tool.labels:
             add_doc_kwds['labels'] = to_unicode(" ".join(tool.labels))
-        if index_help and tool.help:
-            try:
-                raw_html = tool.help.render(host_url="", static_path="")
-                cleantext = clean(raw_html, tags=[''], strip=True).replace('\n', ' ')
-                add_doc_kwds['help'] = to_unicode(cleantext)
-            except Exception:
-                # Don't fail to build index just because a help message
-                # won't render.
-                pass
+        if index_help:
+            raw_help = tool.raw_help
+            if raw_help:
+                try:
+                    add_doc_kwds['help'] = to_unicode(raw_help)
+                except Exception:
+                    # Don't fail to build index just because a help message
+                    # won't render.
+                    pass
         return add_doc_kwds
 
     def search(self, q, tool_name_boost, tool_section_boost, tool_description_boost, tool_label_boost, tool_stub_boost, tool_help_boost, tool_search_limit, tool_enable_ngram_search, tool_ngram_minsize, tool_ngram_maxsize):

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -6,7 +6,6 @@ import logging
 import re
 import tempfile
 
-from bleach import clean
 from whoosh import analysis
 from whoosh.analysis import StandardAnalyzer
 from whoosh.fields import (


### PR DESCRIPTION
Just use the simpler raw rST (or Markdown in the future). This should prevent all rst_to_html loading from happening at Galaxy startup - the existing caching should allow it to just be loaded and cached on first use.