### PR TITLE
Update requirements and use pyuwsgi

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/Pipfile
+++ b/lib/galaxy/dependencies/pipfiles/default/Pipfile
@@ -38,7 +38,7 @@ SQLAlchemy-Utils = "*"
 Mercurial = {version = "<=3.7.3", markers = "python_version < '3'"}
 nodeenv = "*"
 pycryptodome = "*"
-uWSGI = "*"
+pyuwsgi = "*"
 pysam = "==0.15.2"
 bdbag = "==1.4.1"  # 1.5.0 requires Python >=2.7.9
 bleach = "*"

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -8,18 +8,18 @@ babel==2.7.0
 certifi==2019.6.16
 chardet==3.0.4
 commonmark==0.9.0
-configparser==3.7.4 ; python_version < '3.2'
+configparser==3.8.1 ; python_version < '3.2'
 contextlib2==0.5.5 ; python_version < '3.5'
-coverage==4.5.3
-docutils==0.14
+coverage==4.5.4
+docutils==0.15.2
 funcsigs==1.0.2 ; python_version < '3.3'
 future==0.17.1
 gunicorn==19.9.0
 idna==2.8
 imagesize==1.1.0
-importlib-metadata==0.18
+importlib-metadata==0.19
 jinja2==2.10.1
-lxml==4.3.4
+lxml==4.4.1
 markdown==2.6.11
 markupsafe==1.1.1
 mirakuru==1.1.0
@@ -27,7 +27,7 @@ mock==3.0.5
 more-itertools==5.0.0
 nose==1.3.7
 nosehtml==0.4.5
-packaging==19.0
+packaging==19.1
 pathlib2==2.3.2 ; python_version < '3'
 pathtools==0.1.2
 pluggy==0.12.0
@@ -36,16 +36,16 @@ psutil==5.6.3
 py==1.8.0
 pygithub3==0.5.1 ; python_version < '3'
 pygments==2.4.2
-pyparsing==2.4.0
+pyparsing==2.4.2
 pytest-cov==2.7.1
-pytest-html==1.21.1
+pytest-html==1.22.0
 pytest-metadata==1.8.0
 pytest-postgresql==1.4.1
 pytest-pythonpath==0.7.3
-pytest==4.6.4
-pytz==2019.1
-pyyaml==5.1.1
-recommonmark==0.5.0
+pytest==4.6.5
+pytz==2019.2
+pyyaml==5.1.2
+recommonmark==0.6.0
 requests==2.22.0
 scandir==1.10.0 ; python_version < '3.5'
 selenium==3.141.0
@@ -61,4 +61,4 @@ typing==3.7.4 ; python_version < '3.5'
 urllib3==1.25.3 ; python_version == '2.7'
 watchdog==0.9.0
 wcwidth==0.1.7 ; sys_platform != 'win32'
-zipp==0.5.1
+zipp==0.5.2

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -1,7 +1,7 @@
 -i https://wheels.galaxyproject.org/simple
 --extra-index-url https://pypi.python.org/simple
-adal==1.2.1
-amqp==2.5.0
+adal==1.2.2
+amqp==2.5.1
 appdirs==1.4.3
 asn1crypto==0.24.0
 attrs==19.1.0
@@ -24,12 +24,12 @@ bagit==1.6.4
 bcrypt==3.1.7
 bdbag==1.4.1
 beaker==1.10.1
-bioblend==0.12.0
+bioblend==0.13.0
 bleach==3.1.0
 boltons==19.1.0
 boto3==1.9.114
 boto==2.49.0
-botocore==1.12.180
+botocore==1.12.212
 bx-python==0.8.4
 bz2file==0.98 ; python_version < '3.3'
 cachecontrol==0.11.7
@@ -42,16 +42,17 @@ cliff==2.15.0
 cloudauthz==0.6.0
 cloudbridge==2.0.0
 cmd2==0.8.9
+configparser==3.8.1 ; python_version < '3.2'
 contextlib2==0.5.5 ; python_version < '3.5'
 cryptography==2.7
 cwltool==1.0.20180721142728
 debtcollector==1.21.0
 decorator==4.4.0
-deprecated==1.2.5
-deprecation==2.0.6
+deprecated==1.2.6
+deprecation==2.0.7
 dictobj==0.4
 docopt==0.6.2
-docutils==0.14
+docutils==0.15.2
 dogpile.cache==0.7.1
 ecdsa==0.13.2
 enum34==1.1.6 ; python_version < '3.4'
@@ -59,28 +60,29 @@ fabric3==1.14.post1
 funcsigs==1.0.2 ; python_version < '3.3'
 functools32==3.2.3.post2 ; python_version < '3.2'
 future==0.17.1
-futures==3.2.0 ; python_version == '2.6' or python_version == '2.7'
+futures==3.3.0 ; python_version == '2.6' or python_version == '2.7'
 galaxy-sequence-utils==1.1.3
 google-api-python-client==1.7.8
 google-auth-httplib2==0.0.3
 google-auth==1.6.3
-gxformat2==0.8.4
+gxformat2==0.9.0
 h5py==2.9.0
-httplib2==0.13.0
+httplib2==0.13.1
 idna==2.8
+importlib-metadata==0.19
 ipaddress==1.0.22 ; python_version < '3.3'
 isa-rwval==0.10.7
 iso8601==0.1.12
 isodate==0.6.0
 jmespath==0.9.4
-jsonpatch==1.23
+jsonpatch==1.24
 jsonpointer==2.0
-jsonschema==3.0.1
-keystoneauth1==3.14.0
-kombu==4.6.3
+jsonschema==3.0.2
+keystoneauth1==3.17.0
+kombu==4.6.4
 lockfile==0.12.2
-lxml==4.3.4
-mako==1.0.12
+lxml==4.4.1
+mako==1.1.0
 markupsafe==1.1.1
 mercurial==3.7.3 ; python_version < '3'
 mistune==0.8.4
@@ -97,31 +99,31 @@ nodeenv==1.3.3
 nose==1.3.7
 numpy==1.16.4
 oauth2client==4.1.3
-oauthlib==3.0.1
+oauthlib==3.1.0
 openstacksdk==0.17.0
 os-client-config==1.32.0
 os-service-types==1.7.0
 osc-lib==1.13.0
-oslo.config==6.10.0
+oslo.config==6.11.0
 oslo.context==2.22.1
 oslo.i18n==3.23.1
 oslo.log==3.44.0
 oslo.serialization==2.29.1
 oslo.utils==3.41.0
-packaging==19.0
+packaging==19.1
 paramiko==2.6.0
 parsley==1.3
-paste==3.0.8
+paste==3.1.0
 pastedeploy==2.0.1
 pastescript==3.1.0
 pathlib2==2.3.2 ; python_version < '3'
-pbr==5.3.1
+pbr==5.4.2
 prettytable==0.7.2
 prov==1.5.1
 psutil==5.6.3
 pulsar-galaxy-lib==0.12.1
-pyasn1-modules==0.2.5
-pyasn1==0.4.5
+pyasn1-modules==0.2.6
+pyasn1==0.4.6
 pycparser==2.19
 pycryptodome==3.8.2
 pyeventsystem==0.1.0
@@ -130,9 +132,9 @@ pyjwt==1.7.1
 pykwalify==1.7.0
 pynacl==1.3.0
 pyopenssl==19.0.0
-pyparsing==2.4.0
+pyparsing==2.4.2
 pyperclip==1.7.0
-pyrsistent==0.15.2
+pyrsistent==0.15.4
 pysam==0.15.2
 pysftp==0.2.9
 python-cinderclient==4.0.0
@@ -145,8 +147,9 @@ python-neutronclient==6.9.0
 python-novaclient==11.0.0
 python-openid==2.2.5 ; python_version < '3.0'
 python-swiftclient==3.6.0
-pytz==2019.1
-pyyaml==5.1.1
+pytz==2019.2
+pyuwsgi==2.0.18.post0
+pyyaml==5.1.2
 rdflib-jsonld==0.4.0
 rdflib==4.2.2
 repoze.lru==0.7
@@ -157,8 +160,8 @@ requestsexceptions==1.4.0
 rfc3986==1.3.2
 routes==2.4.1
 rsa==4.0
-ruamel.ordereddict==0.4.13 ; platform_python_implementation == 'CPython' and python_version <= '2.7'
-ruamel.yaml==0.15.97
+ruamel.ordereddict==0.4.14 ; platform_python_implementation == 'CPython' and python_version <= '2.7'
+ruamel.yaml==0.15.100
 s3transfer==0.2.1
 scandir==1.10.0 ; python_version < '3.5'
 schema-salad==2.7.20181126142424
@@ -167,8 +170,8 @@ simplejson==3.16.0
 six==1.11.0
 social-auth-core[openidconnect]==3.1.0+gx0
 sqlalchemy-migrate==0.12.0
-sqlalchemy-utils==0.34.0
-sqlalchemy==1.3.5
+sqlalchemy-utils==0.34.2
+sqlalchemy==1.3.7
 sqlparse==0.3.0
 stevedore==1.30.1
 subprocess32==3.5.4 ; python_version < '3.0'
@@ -177,11 +180,10 @@ tempita==0.5.2
 tenacity==4.12.0
 typing-extensions==3.7.4
 typing==3.7.4 ; python_version < '3.5'
-tzlocal==1.5.1
+tzlocal==2.0.0
 unicodecsv==0.14.1 ; python_version < '3.0'
 uritemplate==3.0.0
 urllib3==1.25.3 ; python_version == '2.7'
-uwsgi==2.0.18
 vine==1.3.0
 warlock==1.3.3
 wcwidth==0.1.7 ; sys_platform != 'win32'
@@ -189,3 +191,4 @@ webencodings==0.5.1
 webob==1.8.5
 whoosh==2.7.4
 wrapt==1.11.2
+zipp==0.5.2

--- a/lib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
@@ -1,9 +1,9 @@
 -i https://pypi.python.org/simple
-configparser==3.7.4 ; python_version < '3.2'
+configparser==3.8.1 ; python_version < '3.2'
 entrypoints==0.3
 enum34==1.1.6 ; python_version < '3.4'
 flake8-import-order==0.18.1
-flake8==3.7.7
+flake8==3.7.8
 functools32==3.2.3.post2 ; python_version < '3.2'
 mccabe==0.6.1
 pycodestyle==2.5.0


### PR DESCRIPTION
Discussing this on gitter today @nsoranzo and me found out that the pywusgi wheels are not built with libyaml, so use the same embedded parser that our custom wheels use. Our wheels appears to be not built with ssl support, and neither are the pyuwsgi wheels. So we should be able to use this as a drop-in replacement.