### PR TITLE
Get rid of fix timeout in admin app Selenium test.

### DIFF
--- a/test/selenium_tests/test_admin_app.py
+++ b/test/selenium_tests/test_admin_app.py
@@ -82,7 +82,6 @@ class AdminAppTestCase(SeleniumTestCase):
             job_id = run_response.json()["jobs"][0]["id"]
             self.dataset_populator.wait_for_tool_run(history_id=history_id,
                                                      run_response=run_response,
-                                                     timeout=5,
                                                      assert_ok=False)
 
         admin_component.dm_jobs_button(data_manager="test-data-manager").wait_for_and_click()


### PR DESCRIPTION
Try to avoid these because dockerized, CI tests run slower typically. This test I think is unstable because of this fixed, small timeout. Jobs definitely can take longer than 5 seconds in the tests.