### PR TITLE
Fix bug in build_dependency_manager()

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -760,7 +760,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             if explicit:
                 log.warning("Sanitize log file explicitly specified as '%s' but does not exist, continuing with no tools whitelisted.", self.sanitize_whitelist_file)
 
-    def get(self, key, default):
+    def get(self, key, default=None):
         return self.config_dict.get(key, default)
 
     def get_bool(self, key, default):

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -1160,7 +1160,7 @@ class BaseGalaxyToolBox(AbstractToolBox):
     def _init_dependency_manager(self):
         app_config_dict = self.app.config.config_dict
         conf_file = app_config_dict.get("dependency_resolvers_config_file")
-        default_tool_dependency_dir = os.path.join(self.app.config.data_dir, "dependencies")
+        default_tool_dependency_dir = self.app.config.get('tool_dependency_dir')
         self.dependency_manager = build_dependency_manager(app_config_dict=app_config_dict, conf_file=conf_file,
                                                            default_tool_dependency_dir=default_tool_dependency_dir)
 

--- a/lib/galaxy/webapps/reports/config.py
+++ b/lib/galaxy/webapps/reports/config.py
@@ -61,7 +61,7 @@ class Configuration(object):
             self.redact_email_in_job_name = True
             self.allow_user_deletion = True
 
-    def get(self, key, default):
+    def get(self, key, default=None):
         return self.config_dict.get(key, default)
 
     def check(self):

--- a/lib/galaxy/webapps/tool_shed/config.py
+++ b/lib/galaxy/webapps/tool_shed/config.py
@@ -185,7 +185,7 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         # Backwards compatibility for names used in too many places to fix
         self.datatypes_config = self.datatypes_config_file
 
-    def get(self, key, default):
+    def get(self, key, default=None):
         return self.config_dict.get(key, default)
 
     def get_bool(self, key, default):


### PR DESCRIPTION
This fixes #8656 , so https://github.com/galaxyproject/usegalaxy-playbook/commit/294f464d67bc30a898ce223aad37cd6aa77ff1d5 should be no longer necessary.

The argument default_tool_dependency_dir should not be assigned a value
by default, because sometimes (at least for TS), it should be `None`. If set by default, it will cause this to be always `True`: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/deps/__init__.py#L77
and, as a result, TS will try to create <data_dir>/dependencies and load conda.

Also, add default value `None` to `get()` methods of each of the webapps
configuration objects (that way those methods behave more like a dictionary's `get()`. 

Note: the default_tool_dependency_dir argument is probably redundant; also, the get() methods can be moved to the base class, etc.; but those belong in separate commits, I think.

Requesting John's review as this modifies 450ae76ddb297312b226d8bf8a2f8ef58afd993f

EDIT: apparently I can't request reviewers using the reviewers feature. So, ping @jmchilton @martenson 