### PR TITLE
Enable GEDA parameters to declare allow_cors="true"

### DIFF
--- a/display_applications/icn3d/icn3d_simple.xml
+++ b/display_applications/icn3d/icn3d_simple.xml
@@ -2,6 +2,6 @@
 <display id="icn3d_simple" version="1.0.0" name="view in iCn3D at">
     <dynamic_links from_data_table="icn3d_simple_display" skip_startswith="#" id="value" name="name">
         <url>${ url % {  'icn3d_file_type': $icn3d_file.ext, 'icn3d_file_url_qp': $icn3d_file.qp } }</url>
-        <param type="data" name="icn3d_file" url="galaxy_${DATASET_HASH}.${dataset.ext}" />
+        <param type="data" name="icn3d_file" url="galaxy_${DATASET_HASH}.${dataset.ext}" allow_cors="true" />
     </dynamic_links>
 </display>

--- a/display_applications/intermine/intermine_simple.xml
+++ b/display_applications/intermine/intermine_simple.xml
@@ -2,6 +2,6 @@
 <display id="intermine_simple" version="1.0.0" name="view intermine at">
     <dynamic_links from_data_table="intermine_simple_display" skip_startswith="#" id="value" name="name">
         <url>${ url % { 'intermine_file_url_qp': $intermine_file.qp } }</url>
-        <param type="data" name="intermine_file" url="galaxy_${DATASET_HASH}.intermine" />
+        <param type="data" name="intermine_file" url="galaxy_${DATASET_HASH}.intermine" allow_cors="true" />
     </dynamic_links>
 </display>

--- a/lib/galaxy/datatypes/display_applications/application.py
+++ b/lib/galaxy/datatypes/display_applications/application.py
@@ -252,6 +252,10 @@ class PopulatedDisplayApplicationLink(object):
                 return name
         raise ValueError("Unknown URL parameter name provided: %s" % url)
 
+    @property
+    def allow_cors(self):
+        return self.link.allow_cors
+
 
 class DisplayApplication(object):
     @classmethod

--- a/lib/galaxy/datatypes/display_applications/parameters.py
+++ b/lib/galaxy/datatypes/display_applications/parameters.py
@@ -32,6 +32,7 @@ class DisplayApplicationParameter(object):
         self.strip = string_as_bool(elem.get('strip', 'False'))
         self.strip_https = string_as_bool(elem.get('strip_https', 'False'))
         self.allow_override = string_as_bool(elem.get('allow_override', 'False'))  # Passing query param app_<name>=<value> to dataset controller allows override if this is true.
+        self.allow_cors = string_as_bool(elem.get('allow_cors', 'False'))
 
     def get_value(self, other_values, dataset_hash, user_hash, trans):
         raise Exception('get_value() is unimplemented for DisplayApplicationDataParameter')

--- a/lib/galaxy/datatypes/display_applications/xsd/geda.xsd
+++ b/lib/galaxy/datatypes/display_applications/xsd/geda.xsd
@@ -268,6 +268,11 @@ A data param that provides a BGZIP file (from an initial VCF file), with a Tabix
                         <xs:documentation xml:lang="en">'dataset' is default name assigned to dataset to be displayed</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="allow_cors" type="PermissiveBoolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">Automatically enable CORS for origin of request.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -276,6 +276,15 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
         t = Translations.load(dirname='locale', locales=locales, domain='ginga')
         self.template_context.update(dict(_=t.ugettext, n_=t.ugettext, N_=t.ungettext))
 
+    def set_cors_origin(self, origin=None):
+        if origin is None:
+            origin = self.request.headers.get("Origin", None)
+        if origin:
+            self.response.headers['Access-Control-Allow-Origin'] = origin
+        elif 'Access-Control-Allow-Origin' in self.response.headers:
+            log.debug(str(dir(self.response.headers)))
+            del self.response.headers['Access-Control-Allow-Origin']
+
     def set_cors_headers(self):
         """Allow CORS requests if configured to do so by echoing back the request's
         'Origin' header (if any) as the response header 'Access-Control-Allow-Origin'
@@ -313,7 +322,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
         origin = urlparse(origin_header).hostname
         # check against the list of allowed strings/regexp hostnames, echo original if cleared
         if is_allowed_origin(origin):
-            self.response.headers['Access-Control-Allow-Origin'] = origin_header
+            self.set_cors_origin(origin=origin_header)
             # TODO: see the to do on ALLOWED_METHODS above
             # self.response.headers[ 'Access-Control-Allow-Methods' ] = ', '.join( ALLOWED_METHODS )
 

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -282,7 +282,6 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
         if origin:
             self.response.headers['Access-Control-Allow-Origin'] = origin
         elif 'Access-Control-Allow-Origin' in self.response.headers:
-            log.debug(str(dir(self.response.headers)))
             del self.response.headers['Access-Control-Allow-Origin']
 
     def set_cors_headers(self):

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -834,6 +834,9 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                         else:
                             rval = str(value)
                             content_length = len(rval)
+                        # Set Access-Control-Allow-Origin as specified in GEDA
+                        if value.parameter.allow_cors:
+                            trans.set_cors_origin()
                         trans.response.set_content_type(value.mime_type(action_param_extra=action_param_extra))
                         trans.response.headers['Content-Length'] = content_length
                         return rval


### PR DESCRIPTION
to automatically set Access-Control-Allow-Origin to Origin of request.