### PR TITLE
[19.09] Allow users to switch toolsheds if main toolshed is unavailable

### DIFF
--- a/client/galaxy/scripts/components/Toolshed/Categories.vue
+++ b/client/galaxy/scripts/components/Toolshed/Categories.vue
@@ -65,7 +65,7 @@ export default {
                 });
         },
         onCategory(category) {
-            this.$emit("onCategory", category);
+            this.$emit("onCategory", `category:${category}`);
         }
     }
 };

--- a/client/galaxy/scripts/components/Toolshed/Categories.vue
+++ b/client/galaxy/scripts/components/Toolshed/Categories.vue
@@ -65,7 +65,7 @@ export default {
                 });
         },
         onCategory(category) {
-            this.$emit("onCategory", `category:${category}`);
+            this.$emit("onCategory", `category:'${category}'`);
         }
     }
 };

--- a/client/galaxy/scripts/components/Toolshed/Index.vue
+++ b/client/galaxy/scripts/components/Toolshed/Index.vue
@@ -1,21 +1,21 @@
 <template>
     <div class="overflow-auto h-100 p-1" @scroll="onScroll">
+        <b-input
+            class="mb-3"
+            placeholder="search repositories"
+            v-model="queryInput"
+            @input="delayQuery"
+            @change="setQuery"
+        />
+        <serverselection
+            :toolshedUrl="toolshedUrl"
+            :toolshedUrls="toolshedUrls"
+            :total="total"
+            :loading="loading"
+            @onToolshed="setToolshed"
+        />
         <div v-if="error" class="alert alert-danger">{{ error }}</div>
         <div v-else>
-            <b-input
-                class="mb-3"
-                placeholder="search repositories"
-                v-model="queryInput"
-                @input="delayQuery"
-                @change="setQuery"
-            />
-            <serverselection
-                :toolshedUrl="toolshedUrl"
-                :toolshedUrls="toolshedUrls"
-                :total="total"
-                :loading="loading"
-                @onToolshed="setToolshed"
-            />
             <repositories
                 :query="query"
                 :scrolled="scrolled"
@@ -102,6 +102,7 @@ export default {
             this.query = this.queryInput = query;
         },
         setToolshed(url) {
+            this.error = null;
             this.toolshedUrl = url;
         },
         setTotal(total) {

--- a/lib/galaxy/webapps/galaxy/api/toolshed.py
+++ b/lib/galaxy/webapps/galaxy/api/toolshed.py
@@ -335,6 +335,9 @@ class ToolShedController(BaseAPIController):
                 pathspec.append(params.pop("id"))
             if "action" in params:
                 pathspec.append(params.pop("action"))
-            return json.loads(util.url_get(tool_shed_url, params=dict(params), pathspec=pathspec))
+            try:
+                return json.loads(util.url_get(tool_shed_url, params=dict(params), pathspec=pathspec))
+            except Exception as e:
+                raise MessageException("Invalid server response. %s." % str(e))
         else:
             raise MessageException("Invalid toolshed url.")


### PR DESCRIPTION
This PR allows users to switch to a different toolshed if the main toolshed is not available. It also improves the error message shown if a toolshed server is unavailable. Finally it adds the new `category` search option to category selections.