### PR TITLE
Fix `new_secure_hash()` when passed an empty string

### DIFF
--- a/lib/galaxy/util/hash_util.py
+++ b/lib/galaxy/util/hash_util.py
@@ -65,15 +65,12 @@ def md5_hash_file(path):
         return None
 
 
-def new_secure_hash(text_type=None):
+def new_secure_hash(text_type):
     """
-    Returns either a sha1 hash object (if called with no arguments), or a
-    hexdigest of the sha1 hash of the argument `text_type`.
+    Returns the hexdigest of the sha1 hash of the argument `text_type`.
     """
-    if text_type:
-        return sha1(smart_str(text_type)).hexdigest()
-    else:
-        return sha1()
+    assert text_type is not None
+    return sha1(smart_str(text_type)).hexdigest()
 
 
 def hmac_new(key, value):


### PR DESCRIPTION
Fix LDAP authentication with `use_pbkdf2: false`, reported in https://help.galaxyproject.org/t/new-user-auto-creation-with-ldap-authentication-failing/2191