### PR TITLE
Enable mulled containers by default for 19.09.

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -536,18 +536,18 @@
 :Type: bool
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enable_beta_mulled_containers``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enable_mulled_containers``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Enable Galaxy to fetch Docker containers registered with quay.io
-    generated from tool requirements resolved through conda. These
+    Enable Galaxy to fetch containers registered with quay.io
+    generated from tool requirements resolved through Conda. These
     containers (when available) have been generated using mulled -
-    https://github.com/mulled . These containers are highly beta and
-    availability will vary by tool. This option will additionally only
-    be used for job destinations with Docker enabled.
-:Default: ``false``
+    https://github.com/mulled. Container availability will vary by
+    tool, this option will only be used for job destinations with
+    Docker or Singularity enabled.
+:Default: ``true``
 :Type: bool
 
 
@@ -559,7 +559,7 @@
     Container resolvers configuration (beta). Set up a file describing
     container resolvers to use when discovering containers for Galaxy.
     If this is set to None, the default containers loaded is
-    determined by enable_beta_mulled_containers.
+    determined by enable_mulled_containers.
 :Default: ````
 :Type: str
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -543,7 +543,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             # self, populate config_dict
             self.config_dict["conda_mapping_files"] = conda_mapping_files
 
-        self.enable_beta_mulled_containers = string_as_bool(kwargs.get('enable_beta_mulled_containers', 'False'))
+        self.enable_mulled_containers = string_as_bool(kwargs.get('enable_mulled_containers', 'True'))
         containers_resolvers_config_file = kwargs.get('containers_resolvers_config_file', None)
         if containers_resolvers_config_file:
             containers_resolvers_config_file = resolve_path(containers_resolvers_config_file, self.root)
@@ -1144,7 +1144,7 @@ class ConfiguresGalaxyMixin(object):
             outputs_to_working_directory=self.config.outputs_to_working_directory,
             container_image_cache_path=self.config.container_image_cache_path,
             library_import_dir=self.config.library_import_dir,
-            enable_beta_mulled_containers=self.config.enable_beta_mulled_containers,
+            enable_mulled_containers=self.config.enable_mulled_containers,
             containers_resolvers_config_file=self.config.containers_resolvers_config_file,
             involucro_path=self.config.involucro_path,
             involucro_auto_init=self.config.involucro_auto_init,

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -298,6 +298,7 @@ OPTION_ACTIONS = {
     'tool_submission_burst_threads': _DeprecatedAndDroppedAction(),
     'tool_submission_burst_at': _DeprecatedAndDroppedAction(),
     'toolform_upgrade': _DeprecatedAndDroppedAction(),
+    'enable_beta_mulled_containers': _DeprecatedAndDroppedAction(),
 }
 
 

--- a/lib/galaxy/config/sample/container_resolvers_conf.xml.sample
+++ b/lib/galaxy/config/sample/container_resolvers_conf.xml.sample
@@ -3,8 +3,8 @@
   <!-- explicit: resolves container URI for a job through explict container
        tags in the tool XML wrapper. -->
 
-  <!-- All mulled flavors below only work if enable_beta_mulled_containers is
-       set to true in the galaxy.yaml config file. -->
+  <!-- All mulled flavors below work by default unless enable_mulled_containers is
+       set to false in the galaxy.yaml config file. -->
 
   <!-- <cached_mulled /> -->
   <!-- cached_mulled: resolves container URI through bioconda to mulled
@@ -14,8 +14,7 @@
   <!-- <cached_mulled_singularity /> -->
   <!-- cached_mulled_singularity: resolves container URI through
        bioconda to mulled automatic mapping, preferring cached singularity
-       images to building local singularity images. Only works with
-       enable_beta_mulled_containers set to true in the galaxy.yaml config file.
+       images to building local singularity images.
        -->
 
   <!-- <mulled auto_install="True"/> -->

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -343,18 +343,18 @@ galaxy:
   # https://github.com/galaxyproject/galaxy/issues/6513.
   #legacy_eager_objectstore_initialization: false
 
-  # Enable Galaxy to fetch Docker containers registered with quay.io
-  # generated from tool requirements resolved through conda. These
-  # containers (when available) have been generated using mulled -
-  # https://github.com/mulled . These containers are highly beta and
-  # availability will vary by tool. This option will additionally only
-  # be used for job destinations with Docker enabled.
-  #enable_beta_mulled_containers: false
+  # Enable Galaxy to fetch containers registered with quay.io generated
+  # from tool requirements resolved through Conda. These containers
+  # (when available) have been generated using mulled -
+  # https://github.com/mulled. Container availability will vary by tool,
+  # this option will only be used for job destinations with Docker or
+  # Singularity enabled.
+  #enable_mulled_containers: true
 
   # Container resolvers configuration (beta). Set up a file describing
   # container resolvers to use when discovering containers for Galaxy.
   # If this is set to None, the default containers loaded is determined
-  # by enable_beta_mulled_containers.
+  # by enable_mulled_containers.
   #containers_resolvers_config_file: ''
 
   # involucro is a tool used to build Docker or Singularity containers

--- a/lib/galaxy/tool_util/deps/containers.py
+++ b/lib/galaxy/tool_util/deps/containers.py
@@ -178,7 +178,7 @@ class ContainerRegistry(object):
 
     def __init__(self, app_info):
         self.resolver_classes = self.__resolvers_dict()
-        self.enable_beta_mulled_containers = app_info.enable_beta_mulled_containers
+        self.enable_mulled_containers = app_info.enable_mulled_containers
         self.app_info = app_info
         self.container_resolvers = self.__build_container_resolvers(app_info)
 
@@ -203,7 +203,7 @@ class ContainerRegistry(object):
             ExplicitContainerResolver(self.app_info),
             ExplicitSingularityContainerResolver(self.app_info),
         ]
-        if self.enable_beta_mulled_containers:
+        if self.enable_mulled_containers:
             default_resolvers.extend([
                 CachedMulledDockerContainerResolver(self.app_info, namespace="biocontainers"),
                 CachedMulledDockerContainerResolver(self.app_info, namespace="local"),

--- a/lib/galaxy/tool_util/deps/dependencies.py
+++ b/lib/galaxy/tool_util/deps/dependencies.py
@@ -12,7 +12,7 @@ class AppInfo(object):
         outputs_to_working_directory=False,
         container_image_cache_path=None,
         library_import_dir=None,
-        enable_beta_mulled_containers=False,
+        enable_mulled_containers=False,
         containers_resolvers_config_file=None,
         involucro_path=None,
         involucro_auto_init=True,
@@ -24,7 +24,7 @@ class AppInfo(object):
         self.outputs_to_working_directory = outputs_to_working_directory
         self.container_image_cache_path = container_image_cache_path
         self.library_import_dir = library_import_dir
-        self.enable_beta_mulled_containers = enable_beta_mulled_containers
+        self.enable_mulled_containers = enable_mulled_containers
         self.containers_resolvers_config_file = containers_resolvers_config_file
         self.involucro_path = involucro_path
         self.involucro_auto_init = involucro_auto_init

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -410,17 +410,16 @@ mapping:
           considered deprecated and this option will likely be removed in future versions of
           Galaxy. For more information see https://github.com/galaxyproject/galaxy/issues/6513.
 
-      enable_beta_mulled_containers:
+      enable_mulled_containers:
         type: bool
-        default: false
+        default: true
         required: false
         desc: |
-          Enable Galaxy to fetch Docker containers registered with quay.io generated
-          from tool requirements resolved through conda. These containers (when
-          available) have been generated using mulled - https://github.com/mulled .
-          These containers are highly beta and availability will vary by tool.
-          This option will additionally only be used for job destinations with
-          Docker enabled.
+          Enable Galaxy to fetch containers registered with quay.io generated
+          from tool requirements resolved through Conda. These containers (when
+          available) have been generated using mulled - https://github.com/mulled.
+          Container availability will vary by tool, this option will only be used
+          for job destinations with Docker or Singularity enabled.
 
       containers_resolvers_config_file:
         type: str
@@ -430,7 +429,7 @@ mapping:
           Container resolvers configuration (beta). Set up a file describing
           container resolvers to use when discovering containers for Galaxy. If
           this is set to None, the default containers loaded is determined by
-          enable_beta_mulled_containers.
+          enable_mulled_containers.
 
       involucro_path:
         type: str

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -57,7 +57,6 @@ class DockerizedJobsIntegrationTestCase(integration_util.IntegrationTestCase, Ru
         config["tool_dependency_dir"] = "none"
         config["conda_auto_init"] = False
         config["conda_auto_install"] = False
-        config["enable_beta_mulled_containers"] = "true"
 
     @classmethod
     def setUpClass(cls):

--- a/test/integration/test_handler_assignment_methods.py
+++ b/test/integration/test_handler_assignment_methods.py
@@ -43,7 +43,6 @@ class BaseHandlerAssignmentMethodIntegrationTestCase(integration_util.Integratio
         config["job_config_file"] = os.path.join(cls.jobs_directory, "job_conf.xml")
         # Disable tool dependency resolution.
         config["tool_dependency_dir"] = "none"
-        config["enable_beta_mulled_containers"] = "true"
 
 
 class DBPreassignHandlerAssignmentMethodIntegrationTestCase(BaseHandlerAssignmentMethodIntegrationTestCase):

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -189,7 +189,6 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
         config["default_job_shell"] = '/bin/sh'
         # Disable tool dependency resolution.
         config["tool_dependency_dir"] = "none"
-        config["enable_beta_mulled_containers"] = "true"
 
     @skip_without_tool("job_environment_default")
     def test_job_environment(self):

--- a/test/integration/test_kubernetes_staging.py
+++ b/test/integration/test_kubernetes_staging.py
@@ -94,7 +94,6 @@ class BaseKubernetesStagingIntegrationTestCase(BaseJobEnvironmentIntegrationTest
         config["default_job_shell"] = '/bin/sh'
         # Disable tool dependency resolution.
         config["tool_dependency_dir"] = "none"
-        config["enable_beta_mulled_containers"] = "true"
 
     @skip_without_tool("job_environment_default")
     def test_job_environment(self):


### PR DESCRIPTION
It has been in beta for too long and it is has really seen some serious use over the last year. I think it is time to enable it by default?