### PR TITLE
Fix markup in ToolEntryPoints, format client

### DIFF
--- a/client/galaxy/scripts/components/Alert.vue
+++ b/client/galaxy/scripts/components/Alert.vue
@@ -8,34 +8,34 @@
 <script>
 export default {
     props: {
-	/**
+        /**
          * Message to display in the alert
          */
         message: {
             type: String,
             default: ""
         },
-	/**
+        /**
          * Alias for variant, takes precedence if both are set
          */
         status: {
             type: String,
             default: ""
         },
-	/**
+        /**
          * Alert type, one of done/success, info, warning, error/danger
          */
         variant: {
             type: String,
             default: "done"
         },
-	/** Display a close button in the alert that allows it to be dismissed */
+        /** Display a close button in the alert that allows it to be dismissed */
         dismissible: Boolean,
-	/** Label for the close button, for aria */
+        /** Label for the close button, for aria */
         dismissLabel: String,
-	/** If a number, number of seconds to show before dismissing */
+        /** If a number, number of seconds to show before dismissing */
         show: [Boolean, Number],
-	/** Should the alert fade out */
+        /** Should the alert fade out */
         fade: Boolean
     },
     computed: {

--- a/client/galaxy/scripts/components/Tags/StatelessTags.vue
+++ b/client/galaxy/scripts/components/Tags/StatelessTags.vue
@@ -4,7 +4,13 @@ upstream component or environment that is accessed through props and events -->
 
 <template>
     <div class="tags-display" :class="tagContainerClasses">
-        <a v-if="linkVisible" href="javascript:void(0)" role="button" class="toggle-link" @click.prevent="toggleTagDisplay">
+        <a
+            v-if="linkVisible"
+            href="javascript:void(0)"
+            role="button"
+            class="toggle-link"
+            @click.prevent="toggleTagDisplay"
+        >
             {{ linkText | localize }}
         </a>
         <vue-tags-input

--- a/client/galaxy/scripts/components/ToolEntryPoints/ToolEntryPoints.vue
+++ b/client/galaxy/scripts/components/ToolEntryPoints/ToolEntryPoints.vue
@@ -1,30 +1,29 @@
 <template>
     <div class="infomessagelarge">
-        <p v-if="entryPoints.length==0" >
+        <p v-if="entryPoints.length == 0">
             Waiting for InteractiveTool result view(s) to become available.
         </p>
-        <p v-else-if="entryPoints.length==1" >
-            <span v-if="entryPoints[0].active" >
-                There is an InteractiveTool result view available, <a :href="entryPoints[0].target">click here to display</a>.
+        <p v-else-if="entryPoints.length == 1">
+            <span v-if="entryPoints[0].active">
+                There is an InteractiveTool result view available,
+                <a :href="entryPoints[0].target">click here to display</a>.
             </span>
             <span v-else>
                 There is an InteractiveTool result view available, waiting for view to become active...
             </span>
         </p>
-        <p v-else>
+        <div v-else>
             There are multiple InteractiveTool result views available:
             <ul>
-                <li v-for="entryPoint of entryPoints" v-bind:key="entryPoint.id" >
+                <li v-for="entryPoint of entryPoints" v-bind:key="entryPoint.id">
                     {{ entryPoint.name }}
-                    <span v-if="entryPoint.active">
-                        (<a :href="entryPoints[0].target">click here to display</a>)
-                    </span>
+                    <span v-if="entryPoint.active"> (<a :href="entryPoints[0].target">click here to display</a>) </span>
                     <span v-else>
                         (waiting to become active...)
                     </span>
                 </li>
             </ul>
-        </p>
+        </div>
 
         You may also access all active InteractiveTools from the User menu.
     </div>
@@ -41,24 +40,24 @@ export default {
     },
     data() {
         return {
-            entryPoints: [],
+            entryPoints: []
         };
     },
     created: function() {
         this.pollEntryPoints();
     },
-    beforeDestroy: function(){
+    beforeDestroy: function() {
         clearPolling();
     },
     methods: {
         pollEntryPoints: function() {
-            const onUpdate = (entryPoints) => {
+            const onUpdate = entryPoints => {
                 this.entryPoints = entryPoints;
-            }
-            const onError = (e) => {
+            };
+            const onError = e => {
                 console.error(e);
-            }
-            pollUntilActive(onUpdate, onError, {"job_id": this.jobId})
+            };
+            pollUntilActive(onUpdate, onError, { job_id: this.jobId });
         }
     }
 };

--- a/client/galaxy/scripts/components/Toolshed/Categories.vue
+++ b/client/galaxy/scripts/components/Toolshed/Categories.vue
@@ -6,7 +6,12 @@
         </div>
         <b-table v-else striped :items="categories" :fields="fields">
             <template slot="name" slot-scope="data">
-                <b-link href="javascript:void(0)" role="button" class="font-weight-bold" @click="onCategory(data.value)">
+                <b-link
+                    href="javascript:void(0)"
+                    role="button"
+                    class="font-weight-bold"
+                    @click="onCategory(data.value)"
+                >
                     {{ data.value }}
                 </b-link>
             </template>

--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -12,16 +12,24 @@
                             <b-form-group label="Password">
                                 <b-form-input name="password" type="password" v-model="password" />
                                 <b-form-text
-                                    >Forgot password? <a @click="reset" href="javascript:void(0)" role="button">Click here to reset your
-                                    password.</a> </b-form-text
-                                >
+                                    >Forgot password?
+                                    <a @click="reset" href="javascript:void(0)" role="button"
+                                        >Click here to reset your password.</a
+                                    >
+                                </b-form-text>
                             </b-form-group>
                             <b-button name="login" type="submit">Login</b-button>
                         </b-card-body>
                         <b-card-footer>
                             Don't have an account?
                             <span v-if="allowUserCreation">
-                                <a id="register-toggle" href="javascript:void(0)" role="button" @click.prevent="toggleLogin">Register here.</a>
+                                <a
+                                    id="register-toggle"
+                                    href="javascript:void(0)"
+                                    role="button"
+                                    @click.prevent="toggleLogin"
+                                    >Register here.</a
+                                >
                             </span>
                             <span v-else>
                                 Registration for this Galaxy instance is disabled. Please contact an administrator for

--- a/client/galaxy/scripts/components/login/Register.vue
+++ b/client/galaxy/scripts/components/login/Register.vue
@@ -37,7 +37,9 @@
                         </b-card-body>
                         <b-card-footer v-if="!isAdmin">
                             Already have an account?
-                            <a id="login-toggle" href="javascript:void(0)" role="button" @click.prevent="toggleLogin">Log in here.</a>
+                            <a id="login-toggle" href="javascript:void(0)" role="button" @click.prevent="toggleLogin"
+                                >Log in here.</a
+                            >
                         </b-card-footer>
                     </b-card>
                 </b-form>

--- a/client/galaxy/scripts/mvc/entrypoints/poll.js
+++ b/client/galaxy/scripts/mvc/entrypoints/poll.js
@@ -5,29 +5,29 @@ let interval;
 
 export const clearPolling = () => {
     clearInterval(interval);
-}
+};
 
 export const pollUntilActive = (onUpdate, onError, params) => {
     clearPolling();
     const url = getAppRoot() + `api/entry_points`;
     console.log(params);
     axios
-        .get(url, {params: params})
+        .get(url, { params: params })
         .then(response => {
             const entryPoints = [];
             let allReady = true;
             response.data.forEach((entryPoint, i) => {
                 entryPoints.push(entryPoint);
-                if(! entryPoint.active) {
+                if (!entryPoint.active) {
                     allReady = false;
                 }
             });
-            onUpdate(entryPoints)
-            if(! allReady || entryPoints.length == 0) {
+            onUpdate(entryPoints);
+            if (!allReady || entryPoints.length == 0) {
                 interval = setInterval(() => {
                     pollUntilActive(onUpdate, onError, params);
                 }, 3000);
             }
         })
         .catch(onError);
-}
+};

--- a/client/galaxy/scripts/mvc/entrypoints/view.js
+++ b/client/galaxy/scripts/mvc/entrypoints/view.js
@@ -2,29 +2,28 @@ import $ from "jquery";
 import GridView from "mvc/grid/grid-view";
 import { clearPolling, pollUntilActive } from "mvc/entrypoints/poll";
 
-
 export default GridView.extend({
     init_grid_elements: function() {
         GridView.prototype.init_grid_elements.call(this);
 
         const activated = {};
 
-        const onUpdate = (entryPoints) => {
-            entryPoints.forEach((entryPoint) => {
+        const onUpdate = entryPoints => {
+            entryPoints.forEach(entryPoint => {
                 const entryPointId = entryPoint.id;
-                if (entryPoint.active && ! activated[entryPointId]) {
-                    const $link = $(`.entry-point-link[entry_point_id='${entryPointId}']`)
+                if (entryPoint.active && !activated[entryPointId]) {
+                    const $link = $(`.entry-point-link[entry_point_id='${entryPointId}']`);
                     if ($link.length > 0) {
                         $link.attr("href", entryPoint["target"]);
                         activated[entryPointId] = true;
                     }
                 }
             });
-        }
-        const onError = (e) => {
+        };
+        const onError = e => {
             console.error(e);
-        }
-        pollUntilActive(onUpdate, onError, {"running": true});
+        };
+        pollUntilActive(onUpdate, onError, { running: true });
     },
     remove: function() {
         // Your processing code here

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -785,8 +785,8 @@ export default Backbone.View.extend({
                 $("<a/>")
                     .attr({
                         "aria-label": "clone node",
-                        "role": "button",
-                        "href": "javascript:void(0)"
+                        role: "button",
+                        href: "javascript:void(0)"
                     })
                     .addClass("fa-icon-button fa fa-files-o node-clone")
                     .click(e => {
@@ -798,8 +798,8 @@ export default Backbone.View.extend({
             $("<a/>")
                 .attr({
                     "aria-label": "destroy node",
-                    "role": "button",
-                    "href": "javascript:void(0)"
+                    role: "button",
+                    href: "javascript:void(0)"
                 })
                 .addClass("fa-icon-button fa fa-times node-destroy")
                 .click(e => {


### PR DESCRIPTION
Fixes usage of `<p>` tag in `ToolEntryPoints` and applies `make client-format` to client code.