### PR TITLE
fix memory statement for drmaa (SGE/UNIVA)

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT.sh
@@ -2,7 +2,7 @@ if [ -n "$SLURM_JOB_ID" ]; then
     GALAXY_MEMORY_MB=`scontrol -do show job "$SLURM_JOB_ID" | sed 's/.*\( \|^\)Mem=\([0-9][0-9]*\)\( \|$\).*/\2/p;d'` 2>memory_statement.log
 fi
 if [ -n "$SGE_HGR_h_vmem" ]; then
-    GALAXY_MEMORY_MB_PER_SLOT=`echo "$SGE_HGR_h_vmem" | sed 's/G$/ * 1024/' | bc | cut -d"." -f1` 2>memory_statement.log
+    GALAXY_MEMORY_MB=`echo "$SGE_HGR_h_vmem" | sed 's/G$/ * 1024/' | bc | cut -d"." -f1` 2>memory_statement.log
 fi
 
 if [ -z "$GALAXY_MEMORY_MB_PER_SLOT" -a -n "$GALAXY_MEMORY_MB" ]; then


### PR DESCRIPTION
The environment variable `SGE_HGR_h_vmem` turns out to be the total memory for all slots (cores).

In the original implementation I was unfortunatelly tricked by the fact that the resource request parameter `-l h_vmem` needs to be specified per core.