### PR TITLE
explicitly declare expression as sql.text

### DIFF
--- a/lib/tool_shed/repository_registry.py
+++ b/lib/tool_shed/repository_registry.py
@@ -1,7 +1,6 @@
 import logging
 
 from sqlalchemy import and_, false, or_
-from sqlalchemy.sql import text
 
 import tool_shed.repository_types.util as rt_util
 from galaxy.webapps.tool_shed import model
@@ -148,11 +147,9 @@ class Registry(object):
             latest_installable_changeset_revision, is_level_one_certified = certified_level_one_tuple
             if is_level_one_certified:
                 certified_level_one_tuples.append(certified_level_one_tuple)
-                clause_list.append(text("%s=%d and %s='%s'" % (model.RepositoryMetadata.table.c.repository_id,
-                                                               repository.id,
-                                                               model.RepositoryMetadata.table.c.changeset_revision,
-                                                               latest_installable_changeset_revision)
-                                        ))
+                clause_list.append(and_(
+                    model.RepositoryMetadata.table.c.repository_id == repository.id,
+                    model.RepositoryMetadata.table.c.changeset_revision == latest_installable_changeset_revision))
         return clause_list
 
     def get_certified_level_one_tuple(self, repository):

--- a/lib/tool_shed/repository_registry.py
+++ b/lib/tool_shed/repository_registry.py
@@ -1,6 +1,7 @@
 import logging
 
 from sqlalchemy import and_, false, or_
+from sqlalchemy.sql import text
 
 import tool_shed.repository_types.util as rt_util
 from galaxy.webapps.tool_shed import model
@@ -147,10 +148,11 @@ class Registry(object):
             latest_installable_changeset_revision, is_level_one_certified = certified_level_one_tuple
             if is_level_one_certified:
                 certified_level_one_tuples.append(certified_level_one_tuple)
-                clause_list.append("%s=%d and %s='%s'" % (model.RepositoryMetadata.table.c.repository_id,
-                                                          repository.id,
-                                                          model.RepositoryMetadata.table.c.changeset_revision,
-                                                          latest_installable_changeset_revision))
+                clause_list.append(text("%s=%d and %s='%s'" % (model.RepositoryMetadata.table.c.repository_id,
+                                                               repository.id,
+                                                               model.RepositoryMetadata.table.c.changeset_revision,
+                                                               latest_installable_changeset_revision)
+                                        ))
         return clause_list
 
     def get_certified_level_one_tuple(self, repository):


### PR DESCRIPTION
fixes `ArgumentError: Textual SQL expression 'repository_metadata.repos...' should be explicitly declared as text('repository_metadata.repos...')`
failure during startup

this is probably TS reacting to sqlalchemy upgrade