### PR TITLE
Add API to tag library datasets

### DIFF
--- a/client/galaxy/scripts/mvc/library/library-dataset-view.js
+++ b/client/galaxy/scripts/mvc/library/library-dataset-view.js
@@ -116,9 +116,7 @@ var LibraryDatasetView = Backbone.View.extend({
         const container = this.$el.find(".nametags")[0];
         if (container) {
             const str_tags = this.model.get("tags");
-            if (typeof str_tags === "string") {
-                this.model.set({ tags: str_tags.split(', ') });
-            }
+            this.model.set({ tags: str_tags.split(', ') });
             const { id, model_class, tags } = this.model.attributes;
             const storeKey = `${model_class}-${id}`;
             mountNametags({ storeKey, tags }, container);

--- a/client/galaxy/scripts/mvc/library/library-dataset-view.js
+++ b/client/galaxy/scripts/mvc/library/library-dataset-view.js
@@ -8,6 +8,7 @@ import { Toast } from "ui/toast";
 import mod_library_model from "mvc/library/library-model";
 import mod_utils from "utils/utils";
 import mod_select from "mvc/ui/ui-select";
+import { mountNametags } from "components/Nametags";
 
 var LibraryDatasetView = Backbone.View.extend({
     el: "#center",
@@ -108,6 +109,16 @@ var LibraryDatasetView = Backbone.View.extend({
         this.$el.html(template({ item: this.model }));
         $(".peek").html(this.model.get("peek"));
         $('#center [data-toggle="tooltip"]').tooltip({ trigger: "hover" });
+        this._mountNametags("initialize");
+    },
+
+    _mountNametags(context) {
+        const container = this.$el.find(".nametags")[0];
+        if (container) {
+            const { id, model_class, tags } = this.model.attributes;
+            const storeKey = `${model_class}-${id}`;
+            mountNametags({ storeKey, tags }, container);
+        }
     },
 
     fetchVersion: function(options) {
@@ -766,7 +777,7 @@ var LibraryDatasetView = Backbone.View.extend({
                         <% if (item.get("tags")) { %>
                             <tr>
                                 <th scope="row">Tags</th>
-                                <td scope="row"><%= _.escape(item.get("tags")) %></td>
+                                <td scope="row"><div class="nametags"><!-- Nametags mount here --></div></td>
                             </tr>
                         <% } %>
                         <% if ( item.get("uuid") !== "ok" ) { %>
@@ -949,7 +960,7 @@ var LibraryDatasetView = Backbone.View.extend({
                         <% if (item.get("tags")) { %>
                             <tr>
                                 <th scope="row">Tags</th>
-                                <td scope="row"><%= _.escape(item.get("tags")) %></td>
+                                <td scope="row"><div class="nametags"><!-- Nametags mount here --></div></td>
                             </tr>
                         <% } %>
                     </table>
@@ -1069,7 +1080,7 @@ var LibraryDatasetView = Backbone.View.extend({
                         <% if (item.get("tags")) { %>
                             <tr>
                                 <th scope="row">Tags</th>
-                                <td scope="row"><%= _.escape(item.get("tags")) %></td>
+                                <td scope="row"><div class="nametags"><!-- Nametags mount here --></div></td>
                             </tr>
                         <% } %>
                     </table>
@@ -1194,7 +1205,7 @@ var LibraryDatasetView = Backbone.View.extend({
         return _.template(
             `<div>
                 <div class="library-modal-item">
-                    Select history: 
+                    Select history:
                     <select id="dataset_import_single" name="dataset_import_single"
                         style="width:50%; margin-bottom: 1em;" autofocus>
                         <% _.each(histories, function(history) { %>
@@ -1204,7 +1215,7 @@ var LibraryDatasetView = Backbone.View.extend({
                         <% }); %>
                     </select>
                 </div>
-                <div class="library-modal-item">or create new: 
+                <div class="library-modal-item">or create new:
                     <input type="text" name="history_name" value="" placeholder="name of the new history"
                         style="width:50%;" />
                 </div>

--- a/client/galaxy/scripts/mvc/library/library-dataset-view.js
+++ b/client/galaxy/scripts/mvc/library/library-dataset-view.js
@@ -115,10 +115,13 @@ var LibraryDatasetView = Backbone.View.extend({
     _mountNametags(context) {
         const container = this.$el.find(".nametags")[0];
         if (container) {
-            this.model.set({ tags: this.model.get("tags").split(', ') });
-            const { id, model_class, tags } = this.model.attributes;
-            const storeKey = `${model_class}-${id}`;
-            mountNametags({ storeKey, tags }, container);
+            const str_tags = this.model.get("tags");
+            if (typeof str_tags === "string") {
+                this.model.set({ tags: str_tags.split(', ') });
+                const { id, model_class, tags } = this.model.attributes;
+                const storeKey = `${model_class}-${id}`;
+                mountNametags({ storeKey, tags }, container);
+            }
         }
     },
 

--- a/client/galaxy/scripts/mvc/library/library-dataset-view.js
+++ b/client/galaxy/scripts/mvc/library/library-dataset-view.js
@@ -116,7 +116,9 @@ var LibraryDatasetView = Backbone.View.extend({
         const container = this.$el.find(".nametags")[0];
         if (container) {
             const str_tags = this.model.get("tags");
-            this.model.set({ tags: str_tags.split(', ') });
+            if (typeof str_tags === "string") {
+                this.model.set({ tags: str_tags.split(', ') });
+            }
             const { id, model_class, tags } = this.model.attributes;
             const storeKey = `${model_class}-${id}`;
             mountNametags({ storeKey, tags }, container);

--- a/client/galaxy/scripts/mvc/library/library-dataset-view.js
+++ b/client/galaxy/scripts/mvc/library/library-dataset-view.js
@@ -115,6 +115,7 @@ var LibraryDatasetView = Backbone.View.extend({
     _mountNametags(context) {
         const container = this.$el.find(".nametags")[0];
         if (container) {
+            this.model.set({ tags: this.model.get("tags").split(', ') });
             const { id, model_class, tags } = this.model.attributes;
             const storeKey = `${model_class}-${id}`;
             mountNametags({ storeKey, tags }, container);

--- a/client/galaxy/scripts/mvc/library/library-dataset-view.js
+++ b/client/galaxy/scripts/mvc/library/library-dataset-view.js
@@ -118,10 +118,10 @@ var LibraryDatasetView = Backbone.View.extend({
             const str_tags = this.model.get("tags");
             if (typeof str_tags === "string") {
                 this.model.set({ tags: str_tags.split(', ') });
-                const { id, model_class, tags } = this.model.attributes;
-                const storeKey = `${model_class}-${id}`;
-                mountNametags({ storeKey, tags }, container);
             }
+            const { id, model_class, tags } = this.model.attributes;
+            const storeKey = `${model_class}-${id}`;
+            mountNametags({ storeKey, tags }, container);
         }
     },
 
@@ -168,6 +168,7 @@ var LibraryDatasetView = Backbone.View.extend({
         });
         $(".peek").html(this.model.get("peek"));
         $('#center [data-toggle="tooltip"]').tooltip({ trigger: "hover" });
+        this._mountNametags("listener");
     },
 
     downloadDataset: function() {

--- a/client/galaxy/scripts/mvc/library/library-folderlist-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderlist-view.js
@@ -509,7 +509,7 @@ var FolderListView = Backbone.View.extend({
                         <span title="Sorted by Desc." class="sort-icon-message fa"></span>
                     </th>
                     <th style="width:5%;">
-                        <a title="Click to reverse order">Tags</a>
+                        <span>Tags</span>
                     </th>
                     <th style="width:5%;">
                         <a class="sort-folder-file_ext" title="Click to reverse order" href="javascript:void(0)" role="button">Data Type</a>

--- a/client/galaxy/scripts/mvc/library/library-folderlist-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderlist-view.js
@@ -509,8 +509,7 @@ var FolderListView = Backbone.View.extend({
                         <span title="Sorted by Desc." class="sort-icon-message fa"></span>
                     </th>
                     <th style="width:5%;">
-                        <a class="sort-folder-tags" title="Click to reverse order" href="javascript:void(0)" role="button">Tags</a>
-                        <span title="Sorted by Tags" class="sort-icon-tags fa"></span>
+                        <a title="Click to reverse order">Tags</a>
                     </th>
                     <th style="width:5%;">
                         <a class="sort-folder-file_ext" title="Click to reverse order" href="javascript:void(0)" role="button">Data Type</a>

--- a/client/galaxy/scripts/mvc/library/library-folderlist-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderlist-view.js
@@ -509,6 +509,10 @@ var FolderListView = Backbone.View.extend({
                         <span title="Sorted by Desc." class="sort-icon-message fa"></span>
                     </th>
                     <th style="width:5%;">
+                        <a class="sort-folder-tags" title="Click to reverse order" href="javascript:void(0)" role="button">Tags</a>
+                        <span title="Sorted by Tags" class="sort-icon-tags fa"></span>
+                    </th>
+                    <th style="width:5%;">
                         <a class="sort-folder-file_ext" title="Click to reverse order" href="javascript:void(0)" role="button">Data Type</a>
                         <span title="Sorted by Type" class="sort-icon-file_ext fa"></span>
                     </th>

--- a/client/galaxy/scripts/mvc/library/library-folderrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderrow-view.js
@@ -82,10 +82,10 @@ var FolderRowView = Backbone.View.extend({
             const str_tags = this.model.get("tags");
             if (typeof str_tags === "string") {
                 this.model.set({ tags: str_tags.split(', ') });
-                const { id, model_class, tags } = this.model.attributes;
-                const storeKey = `${model_class}-${id}`;
-                mountNametags({ storeKey, tags }, container);
             }
+            const { id, model_class, tags } = this.model.attributes;
+            const storeKey = `${model_class}-${id}`;
+            mountNametags({ storeKey, tags }, container);
         }
     },
 

--- a/client/galaxy/scripts/mvc/library/library-folderrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderrow-view.js
@@ -80,9 +80,7 @@ var FolderRowView = Backbone.View.extend({
         const container = this.$el.find(".nametags")[0];
         if (container) {
             const str_tags = this.model.get("tags");
-            if (typeof str_tags === "string") {
-                this.model.set({ tags: str_tags.split(', ') });
-            }
+            this.model.set({ tags: str_tags.split(', ') });
             const { id, model_class, tags } = this.model.attributes;
             const storeKey = `${model_class}-${id}`;
             mountNametags({ storeKey, tags }, container);

--- a/client/galaxy/scripts/mvc/library/library-folderrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderrow-view.js
@@ -79,10 +79,13 @@ var FolderRowView = Backbone.View.extend({
     _mountNametags(context) {
         const container = this.$el.find(".nametags")[0];
         if (container) {
-            this.model.set({ tags: this.model.get("tags").split(', ') });
-            const { id, model_class, tags } = this.model.attributes;
-            const storeKey = `${model_class}-${id}`;
-            mountNametags({ storeKey, tags }, container);
+            const str_tags = this.model.get("tags");
+            if (typeof str_tags === "string") {
+                this.model.set({ tags: str_tags.split(', ') });
+                const { id, model_class, tags } = this.model.attributes;
+                const storeKey = `${model_class}-${id}`;
+                mountNametags({ storeKey, tags }, container);
+            }
         }
     },
 

--- a/client/galaxy/scripts/mvc/library/library-folderrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderrow-view.js
@@ -270,6 +270,7 @@ var FolderRowView = Backbone.View.extend({
                         <textarea rows="4" class="form-control input_folder_description" placeholder="description" ><%- content_item.get("description") %></textarea>
                     </td>
                 <% } %>
+                <td></td>
                 <td>folder</td>
                 <td></td>
                 <td>
@@ -325,6 +326,7 @@ var FolderRowView = Backbone.View.extend({
                     <a>
                 </td>
                 <td><%- content_item.get("message") %></td>
+                <td><%= _.escape(content_item.get("tags")) %></td>
                 <td><%= _.escape(content_item.get("file_ext")) %></td>
                 <td><%= _.escape(content_item.get("file_size")) %></td>
                 <td><%= _.escape(content_item.get("update_time")) %></td>
@@ -372,6 +374,9 @@ var FolderRowView = Backbone.View.extend({
                 </td>
                 <td>
                     <%- content_item.get("message") %>
+                </td>
+                <td>
+                    <%= _.escape(content_item.get("tags")) %>
                 </td>
                 <td>
                     <%= _.escape(content_item.get("file_ext")) %>
@@ -422,6 +427,7 @@ var FolderRowView = Backbone.View.extend({
                 <% } else { %>
                     <td></td>
                 <% } %>
+                <td></td>
                 <td>
                     folder
                 </td>

--- a/client/galaxy/scripts/mvc/library/library-folderrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderrow-view.js
@@ -80,7 +80,9 @@ var FolderRowView = Backbone.View.extend({
         const container = this.$el.find(".nametags")[0];
         if (container) {
             const str_tags = this.model.get("tags");
-            this.model.set({ tags: str_tags.split(', ') });
+            if (typeof str_tags === "string") {
+                this.model.set({ tags: str_tags.split(', ') });
+            }
             const { id, model_class, tags } = this.model.attributes;
             const storeKey = `${model_class}-${id}`;
             mountNametags({ storeKey, tags }, container);

--- a/client/galaxy/scripts/mvc/library/library-folderrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderrow-view.js
@@ -79,6 +79,7 @@ var FolderRowView = Backbone.View.extend({
     _mountNametags(context) {
         const container = this.$el.find(".nametags")[0];
         if (container) {
+            this.model.set({ tags: this.model.get("tags").split(', ') });
             const { id, model_class, tags } = this.model.attributes;
             const storeKey = `${model_class}-${id}`;
             mountNametags({ storeKey, tags }, container);

--- a/client/galaxy/scripts/mvc/library/library-folderrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderrow-view.js
@@ -6,6 +6,7 @@ import { getGalaxyInstance } from "app";
 import { Toast } from "ui/toast";
 import mod_library_model from "mvc/library/library-model";
 import mod_library_dataset_view from "mvc/library/library-dataset-view";
+import { mountNametags } from "components/Nametags";
 
 var FolderRowView = Backbone.View.extend({
     events: {
@@ -69,7 +70,19 @@ var FolderRowView = Backbone.View.extend({
             })
         );
         this.$el.show();
+
+        this._mountNametags("initialize");
+
         return this;
+    },
+
+    _mountNametags(context) {
+        const container = this.$el.find(".nametags")[0];
+        if (container) {
+            const { id, model_class, tags } = this.model.attributes;
+            const storeKey = `${model_class}-${id}`;
+            mountNametags({ storeKey, tags }, container);
+        }
     },
 
     /**
@@ -326,7 +339,7 @@ var FolderRowView = Backbone.View.extend({
                     <a>
                 </td>
                 <td><%- content_item.get("message") %></td>
-                <td><%= _.escape(content_item.get("tags")) %></td>
+                <td><div class="nametags"><!-- Nametags mount here --></div></td>
                 <td><%= _.escape(content_item.get("file_ext")) %></td>
                 <td><%= _.escape(content_item.get("file_size")) %></td>
                 <td><%= _.escape(content_item.get("update_time")) %></td>
@@ -376,7 +389,7 @@ var FolderRowView = Backbone.View.extend({
                     <%- content_item.get("message") %>
                 </td>
                 <td>
-                    <%= _.escape(content_item.get("tags")) %>
+                    <div class="nametags"><!-- Nametags mount here --></div>
                 </td>
                 <td>
                     <%= _.escape(content_item.get("file_ext")) %>

--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -249,6 +249,7 @@ class LibraryActions(object):
         uploaded_dataset.to_posix_lines = params.get('to_posix_lines', None)
         uploaded_dataset.space_to_tab = params.get('space_to_tab', None)
         uploaded_dataset.tag_using_filenames = params.get('tag_using_filenames', False)
+        uploaded_dataset.tags = params.get('tags', None)
         uploaded_dataset.purge_source = getattr(trans.app.config, 'ftp_upload_purge', True)
         if in_folder:
             uploaded_dataset.in_folder = in_folder

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -238,7 +238,7 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         rval['update_time'] = ldda.update_time.strftime("%Y-%m-%d %I:%M %p")
         rval['can_user_modify'] = trans.user_is_admin or trans.app.security_agent.can_modify_library_item(current_user_roles, ld)
         rval['is_unrestricted'] = trans.app.security_agent.dataset_is_public(ldda.dataset)
-        rval['tags'] = self.tag_handler.get_tags_str(ldda.tags).split(', ')
+        rval['tags'] = self.tag_handler.get_tags_str(ldda.tags)
 
         #  Manage dataset permission is always attached to the dataset itself, not the the ld or ldda to maintain consistency
         rval['can_user_manage'] = trans.user_is_admin or trans.app.security_agent.can_manage_dataset(current_user_roles, ldda.dataset)

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -238,7 +238,7 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         rval['update_time'] = ldda.update_time.strftime("%Y-%m-%d %I:%M %p")
         rval['can_user_modify'] = trans.user_is_admin or trans.app.security_agent.can_modify_library_item(current_user_roles, ld)
         rval['is_unrestricted'] = trans.app.security_agent.dataset_is_public(ldda.dataset)
-        rval['tags'] = self.tag_handler.get_tags_str(ldda.tags)
+        rval['tags'] = self.tag_handler.get_tags_str(ldda.tags).split(', ')
 
         #  Manage dataset permission is always attached to the dataset itself, not the the ld or ldda to maintain consistency
         rval['can_user_manage'] = trans.user_is_admin or trans.app.security_agent.can_manage_dataset(current_user_roles, ldda.dataset)

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -63,6 +63,8 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
             :type  file_ext:        str
             :param genome_build:    new ld's genome build
             :type  genome_build:    str
+            :param tags:            list of dataset tags
+            :type  tags:            list
         :type   payload: dict
 
         :returns:   the changed library dataset
@@ -100,6 +102,12 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         if new_genome_build is not None and new_genome_build != ldda.dbkey:
             ldda.dbkey = new_genome_build
             changed = True
+        new_tags = new_data.get('tags', None)
+        if new_tags is not None and new_tags != ldda.tags:
+            for tag in new_tags:
+                self.tag_handler.delete_item_tags(item=ldda, user=trans.user)
+                self.tag_handler.apply_item_tag(item=ldda, user=trans.user, name='name', value=tag)
+            changed = True
         if changed:
             ldda.update_parent_folder_update_times()
             trans.sa_session.add(ldda)
@@ -129,6 +137,9 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
                 if len(val) < MINIMUM_STRING_LENGTH:
                     raise RequestParameterInvalidException('%s must have at least length of %s' % (key, MINIMUM_STRING_LENGTH))
                 val = validation.validate_and_sanitize_basestring(key, val)
+                validated_payload[key] = val
+            if key in ('tags'):
+                val = validation.validate_and_sanitize_basestring_list(key, val)
                 validated_payload[key] = val
         return validated_payload
 

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -104,8 +104,8 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
             changed = True
         new_tags = new_data.get('tags', None)
         if new_tags is not None and new_tags != ldda.tags:
+            self.tag_handler.delete_item_tags(item=ldda, user=trans.user)
             for tag in new_tags:
-                self.tag_handler.delete_item_tags(item=ldda, user=trans.user)
                 self.tag_handler.apply_item_tag(item=ldda, user=trans.user, name='name', value=tag)
             changed = True
         if changed:

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -223,6 +223,12 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, state
         tag_manager = tags.GalaxyTagHandler(trans.sa_session)
         tag_manager.apply_item_tag(item=ldda, user=trans.user, name='name', value=tag_from_filename)
 
+    tags_list = uploaded_dataset.get('tags', False)
+    if tags_list:
+        tag_manager = tags.GalaxyTagHandler(trans.sa_session)
+        for tag in tags_list:
+            tag_manager.apply_item_tag(item=ldda, user=trans.user, name='name', value=tag)
+
     trans.sa_session.add(ldda)
     if state:
         ldda.state = state

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -158,6 +158,7 @@ def handle_library_params(trans, params, folder_id, replace_dataset=None):
     for role_id in util.listify(params.get('roles', [])):
         role = trans.sa_session.query(trans.app.model.Role).get(role_id)
         library_bunch.roles.append(role)
+    library_bunch.tags = params.get('tags', None)
     return library_bunch
 
 
@@ -280,6 +281,9 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, state
 def new_upload(trans, cntrller, uploaded_dataset, library_bunch=None, history=None, state=None, tag_list=None):
     if library_bunch:
         upload_target_dataset_instance = __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, state)
+        if library_bunch.tags and not uploaded_dataset.tags:
+            for tag in library_bunch.tags:
+                trans.app.tag_handler.apply_item_tag(user=trans.user, item=upload_target_dataset_instance, name='name', value=tag)
     else:
         upload_target_dataset_instance = __new_history_upload(trans, uploaded_dataset, history=history, state=state)
 

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -544,6 +544,7 @@ class UploadDataset(Group):
         d_type = self.get_datatype(trans, context)
         dbkey = self.get_dbkey(context)
         tag_using_filenames = context.get('tag_using_filenames', False)
+        tags = context.get('tags', False)
         force_composite = asbool(context.get('force_composite', 'False'))
         writable_files = d_type.writable_files
         writable_files_offset = 0
@@ -564,6 +565,7 @@ class UploadDataset(Group):
             dataset.composite_files = {}
             dataset.uuid = None
             dataset.tag_using_filenames = None
+            dataset.tags = None
             # load metadata
             files_metadata = context.get(self.metadata_ref, {})
             metadata_name_substition_default_dict = dict((composite_file.substitute_name_with_metadata, d_type.metadata_spec[composite_file.substitute_name_with_metadata].default) for composite_file in d_type.composite_files.values() if composite_file.substitute_name_with_metadata)
@@ -629,6 +631,7 @@ class UploadDataset(Group):
                     dataset.ext = self.get_datatype_ext(trans, context[self.name][i], parent_context=context)
                     dataset.dbkey = self.get_dbkey(context[self.name][i], parent_context=context)
                     dataset.tag_using_filenames = tag_using_filenames
+                    dataset.tags = tags
                     rval.append(dataset)
             return rval
 

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -114,7 +114,7 @@ class FolderContentsController(BaseAPIController, UsesLibraryMixin, UsesLibraryM
                 encoded_ldda_id = trans.security.encode_id(content_item.library_dataset_dataset_association.id)
 
                 tag_manager = tags.GalaxyTagHandler(trans.sa_session)
-                ldda_tags = tag_manager.get_tags_str(content_item.library_dataset_dataset_association.tags)
+                ldda_tags = tag_manager.get_tags_str(content_item.library_dataset_dataset_association.tags).split(', ')
 
                 return_item.update(dict(file_ext=library_dataset_dict['file_ext'],
                                         date_uploaded=library_dataset_dict['date_uploaded'],

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -114,7 +114,7 @@ class FolderContentsController(BaseAPIController, UsesLibraryMixin, UsesLibraryM
                 encoded_ldda_id = trans.security.encode_id(content_item.library_dataset_dataset_association.id)
 
                 tag_manager = tags.GalaxyTagHandler(trans.sa_session)
-                ldda_tags = tag_manager.get_tags_str(content_item.library_dataset_dataset_association.tags).split(', ')
+                ldda_tags = tag_manager.get_tags_str(content_item.library_dataset_dataset_association.tags)
 
                 return_item.update(dict(file_ext=library_dataset_dict['file_ext'],
                                         date_uploaded=library_dataset_dict['date_uploaded'],

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -9,6 +9,7 @@ from galaxy import (
     util
 )
 from galaxy.managers import folders
+from galaxy.model import tags
 from galaxy.web import (
     expose_api,
     expose_api_anonymous
@@ -111,6 +112,10 @@ class FolderContentsController(BaseAPIController, UsesLibraryMixin, UsesLibraryM
 
                 library_dataset_dict = content_item.to_dict()
                 encoded_ldda_id = trans.security.encode_id(content_item.library_dataset_dataset_association.id)
+
+                tag_manager = tags.GalaxyTagHandler(trans.sa_session)
+                ldda_tags = tag_manager.get_tags_str(content_item.library_dataset_dataset_association.tags)
+
                 return_item.update(dict(file_ext=library_dataset_dict['file_ext'],
                                         date_uploaded=library_dataset_dict['date_uploaded'],
                                         update_time=update_time,
@@ -120,7 +125,8 @@ class FolderContentsController(BaseAPIController, UsesLibraryMixin, UsesLibraryM
                                         state=library_dataset_dict['state'],
                                         file_size=nice_size,
                                         raw_size=raw_size,
-                                        ldda_id=encoded_ldda_id))
+                                        ldda_id=encoded_ldda_id,
+                                        tags=ldda_tags))
                 if content_item.library_dataset_dataset_association.message:
                     return_item.update(dict(message=content_item.library_dataset_dataset_association.message))
 

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -20,7 +20,8 @@ from galaxy.managers.collections_util import (
 )
 from galaxy.model import (
     ExtendedMetadata,
-    ExtendedMetadataIndex
+    ExtendedMetadataIndex,
+    tags
 )
 from galaxy.web import expose_api
 from galaxy.webapps.base.controller import (
@@ -155,6 +156,9 @@ class LibraryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
             rval['ldda_id'] = trans.security.encode_id(rval['ldda_id'])
             rval['folder_id'] = 'F' + str(trans.security.encode_id(rval['folder_id']))
             rval['parent_library_id'] = trans.security.encode_id(rval['parent_library_id'])
+
+            tag_manager = tags.GalaxyTagHandler(trans.sa_session)
+            rval['tags'] = tag_manager.get_tags_str(content.library_dataset_dataset_association.tags)
         return rval
 
     @expose_api
@@ -202,6 +206,8 @@ class LibraryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
                 description of the folder to create
             * tag_using_filename: (optional)
                 create tags on datasets using the file's original name
+            * tags: (optional)
+                create the given list of tags on datasets
 
         :returns:   a dictionary describing the new item unless ``from_hdca_id`` is supplied,
                     in that case a list of such dictionaries is returned.
@@ -231,6 +237,7 @@ class LibraryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
         real_folder_id = trans.security.encode_id(parent.id)
 
         payload['tag_using_filenames'] = util.string_as_bool(payload.get('tag_using_filenames', None))
+        payload['tags'] = util.listify(payload.get('tags', None))
 
         # are we copying an HDA to the library folder?
         #   we'll need the id and any message to attach, then branch to that private function

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -174,6 +174,8 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
             :type  file_ext:        str
             :param genome_build:    new ld's genome build
             :type  genome_build:    str
+            :param tags:            list of dataset tags
+            :type  tags:            list
         :type   payload: dict
 
         :returns:   detailed library dataset information


### PR DESCRIPTION
Since #4262, when importing some files to a data library, filename can be added as a tag automatically.
With this PR, I extended the api to allow adding/updating any tags to library datasets.
I also modified the data lib templates to display tags in the UI. Though they're not displayed with pretty colors, and I didn't make the changes to the UI to add/remove tags like history datasets. I'm mostly interested in the API in fact.
I'm also preparing a PR for bioblend for this
Any comments welcome!