### PR TITLE
Remove duplicate logic for 'is_admin' checks

### DIFF
--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -122,9 +122,7 @@ class ProvidesUserContext(object):
 
     @property
     def user_is_admin(self):
-        if self.api_inherit_admin:
-            return True
-        return self.user and self.user.email in self.app.config.admin_users_list
+        return self.api_inherit_admin or self.app.config.is_admin_user(self.user)
 
     @property
     def user_can_do_run_as(self):

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -234,25 +234,18 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         Do not pass trans to simply check if an existing user object is an admin user,
         pass trans when checking permissions.
         """
-        admin_emails = self._admin_emails()
         if user is None:
             # Anonymous session or master_api_key used, if master_api_key is detected
             # return True.
-            rval = bool(trans and trans.user_is_admin)
-            return rval
-        return bool(admin_emails and user.email in admin_emails)
-
-    def _admin_emails(self):
-        """
-        Return a list of admin email addresses from the config file.
-        """
-        return [email.strip() for email in self.app.config.get("admin_users", "").split(",")]
+            return trans and trans.user_is_admin
+        return self.app.config.is_admin_user(user)
 
     def admins(self, filters=None, **kwargs):
         """
         Return a list of admin Users.
         """
-        filters = self._munge_filters(self.model_class.email.in_(self._admin_emails()), filters)
+        admin_emails = self.app.config.admin_users_list
+        filters = self._munge_filters(self.model_class.email.in_(admin_emails), filters)
         return super(UserManager, self).list(filters=filters, **kwargs)
 
     def error_unless_admin(self, user, msg="Administrators only", **kwargs):

--- a/test/unit/managers/base.py
+++ b/test/unit/managers/base.py
@@ -38,8 +38,14 @@ class BaseTestCase(unittest.TestCase):
         self.set_up_trans()
 
     def set_up_mocks(self):
-        self.trans = galaxy_mock.MockTrans(admin_users=admin_users)
+        admin_users_list = [u for u in admin_users.split(',') if u]
+        self.trans = galaxy_mock.MockTrans(admin_users=admin_users, admin_users_list=admin_users_list)
         self.app = self.trans.app
+
+        def mock_is_admin_user(user):
+            return user.email in admin_users
+
+        self.trans.app.config.is_admin_user = mock_is_admin_user
 
     def set_up_managers(self):
         self.user_manager = UserManager(self.app)


### PR DESCRIPTION
This removes duplicate logic for checking if a user is an admin user. Splitting a string of user emails and checking if a given email is in that list should be located in one place only. (same goes for related code, like "`user and user.email in [a list of emails]`")

- Also some minor syntax cleanup/simplification
- And mocking the mock

Done as part of #8493. 


