### PR TITLE
create dynamic options from_dataset for multiple inputs

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -650,20 +650,24 @@ class DynamicOptions(object):
 
     def get_fields(self, trans, other_values):
         if self.dataset_ref_name:
-            dataset = other_values.get(self.dataset_ref_name, None)
-            if not dataset or not hasattr(dataset, 'file_name'):
-                return []  # no valid dataset in history
-            # Ensure parsing dynamic options does not consume more than a megabyte worth memory.
-            path = dataset.file_name
-            if os.path.getsize(path) < 1048576:
-                with open(path) as fh:
-                    options = self.parse_file_fields(fh)
-            else:
-                # Pass just the first megabyte to parse_file_fields.
-                log.warning("Attempting to load options from large file, reading just first megabyte")
-                with open(path, 'r') as fh:
-                    contents = fh.read(1048576)
-                options = self.parse_file_fields(StringIO(contents))
+            datasets = other_values.get(self.dataset_ref_name, None)
+            if not isinstance(datasets, list):
+                datasets = [datasets]
+            options = []
+            for dataset in datasets:
+	            if not dataset or not hasattr(dataset, 'file_name'):
+	                return []  # no valid dataset in history
+	            # Ensure parsing dynamic options does not consume more than a megabyte worth memory.
+	            path = dataset.file_name
+	            if os.path.getsize(path) < 1048576:
+	                with open(path) as fh:
+	                    options.extend(self.parse_file_fields(fh))
+	            else:
+	                # Pass just the first megabyte to parse_file_fields.
+	                log.warning("Attempting to load options from large file, reading just first megabyte")
+	                with open(path, 'r') as fh:
+	                    contents = fh.read(1048576)
+	                options.extend(self.parse_file_fields(StringIO(contents)))
         elif self.tool_data_table:
             options = self.tool_data_table.get_fields()
         elif self.file_fields:

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -655,19 +655,19 @@ class DynamicOptions(object):
                 datasets = [datasets]
             options = []
             for dataset in datasets:
-	            if not dataset or not hasattr(dataset, 'file_name'):
-	                return []  # no valid dataset in history
-	            # Ensure parsing dynamic options does not consume more than a megabyte worth memory.
-	            path = dataset.file_name
-	            if os.path.getsize(path) < 1048576:
-	                with open(path) as fh:
-	                    options.extend(self.parse_file_fields(fh))
-	            else:
-	                # Pass just the first megabyte to parse_file_fields.
-	                log.warning("Attempting to load options from large file, reading just first megabyte")
-	                with open(path, 'r') as fh:
-	                    contents = fh.read(1048576)
-	                options.extend(self.parse_file_fields(StringIO(contents)))
+                if not dataset or not hasattr(dataset, 'file_name'):
+                    return []  # no valid dataset in history
+                # Ensure parsing dynamic options does not consume more than a megabyte worth memory.
+                path = dataset.file_name
+                if os.path.getsize(path) < 1048576:
+                    with open(path) as fh:
+                        options.extend(self.parse_file_fields(fh))
+                else:
+                    # Pass just the first megabyte to parse_file_fields.
+                    log.warning("Attempting to load options from large file, reading just first megabyte")
+                    with open(path, 'r') as fh:
+                        contents = fh.read(1048576)
+                    options.extend(self.parse_file_fields(StringIO(contents)))
         elif self.tool_data_table:
             options = self.tool_data_table.get_fields()
         elif self.file_fields:


### PR DESCRIPTION
If `from_dataset` refers to a input data set with `multiple="true"` no options were generated so far. 
With this changes options are generated from all inputs selected in the inputs. 

Though .. it does not work for collections yet .. suggestions welcome. 

- One would need to iterate over either a HDA, a list of HDAs, a HDCA (or maybe a list of HDCAs and I would like to do this without using 4 if branches. Any ideas?
- Also wondering how to make it work for nested list

Even more wondering if this needs to be limited, since collections might get huge. but maybe we can leave this as tool developer responsibility, it just needs proper documentation. 

Idea came while working on tests for the filters: https://github.com/galaxyproject/galaxy/pull/8481