### PR TITLE
Fix default job metrics in dev/.

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -842,7 +842,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             dependency_resolvers_config_file=[self._in_config_dir('dependency_resolvers_conf.xml')],
             error_report_file=[self._in_config_dir('error_report.yml')],
             job_config_file=[self._in_config_dir('job_conf.xml')],
-            job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml')],
+            job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],
             job_resource_params_file=[self._in_config_dir('job_resource_params_conf.xml')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
             migrated_tools_config=[self._in_config_dir('migrated_tools_conf.xml')],


### PR DESCRIPTION
Broken with the config re-write as part of #921.

The argument for setting based on the sample here and not other places is because the in-Galaxy default is different than the galaxy-job-metrics as a library default (no metrics) I suppose. In that sense, the sample file does contain some logic that doesn't necessarily belong in ``galaxy.job_metrics``.