### PR TITLE
Improve CI reliability by annotating external resources.

### DIFF
--- a/test/api/test_dataset_collections.py
+++ b/test/api/test_dataset_collections.py
@@ -2,7 +2,7 @@ import json
 import tarfile
 
 from base import api
-from base.populators import DatasetCollectionPopulator, DatasetPopulator
+from base.populators import DatasetCollectionPopulator, DatasetPopulator, skip_if_github_down
 from six import BytesIO
 
 
@@ -233,6 +233,7 @@ class DatasetCollectionApiTestCase(api.ApiTestCase):
         element0 = hdca["elements"][0]
         assert element0["element_identifier"] == "samp1"
 
+    @skip_if_github_down
     def test_upload_collection_from_url(self):
         elements = [{"src": "url", "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed", "info": "my cool bed"}]
         targets = [{

--- a/test/api/test_tools_upload.py
+++ b/test/api/test_tools_upload.py
@@ -8,6 +8,7 @@ from base.constants import (
 )
 from base.populators import (
     DatasetPopulator,
+    skip_if_site_down,
     skip_without_datatype,
     uses_test_history,
 )
@@ -484,11 +485,13 @@ class ToolsUploadTestCase(api.ApiTestCase):
             assert extra_file["path"] == "composite"
             assert extra_file["class"] == "File"
 
+    @skip_if_site_down("https://usegalaxy.org")
     def test_upload_from_invalid_url(self):
         history_id, new_dataset = self._upload('https://usegalaxy.org/bla123', assert_ok=False)
         dataset_details = self.dataset_populator.get_history_dataset_details(history_id, dataset_id=new_dataset["id"], assert_ok=False)
         assert dataset_details['state'] == 'error', "expected dataset state to be 'error', but got '%s'" % dataset_details['state']
 
+    @skip_if_site_down("https://usegalaxy.org")
     def test_upload_from_valid_url(self):
         history_id, new_dataset = self._upload('https://usegalaxy.org/api/version')
         self.dataset_populator.get_history_dataset_details(history_id, dataset_id=new_dataset["id"], assert_ok=True)

--- a/test/integration/test_data_manager_table_reload.py
+++ b/test/integration/test_data_manager_table_reload.py
@@ -2,7 +2,7 @@ import random
 import string
 
 from base import integration_util
-from base.populators import DatasetPopulator
+from base.populators import DatasetPopulator, skip_if_toolshed_down
 from nose.plugins.skip import SkipTest
 
 from .uses_shed import CONDA_AUTO_INSTALL_JOB_TIMEOUT, UsesShed
@@ -43,6 +43,7 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         cls.username = cls.get_secure_ascii_digits()
         config["admin_users"] = "%s@galaxy.org" % cls.username
 
+    @skip_if_toolshed_down
     def test_data_manager_installation_table_reload(self):
         """
         Test that we can install data managers, create a new dbkey, and use that dbkey in a downstream data manager.

--- a/test/integration/test_shed_tool_tests.py
+++ b/test/integration/test_shed_tool_tests.py
@@ -1,4 +1,5 @@
 from base import integration_util
+from base.populators import skip_if_toolshed_down
 
 from .uses_shed import UsesShed
 
@@ -13,6 +14,7 @@ class ToolShedToolTestIntegrationTestCase(integration_util.IntegrationTestCase, 
     def handle_galaxy_config_kwds(cls, config):
         cls.configure_shed_and_conda(config)
 
+    @skip_if_toolshed_down
     def test_tool_test(self):
         self.install_repository("devteam", "fastqc", "ff9530579d1f")
         self._run_tool_test("toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71")

--- a/test/selenium_tests/test_tool_form.py
+++ b/test/selenium_tests/test_tool_form.py
@@ -1,7 +1,7 @@
 import json
 
 from base import rules_test_data
-from base.populators import flakey, load_data_dict
+from base.populators import flakey, load_data_dict, skip_if_github_down
 
 from galaxy.selenium.navigates_galaxy import retry_call_during_transitions
 from .framework import (
@@ -185,6 +185,7 @@ class LoggedInToolFormTestCase(SeleniumTestCase):
 
     @selenium_test
     @managed_history
+    @skip_if_github_down
     def test_run_apply_rules_tutorial(self):
         self.home()
         self.upload_rule_start()

--- a/test/selenium_tests/test_workflow_management.py
+++ b/test/selenium_tests/test_workflow_management.py
@@ -1,3 +1,5 @@
+from base.populators import skip_if_github_down
+
 from .framework import (
     retry_assertion_during_transitions,
     selenium_test,
@@ -108,6 +110,7 @@ class WorkflowManagementTestCase(SeleniumTestCase):
     def _assert_showing_n_workflows(self, n):
         self.assertEqual(len(self.workflow_index_table_elements()), n)
 
+    @skip_if_github_down
     def _workflow_import_from_url(self):
         self.workflow_index_click_import()
         url = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test/base/data/test_workflow_1.ga"


### PR DESCRIPTION
And skipping if github, usegalaxy.org, or the tool shed is down for tests that depend on these.