### PR TITLE
python-ldap python3 update and documentation change

### DIFF
--- a/lib/galaxy/config/sample/auth_conf.xml.sample
+++ b/lib/galaxy/config/sample/auth_conf.xml.sample
@@ -102,8 +102,8 @@
             <!-- For Active Directory: -->
 <!--        <bind-user>{sAMAccountName}@dc1.example.com</bind-user>
             <bind-password>{password}</bind-password>
-            <auto-register-username>{sAMAccountName}</auto-register-username>
-            <auto-register-email>{mail}</auto-register-email>
+            <auto-register-username>{username}</auto-register-username>
+            <auto-register-email>{email}</auto-register-email>
             <auto-register-roles>{gidNumber}</auto-register-roles>
 -->
             <!-- For OpenLDAP: -->

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -10,7 +10,7 @@ statsd
 docker
 azure-storage==0.32.0
 # PyRods not in PyPI
-python-ldap==2.4.44
+python-ldap==3.2.0
 python-pam
 galaxycloudrunner
 


### PR DESCRIPTION
Fix Active Directory example and bump the version of `python-ldap` to 3.2.0 as this works on Python 3. Fixes #8615.