### PR TITLE
[19.05] Fix error reporting when input dataset is NoneType

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -181,7 +181,7 @@ class JobController(BaseAPIController, UsesLibraryMixinItems):
         has_duplicate_inputs = False
         for job_input_assoc in job.input_datasets:
             input_dataset_instance = job_input_assoc.dataset
-            if input_dataset_instance is None:
+            if not input_dataset_instance:
                 continue
             if input_dataset_instance.get_total_size() == 0:
                 has_empty_inputs = True


### PR DESCRIPTION
The traceback is
```
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 282, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/api/jobs.py", line 184, in common_problems
    if input_dataset_instance.get_total_size() == 0:
AttributeError: 'NoneType' object has no attribute 'get_total_size'
```

... now it would be great to know when this happens, cause it looks
like it shouldn't happen at all.

Fixes #8448 