### PR TITLE
More bootstrap vue upgrade fixes.

### DIFF
--- a/client/galaxy/scripts/components/Sharing.vue
+++ b/client/galaxy/scripts/components/Sharing.vue
@@ -116,7 +116,7 @@
                             The following users will see this {{ model_class_lc }} in their {{ model_class_lc }} list
                             and will be able to view, import and run it.
                         </template>
-                        <template slot="id" slot-scope="cell">
+                        <template v-slot:cell(id)="cell">
                             <b-button
                                 class="unshare_user"
                                 size="sm"

--- a/client/galaxy/scripts/components/admin/DataManager/DataManagerJobs.vue
+++ b/client/galaxy/scripts/components/admin/DataManager/DataManagerJobs.vue
@@ -42,7 +42,7 @@
             >
                 <!-- Enable cell formatting for the command line column -->
                 <span slot="html" slot-scope="data" v-html="data.value"> </span>
-                <template slot="actions" slot-scope="row">
+                <template v-slot:cell(actions)="row">
                     <b-button-group>
                         <b-button v-b-tooltip.hover title="Rerun" target="_top" :href="jobs[row.index]['runUrl']">
                             <span class="fa fa-refresh" />


### PR DESCRIPTION
Without this the following tests consistently fail:
- Admin app data manager Selenium test.
- History unsharing Selenium test.
