### PR TITLE
Fix client formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,13 +165,13 @@ client-watch: node-deps ## A useful target for parallel development building.
 client-test: node-deps  ## Run JS unit tests via Karma
 	cd client && yarn run test
 
-client-eslint: node-deps  ## Run client linting
+client-eslint: node-deps # Run client linting
 	cd client && yarn run eslint
 
-client-format-check: node-deps  # Run client formatting check
+client-format-check: node-deps # Run client formatting check
 	cd client && yarn run prettier-check
 
-client-lint: client-eslint client-format-check  # ES lint and check format of client
+client-lint: client-eslint client-format-check ## ES lint and check format of client
 
 client-test-watch: client ## Watch and run qunit tests on changes via Karma
 	cd client && yarn run test-watch

--- a/client/galaxy/scripts/components/Markdown/MarkdownEditor.vue
+++ b/client/galaxy/scripts/components/Markdown/MarkdownEditor.vue
@@ -44,6 +44,6 @@ export default {
     padding: 20px;
 
     width: 100%;
-    height: 95%;  /* what now? this is needed or the editor overtakes workflow toolbar when too much text is added */
+    height: 95%; /* what now? this is needed or the editor overtakes workflow toolbar when too much text is added */
 }
 </style>


### PR DESCRIPTION
Broken when I merged forward 19.09.

List `client-lint` instead of `client-eslint` when running `make` with no target.