### PR TITLE
set uwsgi umask default

### DIFF
--- a/doc/source/admin/cluster.md
+++ b/doc/source/admin/cluster.md
@@ -330,7 +330,7 @@ Since this is a complex problem, the current solution does have some caveats:
 
 ### Configuration
 
-You'll need to ensure that all datasets are stored on the filesystem such that they are readable by all users that will use Galaxy: either made readable by a group, or world-readable. If using a group, set your `umask(1)` to `027` or for world-readable, use `022` Setting the umask assumes your underlying filesystem uses POSIX permissions, so if this is not the case, your environment changes may be different.
+You'll need to ensure that all datasets are stored on the filesystem such that they are readable by all users that will use Galaxy: either made readable by a group, or world-readable. If using a group, set your `umask(1)` to `027` or for world-readable, use `022` Setting the umask assumes your underlying filesystem uses POSIX permissions, so if this is not the case, your environment changes may be different. For uWSGI setups (which are the default since release 19.01) the default umask is set in galaxy.yml (with a default of `027`).
 
 The directory specified in `new_file_path` in the Galaxy config should be world-writable, cluster-accessible (via the same absolute path) and have its sticky bit (+t) set. This directory should also be cleaned regularly using a script or program as is appropriate for your site, since temporary files created here may not always be cleaned up under certain conditions.
 

--- a/doc/source/admin/cluster.md
+++ b/doc/source/admin/cluster.md
@@ -330,7 +330,7 @@ Since this is a complex problem, the current solution does have some caveats:
 
 ### Configuration
 
-You'll need to ensure that all datasets are stored on the filesystem such that they are readable by all users that will use Galaxy: either made readable by a group, or world-readable. If using a group, set your `umask(1)` to `027` or for world-readable, use `022` Setting the umask assumes your underlying filesystem uses POSIX permissions, so if this is not the case, your environment changes may be different. For uWSGI setups (which are the default since release 19.01) the default umask is set in galaxy.yml (with a default of `027`).
+You'll need to ensure that all datasets are stored on the filesystem such that they are readable by all users that will use Galaxy: either made readable by a group, or world-readable. If using a group, set your `umask(1)` to `027` or for world-readable, use `022` Setting the umask assumes your underlying filesystem uses POSIX permissions, so if this is not the case, your environment changes may be different. For uWSGI setups (which are the default since release 19.01) the default umask is set in the `uwsgi:` section of `galaxy.yml` .
 
 The directory specified in `new_file_path` in the Galaxy config should be world-writable, cluster-accessible (via the same absolute path) and have its sticky bit (+t) set. This directory should also be cleaned regularly using a script or program as is appropriate for your site, since temporary files created here may not always be cleaned up under certain conditions.
 

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -163,6 +163,11 @@ UWSGI_OPTIONS = OrderedDict([
         'default': True,
         'type': 'bool',
     }),
+    ('umask', {
+        'desc': """uWSGI default umask.""",
+        'default': '027',
+        'type': 'str',
+    }),
     # ('route-uri', {
     #     'default': '^/proxy/ goto:proxy'
     # }),

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -164,7 +164,7 @@ UWSGI_OPTIONS = OrderedDict([
         'type': 'bool',
     }),
     ('umask', {
-        'desc': """uWSGI default umask.""",
+        'desc': """uWSGI default umask. On some systems uWSGI has a default umask of 000, for Galaxy a somewhat safer default is chosen. If Galaxy submits jobs as real user then all users needs to be able to read the files, i.e. the the umask needs to be '022' or the Galaxy users need to be in the same group as the Galaxy system user""",
         'default': '027',
         'type': 'str',
     }),

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -97,8 +97,11 @@ uwsgi:
   enable-threads: true
 
   # On some systems uWSGI has a default umask of 000, for Galaxy a 
-  # somewhat safer default is chosen
-  umask: 022
+  # somewhat safer default is chosen. If Galaxy submits jobs as real
+  # user then all users needs to be able to read the files, i.e.
+  # the the umask needs to be 0o022 or the Galaxy users need to be in the
+  # same group as the Galaxy system user
+  umask: 0o027
 galaxy:
 
   # The directory that will be prepended to relative paths in options

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -96,6 +96,7 @@ uwsgi:
   # Ensure application threads will run if `threads` is unset.
   enable-threads: true
 
+  # uWSGI default umask
   # On some systems uWSGI has a default umask of 000, for Galaxy a 
   # somewhat safer default is chosen. If Galaxy submits jobs as real
   # user then all users needs to be able to read the files, i.e.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -101,7 +101,7 @@ uwsgi:
   # user then all users needs to be able to read the files, i.e.
   # the the umask needs to be 0o022 or the Galaxy users need to be in the
   # same group as the Galaxy system user
-  umask: 0o027
+  umask: 027
 galaxy:
 
   # The directory that will be prepended to relative paths in options

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -99,9 +99,9 @@ uwsgi:
   # On some systems uWSGI has a default umask of 000, for Galaxy a 
   # somewhat safer default is chosen. If Galaxy submits jobs as real
   # user then all users needs to be able to read the files, i.e.
-  # the the umask needs to be 0o022 or the Galaxy users need to be in the
+  # the the umask needs to be '022' or the Galaxy users need to be in the
   # same group as the Galaxy system user
-  umask: 027
+  umask: '027'
 galaxy:
 
   # The directory that will be prepended to relative paths in options

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -96,13 +96,13 @@ uwsgi:
   # Ensure application threads will run if `threads` is unset.
   enable-threads: true
 
-  # uWSGI default umask
-  # On some systems uWSGI has a default umask of 000, for Galaxy a 
-  # somewhat safer default is chosen. If Galaxy submits jobs as real
-  # user then all users needs to be able to read the files, i.e.
-  # the the umask needs to be '022' or the Galaxy users need to be in the
-  # same group as the Galaxy system user
-  umask: '027'
+  # uWSGI default umask. On some systems uWSGI has a default umask of
+  # 000, for Galaxy a somewhat safer default is chosen. If Galaxy
+  # submits jobs as real user then all users needs to be able to read
+  # the files, i.e. the the umask needs to be '022' or the Galaxy users
+  # need to be in the same group as the Galaxy system user
+  umask: 027
+
 galaxy:
 
   # The directory that will be prepended to relative paths in options

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -96,6 +96,9 @@ uwsgi:
   # Ensure application threads will run if `threads` is unset.
   enable-threads: true
 
+  # On some systems uWSGI has a default umask of 000, for Galaxy a 
+  # somewhat safer default is chosen
+  umask: 022
 galaxy:
 
   # The directory that will be prepended to relative paths in options

--- a/lib/galaxy/config/sample/reports.yml.sample
+++ b/lib/galaxy/config/sample/reports.yml.sample
@@ -78,6 +78,13 @@ uwsgi:
   # Ensure application threads will run if `threads` is unset.
   enable-threads: true
 
+  # uWSGI default umask. On some systems uWSGI has a default umask of
+  # 000, for Galaxy a somewhat safer default is chosen. If Galaxy
+  # submits jobs as real user then all users needs to be able to read
+  # the files, i.e. the the umask needs to be '022' or the Galaxy users
+  # need to be in the same group as the Galaxy system user
+  umask: 027
+
 reports:
 
   # Verbosity of console log messages.  Acceptable values can be found

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -78,6 +78,13 @@ uwsgi:
   # Ensure application threads will run if `threads` is unset.
   enable-threads: true
 
+  # uWSGI default umask. On some systems uWSGI has a default umask of
+  # 000, for Galaxy a somewhat safer default is chosen. If Galaxy
+  # submits jobs as real user then all users needs to be able to read
+  # the files, i.e. the the umask needs to be '022' or the Galaxy users
+  # need to be in the same group as the Galaxy system user
+  umask: 027
+
   # Task for rebuilding Toolshed search indexes using the uWSGI
   # cron-like interface.
   cron: 0 -1 -1 -1 -1 python scripts/tool_shed/build_ts_whoosh_index.py -c config/tool_shed.yml --config-section tool_shed

--- a/scripts/get_uwsgi_args.py
+++ b/scripts/get_uwsgi_args.py
@@ -101,7 +101,7 @@ def _get_uwsgi_args(cliargs, kwargs):
                               'unix_signal:15 gracefully_kill_them_all'),
         'py-call-osafterfork': True,
         'cron': '0 -1 -1 -1 -1 python scripts/tool_shed/build_ts_whoosh_index.py %s --config-section tool_shed -d' % ts_cron_config_option,
-        'umask': '0o027',
+        'umask': '027',
     }
     __add_config_file_arg(args, config_file, cliargs.app)
     if not __arg_set('module', uwsgi_kwargs):

--- a/scripts/get_uwsgi_args.py
+++ b/scripts/get_uwsgi_args.py
@@ -101,7 +101,7 @@ def _get_uwsgi_args(cliargs, kwargs):
                               'unix_signal:15 gracefully_kill_them_all'),
         'py-call-osafterfork': True,
         'cron': '0 -1 -1 -1 -1 python scripts/tool_shed/build_ts_whoosh_index.py %s --config-section tool_shed -d' % ts_cron_config_option,
-        'umask': 0o027,
+        'umask': '0o027',
     }
     __add_config_file_arg(args, config_file, cliargs.app)
     if not __arg_set('module', uwsgi_kwargs):

--- a/scripts/get_uwsgi_args.py
+++ b/scripts/get_uwsgi_args.py
@@ -23,7 +23,7 @@ ALIASES = {
     'module': ('mount',),   # mount is not actually an alias for module, but we don't want to set module if mount is set
 }
 DEFAULT_ARGS = {
-    '_all_': ('pythonpath', 'threads', 'buffer-size', 'http', 'static-map', 'static-safe', 'die-on-term', 'hook-master-start', 'enable-threads'),
+    '_all_': ('pythonpath', 'threads', 'buffer-size', 'http', 'static-map', 'static-safe', 'die-on-term', 'hook-master-start', 'enable-threads', 'umask'),
     'galaxy': ('py-call-osafterfork',),
     'reports': (),
     'tool_shed': ('cron',),
@@ -101,6 +101,7 @@ def _get_uwsgi_args(cliargs, kwargs):
                               'unix_signal:15 gracefully_kill_them_all'),
         'py-call-osafterfork': True,
         'cron': '0 -1 -1 -1 -1 python scripts/tool_shed/build_ts_whoosh_index.py %s --config-section tool_shed -d' % ts_cron_config_option,
+        'umask': 0o027,
     }
     __add_config_file_arg(args, config_file, cliargs.app)
     if not __arg_set('module', uwsgi_kwargs):


### PR DESCRIPTION
seems that uWSGI sometimes has a default umask of 000:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=866058

I suggest to chose a somewhat safer default in the uWSGI
section of the galaxy.yml