### PR TITLE
[WIP] Rework SeleniumTestCase.ensure_registered to get failure dumps during registration

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1282,10 +1282,18 @@ class NavigatesGalaxy(HasDriver):
     def logout_if_needed(self):
         if self.is_logged_in():
             self.home()
-            self.click_masthead_user()
-            self.wait_for_and_click(self.navigation.masthead.labels.logout)
-            self.sleep_for(WAIT_TYPES.UX_TRANSITION)
-            assert not self.is_logged_in()
+            self.logout()
+
+    def logout(self):
+        self.components.masthead.logged_in_only.wait_for_visible()
+        self.click_masthead_user()
+        self.components.masthead.logout.wait_for_and_click()
+        try:
+            self.components.masthead.logged_out_only.wait_for_visible()
+        except self.TimeoutException as e:
+            message = "Clicked logout button but waiting for 'Login or Registration' button failed, perhaps the logout button was clicked before the handler was setup?"
+            raise self.prepend_timeout_message(e, message)
+        assert not self.is_logged_in(), "Clicked to logged out and UI reflects a logout, but API still thinks a user is logged in."
 
     def run_tour(self, path, skip_steps=None, sleep_on_steps=None, tour_callback=None):
         skip_steps = skip_steps or []

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -45,6 +45,7 @@ masthead:
       selector: '//a[contains(text(), "Logged in as")]'
 
     logged_in_only: 'a.loggedin-only'
+    logged_out_only: 'a.loggedout-only'
 
   labels:
     # top-level menus

--- a/test/selenium_tests/framework.py
+++ b/test/selenium_tests/framework.py
@@ -223,6 +223,8 @@ class SeleniumTestCase(FunctionalTestCase, NavigatesGalaxy, UsesApiTestCaseMixin
         Overriding this instead of setUp will ensure debug data such as screenshots and stack traces
         are dumped if there are problems with the setup and it will be re-ran on test retries.
         """
+        if self.ensure_registered:
+            self.login()
 
     def tearDown(self):
         exception = None
@@ -297,9 +299,6 @@ class SeleniumTestCase(FunctionalTestCase, NavigatesGalaxy, UsesApiTestCaseMixin
         self.driver.set_window_size(1280, 1000)
 
         self._setup_galaxy_logging()
-
-        if self.ensure_registered:
-            self.login()
 
     def _setup_galaxy_logging(self):
         self.home()

--- a/test/selenium_tests/test_library_landing.py
+++ b/test/selenium_tests/test_library_landing.py
@@ -10,6 +10,7 @@ class LibraryLandingTestCase(SeleniumTestCase):
     requires_admin = True
 
     def setup_with_driver(self):
+        super(LibraryLandingTestCase, self).setup_with_driver()
         self.admin_login()
         self.libraries_open()
 


### PR DESCRIPTION
Looks like a lot of problems are happening before we even enter the test case - so our retry handling for instance will not work and we don't get pretty test outputs recorded by Jenkins. This should fix that second problem.
