### PR TITLE
[WIP] Implement jobs_summary API for workflow invocations.

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -294,28 +294,101 @@ class JobSearch(object):
         return None
 
 
-def fetch_job_states(app, sa_session, job_source_ids, job_source_types):
-    decode = app.security.decode_id
+def invocation_job_source_iter(sa_session, invocation_id):
+    # TODO: Handle subworkflows.
+    join = model.WorkflowInvocationStep.table.join(
+        model.WorkflowInvocation
+    )
+    statement = select(
+        [model.WorkflowInvocationStep.job_id, model.WorkflowInvocationStep.implicit_collection_jobs_id]
+    ).select_from(
+        join
+    ).where(
+        model.WorkflowInvocation.id == invocation_id
+    )
+    for row in sa_session.execute(statement):
+        if row[0]:
+            yield ('Job', row[0])
+        if row[1]:
+            yield ('ImplicitCollectionJobs', row[1])
+
+
+def fetch_job_states(sa_session, job_source_ids, job_source_types):
     assert len(job_source_ids) == len(job_source_types)
     job_ids = set()
     implicit_collection_job_ids = set()
+    workflow_invocations_job_sources = {}
 
     for job_source_id, job_source_type in zip(job_source_ids, job_source_types):
         if job_source_type == "Job":
             job_ids.add(job_source_id)
         elif job_source_type == "ImplicitCollectionJobs":
             implicit_collection_job_ids.add(job_source_id)
+        elif job_source_type == "WorkflowInvocation":
+            workflow_invocation_job_sources = []
+            for (invocation_source_type, invocation_source_id) in invocation_job_source_iter(sa_session, job_source_id):
+                workflow_invocation_job_sources.append((invocation_source_type, invocation_source_id))
+                if invocation_source_type == "Job":
+                    job_ids.add(invocation_source_id)
+                elif invocation_source_type == "ImplicitCollectionJobs":
+                    implicit_collection_job_ids.add(invocation_source_id)
+            workflow_invocations_job_sources[job_source_id] = workflow_invocation_job_sources
         else:
             raise RequestParameterInvalidException("Invalid job source type %s found." % job_source_type)
 
-    # TODO: use above sets and optimize queries on second pass.
+    job_summaries = {}
+    implicit_collection_jobs_summaries = {}
+
+    for job_id in job_ids:
+        job_summaries[job_id] = summarize_jobs_to_dict(sa_session, sa_session.query(model.Job).get(job_id))
+    for implicit_collection_jobs_id in implicit_collection_job_ids:
+        implicit_collection_jobs_summaries[implicit_collection_jobs_id] = summarize_jobs_to_dict(sa_session, sa_session.query(model.ImplicitCollectionJobs).get(implicit_collection_jobs_id))
+
     rval = []
     for job_source_id, job_source_type in zip(job_source_ids, job_source_types):
         if job_source_type == "Job":
-            rval.append(summarize_jobs_to_dict(sa_session, sa_session.query(model.Job).get(decode(job_source_id))))
+            rval.append(job_summaries[job_source_id])
+        elif job_source_type == "ImplicitCollectionJobs":
+            rval.append(implicit_collection_jobs_summaries[job_source_id])
         else:
-            rval.append(summarize_jobs_to_dict(sa_session, sa_session.query(model.ImplicitCollectionJobs).get(decode(job_source_id))))
+            invocation_job_summaries = []
+            invocation_implicit_collection_job_summaries = []
+            for (invocation_job_source_type, invocation_job_source_id) in workflow_invocations_job_sources[job_source_id]:
+                if invocation_job_source_type == "Job":
+                    invocation_job_summaries.append(job_summaries[invocation_job_source_id])
+                else:
+                    invocation_implicit_collection_job_summaries.append(implicit_collection_jobs_summaries[invocation_job_source_id])
+            rval.append(summarize_invocation_jobs(job_source_id, invocation_job_summaries, invocation_implicit_collection_job_summaries))
+    return rval
 
+
+def summarize_invocation_jobs(invocation_id, job_summaries, implicit_collection_job_summaries):
+    states = {}
+    populated_state = "ok"
+
+    def merge_states(component_states):
+        for key, value in component_states.items():
+            if key not in states:
+                states[key] = value
+            else:
+                states[key] += value
+
+    for job_summary in job_summaries:
+        merge_states(job_summary["states"])
+    for implicit_collection_job_summary in implicit_collection_job_summaries:
+        merge_states(implicit_collection_job_summary["states"])
+        component_populated_state = implicit_collection_job_summary["populated_state"]
+        if component_populated_state == "failed":
+            populated_state = "failed"
+        elif component_populated_state == "new" and populated_state != "failed":
+            populated_state = "new"
+
+    rval = {
+        "id": invocation_id,
+        "model": "WorkflowInvocation",
+        "states": states,
+        "populated_state": populated_state,
+    }
     return rval
 
 

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -181,7 +181,7 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
     def index_jobs_summary(self, trans, history_id, **kwd):
         """
         * GET /api/histories/{history_id}/jobs_summary
-            return detailed information about an HDA or HDCAs jobs
+            return job state summary info for jobs, implicit groups jobs for collections or workflow invocations
 
         Warning: We allow anyone to fetch job state information about any object they
         can guess an encoded ID for - it isn't considered protected data. This keeps
@@ -189,13 +189,13 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
         efficient as possible.
 
         :type   history_id: str
-        :param  history_id: encoded id string of the HDA's or the HDCA's History
+        :param  history_id: encoded id string of the target history
         :type   ids:        str[]
         :param  ids:        the encoded ids of job summary objects to return - if ids
                             is specified types must also be specified and have same length.
         :type   types:      str[]
-        :param  types:      type of object represented by elements in the ids array - either
-                            Job or ImplicitCollectionJob.
+        :param  types:      type of object represented by elements in the ids array - any of
+                            Job, ImplicitCollectionJob, or WorkflowInvocation.
 
         :rtype:     dict[]
         :returns:   an array of job summary object dictionaries.
@@ -207,9 +207,9 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
             # TODO: ...
             pass
         else:
-            ids = util.listify(ids)
+            ids = [self.app.security.decode_id(i) for i in util.listify(ids)]
             types = util.listify(types)
-        return [self.encode_all_ids(trans, s) for s in fetch_job_states(self.app, trans.sa_session, ids, types)]
+        return [self.encode_all_ids(trans, s) for s in fetch_job_states(trans.sa_session, ids, types)]
 
     @expose_api_anonymous
     def show_jobs_summary(self, trans, id, history_id, **kwd):

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -566,6 +566,21 @@ def populate_api_routes(webapp, app):
         )
 
         webapp.mapper.connect(
+            'workflow_%s_jobs_summary' % name,
+            '/api/workflows/{workflow_id}/%s/{invocation_id}/jobs_summary' % noun,
+            controller='workflows',
+            action='invocation_jobs_summary',
+            conditions=dict(method=['GET'])
+        )
+        webapp.mapper.connect(
+            'workflow_%s_step_jobs_summary' % name,
+            '/api/workflows/{workflow_id}/%s/{invocation_id}/step_jobs_summary' % noun,
+            controller='workflows',
+            action='invocation_step_jobs_summary',
+            conditions=dict(method=['GET'])
+        )
+
+        webapp.mapper.connect(
             'workflow_%s_step' % name,
             '/api/workflows/{workflow_id}/%s/{invocation_id}/steps/{step_id}' % noun,
             controller='workflows',

--- a/test/api/test_workflows.py
+++ b/test/api/test_workflows.py
@@ -1527,6 +1527,30 @@ text_input:
             elements0 = elements[0]
             assert elements0["element_identifier"] == "el1"
 
+            self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
+
+            jobs_summary_response = self._get("workflows/%s/invocations/%s/jobs_summary" % (workflow_id, invocation_id))
+            self._assert_status_code_is(jobs_summary_response, 200)
+            jobs_summary = jobs_summary_response.json()
+            assert 'states' in jobs_summary
+
+            invocation_states = jobs_summary['states']
+            assert invocation_states and 'ok' in invocation_states, jobs_summary
+            assert invocation_states['ok'] == 2, jobs_summary
+            assert jobs_summary['model'] == 'WorkflowInvocation', jobs_summary
+
+            jobs_summary_response = self._get("workflows/%s/invocations/%s/step_jobs_summary" % (workflow_id, invocation_id))
+            self._assert_status_code_is(jobs_summary_response, 200)
+            jobs_summary = jobs_summary_response.json()
+            assert len(jobs_summary) == 1
+            collection_summary = jobs_summary[0]
+            assert 'states' in collection_summary
+
+            collection_states = collection_summary['states']
+            assert collection_states and 'ok' in collection_states, collection_states
+            assert collection_states['ok'] == 2, collection_summary
+            assert collection_summary['model'] == 'ImplicitCollectionJobs', collection_summary
+
     def test_workflow_run_input_mapping_with_subworkflows(self):
         with self.dataset_populator.test_history() as history_id:
             test_data = """


### PR DESCRIPTION
API backbone used to generate the progress bar for collections but applied to a workflow invocation. Should be helpful in quickly summarizing all the job states in a workflow invocation.

Much more well thought through alternative to the broken #7317 that now offers the ability to summarize across the invocation or summarize each step aggregating across all jobs in a step.

Future steps would be to extend this to work properly with subworkflows and to incorporate WorkflowInvocationStep ``state`` into ``populated_state`` info - since it can encode similar information about whether a step has been expanded yet or not mirroring what ``populated_state`` describes for collections.


