### PR TITLE
[19.05] Decrease amqp log level to INFO

### DIFF
--- a/lib/galaxy/config.py
+++ b/lib/galaxy/config.py
@@ -103,6 +103,10 @@ LOGGING_CONFIG_DEFAULT = {
             'level': 'WARN',
             'qualname': 'routes.middleware',
         },
+        'amqp': {
+            'level': 'INFO',
+            'qualname': 'amqp',
+        },
     },
     'filters': {
         'stack': {


### PR DESCRIPTION
Otherwise you get one of these every second for each process with an AMQP connection:

```
amqp DEBUG 2019-09-24 10:23:13,436 [p:6358,w:1,m:0] [Thread-1] heartbeat_tick : for connection e25923657cbb4fffb077482958021ea8
```

Caused by the changes in #8605.