### PR TITLE
Restrict `/api/histories/shared_with_me` to logged-in users

### DIFF
--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -239,7 +239,7 @@ def expose_api(func, to_json=True, user_required=True, user_or_session_required=
             # error if anon and no session
             if not trans.galaxy_session and user_or_session_required:
                 return __api_error_response(trans, status_code=403, err_code=error_codes.USER_NO_API_KEY,
-                                            err_msg="API authentication required for this request")
+                                            err_msg="API authentication or Galaxy session required for this request")
 
         if trans.request.body:
             try:

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -219,6 +219,9 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
     @expose_api_anonymous
     def citations(self, trans, history_id, **kwd):
         """
+        GET /api/histories/{id}/citations
+        Return all the citations for the tools used to produce the datasets in
+        the history.
         """
         history = self.manager.get_accessible(self.decode_id(history_id), trans.user, current_history=trans.history)
         tool_ids = set([])
@@ -256,8 +259,7 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
             rval.append(history_dict)
         return rval
 
-    # TODO: does this need to be anonymous_and_sessionless? Not just expose_api?
-    @expose_api_anonymous_and_sessionless
+    @expose_api
     def shared_with_me(self, trans, **kwd):
         """
         shared_with_me( self, trans, **kwd )
@@ -443,7 +445,7 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
     @expose_api
     def archive_export(self, trans, id, **kwds):
         """
-        export_archive( self, trans, id, payload )
+        export_archive(self, trans, id, payload)
         * PUT /api/histories/{id}/exports:
             start job (if needed) to create history export for corresponding
             history.


### PR DESCRIPTION
It was returning an empty list anyway for non-authenticated users.

Also differentiate error message for sessionless API request when anonymous access is allowed (i.e. `expose_api_anonymous`).