### PR TITLE
[19.09] Fix to 'portable' metadata for output metadata files.

### DIFF
--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -85,7 +85,9 @@ def set_metadata():
 
 def set_metadata_portable():
     import galaxy.model
-    galaxy.model.metadata.MetadataTempFile.tmp_dir = tool_job_working_directory = os.path.abspath(os.getcwd())
+    tool_job_working_directory = os.path.abspath(os.getcwd())
+    metadata_tmp_files_dir = os.path.join(tool_job_working_directory, "metadata")
+    galaxy.model.metadata.MetadataTempFile.tmp_dir = metadata_tmp_files_dir
 
     metadata_params_path = os.path.join("metadata", "params.json")
     try:


### PR DESCRIPTION
Isolating the changes produced by set-metadata to metadata/ fixes Pulsar remote metadata handling. The changes were always meant to keep metadata isolated to that directory anyway - so this is a good conceptual fix as well.