### PR TITLE
[19.09] Fix typo in workflow invocations admin header.

### DIFF
--- a/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -182,7 +182,7 @@ export default {
         },
         jobStatesSummary() {
             const jobsSummary = this.getInvocationJobsSummaryById(this.invocationId);
-            return ! jobsSummary ? null : new JOB_STATES_MODEL.JobStatesSummary(jobsSummary);
+            return !jobsSummary ? null : new JOB_STATES_MODEL.JobStatesSummary(jobsSummary);
         }
     },
     methods: {

--- a/client/galaxy/scripts/components/admin/AdminServices.js
+++ b/client/galaxy/scripts/components/admin/AdminServices.js
@@ -17,7 +17,7 @@ export function reloadDisplayApplications(ids) {
 }
 
 export function getActiveInvocations() {
-    const params = {include_terminal: "false"};
+    const params = { include_terminal: "false" };
     const url = `${getAppRoot()}api/invocations`;
     return axios.get(url, { params: params });
 }

--- a/client/galaxy/scripts/components/admin/Invocations.vue
+++ b/client/galaxy/scripts/components/admin/Invocations.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <h2 class="mb-3">
-            <span id="invocations-title">Worklfow Invocations</span>
+            <span id="invocations-title">Workflow Invocations</span>
         </h2>
         <b-alert variant="info" show>
             <p>


### PR DESCRIPTION
Includes a format to re-sync (didn't check where this snuck in, but it'll probably happen a few times moving forward as 19.09 doesn't enforce this yet)