### PR TITLE
Client build process refinement

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -90,9 +90,10 @@ function cleanPlugins() {
     return del(["../static/plugins/{visualizations,interactive_environments}/*"], { force: true });
 }
 
-module.exports.fonts = fonts;
-module.exports.stageLibs = stageLibs;
-module.exports.cleanPlugins = cleanPlugins;
-module.exports.buildPlugins = buildPlugins;
-module.exports.plugins = series(cleanPlugins, buildPlugins, stagePlugins);
-module.exports.default = parallel(stageLibs, fonts, module.exports.plugins);
+client = parallel(fonts, stageLibs);
+plugins = series(cleanPlugins, buildPlugins, stagePlugins);
+
+module.exports.client = client;
+module.exports.plugins = plugins;
+
+module.exports.default = parallel(client, plugins);

--- a/client/package.json
+++ b/client/package.json
@@ -64,8 +64,6 @@
     "webpack-production-maps": "GXY_BUILD_SOURCEMAPS=1 webpack -p",
     "gulp": "gulp",
     "save-build-hash": "(git rev-parse HEAD 2>/dev/null || echo '') >../static/client_build_hash.txt",
-    "build-charts": "webpack -p --config ../config/plugins/visualizations/charts/webpack.config.js",
-    "build-scatterplot": "NODE_PATH=./node_modules webpack -p --config ../config/plugins/visualizations/scatterplot/webpack.config.js",
     "prettier": "prettier --write 'galaxy/style/scss/**/*.scss' 'galaxy/scripts/**/{*.js,*.vue}' '!galaxy/scripts/libs/**'",
     "prettier-check": "prettier --check 'galaxy/style/scss/**/*.scss' 'galaxy/scripts/**/{*.js,*.vue}' '!galaxy/scripts/libs/**'",
     "styleguide": "vue-styleguidist server",


### PR DESCRIPTION
Tweaks gulp build targets to be more sensible and clear.  This came about looking at the client build process deconstruction issue referenced below; more clear separation of concerns in the gulp tasks.

Drops targets from primary client package that should not be used anymore (we've moved the building of these to the individual packages).