### PR TITLE
Automate path resolution for config options

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -190,12 +190,17 @@ class BaseAppConfiguration(object):
 class GalaxyAppConfiguration(BaseAppConfiguration):
     deprecated_options = ('database_file', 'track_jobs_in_database')
     default_config_file_name = 'galaxy.yml'
+    # {key: config option, value: deprecated directory name}
+    # If value == first dir in a user path that resolves to key, it will be stripped from the path
+    deprecated_dirs = {'config_dir': 'config', 'data_dir': 'database'}
 
     def __init__(self, **kwargs):
         self._load_schema()  # Load schema from schema definition file
         self._load_config_from_schema()  # Load default propery values from schema
+        self._validate_schema_paths()  # check that paths can be resolved
         self._update_raw_config_from_kwargs(kwargs)  # Overwrite default values passed as kwargs
         self._create_attributes_from_raw_config()  # Create attributes for LOADED properties
+        self._resolve_paths(kwargs)  # Overwrite attributes (not _raw_config) w/resolved paths
         self._process_config(kwargs)  # Finish processing configuration
 
     def _load_schema(self):
@@ -203,24 +208,80 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.appschema = self.schema.app_schema
 
     def _load_config_from_schema(self):
-        self._raw_config = {}  # keeps track of values provided to the app
-        self.reloadable_options = set()
+        self._raw_config = {}  # keeps track of startup values (kwargs or schema default)
+        self.reloadable_options = set()  # config options we can reload at runtime
+        self._paths_to_resolve = {}  # {config option: referenced config option}
         for key, data in self.appschema.items():
             self._raw_config[key] = data.get('default')
             if data.get('reloadable'):
                 self.reloadable_options.add(key)
+            if data.get('path_resolves_to'):
+                self._paths_to_resolve[key] = data.get('path_resolves_to')
+
+    def _validate_schema_paths(self):
+
+        def check_exists(option, key):
+            if not option:
+                message = "Invalid schema: property '{}' listed as path resolution target " \
+                    "for '{}' does not exist".format(resolves_to, key)
+                raise_error(message)
+
+        def check_type_is_str(option, key):
+            if option.get('type') != 'str':
+                message = "Invalid schema: property '{}' should have type 'str'".format(key)
+                raise_error(message)
+
+        def check_is_dag():
+            def walk(key):
+                if key:
+                    if key in visited:
+                        raise_error('Invalid schema: cycle detected')
+                    visited.add(key)
+                    next = self.appschema[key].get('path_resolves_to')
+                    walk(next)
+
+            for key in self._paths_to_resolve:
+                visited = set()
+                walk(key)
+
+        def raise_error(message):
+            log.error(message)
+            raise ConfigurationError(message)
+
+        for key, resolves_to in self._paths_to_resolve.items():
+            parent = self.appschema.get(resolves_to)
+            check_exists(parent, key)
+            check_type_is_str(parent, key)
+            check_type_is_str(self.appschema[key], key)
+            check_is_dag()  # must be called last: walks entire graph
 
     def _update_raw_config_from_kwargs(self, kwargs):
-        type_converters = {
-            'bool': string_as_bool,
-            'int': int,
-            'float': float,
-        }
+
+        def convert_datatype(key, value):
+            datatype = self.appschema[key].get('type')
+            if datatype in type_converters:
+                return type_converters[datatype](value)
+            return value
+
+        def strip_deprecated_dir(key, value):
+            resolves_to = self.appschema[key].get('path_resolves_to')
+            if resolves_to:  # value is a path that will be resolved
+                dir = value.split(os.sep)[0]  # get first directory component
+                if dir == self.deprecated_dirs[resolves_to]:  # dir is deprecated for this option
+                    ignore = dir + os.sep
+                    log.warning(
+                        "Paths for the '%s' option are now relative to '%s', remove the leading '%s' "
+                        "to suppress this warning: %s", key, resolves_to, ignore, value
+                    )
+                    return value[len(ignore):]
+            return value
+
+        type_converters = {'bool': string_as_bool, 'int': int, 'float': float}
+
         for key, value in kwargs.items():
             if key in self.appschema:
-                datatype = self.appschema[key].get('type')
-                if datatype in type_converters:
-                    value = type_converters[datatype](value)
+                value = convert_datatype(key, value)
+                value = strip_deprecated_dir(key, value)
                 self._raw_config[key] = value
 
     def _create_attributes_from_raw_config(self):
@@ -228,6 +289,30 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             if hasattr(self, key):
                 raise ConfigurationError("Attempting to override existing attribute '%s'" % key)
             setattr(self, key, value)
+
+    def _resolve_paths(self, kwargs):
+
+        def resolve(key):
+            if key in _cache:  # resolve each path only once
+                return _cache[key]
+
+            path = getattr(self, key)  # path prior to being resolved
+            parent = self.appschema[key].get('path_resolves_to')
+            if not parent:  # base case: nothing else needs resolving
+                return path
+            parent_path = resolve(parent)  # recursively resolve parent path
+            if path is not None:
+                path = os.path.join(parent_path, path)  # resolve path
+            else:
+                path = parent_path  # or use parent path
+
+            setattr(self, key, path)  # update property
+            _cache[key] = path  # cache it!
+            return path
+
+        _cache = {}
+        for key in self._paths_to_resolve:
+            resolve(key)
 
     def _process_config(self, kwargs):
         self.config_dict = kwargs

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -200,6 +200,11 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self._validate_schema_paths()  # check that paths can be resolved
         self._update_raw_config_from_kwargs(kwargs)  # Overwrite default values passed as kwargs
         self._create_attributes_from_raw_config()  # Create attributes for LOADED properties
+
+        self.config_dict = kwargs
+        self.root = find_root(kwargs)
+        self._set_config_base(kwargs)  # must be called prior to _resolve_paths()
+
         self._resolve_paths(kwargs)  # Overwrite attributes (not _raw_config) w/resolved paths
         self._process_config(kwargs)  # Finish processing configuration
 
@@ -312,10 +317,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             resolve(key)
 
     def _process_config(self, kwargs):
-        self.config_dict = kwargs
-        self.root = find_root(kwargs)
-        self._set_config_base(kwargs)
-
         # Resolve paths of other config files
         self.parse_config_file_options(kwargs)
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -253,7 +253,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             check_exists(parent, key)
             check_type_is_str(parent, key)
             check_type_is_str(self.appschema[key], key)
-            check_is_dag()  # must be called last: walks entire graph
+        check_is_dag()  # must be called last: walks entire graph
 
     def _update_raw_config_from_kwargs(self, kwargs):
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -233,12 +233,12 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
         def check_is_dag():
             def walk(key):
-                if key:
-                    if key in visited:
-                        raise_error('Invalid schema: cycle detected')
-                    visited.add(key)
-                    next = self.appschema[key].get('path_resolves_to')
-                    walk(next)
+                if key in visited:
+                    raise_error('Invalid schema: cycle detected')
+                visited.add(key)
+                parent = self.appschema[key].get('path_resolves_to')
+                if parent:
+                    walk(parent)
 
             for key in self._paths_to_resolve:
                 visited = set()
@@ -266,9 +266,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         def strip_deprecated_dir(key, value):
             resolves_to = self.appschema[key].get('path_resolves_to')
             if resolves_to:  # value is a path that will be resolved
-                dir = value.split(os.sep)[0]  # get first directory component
-                if dir == self.deprecated_dirs[resolves_to]:  # dir is deprecated for this option
-                    ignore = dir + os.sep
+                first_dir = value.split(os.sep)[0]  # get first directory component
+                if first_dir == self.deprecated_dirs[resolves_to]:  # first_dir is deprecated for this option
+                    ignore = first_dir + os.sep
                     log.warning(
                         "Paths for the '%s' option are now relative to '%s', remove the leading '%s' "
                         "to suppress this warning: %s", key, resolves_to, ignore, value

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -232,17 +232,14 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
                 raise_error(message)
 
         def check_is_dag():
-            def walk(key):
-                if key in visited:
-                    raise_error('Invalid schema: cycle detected')
-                visited.add(key)
-                parent = self.appschema[key].get('path_resolves_to')
-                if parent:
-                    walk(parent)
-
+            visited = set()
             for key in self._paths_to_resolve:
-                visited = set()
-                walk(key)
+                visited.clear()
+                while key:
+                    visited.add(key)
+                    key = self.appschema[key].get('path_resolves_to')
+                    if key and key in visited:
+                        raise_error('Invalid schema: cycle detected')
 
         def raise_error(message):
             log.error(message)

--- a/test/unit/config/test_path_graph.py
+++ b/test/unit/config/test_path_graph.py
@@ -1,0 +1,190 @@
+import pytest
+
+from galaxy.config import GalaxyAppConfiguration
+from galaxy.exceptions import ConfigurationError
+
+
+# When a config property 'foo' has an attribute 'path_resolves_to', that attribute is a reference to
+# another property 'bar'. Together, these two properties form a graph where 'foo' and 'bar are
+# vertices and the reference from 'foo' to 'bar' is a directed edge.
+#
+# A schema may have any number of such implicit graphs, each having one or more edges. All together,
+# they should form a DAG (directed acyclic graph).
+#
+# These tests ensure that the graph is loaded correctly for a variety of valid configurations,
+# whereas an invalid configuration raises an error.
+
+
+@pytest.fixture
+def mock_config(monkeypatch):
+    def mock_process_config(self, kwargs):
+        pass
+    monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', mock_process_config)
+
+
+def test_basecase(mock_config, monkeypatch):
+    # Check that a valid graph is loaded correctly (this graph has 2 components)
+    mock_schema = {
+        'component1_path0': {
+            'type': 'str',
+            'default': 'value0',
+        },
+        'component1_path1': {
+            'type': 'str',
+            'default': 'value1',
+            'path_resolves_to': 'component1_path0',
+        },
+        'component1_path2': {
+            'type': 'str',
+            'default': 'value2',
+            'path_resolves_to': 'component1_path1',
+        },
+        'component2_path0': {
+            'type': 'str',
+            'default': 'value3',
+        },
+        'component2_path1': {
+            'type': 'str',
+            'default': 'value4',
+            'path_resolves_to': 'component2_path0',
+        },
+
+    }
+
+    def mock_load_schema(self):
+        self.appschema = mock_schema
+    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
+
+    config = GalaxyAppConfiguration()
+    assert config.component1_path0 == 'value0'
+    assert config.component1_path1 == 'value0/value1'
+    assert config.component1_path2 == 'value0/value1/value2'
+    assert config.component2_path0 == 'value3'
+    assert config.component2_path1 == 'value3/value4'
+
+
+def test_resolves_to_invalid_property(mock_config, monkeypatch):
+    # 'path_resolves_to' should point to an existing property in the schema
+    mock_schema = {
+        'path0': {
+            'type': 'str',
+            'default': 'value0',
+        },
+        'path1': {
+            'type': 'str',
+            'default': 'value1',
+            'path_resolves_to': 'invalid',  # invalid
+        },
+    }
+
+    def mock_load_schema(self):
+        self.appschema = mock_schema
+
+    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
+
+    with pytest.raises(ConfigurationError):
+        GalaxyAppConfiguration()
+
+
+def test_path_resolution_cycle(mock_config, monkeypatch):
+    # Must be a DAG, but this one has a cycle
+    mock_schema = {
+        'path0': {
+            'type': 'str',
+            'default': 'value0',
+            'path_resolves_to': 'path2',
+        },
+        'path1': {
+            'type': 'str',
+            'default': 'value1',
+            'path_resolves_to': 'path0',
+        },
+        'path2': {
+            'type': 'str',
+            'default': 'value2',
+            'path_resolves_to': 'path1',
+        },
+    }
+
+    def mock_load_schema(self):
+        self.appschema = mock_schema
+
+    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
+
+    with pytest.raises(ConfigurationError):
+        GalaxyAppConfiguration()
+
+
+def test_path_invalid_type(mock_config, monkeypatch):
+    # Paths should be strings
+    mock_schema = {
+        'path0': {
+            'type': 'str',
+            'default': 'value0',
+        },
+        'path1': {
+            'type': 'float',  # invalid
+            'default': 'value1',
+            'path_resolves_to': 'path0',
+        },
+    }
+
+    def mock_load_schema(self):
+        self.appschema = mock_schema
+
+    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
+
+    with pytest.raises(ConfigurationError):
+        GalaxyAppConfiguration()
+
+
+def test_resolves_to_invalid_type(mock_config, monkeypatch):
+    # Paths should be strings
+    mock_schema = {
+        'path0': {
+            'type': 'int',  # invalid
+            'default': 'value0',
+        },
+        'path1': {
+            'type': 'str',
+            'default': 'value1',
+            'path_resolves_to': 'path0',
+        },
+    }
+
+    def mock_load_schema(self):
+        self.appschema = mock_schema
+
+    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
+
+    with pytest.raises(ConfigurationError):
+        GalaxyAppConfiguration()
+
+
+def test_resolves_with_empty_component(mock_config, monkeypatch):
+    # A path can be None (root path is never None; may be asigned elsewhere)
+    mock_schema = {
+        'path0': {
+            'type': 'str',
+            'default': 'value0',
+        },
+        'path1': {
+            'type': 'str',
+            'path_resolves_to': 'path0',
+        },
+        'path2': {
+            'type': 'str',
+            'default': 'value2',
+            'path_resolves_to': 'path1',
+        },
+    }
+
+    def mock_load_schema(self):
+        self.appschema = mock_schema
+
+    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
+
+    config = GalaxyAppConfiguration()
+    assert config.path0 == 'value0'
+    assert config.path1 == 'value0'
+    assert config.path2 == 'value0/value2'

--- a/test/unit/config/test_path_resolves_to.py
+++ b/test/unit/config/test_path_resolves_to.py
@@ -1,0 +1,141 @@
+import pytest
+
+from galaxy.config import GalaxyAppConfiguration
+
+
+MOCK_DEPRECATED_DIRS = {
+    'my_config_dir': 'old-config',
+    'my_data_dir': 'old-database',
+}
+
+# Mock properties loaded from schema (all options represent paths)
+MOCK_SCHEMA = {
+    'my_config_dir': {
+        'type': 'str',
+        'default': 'my-config',
+    },
+    'my_data_dir': {
+        'type': 'str',
+        'default': 'my-data',
+    },
+    'path1': {
+        'type': 'str',
+        'default': 'my-config-files',
+        'path_resolves_to': 'my_config_dir',
+    },
+    'path2': {
+        'type': 'str',
+        'default': 'my-data-files',
+        'path_resolves_to': 'my_data_dir',
+    },
+    'path3': {
+        'type': 'str',
+        'default': 'my-other-files',
+    }
+}
+
+
+def test_deprecated_prefixes_set_correctly(monkeypatch):
+    # Before we mock them, check that correct values are assigned
+    def mock_load_schema(self):
+        self.appschema = {}
+
+    def mock_process_config(self, kwargs):
+        pass
+
+    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
+    monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', mock_process_config)
+
+    config = GalaxyAppConfiguration()
+    expected_deprecated_dirs = {'config_dir': 'config', 'data_dir': 'database'}
+
+    assert config.deprecated_dirs == expected_deprecated_dirs
+
+
+@pytest.fixture
+def mock_init(monkeypatch):
+
+    def mock_load_schema(self):
+        self.appschema = MOCK_SCHEMA
+
+    def mock_process_config(self, kwargs):
+        pass  # because we're done before this is called
+
+    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
+    monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', mock_process_config)
+    monkeypatch.setattr(GalaxyAppConfiguration, 'deprecated_dirs', MOCK_DEPRECATED_DIRS)
+
+
+def test_mock_schema_is_loaded(mock_init):
+    # Check that mock is loaded as expected
+    config = GalaxyAppConfiguration()
+    assert len(config._raw_config) == 5
+    assert config._raw_config['my_config_dir'] == 'my-config'
+    assert config._raw_config['my_data_dir'] == 'my-data'
+    assert config._raw_config['path1'] == 'my-config-files'
+    assert config._raw_config['path2'] == 'my-data-files'
+    assert config._raw_config['path3'] == 'my-other-files'
+
+
+def test_no_kwargs(mock_init):
+    # Expected: use default from schema, then resolve
+    config = GalaxyAppConfiguration()
+    assert config.path1 == 'my-config/my-config-files'  # resolved
+    assert config.path2 == 'my-data/my-data-files'  # resolved
+    assert config.path3 == 'my-other-files'  # no change
+
+
+def test_kwargs_relative_path(mock_init):
+    # Expected: use value from kwargs, then resolve
+    new_path1 = 'foo1/bar'
+    new_path2 = 'foo2/bar'
+    config = GalaxyAppConfiguration(path1=new_path1, path2=new_path2)
+
+    assert config.path1 == 'my-config/' + new_path1  # resolved
+    assert config.path2 == 'my-data/' + new_path2  # resolved
+    assert config.path3 == 'my-other-files'  # no change
+
+
+def test_kwargs_ablsolute_path(mock_init):
+    # Expected: use value from kwargs, do NOT resolve
+    new_path1 = '/foo1/bar'
+    new_path2 = '/foo2/bar'
+    config = GalaxyAppConfiguration(path1=new_path1, path2=new_path2)
+
+    assert config.path1 == new_path1  # NOT resolved
+    assert config.path2 == new_path2  # NOT resolved
+    assert config.path3 == 'my-other-files'  # no change
+
+
+def test_kwargs_relative_path_old_prefix(mock_init):
+    # Expect: use value from kwargs, strip old prefix, then resolve
+    new_path1 = 'old-config/foo1/bar'
+    new_path2 = 'old-database/foo2/bar'
+    config = GalaxyAppConfiguration(path1=new_path1, path2=new_path2)
+
+    assert config.path1 == 'my-config/foo1/bar'  # stripped of old prefix, resolved
+    assert config.path2 == 'my-data/foo2/bar'  # stripped of old prefix, resolved
+    assert config.path3 == 'my-other-files'  # no change
+
+
+def test_kwargs_relative_path_old_prefix_for_other_option(mock_init):
+    # Expect: use value from kwargs, do NOT strip old prefix, then resolve
+    # Reason: deprecated dirs are option-specific: we don't want to strip 'old-config'
+    # (deprecated for the config_dir option) if it's used for another option
+    new_path1 = 'old-database/foo1/bar'
+    new_path2 = 'old-config/foo2/bar'
+    config = GalaxyAppConfiguration(path1=new_path1, path2=new_path2)
+
+    assert config.path1 == 'my-config/' + new_path1  # resolved
+    assert config.path2 == 'my-data/' + new_path2  # resolved
+    assert config.path3 == 'my-other-files'  # no change
+
+
+def test_kwargs_relative_path_old_prefix_empty_after_strip(mock_init):
+    # Expect: use value from kwargs, strip old prefix, then resolve
+    new_path1 = 'old-config'
+    config = GalaxyAppConfiguration(path1=new_path1)
+
+    assert config.path1 == 'my-config/'  # stripped of old prefix, then resolved
+    assert config.path2 == 'my-data/my-data-files'  # stripped of old prefix, then resolved
+    assert config.path3 == 'my-other-files'  # no change


### PR DESCRIPTION
See details in commit message.

This allows to:
- add 'path_resolves_to' attributes to properties in the schema (text like "relative path foo will be resolved with respect to bar" can be auto-generated for sample config files and docs)
- for all config options that have 'path_resolves_to' specified, get rid of all `os.path.join/path_resolve` stuff in `config/__init__.py`
- current galaxy installations that have relative paths specified as `config/foo` or `database/foo` will not be broken (warnings will be issued, and path will be resolved automatically - as per @natefoo 's solution)
- path resolution can be specified to arbitrary depth (A > B > ... > root)

Note: path resolution (and schema validation) is handled recursively. However, this doesn't have any effect on performance: both are called once at startup; the graph is trivial: a few vertices (there are only so many paths we need to specify), each with degree=1 or 0 (path_resolves_to can only point to one parent at most), and each vertex is visited once. Of course, this can be done iteratively, but that would make the code less intuitive with no visible performance gain (because the cost of allocating a stack frame for each call is negligible for this n).