### PR TITLE
Dynamic options and metadata filter fixes

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4344,7 +4344,6 @@ class HistoryDatasetCollectionAssociation(DatasetCollectionInstance,
         self.copied_from_history_dataset_collection_association = copied_from_history_dataset_collection_association
         self.implicit_output_name = implicit_output_name
         self.implicit_input_collections = implicit_input_collections
-
     @property
     def history_content_type(self):
         return "dataset_collection"
@@ -4379,9 +4378,8 @@ class HistoryDatasetCollectionAssociation(DatasetCollectionInstance,
         for dataset in self.collection.dataset_elements:
             rval.append(dataset.dataset_instance)
             if multiple is False:
-                break
-        if len(rval) > 0:
-            return rval if multiple else rval[0]
+                return rval
+        return rval
 
     def serialize(self, id_encoder, serialization_options, for_link=False):
         if for_link:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4344,6 +4344,7 @@ class HistoryDatasetCollectionAssociation(DatasetCollectionInstance,
         self.copied_from_history_dataset_collection_association = copied_from_history_dataset_collection_association
         self.implicit_output_name = implicit_output_name
         self.implicit_input_collections = implicit_input_collections
+
     @property
     def history_content_type(self):
         return "dataset_collection"

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4379,8 +4379,9 @@ class HistoryDatasetCollectionAssociation(DatasetCollectionInstance,
         for dataset in self.collection.dataset_elements:
             rval.append(dataset.dataset_instance)
             if multiple is False:
-                return rval
-        return rval
+                break
+        if len(rval) > 0:
+            return rval if multiple else rval[0]
 
     def serialize(self, id_encoder, serialization_options, for_link=False):
         if for_link:

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -132,7 +132,23 @@ class MetadataCollection(Mapping):
             log.info("Attempted to delete invalid key '%s' from MetadataCollection" % name)
 
     def element_is_set(self, name):
-        return bool(self.parent._metadata.get(name, False))
+        """
+        check if the meta data with the given name is set, i.e.
+        - if the such a metadata actually exists and
+        - if its value differs from no_value
+
+        param name the name of the metadata element
+        return True if the value differes from the no_value
+            False if its equal of if no metadata with the name is specified
+        """
+        try:
+            meta_val = self.parent._metadata[name]
+        except KeyError:
+            log.error("no metadata with name %s found"%(name))
+            return False
+
+        meta_spec = self.parent.metadata.spec[name]
+        return meta_val != meta_spec.no_value
 
     def get_metadata_parameter(self, name, **kwd):
         if name in self.spec:

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -144,7 +144,7 @@ class MetadataCollection(Mapping):
         try:
             meta_val = self.parent._metadata[name]
         except KeyError:
-            log.error("no metadata with name %s found"%(name))
+            log.debug("no metadata with name %s found" % (name))
             return False
 
         meta_spec = self.parent.metadata.spec[name]

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3677,6 +3677,23 @@ is the ``none`` preset.</xs:documentation>
 ``<options>`` tag set - modify (e.g. remove, add, sort, ...) the list of values obtained from a locally stored file (e.g.
 a tool data table) or a dataset in the current history.
 
+Currently the following filters are defined:
+
+* ``static_value`` filter options for which the entry in a given ``column`` of the referenced file based on equality to the ``value`` attribute of the filter. 
+* ``regexp`` similar to the ``static_value`` filter, but checks if the regular expression given by ``value`` matches the entry.
+* ``param_value`` filter options for which the entry in a given ``column`` of the referenced file based on properties of another input parameter specified by ``ref``. This property is by default the value of the parameter, but also the values of another attribute (``ref_attribute``) of the parameter can be used, e.g. the extension of a data input.
+* ``data_meta`` populate or filter options based on the metadata of another input parameter specified by ``ref``. If a ``column`` is given options are filtered for which the entry in this column ``column`` is equal to metadata of the input parameter specified by ``ref``. 
+If no ``column`` is given the metadata value of the referenced input is added to the options list (in this case the corresponding ``options`` tag must not have the ``from_data_table`` or ``from_dataset`` attributes). 
+In both cases the desired metadata is selected by ``key``.
+
+The ``static_value`` and ``regexp`` filters can be inverted by setting ``keep`` to true.
+
+* ``add_value``: add an option with a given ``name`` and ``value`` to the options. By default the new option is appended, with ``index`` the insertion position can be specified.
+* ``remove_value``: remove a value from the options. Either specified explicitly with ``value``, the value of another input specifified with ``ref``, or the metatdata ``key`` of another input ``meta_ref``.
+* ``unique_value``: remove options that have duplicate entries in the given ``column``.
+* ``sort_by``: sort options by the entries of a given ``column``.
+* ``multiple_splitter``: split the entries of the specified ``column``(s) in the referenced file using a ``separator``. Thereby the number of columns is increased. 
+
 ### Examples
 
 The following example from Mothur's
@@ -3777,28 +3794,8 @@ demonstrates splitting up strings into multiple values.
     <xs:attribute name="type" type="FilterType" use="required">
       <xs:annotation>
         <xs:documentation xml:lang="en"><![CDATA[
-Currently the following filters are defined:
-
-* ``static_value`` filter options for which the entry in a given ``column`` of the referenced file based on equality to the ``value`` attribute of the filter. 
-* ``regexp`` similar to the ``static_value`` filter, but checks if the regular expression given by ``value`` matches the entry.
-* ``param_value`` filter options for which the entry in a given ``column`` of the referenced file based on properties of another input parameter specified by ``ref``. This property is by default the value of the parameter, but also the values of another attribute (``ref_attribute``) of the parameter can be used, e.g. the extension of a data input.
-* ``data_meta`` If a ``column`` is given options are filtered for which the entry in this column ``column`` is equal to metadata of another input parameter specified by ``ref``. 
-If no ``column`` is given the metadata value of the referenced input is added to the options list (in this case the corresponding ``options`` tag must not have the ``from_data_table`` or ``from_dataset`` attributes). 
-In both cases the desired metadata is selected by ``key``.
-
-The above filters can be inverted by setting ``keep`` to true.
-
-* ``add_value``: add an option with a given ``name`` and ``value`` to the options. By default the new option is appended, with ``index`` the insertion position can be specified.
-* ``remove_value``: remove a value from the options. Either specified explicitly with ``value``, the value of another input specifified with ``ref``, or the metatdata ``key`` of another input ``meta_ref``.
-* ``unique_value``: remove options that have duplicate entries in the given ``column``.
-* ``sort_by``: sort options by the entries of a given ``column``.
-* ``multiple_splitter``: split the entries of the specified ``column``(s) in the referenced file using a ``separator``. Thereby the number of columns is increased. 
-
-Note that filters that are applyed after one of the latter two filters must not refer to 
-
-These values are defined in the module
-[/lib/galaxy/tools/parameters/dynamic_options.py](https://github.com/galaxyproject/galaxy/blob/master/lib/galaxy/tools/parameters/dynamic_options.py)
-in the ``filter_types`` dictionary. 
+Currently the filters in the ``filter_types`` dictionary in the module
+[/lib/galaxy/tools/parameters/dynamic_options.py](https://github.com/galaxyproject/galaxy/blob/master/lib/galaxy/tools/parameters/dynamic_options.py) are defined. 
 
 Deprecated filter types:
 

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -2,8 +2,8 @@
 Support for generating the options for a SelectToolParameter dynamically (based
 on the values of other parameters or other aspects of the current state)
 """
-from collections import OrderedDict
 import copy
+from collections import OrderedDict
 import logging
 import os
 import re

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -7,7 +7,6 @@ import logging
 import os
 import re
 from io import StringIO
-from collections import OrderedDict
 
 from galaxy.model import (
     HistoryDatasetAssociation,
@@ -206,7 +205,7 @@ class DataMetaFilter(Filter):
             if not r.metadata.element_is_set(self.key):
                 continue
             _add_meta(meta_value, r.metadata.get(self.key))
-        log.error("meta_value %s" % str(meta_value))
+
         # if no meta data value could be determined just return a copy
         # of the original options
         if len(meta_value) == 0:

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -2,9 +2,9 @@
 Support for generating the options for a SelectToolParameter dynamically (based
 on the values of other parameters or other aspects of the current state)
 """
-from collections import OrderedDict
 import copy
 import logging
+from collections import OrderedDict
 import os
 import re
 from io import StringIO
@@ -163,7 +163,11 @@ class DataMetaFilter(Filter):
             if isinstance(m, list):
                 meta_value |= set(m)
             elif isinstance(m, dict) or isinstance(m, OrderedDict):
-                meta_value |= set([ "%s,%s" %(k, v) for k, v in m.iteritems() ])
+                meta_value |= set(["%s,%s" % (k, v) for k, v in m.iteritems()])
+            elif isinstance(m, str) and os.path.isfile(m):
+                with open(m) as fh:
+                    for line in fh:
+                        meta_value.add(line)
             else:
                 meta_value.add(m)
 
@@ -218,9 +222,9 @@ class DataMetaFilter(Filter):
         else:
             if not self.dynamic_option.columns:
                 self.dynamic_option.columns = {
-                    "name" : 0,
-                    "value" : 1,
-                    "selected" : 2
+                    "name": 0,
+                    "value": 1,
+                    "selected": 2
                 }
                 self.dynamic_option.largest_index = 2
             for value in meta_value:
@@ -636,7 +640,7 @@ class DynamicOptions:
                             name = "a configuration file"
                         # Perhaps this should be an error, but even a warning is useful.
                         log.warning("Inconsistent number of fields (%i vs %i) in %s using separator %r, check line: %r" %
-                                  (field_count, len(fields), name, self.separator, line))
+                                    (field_count, len(fields), name, self.separator, line))
                     rval.append(fields)
         return rval
 

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -213,9 +213,7 @@ class DataMetaFilter(Filter):
                     "selected" : 2
                 }
                 self.dynamic_option.largest_index = 2
-            if not isinstance(meta_value, list):
-                meta_value = [meta_value]
-            for value in meta_value:
+            for value in reduce(lambda x, y: x + y, meta_value):
                 options.append((value, value, False))
             return options
 

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -9,11 +9,14 @@ import os
 import re
 from io import StringIO
 
-import galaxy.tools
 from galaxy.model import (
     HistoryDatasetAssociation,
     HistoryDatasetCollectionAssociation,
     User
+)
+from galaxy.tools.wrappers import (
+    DatasetFilenameWrapper,
+    DatasetListWrapper
 )
 from galaxy.util import string_as_bool
 from . import validation
@@ -183,14 +186,13 @@ class DataMetaFilter(Filter):
             if self.multiple:
                 return dataset_value in file_value.split(self.separator)
             return file_value == dataset_value
-        ref = other_values.get(self.ref_name, None)
-        if isinstance(ref, HistoryDatasetCollectionAssociation):
-            ref = ref.to_hda_representative(multiple=True)
-        is_data = isinstance(ref, galaxy.tools.wrappers.DatasetFilenameWrapper)
-        is_data_list = isinstance(ref, galaxy.tools.wrappers.DatasetListWrapper) or isinstance(ref, list)
-        is_data_or_data_list = is_data or is_data_list
-        if not isinstance(ref, HistoryDatasetAssociation) and not is_data_or_data_list:
-            return []  # not a valid dataset
+
+        try:
+            ref = _get_ref_data(other_values, self.ref_name)
+        except KeyError:  # no such dataset
+            return []
+        except ValueError:  # not a valid dataset
+            return []
 
         # get the metadata value.
         # - for lists: (of data sets) and collections the meta data values of all
@@ -199,14 +201,10 @@ class DataMetaFilter(Filter):
         # in both cases only meta data that is set (i.e. differs from the no_value)
         # is considered
         meta_value = set()
-        if is_data_list:
-            for r in ref:
-                if not r.metadata.element_is_set(self.key):
-                    continue
-                _add_meta(meta_value, r.metadata.get(self.key))
-        else:
-            if ref.metadata.element_is_set(self.key):
-                _add_meta(meta_value, ref.metadata.get(self.key))
+        for r in ref:
+            if not r.metadata.element_is_set(self.key):
+                continue
+            _add_meta(meta_value, r.metadata.get(self.key))
         log.error("meta_value %s" % str(meta_value))
         # if no meta data value could be determined just return a copy
         # of the original options
@@ -472,7 +470,7 @@ class RemoveValueFilter(Filter):
                 data_ref = other_values.get(self.meta_ref)
                 if isinstance(data_ref, HistoryDatasetCollectionAssociation):
                     data_ref = data_ref.to_hda_representative()
-                if not isinstance(data_ref, HistoryDatasetAssociation) and not isinstance(data_ref, galaxy.tools.wrappers.DatasetFilenameWrapper):
+                if not isinstance(data_ref, HistoryDatasetAssociation) and not isinstance(data_ref, DatasetFilenameWrapper):
                     return options  # cannot modify options
                 value = data_ref.metadata.get(self.metadata_key, None)
         # Default to the second column (i.e. 1) since this used to work only on options produced by the data_meta filter
@@ -734,3 +732,20 @@ class DynamicOptions:
             return self.columns[column_spec]
         # Int?
         return int(column_spec)
+
+
+def _get_ref_data(other_values, ref_name):
+    """
+    get the list of data sets from ref_name 
+    
+    - a KeyError is raised if no such element exists
+    - a ValueError is raised if the element is not of the type DatasetFilenameWrapper, HistoryDatasetAssociation, DatasetListWrapper, or HistoryDatasetCollectionAssociation
+    """
+    ref = other_values[ref_name]
+    if not isinstance(ref, (DatasetFilenameWrapper, HistoryDatasetAssociation, DatasetListWrapper, HistoryDatasetCollectionAssociation)):
+        raise ValueError
+    if isinstance(ref, (DatasetFilenameWrapper, HistoryDatasetAssociation)):
+        ref = [ref]
+    elif isinstance(ref, HistoryDatasetCollectionAssociation):
+        ref = ref.to_hda_representative(multiple=True)
+    return ref

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -164,7 +164,7 @@ class DataMetaFilter(Filter):
             else:
                 meta_value.add(m)
         def compare_meta_value(file_value, dataset_value):
-            if isinstance(dataset_value, list):
+            if isinstance(dataset_value, set):
                 if self.multiple:
                     file_value = file_value.split(self.separator)
                     for value in dataset_value:

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -3,8 +3,8 @@ Support for generating the options for a SelectToolParameter dynamically (based
 on the values of other parameters or other aspects of the current state)
 """
 import copy
-from collections import OrderedDict
 import logging
+from collections import OrderedDict
 import os
 import re
 from io import StringIO

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -172,7 +172,7 @@ class DataMetaFilter(Filter):
             return file_value == dataset_value
         ref = other_values.get(self.ref_name, None)
         if isinstance(ref, HistoryDatasetCollectionAssociation):
-            ref = ref.to_hda_representative(multiple = True)
+            ref = ref.to_hda_representative(multiple=True)
         is_data = isinstance(ref, galaxy.tools.wrappers.DatasetFilenameWrapper)
         is_data_list = isinstance(ref, galaxy.tools.wrappers.DatasetListWrapper) or isinstance(ref, list)
         is_data_or_data_list = is_data or is_data_list
@@ -180,21 +180,20 @@ class DataMetaFilter(Filter):
             return []  # not a valid dataset
 
         # get the metadata value.
-        # - for lists: (of data sets) and collections the unique meta data
-        #   value of all elements is determined (None if they are not unique)
+        # - for lists: (of data sets) and collections the meta data values of all
+        #   elements is determined
         # - for data sets: the meta data value
         # in both cases only meta data that is set (i.e. differs from the no_value)
         # is considered
         meta_value = None
         if is_data_list:
-            meta_value_set = set([ _.metadata.get(self.key, None) for _ in ref if _.metadata.element_is_set(self.key) ])
+            meta_value_set = set([_.metadata.get(self.key, None) for _ in ref if _.metadata.element_is_set(self.key)])
             meta_value_set.discard(None)
-            if len(meta_value_set) == 1:
-                meta_value = meta_value_set.pop()
+            if len(meta_value_set) > 0:
+                meta_value = list(meta_value_set)
         else:
             if ref.metadata.element_is_set(self.key):
-                meta_value = ref.metadata.get(self.key, None)
-
+                meta_value = [ref.metadata.get(self.key, None)]
         # if no meta data value could be determined just return a copy
         # of the original options
         if meta_value is None:

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -165,8 +165,8 @@ class DataMetaFilter(Filter):
         def _add_meta(meta_value, m):
             if isinstance(m, list):
                 meta_value |= set(m)
-            elif isinstance(m, dict) or isinstance(m, OrderedDict):
-                meta_value |= set(["%s,%s" % (k, v) for k, v in m.iteritems()])
+            elif isinstance(m, dict):
+                meta_value |= set(["%s,%s" % (k, v) for k, v in m.items()])
             elif isinstance(m, str) and os.path.isfile(m):
                 with open(m) as fh:
                     for line in fh:

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -4,10 +4,10 @@ on the values of other parameters or other aspects of the current state)
 """
 import copy
 import logging
-from collections import OrderedDict
 import os
 import re
 from io import StringIO
+from collections import OrderedDict
 
 from galaxy.model import (
     HistoryDatasetAssociation,

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -2,6 +2,7 @@
 Support for generating the options for a SelectToolParameter dynamically (based
 on the values of other parameters or other aspects of the current state)
 """
+from collections import OrderedDict
 import copy
 import logging
 import os
@@ -158,11 +159,14 @@ class DataMetaFilter(Filter):
         return self.ref_name
 
     def filter_options(self, options, trans, other_values):
-        def _add_meta( meta_value, m ):
+        def _add_meta(meta_value, m):
             if isinstance(m, list):
                 meta_value |= set(m)
+            elif isinstance(m, dict) or isinstance(m, OrderedDict):
+                meta_value |= set([ "%s,%s" %(k, v) for k, v in m.iteritems() ])
             else:
                 meta_value.add(m)
+
         def compare_meta_value(file_value, dataset_value):
             if isinstance(dataset_value, set):
                 if self.multiple:
@@ -199,6 +203,7 @@ class DataMetaFilter(Filter):
         else:
             if ref.metadata.element_is_set(self.key):
                 _add_meta(meta_value, ref.metadata.get(self.key))
+        log.error("meta_value %s" % str(meta_value))
         # if no meta data value could be determined just return a copy
         # of the original options
         if len(meta_value) == 0:

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -2,9 +2,9 @@
 Support for generating the options for a SelectToolParameter dynamically (based
 on the values of other parameters or other aspects of the current state)
 """
+from collections import OrderedDict
 import copy
 import logging
-from collections import OrderedDict
 import os
 import re
 from io import StringIO
@@ -195,7 +195,6 @@ class DataMetaFilter(Filter):
         except ValueError:  # not a valid dataset
             log.warn("could not filter by metadata: %s not a data or collection parameter" % self.ref_name)
             return []
-
         # get the metadata value.
         # - for lists: (of data sets) and collections the meta data values of all
         #   elements is determined
@@ -748,8 +747,7 @@ class DynamicOptions:
 
 def _get_ref_data(other_values, ref_name):
     """
-    get the list of data sets from ref_name 
-    
+    get the list of data sets from ref_name
     - a KeyError is raised if no such element exists
     - a ValueError is raised if the element is not of the type DatasetFilenameWrapper, HistoryDatasetAssociation, DatasetListWrapper, HistoryDatasetCollectionAssociation, list
     """

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -190,8 +190,10 @@ class DataMetaFilter(Filter):
         try:
             ref = _get_ref_data(other_values, self.ref_name)
         except KeyError:  # no such dataset
+            log.warn("could not filter by metadata: %s unknown" % self.ref_name)
             return []
         except ValueError:  # not a valid dataset
+            log.warn("could not filter by metadata: %s not a data or collection parameter" % self.ref_name)
             return []
 
         # get the metadata value.
@@ -658,20 +660,30 @@ class DynamicOptions:
 
     def get_fields(self, trans, other_values):
         if self.dataset_ref_name:
-            dataset = other_values.get(self.dataset_ref_name, None)
-            if not dataset or not hasattr(dataset, 'file_name'):
-                return []  # no valid dataset in history
-            # Ensure parsing dynamic options does not consume more than a megabyte worth memory.
-            path = dataset.file_name
-            if os.path.getsize(path) < 1048576:
-                with open(path) as fh:
-                    options = self.parse_file_fields(fh)
-            else:
-                # Pass just the first megabyte to parse_file_fields.
-                log.warning("Attempting to load options from large file, reading just first megabyte")
-                with open(path) as fh:
-                    contents = fh.read(1048576)
-                options = self.parse_file_fields(StringIO(contents))
+            try:
+                datasets = _get_ref_data(other_values, self.dataset_ref_name)
+            except KeyError:  # no such dataset
+                log.warn("could not create dynamic options from_dataset: %s unknown" % self.dataset_ref_name)
+                return []
+            except ValueError:  # not a valid dataset
+                log.warn("could not create dynamic options from_dataset: %s not a data or collection parameter" % self.dataset_ref_name)
+                return []
+
+            options = []
+            for dataset in datasets:
+                if not hasattr(dataset, 'file_name'):
+                    continue
+                # Ensure parsing dynamic options does not consume more than a megabyte worth memory.
+                path = dataset.file_name
+                if os.path.getsize(path) < 1048576:
+                    with open(path) as fh:
+                        options += self.parse_file_fields(fh)
+                else:
+                    # Pass just the first megabyte to parse_file_fields.
+                    log.warning("Attempting to load options from large file, reading just first megabyte")
+                    with open(path, 'r') as fh:
+                        contents = fh.read(1048576)
+                    options += self.parse_file_fields(StringIO(contents))
         elif self.tool_data_table:
             options = self.tool_data_table.get_fields()
         elif self.file_fields:
@@ -739,10 +751,10 @@ def _get_ref_data(other_values, ref_name):
     get the list of data sets from ref_name 
     
     - a KeyError is raised if no such element exists
-    - a ValueError is raised if the element is not of the type DatasetFilenameWrapper, HistoryDatasetAssociation, DatasetListWrapper, or HistoryDatasetCollectionAssociation
+    - a ValueError is raised if the element is not of the type DatasetFilenameWrapper, HistoryDatasetAssociation, DatasetListWrapper, HistoryDatasetCollectionAssociation, list
     """
     ref = other_values[ref_name]
-    if not isinstance(ref, (DatasetFilenameWrapper, HistoryDatasetAssociation, DatasetListWrapper, HistoryDatasetCollectionAssociation)):
+    if not isinstance(ref, (DatasetFilenameWrapper, HistoryDatasetAssociation, DatasetListWrapper, HistoryDatasetCollectionAssociation, list)):
         raise ValueError
     if isinstance(ref, (DatasetFilenameWrapper, HistoryDatasetAssociation)):
         ref = [ref]

--- a/test/functional/tools/dbkey_filter_collection.xml
+++ b/test/functional/tools/dbkey_filter_collection.xml
@@ -1,24 +1,14 @@
 <tool id="dbkey_filter_collection_input" name="dbkey_filter_collection_input" version="0.1.0">
     <description>Filter select on dbkey of collection inputs</description>
     <command><![CDATA[
-        #for $input in $inputs#
-        cat $input >> $output;
-        #end for#
+        echo $index >> '$output'
     ]]>
     </command>
-    <!-- test paired and nested lists, lists with multiple=true -->
     <inputs>
         <param format="txt" name="inputs" type="data_collection" collection_type="list" label="Inputs" help="" />
         <param name="index" type="select" label="Using reference genome">
           <options from_data_table="test_fasta_indexes">
             <filter type="data_meta" ref="inputs" key="dbkey" column="1" />
-            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
-          </options>
-        </param>
-        <param format="txt" name="inputs_paired" type="data_collection" collection_type="list:paired" label="Inputs" help="" />
-        <param name="index_multi" type="select" multiple="true" label="Using reference genome">
-          <options from_data_table="test_fasta_indexes">
-            <filter type="data_meta" ref="inputs_paired" key="dbkey" column="1" />
             <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
           </options>
         </param>
@@ -30,95 +20,61 @@
 
     <tests>
         <!-- note: in the following tests two different files are needed
-             because otherwise only the later dbkey is uses. apparently
-             the two data sets would be considered as the same data set -->
+             otherwise, if both collection elements refer to the same file
+             only a single history element is created (i.e. only one of the
+             dbkeys is available) -->
         <!-- can choose a dbkey if it matches input -->
         <test>
             <param name="inputs" >
                 <collection type="list">
                     <element name="e1" value="simple_line.txt" dbkey="hg19"/>
-                    <element name="e2" value="same_simple_line.txt" dbkey="hg19"/>
+                    <element name="e2" value="simple_line_alternative.txt" dbkey="hg19"/>
                 </collection>
             </param>
             <param name="index" value="hg19" />
-            <param name="inputs_paired" >
-                <collection type="list:paired">
-                    <element name="pair1">
-                        <collection type="paired">
-                            <element name="forward" value="simple_line.txt" dbkey="hg19"/>
-                            <element name="reverse" value="same_simple_line.txt" dbkey="hg19"/>
-                        </collection>
-                    </element>
-                </collection>
-            </param>
-            <param name="index_multi" value="hg19" />
-            <output name="output" file="simple_line_x2.txt"/>
+            <output name="output">
+                <assert_contents><has_text text="hg19" /></assert_contents>
+            </output>
         </test>
         <!-- can choose any dbkey if none specified in reference -->
         <test>
             <param name="inputs" >
                 <collection type="list">
                     <element name="e1" value="simple_line.txt"/>
-                    <element name="e2" value="same_simple_line.txt"/>
+                    <element name="e2" value="simple_line_alternative.txt"/>
                 </collection>
             </param>
-            <param name="index" value="hg19" />
-            <param name="inputs_paired" >
-                <collection type="list:paired">
-                    <element name="pair1">
-                        <collection type="paired">
-                            <element name="forward" value="simple_line.txt"/>
-                            <element name="reverse" value="same_simple_line.txt"/>
-                        </collection>
-                    </element>
-                </collection>
-            </param>
-            <param name="index_multi" value="hg18,hg19" />
-            <output name="output" file="simple_line_x2.txt"/>
+            <param name="index" value="hg18" />
+            <output name="output">
+                <assert_contents>
+                    <has_text text="hg18" /></assert_contents>
+            </output>
         </test>
         <!-- can choose any dbkey specified in reference -->
         <test>
             <param name="inputs" >
                 <collection type="list">
                     <element name="e1" value="simple_line.txt" dbkey="hg19"/>
-                    <element name="e2" value="same_simple_line.txt" dbkey="hg18"/>
+                    <element name="e2" value="simple_line_alternative.txt" dbkey="hg18"/>
                 </collection>
             </param>
             <param name="index" value="hg18" />
-            <param name="inputs_paired" >
-                <collection type="list:paired">
-                    <element name="pair1">
-                        <collection type="paired">
-                            <element name="forward" value="simple_line.txt" dbkey="hg19"/>
-                            <element name="reverse" value="same_simple_line.txt" dbkey="hg18"/>
-                        </collection>
-                    </element>
-                </collection>
-            </param>
-            <param name="index_multi" value="hg18,hg19" />
-            <output name="output" file="simple_line_x2.txt"/>
+            <output name="output">
+                <assert_contents><has_text text="hg18" /></assert_contents>
+            </output>
         </test>
         <!-- cant choose a dkkey different from reference -->
         <test expect_failure="true">
             <param name="inputs" >
                 <collection type="list">
                     <element name="e1" value="simple_line.txt" dbkey="hg19"/>
-                    <element name="e2" value="same_simple_line.txt" dbkey="hg19"/>
+                    <element name="e2" value="simple_line_alternative.txt" dbkey="hg19"/>
                 </collection>
             </param>
             <param name="index" value="hg18" />
-            <param name="inputs_paired" >
-                <collection type="list:paired">
-                    <element name="pair1">
-                        <collection type="paired">
-                            <element name="forward" value="simple_line.txt" dbkey="hg19"/>
-                            <element name="reverse" value="same_simple_line.txt" dbkey="hg19"/>
-                        </collection>
-                    </element>
-                </collection>
-            </param>
-            <param name="index_multi" value="hg18" />
-            <output name="output" file="simple_line_x2.txt"/>
+            <output name="output">
+                <assert_contents><not_has_text text="hg18" /></assert_contents>
+            </output>
         </test>
     </tests>
     <help>

--- a/test/functional/tools/dbkey_filter_collection.xml
+++ b/test/functional/tools/dbkey_filter_collection.xml
@@ -15,9 +15,10 @@
             <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
           </options>
         </param>
+        <param format="txt" name="inputs_paired" type="data_collection" collection_type="list:paired" label="Inputs" help="" />
         <param name="index_multi" type="select" multiple="true" label="Using reference genome">
           <options from_data_table="test_fasta_indexes">
-            <filter type="data_meta" ref="inputs" key="dbkey" column="1" />
+            <filter type="data_meta" ref="inputs_paired" key="dbkey" column="1" />
             <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
           </options>
         </param>
@@ -40,6 +41,16 @@
                 </collection>
             </param>
             <param name="index" value="hg19" />
+            <param name="inputs_paired" >
+                <collection type="list:paired">
+                    <element name="pair1">
+                        <collection type="paired">
+                            <element name="forward" value="simple_line.txt" dbkey="hg19"/>
+                            <element name="reverse" value="same_simple_line.txt" dbkey="hg19"/>
+                        </collection>
+                    </element>
+                </collection>
+            </param>
             <param name="index_multi" value="hg19" />
             <output name="output" file="simple_line_x2.txt"/>
         </test>
@@ -52,6 +63,16 @@
                 </collection>
             </param>
             <param name="index" value="hg19" />
+            <param name="inputs_paired" >
+                <collection type="list:paired">
+                    <element name="pair1">
+                        <collection type="paired">
+                            <element name="forward" value="simple_line.txt"/>
+                            <element name="reverse" value="same_simple_line.txt"/>
+                        </collection>
+                    </element>
+                </collection>
+            </param>
             <param name="index_multi" value="hg18,hg19" />
             <output name="output" file="simple_line_x2.txt"/>
         </test>
@@ -64,17 +85,16 @@
                 </collection>
             </param>
             <param name="index" value="hg18" />
-            <param name="index_multi" value="hg18,hg19" />
-            <output name="output" file="simple_line_x2.txt"/>
-        </test>
-        <test>
-            <param name="inputs" >
-                <collection type="list">
-                    <element name="e1" value="simple_line.txt" dbkey="hg19"/>
-                    <element name="e2" value="same_simple_line.txt" dbkey="hg18"/>
+            <param name="inputs_paired" >
+                <collection type="list:paired">
+                    <element name="pair1">
+                        <collection type="paired">
+                            <element name="forward" value="simple_line.txt" dbkey="hg19"/>
+                            <element name="reverse" value="same_simple_line.txt" dbkey="hg18"/>
+                        </collection>
+                    </element>
                 </collection>
             </param>
-            <param name="index" value="hg19" />
             <param name="index_multi" value="hg18,hg19" />
             <output name="output" file="simple_line_x2.txt"/>
         </test>
@@ -87,6 +107,16 @@
                 </collection>
             </param>
             <param name="index" value="hg18" />
+            <param name="inputs_paired" >
+                <collection type="list:paired">
+                    <element name="pair1">
+                        <collection type="paired">
+                            <element name="forward" value="simple_line.txt" dbkey="hg19"/>
+                            <element name="reverse" value="same_simple_line.txt" dbkey="hg19"/>
+                        </collection>
+                    </element>
+                </collection>
+            </param>
             <param name="index_multi" value="hg18" />
             <output name="output" file="simple_line_x2.txt"/>
         </test>

--- a/test/functional/tools/dbkey_filter_collection.xml
+++ b/test/functional/tools/dbkey_filter_collection.xml
@@ -1,5 +1,5 @@
-<tool id="dbkey_filter_collection_input" name="dbkey_filter_multi_input" version="0.1.0">
-    <description>Filter select on dbkey of multiple inputs</description>
+<tool id="dbkey_filter_collection_input" name="dbkey_filter_collection_input" version="0.1.0">
+    <description>Filter select on dbkey of collection inputs</description>
     <command><![CDATA[
         #for $input in $inputs#
         cat $input >> $output;
@@ -15,6 +15,12 @@
             <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
           </options>
         </param>
+        <param name="index_multi" type="select" multiple="true" label="Using reference genome">
+          <options from_data_table="test_fasta_indexes">
+            <filter type="data_meta" ref="inputs" key="dbkey" column="1" />
+            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+          </options>
+        </param>
     </inputs>
 
     <outputs>
@@ -22,47 +28,66 @@
     </outputs>
 
     <tests>
+        <!-- note: in the following tests two different files are needed
+             because otherwise only the later dbkey is uses. apparently
+             the two data sets would be considered as the same data set -->
         <!-- can choose a dbkey if it matches input -->
         <test>
             <param name="inputs" >
-                <collection type="paired">
+                <collection type="list">
                     <element name="e1" value="simple_line.txt" dbkey="hg19"/>
-                    <element name="e2" value="simple_line.txt" dbkey="hg19"/>
+                    <element name="e2" value="same_simple_line.txt" dbkey="hg19"/>
                 </collection>
             </param>
             <param name="index" value="hg19" />
+            <param name="index_multi" value="hg19" />
             <output name="output" file="simple_line_x2.txt"/>
         </test>
         <!-- can choose any dbkey if none specified in reference -->
         <test>
             <param name="inputs" >
-                <collection type="paired">
+                <collection type="list">
                     <element name="e1" value="simple_line.txt"/>
-                    <element name="e2" value="simple_line.txt"/>
+                    <element name="e2" value="same_simple_line.txt"/>
                 </collection>
             </param>
             <param name="index" value="hg19" />
+            <param name="index_multi" value="hg18,hg19" />
             <output name="output" file="simple_line_x2.txt"/>
         </test>
         <!-- can choose any dbkey specified in reference -->
         <test>
             <param name="inputs" >
-                <collection type="paired">
-                    <element name="e1" value="simple_line.txt" dbkey="hg18"/>
-                    <element name="e2" value="simple_line.txt" dbkey="hg19"/>
+                <collection type="list">
+                    <element name="e1" value="simple_line.txt" dbkey="hg19"/>
+                    <element name="e2" value="same_simple_line.txt" dbkey="hg18"/>
                 </collection>
             </param>
             <param name="index" value="hg18" />
+            <param name="index_multi" value="hg18,hg19" />
             <output name="output" file="simple_line_x2.txt"/>
         </test>
         <test>
             <param name="inputs" >
-                <collection type="paired">
-                    <element name="e1" value="simple_line.txt" dbkey="hg18"/>
-                    <element name="e2" value="simple_line.txt" dbkey="hg19"/>
+                <collection type="list">
+                    <element name="e1" value="simple_line.txt" dbkey="hg19"/>
+                    <element name="e2" value="same_simple_line.txt" dbkey="hg18"/>
                 </collection>
             </param>
             <param name="index" value="hg19" />
+            <param name="index_multi" value="hg18,hg19" />
+            <output name="output" file="simple_line_x2.txt"/>
+        </test>
+        <!-- cant choose a dkkey different from reference -->
+        <test expect_failure="true">
+            <param name="inputs" >
+                <collection type="list">
+                    <element name="e1" value="simple_line.txt" dbkey="hg19"/>
+                    <element name="e2" value="same_simple_line.txt" dbkey="hg19"/>
+                </collection>
+            </param>
+            <param name="index" value="hg18" />
+            <param name="index_multi" value="hg18" />
             <output name="output" file="simple_line_x2.txt"/>
         </test>
     </tests>

--- a/test/functional/tools/dbkey_filter_collection.xml
+++ b/test/functional/tools/dbkey_filter_collection.xml
@@ -1,0 +1,71 @@
+<tool id="dbkey_filter_collection_input" name="dbkey_filter_multi_input" version="0.1.0">
+    <description>Filter select on dbkey of multiple inputs</description>
+    <command><![CDATA[
+        #for $input in $inputs#
+        cat $input >> $output;
+        #end for#
+    ]]>
+    </command>
+    <!-- test paired and nested lists, lists with multiple=true -->
+    <inputs>
+        <param format="txt" name="inputs" type="data_collection" collection_type="list" label="Inputs" help="" />
+        <param name="index" type="select" label="Using reference genome">
+          <options from_data_table="test_fasta_indexes">
+            <filter type="data_meta" ref="inputs" key="dbkey" column="1" />
+            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+          </options>
+        </param>
+    </inputs>
+
+    <outputs>
+        <data format="txt" name="output" />
+    </outputs>
+
+    <tests>
+        <!-- can choose a dbkey if it matches input -->
+        <test>
+            <param name="inputs" >
+                <collection type="paired">
+                    <element name="e1" value="simple_line.txt" dbkey="hg19"/>
+                    <element name="e2" value="simple_line.txt" dbkey="hg19"/>
+                </collection>
+            </param>
+            <param name="index" value="hg19" />
+            <output name="output" file="simple_line_x2.txt"/>
+        </test>
+        <!-- can choose any dbkey if none specified in reference -->
+        <test>
+            <param name="inputs" >
+                <collection type="paired">
+                    <element name="e1" value="simple_line.txt"/>
+                    <element name="e2" value="simple_line.txt"/>
+                </collection>
+            </param>
+            <param name="index" value="hg19" />
+            <output name="output" file="simple_line_x2.txt"/>
+        </test>
+        <!-- can choose any dbkey specified in reference -->
+        <test>
+            <param name="inputs" >
+                <collection type="paired">
+                    <element name="e1" value="simple_line.txt" dbkey="hg18"/>
+                    <element name="e2" value="simple_line.txt" dbkey="hg19"/>
+                </collection>
+            </param>
+            <param name="index" value="hg18" />
+            <output name="output" file="simple_line_x2.txt"/>
+        </test>
+        <test>
+            <param name="inputs" >
+                <collection type="paired">
+                    <element name="e1" value="simple_line.txt" dbkey="hg18"/>
+                    <element name="e2" value="simple_line.txt" dbkey="hg19"/>
+                </collection>
+            </param>
+            <param name="index" value="hg19" />
+            <output name="output" file="simple_line_x2.txt"/>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/dbkey_filter_input.xml
+++ b/test/functional/tools/dbkey_filter_input.xml
@@ -22,15 +22,19 @@
         <test>
             <param name="inputs" value="simple_line.txt" dbkey="hg19" />
             <param name="index" value="hg19" />
-            <output name="output" file="simple_line.txt"/>
+            <output name="output" file="simple_line.txt" />
         </test>
-        <!-- cannot pick index otherwise -->
-        <!-- Does this make sense - if no dbkey is defined there is no option
-             available? -->
-        <test expect_failure="true">
+        <!-- choose any dbkey if not specified in reference -->
+        <test>
             <param name="inputs" value="simple_line.txt" />
-            <param name="index" value="hg18" />
-            <output name="output" file="simple_line.txt"/>
+            <param name="index" value="hg19" />
+            <output name="output" file="simple_line.txt" />
+        </test>
+        <!-- cant choose a dkkey different from reference -->
+        <test expect_failure="true">
+            <param name="inputs" value="simple_line.txt" dbkey="hg18" />
+            <param name="index" value="hg19" />
+            <output name="output" file="simple_line.txt" />
         </test>
     </tests>
 

--- a/test/functional/tools/dbkey_filter_multi_input.xml
+++ b/test/functional/tools/dbkey_filter_multi_input.xml
@@ -27,6 +27,18 @@
             <param name="index" value="hg19" />
             <output name="output" file="simple_line_x2.txt"/>
         </test>
+        <!-- can choose any dbkey if none specified in reference -->
+        <test>
+            <param name="inputs" value="simple_line.txt,simple_line.txt" />
+            <param name="index" value="hg19" />
+            <output name="output" file="simple_line_x2.txt"/>
+        </test>
+        <!-- can choose any dbkey none specified in reference -->
+        <test expect_failure="true">
+            <param name="inputs" value="simple_line.txt,simple_line.txt" dbkey="hg19"/>
+            <param name="index" value="hg18" />
+            <output name="output" file="simple_line_x2.txt"/>
+        </test>
     </tests>
 
     <help>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -44,6 +44,7 @@
   <tool file="inputs_as_json_profile.xml" />
   <tool file="inputs_as_json_with_paths.xml" />
   <tool file="filter_static_regexp.xml" />
+  <tool file="select_from_dataset.xml" />
   <tool file="dbkey_filter_input.xml" />
   <tool file="dbkey_filter_multi_input.xml" />
   <tool file="dbkey_filter_collection.xml" />

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -48,6 +48,7 @@
   <tool file="dbkey_filter_input.xml" />
   <tool file="dbkey_filter_multi_input.xml" />
   <tool file="dbkey_filter_collection.xml" />
+  <tool file="dbkey_filter_paired_collection.xml" />
   <tool file="dbkey_output_action.xml" />
   <tool file="composite_output.xml" />
   <tool file="composite_output_tests.xml" />

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -46,6 +46,7 @@
   <tool file="filter_static_regexp.xml" />
   <tool file="dbkey_filter_input.xml" />
   <tool file="dbkey_filter_multi_input.xml" />
+  <tool file="dbkey_filter_collection.xml" />
   <tool file="dbkey_output_action.xml" />
   <tool file="composite_output.xml" />
   <tool file="composite_output_tests.xml" />

--- a/test/functional/tools/select_from_dataset.xml
+++ b/test/functional/tools/select_from_dataset.xml
@@ -1,0 +1,64 @@
+<tool id="select_from_dataset" name="select_from_dataset" version="0.1.0">
+    <description>Create dynamic options from data sets</description>
+    <command><![CDATA[
+        echo select_single $select_single > '$output' && 
+        echo select_multiple $select_multiple >> '$output' &&
+        echo select_collection $select_collection >> '$output'
+    ]]></command>
+	<inputs>
+        <param name="single" type="data" format="tabular" label="single"/>
+        <param name="select_single" type="select" label="select_single">
+          <options from_dataset="single">
+              <column name="name" index="0"/>
+              <column name="value" index="0"/>
+              <validator type="no_options" message="No data is available in single" />
+          </options>
+        </param>
+        <param name="multiple" type="data" format="tabular" multiple="true" label="multiple"/>
+        <param name="select_multiple" type="select" multiple="true" label="select_multiple">
+          <options from_dataset="multiple">
+              <column name="name" index="0"/>
+              <column name="value" index="0"/>
+            <validator type="no_options" message="No data is available in single" />
+          </options>
+        </param>
+		<param name="collection" type="data_collection" format="tabular" collection_type="list" label="collection"/>
+        <param name="select_collection" type="select" multiple="true" label="select_collection">
+          <options from_dataset="collection">
+              <column name="name" index="0"/>
+              <column name="value" index="0"/>
+            <validator type="no_options" message="No data is available in single" />
+          </options>
+		</param>
+    </inputs>
+
+    <outputs>
+        <data format="txt" name="output" />
+    </outputs>
+
+    <tests>
+        <test>
+            <param name="single" value="1.tabular" />
+			<param name="select_single" value="chr10" />
+            <param name="multiple" value="1.tabular,2.tabular" />
+            <param name="select_multiple" value="chr10,7" />
+			<param name="collection">
+			    <collection type="list">
+					<element name="1" value="1.tabular" />
+					<element name="2" value="2.tabular" />
+                </collection>
+	        </param>
+			<param name="select_collection" value="chr10,7" />
+            <output name="output">
+                <assert_contents>
+                    <has_text text="select_single chr10" />    
+                    <has_text text="select_multiple chr10,7" />    
+                    <has_text text="select_collection chr10,7" />    
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+
+    <help>
+    </help>
+</tool>

--- a/test/unit/tools/test_select_parameters.py
+++ b/test/unit/tools/test_select_parameters.py
@@ -11,7 +11,7 @@ class SelectToolParameterTestCase(BaseParameterTestCase):
         try:
             self.param.from_json("42", self.trans, {"input_bam": model.HistoryDatasetAssociation()})
         except ValueError as err:
-            assert str(err) == "parameter 'my_name': an invalid option ('42') was selected (valid options: ?)"
+            assert str(err) == "parameter 'my_name': requires a value, but no legal values defined"
             return
         assert False
 


### PR DESCRIPTION
Dynamic options:

- allow creation dynamic options from data parameters with `multiple="true"` and collections see: 
https://github.com/galaxyproject/galaxy/blob/3cb9d3cc5a048fe12f498f1d5a9a02a62e69d86b/test/functional/tools/dbkey_filter_collection.xml

Metadata Filter: 

- Fixes the filter to the documented behavior: Previously the filter removed all options if no meta data was defined in the referred file (which apparently is also not good for using tools in workflows https://github.com/galaxyproject/tools-iuc/pull/2498). This was because the filter assumed a meta data value of `None` if the meta data is not set. Therefore this https://github.com/galaxyproject/galaxy/blob/8ac4dc65ab316763d01975bd1d1b10ca90ee1481/lib/galaxy/tools/parameters/dynamic_options.py\#L201 evaluated to True only for non-existent meta data keys (note that the old statement in this if block never worked). 
The check should be be against the value given in the no_value attribute of the filter
specification. 
	- For the implementation I used the element_is_set function which also just checked for the existence of the meta data. Now it does what the name suggests.
	- For lists and collections the filter depended on the multiple attribute of the filter if all elements were considered. Since this was not documented I changed it to always use all elements
- If the refrered datasets/collections have multipe meta data values set then all of these are allowed, i.e. the options must match at least one of these values. making `meta_value` a list also seems in line with the fact that `compare_meta_value` can process lists of meta data values.

For discussion: 

- I started implementing filtering on more complex metadata types (lists, dicts, files): https://github.com/galaxyproject/galaxy/blob/eca469a53a51bd8717e98636eab62173b02518a4/lib/galaxy/tools/parameters/dynamic_options.py#L166 Not sure if this is really useful as it is now-- in particular for files. I plan to implement `from_dataset_metadata` for selects .. then it might be useful. Maybe for now remove File metadata filtering
- It might be a good idea to deprecate or remove the metadata filtering implemented in RemoveValueFilter https://github.com/galaxyproject/galaxy/blob/eca469a53a51bd8717e98636eab62173b02518a4/lib/galaxy/tools/parameters/dynamic_options.py#L474

More ideas:

- I would suggest to remove/deprecate the `multiple` (and `separator`) attributes [have they ever been used]. Reason: One _should_ be able to achieve the same in combination with the `multiple_splitter` filter.