### PR TITLE
[19.09] More invocation report fixes.

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -20,6 +20,100 @@ import { make_popupmenu } from "ui/popupmenu";
 // TODO; tie into Galaxy state?
 window.workflow_globals = window.workflow_globals || {};
 
+const reportHelp = `
+<div>
+<h3>Overview</h3>
+
+<p>
+    This document Markdown document will be used to generate a report
+    for invocations of this workflow. This document should be Markdown
+    with embedded command for extracting and displaying parts of the workflow,
+    its invocation metadata, its inputs and outputs, etc.. For an overview
+    of standard Markdown visit the <a href="https://commonmark.org/help/tutorial/">commonmark.org
+    tutorial</a>.
+</p>
+
+<p>
+    The Galaxy extensions to Markdown are represented as code blocks, these blocks start
+    with the line <tt>\`\`\`galaxy</tt> and end with the line <tt>\`\`\`</tt> and have a
+    command with arguments that reference parts of the workflow in the middle.
+</p>
+
+<h3>Workflow Commands</h3>
+
+<p>
+    These commands to do not take any arguments and reference the whole workflow. For
+    instance, the following example would display a representation of the workflow in the
+    resulting report:
+</p>
+
+<pre>
+\`\`\`galaxy
+workflow_display()
+\`\`\`
+</pre>
+<dl>
+<dt><tt>workflow_display</tt></dt>
+<dd>Embed a description of the workflow itself in the resulting report.</dd>
+<dt><tt>invocation_inputs</tt></dt>
+<dd>Embed the labeled workflow inputs in the resulting report.</dd>
+<dt><tt>invocation_outputs</tt></dt>
+<dd>Embed the labeled workflow outputs in the resulting report.</dd>
+</dl>
+
+<h3>Step Commands</h3>
+
+<p>
+    These commands reference a workflow step label and refer to job corresponding
+    to that step. A current limitation is the report will break if these refer to
+    a collection mapping step, these must identify a single job. For instance, the
+    following example would show the job parameters the step labeled 'qc' was run
+    with:
+</p>
+
+<pre>
+\`\`\`galaxy
+job_parameters(step=qc)
+\`\`\`
+</pre>
+
+
+<dt><tt>tool_stderr</tt></dt>
+<dd>Embed the tool standard error stream for this step in the resulting report.</dd>
+<dt><tt>tool_stdout</tt></dt>
+<dd>Embed the tool standard output stream for this step in the resulting report.</dd>
+<dt><tt>job_metrics</tt></dt>
+<dd>Embed the job metrics for this step in the resulting report (if user has permission).</dd>
+<dt><tt>job_parameters</tt></dt>
+<dd>Embed the tool parameters for this step in the resulting report.</dd>
+
+<h3>Input/Output Commands</h3>
+
+<p>
+    These commands reference a workflow input or output by label. For instance, the
+    following example would display the dataset collection corresponding to output "Merged BAM":
+</p>
+
+<pre>
+\`\`\`galaxy
+history_dataset_collection_display(output="Merged Bam")
+\`\`\`
+</pre>
+
+<dt><tt>history_dataset_display</tt></dt>
+<dd>Embed a dataset description in the resulting report.</dd>
+<dt><tt>history_dataset_collection_display</tt></dt>
+<dd>Embed a dataset collection description in the resulting report.</dd>
+<dt><tt>history_dataset_as_image</tt></dt>
+<dd>Embed a dataset as an image in the resulting report - the dataset should be an image datatype.</dd>
+<dt><tt>history_dataset_peek</tt></dt>
+<dd>Embed Galaxy's metadata attribute 'peek' into the resulting report - this is datatype dependent metadata but usually this is a few lines from the start of a file.</dd>
+<dt><tt>history_dataset_info</tt></dt>
+<dd>Embed Galaxy's metadata attribute 'info' into the resulting report - this is datatype dependent metadata but usually this is the program output that generated the dataset.</dd>
+</dl>
+</div>
+`;
+
 // Reset tool search to start state.
 function reset_tool_search(initValue) {
     // Function may be called in top frame or in tool_menu_frame;
@@ -364,6 +458,7 @@ export default Backbone.View.extend({
             );
             $("#workflow-save-button").click(() => save_current_workflow());
             $("#workflow-report-button").click(() => edit_report());
+            $("#workflow-report-help-button").click(() => show_report_help());
             $("#workflow-canvas-button").click(() => edit_canvas());
             make_popupmenu($("#workflow-options-button"), {
                 "Save As": workflow_save_as,
@@ -426,6 +521,13 @@ export default Backbone.View.extend({
         function edit_report() {
             $(".workflow-canvas-content").hide();
             $(".workflow-report-content").show();
+        }
+
+        function show_report_help() {
+            const reportHelpBody = $(reportHelp);
+            show_modal("Workflow Invocation Report Help", reportHelpBody, {
+                Ok: hide_modal
+            });
         }
 
         function edit_canvas() {

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -40,17 +40,19 @@ INVOCATION_SECTIONS = [
 ALL_CONTAINER_TYPES = GALAXY_FLAVORED_MARKDOWN_CONTAINERS + INVOCATION_SECTIONS
 GALAXY_FLAVORED_MARKDOWN_CONTAINER_REGEX = "(%s)" % "|".join(ALL_CONTAINER_TYPES)
 
-FUNCTION_ARG = r'\s*\w+\s*=\s*\w+\s*'
+ARG_VAL_REGEX = r'''[\w_\-]+|\"[^\"]+\"|\'[^\']+\''''
+ARG_VAL_CAPTURED_REGEX = r'''(?:([\w_\-]+)|\"([^\"]+)\"|\'([^\']+)\')'''
+FUNCTION_ARG = r'\s*\w+\s*=\s*(?:%s)\s*' % ARG_VAL_REGEX
 FUNCTION_CALL_LINE_TEMPLATE = r'\s*%s\s*\((?:' + FUNCTION_ARG + r')?\)\s*'
 GALAXY_MARKDOWN_FUNCTION_CALL_LINE = re.compile(FUNCTION_CALL_LINE_TEMPLATE % GALAXY_FLAVORED_MARKDOWN_CONTAINER_REGEX)
 
 BLOCK_FENCE_START = re.compile(r'```.*')
 BLOCK_FENCE_END = re.compile(r'```[\s]*')
 
-OUTPUT_LABEL_PATTERN = re.compile(r'output=([\w_\-]+)')
-INPUT_LABEL_PATTERN = re.compile(r'input=([\w_\-]+)')
+OUTPUT_LABEL_PATTERN = re.compile(r'output=\s*%s\s*' % ARG_VAL_CAPTURED_REGEX)
+INPUT_LABEL_PATTERN = re.compile(r'input=\s*%s\s*' % ARG_VAL_CAPTURED_REGEX)
+STEP_LABEL_PATTERN = re.compile(r'step=\s*%s\s*' % ARG_VAL_CAPTURED_REGEX)
 # STEP_OUTPUT_LABEL_PATTERN = re.compile(r'step_output=([\w_\-]+)/([\w_\-]+)')
-STEP_LABEL_PATTERN = re.compile(r'step=([\w_\-]+)')
 ID_PATTERN = re.compile(r'(workflow_id|history_dataset_id|history_dataset_collection_id|job_id)=([\d]+)')
 GALAXY_FLAVORED_MARKDOWN_CONTAINER_LINE_PATTERN = re.compile(
     r"```\s*galaxy\s*"
@@ -166,13 +168,13 @@ def resolve_invocation_markdown(trans, invocation, workflow_markdown):
                 if output_assoc.history_content_type == "dataset":
                     section_markdown += """#### Output Dataset: %s
 ```galaxy
-history_dataset_display(output=%s)
+history_dataset_display(output="%s")
 ```
 """ % (output_assoc.workflow_output.label, output_assoc.workflow_output.label)
                 else:
                     section_markdown += """#### Output Dataset Collection: %s
 ```galaxy
-history_dataset_collection_display(output=%s)
+history_dataset_collection_display(output="%s")
 ```
 """ % (output_assoc.workflow_output.label)
         elif container == "invocation_inputs":
@@ -183,7 +185,7 @@ history_dataset_collection_display(output=%s)
                 if input_assoc.history_content_type == "dataset":
                     section_markdown += """#### Input Dataset: %s
 ```galaxy
-history_dataset_display(input=%s)
+history_dataset_display(input="%s")
 ```
 """ % (input_assoc.workflow_step.label, input_assoc.workflow_step.label)
                 else:
@@ -205,17 +207,23 @@ history_dataset_collection_display(input=%s)
         output_match = re.search(OUTPUT_LABEL_PATTERN, line)
         input_match = re.search(INPUT_LABEL_PATTERN, line)
         step_match = re.search(STEP_LABEL_PATTERN, line)
+
+        def find_non_empty_group(match):
+            for group in match.groups():
+                if group:
+                    return group
+
         if output_match:
             target_match = output_match
-            name = output_match.group(1)
+            name = find_non_empty_group(target_match)
             ref_object = invocation.get_output_object(name)
         elif input_match:
             target_match = input_match
-            name = input_match.group(1)
+            name = find_non_empty_group(target_match)
             ref_object = invocation.get_input_object(name)
         elif step_match:
             target_match = step_match
-            name = step_match.group(1)
+            name = find_non_empty_group(target_match)
             ref_object_type = "job"
             ref_object = invocation.step_invocation_for_label(name).job
         else:

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -242,6 +242,9 @@
                 <a id="workflow-report-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Edit Report" aria-label="Edit Report">
                     <span class="fa fa-edit"></span>
                 </a>
+                <a id="workflow-report-help-button" class="panel-header-button workflow-report-content" href="javascript:void(0)" role="button" title="Report Syntax Help" aria-label="Report Syntax Help">
+                    <span class="fa fa-question"></span>
+                </a>
                 <a id="workflow-canvas-button" class="panel-header-button workflow-report-content" href="javascript:void(0)" role="button" title="Edit Workflow" aria-label="Edit Workflow">
                     <span class="fa fa-sitemap fa-rotate-270"></span>
                 </a>

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -233,7 +233,7 @@
     <div class="unified-panel-header" unselectable="on">
         <div class="unified-panel-header-inner">
             <div class="panel-header-buttons">
-                <a id="workflow-run-button" class="panel-header-button" href="javascript:void(0)" role="button" title="Run" style="display: inline-block;" aria-label="Run">
+                <a id="workflow-run-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Run" style="display: inline-block;" aria-label="Run">
                     <span class="fa fa-play"></span>
                 </a>
                 <a id="workflow-save-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Save" style="display: inline-block;" aria-label="Save">
@@ -245,7 +245,7 @@
                 <a id="workflow-canvas-button" class="panel-header-button workflow-report-content" href="javascript:void(0)" role="button" title="Edit Workflow" aria-label="Edit Workflow">
                     <span class="fa fa-sitemap fa-rotate-270"></span>
                 </a>
-                <a id="workflow-options-button" class="panel-header-button" href="javascript:void(0)" role="button" title="Workflow options" style="display: inline-block;" aria-label="Workflow options">
+                <a id="workflow-options-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Workflow options" style="display: inline-block;" aria-label="Workflow options">
                     <span class="fa fa-cog"></span>
                 </a>
             </div>

--- a/test/unit/test_markdown_validate.py
+++ b/test/unit/test_markdown_validate.py
@@ -69,3 +69,41 @@ job_metrics(job_id=THISFAKEID
 job_metrics(THISFAKEID)
 ```
 """)
+    # assert quotes are fine
+    assert_markdown_valid("""
+```galaxy
+job_metrics(output="Moo Cow")
+```
+""")
+    assert_markdown_valid("""
+```galaxy
+job_metrics(output='Moo Cow')
+```
+""")
+    # assert spaces require quotes
+    assert_markdown_invalid("""
+```galaxy
+job_metrics(output=Moo Cow)
+```
+""")
+    # assert unmatched quotes invalid
+    assert_markdown_invalid("""
+```galaxy
+job_metrics(output="Moo Cow)
+```
+""")
+    assert_markdown_invalid("""
+```galaxy
+job_metrics(output=Moo Cow")
+```
+""")
+    assert_markdown_invalid("""
+```galaxy
+job_metrics(output='Moo Cow)
+```
+""")
+    assert_markdown_invalid("""
+```galaxy
+job_metrics(output=Moo Cow')
+```
+""")


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/8751.

- Hide run/settings button when editing report - since saving won't work anyway. Less jarring and won't result in broken workflows.
- Add small syntax guide to the invocation report editor.
- Fix invocation syntax for spaces in input/output names.
