### PR TITLE
[19.09] Fix autocreation of shed_*_conf.xml

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -231,8 +231,28 @@
     Tool config files, defines what tools are available in Galaxy.
     Tools can be locally developed or installed from Galaxy tool
     sheds. (config/tool_conf.xml.sample will be used if left unset and
-    config/tool_conf.xml does not exist).
-:Default: ``config/tool_conf.xml,config/shed_tool_conf.xml``
+    config/tool_conf.xml does not exist). Can be a single file, a list
+    of files, or (for backwards compatibility) a comma-separated list
+    of files.
+:Default: ``config/tool_conf.xml``
+:Type: list or str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~
+``shed_tool_config_file``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Tool config file for tools installed from the Galaxy Tool Shed.
+    Must be writable by Galaxy and generally should not be edited by
+    hand. In older Galaxy releases, this file was part of the
+    tool_config_file option. It is still possible to specify this file
+    (and other shed-enabled tool config files) in tool_config_file,
+    but in the standard case of a single shed-enabled tool config,
+    this option is preferable. This file will be created automatically
+    upon tool installation, whereas Galaxy will fail to start if any
+    files in tool_config_file cannot be read.
+:Default: ``config/shed_tool_conf.xml``
 :Type: str
 
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -181,6 +181,7 @@ class BaseAppConfiguration(object):
             paths = []
             if config_kwargs.get(var, None) is not None:
                 paths = listify(config_kwargs.get(var))
+                setattr(self, var + '_set', True)
             else:
                 for value in values:
                     for path in listify(value):
@@ -191,6 +192,7 @@ class BaseAppConfiguration(object):
                         break
                 else:
                     paths = listify(values[-1])
+                setattr(self, var + '_set', False)
             setattr(self, var, [resolve_path(x, self.root) for x in paths])
 
 
@@ -204,12 +206,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
         self._set_config_base(kwargs)
         self._set_reloadable_properties(kwargs)
-
-        # Configs no longer read from samples
-        self.migrated_tools_config = resolve_path(kwargs.get('migrated_tools_conf', 'migrated_tools_conf.xml'), self.mutable_config_dir)
-        self.shed_tool_conf = resolve_path(kwargs.get('shed_tool_conf', 'shed_tool_conf.xml'), self.mutable_config_dir)
-        for name in ('migrated_tools_config', 'shed_tool_conf'):
-            setattr(self, name + '_set', kwargs.get(name, None) is not None)
 
         # Resolve paths of other config files
         self.parse_config_file_options(kwargs)
@@ -272,8 +268,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.oidc_config = kwargs.get("oidc_config_file", self.oidc_config_file)
         self.oidc_backends_config = kwargs.get("oidc_backends_config_file", self.oidc_backends_config_file)
         self.oidc = []
-        # The value of migrated_tools_config is the file reserved for containing only those tools that have been eliminated from the distribution
-        # and moved to the tool shed. It is created on demand.
         self.integrated_tool_panel_config = resolve_path(kwargs.get('integrated_tool_panel_config', 'integrated_tool_panel.xml'), self.mutable_config_dir)
         integrated_tool_panel_tracking_directory = kwargs.get('integrated_tool_panel_tracking_directory', None)
         if integrated_tool_panel_tracking_directory:
@@ -853,6 +847,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             oidc_backends_config_file=[self._in_config_dir('oidc_backends_config.yml')],
             oidc_config_file=[self._in_config_dir('oidc_config.yml')],
             shed_data_manager_config_file=[self._in_mutable_config_dir('shed_data_manager_conf.xml')],
+            shed_tool_config_file=[self._in_mutable_config_dir('shed_tool_conf.xml')],
             shed_tool_data_table_config=[self._in_mutable_config_dir('shed_tool_data_table_conf.xml')],
             tool_destinations_config_file=[self._in_config_dir('tool_destinations.yml')],
             tool_sheds_config_file=[self._in_config_dir('tool_sheds_conf.xml')],
@@ -860,43 +855,16 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             workflow_resource_params_file=[self._in_config_dir('workflow_resource_params_conf.xml')],
             workflow_schedulers_config_file=[self._in_config_dir('config/workflow_schedulers_conf.xml')],
         )
-        if running_from_source:
-            listify_defaults = {
-                'tool_data_table_config_path': ['config/tool_data_table_conf.xml',
-                                                'tool_data_table_conf.xml',
-                                                'lib/galaxy/config/sample/tool_data_table_conf.xml.sample'],
-                # rationale:
-                # [0]: user has explicitly created config/tool_conf.xml but did not
-                #      move their existing shed_tool_conf.xml, don't use
-                #      config/shed_tool_conf.xml, which is probably the empty
-                #      version copied from the sample, or else their shed tools
-                #      will disappear
-                # [1]: user has created config/tool_conf.xml and, having passed
-                #      [0], probably moved their shed_tool_conf.xml as well
-                # [2]: user has done nothing, use the old files
-                # [3]: fresh install (shed_tool_conf will be added later)
-                'tool_config_file': ['config/tool_conf.xml,shed_tool_conf.xml',
-                                     'config/tool_conf.xml,config/shed_tool_conf.xml',
-                                     'tool_conf.xml,shed_tool_conf.xml',
-                                     'lib/galaxy/config/sample/tool_conf.xml.sample']
-            }
-        else:
-            listify_defaults = {
-                'tool_data_table_config_path': [
-                    self._in_config_dir('tool_data_table_conf.xml'),
-                    self._in_sample_dir('tool_data_table_conf.xml.sample')],
-                'tool_config_file': [
-                    self._in_config_dir('tool_conf.xml'),
-                    self._in_sample_dir('tool_conf.xml.sample')]
-            }
+        listify_defaults = {
+            'tool_data_table_config_path': [
+                self._in_config_dir('tool_data_table_conf.xml'),
+                self._in_sample_dir('tool_data_table_conf.xml.sample')],
+            'tool_config_file': [
+                self._in_config_dir('tool_conf.xml'),
+                self._in_sample_dir('tool_conf.xml.sample')]
+        }
 
         self._parse_config_file_options(defaults, listify_defaults, kwargs)
-
-        # If the user has configured a shed tool config in tool_config_file
-        # this would add a second, but since we're not parsing them yet we
-        # don't know if that's the case.
-        if not running_from_source and self.shed_tool_conf not in self.tool_config_file:
-            self.tool_config_file.append(self.shed_tool_conf)
 
         # Backwards compatibility for names used in too many places to fix
         self.datatypes_config = self.datatypes_config_file
@@ -948,10 +916,8 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             self._ensure_directory(path)
         # Check that required files exist
         tool_configs = self.tool_configs
-        if self.migrated_tools_config not in tool_configs and os.path.exists(self.migrated_tools_config):
-            tool_configs.append(self.migrated_tools_config)
         for path in tool_configs:
-            if not os.path.exists(path) and path != self.shed_tool_conf:
+            if not os.path.exists(path) and path not in (self.shed_tool_config_file, self.migrated_tools_config):
                 raise ConfigurationError("Tool config file not found: %s" % path)
         for datatypes_config in listify(self.datatypes_config):
             if not os.path.isfile(datatypes_config):
@@ -1112,12 +1078,15 @@ class ConfiguresGalaxyMixin(object):
 
     def wait_for_toolbox_reload(self, old_toolbox):
         timer = ExecutionTimer()
-        while True:
-            # Wait till toolbox reload has been triggered
-            # (or more than 60 seconds have passed)
-            if self.toolbox.has_reloaded(old_toolbox) or timer.elapsed > 60:
+        log.debug('Waiting for toolbox reload')
+        # Wait till toolbox reload has been triggered (or more than 60 seconds have passed)
+        while timer.elapsed < 60:
+            if self.toolbox.has_reloaded(old_toolbox):
+                log.debug('Finished waiting for toolbox reload %s', timer)
                 break
             time.sleep(0.1)
+        else:
+            log.warning('Waiting for toolbox reload timed out after 60 seconds')
 
     def _configure_toolbox(self):
         from galaxy import tools
@@ -1131,9 +1100,26 @@ class ConfiguresGalaxyMixin(object):
         from galaxy.managers.tools import DynamicToolManager
         self.dynamic_tools_manager = DynamicToolManager(self)
         self._toolbox_lock = threading.RLock()
-        # Initialize the tools, making sure the list of tool configs includes the reserved migrated_tools_conf.xml file.
+        # Initialize the tools, making sure the list of tool configs includes automatically generated dynamic
+        # (shed-enabled) tool configs, which are created on demand.
         tool_configs = self.config.tool_configs
-        if self.config.migrated_tools_config not in tool_configs:
+        # If the user has configured a shed tool config in tool_config_file this would add a second, but since we're not
+        # parsing them yet we don't know if that's the case. We'll assume that the standard shed_tool_conf.xml location
+        # is in use, and warn if we suspect there to be problems.
+        if self.config.shed_tool_config_file not in tool_configs:
+            # This seems like the likely case for problems in older deployments
+            if self.config.tool_config_file_set and not self.config.shed_tool_config_file_set:
+                log.warning(
+                    "The default shed tool config file (%s) has been added to the tool_config_file option, if this is "
+                    "not the desired behavior, please set shed_tool_config_file to your primary shed-enabled tool "
+                    "config file"
+                )
+            tool_configs.append(self.config.shed_tool_config_file)
+        # The value of migrated_tools_config is the file reserved for containing only those tools that have been
+        # eliminated from the distribution and moved to the tool shed. If migration checking is disabled, only add it if
+        # it exists (since this may be an existing deployment where migrations were previously run).
+        if ((self.config.check_migrate_tools or os.path.exists(self.config.migrated_tools_config))
+                and self.config.migrated_tools_config not in tool_configs):
             tool_configs.append(self.config.migrated_tools_config)
         self.toolbox = tools.ToolBox(tool_configs, self.config.tool_path, self)
         galaxy_root_dir = os.path.abspath(self.config.root)

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -197,8 +197,21 @@ galaxy:
   # Tool config files, defines what tools are available in Galaxy. Tools
   # can be locally developed or installed from Galaxy tool sheds.
   # (config/tool_conf.xml.sample will be used if left unset and
-  # config/tool_conf.xml does not exist).
-  #tool_config_file: config/tool_conf.xml,config/shed_tool_conf.xml
+  # config/tool_conf.xml does not exist). Can be a single file, a list
+  # of files, or (for backwards compatibility) a comma-separated list of
+  # files.
+  #tool_config_file: config/tool_conf.xml
+
+  # Tool config file for tools installed from the Galaxy Tool Shed. Must
+  # be writable by Galaxy and generally should not be edited by hand. In
+  # older Galaxy releases, this file was part of the tool_config_file
+  # option. It is still possible to specify this file (and other shed-
+  # enabled tool config files) in tool_config_file, but in the standard
+  # case of a single shed-enabled tool config, this option is
+  # preferable. This file will be created automatically upon tool
+  # installation, whereas Galaxy will fail to start if any files in
+  # tool_config_file cannot be read.
+  #shed_tool_config_file: config/shed_tool_conf.xml
 
   # Enable / disable checking if any tools defined in the above non-shed
   # tool_config_files (i.e., tool_conf.xml) have been migrated from the

--- a/lib/galaxy/config_watchers.py
+++ b/lib/galaxy/config_watchers.py
@@ -117,9 +117,6 @@ class ConfigWatchers(object):
         tool_config_paths = []
         if hasattr(self.app.config, 'tool_configs'):
             tool_config_paths = self.app.config.tool_configs
-        if hasattr(self.app.config, 'migrated_tools_config'):
-            if self.app.config.migrated_tools_config not in tool_config_paths:
-                tool_config_paths.append(self.app.config.migrated_tools_config)
         return tool_config_paths
 
     @property

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -178,8 +178,6 @@ def _get_new_toolbox(app):
     if hasattr(app, 'tool_shed_repository_cache'):
         app.tool_shed_repository_cache.rebuild()
     tool_configs = app.config.tool_configs
-    if app.config.migrated_tools_config not in tool_configs:
-        tool_configs.append(app.config.migrated_tools_config)
 
     new_toolbox = tools.ToolBox(tool_configs, app.config.tool_path, app)
     new_toolbox.data_manager_tools = app.toolbox.data_manager_tools

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -115,7 +115,12 @@ class ToolConfWatcher(object):
                         else:
                             continue
                     new_mod_time = os.path.getmtime(path)
-                    if new_mod_time > mod_time:
+                    # mod_time can be None if a non-required config was just created
+                    if not mod_time:
+                        self.paths[path] = new_mod_time
+                        log.debug("The file '%s' has been created.", path)
+                        do_reload = True
+                    elif new_mod_time > mod_time:
                         new_hash = md5_hash_file(path)
                         if hashes[path] != new_hash:
                             self.paths[path] = new_mod_time

--- a/lib/galaxy/util/tool_shed/xml_util.py
+++ b/lib/galaxy/util/tool_shed/xml_util.py
@@ -76,10 +76,10 @@ def create_element(tag, attributes=None, sub_elements=None):
     return None
 
 
-def parse_xml(file_name):
+def parse_xml(file_name, check_exists=True):
     """Returns a parsed xml tree with comments intact."""
     error_message = ''
-    if not os.path.exists(file_name):
+    if check_exists and not os.path.exists(file_name):
         return None, "File does not exist %s" % str(file_name)
 
     with open(file_name, 'r') as fobj:

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -186,14 +186,30 @@ mapping:
           nodes that will run Galaxy jobs, unless using Pulsar.
 
       tool_config_file:
-        type: str
-        default: config/tool_conf.xml,config/shed_tool_conf.xml
+        type: list or str
+        default: config/tool_conf.xml
         required: false
         desc: |
           Tool config files, defines what tools are available in Galaxy.
           Tools can be locally developed or installed from Galaxy tool sheds.
           (config/tool_conf.xml.sample will be used if left unset and
-          config/tool_conf.xml does not exist).
+          config/tool_conf.xml does not exist). Can be a single file, a list of
+          files, or (for backwards compatibility) a comma-separated list of files.
+
+      shed_tool_config_file:
+        type: str
+        default: config/shed_tool_conf.xml
+        required: false
+        desc: |
+          Tool config file for tools installed from the Galaxy Tool Shed. Must
+          be writable by Galaxy and generally should not be edited by hand. In
+          older Galaxy releases, this file was part of the tool_config_file
+          option. It is still possible to specify this file (and other
+          shed-enabled tool config files) in tool_config_file, but in the
+          standard case of a single shed-enabled tool config, this option is
+          preferable. This file will be created automatically upon tool
+          installation, whereas Galaxy will fail to start if any files in
+          tool_config_file cannot be read.
 
       check_migrate_tools:
         type: bool

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -186,7 +186,7 @@ mapping:
           nodes that will run Galaxy jobs, unless using Pulsar.
 
       tool_config_file:
-        type: list or str
+        type: any
         default: config/tool_conf.xml
         required: false
         desc: |

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -1129,6 +1129,8 @@ class AdminToolshed(AdminGalaxy):
         install_repository_dependencies = CheckboxField.is_checked(kwd.get('install_repository_dependencies', ''))
         install_tool_dependencies = CheckboxField.is_checked(kwd.get('install_tool_dependencies', ''))
         install_resolver_dependencies = CheckboxField.is_checked(kwd.get('install_resolver_dependencies', ''))
+        if not suc.have_shed_tool_conf_for_install(trans.app):
+            raise Exception("No valid shed tool configuration file available, please configure one")
         shed_tool_conf, tool_path, relative_install_dir = \
             suc.get_tool_panel_config_tool_path_install_dir(trans.app, tool_shed_repository)
         repository_clone_url = common_util.generate_clone_url_for_installed_repository(trans.app, tool_shed_repository)

--- a/lib/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/installed_repository_manager.py
@@ -40,8 +40,6 @@ class InstalledRepositoryManager(object):
         self.install_model = self.app.install_model
         self.context = self.install_model.context
         self.tool_configs = self.app.config.tool_configs
-        if self.app.config.migrated_tools_config not in self.tool_configs:
-            self.tool_configs.append(self.app.config.migrated_tools_config)
 
         self.tool_trees = []
         for tool_config in self.tool_configs:

--- a/lib/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/data_manager.py
@@ -59,7 +59,7 @@ class DataManagerHandler(object):
                 repository_tools_by_guid[tool_tup[1]] = dict(tool_config_filename=tool_tup[0], tool=tool_tup[2])
             # Load existing data managers.
             try:
-                tree, error_message = xml_util.parse_xml(shed_data_manager_conf_filename)
+                tree, error_message = xml_util.parse_xml(shed_data_manager_conf_filename, check_exists=False)
             except (OSError, IOError) as exc:
                 if exc.errno == errno.ENOENT:
                     with open(shed_data_manager_conf_filename, 'w') as fh:

--- a/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -32,14 +32,18 @@ class ToolPanelManager(object):
         shed_tool_conf = shed_tool_conf_dict['config_filename']
         tool_path = shed_tool_conf_dict['tool_path']
         config_elems = []
+        # Ideally shed_tool_conf.xml would be created before the repo is cloned and added to the DB, but this is called
+        # from too many places to make it feasible at this time
         try:
-            tree, error_message = xml_util.parse_xml(shed_tool_conf)
+            tree, error_message = xml_util.parse_xml(shed_tool_conf, check_exists=False)
         except (OSError, IOError) as exc:
             if (exc.errno == errno.ENOENT and shed_tool_conf_dict.get('create', None) is not None):
+                log.info('Creating shed tool config with default contents: %s', shed_tool_conf)
                 with open(shed_tool_conf, 'w') as fh:
                     fh.write(shed_tool_conf_dict['create'])
                 tree, error_message = xml_util.parse_xml(shed_tool_conf)
             else:
+                log.error('Unable to load shed tool config: %s', shed_tool_conf)
                 raise
         if tree:
             root = tree.getroot()
@@ -51,6 +55,8 @@ class ToolPanelManager(object):
             # Persist the altered shed_tool_config file.
             self.config_elems_to_xml_file(config_elems, shed_tool_conf, tool_path)
             self.app.wait_for_toolbox_reload(old_toolbox)
+        else:
+            log.error(error_message)
 
     def add_to_tool_panel(self, repository_name, repository_clone_url, changeset_revision, repository_tools_tups, owner,
                           shed_tool_conf, tool_panel_dict, new_install=True, tool_panel_section_mapping={}):


### PR DESCRIPTION
Also stop checking `cwd` for `galaxy.yml`.

Fixes #8484 

Opinions welcome on `shed_tool_config_file`. I think this was something @jmchilton and I discussed many years ago, and it was part of #921, but I sorta forgot about it. Rationale is in the release notes text below.

----

For the release notes:

# Tool configuration file handling changes
  
## Shed tool configuration file

There have been a few changes to the way that Galaxy loads tool panel configuration files (e.g. `tool_conf.xml` and `shed_tool_conf.xml`) that deployers should be aware of before upgrading.

A new configuration option named `shed_tool_config_file` has been added, with a default value of `config/shed_tool_conf.xml`, and that path has been removed from the default value of the `tool_config_file` option.  This new option makes it possible for Galaxy to create the shed tool configuration file (e.g.  `shed_tool_conf.xml`) file on demand and moves us one step closer to a Galaxy installation that does not need to be run from the root of its source directory.

If you make no changes to your configuration, you should not encounter any problems. However, if you are using a non-default path to your primary shed tool config file, you should modify these options to remove the path of your primary `shed_tool_conf.xml` from `tool_config_file` and set it in `shed_tool_config_file`. Although Galaxy will continue to operate properly if you do not make this change, failure to do so will result in a second shed tool panel config file being created and loaded at startup time.

Although an unusual configuration, if you have multiple shed tool config files, you can still load them in `tool_config_file`, just be sure that one of them is set in `shed_tool_config_file`.

Note that Galaxy will fail to start if any of the files specified in `tool_conf_file` cannot be read at startup, whereas it will only fail to start if the file specified in `shed_tool_config_file` cannot be created (if it does not already exist).

## Migrated tools configuration file

Galaxy contains a (now unused) system for automatically installing tools from the Tool Shed that had been migrated out of the Galaxy source code after the creation of the Tool Shed. Older deployments that used this system may have tools in the migrated tools config file, `config/migrated_tools_conf.xml.sample` (by default). As of this release, an empty `migrated_tools_conf.xml` file is not created by default for new installations, but will still be read if it is found at the default path. The path can be changed with the `migrated_tools_config` option, and you can force Galaxy to fail startup if the file is missing by adding it to the `tool_config_file` option.

# Configuration file path defaults

## Deprecated paths will no longer be searched

The default location for Galaxy's configuration files has been in the `config/` directory for many years, prior to which the default was the root of the Galaxy directory. As of this release, Galaxy will no longer look in the current directory for configuration files, so you will need to specify the path to `galaxy.yml` e.g. with `uwsgi --yaml /path/to/galaxy.yml`, `GALAXY_CONFIG_FILE=/path/to/galaxy.yml run.sh`, or similar means, if it is not in the default location.

## Default paths to additional configuration files

As of this release, all other configuration files (e.g. `datatypes_conf.xml`, `job_conf.xml`) are searched for in the same directory as `galaxy.yml`. Prior to this release, the default was in the `config/` directory of the current working directory at startup (which has always been, and for the time being continues to be, the root of the Galaxy source).  This means that you do not need to individually configure the paths to these files in `galaxy.yml` if you are storing them in non-default locations.
