### PR TITLE
[19.09] Build dependency manager only for galaxy app

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -1161,7 +1161,8 @@ class BaseGalaxyToolBox(AbstractToolBox):
         return looks_like_a_tool(path, enable_beta_formats=getattr(self.app.config, "enable_beta_tool_formats", False))
 
     def _init_dependency_manager(self):
-        if self.app.name != 'galaxy':
+        use_tool_dependency_resolution = getattr(self.app, "use_tool_dependency_resolution", True)
+        if not use_tool_dependency_resolution:
             self.dependency_manager = NullDependencyManager()
             return
         app_config_dict = self.app.config.config_dict

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -15,7 +15,10 @@ from six import iteritems
 from six.moves.urllib.parse import urlparse
 
 from galaxy.exceptions import MessageException, ObjectNotFound
-from galaxy.tool_util.deps import build_dependency_manager
+from galaxy.tool_util.deps import (
+    build_dependency_manager,
+    NullDependencyManager
+)
 from galaxy.tool_util.loader_directory import looks_like_a_tool
 from galaxy.util import (
     ExecutionTimer,
@@ -1158,6 +1161,9 @@ class BaseGalaxyToolBox(AbstractToolBox):
         return looks_like_a_tool(path, enable_beta_formats=getattr(self.app.config, "enable_beta_tool_formats", False))
 
     def _init_dependency_manager(self):
+        if self.app.name != 'galaxy':
+            self.dependency_manager = NullDependencyManager()
+            return
         app_config_dict = self.app.config.config_dict
         conf_file = app_config_dict.get("dependency_resolvers_config_file")
         default_tool_dependency_dir = os.path.join(self.app.config.data_dir, "dependencies")

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -259,7 +259,7 @@ mapping:
           to this path, such as the default conda prefix, default Galaxy packages path, legacy
           tool shed dependencies path, and the dependency cache directory.
 
-          Set the string to None to explicitly disable tool dependency handling.
+          Set the string to null to explicitly disable tool dependency handling.
           If this option is set to none or an invalid path, installing tools with dependencies
           from the Tool Shed or in Conda will fail.
 

--- a/lib/galaxy/webapps/tool_shed/app.py
+++ b/lib/galaxy/webapps/tool_shed/app.py
@@ -64,6 +64,7 @@ class UniverseApplication(object):
         from galaxy.managers.citations import CitationsManager
         self.citations_manager = CitationsManager(self)
         # The Tool Shed makes no use of a Galaxy toolbox, but this attribute is still required.
+        self.use_tool_dependency_resolution = False
         self.toolbox = tools.ToolBox([], self.config.tool_path, self)
         # Initialize the Tool Shed security agent.
         self.security_agent = self.model.security_agent

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -66,6 +66,15 @@ class ToolsTestCase(api.ApiTestCase):
         tool_ids = [_["id"] for _ in tools_index]
         assert "upload1" in tool_ids
 
+    @skip_without_tool("test_sam_to_bam_conversions")
+    def test_requirements(self):
+        requirements_response = self._get("tools/%s/requirements" % "test_sam_to_bam_conversions", admin=True)
+        self._assert_status_code_is_ok(requirements_response)
+        requirements = requirements_response.json()
+        assert len(requirements) == 1, requirements
+        requirement = requirements[0]
+        assert requirement['name'] == 'samtools', requirement
+
     @skip_without_tool("cat1")
     def test_show_repeat(self):
         tool_info = self._show_valid_tool("cat1")

--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -155,7 +155,6 @@ def setup_galaxy_config(
     tmpdir = os.path.realpath(tmpdir)
     if not os.path.exists(tmpdir):
         os.makedirs(tmpdir)
-    file_path = os.path.join(tmpdir, 'files')
     template_cache_path = tempfile.mkdtemp(prefix='compiled_templates_', dir=tmpdir)
     new_file_path = tempfile.mkdtemp(prefix='new_files_path_', dir=tmpdir)
     job_working_directory = tempfile.mkdtemp(prefix='job_working_directory_', dir=tmpdir)
@@ -175,9 +174,6 @@ def setup_galaxy_config(
         library_import_dir = None
     job_config_file = os.environ.get('GALAXY_TEST_JOB_CONFIG_FILE', default_job_config_file)
     tool_path = os.environ.get('GALAXY_TEST_TOOL_PATH', 'tools')
-    tool_dependency_dir = os.environ.get('GALAXY_TOOL_DEPENDENCY_DIR', None)
-    if tool_dependency_dir is None:
-        tool_dependency_dir = tempfile.mkdtemp(dir=tmpdir, prefix="tool_dependencies")
     tool_data_table_config_path = _tool_data_table_config_path(default_tool_data_table_config_path)
     default_data_manager_config = None
     for data_manager_config in ['config/data_manager_conf.xml', 'data_manager_conf.xml']:
@@ -221,10 +217,10 @@ def setup_galaxy_config(
         conda_auto_install=conda_auto_install,
         cleanup_job=cleanup_job,
         retry_metadata_internally=False,
+        data_dir=tmpdir,
         data_manager_config_file=data_manager_config_file,
         enable_beta_tool_formats=True,
         expose_dataset_path=True,
-        file_path=file_path,
         ftp_upload_purge=False,
         galaxy_data_manager_data_path=galaxy_data_manager_data_path,
         id_secret='changethisinproductiontoo',
@@ -292,11 +288,12 @@ backends:
     if enable_tool_shed_check:
         config["enable_tool_shed_check"] = enable_tool_shed_check
         config["hours_between_check"] = 0.001
+    tool_dependency_dir = os.environ.get('GALAXY_TOOL_DEPENDENCY_DIR')
     if tool_dependency_dir:
         config["tool_dependency_dir"] = tool_dependency_dir
-        # Used by shed's twill dependency stuff - todo read from
-        # Galaxy's config API.
-        os.environ["GALAXY_TEST_TOOL_DEPENDENCY_DIR"] = tool_dependency_dir
+    # Used by shed's twill dependency stuff
+    # TODO: read from Galaxy's config API.
+    os.environ["GALAXY_TEST_TOOL_DEPENDENCY_DIR"] = tool_dependency_dir or os.path.join(tmpdir, 'dependencies')
     return config
 
 


### PR DESCRIPTION
Fix https://github.com/galaxyproject/galaxy/issues/8656

Broken in https://github.com/galaxyproject/galaxy/pull/8152

Add test for bug introduced in https://github.com/galaxyproject/galaxy/pull/8660 when trying to fix #8656 on the dev branch.