### PR TITLE
Fix startup checks when using a Conda env

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -164,14 +164,8 @@ fi
 # activate virtualenv or conda env, sets $GALAXY_VIRTUAL_ENV and $GALAXY_CONDA_ENV
 setup_python
 
-if [ $SET_VENV -eq 1 ] && [ -z "$VIRTUAL_ENV" ] && [ -z "$CONDA_DEFAULT_ENV" ]; then
+if [ $SET_VENV -eq 1 ] && [ -z "$VIRTUAL_ENV" ]; then
     echo "ERROR: A virtualenv cannot be found. Please create a virtualenv in $GALAXY_VIRTUAL_ENV, or activate one."
-    exit 1
-fi
-
-# this shouldn't happen, but check just in case
-if [ -z "$VIRTUAL_ENV" ] && [ "$CONDA_DEFAULT_ENV" = "base" ] || [ "$CONDA_DEFAULT_ENV" = "root" ]; then
-    echo "ERROR: Conda is in 'base' environment, refusing to continue"
     exit 1
 fi
 

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -113,6 +113,10 @@ setup_python() {
             if [ "$CONDA_DEFAULT_ENV" != "$GALAXY_CONDA_ENV" ]; then
                 conda_activate
             fi
+            if [ "$CONDA_DEFAULT_ENV" = "base" ] || [ "$CONDA_DEFAULT_ENV" = "root" ]; then
+                echo "ERROR: Conda is in 'base' environment, refusing to continue"
+                exit 1
+            fi
         fi
     fi
 


### PR DESCRIPTION
Unless `--skip-venv` is specified, Galaxy creates/activates a virtualenv also when using a Conda environment.