### PR TITLE
More robust login/logout with Selenium.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -427,19 +427,14 @@ class NavigatesGalaxy(HasDriver):
             confirm=confirm
         ))
         self.wait_for_and_click(self.navigation.registration.selectors.submit)
-        # Give the browser a bit of time to submit the request.
-        # It would be good to eliminate this sleep, but it can't be because Galaxy
-        # doesn't swap the "User" menu automatically after it registers a user and
-        # and the donemessage visible comment below doesn't work when using Selenium.
-        # Something about the Selenium session or quickness of registering causes the
-        # following in the Galaxy logs which gets propaged to the GUI as a generic error:
-        # /api/histories/cfc05ccec54895e2/contents?keys=type_id%2Celement_count&order=hid&v=dev&q=history_content_type&q=deleted&q=purged&q=visible&qv=dataset_collection&qv=False&qv=False&qv=True HTTP/1.1" 403 - "http://localhost:8080/"
-        # Like the logged in user doesn't have permission to the previously anonymous user's
-        # history, it is odd but I cannot replicate this outside of Selenium.
-        time.sleep(1.35)
+        if assert_valid is False:
+            self.assert_error_message()
+        elif assert_valid:
+            self.wait_for_logged_in()
 
-        if assert_valid:
-            # self.wait_for_selector_visible(".donemessage")
+            # Code below previously was needed because there was a bug that would prevent the masthead from changing,
+            # the bug seems maybe to be fixed though - so we could consider eliminating these extra checks to speed
+            # up tests.
             self.home()
             self.wait_for_logged_in()
             self.click_masthead_user()

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1280,10 +1280,18 @@ class NavigatesGalaxy(HasDriver):
     def logout_if_needed(self):
         if self.is_logged_in():
             self.home()
-            self.click_masthead_user()
-            self.wait_for_and_click(self.navigation.masthead.labels.logout)
-            self.sleep_for(WAIT_TYPES.UX_TRANSITION)
-            assert not self.is_logged_in()
+            self.logout()
+
+    def logout(self):
+        self.components.masthead.logged_in_only.wait_for_visible()
+        self.click_masthead_user()
+        self.components.masthead.logout.wait_for_and_click()
+        try:
+            self.components.masthead.logged_out_only.wait_for_visible()
+        except self.TimeoutException as e:
+            message = "Clicked logout button but waiting for 'Login or Registration' button failed, perhaps the logout button was clicked before the handler was setup?"
+            raise self.prepend_timeout_message(e, message)
+        assert not self.is_logged_in(), "Clicked to logged out and UI reflects a logout, but API still thinks a user is logged in."
 
     def run_tour(self, path, skip_steps=None, sleep_on_steps=None, tour_callback=None):
         skip_steps = skip_steps or []

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -441,6 +441,7 @@ class NavigatesGalaxy(HasDriver):
         if assert_valid:
             # self.wait_for_selector_visible(".donemessage")
             self.home()
+            self.wait_for_logged_in()
             self.click_masthead_user()
             # Make sure the user menu was dropped down
             user_menu = self.components.masthead.user_menu.wait_for_visible()
@@ -461,15 +462,20 @@ class NavigatesGalaxy(HasDriver):
 
     def wait_for_logged_in(self):
         try:
-            self.wait_for_visible(self.navigation.masthead.selectors.logged_in_only)
+            self.components.masthead.logged_in_only.wait_for_visible()
         except self.TimeoutException as e:
+            ui_logged_out = self.components.masthead.logged_out_only.is_displayed
+            if ui_logged_out:
+                dom_message = "Element a.loggedout-only is present in DOM, indicating Login or Register button still in masthead."
+            else:
+                dom_message = "Element a.loggedout-only is *not* present in DOM."
             user_info = self.api_get("users/current")
             if "username" in user_info:
-                template = "Failed waiting for masthead to update for login, but user API response indicates [%s] is logged in. This seems to be a bug in Galaxy. API response was [%s]. "
-                message = template % (user_info["username"], user_info)
+                template = "Failed waiting for masthead to update for login, but user API response indicates [%s] is logged in. This seems to be a bug in Galaxy. %s logged API response was [%s]. "
+                message = template % (user_info["username"], dom_message, user_info)
                 raise self.prepend_timeout_message(e, message)
             else:
-                raise NotLoggedInException(e, user_info)
+                raise NotLoggedInException(e, user_info, dom_message)
 
     def click_center(self):
         action_chains = self.action_chains()
@@ -1466,9 +1472,9 @@ class NavigatesGalaxy(HasDriver):
 
 class NotLoggedInException(TimeoutException):
 
-    def __init__(self, timeout_exception, user_info):
-        template = "Waiting for UI to reflect user logged in but it did not occur. API indicates no user is currently logged in. API response was [%s]. %s"
-        msg = template % (user_info, timeout_exception.msg)
+    def __init__(self, timeout_exception, user_info, dom_message):
+        template = "Waiting for UI to reflect user logged in but it did not occur. API indicates no user is currently logged in. %s API response was [%s]. %s"
+        msg = template % (dom_message, user_info, timeout_exception.msg)
         super(NotLoggedInException, self).__init__(
             msg=msg,
             screen=timeout_exception.screen,

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -45,6 +45,7 @@ masthead:
       selector: '//a[contains(text(), "Logged in as")]'
 
     logged_in_only: 'a.loggedin-only'
+    logged_out_only: 'a.loggedout-only'
 
   labels:
     # top-level menus

--- a/test/selenium_tests/framework.py
+++ b/test/selenium_tests/framework.py
@@ -223,6 +223,8 @@ class SeleniumTestCase(FunctionalTestCase, NavigatesGalaxy, UsesApiTestCaseMixin
         Overriding this instead of setUp will ensure debug data such as screenshots and stack traces
         are dumped if there are problems with the setup and it will be re-ran on test retries.
         """
+        if self.ensure_registered:
+            self.login()
 
     def tearDown(self):
         exception = None
@@ -297,9 +299,6 @@ class SeleniumTestCase(FunctionalTestCase, NavigatesGalaxy, UsesApiTestCaseMixin
         self.driver.set_window_size(1280, 1000)
 
         self._setup_galaxy_logging()
-
-        if self.ensure_registered:
-            self.login()
 
     def _setup_galaxy_logging(self):
         self.home()

--- a/test/selenium_tests/test_library_landing.py
+++ b/test/selenium_tests/test_library_landing.py
@@ -10,6 +10,7 @@ class LibraryLandingTestCase(SeleniumTestCase):
     requires_admin = True
 
     def setup_with_driver(self):
+        super(LibraryLandingTestCase, self).setup_with_driver()
         self.admin_login()
         self.libraries_open()
 


### PR DESCRIPTION
- There was a UI bug with masthead not reflecting being logged in that we needed to work around previously but I'm hoping that is now fixed and this proves to be more robust than that previous sleep command.
- Capture more test context when problems occur during setup (i.e. if ensure_registered is enabled).
- Better error reporting/exception message for login failures.
- Better error message when a Selenium logout failure occurs.