### PR TITLE
[PROCEDURES] add Matthias Bernt to the committers group

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -43,6 +43,7 @@ Members
 
 - Enis Afgan (@afgane)
 - Dannon Baker (@dannon)
+- Matthias Bernt (@bernt-matthias)
 - Daniel Blankenberg (@blankenberg)
 - Dave Bouvier (@davebx)
 - Martin Čech (@martenson)


### PR DESCRIPTION
Matthias Bernt has been an important community member for quite some time. His contributions to various projects under the Galaxy umbrella like IUC-tools, training-material, and core are numerous and of very high quality. With code he routinely includes complementary reasoning, tests and documentation, which is something we all strive for. 

I propose we add Matthias to the Galaxy committers group so he can use his expertise and skills to influence Galaxy even more.

cc @bernt-matthias 

@galaxyproject/core please vote
