### PR TITLE
Fix absolutely positioned elements and children from displaying off-screen.

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -105,6 +105,8 @@ body {
     @extend .d-flex;
     @extend .flex-column;
     @extend .full-content;
+    top: 0px;
+    left: 0px;
 }
 
 #columns {

--- a/templates/base/base_panels.mako
+++ b/templates/base/base_panels.mako
@@ -166,7 +166,7 @@
                 </div>
             </noscript>
         %endif
-        <div id="everything" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+        <div id="everything">
             
             ## Background displays first
             <div id="background"></div>


### PR DESCRIPTION
I came across this in dev, seems to have been broken in the style overhaul (specifically 308b376a77a67667ff86a456cc05daff0e72e5f2), but I'm wondering if this isn't something unique to my situation given nobody else noticed it?

Without this, my page layout looks like:

![image](https://user-images.githubusercontent.com/155398/63110065-9fc49a80-bf58-11e9-989b-400aa20386fe.png)

Note masthead off screen and `#everything` shifted up.