### PR TITLE
Start using path_resolves_to; add integration tests

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -650,7 +650,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.interactivetool_prefix = kwargs.get("interactivetools_prefix", "interactivetool")
         self.interactivetools_enable = string_as_bool(kwargs.get('interactivetools_enable', False))
 
-        self.citation_cache_data_dir = os.path.join(self.data_dir, self.citation_cache_data_dir)
         self.citation_cache_lock_dir = os.path.join(self.data_dir, self.citation_cache_lock_dir)
 
         self.containers_conf = parse_containers_config(self.containers_config_file)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -412,7 +412,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             if len(ip.strip()) > 0
         ]
         self.template_path = os.path.join(self.root, kwargs.get("template_path", "templates"))
-        self.template_cache = os.path.join(self.data_dir, self.template_cache_path)
+        self.template_cache = self.template_cache_path
         self.job_queue_cleanup_interval = int(kwargs.get("job_queue_cleanup_interval", "5"))
         self.cluster_files_directory = self.resolve_path(os.path.join(self.data_dir, self.cluster_files_directory))
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -341,8 +341,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         # Install database related configuration (if different).
         self.install_database_engine_options = get_database_engine_options(kwargs, model_prefix="install_")
 
-        # new_file_path and legacy_home_dir can be overridden per destination in job_conf.
-        self.new_file_path = os.path.join(self.data_dir, self.new_file_path)
         override_tempdir = string_as_bool(kwargs.get("override_tempdir", "True"))
         if override_tempdir:
             tempfile.tempdir = self.new_file_path

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -638,7 +638,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         if ie_dirs:
             self.visualization_plugins_directory += ",%s" % ie_dirs
 
-        self.proxy_session_map = os.path.join(self.data_dir, self.dynamic_proxy_session_map)
+        self.proxy_session_map = self.dynamic_proxy_session_map
         self.manage_dynamic_proxy = string_as_bool(kwargs.get("dynamic_proxy_manage", "True"))  # Set to false if being launched externally
 
         # InteractiveTools propagator mapping file

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -650,8 +650,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.interactivetool_prefix = kwargs.get("interactivetools_prefix", "interactivetool")
         self.interactivetools_enable = string_as_bool(kwargs.get('interactivetools_enable', False))
 
-        self.citation_cache_lock_dir = os.path.join(self.data_dir, self.citation_cache_lock_dir)
-
         self.containers_conf = parse_containers_config(self.containers_config_file)
 
         # Compliance/Policy variables

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -349,7 +349,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         if override_tempdir:
             tempfile.tempdir = self.new_file_path
         self.shared_home_dir = kwargs.get("shared_home_dir", None)
-        self.openid_consumer_cache_path = os.path.join(self.data_dir, self.openid_consumer_cache_path)
         self.cookie_path = kwargs.get("cookie_path", None)
         self.tool_path = os.path.join(self.root, self.tool_path)
         self.tool_data_path = os.path.join(self.root, self.tool_data_path)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -332,7 +332,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
                                               "sqlite:///%s?isolation_level=IMMEDIATE" % os.path.join(self.data_dir, "universe.sqlite"))
         self.database_engine_options = get_database_engine_options(kwargs)
         self.database_create_tables = string_as_bool(kwargs.get("database_create_tables", "True"))
-        self.database_query_profiling_proxy = string_as_bool(kwargs.get("database_query_profiling_proxy", "False"))
         self.database_encoding = kwargs.get("database_encoding", None)  # Create new databases with this encoding.
         self.thread_local_log = None
         if string_as_bool(kwargs.get("enable_per_request_sql_debugging", "False")):
@@ -639,7 +638,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             self.visualization_plugins_directory += ",%s" % ie_dirs
 
         self.proxy_session_map = self.dynamic_proxy_session_map
-        self.manage_dynamic_proxy = string_as_bool(kwargs.get("dynamic_proxy_manage", "True"))  # Set to false if being launched externally
+        self.manage_dynamic_proxy = self.dynamic_proxy_manage  # Set to false if being launched externally
 
         # InteractiveTools propagator mapping file
         self.interactivetool_map = self.resolve_path(kwargs.get("interactivetools_map", os.path.join(self.data_dir, "interactivetools_map.sqlite")))

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -341,8 +341,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         # Install database related configuration (if different).
         self.install_database_engine_options = get_database_engine_options(kwargs, model_prefix="install_")
 
-        # Where dataset files are stored
-        self.file_path = os.path.join(self.data_dir, self.file_path)
         # new_file_path and legacy_home_dir can be overridden per destination in job_conf.
         self.new_file_path = os.path.join(self.data_dir, self.new_file_path)
         override_tempdir = string_as_bool(kwargs.get("override_tempdir", "True"))

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -414,7 +414,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.template_path = os.path.join(self.root, kwargs.get("template_path", "templates"))
         self.template_cache = self.template_cache_path
         self.job_queue_cleanup_interval = int(kwargs.get("job_queue_cleanup_interval", "5"))
-        self.cluster_files_directory = self.resolve_path(os.path.join(self.data_dir, self.cluster_files_directory))
+        self.cluster_files_directory = self.resolve_path(self.cluster_files_directory)
 
         # Fall back to legacy job_working_directory config variable if set.
         self.jobs_directory = os.path.join(self.data_dir, kwargs.get("jobs_directory", self.job_working_directory))

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -516,7 +516,7 @@ def _validate(args, app_desc):
     fp = tempfile.NamedTemporaryFile('w', delete=False, suffix=".yml")
 
     def _clean(p, k, v):
-        return k != 'reloadable'
+        return k not in ['reloadable', 'path_resolves_to']
 
     clean_schema = remap(app_desc.schema.raw_schema, _clean)
     ordered_dump(clean_schema, fp)

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -671,13 +671,11 @@ mapping:
       template_cache_path:
         type: str
         default: compiled_templates
+        path_resolves_to: data_dir
         required: false
         desc: |
           Mako templates are compiled as needed and cached for reuse, this directory is
           used for the cache
-
-          Default value will be resolved to 'database/compiled_templates' where 'database' is the
-          default value of the 'data_dir' option).
 
       check_job_script_integrity:
         type: bool

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -180,13 +180,11 @@ mapping:
       new_file_path:
         type: str
         default: tmp
+        path_resolves_to: data_dir
         required: false
         desc: |
           Where temporary files are stored. It must be accessible at the same path on any cluster
           nodes that will run Galaxy jobs, unless using Pulsar.
-
-          Default value will be resolved to 'database/tmp' where 'database' is the default value
-          of the 'data_dir' option).
 
       tool_config_file:
         type: any

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -729,14 +729,12 @@ mapping:
       citation_cache_data_dir:
         type: str
         default: citations/data
+        path_resolves_to: data_dir
         required: false
         desc: |
           Citation related caching.  Tool citations information maybe fetched from
           external sources such as https://doi.org/ by Galaxy - the following
           parameters can be used to control the caching used to store this information.
-
-          Default value will be resolved to 'database/citations/data' where 'database' is the
-          default value of the 'data_dir' option).
 
       citation_cache_lock_dir:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -739,14 +739,12 @@ mapping:
       citation_cache_lock_dir:
         type: str
         default: citations/locks
+        path_resolves_to: data_dir
         required: false
         desc: |
           Citation related caching.  Tool citations information maybe fetched from
           external sources such as https://doi.org/ by Galaxy - the following
           parameters can be used to control the caching used to store this information.
-
-          Default value will be resolved to 'database/citations/locks' where 'database' is the
-          default value of the 'data_dir' option).
 
       object_store_config_file:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -171,13 +171,11 @@ mapping:
       file_path:
         type: str
         default: files
+        path_resolves_to: data_dir
         required: false
         desc: |
           Where dataset files are stored. It must be accessible at the same path on any cluster
           nodes that will run Galaxy jobs, unless using Pulsar.
-
-          Default value will be resolved to 'database/files' where 'database' is the default value
-          of the 'data_dir' option).
 
       new_file_path:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -661,12 +661,11 @@ mapping:
       cluster_files_directory:
         type: str
         default: pbs
+        path_resolves_to: data_dir
         required: false
         desc: |
           If using a cluster, Galaxy will write job scripts and stdout/stderr to this
           directory.
-
-          Value will be resolved with respect to <data_dir>.
 
       template_cache_path:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2261,12 +2261,10 @@ mapping:
       openid_consumer_cache_path:
         type: str
         default: openid_consumer_cache
+        path_resolves_to: data_dir
         required: false
         desc: |
           If OpenID is enabled, consumer cache directory to use.
-
-          Default value will be resolved to 'database/openid_consumer_cache' where 'database' is the
-          default value of the 'data_dir' option).
 
       enable_tool_tags:
         type: bool

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1327,13 +1327,11 @@ mapping:
       dynamic_proxy_session_map:
         type: str
         default: session_map.sqlite
+        path_resolves_to: data_dir
         required: false
         desc: |
           The NodeJS dynamic proxy can use an SQLite database or a JSON file for IPC,
           set that here.
-
-          Default value will be resolved to 'database/session_map.sqlite' where 'database' is the
-          default value of the 'data_dir' option).
 
       dynamic_proxy_bind_port:
         type: int

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -1,0 +1,33 @@
+import os
+
+from base import integration_util
+
+
+class ConfigDefaultsTestCase(integration_util.IntegrationTestCase):
+    """
+    Test automatic creation of configuration properties and assignment of
+    default values specified in the schema.
+    """
+    def get_default(self, key):
+        return self._app.config.appschema[key]['default']
+
+    def test_default_database_engine_option_pool_size(self):
+        expect = self.get_default('database_engine_option_pool_size')
+        assert expect == self._app.config.database_engine_option_pool_size
+
+    def test_default_database_engine_option_max_overflow(self):
+        expect = self.get_default('database_engine_option_max_overflow')
+        assert expect == self._app.config.database_engine_option_max_overflow
+
+    def test_default_database_engine_option_pool_recycle(self):
+        expect = self.get_default('database_engine_option_pool_recycle')
+        assert expect == self._app.config.database_engine_option_pool_recycle
+
+    def test_default_database_engine_option_server_side_cursors(self):
+        expect = self.get_default('database_engine_option_server_side_cursors')
+        assert expect == self._app.config.database_engine_option_server_side_cursors
+
+    def test_default_database_query_profiling_proxy(self):
+        expect = self.get_default('database_query_profiling_proxy')
+        assert expect == self._app.config.database_query_profiling_proxy
+

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -1,3 +1,5 @@
+import os
+
 from base import integration_util
 
 
@@ -20,3 +22,4 @@ class ConfigDefaultsTestCase(integration_util.IntegrationTestCase):
     def test_default_database_query_profiling_proxy(self):
         expect = self.get_default('database_query_profiling_proxy')
         assert expect == self._app.config.database_query_profiling_proxy
+

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -1,5 +1,3 @@
-import os
-
 from base import integration_util
 
 
@@ -22,4 +20,3 @@ class ConfigDefaultsTestCase(integration_util.IntegrationTestCase):
     def test_default_database_query_profiling_proxy(self):
         expect = self.get_default('database_query_profiling_proxy')
         assert expect == self._app.config.database_query_profiling_proxy
-

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -9,14 +9,6 @@ class ConfigDefaultsTestCase(integration_util.IntegrationTestCase):
     def get_default(self, key):
         return self._app.config.appschema[key]['default']
 
-    def test_default_database_engine_option_pool_size(self):
-        expect = self.get_default('database_engine_option_pool_size')
-        assert expect == self._app.config.database_engine_option_pool_size
-
-    def test_default_database_engine_option_max_overflow(self):
-        expect = self.get_default('database_engine_option_max_overflow')
-        assert expect == self._app.config.database_engine_option_max_overflow
-
     def test_default_database_engine_option_pool_recycle(self):
         expect = self.get_default('database_engine_option_pool_recycle')
         assert expect == self._app.config.database_engine_option_pool_recycle

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -1,5 +1,3 @@
-import os
-
 from base import integration_util
 
 
@@ -30,4 +28,3 @@ class ConfigDefaultsTestCase(integration_util.IntegrationTestCase):
     def test_default_database_query_profiling_proxy(self):
         expect = self.get_default('database_query_profiling_proxy')
         assert expect == self._app.config.database_query_profiling_proxy
-

--- a/test/integration/test_config_resolve_paths.py
+++ b/test/integration/test_config_resolve_paths.py
@@ -34,3 +34,8 @@ class ConfigResolvePathsTestCase(integration_util.IntegrationTestCase):
         schema_default = self.get_default('file_path')
         expect = os.path.join(self.data_dir, schema_default)
         assert expect == self._app.config.file_path
+
+    def test_resolve_cluster_files_directory(self):
+        schema_default = self.get_default('cluster_files_directory')
+        expect = os.path.join(self.data_dir, schema_default)
+        assert expect == self._app.config.cluster_files_directory

--- a/test/integration/test_config_resolve_paths.py
+++ b/test/integration/test_config_resolve_paths.py
@@ -44,4 +44,3 @@ class ConfigResolvePathsTestCase(integration_util.IntegrationTestCase):
         schema_default = self.get_default('dynamic_proxy_session_map')
         expect = os.path.join(self.data_dir, schema_default)
         assert expect == self._app.config.proxy_session_map  # 'dynamic' previx is dropped
-

--- a/test/integration/test_config_resolve_paths.py
+++ b/test/integration/test_config_resolve_paths.py
@@ -44,3 +44,4 @@ class ConfigResolvePathsTestCase(integration_util.IntegrationTestCase):
         schema_default = self.get_default('dynamic_proxy_session_map')
         expect = os.path.join(self.data_dir, schema_default)
         assert expect == self._app.config.proxy_session_map  # 'dynamic' previx is dropped
+

--- a/test/integration/test_config_resolve_paths.py
+++ b/test/integration/test_config_resolve_paths.py
@@ -6,8 +6,13 @@ from base import integration_util
 class ConfigResolvePathsTestCase(integration_util.IntegrationTestCase):
 
     def test_resolve_openid_consumer_cache_path(self):
-
         data_dir = self._app.config.data_dir
         schema_default = self._app.config.appschema['openid_consumer_cache_path']['default']
         expected = os.path.join(data_dir, schema_default)
         assert expected == self._app.config.openid_consumer_cache_path
+
+    def test_resolve_citation_cache_data_dir(self):
+        data_dir = self._app.config.data_dir
+        schema_default = self._app.config.appschema['citation_cache_data_dir']['default']
+        expected = os.path.join(data_dir, schema_default)
+        assert expected == self._app.config.citation_cache_data_dir

--- a/test/integration/test_config_resolve_paths.py
+++ b/test/integration/test_config_resolve_paths.py
@@ -16,3 +16,9 @@ class ConfigResolvePathsTestCase(integration_util.IntegrationTestCase):
         schema_default = self._app.config.appschema['citation_cache_data_dir']['default']
         expected = os.path.join(data_dir, schema_default)
         assert expected == self._app.config.citation_cache_data_dir
+
+    def test_resolve_citation_cache_lock_dir(self):
+        data_dir = self._app.config.data_dir
+        schema_default = self._app.config.appschema['citation_cache_lock_dir']['default']
+        expected = os.path.join(data_dir, schema_default)
+        assert expected == self._app.config.citation_cache_lock_dir

--- a/test/integration/test_config_resolve_paths.py
+++ b/test/integration/test_config_resolve_paths.py
@@ -39,3 +39,9 @@ class ConfigResolvePathsTestCase(integration_util.IntegrationTestCase):
         schema_default = self.get_default('cluster_files_directory')
         expect = os.path.join(self.data_dir, schema_default)
         assert expect == self._app.config.cluster_files_directory
+
+    def test_resolve_dynamic_proxy_session_map(self):
+        schema_default = self.get_default('dynamic_proxy_session_map')
+        expect = os.path.join(self.data_dir, schema_default)
+        assert expect == self._app.config.proxy_session_map  # 'dynamic' previx is dropped
+

--- a/test/integration/test_config_resolve_paths.py
+++ b/test/integration/test_config_resolve_paths.py
@@ -4,21 +4,28 @@ from base import integration_util
 
 
 class ConfigResolvePathsTestCase(integration_util.IntegrationTestCase):
+    """
+    Test automatic path resolution of configuration properties that use the
+    'path_resolves_to' attribute.
+    """
+    def setUp(self):
+        super(ConfigResolvePathsTestCase, self).setUp()
+        self.data_dir = self._app.config.data_dir
+
+    def get_default(self, key):
+        return self._app.config.appschema[key]['default']
 
     def test_resolve_openid_consumer_cache_path(self):
-        data_dir = self._app.config.data_dir
-        schema_default = self._app.config.appschema['openid_consumer_cache_path']['default']
-        expected = os.path.join(data_dir, schema_default)
-        assert expected == self._app.config.openid_consumer_cache_path
+        schema_default = self.get_default('openid_consumer_cache_path')
+        expect = os.path.join(self.data_dir, schema_default)
+        assert expect == self._app.config.openid_consumer_cache_path
 
     def test_resolve_citation_cache_data_dir(self):
-        data_dir = self._app.config.data_dir
-        schema_default = self._app.config.appschema['citation_cache_data_dir']['default']
-        expected = os.path.join(data_dir, schema_default)
-        assert expected == self._app.config.citation_cache_data_dir
+        schema_default = self.get_default('citation_cache_data_dir')
+        expect = os.path.join(self.data_dir, schema_default)
+        assert expect == self._app.config.citation_cache_data_dir
 
     def test_resolve_citation_cache_lock_dir(self):
-        data_dir = self._app.config.data_dir
-        schema_default = self._app.config.appschema['citation_cache_lock_dir']['default']
-        expected = os.path.join(data_dir, schema_default)
-        assert expected == self._app.config.citation_cache_lock_dir
+        schema_default = self.get_default('citation_cache_lock_dir')
+        expect = os.path.join(self.data_dir, schema_default)
+        assert expect == self._app.config.citation_cache_lock_dir

--- a/test/integration/test_config_resolve_paths.py
+++ b/test/integration/test_config_resolve_paths.py
@@ -1,0 +1,13 @@
+import os
+
+from base import integration_util
+
+
+class ConfigResolvePathsTestCase(integration_util.IntegrationTestCase):
+
+    def test_resolve_openid_consumer_cache_path(self):
+
+        data_dir = self._app.config.data_dir
+        schema_default = self._app.config.appschema['openid_consumer_cache_path']['default']
+        expected = os.path.join(data_dir, schema_default)
+        assert expected == self._app.config.openid_consumer_cache_path

--- a/test/integration/test_config_resolve_paths.py
+++ b/test/integration/test_config_resolve_paths.py
@@ -29,3 +29,8 @@ class ConfigResolvePathsTestCase(integration_util.IntegrationTestCase):
         schema_default = self.get_default('citation_cache_lock_dir')
         expect = os.path.join(self.data_dir, schema_default)
         assert expect == self._app.config.citation_cache_lock_dir
+
+    def test_resolve_file_path(self):
+        schema_default = self.get_default('file_path')
+        expect = os.path.join(self.data_dir, schema_default)
+        assert expect == self._app.config.file_path

--- a/test/unit/config/config_manage/test_config_manage.py
+++ b/test/unit/config/config_manage/test_config_manage.py
@@ -80,15 +80,15 @@ def test_build_uwsgi_yaml():
     with _config_directory("1607_root_samples") as config_dir:
         config_dir.manage_cli(["build_uwsgi_yaml"])
 
-
-def test_validate_simple_config():
-    with _config_directory("simple") as config_dir:
-        config_dir.manage_cli(["validate", "galaxy"])
-
-
-def test_validate_embedded_config():
-    with _config_directory("embedded") as config_dir:
-        config_dir.manage_cli(["validate", "galaxy"])
+# TODO disabled until path_resolves_to is parsed correctly
+# def test_validate_simple_config():
+#     with _config_directory("simple") as config_dir:
+#         config_dir.manage_cli(["validate", "galaxy"])
+#
+#
+# def test_validate_embedded_config():
+#     with _config_directory("embedded") as config_dir:
+#         config_dir.manage_cli(["validate", "galaxy"])
 
 
 class _TestConfigDirectory(object):

--- a/test/unit/config/config_manage/test_config_manage.py
+++ b/test/unit/config/config_manage/test_config_manage.py
@@ -80,15 +80,15 @@ def test_build_uwsgi_yaml():
     with _config_directory("1607_root_samples") as config_dir:
         config_dir.manage_cli(["build_uwsgi_yaml"])
 
-# TODO disabled until path_resolves_to is parsed correctly
-# def test_validate_simple_config():
-#     with _config_directory("simple") as config_dir:
-#         config_dir.manage_cli(["validate", "galaxy"])
-#
-#
-# def test_validate_embedded_config():
-#     with _config_directory("embedded") as config_dir:
-#         config_dir.manage_cli(["validate", "galaxy"])
+
+def test_validate_simple_config():
+    with _config_directory("simple") as config_dir:
+        config_dir.manage_cli(["validate", "galaxy"])
+
+
+def test_validate_embedded_config():
+    with _config_directory("embedded") as config_dir:
+        config_dir.manage_cli(["validate", "galaxy"])
 
 
 class _TestConfigDirectory(object):


### PR DESCRIPTION
Summary:
This is the first attempt to use the `path_resolves_to` schema attribute to automate path resolution: 
- a statement of the form `self.foo = os.path.join(self.data_dir, self.foo)` is removed from `config/__init__.py`
- attribute `path_resolves_to: data_dir` is added to foo's definition in config_schema.yml.
As a result, path resolution logic is located in one place only, and is stated declaratively.

A few issues have been taken care of (#8728, https://github.com/galaxyproject/galaxy/pull/8689/commits/491a8bf3e76c3d7632fb89e433309cbb8b75da06 ).

Other modifications:
- Added integration tests to ensure that paths are resolved correctly for config options that use the `path_resolves_to` attribute.
- Added integration tests for a few config options to ensure schema defaults are assigned.
@jmchilton is this a reasonable approach to test this? If so, I'll add the rest.

Also ping @natefoo, @nsoranzo . 





