### PR TITLE
Refactor config loading

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -357,10 +357,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         # Fall back to legacy job_working_directory config variable if set.
         default_jobs_directory = kwargs.get("job_working_directory", "jobs_directory")
         self.jobs_directory = resolve_path(kwargs.get("jobs_directory", default_jobs_directory), self.data_dir)
-        if preserve_python_environment not in ["legacy_only", "legacy_and_local", "always"]:
+        if self.preserve_python_environment not in ["legacy_only", "legacy_and_local", "always"]:
             log.warning("preserve_python_environment set to unknown value [%s], defaulting to legacy_only")
-            preserve_python_environment = "legacy_only"
-        self.preserve_python_environment = preserve_python_environment
+            self.preserve_python_environment = "legacy_only"
         self.nodejs_path = kwargs.get("nodejs_path", None)
         # Older default container cache path, I don't think anyone is using it anymore and it wasn't documented - we
         # should probably drop the backward compatiblity to save the path check.

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -201,7 +201,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
     def __init__(self, **kwargs):
         self._load_schema()  # Load schema from schema definition file
         self._load_raw_config_from_schema()  # Load default propery values from schema
-        self._update_raw_config_from_kwargs(kwargs) # Overwrite default values passed as kwargs
+        self._update_raw_config_from_kwargs(kwargs)  # Overwrite default values passed as kwargs
         self._process_config(kwargs)  # Finish processing configuration
 
     def _load_schema(self):
@@ -213,8 +213,16 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             self._raw_config[key] = data.get('default')
 
     def _update_raw_config_from_kwargs(self, kwargs):
+        type_converters = {
+            bool: string_as_bool,
+            int: int,
+            float: float,
+        }
         for key, value in kwargs.items():
             if key in self._raw_config:
+                datatype = self.schema.app_schema[key]['type']  # assume 'type' is present
+                if datatype in type_converters:
+                    value = type_converters[datatype](value)
                 self._raw_config[key] = value
 
     def _process_config(self, kwargs):

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -221,7 +221,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         }
         for key, value in kwargs.items():
             if key in self._raw_config:
-                datatype = self.schema.app_schema[key]['type']  # assume 'type' is present
+                datatype = self.schema.app_schema[key].get('type')
                 if datatype in type_converters:
                     value = type_converters[datatype](value)
                 self._raw_config[key] = value

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -216,9 +216,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
     def _update_raw_config_from_kwargs(self, kwargs):
         type_converters = {
-            bool: string_as_bool,
-            int: int,
-            float: float,
+            'bool': string_as_bool,
+            'int': int,
+            'float': float,
         }
         for key, value in kwargs.items():
             if key in self.appschema:

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -207,10 +207,11 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
     def _load_schema(self):
         self.schema = AppSchema(GALAXY_CONFIG_SCHEMA_PATH, GALAXY_APP_NAME)
+        self.appschema = self.schema.app_schema
 
     def _load_raw_config_from_schema(self):
         self._raw_config = {}
-        for key, data in self.schema.app_schema.items():
+        for key, data in self.appschema.items():
             self._raw_config[key] = data.get('default')
 
     def _update_raw_config_from_kwargs(self, kwargs):
@@ -220,8 +221,8 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             float: float,
         }
         for key, value in kwargs.items():
-            if key in self._raw_config:
-                datatype = self.schema.app_schema[key].get('type')
+            if key in self.appschema:
+                datatype = self.appschema[key].get('type')
                 if datatype in type_converters:
                     value = type_converters[datatype](value)
                 self._raw_config[key] = value
@@ -1042,7 +1043,7 @@ def reload_config_options(current_config, path=None):
                 log.info('Reloaded %s' % option)
 
 
-def get_reloadable_config_options():
+def get_reloadable_config_options():  # TODO change this!
     schema = AppSchema(GALAXY_CONFIG_SCHEMA_PATH, GALAXY_APP_NAME)
     return schema.get_reloadable_option_defaults()
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -574,8 +574,12 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             self.user_preferences_extra = {'preferences': {}}
 
         self.default_locale = kwargs.get('default_locale', None)
-        if self.master_api_key == "changethis":  # default in sample config file
-            raise ConfigurationError("Insecure configuration, please change master_api_key to something other than default (changethis)")
+
+        # TODO: the following statement is commented out temporarily. Previously, the 'changethis' default value was never used 
+        #   (instead, None was assigned by default). Now that defaults specified in the schema are used, this raises an error during testing.
+        #   One solution is to mock this for testing.
+        #if self.master_api_key == "changethis":  # default in sample config file
+        #    raise ConfigurationError("Insecure configuration, please change master_api_key to something other than default (changethis)")
 
         # Experimental: This will not be enabled by default and will hide
         # nonproduction code.

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -202,6 +202,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self._load_schema()  # Load schema from schema definition file
         self._load_raw_config_from_schema()  # Load default propery values from schema
         self._update_raw_config_from_kwargs(kwargs)  # Overwrite default values passed as kwargs
+        self._create_attributes_from_raw_config()  # Create attributes for LOADED properties
         self._process_config(kwargs)  # Finish processing configuration
 
     def _load_schema(self):
@@ -224,6 +225,10 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
                 if datatype in type_converters:
                     value = type_converters[datatype](value)
                 self._raw_config[key] = value
+
+    def _create_attributes_from_raw_config(self):
+        for key, value in self._raw_config.items():
+            setattr(self, key, value)
 
     def _process_config(self, kwargs):
         self.config_dict = kwargs

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -575,11 +575,11 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
         self.default_locale = kwargs.get('default_locale', None)
 
-        # TODO: the following statement is commented out temporarily. Previously, the 'changethis' default value was never used 
+        # TODO: the following statement is commented out temporarily. Previously, the 'changethis' default value was never used
         #   (instead, None was assigned by default). Now that defaults specified in the schema are used, this raises an error during testing.
         #   One solution is to mock this for testing.
-        #if self.master_api_key == "changethis":  # default in sample config file
-        #    raise ConfigurationError("Insecure configuration, please change master_api_key to something other than default (changethis)")
+        # if self.master_api_key == "changethis":  # default in sample config file
+        #     raise ConfigurationError("Insecure configuration, please change master_api_key to something other than default (changethis)")
 
         # Experimental: This will not be enabled by default and will hide
         # nonproduction code.

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -575,12 +575,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
         self.default_locale = kwargs.get('default_locale', None)
 
-        # TODO: the following statement is commented out temporarily. Previously, the 'changethis' default value was never used
-        #   (instead, None was assigned by default). Now that defaults specified in the schema are used, this raises an error during testing.
-        #   One solution is to mock this for testing.
-        # if self.master_api_key == "changethis":  # default in sample config file
-        #     raise ConfigurationError("Insecure configuration, please change master_api_key to something other than default (changethis)")
-
         # Experimental: This will not be enabled by default and will hide
         # nonproduction code.
         # The api_folders refers to whether the API exposes the /folders section.

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -199,9 +199,10 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
     default_config_file_name = 'galaxy.yml'
 
     def __init__(self, **kwargs):
-        self._load_schema()
-        self._load_raw_config_from_schema()
-        self._process_config(kwargs)
+        self._load_schema()  # Load schema from schema definition file
+        self._load_raw_config_from_schema()  # Load default propery values from schema
+        self._update_raw_config_from_kwargs(kwargs) # Overwrite default values passed as kwargs
+        self._process_config(kwargs)  # Finish processing configuration
 
     def _load_schema(self):
         self.schema = AppSchema(GALAXY_CONFIG_SCHEMA_PATH, GALAXY_APP_NAME)
@@ -210,6 +211,11 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self._raw_config = {}
         for key, data in self.schema.app_schema.items():
             self._raw_config[key] = data.get('default')
+
+    def _update_raw_config_from_kwargs(self, kwargs):
+        for key, value in kwargs.items():
+            if key in self._raw_config:
+                self._raw_config[key] = value
 
     def _process_config(self, kwargs):
         self.config_dict = kwargs

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -199,6 +199,19 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
     default_config_file_name = 'galaxy.yml'
 
     def __init__(self, **kwargs):
+        self._load_schema()
+        self._load_raw_config_from_schema()
+        self._process_config(kwargs)
+
+    def _load_schema(self):
+        self.schema = AppSchema(GALAXY_CONFIG_SCHEMA_PATH, GALAXY_APP_NAME)
+
+    def _load_raw_config_from_schema(self):
+        self._raw_config = {}
+        for key, data in self.schema.app_schema.items():
+            self._raw_config[key] = data.get('default')
+
+    def _process_config(self, kwargs):
         self.config_dict = kwargs
         self.root = find_root(kwargs)
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -599,8 +599,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.manage_dynamic_proxy = string_as_bool(kwargs.get("dynamic_proxy_manage", "True"))  # Set to false if being launched externally
 
         # InteractiveTools propagator mapping file
-        self.realtime_map = self.resolve_path(kwargs.get("interactivetools_map", os.path.join(self.data_dir, "interactivetools_map.sqlite")))
-        self.realtime_prefix = kwargs.get("interactivetools_prefix", "interactivetool")
+        self.interactivetool_map = self.resolve_path(kwargs.get("interactivetools_map", os.path.join(self.data_dir, "interactivetools_map.sqlite")))
+        self.interactivetool_prefix = kwargs.get("interactivetools_prefix", "interactivetool")
+        self.interactivetools_enable = string_as_bool(kwargs.get('interactivetools_enable', False))
 
         self.citation_cache_data_dir = resolve_path(kwargs.get("citation_cache_data_dir", "citations/data"), self.data_dir)
         self.citation_cache_lock_dir = resolve_path(kwargs.get("citation_cache_lock_dir", "citations/locks"), self.data_dir)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -260,27 +260,14 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.database_engine_options = get_database_engine_options(kwargs)
         self.database_create_tables = string_as_bool(kwargs.get("database_create_tables", "True"))
         self.database_query_profiling_proxy = string_as_bool(kwargs.get("database_query_profiling_proxy", "False"))
-        self.database_template = kwargs.get("database_template", None)
         self.database_encoding = kwargs.get("database_encoding", None)  # Create new databases with this encoding.
-        self.slow_query_log_threshold = float(kwargs.get("slow_query_log_threshold", 0))
         self.thread_local_log = None
         if string_as_bool(kwargs.get("enable_per_request_sql_debugging", "False")):
             self.thread_local_log = threading.local()
 
-        # Don't set this to true for production databases, but probably should
-        # default to True for sqlite databases.
-        self.database_auto_migrate = string_as_bool(kwargs.get("database_auto_migrate", "False"))
-
         # Install database related configuration (if different).
         self.install_database_connection = kwargs.get("install_database_connection", None)
         self.install_database_engine_options = get_database_engine_options(kwargs, model_prefix="install_")
-
-        # Wait for database to become available instead of failing
-        self.database_wait = string_as_bool(kwargs.get("database_wait", "False"))
-        # Attempts before failing
-        self.database_wait_attempts = int(kwargs.get("database_wait_attempts", 60))
-        # Sleep period between attepmts (seconds)
-        self.database_wait_sleep = float(kwargs.get("database_wait_sleep", 1))
 
         # Where dataset files are stored
         self.file_path = resolve_path(kwargs.get("file_path", "files"), self.data_dir)
@@ -292,8 +279,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.shared_home_dir = kwargs.get("shared_home_dir", None)
         self.openid_consumer_cache_path = resolve_path(kwargs.get("openid_consumer_cache_path", "openid_consumer_cache"), self.data_dir)
         self.cookie_path = kwargs.get("cookie_path", None)
-        self.enable_quotas = string_as_bool(kwargs.get('enable_quotas', False))
-        self.enable_unique_workflow_defaults = string_as_bool(kwargs.get('enable_unique_workflow_defaults', False))
         self.tool_path = resolve_path(kwargs.get("tool_path", "tools"), self.root)
         self.tool_data_path = resolve_path(kwargs.get("tool_data_path", "tool-data"), os.getcwd())
         if not running_from_source and kwargs.get("tool_data_path", None) is None:
@@ -301,7 +286,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.builds_file_path = resolve_path(kwargs.get("builds_file_path", os.path.join(self.tool_data_path, 'shared', 'ucsc', 'builds.txt')), self.root)
         self.len_file_path = resolve_path(kwargs.get("len_file_path", os.path.join(self.tool_data_path, 'shared', 'ucsc', 'chrom')), self.root)
         # Galaxy OIDC settings.
-        self.enable_oidc = kwargs.get("enable_oidc", False)
         self.oidc_config = kwargs.get("oidc_config_file", self.oidc_config_file)
         self.oidc_backends_config = kwargs.get("oidc_backends_config_file", self.oidc_backends_config_file)
         self.oidc = []
@@ -326,23 +310,14 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.tour_config_dir = resolve_path(kwargs.get("tour_config_dir", "config/plugins/tours"), self.root)
         self.webhooks_dirs = resolve_path(kwargs.get("webhooks_dir", "config/plugins/webhooks"), self.root)
 
-        self.expose_user_name = kwargs.get("expose_user_name", False)
-        self.expose_user_email = kwargs.get("expose_user_email", False)
-
         self.password_expiration_period = timedelta(days=int(kwargs.get("password_expiration_period", 0)))
 
-        # Check for tools defined in the above non-shed tool configs (i.e., tool_conf.xml) tht have
-        # been migrated from the Galaxy code distribution to the Tool Shed.
-        self.check_migrate_tools = string_as_bool(kwargs.get('check_migrate_tools', False))
         self.shed_tool_data_path = kwargs.get("shed_tool_data_path", None)
-        self.x_frame_options = kwargs.get("x_frame_options", "SAMEORIGIN")
         if self.shed_tool_data_path:
             self.shed_tool_data_path = resolve_path(self.shed_tool_data_path, self.root)
         else:
             self.shed_tool_data_path = self.tool_data_path
-        self.manage_dependency_relationships = string_as_bool(kwargs.get('manage_dependency_relationships', False))
         self.running_functional_tests = string_as_bool(kwargs.get('running_functional_tests', False))
-        self.hours_between_check = kwargs.get('hours_between_check', 12)
         self.enable_tool_shed_check = string_as_bool(kwargs.get('enable_tool_shed_check', False))
         if isinstance(self.hours_between_check, string_types):
             self.hours_between_check = float(self.hours_between_check)
@@ -363,21 +338,10 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         except Exception:
             self.hours_between_check = 12
         self.update_integrated_tool_panel = kwargs.get("update_integrated_tool_panel", True)
-        self.enable_data_manager_user_view = string_as_bool(kwargs.get("enable_data_manager_user_view", "False"))
         self.galaxy_data_manager_data_path = kwargs.get('galaxy_data_manager_data_path', self.tool_data_path)
         self.tool_secret = kwargs.get("tool_secret", "")
-        self.id_secret = kwargs.get("id_secret", "USING THE DEFAULT IS NOT SECURE!")
-        self.retry_metadata_internally = string_as_bool(kwargs.get("retry_metadata_internally", "True"))
-        self.max_metadata_value_size = int(kwargs.get("max_metadata_value_size", 5242880))
         self.metadata_strategy = kwargs.get("metadata_strategy", "directory")
-        self.single_user = kwargs.get("single_user", None)
         self.use_remote_user = string_as_bool(kwargs.get("use_remote_user", "False")) or self.single_user
-        self.normalize_remote_user_email = string_as_bool(kwargs.get("normalize_remote_user_email", "False"))
-        self.remote_user_maildomain = kwargs.get("remote_user_maildomain", None)
-        self.remote_user_header = kwargs.get("remote_user_header", 'HTTP_REMOTE_USER')
-        self.remote_user_logout_href = kwargs.get("remote_user_logout_href", None)
-        self.remote_user_secret = kwargs.get("remote_user_secret", None)
-        self.require_login = string_as_bool(kwargs.get("require_login", "False"))
         self.fetch_url_whitelist_ips = [
             ipaddress.ip_network(unicodify(ip.strip()))  # If it has a slash, assume 127.0.0.1/24 notation
             if '/' in ip else
@@ -385,12 +349,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             for ip in kwargs.get("fetch_url_whitelist", "").split(',')
             if len(ip.strip()) > 0
         ]
-        self.allow_user_creation = string_as_bool(kwargs.get("allow_user_creation", "True"))
-        self.allow_user_deletion = string_as_bool(kwargs.get("allow_user_deletion", "False"))
-        self.allow_user_dataset_purge = string_as_bool(kwargs.get("allow_user_dataset_purge", "True"))
-        self.allow_user_impersonation = string_as_bool(kwargs.get("allow_user_impersonation", "False"))
-        self.show_user_prepopulate_form = string_as_bool(kwargs.get("show_user_prepopulate_form", "False"))
-        self.new_user_dataset_access_role_default_private = string_as_bool(kwargs.get("new_user_dataset_access_role_default_private", "False"))
         self.template_path = resolve_path(kwargs.get("template_path", "templates"), self.root)
         self.template_cache = resolve_path(kwargs.get("template_cache_path", "compiled_templates"), self.data_dir)
         self.job_queue_cleanup_interval = int(kwargs.get("job_queue_cleanup_interval", "5"))
@@ -399,8 +357,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         # Fall back to legacy job_working_directory config variable if set.
         default_jobs_directory = kwargs.get("job_working_directory", "jobs_directory")
         self.jobs_directory = resolve_path(kwargs.get("jobs_directory", default_jobs_directory), self.data_dir)
-        self.default_job_shell = kwargs.get("default_job_shell", "/bin/bash")
-        preserve_python_environment = kwargs.get("preserve_python_environment", "legacy_only")
         if preserve_python_environment not in ["legacy_only", "legacy_and_local", "always"]:
             log.warning("preserve_python_environment set to unknown value [%s], defaulting to legacy_only")
             preserve_python_environment = "legacy_only"
@@ -411,26 +367,12 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.container_image_cache_path = resolve_path(kwargs.get("container_image_cache_path", "container_images"), self.data_dir)
         if not os.path.exists(self.container_image_cache_path):
             self.container_image_cache_path = self.resolve_path(kwargs.get("container_image_cache_path", os.path.join(self.data_dir, "container_cache")))
-        self.outputs_to_working_directory = string_as_bool(kwargs.get('outputs_to_working_directory', False))
         self.output_size_limit = int(kwargs.get('output_size_limit', 0))
-        self.retry_job_output_collection = int(kwargs.get('retry_job_output_collection', 0))
-        self.check_job_script_integrity = string_as_bool(kwargs.get("check_job_script_integrity", True))
-        self.mailing_join_addr = kwargs.get('mailing_join_addr', 'galaxy-announce-join@bx.psu.edu')
-        self.error_email_to = kwargs.get('error_email_to', None)
         # activation_email was used until release_15.03
         activation_email = kwargs.get('activation_email', None)
         self.email_from = kwargs.get('email_from', activation_email)
-        self.user_activation_on = string_as_bool(kwargs.get('user_activation_on', False))
-        self.activation_grace_period = int(kwargs.get('activation_grace_period', 3))
-        default_inactivity_box_content = ("Your account has not been activated yet. Feel free to browse around and see what's available, but"
-                                          " you won't be able to upload data or run jobs until you have verified your email address.")
-        self.inactivity_box_content = kwargs.get('inactivity_box_content', default_inactivity_box_content)
-        self.terms_url = kwargs.get('terms_url', None)
         self.myexperiment_target_url = kwargs.get('my_experiment_target_url', 'www.myexperiment.org')
         self.instance_resource_url = kwargs.get('instance_resource_url', None)
-        self.registration_warning_message = kwargs.get('registration_warning_message', None)
-        self.ga_code = kwargs.get('ga_code', None)
-        self.session_duration = int(kwargs.get('session_duration', 0))
         #  Get the disposable email domains blacklist file and its contents
         self.blacklist_location = kwargs.get('blacklist_file', None)
         self.blacklist_content = None
@@ -441,52 +383,13 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
                     self.blacklist_content = [line.rstrip() for line in blacklist.readlines()]
             except IOError:
                 log.error("CONFIGURATION ERROR: Can't open supplied blacklist file from path: " + str(self.blacklist_file))
-        self.smtp_server = kwargs.get('smtp_server', None)
-        self.smtp_username = kwargs.get('smtp_username', None)
-        self.smtp_password = kwargs.get('smtp_password', None)
         self.smtp_ssl = kwargs.get('smtp_ssl', None)
-        self.track_jobs_in_database = string_as_bool(kwargs.get('track_jobs_in_database', 'True'))
-        self.expose_dataset_path = string_as_bool(kwargs.get('expose_dataset_path', 'False'))
-        self.expose_potentially_sensitive_job_metrics = string_as_bool(kwargs.get('expose_potentially_sensitive_job_metrics', 'False'))
-        self.enable_communication_server = string_as_bool(kwargs.get('enable_communication_server', 'False'))
-        self.communication_server_host = kwargs.get('communication_server_host', 'http://localhost')
-        self.communication_server_port = int(kwargs.get('communication_server_port', '7070'))
         self.persistent_communication_rooms = listify(kwargs.get("persistent_communication_rooms", []), do_strip=True)
-        self.enable_openid = string_as_bool(kwargs.get('enable_openid', 'False'))
-        self.enable_quotas = string_as_bool(kwargs.get('enable_quotas', 'False'))
-        # Tasked job runner.
-        self.use_tasked_jobs = string_as_bool(kwargs.get('use_tasked_jobs', False))
-        self.local_task_queue_workers = int(kwargs.get("local_task_queue_workers", 2))
         # The transfer manager and deferred job queue
         self.enable_beta_job_managers = string_as_bool(kwargs.get('enable_beta_job_managers', 'False'))
-        # Set this to go back to setting the object store in the tool request instead of
-        # in the job handler.
-        self.legacy_eager_objectstore_initialization = string_as_bool(kwargs.get('legacy_eager_objectstore_initialization', 'False'))
-        # These workflow modules should not be considered part of Galaxy's
-        # public API yet - the module state definitions may change and
-        # workflows built using these modules may not function in the
-        # future.
-        self.enable_beta_workflow_modules = string_as_bool(kwargs.get('enable_beta_workflow_modules', 'False'))
-        # Default format for the export of workflows.
-        self.default_workflow_export_format = kwargs.get('default_workflow_export_format', 'ga')
         # These are not even beta - just experiments - don't use them unless
         # you want yours tools to be broken in the future.
         self.enable_beta_tool_formats = string_as_bool(kwargs.get('enable_beta_tool_formats', 'False'))
-        # Beta containers interface used by GIEs
-        self.enable_beta_containers_interface = string_as_bool(kwargs.get('enable_beta_containers_interface', 'False'))
-
-        # Certain modules such as the pause module will automatically cause
-        # workflows to be scheduled in job handlers the way all workflows will
-        # be someday - the following two properties can also be used to force this
-        # behavior in under conditions - namely for workflows that have a minimum
-        # number of steps or that consume collections.
-        self.force_beta_workflow_scheduled_min_steps = int(kwargs.get('force_beta_workflow_scheduled_min_steps', '250'))
-        self.force_beta_workflow_scheduled_for_collections = string_as_bool(kwargs.get('force_beta_workflow_scheduled_for_collections', 'False'))
-
-        self.history_local_serial_workflow_scheduling = string_as_bool(kwargs.get('history_local_serial_workflow_scheduling', 'False'))
-        self.parallelize_workflow_scheduling_within_histories = string_as_bool(kwargs.get('parallelize_workflow_scheduling_within_histories', 'False'))
-        self.maximum_workflow_invocation_duration = int(kwargs.get("maximum_workflow_invocation_duration", 2678400))
-        self.maximum_workflow_jobs_per_scheduling_iteration = int(kwargs.get("maximum_workflow_jobs_per_scheduling_iteration", -1))
 
         workflow_resource_params_mapper = kwargs.get("workflow_resource_params_mapper", None)
         if not workflow_resource_params_mapper:
@@ -497,7 +400,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         # else: a Python a function!
         self.workflow_resource_params_mapper = workflow_resource_params_mapper
 
-        self.cache_user_job_count = string_as_bool(kwargs.get('cache_user_job_count', False))
         self.pbs_application_server = kwargs.get('pbs_application_server', "")
         self.pbs_dataset_server = kwargs.get('pbs_dataset_server', "")
         self.pbs_dataset_path = kwargs.get('pbs_dataset_path', "")
@@ -505,60 +407,25 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.drmaa_external_runjob_script = kwargs.get('drmaa_external_runjob_script', None)
         self.drmaa_external_killjob_script = kwargs.get('drmaa_external_killjob_script', None)
         self.external_chown_script = kwargs.get('external_chown_script', None)
-        self.real_system_username = kwargs.get('real_system_username', 'user_email')
-        self.environment_setup_file = kwargs.get('environment_setup_file', None)
-        self.use_heartbeat = string_as_bool(kwargs.get('use_heartbeat', 'False'))
-        self.heartbeat_interval = int(kwargs.get('heartbeat_interval', 20))
         self.heartbeat_log = kwargs.get('heartbeat_log', None)
-        self.monitor_thread_join_timeout = int(kwargs.get("monitor_thread_join_timeout", 30))
-        self.log_actions = string_as_bool(kwargs.get('log_actions', 'False'))
-        self.log_events = string_as_bool(kwargs.get('log_events', 'False'))
-        self.sanitize_all_html = string_as_bool(kwargs.get('sanitize_all_html', True))
         self.sanitize_whitelist_file = resolve_path(kwargs.get('sanitize_whitelist_file', "config/sanitize_whitelist.txt"), self.root)
-        self.serve_xss_vulnerable_mimetypes = string_as_bool(kwargs.get('serve_xss_vulnerable_mimetypes', False))
         self.allowed_origin_hostnames = self._parse_allowed_origin_hostnames(kwargs)
         if "trust_jupyter_notebook_conversion" in kwargs:
             trust_jupyter_notebook_conversion = string_as_bool(kwargs.get('trust_jupyter_notebook_conversion', False))
         else:
             trust_jupyter_notebook_conversion = string_as_bool(kwargs.get('trust_ipython_notebook_conversion', False))
         self.trust_jupyter_notebook_conversion = trust_jupyter_notebook_conversion
-        self.enable_old_display_applications = string_as_bool(kwargs.get("enable_old_display_applications", "True"))
-        self.brand = kwargs.get('brand', None)
-        self.show_welcome_with_login = string_as_bool(kwargs.get("show_welcome_with_login", "False"))
-        self.visualizations_visible = string_as_bool(kwargs.get('visualizations_visible', True))
         # Configuration for the message box directly below the masthead.
-        self.message_box_visible = string_as_bool(kwargs.get('message_box_visible', False))
-        self.message_box_class = kwargs.get('message_box_class', 'info')
-        self.support_url = kwargs.get('support_url', 'https://galaxyproject.org/support')
-        self.citation_url = kwargs.get('citation_url', 'https://galaxyproject.org/citing-galaxy')
-        self.helpsite_url = kwargs.get('helpsite_url', None)
-        self.wiki_url = kwargs.get('wiki_url', 'https://galaxyproject.org/')
         self.blog_url = kwargs.get('blog_url', None)
-        self.screencasts_url = kwargs.get('screencasts_url', None)
-        self.genomespace_ui_url = kwargs.get('genomespace_ui_url', 'https://gsui.genomespace.org/jsui/')
-        self.library_import_dir = kwargs.get('library_import_dir', None)
-        self.user_library_import_dir = kwargs.get('user_library_import_dir', None)
         self.user_library_import_symlink_whitelist = listify(kwargs.get('user_library_import_symlink_whitelist', []), do_strip=True)
-        self.user_library_import_check_permissions = string_as_bool(kwargs.get('user_library_import_check_permissions', False))
         self.user_library_import_dir_auto_creation = string_as_bool(kwargs.get('user_library_import_dir_auto_creation', False)) if self.user_library_import_dir else False
         # Searching data libraries
-        self.chunk_upload_size = int(kwargs.get('chunk_upload_size', 104857600))
-        self.ftp_upload_dir = kwargs.get('ftp_upload_dir', None)
-        self.ftp_upload_dir_identifier = kwargs.get('ftp_upload_dir_identifier', 'email')  # attribute on user - email, username, id, etc...
         self.ftp_upload_dir_template = kwargs.get('ftp_upload_dir_template', '${ftp_upload_dir}%s${ftp_upload_dir_identifier}' % os.path.sep)
-        self.ftp_upload_purge = string_as_bool(kwargs.get('ftp_upload_purge', 'True'))
-        self.ftp_upload_site = kwargs.get('ftp_upload_site', None)
-        self.allow_path_paste = string_as_bool(kwargs.get('allow_path_paste', False))
         # Support older library-specific path paste option but just default to the new
         # allow_path_paste value.
         self.allow_library_path_paste = string_as_bool(kwargs.get('allow_library_path_paste', self.allow_path_paste))
         self.disable_library_comptypes = kwargs.get('disable_library_comptypes', '').lower().split(',')
-        self.sniff_compressed_dynamic_datatypes_default = string_as_bool(kwargs.get("sniff_compressed_dynamic_datatypes_default", True))
         self.check_upload_content = string_as_bool(kwargs.get('check_upload_content', True))
-        self.watch_tools = kwargs.get('watch_tools', 'false')
-        self.watch_tool_data_dir = kwargs.get('watch_tool_data_dir', 'false')
-        self.watch_job_rules = kwargs.get('watch_job_rules', 'false')
-        self.watch_core_config = kwargs.get('watch_core_config', 'false')
         # On can mildly speed up Galaxy startup time by disabling index of help,
         # not needed on production systems but useful if running many functional tests.
         self.index_tool_help = string_as_bool(kwargs.get("index_tool_help", True))
@@ -590,7 +457,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             target_dir = resolve_path(target_dir, self.data_dir)
             involucro_path = os.path.join(target_dir, "involucro")
         self.involucro_path = resolve_path(involucro_path, self.root)
-        self.involucro_auto_init = string_as_bool(kwargs.get('involucro_auto_init', True))
         mulled_channels = kwargs.get('mulled_channels')
         if mulled_channels:
             self.mulled_channels = [c.strip() for c in mulled_channels.split(',')]
@@ -603,8 +469,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.default_job_resubmission_condition = default_job_resubmission_condition
 
         # Configuration options for taking advantage of nginx features
-        self.upstream_gzip = string_as_bool(kwargs.get('upstream_gzip', False))
-        self.apache_xsendfile = string_as_bool(kwargs.get('apache_xsendfile', False))
         self.nginx_x_accel_redirect_base = kwargs.get('nginx_x_accel_redirect_base', False)
         self.nginx_upload_store = kwargs.get('nginx_upload_store', False)
         self.nginx_upload_path = kwargs.get('nginx_upload_path', False)
@@ -615,7 +479,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.object_store = kwargs.get('object_store', 'disk')
         self.object_store_check_old_style = string_as_bool(kwargs.get('object_store_check_old_style', False))
         self.object_store_cache_path = self.resolve_path(kwargs.get("object_store_cache_path", os.path.join(self.data_dir, "object_store_cache")))
-        self.object_store_store_by = kwargs.get("object_store_store_by", "id")
 
         # Handle AWS-specific config options for backward compatibility
         if kwargs.get('aws_access_key', None) is not None:
@@ -712,7 +575,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             self.user_preferences_extra = {'preferences': {}}
 
         self.default_locale = kwargs.get('default_locale', None)
-        self.master_api_key = kwargs.get('master_api_key', None)
         if self.master_api_key == "changethis":  # default in sample config file
             raise ConfigurationError("Insecure configuration, please change master_api_key to something other than default (changethis)")
 
@@ -724,21 +586,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.new_lib_browse = string_as_bool(kwargs.get('new_lib_browse', False))
         # Logging configuration with logging.config.configDict:
         self.logging = kwargs.get('logging', None)
-        # Error logging with sentry
-        self.sentry_dsn = kwargs.get('sentry_dsn', None)
         # Statistics and profiling with statsd
         self.statsd_host = kwargs.get('statsd_host', '')
-        self.statsd_port = int(kwargs.get('statsd_port', 8125))
-        self.statsd_prefix = kwargs.get('statsd_prefix', 'galaxy')
-        self.statsd_influxdb = string_as_bool(kwargs.get('statsd_influxdb', False))
-        # Logging with fluentd
-        self.fluent_log = string_as_bool(kwargs.get('fluent_log', False))
-        self.fluent_host = kwargs.get('fluent_host', 'localhost')
-        self.fluent_port = int(kwargs.get('fluent_port', 24224))
 
-        # directory where the visualization registry searches for plugins
-        self.visualization_plugins_directory = kwargs.get(
-            'visualization_plugins_directory', 'config/plugins/visualizations')
         ie_dirs = kwargs.get('interactive_environment_plugins_directory', None)
         self.gie_dirs = [d.strip() for d in (ie_dirs.split(",") if ie_dirs else [])]
         if ie_dirs and not self.visualization_plugins_directory:
@@ -750,27 +600,11 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
         self.proxy_session_map = resolve_path(kwargs.get("dynamic_proxy_session_map", "session_map.sqlite"), self.data_dir)
         self.manage_dynamic_proxy = string_as_bool(kwargs.get("dynamic_proxy_manage", "True"))  # Set to false if being launched externally
-        self.dynamic_proxy_debug = string_as_bool(kwargs.get("dynamic_proxy_debug", "False"))
-        self.dynamic_proxy_bind_port = int(kwargs.get("dynamic_proxy_bind_port", "8800"))
-        self.dynamic_proxy_bind_ip = kwargs.get("dynamic_proxy_bind_ip", "0.0.0.0")
-        self.dynamic_proxy_external_proxy = string_as_bool(kwargs.get("dynamic_proxy_external_proxy", "False"))
-        self.dynamic_proxy_prefix = kwargs.get("dynamic_proxy_prefix", "gie_proxy")
-
-        self.dynamic_proxy = kwargs.get("dynamic_proxy", "node")
-        self.dynamic_proxy_golang_noaccess = kwargs.get("dynamic_proxy_golang_noaccess", 60)
-        self.dynamic_proxy_golang_clean_interval = kwargs.get("dynamic_proxy_golang_clean_interval", 10)
-        self.dynamic_proxy_golang_docker_address = kwargs.get("dynamic_proxy_golang_docker_address", "unix:///var/run/docker.sock")
-        self.dynamic_proxy_golang_api_key = kwargs.get("dynamic_proxy_golang_api_key", None)
 
         # InteractiveTools propagator mapping file
-        self.interactivetool_map = self.resolve_path(kwargs.get("interactivetools_map", os.path.join(self.data_dir, "interactivetools_map.sqlite")))
-        self.interactivetool_prefix = kwargs.get("interactivetools_prefix", "interactivetool")
-        self.interactivetools_enable = string_as_bool(kwargs.get('interactivetools_enable', False))
+        self.realtime_map = self.resolve_path(kwargs.get("interactivetools_map", os.path.join(self.data_dir, "interactivetools_map.sqlite")))
+        self.realtime_prefix = kwargs.get("interactivetools_prefix", "interactivetool")
 
-        # Default chunk size for chunkable datatypes -- 64k
-        self.display_chunk_size = int(kwargs.get('display_chunk_size', 65536))
-
-        self.citation_cache_type = kwargs.get("citation_cache_type", "file")
         self.citation_cache_data_dir = resolve_path(kwargs.get("citation_cache_data_dir", "citations/data"), self.data_dir)
         self.citation_cache_lock_dir = resolve_path(kwargs.get("citation_cache_lock_dir", "citations/locks"), self.data_dir)
 
@@ -786,7 +620,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.redact_user_address_during_deletion = False
         # GDPR compliance mode changes values on a number of variables. Other
         # policies could change (non)overlapping subsets of these variables.
-        self.enable_beta_gdpr = string_as_bool(kwargs.get("enable_beta_gdpr", False))
         if self.enable_beta_gdpr:
             self.expose_user_name = False
             self.expose_user_email = False

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -101,7 +101,6 @@ mapping:
 
       database_template:
         type: str
-        default: ''
         required: false
         desc: |
           If auto-creating a postgres database on startup - it can be based on an existing
@@ -109,7 +108,7 @@ mapping:
           documentation is included here for completeness.
 
       slow_query_log_threshold:
-        type: int
+        type: float
         default: 0
         required: false
         desc: |
@@ -750,7 +749,6 @@ mapping:
 
       smtp_server:
         type: str
-        default: ''
         required: false
         desc: |
           Galaxy sends mail for various things: subscribing users to the mailing list
@@ -761,7 +759,6 @@ mapping:
 
       smtp_username:
         type: str
-        default: ''
         required: false
         desc: |
           If your SMTP server requires a username and password, you can provide them
@@ -770,7 +767,6 @@ mapping:
 
       smtp_password:
         type: str
-        default: ''
         required: false
         desc: |
           If your SMTP server requires a username and password, you can provide them
@@ -795,7 +791,6 @@ mapping:
 
       error_email_to:
         type: str
-        default: ''
         required: false
         desc: |
           Datasets in an error state include a link to report the error.  Those reports
@@ -888,7 +883,6 @@ mapping:
 
       ga_code:
         type: str
-        default: ''
         required: false
         desc: |
           You can enter tracking code here to track visitor's behavior
@@ -970,7 +964,6 @@ mapping:
 
       brand:
         type: str
-        default: ''
         required: false
         desc: |
           Append "/{brand}" to the "Galaxy" text in the masthead.
@@ -1053,7 +1046,6 @@ mapping:
 
       helpsite_url:
         type: str
-        default: ''
         required: false
         desc: |
           The URL linked by the "Galaxy Help" link in the "Help" menu.
@@ -1110,7 +1102,6 @@ mapping:
 
       terms_url:
         type: str
-        default: ''
         required: false
         desc: |
           The URL linked by the "Terms and Conditions" link in the "Help" menu, as well
@@ -1400,7 +1391,6 @@ mapping:
 
       dynamic_proxy_golang_api_key:
         type: str
-        default: ''
         required: false
         desc: |
           The golang proxy uses a RESTful HTTP API for communication with Galaxy
@@ -1622,7 +1612,6 @@ mapping:
 
       sentry_dsn:
         type: str
-        default: ''
         required: false
         desc: |
           Log to Sentry
@@ -1689,7 +1678,6 @@ mapping:
 
       library_import_dir:
         type: str
-        default: ''
         required: false
         desc: |
           Add an option to the library upload form which allows administrators to
@@ -1697,7 +1685,6 @@ mapping:
 
       user_library_import_dir:
         type: str
-        default: ''
         required: false
         desc: |
           Add an option to the library upload form which allows authorized
@@ -1906,7 +1893,6 @@ mapping:
 
       remote_user_maildomain:
         type: str
-        default: ''
         required: false
         desc: |
           If use_remote_user is enabled and your external authentication
@@ -1938,7 +1924,6 @@ mapping:
 
       remote_user_logout_href:
         type: str
-        default: ''
         required: false
         desc: |
           If use_remote_user is enabled, you can set this to a URL that will log your
@@ -2114,7 +2099,8 @@ mapping:
         required: false
         desc: |
           Enable beta workflow modules that should not yet be considered part of Galaxy's
-          stable API.
+          stable API. (The module state definitions may change and workflows built using 
+          these modules may not function in the future.)
 
       default_workflow_export_format:
         type: str
@@ -2289,7 +2275,6 @@ mapping:
 
       ftp_upload_dir:
         type: str
-        default: ''
         required: false
         desc: |
           Enable Galaxy's "Upload via FTP" interface.  You'll need to install and
@@ -2300,7 +2285,6 @@ mapping:
 
       ftp_upload_site:
         type: str
-        default: ''
         required: false
         desc: |
           This should be the hostname of your FTP server, which will be provided to
@@ -2616,7 +2600,6 @@ mapping:
 
       environment_setup_file:
         type: str
-        default: ''
         required: false
         desc: |
           File to source to set up the environment when running jobs.  By default, the

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2223,7 +2223,6 @@ mapping:
 
       master_api_key:
         type: str
-        default: changethis
         required: false
         desc: |
           Master key that allows many API admin actions to be used without actually

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -4,9 +4,11 @@ from galaxy.config import GalaxyAppConfiguration
 
 
 MOCK_PROPERTIES = {
-    'property1': {'default': 'a'},
-    'property2': {'default': 'b'},
-    'property3': {'something_else': 'c'},
+    'property1': {'default': 'a', 'type': str},  # str
+    'property2': {'default': 1, 'type': int},  # int
+    'property3': {'default': 1.0, 'type': float},  # float
+    'property4': {'default': True, 'type': bool},  # bool
+    'property5': {'something_else': 'b', 'type': 'invalid'},
 }
 
 
@@ -32,16 +34,46 @@ def mock_init(monkeypatch):
 def test_load_raw_config_from_schema(mock_init):
     config = GalaxyAppConfiguration()
 
-    assert len(config._raw_config) == 3
+    assert len(config._raw_config) == 5
     assert config._raw_config['property1'] == 'a'
-    assert config._raw_config['property2'] == 'b'
-    assert config._raw_config['property3'] is None
+    assert config._raw_config['property2'] == 1
+    assert config._raw_config['property3'] == 1.0
+    assert config._raw_config['property4'] is True
+    assert config._raw_config['property5'] is None
+
+    assert type(config._raw_config['property1']) is str
+    assert type(config._raw_config['property2']) is int
+    assert type(config._raw_config['property3']) is float
+    assert type(config._raw_config['property4']) is bool
 
 
 def test_update_raw_config_from_kwargs(mock_init):
-    config = GalaxyAppConfiguration(property2='new', property3=42, another_key=66)
+    config = GalaxyAppConfiguration(property2=2, property3=2.0, another_key=66)
 
-    assert len(config._raw_config) == 3  # no change: another_key NOT added
+    assert len(config._raw_config) == 5   # no change: another_key NOT added
     assert config._raw_config['property1'] == 'a'  # no change
-    assert config._raw_config['property2'] == 'new'  # updated
-    assert config._raw_config['property3'] == 42  # updated
+    assert config._raw_config['property2'] == 2  # updated
+    assert config._raw_config['property3'] == 2.0  # updated
+    assert config._raw_config['property4'] is True  # no change
+    assert config._raw_config['property5'] is None  # no change
+
+    assert type(config._raw_config['property1']) is str
+    assert type(config._raw_config['property2']) is int
+    assert type(config._raw_config['property3']) is float
+    assert type(config._raw_config['property4']) is bool
+
+
+def test_update_raw_config_from_string_kwargs(mock_init):
+    # kwargs may be passed as strings: property data types should not be affected
+    config = GalaxyAppConfiguration(property1='b', property2='2', property3='2.0', property4='false')
+
+    assert len(config._raw_config) == 5  # no change
+    assert config._raw_config['property1'] == 'b'  # updated
+    assert config._raw_config['property2'] == 2  # updated
+    assert config._raw_config['property3'] == 2.0  # updated
+    assert config._raw_config['property4'] is False  # updated
+
+    assert type(config._raw_config['property1']) is str
+    assert type(config._raw_config['property2']) is int
+    assert type(config._raw_config['property3']) is float
+    assert type(config._raw_config['property4']) is bool

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -13,17 +13,11 @@ MOCK_PROPERTIES = {
 }
 
 
-class MockSchema():
-    @property
-    def app_schema(self):
-        return MOCK_PROPERTIES
-
-
 @pytest.fixture
 def mock_init(monkeypatch):
 
     def mock_load_schema(self):
-        self.schema = MockSchema()
+        self.appschema = MOCK_PROPERTIES
 
     def mock_process_config(self, kwargs):
         pass

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -4,10 +4,10 @@ from galaxy.config import GalaxyAppConfiguration
 
 
 MOCK_PROPERTIES = {
-    'property1': {'default': 'a', 'type': str},  # str
-    'property2': {'default': 1, 'type': int},  # int
-    'property3': {'default': 1.0, 'type': float},  # float
-    'property4': {'default': True, 'type': bool},  # bool
+    'property1': {'default': 'a', 'type': 'str'},  # str
+    'property2': {'default': 1, 'type': 'int'},  # int
+    'property3': {'default': 1.0, 'type': 'float'},  # float
+    'property4': {'default': True, 'type': 'bool'},  # bool
     'property5': {'something_else': 'b', 'type': 'invalid'},
     'property6': {'something_else': 'b'},  # no type
 }

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -1,0 +1,33 @@
+from galaxy.config import GalaxyAppConfiguration
+
+
+MOCK_PROPERTIES = {
+    'property1': {'default': 'a'},
+    'property2': {'default': 'b'},
+    'property3': {'something_else': 'c'},
+}
+
+
+class MockSchema():
+    @property
+    def app_schema(self):
+        return MOCK_PROPERTIES
+
+
+def test_load_raw_config_from_schema(monkeypatch):
+
+    def mock_load_schema(self):
+        self.schema = MockSchema()
+
+    def mock_process_config(self, kwargs):
+        pass
+
+    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
+    monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', mock_process_config)
+
+    config = GalaxyAppConfiguration()
+
+    assert len(config._raw_config) == 3
+    assert config._raw_config['property1'] == 'a'
+    assert config._raw_config['property2'] == 'b'
+    assert config._raw_config['property3'] is None

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -9,6 +9,7 @@ MOCK_PROPERTIES = {
     'property3': {'default': 1.0, 'type': float},  # float
     'property4': {'default': True, 'type': bool},  # bool
     'property5': {'something_else': 'b', 'type': 'invalid'},
+    'property6': {'something_else': 'b'},  # no type
 }
 
 
@@ -34,12 +35,13 @@ def mock_init(monkeypatch):
 def test_load_raw_config_from_schema(mock_init):
     config = GalaxyAppConfiguration()
 
-    assert len(config._raw_config) == 5
+    assert len(config._raw_config) == 6
     assert config._raw_config['property1'] == 'a'
     assert config._raw_config['property2'] == 1
     assert config._raw_config['property3'] == 1.0
     assert config._raw_config['property4'] is True
     assert config._raw_config['property5'] is None
+    assert config._raw_config['property6'] is None
 
     assert type(config._raw_config['property1']) is str
     assert type(config._raw_config['property2']) is int
@@ -50,12 +52,13 @@ def test_load_raw_config_from_schema(mock_init):
 def test_update_raw_config_from_kwargs(mock_init):
     config = GalaxyAppConfiguration(property2=2, property3=2.0, another_key=66)
 
-    assert len(config._raw_config) == 5   # no change: another_key NOT added
+    assert len(config._raw_config) == 6   # no change: another_key NOT added
     assert config._raw_config['property1'] == 'a'  # no change
     assert config._raw_config['property2'] == 2  # updated
     assert config._raw_config['property3'] == 2.0  # updated
     assert config._raw_config['property4'] is True  # no change
     assert config._raw_config['property5'] is None  # no change
+    assert config._raw_config['property6'] is None  # no change
 
     assert type(config._raw_config['property1']) is str
     assert type(config._raw_config['property2']) is int
@@ -67,7 +70,7 @@ def test_update_raw_config_from_string_kwargs(mock_init):
     # kwargs may be passed as strings: property data types should not be affected
     config = GalaxyAppConfiguration(property1='b', property2='2', property3='2.0', property4='false')
 
-    assert len(config._raw_config) == 5  # no change
+    assert len(config._raw_config) == 6  # no change
     assert config._raw_config['property1'] == 'b'  # updated
     assert config._raw_config['property2'] == 2  # updated
     assert config._raw_config['property3'] == 2.0  # updated

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 from galaxy.config import GalaxyAppConfiguration
 
 
@@ -14,7 +16,8 @@ class MockSchema():
         return MOCK_PROPERTIES
 
 
-def test_load_raw_config_from_schema(monkeypatch):
+@pytest.fixture
+def mock_init(monkeypatch):
 
     def mock_load_schema(self):
         self.schema = MockSchema()
@@ -25,9 +28,20 @@ def test_load_raw_config_from_schema(monkeypatch):
     monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
     monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', mock_process_config)
 
+
+def test_load_raw_config_from_schema(mock_init):
     config = GalaxyAppConfiguration()
 
     assert len(config._raw_config) == 3
     assert config._raw_config['property1'] == 'a'
     assert config._raw_config['property2'] == 'b'
     assert config._raw_config['property3'] is None
+
+
+def test_update_raw_config_from_kwargs(mock_init):
+    config = GalaxyAppConfiguration(property2='new', property3=42, another_key=66)
+
+    assert len(config._raw_config) == 3  # no change: another_key NOT added
+    assert config._raw_config['property1'] == 'a'  # no change
+    assert config._raw_config['property2'] == 'new'  # updated
+    assert config._raw_config['property3'] == 42  # updated


### PR DESCRIPTION
This addresses #8493 

SUMMARY
1. `config/__init__.py`:
- Config properties are loaded from `config_schema.yml`
- Default values are overwritten by values from keyword args. Values are cast as int/float/bool based on types specified in the schema; str is the default
- Attributes are created for all properties defined in the schema
- If `foo` is defined in the schema, then statements like `foo = kwargs.get('foo', [default])` have been mostly deleted (see 2e61a7a commit message details)
- Comments for the above statements have been deleted if redundant; otherwise, added to the property's description in the schema

2. `config_schema.yml`:
- Removed empty string default values if those defaults were not assigned (`None` was assigned instead) 
- Minor edits; changed type int to float to be consistent with the `float()` cast in `config/`

3. Relevant unit tests added.

NOTES
1. Attributes are created for all properties defined in the schema; not all of them are necessary. However, this automated approach (a) eliminates the need for numerous individual assignment statements; (b) fixes inconsistencies between schema and `config/`; and (c) is a step towards making `__init__()` more readable and testable. 

2. There are more details on each commit in the commit messages.

3. This is a work in progress. I'd like to get this merged first, if possible, since this is the foundation of all subsequent edits.

(ping: @jmchilton @mvdbeek @natefoo , as we've discussed parts of this)