### PR TITLE
Issue#8491:Workflow Text Overlap on small screen - fix

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1663,6 +1663,16 @@ div.toolSectionWrapper {
     opacity: 1;
 }
 
+.center-panel .page-container, .center-panel ul.manage-table-actions {
+    display: inline-block;
+    margin-top: 0;
+}
+
+@media (max-width: 1065px) {
+    .center-panel ul.manage-table-actions { padding-left: 0; float: none; }
+    .center-panel ul.manage-table-actions li { margin-top: 3px; }
+}
+
 /* TEMPORARY, REFACTOR THIS -- This is only image-related styles from the
  * workflow editor; everything should be moved out of the mako and into its own
  * file */


### PR DESCRIPTION
This commit solves the issue #8491 
Some text on the workflow window overlaps when the browser window is too small. 