### PR TITLE
Make Masthead and workflow page screenreader friendly

### DIFF
--- a/client/galaxy/scripts/components/FavoritesButton.vue
+++ b/client/galaxy/scripts/components/FavoritesButton.vue
@@ -5,6 +5,8 @@
         v-b-tooltip.hover
         :title="tooltipText"
         href="javascript:void(0)"
+        role="button"
+        aria-label="Show favorite tools"
     >
         <span class="fa fa-star-o"></span>
     </a>

--- a/client/galaxy/scripts/components/Tool.vue
+++ b/client/galaxy/scripts/components/Tool.vue
@@ -26,7 +26,7 @@
 
 <script>
 import { getGalaxyInstance } from "app"; // FIXME:
-import ariaAlert from "utils/ariaAlert"
+import ariaAlert from "utils/ariaAlert";
 
 export default {
     name: "Tool",

--- a/client/galaxy/scripts/components/Tool.vue
+++ b/client/galaxy/scripts/components/Tool.vue
@@ -26,6 +26,7 @@
 
 <script>
 import { getGalaxyInstance } from "app"; // FIXME:
+import ariaAlert from "utils/ariaAlert"
 
 export default {
     name: "Tool",
@@ -54,6 +55,7 @@ export default {
                     version: this.tool.version
                 });
             }
+            ariaAlert(`${this.tool.name} opened in galaxy center panel`);
         }
     },
     created() {}

--- a/client/galaxy/scripts/components/ToolSection.vue
+++ b/client/galaxy/scripts/components/ToolSection.vue
@@ -1,15 +1,15 @@
 <template>
     <div>
         <div v-if="category.model_class.endsWith('ToolSection')" class="toolSectionWrapper">
-            <div class="toolSectionTitle">
-                <a @click="opened = !opened" href="javascript:void(0)">
+            <div :id="category.name" class="toolSectionTitle">
+                <a @click="toggleToolSectionMenu" href="javascript:void(0)" role="button">
                     <span>
                         {{ category.name }}
                     </span>
                 </a>
             </div>
             <transition name="slide">
-                <div v-if="opened">
+                <div v-if="opened" >
                     <template v-for="tool in category.elems">
                         <tool v-if="tool.model_class.endsWith('Tool')" :tool="tool" :key="tool.id"></tool>
                         <div v-else-if="tool.model_class === 'ToolSectionLabel'" class="toolPanelLabel" :key="tool.id">
@@ -34,6 +34,7 @@
 
 <script>
 import Tool from "./Tool.vue";
+import ariaAlert from "utils/ariaAlert"
 
 export default {
     name: "ToolSection",
@@ -48,7 +49,13 @@ export default {
             type: Boolean
         }
     },
-    methods: {},
+    methods: {
+        toggleToolSectionMenu(e) {
+            this.opened = !this.opened;
+            const currentState = this.opened ? "opened" : "closed";
+            ariaAlert(`${this.category.name} tools menu ${currentState}`);
+        }
+    },
     data() {
         return {
             opened: false

--- a/client/galaxy/scripts/components/ToolSection.vue
+++ b/client/galaxy/scripts/components/ToolSection.vue
@@ -9,7 +9,7 @@
                 </a>
             </div>
             <transition name="slide">
-                <div v-if="opened" >
+                <div v-if="opened">
                     <template v-for="tool in category.elems">
                         <tool v-if="tool.model_class.endsWith('Tool')" :tool="tool" :key="tool.id"></tool>
                         <div v-else-if="tool.model_class === 'ToolSectionLabel'" class="toolPanelLabel" :key="tool.id">
@@ -34,7 +34,7 @@
 
 <script>
 import Tool from "./Tool.vue";
-import ariaAlert from "utils/ariaAlert"
+import ariaAlert from "utils/ariaAlert";
 
 export default {
     name: "ToolSection",

--- a/client/galaxy/scripts/components/Toolshed/Index.vue
+++ b/client/galaxy/scripts/components/Toolshed/Index.vue
@@ -4,11 +4,11 @@
         <div v-else>
             <b-input-group class="mb-3">
                 <b-input
-                        placeholder="Search Repositories"
-                        v-model="queryInput"
-                        @input="delayQuery"
-                        @change="setQuery"
-                        @keydown.esc="setQuery()"
+                    placeholder="Search Repositories"
+                    v-model="queryInput"
+                    @input="delayQuery"
+                    @change="setQuery"
+                    @keydown.esc="setQuery()"
                 />
                 <b-input-group-append>
                     <b-btn :disabled="!queryInput" @click="setQuery()">
@@ -27,64 +27,64 @@
     </div>
 </template>
 <script>
-    import SearchList from "./SearchList/Index.vue";
-    import InstalledList from "./InstalledList/Index.vue";
-    export default {
-        components: {
-            SearchList,
-            InstalledList
-        },
-        data() {
-            return {
-                queryInput: null,
-                queryDelay: 1000,
-                queryTimer: null,
-                queryLength: 3,
-                query: null,
-                scrolled: false,
-                loading: false,
-                total: 0,
-                error: null,
-                tabValue: true,
-                tabOptions: [{ text: "Search All", value: true }, { text: "Installed Only", value: false }]
-            };
-        },
-        watch: {
-            tabValue() {
-                this.setQuery("");
-            }
-        },
-        computed: {
-            queryEmpty() {
-                return !this.query || this.query.length < this.queryLength;
-            }
-        },
-        methods: {
-            clearTimer() {
-                if (this.queryTimer) {
-                    clearTimeout(this.queryTimer);
-                }
-            },
-            delayQuery(query) {
-                this.clearTimer();
-                if (query) {
-                    this.queryTimer = setTimeout(() => {
-                        this.setQuery(query);
-                    }, this.queryDelay);
-                } else {
-                    this.setQuery(query);
-                }
-            },
-            setError(error) {
-                this.error = error;
-            },
-            setQuery(query) {
-                this.clearTimer();
-                this.query = this.queryInput = query;
-            },
-            onScroll({ target: { scrollTop, clientHeight, scrollHeight } }) {
-                this.scrolled = scrollTop + clientHeight >= scrollHeight;
-            }
+import SearchList from "./SearchList/Index.vue";
+import InstalledList from "./InstalledList/Index.vue";
+export default {
+    components: {
+        SearchList,
+        InstalledList
+    },
+    data() {
+        return {
+            queryInput: null,
+            queryDelay: 1000,
+            queryTimer: null,
+            queryLength: 3,
+            query: null,
+            scrolled: false,
+            loading: false,
+            total: 0,
+            error: null,
+            tabValue: true,
+            tabOptions: [{ text: "Search All", value: true }, { text: "Installed Only", value: false }]
+        };
+    },
+    watch: {
+        tabValue() {
+            this.setQuery("");
         }
-    };
+    },
+    computed: {
+        queryEmpty() {
+            return !this.query || this.query.length < this.queryLength;
+        }
+    },
+    methods: {
+        clearTimer() {
+            if (this.queryTimer) {
+                clearTimeout(this.queryTimer);
+            }
+        },
+        delayQuery(query) {
+            this.clearTimer();
+            if (query) {
+                this.queryTimer = setTimeout(() => {
+                    this.setQuery(query);
+                }, this.queryDelay);
+            } else {
+                this.setQuery(query);
+            }
+        },
+        setError(error) {
+            this.error = error;
+        },
+        setQuery(query) {
+            this.clearTimer();
+            this.query = this.queryInput = query;
+        },
+        onScroll({ target: { scrollTop, clientHeight, scrollHeight } }) {
+            this.scrolled = scrollTop + clientHeight >= scrollHeight;
+        }
+    }
+};
 </script>

--- a/client/galaxy/scripts/components/Toolshed/Index.vue
+++ b/client/galaxy/scripts/components/Toolshed/Index.vue
@@ -4,11 +4,11 @@
         <div v-else>
             <b-input-group class="mb-3">
                 <b-input
-                    placeholder="Search Repositories"
-                    v-model="queryInput"
-                    @input="delayQuery"
-                    @change="setQuery"
-                    @keydown.esc="setQuery()"
+                        placeholder="Search Repositories"
+                        v-model="queryInput"
+                        @input="delayQuery"
+                        @change="setQuery"
+                        @keydown.esc="setQuery()"
                 />
                 <b-input-group-append>
                     <b-btn :disabled="!queryInput" @click="setQuery()">
@@ -27,64 +27,64 @@
     </div>
 </template>
 <script>
-import SearchList from "./SearchList/Index.vue";
-import InstalledList from "./InstalledList/Index.vue";
-export default {
-    components: {
-        SearchList,
-        InstalledList
-    },
-    data() {
-        return {
-            queryInput: null,
-            queryDelay: 1000,
-            queryTimer: null,
-            queryLength: 3,
-            query: null,
-            scrolled: false,
-            loading: false,
-            total: 0,
-            error: null,
-            tabValue: true,
-            tabOptions: [{ text: "Search All", value: true }, { text: "Installed Only", value: false }]
-        };
-    },
-    watch: {
-        tabValue() {
-            this.setQuery("");
-        }
-    },
-    computed: {
-        queryEmpty() {
-            return !this.query || this.query.length < this.queryLength;
-        }
-    },
-    methods: {
-        clearTimer() {
-            if (this.queryTimer) {
-                clearTimeout(this.queryTimer);
+    import SearchList from "./SearchList/Index.vue";
+    import InstalledList from "./InstalledList/Index.vue";
+    export default {
+        components: {
+            SearchList,
+            InstalledList
+        },
+        data() {
+            return {
+                queryInput: null,
+                queryDelay: 1000,
+                queryTimer: null,
+                queryLength: 3,
+                query: null,
+                scrolled: false,
+                loading: false,
+                total: 0,
+                error: null,
+                tabValue: true,
+                tabOptions: [{ text: "Search All", value: true }, { text: "Installed Only", value: false }]
+            };
+        },
+        watch: {
+            tabValue() {
+                this.setQuery("");
             }
         },
-        delayQuery(query) {
-            this.clearTimer();
-            if (query) {
-                this.queryTimer = setTimeout(() => {
+        computed: {
+            queryEmpty() {
+                return !this.query || this.query.length < this.queryLength;
+            }
+        },
+        methods: {
+            clearTimer() {
+                if (this.queryTimer) {
+                    clearTimeout(this.queryTimer);
+                }
+            },
+            delayQuery(query) {
+                this.clearTimer();
+                if (query) {
+                    this.queryTimer = setTimeout(() => {
+                        this.setQuery(query);
+                    }, this.queryDelay);
+                } else {
                     this.setQuery(query);
-                }, this.queryDelay);
-            } else {
-                this.setQuery(query);
+                }
+            },
+            setError(error) {
+                this.error = error;
+            },
+            setQuery(query) {
+                this.clearTimer();
+                this.query = this.queryInput = query;
+            },
+            onScroll({ target: { scrollTop, clientHeight, scrollHeight } }) {
+                this.scrolled = scrollTop + clientHeight >= scrollHeight;
             }
-        },
-        setError(error) {
-            this.error = error;
-        },
-        setQuery(query) {
-            this.clearTimer();
-            this.query = this.queryInput = query;
-        },
-        onScroll({ target: { scrollTop, clientHeight, scrollHeight } }) {
-            this.scrolled = scrollTop + clientHeight >= scrollHeight;
         }
-    }
-};
+    };
 </script>

--- a/client/galaxy/scripts/components/UploadButton.vue
+++ b/client/galaxy/scripts/components/UploadButton.vue
@@ -1,10 +1,5 @@
 <template>
-    <div
-        class="upload-button"
-        v-b-tooltip.hover
-        title="Download from URL or upload files from disk"
-        @click="showUploadDialog"
-    >
+    <div class="upload-button">
         <div class="progress">
             <div
                 class="progress-bar progress-bar-notransition"
@@ -18,6 +13,10 @@
                 id="tool-panel-upload-button"
                 @click="showUploadDialog"
                 href="javascript:void(0)"
+                role="button"
+                v-b-tooltip.hover
+                aria-label="Download from URL or upload files from disk"
+                title="Download from URL or upload files from disk"
             >
                 <span class="fa fa-upload"></span>
             </a>

--- a/client/galaxy/scripts/layout/masthead.js
+++ b/client/galaxy/scripts/layout/masthead.js
@@ -97,7 +97,7 @@ const View = Backbone.View.extend({
     /** body template */
     _template: function() {
         return `
-            <nav id="masthead" class="navbar navbar-expand justify-content-center navbar-dark">
+            <nav id="masthead" class="navbar navbar-expand justify-content-center navbar-dark" role="navigation" aria-label="Main">
                 <a class="navbar-brand" aria-label="homepage">
                     <img alt="logo" class="navbar-brand-image"/>
                     <span class="navbar-brand-title"/>

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -72,6 +72,8 @@ const Collection = Backbone.Collection.extend({
                 title: _l("Visualize"),
                 tooltip: _l("Visualize datasets"),
                 disabled: !Galaxy.user.id,
+                attributes: { "aria-haspopup": "true", "aria-expanded": "false" },
+
                 menu: [
                     {
                         title: _l("Create Visualization"),
@@ -366,6 +368,7 @@ const Tab = Backbone.View.extend({
             .addClass(this.model.get("icon") && `nav-icon fa ${this.model.get("icon")}`)
             .addClass(this.model.get("menu") && "dropdown-toggle")
             .addClass(this.model.get("toggle") && "toggle")
+            .attr("id", this.model.get("menu") && `dropdown-button-${this.model.get("id")}`)
             .attr("target", this.model.get("target"))
             .attr("href", this.model.get("url"))
             .attr("title", this.model.get("tooltip"))
@@ -395,6 +398,7 @@ const Tab = Backbone.View.extend({
                 }
             });
             this.$menu.addClass("dropdown-menu");
+            this.$menu.attr("aria-labelledby", this.$menu.siblings(".dropdown-toggle").attr("id"));
             this.$link.append($("<b/>").addClass("caret"));
         }
         return this;

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -70,10 +70,9 @@ const Collection = Backbone.Collection.extend({
             this.add({
                 id: "visualization",
                 title: _l("Visualize"),
+                url: "javascript:void(0)",
                 tooltip: _l("Visualize datasets"),
                 disabled: !Galaxy.user.id,
-                attributes: { "aria-haspopup": "true", "aria-expanded": "false" },
-
                 menu: [
                     {
                         title: _l("Create Visualization"),
@@ -95,7 +94,7 @@ const Collection = Backbone.Collection.extend({
         this.add({
             id: "shared",
             title: _l("Shared Data"),
-            url: "library/index",
+            url: "javascript:void(0)",
             tooltip: _l("Access published resources"),
             menu: [
                 {
@@ -179,6 +178,7 @@ const Collection = Backbone.Collection.extend({
         const helpTab = {
             id: "help",
             title: _l("Help"),
+            url: "javascript:void(0)",
             tooltip: _l("Support, contact, and community"),
             menu: [
                 {
@@ -262,6 +262,7 @@ const Collection = Backbone.Collection.extend({
                 id: "user",
                 title: _l("User"),
                 cls: "loggedin-only",
+                url: "javascript:void(0)",
                 tooltip: _l("Account and saved data"),
                 menu: [
                     {
@@ -369,6 +370,7 @@ const Tab = Backbone.View.extend({
             .addClass(this.model.get("menu") && "dropdown-toggle")
             .addClass(this.model.get("toggle") && "toggle")
             .attr("id", this.model.get("menu") && `dropdown-button-${this.model.get("id")}`)
+            .attr("aria-haspopup", this.model.get("menu") && "true")
             .attr("target", this.model.get("target"))
             .attr("href", this.model.get("url"))
             .attr("title", this.model.get("tooltip"))
@@ -399,6 +401,7 @@ const Tab = Backbone.View.extend({
             });
             this.$menu.addClass("dropdown-menu");
             this.$menu.attr("aria-labelledby", this.$menu.siblings(".dropdown-toggle").attr("id"));
+            this.$menu.attr("role", "menu");
             this.$link.append($("<b/>").addClass("caret"));
         }
         return this;
@@ -417,6 +420,7 @@ const Tab = Backbone.View.extend({
             .addClass("dropdown-item")
             .attr("href", options.url)
             .attr("target", options.target)
+            .attr("role", "menuitem")
             .html(options.title)
             .on("click", e => {
                 e.preventDefault();

--- a/client/galaxy/scripts/layout/panel.js
+++ b/client/galaxy/scripts/layout/panel.js
@@ -266,7 +266,7 @@ const CenterPanel = Backbone.View.extend({
     template: function() {
         return (
             '<div class="center-container">' +
-            '<iframe id="galaxy_main" name="galaxy_main" frameborder="0" class="center-frame" />' +
+            '<iframe id="galaxy_main" name="galaxy_main" frameborder="0" class="center-frame" title="galaxy main frame"/>' +
             '<div class="center-panel" />' +
             "</div>"
         );

--- a/client/galaxy/scripts/mvc/tool/tool-form-base.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-base.js
@@ -6,7 +6,7 @@ import $ from "jquery";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import _l from "utils/localization";
-// import Utils from "utils/utils";
+import ariaAlert from "utils/ariaAlert"
 import Deferred from "utils/deferred";
 import Ui from "mvc/ui/ui-misc";
 import FormBase from "mvc/form/form-view";
@@ -125,6 +125,7 @@ export default FormBase.extend({
                         favorite_button.hide();
                         remove_favorite_button.show();
                         Galaxy.user.updateFavorites("tools", response.data);
+                        ariaAlert("added to favorites");
                     });
             }
         });
@@ -143,6 +144,7 @@ export default FormBase.extend({
                         remove_favorite_button.hide();
                         favorite_button.show();
                         Galaxy.user.updateFavorites("tools", response.data);
+                        ariaAlert("removed from favorites");
                     });
             }
         });

--- a/client/galaxy/scripts/mvc/tool/tool-form-base.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-base.js
@@ -6,7 +6,7 @@ import $ from "jquery";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import _l from "utils/localization";
-import ariaAlert from "utils/ariaAlert"
+import ariaAlert from "utils/ariaAlert";
 import Deferred from "utils/deferred";
 import Ui from "mvc/ui/ui-misc";
 import FormBase from "mvc/form/form-view";

--- a/client/galaxy/scripts/mvc/ui/ui-options.js
+++ b/client/galaxy/scripts/mvc/ui/ui-options.js
@@ -272,7 +272,7 @@ RadioButton.View = Base.extend({
 
     /** Template for a single option */
     _templateOption: function(pair) {
-        var $el = $("<label/>").addClass("btn btn-secondary m-0");
+        var $el = $("<label/>").addClass("btn btn-secondary m-0").attr("role", "button");
         if (pair.icon) {
             $el.append(
                 $("<i/>")

--- a/client/galaxy/scripts/mvc/ui/ui-options.js
+++ b/client/galaxy/scripts/mvc/ui/ui-options.js
@@ -272,7 +272,9 @@ RadioButton.View = Base.extend({
 
     /** Template for a single option */
     _templateOption: function(pair) {
-        var $el = $("<label/>").addClass("btn btn-secondary m-0").attr("role", "button");
+        var $el = $("<label/>")
+            .addClass("btn btn-secondary m-0")
+            .attr("role", "button");
         if (pair.icon) {
             $el.append(
                 $("<i/>")

--- a/client/galaxy/scripts/mvc/ui/ui-portlet.js
+++ b/client/galaxy/scripts/mvc/ui/ui-portlet.js
@@ -213,13 +213,13 @@ export var View = Backbone.View.extend({
             .append(
                 $("<div/>")
                     .addClass("portlet-header")
-                    .append($("<div/>").addClass("portlet-operations"))
                     .append(
                         $("<div/>")
                             .addClass("portlet-title")
                             .append($("<i/>").addClass("portlet-title-icon"))
                             .append($("<span/>").addClass("portlet-title-text"))
                     )
+                    .append($("<div/>").addClass("portlet-operations"))
             )
             .append(
                 $("<div/>")

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
@@ -332,7 +332,7 @@ var BaseOutputTerminalView = TerminalView.extend({
                 inputChoicesMenu.firstChild.classList.add("active");
                 inputChoicesMenu.firstChild.focus();
             } else {
-                //alert user that there are no available inputs to connect to for this output
+                ariaAlert("There are no available inputs for this selected output");
             }
         };
 

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
@@ -3,7 +3,7 @@ import _ from "underscore";
 import Backbone from "backbone";
 import Terminals from "mvc/workflow/workflow-terminals";
 import Connector from "mvc/workflow/workflow-connector";
-import ariaAlert from "utils/ariaAlert"
+import ariaAlert from "utils/ariaAlert";
 
 // TODO; tie into Galaxy state?
 window.workflow_globals = window.workflow_globals || {};
@@ -211,7 +211,10 @@ var BaseOutputTerminalView = TerminalView.extend({
         const terminal = this.terminalForOutput(output);
         this.setupMappingView(terminal);
         this.el.terminal = terminal;
-        this.$el.attr("aria-label", `connect output ${name} from ${node.name} to input. Press space to see a list of available inputs`);
+        this.$el.attr(
+            "aria-label",
+            `connect output ${name} from ${node.name} to input. Press space to see a list of available inputs`
+        );
         this.$el.attr("output-name", name);
         this.$el.attr("id", id);
         this.$el.attr("tabindex", "0");
@@ -230,45 +233,42 @@ var BaseOutputTerminalView = TerminalView.extend({
     },
 
     screenReaderSelectOutputNode: function(e) {
-        const inputChoiceKeyDown = (e) => {
+        const inputChoiceKeyDown = e => {
             e.stopPropagation();
             const currentItem = e.currentTarget;
             const previousItem = currentItem.previousSibling;
             const nextItem = currentItem.nextSibling;
             const inputTerminal = currentItem.input.context.terminal;
 
-           const switchActiveItem = (currentActive, newActive ) => {
+            const switchActiveItem = (currentActive, newActive) => {
                 newActive.classList.add("active");
                 newActive.focus();
                 currentActive.classList.remove("active");
-           }
+            };
 
             const removeMenu = () => {
                 $(currentItem.parentNode).remove();
-                this.$el.removeAttr('aria-owns');
-                this.$el.attr('aria-grabbed', 'false');
+                this.$el.removeAttr("aria-owns");
+                this.$el.attr("aria-grabbed", "false");
                 this.$el.focus();
-            }
+            };
 
-            switch (e.keyCode)
-            {
-                case 40 : // Down arrow
+            switch (e.keyCode) {
+                case 40: // Down arrow
                     if (nextItem) {
                         switchActiveItem(currentItem, nextItem);
-                    }
-                    else {
+                    } else {
                         switchActiveItem(currentItem, currentItem.parentNode.firstChild);
                     }
                     break;
-                case 38 : // Up arrow
+                case 38: // Up arrow
                     if (previousItem) {
                         switchActiveItem(currentItem, previousItem);
-                    }
-                    else {
+                    } else {
                         switchActiveItem(currentItem, currentItem.parentNode.lastChild);
                     }
                     break;
-                case 32 : // Space
+                case 32: // Space
                     removeMenu();
                     new Connector(this.el.terminal, inputTerminal).redraw();
                     ariaAlert("Node connected");
@@ -279,7 +279,8 @@ var BaseOutputTerminalView = TerminalView.extend({
                             .attr("tabindex", "0")
                             .attr("aria-label", "delete terminal")
                             .on("keydown click", e => {
-                                if (e.keyCode === 32 || e.type === "click") { //Space or Click
+                                if (e.keyCode === 32 || e.type === "click") {
+                                    //Space or Click
                                     $.each(inputTerminal.connectors, (_, x) => {
                                         if (x) {
                                             x.destroy();
@@ -298,7 +299,7 @@ var BaseOutputTerminalView = TerminalView.extend({
         };
         const buildInputChoicesMenu = () => {
             const inputChoicesMenu = document.createElement("ul");
-            $(inputChoicesMenu).focusout((e) =>  {
+            $(inputChoicesMenu).focusout(e => {
                 /* focus is still inside child element of menu so don't hide */
                 if (inputChoicesMenu.contains(e.relatedTarget)) {
                     return;
@@ -307,37 +308,36 @@ var BaseOutputTerminalView = TerminalView.extend({
             });
             inputChoicesMenu.id = "input-choices-menu";
             inputChoicesMenu.className = "list-group";
-            inputChoicesMenu.setAttribute('role', 'menu');
-            this.$el.attr('aria-grabbed', 'true');
-            this.$el.attr('aria-owns', 'input-choices-menu');
+            inputChoicesMenu.setAttribute("role", "menu");
+            this.$el.attr("aria-grabbed", "true");
+            this.$el.attr("aria-owns", "input-choices-menu");
 
-            $('.input-terminal').each((i, el) => {
+            $(".input-terminal").each((i, el) => {
                 const input = $(el);
                 const inputTerminal = input.context.terminal;
                 const connectionAcceptable = inputTerminal.canAccept(this.el.terminal);
                 if (connectionAcceptable.canAccept) {
-                    const inputChoiceItem = document.createElement('li');
+                    const inputChoiceItem = document.createElement("li");
                     inputChoiceItem.textContent = `${inputTerminal.name} in ${inputTerminal.node.name} node`;
                     inputChoiceItem.tabIndex = -1;
-                    inputChoiceItem.input= input;
+                    inputChoiceItem.input = input;
                     inputChoiceItem.onkeydown = inputChoiceKeyDown;
                     inputChoiceItem.className = "list-group-item";
-                    inputChoiceItem.setAttribute('role', 'menuitem');
+                    inputChoiceItem.setAttribute("role", "menuitem");
                     inputChoicesMenu.appendChild(inputChoiceItem);
                 }
-
             });
             if (inputChoicesMenu.firstChild) {
                 this.$el.append(inputChoicesMenu);
                 inputChoicesMenu.firstChild.classList.add("active");
                 inputChoicesMenu.firstChild.focus();
-            }
-            else {
+            } else {
                 //alert user that there are no available inputs to connect to for this output
             }
         };
 
-        if (e.keyCode === 32) { //Space
+        if (e.keyCode === 32) {
+            //Space
             ariaAlert("Node selected");
             buildInputChoicesMenu();
         }

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -879,8 +879,8 @@ export default Backbone.View.extend({
 
     prebuildNode: function(type, title_text, content_id) {
         var self = this;
-        var $f = $(`<div class='toolForm toolFormInCanvas' tabindex = '0' aria-label='Node ${title_text}'/>`);
-        var $title = $(`<div class='toolFormTitle unselectable'><span class='nodeTitle'>${title_text}</div></div>`);
+        var $f = $(`<div class='toolForm toolFormInCanvas'/>`);
+        var $title = $(`<div class='toolFormTitle unselectable'><span class='nodeTitle'>${title_text}</span><span class="sr-only">&nbspNode</span></div>`);
         add_node_icon($title.find(".nodeTitle"), type);
         $f.append($title);
         $f.css("left", $(window).scrollLeft() + 20);
@@ -931,7 +931,7 @@ export default Backbone.View.extend({
             left: -o.left + p.width() / 2 - width / 2,
             top: -o.top + p.height() / 2 - height / 2
         });
-        buttons.prependTo($f.find(".toolFormTitle"));
+        buttons.appendTo($f.find(".toolFormTitle"));
         width += buttons.width() + 10;
         $f.css("width", width);
         $f.bind("dragstart", () => {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -880,7 +880,9 @@ export default Backbone.View.extend({
     prebuildNode: function(type, title_text, content_id) {
         var self = this;
         var $f = $(`<div class='toolForm toolFormInCanvas'/>`);
-        var $title = $(`<div class='toolFormTitle unselectable'><span class='nodeTitle'>${title_text}</span><span class="sr-only">&nbspNode</span></div>`);
+        var $title = $(
+            `<div class='toolFormTitle unselectable'><span class='nodeTitle'>${title_text}</span><span class="sr-only">&nbspNode</span></div>`
+        );
         add_node_icon($title.find(".nodeTitle"), type);
         $f.append($title);
         $f.css("left", $(window).scrollLeft() + 20);

--- a/client/galaxy/scripts/utils/ariaAlert.js
+++ b/client/galaxy/scripts/utils/ariaAlert.js
@@ -8,7 +8,7 @@ function ariaAlert(message) {
     document.body.appendChild(alert);
     setTimeout(function() {
         document.body.removeChild(alert);
-    }, 2000)
+    }, 2000);
 }
 
 //==============================================================================

--- a/client/galaxy/scripts/utils/ariaAlert.js
+++ b/client/galaxy/scripts/utils/ariaAlert.js
@@ -1,0 +1,15 @@
+/** This Util is used for alerting users who use assistive technologies such as screen readers
+ *  @param {String} message
+ */
+function ariaAlert(message) {
+    const alert = document.createElement("p");
+    alert.textContent = message;
+    alert.setAttribute("role", "alert");
+    document.body.appendChild(alert);
+    setTimeout(function() {
+        document.body.removeChild(alert);
+    }, 2000)
+}
+
+//==============================================================================
+export default ariaAlert;

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1762,10 +1762,16 @@ div.toolSectionWrapper {
     min-height: 50px;
 }
 
+#input-choices-menu {
+
+    color: black;
+}
+
 /* For Vue */
 [v-cloak] {
     display: none;
 }
+
 
 /* Toolshed, reports custom styles from mako templates */
 body.toolshed,

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1761,9 +1761,7 @@ div.toolSectionWrapper {
     min-width: 50px;
     min-height: 50px;
 }
-
 #input-choices-menu {
-
     color: black;
 }
 
@@ -1771,7 +1769,6 @@ div.toolSectionWrapper {
 [v-cloak] {
     display: none;
 }
-
 
 /* Toolshed, reports custom styles from mako templates */
 body.toolshed,

--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -192,6 +192,7 @@ $ui-margin-horizontal-large: $margin-v * 2;
         @extend .rounded;
         background: $portlet-bg-color;
         .portlet-title {
+            float: left;
             .portlet-title-text.collapsible {
                 cursor: pointer;
                 text-decoration: underline;

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -232,6 +232,8 @@
 
     <div class="unified-panel-header" unselectable="on">
         <div class="unified-panel-header-inner">
+            <span class="sr-only">Workflow Editor&nbsp;</span>
+            ${h.to_unicode( stored.name ) | h}
             <div class="panel-header-buttons">
                 <a id="workflow-run-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Run" style="display: inline-block;" aria-label="Run">
                     <span class="fa fa-play"></span>
@@ -252,7 +254,6 @@
                     <span class="fa fa-cog"></span>
                 </a>
             </div>
-            ${h.to_unicode( stored.name ) | h}
         </div>
     </div>
     <div class="unified-panel-body" id="workflow-canvas-body">
@@ -269,7 +270,7 @@
             <div id="workflow-parameters-container">
             </div>
         </div>
-        <div class="workflow-overview workflow-canvas-content">
+        <div class="workflow-overview workflow-canvas-content" aria-hidden="true">
             <div style="position: relative; overflow: hidden; width: 100%; height: 100%; border-top: solid gray 1px; border-left: solid grey 1px;">
                 <div id="overview" style="position: absolute;">
                     <canvas width="0" height="0" style="background: white; width: 100%; height: 100%;" id="overview-canvas"></canvas>


### PR DESCRIPTION
This pull request makes the Masthead and workflow page more screenreader friendly. The largest change is to the workflow where a new function is added ```screenReaderSelectOutputNode```. This function allows nodes to be connected in the workflow only using a keyboard (People who use screenreaders typically don't use the mouse). Previously it relied heavily on the mouse because of the drag and drop functionality.