### PR TITLE
Interactive modification of invocation report.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -888,6 +888,9 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         workflow_invocation = self.workflow_manager.get_invocation(trans, decoded_workflow_invocation_id)
         generator_plugin_type = kwd.get("generator_plugin_type")
         runtime_report_config_json = kwd.get("runtime_report_config_json")
+        invocation_markdown = kwd.get("invocation_markdown", None)
+        if invocation_markdown:
+            runtime_report_config_json = {"markdown": invocation_markdown}
         return generate_report_json(
             trans, workflow_invocation, runtime_report_config_json=runtime_report_config_json, plugin_type=generator_plugin_type
         )

--- a/lib/galaxy/workflow/reports/generators/__init__.py
+++ b/lib/galaxy/workflow/reports/generators/__init__.py
@@ -47,6 +47,7 @@ class WorkflowMarkdownGeneratorPlugin(WorkflowReportGeneratorPlugin):
         rval = {
             "render_format": "markdown",  # Presumably the frontend could render things other ways.
             "markdown": export_markdown,
+            "invocation_markdown": workflow_markdown,
         }
         rval.update(extra_rendering_data)
         return rval


### PR DESCRIPTION
Press control-e while viewing an invocation report and allow the Markdown to be edited in realtime. Press escape to go back to the viewing mode and see the changed markdown rendered.

Results aren't persisted anywhere but copy and paste can be used to save template back into the workflow and this becomes like an interactive preview functionality.