### PR TITLE
Fix MySQL database creation and migrations

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1161,8 +1161,7 @@ model.FormDefinition.table = Table(
     Column("update_time", DateTime, default=now, onupdate=now),
     Column("name", TrimmedString(255), nullable=False),
     Column("desc", TEXT),
-    Column("form_definition_current_id", Integer,
-        ForeignKey("form_definition_current.id", name='for_def_form_def_current_id_fk', use_alter=True), index=True),
+    Column("form_definition_current_id", Integer, ForeignKey("form_definition_current.id", use_alter=True), index=True, nullable=False),
     Column("fields", JSONType()),
     Column("type", TrimmedString(255), index=True),
     Column("layout", JSONType()))

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     false,
     ForeignKey,
     func,
+    Index,
     Integer,
     MetaData,
     not_,
@@ -198,8 +199,10 @@ model.History.table = Table(
     Column("importing", Boolean, index=True, default=False),
     Column("genome_build", TrimmedString(40)),
     Column("importable", Boolean, default=False),
-    Column("slug", TEXT, index=True),
-    Column("published", Boolean, index=True, default=False))
+    Column("slug", TEXT),
+    Column("published", Boolean, index=True, default=False),
+    Index('ix_history_slug', 'slug', mysql_length=200),
+)
 
 model.HistoryUserShareAssociation.table = Table(
     "history_user_share_association", metadata,
@@ -549,13 +552,15 @@ model.LibraryFolder.table = Table(
     Column("parent_id", Integer, ForeignKey("library_folder.id"), nullable=True, index=True),
     Column("create_time", DateTime, default=now),
     Column("update_time", DateTime, default=now, onupdate=now),
-    Column("name", TEXT, index=True),
+    Column("name", TEXT),
     Column("description", TEXT),
     Column("order_id", Integer),  # not currently being used, but for possible future use
     Column("item_count", Integer),
     Column("deleted", Boolean, index=True, default=False),
     Column("purged", Boolean, index=True, default=False),
-    Column("genome_build", TrimmedString(40)))
+    Column("genome_build", TrimmedString(40)),
+    Index('ix_library_folder_name', 'name', mysql_length=200),
+)
 
 model.LibraryInfoAssociation.table = Table(
     "library_info_association", metadata,
@@ -940,9 +945,11 @@ model.StoredWorkflow.table = Table(
     Column("name", TEXT),
     Column("deleted", Boolean, default=False),
     Column("importable", Boolean, default=False),
-    Column("slug", TEXT, index=True),
-    Column("from_path", TEXT, index=True),
-    Column("published", Boolean, index=True, default=False))
+    Column("slug", TEXT),
+    Column("from_path", TEXT),
+    Column("published", Boolean, index=True, default=False),
+    Index('ix_stored_workflow_slug', 'slug', mysql_length=200),
+)
 
 model.Workflow.table = Table(
     "workflow", metadata,
@@ -990,7 +997,7 @@ model.WorkflowStepInput.table = Table(
     Column("default_value", JSONType),
     Column("default_value_set", Boolean, default=False),
     Column("runtime_value", Boolean, default=False),
-    UniqueConstraint("workflow_step_id", "name"),
+    Index('ix_workflow_step_input_workflow_step_id_name_unique', "workflow_step_id", "name", unique=True, mysql_length={'name': 200}),
 )
 
 
@@ -1081,18 +1088,18 @@ model.WorkflowInvocationOutputDatasetAssociation.table = Table(
     "workflow_invocation_output_dataset_association", metadata,
     Column("id", Integer, primary_key=True),
     Column("workflow_invocation_id", Integer, ForeignKey("workflow_invocation.id"), index=True),
-    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id"), index=True),
+    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id")),
     Column("dataset_id", Integer, ForeignKey("history_dataset_association.id"), index=True),
-    Column("workflow_output_id", Integer, ForeignKey("workflow_output.id"), index=True),
+    Column("workflow_output_id", Integer, ForeignKey("workflow_output.id")),
 )
 
 model.WorkflowInvocationOutputDatasetCollectionAssociation.table = Table(
     "workflow_invocation_output_dataset_collection_association", metadata,
     Column("id", Integer, primary_key=True),
-    Column("workflow_invocation_id", Integer, ForeignKey("workflow_invocation.id"), index=True),
-    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id"), index=True),
-    Column("dataset_collection_id", Integer, ForeignKey("history_dataset_collection_association.id"), index=True),
-    Column("workflow_output_id", Integer, ForeignKey("workflow_output.id"), index=True),
+    Column("workflow_invocation_id", Integer, ForeignKey("workflow_invocation.id", name='fk_wiodca_wii'), index=True),
+    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id", name='fk_wiodca_wsi')),
+    Column("dataset_collection_id", Integer, ForeignKey("history_dataset_collection_association.id", name='fk_wiodca_dci'), index=True),
+    Column("workflow_output_id", Integer, ForeignKey("workflow_output.id", name='fk_wiodca_woi')),
 )
 
 model.WorkflowInvocationStepOutputDatasetAssociation.table = Table(
@@ -1106,18 +1113,18 @@ model.WorkflowInvocationStepOutputDatasetAssociation.table = Table(
 model.WorkflowInvocationStepOutputDatasetCollectionAssociation.table = Table(
     "workflow_invocation_step_output_dataset_collection_association", metadata,
     Column("id", Integer, primary_key=True),
-    Column("workflow_invocation_step_id", Integer, ForeignKey("workflow_invocation_step.id"), index=True),
-    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id"), index=True),
-    Column("dataset_collection_id", Integer, ForeignKey("history_dataset_collection_association.id"), index=True),
+    Column("workflow_invocation_step_id", Integer, ForeignKey("workflow_invocation_step.id", name='fk_wisodca_wisi'), index=True),
+    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id", name='fk_wisodca_wsi')),
+    Column("dataset_collection_id", Integer, ForeignKey("history_dataset_collection_association.id", name='fk_wisodca_dci'), index=True),
     Column("output_name", String(255), nullable=True),
 )
 
 model.WorkflowInvocationToSubworkflowInvocationAssociation.table = Table(
     "workflow_invocation_to_subworkflow_invocation_association", metadata,
     Column("id", Integer, primary_key=True),
-    Column("workflow_invocation_id", Integer, ForeignKey("workflow_invocation.id"), index=True),
-    Column("subworkflow_invocation_id", Integer, ForeignKey("workflow_invocation.id"), index=True),
-    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id")),
+    Column("workflow_invocation_id", Integer, ForeignKey("workflow_invocation.id", name='fk_wfi_swi_wfi'), index=True),
+    Column("subworkflow_invocation_id", Integer, ForeignKey("workflow_invocation.id", name='fk_wfi_swi_swi'), index=True),
+    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id", name='fk_wfi_swi_ws')),
 )
 
 model.StoredWorkflowUserShareAssociation.table = Table(
@@ -1185,8 +1192,10 @@ model.Page.table = Table(
     Column("title", TEXT),
     Column("deleted", Boolean, index=True, default=False),
     Column("importable", Boolean, index=True, default=False),
-    Column("slug", TEXT, unique=True, index=True),
-    Column("published", Boolean, index=True, default=False))
+    Column("slug", TEXT),
+    Column("published", Boolean, index=True, default=False),
+    Index('ix_page_slug', 'slug', mysql_length=200),
+)
 
 model.PageRevision.table = Table(
     "page_revision", metadata,
@@ -1213,11 +1222,14 @@ model.Visualization.table = Table(
         ForeignKey("visualization_revision.id", use_alter=True, name='visualization_latest_revision_id_fk'), index=True),
     Column("title", TEXT),
     Column("type", TEXT),
-    Column("dbkey", TEXT, index=True),
+    Column("dbkey", TEXT),
     Column("deleted", Boolean, default=False, index=True),
     Column("importable", Boolean, default=False, index=True),
-    Column("slug", TEXT, index=True),
-    Column("published", Boolean, default=False, index=True))
+    Column("slug", TEXT),
+    Column("published", Boolean, default=False, index=True),
+    Index('ix_visualization_dbkey', 'dbkey', mysql_length=200),
+    Index('ix_visualization_slug', 'slug', mysql_length=200),
+)
 
 model.VisualizationRevision.table = Table(
     "visualization_revision", metadata,
@@ -1226,8 +1238,10 @@ model.VisualizationRevision.table = Table(
     Column("update_time", DateTime, default=now, onupdate=now),
     Column("visualization_id", Integer, ForeignKey("visualization.id"), index=True, nullable=False),
     Column("title", TEXT),
-    Column("dbkey", TEXT, index=True),
-    Column("config", JSONType))
+    Column("dbkey", TEXT),
+    Column("config", JSONType),
+    Index('ix_visualization_revision_dbkey', 'dbkey', mysql_length=200),
+)
 
 model.VisualizationUserShareAssociation.table = Table(
     "visualization_user_share_association", metadata,
@@ -1250,7 +1264,9 @@ model.DataManagerJobAssociation.table = Table(
     Column("create_time", DateTime, default=now),
     Column("update_time", DateTime, index=True, default=now, onupdate=now),
     Column("job_id", Integer, ForeignKey("job.id"), index=True),
-    Column("data_manager_id", TEXT, index=True))
+    Column("data_manager_id", TEXT),
+    Index('ix_data_manager_job_association_data_manager_id', 'data_manager_id', mysql_length=200),
+)
 
 # Tagging tables.
 model.Tag.table = Table(
@@ -1380,7 +1396,9 @@ model.HistoryAnnotationAssociation.table = Table(
     Column("id", Integer, primary_key=True),
     Column("history_id", Integer, ForeignKey("history.id"), index=True),
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-    Column("annotation", TEXT, index=True))
+    Column("annotation", TEXT),
+    Index('ix_history_anno_assoc_annotation', 'annotation', mysql_length=200),
+)
 
 model.HistoryDatasetAssociationAnnotationAssociation.table = Table(
     "history_dataset_association_annotation_association", metadata,
@@ -1388,35 +1406,45 @@ model.HistoryDatasetAssociationAnnotationAssociation.table = Table(
     Column("history_dataset_association_id", Integer,
         ForeignKey("history_dataset_association.id"), index=True),
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-    Column("annotation", TEXT, index=True))
+    Column("annotation", TEXT),
+    Index('ix_history_dataset_anno_assoc_annotation', 'annotation', mysql_length=200),
+)
 
 model.StoredWorkflowAnnotationAssociation.table = Table(
     "stored_workflow_annotation_association", metadata,
     Column("id", Integer, primary_key=True),
     Column("stored_workflow_id", Integer, ForeignKey("stored_workflow.id"), index=True),
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-    Column("annotation", TEXT, index=True))
+    Column("annotation", TEXT),
+    Index('ix_stored_workflow_ann_assoc_annotation', 'annotation', mysql_length=200),
+)
 
 model.WorkflowStepAnnotationAssociation.table = Table(
     "workflow_step_annotation_association", metadata,
     Column("id", Integer, primary_key=True),
     Column("workflow_step_id", Integer, ForeignKey("workflow_step.id"), index=True),
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-    Column("annotation", TEXT, index=True))
+    Column("annotation", TEXT),
+    Index('ix_workflow_step_ann_assoc_annotation', 'annotation', mysql_length=200),
+)
 
 model.PageAnnotationAssociation.table = Table(
     "page_annotation_association", metadata,
     Column("id", Integer, primary_key=True),
     Column("page_id", Integer, ForeignKey("page.id"), index=True),
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-    Column("annotation", TEXT, index=True))
+    Column("annotation", TEXT),
+    Index('ix_page_annotation_association_annotation', 'annotation', mysql_length=200),
+)
 
 model.VisualizationAnnotationAssociation.table = Table(
     "visualization_annotation_association", metadata,
     Column("id", Integer, primary_key=True),
     Column("visualization_id", Integer, ForeignKey("visualization.id"), index=True),
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-    Column("annotation", TEXT, index=True))
+    Column("annotation", TEXT),
+    Index('ix_visualization_annotation_association_annotation', 'annotation', mysql_length=200),
+)
 
 model.HistoryDatasetCollectionAssociationAnnotationAssociation.table = Table(
     "history_dataset_collection_annotation_association", metadata,
@@ -1424,7 +1452,8 @@ model.HistoryDatasetCollectionAssociationAnnotationAssociation.table = Table(
     Column("history_dataset_collection_id", Integer,
         ForeignKey("history_dataset_collection_association.id"), index=True),
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-    Column("annotation", TEXT, index=True))
+    Column("annotation", TEXT),
+)
 
 model.LibraryDatasetCollectionAnnotationAssociation.table = Table(
     "library_dataset_collection_annotation_association", metadata,
@@ -1432,7 +1461,8 @@ model.LibraryDatasetCollectionAnnotationAssociation.table = Table(
     Column("library_dataset_collection_id", Integer,
         ForeignKey("library_dataset_collection_association.id"), index=True),
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-    Column("annotation", TEXT, index=True))
+    Column("annotation", TEXT),
+)
 
 # Ratings tables.
 model.HistoryRatingAssociation.table = Table("history_rating_association", metadata,

--- a/lib/galaxy/model/migrate/check.py
+++ b/lib/galaxy/model/migrate/check.py
@@ -62,16 +62,16 @@ def create_or_verify_database(url, galaxy_config_file, engine_options={}, app=No
         migrate_to_current_version(engine, db_schema)
 
     meta = MetaData(bind=engine)
-    if new_database and app:
+    if new_database:
         log.info("Creating new database from scratch, skipping migrations")
         current_version = migrate_repository.version().version
-        mapping.init(file_path=app.config.file_path, url=url, map_install_models=map_install_models, create_tables=True)
+        mapping.init(file_path='/tmp', url=url, map_install_models=map_install_models, create_tables=True)
         schema.ControlledSchema.create(engine, migrate_repository, version=current_version)
         db_schema = schema.ControlledSchema(engine, migrate_repository)
         assert db_schema.version == current_version
         migrate()
         return
-    elif getattr(app.config, 'database_auto_migrate', False):
+    elif app and getattr(app.config, 'database_auto_migrate', False):
         migrate()
         return
 

--- a/lib/galaxy/model/migrate/versions/0001_initial_tables.py
+++ b/lib/galaxy/model/migrate/versions/0001_initial_tables.py
@@ -1,13 +1,30 @@
+from __future__ import print_function
+
 import datetime
 import logging
 
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, Numeric, String, Table, TEXT
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Numeric,
+    String,
+    Table,
+    TEXT
+)
 
 # Need our custom types, but don't import anything else from model
-from galaxy.model.custom_types import JSONType, MetadataType, TrimmedString
+from galaxy.model.custom_types import (
+    JSONType,
+    MetadataType,
+    TrimmedString
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 # Tables as of changeset 1464:c7acaa1bb88f
@@ -197,5 +214,6 @@ StoredWorkflowMenuEntry_table = Table("stored_workflow_menu_entry", metadata,
 
 
 def upgrade(migrate_engine):
+    print(__doc__)
     metadata.bind = migrate_engine
     metadata.create_all()

--- a/lib/galaxy/model/migrate/versions/0002_metadata_file_table.py
+++ b/lib/galaxy/model/migrate/versions/0002_metadata_file_table.py
@@ -1,14 +1,28 @@
 """
 """
+from __future__ import print_function
+
 import datetime
 import logging
 
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, Table, TEXT
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table,
+    TEXT
+)
 
-from galaxy.model.migrate.versions.util import create_table, drop_table
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 # New table in changeset 1568:0b022adfdc34
@@ -23,6 +37,7 @@ MetadataFile_table = Table("metadata_file", metadata,
 
 
 def upgrade(migrate_engine):
+    print(__doc__)
     metadata.bind = migrate_engine
     metadata.reflect()
 

--- a/lib/galaxy/model/migrate/versions/0003_security_and_libraries.py
+++ b/lib/galaxy/model/migrate/versions/0003_security_and_libraries.py
@@ -331,9 +331,9 @@ def upgrade(migrate_engine):
     # Add 2 new columns to the galaxy_user table
     User_table = Table("galaxy_user", metadata, autoload=True)
     col = Column('deleted', Boolean, index=True, default=False)
-    add_column(col, User_table, index_name='ix_galaxy_user_deleted')
+    add_column(col, User_table, metadata, index_name='ix_galaxy_user_deleted')
     col = Column('purged', Boolean, index=True, default=False)
-    add_column(col, User_table, index_name='ix_galaxy_user_purged')
+    add_column(col, User_table, metadata, index_name='ix_galaxy_user_purged')
     # Add 1 new column to the history_dataset_association table
     HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
     col = Column('copied_from_library_dataset_dataset_association_id', Integer, nullable=True)

--- a/lib/galaxy/model/migrate/versions/0003_security_and_libraries.py
+++ b/lib/galaxy/model/migrate/versions/0003_security_and_libraries.py
@@ -1,32 +1,42 @@
 """
 """
+from __future__ import print_function
+
 import datetime
 import logging
-import sys
 
 from migrate import ForeignKeyConstraint
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, MetaData, String, Table, TEXT
-from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    TEXT
+)
 
-from galaxy.model.custom_types import JSONType, MetadataType, TrimmedString
+from galaxy.model.custom_types import (
+    JSONType,
+    MetadataType,
+    TrimmedString
+)
 from galaxy.model.migrate.versions.util import (
     add_column,
     add_index,
+    drop_column,
     drop_index,
+    drop_table,
     engine_false,
     localtimestamp,
     nextval
 )
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 # New tables as of changeset 2341:5498ac35eedd
@@ -314,108 +324,57 @@ Index("ix_jeom_library_dataset_dataset_association_id", JobExternalOutputMetadat
 
 
 def upgrade(migrate_engine):
+    print(__doc__)
     metadata.bind = migrate_engine
     metadata.reflect()
 
     # Add 2 new columns to the galaxy_user table
-    try:
-        User_table = Table("galaxy_user", metadata, autoload=True)
-    except NoSuchTableError:
-        User_table = None
-        log.debug("Failed loading table galaxy_user")
-    if User_table is not None:
-        col = Column('deleted', Boolean, index=True, default=False)
-        add_column(col, User_table, index_name='ix_galaxy_user_deleted')
-        col = Column('purged', Boolean, index=True, default=False)
-        add_column(col, User_table, index_name='ix_galaxy_user_purged')
+    User_table = Table("galaxy_user", metadata, autoload=True)
+    col = Column('deleted', Boolean, index=True, default=False)
+    add_column(col, User_table, index_name='ix_galaxy_user_deleted')
+    col = Column('purged', Boolean, index=True, default=False)
+    add_column(col, User_table, index_name='ix_galaxy_user_purged')
     # Add 1 new column to the history_dataset_association table
-    try:
-        HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
-    except NoSuchTableError:
-        HistoryDatasetAssociation_table = None
-        log.debug("Failed loading table history_dataset_association")
-    if HistoryDatasetAssociation_table is not None:
-        try:
-            col = Column('copied_from_library_dataset_dataset_association_id', Integer, nullable=True)
-            col.create(HistoryDatasetAssociation_table)
-            assert col is HistoryDatasetAssociation_table.c.copied_from_library_dataset_dataset_association_id
-        except Exception:
-            log.exception("Adding column 'copied_from_library_dataset_dataset_association_id' to history_dataset_association table failed.")
+    HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
+    col = Column('copied_from_library_dataset_dataset_association_id', Integer, nullable=True)
+    add_column(col, HistoryDatasetAssociation_table, metadata)
     # Add 1 new column to the metadata_file table
-    try:
-        MetadataFile_table = Table("metadata_file", metadata, autoload=True)
-    except NoSuchTableError:
-        MetadataFile_table = None
-        log.debug("Failed loading table metadata_file")
-    if MetadataFile_table is not None:
-        try:
-            col = Column('lda_id', Integer, index=True, nullable=True)
-            col.create(MetadataFile_table, index_name='ix_metadata_file_lda_id')
-            assert col is MetadataFile_table.c.lda_id
-        except Exception:
-            log.exception("Adding column 'lda_id' to metadata_file table failed.")
+    MetadataFile_table = Table("metadata_file", metadata, autoload=True)
+    col = Column('lda_id', Integer, index=True, nullable=True)
+    add_column(col, MetadataFile_table, metadata, index_name='ix_metadata_file_lda_id')
     # Add 1 new column to the stored_workflow table - changeset 2328
-    try:
-        StoredWorkflow_table = Table("stored_workflow", metadata,
-            Column("latest_workflow_id", Integer,
-                ForeignKey("workflow.id", use_alter=True, name='stored_workflow_latest_workflow_id_fk'), index=True),
-            autoload=True, extend_existing=True)
-    except NoSuchTableError:
-        StoredWorkflow_table = None
-        log.debug("Failed loading table stored_workflow")
-    if StoredWorkflow_table is not None:
-        try:
-            col = Column('importable', Boolean, default=False)
-            col.create(StoredWorkflow_table)
-            assert col is StoredWorkflow_table.c.importable
-        except Exception:
-            log.exception("Adding column 'importable' to stored_workflow table failed.")
+    StoredWorkflow_table = Table("stored_workflow", metadata,
+        Column("latest_workflow_id", Integer,
+            ForeignKey("workflow.id", use_alter=True, name='stored_workflow_latest_workflow_id_fk'), index=True),
+        autoload=True, extend_existing=True)
+    col = Column('importable', Boolean, default=False)
+    add_column(col, StoredWorkflow_table, metadata)
     # Create an index on the Job.state column - changeset 2192
     add_index('ix_job_state', 'job', 'state', metadata)
     # Add all of the new tables above
     metadata.create_all()
     # Add 1 foreign key constraint to the history_dataset_association table
+    LibraryDatasetDatasetAssociation_table = Table("library_dataset_dataset_association", metadata, autoload=True)
     try:
-        HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
-    except NoSuchTableError:
-        HistoryDatasetAssociation_table = None
-        log.debug("Failed loading table history_dataset_association")
-    try:
-        LibraryDatasetDatasetAssociation_table = Table("library_dataset_dataset_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryDatasetDatasetAssociation_table = None
-        log.debug("Failed loading table library_dataset_dataset_association")
-    if HistoryDatasetAssociation_table is not None and LibraryDatasetDatasetAssociation_table is not None:
+        cons = ForeignKeyConstraint([HistoryDatasetAssociation_table.c.copied_from_library_dataset_dataset_association_id],
+                                    [LibraryDatasetDatasetAssociation_table.c.id],
+                                    name='history_dataset_association_copied_from_library_dataset_da_fkey')
+        # Create the constraint
+        cons.create()
+    except Exception:
+        log.exception("Adding foreign key constraint 'history_dataset_association_copied_from_library_dataset_da_fkey' to table 'history_dataset_association' failed.")
+    # Add 1 foreign key constraint to the metadata_file table
+    LibraryDatasetDatasetAssociation_table = Table("library_dataset_dataset_association", metadata, autoload=True)
+    if migrate_engine.name != 'sqlite':
+        # Sqlite can't alter table add foreign key.
         try:
-            cons = ForeignKeyConstraint([HistoryDatasetAssociation_table.c.copied_from_library_dataset_dataset_association_id],
+            cons = ForeignKeyConstraint([MetadataFile_table.c.lda_id],
                                         [LibraryDatasetDatasetAssociation_table.c.id],
-                                        name='history_dataset_association_copied_from_library_dataset_da_fkey')
+                                        name='metadata_file_lda_id_fkey')
             # Create the constraint
             cons.create()
         except Exception:
-            log.exception("Adding foreign key constraint 'history_dataset_association_copied_from_library_dataset_da_fkey' to table 'history_dataset_association' failed.")
-    # Add 1 foreign key constraint to the metadata_file table
-    try:
-        MetadataFile_table = Table("metadata_file", metadata, autoload=True)
-    except NoSuchTableError:
-        MetadataFile_table = None
-        log.debug("Failed loading table metadata_file")
-    try:
-        LibraryDatasetDatasetAssociation_table = Table("library_dataset_dataset_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryDatasetDatasetAssociation_table = None
-        log.debug("Failed loading table library_dataset_dataset_association")
-    if migrate_engine.name != 'sqlite':
-        # Sqlite can't alter table add foreign key.
-        if MetadataFile_table is not None and LibraryDatasetDatasetAssociation_table is not None:
-            try:
-                cons = ForeignKeyConstraint([MetadataFile_table.c.lda_id],
-                                            [LibraryDatasetDatasetAssociation_table.c.id],
-                                            name='metadata_file_lda_id_fkey')
-                # Create the constraint
-                cons.create()
-            except Exception:
-                log.exception("Adding foreign key constraint 'metadata_file_lda_id_fkey' to table 'metadata_file' failed.")
+            log.exception("Adding foreign key constraint 'metadata_file_lda_id_fkey' to table 'metadata_file' failed.")
     # Make sure we have at least 1 user
     cmd = "SELECT * FROM galaxy_user;"
     users = migrate_engine.execute(cmd).fetchall()
@@ -505,222 +464,72 @@ def downgrade(migrate_engine):
 
     # NOTE: all new data added in the upgrade method is eliminated here via table drops
     # Drop 1 foreign key constraint from the metadata_file table
+    MetadataFile_table = Table("metadata_file", metadata, autoload=True)
+    LibraryDatasetDatasetAssociation_table = Table("library_dataset_dataset_association", metadata, autoload=True)
     try:
-        MetadataFile_table = Table("metadata_file", metadata, autoload=True)
-    except NoSuchTableError:
-        MetadataFile_table = None
-        log.debug("Failed loading table metadata_file")
-    try:
-        LibraryDatasetDatasetAssociation_table = Table("library_dataset_dataset_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryDatasetDatasetAssociation_table = None
-        log.debug("Failed loading table library_dataset_dataset_association")
-    if MetadataFile_table is not None and LibraryDatasetDatasetAssociation_table is not None:
-        try:
-            cons = ForeignKeyConstraint([MetadataFile_table.c.lda_id],
-                                        [LibraryDatasetDatasetAssociation_table.c.id],
-                                        name='metadata_file_lda_id_fkey')
-            # Drop the constraint
-            cons.drop()
-        except Exception:
-            log.exception("Dropping foreign key constraint 'metadata_file_lda_id_fkey' from table 'metadata_file' failed.")
+        cons = ForeignKeyConstraint([MetadataFile_table.c.lda_id],
+                                    [LibraryDatasetDatasetAssociation_table.c.id],
+                                    name='metadata_file_lda_id_fkey')
+        # Drop the constraint
+        cons.drop()
+    except Exception:
+        log.exception("Dropping foreign key constraint 'metadata_file_lda_id_fkey' from table 'metadata_file' failed.")
     # Drop 1 foreign key constraint from the history_dataset_association table
+    HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
+    LibraryDatasetDatasetAssociation_table = Table("library_dataset_dataset_association", metadata, autoload=True)
     try:
-        HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
-    except NoSuchTableError:
-        HistoryDatasetAssociation_table = None
-        log.debug("Failed loading table history_dataset_association")
-    try:
-        LibraryDatasetDatasetAssociation_table = Table("library_dataset_dataset_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryDatasetDatasetAssociation_table = None
-        log.debug("Failed loading table library_dataset_dataset_association")
-    if HistoryDatasetAssociation_table is not None and LibraryDatasetDatasetAssociation_table is not None:
-        try:
-            cons = ForeignKeyConstraint([HistoryDatasetAssociation_table.c.copied_from_library_dataset_dataset_association_id],
-                                        [LibraryDatasetDatasetAssociation_table.c.id],
-                                        name='history_dataset_association_copied_from_library_dataset_da_fkey')
-            # Drop the constraint
-            cons.drop()
-        except Exception:
-            log.exception("Dropping foreign key constraint 'history_dataset_association_copied_from_library_dataset_da_fkey' from table 'history_dataset_association' failed.")
+        cons = ForeignKeyConstraint([HistoryDatasetAssociation_table.c.copied_from_library_dataset_dataset_association_id],
+                                    [LibraryDatasetDatasetAssociation_table.c.id],
+                                    name='history_dataset_association_copied_from_library_dataset_da_fkey')
+        # Drop the constraint
+        cons.drop()
+    except Exception:
+        log.exception("Dropping foreign key constraint 'history_dataset_association_copied_from_library_dataset_da_fkey' from table 'history_dataset_association' failed.")
     # Drop all of the new tables above
-    try:
-        UserGroupAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping user_group_association table failed.")
-    try:
-        UserRoleAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping user_role_association table failed.")
-    try:
-        GroupRoleAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping group_role_association table failed.")
-    try:
-        Group_table.drop()
-    except Exception:
-        log.exception("Dropping galaxy_group table failed.")
-    try:
-        DatasetPermissions_table.drop()
-    except Exception:
-        log.exception("Dropping dataset_permissions table failed.")
-    try:
-        LibraryPermissions_table.drop()
-    except Exception:
-        log.exception("Dropping library_permissions table failed.")
-    try:
-        LibraryFolderPermissions_table.drop()
-    except Exception:
-        log.exception("Dropping library_folder_permissions table failed.")
-    try:
-        LibraryDatasetPermissions_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset_permissions table failed.")
-    try:
-        LibraryDatasetDatasetAssociationPermissions_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset_dataset_association_permissions table failed.")
-    try:
-        LibraryItemInfoPermissions_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info_permissions table failed.")
-    try:
-        LibraryItemInfoTemplatePermissions_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info_template_permissions table failed.")
-    try:
-        DefaultUserPermissions_table.drop()
-    except Exception:
-        log.exception("Dropping default_user_permissions table failed.")
-    try:
-        DefaultHistoryPermissions_table.drop()
-    except Exception:
-        log.exception("Dropping default_history_permissions table failed.")
-    try:
-        Role_table.drop()
-    except Exception:
-        log.exception("Dropping role table failed.")
-    try:
-        LibraryDatasetDatasetInfoAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset_dataset_info_association table failed.")
-    try:
-        LibraryDataset_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset table failed.")
-    try:
-        LibraryDatasetDatasetAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset_dataset_association table failed.")
-    try:
-        LibraryDatasetDatasetInfoTemplateAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset_dataset_info_template_association table failed.")
-    try:
-        JobExternalOutputMetadata_table.drop()
-    except Exception:
-        log.exception("Dropping job_external_output_metadata table failed.")
-    try:
-        Library_table.drop()
-    except Exception:
-        log.exception("Dropping library table failed.")
-    try:
-        LibraryFolder_table.drop()
-    except Exception:
-        log.exception("Dropping library_folder table failed.")
-    try:
-        LibraryItemInfoTemplateElement_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info_template_element table failed.")
-    try:
-        LibraryInfoTemplateAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_info_template_association table failed.")
-    try:
-        LibraryFolderInfoTemplateAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_folder_info_template_association table failed.")
-    try:
-        LibraryDatasetInfoTemplateAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset_info_template_association table failed.")
-    try:
-        LibraryInfoAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_info_association table failed.")
-    try:
-        LibraryFolderInfoAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_folder_info_association table failed.")
-    try:
-        LibraryDatasetInfoAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset_info_association table failed.")
-    try:
-        LibraryItemInfoElement_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info_element table failed.")
-    try:
-        LibraryItemInfo_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info table failed.")
-    try:
-        LibraryItemInfoTemplate_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info_template table failed.")
+    TABLES = [
+        UserGroupAssociation_table,
+        UserRoleAssociation_table,
+        GroupRoleAssociation_table,
+        Group_table,
+        DatasetPermissions_table,
+        LibraryPermissions_table,
+        LibraryFolderPermissions_table,
+        LibraryDatasetPermissions_table,
+        LibraryDatasetDatasetAssociationPermissions_table,
+        LibraryItemInfoPermissions_table,
+        LibraryItemInfoTemplatePermissions_table,
+        DefaultUserPermissions_table,
+        DefaultHistoryPermissions_table,
+        Role_table,
+        LibraryDatasetDatasetInfoAssociation_table,
+        LibraryDataset_table,
+        LibraryDatasetDatasetAssociation_table,
+        LibraryDatasetDatasetInfoTemplateAssociation_table,
+        JobExternalOutputMetadata_table,
+        Library_table,
+        LibraryFolder_table,
+        LibraryItemInfoTemplateElement_table,
+        LibraryInfoTemplateAssociation_table,
+        LibraryFolderInfoTemplateAssociation_table,
+        LibraryDatasetInfoTemplateAssociation_table,
+        LibraryInfoAssociation_table,
+        LibraryFolderInfoAssociation_table,
+        LibraryDatasetInfoAssociation_table,
+        LibraryItemInfoElement_table,
+        LibraryItemInfo_table,
+        LibraryItemInfoTemplate_table,
+    ]
+    for table in TABLES:
+        drop_table(table)
     # Drop the index on the Job.state column - changeset 2192
     drop_index('ix_job_state', 'job', 'state', metadata)
     # Drop 1 column from the stored_workflow table - changeset 2328
-    try:
-        StoredWorkflow_table = Table("stored_workflow", metadata, autoload=True)
-    except NoSuchTableError:
-        StoredWorkflow_table = None
-        log.debug("Failed loading table stored_workflow")
-    if StoredWorkflow_table is not None:
-        try:
-            col = StoredWorkflow_table.c.importable
-            col.drop()
-        except Exception:
-            log.exception("Dropping column 'importable' from stored_workflow table failed.")
+    drop_column('importable', 'stored_workflow', metadata)
     # Drop 1 column from the metadata_file table
-    try:
-        MetadataFile_table = Table("metadata_file", metadata, autoload=True)
-    except NoSuchTableError:
-        MetadataFile_table = None
-        log.debug("Failed loading table metadata_file")
-    if MetadataFile_table is not None:
-        try:
-            col = MetadataFile_table.c.lda_id
-            col.drop()
-        except Exception:
-            log.exception("Dropping column 'lda_id' from metadata_file table failed.")
+    drop_column('lda_id', 'metadata_file', metadata)
     # Drop 1 column from the history_dataset_association table
-    try:
-        HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
-    except NoSuchTableError:
-        HistoryDatasetAssociation_table = None
-        log.debug("Failed loading table history_dataset_association")
-    if HistoryDatasetAssociation_table is not None:
-        try:
-            col = HistoryDatasetAssociation_table.c.copied_from_library_dataset_dataset_association_id
-            col.drop()
-        except Exception:
-            log.exception("Dropping column 'copied_from_library_dataset_dataset_association_id' from history_dataset_association table failed.")
+    drop_column('copied_from_library_dataset_dataset_association_id', HistoryDatasetAssociation_table)
     # Drop 2 columns from the galaxy_user table
-    try:
-        User_table = Table("galaxy_user", metadata, autoload=True)
-    except NoSuchTableError:
-        User_table = None
-        log.debug("Failed loading table galaxy_user")
-    if User_table is not None:
-        try:
-            col = User_table.c.deleted
-            col.drop()
-        except Exception:
-            log.exception("Dropping column 'deleted' from galaxy_user table failed.")
-        try:
-            col = User_table.c.purged
-            col.drop()
-        except Exception:
-            log.exception("Dropping column 'purged' from galaxy_user table failed.")
+    User_table = Table("galaxy_user", metadata, autoload=True)
+    drop_column('deleted', User_table)
+    drop_column('purged', User_table)

--- a/lib/galaxy/model/migrate/versions/0004_indexes_and_defaults.py
+++ b/lib/galaxy/model/migrate/versions/0004_indexes_and_defaults.py
@@ -1,7 +1,8 @@
 """
 """
+from __future__ import print_function
+
 import logging
-import sys
 
 from sqlalchemy import (
     MetaData,
@@ -14,21 +15,17 @@ from galaxy.model.migrate.versions.util import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
+    print(__doc__)
     metadata.bind = migrate_engine
     metadata.reflect()
 
     User_table = Table("galaxy_user", metadata, autoload=True)
+    # The next add_index() calls are not needed any more after commit
+    # 7ee93c0995123b0f357abd649326295dfa06766c , but harmless
     add_index('ix_galaxy_user_deleted', User_table, 'deleted')
     add_index('ix_galaxy_user_purged', User_table, 'purged')
     # Set the default data in the galaxy_user table, but only for null values

--- a/lib/galaxy/model/migrate/versions/0005_cleanup_datasets_fix.py
+++ b/lib/galaxy/model/migrate/versions/0005_cleanup_datasets_fix.py
@@ -1,18 +1,42 @@
+from __future__ import print_function
+
 import datetime
 import errno
 import logging
 import os
 import time
 
-from sqlalchemy import and_, Boolean, Column, DateTime, false, ForeignKey, Integer, MetaData, not_, Numeric, Table, TEXT, true
-from sqlalchemy.orm import backref, mapper, relation, scoped_session, sessionmaker
+from sqlalchemy import (
+    and_,
+    Boolean,
+    Column,
+    DateTime,
+    false,
+    ForeignKey,
+    Integer,
+    MetaData,
+    not_,
+    Numeric,
+    Table,
+    TEXT,
+    true
+)
+from sqlalchemy.orm import (
+    backref,
+    mapper,
+    relation,
+    scoped_session,
+    sessionmaker
+)
 
-from galaxy.model.custom_types import MetadataType, TrimmedString
+from galaxy.model.custom_types import (
+    MetadataType,
+    TrimmedString
+)
 from galaxy.model.metadata import MetadataCollection
 from galaxy.util.bunch import Bunch
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 now = datetime.datetime.utcnow
 metadata = MetaData()
 context = scoped_session(sessionmaker(autoflush=False, autocommit=True))
@@ -690,7 +714,9 @@ def __guess_dataset_by_filename(filename):
 
 
 def upgrade(migrate_engine):
+    print(__doc__)
     metadata.bind = migrate_engine
+
     log.debug("Fixing a discrepancy concerning deleted shared history items.")
     affected_items = 0
     start_time = time.time()
@@ -734,5 +760,4 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
-    log.debug("Downgrade is not possible.")
+    pass

--- a/lib/galaxy/model/migrate/versions/0006_change_qual_datatype.py
+++ b/lib/galaxy/model/migrate/versions/0006_change_qual_datatype.py
@@ -5,18 +5,10 @@ column, specifically 'qual' is changed to be 'qual454'.
 from __future__ import print_function
 
 import logging
-import sys
 
 from sqlalchemy import MetaData
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 

--- a/lib/galaxy/model/migrate/versions/0009_request_table.py
+++ b/lib/galaxy/model/migrate/versions/0009_request_table.py
@@ -6,21 +6,20 @@ This migration script adds a new column to 2 tables:
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Boolean, Column, MetaData
+from sqlalchemy import (
+    Boolean,
+    Column,
+    MetaData
+)
 
 from galaxy.model.custom_types import TrimmedString
-from galaxy.model.migrate.versions.util import add_column, drop_column
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 

--- a/lib/galaxy/model/migrate/versions/0010_hda_display_at_authz_table.py
+++ b/lib/galaxy/model/migrate/versions/0010_hda_display_at_authz_table.py
@@ -12,21 +12,20 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table
+)
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import TrimmedString
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 HistoryDatasetAssociationDisplayAtAuthorization_table = Table("history_dataset_association_display_at_authorization", metadata,
@@ -39,9 +38,8 @@ HistoryDatasetAssociationDisplayAtAuthorization_table = Table("history_dataset_a
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-    # Load existing tables
+    metadata.bind = migrate_engine
     metadata.reflect()
     try:
         HistoryDatasetAssociationDisplayAtAuthorization_table.create()

--- a/lib/galaxy/model/migrate/versions/0011_v0010_mysql_index_fix.py
+++ b/lib/galaxy/model/migrate/versions/0011_v0010_mysql_index_fix.py
@@ -1,6 +1,6 @@
 """
 This script fixes a problem introduced in the previous migration script
-0010_hda_display_at_atuhz_table.py .  MySQL has a name length limit and
+0010_hda_display_at_authz_table.py .  MySQL has a name length limit and
 thus the index "ix_hdadaa_history_dataset_association_id" has to be
 manually created.
 """
@@ -8,7 +8,6 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 
 from sqlalchemy import MetaData
 
@@ -17,14 +16,8 @@ from galaxy.model.migrate.versions.util import (
     drop_index,
 )
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 

--- a/lib/galaxy/model/migrate/versions/0012_user_address.py
+++ b/lib/galaxy/model/migrate/versions/0012_user_address.py
@@ -8,21 +8,27 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, Table, TEXT
-from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table,
+    TEXT
+)
 
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    create_table,
+    drop_column
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 UserAddress_table = Table("user_address", metadata,
@@ -49,38 +55,19 @@ def upgrade(migrate_engine):
     metadata.reflect()
 
     # Add all of the new tables above
-    try:
-        UserAddress_table.create()
-    except Exception:
-        log.exception("Creating user_address table failed.")
+    create_table(UserAddress_table)
     # Add 1 column to the request_type table
-    try:
-        RequestType_table = Table("request_type", metadata, autoload=True)
-    except NoSuchTableError:
-        RequestType_table = None
-        log.debug("Failed loading table request_type")
-    if RequestType_table is not None:
-        try:
-            col = Column("deleted", Boolean, index=True, default=False)
-            col.create(RequestType_table, index_name='ix_request_type_deleted')
-            assert col is RequestType_table.c.deleted
-        except Exception:
-            log.exception("Adding column 'deleted' to request_type table failed.")
+    col = Column("deleted", Boolean, index=True, default=False)
+    add_column(col, 'request_type', metadata, index_name='ix_request_type_deleted')
 
     # Delete the submitted column
     # This fails for sqlite, so skip the drop -- no conflicts in the future
-    try:
-        Request_table = Table("request", metadata, autoload=True)
-    except NoSuchTableError:
-        Request_table = None
-        log.debug("Failed loading table request")
-    if Request_table is not None:
-        # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
-        if migrate_engine.name != 'sqlite':
-            Request_table.c.submitted.drop()
-        col = Column("state", TrimmedString(255), index=True)
-        col.create(Request_table, index_name='ix_request_state')
-        assert col is Request_table.c.state
+    Request_table = Table("request", metadata, autoload=True)
+    # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
+    if migrate_engine.name != 'sqlite':
+        drop_column('submitted', Request_table)
+    col = Column("state", TrimmedString(255), index=True)
+    add_column(col, Request_table, index_name='ix_request_state')
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0012_user_address.py
+++ b/lib/galaxy/model/migrate/versions/0012_user_address.py
@@ -67,7 +67,7 @@ def upgrade(migrate_engine):
     if migrate_engine.name != 'sqlite':
         drop_column('submitted', Request_table)
     col = Column("state", TrimmedString(255), index=True)
-    add_column(col, Request_table, index_name='ix_request_state')
+    add_column(col, Request_table, metadata, index_name='ix_request_state')
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0013_change_lib_item_templates_to_forms.py
+++ b/lib/galaxy/model/migrate/versions/0013_change_lib_item_templates_to_forms.py
@@ -18,19 +18,40 @@ with a shortened name.
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Column, ForeignKey, Index, Integer, MetaData, Table
-from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    Table
+)
+
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
 metadata = MetaData()
+
+OLD_TABLE_NAMES = [
+    'library_item_info_permissions',
+    'library_item_info_template_permissions',
+    'library_item_info_element',
+    'library_item_info_template_element',
+    'library_info_template_association',
+    'library_folder_info_template_association',
+    'library_dataset_info_template_association',
+    'library_dataset_dataset_info_template_association',
+    'library_info_association',
+    'library_folder_info_association',
+    'library_dataset_info_association',
+    'library_dataset_dataset_info_association',
+    'library_item_info',
+    'library_item_info_template',
+]
 
 LibraryInfoAssociation_table = Table('library_info_association', metadata,
                                      Column("id", Integer, primary_key=True),
@@ -50,167 +71,27 @@ LibraryDatasetDatasetInfoAssociation_table = Table('library_dataset_dataset_info
                                                    Column("form_definition_id", Integer, ForeignKey("form_definition.id"), index=True),
                                                    Column("form_values_id", Integer, ForeignKey("form_values.id"), index=True))
 
+NEW_TABLES = [
+    LibraryInfoAssociation_table,
+    LibraryFolderInfoAssociation_table,
+    LibraryDatasetDatasetInfoAssociation_table
+]
+
 
 def upgrade(migrate_engine):
     print(__doc__)
     metadata.bind = migrate_engine
-    # Load existing tables
     metadata.reflect()
+
     # Drop all of the original library_item_info tables
     # NOTE: all existing library item into template data is eliminated here via table drops
-    try:
-        LibraryItemInfoPermissions_table = Table("library_item_info_permissions", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryItemInfoPermissions_table = None
-        log.debug("Failed loading table library_item_info_permissions")
-    try:
-        LibraryItemInfoPermissions_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info_permissions table failed.")
-
-    try:
-        LibraryItemInfoTemplatePermissions_table = Table("library_item_info_template_permissions", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryItemInfoTemplatePermissions_table = None
-        log.debug("Failed loading table library_item_info_template_permissions")
-    try:
-        LibraryItemInfoTemplatePermissions_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info_template_permissions table failed.")
-
-    try:
-        LibraryItemInfoElement_table = Table("library_item_info_element", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryItemInfoElement_table = None
-        log.debug("Failed loading table library_item_info_element")
-    try:
-        LibraryItemInfoElement_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info_element table failed.")
-
-    try:
-        LibraryItemInfoTemplateElement_table = Table("library_item_info_template_element", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryItemInfoTemplateElement_table = None
-        log.debug("Failed loading table library_item_info_template_element")
-    try:
-        LibraryItemInfoTemplateElement_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info_template_element table failed.")
-
-    try:
-        LibraryInfoTemplateAssociation_table = Table("library_info_template_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryInfoTemplateAssociation_table = None
-        log.debug("Failed loading table library_info_template_association")
-    try:
-        LibraryInfoTemplateAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_info_template_association table failed.")
-
-    try:
-        LibraryFolderInfoTemplateAssociation_table = Table("library_folder_info_template_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryFolderInfoTemplateAssociation_table = None
-        log.debug("Failed loading table library_folder_info_template_association")
-    try:
-        LibraryFolderInfoTemplateAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_folder_info_template_association table failed.")
-
-    try:
-        LibraryDatasetInfoTemplateAssociation_table = Table("library_dataset_info_template_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryDatasetInfoTemplateAssociation_table = None
-        log.debug("Failed loading table library_dataset_info_template_association")
-    try:
-        LibraryDatasetInfoTemplateAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset_info_template_association table failed.")
-
-    try:
-        LibraryDatasetDatasetInfoTemplateAssociation_table = Table("library_dataset_dataset_info_template_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryDatasetDatasetInfoTemplateAssociation_table = None
-        log.debug("Failed loading table library_dataset_dataset_info_template_association")
-    try:
-        LibraryDatasetDatasetInfoTemplateAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset_dataset_info_template_association table failed.")
-
-    try:
-        LibraryInfoAssociation_table = Table("library_info_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryInfoAssociation_table = None
-        log.debug("Failed loading table library_info_association")
-    try:
-        LibraryInfoAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_info_association table failed.")
-
-    try:
-        LibraryFolderInfoAssociation_table = Table("library_folder_info_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryFolderInfoAssociation_table = None
-        log.debug("Failed loading table library_folder_info_association")
-    try:
-        LibraryFolderInfoAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_folder_info_association table failed.")
-
-    try:
-        LibraryDatasetInfoAssociation_table = Table("library_dataset_info_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryDatasetInfoAssociation_table = None
-        log.debug("Failed loading table library_dataset_info_association")
-    try:
-        LibraryDatasetInfoAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset_info_association table failed.")
-
-    try:
-        LibraryDatasetDatasetInfoAssociation_table = Table("library_dataset_dataset_info_association", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryDatasetDatasetInfoAssociation_table = None
-        log.debug("Failed loading table library_dataset_dataset_info_association")
-    try:
-        LibraryDatasetDatasetInfoAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping library_dataset_dataset_info_association table failed.")
-
-    try:
-        LibraryItemInfo_table = Table("library_item_info", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryItemInfo_table = None
-        log.debug("Failed loading table library_item_info")
-    try:
-        LibraryItemInfo_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info table failed.")
-
-    try:
-        LibraryItemInfoTemplate_table = Table("library_item_info_template", metadata, autoload=True)
-    except NoSuchTableError:
-        LibraryItemInfoTemplate_table = None
-        log.debug("Failed loading table library_item_info_template")
-    try:
-        LibraryItemInfoTemplate_table.drop()
-    except Exception:
-        log.exception("Dropping library_item_info_template table failed.")
+    for table_name in OLD_TABLE_NAMES:
+        drop_table(table_name, metadata)
 
     # Create all new tables above
-    try:
-        LibraryInfoAssociation_table.create()
-    except Exception:
-        log.exception("Creating library_info_association table failed.")
-    try:
-        LibraryFolderInfoAssociation_table.create()
-    except Exception:
-        log.exception("Creating library_folder_info_association table failed.")
-    try:
-        LibraryDatasetDatasetInfoAssociation_table.create()
-    except Exception:
-        log.exception("Creating library_dataset_dataset_info_association table failed.")
+    for table in NEW_TABLES:
+        create_table(table)
+
     # Fix index on LibraryDatasetDatasetInfoAssociation_table for mysql
     if migrate_engine.name == 'mysql':
         # Load existing tables
@@ -223,5 +104,4 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
-    log.debug("Downgrade is not possible.")
+    pass

--- a/lib/galaxy/model/migrate/versions/0013_change_lib_item_templates_to_forms.py
+++ b/lib/galaxy/model/migrate/versions/0013_change_lib_item_templates_to_forms.py
@@ -10,10 +10,6 @@ new association tables:
 1) library_info_association
 2) library_folder_info_association
 3) library_dataset_dataset_info_association
-
-If using mysql, this script will throw an (OperationalError) exception due to a long index name on
-the library_dataset_dataset_info_association table, which is OK because the script creates an index
-with a shortened name.
 """
 from __future__ import print_function
 
@@ -22,7 +18,6 @@ import logging
 from sqlalchemy import (
     Column,
     ForeignKey,
-    Index,
     Integer,
     MetaData,
     Table
@@ -91,16 +86,6 @@ def upgrade(migrate_engine):
     # Create all new tables above
     for table in NEW_TABLES:
         create_table(table)
-
-    # Fix index on LibraryDatasetDatasetInfoAssociation_table for mysql
-    if migrate_engine.name == 'mysql':
-        # Load existing tables
-        metadata.reflect()
-        i = Index("ix_lddaia_ldda_id", LibraryDatasetDatasetInfoAssociation_table.c.library_dataset_dataset_association_id)
-        try:
-            i.create()
-        except Exception:
-            log.exception("Adding index 'ix_lddaia_ldda_id' to table 'library_dataset_dataset_info_association' table failed.")
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0014_pages.py
+++ b/lib/galaxy/model/migrate/versions/0014_pages.py
@@ -21,15 +21,18 @@ now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
-Page_table = Table("page", metadata,
-                   Column("id", Integer, primary_key=True),
-                   Column("create_time", DateTime, default=now),
-                   Column("update_time", DateTime, default=now, onupdate=now),
-                   Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True, nullable=False),
-                   Column("latest_revision_id", Integer,
-                          ForeignKey("page_revision.id", use_alter=True, name='page_latest_revision_id_fk'), index=True),
-                   Column("title", TEXT),
-                   Column("slug", TEXT, unique=True, index=True))
+Page_table = Table(
+    "page", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("create_time", DateTime, default=now),
+    Column("update_time", DateTime, default=now, onupdate=now),
+    Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True, nullable=False),
+    Column("latest_revision_id", Integer,
+        ForeignKey("page_revision.id", use_alter=True, name='page_latest_revision_id_fk'), index=True),
+    Column("title", TEXT),
+    Column("slug", TEXT),
+    Index('ix_page_slug', 'slug', unique=True, mysql_length=200),
+)
 
 PageRevision_table = Table("page_revision", metadata,
                            Column("id", Integer, primary_key=True),
@@ -45,21 +48,7 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        if migrate_engine.name == 'mysql':
-            # Strip slug index prior to creation so we can do it manually.
-            slug_index = None
-            for ix in Page_table.indexes:
-                if ix.name == 'ix_page_slug':
-                    slug_index = ix
-            Page_table.indexes.remove(slug_index)
-        Page_table.create()
-        if migrate_engine.name == 'mysql':
-            # Create slug index manually afterward.
-            i = Index("ix_page_slug", Page_table.c.slug, mysql_length=200)
-            i.create()
-    except Exception:
-        log.exception("Could not create page table")
+    create_table(Page_table)
     create_table(PageRevision_table)
 
     col = Column('username', String(255), index=True, unique=True, default=False)

--- a/lib/galaxy/model/migrate/versions/0015_tagging.py
+++ b/lib/galaxy/model/migrate/versions/0015_tagging.py
@@ -1,12 +1,6 @@
 """
 This migration script adds the tables necessary to support tagging of histories,
 datasets, and history-dataset associations (user views of datasets).
-
-If using mysql, this script will display the following error, which is corrected in the next
-migration script:
-history_dataset_association_tag_association table failed:  (OperationalError)
-(1059, "Identifier name 'ix_history_dataset_association_tag_association_history_dataset_association_id'
-is too long)
 """
 from __future__ import print_function
 

--- a/lib/galaxy/model/migrate/versions/0016_v0015_mysql_index_fix.py
+++ b/lib/galaxy/model/migrate/versions/0016_v0015_mysql_index_fix.py
@@ -1,13 +1,18 @@
 """
-This script fixes a problem introduced in 0015_tagging.py. MySQL has a name length
-limit and thus the index "ix_hda_ta_history_dataset_association_id" has to be
-manually created.
+This script was used to fix a problem introduced in 0015_tagging.py. MySQL has a
+name length limit and thus the index "ix_hda_ta_history_dataset_association_id"
+had to be manually created.
+
+This is now fixed in SQLAlchemy Migrate.
 """
 from __future__ import print_function
 
 import logging
 
-from sqlalchemy import MetaData
+from sqlalchemy import (
+    MetaData,
+    Table
+)
 
 from galaxy.model.migrate.versions.util import (
     add_index,
@@ -23,7 +28,9 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    add_index('ix_hda_ta_history_dataset_association_id', 'history_dataset_association_tag_association', 'history_dataset_association_id', metadata)
+    HistoryDatasetAssociationTagAssociation_table = Table('history_dataset_association_tag_association', metadata, autoload=True)
+    if not any([_.name for _ in index.columns] == ['history_dataset_association_id'] for index in HistoryDatasetAssociationTagAssociation_table.indexes):
+        add_index('ix_hda_ta_history_dataset_association_id', HistoryDatasetAssociationTagAssociation_table, 'history_dataset_association_id')
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0017_library_item_indexes.py
+++ b/lib/galaxy/model/migrate/versions/0017_library_item_indexes.py
@@ -5,17 +5,14 @@ library_dataset.name, library_dataset_dataset_association.name.
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Index, MetaData, Table
+from sqlalchemy import (
+    Index,
+    MetaData,
+    Table
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
 metadata = MetaData()
 
 

--- a/lib/galaxy/model/migrate/versions/0017_library_item_indexes.py
+++ b/lib/galaxy/model/migrate/versions/0017_library_item_indexes.py
@@ -6,10 +6,11 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import (
-    Index,
-    MetaData,
-    Table
+from sqlalchemy import MetaData
+
+from galaxy.model.migrate.versions.util import (
+    add_index,
+    drop_index
 )
 
 log = logging.getLogger(__name__)
@@ -17,33 +18,19 @@ metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-    LibraryFolder_table = Table("library_folder", metadata, autoload=True)
-    LibraryDatasetDatasetAssociation_table = Table("library_dataset_dataset_association", metadata, autoload=True)
-    LibraryDataset_table = Table("library_dataset", metadata, autoload=True)
-    # Load existing tables
+    metadata.bind = migrate_engine
     metadata.reflect()
-    # Add 1 index to the library_folder table
-    i = Index('ix_library_folder_name', LibraryFolder_table.c.name, mysql_length=200)
-    try:
-        i.create()
-    except Exception:
-        log.exception("Adding index 'ix_library_folder_name' to library_folder table failed.")
-    # Add 1 index to the library_dataset_dataset_association table
-    i = Index('ix_library_dataset_dataset_association_name', LibraryDatasetDatasetAssociation_table.c.name)
-    try:
-        i.create()
-    except Exception:
-        log.exception("Adding index 'ix_library_dataset_dataset_association_name' to library_dataset_dataset_association table failed.")
-    # Add 1 index to the library_dataset table
-    i = Index('ix_library_dataset_name', LibraryDataset_table.c.name)
-    try:
-        i.create()
-    except Exception:
-        log.exception("Adding index 'ix_library_dataset_name' to library_dataset table failed.")
+
+    add_index('ix_library_folder_name', 'library_folder', 'name', metadata)
+    add_index('ix_library_dataset_dataset_association_name', 'library_dataset_dataset_association', 'name', metadata)
+    add_index('ix_library_dataset_name', 'library_dataset', 'name', metadata)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
-    log.debug("Downgrade is not possible.")
+    metadata.reflect()
+
+    drop_index('ix_library_dataset_name', 'library_dataset', 'name', metadata)
+    drop_index('ix_library_dataset_dataset_association_name', 'library_dataset_dataset_association', 'name', metadata)
+    drop_index('ix_library_folder_name', 'library_folder', 'name', metadata)

--- a/lib/galaxy/model/migrate/versions/0019_request_library_folder.py
+++ b/lib/galaxy/model/migrate/versions/0019_request_library_folder.py
@@ -6,79 +6,54 @@ to the form_definition table.
 from __future__ import print_function
 
 import logging
-import sys
 
 from migrate import ForeignKeyConstraint
-from sqlalchemy import Column, Integer, MetaData, Table
-from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy import (
+    Column,
+    Integer,
+    MetaData,
+    Table
+)
 
-# Need our custom types, but don't import anything else from model
-from galaxy.model.custom_types import JSONType, TrimmedString
+from galaxy.model.custom_types import (
+    JSONType,
+    TrimmedString
+)
+from galaxy.model.migrate.versions.util import (
+    add_column,
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-    # Load existing tables
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     # Create the folder_id column
-    try:
-        Request_table = Table("request", metadata, autoload=True)
-    except NoSuchTableError:
-        Request_table = None
-        log.debug("Failed loading table request")
-    if Request_table is not None:
+    Request_table = Table("request", metadata, autoload=True)
+    col = Column("folder_id", Integer, index=True)
+    add_column(col, Request_table, index_name='ix_request_folder_id')
+    LibraryFolder_table = Table("library_folder", metadata, autoload=True)
+    # Add 1 foreign key constraint to the library_folder table
+    if migrate_engine.name != 'sqlite':
         try:
-            col = Column("folder_id", Integer, index=True)
-            col.create(Request_table, index_name='ix_request_folder_id')
-            assert col is Request_table.c.folder_id
+            cons = ForeignKeyConstraint([Request_table.c.folder_id],
+                                        [LibraryFolder_table.c.id],
+                                        name='request_folder_id_fk')
+            # Create the constraint
+            cons.create()
         except Exception:
-            log.exception("Adding column 'folder_id' to request table failed.")
-        try:
-            LibraryFolder_table = Table("library_folder", metadata, autoload=True)
-        except NoSuchTableError:
-            LibraryFolder_table = None
-            log.debug("Failed loading table library_folder")
-        # Add 1 foreign key constraint to the library_folder table
-        if migrate_engine.name != 'sqlite' and Request_table is not None and LibraryFolder_table is not None:
-            try:
-                cons = ForeignKeyConstraint([Request_table.c.folder_id],
-                                            [LibraryFolder_table.c.id],
-                                            name='request_folder_id_fk')
-                # Create the constraint
-                cons.create()
-            except Exception:
-                log.exception("Adding foreign key constraint 'request_folder_id_fk' to table 'library_folder' failed.")
+            log.exception("Adding foreign key constraint 'request_folder_id_fk' to table 'library_folder' failed.")
     # Create the type column in form_definition
-    try:
-        FormDefinition_table = Table("form_definition", metadata, autoload=True)
-    except NoSuchTableError:
-        FormDefinition_table = None
-        log.debug("Failed loading table form_definition")
-    if FormDefinition_table is not None:
-        try:
-            col = Column("type", TrimmedString(255), index=True)
-            col.create(FormDefinition_table, index_name='ix_form_definition_type')
-            assert col is FormDefinition_table.c.type
-        except Exception:
-            log.exception("Adding column 'type' to form_definition table failed.")
-        try:
-            col = Column("layout", JSONType())
-            col.create(FormDefinition_table)
-            assert col is FormDefinition_table.c.layout
-        except Exception:
-            log.exception("Adding column 'layout' to form_definition table failed.")
+    FormDefinition_table = Table("form_definition", metadata, autoload=True)
+    col = Column("type", TrimmedString(255), index=True)
+    add_column(col, FormDefinition_table, index_name='ix_form_definition_type')
+    col = Column("layout", JSONType())
+    add_column(col, FormDefinition_table)
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
     pass

--- a/lib/galaxy/model/migrate/versions/0019_request_library_folder.py
+++ b/lib/galaxy/model/migrate/versions/0019_request_library_folder.py
@@ -7,9 +7,9 @@ from __future__ import print_function
 
 import logging
 
-from migrate import ForeignKeyConstraint
 from sqlalchemy import (
     Column,
+    ForeignKey,
     Integer,
     MetaData,
     Table
@@ -33,26 +33,14 @@ def upgrade(migrate_engine):
     metadata.reflect()
 
     # Create the folder_id column
-    Request_table = Table("request", metadata, autoload=True)
-    col = Column("folder_id", Integer, index=True)
-    add_column(col, Request_table, index_name='ix_request_folder_id')
-    LibraryFolder_table = Table("library_folder", metadata, autoload=True)
-    # Add 1 foreign key constraint to the library_folder table
-    if migrate_engine.name != 'sqlite':
-        try:
-            cons = ForeignKeyConstraint([Request_table.c.folder_id],
-                                        [LibraryFolder_table.c.id],
-                                        name='request_folder_id_fk')
-            # Create the constraint
-            cons.create()
-        except Exception:
-            log.exception("Adding foreign key constraint 'request_folder_id_fk' to table 'library_folder' failed.")
+    col = Column("folder_id", Integer, ForeignKey('library_folder.id'), index=True)
+    add_column(col, 'request', metadata, index_name='ix_request_folder_id')
     # Create the type column in form_definition
     FormDefinition_table = Table("form_definition", metadata, autoload=True)
     col = Column("type", TrimmedString(255), index=True)
-    add_column(col, FormDefinition_table, index_name='ix_form_definition_type')
+    add_column(col, FormDefinition_table, metadata, index_name='ix_form_definition_type')
     col = Column("layout", JSONType())
-    add_column(col, FormDefinition_table)
+    add_column(col, FormDefinition_table, metadata)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0020_library_upload_job.py
+++ b/lib/galaxy/model/migrate/versions/0020_library_upload_job.py
@@ -8,7 +8,6 @@ column.
 from __future__ import print_function
 
 import logging
-import sys
 
 from sqlalchemy import (
     Column,
@@ -29,13 +28,6 @@ from galaxy.model.migrate.versions.util import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 JobToOutputLibraryDataset_table = Table("job_to_output_library_dataset", metadata,

--- a/lib/galaxy/model/migrate/versions/0020_library_upload_job.py
+++ b/lib/galaxy/model/migrate/versions/0020_library_upload_job.py
@@ -46,11 +46,7 @@ def upgrade(migrate_engine):
     create_table(JobToOutputLibraryDataset_table)
 
     # Create the library_folder_id column
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        col = Column("library_folder_id", Integer, ForeignKey('library_folder.id', name='job_library_folder_id_fk'), index=True)
-    else:
-        col = Column("library_folder_id", Integer, index=True)
+    col = Column("library_folder_id", Integer, ForeignKey('library_folder.id', name='job_library_folder_id_fk'), index=True)
     add_column(col, 'job', metadata, index_name='ix_job_library_folder_id')
 
     # Create the ix_dataset_state index

--- a/lib/galaxy/model/migrate/versions/0024_page_slug_unique_constraint.py
+++ b/lib/galaxy/model/migrate/versions/0024_page_slug_unique_constraint.py
@@ -6,7 +6,15 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Index, MetaData, Table
+from sqlalchemy import (
+    MetaData,
+    Table
+)
+
+from galaxy.model.migrate.versions.util import (
+    add_index,
+    drop_index
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -20,16 +28,13 @@ def upgrade(migrate_engine):
     Page_table = Table("page", metadata, autoload=True)
     try:
         # Sqlite doesn't support .alter, so we need to drop an recreate
-        i = Index("ix_page_slug", Page_table.c.slug)
-        i.drop()
+        drop_index("ix_page_slug", Page_table, 'slug')
 
-        i = Index("ix_page_slug", Page_table.c.slug, unique=False)
-        i.create()
+        add_index("ix_page_slug", Page_table, 'slug', unique=False)
     except Exception:
         # Mysql doesn't have a named index, but alter should work
         Page_table.c.slug.alter(unique=False)
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
-    metadata.reflect()
+    pass

--- a/lib/galaxy/model/migrate/versions/0025_user_info.py
+++ b/lib/galaxy/model/migrate/versions/0025_user_info.py
@@ -4,7 +4,6 @@ This script adds a foreign key to the form_values table in the galaxy_user table
 from __future__ import print_function
 
 import logging
-import sys
 
 from sqlalchemy import (
     Column,
@@ -13,16 +12,12 @@ from sqlalchemy import (
     MetaData
 )
 
-from galaxy.model.migrate.versions.util import add_column, drop_column
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 

--- a/lib/galaxy/model/migrate/versions/0025_user_info.py
+++ b/lib/galaxy/model/migrate/versions/0025_user_info.py
@@ -26,11 +26,7 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        col = Column("form_values_id", Integer, ForeignKey('form_values.id', name='user_form_values_id_fk'), index=True)
-    else:
-        col = Column("form_values_id", Integer, index=True)
+    col = Column("form_values_id", Integer, ForeignKey('form_values.id', name='user_form_values_id_fk'), index=True)
     add_column(col, 'galaxy_user', metadata, index_name='ix_galaxy_user_form_values_id')
 
 

--- a/lib/galaxy/model/migrate/versions/0027_request_events.py
+++ b/lib/galaxy/model/migrate/versions/0027_request_events.py
@@ -57,9 +57,7 @@ def upgrade(migrate_engine):
     cmd = cmd % (nextval(migrate_engine, 'request_event'), localtimestamp(migrate_engine), localtimestamp(migrate_engine), 'Imported from request table')
     migrate_engine.execute(cmd)
 
-    if migrate_engine.name != 'sqlite':
-        # Delete the state column
-        drop_column('state', 'request', metadata)
+    drop_column('state', 'request', metadata)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0027_request_events.py
+++ b/lib/galaxy/model/migrate/versions/0027_request_events.py
@@ -6,22 +6,27 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table, TEXT
-from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table,
+    TEXT
+)
 
 from galaxy.model.custom_types import TrimmedString
-from galaxy.model.migrate.versions.util import localtimestamp, nextval
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_column,
+    localtimestamp,
+    nextval
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 RequestEvent_table = Table('request_event', metadata,
@@ -38,13 +43,8 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    # Add new request_event table
-    try:
-        RequestEvent_table.create()
-    except Exception:
-        log.exception("Creating request_event table failed.")
+    create_table(RequestEvent_table)
     # move the current state of all existing requests to the request_event table
-
     cmd = \
         "INSERT INTO request_event " + \
         "SELECT %s AS id," + \
@@ -59,16 +59,7 @@ def upgrade(migrate_engine):
 
     if migrate_engine.name != 'sqlite':
         # Delete the state column
-        try:
-            Request_table = Table("request", metadata, autoload=True)
-        except NoSuchTableError:
-            Request_table = None
-            log.debug("Failed loading table request")
-        if Request_table is not None:
-            try:
-                Request_table.c.state.drop()
-            except Exception:
-                log.exception("Deleting column 'state' to request table failed.")
+        drop_column('state', 'request', metadata)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0028_external_metadata_file_override.py
+++ b/lib/galaxy/model/migrate/versions/0028_external_metadata_file_override.py
@@ -6,35 +6,33 @@ set up with read-only access to database/files
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Column, MetaData, String, Table
+from sqlalchemy import (
+    Column,
+    MetaData,
+    String,
+)
+
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-    # Load existing tables
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        job_external_output_metadata = Table("job_external_output_metadata", metadata, autoload=True)
-        col = Column("filename_override_metadata", String(255))
-        col.create(job_external_output_metadata)
-        assert col is job_external_output_metadata.c.filename_override_metadata
-    except Exception:
-        log.exception("Adding column 'filename_override_metadata' to job_external_output_metadata table failed.")
+
+    col = Column("filename_override_metadata", String(255))
+    add_column(col, 'job_external_output_metadata', metadata)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
-    pass
+    metadata.reflect()
+
+    drop_column('filename_override_metadata', 'job_external_output_metadata', metadata)

--- a/lib/galaxy/model/migrate/versions/0030_history_slug_column.py
+++ b/lib/galaxy/model/migrate/versions/0030_history_slug_column.py
@@ -5,9 +5,18 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, Index, MetaData, Table, TEXT
+from sqlalchemy import (
+    Column,
+    MetaData,
+    Table,
+    TEXT
+)
 
-from galaxy.model.migrate.versions.util import drop_column
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    add_index,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -19,18 +28,11 @@ def upgrade(migrate_engine):
     metadata.reflect()
 
     History_table = Table("history", metadata, autoload=True)
-
-    # Mysql needs manual index creation because of max length index.
-    if migrate_engine.name != 'mysql':
-        # Create slug column.
-        c = Column("slug", TEXT, index=True)
-        c.create(History_table, index_name='ix_history_slug')
-    else:
-        c = Column("slug", TEXT)
-        c.create(History_table, index_name='')
-        i = Index("ix_history_slug", History_table.c.slug, mysql_length=200)
-        i.create()
-    assert c is History_table.c.slug
+    c = Column("slug", TEXT)
+    add_column(c, History_table, metadata)
+    # Index needs to be added separately because MySQL cannot index a TEXT/BLOB
+    # column without specifying mysql_length
+    add_index('ix_history_slug', History_table, 'slug')
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0031_community_and_workflow_tags.py
+++ b/lib/galaxy/model/migrate/versions/0031_community_and_workflow_tags.py
@@ -50,11 +50,7 @@ def upgrade(migrate_engine):
     metadata.reflect()
 
     # Create user_id column in history_tag_association table.
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        c = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True)
-    else:
-        c = Column("user_id", Integer, index=True)
+    c = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True)
     add_column(c, 'history_tag_association', metadata, index_name='ix_history_tag_association_user_id')
 
     # Populate column so that user_id is the id of the user who owns the history (and, up to now, was the only person able to tag the history).
@@ -62,11 +58,7 @@ def upgrade(migrate_engine):
         "UPDATE history_tag_association SET user_id=( SELECT user_id FROM history WHERE history_tag_association.history_id = history.id )")
 
     # Create user_id column in history_dataset_association_tag_association table.
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        c = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True)
-    else:
-        c = Column("user_id", Integer, index=True)
+    c = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True)
     add_column(c, 'history_dataset_association_tag_association', metadata, index_name='ix_history_dataset_association_tag_association_user_id')
 
     # Populate column so that user_id is the id of the user who owns the history_dataset_association (and, up to now, was the only person able to tag the page).
@@ -74,12 +66,7 @@ def upgrade(migrate_engine):
         "UPDATE history_dataset_association_tag_association SET user_id=( SELECT history.user_id FROM history, history_dataset_association WHERE history_dataset_association.history_id = history.id AND history_dataset_association.id = history_dataset_association_tag_association.history_dataset_association_id)")
 
     # Create user_id column in page_tag_association table.
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        c = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True)
-    else:
-        # Create user_id column in page_tag_association table.
-        c = Column("user_id", Integer, index=True)
+    c = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True)
     add_column(c, 'page_tag_association', metadata, index_name='ix_page_tag_association_user_id')
 
     # Populate column so that user_id is the id of the user who owns the page (and, up to now, was the only person able to tag the page).

--- a/lib/galaxy/model/migrate/versions/0033_published_cols_for_histories_and_workflows.py
+++ b/lib/galaxy/model/migrate/versions/0033_published_cols_for_histories_and_workflows.py
@@ -22,7 +22,7 @@ def upgrade(migrate_engine):
     # Create published column in history table.
     History_table = Table("history", metadata, autoload=True)
     c = Column("published", Boolean, index=True)
-    add_column(c, History_table, index_name='ix_history_published')
+    add_column(c, History_table, metadata, index_name='ix_history_published')
     if migrate_engine.name != 'sqlite':
         # Create index for published column in history table.
         try:
@@ -35,7 +35,7 @@ def upgrade(migrate_engine):
     # Create published column in stored workflows table.
     StoredWorkflow_table = Table("stored_workflow", metadata, autoload=True)
     c = Column("published", Boolean, index=True)
-    add_column(c, StoredWorkflow_table, index_name='ix_stored_workflow_published')
+    add_column(c, StoredWorkflow_table, metadata, index_name='ix_stored_workflow_published')
     if migrate_engine.name != 'sqlite':
         # Create index for published column in stored workflows table.
         try:
@@ -48,7 +48,7 @@ def upgrade(migrate_engine):
     # Create importable column in page table.
     Page_table = Table("page", metadata, autoload=True)
     c = Column("importable", Boolean, index=True)
-    add_column(c, Page_table, index_name='ix_page_importable')
+    add_column(c, Page_table, metadata, index_name='ix_page_importable')
     if migrate_engine.name != 'sqlite':
         # Create index for importable column in page table.
         try:

--- a/lib/galaxy/model/migrate/versions/0035_item_annotations_and_workflow_step_tags.py
+++ b/lib/galaxy/model/migrate/versions/0035_item_annotations_and_workflow_step_tags.py
@@ -5,36 +5,63 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, ForeignKey, Index, Integer, MetaData, Table, TEXT, Unicode
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    Table,
+    TEXT,
+    Unicode
+)
+
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 # Annotation tables.
 
-HistoryAnnotationAssociation_table = Table("history_annotation_association", metadata,
-                                           Column("id", Integer, primary_key=True),
-                                           Column("history_id", Integer, ForeignKey("history.id"), index=True),
-                                           Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-                                           Column("annotation", TEXT))
+HistoryAnnotationAssociation_table = Table(
+    "history_annotation_association", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("history_id", Integer, ForeignKey("history.id"), index=True),
+    Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
+    Column("annotation", TEXT),
+    Index("ix_history_anno_assoc_annotation", 'annotation', mysql_length=200),
+)
 
-HistoryDatasetAssociationAnnotationAssociation_table = Table("history_dataset_association_annotation_association", metadata,
-                                                             Column("id", Integer, primary_key=True),
-                                                             Column("history_dataset_association_id", Integer, ForeignKey("history_dataset_association.id"), index=True),
-                                                             Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-                                                             Column("annotation", TEXT))
+HistoryDatasetAssociationAnnotationAssociation_table = Table(
+    "history_dataset_association_annotation_association", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("history_dataset_association_id", Integer,
+        ForeignKey("history_dataset_association.id"), index=True),
+    Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
+    Column("annotation", TEXT),
+    Index("ix_history_dataset_anno_assoc_annotation", 'annotation', mysql_length=200),
+)
 
-StoredWorkflowAnnotationAssociation_table = Table("stored_workflow_annotation_association", metadata,
-                                                  Column("id", Integer, primary_key=True),
-                                                  Column("stored_workflow_id", Integer, ForeignKey("stored_workflow.id"), index=True),
-                                                  Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-                                                  Column("annotation", TEXT))
+StoredWorkflowAnnotationAssociation_table = Table(
+    "stored_workflow_annotation_association", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("stored_workflow_id", Integer, ForeignKey("stored_workflow.id"), index=True),
+    Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
+    Column("annotation", TEXT),
+    Index("ix_stored_workflow_ann_assoc_annotation", 'annotation', mysql_length=200),
+)
 
-WorkflowStepAnnotationAssociation_table = Table("workflow_step_annotation_association", metadata,
-                                                Column("id", Integer, primary_key=True),
-                                                Column("workflow_step_id", Integer, ForeignKey("workflow_step.id"), index=True),
-                                                Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-                                                Column("annotation", TEXT))
+WorkflowStepAnnotationAssociation_table = Table(
+    "workflow_step_annotation_association", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id"), index=True),
+    Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
+    Column("annotation", TEXT),
+    Index("ix_workflow_step_ann_assoc_annotation", 'annotation', mysql_length=200),
+)
 
 # Tagging tables.
 
@@ -47,86 +74,27 @@ WorkflowStepTagAssociation_table = Table("workflow_step_tag_association", metada
                                          Column("value", Unicode(255), index=True),
                                          Column("user_value", Unicode(255), index=True))
 
+TABLES = [
+    HistoryAnnotationAssociation_table,
+    HistoryDatasetAssociationAnnotationAssociation_table,
+    StoredWorkflowAnnotationAssociation_table,
+    WorkflowStepAnnotationAssociation_table,
+    WorkflowStepTagAssociation_table
+]
+
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
-    # Create history_annotation_association table.
-    try:
-        HistoryAnnotationAssociation_table.create()
-    except Exception:
-        log.exception("Creating history_annotation_association table failed.")
-
-    # Create history_dataset_association_annotation_association table.
-    try:
-        HistoryDatasetAssociationAnnotationAssociation_table.create()
-    except Exception:
-        log.exception("Creating history_dataset_association_annotation_association table failed.")
-
-    # Create stored_workflow_annotation_association table.
-    try:
-        StoredWorkflowAnnotationAssociation_table.create()
-    except Exception:
-        log.exception("Creating stored_workflow_annotation_association table failed.")
-
-    # Create workflow_step_annotation_association table.
-    try:
-        WorkflowStepAnnotationAssociation_table.create()
-    except Exception:
-        log.exception("Creating workflow_step_annotation_association table failed.")
-
-    # Create workflow_step_tag_association table.
-    try:
-        WorkflowStepTagAssociation_table.create()
-    except Exception:
-        log.exception("Creating workflow_step_tag_association table failed.")
-
-    haaa = Index("ix_history_anno_assoc_annotation", HistoryAnnotationAssociation_table.c.annotation, mysql_length=200)
-    hdaaa = Index("ix_history_dataset_anno_assoc_annotation", HistoryDatasetAssociationAnnotationAssociation_table.c.annotation, mysql_length=200)
-    swaaa = Index("ix_stored_workflow_ann_assoc_annotation", StoredWorkflowAnnotationAssociation_table.c.annotation, mysql_length=200)
-    wsaaa = Index("ix_workflow_step_ann_assoc_annotation", WorkflowStepAnnotationAssociation_table.c.annotation, mysql_length=200)
-
-    try:
-        haaa.create()
-        hdaaa.create()
-        swaaa.create()
-        wsaaa.create()
-    except Exception:
-        log.exception("Creating annotation indices failed.")
+    for table in TABLES:
+        create_table(table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    # Drop history_annotation_association table.
-    try:
-        HistoryAnnotationAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping history_annotation_association table failed.")
-
-    # Drop history_dataset_association_annotation_association table.
-    try:
-        HistoryDatasetAssociationAnnotationAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping history_dataset_association_annotation_association table failed.")
-
-    # Drop stored_workflow_annotation_association table.
-    try:
-        StoredWorkflowAnnotationAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping stored_workflow_annotation_association table failed.")
-
-    # Drop workflow_step_annotation_association table.
-    try:
-        WorkflowStepAnnotationAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping workflow_step_annotation_association table failed.")
-
-    # Drop workflow_step_tag_association table.
-    try:
-        WorkflowStepTagAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping workflow_step_tag_association table failed.")
+    for table in TABLES:
+        drop_table(table)

--- a/lib/galaxy/model/migrate/versions/0037_samples_library.py
+++ b/lib/galaxy/model/migrate/versions/0037_samples_library.py
@@ -49,23 +49,15 @@ def upgrade(migrate_engine):
     # Add the dataset_files column in 'sample' table
     Sample_table = Table("sample", metadata, autoload=True)
     col = Column("dataset_files", JSONType())
-    add_column(col, Sample_table)
+    add_column(col, Sample_table, metadata)
 
     # Add the library_id column in 'sample' table
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        col = Column("library_id", Integer, ForeignKey("library.id"), index=True)
-    else:
-        col = Column("library_id", Integer, index=True)
-    add_column(col, Sample_table, index_name='ix_sample_library_id')
+    col = Column("library_id", Integer, ForeignKey("library.id"), index=True)
+    add_column(col, Sample_table, metadata, index_name='ix_sample_library_id')
 
     # Add the library_id column in 'sample' table
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        col = Column("folder_id", Integer, ForeignKey("library_folder.id"), index=True)
-    else:
-        col = Column("folder_id", Integer, index=True)
-    add_column(col, Sample_table, index_name='ix_sample_library_folder_id')
+    col = Column("folder_id", Integer, ForeignKey("library_folder.id"), index=True)
+    add_column(col, Sample_table, metadata, index_name='ix_sample_library_folder_id')
 
 
 def downgrade(migrate_engine):
@@ -78,18 +70,10 @@ def downgrade(migrate_engine):
     drop_column('dataset_files', Sample_table)
 
     Request_table = Table("request", metadata, autoload=True)
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        col = Column('folder_id', Integer, ForeignKey('library_folder.id', name='request_folder_id_fk'), index=True)
-    else:
-        col = Column('folder_id', Integer, index=True)
-    add_column(col, Request_table, index_name='ix_request_folder_id')
+    col = Column('folder_id', Integer, ForeignKey('library_folder.id', name='request_folder_id_fk'), index=True)
+    add_column(col, Request_table, metadata, index_name='ix_request_folder_id')
 
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        col = Column('library_id', Integer, ForeignKey("library.id"), index=True)
-    else:
-        col = Column('library_id', Integer, index=True)
-    add_column(col, Request_table, index_name='ix_request_library_id')
+    col = Column('library_id', Integer, ForeignKey("library.id"), index=True)
+    add_column(col, Request_table, metadata, index_name='ix_request_library_id')
 
     drop_column('datatx_info', 'request_type', metadata)

--- a/lib/galaxy/model/migrate/versions/0037_samples_library.py
+++ b/lib/galaxy/model/migrate/versions/0037_samples_library.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 
 from sqlalchemy import (
     Column,
@@ -26,15 +25,8 @@ from galaxy.model.migrate.versions.util import (
     drop_column
 )
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 

--- a/lib/galaxy/model/migrate/versions/0037_samples_library.py
+++ b/lib/galaxy/model/migrate/versions/0037_samples_library.py
@@ -41,9 +41,11 @@ def upgrade(migrate_engine):
 
     # Delete the library_id column in 'request' table
     Request_table = Table("request", metadata, autoload=True)
+    # TODO: Dropping a column used in a foreign key fails in MySQL, need to remove the FK first.
     drop_column('library_id', Request_table)
 
     # Delete the folder_id column in 'request' table
+    # TODO: Dropping a column used in a foreign key fails in MySQL, need to remove the FK first.
     drop_column('folder_id', Request_table)
 
     # Add the dataset_files column in 'sample' table
@@ -70,7 +72,7 @@ def downgrade(migrate_engine):
     drop_column('dataset_files', Sample_table)
 
     Request_table = Table("request", metadata, autoload=True)
-    col = Column('folder_id', Integer, ForeignKey('library_folder.id', name='request_folder_id_fk'), index=True)
+    col = Column('folder_id', Integer, ForeignKey('library_folder.id'), index=True)
     add_column(col, Request_table, metadata, index_name='ix_request_folder_id')
 
     col = Column('library_id', Integer, ForeignKey("library.id"), index=True)

--- a/lib/galaxy/model/migrate/versions/0039_add_synopsis_column_to_library_table.py
+++ b/lib/galaxy/model/migrate/versions/0039_add_synopsis_column_to_library_table.py
@@ -5,15 +5,20 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, MetaData, Table, TEXT
+from sqlalchemy import (
+    Column,
+    MetaData,
+    Table,
+    TEXT
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
     try:
         Library_table = Table("library", metadata, autoload=True)

--- a/lib/galaxy/model/migrate/versions/0040_page_annotations.py
+++ b/lib/galaxy/model/migrate/versions/0040_page_annotations.py
@@ -5,16 +5,32 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table, TEXT
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    Table,
+    TEXT
+)
+
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
-PageAnnotationAssociation_table = Table("page_annotation_association", metadata,
-                                        Column("id", Integer, primary_key=True),
-                                        Column("page_id", Integer, ForeignKey("page.id"), index=True),
-                                        Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-                                        Column("annotation", TEXT, index=True))
+PageAnnotationAssociation_table = Table(
+    "page_annotation_association", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("page_id", Integer, ForeignKey("page.id"), index=True),
+    Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
+    Column("annotation", TEXT),
+    Index('ix_page_annotation_association_annotation', 'annotation', mysql_length=200),
+)
 
 
 def upgrade(migrate_engine):
@@ -22,19 +38,11 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    # Create history_annotation_association table.
-    try:
-        PageAnnotationAssociation_table.create()
-    except Exception:
-        log.exception("Creating page_annotation_association table failed.")
+    create_table(PageAnnotationAssociation_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    # Drop page_annotation_association table.
-    try:
-        PageAnnotationAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping page_annotation_association table failed.")
+    drop_table(PageAnnotationAssociation_table)

--- a/lib/galaxy/model/migrate/versions/0041_workflow_invocation.py
+++ b/lib/galaxy/model/migrate/versions/0041_workflow_invocation.py
@@ -6,11 +6,20 @@ from __future__ import print_function
 import datetime
 import logging
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table
+)
 
-from galaxy.model.migrate.versions.util import create_table, drop_table
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
-logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 now = datetime.datetime.utcnow
 metadata = MetaData()

--- a/lib/galaxy/model/migrate/versions/0043_visualization_sharing_tagging_annotating.py
+++ b/lib/galaxy/model/migrate/versions/0043_visualization_sharing_tagging_annotating.py
@@ -5,9 +5,26 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Boolean, Column, ForeignKey, Index, Integer, MetaData, Table, TEXT, Unicode
+from sqlalchemy import (
+    Boolean,
+    Column,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    Table,
+    TEXT,
+    Unicode
+)
 
-from galaxy.model.migrate.versions.util import engine_false
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    add_index,
+    create_table,
+    drop_column,
+    drop_table,
+    engine_false
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -32,11 +49,20 @@ VisualizationTagAssociation_table = Table("visualization_tag_association", metad
 
 # Annotating visualizations.
 
-VisualizationAnnotationAssociation_table = Table("visualization_annotation_association", metadata,
-                                                 Column("id", Integer, primary_key=True),
-                                                 Column("visualization_id", Integer, ForeignKey("visualization.id"), index=True),
-                                                 Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
-                                                 Column("annotation", TEXT, index=False))
+VisualizationAnnotationAssociation_table = Table(
+    "visualization_annotation_association", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("visualization_id", Integer, ForeignKey("visualization.id"), index=True),
+    Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
+    Column("annotation", TEXT),
+    Index('ix_visualization_annotation_association_annotation', 'annotation', mysql_length=200),
+)
+
+TABLES = [
+    VisualizationUserShareAssociation_table,
+    VisualizationTagAssociation_table,
+    VisualizationAnnotationAssociation_table
+]
 
 
 def upgrade(migrate_engine):
@@ -44,134 +70,54 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    Visualiation_table = Table("visualization", metadata, autoload=True)
-    # Create visualization_user_share_association table.
-    try:
-        VisualizationUserShareAssociation_table.create()
-    except Exception:
-        log.exception("Creating visualization_user_share_association table failed.")
+    for table in TABLES:
+        create_table(table)
 
     # Add columns & create indices for supporting sharing to visualization table.
+    Visualization_table = Table("visualization", metadata, autoload=True)
     deleted_column = Column("deleted", Boolean, default=False, index=True)
-    importable_column = Column("importable", Boolean, default=False, index=True)
-    slug_column = Column("slug", TEXT)
-    published_column = Column("published", Boolean, index=True)
-
+    add_column(deleted_column, Visualization_table, metadata, index_name="ix_visualization_deleted")
     try:
-        # Add column.
-        deleted_column.create(Visualiation_table, index_name="ix_visualization_deleted")
-        assert deleted_column is Visualiation_table.c.deleted
-
         # Fill column with default value.
         cmd = "UPDATE visualization SET deleted = %s" % engine_false(migrate_engine)
         migrate_engine.execute(cmd)
     except Exception:
-        log.exception("Adding deleted column to visualization table failed.")
+        log.exception("Updating column 'deleted' of table 'visualization' failed.")
 
+    importable_column = Column("importable", Boolean, default=False, index=True)
+    add_column(importable_column, Visualization_table, metadata, index_name='ix_visualization_importable')
     try:
-        # Add column.
-        importable_column.create(Visualiation_table, index_name='ix_visualization_importable')
-        assert importable_column is Visualiation_table.c.importable
-
         # Fill column with default value.
         cmd = "UPDATE visualization SET importable = %s" % engine_false(migrate_engine)
         migrate_engine.execute(cmd)
     except Exception:
-        log.exception("Adding importable column to visualization table failed.")
+        log.exception("Updating column 'importable' of table 'visualization' failed.")
 
+    slug_column = Column("slug", TEXT)
+    add_column(slug_column, Visualization_table, metadata)
+    # Index needs to be added separately because MySQL cannot index a TEXT/BLOB
+    # column without specifying mysql_length
+    add_index('ix_visualization_slug', Visualization_table, 'slug')
+
+    published_column = Column("published", Boolean, index=True)
+    add_column(published_column, Visualization_table, metadata, index_name='ix_visualization_published')
     try:
-        slug_column.create(Visualiation_table)
-        assert slug_column is Visualiation_table.c.slug
-    except Exception:
-        log.exception("Adding slug column to visualization table failed.")
-
-    try:
-        if migrate_engine.name == 'mysql':
-            # Have to create index manually.
-            cmd = "CREATE INDEX ix_visualization_slug ON visualization ( slug ( 100 ) )"
-            migrate_engine.execute(cmd)
-        else:
-            i = Index("ix_visualization_slug", Visualiation_table.c.slug)
-            i.create()
-    except Exception:
-        log.exception("Adding index 'ix_visualization_slug' failed.")
-
-    try:
-        # Add column.
-        published_column.create(Visualiation_table, index_name='ix_visualization_published')
-        assert published_column is Visualiation_table.c.published
-
         # Fill column with default value.
         cmd = "UPDATE visualization SET published = %s" % engine_false(migrate_engine)
         migrate_engine.execute(cmd)
     except Exception:
-        log.exception("Adding published column to visualization table failed.")
-
-    # Create visualization_tag_association table.
-    try:
-        VisualizationTagAssociation_table.create()
-    except Exception:
-        log.exception("Creating visualization_tag_association table failed.")
-
-    # Create visualization_annotation_association table.
-    try:
-        VisualizationAnnotationAssociation_table.create()
-    except Exception:
-        log.exception("Creating visualization_annotation_association table failed.")
-
-    # Need to create index for visualization annotation manually to deal with errors.
-    try:
-        if migrate_engine.name == 'mysql':
-            # Have to create index manually.
-            cmd = "CREATE INDEX ix_visualization_annotation_association_annotation ON visualization_annotation_association ( annotation ( 100 ) )"
-            migrate_engine.execute(cmd)
-        else:
-            i = Index("ix_visualization_annotation_association_annotation", VisualizationAnnotationAssociation_table.c.annotation)
-            i.create()
-    except Exception:
-        log.exception("Adding index 'ix_visualization_annotation_association_annotation' failed.")
+        log.exception("Updating column 'published' of table 'visualization' failed.")
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    Visualiation_table = Table("visualization", metadata, autoload=True)
-    # Drop visualization_user_share_association table.
-    try:
-        VisualizationUserShareAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping visualization_user_share_association table failed.")
+    Visualization_table = Table("visualization", metadata, autoload=True)
+    drop_column('deleted', Visualization_table)
+    drop_column('importable', Visualization_table)
+    drop_column('slug', Visualization_table)
+    drop_column('published', Visualization_table)
 
-    # Drop columns for supporting sharing from visualization table.
-    try:
-        Visualiation_table.c.deleted.drop()
-    except Exception:
-        log.exception("Dropping deleted column from visualization table failed.")
-
-    try:
-        Visualiation_table.c.importable.drop()
-    except Exception:
-        log.exception("Dropping importable column from visualization table failed.")
-
-    try:
-        Visualiation_table.c.slug.drop()
-    except Exception:
-        log.exception("Dropping slug column from visualization table failed.")
-
-    try:
-        Visualiation_table.c.published.drop()
-    except Exception:
-        log.exception("Dropping published column from visualization table failed.")
-
-    # Drop visualization_tag_association table.
-    try:
-        VisualizationTagAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping visualization_tag_association table failed.")
-
-    # Drop visualization_annotation_association table.
-    try:
-        VisualizationAnnotationAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping visualization_annotation_association table failed.")
+    for table in TABLES:
+        drop_table(table)

--- a/lib/galaxy/model/migrate/versions/0046_post_job_actions.py
+++ b/lib/galaxy/model/migrate/versions/0046_post_job_actions.py
@@ -5,12 +5,21 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, ForeignKey, Integer, MetaData, String, Table
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table
+)
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import JSONType
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
-logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 metadata = MetaData()
 
@@ -21,27 +30,15 @@ PostJobAction_table = Table("post_job_action", metadata,
                             Column("output_name", String(255), nullable=True),
                             Column("action_arguments", JSONType, nullable=True))
 
-# PostJobActionAssociation_table = Table("post_job_action_association", metadata,
-#     Column("id", Integer, primary_key=True),
-#     Column("post_job_action_id", Integer, ForeignKey("post_job_action.id"), index=True, nullable=False),
-#     Column("job_id", Integer, ForeignKey("job.id"), index=True, nullable=False))
-
-tables = [PostJobAction_table]  # , PostJobActionAssociation_table]
-
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    for table in tables:
-        try:
-            table.create()
-        except Exception:
-            log.exception("Failed to create table '%s', ignoring (might result in wrong schema)" % table.name)
+    create_table(PostJobAction_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    for table in tables:
-        table.drop()
+    drop_table(PostJobAction_table)

--- a/lib/galaxy/model/migrate/versions/0047_job_table_user_id_column.py
+++ b/lib/galaxy/model/migrate/versions/0047_job_table_user_id_column.py
@@ -28,12 +28,8 @@ def upgrade(migrate_engine):
     metadata.reflect()
 
     Job_table = Table("job", metadata, autoload=True)
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        col = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True, nullable=True)
-    else:
-        col = Column("user_id", Integer, nullable=True)
-    add_column(col, Job_table, index_name='ix_job_user_id')
+    col = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True, nullable=True)
+    add_column(col, Job_table, metadata, index_name='ix_job_user_id')
     try:
         cmd = "SELECT job.id AS galaxy_job_id, " \
             + "galaxy_session.user_id AS galaxy_user_id " \

--- a/lib/galaxy/model/migrate/versions/0047_job_table_user_id_column.py
+++ b/lib/galaxy/model/migrate/versions/0047_job_table_user_id_column.py
@@ -4,21 +4,21 @@ Add a user_id column to the job table.
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table
-from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table
+)
 
-from galaxy.model.migrate.versions.util import add_column, drop_column
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 
@@ -27,37 +27,32 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
+    Job_table = Table("job", metadata, autoload=True)
+    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
+    if migrate_engine.name != 'sqlite':
+        col = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True, nullable=True)
+    else:
+        col = Column("user_id", Integer, nullable=True)
+    add_column(col, Job_table, index_name='ix_job_user_id')
     try:
-        Job_table = Table("job", metadata, autoload=True)
-    except NoSuchTableError:
-        Job_table = None
-        log.debug("Failed loading table job")
-    if Job_table is not None:
-        # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-        if migrate_engine.name != 'sqlite':
-            col = Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True, nullable=True)
-        else:
-            col = Column("user_id", Integer, nullable=True)
-        add_column(col, Job_table, index_name='ix_job_user_id')
-        try:
-            cmd = "SELECT job.id AS galaxy_job_id, " \
-                + "galaxy_session.user_id AS galaxy_user_id " \
-                + "FROM job " \
-                + "JOIN galaxy_session ON job.session_id = galaxy_session.id;"
-            job_users = migrate_engine.execute(cmd).fetchall()
-            print("Updating user_id column in job table for ", len(job_users), " rows...")
-            print("")
-            update_count = 0
-            for row in job_users:
-                if row.galaxy_user_id:
-                    cmd = "UPDATE job SET user_id = %d WHERE id = %d" % (int(row.galaxy_user_id), int(row.galaxy_job_id))
-                    update_count += 1
-                migrate_engine.execute(cmd)
-            print("Updated the user_id column for ", update_count, " rows in the job table.  ")
-            print(len(job_users) - update_count, " rows have no user_id since the value was NULL in the galaxy_session table.")
-            print("")
-        except Exception:
-            log.exception("Updating job.user_id column failed.")
+        cmd = "SELECT job.id AS galaxy_job_id, " \
+            + "galaxy_session.user_id AS galaxy_user_id " \
+            + "FROM job " \
+            + "JOIN galaxy_session ON job.session_id = galaxy_session.id;"
+        job_users = migrate_engine.execute(cmd).fetchall()
+        print("Updating user_id column in job table for ", len(job_users), " rows...")
+        print("")
+        update_count = 0
+        for row in job_users:
+            if row.galaxy_user_id:
+                cmd = "UPDATE job SET user_id = %d WHERE id = %d" % (int(row.galaxy_user_id), int(row.galaxy_job_id))
+                update_count += 1
+            migrate_engine.execute(cmd)
+        print("Updated column 'user_id' for ", update_count, " rows of table 'job'.")
+        print(len(job_users) - update_count, " rows have no user_id since the value was NULL in the galaxy_session table.")
+        print("")
+    except Exception:
+        log.exception("Updating column 'user_id' of table 'job' failed.")
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0048_dataset_instance_state_column.py
+++ b/lib/galaxy/model/migrate/versions/0048_dataset_instance_state_column.py
@@ -4,21 +4,19 @@ Add a state column to the history_dataset_association and library_dataset_datase
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Column, MetaData, Table
-from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy import (
+    Column,
+    MetaData,
+)
 
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 DATASET_INSTANCE_TABLE_NAMES = ['history_dataset_association', 'library_dataset_dataset_association']
@@ -29,36 +27,15 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    dataset_instance_tables = []
     for table_name in DATASET_INSTANCE_TABLE_NAMES:
-        try:
-            dataset_instance_tables.append((table_name, Table(table_name, metadata, autoload=True)))
-        except NoSuchTableError:
-            log.debug("Failed loading table %s" % table_name)
-    if dataset_instance_tables:
-        for table_name, dataset_instance_table in dataset_instance_tables:
-            index_name = "ix_%s_state" % table_name
-            try:
-                col = Column("state", TrimmedString(64), index=True, nullable=True)
-                col.create(dataset_instance_table, index_name=index_name)
-                assert col is dataset_instance_table.c.state
-            except Exception:
-                log.exception("Adding column 'state' to %s table failed.", table_name)
+        col = Column("state", TrimmedString(64), index=True, nullable=True)
+        index_name = "ix_%s_state" % table_name
+        add_column(col, table_name, metadata, index_name=index_name)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    dataset_instance_tables = []
+
     for table_name in DATASET_INSTANCE_TABLE_NAMES:
-        try:
-            dataset_instance_tables.append((table_name, Table(table_name, metadata, autoload=True)))
-        except NoSuchTableError:
-            log.debug("Failed loading table %s" % table_name)
-    if dataset_instance_tables:
-        for table_name, dataset_instance_table in dataset_instance_tables:
-            try:
-                col = dataset_instance_table.c.state
-                col.drop()
-            except Exception:
-                log.exception("Dropping column 'state' from %s table failed.", table_name)
+        drop_column('state', table_name, metadata)

--- a/lib/galaxy/model/migrate/versions/0051_imported_col_for_jobs_table.py
+++ b/lib/galaxy/model/migrate/versions/0051_imported_col_for_jobs_table.py
@@ -21,7 +21,7 @@ def upgrade(migrate_engine):
     # Create and initialize imported column in job table.
     Jobs_table = Table("job", metadata, autoload=True)
     c = Column("imported", Boolean, default=False, index=True)
-    add_column(c, Jobs_table, index_name="ix_job_imported")
+    add_column(c, Jobs_table, metadata, index_name="ix_job_imported")
     try:
         migrate_engine.execute("UPDATE job SET imported=%s" % engine_false(migrate_engine))
     except Exception:

--- a/lib/galaxy/model/migrate/versions/0052_sample_dataset_table.py
+++ b/lib/galaxy/model/migrate/versions/0052_sample_dataset_table.py
@@ -75,5 +75,4 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
     pass

--- a/lib/galaxy/model/migrate/versions/0054_visualization_dbkey.py
+++ b/lib/galaxy/model/migrate/versions/0054_visualization_dbkey.py
@@ -6,9 +6,18 @@ from __future__ import print_function
 import logging
 from json import loads
 
-from sqlalchemy import Column, Index, MetaData, Table, TEXT
+from sqlalchemy import (
+    Column,
+    MetaData,
+    Table,
+    TEXT
+)
 
-from galaxy.model.migrate.versions.util import add_column, drop_column
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    add_index,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -27,11 +36,10 @@ def upgrade(migrate_engine):
     add_column(x, Visualization_table, metadata)
     y = Column("dbkey", TEXT)
     add_column(y, Visualization_revision_table, metadata)
-    # Manually create indexes for compatability w/ mysql_length.
-    xi = Index("ix_visualization_dbkey", Visualization_table.c.dbkey, mysql_length=200)
-    xi.create()
-    yi = Index("ix_visualization_revision_dbkey", Visualization_revision_table.c.dbkey, mysql_length=200)
-    yi.create()
+    # Indexes need to be added separately because MySQL cannot index a TEXT/BLOB
+    # column without specifying mysql_length
+    add_index("ix_visualization_dbkey", Visualization_table, 'dbkey')
+    add_index("ix_visualization_revision_dbkey", Visualization_revision_table, 'dbkey')
 
     all_viz = migrate_engine.execute("SELECT visualization.id as viz_id, visualization_revision.id as viz_rev_id, visualization_revision.config FROM visualization_revision \
                     LEFT JOIN visualization ON visualization.id=visualization_revision.visualization_id")

--- a/lib/galaxy/model/migrate/versions/0054_visualization_dbkey.py
+++ b/lib/galaxy/model/migrate/versions/0054_visualization_dbkey.py
@@ -24,9 +24,9 @@ def upgrade(migrate_engine):
 
     # Create dbkey columns.
     x = Column("dbkey", TEXT)
-    add_column(x, Visualization_table)
+    add_column(x, Visualization_table, metadata)
     y = Column("dbkey", TEXT)
-    add_column(y, Visualization_revision_table)
+    add_column(y, Visualization_revision_table, metadata)
     # Manually create indexes for compatability w/ mysql_length.
     xi = Index("ix_visualization_dbkey", Visualization_table.c.dbkey, mysql_length=200)
     xi.create()

--- a/lib/galaxy/model/migrate/versions/0056_workflow_outputs.py
+++ b/lib/galaxy/model/migrate/versions/0056_workflow_outputs.py
@@ -5,11 +5,21 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, ForeignKey, Integer, MetaData, String, Table
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table
+)
 
-logging.basicConfig(level=logging.DEBUG)
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
+
 log = logging.getLogger(__name__)
-
 metadata = MetaData()
 
 WorkflowOutput_table = Table("workflow_output", metadata,
@@ -17,22 +27,15 @@ WorkflowOutput_table = Table("workflow_output", metadata,
                              Column("workflow_step_id", Integer, ForeignKey("workflow_step.id"), index=True, nullable=False),
                              Column("output_name", String(255), nullable=True))
 
-tables = [WorkflowOutput_table]
-
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    for table in tables:
-        try:
-            table.create()
-        except Exception:
-            log.warning("Failed to create table '%s', ignoring (might result in wrong schema)" % table.name)
+    create_table(WorkflowOutput_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    for table in tables:
-        table.drop()
+    drop_table(WorkflowOutput_table)

--- a/lib/galaxy/model/migrate/versions/0057_request_notify.py
+++ b/lib/galaxy/model/migrate/versions/0057_request_notify.py
@@ -33,7 +33,7 @@ def upgrade(migrate_engine):
 
     # create the column again as JSONType
     col = Column("notification", JSONType())
-    add_column(col, Request_table)
+    add_column(col, Request_table, metadata)
 
     cmd = "SELECT id, user_id, notify FROM request"
     result = migrate_engine.execute(cmd)
@@ -55,6 +55,6 @@ def downgrade(migrate_engine):
     Request_table = Table("request", metadata, autoload=True)
     if migrate_engine.name != 'sqlite':
         c = Column("notify", Boolean, default=False)
-        add_column(c, Request_table)
+        add_column(c, Request_table, metadata)
 
     drop_column('notification', Request_table)

--- a/lib/galaxy/model/migrate/versions/0059_sample_dataset_file_path.py
+++ b/lib/galaxy/model/migrate/versions/0059_sample_dataset_file_path.py
@@ -49,5 +49,4 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
     pass

--- a/lib/galaxy/model/migrate/versions/0061_tasks.py
+++ b/lib/galaxy/model/migrate/versions/0061_tasks.py
@@ -6,11 +6,25 @@ from __future__ import print_function
 import datetime
 import logging
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, String, Table, TEXT
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    TEXT
+)
+
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
 log = logging.getLogger(__name__)
-metadata = MetaData()
 now = datetime.datetime.utcnow
+metadata = MetaData()
 
 Task_table = Table("task", metadata,
                    Column("id", Integer, primary_key=True),
@@ -29,22 +43,17 @@ Task_table = Table("task", metadata,
                    Column("task_runner_name", String(255)),
                    Column("task_runner_external_id", String(255)))
 
-tables = [Task_table]
-
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    for table in tables:
-        try:
-            table.create()
-        except Exception:
-            log.warning("Failed to create table '%s', ignoring (might result in wrong schema)" % table.name)
+
+    create_table(Task_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    for table in tables:
-        table.drop()
+
+    drop_table(Task_table)

--- a/lib/galaxy/model/migrate/versions/0065_add_name_to_form_fields_and_values.py
+++ b/lib/galaxy/model/migrate/versions/0065_add_name_to_form_fields_and_values.py
@@ -6,41 +6,36 @@ table, the 'content' column is now a JSON dict instead of a list.
 from __future__ import print_function
 
 import logging
-import sys
-from json import dumps, loads
+from json import (
+    dumps,
+    loads
+)
 
-from sqlalchemy import MetaData, Table
+from sqlalchemy import (
+    MetaData,
+    Table
+)
 
 from galaxy.model.custom_types import _sniffnfix_pg9_hex
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        Table("form_definition", metadata, autoload=True)
-    except Exception:
-        log.exception("Loading 'form_definition' table failed.")
-    try:
-        Table("form_values", metadata, autoload=True)
-    except Exception:
-        log.exception("Loading 'form_values' table failed.")
+
+    Table("form_definition", metadata, autoload=True)
+    Table("form_values", metadata, autoload=True)
 
     def get_value(lst, index):
         try:
             return str(lst[index]).replace("'", "''")
         except IndexError:
             return ''
+
     # Go through the entire table and add a 'name' attribute for each field
     # in the list of fields for each form definition
     cmd = "SELECT f.id, f.fields FROM form_definition AS f"
@@ -89,14 +84,9 @@ def upgrade(migrate_engine):
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        Table("form_definition", metadata, autoload=True)
-    except Exception:
-        log.exception("Loading 'form_definition' table failed.")
-    try:
-        Table("form_values", metadata, autoload=True)
-    except Exception:
-        log.exception("Loading 'form_values' table failed.")
+
+    Table("form_definition", metadata, autoload=True)
+    Table("form_values", metadata, autoload=True)
     # remove the name attribute in the content column JSON dict in the form_values table
     # and restore it to a list of values
     cmd = "SELECT form_values.id, form_values.content, form_definition.fields" \

--- a/lib/galaxy/model/migrate/versions/0067_populate_sequencer_table.py
+++ b/lib/galaxy/model/migrate/versions/0067_populate_sequencer_table.py
@@ -178,7 +178,7 @@ def upgrade(migrate_engine):
     RequestType_table = Table("request_type", metadata, autoload=True)
     # create foreign key field to the sequencer table in the request_type table
     col = Column("sequencer_id", Integer, ForeignKey("sequencer.id"), nullable=True)
-    add_column(col, RequestType_table)
+    add_column(col, RequestType_table, metadata)
     # copy the sequencer information contained in the 'datatx_info' column
     # of the request_type table to the form values referenced in the sequencer table
     cmd = "SELECT id, name, datatx_info FROM request_type ORDER BY id ASC"
@@ -223,7 +223,7 @@ def downgrade(migrate_engine):
     RequestType_table = Table("request_type", metadata, autoload=True)
     # create the 'datatx_info' column
     col = Column("datatx_info", JSONType())
-    add_column(col, RequestType_table)
+    add_column(col, RequestType_table, metadata)
     # restore the datatx_info column data in the request_type table with data from
     # the sequencer and the form_values table
     cmd = "SELECT request_type.id, form_values.content "\

--- a/lib/galaxy/model/migrate/versions/0067_populate_sequencer_table.py
+++ b/lib/galaxy/model/migrate/versions/0067_populate_sequencer_table.py
@@ -9,11 +9,22 @@ from __future__ import print_function
 import logging
 from json import dumps, loads
 
-from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table
-from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table
+)
 
 from galaxy.model.custom_types import JSONType
-from galaxy.model.migrate.versions.util import localtimestamp, nextval
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column,
+    engine_false,
+    localtimestamp,
+    nextval
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -28,17 +39,6 @@ def get_latest_id(migrate_engine, table):
         raise Exception('Unable to get the latest id in the %s table.' % table)
 
 
-def boolean(migrate_engine, value):
-    if migrate_engine.name in ['mysql', 'postgres', 'postgresql']:
-        return value
-    elif migrate_engine.name == 'sqlite':
-        if value in ['True', 'true']:
-            return 1
-        return 0
-    else:
-        raise Exception('Unable to convert data for unknown database type: %s' % migrate_engine.name)
-
-
 def create_sequencer_form_definition(migrate_engine):
     '''
     Create a new form_definition containing 5 fields (host, username, password,
@@ -46,12 +46,12 @@ def create_sequencer_form_definition(migrate_engine):
     dict in the request_type table
     '''
     # create new form_definition_current in the db
-    cmd = "INSERT INTO form_definition_current VALUES ( %s, %s, %s, %s, %s )"
-    cmd = cmd % (nextval(migrate_engine, 'form_definition_current'),
-                 localtimestamp(migrate_engine),
-                 localtimestamp(migrate_engine),
-                 'NULL',
-                 boolean(migrate_engine, 'false'))
+    cmd = "INSERT INTO form_definition_current VALUES ( %s, %s, %s, %s, %s )" % (
+        nextval(migrate_engine, 'form_definition_current'),
+        localtimestamp(migrate_engine),
+        localtimestamp(migrate_engine),
+        'NULL',
+        engine_false(migrate_engine))
     migrate_engine.execute(cmd)
     # get this form_definition_current id
     form_definition_current_id = get_latest_id(migrate_engine, 'form_definition_current')
@@ -149,17 +149,17 @@ def add_sequencer(migrate_engine, sequencer_index, sequencer_form_definition_id,
     desc = ''
     version = ''
     sequencer_type_id = 'simple_unknown_sequencer'
-    cmd = "INSERT INTO sequencer VALUES ( %s, %s, %s, '%s', '%s', '%s', '%s', %s, %s, %s )"
-    cmd = cmd % (nextval(migrate_engine, 'sequencer'),
-                 localtimestamp(migrate_engine),
-                 localtimestamp(migrate_engine),
-                 name,
-                 desc,
-                 sequencer_type_id,
-                 version,
-                 sequencer_form_definition_id,
-                 sequencer_form_values_id,
-                 boolean(migrate_engine, 'false'))
+    cmd = "INSERT INTO sequencer VALUES ( %s, %s, %s, '%s', '%s', '%s', '%s', %s, %s, %s )" % (
+        nextval(migrate_engine, 'sequencer'),
+        localtimestamp(migrate_engine),
+        localtimestamp(migrate_engine),
+        name,
+        desc,
+        sequencer_type_id,
+        version,
+        sequencer_form_definition_id,
+        sequencer_form_values_id,
+        engine_false(migrate_engine))
     migrate_engine.execute(cmd)
     return get_latest_id(migrate_engine, 'sequencer')
 
@@ -175,28 +175,10 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        RequestType_table = Table("request_type", metadata, autoload=True)
-    except NoSuchTableError:
-        RequestType_table = None
-        log.debug("Failed loading table 'request_type'")
-    if RequestType_table is None:
-        return
-    # load the sequencer table
-    try:
-        Sequencer_table = Table("sequencer", metadata, autoload=True)
-    except NoSuchTableError:
-        Sequencer_table = None
-        log.debug("Failed loading table 'sequencer'")
-    if Sequencer_table is None:
-        return
+    RequestType_table = Table("request_type", metadata, autoload=True)
     # create foreign key field to the sequencer table in the request_type table
-    try:
-        col = Column("sequencer_id", Integer, ForeignKey("sequencer.id"), nullable=True)
-        col.create(RequestType_table)
-        assert col is RequestType_table.c.sequencer_id
-    except Exception:
-        log.exception("Creating column 'sequencer_id' in the 'request_type' table failed.")
+    col = Column("sequencer_id", Integer, ForeignKey("sequencer.id"), nullable=True)
+    add_column(col, RequestType_table)
     # copy the sequencer information contained in the 'datatx_info' column
     # of the request_type table to the form values referenced in the sequencer table
     cmd = "SELECT id, name, datatx_info FROM request_type ORDER BY id ASC"
@@ -231,50 +213,35 @@ def upgrade(migrate_engine):
                 sequencer_index = sequencer_index + 1
 
     # Finally delete the 'datatx_info' column from the request_type table
-    try:
-        RequestType_table.c.datatx_info.drop()
-    except Exception:
-        log.exception("Deleting column 'datatx_info' in the 'request_type' table failed.")
+    drop_column('datatx_info', RequestType_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        RequestType_table = Table("request_type", metadata, autoload=True)
-    except NoSuchTableError:
-        RequestType_table = None
-        log.debug("Failed loading table 'request_type'")
-    if RequestType_table is not None:
-        # create the 'datatx_info' column
-        try:
-            col = Column("datatx_info", JSONType())
-            col.create(RequestType_table)
-            assert col is RequestType_table.c.datatx_info
-        except Exception:
-            log.exception("Creating column 'datatx_info' in the 'request_type' table failed.")
-        # restore the datatx_info column data in the request_type table with data from
-        # the sequencer and the form_values table
-        cmd = "SELECT request_type.id, form_values.content "\
-              + " FROM request_type, sequencer, form_values "\
-              + " WHERE request_type.sequencer_id=sequencer.id AND sequencer.form_values_id=form_values.id "\
-              + " ORDER  BY request_type.id ASC"
-        result = migrate_engine.execute(cmd)
-        for row in result:
-            request_type_id = row[0]
-            seq_values = loads(str(row[1]))
-            # create the datatx_info json dict
-            datatx_info = dumps(dict(host=seq_values.get('field_0', ''),
-                                     username=seq_values.get('field_1', ''),
-                                     password=seq_values.get('field_2', ''),
-                                     data_dir=seq_values.get('field_3', ''),
-                                     rename_dataset=seq_values.get('field_4', '')))
-            # update the column
-            cmd = "UPDATE request_type SET datatx_info='%s' WHERE id=%i" % (datatx_info, request_type_id)
-            migrate_engine.execute(cmd)
-        # delete foreign key field to the sequencer table in the request_type table
-        try:
-            RequestType_table.c.sequencer_id.drop()
-        except Exception:
-            log.exception("Deleting column 'sequencer_id' in the 'request_type' table failed.")
+    RequestType_table = Table("request_type", metadata, autoload=True)
+    # create the 'datatx_info' column
+    col = Column("datatx_info", JSONType())
+    add_column(col, RequestType_table)
+    # restore the datatx_info column data in the request_type table with data from
+    # the sequencer and the form_values table
+    cmd = "SELECT request_type.id, form_values.content "\
+          + " FROM request_type, sequencer, form_values "\
+          + " WHERE request_type.sequencer_id=sequencer.id AND sequencer.form_values_id=form_values.id "\
+          + " ORDER  BY request_type.id ASC"
+    result = migrate_engine.execute(cmd)
+    for row in result:
+        request_type_id = row[0]
+        seq_values = loads(str(row[1]))
+        # create the datatx_info json dict
+        datatx_info = dumps(dict(host=seq_values.get('field_0', ''),
+                                 username=seq_values.get('field_1', ''),
+                                 password=seq_values.get('field_2', ''),
+                                 data_dir=seq_values.get('field_3', ''),
+                                 rename_dataset=seq_values.get('field_4', '')))
+        # update the column
+        cmd = "UPDATE request_type SET datatx_info='%s' WHERE id=%i" % (datatx_info, request_type_id)
+        migrate_engine.execute(cmd)
+    # delete foreign key field to the sequencer table in the request_type table
+    drop_column('sequencer_id', RequestType_table)

--- a/lib/galaxy/model/migrate/versions/0068_rename_sequencer_to_external_services.py
+++ b/lib/galaxy/model/migrate/versions/0068_rename_sequencer_to_external_services.py
@@ -103,7 +103,7 @@ def upgrade(migrate_engine):
             sequencer_id)
         migrate_engine.execute(cmd)
 
-    # drop the 'sequencer_id' column in the 'request_type' table
+    # TODO: Dropping a column used in a foreign key fails in MySQL, need to remove the FK first.
     drop_column('sequencer_id', 'request_type', metadata)
 
 

--- a/lib/galaxy/model/migrate/versions/0068_rename_sequencer_to_external_services.py
+++ b/lib/galaxy/model/migrate/versions/0068_rename_sequencer_to_external_services.py
@@ -49,12 +49,8 @@ def upgrade(migrate_engine):
 
     # Add 'external_services_id' column to 'sample_dataset' table
     SampleDataset_table = Table("sample_dataset", metadata, autoload=True)
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        col = Column("external_service_id", Integer, ForeignKey("external_service.id", name='sample_dataset_external_services_id_fk'), index=True)
-    else:
-        col = Column("external_service_id", Integer, index=True)
-    add_column(col, SampleDataset_table, index_name="ix_sample_dataset_external_service_id")
+    col = Column("external_service_id", Integer, ForeignKey("external_service.id", name='sample_dataset_external_services_id_fk'), index=True)
+    add_column(col, SampleDataset_table, metadata, index_name="ix_sample_dataset_external_service_id")
 
     # populate the column
     cmd = "SELECT sample_dataset.id, request_type.sequencer_id " \
@@ -75,7 +71,7 @@ def upgrade(migrate_engine):
     # create the column as 'external_service_type_id'
     ExternalServices_table = Table("external_service", metadata, autoload=True)
     col = Column("external_service_type_id", TrimmedString(255))
-    add_column(col, ExternalServices_table)
+    add_column(col, ExternalServices_table, metadata)
 
     # populate this new column
     cmd = "UPDATE external_service SET external_service_type_id=sequencer_type_id"
@@ -149,7 +145,7 @@ def downgrade(migrate_engine):
     # create the column 'sequencer_type_id'
     Sequencer_table = Table("sequencer", metadata, autoload=True)
     col = Column("sequencer_type_id", TrimmedString(255))  # should also have nullable=False
-    add_column(col, Sequencer_table)
+    add_column(col, Sequencer_table, metadata)
 
     # populate this new column
     cmd = "UPDATE sequencer SET sequencer_type_id=external_service_type_id"

--- a/lib/galaxy/model/migrate/versions/0071_add_history_and_workflow_to_sample.py
+++ b/lib/galaxy/model/migrate/versions/0071_add_history_and_workflow_to_sample.py
@@ -21,10 +21,10 @@ def upgrade(migrate_engine):
 
     Sample_table = Table("sample", metadata, autoload=True)
     c1 = Column("workflow", JSONType, nullable=True)
-    add_column(c1, Sample_table)
+    add_column(c1, Sample_table, metadata)
 
     c2 = Column("history_id", Integer, ForeignKey("history.id"), nullable=True)
-    add_column(c2, Sample_table)
+    add_column(c2, Sample_table, metadata)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0073_add_ldda_to_implicit_conversion_table.py
+++ b/lib/galaxy/model/migrate/versions/0073_add_ldda_to_implicit_conversion_table.py
@@ -26,11 +26,7 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        c = Column("ldda_parent_id", Integer, ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True)
-    else:
-        c = Column("ldda_parent_id", Integer, index=True, nullable=True)
+    c = Column("ldda_parent_id", Integer, ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True)
     add_column(c, 'implicitly_converted_dataset_association', metadata, index_name='ix_implicitly_converted_dataset_assoc_ldda_parent_id')
 
 

--- a/lib/galaxy/model/migrate/versions/0076_fix_form_values_data_corruption.py
+++ b/lib/galaxy/model/migrate/versions/0076_fix_form_values_data_corruption.py
@@ -86,5 +86,4 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
     pass

--- a/lib/galaxy/model/migrate/versions/0078_add_columns_for_disk_usage_accounting.py
+++ b/lib/galaxy/model/migrate/versions/0078_add_columns_for_disk_usage_accounting.py
@@ -25,7 +25,7 @@ def upgrade(migrate_engine):
 
     HistoryDatasetAssociation_table = Table("history_dataset_association", metadata, autoload=True)
     c = Column("purged", Boolean, index=True, default=False)
-    add_column(c, HistoryDatasetAssociation_table, index_name="ix_history_dataset_association_purged")
+    add_column(c, HistoryDatasetAssociation_table, metadata, index_name="ix_history_dataset_association_purged")
     try:
         migrate_engine.execute(HistoryDatasetAssociation_table.update().values(purged=False))
     except Exception:

--- a/lib/galaxy/model/migrate/versions/0082_add_tool_shed_repository_table.py
+++ b/lib/galaxy/model/migrate/versions/0082_add_tool_shed_repository_table.py
@@ -5,22 +5,25 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 
-from sqlalchemy import Boolean, Column, DateTime, Integer, MetaData, Table, TEXT
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Integer,
+    MetaData,
+    Table,
+    TEXT
+)
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 # New table to store information about cloned tool shed repositories.
@@ -40,16 +43,12 @@ def upgrade(migrate_engine):
     print(__doc__)
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        ToolShedRepository_table.create()
-    except Exception:
-        log.exception("Creating tool_shed_repository table failed.")
+
+    create_table(ToolShedRepository_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        ToolShedRepository_table.drop()
-    except Exception:
-        log.exception("Dropping tool_shed_repository table failed.")
+
+    drop_table(ToolShedRepository_table)

--- a/lib/galaxy/model/migrate/versions/0083_add_prepare_files_to_task.py
+++ b/lib/galaxy/model/migrate/versions/0083_add_prepare_files_to_task.py
@@ -20,10 +20,10 @@ def upgrade(migrate_engine):
 
     task_table = Table("task", metadata, autoload=True)
     c = Column("prepare_input_files_cmd", TEXT, nullable=True)
-    add_column(c, task_table)
+    add_column(c, task_table, metadata)
 
     c = Column("working_directory", String(1024), nullable=True)
-    add_column(c, task_table)
+    add_column(c, task_table, metadata)
 
     # remove the 'part_file' column - nobody used tasks before this, so no data needs to be migrated
     drop_column('part_file', task_table)
@@ -35,7 +35,7 @@ def downgrade(migrate_engine):
 
     task_table = Table("task", metadata, autoload=True)
     c = Column("part_file", String(1024), nullable=True)
-    add_column(c, task_table)
+    add_column(c, task_table, metadata)
 
     drop_column('working_directory', task_table)
     drop_column('prepare_input_files_cmd', task_table)

--- a/lib/galaxy/model/migrate/versions/0084_add_ldda_id_to_implicit_conversion_table.py
+++ b/lib/galaxy/model/migrate/versions/0084_add_ldda_id_to_implicit_conversion_table.py
@@ -26,11 +26,7 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    # SQLAlchemy Migrate has a bug when adding a column with both a ForeignKey and a index in SQLite
-    if migrate_engine.name != 'sqlite':
-        c = Column("ldda_id", Integer, ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True)
-    else:
-        c = Column("ldda_id", Integer, index=True, nullable=True)
+    c = Column("ldda_id", Integer, ForeignKey("library_dataset_dataset_association.id"), index=True, nullable=True)
     add_column(c, 'implicitly_converted_dataset_association', metadata, index_name='ix_implicitly_converted_ds_assoc_ldda_id')
 
 

--- a/lib/galaxy/model/migrate/versions/0086_add_tool_shed_repository_table_columns.py
+++ b/lib/galaxy/model/migrate/versions/0086_add_tool_shed_repository_table_columns.py
@@ -30,15 +30,15 @@ def upgrade(migrate_engine):
 
     ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
     c = Column("metadata", JSONType(), nullable=True)
-    add_column(c, ToolShedRepository_table)
+    add_column(c, ToolShedRepository_table, metadata)
     c = Column("includes_datatypes", Boolean, index=True, default=False)
-    add_column(c, ToolShedRepository_table, index_name="ix_tool_shed_repository_includes_datatypes")
+    add_column(c, ToolShedRepository_table, metadata, index_name="ix_tool_shed_repository_includes_datatypes")
     try:
         migrate_engine.execute("UPDATE tool_shed_repository SET includes_datatypes=%s" % engine_false(migrate_engine))
     except Exception:
         log.exception("Updating column 'includes_datatypes' of table 'tool_shed_repository' failed.")
     c = Column("update_available", Boolean, default=False)
-    add_column(c, ToolShedRepository_table)
+    add_column(c, ToolShedRepository_table, metadata)
     try:
         migrate_engine.execute("UPDATE tool_shed_repository SET update_available=%s" % engine_false(migrate_engine))
     except Exception:

--- a/lib/galaxy/model/migrate/versions/0086_add_tool_shed_repository_table_columns.py
+++ b/lib/galaxy/model/migrate/versions/0086_add_tool_shed_repository_table_columns.py
@@ -4,21 +4,22 @@ Migration script to add the metadata, update_available and includes_datatypes co
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Boolean, Column, MetaData, Table
+from sqlalchemy import (
+    Boolean,
+    Column,
+    MetaData,
+    Table
+)
 
 from galaxy.model.custom_types import JSONType
-from galaxy.model.migrate.versions.util import add_column, drop_column, engine_false
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column,
+    engine_false
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 

--- a/lib/galaxy/model/migrate/versions/0087_tool_id_guid_map_table.py
+++ b/lib/galaxy/model/migrate/versions/0087_tool_id_guid_map_table.py
@@ -5,22 +5,25 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 
-from sqlalchemy import Column, DateTime, Integer, MetaData, String, Table, TEXT
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    TEXT
+)
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 ToolIdGuidMap_table = Table("tool_id_guid_map", metadata,
@@ -36,19 +39,15 @@ ToolIdGuidMap_table = Table("tool_id_guid_map", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        ToolIdGuidMap_table.create()
-    except Exception:
-        log.exception("Creating tool_id_guid_map table failed.")
+
+    create_table(ToolIdGuidMap_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        ToolIdGuidMap_table.drop()
-    except Exception:
-        log.exception("Dropping tool_id_guid_map table failed.")
+
+    drop_table(ToolIdGuidMap_table)

--- a/lib/galaxy/model/migrate/versions/0087_tool_id_guid_map_table.py
+++ b/lib/galaxy/model/migrate/versions/0087_tool_id_guid_map_table.py
@@ -9,6 +9,7 @@ import logging
 from sqlalchemy import (
     Column,
     DateTime,
+    Index,
     Integer,
     MetaData,
     String,
@@ -26,16 +27,19 @@ log = logging.getLogger(__name__)
 now = datetime.datetime.utcnow
 metadata = MetaData()
 
-ToolIdGuidMap_table = Table("tool_id_guid_map", metadata,
-                            Column("id", Integer, primary_key=True),
-                            Column("create_time", DateTime, default=now),
-                            Column("update_time", DateTime, default=now, onupdate=now),
-                            Column("tool_id", String(255)),
-                            Column("tool_version", TEXT),
-                            Column("tool_shed", TrimmedString(255)),
-                            Column("repository_owner", TrimmedString(255)),
-                            Column("repository_name", TrimmedString(255)),
-                            Column("guid", TEXT, index=True, unique=True))
+ToolIdGuidMap_table = Table(
+    "tool_id_guid_map", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("create_time", DateTime, default=now),
+    Column("update_time", DateTime, default=now, onupdate=now),
+    Column("tool_id", String(255)),
+    Column("tool_version", TEXT),
+    Column("tool_shed", TrimmedString(255)),
+    Column("repository_owner", TrimmedString(255)),
+    Column("repository_name", TrimmedString(255)),
+    Column("guid", TEXT),
+    Index('ix_tool_id_guid_map_guid', 'guid', unique=True, mysql_length=200),
+)
 
 
 def upgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0088_add_installed_changeset_revison_column.py
+++ b/lib/galaxy/model/migrate/versions/0088_add_installed_changeset_revison_column.py
@@ -4,35 +4,29 @@ Migration script to add the installed_changeset_revision column to the tool_shed
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Column, MetaData, Table
+from sqlalchemy import (
+    Column,
+    MetaData
+)
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
+
     col = Column("installed_changeset_revision", TrimmedString(255))
-    try:
-        col.create(ToolShedRepository_table)
-        assert col is ToolShedRepository_table.c.installed_changeset_revision
-    except Exception:
-        log.exception("Adding installed_changeset_revision column to the tool_shed_repository table failed.")
+    add_column(col, 'tool_shed_repository', metadata)
     # Update each row by setting the value of installed_changeset_revison to be the value of changeset_revision.
     # This will be problematic if the value of changeset_revision was updated to something other than the value
     # that it was when the repository was installed (because the install path determined in real time will attempt to
@@ -50,14 +44,11 @@ def upgrade(migrate_engine):
             + "WHERE changeset_revision = '%s';" % row.changeset_revision
         migrate_engine.execute(cmd)
         update_count += 1
-    print("Updated the installed_changeset_revision column for ", update_count, " rows in the tool_shed_repository table.  ")
+    print("Updated the installed_changeset_revision column for ", update_count, " rows in the tool_shed_repository table.")
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
-    try:
-        ToolShedRepository_table.c.installed_changeset_revision.drop()
-    except Exception:
-        log.exception("Dropping column installed_changeset_revision from the tool_shed_repository table failed.")
+
+    drop_column('installed_changeset_revision', 'tool_shed_repository', metadata)

--- a/lib/galaxy/model/migrate/versions/0090_add_tool_shed_repository_table_columns.py
+++ b/lib/galaxy/model/migrate/versions/0090_add_tool_shed_repository_table_columns.py
@@ -4,20 +4,21 @@ Migration script to add the uninstalled and dist_to_shed columns to the tool_she
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Boolean, Column, MetaData, Table
+from sqlalchemy import (
+    Boolean,
+    Column,
+    MetaData,
+    Table
+)
 
-from galaxy.model.migrate.versions.util import drop_column, engine_false
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column,
+    engine_false
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 
@@ -28,19 +29,17 @@ def upgrade(migrate_engine):
 
     ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
     c = Column("uninstalled", Boolean, default=False)
+    add_column(c, ToolShedRepository_table, metadata)
     try:
-        c.create(ToolShedRepository_table)
-        assert c is ToolShedRepository_table.c.uninstalled
         migrate_engine.execute("UPDATE tool_shed_repository SET uninstalled=%s" % engine_false(migrate_engine))
     except Exception:
-        log.exception("Adding uninstalled column to the tool_shed_repository table failed.")
+        log.exception("Updating column 'uninstalled' of table 'tool_shed_repository' failed.")
     c = Column("dist_to_shed", Boolean, default=False)
+    add_column(c, ToolShedRepository_table, metadata)
     try:
-        c.create(ToolShedRepository_table)
-        assert c is ToolShedRepository_table.c.dist_to_shed
         migrate_engine.execute("UPDATE tool_shed_repository SET dist_to_shed=%s" % engine_false(migrate_engine))
     except Exception:
-        log.exception("Adding dist_to_shed column to the tool_shed_repository table failed.")
+        log.exception("Updating column 'dist_to_shed' of table 'tool_shed_repository' failed.")
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0091_add_tool_version_tables.py
+++ b/lib/galaxy/model/migrate/versions/0091_add_tool_version_tables.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Column,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     MetaData,
     String,
@@ -87,7 +88,8 @@ def upgrade(migrate_engine):
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
 
-    ToolIdGuidMap_table = Table("tool_id_guid_map", metadata,
+    ToolIdGuidMap_table = Table(
+        "tool_id_guid_map", metadata,
         Column("id", Integer, primary_key=True),
         Column("create_time", DateTime, default=now),
         Column("update_time", DateTime, default=now, onupdate=now),
@@ -96,7 +98,9 @@ def downgrade(migrate_engine):
         Column("tool_shed", TrimmedString(255)),
         Column("repository_owner", TrimmedString(255)),
         Column("repository_name", TrimmedString(255)),
-        Column("guid", TEXT, index=True, unique=True))
+        Column("guid", TEXT),
+        Index('ix_tool_id_guid_map_guid', 'guid', unique=True, mysql_length=200),
+    )
 
     metadata.reflect()
     try:

--- a/lib/galaxy/model/migrate/versions/0091_add_tool_version_tables.py
+++ b/lib/galaxy/model/migrate/versions/0091_add_tool_version_tables.py
@@ -5,23 +5,30 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 from json import loads
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, String, Table, TEXT
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    TEXT
+)
 
-from galaxy.model.custom_types import _sniffnfix_pg9_hex, TrimmedString
-from galaxy.model.migrate.versions.util import localtimestamp, nextval
+from galaxy.model.custom_types import (
+    _sniffnfix_pg9_hex,
+    TrimmedString
+)
+from galaxy.model.migrate.versions.util import (
+    localtimestamp,
+    nextval
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 

--- a/lib/galaxy/model/migrate/versions/0092_add_migrate_tools_table.py
+++ b/lib/galaxy/model/migrate/versions/0092_add_migrate_tools_table.py
@@ -4,21 +4,22 @@ Migration script to create the migrate_tools table.
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Column, Integer, MetaData, Table, TEXT
+from sqlalchemy import (
+    Column,
+    Integer,
+    MetaData,
+    Table,
+    TEXT
+)
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 MigrateTools_table = Table("migrate_tools", metadata,
@@ -28,23 +29,20 @@ MigrateTools_table = Table("migrate_tools", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
-
+    metadata.bind = migrate_engine
     metadata.reflect()
-    # Create the table.
+
+    create_table(MigrateTools_table)
     try:
-        MigrateTools_table.create()
         cmd = "INSERT INTO migrate_tools VALUES ('GalaxyTools', 'lib/galaxy/tool_shed/migrate', %d)" % 1
         migrate_engine.execute(cmd)
     except Exception:
-        log.exception("Creating migrate_tools table failed.")
+        log.exception("Inserting into table 'migrate_tools' failed.")
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        MigrateTools_table.drop()
-    except Exception:
-        log.exception("Dropping migrate_tools table failed.")
+
+    drop_table(MigrateTools_table)

--- a/lib/galaxy/model/migrate/versions/0097_add_ctx_rev_column.py
+++ b/lib/galaxy/model/migrate/versions/0097_add_ctx_rev_column.py
@@ -4,42 +4,33 @@ Migration script to add the ctx_rev column to the tool_shed_repository table.
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Column, MetaData, Table
+from sqlalchemy import (
+    Column,
+    MetaData
+)
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
+
     col = Column("ctx_rev", TrimmedString(10))
-    try:
-        col.create(ToolShedRepository_table)
-        assert col is ToolShedRepository_table.c.ctx_rev
-    except Exception:
-        log.exception("Adding ctx_rev column to the tool_shed_repository table failed.")
+    add_column(col, 'tool_shed_repository', metadata)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
-    try:
-        ToolShedRepository_table.c.ctx_rev.drop()
-    except Exception:
-        log.exception("Dropping column ctx_rev from the tool_shed_repository table failed.")
+
+    drop_column('ctx_rev', 'tool_shed_repository', metadata)

--- a/lib/galaxy/model/migrate/versions/0098_genome_index_tool_data_table.py
+++ b/lib/galaxy/model/migrate/versions/0098_genome_index_tool_data_table.py
@@ -5,24 +5,26 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, String, Table
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table
+)
 
-from galaxy.model.migrate.versions.util import create_table, drop_table
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
-# New table in changeset TODO:TODO
 GenomeIndexToolData_table = Table("genome_index_tool_data", metadata,
                                   Column("id", Integer, primary_key=True),
                                   Column("job_id", Integer, ForeignKey("job.id"), index=True),

--- a/lib/galaxy/model/migrate/versions/0099_add_tool_dependency_table.py
+++ b/lib/galaxy/model/migrate/versions/0099_add_tool_dependency_table.py
@@ -5,21 +5,25 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData, Table
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table
+)
 
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 # New table to store information about cloned tool shed repositories.
@@ -36,19 +40,15 @@ ToolDependency_table = Table("tool_dependency", metadata,
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        ToolDependency_table.create()
-    except Exception:
-        log.exception("Creating tool_dependency table failed.")
+
+    create_table(ToolDependency_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        ToolDependency_table.drop()
-    except Exception:
-        log.exception("Dropping tool_dependency table failed.")
+
+    drop_table(ToolDependency_table)

--- a/lib/galaxy/model/migrate/versions/0100_alter_tool_dependency_table_version_column.py
+++ b/lib/galaxy/model/migrate/versions/0100_alter_tool_dependency_table_version_column.py
@@ -4,24 +4,21 @@ Migration script to alter the type of the tool_dependency.version column from Tr
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import MetaData, Table
+from sqlalchemy import (
+    MetaData,
+    Table
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
+
     Table("tool_dependency", metadata, autoload=True)
     # Change the tool_dependency table's version column from TrimmedString to Text.
     if migrate_engine.name in ['postgres', 'postgresql']:
@@ -46,6 +43,5 @@ def upgrade(migrate_engine):
 
 
 def downgrade(migrate_engine):
-    metadata.bind = migrate_engine
     # Not necessary to change column type Text to TrimmedString(40).
     pass

--- a/lib/galaxy/model/migrate/versions/0101_drop_installed_changeset_revision_column.py
+++ b/lib/galaxy/model/migrate/versions/0101_drop_installed_changeset_revision_column.py
@@ -4,7 +4,6 @@ Migration script to drop the installed_changeset_revision column from the tool_d
 from __future__ import print_function
 
 import logging
-import sys
 
 from sqlalchemy import (
     Column,
@@ -18,13 +17,6 @@ from galaxy.model.migrate.versions.util import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 

--- a/lib/galaxy/model/migrate/versions/0102_add_tool_dependency_status_columns.py
+++ b/lib/galaxy/model/migrate/versions/0102_add_tool_dependency_status_columns.py
@@ -33,10 +33,10 @@ def upgrade(migrate_engine):
         col = Column("status", TrimmedString(255))
     else:
         col = Column("status", TrimmedString(255), nullable=False)
-    add_column(col, ToolDependency_table)
+    add_column(col, ToolDependency_table, metadata)
 
     col = Column("error_message", TEXT)
-    add_column(col, ToolDependency_table)
+    add_column(col, ToolDependency_table, metadata)
 
     # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
     # TODO move to alembic.
@@ -51,7 +51,7 @@ def downgrade(migrate_engine):
     ToolDependency_table = Table("tool_dependency", metadata, autoload=True)
     if migrate_engine.name != 'sqlite':
         col = Column("uninstalled", Boolean, default=False)
-        add_column(col, ToolDependency_table)
+        add_column(col, ToolDependency_table, metadata)
 
     drop_column('error_message', ToolDependency_table)
     drop_column('status', ToolDependency_table)

--- a/lib/galaxy/model/migrate/versions/0102_add_tool_dependency_status_columns.py
+++ b/lib/galaxy/model/migrate/versions/0102_add_tool_dependency_status_columns.py
@@ -4,21 +4,22 @@ Migration script to add status and error_message columns to the tool_dependency 
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Boolean, Column, MetaData, Table, TEXT
+from sqlalchemy import (
+    Boolean,
+    Column,
+    MetaData,
+    Table,
+    TEXT
+)
 
 from galaxy.model.custom_types import TrimmedString
-from galaxy.model.migrate.versions.util import add_column, drop_column
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 

--- a/lib/galaxy/model/migrate/versions/0104_update_genome_downloader_job_parameters.py
+++ b/lib/galaxy/model/migrate/versions/0104_update_genome_downloader_job_parameters.py
@@ -1,26 +1,30 @@
 """
 Migration script to update the deferred job parameters for liftover transfer jobs.
 """
+from __future__ import print_function
+
 import datetime
 import logging
-import sys
 
-from sqlalchemy import Column, DateTime, Integer, MetaData, String, Table
-from sqlalchemy.orm import mapper, scoped_session, sessionmaker
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Integer,
+    MetaData,
+    String,
+    Table
+)
+from sqlalchemy.orm import (
+    mapper,
+    scoped_session,
+    sessionmaker
+)
 
-# Need our custom types, but don't import anything else from model
 from galaxy.model.custom_types import JSONType
 from galaxy.util.bunch import Bunch
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
+now = datetime.datetime.utcnow
 metadata = MetaData()
 context = scoped_session(sessionmaker(autoflush=False, autocommit=True))
 
@@ -51,6 +55,7 @@ mapper(DeferredJob, DeferredJob.table, properties={})
 
 
 def upgrade(migrate_engine):
+    print(__doc__)
     metadata.bind = migrate_engine
 
     liftoverjobs = dict()

--- a/lib/galaxy/model/migrate/versions/0105_add_cleanup_event_table.py
+++ b/lib/galaxy/model/migrate/versions/0105_add_cleanup_event_table.py
@@ -5,21 +5,20 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table
+)
 
 from galaxy.model.custom_types import TrimmedString
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 # New table to log cleanup events
@@ -84,8 +83,8 @@ CleanupEventImplicitlyConvertedDatasetAssociationAssociation_table = Table("clea
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
     try:
         CleanupEvent_table.create()

--- a/lib/galaxy/model/migrate/versions/0106_add_missing_indexes.py
+++ b/lib/galaxy/model/migrate/versions/0106_add_missing_indexes.py
@@ -66,5 +66,6 @@ def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
+    # TODO: Dropping a column used in a foreign key fails in MySQL, need to remove the FK first.
     for ix, table, col in indexes:
         drop_index(ix, table, col, metadata)

--- a/lib/galaxy/model/migrate/versions/0106_add_missing_indexes.py
+++ b/lib/galaxy/model/migrate/versions/0106_add_missing_indexes.py
@@ -13,7 +13,6 @@ from galaxy.model.migrate.versions.util import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 metadata = MetaData()
 
 indexes = (

--- a/lib/galaxy/model/migrate/versions/0109_add_repository_dependency_tables.py
+++ b/lib/galaxy/model/migrate/versions/0109_add_repository_dependency_tables.py
@@ -5,19 +5,23 @@ from __future__ import print_function
 
 import datetime
 import logging
-import sys
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table
+)
 
-now = datetime.datetime.utcnow
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
+
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 RepositoryDependency_table = Table("repository_dependency", metadata,
@@ -38,24 +42,14 @@ def upgrade(migrate_engine):
     print(__doc__)
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        RepositoryDependency_table.create()
-    except Exception:
-        log.exception("Creating repository_dependency table failed.")
-    try:
-        RepositoryRepositoryDependencyAssociation_table.create()
-    except Exception:
-        log.exception("Creating repository_repository_dependency_association table failed.")
+
+    create_table(RepositoryDependency_table)
+    create_table(RepositoryRepositoryDependencyAssociation_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        RepositoryRepositoryDependencyAssociation_table.drop()
-    except Exception:
-        log.exception("Dropping repository_repository_dependency_association table failed.")
-    try:
-        RepositoryDependency_table.drop()
-    except Exception:
-        log.exception("Dropping repository_dependency table failed.")
+
+    drop_table(RepositoryRepositoryDependencyAssociation_table)
+    drop_table(RepositoryDependency_table)

--- a/lib/galaxy/model/migrate/versions/0112_add_data_manager_history_association_and_data_manager_job_association_tables.py
+++ b/lib/galaxy/model/migrate/versions/0112_add_data_manager_history_association_and_data_manager_job_association_tables.py
@@ -6,11 +6,18 @@ from __future__ import print_function
 import datetime
 import logging
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table, TEXT
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table,
+    TEXT
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 DataManagerHistoryAssociation_table = Table("data_manager_history_association", metadata,
@@ -32,6 +39,7 @@ def upgrade(migrate_engine):
     print(__doc__)
     metadata.bind = migrate_engine
     metadata.reflect()
+
     try:
         DataManagerHistoryAssociation_table.create()
         log.debug("Created data_manager_history_association table")
@@ -47,6 +55,7 @@ def upgrade(migrate_engine):
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
+
     try:
         DataManagerHistoryAssociation_table.drop()
         log.debug("Dropped data_manager_history_association table")

--- a/lib/galaxy/model/migrate/versions/0112_add_data_manager_history_association_and_data_manager_job_association_tables.py
+++ b/lib/galaxy/model/migrate/versions/0112_add_data_manager_history_association_and_data_manager_job_association_tables.py
@@ -10,10 +10,16 @@ from sqlalchemy import (
     Column,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     MetaData,
     Table,
     TEXT
+)
+
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
 )
 
 log = logging.getLogger(__name__)
@@ -27,12 +33,17 @@ DataManagerHistoryAssociation_table = Table("data_manager_history_association", 
                                             Column("history_id", Integer, ForeignKey("history.id"), index=True),
                                             Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True))
 
-DataManagerJobAssociation_table = Table("data_manager_job_association", metadata,
-                                        Column("id", Integer, primary_key=True),
-                                        Column("create_time", DateTime, default=now),
-                                        Column("update_time", DateTime, index=True, default=now, onupdate=now),
-                                        Column("job_id", Integer, ForeignKey("job.id"), index=True),
-                                        Column("data_manager_id", TEXT, index=True))
+DataManagerJobAssociation_table = Table(
+    "data_manager_job_association", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("create_time", DateTime, default=now),
+    Column("update_time", DateTime, index=True, default=now, onupdate=now),
+    Column("job_id", Integer, ForeignKey("job.id"), index=True),
+    Column("data_manager_id", TEXT),
+    Index('ix_data_manager_job_association_data_manager_id', 'data_manager_id', mysql_length=200),
+)
+
+TABLES = [DataManagerHistoryAssociation_table, DataManagerJobAssociation_table]
 
 
 def upgrade(migrate_engine):
@@ -40,29 +51,13 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        DataManagerHistoryAssociation_table.create()
-        log.debug("Created data_manager_history_association table")
-    except Exception:
-        log.exception("Creating data_manager_history_association table failed.")
-    try:
-        DataManagerJobAssociation_table.create()
-        log.debug("Created data_manager_job_association table")
-    except Exception:
-        log.exception("Creating data_manager_job_association table failed.")
+    for table in TABLES:
+        create_table(table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        DataManagerHistoryAssociation_table.drop()
-        log.debug("Dropped data_manager_history_association table")
-    except Exception:
-        log.exception("Dropping data_manager_history_association table failed.")
-    try:
-        DataManagerJobAssociation_table.drop()
-        log.debug("Dropped data_manager_job_association table")
-    except Exception:
-        log.exception("Dropping data_manager_job_association table failed.")
+    for table in TABLES:
+        drop_table(table)

--- a/lib/galaxy/model/migrate/versions/0113_update_migrate_tools_table.py
+++ b/lib/galaxy/model/migrate/versions/0113_update_migrate_tools_table.py
@@ -4,15 +4,8 @@ Migration script to update the migrate_tools.repository_path column to point to 
 from __future__ import print_function
 
 import logging
-import sys
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
 
 
 def upgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0114_update_migrate_tools_table_again.py
+++ b/lib/galaxy/model/migrate/versions/0114_update_migrate_tools_table_again.py
@@ -4,15 +4,8 @@ Migration script to update the migrate_tools.repository_path column to point to 
 from __future__ import print_function
 
 import logging
-import sys
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
 
 
 def upgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0116_drop_update_available_col_add_tool_shed_status_col.py
+++ b/lib/galaxy/model/migrate/versions/0116_drop_update_available_col_add_tool_shed_status_col.py
@@ -4,22 +4,22 @@ Migration script to drop the update_available Boolean column and replace it with
 from __future__ import print_function
 
 import logging
-import sys
 
-from sqlalchemy import Boolean, Column, MetaData, Table
-from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy import (
+    Boolean,
+    Column,
+    MetaData,
+    Table
+)
 
 from galaxy.model.custom_types import JSONType
-from galaxy.model.migrate.versions.util import add_column, drop_column, engine_false
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column,
+    engine_false
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-format = "%(name)s %(levelname)s %(asctime)s %(message)s"
-formatter = logging.Formatter(format)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 metadata = MetaData()
 
 
@@ -28,35 +28,25 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
-    except NoSuchTableError:
-        ToolShedRepository_table = None
-        log.debug("Failed loading table tool_shed_repository")
-    if ToolShedRepository_table is not None:
-        # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
-        if migrate_engine.name != 'sqlite':
-            drop_column('update_available', ToolShedRepository_table)
-        c = Column("tool_shed_status", JSONType, nullable=True)
-        add_column(c, ToolShedRepository_table)
+    ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
+    # SQLAlchemy Migrate has a bug when dropping a boolean column in SQLite
+    if migrate_engine.name != 'sqlite':
+        drop_column('update_available', ToolShedRepository_table)
+    c = Column("tool_shed_status", JSONType, nullable=True)
+    add_column(c, ToolShedRepository_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
-    except NoSuchTableError:
-        ToolShedRepository_table = None
-        log.debug("Failed loading table tool_shed_repository")
-    if ToolShedRepository_table is not None:
-        # For some unknown reason it is no longer possible to drop a column in a migration script if using the sqlite database.
-        if migrate_engine.name != 'sqlite':
-            drop_column('tool_shed_status', ToolShedRepository_table)
-            c = Column("update_available", Boolean, default=False)
-            add_column(c, ToolShedRepository_table)
-            try:
-                migrate_engine.execute("UPDATE tool_shed_repository SET update_available=%s" % engine_false(migrate_engine))
-            except Exception:
-                log.exception("Updating column 'update_available' of table 'tool_shed_repository' failed.")
+    ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
+    # For some unknown reason it is no longer possible to drop a column in a migration script if using the sqlite database.
+    if migrate_engine.name != 'sqlite':
+        drop_column('tool_shed_status', ToolShedRepository_table)
+        c = Column("update_available", Boolean, default=False)
+        add_column(c, ToolShedRepository_table)
+        try:
+            migrate_engine.execute("UPDATE tool_shed_repository SET update_available=%s" % engine_false(migrate_engine))
+        except Exception:
+            log.exception("Updating column 'update_available' of table 'tool_shed_repository' failed.")

--- a/lib/galaxy/model/migrate/versions/0116_drop_update_available_col_add_tool_shed_status_col.py
+++ b/lib/galaxy/model/migrate/versions/0116_drop_update_available_col_add_tool_shed_status_col.py
@@ -33,7 +33,7 @@ def upgrade(migrate_engine):
     if migrate_engine.name != 'sqlite':
         drop_column('update_available', ToolShedRepository_table)
     c = Column("tool_shed_status", JSONType, nullable=True)
-    add_column(c, ToolShedRepository_table)
+    add_column(c, ToolShedRepository_table, metadata)
 
 
 def downgrade(migrate_engine):
@@ -41,12 +41,10 @@ def downgrade(migrate_engine):
     metadata.reflect()
 
     ToolShedRepository_table = Table("tool_shed_repository", metadata, autoload=True)
-    # For some unknown reason it is no longer possible to drop a column in a migration script if using the sqlite database.
-    if migrate_engine.name != 'sqlite':
-        drop_column('tool_shed_status', ToolShedRepository_table)
-        c = Column("update_available", Boolean, default=False)
-        add_column(c, ToolShedRepository_table)
-        try:
-            migrate_engine.execute("UPDATE tool_shed_repository SET update_available=%s" % engine_false(migrate_engine))
-        except Exception:
-            log.exception("Updating column 'update_available' of table 'tool_shed_repository' failed.")
+    drop_column('tool_shed_status', ToolShedRepository_table)
+    c = Column("update_available", Boolean, default=False)
+    add_column(c, ToolShedRepository_table, metadata)
+    try:
+        migrate_engine.execute("UPDATE tool_shed_repository SET update_available=%s" % engine_false(migrate_engine))
+    except Exception:
+        log.exception("Updating column 'update_available' of table 'tool_shed_repository' failed.")

--- a/lib/galaxy/model/migrate/versions/0119_job_metrics.py
+++ b/lib/galaxy/model/migrate/versions/0119_job_metrics.py
@@ -5,9 +5,20 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, ForeignKey, Integer, MetaData, Numeric, Table, Unicode
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Numeric,
+    Table,
+    Unicode
+)
 
-from galaxy.model.migrate.versions.util import create_table, drop_table
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()

--- a/lib/galaxy/model/migrate/versions/0123_add_workflow_request_tables.py
+++ b/lib/galaxy/model/migrate/versions/0123_add_workflow_request_tables.py
@@ -5,10 +5,28 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, ForeignKey, Integer, MetaData, String, Table, TEXT, Unicode
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    TEXT,
+    Unicode
+)
 
-from galaxy.model.custom_types import JSONType, TrimmedString, UUIDType
-from galaxy.model.migrate.versions.util import add_column, create_table, drop_column, drop_table
+from galaxy.model.custom_types import (
+    JSONType,
+    TrimmedString,
+    UUIDType
+)
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    create_table,
+    drop_column,
+    drop_table
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -62,8 +80,8 @@ TABLES = [
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     for table in TABLES:

--- a/lib/galaxy/model/migrate/versions/0127_output_collection_adjustments.py
+++ b/lib/galaxy/model/migrate/versions/0127_output_collection_adjustments.py
@@ -5,10 +5,23 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table, TEXT, Unicode
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table,
+    TEXT,
+    Unicode
+)
 
 from galaxy.model.custom_types import TrimmedString
-from galaxy.model.migrate.versions.util import add_column, create_table, drop_column, drop_table
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    create_table,
+    drop_column,
+    drop_table
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -22,18 +35,12 @@ JobToImplicitOutputDatasetCollectionAssociation_table = Table(
 )
 
 
-TABLES = [
-    JobToImplicitOutputDatasetCollectionAssociation_table,
-]
-
-
 def upgrade(migrate_engine):
     print(__doc__)
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    for table in TABLES:
-        create_table(table)
+    create_table(JobToImplicitOutputDatasetCollectionAssociation_table)
 
     dataset_collection_table = Table("dataset_collection", metadata, autoload=True)
     # need server_default because column in non-null
@@ -48,8 +55,7 @@ def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    for table in TABLES:
-        drop_table(table)
+    drop_table(JobToImplicitOutputDatasetCollectionAssociation_table)
 
     dataset_collection_table = Table("dataset_collection", metadata, autoload=True)
     drop_column('populated_state', dataset_collection_table)

--- a/lib/galaxy/model/migrate/versions/0127_output_collection_adjustments.py
+++ b/lib/galaxy/model/migrate/versions/0127_output_collection_adjustments.py
@@ -45,10 +45,10 @@ def upgrade(migrate_engine):
     dataset_collection_table = Table("dataset_collection", metadata, autoload=True)
     # need server_default because column in non-null
     populated_state_column = Column('populated_state', TrimmedString(64), default='ok', server_default="ok", nullable=False)
-    add_column(populated_state_column, dataset_collection_table)
+    add_column(populated_state_column, dataset_collection_table, metadata)
 
     populated_message_column = Column('populated_state_message', TEXT, nullable=True)
-    add_column(populated_message_column, dataset_collection_table)
+    add_column(populated_message_column, dataset_collection_table, metadata)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0136_collection_and_workflow_state.py
+++ b/lib/galaxy/model/migrate/versions/0136_collection_and_workflow_state.py
@@ -39,10 +39,10 @@ workflow_invocation_output_dataset_association_table = Table(
 workflow_invocation_output_dataset_collection_association_table = Table(
     "workflow_invocation_output_dataset_collection_association", metadata,
     Column("id", Integer, primary_key=True),
-    Column("workflow_invocation_id", Integer, ForeignKey("workflow_invocation.id"), index=True),
-    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id")),
-    Column("dataset_collection_id", Integer, ForeignKey("history_dataset_collection_association.id"), index=True),
-    Column("workflow_output_id", Integer, ForeignKey("workflow_output.id")),
+    Column("workflow_invocation_id", Integer, ForeignKey("workflow_invocation.id", name='fk_wiodca_wii'), index=True),
+    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id", name='fk_wiodca_wsi')),
+    Column("dataset_collection_id", Integer, ForeignKey("history_dataset_collection_association.id", name='fk_wiodca_dci'), index=True),
+    Column("workflow_output_id", Integer, ForeignKey("workflow_output.id", name='fk_wiodca_woi')),
 )
 
 workflow_invocation_step_output_dataset_association_table = Table(
@@ -56,9 +56,9 @@ workflow_invocation_step_output_dataset_association_table = Table(
 workflow_invocation_step_output_dataset_collection_association_table = Table(
     "workflow_invocation_step_output_dataset_collection_association", metadata,
     Column("id", Integer, primary_key=True),
-    Column("workflow_invocation_step_id", Integer, ForeignKey("workflow_invocation_step.id"), index=True),
-    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id")),
-    Column("dataset_collection_id", Integer, ForeignKey("history_dataset_collection_association.id"), index=True),
+    Column("workflow_invocation_step_id", Integer, ForeignKey("workflow_invocation_step.id", name='fk_wisodca_wisi'), index=True),
+    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id", name='fk_wisodca_wsi')),
+    Column("dataset_collection_id", Integer, ForeignKey("history_dataset_collection_association.id", name='fk_wisodca_dci'), index=True),
     Column("output_name", String(255), nullable=True),
 )
 
@@ -70,8 +70,8 @@ implicit_collection_jobs_table = Table(
 
 implicit_collection_jobs_job_association_table = Table(
     "implicit_collection_jobs_job_association", metadata,
-    Column("implicit_collection_jobs_id", Integer, ForeignKey("implicit_collection_jobs.id"), index=True),
     Column("id", Integer, primary_key=True),
+    Column("implicit_collection_jobs_id", Integer, ForeignKey("implicit_collection_jobs.id"), index=True),
     Column("job_id", Integer, ForeignKey("job.id"), index=True),  # Consider making this nullable...
     Column("order_index", Integer, nullable=False),
 )

--- a/lib/galaxy/model/migrate/versions/0139_add_history_dataset_association_history_table.py
+++ b/lib/galaxy/model/migrate/versions/0139_add_history_dataset_association_history_table.py
@@ -6,13 +6,26 @@ from __future__ import print_function
 import datetime
 import logging
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table
+)
 
-from galaxy.model.custom_types import MetadataType, TrimmedString
+from galaxy.model.custom_types import (
+    MetadataType,
+    TrimmedString
+)
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 HistoryDatasetAssociationHistory_table = Table(
@@ -32,18 +45,12 @@ def upgrade(migrate_engine):
     print(__doc__)
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        HistoryDatasetAssociationHistory_table.create()
-        log.debug("Created history_dataset_association_history table")
-    except Exception:
-        log.exception("Creating history_dataset_association_history table failed.")
+
+    create_table(HistoryDatasetAssociationHistory_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        HistoryDatasetAssociationHistory_table.drop()
-        log.debug("Dropped history_dataset_association_history table")
-    except Exception:
-        log.exception("Dropping history_dataset_association_history table failed.")
+
+    drop_table(HistoryDatasetAssociationHistory_table)

--- a/lib/galaxy/model/migrate/versions/0144_add_cleanup_event_user_table.py
+++ b/lib/galaxy/model/migrate/versions/0144_add_cleanup_event_user_table.py
@@ -6,12 +6,22 @@ from __future__ import print_function
 import datetime
 import logging
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table
+)
+
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
 now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-
 metadata = MetaData()
 
 # New table to log cleanup events
@@ -28,19 +38,11 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        CleanupEventUserAssociation_table.create()
-        log.debug("Created cleanup_event_user_association table")
-    except Exception:
-        log.exception("Creating cleanup_event_user_association table failed.")
+    create_table(CleanupEventUserAssociation_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        CleanupEventUserAssociation_table.drop()
-        log.debug("Dropped cleanup_event_user_association table")
-    except Exception:
-        log.exception("Dropping cleanup_event_user_association table failed.")
+    drop_table(CleanupEventUserAssociation_table)

--- a/lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py
+++ b/lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py
@@ -5,20 +5,22 @@ from __future__ import print_function
 
 import logging
 
+from migrate import ForeignKeyConstraint as MigrateForeignKeyConstraint
 from sqlalchemy import (
     Boolean,
     Column,
     ForeignKey,
+    Index,
     Integer,
     MetaData,
     Table,
     TEXT,
-    UniqueConstraint
 )
 
 from galaxy.model.custom_types import JSONType
 from galaxy.model.migrate.versions.util import (
     create_table,
+    drop_index,
     drop_table
 )
 
@@ -37,7 +39,7 @@ WorkflowStepInput_table = Table(
     Column("default_value", JSONType),
     Column("default_value_set", Boolean, default=False),
     Column("runtime_value", Boolean, default=False),
-    UniqueConstraint("workflow_step_id", "name"),
+    Index('ix_workflow_step_input_workflow_step_id_name_unique', "workflow_step_id", "name", unique=True, mysql_length={'name': 200}),
 )
 
 
@@ -47,11 +49,15 @@ def upgrade(migrate_engine):
     metadata.reflect()
 
     OldWorkflowStepConnection_table = Table("workflow_step_connection", metadata, autoload=True)
-    for index in OldWorkflowStepConnection_table.indexes:
+    for fkc in OldWorkflowStepConnection_table.foreign_key_constraints:
+        mfkc = MigrateForeignKeyConstraint([_.parent for _ in fkc.elements], [_.column for _ in fkc.elements], name=fkc.name)
         try:
-            index.drop()
+            mfkc.drop()
         except Exception:
-            log.exception("Dropping index '%s' from table '%s' failed", index, OldWorkflowStepConnection_table)
+            log.exception("Dropping foreign key constraint '%s' from table '%s' failed", mfkc.name, OldWorkflowStepConnection_table)
+
+    for index in OldWorkflowStepConnection_table.indexes:
+        drop_index(index, OldWorkflowStepConnection_table)
     OldWorkflowStepConnection_table.rename("workflow_step_connection_preupgrade145")
     # Try to deregister that table to work around some caching problems it seems.
     OldWorkflowStepConnection_table.deregister()
@@ -86,8 +92,15 @@ def downgrade(migrate_engine):
     metadata.bind = migrate_engine
 
     NewWorkflowStepConnection_table = Table("workflow_step_connection", metadata, autoload=True)
+    for fkc in NewWorkflowStepConnection_table.foreign_key_constraints:
+        mfkc = MigrateForeignKeyConstraint([_.parent for _ in fkc.elements], [_.column for _ in fkc.elements], name=fkc.name)
+        try:
+            mfkc.drop()
+        except Exception:
+            log.exception("Dropping foreign key constraint '%s' from table '%s' failed", mfkc.name, NewWorkflowStepConnection_table)
+
     for index in NewWorkflowStepConnection_table.indexes:
-        index.drop()
+        drop_index(index, NewWorkflowStepConnection_table)
     NewWorkflowStepConnection_table.rename("workflow_step_connection_predowngrade145")
     # Try to deregister that table to work around some caching problems it seems.
     NewWorkflowStepConnection_table.deregister()

--- a/lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py
+++ b/lib/galaxy/model/migrate/versions/0145_add_workflow_step_input.py
@@ -17,7 +17,10 @@ from sqlalchemy import (
 )
 
 from galaxy.model.custom_types import JSONType
-from galaxy.model.migrate.versions.util import create_table, drop_table
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()

--- a/lib/galaxy/model/migrate/versions/0146_workflow_paths.py
+++ b/lib/galaxy/model/migrate/versions/0146_workflow_paths.py
@@ -11,12 +11,13 @@ from sqlalchemy import (
     TEXT,
 )
 
-from galaxy.model.migrate.versions.util import add_column, drop_column
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
-
-from_path_column = Column("from_path", TEXT, nullable=True)
 
 
 def upgrade(migrate_engine):
@@ -24,6 +25,7 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
+    from_path_column = Column("from_path", TEXT)
     add_column(from_path_column, "stored_workflow", metadata)
 
 

--- a/lib/galaxy/model/migrate/versions/0147_job_messages.py
+++ b/lib/galaxy/model/migrate/versions/0147_job_messages.py
@@ -5,7 +5,12 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, MetaData, Table, TEXT
+from sqlalchemy import (
+    Column,
+    MetaData,
+    Table,
+    TEXT
+)
 
 from galaxy.model.custom_types import JSONType
 from galaxy.model.migrate.versions.util import (

--- a/lib/galaxy/model/migrate/versions/0147_job_messages.py
+++ b/lib/galaxy/model/migrate/versions/0147_job_messages.py
@@ -30,19 +30,19 @@ def upgrade(migrate_engine):
 
     jobs_table = Table("job", metadata, autoload=True)
     job_messages_column = Column("job_messages", JSONType, nullable=True)
-    add_column(job_messages_column, jobs_table)
+    add_column(job_messages_column, jobs_table, metadata)
     job_job_stdout_column = Column("job_stdout", TEXT, nullable=True)
-    add_column(job_job_stdout_column, jobs_table)
+    add_column(job_job_stdout_column, jobs_table, metadata)
     job_job_stderr_column = Column("job_stderr", TEXT, nullable=True)
-    add_column(job_job_stderr_column, jobs_table)
+    add_column(job_job_stderr_column, jobs_table, metadata)
 
     tasks_table = Table("task", metadata, autoload=True)
     task_job_messages_column = Column("job_messages", JSONType, nullable=True)
-    add_column(task_job_messages_column, tasks_table)
+    add_column(task_job_messages_column, tasks_table, metadata)
     task_job_stdout_column = Column("job_stdout", TEXT, nullable=True)
-    add_column(task_job_stdout_column, tasks_table)
+    add_column(task_job_stdout_column, tasks_table, metadata)
     task_job_stderr_column = Column("job_stderr", TEXT, nullable=True)
-    add_column(task_job_stderr_column, tasks_table)
+    add_column(task_job_stderr_column, tasks_table, metadata)
 
     for table in [jobs_table, tasks_table]:
         alter_column('stdout', table, name='tool_stdout')

--- a/lib/galaxy/model/migrate/versions/0148_add_checksum_table.py
+++ b/lib/galaxy/model/migrate/versions/0148_add_checksum_table.py
@@ -5,13 +5,22 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table, TEXT
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table,
+    TEXT
+)
 
 from galaxy.model.custom_types import JSONType
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-
 metadata = MetaData()
 
 dataset_source_table = Table(
@@ -45,20 +54,14 @@ def upgrade(migrate_engine):
     print(__doc__)
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        dataset_source_table.create()
-        dataset_hash_table.create()
-        dataset_source_hash_table.create()
-    except Exception:
-        log.exception("Adding dataset source and hash tables failed.")
+    create_table(dataset_source_table)
+    create_table(dataset_hash_table)
+    create_table(dataset_source_hash_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
-    try:
-        dataset_source_hash_table.drop()
-        dataset_hash_table.drop()
-        dataset_source_table.drop()
-    except Exception:
-        log.exception("Dropping dataset source and hash tables failed.")
+    drop_table(dataset_source_hash_table)
+    drop_table(dataset_hash_table)
+    drop_table(dataset_source_table)

--- a/lib/galaxy/model/migrate/versions/0149_dynamic_tools.py
+++ b/lib/galaxy/model/migrate/versions/0149_dynamic_tools.py
@@ -38,14 +38,9 @@ def upgrade(migrate_engine):
 
     create_table(DynamicTool_table)
 
-    if migrate_engine.name in ['postgres', 'postgresql']:
-        workflow_dynamic_tool_id_column = Column("dynamic_tool_id", Integer, ForeignKey("dynamic_tool.id"), nullable=True)
-        job_workflow_dynamic_tool_id_column = Column("dynamic_tool_id", Integer, ForeignKey("dynamic_tool.id"), nullable=True)
-    else:
-        workflow_dynamic_tool_id_column = Column("dynamic_tool_id", Integer, nullable=True)
-        job_workflow_dynamic_tool_id_column = Column("dynamic_tool_id", Integer, nullable=True)
-
+    workflow_dynamic_tool_id_column = Column("dynamic_tool_id", Integer, ForeignKey("dynamic_tool.id"), nullable=True)
     add_column(workflow_dynamic_tool_id_column, "workflow_step", metadata)
+    job_workflow_dynamic_tool_id_column = Column("dynamic_tool_id", Integer, ForeignKey("dynamic_tool.id"), nullable=True)
     add_column(job_workflow_dynamic_tool_id_column, "job", metadata)
 
 

--- a/lib/galaxy/model/migrate/versions/0149_dynamic_tools.py
+++ b/lib/galaxy/model/migrate/versions/0149_dynamic_tools.py
@@ -9,8 +9,8 @@ from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, MetaData,
 from galaxy.model.custom_types import JSONType, UUIDType
 from galaxy.model.migrate.versions.util import add_column, create_table, drop_column, drop_table
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 
@@ -30,18 +30,13 @@ DynamicTool_table = Table(
     Column("value", JSONType()),
 )
 
-TABLES = [
-    DynamicTool_table,
-]
-
 
 def upgrade(migrate_engine):
     print(__doc__)
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    for table in TABLES:
-        create_table(table)
+    create_table(DynamicTool_table)
 
     if migrate_engine.name in ['postgres', 'postgresql']:
         workflow_dynamic_tool_id_column = Column("dynamic_tool_id", Integer, ForeignKey("dynamic_tool.id"), nullable=True)
@@ -60,6 +55,4 @@ def downgrade(migrate_engine):
 
     drop_column("dynamic_tool_id", "workflow_step", metadata)
     drop_column("dynamic_tool_id", "job", metadata)
-
-    for table in TABLES:
-        drop_table(table)
+    drop_table(DynamicTool_table)

--- a/lib/galaxy/model/migrate/versions/0150_add_create_time_field_for_cloudauthz.py
+++ b/lib/galaxy/model/migrate/versions/0150_add_create_time_field_for_cloudauthz.py
@@ -21,7 +21,7 @@ def upgrade(migrate_engine):
 
     cloudauthz_table = Table("cloudauthz", metadata, autoload=True)
     create_time_column = Column('create_time', DateTime)
-    add_column(create_time_column, cloudauthz_table)
+    add_column(create_time_column, cloudauthz_table, metadata)
 
 
 def downgrade(migrate_engine):

--- a/lib/galaxy/model/migrate/versions/0151_add_worker_process.py
+++ b/lib/galaxy/model/migrate/versions/0151_add_worker_process.py
@@ -15,7 +15,10 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 
-from galaxy.model.migrate.versions.util import create_table, drop_table
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 from galaxy.model.orm.now import now
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/model/migrate/versions/0152_add_metadata_file_uuid.py
+++ b/lib/galaxy/model/migrate/versions/0152_add_metadata_file_uuid.py
@@ -6,10 +6,16 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import Column, MetaData
+from sqlalchemy import (
+    Column,
+    MetaData
+)
 
 from galaxy.model.custom_types import UUIDType
-from galaxy.model.migrate.versions.util import add_column, drop_column
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/model/migrate/versions/0153_add_custos_authnz_token_table.py
+++ b/lib/galaxy/model/migrate/versions/0153_add_custos_authnz_token_table.py
@@ -5,8 +5,22 @@ from __future__ import print_function
 
 import logging
 
-from sqlalchemy import (Column, DateTime, ForeignKey, Integer, MetaData,
-                        String, Table, Text, UniqueConstraint)
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    Text,
+    UniqueConstraint
+)
+
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
 
 log = logging.getLogger(__name__)
 metadata = MetaData()
@@ -32,17 +46,11 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        CustosAuthnzToken_table.create()
-    except Exception:
-        log.exception("Failed to create custos_authnz_token table")
+    create_table(CustosAuthnzToken_table)
 
 
 def downgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    try:
-        CustosAuthnzToken_table.drop()
-    except Exception:
-        log.exception("Failed to drop custos_authnz_token table")
+    drop_table(CustosAuthnzToken_table)

--- a/lib/galaxy/model/migrate/versions/0154_created_from_basename.py
+++ b/lib/galaxy/model/migrate/versions/0154_created_from_basename.py
@@ -4,18 +4,25 @@ Adds created_from_basename to dataset.
 import datetime
 import logging
 
-from sqlalchemy import Column, MetaData, TEXT
+from sqlalchemy import (
+    Column,
+    MetaData,
+    TEXT
+)
 
-from galaxy.model.migrate.versions.util import add_column, drop_column
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     created_from_basename_column = Column("created_from_basename", TEXT, default=None)

--- a/lib/galaxy/model/migrate/versions/0155_job_galaxy_version.py
+++ b/lib/galaxy/model/migrate/versions/0155_job_galaxy_version.py
@@ -1,21 +1,30 @@
 """
 Add 'galaxy_version' attribute to Job table.
 """
+from __future__ import print_function
+
 import datetime
 import logging
 
-from sqlalchemy import Column, MetaData, String
+from sqlalchemy import (
+    Column,
+    MetaData,
+    String
+)
 
-from galaxy.model.migrate.versions.util import add_column, drop_column
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    drop_column
+)
 
-now = datetime.datetime.utcnow
 log = logging.getLogger(__name__)
+now = datetime.datetime.utcnow
 metadata = MetaData()
 
 
 def upgrade(migrate_engine):
-    metadata.bind = migrate_engine
     print(__doc__)
+    metadata.bind = migrate_engine
     metadata.reflect()
 
     created_from_basename_column = Column("galaxy_version", String(64), default=None)

--- a/lib/galaxy/model/migrate/versions/util.py
+++ b/lib/galaxy/model/migrate/versions/util.py
@@ -1,9 +1,12 @@
 import logging
 
 from sqlalchemy import (
+    BLOB,
     Index,
-    Table
+    Table,
+    Text
 )
+from sqlalchemy.dialects.mysql import MEDIUMBLOB
 
 log = logging.getLogger(__name__)
 
@@ -124,7 +127,7 @@ def drop_column(column_name, table, metadata=None):
         log.exception("Dropping column '%s' from table '%s' failed.", column_name, table)
 
 
-def add_index(index_name, table, column_name, metadata=None):
+def add_index(index_name, table, column_name, metadata=None, **kwds):
     """
     :param table: Table to add the index to
     :type table: :class:`Table` or str
@@ -137,7 +140,11 @@ def add_index(index_name, table, column_name, metadata=None):
             assert metadata is not None
             table = Table(table, metadata, autoload=True)
         if index_name not in [ix.name for ix in table.indexes]:
-            index = Index(index_name, table.c[column_name])
+            column = table.c[column_name]
+            # MySQL cannot index a TEXT/BLOB column without specifying mysql_length
+            if isinstance(column.type, (BLOB, MEDIUMBLOB, Text)):
+                kwds.setdefault('mysql_length', 200)
+            index = Index(index_name, column, **kwds)
             index.create()
         else:
             log.debug("Index '%s' on column '%s' in table '%s' already exists.", index_name, column_name, table)
@@ -145,8 +152,11 @@ def add_index(index_name, table, column_name, metadata=None):
         log.exception("Adding index '%s' on column '%s' to table '%s' failed.", index_name, column_name, table)
 
 
-def drop_index(index_name, table, column_name, metadata=None):
+def drop_index(index, table, column_name=None, metadata=None):
     """
+    :param index: Index to drop
+    :type index: :class:`Index` or str
+
     :param table: Table to drop the index from
     :type table: :class:`Table` or str
 
@@ -154,13 +164,15 @@ def drop_index(index_name, table, column_name, metadata=None):
     :type metadata: :class:`Metadata`
     """
     try:
-        if not isinstance(table, Table):
-            assert metadata is not None
-            table = Table(table, metadata, autoload=True)
-        if index_name in [ix.name for ix in table.indexes]:
-            index = Index(index_name, table.c[column_name])
-            index.drop()
-        else:
-            log.debug("Index '%s' in table '%s' does not exist.", index_name, table)
+        if not isinstance(index, Index):
+            if not isinstance(table, Table):
+                assert metadata is not None
+                table = Table(table, metadata, autoload=True)
+            if index in [ix.name for ix in table.indexes]:
+                index = Index(index, table.c[column_name])
+            else:
+                log.debug("Index '%s' in table '%s' does not exist.", index, table)
+                return
+        index.drop()
     except Exception:
-        log.exception("Dropping index '%s' from table '%s' failed", index_name, table)
+        log.exception("Dropping index '%s' from table '%s' failed", index, table)

--- a/lib/galaxy/model/migrate/versions/util.py
+++ b/lib/galaxy/model/migrate/versions/util.py
@@ -51,8 +51,15 @@ def create_table(table):
         log.exception("Creating table '%s' failed.", table)
 
 
-def drop_table(table):
+def drop_table(table, metadata=None):
+    """
+    :param table: Table to drop
+    :type table: :class:`Table` or str
+    """
     try:
+        if not isinstance(table, Table):
+            assert metadata is not None
+            table = Table(table, metadata, autoload=True)
         table.drop()
     except Exception:
         log.exception("Dropping table '%s' failed.", table)

--- a/scripts/create_db.py
+++ b/scripts/create_db.py
@@ -15,6 +15,7 @@ database will be constructed.
 .. seealso: galaxy.ini, specifically the settings: database_connection and
 database file
 """
+import logging
 import os.path
 import sys
 
@@ -24,6 +25,9 @@ from galaxy.model.migrate.check import create_or_verify_database as create_db
 from galaxy.model.orm.scripts import get_config
 from galaxy.model.tool_shed_install.migrate.check import create_or_verify_database as create_install_db
 from galaxy.webapps.tool_shed.model.migrate.check import create_or_verify_database as create_tool_shed_db
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
 
 
 def invoke_create():

--- a/scripts/manage_db.py
+++ b/scripts/manage_db.py
@@ -1,6 +1,7 @@
 """ This script parses Galaxy or Tool Shed config file for database connection
 and then delegates to sqlalchemy_migrate shell main function in
 migrate.versioning.shell. """
+import logging
 import os.path
 import sys
 
@@ -9,6 +10,9 @@ from migrate.versioning.shell import main
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, 'lib')))
 
 from galaxy.model.orm.scripts import get_config
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
 
 
 def invoke_migrate_main():


### PR DESCRIPTION
Fix https://github.com/galaxyproject/galaxy/issues/6401 and https://github.com/galaxyproject/galaxy/issues/8400 .

Also:
- fix `create_db.sh`
- Enable on-screen logging for `create_db.py` and `manage_db.py`
- Another huge round of migration refactoring
- Handle better an SQLAlchemy Migrate issue when adding a column with both a `ForeignKey` and an index in SQLite.
- Remove `index=True` from some `Column()` definitions in `lib/galaxy/model/mapping.py` when the index was not part of any migration.

In total, this removes over 500 lines of code.

To test:
- migrations on SQLite:
  `$ rm -f database/universe.sqlite && sqlite3 database/universe.sqlite 'VACUUM;' && ./create_db.sh`
- migrations on PostgreSQL: create an empty 'galaxy' database, then:
  `$ GALAXY_CONFIG_DATABASE_CONNECTION=postgresql://@/galaxy?host=/var/run/postgresql ./create_db.sh`
- migrations on MySQL: create an empty 'galaxy' database, then:
  `$ GALAXY_CONFIG_DATABASE_CONNECTION='mysql://DB_USER:DB_PASS@localhost/galaxy' ./create_db.sh`
- database creation from scratch on SQLite:
  `$ rm -f database/universe.sqlite && ./create_db.sh`
- database creation from scratch on PostgreSQL (the PostgreSQL role needs to be able to create new databases): remove the 'galaxy' database, then:
  `$ GALAXY_CONFIG_DATABASE_CONNECTION=postgresql://@/galaxy?host=/var/run/postgresql ./create_db.sh`
- migrations on MySQL: delete the 'galaxy' database, then:
  `$ GALAXY_CONFIG_DATABASE_CONNECTION='mysql://DB_USER:DB_PASS@localhost/galaxy' ./create_db.sh`