### PR TITLE
[19.09] Backport tool panel toggle fix

### DIFF
--- a/client/galaxy/scripts/components/Markdown/MarkdownEditor.vue
+++ b/client/galaxy/scripts/components/Markdown/MarkdownEditor.vue
@@ -44,6 +44,6 @@ export default {
     padding: 20px;
 
     width: 100%;
-    height: 95%;  /* what now? this is needed or the editor overtakes workflow toolbar when too much text is added */
+    height: 95%; /* what now? this is needed or the editor overtakes workflow toolbar when too much text is added */
 }
 </style>

--- a/client/galaxy/scripts/components/ToolBox.vue
+++ b/client/galaxy/scripts/components/ToolBox.vue
@@ -142,5 +142,6 @@ export default {
     display: flex;
     flex-flow: column;
     height: 100%;
+    overflow: auto;
 }
 </style>


### PR DESCRIPTION
xref #8764 
Noticed release had gotten out of sync w/ client-format, included that on top o the backport.