### PR TITLE
Hack around int default for float type in Galaxy schema.

### DIFF
--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -106,7 +106,7 @@ mapping:
           documentation is included here for completeness.
 
       slow_query_log_threshold:
-        type: float
+        type: any
         default: 0
         required: false
         desc: |


### PR DESCRIPTION
Causing dev branch CI tests to fail.