### PR TITLE
[WIP] Improve error message and debug information when selenium logout fails.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1282,10 +1282,18 @@ class NavigatesGalaxy(HasDriver):
     def logout_if_needed(self):
         if self.is_logged_in():
             self.home()
-            self.click_masthead_user()
-            self.wait_for_and_click(self.navigation.masthead.labels.logout)
-            self.sleep_for(WAIT_TYPES.UX_TRANSITION)
-            assert not self.is_logged_in()
+            self.logout()
+
+    def logout(self):
+        self.components.masthead.logged_in_only.wait_for_visible()
+        self.click_masthead_user()
+        self.components.masthead.logout.wait_for_and_click()
+        try:
+            self.components.masthead.logged_out_only.wait_for_visible()
+        except self.TimeoutException as e:
+            message = "Clicked logout button but waiting for 'Login or Registration' button failed, perhaps the logout button was clicked before the handler was setup?"
+            raise self.prepend_timeout_message(e, message)
+        assert not self.is_logged_in(), "Clicked to logged out and UI reflects a logout, but API still thinks a user is logged in."
 
     def run_tour(self, path, skip_steps=None, sleep_on_steps=None, tour_callback=None):
         skip_steps = skip_steps or []

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -45,6 +45,7 @@ masthead:
       selector: '//a[contains(text(), "Logged in as")]'
 
     logged_in_only: 'a.loggedin-only'
+    logged_out_only: 'a.loggedout-only'
 
   labels:
     # top-level menus


### PR DESCRIPTION
xref https://jenkins.galaxyproject.org/view/Marten/job/detect_unstable/9/artifact/9-test-errors/test_unsharing2019091718381568745481/

I assume what is happening here is there is a UI bug where you can click 'logout' before a handler is attached to the button. We can probably just retry but lets see better error handling first to verify and then I'll make it do retries.
