### PR TITLE
Remove seemingly unneeded deepcopy's in macro expansion.

### DIFF
--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -173,7 +173,7 @@ def _expand_yield_statements(macro_def, expand_el):
             if macro_def_el.tag == "yield":
                 for target in expand_el_children:
                     i += 1
-                    macro_def.insert(i, deepcopy(target))
+                    macro_def.insert(i, target)
                 macro_def.remove(macro_def_el)
                 continue
 
@@ -269,7 +269,7 @@ def _xml_replace(query, targets, parent_map):
     current_index = matching_index
     for target in targets:
         current_index += 1
-        parent_el.insert(current_index, deepcopy(target))
+        parent_el.insert(current_index, target)
     parent_el.remove(query)
 
 

--- a/test/unit/tool_util/test_tool_loader.py
+++ b/test/unit/tool_util/test_tool_loader.py
@@ -277,7 +277,7 @@ def test_loader():
         assert input_els[1].text == "world"
         assert input_els[2].text == "the_default"
 
-    # Test macros XML macros with @ expansions and recurisve
+    # Test macros XML macros with @ expansions and recursive
     with TestToolDirectory() as tool_dir:
         tool_dir.write('''
 <tool>

--- a/test/unit/tool_util/test_tool_loader.py
+++ b/test/unit/tool_util/test_tool_loader.py
@@ -62,8 +62,19 @@ def test_loader():
     <expand macro="inputs">
         <input name="first_input" />
     </expand>
+    <expand macro="inputs">
+        <input name="second_input" />
+    </expand>
+    <expand macro="inputs">
+        <input name="third_input" />
+    </expand>
     <macros>
         <macro name="inputs">
+            <expand macro="foo">
+                <yield />
+            </expand>
+        </macro>
+        <macro name="foo">
             <inputs>
                 <yield />
             </inputs>
@@ -71,7 +82,9 @@ def test_loader():
     </macros>
 </tool>''')
         xml = tool_dir.load()
-        assert xml.find("inputs").find("input").get("name") == "first_input"
+        assert xml.findall("inputs")[0].find("input").get("name") == "first_input"
+        assert xml.findall("inputs")[1].find("input").get("name") == "second_input"
+        assert xml.findall("inputs")[2].find("input").get("name") == "third_input"
 
     # Test recursive macro applications.
     with TestToolDirectory() as tool_dir:
@@ -227,6 +240,8 @@ def test_loader():
         tool_dir.write('''
 <tool>
     <expand macro="inputs" bar="hello" />
+    <expand macro="inputs" bar="my awesome" />
+    <expand macro="inputs" bar="doggo" />
     <macros>
         <xml name="inputs" tokens="bar" token_quote="$$">
             <inputs type="the type is $$BAR$$" />
@@ -236,8 +251,10 @@ def test_loader():
 ''')
         xml = tool_dir.load()
         input_els = xml.findall("inputs")
-        assert len(input_els) == 1
+        assert len(input_els) == 3
         assert input_els[0].attrib["type"] == "the type is hello"
+        assert input_els[1].attrib["type"] == "the type is my awesome"
+        assert input_els[2].attrib["type"] == "the type is doggo"
 
     # Test macros XML macros with @ expansions in text
     with TestToolDirectory() as tool_dir:
@@ -259,3 +276,28 @@ def test_loader():
         assert input_els[0].text == "hello"
         assert input_els[1].text == "world"
         assert input_els[2].text == "the_default"
+
+    # Test macros XML macros with @ expansions and recurisve
+    with TestToolDirectory() as tool_dir:
+        tool_dir.write('''
+<tool>
+    <expand macro="inputs" foo="hello" />
+    <expand macro="inputs" foo="world" />
+    <expand macro="inputs" />
+    <macros>
+        <xml name="inputs" token_foo="the_default">
+            <expand macro="real_inputs"><cow>@FOO@</cow></expand>
+        </xml>
+        <xml name="real_inputs">
+            <inputs><yield /></inputs>
+        </xml>
+    </macros>
+</tool>
+''')
+        xml = tool_dir.load()
+        input_els = xml.findall("inputs")
+        assert len(input_els) == 3
+        print(input_els[0].text)
+        assert input_els[0].find("cow").text == "hello"
+        assert input_els[1].find("cow").text == "world"
+        assert input_els[2].find("cow").text == "the_default"

--- a/test/unit/tool_util/test_tool_loader.py
+++ b/test/unit/tool_util/test_tool_loader.py
@@ -297,7 +297,6 @@ def test_loader():
         xml = tool_dir.load()
         input_els = xml.findall("inputs")
         assert len(input_els) == 3
-        print(input_els[0].text)
         assert input_els[0].find("cow").text == "hello"
         assert input_els[1].find("cow").text == "world"
         assert input_els[2].find("cow").text == "the_default"


### PR DESCRIPTION
Timings using test_loader.py.

Before:

```
load_with_references (/Users/john/workspace/galaxy/lib/galaxy/util/xml_macros.py:11)
function called 14 times

         26836 function calls (23318 primitive calls) in 0.028 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 121 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       14    0.000    0.000    0.028    0.002 xml_macros.py:11(load_with_references)
    44/14    0.000    0.000    0.018    0.001 xml_macros.py:127(_expand_macros)
    30/27    0.000    0.000    0.017    0.001 xml_macros.py:141(_expand_macro)
  1608/78    0.004    0.000    0.010    0.000 copy.py:145(deepcopy)
```

After:

```
load_with_references (/Users/john/workspace/galaxy/lib/galaxy/util/xml_macros.py:11)
function called 14 times

         18269 function calls (15767 primitive calls) in 0.020 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 121 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       14    0.000    0.000    0.020    0.001 xml_macros.py:11(load_with_references)
    44/14    0.000    0.000    0.011    0.001 xml_macros.py:127(_expand_macros)
    30/27    0.000    0.000    0.009    0.000 xml_macros.py:141(_expand_macro)
       15    0.000    0.000    0.007    0.000 xml_macros.py:311(_parse_xml)
       14    0.000    0.000    0.007    0.000 xml_macros.py:51(raw_xml_tree)
       15    0.000    0.000    0.006    0.000 ElementTree.py:1180(parse)
       15    0.000    0.000    0.006    0.000 ElementTree.py:644(parse)
   672/30    0.002    0.000    0.005    0.000 copy.py:145(deepcopy)
```

Also add more tests to try to verify the deepcopys are not needed.