### PR TITLE
[19.09] Force a flush after user disk usage recalculation.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -547,6 +547,7 @@ class User(Dictifiable, RepresentById):
         usage = sa_session.scalar(sql_calc, {'id': self.id})
         if not dryrun:
             self.set_disk_usage(usage)
+            sa_session.flush()
         return usage
 
     @staticmethod


### PR DESCRIPTION
xref #8773 -- this seems to work fine locally with or without the flush, but on main we were seeing it not apply after the transaction was finished.