### PR TITLE
Use outputs/ and configs/ directories for Galaxy jobs.

### DIFF
--- a/lib/galaxy/job_execution/datasets.py
+++ b/lib/galaxy/job_execution/datasets.py
@@ -82,14 +82,18 @@ class OutputsToWorkingDirectoryPathRewriter(object):
     is responsible for copying these out after job is complete.
     """
 
-    def __init__(self, working_directory):
+    def __init__(self, working_directory, outputs_directory_name):
         self.working_directory = working_directory
+        self.outputs_directory_name = outputs_directory_name
 
     def rewrite_dataset_path(self, dataset, dataset_type):
         """ Keep path the same.
         """
         if dataset_type == 'output':
-            false_path = os.path.abspath(os.path.join(self.working_directory, "galaxy_dataset_%d.dat" % dataset.id))
+            base_output_directory = os.path.abspath(self.working_directory)
+            if self.outputs_directory_name is not None:
+                base_output_directory = os.path.join(base_output_directory, self.outputs_directory_name)
+            false_path = os.path.join(base_output_directory, "galaxy_dataset_%d.dat" % dataset.id)
             return false_path
         else:
             return None

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -19,6 +19,7 @@ from abc import ABCMeta, abstractmethod
 from json import loads
 from xml.etree import ElementTree
 
+import packaging.version
 import six
 import yaml
 from pulsar.client.staging import COMMAND_VERSION_FILENAME
@@ -894,7 +895,8 @@ class JobWrapper(HasResourceParameters):
         if self._dataset_path_rewriter is None:
             outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
             if outputs_to_working_directory:
-                self._dataset_path_rewriter = OutputsToWorkingDirectoryPathRewriter(self.working_directory)
+                output_directory = self.outputs_directory
+                self._dataset_path_rewriter = OutputsToWorkingDirectoryPathRewriter(self.working_directory, output_directory)
             else:
                 self._dataset_path_rewriter = NullDatasetPathRewriter()
         return self._dataset_path_rewriter
@@ -902,6 +904,17 @@ class JobWrapper(HasResourceParameters):
     @property
     def dataset_path_rewriter(self):
         return self._job_dataset_path_rewriter
+
+    @property
+    def outputs_directory(self):
+        """Default location of ``outputs_to_working_directory``.
+        """
+        return None if self.created_with_galaxy_version < packaging.version.parse("20.01") else "outputs"
+
+    @property
+    def created_with_galaxy_version(self):
+        galaxy_version = self.get_job().galaxy_version or "19.05"
+        return packaging.version.parse(galaxy_version)
 
     @property
     def dependency_shell_commands(self):
@@ -2121,7 +2134,7 @@ class JobWrapper(HasResourceParameters):
     def get_output_destination(self, output_path):
         """
         Destination for outputs marked as from_work_dir. This is the normal case,
-        just copy these files directly to the ulimate destination.
+        just copy these files directly to the ultimate destination.
         """
         return output_path
 

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2409,7 +2409,7 @@ class ComputeEnvironment(object):
 class SimpleComputeEnvironment(object):
 
     def config_directory(self):
-        return self.working_directory()
+        return os.path.join(self.working_directory(), "configs")
 
     def sep(self):
         return os.path.sep

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -101,7 +101,7 @@ def build_command(
 
         # Remove the working directory incase this is for instance a SLURM re-submission.
         # xref https://github.com/galaxyproject/galaxy/issues/3289
-        commands_builder.prepend_command("rm -rf working; mkdir -p working; cd working")
+        commands_builder.prepend_command("rm -rf working outputs; mkdir -p working outputs; cd working")
 
     container_monitor_command = job_wrapper.container_monitor_command(container)
     if container_monitor_command:
@@ -158,7 +158,7 @@ def __externalize_commands(job_wrapper, shell, commands_builder, remote_command_
         commands = "%s %s" % (shell, join(remote_command_params['script_directory'], script_name))
         for_pulsar = True
     if not for_pulsar:
-        commands += " > ../tool_stdout 2> ../tool_stderr"
+        commands += " > ../outputs/tool_stdout 2> ../outputs/tool_stderr"
     log.info("Built script [%s] for tool command [%s]" % (local_container_script, tool_commands))
     return commands
 

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -296,7 +296,7 @@ class BaseJobRunner(object):
         output_paths = {}
         for dataset_path in job_wrapper.get_output_fnames():
             path = dataset_path.real_path
-            if self.app.config.outputs_to_working_directory:
+            if job_wrapper.get_destination_configuration("outputs_to_working_directory", False):
                 path = dataset_path.false_path
             output_paths[dataset_path.dataset_id] = path
 
@@ -475,8 +475,12 @@ class BaseJobRunner(object):
             job = job_state.job_wrapper.get_job()
             exit_code = job_state.read_exit_code()
 
-            tool_stdout_path = os.path.join(job_wrapper.working_directory, "tool_stdout")
-            tool_stderr_path = os.path.join(job_wrapper.working_directory, "tool_stderr")
+            outputs_directory = os.path.join(job_wrapper.working_directory, "outputs")
+            if not os.path.exists(outputs_directory):
+                outputs_directory = job_wrapper.working_directory
+
+            tool_stdout_path = os.path.join(outputs_directory, "tool_stdout")
+            tool_stderr_path = os.path.join(outputs_directory, "tool_stderr")
             # TODO: These might not exist for running jobs at the upgrade to 19.XX, remove that
             # assumption in 20.XX.
             if os.path.exists(tool_stdout_path):

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -36,6 +36,7 @@ from galaxy.tools.wrappers import (
 )
 from galaxy.util import (
     find_instance_nested,
+    safe_makedirs,
     unicodify,
 )
 from galaxy.util.bunch import Bunch
@@ -525,7 +526,9 @@ class ToolEvaluator(object):
         for name, filename, content in self.tool.config_files:
             config_text, is_template = self.__build_config_file_text(content)
             # If a particular filename was forced by the config use it
-            directory = self.local_working_directory
+            directory = os.path.join(self.local_working_directory, "configs")
+            if not os.path.exists(directory):
+                os.makedirs(directory)
             if filename is not None:
                 config_filename = os.path.join(directory, filename)
             else:
@@ -601,6 +604,9 @@ class ToolEvaluator(object):
         return json.dumps(wrapped_json.json_wrap(self.tool.inputs, self.param_dict, handle_files=handle_files)), False
 
     def __write_workdir_file(self, config_filename, content, context, is_template=True, strip=False):
+        parent_dir = os.path.dirname(config_filename)
+        if not os.path.exists(parent_dir):
+            safe_makedirs(parent_dir)
         if is_template:
             value = fill_template(content, context=context, python_template_version=self.tool.python_template_version)
         else:

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -46,7 +46,7 @@ class TestCommandFactory(TestCase):
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
         self.__assert_command_is(_surround_command(
-            "%s %s/tool_script.sh > ../tool_stdout 2> ../tool_stderr; return_code=$?" % (
+            "%s %s/tool_script.sh > ../outputs/tool_stdout 2> ../outputs/tool_stderr; return_code=$?" % (
                 self.job_wrapper.shell,
                 self.job_wrapper.working_directory,
             )))
@@ -157,7 +157,7 @@ class TestCommandFactory(TestCase):
 
 
 def _surround_command(command):
-    return '''rm -rf working; mkdir -p working; cd working; %s; sh -c "exit $return_code"''' % command
+    return '''rm -rf working outputs; mkdir -p working outputs; cd working; %s; sh -c "exit $return_code"''' % command
 
 
 class MockJobWrapper(object):

--- a/test/unit/tools/test_evaluation.py
+++ b/test/unit/tools/test_evaluation.py
@@ -126,7 +126,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         config_filename = extra_filenames[0]
         config_basename = os.path.basename(config_filename)
         # Verify config file written into working directory.
-        self.assertEqual(os.path.join(self.test_directory, config_basename), config_filename)
+        self.assertEqual(os.path.join(self.test_directory, "configs", config_basename), config_filename)
         # Verify config file contents are evaluated against parameters.
         assert open(config_filename, "r").read() == "4"
         self.assertEqual(command_line, "prog1 %s" % config_filename)


### PR DESCRIPTION
More structured job directories aligned with Pulsar with real ramifications in terms of job isolation & security. The tool container shouldn't be expected to mount the job directory read-write - creating an outputs directory like used by Pulsar is a way around this - only the outputs and working directory will need to be mounted rw. This will also allow Pulsar to read these files when doing extended metadata collection remotely - since Pulsar won't default to mounting this directory read-write.