### PR TITLE
User-facing Workflow Invocation Grid

### DIFF
--- a/client/galaxy/scripts/components/History/HistoryDropdown.vue
+++ b/client/galaxy/scripts/components/History/HistoryDropdown.vue
@@ -11,9 +11,7 @@
         </b-link>
         <div class="dropdown-menu" aria-labelledby="history-dropdown">
             <a class="dropdown-item" :href="urlView">View</a>
-            <!--
             <a class="dropdown-item" href="#" @click="onSwitch">Switch To</a>
-            -->
             <a class="dropdown-item" :href="urlShowStructure">Structure</a>
             <a class="dropdown-item" :href="urlSharing">Sharing</a>
         </div>
@@ -21,7 +19,7 @@
 </template>
 <script>
 import { getAppRoot } from "onload/loadConfig";
-import jQuery from "jquery";
+import { getGalaxyInstance } from "app";
 
 export default {
     props: ["history"],
@@ -37,9 +35,8 @@ export default {
     },
     methods: {
         onSwitch: function() {
-            // this switches the history, but doesn't trigger a reload yet...
-            // extract as service from history-model?
-            jQuery.getJSON(`${getAppRoot()}history/set_as_current?id=${this.history.id}`);
+            const Galaxy = getGalaxyInstance();
+            Galaxy.currHistoryPanel.switchToHistory(this.history.id);
         }
     }
 };

--- a/client/galaxy/scripts/components/HistoryDropdown.vue
+++ b/client/galaxy/scripts/components/HistoryDropdown.vue
@@ -1,0 +1,46 @@
+<template>
+    <div>
+        <b-link
+            id="history-dropdown"
+            class="history-dropdown font-weight-bold"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="false"
+        >
+            {{ history.name }}
+        </b-link>
+        <div class="dropdown-menu" aria-labelledby="history-dropdown">
+            <a class="dropdown-item" :href="urlView">View</a>
+            <!--
+            <a class="dropdown-item" href="#" @click="onSwitch">Switch To</a>
+            -->
+            <a class="dropdown-item" :href="urlShowStructure">Structure</a>
+            <a class="dropdown-item" :href="urlSharing">Sharing</a>
+        </div>
+    </div>
+</template>
+<script>
+import { getAppRoot } from "onload/loadConfig";
+import jQuery from "jquery";
+
+export default {
+    props: ["history"],
+    data() {
+        return {
+            urlView: `${getAppRoot()}histories/view?id=${this.history.id}`,
+            urlShowStructure: `${getAppRoot()}histories/show_structure?id=${this.history.id}`,
+            urlSharing: `${getAppRoot()}histories/sharing?id=${this.history.id}`
+        };
+    },
+    created() {
+        this.root = getAppRoot();
+    },
+    methods: {
+        onSwitch: function() {
+            // this switches the history, but doesn't trigger a reload yet...
+            // extract as service from history-model?
+            jQuery.getJSON(`${getAppRoot()}history/set_as_current?id=${this.history.id}`);
+        }
+    }
+};
+</script>

--- a/client/galaxy/scripts/components/User/RecentInvocations.vue
+++ b/client/galaxy/scripts/components/User/RecentInvocations.vue
@@ -2,7 +2,6 @@
     <invocations
         :invocationItems="invocationItems"
         :loading="loading"
-        :busy="busy"
         headerMessage="Your most recent workflow invocations are displayed on this page."
         noInvocationsMessage="There are no workflow invocations to show."
     >
@@ -10,7 +9,7 @@
 </template>
 
 <script>
-import Invocations from "components/admin/Invocations";
+import Invocations from "../Workflow/Invocations";
 import { getRecentInvocations } from "./UserServices";
 
 export default {
@@ -20,8 +19,7 @@ export default {
     data() {
         return {
             invocationItems: [],
-            loading: true,
-            busy: true
+            loading: true
         };
     },
     created() {
@@ -29,7 +27,6 @@ export default {
             .then(response => {
                 this.invocationItems = response.data;
                 this.loading = false;
-                this.busy = false;
             })
             .catch(this.handleError);
     },

--- a/client/galaxy/scripts/components/User/RecentInvocations.vue
+++ b/client/galaxy/scripts/components/User/RecentInvocations.vue
@@ -1,10 +1,11 @@
 <template>
     <invocations
-        :invocationItems="invocationItems" 
+        :invocationItems="invocationItems"
         :loading="loading"
         :busy="busy"
         headerMessage="Your most recent workflow invocations are displayed on this page."
-        noInvocationsMessage="There are no workflow invocations to show.">
+        noInvocationsMessage="There are no workflow invocations to show."
+    >
     </invocations>
 </template>
 
@@ -20,7 +21,7 @@ export default {
         return {
             invocationItems: [],
             loading: true,
-            busy: true,
+            busy: true
         };
     },
     created() {

--- a/client/galaxy/scripts/components/User/RecentInvocations.vue
+++ b/client/galaxy/scripts/components/User/RecentInvocations.vue
@@ -1,0 +1,41 @@
+<template>
+    <invocations
+        :invocationItems="invocationItems" 
+        :loading="loading"
+        :busy="busy"
+        headerMessage="Your most recent workflow invocations are displayed on this page."
+        noInvocationsMessage="There are no workflow invocations to show.">
+    </invocations>
+</template>
+
+<script>
+import Invocations from "components/admin/Invocations";
+import { getRecentInvocations } from "./UserServices";
+
+export default {
+    components: {
+        Invocations
+    },
+    data() {
+        return {
+            invocationItems: [],
+            loading: true,
+            busy: true,
+        };
+    },
+    created() {
+        getRecentInvocations()
+            .then(response => {
+                this.invocationItems = response.data;
+                this.loading = false;
+                this.busy = false;
+            })
+            .catch(this.handleError);
+    },
+    methods: {
+        handleError(error) {
+            console.error(error);
+        }
+    }
+};
+</script>

--- a/client/galaxy/scripts/components/User/UserServices.js
+++ b/client/galaxy/scripts/components/User/UserServices.js
@@ -1,0 +1,11 @@
+import { getAppRoot } from "onload/loadConfig";
+import axios from "axios";
+import { getGalaxyInstance } from "app";
+
+
+export function getRecentInvocations() {
+    const Galaxy = getGalaxyInstance()
+    const params = {user_id: Galaxy.user.id, limit: 150};
+    const url = `${getAppRoot()}api/invocations`;
+    return axios.get(url, { params: params });
+}

--- a/client/galaxy/scripts/components/User/UserServices.js
+++ b/client/galaxy/scripts/components/User/UserServices.js
@@ -2,10 +2,9 @@ import { getAppRoot } from "onload/loadConfig";
 import axios from "axios";
 import { getGalaxyInstance } from "app";
 
-
 export function getRecentInvocations() {
-    const Galaxy = getGalaxyInstance()
-    const params = {user_id: Galaxy.user.id, limit: 150};
+    const Galaxy = getGalaxyInstance();
+    const params = { user_id: Galaxy.user.id, limit: 150 };
     const url = `${getAppRoot()}api/invocations`;
     return axios.get(url, { params: params });
 }

--- a/client/galaxy/scripts/components/Workflow/Invocations.vue
+++ b/client/galaxy/scripts/components/Workflow/Invocations.vue
@@ -37,14 +37,14 @@
                     <b-button
                         v-b-tooltip.hover.bottom
                         title="Show Invocation Details"
-                        class="btn-sm fa fa-plus"
+                        class="btn-sm fa fa-chevron-down"
                         v-if="!data.detailsShowing"
                         @click.stop="swapRowDetails(data)"
                     />
                     <b-button
                         v-b-tooltip.hover.bottom
                         title="Hide Invocation Details"
-                        class="btn-sm fa fa-minus"
+                        class="btn-sm fa fa-chevron-up"
                         v-if="data.detailsShowing"
                         @click.stop="swapRowDetails(data)"
                     />

--- a/client/galaxy/scripts/components/Workflow/Invocations.vue
+++ b/client/galaxy/scripts/components/Workflow/Invocations.vue
@@ -19,7 +19,6 @@
                 :items="invocationItemsComputed"
                 v-model="invocationItemsModel"
                 hover
-                responsive
                 striped
                 caption-top
                 :busy="loading"

--- a/client/galaxy/scripts/components/Workflow/WorkflowDropdown.vue
+++ b/client/galaxy/scripts/components/Workflow/WorkflowDropdown.vue
@@ -10,7 +10,7 @@
             <span :class="icon" />
             {{ workflow.name }}
         </b-link>
-        <p>{{ workflow.description }}</p>
+        <p v-if="workflow.description">{{ workflow.description }}</p>
         <div v-if="workflow.shared" class="dropdown-menu" aria-labelledby="workflow-dropdown">
             <a class="dropdown-item" href="#" @click="onCopy">Copy</a>
             <a class="dropdown-item" :href="urlViewShared">View</a>

--- a/client/galaxy/scripts/components/admin/ActiveInvocations.vue
+++ b/client/galaxy/scripts/components/admin/ActiveInvocations.vue
@@ -5,6 +5,7 @@
         :busy="busy"
         headerMessage="Workflow invocations that are still being scheduled are displayed on this page."
         noInvocationsMessage="There are no scheduling workflow invocations to show currently."
+        :ownerGrid="false"
         >
     </invocations>
 </template>

--- a/client/galaxy/scripts/components/admin/ActiveInvocations.vue
+++ b/client/galaxy/scripts/components/admin/ActiveInvocations.vue
@@ -2,7 +2,6 @@
     <invocations
         :invocationItems="invocationItems"
         :loading="loading"
-        :busy="busy"
         headerMessage="Workflow invocations that are still being scheduled are displayed on this page."
         noInvocationsMessage="There are no scheduling workflow invocations to show currently."
         :ownerGrid="false"
@@ -11,7 +10,7 @@
 </template>
 
 <script>
-import Invocations from "./Invocations";
+import Invocations from "../Workflow/Invocations";
 import { getActiveInvocations } from "./AdminServices";
 
 export default {
@@ -21,8 +20,7 @@ export default {
     data() {
         return {
             invocationItems: [],
-            loading: true,
-            busy: true
+            loading: true
         };
     },
     created() {
@@ -30,7 +28,6 @@ export default {
             .then(response => {
                 this.invocationItems = response.data;
                 this.loading = false;
-                this.busy = false;
             })
             .catch(this.handleError);
     },

--- a/client/galaxy/scripts/components/admin/ActiveInvocations.vue
+++ b/client/galaxy/scripts/components/admin/ActiveInvocations.vue
@@ -1,0 +1,42 @@
+<template>
+    <invocations
+        :invocationItems="invocationItems" 
+        :loading="loading"
+        :busy="busy"
+        headerMessage="Workflow invocations that are still being scheduled are displayed on this page."
+        noInvocationsMessage="There are no scheduling workflow invocations to show currently."
+        >
+    </invocations>
+</template>
+
+<script>
+import Invocations from "./Invocations";
+import { getActiveInvocations } from "./AdminServices";
+
+export default {
+    components: {
+        Invocations
+    },
+    data() {
+        return {
+            invocationItems: [],
+            loading: true,
+            busy: true,
+        };
+    },
+    created() {
+        getActiveInvocations()
+            .then(response => {
+                this.invocationItems = response.data;
+                this.loading = false;
+                this.busy = false;
+            })
+            .catch(this.handleError);
+    },
+    methods: {
+        handleError(error) {
+            console.error(error);
+        }
+    }
+};
+</script>

--- a/client/galaxy/scripts/components/admin/ActiveInvocations.vue
+++ b/client/galaxy/scripts/components/admin/ActiveInvocations.vue
@@ -1,12 +1,12 @@
 <template>
     <invocations
-        :invocationItems="invocationItems" 
+        :invocationItems="invocationItems"
         :loading="loading"
         :busy="busy"
         headerMessage="Workflow invocations that are still being scheduled are displayed on this page."
         noInvocationsMessage="There are no scheduling workflow invocations to show currently."
         :ownerGrid="false"
-        >
+    >
     </invocations>
 </template>
 
@@ -22,7 +22,7 @@ export default {
         return {
             invocationItems: [],
             loading: true,
-            busy: true,
+            busy: true
         };
     },
     created() {

--- a/client/galaxy/scripts/components/admin/Invocations.vue
+++ b/client/galaxy/scripts/components/admin/Invocations.vue
@@ -46,6 +46,14 @@
                         -->
                     </div>
                 </template>
+                <template v-slot:cell(history_id)="data">
+                    <div v-if="!ownerGrid || !getHistoryById(data.item.history_id)">
+                        {{ data.item.history_id }}
+                    </div>
+                    <div v-else>
+                        <history-dropdown :history="getHistoryById(data.item.history_id)" />
+                    </div>
+                </template>
             </b-table>
         </div>
     </div>
@@ -56,27 +64,29 @@ import { getRootFromIndexLink } from "onload";
 import { WorkflowInvocationState } from "components/WorkflowInvocationState";
 import LoadingSpan from "components/LoadingSpan";
 import WorkflowDropdown from "components/Workflow/WorkflowDropdown";
+import HistoryDropdown from "components/HistoryDropdown";
 import { mapCacheActions } from "vuex-cache";
 import { mapGetters } from "vuex";
-
 
 export default {
     components: {
         WorkflowInvocationState,
         LoadingSpan,
-        WorkflowDropdown
+        WorkflowDropdown,
+        HistoryDropdown
     },
     props: {
         invocationItems: { type: Array, default: [] },
         busy: { type: Boolean, default: true },
         loading: { type: Boolean, default: true },
         noInvocationsMessage: { type: String },
-        headerMessage: { type: String, default: '' },
+        headerMessage: { type: String, default: "" },
         ownerGrid: { type: Boolean, default: true }
     },
     data() {
         let fields = [
             { key: "workflow_id", label: "Workflow" },
+            { key: "history_id", label: "History" },
             { key: "id", label: "Invocation ID", sortable: true },
             { key: "state" },
             { key: "update_time", label: "Last Update", sortable: true },
@@ -85,30 +95,32 @@ export default {
         return {
             invocationItemsModel: [],
             invocationFields: fields,
-            status: "",
+            status: ""
         };
     },
     computed: {
-        ...mapGetters(["getWorkflowByInstanceId"]),
+        ...mapGetters(["getWorkflowByInstanceId", "getHistoryById"]),
         invocationItemsComputed() {
             return this.computeItems(this.invocationItems);
         }
     },
     methods: {
-        ...mapCacheActions(["fetchWorkflowForInstanceId"]),
+        ...mapCacheActions(["fetchWorkflowForInstanceId", "fetchHistoryForId"]),
         editLink(workflowId) {
-            return getRootFromIndexLink() + 'workflow/editor?id=' + this.getWorkflowByInstanceId(workflowId).id
+            return getRootFromIndexLink() + "workflow/editor?id=" + this.getWorkflowByInstanceId(workflowId).id;
         },
         computeItems(items) {
             return items.map(invocation => {
-                if( this.ownerGrid ) {
+                if (this.ownerGrid) {
                     this.fetchWorkflowForInstanceId(invocation["workflow_id"]);
+                    this.fetchHistoryForId(invocation["history_id"]);
                 }
                 return {
                     id: invocation["id"],
                     create_time: invocation["create_time"],
                     update_time: invocation["update_time"],
                     workflow_id: invocation["workflow_id"],
+                    history_id: invocation["history_id"],
                     state: invocation["state"],
                     _showDetails: false
                 };

--- a/client/galaxy/scripts/components/admin/Invocations.vue
+++ b/client/galaxy/scripts/components/admin/Invocations.vue
@@ -35,52 +35,80 @@
                         <workflow-invocation-state :invocationId="row.item.id" :provideContext="false" />
                     </b-card>
                 </template>
+                <template v-slot:cell(workflow_id)="data">
+                    <div v-if="!ownerGrid || !getWorkflowByInstanceId(data.item.workflow_id)">
+                        {{ data.item.workflow_id }}
+                    </div>
+                    <div v-else>
+                        <workflow-dropdown :workflow="getWorkflowByInstanceId(data.item.workflow_id)" />
+                        <!--
+                        <a :href="editLink(data.item.workflow_id)">{{ getWorkflowByInstanceId(data.item.workflow_id).name }}</a>
+                        -->
+                    </div>
+                </template>
             </b-table>
         </div>
     </div>
 </template>
 
 <script>
+import { getRootFromIndexLink } from "onload";
 import { WorkflowInvocationState } from "components/WorkflowInvocationState";
 import LoadingSpan from "components/LoadingSpan";
+import WorkflowDropdown from "components/Workflow/WorkflowDropdown";
+import { mapCacheActions } from "vuex-cache";
+import { mapGetters } from "vuex";
+
 
 export default {
     components: {
         WorkflowInvocationState,
-        LoadingSpan
+        LoadingSpan,
+        WorkflowDropdown
     },
     props: {
         invocationItems: { type: Array, default: [] },
         busy: { type: Boolean, default: true },
         loading: { type: Boolean, default: true },
         noInvocationsMessage: { type: String },
-        headerMessage: { type: String, default: '' }
+        headerMessage: { type: String, default: '' },
+        ownerGrid: { type: Boolean, default: true }
     },
     data() {
+        let fields = [
+            { key: "workflow_id", label: "Workflow" },
+            { key: "id", label: "Invocation ID", sortable: true },
+            { key: "state" },
+            { key: "update_time", label: "Last Update", sortable: true },
+            { key: "create_time", label: "Invocation Time", sortable: true }
+        ];
         return {
             invocationItemsModel: [],
-            invocationFields: [
-                { key: "id", label: "Invocation ID", sortable: true },
-                // { key: "user" },
-                { key: "state" },
-                { key: "update_time", label: "Last Update", sortable: true },
-                { key: "create_time", label: "Invocation Time", sortable: true }
-            ],
+            invocationFields: fields,
             status: "",
         };
     },
     computed: {
+        ...mapGetters(["getWorkflowByInstanceId"]),
         invocationItemsComputed() {
             return this.computeItems(this.invocationItems);
         }
     },
     methods: {
+        ...mapCacheActions(["fetchWorkflowForInstanceId"]),
+        editLink(workflowId) {
+            return getRootFromIndexLink() + 'workflow/editor?id=' + this.getWorkflowByInstanceId(workflowId).id
+        },
         computeItems(items) {
             return items.map(invocation => {
+                if( this.ownerGrid ) {
+                    this.fetchWorkflowForInstanceId(invocation["workflow_id"]);
+                }
                 return {
                     id: invocation["id"],
                     create_time: invocation["create_time"],
                     update_time: invocation["update_time"],
+                    workflow_id: invocation["workflow_id"],
                     state: invocation["state"],
                     _showDetails: false
                 };

--- a/client/galaxy/scripts/components/admin/Invocations.vue
+++ b/client/galaxy/scripts/components/admin/Invocations.vue
@@ -3,17 +3,15 @@
         <h2 class="mb-3">
             <span id="invocations-title">Workflow Invocations</span>
         </h2>
-        <b-alert variant="info" show>
-            <p>
-                Workflow invocations that are still being scheduled are displayed on this page.
-            </p>
+        <b-alert variant="info" show v-if="headerMessage">
+            {{ headerMessage }}
         </b-alert>
         <b-alert v-if="loading" variant="info" show>
             <loading-span message="Loading workflow invocation job data" />
         </b-alert>
         <div v-else>
             <b-alert v-if="!invocationItemsComputed.length" variant="secondary" show>
-                There are no scheduling workflow invocations to show currently.
+                {{ noInvocationsMessage }}
             </b-alert>
             <b-table
                 v-else
@@ -44,7 +42,6 @@
 
 <script>
 import { WorkflowInvocationState } from "components/WorkflowInvocationState";
-import { getActiveInvocations } from "./AdminServices";
 import LoadingSpan from "components/LoadingSpan";
 
 export default {
@@ -52,9 +49,15 @@ export default {
         WorkflowInvocationState,
         LoadingSpan
     },
+    props: {
+        invocationItems: { type: Array, default: [] },
+        busy: { type: Boolean, default: true },
+        loading: { type: Boolean, default: true },
+        noInvocationsMessage: { type: String },
+        headerMessage: { type: String, default: '' }
+    },
     data() {
         return {
-            invocationItems: [],
             invocationItemsModel: [],
             invocationFields: [
                 { key: "id", label: "Invocation ID", sortable: true },
@@ -64,17 +67,12 @@ export default {
                 { key: "create_time", label: "Invocation Time", sortable: true }
             ],
             status: "",
-            loading: true,
-            busy: true
         };
     },
     computed: {
         invocationItemsComputed() {
             return this.computeItems(this.invocationItems);
         }
-    },
-    created() {
-        this.update();
     },
     methods: {
         computeItems(items) {
@@ -87,16 +85,6 @@ export default {
                     _showDetails: false
                 };
             });
-        },
-        update() {
-            this.busy = true;
-            getActiveInvocations()
-                .then(response => {
-                    this.invocationItems = response.data;
-                    this.loading = false;
-                    this.busy = false;
-                })
-                .catch(this.handleError);
         },
         showRowDetails(row, index, e) {
             if (e.target.nodeName != "A") {

--- a/client/galaxy/scripts/entry/admin/AdminRouter.js
+++ b/client/galaxy/scripts/entry/admin/AdminRouter.js
@@ -8,7 +8,7 @@ import Router from "layout/router";
 import DataTables from "components/admin/DataTables.vue";
 import DataTypes from "components/admin/DataTypes.vue";
 import Jobs from "components/admin/Jobs.vue";
-import Invocations from "components/admin/Invocations.vue";
+import ActiveInvocations from "components/admin/ActiveInvocations.vue";
 import DataManagerView from "components/admin/DataManager/DataManagerView.vue";
 import DataManagerRouter from "components/admin/DataManager/DataManagerRouter.vue";
 import Register from "components/login/Register.vue";
@@ -128,7 +128,7 @@ export const getAdminRouter = (Galaxy, options) => {
         },
 
         show_invocations: function() {
-            this._display_vue_helper(Invocations);
+            this._display_vue_helper(ActiveInvocations);
         },
 
         show_error_stack: function() {

--- a/client/galaxy/scripts/entry/analysis/AnalysisRouter.js
+++ b/client/galaxy/scripts/entry/analysis/AnalysisRouter.js
@@ -92,11 +92,11 @@ export const getAnalysisRouter = Galaxy =>
             return (Galaxy.user && Galaxy.user.id) || this.require_login.indexOf(name) == -1;
         },
 
-        _display_vue_helper: function(component, props = {}) {
+        _display_vue_helper: function(component, propsData = {}) {
             const instance = Vue.extend(component);
             const container = document.createElement("div");
             this.page.display(container);
-            return new instance({ store, props }).$mount(container);
+            return new instance({ store, propsData }).$mount(container);
         },
 
         show_tours: function(tour_id) {

--- a/client/galaxy/scripts/entry/analysis/AnalysisRouter.js
+++ b/client/galaxy/scripts/entry/analysis/AnalysisRouter.js
@@ -30,7 +30,7 @@ import WorkflowList from "components/Workflow/WorkflowList.vue";
 import HistoryImport from "components/HistoryImport.vue";
 import HistoryView from "components/HistoryView.vue";
 import WorkflowInvocationReport from "components/WorkflowInvocationReport.vue";
-import RecentInvocations from "components/User/RecentInvocations.vue"
+import RecentInvocations from "components/User/RecentInvocations.vue";
 import HistoryList from "mvc/history/history-list";
 import PluginList from "components/PluginList.vue";
 import ToolFormComposite from "mvc/tool/tool-form-composite";
@@ -96,7 +96,7 @@ export const getAnalysisRouter = Galaxy =>
             const instance = Vue.extend(component);
             const container = document.createElement("div");
             this.page.display(container);
-            return new instance({ store, props}).$mount(container);
+            return new instance({ store, props }).$mount(container);
         },
 
         show_tours: function(tour_id) {

--- a/client/galaxy/scripts/entry/analysis/AnalysisRouter.js
+++ b/client/galaxy/scripts/entry/analysis/AnalysisRouter.js
@@ -30,6 +30,7 @@ import WorkflowList from "components/Workflow/WorkflowList.vue";
 import HistoryImport from "components/HistoryImport.vue";
 import HistoryView from "components/HistoryView.vue";
 import WorkflowInvocationReport from "components/WorkflowInvocationReport.vue";
+import RecentInvocations from "components/User/RecentInvocations.vue"
 import HistoryList from "mvc/history/history-list";
 import PluginList from "components/PluginList.vue";
 import ToolFormComposite from "mvc/tool/tool-form-composite";
@@ -42,6 +43,7 @@ import Citations from "components/Citations.vue";
 import DisplayStructure from "components/DisplayStructured.vue";
 import Vue from "vue";
 import { CloudAuth } from "components/User/CloudAuth";
+import store from "store";
 
 /** Routes */
 export const getAnalysisRouter = Galaxy =>
@@ -64,6 +66,7 @@ export const getAnalysisRouter = Galaxy =>
             "(/)workflows/import": "show_workflows_import",
             "(/)workflows/run(/)": "show_workflows_run",
             "(/)workflows(/)list": "show_workflows",
+            "(/)workflows/invocations": "show_workflow_invocations",
             "(/)workflows/invocations/report": "show_workflow_invocation_report",
             "(/)workflows/list_published(/)": "show_workflows_published",
             "(/)workflows/create(/)": "show_workflows_create",
@@ -93,7 +96,7 @@ export const getAnalysisRouter = Galaxy =>
             const instance = Vue.extend(component);
             const container = document.createElement("div");
             this.page.display(container);
-            return new instance(props).$mount(container);
+            return new instance({ store, props}).$mount(container);
         },
 
         show_tours: function(tour_id) {
@@ -188,10 +191,11 @@ export const getAnalysisRouter = Galaxy =>
 
         show_workflow_invocation_report: function() {
             const invocationId = QueryStringParsing.get("id");
-            var reportInstance = Vue.extend(WorkflowInvocationReport);
-            var vm = document.createElement("div");
-            this.page.display(vm);
-            new reportInstance({ propsData: { invocationId: invocationId } }).$mount(vm);
+            this._display_vue_helper(WorkflowInvocationReport, { invocationId: invocationId });
+        },
+
+        show_workflow_invocations: function() {
+            this._display_vue_helper(RecentInvocations, {});
         },
 
         show_history_structure: function() {

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -302,7 +302,13 @@ const Collection = Backbone.Collection.extend({
                         title: _l("Pages"),
                         url: "pages/list",
                         target: "__use_router__"
-                    }
+                    },
+                    {
+                        title: _l("Workflow Invocations"),
+                        url: "workflows/invocations",
+                        target: "__use_router__"
+                    },
+
                 ]
             };
             if (Galaxy.config.visualizations_visible) {

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -307,8 +307,7 @@ const Collection = Backbone.Collection.extend({
                         title: _l("Workflow Invocations"),
                         url: "workflows/invocations",
                         target: "__use_router__"
-                    },
-
+                    }
                 ]
             };
             if (Galaxy.config.visualizations_visible) {

--- a/client/galaxy/scripts/store/historyStore.js
+++ b/client/galaxy/scripts/store/historyStore.js
@@ -1,0 +1,34 @@
+export const state = {
+    historiesById: {}
+};
+
+import Vue from "vue";
+import { getAppRoot } from "onload/loadConfig";
+import axios from "axios";
+
+const getters = {
+    getHistoryById: state => historyId => {
+        return state.historiesById[historyId];
+    }
+};
+
+const actions = {
+    fetchHistoryForId: async ({ commit }, historyId) => {
+        const params = {};
+        const { data } = await axios.get(`${getAppRoot()}api/histories/${historyId}`, { params });
+        commit("saveHistoryForId", { historyId, historyData: data });
+    }
+};
+
+const mutations = {
+    saveHistoryForId: (state, { historyId, historyData }) => {
+        Vue.set(state.historiesById, historyId, historyData);
+    }
+};
+
+export const historyStore = {
+    state,
+    getters,
+    actions,
+    mutations
+};

--- a/client/galaxy/scripts/store/index.js
+++ b/client/galaxy/scripts/store/index.js
@@ -13,6 +13,7 @@ import { invocationStore } from "./invocationStore";
 import { userStore } from "./userStore";
 import { configStore } from "./configStore";
 import { workflowStore } from "./workflowStore";
+import { historyStore } from "./historyStore";
 
 Vue.use(Vuex);
 
@@ -32,7 +33,8 @@ export function createStore() {
             invocations: invocationStore,
             user: userStore,
             config: configStore,
-            workflows: workflowStore
+            workflows: workflowStore,
+            history: historyStore
         }
     });
 }

--- a/client/galaxy/scripts/store/index.js
+++ b/client/galaxy/scripts/store/index.js
@@ -12,6 +12,7 @@ import { jobMetricsStore } from "./jobMetricsStore";
 import { invocationStore } from "./invocationStore";
 import { userStore } from "./userStore";
 import { configStore } from "./configStore";
+import { workflowStore } from "./workflowStore";
 
 Vue.use(Vuex);
 
@@ -30,7 +31,8 @@ export function createStore() {
             jobMetrics: jobMetricsStore,
             invocations: invocationStore,
             user: userStore,
-            config: configStore
+            config: configStore,
+            workflows: workflowStore
         }
     });
 }

--- a/client/galaxy/scripts/store/workflowStore.js
+++ b/client/galaxy/scripts/store/workflowStore.js
@@ -1,0 +1,34 @@
+export const state = {
+    workflowsByInstanceId: {},
+};
+
+import Vue from "vue";
+import { getAppRoot } from "onload/loadConfig";
+import axios from "axios";
+
+const getters = {
+    getWorkflowByInstanceId: state => workflowId => {
+        return state.workflowsByInstanceId[workflowId];
+    }
+};
+
+const actions = {
+    fetchWorkflowForInstanceId: async ({ commit }, workflowId) => {
+        const params = { instance: "true" };
+        const { data } = await axios.get(`${getAppRoot()}api/workflows/${workflowId}`, { params });
+        commit("saveWorkflowForInstanceId", { workflowId, workflowData: data });
+    }
+};
+
+const mutations = {
+    saveWorkflowForInstanceId: (state, { workflowId, workflowData }) => {
+        Vue.set(state.workflowsByInstanceId, workflowId, workflowData);
+    }
+};
+
+export const workflowStore = {
+    state,
+    getters,
+    actions,
+    mutations
+};

--- a/client/galaxy/scripts/store/workflowStore.js
+++ b/client/galaxy/scripts/store/workflowStore.js
@@ -1,5 +1,5 @@
 export const state = {
-    workflowsByInstanceId: {},
+    workflowsByInstanceId: {}
 };
 
 import Vue from "vue";

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -194,10 +194,10 @@ class WorkflowsManager(object):
         trans.sa_session.flush()
         return workflow_invocation_step
 
-    def build_invocations_query(self, trans, stored_workflow_id=None, history_id=None, user_id=None, include_terminal=True):
+    def build_invocations_query(self, trans, stored_workflow_id=None, history_id=None, user_id=None, include_terminal=True, limit=None):
         """Get invocations owned by the current user."""
         sa_session = trans.sa_session
-        invocations_query = sa_session.query(model.WorkflowInvocation)
+        invocations_query = sa_session.query(model.WorkflowInvocation).order_by(model.WorkflowInvocation.table.c.id.desc())
         if stored_workflow_id is not None:
             stored_workflow = sa_session.query(model.StoredWorkflow).get(stored_workflow_id)
             if not stored_workflow:
@@ -224,6 +224,9 @@ class WorkflowsManager(object):
             invocations_query = invocations_query.filter(
                 model.WorkflowInvocation.table.c.state.in_(model.WorkflowInvocation.non_terminal_states)
             )
+
+        if limit is not None:
+            invocations_query = invocations_query.limit(limit)
 
         return [inv for inv in invocations_query if self.check_security(trans,
                                                                         inv,

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -151,6 +151,7 @@ def app_factory(global_conf, load_app_kwds={}, **kwargs):
     webapp.add_client_route('/workflows/create')
     webapp.add_client_route('/workflows/run')
     webapp.add_client_route('/workflows/import')
+    webapp.add_client_route('/workflows/invocations')
     webapp.add_client_route('/workflows/invocations/report')
     webapp.add_client_route('/custom_builds')
     webapp.add_client_route('/interactivetool_entry_points/list')


### PR DESCRIPTION
- Refactor generic grid out of admin-centric invocation grid introduced in #8664 
- Add contextual menus for target workflow and history based on WorkflowDropdown added in #8551.
- Add workflow and history vuex stores for caching storedworkflow and history data fetched from the server (based on vuex-cache pattern introduced in #8044
- Update all workflow APIs to allow fetching stored workflows from a stored workflow ID or a workflow ID using the new query parameter (``instance=false`` - override default of ``false`` to ``true`` to fetch by a ``model.Workflow`` ID instead of a ``model.StoredWorkflow`` ID).

I had a request from another developer that the basic version of this grid (5d916e3) without the contextual menus should be backported to 19.09 - I think that is reasonable but I also recognize it was already a big ask to get #8664 in.

<img width="297" alt="Screen Shot 2019-09-24 at 10 19 59 AM" src="https://user-images.githubusercontent.com/216771/65520097-0a041f80-deb5-11e9-80ac-2557b36c252f.png">

<img width="1131" alt="Screen Shot 2019-09-24 at 10 20 44 AM" src="https://user-images.githubusercontent.com/216771/65520105-0d97a680-deb5-11e9-81a4-6626dd028337.png">

<img width="1149" alt="Screen Shot 2019-09-24 at 10 20 52 AM" src="https://user-images.githubusercontent.com/216771/65520116-138d8780-deb5-11e9-983f-4937f11ba680.png">

