### PR TITLE
[19.09] Only schedule file watching if an observer exists

### DIFF
--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -162,10 +162,6 @@ class ToolWatcher(BaseWatcher):
         self.tool_dir_callbacks = {}
         self.monitored_dirs = {}
 
-    def monitor(self, dir):
-        if self.observer is not None:
-            self.observer.schedule(self.event_handler, dir, recursive=False)
-
     def watch_file(self, tool_file, tool_id):
         tool_file = os.path.abspath(tool_file)
         self.tool_file_ids[tool_file] = tool_id

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -163,7 +163,8 @@ class ToolWatcher(BaseWatcher):
         self.monitored_dirs = {}
 
     def monitor(self, dir):
-        self.observer.schedule(self.event_handler, dir, recursive=False)
+        if self.observer is not None:
+            self.observer.schedule(self.event_handler, dir, recursive=False)
 
     def watch_file(self, tool_file, tool_id):
         tool_file = os.path.abspath(tool_file)

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -166,12 +166,10 @@ class ToolWatcher(BaseWatcher):
         self.tool_file_ids[tool_file] = tool_id
         tool_dir = os.path.dirname(tool_file)
         if tool_dir not in self.monitored_dirs:
-            self.monitored_dirs[tool_dir] = tool_dir
             self.monitor(tool_dir)
 
     def watch_directory(self, tool_dir, callback):
         tool_dir = os.path.abspath(tool_dir)
         self.tool_dir_callbacks[tool_dir] = callback
         if tool_dir not in self.monitored_dirs:
-            self.monitored_dirs[tool_dir] = tool_dir
             self.monitor(tool_dir)

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -160,7 +160,6 @@ class ToolWatcher(BaseWatcher):
         self.toolbox = toolbox
         self.tool_file_ids = {}
         self.tool_dir_callbacks = {}
-        self.monitored_dirs = {}
 
     def watch_file(self, tool_file, tool_id):
         tool_file = os.path.abspath(tool_file)

--- a/lib/galaxy/util/watcher.py
+++ b/lib/galaxy/util/watcher.py
@@ -79,10 +79,10 @@ class BaseWatcher(object):
             self.observer.start()
             self.resume_watching()
 
-    def monitor(self, dir, recursive=False):
-        self.monitored_dirs[dir] = recursive
+    def monitor(self, dir_path, recursive=False):
+        self.monitored_dirs[dir_path] = recursive
         if self.observer is not None:
-            self.observer.schedule(self.event_handler, dir, recursive=recursive)
+            self.observer.schedule(self.event_handler, dir_path, recursive=recursive)
 
     def resume_watching(self):
         for dir_path, recursive in self.monitored_dirs.items():

--- a/lib/galaxy/util/watcher.py
+++ b/lib/galaxy/util/watcher.py
@@ -97,7 +97,8 @@ class Watcher(BaseWatcher):
         self.event_handler = event_handler_class(self)
 
     def monitor(self, dir, recursive=False):
-        self.observer.schedule(self.event_handler, dir, recursive=recursive)
+        if self.observer is not None:
+            self.observer.schedule(self.event_handler, dir, recursive=recursive)
 
     def watch_file(self, file_path, callback=None):
         file_path = os.path.abspath(file_path)


### PR DESCRIPTION
The observer may not exist if watching is turned off or if the current
thread is not the active watcher thread. This fixes
https://github.com/galaxyproject/planemo/issues/955