### PR TITLE
GRT: Ensure correct encoding, no partial lines

### DIFF
--- a/scripts/grt/export.py
+++ b/scripts/grt/export.py
@@ -20,9 +20,11 @@ import galaxy
 import galaxy.app
 import galaxy.config
 from galaxy.objectstore import build_object_store_from_config
-from galaxy.util import hash_util
+from galaxy.util import (
+    hash_util,
+    unicodify
+)
 from galaxy.util.script import app_properties_from_args, populate_config_args
-from galaxy.util import unicodify
 
 sample_config = os.path.abspath(os.path.join(os.path.dirname(__file__), 'grt.yml.sample'))
 default_config = os.path.abspath(os.path.join(os.path.dirname(__file__), 'grt.yml'))

--- a/scripts/grt/export.py
+++ b/scripts/grt/export.py
@@ -158,11 +158,11 @@ def main(argv):
 
             try:
                 line = [
-                    str(job[0]), # id
-                    job[2], # tool_id
-                    job[3], # tool_version
-                    job[4], # state
-                    str(job[5]) # create_time
+                    str(job[0]),  # id
+                    job[2],  # tool_id
+                    job[3],  # tool_version
+                    job[4],  # state
+                    str(job[5])  # create_time
                 ]
                 cline = unicodify('\t'.join(line) + '\n')
                 handle_job.write(cline)
@@ -243,12 +243,12 @@ def main(argv):
 
             try:
                 line = [
-                    str(job[0]), # Job ID
-                    str(hda_id), # HDA ID
-                    str(hdas[hda_id][1]), # Extension
-                    round_to_2sd(datasets[dataset_id][0]), # File size
-                    job[2], # Parameter name
-                    str(filetype) # input/output
+                    str(job[0]),  # Job ID
+                    str(hda_id),  # HDA ID
+                    str(hdas[hda_id][1]),  # Extension
+                    round_to_2sd(datasets[dataset_id][0]),  # File size
+                    job[2],  # Parameter name
+                    str(filetype)  # input/output
                 ]
                 cline = unicodify('\t'.join(line) + '\n')
                 handle_datasets.write(cline)
@@ -276,10 +276,10 @@ def main(argv):
 
             try:
                 line = [
-                    str(metric[0]),
-                    metric[1],
-                    metric[2],
-                    str(metric[3])
+                    str(metric[0]),  # job id
+                    metric[1],  # plugin
+                    metric[2],  # name
+                    str(metric[3])  # value
                 ]
 
                 cline = unicodify('\t'.join(line) + '\n')

--- a/scripts/grt/export.py
+++ b/scripts/grt/export.py
@@ -4,6 +4,7 @@
 See doc/source/admin/grt.rst for more detailed usage information.
 """
 import argparse
+import io
 import json
 import logging
 import os
@@ -143,7 +144,7 @@ def main(argv):
     blacklisted_tools = config['sanitization']['tools']
 
     annotate('export_jobs_start', 'Exporting Jobs')
-    handle_job = open(REPORT_BASE + '.jobs.tsv', 'w')
+    handle_job = io.open(REPORT_BASE + '.jobs.tsv', 'w', encoding='utf-8')
     handle_job.write('\t'.join(('id', 'tool_id', 'tool_version', 'state', 'create_time')) + '\n')
     for offset_start in range(last_job_sent, end_job_id, args.batch_size):
         logging.debug("Processing %s:%s", offset_start, min(end_job_id, offset_start + args.batch_size))
@@ -164,7 +165,7 @@ def main(argv):
                     str(job[5]) # create_time
                 ]
                 cline = unicodify('\t'.join(line) + '\n')
-                handle_job.write(cline.encode('utf-8'))
+                handle_job.write(cline)
             except Exception:
                 logging.warning("Unable to write out a 'handle_job' row. Ignoring the row.", exc_info=True)
                 continue
@@ -177,7 +178,7 @@ def main(argv):
     annotate('export_jobs_end')
 
     annotate('export_datasets_start', 'Exporting Datasets')
-    handle_datasets = open(REPORT_BASE + '.datasets.tsv', 'w')
+    handle_datasets = io.open(REPORT_BASE + '.datasets.tsv', 'w', encoding='utf-8')
     handle_datasets.write('\t'.join(('job_id', 'dataset_id', 'extension', 'file_size', 'param_name', 'type')) + '\n')
     for offset_start in range(last_job_sent, end_job_id, args.batch_size):
         logging.debug("Processing %s:%s", offset_start, min(end_job_id, offset_start + args.batch_size))
@@ -250,7 +251,7 @@ def main(argv):
                     str(filetype) # input/output
                 ]
                 cline = unicodify('\t'.join(line) + '\n')
-                handle_datasets.write(cline.encode('utf-8'))
+                handle_datasets.write(cline)
             except Exception:
                 logging.warning("Unable to write out a 'handle_datasets' row. Ignoring the row.", exc_info=True)
                 continue
@@ -258,7 +259,7 @@ def main(argv):
     annotate('export_datasets_end')
 
     annotate('export_metric_num_start', 'Exporting Metrics (Numeric)')
-    handle_metric_num = open(REPORT_BASE + '.metric_num.tsv', 'w')
+    handle_metric_num = io.open(REPORT_BASE + '.metric_num.tsv', 'w', encoding='utf-8')
     handle_metric_num.write('\t'.join(('job_id', 'plugin', 'name', 'value')) + '\n')
     for offset_start in range(last_job_sent, end_job_id, args.batch_size):
         logging.debug("Processing %s:%s", offset_start, min(end_job_id, offset_start + args.batch_size))
@@ -282,7 +283,7 @@ def main(argv):
                 ]
 
                 cline = unicodify('\t'.join(line) + '\n')
-                handle_metric_num.write(cline.encode('utf-8'))
+                handle_metric_num.write(cline)
             except Exception:
                 logging.warning("Unable to write out a 'handle_metric_num' row. Ignoring the row.", exc_info=True)
                 continue


### PR DESCRIPTION
Younger, less wise @erasche made some strange and questionable decisions. Among them, a bazillion write calls because oh no building a string buffer. the memory usage! the horror. muh performance. (/s) 

So fixing that so we don't write partial lines if we bail out, and additionally writing utf8 because I found a non-ascii character in a tool output name which was fun to track down. But such things should be permitted, so, let's support it?

it could be backported to 19.09, but, no one is really running this other than us anyway sooooo...
