### PR TITLE
Add file extensions when downloading from data libraries

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -623,6 +623,9 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                 zpath = os.path.split(path)[-1]  # comes as base_name/fname
                 outfname, zpathext = os.path.splitext(zpath)
 
+                if zpathext == '':
+                    path = '.'.join([path, ldda.extension]) # Add extension if we don't have one
+
                 if is_composite:
                     # need to add all the components from the extra_files_path to the zip
                     if zpathext == '':
@@ -647,6 +650,8 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                         efp, fname = os.path.split(fpath)
                         if fname > '':
                             fname = fname.translate(trantab)
+                        if zpathext == '':
+                            fname = '.'.join([fname, ldda.extension])  # Add extension if we don't have one
                         try:
                             if format == 'zip':
                                 archive.add(fpath, fname)
@@ -702,7 +707,11 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                 fStat = os.stat(dataset.file_name)
                 trans.response.set_content_type(ldda.get_mime())
                 trans.response.headers['Content-Length'] = int(fStat.st_size)
-                fname = ldda.name
+                zname, zext = os.path.splitext(ldda.name)
+                if zext == '':
+                    fname = '.'.join([ldda.name, ldda.extension])
+                else:
+                    fname = ldda.name
                 fname = ''.join(c in util.FILENAME_VALID_CHARS and c or '_' for c in fname)[0:150]
                 trans.response.headers["Content-Disposition"] = 'attachment; filename="%s"' % fname
                 try:

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -619,12 +619,10 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                 path += ldda.name
                 while path in seen:
                     path += '_'
+                path = "{path}.{extension}".format(path=path, extension=ldda.extension)
                 seen.append(path)
                 zpath = os.path.split(path)[-1]  # comes as base_name/fname
                 outfname, zpathext = os.path.splitext(zpath)
-
-                if zpathext == '':
-                    path = '.'.join([path, ldda.extension])  # Add extension if we don't have one
 
                 if is_composite:
                     # need to add all the components from the extra_files_path to the zip
@@ -650,8 +648,6 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                         efp, fname = os.path.split(fpath)
                         if fname > '':
                             fname = fname.translate(trantab)
-                        if zpathext == '':
-                            fname = '.'.join([fname, ldda.extension])  # Add extension if we don't have one
                         try:
                             if format == 'zip':
                                 archive.add(fpath, fname)
@@ -707,11 +703,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                 fStat = os.stat(dataset.file_name)
                 trans.response.set_content_type(ldda.get_mime())
                 trans.response.headers['Content-Length'] = int(fStat.st_size)
-                zname, zext = os.path.splitext(ldda.name)
-                if zext == '':
-                    fname = '.'.join([ldda.name, ldda.extension])
-                else:
-                    fname = ldda.name
+                fname = "{path}.{extension}".format(path=ldda.name, extension=ldda.extension)
                 fname = ''.join(c in util.FILENAME_VALID_CHARS and c or '_' for c in fname)[0:150]
                 trans.response.headers["Content-Disposition"] = 'attachment; filename="%s"' % fname
                 try:

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -624,7 +624,7 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
                 outfname, zpathext = os.path.splitext(zpath)
 
                 if zpathext == '':
-                    path = '.'.join([path, ldda.extension]) # Add extension if we don't have one
+                    path = '.'.join([path, ldda.extension])  # Add extension if we don't have one
 
                 if is_composite:
                     # need to add all the components from the extra_files_path to the zip


### PR DESCRIPTION
Currently if the file was imported from the history and the dataset name didn't specify a file extension in there, it will download a file without a file extension.
In order to make it more convenient for the users, this adds the extension if possible.