### PR TITLE
Fix authentication provider exception not logged

### DIFF
--- a/lib/galaxy/auth/__init__.py
+++ b/lib/galaxy/auth/__init__.py
@@ -64,8 +64,9 @@ class AuthManager(object):
                 if auth_results[0] is True:
                     try:
                         auth_return = parse_auth_results(trans, auth_results, options)
-                    except Conflict:
-                        break
+                    except Conflict as conflict:
+                        log.exception(conflict)
+                        raise
                     return auth_return
                 elif auth_results[0] is None:
                     auto_email = str(auth_results[1]).lower()

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -14,6 +14,7 @@ from galaxy import (
     util,
     web
 )
+from galaxy.exceptions import Conflict
 from galaxy.managers import users
 from galaxy.queue_worker import send_local_control_task
 from galaxy.security.validate_user_input import (
@@ -82,7 +83,10 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesApiKeysMixin):
         """
         Does the autoregistration if enabled. Returns a message
         """
-        autoreg = trans.app.auth_manager.check_auto_registration(trans, login, password)
+        try:
+            autoreg = trans.app.auth_manager.check_auto_registration(trans, login, password)
+        except Conflict as conflict:
+            return "Auto-registration failed, {}".format(conflict), None
         user = None
         if autoreg["auto_reg"]:
             email = autoreg["email"]


### PR DESCRIPTION
This a copy of the PR  #7139 closed after a failing rebase tentative.
During an external provider authentication, log and reraise the exception properly instead of ignoring it when the provider raise one.