### PR TITLE
Encode lines in filter_file_fields

### DIFF
--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -675,15 +675,15 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
             rval = ""
             for line in reader:
                 if line.lstrip().startswith(self.comment_char):
-                    rval += line.encode('utf-8')
+                    rval += line
                 else:
                     line_s = line.rstrip("\n\r")
                     if line_s:
                         fields = line_s.split(self.separator)
                         if fields != values:
-                            rval += line.encode('utf-8')
+                            rval += line
 
-        with open(loc_file, 'wb') as writer:
+        with open(loc_file, 'w') as writer:
             writer.write(rval)
 
         return rval

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -675,13 +675,13 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
             rval = ""
             for line in reader:
                 if line.lstrip().startswith(self.comment_char):
-                    rval += line
+                    rval += line.encode('utf-8')
                 else:
                     line_s = line.rstrip("\n\r")
                     if line_s:
                         fields = line_s.split(self.separator)
                         if fields != values:
-                            rval += line
+                            rval += line.encode('utf-8')
 
         with open(loc_file, 'wb') as writer:
             writer.write(rval)


### PR DESCRIPTION
I run Galaxy 19.09 with Python 3.7.

When removing an entry from the data tables, this entry isn't always encoded. This pull request ensures that the encoding is always present.

```
galaxy.jobs.runners ERROR 2019-09-17 11:48:33,758 [p:48274,w:0,m:4] [DRMAARunner.work_thread-3] (181494/884126) Job wrapper finish method failed
Traceback (most recent call last):
  File "lib/galaxy/jobs/runners/__init__.py", line 520, in _finish_or_resubmit_job
    job_wrapper.finish(tool_stdout, tool_stderr, exit_code, check_output_detected_state=check_output_detected_state, job_stdout=job_stdout, job_stderr=job_stderr)
  File "lib/galaxy/jobs/__init__.py", line 1636, in finish
    self.tool.exec_after_process(self.app, inp_data, out_data, param_dict, job=job)
  File "lib/galaxy/tools/__init__.py", line 2514, in exec_after_process
    data_manager.process_result(out_data)
  File "lib/galaxy/tools/data_manager/manager.py", line 357, in process_result
    data_table.remove_entry(list(data_table_value.values()))
  File "lib/galaxy/tools/data/__init__.py", line 290, in remove_entry
    self._remove_entry(values)
  File "lib/galaxy/tools/data/__init__.py", line 664, in _remove_entry
    self.filter_file_fields(filename, values)
  File "lib/galaxy/tools/data/__init__.py", line 687, in filter_file_fields
    writer.write(rval)
TypeError: a bytes-like object is required, not 'str'
```