### PR TITLE
Add area/configuration label

### DIFF
--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -110,6 +110,7 @@ particular domain, as well as more organized release notes.
 - ``area/cleanup`` - General code cleanup
 - ``area/client-build``
 - ``area/compliance``
+- ``area/configuration`` - Galaxy's configuration system
 - ``area/cwl`` - changes related to supporting the common workflow language in Galaxy
 - ``area/database`` - Change requires a modification to Galaxy's database
 - ``area/dataset-collections``


### PR DESCRIPTION
There's a considerable amount of work done on Galaxy's configuration
system, from definition in the schema to loading and processing
configuration options, to handling configuration files. Currently, there
is no easy way to tag this: the "area" label that has been used is
"admin", but I don't think that's correct: modifying how configuration
is processed by the system is very different from how it is utilized by
the user.

I realize that would add yet another option when tagging an issue or PR,
but I think the benefit of accurately tagging that work outweighs a
little bit of added complexity. I'll be happy to retag relevant issues and
PRs (for the past several months or even 2019, maybe?) if this is approved.