### PR TITLE
[19.09] Drop "Manage" from admin workflow Invocation link.

### DIFF
--- a/client/galaxy/scripts/entry/panels/admin-panel.js
+++ b/client/galaxy/scripts/entry/panels/admin-panel.js
@@ -36,13 +36,13 @@ const AdminPanel = Backbone.View.extend({
                         id: "admin-link-display-applications"
                     },
                     {
-                        title: _l("Manage jobs"),
+                        title: _l("Jobs"),
                         url: "admin/jobs",
                         target: "__use_router__",
                         id: "admin-link-jobs"
                     },
                     {
-                        title: _l("Manage workflow invocations"),
+                        title: _l("Workflow invocations"),
                         url: "admin/invocations",
                         target: "__use_router__",
                         id: "admin-link-invocations"


### PR DESCRIPTION
Requested by @martenson on https://github.com/galaxyproject/galaxy/pull/8664. Also drop Manage in "Manage Jobs" link for symmetry? Or should I not do that?