### PR TITLE
[19.05] Capture missing log messages

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -88,18 +88,13 @@ PATH_LIST_DEFAULTS = dict(
 )
 
 LOGGING_CONFIG_DEFAULT = {
+    'disable_existing_loggers': False,
     'version': 1,
     'root': {
         'handlers': ['console'],
-        'level': 'INFO',
+        'level': 'DEBUG',
     },
     'loggers': {
-        'galaxy': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': 0,
-            'qualname': 'galaxy',
-        },
         'paste.httpserver.ThreadPool': {
             'level': 'WARN',
             'qualname': 'paste.httpserver.ThreadPool',


### PR DESCRIPTION
While trying to fix another issue I discovered that some messages from certain modules were not being logged, no matter what level the message's level. Non-`galaxy.*` modules (e.g. `tool_shed.*`, `pulsar.*`) were falling to the `root` logger config, which was not defaulting to `DEBUG` nor honoring the value of `log_level` in the Galaxy config.

Rather than add `tool_shed`, `pulsar`, and whatever other packages we end up with to the logging config, it made more sense to drop the `galaxy` logger altogether and properly configure the `root` logger. This meant that the default of `disable_existing_loggers` had to be changed to not disable - otherwise, any `logging.getLogger(__name__)` calls that happened before logging configuration (so most of them) would ultimately be disabled (aka messages silently dropped).

As all sorts of packages will now be logging at `DEBUG` level, we may need to make some adjustments as we've already done for Paste and Routes. But this seems better than a ton of messages being lost at the `DEBUG` level.

The release notes for 19.09 should probably mention that anyone running a custom dict logging config should update accordingly.