### PR TITLE
Better error handling for registration not logging Selenium user in.

### DIFF
--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -45,6 +45,7 @@ masthead:
       selector: '//a[contains(text(), "Logged in as")]'
 
     logged_in_only: 'a.loggedin-only'
+    logged_out_only: 'a.loggedout-only'
 
   labels:
     # top-level menus


### PR DESCRIPTION
xref https://jenkins.galaxyproject.org/view/Marten/job/detect_unstable/9/artifact/9-test-errors/test_wrong_password2019091718471568746020/

xref https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/selenium/navigates_galaxy.py#L430

