### PR TITLE
Break config/ dependency on config_manage script

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -24,6 +24,7 @@ import yaml
 from six import string_types
 from six.moves import configparser
 
+from galaxy.config.schema import AppSchema
 from galaxy.containers import parse_containers_config
 from galaxy.exceptions import ConfigurationError
 from galaxy.model import mapping
@@ -47,11 +48,12 @@ from galaxy.web_stack import (
     get_stack_facts,
     register_postfork_function
 )
-from .config_manage import GALAXY_APP
 from ..version import VERSION_MAJOR
 
 log = logging.getLogger(__name__)
 
+GALAXY_APP_NAME = 'galaxy'
+GALAXY_CONFIG_SCHEMA_PATH = 'lib/galaxy/webapps/galaxy/config_schema.yml'
 LOGGING_CONFIG_DEFAULT = {
     'version': 1,
     'root': {
@@ -1009,7 +1011,8 @@ def reload_config_options(current_config, path=None):
 
 
 def get_reloadable_config_options():
-    return GALAXY_APP.schema.get_reloadable_option_defaults()
+    schema = AppSchema(GALAXY_CONFIG_SCHEMA_PATH, GALAXY_APP_NAME)
+    return schema.get_reloadable_option_defaults()
 
 
 def get_database_engine_options(kwargs, model_prefix=''):

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -25,6 +25,8 @@ except ImportError:
 if __name__ == '__main__':
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)))
 
+
+from galaxy.config import GALAXY_CONFIG_SCHEMA_PATH
 from galaxy.config.schema import AppSchema, Schema
 from galaxy.util import safe_makedirs
 from galaxy.util.properties import nice_config_parser
@@ -308,7 +310,7 @@ def _sample_destination(self):
 
 
 def _schema(self):
-    return AppSchema(self)
+    return AppSchema(self.schema_path, self.app_name)
 
 
 App.app_name = property(_app_name)
@@ -323,7 +325,7 @@ GALAXY_APP = App(
     "8080",
     ["galaxy.web.buildapp:app_factory"],  # TODO: Galaxy could call factory a few different things and they'd all be fine.
     "config/galaxy.yml",
-    "lib/galaxy/webapps/galaxy/config_schema.yml",
+    GALAXY_CONFIG_SCHEMA_PATH,
     'galaxy.webapps.galaxy.buildapp:uwsgi_app()',
 )
 SHED_APP = App(

--- a/lib/galaxy/config/schema.py
+++ b/lib/galaxy/config/schema.py
@@ -29,10 +29,10 @@ class Schema(object):
 
 class AppSchema(Schema):
 
-    def __init__(self, app_desc):
-        self.raw_schema = self._read_schema(app_desc.schema_path)
+    def __init__(self, schema_path, app_name):
+        self.raw_schema = self._read_schema(schema_path)
         self.description = self.raw_schema.get("desc", None)
-        app_schema = self.raw_schema['mapping'][app_desc.app_name]['mapping']
+        app_schema = self.raw_schema['mapping'][app_name]['mapping']
         super(AppSchema, self).__init__(app_schema)
         self.reloadable_options = self._load_reloadable_options(app_schema)  # TODO redo
 

--- a/test/unit/config/test_schema.py
+++ b/test/unit/config/test_schema.py
@@ -18,11 +18,6 @@ MOCK_YAML = '''
     '''
 
 
-class MockGalaxyApp():
-    app_name = 'mockgalaxy'
-    schema_path = None
-
-
 def test_schema_is_loaded(monkeypatch):
 
     def mock_read_schema(self, path):
@@ -34,7 +29,7 @@ def test_schema_is_loaded(monkeypatch):
     monkeypatch.setattr(AppSchema, '_read_schema', mock_read_schema)
     monkeypatch.setattr(OrderedLoader, '__init__', mock_init)
 
-    loaded_schema = AppSchema(MockGalaxyApp())
+    loaded_schema = AppSchema('no path', 'mockgalaxy')
     data = ordered_load(MOCK_YAML)
 
     assert loaded_schema.description == data['desc']


### PR DESCRIPTION
This is another step towards refactoring config as described in #8493.

Summary of changes:
- Change `__init__` method signature in `schema.py` to break its dependency on object defined in `config_manage.py`
- Adjust relevant unit test + `config_manage.py`
- Reverse dependency: `config_manage.py` now imports the schema file path from `config/__init__.py`

Rationale:
An AppSchema object requires (1) the path to the schema file, and (2) the app name. Both were passed to its constructor as members of an object defined in `config_manage.py`. This made the AppSchema object (and, consequently, any modules importing it) dependent on `config_manage.py`, which is problematic (see #8509 for rationale). Also, schema_path and app_name were the only properties of the passed object used by AppSchema; all other properties were specific to `config_manage.py`. This commit breaks this dependency, and will allow to read in a schema file at startup without using `config_manage.py`.

Concerns:
1. I am not sure that a constant in `__init__.py` is the best place for specifying the path to the schema file. 
2. Now `config_manage.py` imports the schema path from `__init__.py`. I think a better solution would be for both modules to access this value from another location, but creating a module just for that seems overkill.
In both cases, I think the suggested approach is good enough for now, and can be edited as needed.