### PR TITLE
[19.09] Bugfix for reports with output collections.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5071,7 +5071,7 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         for output_dataset_assoc in self.output_datasets:
             outputs.append(output_dataset_assoc)
         for output_dataset_collection_assoc in self.output_dataset_collections:
-            outputs.append(output_dataset_collection_assoc.dataset_collection)
+            outputs.append(output_dataset_collection_assoc)
         return outputs
 
     @property


### PR DESCRIPTION
Reported by bgruening:

```
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 282, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/api/workflows.py", line 887, in show_invocation_report
    trans, workflow_invocation, runtime_report_config_json=runtime_report_config_json, plugin_type=generator_plugin_type
  File "lib/galaxy/workflow/reports/__init__.py", line 11, in generate_report_json
    return plugin.generate_report_json(trans, invocation, runtime_report_config_json=runtime_report_config_json)
  File "lib/galaxy/workflow/reports/generators/__init__.py", line 45, in generate_report_json
    internal_markdown = resolve_invocation_markdown(trans, invocation, workflow_markdown)
  File "lib/galaxy/managers/markdown_util.py", line 236, in resolve_invocation_markdown
    workflow_markdown,
  File "lib/galaxy/managers/markdown_util.py", line 329, in _remap_galaxy_markdown_calls
    return _remap_galaxy_markdown_containers(_remap_container, markdown)
  File "lib/galaxy/managers/markdown_util.py", line 297, in _remap_galaxy_markdown_containers
    (replacement, whole_block) = func(match.group(1))
  File "lib/galaxy/managers/markdown_util.py", line 327, in _remap_container
    return func(match.group(1), matching_line + "\n")
  File "lib/galaxy/managers/markdown_util.py", line 163, in _section_remap
    if not output_assoc.workflow_output.label:
AttributeError: 'HistoryDatasetCollectionAssociation' object has no attribute 'workflow_output'
```
