### PR TITLE
Do not overwrite existing attributes

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -225,10 +225,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
     def _create_attributes_from_raw_config(self):
         for key, value in self._raw_config.items():
-            if not hasattr(self, key):
-                setattr(self, key, value)
-            else:
-                log.debug("Can't override existing attribute %s ", key)
+            if hasattr(self, key):
+                raise ConfigurationError("Attempting to override existing attribute %s ", key)
+            setattr(self, key, value)
 
     def _process_config(self, kwargs):
         self.config_dict = kwargs

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -226,7 +226,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
     def _create_attributes_from_raw_config(self):
         for key, value in self._raw_config.items():
             if hasattr(self, key):
-                raise ConfigurationError("Attempting to override existing attribute %s ", key)
+                raise ConfigurationError("Attempting to override existing attribute '%s'" % key)
             setattr(self, key, value)
 
     def _process_config(self, kwargs):

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -225,7 +225,10 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
     def _create_attributes_from_raw_config(self):
         for key, value in self._raw_config.items():
-            setattr(self, key, value)
+            if not hasattr(self, key):
+                setattr(self, key, value)
+            else:
+                log.debug("Can't override existing attribute %s ", key)
 
     def _process_config(self, kwargs):
         self.config_dict = kwargs


### PR DESCRIPTION
This is a safeguard against introducing a bug. This edit prevents the
config loading code from overwriting the value of an existing attribute.

The config loading procedure automatically creates attributes of the
GalaxyAppConfiguration object for each property in the schema. If the
schema contains a property with the same name as an existing attribute
(e.g., `reloadable_options`, `schema`, etc.), that attribute will be
overwritten. Worse, if the call to `_set_config_base()` is moved before
the call to `_create_attributes_from_raw_config()`, the values of
`config_dir` and `data_dir` will be set to `None`, because those are
present in the schema. This fix prevents this from happening.