### PR TITLE
Factor out yaml read/write from config_manage.py

### DIFF
--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -29,9 +29,9 @@ from galaxy.config.schema import AppSchema, Schema
 from galaxy.util import safe_makedirs
 from galaxy.util.properties import nice_config_parser
 from galaxy.util.yaml_util import (
+    OPTION_DEFAULTS,
     ordered_dump,
     ordered_load,
-    OPTION_DEFAULTS,
 )
 
 

--- a/lib/galaxy/config/schema.py
+++ b/lib/galaxy/config/schema.py
@@ -1,6 +1,6 @@
 from galaxy.util.yaml_util import (
-    ordered_load,
     OPTION_DEFAULTS,
+    ordered_load,
 )
 
 

--- a/lib/galaxy/config/schema.py
+++ b/lib/galaxy/config/schema.py
@@ -1,0 +1,54 @@
+from galaxy.util.yaml_util import (
+    ordered_load,
+    OPTION_DEFAULTS,
+)
+
+
+UNKNOWN_OPTION = {
+    "type": "str",
+    "required": False,
+    "unknown_option": True,
+    "desc": "Unknown option, may want to remove or report to Galaxy team."
+}
+
+
+class Schema(object):
+
+    def __init__(self, mapping):
+        self.app_schema = mapping
+
+    def get_app_option(self, name):
+        try:
+            raw_option = self.app_schema[name]
+        except KeyError:
+            raw_option = UNKNOWN_OPTION
+        option = OPTION_DEFAULTS.copy()
+        option.update(raw_option)
+        return option
+
+
+class AppSchema(Schema):
+
+    def __init__(self, app_desc):
+        self.raw_schema = self._read_schema(app_desc.schema_path)
+        self.description = self.raw_schema.get("desc", None)
+        app_schema = self.raw_schema['mapping'][app_desc.app_name]['mapping']
+        super(AppSchema, self).__init__(app_schema)
+        self.reloadable_options = self._load_reloadable_options(app_schema)  # TODO redo
+
+    def _read_schema(self, path):
+        with open(path, "r") as f:
+            return ordered_load(f)
+
+    def get_reloadable_option_defaults(self):  # TODO redo
+        option_dict = {}
+        for key in self.reloadable_options:
+            option_dict[key] = self.get_app_option(key)["default"]
+        return option_dict
+
+    def _load_reloadable_options(self, mapping):  # TODO redo
+        reloadable_options = []
+        for key, option in mapping.items():
+            if option.get("reloadable", False):
+                reloadable_options.append(key)
+        return reloadable_options

--- a/lib/galaxy/util/yaml_util.py
+++ b/lib/galaxy/util/yaml_util.py
@@ -1,6 +1,7 @@
 import os
-import yaml
 from collections import OrderedDict
+
+import yaml
 
 
 OPTION_DEFAULTS = {

--- a/lib/galaxy/util/yaml_util.py
+++ b/lib/galaxy/util/yaml_util.py
@@ -1,0 +1,49 @@
+import os
+import yaml
+from collections import OrderedDict
+
+
+OPTION_DEFAULTS = {
+    "type": "str",
+    "unknown_option": False,
+    "default": None,
+    "desc": None,
+}
+
+
+def ordered_load(stream):
+    def construct_mapping(loader, node):
+        loader.flatten_mapping(node)
+        return OrderedDict(loader.construct_pairs(node))
+
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping)
+    OrderedLoader.add_constructor('!include', OrderedLoader.include)
+
+    return yaml.load(stream, OrderedLoader)
+
+
+class OrderedLoader(yaml.Loader):
+    # This class was pulled out of ordered_load() for the sake of
+    # mocking __init__ in a unit test.
+    def __init__(self, stream):
+        self._root = os.path.split(stream.name)[0]
+        super(OrderedLoader, self).__init__(stream)
+
+    def include(self, node):
+        filename = os.path.join(self._root, self.construct_scalar(node))
+        with open(filename, 'r') as f:
+            return yaml.load(f, OrderedLoader)
+
+
+def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
+    class OrderedDumper(Dumper):
+        pass
+
+    def _dict_representer(dumper, data):
+        return dumper.represent_mapping(
+            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+            list(data.items()))
+    OrderedDumper.add_representer(OrderedDict, _dict_representer)
+    return yaml.dump(data, stream, OrderedDumper, **kwds)

--- a/test/unit/config/test_schema.py
+++ b/test/unit/config/test_schema.py
@@ -1,0 +1,43 @@
+from galaxy.config.schema import AppSchema
+from galaxy.util.yaml_util import (
+    ordered_load,
+    OrderedLoader,
+)
+
+MOCK_YAML = '''
+    type: map
+    desc: mocked schema
+    foo: bar
+    mapping:
+      mockgalaxy:
+        type: map
+        mapping:
+          option:
+            attr1: a
+            attr2: b
+    '''
+
+
+class MockGalaxyApp():
+    app_name = 'mockgalaxy'
+    schema_path = None
+
+
+def test_schema_is_loaded(monkeypatch):
+
+    def mock_read_schema(self, path):
+        return ordered_load(MOCK_YAML)
+
+    def mock_init(self, stream):
+        super(OrderedLoader, self).__init__(stream)
+
+    monkeypatch.setattr(AppSchema, '_read_schema', mock_read_schema)
+    monkeypatch.setattr(OrderedLoader, '__init__', mock_init)
+
+    loaded_schema = AppSchema(MockGalaxyApp())
+    data = ordered_load(MOCK_YAML)
+
+    assert loaded_schema.description == data['desc']
+    assert loaded_schema.raw_schema['foo'] == 'bar'
+    assert loaded_schema.app_schema['option']['attr1'] == 'a'
+    assert loaded_schema.get_app_option('option')['attr2'] == 'b'


### PR DESCRIPTION
This is a step towards refactoring config as described in #8493.

Summary of changes:
- Move yaml processing into new utility module under galaxy/util (is this a good location?)
- Factor out Schema classes out of config_manage into schema module
- Add unit test for new schema module (to verify that the schema is loaded correctly)
- Move OrderedLoader out of function scope to accommodate unit test 

Rationale:
The primary responsibility of `config_manage.py` is servicing calls from Makefiles (linting, building sample yaml, building rst, converting from ini, etc.). This included reading a schema definition from a yaml file and loading it into a Schema (or AppSchema) object. 

Due to the need for reading the schema at startup (as per #8493), `config_manage` is now imported into `config/__init__`. 

Given that (1) `config_manage.py` was intended to be used as a script rather than a library module, and (2) loading yaml is only a small fraction of what it does, pulling out this functionality into a utility module and then using it for both use cases seems a reasonable approach.

