### PR TITLE
[19.09] Small fixes for issues with the invocation report editor.

### DIFF
--- a/client/galaxy/scripts/components/Markdown/MarkdownEditor.vue
+++ b/client/galaxy/scripts/components/Markdown/MarkdownEditor.vue
@@ -44,6 +44,6 @@ export default {
     padding: 20px;
 
     width: 100%;
-    height: 100%;
+    height: 95%;  /* what now? this is needed or the editor overtakes workflow toolbar when too much text is added */
 }
 </style>

--- a/client/galaxy/scripts/mvc/workflow/workflow-manager.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-manager.js
@@ -240,7 +240,7 @@ class Workflow {
         // First pass, nodes
         var using_workflow_outputs = false;
         wf.workflow_version = data.version;
-        wf.report = data.report;
+        wf.report = data.report || {};
         const markdownEditorInstance = Vue.extend(MarkdownEditor);
         new markdownEditorInstance({
             propsData: {

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -236,7 +236,7 @@
                 <a id="workflow-run-button" class="panel-header-button" href="javascript:void(0)" role="button" title="Run" style="display: inline-block;" aria-label="Run">
                     <span class="fa fa-play"></span>
                 </a>
-                <a id="workflow-save-button" class="panel-header-button" href="javascript:void(0)" role="button" title="Save" style="display: inline-block;" aria-label="Save">
+                <a id="workflow-save-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Save" style="display: inline-block;" aria-label="Save">
                     <span class="fa fa-floppy-o"></span>
                 </a>
                 <a id="workflow-report-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Edit Report" aria-label="Edit Report">


### PR DESCRIPTION
See commit description for each for more details. The CSS problem in particular is very hacky - if someone wants to take a pass at improving that. I spent an hour and couldn't get anything with flex stretching, etc... to work here but this 95% thing seemed to at least fix the problem - I'm sure it results in some ugliness at different resolutions but hopefully the problem or not getting to hit the save button is fixed.