### PR TITLE
Allow admins to disable the visualizations tab in the masthead

### DIFF
--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -66,24 +66,26 @@ const Collection = Backbone.Collection.extend({
         //
         // Visualization tab.
         //
-        this.add({
-            id: "visualization",
-            title: _l("Visualize"),
-            tooltip: _l("Visualize datasets"),
-            disabled: !Galaxy.user.id,
-            menu: [
-                {
-                    title: _l("Create Visualization"),
-                    url: "visualizations",
-                    target: "__use_router__"
-                },
-                {
-                    title: _l("Interactive Environments"),
-                    url: "visualization/gie_list",
-                    target: "galaxy_main"
-                }
-            ]
-        });
+        if (Galaxy.config.visualizations_visible) {
+            this.add({
+                id: "visualization",
+                title: _l("Visualize"),
+                tooltip: _l("Visualize datasets"),
+                disabled: !Galaxy.user.id,
+                menu: [
+                    {
+                        title: _l("Create Visualization"),
+                        url: "visualizations",
+                        target: "__use_router__"
+                    },
+                    {
+                        title: _l("Interactive Environments"),
+                        url: "visualization/gie_list",
+                        target: "galaxy_main"
+                    }
+                ]
+            });
+        }
 
         //
         // 'Shared Items' or Libraries tab.

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -299,14 +299,16 @@ const Collection = Backbone.Collection.extend({
                         title: _l("Pages"),
                         url: "pages/list",
                         target: "__use_router__"
-                    },
-                    {
-                        title: _l("Visualizations"),
-                        url: "visualizations/list",
-                        target: "__use_router__"
                     }
                 ]
             };
+            if (Galaxy.config.visualizations_visible) {
+                userTab.menu.push({
+                    title: _l("Visualizations"),
+                    url: "visualizations/list",
+                    target: "__use_router__"
+                });
+            }
         }
         this.add(userTab);
         return new $.Deferred().resolve().promise();

--- a/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
@@ -264,8 +264,14 @@ var DatasetListItemEdit = _super.extend(
         _renderVisualizationsButton: function() {
             //TODO: someday - lazyload visualizations
             const Galaxy = getGalaxyInstance();
-            let visualizations = this.model.get("visualizations");
-            if (!Galaxy.config.visualizations_visible || this.model.isDeletedOrPurged() || !this.hasUser || !this.model.hasData() || _.isEmpty(visualizations)) {
+            const visualizations = this.model.get("visualizations");
+            if (
+                !Galaxy.config.visualizations_visible ||
+                this.model.isDeletedOrPurged() ||
+                !this.hasUser ||
+                !this.model.hasData() ||
+                _.isEmpty(visualizations)
+            ) {
                 return null;
             }
             if (!_.isObject(visualizations[0])) {

--- a/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
@@ -263,15 +263,15 @@ var DatasetListItemEdit = _super.extend(
         /** Render an icon-button or popupmenu of links based on the applicable visualizations */
         _renderVisualizationsButton: function() {
             //TODO: someday - lazyload visualizations
-            var visualizations = this.model.get("visualizations");
-            if (this.model.isDeletedOrPurged() || !this.hasUser || !this.model.hasData() || _.isEmpty(visualizations)) {
+            const Galaxy = getGalaxyInstance();
+            let visualizations = this.model.get("visualizations");
+            if (!Galaxy.config.visualizations_visible || this.model.isDeletedOrPurged() || !this.hasUser || !this.model.hasData() || _.isEmpty(visualizations)) {
                 return null;
             }
             if (!_.isObject(visualizations[0])) {
                 this.warn("Visualizations have been switched off");
                 return null;
             }
-
             if (visualizations.length >= 1) {
                 const dsid = this.model.get("id");
                 const url = getAppRoot() + "visualizations?dataset_id=" + dsid;
@@ -281,7 +281,6 @@ var DatasetListItemEdit = _super.extend(
                     classes: "visualization-link",
                     faIcon: "fa-bar-chart-o",
                     onclick: ev => {
-                        const Galaxy = getGalaxyInstance();
                         if (Galaxy.frame && Galaxy.frame.active) {
                             ev.preventDefault();
                             Galaxy.frame.add({ url: url, title: "Visualization" });

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1211,6 +1211,16 @@
 :Type: bool
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+``visualizations_visible``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Show visualization tab in masthead.
+:Default: ``true``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~
 ``message_box_visible``
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1216,7 +1216,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Show visualization tab in masthead.
+    Show visualization tab and list in masthead.
 :Default: ``true``
 :Type: bool
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -489,6 +489,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.brand = kwargs.get('brand', None)
         self.welcome_url = kwargs.get('welcome_url', '/static/welcome.html')
         self.show_welcome_with_login = string_as_bool(kwargs.get("show_welcome_with_login", "False"))
+        self.visualizations_visible = string_as_bool(kwargs.get('visualizations_visible', True))
         # Configuration for the message box directly below the masthead.
         self.message_box_visible = string_as_bool(kwargs.get('message_box_visible', False))
         self.message_box_content = kwargs.get('message_box_content', None)

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -657,6 +657,9 @@ galaxy:
   # third-party server, tricking a Galaxy user to access said site.
   #enable_old_display_applications: true
 
+  # Show visualization tab in masthead.
+  #visualizations_visible: true
+
   # Show a message box under the masthead.
   #message_box_visible: false
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -657,7 +657,7 @@ galaxy:
   # third-party server, tricking a Galaxy user to access said site.
   #enable_old_display_applications: true
 
-  # Show visualization tab in masthead.
+  # Show visualization tab and list in masthead.
   #visualizations_visible: true
 
   # Show a message box under the masthead.

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -78,6 +78,7 @@ class ConfigSerializer(base.ModelSerializer):
             'version_major'                     : _defaults_to(None),
             'require_login'                     : _defaults_to(None),
             'inactivity_box_content'            : _defaults_to(None),
+            'visualizations_visible'            : _defaults_to(True),
             'message_box_content'               : _defaults_to(None),
             'message_box_visible'               : _defaults_to(False),
             'message_box_class'                 : _defaults_to('info'),

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -914,7 +914,7 @@ mapping:
         default: true
         required: false
         desc: |
-          Show visualization tab in masthead.
+          Show visualization tab and list in masthead.
 
       message_box_visible:
         type: bool

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -909,6 +909,13 @@ mapping:
           Galaxy server, but contains a redirect to a third-party server, tricking a
           Galaxy user to access said site.
 
+      visualizations_visible:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          Show visualization tab in masthead.
+
       message_box_visible:
         type: bool
         default: false


### PR DESCRIPTION
This PR enables administrators to disable the visualizations tab in the masthead by adding a new configuration attribute to the config schema: `visualizations_visible`. It is optional and defaults to `True`. Adding this feature is part of our effort to enable interface customization and feature control for a given Galaxy instance.