### PR TITLE
[19.05] Register job data when testing a tool with missing input file

### DIFF
--- a/lib/galaxy/tools/verify/interactor.py
+++ b/lib/galaxy/tools/verify/interactor.py
@@ -746,15 +746,8 @@ def verify_tool(tool_id,
     if test_history is None:
         test_history = galaxy_interactor.new_history()
 
-    stage_data_in_history(galaxy_interactor,
-                          tool_id,
-                          testdef.test_data(),
-                          history=test_history,
-                          force_path_paste=force_path_paste,
-                          maxseconds=maxseconds)
-
-    # Once data is ready, run the tool and check the outputs - record API
-    # input, job info, tool run exception, as well as exceptions related to
+    # Upload data to test_history, run the tool and check the outputs - record
+    # API input, job info, tool run exception, as well as exceptions related to
     # job output checking and register they with the test plugin so it can
     # record structured information.
     tool_inputs = None
@@ -764,6 +757,12 @@ def verify_tool(tool_id,
     expected_failure_occurred = False
     begin_time = time.time()
     try:
+        stage_data_in_history(galaxy_interactor,
+                            tool_id,
+                            testdef.test_data(),
+                            history=test_history,
+                            force_path_paste=force_path_paste,
+                            maxseconds=maxseconds)
         try:
             tool_response = galaxy_interactor.run_tool(testdef, test_history, resource_parameters=resource_parameters)
             data_list, jobs, tool_inputs = tool_response.outputs, tool_response.jobs, tool_response.inputs


### PR DESCRIPTION
Running `planemo test` for a tool for which an input file is missing from the `test-data` directory results in the following traceback:

```
There were problems with 1 test(s) - out of 1 test(s) executed. See /usr/users/ga002/soranzon/software/nsoranzo_isatools-galaxy/tool_test_output.html for detailed breakdown.
Traceback (most recent call last):
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/planemo/test/results.py", line 115, in get_dict_value
    return data[key]
TypeError: 'NoneType' object is not subscriptable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/bin/planemo", line 10, in <module>
    sys.exit(planemo())
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/planemo/cli.py", line 189, in handle_blended_options
    return f(*args, **kwds)
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/planemo/commands/cmd_test.py", line 93, in cli
    return_value = run_in_config(ctx, config, **kwds)
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/planemo/galaxy/test/actions.py", line 118, in run_in_config
    kwds=kwds
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/planemo/galaxy/test/actions.py", line 132, in handle_reports_and_summary
    **kwds
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/planemo/galaxy/test/actions.py", line 223, in _handle_summary
    **kwds
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/planemo/galaxy/test/actions.py", line 235, in _summarize_tests_full
    _summarize_test_case(test_case_data, **kwds)
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/planemo/galaxy/test/actions.py", line 254, in _summarize_test_case
    get_dict_value("data", structured_data)
  File "/usr/users/ga002/soranzon/software/nsoranzo_planemo/.venv3/lib/python3.6/site-packages/planemo/test/results.py", line 117, in get_dict_value
    raise KeyError("No key [%s] in [%s]" % (key, data))
KeyError: 'No key [status] in [None]'
```

This is fixed by moving the `stage_data_in_history()` call inside the try/finally block.

Fix https://github.com/galaxyproject/planemo/issues/942 .