### PR TITLE
Modify schema defaults and their loading

### DIFF
--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -45,13 +45,15 @@ mapping:
 
       database_connection:
         type: str
-        default: sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE
         required: false
         desc: |
           By default, Galaxy uses a SQLite database at 'database/universe.sqlite'.  You
           may use a SQLAlchemy connection string to specify an external database
           instead.  This string takes many options which are explained in detail in the
           config file documentation.
+
+          Sample default 'sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE'
+          where './database' is the resolved default value of the 'data_dir' option).
 
       database_engine_option_pool_size:
         type: int
@@ -126,7 +128,6 @@ mapping:
 
       install_database_connection:
         type: str
-        default: sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE
         required: false
         desc: |
           By default, Galaxy will use the same database to track user data and
@@ -135,6 +136,9 @@ mapping:
           instances with pretested installs.  The following option can be used to
           separate the tool shed install database (all other options listed above
           but prefixed with install_ are also available).
+
+          Sample default 'sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE'
+          where './database' is the resolved default value of the 'data_dir' option).
 
       database_auto_migrate:
         type: bool
@@ -168,19 +172,25 @@ mapping:
 
       file_path:
         type: str
-        default: database/files
+        default: files
         required: false
         desc: |
-          Where dataset files are stored. It must accessible at the same path on any cluster
+          Where dataset files are stored. It must be accessible at the same path on any cluster
           nodes that will run Galaxy jobs, unless using Pulsar.
+
+          Default value will be resolved to 'database/files' where 'database' is the default value
+          of the 'data_dir' option).
 
       new_file_path:
         type: str
-        default: database/tmp
+        default: tmp
         required: false
         desc: |
-          Where temporary files are stored. It must accessible at the same path on any cluster
+          Where temporary files are stored. It must be accessible at the same path on any cluster
           nodes that will run Galaxy jobs, unless using Pulsar.
+
+          Default value will be resolved to 'database/tmp' where 'database' is the default value
+          of the 'data_dir' option).
 
       tool_config_file:
         type: any
@@ -221,12 +231,15 @@ mapping:
 
       migrated_tools_config:
         type: str
-        default: config/migrated_tools_conf.xml
+        default: migrated_tools_conf.xml
         required: false
         desc: |
           Tool config maintained by tool migration scripts.  If you use the migration
           scripts to install tools that have been migrated to the tool shed upon a new
           release, they will be added to this tool config file.
+
+          Default value will be resolved to 'config/migrated_tools_conf.xml' where 'config' is the
+          default value of the 'config_dir' option).
 
       integrated_tool_panel_config:
         type: str
@@ -249,7 +262,7 @@ mapping:
 
       tool_dependency_dir:
         type: str
-        default: database/dependencies
+        default: dependencies
         required: false
         desc: |
           Various dependency resolver configuration parameters will have defaults set relative
@@ -259,6 +272,9 @@ mapping:
           Set the string to None to explicitly disable tool dependency handling.
           If this option is set to none or an invalid path, installing tools with dependencies
           from the Tool Shed or in Conda will fail.
+
+          Default value will be resolved to 'database/dependencies' where 'database' is the default
+          value of the 'data_dir' option).
 
       dependency_resolvers_config_file:
         type: str
@@ -274,12 +290,13 @@ mapping:
 
       conda_prefix:
         type: str
-        default: <tool_dependency_dir>/_conda
         required: false
         desc: |
-          conda_prefix is the location on the filesystem where Conda packages and environments are installed
-          IMPORTANT: Due to a current limitation in conda, the total length of the
+          conda_prefix is the location on the filesystem where Conda packages and environments are
+          installed IMPORTANT: Due to a current limitation in conda, the total length of the
           conda_prefix and the job_working_directory path should be less than 50 characters!
+
+          Sample default '<tool_dependency_dir>/_conda'
 
       conda_exec:
         type: str
@@ -355,11 +372,12 @@ mapping:
 
       tool_dependency_cache_dir:
         type: str
-        default: <tool_dependency_dir>/_cache
         required: false
         desc: |
           By default the tool_dependency_cache_dir is the _cache directory
-          of the tool dependency directory
+          of the tool dependency directory.
+
+          Sample default '<tool_dependency_dir>/_cache'
 
       precache_dependencies:
         type: bool
@@ -464,10 +482,11 @@ mapping:
 
       mulled_channels:
         type: str
-        default: 'conda-forge,bioconda'
         required: false
         desc: |
           Conda channels to use when building Docker or Singularity containers using involucro.
+
+          Sample default 'conda-forge,bioconda'
 
       enable_tool_shed_check:
         type: bool
@@ -637,12 +656,15 @@ mapping:
 
       job_working_directory:
         type: str
-        default: database/jobs_directory
+        default: jobs_directory
         required: false
         desc: |
           Each job is given a unique empty directory as its current working directory.
           This option defines in what parent directory those directories will be
           created.
+
+          Default value will be resolved to 'database/jobs_directory' where 'database' is the
+          default value of the 'data_dir' option).
 
       cluster_files_directory:
         type: str
@@ -654,11 +676,14 @@ mapping:
 
       template_cache_path:
         type: str
-        default: database/compiled_templates
+        default: compiled_templates
         required: false
         desc: |
           Mako templates are compiled as needed and cached for reuse, this directory is
           used for the cache
+
+          Default value will be resolved to 'database/compiled_templates' where 'database' is the
+          default value of the 'data_dir' option).
 
       check_job_script_integrity:
         type: bool
@@ -705,21 +730,27 @@ mapping:
 
       citation_cache_data_dir:
         type: str
-        default: database/citations/data
+        default: citations/data
         required: false
         desc: |
           Citation related caching.  Tool citations information maybe fetched from
           external sources such as https://doi.org/ by Galaxy - the following
           parameters can be used to control the caching used to store this information.
 
+          Default value will be resolved to 'database/citations/data' where 'database' is the
+          default value of the 'data_dir' option).
+
       citation_cache_lock_dir:
         type: str
-        default: database/citations/lock
+        default: citations/locks
         required: false
         desc: |
           Citation related caching.  Tool citations information maybe fetched from
           external sources such as https://doi.org/ by Galaxy - the following
           parameters can be used to control the caching used to store this information.
+
+          Default value will be resolved to 'database/citations/locks' where 'database' is the
+          default value of the 'data_dir' option).
 
       object_store_config_file:
         type: str
@@ -772,12 +803,13 @@ mapping:
 
       mailing_join_addr:
         type: str
-        default: galaxy-announce-join@bx.psu.edu
         required: false
         desc: |
           On the user registration form, users may choose to join a mailing list. This
           is the address used to subscribe to the list. Uncomment and leave empty if you
           want to remove this option from the user registration form.
+
+          Sample default 'galaxy-announce-join@bx.psu.edu'
 
       error_email_to:
         type: str
@@ -800,11 +832,12 @@ mapping:
 
       instance_resource_url:
         type: str
-        default: https://galaxyproject.org/
         required: false
         desc: |
           URL of the support resource for the galaxy instance.  Used in activation
           emails.
+
+          Sample default 'https://galaxyproject.org/'
 
       blacklist_file:
         type: str
@@ -1299,11 +1332,14 @@ mapping:
 
       dynamic_proxy_session_map:
         type: str
-        default: database/session_map.sqlite
+        default: session_map.sqlite
         required: false
         desc: |
           The NodeJS dynamic proxy can use an SQLite database or a JSON file for IPC,
           set that here.
+
+          Default value will be resolved to 'database/session_map.sqlite' where 'database' is the
+          default value of the 'data_dir' option).
 
       dynamic_proxy_bind_port:
         type: int
@@ -1586,11 +1622,12 @@ mapping:
 
       heartbeat_log:
         type: str
-        default: heartbeat_{server_name}.log
         required: false
         desc: |
           Heartbeat log filename. Can accept the template variables {server_name} and
           {pid}
+
+          Sample default 'heartbeat_{server_name}.log'
 
       sentry_dsn:
         type: str
@@ -2195,7 +2232,6 @@ mapping:
 
       api_allow_run_as:
         type: str
-        default: ''
         required: false
         desc: |
           Optional list of email addresses of API users who can make calls on behalf of
@@ -2219,10 +2255,13 @@ mapping:
 
       openid_consumer_cache_path:
         type: str
-        default: database/openid_consumer_cache
+        default: openid_consumer_cache
         required: false
         desc: |
           If OpenID is enabled, consumer cache directory to use.
+
+          Default value will be resolved to 'database/openid_consumer_cache' where 'database' is the
+          default value of the 'data_dir' option).
 
       enable_tool_tags:
         type: bool
@@ -2537,16 +2576,16 @@ mapping:
 
       drmaa_external_runjob_script:
         type: str
-        default: sudo -E scripts/drmaa_external_runner.py --assign_all_groups
         required: false
         desc: |
           When running DRMAA jobs as the Galaxy user
           (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
           this script is used to run the job script Galaxy generates for a tool execution.
 
+          Sample default 'sudo -E scripts/drmaa_external_runner.py --assign_all_groups'
+
       drmaa_external_killjob_script:
         type: str
-        default: sudo -E scripts/drmaa_external_killer.py
         required: false
         desc: |
           When running DRMAA jobs as the Galaxy user
@@ -2554,15 +2593,18 @@ mapping:
           this script is used to kill such jobs by Galaxy (e.g. if the user cancels
           the job).
 
+          Sample default 'sudo -E scripts/drmaa_external_killer.py'
+
       external_chown_script:
         type: str
-        default: sudo -E scripts/external_chown_script.py
         required: false
         desc: |
           When running DRMAA jobs as the Galaxy user
           (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
           this script is used transfer permissions back and forth between the Galaxy user
           and the user that is running the job.
+
+          Sample default 'sudo -E scripts/external_chown_script.py'
 
       real_system_username:
         type: str
@@ -2696,7 +2738,7 @@ mapping:
 
       toolbox_filter_base_modules:
         type: str
-        default: galaxy.tools.toolbox.filters,galaxy.tools.filters
+        default: galaxy.tools.filters,galaxy.tools.toolbox.filters
         required: false
         desc: |
           The base module(s) that are searched for modules for toolbox filtering

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -293,8 +293,7 @@ mapping:
         required: false
         desc: |
           conda_prefix is the location on the filesystem where Conda packages and environments are
-          installed IMPORTANT: Due to a current limitation in conda, the total length of the
-          conda_prefix and the job_working_directory path should be less than 50 characters!
+          installed.
 
           Sample default '<tool_dependency_dir>/_conda'
 

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -238,7 +238,7 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
 
     def _try_until_no_errors(self, f):
         e = None
-        for i in range(30):
+        for i in range(40):
             try:
                 f()
                 return


### PR DESCRIPTION
- Modify defaults in the schema so that correct values are loaded (add
  notes to description where applicable).
- When the default in schema was inconcsistent with the default loaded
  in `__init__.py`, use the latter.
- Replace `kwargs.get(foo, default)` with `self.foo` if default is set
  correctly in the schema.
- Remove redundant assignments and variables (there are still more
  left).
- The defalt for `citation_cache_lock_dir` should be `citations/locks`.
- In a few cases where defaults are NOT loaded in `__init__.py`, and the
  values are clearly meant to be suggested values, move those defaults
  into description.

Ref #8493

Most likely will need to be resolved against #8610 