### PR TITLE
GitLab error reporting

### DIFF
--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -90,7 +90,7 @@ class GitLabPlugin(BaseGitPlugin):
 
                 # Find the repo inside the ToolShed
                 ts_repourl = self._get_gitrepo_from_ts(job, ts_url)
-                
+
                 # Remove .git from the repository URL if this was specified
                 if ts_repourl.endswith(".git"):
                     ts_repourl = ts_repourl[:-4]
@@ -146,7 +146,7 @@ class GitLabPlugin(BaseGitPlugin):
                         if gitlab_projecturl not in self.git_project_cache:
                             self.git_project_cache[gitlab_projecturl] = self.gitlab.projects.get(gitlab_urlencodedpath)
                         gl_project = self.git_project_cache[gitlab_projecturl]
-                        
+
                         # Submit issue to default project
                         self._create_issue(issue_cache_key, error_title, error_message, gl_project, gl_userid=gl_userid)
                 else:


### PR DESCRIPTION
*  Fix potential issues and add more logging for assigning a user to an issue. 
*  Fix a slight oversight on the if statements.
*  Removing `.git` extension from URL as python-gitlab can't create the issue if this is present
*  If a project on Gitlab is private or not accessible for the user whose token is being used, then default to the default repository. Possibly adding a comment that the original repository is not accessible. 